### PR TITLE
Fix Bug #70027:

### DIFF
--- a/web/projects/portal/src/app/vsobjects/format/vs-formats-pane.component.html
+++ b/web/projects/portal/src/app/vsobjects/format/vs-formats-pane.component.html
@@ -99,9 +99,6 @@
           </alpha-dropdown>
           <label>_#(Alpha)</label>
         </div>
-        <div *ngIf=alphaInvalid class="col-12 alert alert-danger">
-          _#(viewer.flash.format.invalidTransparencyError)
-        </div>
       </div>
     </div>
     <div class="row g-0 form-row-float-label mt-4">


### PR DESCRIPTION
merge 13.8 to 14.0.now alpha can not clear value to null since it have default value 100, so the warning for it is useless, so just remove it.