### PR TITLE
Fix Bug #70462:

### DIFF
--- a/web/projects/shared/util/datasource/data-source-settings-page.ts
+++ b/web/projects/shared/util/datasource/data-source-settings-page.ts
@@ -325,8 +325,8 @@ export abstract class DataSourceSettingsPage implements OnInit {
       ).subscribe((connection: ConnectionStatus) => {
          this.databaseStatus = connection.status;
 
-         if(this.showTestMessage && !!this.database.cloudError) {
-            if(!connection.connected) {
+         if(this.showTestMessage) {
+            if(!connection.connected && !!this.database.cloudError) {
                this.databaseStatus += "\n" + this.database.cloudError;
             }
 


### PR DESCRIPTION
Triggered by the changes in #70256, if the cloudError of the database is null, it indicates that the current environment is not in the cloud, and the databaseStatus should be directly output.