### PR TITLE
fix Bug #70548：

### DIFF
--- a/web/projects/shared/util/date-type-formatter.ts
+++ b/web/projects/shared/util/date-type-formatter.ts
@@ -111,7 +111,7 @@ export class DateTypeFormatter {
    }
 
    public static getLocalTime(value: number, format: string): string {
-      if(value == 0 || value == null) {
+      if(value <= 0 || value == null) {
          return null;
       }
 


### PR DESCRIPTION
when timestamp <= 0, should show empty for time. it means no time for it.