### PR TITLE
fix Bug #70571：

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.html
@@ -173,7 +173,7 @@
                  class="sort-button vs-header-cell-button-sort hover-bg-secondary" aria-hidden="true"
                  title="_#(viewer.viewsheet.table.sortColumn)"
                  (click)="sortColumn($event, _cell)">
-                <label class="sort-number">{{displaySortNumber(_cell)}}</label>
+                <label *ngIf="displaySortNumber(_cell) > 0" class="sort-number">{{displaySortNumber(_cell)}}</label>
               </i>
               <div class="chip" title="_#(Chip)"></div>
             </td>


### PR DESCRIPTION
when sort number is 0, should show icon as old version, if number is large than 0, should number instand of the icon.