### PR TITLE
fix Bug #70395

### DIFF
--- a/web/projects/em/src/app/common/util/mat-ckeditor/mat-ckeditor.component.ts
+++ b/web/projects/em/src/app/common/util/mat-ckeditor/mat-ckeditor.component.ts
@@ -128,12 +128,14 @@ export class MatCkeditorComponent
    }
 
    set content(value: string) {
-      this.value = value;
-      this.stateChanges.next();
-      this.valueChange.emit(value);
+      if(this.value !== value) {
+         this.value = value;
+         this.stateChanges.next();
+         this.valueChange.emit(value);
 
-      if(this._onChange) {
-         this._onChange(value);
+         if(this._onChange) {
+            this._onChange(value);
+         }
       }
    }
 


### PR DESCRIPTION
The change event should only be triggered when the value actually changes; otherwise, it will mistakenly indicate that the message in "Deliver to Emails" has been modified, causing the task to be marked as changed.