### PR TITLE
Bug #70266 Load VSBookmark from the storage before checking if bookmark exists

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
@@ -752,13 +752,8 @@ public class RuntimeViewsheet extends RuntimeSheet {
     * @return <tt>true</tt> if contains it, <tt>false</tt> otherwise.
     */
    public boolean containsBookmark(String name, IdentityID user) {
-      if(getUserBookmark(user) == null) {
-         return false;
-      }
-
-      VSBookmark bookmark = getUserBookmark(user);
-
-      return bookmark.containsBookmark(name);
+      VSBookmark bookmark = getVSBookmark(user.convertToKey());
+      return bookmark != null && bookmark.containsBookmark(name);
    }
 
    /**


### PR DESCRIPTION
Load VSBookmark from the storage before checking if a bookmark with the given name exists. This will ensure that we're checking against the most recent copy of VSBookmark.