### PR TITLE
fix Bug #70623

### DIFF
--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/add-theme-dialog/add-theme-dialog.component.html
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/add-theme-dialog/add-theme-dialog.component.html
@@ -23,6 +23,7 @@
     <input matInput formControlName="name" placeholder="_#(Name)"/>
     <mat-error *ngIf="form.controls.name?.errors?.required">_#(em.laf.theme.nameRequired)</mat-error>
     <mat-error *ngIf="form.controls.name?.errors?.duplicateName">_#(em.laf.theme.duplicateName)</mat-error>
+    <mat-error *ngIf="form.controls.name?.errors?.containsSpecialCharsForName">_#(common.sree.internal.invalidCharInName)</mat-error>
   </mat-form-field>
   <mat-form-field appearance="outline" color="accent">
     <mat-label>_#(Theme JAR File)</mat-label>

--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/add-theme-dialog/add-theme-dialog.component.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/add-theme-dialog/add-theme-dialog.component.ts
@@ -38,7 +38,11 @@ export class AddThemeDialogComponent implements OnInit {
       this.ids = data.ids;
       const initialJar = data.jar ? [data.jar] : [];
       this.form = fb.group({
-         name: [data.name, [Validators.required, FormValidators.duplicateName(() => data.names)]],
+         name: [data.name, [
+            Validators.required,
+            FormValidators.duplicateName(() => data.names),
+            FormValidators.isValidDataSpaceFileName
+         ]],
          jar: [initialJar]
       });
    }


### PR DESCRIPTION
When adding a theme, the validation logic for the theme name should be the same as the validation logic for the data space file name.