### PR TITLE
fix Bug #70490, Bug #70488,Bug #70487

### DIFF
--- a/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
@@ -41,7 +41,6 @@ import java.beans.PropertyChangeListener;
 import java.io.Serializable;
 import java.lang.SecurityException;
 import java.lang.reflect.Method;
-import java.security.Principal;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
@@ -1528,7 +1527,7 @@ public class DataSourceRegistry implements MessageListener {
          }
 
          //if object is null, retry with host-org when global default visible
-         if(result == null && SUtil.isDefaultVSGloballyVisible() && !isCheckingDuplicate() &&
+         if(result == null && SUtil.isDefaultVSGloballyVisible() && !ignoreGlobalShare() &&
                               !Tool.equals(orgId, Organization.getDefaultOrganizationID())) {
             orgId = Organization.getDefaultOrganizationID();
             AssetEntry hentry = (AssetEntry) entry.clone();
@@ -1556,10 +1555,9 @@ public class DataSourceRegistry implements MessageListener {
       return obj == null ? null : obj.getObject(cloneIt);
    }
 
-   private boolean isCheckingDuplicate() {
-      XPrincipal principal = (XPrincipal) (ThreadContext.getContextPrincipal());
-      String isCheckingDuplicate = principal.getProperty("datasource.isCheckingDuplicate");
-      return isCheckingDuplicate != null && Boolean.parseBoolean(isCheckingDuplicate);
+   private boolean ignoreGlobalShare() {
+      Boolean isCheckingDuplicate = DataSourceRegistry.IGNORE_GLOBAL_SHARE.get();
+      return isCheckingDuplicate != null && isCheckingDuplicate;
    }
 
    /**
@@ -1975,6 +1973,7 @@ public class DataSourceRegistry implements MessageListener {
 
    private static final IndexedStorage.Filter datasourceFilter =
       DataSourceRegistry::matchesDataSourceFilter;
+   public static ThreadLocal<Boolean> IGNORE_GLOBAL_SHARE = ThreadLocal.withInitial(() -> false);
 
    public static final class Reference // NOSONAR this is an inner class that is only referenced in the annotation
       extends SingletonManager.Reference<DataSourceRegistry>

--- a/core/src/main/java/inetsoft/web/portal/controller/database/DataSourceService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/DataSourceService.java
@@ -21,8 +21,7 @@ import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.security.SecurityException;
 import inetsoft.sree.security.*;
-import inetsoft.uql.XDataSource;
-import inetsoft.uql.XRepository;
+import inetsoft.uql.*;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.erm.*;
@@ -118,14 +117,21 @@ public class DataSourceService {
     * @throws Exception if could not check for duplicate models
     */
    public boolean isUniqueModelName(String database, String name) throws Exception {
-      XDataModel dataModel = repository.getDataModel(database);
+      DataSourceRegistry.IGNORE_GLOBAL_SHARE.set(true);
 
-      if(dataModel == null) {
-         throw new FileNotFoundException(database);
+      try {
+         XDataModel dataModel = repository.getDataModel(database);
+
+         if(dataModel == null) {
+            throw new FileNotFoundException(database);
+         }
+
+         return dataModel.getLogicalModel(name) != null || dataModel.getPartition(name) != null ||
+            dataModel.getVirtualPrivateModel(name) != null;
       }
-
-      return dataModel.getLogicalModel(name) != null || dataModel.getPartition(name) != null ||
-         dataModel.getVirtualPrivateModel(name) != null;
+      finally {
+         DataSourceRegistry.IGNORE_GLOBAL_SHARE.remove();
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/portal/data/DataSourceBrowserService.java
+++ b/core/src/main/java/inetsoft/web/portal/data/DataSourceBrowserService.java
@@ -581,26 +581,40 @@ public class DataSourceBrowserService {
     * @return a result in the form of CheckDuplicateResponse.
     */
    public CheckDuplicateResponse checkFolderDuplicate(String name) throws Exception {
-      boolean folderExist = repository.getDataSourceFolder(name) != null;
-      boolean dbExist = repository.getDataSource(name) != null;
+      DataSourceRegistry.IGNORE_GLOBAL_SHARE.set(true);
 
-      return new CheckDuplicateResponse(folderExist || dbExist);
+      try {
+         boolean folderExist = repository.getDataSourceFolder(name) != null;
+         boolean dbExist = repository.getDataSource(name) != null;
+
+         return new CheckDuplicateResponse(folderExist || dbExist);
+      }
+      finally {
+         DataSourceRegistry.IGNORE_GLOBAL_SHARE.remove();
+      }
    }
 
    public CheckDuplicateResponse checkItemsDuplicate(DataSourceInfo[] items, String path) {
-      final DataSourceRegistry registry = DataSourceRegistry.getRegistry();
+      DataSourceRegistry.IGNORE_GLOBAL_SHARE.set(true);
 
-      for(DataSourceInfo item : items) {
-         String ipath = item.path();
-         String iname = ipath.substring(ipath.lastIndexOf('/') + 1);
-         ipath = (path == null || "/".equals(path)) ? iname : path + "/" + iname;
+      try {
+         final DataSourceRegistry registry = DataSourceRegistry.getRegistry();
 
-         if(registry.getDataSource(ipath) != null || registry.getDataSourceFolder(ipath) != null) {
-            return new CheckDuplicateResponse(true);
+         for(DataSourceInfo item : items) {
+            String ipath = item.path();
+            String iname = ipath.substring(ipath.lastIndexOf('/') + 1);
+            ipath = (path == null || "/".equals(path)) ? iname : path + "/" + iname;
+
+            if(registry.getDataSource(ipath) != null || registry.getDataSourceFolder(ipath) != null) {
+               return new CheckDuplicateResponse(true);
+            }
          }
-      }
 
-      return new CheckDuplicateResponse(false);
+         return new CheckDuplicateResponse(false);
+      }
+      finally {
+         DataSourceRegistry.IGNORE_GLOBAL_SHARE.remove();
+      }
    }
 
    public void moveDataSource(MoveCommand[] items, Principal principal) throws Exception {

--- a/core/src/main/java/inetsoft/web/portal/data/DataSourceController.java
+++ b/core/src/main/java/inetsoft/web/portal/data/DataSourceController.java
@@ -603,13 +603,7 @@ public class DataSourceController {
    @GetMapping("/api/portal/data/datasources/checkDuplicate/**")
    //@Secured(permissions = @RequiredPermission(ActionTypes.DATA_TAB))
    public boolean checkDatasourceDuplicate(@RemainingPath String name) throws Exception {
-      //handle globally exposed default org assets from getting hit badly
-      XPrincipal principal = (XPrincipal) (ThreadContext.getContextPrincipal());
-      principal.setProperty("datasource.isCheckingDuplicate", "true");
-      boolean isDuplicate = datasourcesService.checkDuplicate(name);
-      principal.setProperty("datasource.isCheckingDuplicate", null);
-
-      return isDuplicate;
+      return datasourcesService.checkDuplicate(name);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/portal/data/DatasourcesBaseService.java
+++ b/core/src/main/java/inetsoft/web/portal/data/DatasourcesBaseService.java
@@ -289,7 +289,14 @@ public abstract class DatasourcesBaseService {
     * @throws Exception if failed to check the data sources
     */
    public boolean checkDuplicate(String name) throws Exception {
-      return repository.getDataSource(name) != null;
+      DataSourceRegistry.IGNORE_GLOBAL_SHARE.set(true);
+
+      try {
+         return repository.getDataSource(name) != null;
+      }
+      finally {
+         DataSourceRegistry.IGNORE_GLOBAL_SHARE.remove();
+      }
    }
 
    @Audited(


### PR DESCRIPTION
1. remove logic of setting datasource.isCheckingDuplicate property of the current principal as true for check datasource items duplicate. it maybe affects other requests and threads.

2.  replace it with DataSourceRegistry.IGNORE_GLOBAL_SHARE thread local.