### PR TITLE
Bug #70253 fix viewsheet not opening when a variable has the same name as existing assembly name

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
@@ -5417,8 +5417,8 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
    /**
     * Get all disabled variable names.
     */
-   public List<String> getDisabledVariables() {
-      List<String> list = new ArrayList<>();
+   public Set<String> getDisabledVariables() {
+      Set<String> list = new LinkedHashSet<>();
       list.addAll(Arrays.asList(vinfo.getDisabledVariables()));
 
       for(Assembly assembly : getAssemblies()) {


### PR DESCRIPTION
Only ignore variables that have the same name as InputVSAssembly and don't send a CollectParametersCommand when the resulting variable list is empty. If there is nothing to enter then proceed with opening the viewsheet.

This reduces the scope of the change for Bug #57803 and makes sure that it doesn't break the changes for Bug #69536.