### PR TITLE
fix Bug #70126:

### DIFF
--- a/web/projects/em/src/app/settings/schedule/task-condition-pane/time-zone-select/time-zone-select-component.ts
+++ b/web/projects/em/src/app/settings/schedule/task-condition-pane/time-zone-select/time-zone-select-component.ts
@@ -75,7 +75,7 @@ export class TimeZoneSelectComponent implements OnInit, ControlValueAccessor {
 
    setTimeZoneLabel(changed: boolean) {
       let timeZoneLabel = this.dateTimeService
-         .getTimeZoneLabel(this.timeZoneOptions, this.timeZoneId, this.serverTimeZone);
+         .getTimeZoneLabel(this.timeZoneOptions, this.timeZoneId, this.timeZoneOptions[0].timeZoneId);
       this.labelChanged.emit(timeZoneLabel);
 
       if(changed) {


### PR DESCRIPTION
should set default to select local timem zone not server time zone, in normal cases, we want using local time zone to set time.