### PR TITLE
fix Bug #70390. 

### DIFF
--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.html
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.html
@@ -329,7 +329,7 @@
         </ng-container>
       </ng-container>
       <div class="d-inline-block">
-        <button type="button" class="viewer-toolbar-btn icon-hover-bg  bg-white1 no-caret" (click)="showBookmarks()"
+        <button type="button" class="viewer-toolbar-btn icon-hover-bg  bg-white1 no-caret" (click)="showBookmarks(false)"
                 [fixedDropdown]="bookmarkDropdown" dropdownPlacement="bottom"
                 *ngIf="bookmarksVisible()"
                 title="_#(Bookmarks)" aria-haspopup="true"

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -1470,7 +1470,7 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
       this.viewsheetClient.sendEvent(TOGGLE_STATUS_URI, event);
    }
 
-   showBookmarks(): void {
+   showBookmarks(gotoBookmark: boolean = true): void {
       this.http.get<boolean>("../api/vs/bookmark/isDefaultOrgAsset/" + Tool.byteEncode(this.runtimeId)).subscribe( (isDefaultOrgAsset) => this.isDefaultOrgAsset = isDefaultOrgAsset);
 
       let bookmarkName: string = null;
@@ -1490,7 +1490,7 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
       this.getBookmarks().subscribe(data => {
             this.vsBookmarkList = data;
 
-            if(bookmarkName != null) {
+            if(bookmarkName != null && gotoBookmark) {
                let bookmark = this.vsBookmarkList.find(
                   f => f.name == bookmarkName && (!bookmarkUser || bookmarkUser == convertToKey(f.owner))
                );


### PR DESCRIPTION
When clicking the bookmark icon to display bookmarks, do not goto to a specific bookmark, as doing so would cause the loss of ongoing operations, making it impossible to save these changes.