### PR TITLE
fix Bug #70603

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ImagePreviewPaneController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ImagePreviewPaneController.java
@@ -64,10 +64,14 @@ public class ImagePreviewPaneController {
    public void getImagePreview(@PathVariable("name") String name,
                                @PathVariable("type") String type,
                                @RemainingPath String runtimeId,
+                               @RequestParam(value = "encoded", defaultValue = "true", required = false) boolean encoded,
                                Principal principal, HttpServletResponse response)
       throws Exception
    {
-      name = Tool.byteDecode(name);
+      if(encoded) {
+         name = Tool.byteDecode(name);
+      }
+
       runtimeId = Tool.byteDecode(runtimeId);
 
       if(name.toLowerCase().endsWith(".gif")) {

--- a/web/projects/portal/src/app/widget/image-editor/image-preview-pane.component.ts
+++ b/web/projects/portal/src/app/widget/image-editor/image-preview-pane.component.ts
@@ -124,9 +124,11 @@ export class ImagePreviewPane implements OnInit, AfterViewInit {
 
    public get imageSrc(): string {
       if(this.selectedImageNode && this.selectedImageNode.data && this.selectedImageNode.type) {
-         return "../api/image/composer/vs/image-preview-pane/image/" + Tool.byteEncode(this.selectedImageNode.data)
+         const image: string = this.selectedImageNode.data;
+         const encodedImage: string = Tool.byteEncode(image, false);
+         return "../api/image/composer/vs/image-preview-pane/image/" + encodedImage
             + "/" + this.selectedImageNode.type + "/" + Tool.byteEncode(this.runtimeId)
-            + "?" + this.currentTime;
+            + "?encoded=" + (image !== encodedImage) + "&" + this.currentTime;
       }
       else {
          return "assets/emptyimage.gif";


### PR DESCRIPTION
If the image name contains a byte-encoded string, such as `~_2e_~`, and it remains unchanged after calling `byteEncode`, then there is no need to decode it in the controller. Otherwise, it may result in an incorrect image name.