### PR TITLE
Fix Bug #70349:

### DIFF
--- a/core/src/main/java/inetsoft/util/dep/ViewsheetAsset.java
+++ b/core/src/main/java/inetsoft/util/dep/ViewsheetAsset.java
@@ -172,8 +172,8 @@ public class ViewsheetAsset extends AbstractSheetAsset implements FolderChangeab
                processDVScript(dvalues, dependencies, sheet);
                processScript(vinfo0.getScript(), dependencies, desc, sheet);
 
-               if(sheet.getBaseEntry() != null) {
-                  CalculateRef[] calcFields = sheet.getCalcFields(sheet.getBaseEntry().getName());
+               if(sheet.getBaseWorksheet() != null) {
+                  CalculateRef[] calcFields = sheet.getCalcFields(sheet.getBaseWorksheet().getPrimaryAssemblyName());
 
                   if(calcFields != null) {
                      for(CalculateRef calcRef : calcFields) {

--- a/core/src/main/java/inetsoft/util/dep/ViewsheetAsset.java
+++ b/core/src/main/java/inetsoft/util/dep/ViewsheetAsset.java
@@ -148,6 +148,22 @@ public class ViewsheetAsset extends AbstractSheetAsset implements FolderChangeab
 
          getDeviceDependency(sheet, dependencies);
 
+         if(sheet.getBaseWorksheet() != null) {
+            for(Assembly wassembly: sheet.getBaseWorksheet().getAssemblies()) {
+               CalculateRef[] calcFields = sheet.getCalcFields(wassembly.getName());
+
+               if(calcFields != null) {
+                  for(CalculateRef calcRef : calcFields) {
+                     DataRef ref = calcRef.getDataRef();
+
+                     if(ref instanceof ExpressionRef exprRef) {
+                        processScript(exprRef.getExpression(), dependencies, desc, sheet);
+                     }
+                  }
+               }
+            }
+         }
+
          // do not recursively get assemblies
          Assembly[] assemblies = sheet.getAssemblies();
 
@@ -171,21 +187,6 @@ public class ViewsheetAsset extends AbstractSheetAsset implements FolderChangeab
                List<DynamicValue> dvalues = vinfo0.getViewDynamicValues(false);
                processDVScript(dvalues, dependencies, sheet);
                processScript(vinfo0.getScript(), dependencies, desc, sheet);
-
-               if(sheet.getBaseWorksheet() != null) {
-                  CalculateRef[] calcFields = sheet.getCalcFields(sheet.getBaseWorksheet().getPrimaryAssemblyName());
-
-                  if(calcFields != null) {
-                     for(CalculateRef calcRef : calcFields) {
-                        DataRef ref = calcRef.getDataRef();
-
-                        if(ref != null && ref instanceof ExpressionRef) {
-                           ExpressionRef exprRef = (ExpressionRef) ref;
-                           processScript(exprRef.getExpression(), dependencies, desc, sheet);
-                        }
-                     }
-                  }
-               }
             }
 
             if(assembly instanceof ChartVSAssembly) {


### PR DESCRIPTION
The fix for bug #70134 may result in occasionally fetching the wrong key from the calcmap, so we use sheet.getBaseWorksheet().getPrimaryAssemblyName() to retrieve it.