### PR TITLE
Fix Bug #70173:

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/general/DataSpaceSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/general/DataSpaceSettingsService.java
@@ -151,7 +151,7 @@ public class DataSpaceSettingsService extends BackupSupport {
 
       for(int i = 0; i <= deleteCount; i++) {
          try {
-            storageService.delete(BACKUP_FOLDER + "\\"+ zips.get(i));
+            storageService.delete(BACKUP_FOLDER + File.separator + zips.get(i));
          }
          catch(IOException e) {
             LOG.error("Failed to delete backup file {}", zips.get(i), e);


### PR DESCRIPTION
Cloud environments typically use Linux or Unix systems, where the file path separator is / instead of \. Using File.separator ensures cross-platform compatibility.