### PR TITLE
fix Bug #70631：

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/LocalDependencyHandler.java
+++ b/core/src/main/java/inetsoft/uql/asset/LocalDependencyHandler.java
@@ -2019,6 +2019,11 @@ public class LocalDependencyHandler implements DependencyHandler {
                entry = new AssetEntry(AssetRepository.GLOBAL_SCOPE,
                                       AssetEntry.Type.SCHEDULE_TASK, "/" + path, null);
             }
+            else if(asset instanceof DashboardAsset) {
+               IdentityID user = asset.getUser();
+               entry = new AssetEntry(user == null ? AssetRepository.GLOBAL_SCOPE :
+                  AssetRepository.USER_SCOPE, AssetEntry.Type.DASHBOARD, asset.getPath(), user);
+            }
             else if(asset instanceof ScriptAsset) {
                String path = asset.getPath();
                entry = new AssetEntry(

--- a/core/src/main/java/inetsoft/uql/asset/sync/DependencyTransformer.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/DependencyTransformer.java
@@ -917,6 +917,10 @@ public abstract class DependencyTransformer {
          return name;
       }
 
+      if(info.isDashboard()) {
+         return name;
+      }
+
       if(info.isTableStyle()) {
          return getAssetId(name, AssetEntry.Type.TABLE_STYLE);
       }
@@ -994,6 +998,10 @@ public abstract class DependencyTransformer {
       }
 
       if(info.isVPM()) {
+         return true;
+      }
+
+      if(info.isDashboard()) {
          return true;
       }
 

--- a/core/src/main/java/inetsoft/uql/asset/sync/RenameInfo.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/RenameInfo.java
@@ -149,6 +149,11 @@ public class RenameInfo implements Serializable, XMLSerializable, Cloneable {
     */
    public static final int VPM = BOOKMARK << 1;
 
+   /**
+    * Dashboard dependency.
+    */
+   public static final int DASHBOARD = VPM << 1;
+
    public RenameInfo() {
       super();
    }
@@ -289,6 +294,10 @@ public class RenameInfo implements Serializable, XMLSerializable, Cloneable {
 
    public boolean isViewsheet() {
       return (type & VIEWSHEET) == VIEWSHEET;
+   }
+
+   public boolean isDashboard() {
+      return (type & DASHBOARD) == DASHBOARD;
    }
 
    public boolean isReplet() {

--- a/core/src/main/java/inetsoft/uql/asset/sync/TaskAssetDependencyTransformer.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/TaskAssetDependencyTransformer.java
@@ -408,6 +408,9 @@ public class TaskAssetDependencyTransformer extends DependencyTransformer {
       else if(info.isTask()) {
          type = ScheduleTaskAsset.SCHEDULETASK;
       }
+      else if(info.isDashboard()) {
+         type = DashboardAsset.DASHBOARD;
+      }
 
       String newPath = null;
       IdentityID newUser = null;

--- a/core/src/main/java/inetsoft/web/portal/controller/DashboardController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/DashboardController.java
@@ -26,6 +26,8 @@ import inetsoft.sree.web.dashboard.*;
 import inetsoft.uql.XPrincipal;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.AssetUtil;
+import inetsoft.uql.asset.sync.RenameInfo;
+import inetsoft.uql.asset.sync.RenameTransformHandler;
 import inetsoft.uql.util.*;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.ViewsheetInfo;
@@ -424,6 +426,20 @@ public class DashboardController {
 
          if(!oldName.equals(dashboardModel.name())) {
             registry.renameDashboard(oldName, dashboardModel.name());
+            String okey = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.DASHBOARD,
+               oldName, null).toIdentifier();
+            String nkey = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.DASHBOARD,
+               dashboardModel.name(), null).toIdentifier();
+
+            if("u".equals(dashboardModel.type())) {
+               okey = new AssetEntry(AssetRepository.USER_SCOPE, AssetEntry.Type.DASHBOARD, oldName,
+                  user).toIdentifier();
+               nkey = new AssetEntry(AssetRepository.USER_SCOPE, AssetEntry.Type.DASHBOARD,
+                  dashboardModel.name(), user).toIdentifier();
+            }
+
+            RenameInfo rinfo = new RenameInfo(okey, nkey, RenameInfo.DASHBOARD);
+            RenameTransformHandler.getTransformHandler().addTransformTask(rinfo);
          }
 
          // remove the base vs is a new vs replaces it


### PR DESCRIPTION
1. when task using user dashboard or global dashboard(not viewsheet) in it, should save dashboard dependency in dependency storage.
2. when rename dashboard in portal, should create dashboard asset id for rename info to transform tasks using it.
3. for portal, user dashboard will get from login user, so should using login user to create asset id for user dashboard.
4. after transform tasks, should update storage to new key in dependency storage in order to fix next time rename.
5. add dashboard type in Rename info check if action is rename dashboard or not.
6. for dashboard dependency should using asset identifier as oldname/newname because it should split glocal dashboard and user dashboard(global dashobard will be:  ds name +　”__global“,　 user dashboard will have user scope and user identity info in it)
7. add dashboard type when transform tasks.