### PR TITLE
fix Bug #70189

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/properties/PropertiesController.java
+++ b/core/src/main/java/inetsoft/web/admin/properties/PropertiesController.java
@@ -22,6 +22,7 @@ import inetsoft.sree.SreeEnv;
 import inetsoft.util.Tool;
 import inetsoft.util.audit.ActionRecord;
 import inetsoft.web.MapSessionRepository;
+import inetsoft.web.admin.security.PropertyModel;
 import inetsoft.web.security.DeniedMultiTenancyOrgUser;
 import inetsoft.web.viewsheet.AuditObjectName;
 import inetsoft.web.viewsheet.Audited;
@@ -56,23 +57,30 @@ public class PropertiesController {
    )
    @PutMapping("/api/admin/properties/edit")
    public void editProperty(Principal user,
-                            @RequestParam(value = "property", required = true) @AuditObjectName
-                               String property,
-                            @RequestParam(value = "value", required = true) String value)
+                            @RequestBody @AuditObjectName("name()") PropertyModel property)
       throws Exception
    {
-      property = property.trim();
-      value = value.trim();
+      String propertyName = property.name();
+
+      if(propertyName != null) {
+         propertyName = propertyName.trim();
+      }
+
+      String value = property.value();
+
+      if(value != null) {
+         value = value.trim();
+      }
 
       if("".equals(value)) {
-         value = SreeEnv.getProperty(property);
+         value = SreeEnv.getProperty(propertyName);
          value = value == null ? "" : value;
       }
 
-      SreeEnv.setProperty(property, value);
+      SreeEnv.setProperty(propertyName, value);
       SreeEnv.save();
 
-      if(Tool.equals(property,"http.session.timeout")) {
+      if(Tool.equals(propertyName,"http.session.timeout")) {
          mapSessionRepository.updateSessionTimeout(value);
       }
    }

--- a/web/projects/em/src/app/settings/properties/property-settings-services/property-settings-datasource.service.ts
+++ b/web/projects/em/src/app/settings/properties/property-settings-services/property-settings-datasource.service.ts
@@ -113,10 +113,12 @@ export class PropertySettingsDatasourceService {
    }
 
    changeRow(row: PropertySetting): Observable<void> {
-      const params: HttpParams = new HttpParams()
-         .set("property", row.propertyName)
-         .set("value", row.propertyValue);
-      return this.http.put<void>("../api/admin/properties/edit", null, {params});
+      let property = {
+         name: row.propertyName,
+         value: row.propertyValue
+      };
+
+      return this.http.put<void>("../api/admin/properties/edit", property);
    }
 
    cancelRow() {


### PR DESCRIPTION
use the request body to replace the request query for edit property endpoint, because the value may be too long for the request query.