### PR TITLE
bug-70447

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/SUtil.java
+++ b/core/src/main/java/inetsoft/sree/internal/SUtil.java
@@ -2090,7 +2090,7 @@ public class SUtil {
          if(paths.length > 3) {
             String user = paths[2];
 
-            if(!user.contains(IdentityID.KEY_DELIMITER)) {
+            if(!user.contains(IdentityID.KEY_DELIMITER) && !user.equals("_NULL_")) {
                paths[2] =
                   user + IdentityID.KEY_DELIMITER + OrganizationManager.getInstance().getCurrentOrgID();
                path = String.join("^", paths);

--- a/web/projects/em/src/app/settings/content/repository/import-export/selected-asset-list/selected-asset-list.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/import-export/selected-asset-list/selected-asset-list.component.ts
@@ -20,6 +20,7 @@ import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from "@angu
 import { MatSort } from "@angular/material/sort";
 import { MatTableDataSource } from "@angular/material/table";
 import { DateTypeFormatter } from "../../../../../../../../shared/util/date-type-formatter";
+import { Tool } from "../../../../../../../../shared/util/tool";
 import { SelectedAssetModel } from "../selected-asset-model";
 
 @Component({
@@ -81,6 +82,10 @@ export class SelectedAssetListComponent implements OnInit {
          let paths = path.split("^");
 
          if(paths.length > 3) {
+            if(Tool.isEquals(paths[2], "_NULL_")) {
+               paths[2] = "anonymous";
+            }
+
             return paths[2] + "/" + paths[3];
          }
       }


### PR DESCRIPTION
1. Anonymous users should be displayed as "anonymous."

2. When exporting, for VS created by anonymous users, the original path should be used (e.g., 8^128^__NULL__^Untitled-3^host-org).  The system should not append ~;~ + org after __NULL__.  Instead, the original identifier should be used as the path;  otherwise, the file cannot be found during lookup.