### PR TITLE
fix Bug #70110. Disable switching condition type and show a warning message until the task save is completed.

### DIFF
--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -4954,6 +4954,7 @@ port=port
 portal.history.bar.enable=Enable History Bar
 portal.schedule.cancel.confirm=The task will be discarded, do you want to continue?
 portal.schedule.tastchanged=Task Changed
+portal.schedule.isSaving.warning=The current task save operation has not finished yet. Please wait until it is completed before switching the condition type.
 portal.schedule.unsave.confirm=The task has unsaved changes, close anyway?
 portal.schedule.task.action.duplicateFormat=That format is already in the list. Override? If not, please choose another format.
 post=post

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.component.ts
@@ -85,6 +85,7 @@ export class TaskConditionPane implements OnInit, OnChanges {
    @Output() listViewChanged = new EventEmitter<boolean>();
    @Output() closeEditor = new EventEmitter<TaskConditionPaneModel>();
    @Output() cancelTask = new EventEmitter();
+   @Output() showMessage: EventEmitter<string> = new EventEmitter<string>();
 
    @Input()
    get model(): TaskConditionPaneModel {
@@ -205,6 +206,7 @@ export class TaskConditionPane implements OnInit, OnChanges {
    localTimeZoneOffset = 0;
    localTimeZoneId: string;
    localTimeZoneLabel: string;
+   isSaving:boolean = false;
 
    get startTime(): NgbTimeStruct {
       return this._startTime;
@@ -551,6 +553,11 @@ export class TaskConditionPane implements OnInit, OnChanges {
    }
 
    public changeConditionType(option: any): void {
+      if(this.isSaving) {
+         this.showMessage.emit("_#(js:portal.schedule.isSaving.warning)");
+         return;
+      }
+
       this.saveConditionType(this.selectedOption);
       const optionType = option.value;
 
@@ -589,7 +596,9 @@ export class TaskConditionPane implements OnInit, OnChanges {
    }
 
    public save(ok: boolean): void {
+      this.isSaving = true;
       this.saveTask().then(() => {
+         this.isSaving = false;
          storeCondition(this.condition);
          this.updateTimesAndDates();
          this.form.markAsPristine();
@@ -598,6 +607,8 @@ export class TaskConditionPane implements OnInit, OnChanges {
          if(ok && this.model.conditions.length > 1 && !this.listView) {
             this.changeView(true);
          }
+      }).finally(() => {
+         this.isSaving = false;
       });
    }
 

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/schedule-task-editor.component.html
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/schedule-task-editor.component.html
@@ -78,7 +78,8 @@
                        (loaded)="updateConditionModel($event)"
                        (updateTaskName)="updateOldTaskName($event)"
                        (closeEditor)="onCloseEditor()"
-                       (cancelTask)="onCancelTask()">
+                       (cancelTask)="onCancelTask()"
+                       (showMessage)="notifications.warning($event)">
   </task-condition-pane>
   <task-action-pane *ngIf="selectedTab === 'action'"
                     [model]="model.taskActionPaneModel"


### PR DESCRIPTION
fix Bug #70110. Disable switching condition type and show a warning message until the task save is completed.