### PR TITLE
fix Bug #70487

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/data/DataSourceController.java
+++ b/core/src/main/java/inetsoft/web/portal/data/DataSourceController.java
@@ -200,7 +200,15 @@ public class DataSourceController {
          path = parentPath + "/" + request.newName();
       }
 
-      return dataSourceBrowserService.checkFolderDuplicate(path);
+      XPrincipal xPrincipal = (XPrincipal) principal;
+
+      try {
+         xPrincipal.setProperty("datasource.isCheckingDuplicate", "true");
+         return dataSourceBrowserService.checkFolderDuplicate(path);
+      }
+      finally {
+         xPrincipal.setProperty("datasource.isCheckingDuplicate", null);
+      }
    }
 
    @GetMapping("api/data/datasources/browser")


### PR DESCRIPTION
set datasource.isCheckingDuplicate property of the current principal as true for check datasource folder duplicate. it is same with DataSourceController.checkDatasourceDuplicate.

 if set this property it will not check the global share datasource folders.