### PR TITLE
Fix Bug #69036:

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/sync/AssetWSDependencyTransformer.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/AssetWSDependencyTransformer.java
@@ -255,6 +255,10 @@ public class AssetWSDependencyTransformer extends AssetHyperlinkDependencyTransf
 
    @Override
    protected void renameAutoDrill(Element doc, RenameInfo rinfo) {
+      if(rinfo.isTable()) {
+         return;
+      }
+
       NodeList list = getChildNodes(doc, ".//XDrillInfo/drillPath");
 
       for(int i = 0; i < list.getLength(); i++) {
@@ -263,26 +267,25 @@ public class AssetWSDependencyTransformer extends AssetHyperlinkDependencyTransf
          String oname = rinfo.getOldName();
          String nname = rinfo.getNewName();
 
-         if(!rinfo.isTable()) {
-            AssetEntry oentry = AssetEntry.createAssetEntry(oname);
-            AssetEntry nentry = AssetEntry.createAssetEntry(nname);
+         AssetEntry oentry = AssetEntry.createAssetEntry(oname);
+         AssetEntry nentry = AssetEntry.createAssetEntry(nname);
 
-            if((Hyperlink.VIEWSHEET_LINK + "").equals(Tool.getAttribute(elem, "linkType"))) {
-               replaceAttribute(elem, "link", oname, nname, true);
-            }
+         if((Hyperlink.VIEWSHEET_LINK + "").equals(Tool.getAttribute(elem, "linkType"))) {
+            replaceAttribute(elem, "link", oname, nname, true);
+         }
 
-            NodeList assets = getChildNodes(elem, "./subquery/worksheetEntry/assetEntry");
+         NodeList assets = getChildNodes(elem, "./subquery/worksheetEntry/assetEntry");
 
-            for(int j = 0; j < assets.getLength(); j++) {
-               Element assetElem = (Element) assets.item(j);
-               Element path = Tool.getChildNodeByTagName(assetElem, "path");
-               String pathVal = Tool.getValue(path);
+         for(int j = 0; j < assets.getLength(); j++) {
+            Element assetElem = (Element) assets.item(j);
+            Element path = Tool.getChildNodeByTagName(assetElem, "path");
+            String pathVal = Tool.getValue(path);
 
-               if(!rinfo.isColumn() && Tool.equals(pathVal, oentry.getPath())) {
-                  XMLTool.replaceValue(path, nentry.getPath());
-               }
+            if(!rinfo.isColumn() && Tool.equals(pathVal, oentry.getPath())) {
+               XMLTool.replaceValue(path, nentry.getPath());
             }
          }
+
 
          NodeList fieldNodes = getChildNodes(elem, "./parameterField");
 

--- a/core/src/main/java/inetsoft/uql/asset/sync/AssetWSDependencyTransformer.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/AssetWSDependencyTransformer.java
@@ -262,24 +262,25 @@ public class AssetWSDependencyTransformer extends AssetHyperlinkDependencyTransf
 
          String oname = rinfo.getOldName();
          String nname = rinfo.getNewName();
-         AssetEntry oentry = AssetEntry.createAssetEntry(rinfo.isWorksheet() ?
-                                                            "ws:" + oname : oname);
-         AssetEntry nentry = AssetEntry.createAssetEntry(rinfo.isWorksheet() ?
-                                                            "ws:" + nname : nname);
 
-         if((Hyperlink.VIEWSHEET_LINK + "").equals(Tool.getAttribute(elem, "linkType"))) {
-            replaceAttribute(elem, "link", oname, nname, true);
-         }
+         if(!rinfo.isTable()) {
+            AssetEntry oentry = AssetEntry.createAssetEntry(oname);
+            AssetEntry nentry = AssetEntry.createAssetEntry(nname);
 
-         NodeList assets = getChildNodes(elem, "./subquery/worksheetEntry/assetEntry");
+            if((Hyperlink.VIEWSHEET_LINK + "").equals(Tool.getAttribute(elem, "linkType"))) {
+               replaceAttribute(elem, "link", oname, nname, true);
+            }
 
-         for(int j = 0; j < assets.getLength(); j++) {
-            Element assetElem = (Element) assets.item(j);
-            Element path = Tool.getChildNodeByTagName(assetElem, "path");
-            String pathVal = Tool.getValue(path);
+            NodeList assets = getChildNodes(elem, "./subquery/worksheetEntry/assetEntry");
 
-            if(!rinfo .isColumn() && Tool.equals(pathVal, oentry.getPath())) {
-               XMLTool.replaceValue(path, nentry.getPath());
+            for(int j = 0; j < assets.getLength(); j++) {
+               Element assetElem = (Element) assets.item(j);
+               Element path = Tool.getChildNodeByTagName(assetElem, "path");
+               String pathVal = Tool.getValue(path);
+
+               if(!rinfo.isColumn() && Tool.equals(pathVal, oentry.getPath())) {
+                  XMLTool.replaceValue(path, nentry.getPath());
+               }
             }
          }
 


### PR DESCRIPTION
Revisiting Bug #69036: When renaming a table, there is no need to update the worksheetEntry, and thus no need to build an entry.