### PR TITLE
fix Bug #70678

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -905,8 +905,16 @@ public class IdentityService {
    }
 
    private void addNewOrgTaskToScheduleServer(String orgId) throws RemoteException {
-      Vector<ScheduleTask> scheduleTasks =
-         ScheduleManager.getScheduleManager().getScheduleTasks(orgId);
+      Vector<ScheduleTask> scheduleTasks = new Vector<>();
+
+      try {
+         scheduleTasks = OrganizationManager.runInOrgScope(orgId,
+            () -> ScheduleManager.getScheduleManager().getScheduleTasks(orgId));
+      }
+      catch(Exception e) {
+         LOG.warn("Could not get tasks from: "+ orgId);
+      }
+
       ScheduleServer scheduleServer = ScheduleServer.getInstance();
 
       if(scheduleTasks == null || scheduleServer == null) {


### PR DESCRIPTION
 after clone the org, will add new org task to scheduler server. during load the new org tasks, should switch current org to new org id, because the backup action will use the current org id during parse xml.