### PR TITLE
fix Bug #70287.

### DIFF
--- a/web/projects/portal/src/app/vsobjects/dialog/profiling-dialog.component.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/profiling-dialog.component.ts
@@ -29,8 +29,6 @@ import {
    ViewChild
 } from "@angular/core";
 import { NgbTooltip } from "@ng-bootstrap/ng-bootstrap";
-import { toNumber } from "lodash";
-import { DateTypeFormatter } from "../../../../../shared/util/date-type-formatter";
 import { GuiTool } from "../../common/util/gui-tool";
 import { XConstants } from "../../common/util/xconstants";
 import { BaseTableCellModel } from "../../vsobjects/model/base-table-cell-model";
@@ -129,7 +127,8 @@ export class ProfilingDialog implements OnInit {
    }
 
    get tableUri(): string {
-      return GET_PROFILE_TABLE_URL + "?isViewsheet=" + this.isViewsheet;
+      return GET_PROFILE_TABLE_URL + "?isViewsheet=" + this.isViewsheet +
+         "&timeZone=" + Intl.DateTimeFormat().resolvedOptions().timeZone;
    }
 
    get showDetails(): boolean {
@@ -200,7 +199,7 @@ export class ProfilingDialog implements OnInit {
 
    reloadTable(event: ProfileTableDataEvent) {
        this.modelService.putModel(this.tableUri, event).subscribe((data: any) => {
-         this.tableData = this.updateTableDateLabel(data.body);
+         this.tableData = data.body;
       });
    }
 
@@ -289,27 +288,8 @@ export class ProfilingDialog implements OnInit {
 
    exportTable(): void {
       const url = GET_PROFILE_EXPORT + "?name=" + encodeURIComponent(this.objName) +
-         "&isViewsheet=" + this.isViewsheet;
+         "&isViewsheet=" + this.isViewsheet +
+         "&timeZone=" + Intl.DateTimeFormat().resolvedOptions().timeZone;
       this.downloadService.download(url);
-   }
-
-   updateTableDateLabel(tableData: BaseTableCellModel[][]): BaseTableCellModel[][] {
-      let start = "Start Timestamp";
-      let end = "End Timestamp";
-      let startDate = this.tableData[0].findIndex(cell => cell.cellLabel === start);
-      let endDate = this.tableData[0].findIndex(cell => cell.cellLabel === end);
-      let dateFormat = "HH:mm:ss:SSS"
-
-      const formatDate = (row, index) => {
-         if(row[index] && row[index].cellLabel !== start && row[index].cellLabel !== end) {
-            row[index].cellLabel = DateTypeFormatter.format(toNumber(row[index].cellLabel), dateFormat, false);
-         }
-      };
-
-     return tableData.map(row => {
-               formatDate(row, startDate);
-               formatDate(row, endDate);
-               return row
-            });
    }
 }

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -3300,7 +3300,10 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
          sortCol: 0
       };
 
-      let params = new HttpParams().set("isViewsheet", "true").set("name", objName);
+      let params = new HttpParams()
+         .set("isViewsheet", "true")
+         .set("name", objName)
+         .set("timeZone", Intl.DateTimeFormat().resolvedOptions().timeZone);
 
       this.modelService.putModel(GET_PROFILE_TABLE_URL, event, params)
          .subscribe((data: any) => {


### PR DESCRIPTION
Format the timestamp using the client's time zone. Such processing should not be done on the frontend because if the data volume is large, formatting will be slow, leading to the initial display of timestamp data and subsequent refresh into time format.