### PR TITLE
Fix Bug #70093:

### DIFF
--- a/web/projects/shared/util/guard/can-component-deactivate.service.ts
+++ b/web/projects/shared/util/guard/can-component-deactivate.service.ts
@@ -26,6 +26,10 @@ export class CanComponentDeactivateService implements CanDeactivate<CanComponent
                  currentState: RouterStateSnapshot,
                  nextState?: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean
    {
+      if(!component) {
+         return true;
+      }
+
       return component.canDeactivate(component, currentRoute, currentState, nextState);
    }
 }


### PR DESCRIPTION
Because "Enable Security" is set to false, the Security Providers page is directly hidden, which means the CanDeactivate guard is not triggered. The purpose of the CanDeactivate guard is to show a dialog if the form has not been saved. However, when "Enable Security" is false, there's no need to consider whether the form has been saved, so the CanDeactivate guard is not required, and the navigation can proceed directly.