### PR TITLE
Fix Bug #70045:

### DIFF
--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.ts
@@ -630,6 +630,7 @@ export class ActionAccordion implements OnInit, OnChanges, OnDestroy {
 
                   if(modify) {
                      this.action.filePaths.splice(this.selectedFormatIndex, 1);
+                     this.action.saveFormats.splice(this.selectedFormatIndex, 1);
                      this.saveStrings.splice(this.selectedFormatIndex, 1);
                   }
 


### PR DESCRIPTION
When overwriting an existing format, the options in the model's saveFormats should be removed along with the deletion of the path.