### PR TITLE
Fix Bug #70173:

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/general/DataSpaceSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/general/DataSpaceSettingsService.java
@@ -151,7 +151,7 @@ public class DataSpaceSettingsService extends BackupSupport {
 
       for(int i = 0; i <= deleteCount; i++) {
          try {
-            storageService.delete(zips.get(i));
+            storageService.delete(BACKUP_FOLDER + "\\"+ zips.get(i));
          }
          catch(IOException e) {
             LOG.error("Failed to delete backup file {}", zips.get(i), e);


### PR DESCRIPTION
The meaning of asset.backup.count is that if the configured backupCount is 3 (i.e., asset.backup.count = 3), the code will ensure that at most 3 .zip files are kept in the backup directory.  If there are more than 3 backup files, it will delete the oldest backups until only 3 files remain.  When deleting, the file path needs to be obtained, which has an additional file layer compared to the path in the YAML.  Simply add backup to the path.