### PR TITLE
fix Bug #70511

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/RepositoryTreeController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/RepositoryTreeController.java
@@ -417,7 +417,7 @@ public class RepositoryTreeController {
             }
 
             if(nentry.isViewsheet() && assetEntry.getProperty("__bookmark_id__") != null) {
-               nentry.setProperty("__bookmark_id__", nentry.toIdentifier());
+               nentry.setProperty("__bookmark_id__", VSUtil.createBookmarkIdentifier(nentry));
             }
 
             if(nentry.isViewsheet() || nentry.isVSSnapshot()) {


### PR DESCRIPTION
identifier of the asset entry can not as the bookmark id, should use the VSUtil.createBookmarkIdentifier() to generate the bookmark id, it will process some special char.