### PR TITLE
Feature #70119 RuntimeSheetTransformController service proxy

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/RuntimeSheetTransformController.java
+++ b/core/src/main/java/inetsoft/web/composer/RuntimeSheetTransformController.java
@@ -46,11 +46,13 @@ public class RuntimeSheetTransformController implements MessageListener {
    @Autowired
    public RuntimeSheetTransformController(AnalyticRepository repository,
                                           ViewsheetService viewsheetService,
-                                          SimpMessagingTemplate messagingTemplate)
+                                          SimpMessagingTemplate messagingTemplate,
+                                          RuntimeSheetTransformServiceProxy runtimeSheetTransformService)
    {
       this.repository = repository;
       this.viewsheetService = viewsheetService;
       this.messagingTemplate = messagingTemplate;
+      this.runtimeSheetTransformService = runtimeSheetTransformService;
       clusterInstance = Cluster.getInstance();
    }
 
@@ -227,7 +229,8 @@ public class RuntimeSheetTransformController implements MessageListener {
             .forEach(sheet -> {
                ArrayList<RenameInfo> renameInfos = new ArrayList<>();
                renameInfos.add(renameInfo);
-               viewsheetService.updateRenameInfos(sheet.getID(), sheet.getEntry(), renameInfos);
+               runtimeSheetTransformService.updateRenameInfos(sheet.getID(),
+                                                              sheet.getEntry(), renameInfos);
                sendMessage(sheet.getID(), sheet.getEntry(), false);
             });
       }
@@ -271,4 +274,5 @@ public class RuntimeSheetTransformController implements MessageListener {
    private AnalyticRepository repository;
    private ViewsheetService viewsheetService;
    private SimpMessagingTemplate messagingTemplate;
+   private RuntimeSheetTransformServiceProxy runtimeSheetTransformService;
 }

--- a/core/src/main/java/inetsoft/web/composer/RuntimeSheetTransformService.java
+++ b/core/src/main/java/inetsoft/web/composer/RuntimeSheetTransformService.java
@@ -25,7 +25,7 @@ import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.sync.RenameInfo;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @ClusterProxy
@@ -36,7 +36,7 @@ public class RuntimeSheetTransformService {
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void updateRenameInfos(@ClusterProxyKey String id,
-                                 AssetEntry entry, ArrayList<RenameInfo> renameInfos) {
+                                 AssetEntry entry, List<RenameInfo> renameInfos) {
       viewsheetService.updateRenameInfos(id, entry, renameInfos);
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/RuntimeSheetTransformService.java
+++ b/core/src/main/java/inetsoft/web/composer/RuntimeSheetTransformService.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.composer;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.cluster.*;
+import inetsoft.report.composition.WorksheetEngine;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.sync.RenameInfo;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+
+@Service
+@ClusterProxy
+public class RuntimeSheetTransformService {
+   public RuntimeSheetTransformService(ViewsheetService viewsheetService) {
+      this.viewsheetService = viewsheetService;
+   }
+
+   @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   public Void updateRenameInfos(@ClusterProxyKey String id,
+                                 AssetEntry entry, ArrayList<RenameInfo> renameInfos) {
+      viewsheetService.updateRenameInfos(id, entry, renameInfos);
+      return null;
+   }
+
+   ViewsheetService viewsheetService;
+}


### PR DESCRIPTION
RuntimeSheetTransformController has multiple methods iterating through the the runtime viewsheets, but only one actually processes the rvs.
The other methods just send even messages with the runtime viewsheet ID to be handled elsewhere.