### PR TITLE
fix Bug #69773:

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleConditionService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleConditionService.java
@@ -336,8 +336,11 @@ public class ScheduleConditionService {
          }
 
          value = parameterValue.getValue();
-      }
 
+         if(value instanceof Date) {
+            return parameterValue.getDataType();
+         }
+      }
 
       if(value instanceof Boolean) {
          type = XSchema.BOOLEAN;


### PR DESCRIPTION
the bug is caused by date and time instant data will saved by same type in server(use timestamp to save it) so when timestamp without time it will treat it as date. This is old logic for report. When get parameter from report, it will get all parameter name and parameter value and type will according to value. But in styleBI, we do not support report, so we can just get data type from its defined type.

For array timeinstant, it will caused old logic, do not have issue. only change not aray timeinstant case.