### PR TITLE
bug-70398

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/LocalDependencyHandler.java
+++ b/core/src/main/java/inetsoft/uql/asset/LocalDependencyHandler.java
@@ -1026,8 +1026,8 @@ public class LocalDependencyHandler implements DependencyHandler {
       updateDeviceDependencies(vs, entry, add, cache);
 
       if(!vs.getCalcFieldSources().isEmpty()) {
-         for(String calcField : vs.getCalcFieldSources()) {
-            updateScriptDependencies(vs, calcField, entry, add, cache);
+         for(String tname : vs.getCalcFieldSources()) {
+            updateScriptDependencies(vs, tname, entry, add, cache);
          }
       }
 
@@ -1329,10 +1329,10 @@ public class LocalDependencyHandler implements DependencyHandler {
       updateScriptDependencies(script, entry, add, cache);
    }
 
-   private void updateScriptDependencies(Viewsheet vs, String calcField, AssetEntry entry,
+   private void updateScriptDependencies(Viewsheet vs, String tname, AssetEntry entry,
                                          boolean add, boolean cache)
    {
-      CalculateRef[] calcFields = vs.getCalcFields(calcField);
+      CalculateRef[] calcFields = vs.getCalcFields(tname);
 
       if(calcFields != null) {
          for(CalculateRef calcRef : calcFields) {

--- a/core/src/main/java/inetsoft/uql/asset/LocalDependencyHandler.java
+++ b/core/src/main/java/inetsoft/uql/asset/LocalDependencyHandler.java
@@ -1024,7 +1024,12 @@ public class LocalDependencyHandler implements DependencyHandler {
       updateRunQueryDependencies(vs, entry, add, cache);
       updateScriptDependencies(vs, entry, add, cache);
       updateDeviceDependencies(vs, entry, add, cache);
-      updateScriptDependencies(vs, base, entry, add, cache);
+
+      if(!vs.getCalcFieldSources().isEmpty()) {
+         for(String calcField : vs.getCalcFieldSources()) {
+            updateScriptDependencies(vs, calcField, entry, add, cache);
+         }
+      }
 
       for(Assembly assembly : vs.getAssemblies()) {
          if(assembly instanceof Viewsheet) {
@@ -1324,14 +1329,10 @@ public class LocalDependencyHandler implements DependencyHandler {
       updateScriptDependencies(script, entry, add, cache);
    }
 
-   private void updateScriptDependencies(Viewsheet vs, AssetEntry base, AssetEntry entry,
+   private void updateScriptDependencies(Viewsheet vs, String calcField, AssetEntry entry,
                                          boolean add, boolean cache)
    {
-      if(base == null) {
-         return;
-      }
-
-      CalculateRef[] calcFields = vs.getCalcFields(base.getName());
+      CalculateRef[] calcFields = vs.getCalcFields(calcField);
 
       if(calcFields != null) {
          for(CalculateRef calcRef : calcFields) {


### PR DESCRIPTION
When using vs.getBaseEntry(), sometimes the key from the calcmap cannot be retrieved.   In such cases, switching to vs.getCalcFieldSources() resolve the issue.