### PR TITLE
Bug #70064

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/Permission.java
+++ b/core/src/main/java/inetsoft/sree/security/Permission.java
@@ -395,7 +395,7 @@ public class Permission implements Serializable, Cloneable, XMLSerializable {
       Set<PermissionIdentity> filteredGrants = new HashSet<>();
 
       for(PermissionIdentity grant : grants) {
-         if(currentOrgID.equals(grant.organizationID)) {
+         if(currentOrgID.equals(grant.organizationID) || identityType != Identity.USER) {
             filteredGrants.add(grant);
          }
       }


### PR DESCRIPTION
In Role, both Administrator and Organization Administrator are global roles.   Therefore, the org values of both are null, which leads to the failure of applying the permissions.   This issue is caused by the modification of bug 69738.   Bug 69738 only consider the cases where identityType is equal to Identity.USER.   Thus, it is only necessary to check other conditions that are not user type.