### PR TITLE
Bug #70410

### DIFF
--- a/core/src/main/java/inetsoft/util/credential/AccountTokenCredentialFactory.java
+++ b/core/src/main/java/inetsoft/util/credential/AccountTokenCredentialFactory.java
@@ -32,6 +32,6 @@ public class AccountTokenCredentialFactory implements CredentialFactory {
 
    @Override
    public Credential createCredential(boolean forceLocal) {
-      return isLocal() ? new LocalAccountSecretCrendential() : new CloudAccountSecretCrendential();
+      return isLocal() || forceLocal ? new LocalAccountSecretCrendential() : new CloudAccountSecretCrendential();
    }
 }


### PR DESCRIPTION
This bug occurred because after check off 'Use Secret ID', an instance of CloudAccountSecretCredential was created.  The root cause was that the forceLocal parameter was not used, which led to the creation of an incorrect instance.  Adding forceLocal to create a LocalAccountSecretCredential instead will fix the issue.