### PR TITLE
Fix Bug #70448:

### DIFF
--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/surveymonkey/SurveyMonkeyDataSource.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/surveymonkey/SurveyMonkeyDataSource.java
@@ -134,5 +134,10 @@ public class SurveyMonkeyDataSource extends OAuthEndpointJsonDataSource<SurveyMo
       return Objects.hash(super.hashCode(), rowLimit);
    }
 
+   @Override
+   protected boolean supportCredentialId() {
+      return false;
+   }
+
    private int rowLimit = 0;
 }


### PR DESCRIPTION
Since the access token is generated through authorization, there is no need to display the "Use Secret ID" checkbox.