### PR TITLE
fix Bug #70581

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/OpenIDConfig.java
+++ b/core/src/main/java/inetsoft/web/admin/security/OpenIDConfig.java
@@ -120,6 +120,10 @@ public class OpenIDConfig implements OpenIDSSOConfig {
       return SreeEnv.getProperty("openid.audience", getClientIdRealValue());
    }
 
+   public String getAudienceValue() {
+      return SreeEnv.getProperty("openid.audience");
+   }
+
    public void setAudience(String audience) {
       SreeEnv.setProperty("openid.audience", audience);
    }

--- a/core/src/main/java/inetsoft/web/admin/security/SSOSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/SSOSettingsService.java
@@ -119,7 +119,7 @@ public class SSOSettingsService {
             .clientSecret(openIDConfig.getClientSecret())
             .scopes(openIDConfig.getScopes())
             .issuer(openIDConfig.getIssuer())
-            .audience(openIDConfig.getAudience())
+            .audience(openIDConfig.getAudienceValue())
             .tokenEndpoint(openIDConfig.getTokenEndpoint())
             .authorizationEndpoint(openIDConfig.getAuthorizationEndpoint())
             .jwksUri(openIDConfig.getJwksUri())


### PR DESCRIPTION
 do not send the sso audience to client when audience is empty. because it will get client id as audience for default, after apply setting, the client id will be set to audience, and it will not be changed next changing.