### PR TITLE
fix Bug #70415, Optimize the logic of editing calcfield

### DIFF
--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -3365,6 +3365,7 @@ common.tree.deleteCalField=Delete the Calculated Field?
 common.tree.deleteForbidden=Cannot delete an opened asset or a folder containing an opened asset.
 common.tree.deleteSelected=Delete the selected asset(s)?
 common.tree.deleteTrashcan=Are you sure you want to remove the following asset(s) permanently?
+common.tree.editCalcField=The column is already used by assemblies [{0}].\nSwitching between Detail and Aggregate types may cause it to be removed from assembly binding if it is no longer applicable\! Proceed?
 common.tree.removeFolder=Remove the folder and its contents?
 common.tree.renameForbidden=Cannot rename an opened asset or a folder containing an opened asset.
 common.undefinedPrimaryAssembly2=Primary assembly not found in Data Worksheet\: {0}


### PR DESCRIPTION
1. When switching between Detail and Aggregate types and also the calcfield was used by any bindable assembly, should popup confirm dialog to let the user know the effect.

2. Once user confirmed or directly apply the changes(calc type not changed), should force to sync the assemblies which used the calcfield. so remove the old logic of checking used assemblies.