### PR TITLE
Fix Bug #70707:

### DIFF
--- a/core/src/main/java/inetsoft/util/migrate/MigrateScheduleTask.java
+++ b/core/src/main/java/inetsoft/util/migrate/MigrateScheduleTask.java
@@ -306,20 +306,23 @@ public class MigrateScheduleTask extends MigrateDocumentTask {
 
          for(String email : emails.split("[;,]", 0)) {
             email = StringUtils.normalizeSpace(email);
+            String suffix = email.endsWith(Identity.USER_SUFFIX) ? Identity.USER_SUFFIX : Identity.GROUP_SUFFIX;
 
-            if(Tool.matchEmail(email) || !email.endsWith(Identity.USER_SUFFIX)) {
+            if(Tool.matchEmail(email) || (!email.endsWith(Identity.USER_SUFFIX) &&
+               !email.endsWith(Identity.GROUP_SUFFIX)))
+            {
                emailList.add(email);
                continue;
             }
 
-            String userName = email.substring(0, email.lastIndexOf(Identity.USER_SUFFIX));
+            String userName = email.substring(0, email.lastIndexOf(suffix));
 
             if(!Tool.equals(getOldName(), userName)) {
                emailList.add(email);
                continue;
             }
 
-            emailList.add(getNewName() + Identity.USER_SUFFIX);
+            emailList.add(getNewName() + suffix);
          }
 
          mailToItem.setAttribute("email", String.join(",", emailList));

--- a/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
@@ -631,6 +631,8 @@ public class UserTreeService {
       identityService.setIdentity(oldGroup, model, provider, principal);
       identityService.setIdentityPermissions(oldID, newID, ResourceType.SECURITY_GROUP,
                                              principal, permittedIdentities, "");
+      IndexedStorage storage = IndexedStorage.getIndexedStorage();
+      storage.migrateStorageData(oldID.getName(), newID.getName());
    }
 
    /**


### PR DESCRIPTION
Since a task's email can belong to either a user or a group, renaming a group should follow the same modification process as renaming a user.