### PR TITLE
fix Bug #70282

### DIFF
--- a/web/projects/portal/src/app/composer/gui/tablestyle/editor/save-table-style-dialog.component.html
+++ b/web/projects/portal/src/app/composer/gui/tablestyle/editor/save-table-style-dialog.component.html
@@ -33,8 +33,8 @@
                            </span>
                   <span *ngIf="form.controls['name'].errors && ! form.controls['name']
                               .errors['assetNameStartWithCharDigit'] &&
-                              form.controls['name'].errors['assetEntryBannedCharacters']" class="invalid-feedback">
-                              _#(composer.sheet.checkSpeChar)
+                              form.controls['name'].errors['containsSpecialCharsForName']" class="invalid-feedback">
+                              _#(common.sree.internal.invalidCharInName)
                            </span>
                   <span
                      *ngIf="form.controls['name'].errors && form.controls['name']

--- a/web/projects/portal/src/app/composer/gui/tablestyle/editor/save-table-style-dialog.component.ts
+++ b/web/projects/portal/src/app/composer/gui/tablestyle/editor/save-table-style-dialog.component.ts
@@ -65,7 +65,7 @@ export class SaveTableStyleDialog implements OnInit {
       this.form = new UntypedFormGroup({
          name: new UntypedFormControl(this.model.name, [
             Validators.required,
-            FormValidators.assetEntryBannedCharacters,
+            FormValidators.isValidReportName,
             FormValidators.assetNameStartWithCharDigit
          ])});
 


### PR DESCRIPTION
According to the old version of the code, the table style name role is same to report. do not allow the '~' char for it(see LibManager.SEPARATOR)