### PR TITLE
Bug #70172

### DIFF
--- a/core/src/main/java/inetsoft/report/filter/AverageFormula.java
+++ b/core/src/main/java/inetsoft/report/filter/AverageFormula.java
@@ -199,7 +199,7 @@ public class AverageFormula implements PercentageFormula {
       if(keepType && dataType != null && (dataType == Long.class || dataType == Integer.class ||
          dataType == Short.class))
       {
-         douResult = (long) douResult;
+         return (long) douResult;
       }
 
       return douResult;


### PR DESCRIPTION
When converting a double value to a long type and then assigning it back to a double parameter, the resulting value still retains decimal points, thus appearing as a double.  To obtain the correct value, directly returning the converted long type will yield the accurate result.