### PR TITLE
fix Bug #70203

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/CloudRunnerServerScheduleClient.java
+++ b/core/src/main/java/inetsoft/sree/schedule/CloudRunnerServerScheduleClient.java
@@ -19,8 +19,10 @@
 package inetsoft.sree.schedule;
 
 import inetsoft.sree.internal.cluster.Cluster;
-import inetsoft.util.SingletonManager;
 import inetsoft.util.health.HealthStatus;
+import org.quartz.SchedulerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.rmi.RemoteException;
 import java.util.Optional;
@@ -39,7 +41,12 @@ public class CloudRunnerServerScheduleClient extends ScheduleClient {
 
    @Override
    public void stopServer() throws RemoteException {
-      getSchedule().stop();
+      try {
+         Scheduler.disposeScheduler();
+      }
+      catch(SchedulerException e) {
+         LOG.error("Failed to stop scheduler", e);
+      }
    }
 
    @Override
@@ -118,4 +125,6 @@ public class CloudRunnerServerScheduleClient extends ScheduleClient {
    private ScheduleServer getSchedule() {
       return ScheduleServer.getInstance();
    }
+
+   private static final Logger LOG = LoggerFactory.getLogger(CloudRunnerServerScheduleClient.class);
 }

--- a/core/src/main/java/inetsoft/sree/schedule/RestartSchedulerMessage.java
+++ b/core/src/main/java/inetsoft/sree/schedule/RestartSchedulerMessage.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.sree.schedule;
+
+import java.io.Serializable;
+
+public class RestartSchedulerMessage implements Serializable {
+}

--- a/core/src/main/java/inetsoft/sree/schedule/Scheduler.java
+++ b/core/src/main/java/inetsoft/sree/schedule/Scheduler.java
@@ -120,6 +120,19 @@ public class Scheduler {
    }
 
    /**
+    * Dispose the scheduler.
+    *
+    */
+   public static synchronized void disposeScheduler() throws SchedulerException {
+      if(INSTANCE == null) {
+         return;
+      }
+
+      INSTANCE.stop();
+      INSTANCE = null;
+   }
+
+   /**
     * Starts this scheduler instance.
     */
    public void start() {

--- a/core/src/main/java/inetsoft/web/admin/schedule/SchedulerConfigurationService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/SchedulerConfigurationService.java
@@ -19,6 +19,7 @@ package inetsoft.web.admin.schedule;
 
 import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.internal.cluster.Cluster;
 import inetsoft.sree.schedule.*;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
@@ -26,6 +27,7 @@ import inetsoft.storage.ExternalStorageService;
 import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
 import inetsoft.util.audit.ActionRecord;
+import inetsoft.util.config.InetsoftConfig;
 import inetsoft.web.admin.content.repository.ResourcePermissionService;
 import inetsoft.web.admin.schedule.model.*;
 import inetsoft.web.admin.schedule.model.CheckMailInfo;
@@ -135,6 +137,10 @@ public class SchedulerConfigurationService {
       setServerLocations(model.serverLocations());
       SreeEnv.setProperty("schedule.save.autoSuffix", model.saveAutoSuffix());
       SreeEnv.save();
+
+      if(InetsoftConfig.getInstance().getCloudRunner() != null) {
+         Cluster.getInstance().sendMessage(new RestartSchedulerMessage());
+      }
    }
 
    public ScheduleStatusModel getStatus() {
@@ -184,7 +190,11 @@ public class SchedulerConfigurationService {
    }
 
    public void setStatus(ScheduleStatusModel status) throws Exception {
-      switch(Objects.requireNonNull(status.action())) {
+      setStatus(status.action());
+   }
+
+   public void setStatus(String action) throws Exception {
+      switch(Objects.requireNonNull(action)) {
       case "start":
          SUtil.stopScheduler();
          SUtil.startScheduler();


### PR DESCRIPTION
For the scheduler cloud runner, automatically restart the scheduler server when the schedule configuration is changed to apply the latest config. This is because when configuring the cloud runner, the user does not have a way to restart the scheduler.