### PR TITLE
fix Bug #70583:

### DIFF
--- a/web/projects/em/src/app/page-header/page-header.component.ts
+++ b/web/projects/em/src/app/page-header/page-header.component.ts
@@ -103,11 +103,19 @@ export class PageHeaderComponent implements OnInit, OnDestroy {
       const params = new HttpParams()
          .set("provider", !!currentProvider ? currentProvider : "")
          .set("providerChanged", !!providerChanged ? providerChanged : "false");
+      let oldOrg = this.model != null ? this.model.currOrgID : null;
 
       this.http.get("../api/em/pageheader/get-pageheader-model", { params })
          .subscribe((result: EmPageHeaderModel) => {
             this.model = result;
             this.currentProvider = result.providerName;
+
+            if(oldOrg != null && this.model != null && this.model.currOrgID != oldOrg) {
+               let currRoute = this.router.url;
+               this.routeToPath(currRoute);
+               this.usersService.loadScheduleUsers();
+            }
+
             this.initSearchResults();
          });
    }


### PR DESCRIPTION
the bug is caused by when clone host org to create new org, if change page to task list before clone is finished, then task list will load host tasks, then after clone is finish, it will reload EmPageHeaderModel, it should refresh page if current org is changed.