### PR TITLE
fix Bug #70174. 

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/SSOSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/SSOSettingsService.java
@@ -174,7 +174,7 @@ public class SSOSettingsService {
                Tool.equals(Organization.getDefaultOrganizationID(), r.getOrgID());
          })
          .map(role -> NameLabelTuple.builder()
-            .name(role.convertToKey())
+            .name(role.getName())
             .label(role.getName()).build())
          .toArray(NameLabelTuple[]::new);
    }

--- a/core/src/main/java/inetsoft/web/security/AbstractSecurityFilter.java
+++ b/core/src/main/java/inetsoft/web/security/AbstractSecurityFilter.java
@@ -170,8 +170,12 @@ public abstract class AbstractSecurityFilter
       final IdentityID pId = principal == null ? null : IdentityID.getIdentityIDFromKey(principal.getName());
       final IdentityID[] currentRoles = principal.getRoles();
       final String[] roles = getSSODefaultRole();
+      IdentityID[] defRoles = Arrays.stream(roles)
+         .map(role -> "Administrator".equals(role) ? new IdentityID(role, null)
+            : new IdentityID(role, Organization.getDefaultOrganizationID()))
+         .toArray(IdentityID[]::new);
       final IdentityID[] newRoles =
-         Stream.concat(Arrays.stream(roles).map(IdentityID::getIdentityIDFromKey), Arrays.stream(currentRoles)).toArray(IdentityID[]::new);
+         Stream.concat(Arrays.stream(defRoles), Arrays.stream(currentRoles)).toArray(IdentityID[]::new);
       principal.setRoles(newRoles);
       createSession(request, principal);
       final ClientInfo info = createClientInfo(principal.getIdentityID(), request);


### PR DESCRIPTION
When setting the `sso.default.roles` property, there is no need to explicitly set the organization ID, as this property currently only takes effect in non-multi-tenant environments.