### PR TITLE
Fix Bug #70550:

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-data-model-browser/data-model-browser.service.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-data-model-browser/data-model-browser.service.ts
@@ -675,7 +675,7 @@ export class DataModelBrowserService {
 
             if(type == PortalDataType.VPM) {
                this.router.navigate([routePath, "vpm",
-                     Tool.byteEncode(database + "/" + result.name), routeParams],
+                     Tool.byteEncode(database) + "/" + Tool.byteEncode(result.name), routeParams],
                   { relativeTo: this.route });
             }
             else if(type == PortalDataType.PARTITION) {


### PR DESCRIPTION
In byteEncode, the "/" character is also treated as a special character and gets encoded, which prevents navigation from working properly.