### PR TITLE
fix Bug #70264:

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/TimeCondition.java
+++ b/core/src/main/java/inetsoft/sree/schedule/TimeCondition.java
@@ -385,7 +385,7 @@ public class TimeCondition implements ScheduleCondition, XMLSerializable, Binary
          long start = cal1.getTimeInMillis();
 
          if(containsIn(days_of_week,  cal1.get(Calendar.DAY_OF_WEEK))) {
-            Calendar calEnd = Calendar.getInstance(TimeZone.getDefault());
+            Calendar calEnd = Calendar.getInstance(getTimeZone());
             calEnd.setTime(new Date(curr));
             calEnd.set(Calendar.HOUR_OF_DAY, hour_end);
             calEnd.set(Calendar.MINUTE, minute_end);


### PR DESCRIPTION
the bug is caused by end time using server time zone but current time using local time zone, so it will compare wrong, all calculate and compare should using local time zone to do.