### PR TITLE
Fix Bug #70449:

### DIFF
--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/linkedin/LinkedinDataSource.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/linkedin/LinkedinDataSource.java
@@ -93,6 +93,11 @@ public class LinkedinDataSource extends OAuthEndpointJsonDataSource<LinkedinData
    }
 
    @Override
+   protected boolean supportCredentialId() {
+      return false;
+   }
+
+   @Override
    protected String getTestSuffix() {
       return "/v2/me";
    }


### PR DESCRIPTION
Since the access token is generated through authorization, there is no need to display the "Use Secret ID" checkbox.