### PR TITLE
Fix Bug #70294:

### DIFF
--- a/core/src/main/resources/inetsoft/web/resources/js/login.js
+++ b/core/src/main/resources/inetsoft/web/resources/js/login.js
@@ -248,8 +248,8 @@ function authenticateUser(userName, password, loginAsName, requestedUrl, firstLo
 
    headers["X-Requested-With"] = "XMLHttpRequest";
    headers["Authorization"] = "Basic " + btoa(encodeURIComponent(userName) + ":" + encodeURIComponent(password));
-   headers["LoginAsUser"] = loginAsName;
-   headers["FirstLogin"] = firstLogin;
+   headers["LoginAsUser"] = encodeURIComponent(loginAsName);
+   headers["FirstLogin"] = encodeURIComponent(firstLogin);
 
    $.ajax({
       url: requestedUrl,


### PR DESCRIPTION
The reason for the login failure is that the header information contains non-ISO-8859-1 characters, specifically Chinese characters. The solution is to use encodeURIComponent to encode the Chinese characters.