### PR TITLE
Feature #70119  VSBindingController service proxy

### DIFF
--- a/core/src/main/java/inetsoft/web/binding/VSBindingController.java
+++ b/core/src/main/java/inetsoft/web/binding/VSBindingController.java
@@ -44,11 +44,11 @@ import java.security.Principal;
 @RestController
 public class VSBindingController {
    @Autowired
-   public VSBindingController(ViewsheetService viewsheetService,
-                              VSBindingService vsBindingService)
+   public VSBindingController(VSBindingService vsBindingService,
+                              VSBindingServiceProxy vsBindingServiceProxy)
    {
-      this.viewsheetService = viewsheetService;
       this.vsBindingService = vsBindingService;
+      this.vsBindingServiceProxy = vsBindingServiceProxy;
    }
 
    /**
@@ -84,11 +84,7 @@ public class VSBindingController {
       @RequestParam("temporarySheet") boolean temporarySheet, Principal principal)
       throws Exception
    {
-      String id = this.vsBindingService.createRuntimeSheet(vsId, viewer, temporarySheet,
-         principal, assemblyName);
-      RuntimeViewsheet rvs = viewsheetService.getViewsheet(id, principal);
-      Viewsheet vs = rvs.getViewsheet();
-      return new BindingPaneData(id, vs.getViewsheetInfo().isMetadata());
+      return vsBindingServiceProxy.open(vsId, assemblyName, viewer, temporarySheet, principal);
    }
 
    /**
@@ -108,8 +104,7 @@ public class VSBindingController {
                         Principal principal)
       throws Exception
    {
-      return vsBindingService.finishEdit(viewsheetService, Tool.byteDecode(vsId),
-         assemblyName, editMode, originalMode, principal);
+      return vsBindingServiceProxy.commit(vsId, assemblyName, editMode, originalMode, principal);
    }
 
    /**
@@ -149,10 +144,10 @@ public class VSBindingController {
                                                 Principal principal)
       throws Exception
    {
-      return this.vsBindingService.checkVSSelectionTrap(event, runtimeId, principal);
+      return vsBindingServiceProxy.checkVSSelectionTrap(runtimeId, event, linkUri, principal);
    }
 
-   private final ViewsheetService viewsheetService;
    private final VSBindingService vsBindingService;
+   private final VSBindingServiceProxy vsBindingServiceProxy;
    private static final Logger LOG = LoggerFactory.getLogger(VSBindingController.class);
 }

--- a/core/src/main/java/inetsoft/web/binding/VSBindingService.java
+++ b/core/src/main/java/inetsoft/web/binding/VSBindingService.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.binding;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.cluster.*;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.WorksheetEngine;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.util.Tool;
+import inetsoft.web.binding.model.BindingPaneData;
+import inetsoft.web.composer.model.vs.VSTableTrapModel;
+import inetsoft.web.viewsheet.event.InsertSelectionChildEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+
+@Service
+@ClusterProxy
+public class VSBindingService {
+   @Autowired
+   public VSBindingService(ViewsheetService viewsheetService,
+                              inetsoft.web.binding.service.VSBindingService vsBindingService)
+   {
+      this.viewsheetService = viewsheetService;
+      this.vsBindingService = vsBindingService;
+   }
+
+
+   @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   public BindingPaneData open(@ClusterProxyKey String vsId, String assemblyName, boolean viewer,
+                               boolean temporarySheet, Principal principal)
+      throws Exception
+   {
+      String id = this.vsBindingService.createRuntimeSheet(vsId, viewer, temporarySheet,
+                                                           principal, assemblyName);
+      RuntimeViewsheet rvs = viewsheetService.getViewsheet(id, principal);
+      Viewsheet vs = rvs.getViewsheet();
+      return new BindingPaneData(id, vs.getViewsheetInfo().isMetadata());
+   }
+
+   @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   public String commit(@ClusterProxyKey String vsId, String assemblyName,
+                        String editMode, String originalMode,
+                        Principal principal)
+      throws Exception
+   {
+      return vsBindingService.finishEdit(viewsheetService, Tool.byteDecode(vsId),
+                                         assemblyName, editMode, originalMode, principal);
+   }
+
+   @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   public VSTableTrapModel checkVSSelectionTrap(@ClusterProxyKey String runtimeId,
+                                                InsertSelectionChildEvent event,
+                                                String linkUri,
+                                                Principal principal)
+      throws Exception
+   {
+      return this.vsBindingService.checkVSSelectionTrap(event, runtimeId, principal);
+   }
+
+   private final ViewsheetService viewsheetService;
+   private final inetsoft.web.binding.service.VSBindingService vsBindingService;
+}


### PR DESCRIPTION
The insertChild() controller method uses RuntimeViewsheetRef in the service, so I'll need to revisit it once it is moved out of the service.