### PR TITLE
Bug #70105  Fix Condition description for Run Once Tasks

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/TimeCondition.java
+++ b/core/src/main/java/inetsoft/sree/schedule/TimeCondition.java
@@ -488,7 +488,6 @@ public class TimeCondition implements ScheduleCondition, XMLSerializable, Binary
          Date displayTime = new Date(time.getTime() + tz.getOffset(now) - serverTZ.getOffset(now));
 
          cal.setTime(displayTime);
-         cal.setTimeZone(tz);
 
          boolean dst = tz.inDaylightTime(displayTime);
          return catalog.getString("TimeCondition") + ": at " +


### PR DESCRIPTION
When calculating 12-hour time for Run Once tasks, do not do an extra timezone conversion