### PR TITLE
Bug 70061

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/VSModelContext.java
+++ b/core/src/main/java/inetsoft/report/composition/VSModelContext.java
@@ -300,8 +300,7 @@ public class VSModelContext extends AbstractModelContext {
 
          if(Tool.equals(ref.getAttribute(), measureValue)) {
             addAttributes(all, ref);
-            AggregateRef agg = new AggregateRef(ref,
-                                                AggregateFormula.getFormula(formula));
+            AggregateRef agg = new AggregateRef(ref, AggregateFormula.getFormula(formula));
             addAttributes(aggs, agg);
             found = true;
          }

--- a/core/src/main/java/inetsoft/report/composition/VSModelContext.java
+++ b/core/src/main/java/inetsoft/report/composition/VSModelContext.java
@@ -293,6 +293,7 @@ public class VSModelContext extends AbstractModelContext {
       TableAssembly table = (TableAssembly) ws.getAssembly(tname);
       ColumnSelection selection = table == null ? new ColumnSelection() :
          table.getColumnSelection(true).clone();
+      boolean found = false;
 
       for(int i = 0; i < selection.getAttributeCount(); i++) {
          DataRef ref = selection.getAttribute(i);
@@ -300,9 +301,17 @@ public class VSModelContext extends AbstractModelContext {
          if(Tool.equals(ref.getAttribute(), measureValue)) {
             addAttributes(all, ref);
             AggregateRef agg = new AggregateRef(ref,
-               AggregateFormula.getFormula(formula));
+                                                AggregateFormula.getFormula(formula));
             addAttributes(aggs, agg);
+            found = true;
          }
+      }
+
+      if(!found && vs.getCalcField(tname, measureValue) != null) {
+         CalculateRef calc = vs.getCalcField(tname, measureValue);
+         addAttributes(all, calc);
+         AggregateRef agg = new AggregateRef(calc, AggregateFormula.getFormula(formula));
+         addAttributes(aggs, agg);
       }
    }
 


### PR DESCRIPTION
fix Bug #70061:
the bug is caused by when using calc field as measure value in selection list, the source table can not find the column because calc field is saved in vs, so get calc from vs and add it to check trap.