### PR TITLE
fix Bug #70059:

### DIFF
--- a/web/projects/portal/src/app/composer/dialog/ws/aggregate-dialog.component.ts
+++ b/web/projects/portal/src/app/composer/dialog/ws/aggregate-dialog.component.ts
@@ -211,7 +211,9 @@ export class AggregateDialog implements OnInit {
 
       for(const grayField of grayedFields) {
          const matchedColumn =
-            this.model.columns.find((column) => ColumnRef.equal(grayField, column));
+            this.model.columns.find((column) => ColumnRef.equal(grayField, column) ||
+               column.alias != null && column.attribute == grayField.attribute &&
+               column.entity == grayField.entity);
 
          if(matchedColumn != null) {
             updatedTrapFields.push(matchedColumn);


### PR DESCRIPTION
the bug is caused by when column have alias, when check the column is trap or not only using equals to find column. So if it have alias, will not find in grayed out fields. so we should compare attribute and its entity when have alias in column