### PR TITLE
fix Bug #70459

### DIFF
--- a/core/src/main/java/inetsoft/sree/web/dashboard/DashboardRegistry.java
+++ b/core/src/main/java/inetsoft/sree/web/dashboard/DashboardRegistry.java
@@ -157,7 +157,7 @@ public class DashboardRegistry implements SessionListener {
             nregistry = new DashboardRegistry(norg.getId());
          }
          else {
-            nregistry = new UserDashboardRegistry(identityID);
+            nregistry = new UserDashboardRegistry(new IdentityID(name, norg.getId()));
          }
 
          String[] dashboardNames = registry.getDashboardNames();

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -1022,7 +1022,7 @@ public class IdentityService {
    public void copyDashboardRegistry(Organization oorg, Organization norg) {
       DashboardRegistry.copyRegistry(null, oorg, norg);
 
-      for(IdentityID user : securityEngine.getUsers()) {
+      for(IdentityID user : securityEngine.getOrgUsers(oorg.getId())) {
          DashboardRegistry.copyRegistry(user, oorg, norg);
       }
    }


### PR DESCRIPTION
1.  user of the UserDashboardRegistry should use new org id when copy dashboard registry from old org to new org. 
2.  after change org id, just copy the old org user`s DashboardRegistry.