### PR TITLE
Bug #70256  Created "datasource.cloudError" property to allow custom error messages for cloud data sources connection tests.

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/JDBCDataSource.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/JDBCDataSource.java
@@ -985,6 +985,12 @@ public class JDBCDataSource extends AdditionalConnectionDataSource<JDBCDataSourc
          unasgn = "true".equalsIgnoreCase(attr);
       }
 
+      attr = Tool.getAttribute(root, "cloudHosted");
+
+      if(attr != null) {
+         cloudHosted = "true".equalsIgnoreCase(attr);
+      }
+
       setDatabaseType0();
       resetDatabaseDefinition();
    }
@@ -1004,7 +1010,8 @@ public class JDBCDataSource extends AdditionalConnectionDataSource<JDBCDataSourc
          "\" nameOption=\"" + option +
          "\" ansiJoin=\"" + ansiJoin +
          "\" unasgn=\"" + unasgn +
-         "\" custom=\"" + custom + "\"");
+         "\" custom=\"" + custom +
+         "\" cloudHosted=\"" + cloudHosted + "\"");
 
       if(defaultdb != null) {
          writer.print(" defaultDB=\"" + Tool.escape(defaultdb) + "\"");
@@ -1228,6 +1235,21 @@ public class JDBCDataSource extends AdditionalConnectionDataSource<JDBCDataSourc
       return systemSchemas;
    }
 
+   /**
+    * Set if this data source is recognized as a cloud-hosted datasource
+    * @param cloudHosted indicates if the data source is cloud-hosted
+    */
+   public void setCloudHosted(boolean cloudHosted) {
+      this.cloudHosted = cloudHosted;
+   }
+
+   /**
+    * Get if this data source is recognized as a cloud-hosted datasource
+    * @return true if the datasource is cloud-hosted
+    */
+   public boolean isCloudHosted() {
+      return cloudHosted;
+   }
    /**
     * Get a list of the catalogs this datasource uses for system tables.
     */
@@ -1569,6 +1591,7 @@ public class JDBCDataSource extends AdditionalConnectionDataSource<JDBCDataSourc
    private boolean custom = false;
    private boolean unasgn = false;
    private String runtimeProductName = null;
+   private boolean cloudHosted = false;
 
    public static final String JDBC_URL_TEMPLATE = "jdbc:<subprotocol>://<host>[:<port>]/databaseName";
 

--- a/core/src/main/java/inetsoft/uql/jdbc/util/JDBCUtil.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/util/JDBCUtil.java
@@ -965,6 +965,11 @@ public class JDBCUtil {
       String testQuery = SreeEnv.getProperty(
          "inetsoft.uql.jdbc.pool." + jdbcDataSource.getFullName() + ".connectionTestQuery");
 
+      if(jdbcDataSource.isCloudHosted()) {
+         String cloudErrorMessage = SreeEnv.getProperty("datasource.cloudError", "");
+         result.setCloudError(cloudErrorMessage);
+      }
+
       if(type.getType().equals(CustomDatabaseType.TYPE)) {
          CustomDatabaseType.CustomDatabaseInfo customInfo =
             (CustomDatabaseType.CustomDatabaseInfo) result.getInfo();

--- a/core/src/main/java/inetsoft/uql/listing/AmazonAuroraMySQLDataSourceListing.java
+++ b/core/src/main/java/inetsoft/uql/listing/AmazonAuroraMySQLDataSourceListing.java
@@ -34,6 +34,7 @@ public class AmazonAuroraMySQLDataSourceListing extends DataSourceListing {
       ds.setURL("jdbc:mysql://instance.accountId.region.rds.amazonaws.com:3306/databaseName");
       ds.setDriver("com.mysql.jdbc.Driver");
       ds.setProductName("AMAZON AURORA");
+      ds.setCloudHosted(true);
 
       return ds;
    }

--- a/core/src/main/java/inetsoft/uql/listing/AmazonAuroraPostgreSQLDataSourceListing.java
+++ b/core/src/main/java/inetsoft/uql/listing/AmazonAuroraPostgreSQLDataSourceListing.java
@@ -34,6 +34,7 @@ public class AmazonAuroraPostgreSQLDataSourceListing extends DataSourceListing {
       ds.setURL("jdbc:postgresql://instance.accountId.region.rds.amazonaws.com:5432/databaseName");
       ds.setDriver("org.postgresql.Driver");
       ds.setProductName("AMAZON AURORA");
+      ds.setCloudHosted(true);
       return ds;
    }
 }

--- a/core/src/main/java/inetsoft/uql/listing/AmazonEMRDataSourceListing.java
+++ b/core/src/main/java/inetsoft/uql/listing/AmazonEMRDataSourceListing.java
@@ -32,6 +32,7 @@ public class AmazonEMRDataSourceListing extends DataSourceListing {
       ds.setName(getAvailableName());
       ds.setURL("jdbc:hive2://<hostname>:<port>/<db>");
       ds.setDriver("com.amazon.hive.jdbc41.HS2Driver");
+      ds.setCloudHosted(true);
 
       return ds;
    }

--- a/core/src/main/java/inetsoft/uql/listing/AmazonRedshiftDataSourceListing.java
+++ b/core/src/main/java/inetsoft/uql/listing/AmazonRedshiftDataSourceListing.java
@@ -32,6 +32,7 @@ public class AmazonRedshiftDataSourceListing extends DataSourceListing {
       ds.setName(getAvailableName());
       ds.setURL("jdbc:redshift://<endpoint>:<port>/<database>");
       ds.setDriver("com.amazon.redshift.Driver");
+      ds.setCloudHosted(true);
 
       return ds;
    }

--- a/core/src/main/java/inetsoft/uql/listing/GoogleBigQueryDataSourceListing.java
+++ b/core/src/main/java/inetsoft/uql/listing/GoogleBigQueryDataSourceListing.java
@@ -32,6 +32,7 @@ public class GoogleBigQueryDataSourceListing extends DataSourceListing {
       ds.setName(getAvailableName());
       ds.setURL("jdbc:bigquery://<host>:<port>;ProjectId=<Project>;OAuthType=<AuthValue>;");
       ds.setDriver("com.simba.googlebigquery.jdbc42.Driver");
+      ds.setCloudHosted(true);
 
       return ds;
    }

--- a/core/src/main/java/inetsoft/uql/listing/NetezzaDataSourceListing.java
+++ b/core/src/main/java/inetsoft/uql/listing/NetezzaDataSourceListing.java
@@ -32,6 +32,7 @@ public class NetezzaDataSourceListing extends DataSourceListing {
       ds.setName(getAvailableName());
       ds.setURL("jdbc:netezza://<host>[:<port>]/<database>");
       ds.setDriver("org.netezza.Driver");
+      ds.setCloudHosted(true);
 
       return ds;
    }

--- a/core/src/main/java/inetsoft/uql/listing/SnowflakeDataSourceListing.java
+++ b/core/src/main/java/inetsoft/uql/listing/SnowflakeDataSourceListing.java
@@ -32,6 +32,7 @@ public class SnowflakeDataSourceListing extends DataSourceListing {
       ds.setName(getAvailableName());
       ds.setURL("jdbc:snowflake://<account_name>.snowflakecomputing.com/[?db=<database>]");
       ds.setDriver("net.snowflake.client.jdbc.SnowflakeDriver");
+      ds.setCloudHosted(true);
 
       return ds;
    }

--- a/core/src/main/java/inetsoft/web/admin/content/database/DatabaseDefinition.java
+++ b/core/src/main/java/inetsoft/web/admin/content/database/DatabaseDefinition.java
@@ -205,6 +205,14 @@ public class DatabaseDefinition {
       this.changeDefaultDB = changeDefaultDB;
    }
 
+   public String getCloudError() {
+      return cloudError;
+   }
+
+   public void setCloudError(String cloudError) {
+      this.cloudError = cloudError;
+   }
+
    private String name;
    private String oname;
    private String type;
@@ -223,4 +231,5 @@ public class DatabaseDefinition {
    private int option;
    private String defaultdb = null; // set the default database
    private boolean changeDefaultDB;
+   private String cloudError;
 }

--- a/core/src/main/java/inetsoft/web/admin/content/repository/DatabaseDatasourcesService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/DatabaseDatasourcesService.java
@@ -466,6 +466,7 @@ public class DatabaseDatasourcesService {
       jdbcDataSource.setTransactionIsolation(newSrc.getTransactionIsolation());
       jdbcDataSource.setTableNameOption(newSrc.getTableNameOption());
       jdbcDataSource.setAnsiJoin(newSrc.isAnsiJoin());
+      jdbcDataSource.setCloudHosted(database.getCloudError() != null);
 
       boolean additionalChange = false;
 
@@ -1029,6 +1030,7 @@ public class DatabaseDatasourcesService {
       xds.setTransactionIsolation(definition.getTransactionIsolation());
       xds.setCustomEditMode(definition.getInfo().isCustomEditMode());
       xds.setCustom(type.equals(CustomDatabaseType.TYPE));
+      xds.setCloudHosted(definition.getCloudError() != null);
       String url = databaseType.formatUrl(definition.getNetwork(), definition.getInfo());
 
       if(buildCustomUrl && definition.getInfo().isCustomEditMode()) {

--- a/core/src/main/java/inetsoft/web/portal/data/DatabaseDatasourcesController.java
+++ b/core/src/main/java/inetsoft/web/portal/data/DatabaseDatasourcesController.java
@@ -34,7 +34,9 @@ import inetsoft.web.portal.model.database.StringWrapper;
 import inetsoft.web.portal.model.database.events.CheckDependenciesEvent;
 import inetsoft.web.security.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.security.Principal;
 import java.util.ArrayList;
@@ -111,6 +113,13 @@ public class DatabaseDatasourcesController {
                                                     @RequestBody() DatabaseDefinition model,
                                                     Principal principal)
    {
+      boolean test504 = true;
+
+      if(test504) {
+         throw new ResponseStatusException(HttpStatus.GATEWAY_TIMEOUT, "504 Gateway Timeout");
+      }
+
+
       return this.databaseDatasourcesService.testDataSourceConnection(path, model, principal);
    }
 

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -4165,6 +4165,7 @@ em.data.databases.driverUploadError=An error prevented the driver(s) from being 
 em.data.databases.duplicateDatabaseName=A database with the same name already exists
 em.data.databases.duplicateFolder=A folder with the same name already exists
 em.data.databases.error=An error prevented the database from being updated.
+em.data.databases.error.gatewayTimeout=504 Gateway Timeout: The server did not respond in time.
 em.data.databases.getDatabaseError=An error prevented the database definition from being loaded.
 em.data.databases.installError=An error prevented the plugins(s) from being installed.
 em.data.databases.pluginSuccessful=Successfully installed plugin(s)\!

--- a/web/projects/shared/util/model/database-definition-model.ts
+++ b/web/projects/shared/util/model/database-definition-model.ts
@@ -35,4 +35,5 @@ export interface DatabaseDefinitionModel {
    tableNameOption: number;
    defaultDatabase: string;
    changeDefaultDB: boolean;
+   cloudError?: string;
 }


### PR DESCRIPTION
Fixes the error message handling when testing a data source connection.
Also has a new message specifically for 504 errors, and an additional custom message for cloud hosted data sources.
This message is configured by setting the "datasource.cloudError" property.
The datasources are specified as "cloud-hosted" by setting the field in their listing class.