### PR TITLE
fix Bug #70138, in the VS wizard, selecting columns can result in rap…

### DIFF
--- a/core/src/main/java/inetsoft/web/vswizard/handler/VSWizardBindingHandler.java
+++ b/core/src/main/java/inetsoft/web/vswizard/handler/VSWizardBindingHandler.java
@@ -2165,6 +2165,10 @@ public class VSWizardBindingHandler {
             }
          }
          catch(Exception ex) {
+            if(rvs.isDisposed()) {
+               return;
+            }
+
             LOG.error("Failed to get chart data", ex);
          }
 


### PR DESCRIPTION
fix Bug #70138, in the VS wizard, selecting columns can result in rapid creation and disposal of assemblies, should not display exceptions caused by disposed reason.