### PR TITLE
Fix Bug #70351:

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
@@ -566,7 +566,16 @@ public class RuntimeViewsheet extends RuntimeSheet {
     */
    public boolean gotoBookmark(String name, IdentityID user) throws Exception {
       boolean isHome = VSBookmark.HOME_BOOKMARK.equals(name);
-      VSBookmark bookmark = getUserBookmark(user);
+      VSBookmark bookmark = null;
+
+      if(bookmarkUpdated(name, user)) {
+         bookmark = rep.getVSBookmark(entry, new XPrincipal(user));
+         bookmarksMap.put(user.convertToKey(), bookmark);
+      }
+      else {
+         bookmark = getUserBookmark(user);
+      }
+
       Viewsheet processedViewsheet = null;
 
       // @by davidd bug1370989280980, If goto Home bookmark but it does not


### PR DESCRIPTION
Determine if the bookmark has been modified by another user. If it has been modified, the value should be retrieved from storage instead of using the cached value, and the cached bookmark should be updated accordingly.