### PR TITLE
code review

### DIFF
--- a/core/src/main/java/inetsoft/util/dep/ViewsheetAsset.java
+++ b/core/src/main/java/inetsoft/util/dep/ViewsheetAsset.java
@@ -148,9 +148,9 @@ public class ViewsheetAsset extends AbstractSheetAsset implements FolderChangeab
 
          getDeviceDependency(sheet, dependencies);
 
-         if(sheet.getBaseWorksheet() != null) {
-            for(Assembly wassembly: sheet.getBaseWorksheet().getAssemblies()) {
-               CalculateRef[] calcFields = sheet.getCalcFields(wassembly.getName());
+         if(sheet.getCalcFieldSources() != null) {
+            for(String calcField: sheet.getCalcFieldSources()) {
+               CalculateRef[] calcFields = sheet.getCalcFields(calcField);
 
                if(calcFields != null) {
                   for(CalculateRef calcRef : calcFields) {


### PR DESCRIPTION
The Assemblies in BaseWorksheet cannot accurately retrieve calcFields; they should be obtained based on the sheet's CalcFieldSources.