### PR TITLE
Merge forward Bug #69919 - Prevent bookmarks from getting lost

### DIFF
--- a/core/src/main/java/inetsoft/report/internal/RuntimeAssetEngine.java
+++ b/core/src/main/java/inetsoft/report/internal/RuntimeAssetEngine.java
@@ -455,6 +455,11 @@ public class RuntimeAssetEngine implements AssetRepository {
       return getRepository().getVSBookmark(entry, user);
    }
 
+   @Override
+   public VSBookmark getVSBookmark(AssetEntry entry, Principal user, boolean ignoreCache) throws Exception {
+      return getRepository().getVSBookmark(entry, user, ignoreCache);
+   }
+
    /**
     * Set the viewsheet bookmark.
     * @param entry the entry of the specified viewsheet.

--- a/core/src/main/java/inetsoft/uql/asset/AssetRepository.java
+++ b/core/src/main/java/inetsoft/uql/asset/AssetRepository.java
@@ -389,6 +389,16 @@ public interface AssetRepository {
       throws Exception;
 
    /**
+    * Get the viewsheet bookmark.
+    * @param entry the entry of the specified viewsheet.
+    * @param user the specified user.
+    * @param ignoreCache whether to ignore the cache entry and load directly from the storage
+    * @return the viewsheet bookmark if any, <tt>null<tt> not found.
+    */
+   VSBookmark getVSBookmark(AssetEntry entry, Principal user, boolean ignoreCache)
+      throws Exception;
+
+   /**
     * Set the viewsheet bookmark.
     * @param entry the entry of the specified viewsheet.
     * @param bookmark the specified viewsheet bookmark.

--- a/core/src/main/java/inetsoft/uql/viewsheet/VSBookmark.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/VSBookmark.java
@@ -445,6 +445,10 @@ public class VSBookmark implements XMLSerializable {
              ", " + bookmark + ", " + bmap + ", " + bookmarksInfo + "]";
    }
 
+   public static String getLockKey(String identifier, String bookmarkOwner) {
+      return "VSBookmarkKey_" + identifier + "_" + bookmarkOwner;
+   }
+
    public class DefaultBookmark {
       public DefaultBookmark(String name, IdentityID owner) {
          this.name = name;


### PR DESCRIPTION
Prevent bookmarks from getting lost. Make changes to the VSBookmark instance from the storage as it could have changes from other inetsoft server instances or other runtime viewsheets. Add a distributed lock around this area of the code to prevent race conditions. Debounce the code to update last accessed time of a bookmark and do it in a separate thread.