### PR TITLE
fix Bug #70248,

### DIFF
--- a/core/src/main/java/inetsoft/mv/MVManager.java
+++ b/core/src/main/java/inetsoft/mv/MVManager.java
@@ -942,7 +942,14 @@ public final class MVManager {
          try {
             for(String key : mvs.keySet(orgID)) {
                try {
-                  defs.add(mvs.get(key, orgID));
+                  MVDef mvDef = mvs.get(key, orgID);
+
+                  if(mvDef != null) {
+                     defs.add(mvs.get(key, orgID));
+                  }
+                  else {
+                     LOG.warn("Can not find the MV definition: " + key + " " + orgID);
+                  }
                }
                catch(Exception e) {
                   LOG.error("Failed to read MV definition: " + key + " " + orgID, e);


### PR DESCRIPTION
ignore the mvDef and log it when can not get the mvDef by key. to ensure the cycle task can load correctly when the storage has error.