### PR TITLE
fix Bug #70405.

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
@@ -900,10 +900,6 @@ public class UserTreeService {
          throw e;
       }
       finally {
-         if(newOrgId != null) {
-            fireCreateOrganizationEvent(EditOrganizationEvent.FINSHED, copyFromOrgID, newOrgId, principal);
-         }
-
          ThreadContext.setContextPrincipal(oldPrincipal);
          Audit.getInstance().auditAction(actionRecord, principal);
 

--- a/web/projects/em/src/app/app.component.ts
+++ b/web/projects/em/src/app/app.component.ts
@@ -146,9 +146,13 @@ export class AppComponent implements OnInit, OnDestroy {
       // TODO: display a message of some kind
    }
 
-   notify(notification: any, width?: string): void {
+   notify(notification: any, width?: string, duration?: number): void {
       this.notificationMessage = notification.message;
-      this.dialog.open(this.notificationDialog, { width: !!width ? width : "350px" });
+      const dialog = this.dialog.open(this.notificationDialog, { width: !!width ? width : "350px" });
+
+      if(!!duration) {
+         setTimeout(() => { dialog.close(); }, duration);
+      }
    }
 
    private showExpirationDialog(model: SessionExpirationModel): void {
@@ -213,7 +217,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
    private showEditOrgMessage(message: any) {
       if(!!message) {
-         this.notify({message: message},  "600px");
+         this.notify({message: message},  "600px", 5000);
       }
    }
 }

--- a/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.ts
+++ b/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.ts
@@ -186,6 +186,7 @@ export class UsersSettingsPageComponent implements OnInit, OnDestroy {
    }
 
    public newOrganization(parentGroup: string) {
+      this.loading = true;
       const uri = "../api/em/security/users/create-organization/" + Tool.byteEncodeURLComponent(this.selectedProvider);
       this.http.post<EditOrganizationPaneModel>(uri, {parentGroup})
          .pipe(catchError((error: HttpErrorResponse) => this.errorService.showSnackBar(error)))
@@ -194,6 +195,8 @@ export class UsersSettingsPageComponent implements OnInit, OnDestroy {
                let id: IdentityId = {name: model.name, orgID: model.id};
                this.refreshTree(id, IdentityType.ORGANIZATION);
             }
+
+            this.loading = false;
          });
    }
 


### PR DESCRIPTION
When creating an organization, display a loading page. Automatically close the notification dialog and remove the success notification, as the loading state will exit after a successful creation.