### PR TITLE
Fix Bug #70085:

### DIFF
--- a/web/projects/em/src/app/settings/security/security-provider/authentication-provider-detail-view/authentication-provider-detail-view.component.ts
+++ b/web/projects/em/src/app/settings/security/security-provider/authentication-provider-detail-view/authentication-provider-detail-view.component.ts
@@ -84,12 +84,14 @@ export class AuthenticationProviderDetailViewComponent implements OnInit, OnDest
       if(this.model == null) {
          this.appInfoService.isEnterprise().subscribe(isEnterprise => {
             if(this.model == null) {
-               this.model = {
-                  providerName: "", providerType: undefined,
-                  dbProviderEnabled: isEnterprise,
-                  customProviderEnabled: isEnterprise,
-                  ldapProviderEnabled: !this.isMultiTenant
-               }
+               setTimeout(() => {
+                  this.model = {
+                     providerName: "", providerType: undefined,
+                     dbProviderEnabled: isEnterprise,
+                     customProviderEnabled: isEnterprise,
+                     ldapProviderEnabled: !this.isMultiTenant
+                  }
+               }, 0);
             }
          });
       }


### PR DESCRIPTION
this.appInfoService.isEnterprise().subscribe() is an asynchronous operation. When initializing the model, ldapProviderEnabled depends on the values of this.isMultiTenant and isEnterprise. If this.isMultiTenant or isEnterprise has not been initialized yet, it may cause ldapProviderEnabled to be set to the wrong value, and it will only be correct after refreshing the page. To resolve this, you can delay setting the model to ensure that the asynchronous operation is completed before assigning values.