### PR TITLE
fix Bug #70592:

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/output/text/vs-text.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/output/text/vs-text.component.ts
@@ -461,6 +461,7 @@ export class VSText extends AbstractVSObject<VSTextModel>
 
    ngAfterViewChecked() {
       this.modelChanged();
+      this.textChanged();
 
       // check height on visibility change since height is returned as 0 when div is not visible
       if(this.textHeight == 0 || this.model.containerType == "VSTab") {


### PR DESCRIPTION
The bug only occor on docker firfox open vs in tab first time, it will cut text as "xxx...". After refresh it, it will be ok.

The text in case set text size can set content, so we should not cut text. Should init display text after view is changed. So should call textChanged in ngAfterViewChecked()