### PR TITLE
Fix Bug #70628:

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/AssetEntry.java
+++ b/core/src/main/java/inetsoft/uql/asset/AssetEntry.java
@@ -451,6 +451,11 @@ public class AssetEntry implements AssetObject, Comparable<AssetEntry>, DataSeri
          }
       }
 
+      if(identifier.startsWith("ws:")) {
+         index = index - 3;
+         identifier = identifier.substring(3);
+      }
+
       int scope = Integer.parseInt(identifier.substring(0, index));
       int lindex = index;
       index = identifier.indexOf('^', lindex + 1);


### PR DESCRIPTION
When a worksheet is used by a query, its identifier will have the ws: prefix, so it should be filtered out when creating an entry.