### PR TITLE
fix Bug #70608

### DIFF
--- a/web/projects/portal/src/app/composer/dialog/vs/viewsheet-device-layout-dialog.component.html
+++ b/web/projects/portal/src/app/composer/dialog/vs/viewsheet-device-layout-dialog.component.html
@@ -55,6 +55,9 @@
       <div *ngIf="formDevice.controls.name.errors && formDevice.controls.name.errors.required" class="alert alert-danger">
         <strong>_#(Error)</strong> _#(layout.vsLayout.nameRequired)
       </div>
+      <div *ngIf="formDevice.controls.name.errors && formDevice.controls.name.errors.containsSpecialCharsForName" class="alert alert-danger">
+        <strong>_#(Error)</strong> _#(common.sree.internal.invalidCharInName)
+      </div>
       <div *ngIf="duplicateName()" class="alert alert-danger">
         <strong>_#(Error)</strong> _#(common.duplicateName)
       </div>

--- a/web/projects/portal/src/app/composer/dialog/vs/viewsheet-device-layout-dialog.component.ts
+++ b/web/projects/portal/src/app/composer/dialog/vs/viewsheet-device-layout-dialog.component.ts
@@ -27,6 +27,7 @@ import {
 } from "@angular/core";
 import { UntypedFormControl, UntypedFormGroup, Validators } from "@angular/forms";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
+import { FormValidators } from "../../../../../../shared/util/form-validators";
 import { ScreenSizeDialogModel } from "../../data/vs/screen-size-dialog-model";
 import { ViewsheetDeviceLayoutDialogModel } from "../../data/vs/viewsheet-device-layout-dialog-model";
 import { Tool } from "../../../../../../shared/util/tool";
@@ -102,6 +103,7 @@ export class ViewsheetDeviceLayoutDialog implements OnInit {
       this.formDevice = new UntypedFormGroup({
          name: new UntypedFormControl(this.model.name, [
             Validators.required,
+            FormValidators.validLayoutName,
          ])
       });
    }

--- a/web/projects/shared/util/form-validators.ts
+++ b/web/projects/shared/util/form-validators.ts
@@ -139,6 +139,13 @@ export class FormValidators {
       return null;
    }
 
+   public static validLayoutName(control: UntypedFormControl): ValidationErrors {
+      const str = control.value.trim();
+      let invalidName: boolean = str && /[\/\\%^~<>*|?",]/g.test(str);
+
+      return invalidName ? {containsSpecialCharsForName: true} : null;
+   }
+
    public static invalidAssetItemName(control: UntypedFormControl): ValidationErrors {
       const str = control.value;
       let validName: boolean = str && /^[^\\\/"<'%^]+$/.test(str);


### PR DESCRIPTION
When validating the layout name, the following special characters are not allowed: / \ % ^ ~ < > * | ? ".