### PR TITLE
fix Bug #70680, when copy source org assets to new org, should copy library before IndexedStorage, because the task maybe dependent the library. the task will check dependence.

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -887,6 +887,7 @@ public class IdentityService {
          DashboardManager.getManager().copyStorageData(oOrg.getId(), nOrg.getId());
          DependencyStorageService.getInstance().copyStorageData(oOrg, nOrg);
          RecycleBin.getRecycleBin().copyStorageData(oOrg.getId(), nOrg.getId());
+         updateLibraryStorage(oOrg.getId(), nOrg.getId(), true);
          IndexedStorage.getIndexedStorage().copyStorageData(oOrg, nOrg);
 
          FSService.copyServerNode(oOrg.getId(), nOrg.getId(), true);
@@ -897,7 +898,6 @@ public class IdentityService {
          MVManager.getManager().copyStorageData(oOrg, nOrg);
 
          addNewOrgTaskToScheduleServer(nOrg.getOrganizationID());
-         updateLibraryStorage(oOrg.getId(), nOrg.getId(), true);
       }
       catch(Exception e) {
          LOG.warn("Could not copy Storages from "+ oOrg.getId() +" to "+ nOrg.getId() +", " + e);


### PR DESCRIPTION
when copy source org assets to new org, should copy library before IndexedStorage, because the task maybe dependent the library. the task will check dependence.