### PR TITLE
fix Bug #70394. 

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/ExpressionDialogController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/ExpressionDialogController.java
@@ -130,9 +130,12 @@ public class ExpressionDialogController extends WorksheetController {
       Arrays.stream(ws.getAssemblies()).filter(
             (assembly) -> assembly instanceof VariableAssembly && assembly.isVisible())
          .forEach((variableAssembly) -> {
+            String absoluteName = variableAssembly.getAbsoluteName();
+            String data = absoluteName != null && absoluteName.matches("[a-zA-Z0-9]+") ?
+               "parameter." + absoluteName : "parameter['" + absoluteName + "']";
             variableChildren.add(TreeNodeModel.builder()
-               .label(variableAssembly.getAbsoluteName())
-               .data("parameter." + variableAssembly.getAbsoluteName())
+               .label(absoluteName)
+               .data(data)
                .icon("variable-icon")
                .leaf(true)
                .build());

--- a/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.ts
+++ b/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.ts
@@ -542,7 +542,11 @@ export class FormulaEditorDialog extends BaseResizeableDialogComponent implement
                   }
                }
                else {
-                  const parameterIndex = fexpress.indexOf("parameter.");
+                  let parameterIndex = fexpress.indexOf("parameter.");
+
+                  if(parameterIndex < 0) {
+                     parameterIndex = fexpress.indexOf("parameter['");
+                  }
 
                   if(parameterIndex === 0 && this.isSqlType()) {
                         const variableName = fexpress.substring("parameter.".length);


### PR DESCRIPTION
When the variable name contains characters other than letters and numbers, use `parameter['VAR_NAME']` instead of `parameter.VAR_NAME`.