### PR TITLE
Bug 70196

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/ComposedTableAssembly.java
+++ b/core/src/main/java/inetsoft/uql/asset/ComposedTableAssembly.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.uql.asset;
 
+import inetsoft.sree.SreeEnv;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.internal.*;
 import inetsoft.uql.erm.DataRef;
@@ -496,6 +497,8 @@ public abstract class ComposedTableAssembly extends AbstractTableAssembly {
          return false;
       }
 
+      writer.print("join.table.maxrows_");
+      writer.println(SreeEnv.getProperty("join.table.maxrows", "0"));
       writer.print("Composed[");
       TableAssembly[] tables = getTableAssemblies(true);
 

--- a/core/src/main/java/inetsoft/web/admin/general/DataSpaceSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/general/DataSpaceSettingsService.java
@@ -151,7 +151,7 @@ public class DataSpaceSettingsService extends BackupSupport {
 
       for(int i = 0; i <= deleteCount; i++) {
          try {
-            storageService.delete(zips.get(i));
+            storageService.delete(BACKUP_FOLDER + "\\"+ zips.get(i));
          }
          catch(IOException e) {
             LOG.error("Failed to delete backup file {}", zips.get(i), e);

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -2695,6 +2695,7 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
     * Requests that the server open the viewsheet.
     */
    private openViewsheet0(runtimeId: string = null): void {
+      console.log(52365);
       this.setAppSize();
       let event: OpenViewsheetEvent = new OpenViewsheetEvent(
          this.assetId, this.appSize.width, this.appSize.height, this.mobileDevice,

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -2695,7 +2695,6 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
     * Requests that the server open the viewsheet.
     */
    private openViewsheet0(runtimeId: string = null): void {
-      console.log(52365);
       this.setAppSize();
       let event: OpenViewsheetEvent = new OpenViewsheetEvent(
          this.assetId, this.appSize.width, this.appSize.height, this.mobileDevice,


### PR DESCRIPTION
1.​Fix Bug #70173: When backing up files, the content directory had an extra "backup" folder compared to the YAML file's directory. The directory is now properly added when add the file.
2.Fix Bug #70196: ​Added the join.table.maxrows property to the sheet's cache key.