### PR TITLE
fix Bug #70072

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/sync/TaskAssetDependencyTransformer.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/TaskAssetDependencyTransformer.java
@@ -97,7 +97,7 @@ public class TaskAssetDependencyTransformer extends DependencyTransformer {
          return;
       }
 
-      ScheduleTask scheduleTask = scheduleManager.getScheduleTask(task.getName());
+      ScheduleTask scheduleTask = scheduleManager.getScheduleTask(task.getName(), task.getOrgID());
 
       if(scheduleTask == null) {
          return;


### PR DESCRIPTION
to update the task in scheduler server after TaskAssetDependencyTransformer process the task, should get the schedule task by the org id.