### PR TITLE
fix Bug #70208:

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/Scheduler.java
+++ b/core/src/main/java/inetsoft/sree/schedule/Scheduler.java
@@ -865,8 +865,12 @@ public class Scheduler {
       if(date != null && time != null) {
          Calendar time1 = Calendar.getInstance();
          Calendar date1 = Calendar.getInstance();
-         time1.setTimeZone(TimeZone.getTimeZone(timeZone));
-         date1.setTimeZone(TimeZone.getTimeZone(timeZone));
+
+         if(timeZone != null) {
+            time1.setTimeZone(TimeZone.getTimeZone(timeZone));
+            date1.setTimeZone(TimeZone.getTimeZone(timeZone));
+         }
+
          time1.setTime(time);
          date1.setTime(date);
          date1.set(Calendar.HOUR_OF_DAY, time1.get(Calendar.HOUR_OF_DAY));


### PR DESCRIPTION
fix Bug #70179:
for schedule task condtion, should using condition time zone to check all conditions and then change time to server time zone. In old logic, all time change to server will cause date not rightly. using local time zone all date will not change to other day, so all logic will works rightly.

fix null point of for time zone