### PR TITLE
Fix Bug #70629:

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/sync/RenameTransformHandler.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/RenameTransformHandler.java
@@ -68,13 +68,18 @@ public class RenameTransformHandler implements AutoCloseable {
 
    public void addExtendPartitionsTransformTask(XPartition partition, RenameInfo rinfo) {
       String[] children = partition.getPartitionNames();
+      DependencyStorageService service = DependencyStorageService.getInstance();
 
       for(String child : children) {
-        String nChildPath = rinfo.getNewName() + "^" + child;
-        String oChildPath = rinfo.getOldName() + "^" + child;
-        RenameInfo childInfo = new RenameInfo(oChildPath, nChildPath,
-          RenameInfo.PARTITION | RenameInfo.SOURCE);
-        addTransformTask(childInfo);
+         String nChildPath = rinfo.getNewName() + "^" + child;
+         String oChildPath = rinfo.getOldName() + "^" + child;
+         RenameInfo childInfo = new RenameInfo(oChildPath, nChildPath,
+            RenameInfo.PARTITION | RenameInfo.SOURCE);
+
+         addTransformTask(childInfo);
+         String oldKey = DependencyTransformer.getOldKey(childInfo);
+         String newKey = DependencyTransformer.getKey(childInfo, false);
+         service.rename(oldKey, newKey, rinfo.getOrganizationId());
       }
 
       addTransformTask(rinfo);


### PR DESCRIPTION
When renaming a Physical View, if there is an Extended View, the key in DependencyStorage should also be modified to avoid failure after multiple renames.