### PR TITLE
fix Bug #69851:

### DIFF
--- a/core/src/main/java/inetsoft/uql/XQuery.java
+++ b/core/src/main/java/inetsoft/uql/XQuery.java
@@ -218,8 +218,8 @@ public abstract class XQuery implements Serializable, Cloneable, XMLSerializable
                uvar.getValueNode().getValue() == null && ouvar.getValueNode() != null ||
                "".equals(uvar.getValueNode().getValue()) ||
                (ouvar.getValueNode() != null &&
-                ouvar.getValueNode().getValue() != null &&
-                !(uvar.getValueNode().getValue().equals(ouvar.getValueNode().getValue()))))
+                  ouvar.getValueNode().getValue() != null &&
+                  !(uvar.getValueNode().getValue().equals(ouvar.getValueNode().getValue()))))
             {
                nmap.put(varName, ovar);
             }
@@ -464,6 +464,12 @@ public abstract class XQuery implements Serializable, Cloneable, XMLSerializable
          setName(Tool.getValue(nlist.item(0)));
       }
 
+      nlist = Tool.getChildNodesByTagName(root, "orgId");
+
+      if(nlist.getLength() > 0) {
+         setOrganizationId(Tool.getValue(nlist.item(0)));
+      }
+
       nlist = Tool.getChildNodesByTagName(root, "folder");
 
       if(nlist.getLength() > 0) {
@@ -480,7 +486,7 @@ public abstract class XQuery implements Serializable, Cloneable, XMLSerializable
             this.datasourceFullName = datasourceName;
          }
 
-         XDataSource xds = registry.getDataSource(datasourceName);
+         XDataSource xds = registry.getDataSource(datasourceName, orgId);
          setDataSource(xds != null ? xds : getDataSource());
       }
 
@@ -609,6 +615,10 @@ public abstract class XQuery implements Serializable, Cloneable, XMLSerializable
 
       if(dataSourceName != null) {
          writer.println("<datasource><![CDATA[" + dataSourceName + "]]></datasource>");
+      }
+
+      if(orgId != null) {
+         writer.println("<orgId><![CDATA[" + orgId + "]]></orgId>");
       }
 
       if(partition != null) {
@@ -843,6 +853,7 @@ public abstract class XQuery implements Serializable, Cloneable, XMLSerializable
       try {
          XQuery nquery = (XQuery) super.clone();
          nquery.datasource = datasource == null ? null : (XDataSource) datasource.clone();
+         nquery.orgId = orgId;
          nquery.varmap = new ConcurrentHashMap<>(varmap);
          nquery.propmap = (HashMap<String, Object>) propmap.clone();
          nquery.dependencies = new HashSet<>(dependencies);
@@ -875,6 +886,14 @@ public abstract class XQuery implements Serializable, Cloneable, XMLSerializable
       return super.equals(obj);
    }
 
+   public void setOrganizationId(String orgId) {
+      this.orgId = orgId;
+   }
+
+   public String getOrganizationId() {
+      return this.orgId;
+   }
+
    /**
     * Get the string representation.
     */
@@ -900,6 +919,7 @@ public abstract class XQuery implements Serializable, Cloneable, XMLSerializable
    private long modified;
    private String createdBy;
    private String modifiedBy;
+   private String orgId;
 
    public static final ThreadLocal<Boolean> REMOTE_PUT = ThreadLocal.withInitial(() -> Boolean.FALSE);
 

--- a/core/src/main/java/inetsoft/uql/asset/internal/SQLBoundTableAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/asset/internal/SQLBoundTableAssemblyInfo.java
@@ -107,7 +107,8 @@ public class SQLBoundTableAssemblyInfo extends BoundTableAssemblyInfo {
       if(node != null) {
          String name = Tool.getAttribute(node, "name");
          XRepository repository = XFactory.getRepository();
-         JDBCDataSource dataSource = (JDBCDataSource) repository.getDataSource(name);
+         JDBCDataSource dataSource = (JDBCDataSource) repository.getDataSource(name,
+            query.getOrganizationId());
          query.setDataSource(dataSource);
          UniformSQL sql = (UniformSQL) query.getSQLDefinition();
 

--- a/core/src/main/java/inetsoft/util/dep/AbstractSheetAsset.java
+++ b/core/src/main/java/inetsoft/util/dep/AbstractSheetAsset.java
@@ -73,9 +73,9 @@ public abstract class AbstractSheetAsset extends AbstractXAsset {
       Element root = doc.getDocumentElement();
       boolean overwriting = config != null && config.isOverwriting();
       AbstractSheet sheet0 = getSheet();
-      parseSheet(sheet0, root, config);
-      AssetRepository engine = AssetUtil.getAssetRepository(false);
       AssetEntry entry = getAssetEntry();
+      parseSheet(sheet0, root, config, entry.getOrgID());
+      AssetRepository engine = AssetUtil.getAssetRepository(false);
       AssetEntry pentry = entry.getParent();
 
       if(engine.containsEntry(entry)) {
@@ -381,7 +381,7 @@ public abstract class AbstractSheetAsset extends AbstractXAsset {
     * Parse sheet.
     */
    protected void parseSheet(AbstractSheet sheet, Element elem,
-                             XAssetConfig config)
+                             XAssetConfig config, String orgId)
       throws Exception
    {
       sheet.parseXML(elem);

--- a/core/src/main/java/inetsoft/util/dep/ViewsheetAsset.java
+++ b/core/src/main/java/inetsoft/util/dep/ViewsheetAsset.java
@@ -517,7 +517,7 @@ public class ViewsheetAsset extends AbstractSheetAsset implements FolderChangeab
     * Parse sheet.
     */
    @Override
-   protected void parseSheet(AbstractSheet sheet, Element elem, XAssetConfig config)
+   protected void parseSheet(AbstractSheet sheet, Element elem, XAssetConfig config, String orgId)
       throws Exception
    {
       if("viewsheet".equals(elem.getNodeName()) &&

--- a/core/src/main/java/inetsoft/util/dep/WorksheetAsset.java
+++ b/core/src/main/java/inetsoft/util/dep/WorksheetAsset.java
@@ -31,6 +31,7 @@ import inetsoft.util.Tool;
 import inetsoft.util.TransformerManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.w3c.dom.Element;
 
 import java.util.*;
 
@@ -487,6 +488,22 @@ public class WorksheetAsset extends AbstractSheetAsset implements
     */
    public void setSnapshot(boolean snapshot) {
       this.snapshot = snapshot;
+   }
+
+   @Override
+   protected void parseSheet(AbstractSheet sheet, Element elem, XAssetConfig config, String orgId)
+      throws Exception
+   {
+      sheet.parseXML(elem);
+      Worksheet ws = (Worksheet) sheet;
+
+      if(orgId != null) {
+         for(Assembly assembly : ws.getAssemblies()) {
+            if(assembly instanceof SQLBoundTableAssembly) {
+               ((SQLBoundTableAssemblyInfo) assembly.getInfo()).getQuery().setOrganizationId(orgId);
+            }
+         }
+      }
    }
 
    private boolean snapshot = false;

--- a/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
@@ -1091,6 +1091,7 @@ public class QueryManagerService {
       query.setUserQuery(true);
       query.setDataSource(dataSourceService.getDataSource(database));
       query.setSQLDefinition(new UniformSQL());
+      query.setOrganizationId(OrganizationManager.getInstance().getCurrentOrgID());
       return query;
    }
 


### PR DESCRIPTION
the bug is caused by the ws use sql bound query in it, and when run mv, in mv thread, its current organization is host, but the query's organization is other organization, so it will not get right datasource.

 for ws and vs, its identify will have its organztion id, but for datasource in xquery, it do not save its organzation, so we should save organization id in xquery when create query and when import to other organzation. Then when mv to execute sql query, it can get its datasource from right organization.

the bug not existed for sso, but for normal config have the same issue, get datasource from current organization is not safe, should save its organization id in XQuery to keep it always right.