### PR TITLE
Merge forward Bug #70441 - prevent query execution with disposed asset query sandbox

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -683,6 +683,10 @@ public abstract class AssetQuery extends PreAssetQuery {
          }
 
          if(base == null) {
+            if(box.isDisposed()) {
+               throw new RuntimeException("Asset query sandbox is disposed");
+            }
+
             List<String> infos = XUtil.QUERY_INFOS.get();
 
             if(infos == null) {

--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuerySandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuerySandbox.java
@@ -866,6 +866,10 @@ public class AssetQuerySandbox implements Serializable, Cloneable, ActionListene
     */
    public TableLens getTableLens(String name, int mode, VariableTable vars) throws Exception {
       // may be disposed
+      if(isDisposed()) {
+         throw new RuntimeException("Asset query sandbox is disposed");
+      }
+
       if(ws == null) {
          return null;
       }

--- a/core/src/main/java/inetsoft/report/script/formula/TableAssemblyScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/formula/TableAssemblyScriptable.java
@@ -125,7 +125,7 @@ public class TableAssemblyScriptable extends TableArray {
       }
       catch(Exception ex) {
          // ignore if box has been disposed
-         if(box.getWorksheet() != null) {
+         if(!box.isDisposed()) {
             LOG.warn("Failed to get table", ex);
          }
 


### PR DESCRIPTION
This change prevents fresh query execution when the asset query sandbox is already disposed.