### PR TITLE
fix Bug #70621

### DIFF
--- a/core/src/main/java/inetsoft/sree/RepletEngine.java
+++ b/core/src/main/java/inetsoft/sree/RepletEngine.java
@@ -1271,7 +1271,7 @@ public class RepletEngine extends AbstractAssetEngine
                                List<RenameDependencyInfo> renameDependencyInfos)
       throws Exception
    {
-      super.changeSheet0(oentry, ostorage, nentry, nstorage, root, callFireEvent, null);
+      super.changeSheet0(oentry, ostorage, nentry, nstorage, root, callFireEvent, renameDependencyInfos);
 
       if(oentry.getScope() == GLOBAL_SCOPE) {
          SecurityEngine security = getSecurity();


### PR DESCRIPTION
Fix the issue where the viewsheet in dependency info is not updated, causing the viewsheet to not execute the transform logic. Please refer to `AbstractAssetEngine.java:3066`.