### PR TITLE
fix Bug #70660

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/TemplateLocalizationController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/TemplateLocalizationController.java
@@ -107,6 +107,9 @@ public class TemplateLocalizationController {
                try(OutputStream output = response.getOutputStream()) {
                   Files.copy(cachedPath, output);
                }
+               catch(IOException e) {
+                  LOG.warn("Error writing response for {}", path);
+               }
 
                LOG.debug(
                   "Received script request for {} with invalid If-None-Match header " +


### PR DESCRIPTION
Catch exception that occur when writing a response after the client connection is closed.