### PR TITLE
Fix Bug #70325:

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/database/DatabaseDataSourceModelController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/DatabaseDataSourceModelController.java
@@ -18,6 +18,7 @@
 package inetsoft.web.portal.controller.database;
 
 import inetsoft.sree.security.ResourceAction;
+import inetsoft.util.Tool;
 import inetsoft.web.factory.RemainingPath;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,8 +37,10 @@ public class DatabaseDataSourceModelController {
                                         Principal principal)
       throws Exception
    {
+      String path = Tool.byteDecode(databasePath);
+
       return dataSourceService.checkPermission(
-         databasePath, folder, ResourceAction.WRITE, principal);
+         path, folder, ResourceAction.WRITE, principal);
    }
 
    private final DataSourceService dataSourceService;

--- a/core/src/main/java/inetsoft/web/portal/controller/database/LogicalModelController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/LogicalModelController.java
@@ -263,7 +263,9 @@ public class LogicalModelController {
                                           @RequestParam(value = "folder", required = false) String folder,
                                           Principal principal)
    {
-      return modelService.checkPermission(database, folder, name, null,
+      String databasePath = Tool.byteDecode(database);
+
+      return modelService.checkPermission(databasePath, folder, name, null,
          ResourceAction.WRITE, principal);
    }
 

--- a/web/projects/portal/src/app/portal/services/can-database-model-activate.service.ts
+++ b/web/projects/portal/src/app/portal/services/can-database-model-activate.service.ts
@@ -39,10 +39,10 @@ export class CanDatabaseModelActivateService implements CanActivate {
       let databasePath;
 
       if(/datasources\/database\/[\s\S]+\/physicalModel\/[\s\S]+/.test(routeUrl)) {
-         databasePath = Tool.byteDecode(route.params["databasePath"]);
+         databasePath = route.params["databasePath"];
       }
       else if(routeUrl.startsWith("/portal/tab/data/datasources/database/vpm")) {
-         modelPath = Tool.byteDecode(route.params["vpmPath"]);
+         modelPath = route.params["vpmPath"];
          let idx = !modelPath ? -1 : modelPath.lastIndexOf("/");
 
          if(idx == -1 || idx >= modelPath.length) {
@@ -53,7 +53,7 @@ export class CanDatabaseModelActivateService implements CanActivate {
       }
 
       if(/datasources\/database\/[\s\S]+\/physicalModel\/[\s\S]+\/logicalModel\/[\s\S]+/.test(routeUrl)){
-         databasePath = Tool.byteDecode(route.params["databasePath"]);
+         databasePath = route.params["databasePath"];
          logicalModel = true;
       }
 
@@ -81,7 +81,7 @@ export class CanDatabaseModelActivateService implements CanActivate {
          }));
       }
       else {
-         let logicalName = Tool.byteDecode(route.params["logicalModelName"]);
+         let logicalName = route.params["logicalModelName"];
          params = params
             .set("database", databasePath)
             .set("name", logicalName);


### PR DESCRIPTION
Since the databasePath has already been encoded before being passed, decoding it on the frontend could result in special characters being included in the URL, causing the request to fail. Therefore, it should be decoded on the backend.