### PR TITLE
Feature #70119  AutoSaveController service proxy

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
+++ b/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
@@ -1216,6 +1216,6 @@ public class WorksheetEngine extends SheetLibraryEngine implements WorksheetServ
    private boolean server = false; // server flag
    private final Map<Object, List<RenameDependencyInfo>> renameInfoMap;
    private static final Logger LOG = LoggerFactory.getLogger(WorksheetEngine.class);
-   private static final String NEXT_ID_NAME = WorksheetEngine.class.getName() + ".nextId";
-   private static final String CACHE_NAME = WorksheetEngine.class.getName() + ".cache";
+   private static final String NEXT_ID_NAME = "inetsoft.report.composition.WorksheetEngine.nextId";
+   public static final String CACHE_NAME = "inetsoft.report.composition.WorksheetEngine.cache";
 }

--- a/core/src/main/java/inetsoft/web/admin/content/repository/AutoSaveController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/AutoSaveController.java
@@ -39,8 +39,9 @@ import java.util.*;
 @RestController
 public class AutoSaveController {
    @Autowired
-   public AutoSaveController(ViewsheetService viewsheetService) {
+   public AutoSaveController(ViewsheetService viewsheetService, AutoSaveServiceProxy autoSaveService) {
       this.viewsheetService = viewsheetService;
+      this.autoSaveService = autoSaveService;
    }
 
    /**
@@ -105,26 +106,7 @@ public class AutoSaveController {
    private void restoreAutoSaveAsset(String id, String assetName, boolean override,
                                      Principal principal) throws Exception
    {
-      // Get auto save sheet from engine.
-      AssetEntry entry = AutoSaveUtils.createAssetEntry(id);
-      AssetRepository repository = AssetUtil.getAssetRepository(false);
-      AbstractSheet sheet = repository.getSheet(entry, principal, false, AssetContent.ALL);
-      IdentityID pId = IdentityID.getIdentityIDFromKey(principal.getName());
-
-      // Save auto save sheet to engine.
-      AssetEntry.Type type = id.startsWith("8^VIEWSHEET") ? AssetEntry.Type.VIEWSHEET :
-         AssetEntry.Type.WORKSHEET;
-      AssetEntry nentry = new AssetEntry(AssetRepository.GLOBAL_SCOPE, type, assetName,
-         pId);
-
-      if(!override && viewsheetService.isDuplicatedEntry(repository, nentry)) {
-         return;
-      }
-
-      repository.setSheet(nentry, sheet, principal, false);
-      ActionRecord actionRecord = SUtil.getActionRecord(principal, ActionRecord.ACTION_NAME_CREATE,
-         assetName, AssetEventUtil.getObjectType(entry));
-      Audit.getInstance().auditAction(actionRecord, principal);
+      autoSaveService.restoreAutoSaveAssets(id, assetName, override, principal);
    }
 
    /**
@@ -239,4 +221,5 @@ public class AutoSaveController {
    }
 
    private final ViewsheetService viewsheetService;
+   private final AutoSaveServiceProxy autoSaveService;
 }

--- a/core/src/main/java/inetsoft/web/admin/content/repository/AutoSaveController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/AutoSaveController.java
@@ -39,8 +39,7 @@ import java.util.*;
 @RestController
 public class AutoSaveController {
    @Autowired
-   public AutoSaveController(ViewsheetService viewsheetService, AutoSaveServiceProxy autoSaveService) {
-      this.viewsheetService = viewsheetService;
+   public AutoSaveController(AutoSaveServiceProxy autoSaveService) {
       this.autoSaveService = autoSaveService;
    }
 
@@ -220,6 +219,5 @@ public class AutoSaveController {
       return entry != null && entry.isWorksheetFolder() && !entry.isRepositoryFolder();
    }
 
-   private final ViewsheetService viewsheetService;
    private final AutoSaveServiceProxy autoSaveService;
 }

--- a/core/src/main/java/inetsoft/web/admin/content/repository/AutoSaveService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/AutoSaveService.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.admin.content.repository;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.cluster.*;
+import inetsoft.report.composition.WorksheetEngine;
+import inetsoft.report.composition.event.AssetEventUtil;
+import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.security.IdentityID;
+import inetsoft.uql.asset.*;
+import inetsoft.uql.asset.internal.AssetUtil;
+import inetsoft.util.audit.ActionRecord;
+import inetsoft.util.audit.Audit;
+import inetsoft.web.AutoSaveUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.security.Principal;
+import java.util.Map;
+
+@Service
+@ClusterProxy
+public class AutoSaveService {
+   public AutoSaveService(ViewsheetService viewsheetService) {
+      this.viewsheetService =viewsheetService;
+   }
+
+   @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   public Boolean restoreAutoSaveAssets(@ClusterProxyKey String id, String assetName, boolean override,
+                                     Principal principal)
+      throws Exception
+   {
+      // Get auto save sheet from engine.
+      AssetEntry entry = AutoSaveUtils.createAssetEntry(id);
+      AssetRepository repository = AssetUtil.getAssetRepository(false);
+      AbstractSheet sheet = repository.getSheet(entry, principal, false, AssetContent.ALL);
+      IdentityID pId = IdentityID.getIdentityIDFromKey(principal.getName());
+
+      // Save auto save sheet to engine.
+      AssetEntry.Type type = id.startsWith("8^VIEWSHEET") ? AssetEntry.Type.VIEWSHEET :
+         AssetEntry.Type.WORKSHEET;
+      AssetEntry nentry = new AssetEntry(AssetRepository.GLOBAL_SCOPE, type, assetName,
+                                         pId);
+
+      if(!override && viewsheetService.isDuplicatedEntry(repository, nentry)) {
+         return false;
+      }
+
+      repository.setSheet(nentry, sheet, principal, false);
+      ActionRecord actionRecord = SUtil.getActionRecord(principal, ActionRecord.ACTION_NAME_CREATE,
+                                                        assetName, AssetEventUtil.getObjectType(entry));
+      Audit.getInstance().auditAction(actionRecord, principal);
+      return true;
+   }
+
+
+   private final ViewsheetService viewsheetService;
+}


### PR DESCRIPTION
Hardcoded the value for WorksheetEngine.CACHE_NAME, so that it could be used in the @ClusterProxyMethod annotations.
The IgniteCallable<T> generic doesn't accept void for type T, so I made the restoreAutoSaveAssets() method return a Boolean when it returned void before.