### PR TITLE
Bug 70062

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/Permission.java
+++ b/core/src/main/java/inetsoft/sree/security/Permission.java
@@ -395,7 +395,7 @@ public class Permission implements Serializable, Cloneable, XMLSerializable {
       Set<PermissionIdentity> filteredGrants = new HashSet<>();
 
       for(PermissionIdentity grant : grants) {
-         if(currentOrgID.equals(grant.organizationID)) {
+         if(currentOrgID.equals(grant.organizationID) || identityType != Identity.USER) {
             filteredGrants.add(grant);
          }
       }

--- a/core/src/main/java/inetsoft/sree/security/Permission.java
+++ b/core/src/main/java/inetsoft/sree/security/Permission.java
@@ -395,7 +395,7 @@ public class Permission implements Serializable, Cloneable, XMLSerializable {
       Set<PermissionIdentity> filteredGrants = new HashSet<>();
 
       for(PermissionIdentity grant : grants) {
-         if(currentOrgID.equals(grant.organizationID) || identityType != Identity.USER) {
+         if(currentOrgID.equals(grant.organizationID) || identityType == Identity.ROLE && grant.organizationID == null) {
             filteredGrants.add(grant);
          }
       }

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleConditionService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleConditionService.java
@@ -431,7 +431,8 @@ public class ScheduleConditionService {
          else if(XSchema.TIME.equals(type)) {
             SimpleDateFormat formatter =
                new SimpleDateFormat("HH:mm:ss");
-            value = formatter.parse((String) value);
+            Date date = formatter.parse((String) value);
+            value = formatter.format(date);
          }
          else if(XSchema.TIME_INSTANT.equals(type)) {
             String dateTime = (String) value;


### PR DESCRIPTION
The formatter.parse((String) value) returns a Date object, so the resulting value contains a default date.  To get the time string, you just need to format the Date object (which includes the date) back to a time string.