### PR TITLE
fix Bug #70546

### DIFF
--- a/core/src/main/java/inetsoft/sree/web/dashboard/DashboardRegistry.java
+++ b/core/src/main/java/inetsoft/sree/web/dashboard/DashboardRegistry.java
@@ -173,6 +173,13 @@ public class DashboardRegistry implements SessionListener {
 
          if(nregistry != null) {
             map.put(nKey, nregistry);
+
+            try {
+               nregistry.save();
+            }
+            catch(Exception ex) {
+               LOG.error(ex.getMessage(), ex);
+            }
          }
       }
       finally {

--- a/core/src/main/java/inetsoft/sree/web/dashboard/VSDashboard.java
+++ b/core/src/main/java/inetsoft/sree/web/dashboard/VSDashboard.java
@@ -170,6 +170,10 @@ public class VSDashboard implements Dashboard {
             viewsheetEntry.setIdentifier(
                AssetEntry.createAssetEntry(identifier).cloneAssetEntry(organization)
                   .toIdentifier(true));
+
+            if(viewsheetEntry.getOwner() != null && organization != null) {
+               viewsheetEntry.getOwner().setOrgID(organization.getId());
+            }
          }
 
          return cloned;


### PR DESCRIPTION
1. When copying the dashboard registry, the new registry should be saved to the dataspace.
2. If the dashboard references a private viewsheet, the owner's organization ID should be updated.