### PR TITLE
fix Bug #70695, pop up the dependency change and reload warning for the runtime viewsheet

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/sync/AssetDependencyTransformer.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/AssetDependencyTransformer.java
@@ -249,7 +249,7 @@ public class AssetDependencyTransformer extends DependencyTransformer {
             causeInfos = renameSheets(root, infos, asset.isViewsheet());
          }
          else {
-            renameAutoDrills(root, infos);
+            causeInfos = renameAutoDrills(root, infos);
          }
 
          if(getAssetFile() != null) {
@@ -268,10 +268,12 @@ public class AssetDependencyTransformer extends DependencyTransformer {
       return causeInfos;
    }
 
-   protected void renameAutoDrills(Element doc, List<RenameInfo> rinfos) {
+   protected RenameDependencyInfo renameAutoDrills(Element doc, List<RenameInfo> rinfos) {
+      return null;
    }
 
-   protected void renameAutoDrill(Element doc, RenameInfo rinfo) {
+   protected boolean renameAutoDrill(Element doc, RenameInfo rinfo) {
+      return false;
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/asset/sync/AssetHyperlinkDependencyTransformer.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/AssetHyperlinkDependencyTransformer.java
@@ -23,6 +23,7 @@ import inetsoft.util.Tool;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -51,14 +52,19 @@ public class AssetHyperlinkDependencyTransformer extends AssetDependencyTransfor
       }
    }
 
-   protected void renameAutoDrills(Element relem, List<RenameInfo> rinfos) {
+   protected RenameDependencyInfo renameAutoDrills(Element relem, List<RenameInfo> rinfos) {
+      boolean autoDrillChanged = false;
+
       for(RenameInfo rinfo : rinfos) {
-         renameAutoDrill(relem, rinfo);
+         autoDrillChanged |= renameAutoDrill(relem, rinfo);
       }
+
+      return autoDrillChanged ? createRenameDependency(asset.toIdentifier(), new ArrayList<>()) : null;
    }
 
-   protected void renameAutoDrill(Element relem, RenameInfo rinfo) {
+   protected boolean renameAutoDrill(Element relem, RenameInfo rinfo) {
       NodeList list = getChildNodes(relem, ".//XDrillInfo/drillPath");
+      boolean autoDrillChanged = false;
 
       for(int i = 0; i < list.getLength(); i++) {
          Element elem = (Element) list.item(i);
@@ -67,8 +73,10 @@ public class AssetHyperlinkDependencyTransformer extends AssetDependencyTransfor
          String nname = rinfo.getNewName();
 
          if((Hyperlink.VIEWSHEET_LINK + "").equals(Tool.getAttribute(elem, "linkType"))) {
-            replaceAttribute(elem, "link", oname, nname, true);
+            autoDrillChanged |= replaceAttribute(elem, "link", oname, nname, true);
          }
       }
+
+      return autoDrillChanged;
    }
 }

--- a/core/src/main/java/inetsoft/uql/asset/sync/AssetWSDependencyTransformer.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/AssetWSDependencyTransformer.java
@@ -254,11 +254,12 @@ public class AssetWSDependencyTransformer extends AssetHyperlinkDependencyTransf
    }
 
    @Override
-   protected void renameAutoDrill(Element doc, RenameInfo rinfo) {
+   protected boolean renameAutoDrill(Element doc, RenameInfo rinfo) {
       if(rinfo.isTable()) {
-         return;
+         return false;
       }
 
+      boolean autoDrillChanged = false;
       NodeList list = getChildNodes(doc, ".//XDrillInfo/drillPath");
 
       for(int i = 0; i < list.getLength(); i++) {
@@ -270,7 +271,7 @@ public class AssetWSDependencyTransformer extends AssetHyperlinkDependencyTransf
          AssetEntry nentry = AssetEntry.createAssetEntry(nname);
 
          if((Hyperlink.VIEWSHEET_LINK + "").equals(Tool.getAttribute(elem, "linkType"))) {
-            replaceAttribute(elem, "link", oname, nname, true);
+            autoDrillChanged |= replaceAttribute(elem, "link", oname, nname, true);
          }
 
          NodeList assets = getChildNodes(elem, "./subquery/worksheetEntry/assetEntry");
@@ -301,13 +302,15 @@ public class AssetWSDependencyTransformer extends AssetHyperlinkDependencyTransf
                else if(user != null) {
                   assetElem.removeChild(user);
                }
+
+               autoDrillChanged = true;
             }
          }
 
          NodeList fieldNodes = getChildNodes(elem, "./parameterField");
 
          if(fieldNodes == null || fieldNodes.getLength() == 0 && !rinfo .isColumn()) {
-            return;
+            return autoDrillChanged;
          }
 
          for(int j = 0; j < fieldNodes.getLength(); j++) {
@@ -315,10 +318,12 @@ public class AssetWSDependencyTransformer extends AssetHyperlinkDependencyTransf
             String field = Tool.getAttribute(fieldNode, "field");
 
             if(Tool.equals(oname, field)) {
-               replaceAttribute(fieldNode, "field", oname, nname, true);
+               autoDrillChanged |= replaceAttribute(fieldNode, "field", oname, nname, true);
             }
          }
       }
+
+      return autoDrillChanged;
    }
 
    private void renameVSAndAssemblyScript(Element doc, RenameInfo info) {


### PR DESCRIPTION
 pop up the dependency change and reload warning for the runtime viewsheet. when the logic model auto drill is changed by the dependency transformer.