### PR TITLE
fix Bug #70270：

### DIFF
--- a/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.ts
+++ b/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.ts
@@ -86,6 +86,10 @@ export class TaskOptionsPane {
             this.optionsForm.get("endDate").setValue(null);
          }
 
+         if(this.model.timeZone == null) {
+            this.model.timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+         }
+
          this.optionsForm.get("taskEnabled").setValue(this.model.enabled || false);
          this.optionsForm.get("deleteIfNotScheduledToRun").setValue(this.model.deleteIfNotScheduledToRun || false);
          this.optionsForm.get("description").setValue(this.model.description);


### PR DESCRIPTION
the bug is caused by task option time zone should set default value as local time zone. Then if user only set time do not set time zone, should using default time zone.