### PR TITLE
fix Bug #70534

### DIFF
--- a/core/src/main/java/inetsoft/uql/util/filereader/CSVLoader.java
+++ b/core/src/main/java/inetsoft/uql/util/filereader/CSVLoader.java
@@ -93,7 +93,7 @@ public final class CSVLoader {
             dataTable.setExceedLimit(true);
          }
 
-         if(ncol == 0) {
+         if(r == 0) {
             header = getHeaders(lines, firstRow || unpivot, colLimit, removeQuote);
             ncol = header.length;
 
@@ -222,7 +222,7 @@ public final class CSVLoader {
 
          Object[] rdata;
 
-         if(firstLine && !line.equals("")) {
+         if(firstLine) {
             firstLine = false;
             header = getHeaders(lines, firstRow || unpivot, colLimit, removeQuote);
 


### PR DESCRIPTION
Rollback the changes made in Bug #67218. The issue in Bug #67218 was a NullPointerException, which was fixed while addressing Bug #69846. Moreover, the changes in Bug #69846 are the proper solution.