### PR TITLE
fix Bug #70577, refix Bug #70394

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/ExpressionDialogController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/ExpressionDialogController.java
@@ -131,11 +131,9 @@ public class ExpressionDialogController extends WorksheetController {
             (assembly) -> assembly instanceof VariableAssembly && assembly.isVisible())
          .forEach((variableAssembly) -> {
             String absoluteName = variableAssembly.getAbsoluteName();
-            String data = absoluteName != null && absoluteName.matches("[a-zA-Z0-9]+") ?
-               "parameter." + absoluteName : "parameter['" + absoluteName + "']";
             variableChildren.add(TreeNodeModel.builder()
                .label(absoluteName)
-               .data(data)
+               .data("parameter." + absoluteName)
                .icon("variable-icon")
                .leaf(true)
                .build());

--- a/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.ts
+++ b/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.ts
@@ -542,15 +542,18 @@ export class FormulaEditorDialog extends BaseResizeableDialogComponent implement
                   }
                }
                else {
-                  let parameterIndex = fexpress.indexOf("parameter.");
-
-                  if(parameterIndex < 0) {
-                     parameterIndex = fexpress.indexOf("parameter['");
-                  }
+                  const parameterIndex = fexpress.indexOf("parameter.");
 
                   if(parameterIndex === 0 && this.isSqlType()) {
-                        const variableName = fexpress.substring("parameter.".length);
-                        fexpress = `$(${variableName})`;
+                     const variableName = fexpress.substring("parameter.".length);
+                     fexpress = `$(${variableName})`;
+                  }
+                  else if(parameterIndex === 0 && !this.isSqlType()) {
+                     const variableName = fexpress.substring("parameter.".length);
+
+                     if(!/^[a-zA-Z0-9]+$/.test(variableName)) {
+                        fexpress = "parameter['" + variableName + "']";
+                     }
                   }
                   else if(parameterIndex !== 0 && fexpress.indexOf("MV.") !== 0 &&
                      !fexpress.startsWith("field["))


### PR DESCRIPTION
When the variable name contains characters other than letters and numbers, use parameter['VAR_NAME'] instead of parameter.VAR_NAME.