### PR TITLE
Fix Bug #70690:

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VSAssemblyInfo.java
@@ -1520,7 +1520,7 @@ public class VSAssemblyInfo extends AssemblyInfo implements FloatableVSAssemblyI
     * In cases that hyperlink linked asset does not match current orgID, replace orgID to match
     */
    public Hyperlink handleAssetLinkOrgMismatch(Hyperlink link) {
-      String linkPath = link.getLink();
+      String linkPath = link.getLinkValue();
       String curOrgId = OrganizationManager.getInstance().getCurrentOrgID();
       int orgIdx = linkPath.lastIndexOf("^");
 


### PR DESCRIPTION
When VS is opened again, it is no longer in runtime, so the runtime link has no value. Therefore, the link value should be taken directly.