### PR TITLE
fix Bug #70329:

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/Scheduler.java
+++ b/core/src/main/java/inetsoft/sree/schedule/Scheduler.java
@@ -878,21 +878,29 @@ public class Scheduler {
       if(date != null && time != null) {
          Calendar time1 = Calendar.getInstance();
          Calendar date1 = Calendar.getInstance();
+         time1.setTime(time);
+         date1.setTime(date);
 
          if(timeZone != null) {
             time1.setTimeZone(TimeZone.getTimeZone(timeZone));
             date1.setTimeZone(TimeZone.getTimeZone(timeZone));
          }
 
-         time1.setTime(time);
-         date1.setTime(date);
          date1.set(Calendar.HOUR_OF_DAY, time1.get(Calendar.HOUR_OF_DAY));
          date1.set(Calendar.MINUTE, time1.get(Calendar.MINUTE));
          date1.set(Calendar.SECOND, time1.get(Calendar.SECOND));
          time = date1.getTime();
       }
 
-      return time;
+      return toServerDate(time);
+   }
+
+   private static Date toServerDate(Date targetDate) {
+      Calendar calendar = Calendar.getInstance();
+      calendar.setTime(targetDate);
+      calendar.setTimeZone(TimeZone.getDefault());
+
+      return calendar.getTime();
    }
 
    /**

--- a/core/src/main/java/inetsoft/sree/schedule/Scheduler.java
+++ b/core/src/main/java/inetsoft/sree/schedule/Scheduler.java
@@ -892,15 +892,7 @@ public class Scheduler {
          time = date1.getTime();
       }
 
-      return toServerDate(time);
-   }
-
-   private static Date toServerDate(Date targetDate) {
-      Calendar calendar = Calendar.getInstance();
-      calendar.setTime(targetDate);
-      calendar.setTimeZone(TimeZone.getDefault());
-
-      return calendar.getTime();
+      return time;
    }
 
    /**

--- a/core/src/main/java/inetsoft/sree/schedule/Scheduler.java
+++ b/core/src/main/java/inetsoft/sree/schedule/Scheduler.java
@@ -878,14 +878,14 @@ public class Scheduler {
       if(date != null && time != null) {
          Calendar time1 = Calendar.getInstance();
          Calendar date1 = Calendar.getInstance();
-         time1.setTime(time);
-         date1.setTime(date);
 
          if(timeZone != null) {
             time1.setTimeZone(TimeZone.getTimeZone(timeZone));
             date1.setTimeZone(TimeZone.getTimeZone(timeZone));
          }
 
+         time1.setTime(time);
+         date1.setTime(date);
          date1.set(Calendar.HOUR_OF_DAY, time1.get(Calendar.HOUR_OF_DAY));
          date1.set(Calendar.MINUTE, time1.get(Calendar.MINUTE));
          date1.set(Calendar.SECOND, time1.get(Calendar.SECOND));

--- a/core/src/main/java/inetsoft/web/admin/schedule/model/TimeZoneModel.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/model/TimeZoneModel.java
@@ -33,6 +33,7 @@ public interface TimeZoneModel {
    String timeZoneId();
    @Nullable String label();
    @Nullable String hourOffset();
+   int minuteOffset();
 
    static TimeZoneModel.Builder builder() {
       return new TimeZoneModel.Builder();
@@ -91,6 +92,7 @@ public interface TimeZoneModel {
                     .timeZoneId(TimeZone.getDefault().getID())
                     .label(TimeZone.getDefault().getDisplayName() + " (" + Catalog.getCatalog().getString("em.scheduler.servertimezone") + ")")
                     .hourOffset(Catalog.getCatalog().getString(""))
+                    .minuteOffset(TimeZone.getDefault().getRawOffset()/60000)
                     .build());
 
       LocalDateTime now = LocalDateTime.now();
@@ -101,11 +103,13 @@ public interface TimeZoneModel {
             .getId()
             .replace("Z", "+00:00");
          offset = "(UTC" + offset + ")";
+         int minuteOffset = 0;
 
          tzList.add(TimeZoneModel.builder()
                        .timeZoneId(id)
                        .label(tz.getDisplayName())
                        .hourOffset(offset)
+                       .minuteOffset(tz.getRawOffset()/60000)
                        .build());
       }
 

--- a/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.ts
+++ b/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.ts
@@ -34,6 +34,7 @@ import { map, startWith } from "rxjs/operators";
 import { TaskOptionsPaneModel } from "../../../../../../shared/schedule/model/task-options-pane-model";
 import { TimeZoneModel } from "../../../../../../shared/schedule/model/time-zone-model";
 import { ScheduleUsersService } from "../../../../../../shared/schedule/schedule-users.service";
+import { DateTypeFormatter } from "../../../../../../shared/util/date-type-formatter";
 import { FormValidators } from "../../../../../../shared/util/form-validators";
 import { KEY_DELIMITER, IdentityId } from "../../security/users/identity-id";
 import { DateTimeService } from "../task-condition-pane/date-time.service";
@@ -73,14 +74,18 @@ export class TaskOptionsPane {
          this._model = Object.assign({}, value);
 
          if(this.model.startFrom) {
-            this.optionsForm.get("startDate").setValue(new Date(this.model.startFrom));
+            this.optionsForm.get("startDate").setValue(new Date(
+               DateTypeFormatter.convertToLocalTimeZone(this.model.startFrom, this.model.timeZone,
+               this.timeZoneOptions)));
          }
          else {
             this.optionsForm.get("startDate").setValue(null);
          }
 
          if(this.model.stopOn) {
-            this.optionsForm.get("endDate").setValue(new Date(this.model.stopOn));
+            this.optionsForm.get("endDate").setValue(new Date(
+               DateTypeFormatter.convertToLocalTimeZone(this.model.stopOn, this.model.timeZone,
+               this.timeZoneOptions)));
          }
          else {
             this.optionsForm.get("endDate").setValue(null);
@@ -186,10 +191,13 @@ export class TaskOptionsPane {
    fireModelChanged(): void {
       this.model.enabled = !!this.optionsForm.get("taskEnabled").value;
       this.model.deleteIfNotScheduledToRun = !!this.optionsForm.get("deleteIfNotScheduledToRun").value;
+      this.model.timeZone = this.optionsForm.get("timeZone").value;
       let date: Date = this.optionsForm.get("startDate").value;
-      this.model.startFrom = date ? date.getTime() : 0;
+      this.model.startFrom = date ? DateTypeFormatter.convertToOtherTimeZone(date.getTime(),
+         this.model.timeZone, this.timeZoneOptions) : 0;
       date = this.optionsForm.get("endDate").value;
-      this.model.stopOn = date ? date.getTime() : 0;
+      this.model.stopOn = date ? DateTypeFormatter.convertToOtherTimeZone(date.getTime(),
+         this.model.timeZone, this.timeZoneOptions) : 0;
       this.model.description = this.optionsForm.get("description").value;
       this.model.timeZone = this.optionsForm.get("timeZone").value;
       const locale = this.optionsForm.get("locale").value;

--- a/web/projects/shared/schedule/model/time-zone-model.ts
+++ b/web/projects/shared/schedule/model/time-zone-model.ts
@@ -19,4 +19,5 @@ export interface TimeZoneModel {
    timeZoneId: string;
    label: string;
    hourOffset: string;
+   minuteOffset: number;
 }

--- a/web/projects/shared/util/date-type-formatter.ts
+++ b/web/projects/shared/util/date-type-formatter.ts
@@ -23,6 +23,7 @@ import duration from "dayjs/plugin/duration";
 import toObject from "dayjs/plugin/toObject";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import advancedFormat from "dayjs/plugin/advancedFormat";
+import { TimeZoneModel } from "../schedule/model/time-zone-model";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -119,6 +120,33 @@ export class DateTypeFormatter {
       }
 
       return DateTypeFormatter.format(value,  format, true);
+   }
+
+   public static convertToLocalTimeZone(time1: number, tz: string, timeZoneOptions: TimeZoneModel[]): number {
+      let diff = this.getLocalMinuteOffset(timeZoneOptions) - this.getMinuteOffset(tz, timeZoneOptions);
+      const timezoneDiffInMilliseconds = diff * 60 * 1000;
+
+      return time1 - timezoneDiffInMilliseconds;
+   }
+
+   public static convertToOtherTimeZone(time1: number, tz: string, timeZoneOptions: TimeZoneModel[]): number {
+      let diff = this.getLocalMinuteOffset(timeZoneOptions) - this.getMinuteOffset(tz, timeZoneOptions);
+      const timezoneDiffInMilliseconds = diff * 60 * 1000;
+
+      return time1 + timezoneDiffInMilliseconds;
+   }
+
+   public static getLocalMinuteOffset(timeZoneOptions: TimeZoneModel[]): number {
+      const localTimeZoneId = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+      return this.getMinuteOffset(localTimeZoneId, timeZoneOptions);
+   }
+
+   public static getMinuteOffset(tz: string, timeZoneOptions: TimeZoneModel[]): number {
+      let result = timeZoneOptions.find((opt) => opt.timeZoneId == tz &&
+         opt.minuteOffset != null);
+
+      return result.minuteOffset;
    }
 
    public static format(value: number | Date, format: string, autoFix: boolean = true): string | null {


### PR DESCRIPTION
support select time zone for task option dates.

When select date, it will create one date object in client with current local time zone, but it should set model to server with select time zone in model. So we should convert the date to right timestamp.

Such as: in local china local, we select 2025-01-02 00:00:00, it will create date 2025-01-02 00:00:00 UTC+8, and after date.getTime, it will get date 2025-01-01 16:00:00 UTC. It will be wrong.

In fact, if we select date 2025-01-02 00:00:00(2025-01-02 00:00:00 UTC+8) and select time zone to UTC0, we want timestamp to 2025-01-02 00:00:00 UTC0, so we should +8 hours for timestamp to get right time we want.

However, when populate date time to date picker, we should change time to local time zone to shwo right date. so that we can keep date select not changed after reopen pane.

In server, we should also check date is between start date and end date according to the select time zone not server time zone. Also because user date have its own time zone.