### PR TITLE
fix Bug #70407, don't use activities cache when refresh task list.

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
@@ -563,7 +563,7 @@ public class ScheduleService {
       builder.timeFormat(dtfmt);
       builder.showOwners(isSecurityEnabled());
 
-      Map<String, TaskActivity> taskActivities = getTaskActivities();
+      Map<String, TaskActivity> taskActivities = getTaskActivities(false);
       AssetEntry[] entries = null;
 
       if(parentEntry != null) {


### PR DESCRIPTION
Manually refreshing should obtain the latest status, so don't use activities cache when refresh task list.