### PR TITLE
fix Bug #70277:

### DIFF
--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/schedule-task-editor.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/schedule-task-editor.component.ts
@@ -103,7 +103,9 @@ export class ScheduleTaskEditorComponent implements OnInit {
             this.originalModel = Tool.clone(model);
          },
          (error) => {
-            if(error.statusText && error.statusText.toLowerCase() == "forbidden") {
+            if(error.statusText && error.statusText.toLowerCase() == "forbidden" ||
+               error.status == 403)
+            {
                ComponentTool.showMessageDialog(
                   this.modalService, "_#(js:Error)",
                   "You have no schedule permission, please contact administrator");


### PR DESCRIPTION
when using url to link to no permission tasks, it will show error 403, then should show proper warning for user but not only show empty dialog.