### PR TITLE
bug-70348

### DIFF
--- a/web/projects/em/src/app/app.component.ts
+++ b/web/projects/em/src/app/app.component.ts
@@ -85,8 +85,12 @@ export class AppComponent implements OnInit, OnDestroy {
             (message) => this.zone.run(() => this.notify(JSON.parse(message.frame.body)))));
          this.subscription.add(connection.subscribe(
             "/user/session-expiration",
-            (message) => this.zone.run(
-               () => this.showExpirationDialog(JSON.parse(message.frame.body)))));
+            (message) => {
+               const parsedMessage = JSON.parse(message.frame.body);
+               localStorage.setItem("session-expiration", JSON.stringify({data: parsedMessage, timestamp: Date.now()}));
+               this.zone.run(() => this.showExpirationDialog(parsedMessage));
+            })
+         );
          this.subscription.add(connection.subscribe(
             "/user/license-changed",
             (message) => this.zone.run(
@@ -110,6 +114,13 @@ export class AppComponent implements OnInit, OnDestroy {
             this.scrollDirection = direction;
          }
       }));
+
+      window.addEventListener("storage", (event) => {
+         if (event.key === "session-expiration" && event.newValue) {
+            const parsedMessage = JSON.parse(event.newValue);
+            this.zone.run(() => this.showExpirationDialog(parsedMessage.data));
+         }
+      });
 
       this.ssoHeartbeatDispatcher.dispatch();
    }


### PR DESCRIPTION
The bug occurs because listening to the WebSocket event alone will trigger the popup, but it only appears on the last page that was opened.  Using localStorage and the storage event enables a cross-page synchronization mechanism, ensuring that the popup is displayed simultaneously on both the EM and Portal pages.