### PR TITLE
fix Bug #70089

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/AuthenticationService.java
+++ b/core/src/main/java/inetsoft/sree/security/AuthenticationService.java
@@ -140,7 +140,7 @@ public class AuthenticationService {
             }
 
             if(principal != null) {
-               updateLocale(principal, userId, locale);
+               updateLocale(principal, userId, locale, clientLocale);
 
                if(principal instanceof SRPrincipal) {
                   setOlapAuthenticator((SRPrincipal) principal, userId, password);
@@ -453,8 +453,12 @@ public class AuthenticationService {
     * @param userId    the log in name of the user.
     * @param locale    the locale name.
     */
-   private void updateLocale(Principal principal, IdentityID userId, String locale) {
-      String localeName = LocaleService.getInstance().getLocale(locale, userId, principal);
+   private void updateLocale(Principal principal, IdentityID userId, String locale,
+                             Locale clientLocale)
+   {
+      String clientLocaleString = clientLocale != null ? clientLocale.toString() : null;
+      String localeName =
+         LocaleService.getInstance().getLocale(locale, clientLocaleString, userId, principal);
 
       if(principal instanceof SRPrincipal) {
          ((SRPrincipal) principal).setProperty(SRPrincipal.LOCALE, localeName);

--- a/core/src/main/java/inetsoft/sree/security/LocaleService.java
+++ b/core/src/main/java/inetsoft/sree/security/LocaleService.java
@@ -68,6 +68,22 @@ public class LocaleService {
     * @return the locale.
     */
    public String getLocale(String localeName, IdentityID userId, Principal principal) {
+      return getLocale(localeName, null, userId, principal);
+   }
+
+   /**
+    * Gets the locale for the user.
+    *
+    * @param localeName the name of the locale.
+    * @param clientLocale user client locale
+    * @param userId     the user name.
+    * @param principal  a principal object identifying the user.
+    *
+    * @return the locale.
+    */
+   public String getLocale(String localeName, String clientLocale, IdentityID userId,
+                           Principal principal)
+   {
       initLocale();
       String locale = null;
 
@@ -89,6 +105,10 @@ public class LocaleService {
               if(userOrg != null && userOrg.getLocale() != null && !"".equals(userOrg.getLocale())) {
                  locale = userOrg.getLocale();
               }
+            }
+
+            if((locale == null || locale.isEmpty()) && clientLocale != null) {
+               locale = localeMap.containsValue(clientLocale) ? clientLocale : locale;
             }
          }
 


### PR DESCRIPTION
 If the user's locale and the organization's locale are both set to default, use the user's client locale as the primary locale and apply localization based on it.