### PR TITLE
fix Bug #70633:

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
@@ -403,17 +403,21 @@ public class ScheduleService {
       for(int i = 0; i < cnt; i++) {
          ScheduleAction action = task.getAction(i);
 
-         if(action instanceof IndividualAssetBackupAction) {
-            IndividualAssetBackupAction bAction = (IndividualAssetBackupAction) action;
+         if(!(action instanceof IndividualAssetBackupAction)) {
+            continue;
+         }
+            
+         IndividualAssetBackupAction bAction = (IndividualAssetBackupAction) action;
 
-            for(XAsset asset : bAction.getAssets()) {
-               if(asset instanceof ScheduleTaskAsset) {
-                  ScheduleTaskAsset taskAsset = (ScheduleTaskAsset) asset;
+         for(XAsset asset : bAction.getAssets()) {
+            if(!(asset instanceof ScheduleTaskAsset)) {
+               continue;
+            }
+               
+            ScheduleTaskAsset taskAsset = (ScheduleTaskAsset) asset;
 
-                  if(Tool.equals(currentOldTask, taskAsset.getTask())) {
-                     taskAsset.setTask(currentNewPath);
-                  }
-               }
+            if(Tool.equals(currentOldTask, taskAsset.getTask())) {
+               taskAsset.setTask(currentNewPath);
             }
          }
       }

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
@@ -377,6 +377,7 @@ public class ScheduleService {
             oldPath = null;
          }
 
+         renameTaskBackupPaths(currTask, oldPath, oldId, newId);
          scheduleManager.setScheduleTask(newId, currTask, folderEntry, principal);
          taskFolderService.removeTaskFromFolder(oldId, oldPath);
          actionRecord.setActionStatus(ActionRecord.ACTION_STATUS_SUCCESS);
@@ -392,6 +393,30 @@ public class ScheduleService {
       }
 
       return true;
+   }
+
+   private void renameTaskBackupPaths(ScheduleTask task, String path, String oid, String nid) {
+      int cnt = task.getActionCount();
+      String currentOldTask = "/".equals(path) ? oid : path + "/" + oid;
+      String currentNewPath = "/".equals(path) ? nid : path + "/" + nid;
+
+      for(int i = 0; i < cnt; i++) {
+         ScheduleAction action = task.getAction(i);
+
+         if(action instanceof IndividualAssetBackupAction) {
+            IndividualAssetBackupAction bAction = (IndividualAssetBackupAction) action;
+
+            for(XAsset asset : bAction.getAssets()) {
+               if(asset instanceof ScheduleTaskAsset) {
+                  ScheduleTaskAsset taskAsset = (ScheduleTaskAsset) asset;
+
+                  if(Tool.equals(currentOldTask, taskAsset.getTask())) {
+                     taskAsset.setTask(currentNewPath);
+                  }
+               }
+            }
+         }
+      }
    }
 
    public void configureAssetFileBackupTask(ScheduleTask assetFileBackupTask) {

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
@@ -406,7 +406,7 @@ public class ScheduleService {
          if(!(action instanceof IndividualAssetBackupAction)) {
             continue;
          }
-            
+         
          IndividualAssetBackupAction bAction = (IndividualAssetBackupAction) action;
 
          for(XAsset asset : bAction.getAssets()) {


### PR DESCRIPTION
after rename task, it will transform other task using current task, but when current task use current task, it will not transform. In order to avoid cycle for dependency, so we just change its own actions to using new path when rename task.