### PR TITLE
Fix Bug #70078:

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/viewsheet/ViewsheetModel.java
+++ b/core/src/main/java/inetsoft/web/admin/viewsheet/ViewsheetModel.java
@@ -70,7 +70,7 @@ public interface ViewsheetModel extends Serializable {
          }
          else {
             task(null);
-            user = new IdentityID(XPrincipal.SYSTEM, OrganizationManager.getInstance().getCurrentOrgID());
+            user = new IdentityID(XPrincipal.SYSTEM, rvs.getEntry().getOrgID());
          }
 
          id(rvs.getID());


### PR DESCRIPTION
The viewsheet created in the task is public, so the user is null, but it is associated with an organization. Therefore, instead of retrieving the current organization each time the model is accessed, the organization from the runtime viewsheet should be used for isolation.