### PR TITLE
Bug-70679

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.ts
@@ -624,7 +624,8 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
                      type: nodeData.type
                   };
                   this.databaseRoot.children.push(node);
-                  this.tableTree.selectedNode = node;
+                  this.tableTree.selectedNodes = [];
+                  this.tableTree.selectedNodes.push(node)
                   this.selectNode(node);
                   let newTable = this.createPhysicalTableModel(nodeData);
                   let event: EditTableEvent = new EditTableEvent(this.physicalModel.id, newTable);
@@ -1315,15 +1316,14 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
    }
 
    graphNodesSelected(nodes: string[]) {
-      let lastPath = !!nodes && nodes.length > 0 ? nodes[nodes.length - 1] : null;
-
-      if(!lastPath) {
+      if(!nodes && nodes.length == 0) {
          this.tableTree.selectedNode = null;
          this.selectNode(null);
       }
       else {
          this.resetSearchMode();
-         this.selectAndExpandToPath(lastPath);
+         this.tableTree.selectedNodes = [];
+         this.selectAndExpandToPath(nodes);
       }
    }
 
@@ -1361,15 +1361,14 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
     * @param path    the path to find
     * @param parent  the current parent node to search
     */
-   private selectAndExpandToPath(path: string, parent: TreeNodeModel = this.databaseRoot): void {
+   private selectAndExpandToPath(paths: string[], parent: TreeNodeModel = this.databaseRoot): void {
       for(let child of parent.children) {
          const childPath: string = (<DatabaseTreeNodeModel> child.data).path;
 
-         if(childPath === path) {
+         if(paths.includes(childPath)) {
             this.tableTree.selectNode(child);
-            break;
          }
-         else if(path.indexOf(childPath + "/") == 0) {
+         else if(paths.some(p => p.indexOf(childPath + "/") === 0)) {
             child.expanded = true;
 
             if(child.children.length == 0) {
@@ -1377,14 +1376,12 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
                   .subscribe(
                      data => {
                         child.children = data;
-                        this.selectAndExpandToPath(path, child);
+                        this.selectAndExpandToPath(paths, child);
                      });
             }
             else {
-               this.selectAndExpandToPath(path, child);
+               this.selectAndExpandToPath(paths, child);
             }
-
-            break;
          }
       }
    }

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.ts
@@ -1454,7 +1454,6 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
          });
 
          if(newTable) {
-            console.log(3);
             this.editingTable = newTable;
          }
          else {

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.ts
@@ -124,7 +124,7 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
    private subscription: Subscription;
    loadingTree: boolean = false;
    private graphViewModel: GraphViewModel;
-   selectedGraphNode: GraphNodeModel;
+   selectedGraphNode: GraphNodeModel[] = [];
 
    actions: ToolbarAction[] =
       [
@@ -404,7 +404,7 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
     * @param node the node an alias is being created for
     */
    showCreateAliasDialog(node: TreeNodeModel = null): void {
-      node = node ?? this.tableTree.selectedNode;
+      node = node ?? this.tableTree.selectedNode[0];
       this.changeEditingTable(node);
 
       this.tableDuplicateCheck = (name: string) => {
@@ -626,7 +626,7 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
                   this.databaseRoot.children.push(node);
                   this.tableTree.selectedNodes = [];
                   this.tableTree.selectedNodes.push(node)
-                  this.selectNode(node);
+                  this.selectNode([node]);
                   let newTable = this.createPhysicalTableModel(nodeData);
                   let event: EditTableEvent = new EditTableEvent(this.physicalModel.id, newTable);
                   this.httpClient.post<PhysicalModelDefinition>(PHYSICAL_MODELS_INLINE_VIEW_URI + "add", event)
@@ -992,9 +992,22 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
     * Called when user selects node on tree. Navigate router to the selected nodes path.
     * @param node   the selected node on tree
     */
-   selectNode(node: TreeNodeModel): void {
-      this.selectPhysicalGraphNode(node);
-      this.changeEditingTable(node);
+   selectNode(node: TreeNodeModel[]): void {
+      if(node != null && node.length == 1) {
+         this.selectedGraphNode = [];
+         this.selectPhysicalGraphNode(node[0])
+         this.changeEditingTable(node[0]);
+      }
+      else if(node == null) {
+         this.selectedGraphNode = [];
+         this.changeEditingTable(null);
+      }
+      else {
+         this.editingTable = null;
+         node.some(n => {
+            this.selectPhysicalGraphNode(n);
+         })
+      }
    }
 
    onPhysicalGraph(graphViewModel: GraphViewModel): void {
@@ -1012,7 +1025,7 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
          }
 
          if(node.data?.path == this.graphViewModel.graphs[i].node.treeLink) {
-            this.selectedGraphNode = this.graphViewModel.graphs[i].node;
+            this.selectedGraphNode.push(this.graphViewModel.graphs[i].node);
          }
       }
    }
@@ -1316,13 +1329,14 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
    }
 
    graphNodesSelected(nodes: string[]) {
-      if(!nodes && nodes.length == 0) {
-         this.tableTree.selectedNode = null;
+      this.tableTree.selectedNodes = [];
+
+      if(!nodes || nodes.length == 0) {
+         this.tableTree.selectedNode = [];
          this.selectNode(null);
       }
       else {
          this.resetSearchMode();
-         this.tableTree.selectedNodes = [];
          this.selectAndExpandToPath(nodes);
       }
    }
@@ -1440,6 +1454,7 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
          });
 
          if(newTable) {
+            console.log(3);
             this.editingTable = newTable;
          }
          else {

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-graph-pane/physical-graph-pane.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-graph-pane/physical-graph-pane.component.ts
@@ -51,7 +51,7 @@ export class PhysicalGraphPane implements OnInit, AfterViewChecked, OnDestroy {
    @Input() physicalView: string;
    @Input() datasource: string;
    @Input() runtimeId: string;
-   @Input() selectedGraphNode: GraphNodeModel;
+   @Input() selectedGraphNode: GraphNodeModel[];
 
    @Output() onCreateAutoAlias = new EventEmitter<string>();
    @Output() onEditInlineView = new EventEmitter<string>();

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-network-graph/physical-model-network-graph.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-network-graph/physical-model-network-graph.component.ts
@@ -1017,10 +1017,14 @@ export class PhysicalModelNetworkGraphComponent implements OnInit, OnChanges, Af
    }
 
    getSelectedNode(currentNode: GraphNodeModel): boolean {
+      if(this.dragNodes != null && this.dragNodes.length > 0) {
+         return this.dragNodes.some(node => node.node.id === currentNode.id);
+      }
+
       if(this.selectedGraphNode) {
          return currentNode.id === this.selectedGraphNode.id;
       }
 
-      return this.dragNodes.some(node => node.node.id === currentNode.id);
+      return false;
    }
 }

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-network-graph/physical-model-network-graph.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-network-graph/physical-model-network-graph.component.ts
@@ -79,7 +79,7 @@ export class PhysicalModelNetworkGraphComponent implements OnInit, OnChanges, Af
    @Input() graphViewModel: GraphViewModel;
    @Input() highlightConnections: HighlightInfo[];
    @Input() scrollPoint: Point = new Point();
-   @Input() selectedGraphNode: GraphNodeModel;
+   @Input() selectedGraphNode: GraphNodeModel[];
 
    @Output() onCreateAutoAlias = new EventEmitter<string>();
    @Output() onEditInlineView = new EventEmitter<string>();
@@ -1022,7 +1022,7 @@ export class PhysicalModelNetworkGraphComponent implements OnInit, OnChanges, Af
       }
 
       if(this.selectedGraphNode) {
-         return currentNode.id === this.selectedGraphNode.id;
+         return this.selectedGraphNode.some(node => node.id === currentNode.id)
       }
 
       return false;

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-table-tree/physical-model-table-tree-node/physical-model-table-tree-node.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-table-tree/physical-model-table-tree-node/physical-model-table-tree-node.component.html
@@ -22,7 +22,7 @@
          [class.bg-selected]="isSelected()"
          [class.disabled]="disabled"
          [class.form-check]="node.leaf"
-         (click)="selectNode()"
+         (click)="selectNode($event)"
          (dblclick)="hasChildren() ? toggleNode() : null">
       <span *ngIf="hasChildren()"
             [class.disabled]="disabled"

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-table-tree/physical-model-table-tree-node/physical-model-table-tree-node.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-table-tree/physical-model-table-tree-node/physical-model-table-tree-node.component.ts
@@ -84,7 +84,14 @@ export class PhysicalModelTableTreeNodeComponent {
     * @returns {boolean}   true if selected
     */
    isSelected(): boolean {
-      return this.node == this.tree.selectedNode;
+      if(this.tree.selectedNodes != null && this.tree.selectedNodes.length > 0) {
+         return this.tree.selectedNodes.includes(this.node);
+      }
+      else if(this.tree.selectedNode != null) {
+         return this.tree.selectedNode == this.node;
+      }
+
+      return false;
    }
 
    /**
@@ -95,7 +102,8 @@ export class PhysicalModelTableTreeNodeComponent {
          return;
       }
 
-      this.tree.selectNode(this.node);
+      this.tree.selectedNodes = [];
+      this.tree.selectNode0(this.node);
    }
 
    /**

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-table-tree/physical-model-table-tree-node/physical-model-table-tree-node.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-table-tree/physical-model-table-tree-node/physical-model-table-tree-node.component.ts
@@ -87,8 +87,8 @@ export class PhysicalModelTableTreeNodeComponent {
       if(this.tree.selectedNodes != null && this.tree.selectedNodes.length > 0) {
          return this.tree.selectedNodes.includes(this.node);
       }
-      else if(this.tree.selectedNode != null) {
-         return this.tree.selectedNode == this.node;
+      else if(this.tree.selectedNode != null && this.tree.selectedNode.length > 0) {
+         return this.tree.selectedNode.includes(this.node);
       }
 
       return false;
@@ -97,13 +97,19 @@ export class PhysicalModelTableTreeNodeComponent {
    /**
     * Select this node.
     */
-   selectNode(): void {
+   selectNode(event: MouseEvent): void {
       if(!this.node.leaf || this.disabled) {
          return;
       }
 
-      this.tree.selectedNodes = [];
-      this.tree.selectNode0(this.node);
+      if(event.ctrlKey || event.shiftKey) {
+         this.tree.selectedNode.push(this.node)
+      }
+      else {
+         this.tree.selectedNode = [this.node];
+      }
+
+      this.tree.selectNode0(this.tree.selectedNode);
    }
 
    /**

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-table-tree/physical-model-table-tree.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-table-tree/physical-model-table-tree.component.ts
@@ -33,6 +33,7 @@ export class PhysicalModelTableTreeComponent {
    @Output() nodeCheckboxToggled: EventEmitter<TreeNodeModel> = new EventEmitter<TreeNodeModel>();
    @Output() onNodeContextMenu: EventEmitter<{node: TreeNodeModel, event: MouseEvent}> =
       new EventEmitter<{node: TreeNodeModel, event: MouseEvent}>();
+   selectedNodes: TreeNodeModel[] = [];
    selectedNode: TreeNodeModel;
 
    /**
@@ -48,6 +49,11 @@ export class PhysicalModelTableTreeComponent {
     * @param node the node to edit
     */
    selectNode(node: TreeNodeModel): void {
+      this.selectedNodes = this.selectedNodes == null ? [] : this.selectedNodes;
+      this.selectedNodes.push(node);
+   }
+
+   selectNode0(node: TreeNodeModel) {
       this.selectedNode = node;
       this.nodeSelected.emit(node);
    }

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-table-tree/physical-model-table-tree.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-table-tree/physical-model-table-tree.component.ts
@@ -29,12 +29,12 @@ export class PhysicalModelTableTreeComponent {
    @Input() showOnlySelectedTables: boolean = false;
    @Input() disabled = false;
    @Output() nodeExpanded: EventEmitter<TreeNodeModel> = new EventEmitter<TreeNodeModel>();
-   @Output() nodeSelected: EventEmitter<TreeNodeModel> = new EventEmitter<TreeNodeModel>();
+   @Output() nodeSelected: EventEmitter<TreeNodeModel[]> = new EventEmitter<TreeNodeModel[]>();
    @Output() nodeCheckboxToggled: EventEmitter<TreeNodeModel> = new EventEmitter<TreeNodeModel>();
    @Output() onNodeContextMenu: EventEmitter<{node: TreeNodeModel, event: MouseEvent}> =
       new EventEmitter<{node: TreeNodeModel, event: MouseEvent}>();
    selectedNodes: TreeNodeModel[] = [];
-   selectedNode: TreeNodeModel;
+   selectedNode: TreeNodeModel[] = [];
 
    /**
     * Node was expanded, emit node.
@@ -53,8 +53,7 @@ export class PhysicalModelTableTreeComponent {
       this.selectedNodes.push(node);
    }
 
-   selectNode0(node: TreeNodeModel) {
-      this.selectedNode = node;
+   selectNode0(node: TreeNodeModel[]) {
       this.nodeSelected.emit(node);
    }
 


### PR DESCRIPTION
This bug occurs because after making multiple selections on the pane, only the path of the last selected node was passed to the tree. Since the tree on the left and the pane on the right are bound to each other, after the tree receives the path of the last selected node, it selects the corresponding node in the tree, which is then passed back to the pane. As a result, the pane, which had multiple nodes selected, now only highlights the last selected node. This creates a closed loop. To fix it, simply add a new selectNode() method to separate the operations on the tree nodes from the operations on the pane nodes.