### PR TITLE
fix Bug #70273, set removeSemicolonContent of UrlPathHelper to false,…

### DIFF
--- a/core/src/main/java/inetsoft/web/WebConfig.java
+++ b/core/src/main/java/inetsoft/web/WebConfig.java
@@ -262,10 +262,13 @@ public class WebConfig implements WebMvcConfigurer, ApplicationContextAware {
          // WebSphere strips the trailing slash
          UrlPathHelper helper = new UrlPathHelper();
          helper.setAlwaysUseFullPath(true);
+         helper.setRemoveSemicolonContent(false);
          configurer.setUrlPathHelper(helper);
       }
       else if(configurer.getUrlPathHelper() == null) {
-         configurer.setUrlPathHelper(new UrlPathHelper());
+         UrlPathHelper helper = new UrlPathHelper();
+         helper.setRemoveSemicolonContent(false);
+         configurer.setUrlPathHelper(helper);
       }
 
       // need for cjk chars on uri path. (58590)


### PR DESCRIPTION
set removeSemicolonContent of UrlPathHelper to false, to avoid causing get wrong path when path contains identity id which DELIMITER contains ";"