### PR TITLE
fix Bug #70685, show the combobox that switch the current org for Materialized Views page, because it loads mvs of the current org.

### DIFF
--- a/web/projects/em/src/app/page-header/page-header.service.ts
+++ b/web/projects/em/src/app/page-header/page-header.service.ts
@@ -52,6 +52,7 @@ export class PageHeaderService {
       "_#(js:Security Settings Users)",
       "_#(js:Security Settings Actions)",
       "_#(js:Repository)",
+      "_#(js:Materialized Views)",
       "_#(js:Schedule Tasks)",
       "_#(js:Data Cycles)",
       "_#(js:Organization Presentation Settings)",


### PR DESCRIPTION
show the combobox that switch the current org for Materialized Views page, because it loads mvs of the current org.