### PR TITLE
bug-70323

### DIFF
--- a/web/projects/em/src/app/auditing/audit-export-history/audit-export-history.component.ts
+++ b/web/projects/em/src/app/auditing/audit-export-history/audit-export-history.component.ts
@@ -138,7 +138,10 @@ export class AuditExportHistoryComponent implements OnInit, OnDestroy {
       const selectedFolders: string[] = additional.selectedFolders;
 
       if(!!selectedFolders && selectedFolders.length > 0) {
-         selectedFolders.forEach(f => params = params.append("folders", f));
+         selectedFolders.forEach(f => {
+            const encodedFolder = encodeURIComponent(f);
+            params = params.append("folders", encodedFolder);
+         });
       }
 
       return this.http.get<ExportHistoryList>("../api/em/monitoring/audit/exportHistory", {params})


### PR DESCRIPTION
For example, if the folder name is "b$ aa @ & .  #{} 中文_()!,.*?", the presence of a comma (,) causes an issue when passing the parameter to the server.  This is because, by default, @RequestParam treats commas as delimiters, splitting the single string into multiple array elements. As a result, when applying a filter, the comparison is made between "b$ aa @ & .  #{} 中文_()!" and "b$ aa @ & .  #{} 中文_()!,.*?", causing a mismatch and failure to find the folder. To resolve this, the frontend should encode the parameter before sending it, and the backend should decode it upon receiving it to restore the original folder name.