### PR TITLE
fix Bug #70474, show timestamp at the end of the error message.

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/service/datasource/DataSourceStatusService.java
+++ b/core/src/main/java/inetsoft/web/portal/service/datasource/DataSourceStatusService.java
@@ -142,10 +142,10 @@ public class DataSourceStatusService {
 
       Catalog catalog = Catalog.getCatalog(principal);
       String errorMessage = status.getErrorMessage();
+      String time = Tool.formatDateTime(status.getLastUpdateTime());
       String message;
 
       if(status.isConnected()) {
-         String time = Tool.formatDateTime(status.getLastUpdateTime());
          message = catalog.getString("data.datasources.dataSourceConnected", time);
       }
       else {
@@ -160,6 +160,8 @@ public class DataSourceStatusService {
          else {
             message += ": " + errorMessage;
          }
+
+         message += " " + time;
       }
 
       return DataSourceStatus.builder()


### PR DESCRIPTION
show timestamp at the end of the error message.