### PR TITLE
fix Bug #70049:

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/ws/InsertColumnsController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/InsertColumnsController.java
@@ -53,7 +53,7 @@ public class InsertColumnsController extends WorksheetController {
       RuntimeWorksheet rws =
          super.getWorksheetEngine().getWorksheet(runtimeId, principal);
 
-      return validateInsertColumns0(rws, event, principal);
+      return validateInsertColumns0(rws, event, principal, null);
    }
 
    @Undoable

--- a/core/src/main/java/inetsoft/web/composer/ws/ReplaceColumnsController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/ReplaceColumnsController.java
@@ -92,7 +92,8 @@ public class ReplaceColumnsController extends WorksheetController {
                  .name(event.tableName())
                  .build();
 
-         WSInsertColumnsEventValidator validator = validateInsertColumns0(rws, insertEvent, principal);
+         WSInsertColumnsEventValidator validator =
+            validateInsertColumns0(rws, insertEvent, principal, column);
 
          builder.trap(validator.trap());
       }

--- a/core/src/main/java/inetsoft/web/composer/ws/WorksheetController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/WorksheetController.java
@@ -123,7 +123,8 @@ public class WorksheetController {
    protected WSInsertColumnsEventValidator validateInsertColumns0(
       RuntimeWorksheet rws,
       WSInsertColumnsEvent event,
-      Principal principal) throws Exception
+      Principal principal,
+      ColumnRef replaceRef) throws Exception
    {
       WSInsertColumnsEventValidator.Builder builder = WSInsertColumnsEventValidator.builder();
 
@@ -161,6 +162,10 @@ public class WorksheetController {
          }
          else {
             index = 0;
+         }
+
+         if(replaceRef != null) {
+            columns.removeAttribute(replaceRef);
          }
 
          for(AssetEntry entry : event.entries()) {


### PR DESCRIPTION
the bug is caused by when replace column to check trap, it only add new columns to checktrap but do not remove replace column, so it will check wrong trap for column replace action.

in this case, it using two columns from two tables of n:1:n, and then add the third table column to replace the second table column, so there will only two tables for new binding to checktrap. So it should not show warnig for trap. chasm trap should only occur for the three tables.