### PR TITLE
fix Bug #70132

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/jobstore/ClusterJobStore.java
+++ b/core/src/main/java/inetsoft/sree/schedule/jobstore/ClusterJobStore.java
@@ -18,6 +18,7 @@
 package inetsoft.sree.schedule.jobstore;
 
 import inetsoft.sree.internal.cluster.*;
+import inetsoft.util.Tool;
 import org.quartz.Calendar;
 import org.quartz.*;
 import org.quartz.impl.matchers.GroupMatcher;
@@ -177,7 +178,7 @@ public class ClusterJobStore implements JobStore, Serializable {
          storeJob(e.getKey(), true);
          for(final Trigger trigger : e.getValue()) {
             storeTrigger((OperableTrigger) trigger, true,
-               !e.getKey().getKey().equals(trigger.getJobKey()));
+               !Tool.equals(e.getKey().getKey(), trigger.getJobKey()));
          }
       }
    }


### PR DESCRIPTION
call storeTrigger from storeJobsAndTriggers, do not check the job exist. jobsByKey is a LocalClusterMap, it needs some time to sync local map and distributed map, so frequent map operations can lead to inconsistencies between the local map and the distributed map in LocalClusterMap.