### PR TITLE
Fix Bug #70058:

### DIFF
--- a/core/src/main/java/inetsoft/sree/RepletEngine.java
+++ b/core/src/main/java/inetsoft/sree/RepletEngine.java
@@ -690,7 +690,7 @@ public class RepletEngine extends AbstractAssetEngine
          throw new RemoteException("Failed to reset repository folder", ex);
       }
 
-      String orgId = user != null ? ((XPrincipal) user).getOrgId() : null;
+      String orgId = OrganizationManager.getInstance().getCurrentOrgID();
 
       if(SUtil.isDefaultVSGloballyVisible(user) && isDefaultOrgAsset) {
          orgId = Organization.getDefaultOrganizationID();


### PR DESCRIPTION
The change in #69783 caused the current organization of the logged-in user to be fetched, but we might need to query content from other organizations via the web API, so relying on the logged-in user is incorrect. Rework Bug #69783