### PR TITLE
fix Bug #70126:

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/EMScheduleTaskController.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/EMScheduleTaskController.java
@@ -26,8 +26,7 @@ import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
 import inetsoft.web.admin.content.repository.ContentRepositoryTreeNode;
 import inetsoft.web.admin.schedule.model.*;
-import inetsoft.web.security.RequiredPermission;
-import inetsoft.web.security.Secured;
+import inetsoft.web.security.*;
 import inetsoft.web.viewsheet.service.LinkUri;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -73,7 +72,9 @@ public class EMScheduleTaskController {
    )
    @PostMapping("/api/em/schedule/new")
    public ScheduleTaskDialogModel getNewTaskDialogModel(
-      @RequestBody(required = false) ContentRepositoryTreeNode parentInfo, Principal principal) throws Exception
+      @RequestParam("timeZone") String timeZone,
+      @RequestBody(required = false) ContentRepositoryTreeNode parentInfo,
+      Principal principal) throws Exception
    {
       AssetEntry parentEntry = null;
 
@@ -93,7 +94,7 @@ public class EMScheduleTaskController {
             "schedule.tasks.nopermission.create"));
       }
 
-      return scheduleTaskService.getNewTaskDialogModel(null, principal, true, true, parentEntry);
+      return scheduleTaskService.getNewTaskDialogModel(null, principal, true, true, parentEntry, timeZone);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
@@ -77,12 +77,14 @@ public class ScheduleTaskService {
    public ScheduleTaskDialogModel getNewTaskDialogModel(PortalNewTaskRequest model,
                                                         Principal principal) throws Exception
    {
-      return getNewTaskDialogModel(model.getConditionModel(), principal, true, false, model.getParentEntry());
+      return getNewTaskDialogModel(model.getConditionModel(), principal, true, false,
+         model.getParentEntry(), null);
    }
 
    public ScheduleTaskDialogModel getNewTaskDialogModel(ScheduleConditionModel model,
                                                         Principal principal, boolean save,
-                                                        boolean em,  AssetEntry parent)
+                                                        boolean em,  AssetEntry parent,
+                                                        String timeZoneId)
       throws Exception
    {
       Catalog catalog = Catalog.getCatalog(principal);
@@ -130,6 +132,10 @@ public class ScheduleTaskService {
          ((TimeCondition) condition).setHourEnd(1);
          ((TimeCondition) condition).setMinuteEnd(30);
          ((TimeCondition) condition).setSecondEnd(0);
+
+         if(timeZoneId != null) {
+            ((TimeCondition) condition).setTimeZone(TimeZone.getTimeZone(timeZoneId));
+         }
       }
 
       ScheduleTask task = new ScheduleTask(taskName);

--- a/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.ts
+++ b/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.ts
@@ -301,8 +301,11 @@ export class ScheduleTaskListComponent implements OnInit, AfterViewInit, OnDestr
    }
 
    newTask(): void {
+      const localTimeZoneId = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      const params = new HttpParams().set("timeZone", localTimeZoneId);
+
       // http REST requests use URI and a body object with data
-      this.http.post(NEW_TASKS_URI, this.currentFolder).subscribe(
+      this.http.post(NEW_TASKS_URI, this.currentFolder, {params}).subscribe(
          (model: ScheduleTaskDialogModel) => this.navigateToTaskEditor(model.name),
          (error) => {
             let message = error?.error?.type == "SecurityException" ? error.error.message : "Failed to get schedule task model";


### PR DESCRIPTION
the bug is caused by when new task, it will create timecondition in server and set server time zone to the condition. In fact, we want to using local time zone by default. So should deliver the local time zone to server when new task.

Should not set time zone in client after new task because new task in server will create condition with server time zone and save it. We should set client time zone before saved new created task.