### PR TITLE
Fix Bug #70630:

### DIFF
--- a/core/src/main/java/inetsoft/util/dep/TableStyleAsset.java
+++ b/core/src/main/java/inetsoft/util/dep/TableStyleAsset.java
@@ -119,7 +119,9 @@ public class TableStyleAsset extends AbstractXAsset {
     */
    @Override
    public void parseIdentifier(String path, IdentityID userIdentity) {
-      style = path;
+      LibManager manager = LibManager.getManager();
+      XTableStyle tableStyle = manager.getTableStyle(path);
+      style = tableStyle.getID();
    }
 
    public String getLabel() {

--- a/web/projects/em/src/app/settings/schedule/task-action-pane/backup-file/backup-file.component.ts
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/backup-file/backup-file.component.ts
@@ -251,10 +251,7 @@ export class BackupFileComponent implements OnDestroy {
    }
 
    getExportableLabel(node: RepositoryTreeNode): string {
-      if(node.type === RepositoryEntryType.TABLE_STYLE || !node.path) {
-         return node.label;
-      }
-      else if(node.type === RepositoryEntryType.SCHEDULE_TASK || !node.path) {
+      if(node.type === RepositoryEntryType.SCHEDULE_TASK || !node.path) {
          return removeOrganization(node.path, node.owner.orgID);
       }
       else {
@@ -322,7 +319,7 @@ export class BackupFileComponent implements OnDestroy {
          )
          .subscribe((result) => {
             const deniedAssets: SelectedAssetModel[] = assets
-               .filter((asset) => result && !result.selectedAssets
+               .filter((asset) => result && !result.allowedAssets
                   .some((allowedAsset) => allowedAsset.path === asset.path &&
                      allowedAsset.type === asset.type));
 


### PR DESCRIPTION
The path of a tableStyle will change after renaming, so the tableStyleAsset should store the id instead of the path. Additionally, permission validation should compare against the backend's allowed list.