### PR TITLE
fix Bug #70712, adjust the Plugins list UI to avoid excess blank space when the plugins are few.

### DIFF
--- a/web/projects/em/src/app/settings/content/drivers-and-plugins/plugins-view/plugins-view.component.scss
+++ b/web/projects/em/src/app/settings/content/drivers-and-plugins/plugins-view/plugins-view.component.scss
@@ -26,6 +26,7 @@
   .em-staged-file-chooser {
     flex-grow: 1;
     flex-shrink: 1;
+    max-height: fit-content;
   }
 
   .file-loading-indicator {


### PR DESCRIPTION
adjust the Plugins list UI to avoid excess blank space when the plugins are few.