### PR TITLE
Fix Bug #70139, it appears that under the circumstances of using Inhe…

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/OrganizationContextHolder.java
+++ b/core/src/main/java/inetsoft/sree/security/OrganizationContextHolder.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.sree.security;
+
+import inetsoft.web.portal.model.database.StringWrapper;
+
+public class OrganizationContextHolder {
+   public static void setCurrentOrgId(String orgId) {
+      THREAD_LOCAL.set(new StringWrapper(orgId));
+   }
+
+   public static String getCurrentOrgId() {
+      StringWrapper wrapper = THREAD_LOCAL.get();
+      return wrapper != null ? wrapper.getBody() : null;
+   }
+
+   public static void clear() {
+      StringWrapper wrapper = THREAD_LOCAL.get();
+
+      if(wrapper != null) {
+         // Clear the body to ensure that the initial value of inherited threadlocal is also cleared,
+         // thus avoiding interference caused by thread reuse.
+         wrapper.setBody(null);
+      }
+
+      THREAD_LOCAL.remove();
+   }
+
+   private static final InheritableThreadLocal<StringWrapper> THREAD_LOCAL = new InheritableThreadLocal<>();
+}

--- a/core/src/main/java/inetsoft/uql/XPrincipal.java
+++ b/core/src/main/java/inetsoft/uql/XPrincipal.java
@@ -18,15 +18,12 @@
 package inetsoft.uql;
 
 import inetsoft.sree.internal.SUtil;
-import inetsoft.sree.security.AuthenticationProvider;
-import inetsoft.sree.security.IdentityID;
-import inetsoft.sree.security.Organization;
+import inetsoft.sree.security.*;
 import inetsoft.uql.util.Identity;
 import inetsoft.uql.util.XSessionService;
 import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
 import inetsoft.util.script.JavaScriptEngine;
-import jakarta.persistence.Id;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
@@ -603,23 +600,11 @@ public class XPrincipal implements Principal, Serializable, Cloneable {
    }
 
    public String getCurrentOrgId() {
-      String currentOrgId = getThreadCurrentOrgId();
+      String currentOrgId = OrganizationContextHolder.getCurrentOrgId();
       currentOrgId = currentOrgId == null ? getProperty("curr_org_id") : currentOrgId;
       currentOrgId = currentOrgId == null ? getOrgId() : currentOrgId;
 
       return currentOrgId;
-   }
-
-   public static void setThreadCurrentOrgId(String orgId) {
-      CURRENT_ORG_ID.set(orgId);
-   }
-
-   public static String getThreadCurrentOrgId() {
-      return CURRENT_ORG_ID.get();
-   }
-
-   public static void clearThreadCurrentOrgId() {
-      CURRENT_ORG_ID.remove();
    }
 
    // for backward compatibility
@@ -641,5 +626,4 @@ public class XPrincipal implements Principal, Serializable, Cloneable {
    private transient IdentityID[] allGroups;
    private transient long allRolesTimeout = 0;
    private transient long allGroupsTimeout = 0;
-   private static final InheritableThreadLocal<String> CURRENT_ORG_ID = new InheritableThreadLocal<>();
 }

--- a/core/src/main/java/inetsoft/web/portal/model/database/StringWrapper.java
+++ b/core/src/main/java/inetsoft/web/portal/model/database/StringWrapper.java
@@ -21,6 +21,15 @@ package inetsoft.web.portal.model.database;
  * Wrapper for sending strings in requests.
  */
 public class StringWrapper {
+   public StringWrapper() {
+      super();
+   }
+
+   public StringWrapper(String body) {
+      super();
+      setBody(body);
+   }
+
    public String getBody() {
       return body;
    }

--- a/core/src/main/java/inetsoft/web/viewsheet/EventAspect.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/EventAspect.java
@@ -612,7 +612,7 @@ public class EventAspect {
 
    @After("@annotation(SwitchOrg) && within(inetsoft.web..*)")
    public void afterController() {
-      XPrincipal.clearThreadCurrentOrgId();
+      OrganizationContextHolder.clear();
    }
 
    private static class AnnotationParameterTuple<T> {
@@ -642,7 +642,7 @@ public class EventAspect {
    }
 
    public static void switchOrganization(String orgID, Principal principal) throws Exception {
-      XPrincipal.setThreadCurrentOrgId(orgID);
+      OrganizationContextHolder.setCurrentOrgId(orgID);
       ThreadContext.setContextPrincipal(principal);
    }
 


### PR DESCRIPTION
…ritableThreadLocal and thread reuse, a user from organization0 was getting the organization ID of organization1. This issue has been addressed by introducing OrganizationContextHolder:

1. Use StringWrapper instead of a simple string in InheritableThreadLocal, setting a new StringWrapper instance every time the organization is switched. This ensures that the value in the child thread's ThreadLocal is not related to that of the parent thread.
2. Before clearing the ThreadLocal values, first clear the value of StringWrapper, then clear the ThreadLocal value. This guarantees that if a child thread still holds the parent thread's ThreadLocal value, the org ID inside the StringWrapper in the child thread’s ThreadLocal will be cleared, thus preventing interference during thread reuse