### PR TITLE
fix Bug #70555

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalModelManagerService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalModelManagerService.java
@@ -203,17 +203,24 @@ public class PhysicalModelManagerService {
             "Unauthorized access to resource \"" + dataSource + "\" by user " + principal);
       }
 
-      if(!isExtended) {
-         if(dataModel.getPartition(model.getName()) != null) {
-            throw new FileExistsException(path);
+      DataSourceRegistry.IGNORE_GLOBAL_SHARE.set(true);
+
+      try {
+         if(!isExtended) {
+            if(dataModel.getPartition(model.getName()) != null) {
+               throw new FileExistsException(path);
+            }
+         }
+         else {
+            XPartition parentModel = dataModel.getPartition(parent);
+
+            if(parentModel != null && parentModel.getPartition(model.getName()) != null) {
+               throw new FileExistsException(path);
+            }
          }
       }
-      else {
-         XPartition parentModel = dataModel.getPartition(parent);
-
-         if(parentModel != null && parentModel.getPartition(model.getName()) != null) {
-            throw new FileExistsException(path);
-         }
+      finally {
+         DataSourceRegistry.IGNORE_GLOBAL_SHARE.remove();
       }
 
       getRuntimePartition(model.getId()).ifPresent(


### PR DESCRIPTION
Ignore global sharing when creating a physical view; otherwise, a physical view with the same name under the host organization may be retrieved, preventing the physical view from being saved.