### PR TITLE
Bug 70064

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/Permission.java
+++ b/core/src/main/java/inetsoft/sree/security/Permission.java
@@ -395,7 +395,7 @@ public class Permission implements Serializable, Cloneable, XMLSerializable {
       Set<PermissionIdentity> filteredGrants = new HashSet<>();
 
       for(PermissionIdentity grant : grants) {
-         if(currentOrgID.equals(grant.organizationID)) {
+         if(currentOrgID.equals(grant.organizationID) || identityType != Identity.USER) {
             filteredGrants.add(grant);
          }
       }

--- a/core/src/main/java/inetsoft/sree/security/Permission.java
+++ b/core/src/main/java/inetsoft/sree/security/Permission.java
@@ -395,7 +395,7 @@ public class Permission implements Serializable, Cloneable, XMLSerializable {
       Set<PermissionIdentity> filteredGrants = new HashSet<>();
 
       for(PermissionIdentity grant : grants) {
-         if(currentOrgID.equals(grant.organizationID) || identityType != Identity.USER) {
+         if(currentOrgID.equals(grant.organizationID) || identityType == Identity.ROLE && grant.organizationID == null) {
             filteredGrants.add(grant);
          }
       }


### PR DESCRIPTION
This bug occurred because when modifying bug69738, the fact that site admin and org admin are global was not taken into account. The global organization is null, so according to the modified logic, the permission setting for org admin will be lost.  Therefore, it is only necessary to reconsider the situation where orgid is null.