### PR TITLE
bug-70410

### DIFF
--- a/web/projects/portal/src/app/widget/tabular/tabular-boolean-editor.component.html
+++ b/web/projects/portal/src/app/widget/tabular/tabular-boolean-editor.component.html
@@ -17,7 +17,7 @@
   -->
 <div class="form-check pb-2">
   <label class="no-float-label form-check-label">
-    <input type="checkbox" class="form-check-input" [(ngModel)]="value"
+    <input type="checkbox" class="form-check-input"
            [formControl]="valueControl"/>
     <span>{{label}}</span>
   </label>

--- a/web/projects/portal/src/app/widget/tabular/tabular-boolean-editor.component.ts
+++ b/web/projects/portal/src/app/widget/tabular/tabular-boolean-editor.component.ts
@@ -39,7 +39,7 @@ export class TabularBooleanEditor implements OnInit, OnChanges {
    valueControl: UntypedFormControl;
 
    ngOnInit(): void {
-      this.valueControl = new UntypedFormControl();
+      this.valueControl = new UntypedFormControl(this.value);
 
       if(!this.enabled) {
          this.valueControl.disable();

--- a/web/projects/portal/src/app/widget/tabular/tabular-boolean-editor.component.ts
+++ b/web/projects/portal/src/app/widget/tabular/tabular-boolean-editor.component.ts
@@ -64,5 +64,9 @@ export class TabularBooleanEditor implements OnInit, OnChanges {
             }
          }
       }
+
+      if(changes["value"] && changes["value"].currentValue != this.value) {
+         this.valueControl.setValue(changes["value"].currentValue, {emitEvent: false});
+      }
    }
 }


### PR DESCRIPTION
The original code uses both [(ngModel)] and [formControl], which creates conflicts in form control value management. we need to:
   1. Remove [(ngModel)] to avoid conflicts with reactive form controls.
   2. Initialize the form control with the desired default value.