### PR TITLE
Bug #70648

### DIFF
--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/schedule-task-editor.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/schedule-task-editor.component.ts
@@ -184,6 +184,7 @@ export class ScheduleTaskEditorComponent implements OnInit {
             this.updateConditionModel(m.taskConditionPaneModel);
             this.updateActionModel(m.taskActionPaneModel);
             this.updateOptionsModel(m.taskOptionsPaneModel);
+            this.originalModel = Tool.clone(this.model);
             this.saveSuccess();
 
             resolve(m);


### PR DESCRIPTION
After saving, the currently saved model should be used as the originalModel for comparison.