### PR TITLE
bug-70384

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/ContentRepositoryTreeService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/ContentRepositoryTreeService.java
@@ -462,7 +462,7 @@ public class ContentRepositoryTreeService {
                   nodes.add(node);
                   map.put(key, nodes);
                }
-               else {
+               else if(!map.get(key).contains(node)) {
                   map.get(key).add(node);
                }
             }


### PR DESCRIPTION
This bug is a special case.  When security is turned off and there is no login, the user is null when creating a VS in the composer, for example, 8^VIEWSHEET^_NULL_^Untitled-4^127.0.0.1~.  As a result, during the traversal in the em, there is an admin user and an anonymous user, both of which are not null.  This causes the autosavefile to be added twice.  Therefore, deduplication in the map can resolve this issue.