### PR TITLE
fix Bug #70697, VSUtil.isTipView should use the AbsoluteName of the assembly and root vs, because the AbsoluteName is relative to the root vs.

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
@@ -1571,11 +1571,13 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
       }
 
       try {
+         Viewsheet rootVS = getRootViewsheet(this);
+
          for(Assembly assemblyItem : getAssemblies(false, false, true, false, true)) {
             VSAssembly assembly = (VSAssembly) assemblyItem;
             String assemblyName = assembly.getAbsoluteName();
-            boolean isFloat = VSUtil.isPopComponent(assemblyName, this) ||
-               VSUtil.isTipView(assemblyName, this);
+            boolean isFloat = VSUtil.isPopComponent(assemblyName, rootVS) ||
+               VSUtil.isTipView(assemblyName, rootVS);
 
             if(!includeAnnotation) {
                if(assembly instanceof AnnotationVSAssembly ||
@@ -1644,6 +1646,14 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
       }
 
       return bounds;
+   }
+
+   private Viewsheet getRootViewsheet(Viewsheet vs) {
+      if(vs.getViewsheet() == null) {
+         return vs;
+      }
+
+      return getRootViewsheet(vs.getViewsheet());
    }
 
    private boolean isPrimary(VSAssembly assembly) {


### PR DESCRIPTION
 VSUtil.isTipView should use the AbsoluteName of the assembly and root vs, because the AbsoluteName is relative to the root vs.