### PR TITLE
fix Bug #70733, do not use the curOrgID to replace the org id of the query, if org id changed should sync it. it has done in the MigrateWorksheetTask.

### DIFF
--- a/core/src/main/java/inetsoft/uql/XQuery.java
+++ b/core/src/main/java/inetsoft/uql/XQuery.java
@@ -471,11 +471,6 @@ public abstract class XQuery implements Serializable, Cloneable, XMLSerializable
 
       if(nlist.getLength() > 0) {
          setOrganizationId(Tool.getValue(nlist.item(0)));
-         String curOrgID = OrganizationManager.getInstance().getCurrentOrgID();
-
-         if(!this.orgId.equals(curOrgID)) {
-            setOrganizationId(curOrgID);
-         }
       }
 
       nlist = Tool.getChildNodesByTagName(root, "folder");


### PR DESCRIPTION
do not use the curOrgID to replace the org id of the query, if org id changed should sync it. it has done in the MigrateWorksheetTask.