### PR TITLE
fix Bug #70647, Bug #70794

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
@@ -691,8 +691,10 @@ public class ScheduleService {
       String currOrgId = OrganizationManager.getInstance().getCurrentOrgID();
 
       if(Organization.getSelfOrganizationID().equals(((XPrincipal) principal).getOrgId())) {
+         String alias = ((XPrincipal) principal).getAlias();
+         alias = !Tool.isEmptyString(alias) ? alias : null;
          allowedUsers = new IdentityIDWithLabel[] {
-            new IdentityIDWithLabel(IdentityID.getIdentityIDFromKey(principal.getName()), ((XPrincipal) principal).getAlias()) };
+            new IdentityIDWithLabel(IdentityID.getIdentityIDFromKey(principal.getName()), alias) };
       }
       else {
          Arrays.stream(securityProvider.getUsers())
@@ -700,7 +702,8 @@ public class ScheduleService {
             .forEach(u -> allUsers.put(u, securityProvider.getUser(u)));
 
          allowedUsers = allUsers.values().stream()
-            .map(u -> new IdentityIDWithLabel(u.getIdentityID(), u.getAlias()))
+            .map(u -> new IdentityIDWithLabel(
+               u.getIdentityID(), !Tool.isEmptyString(u.getAlias()) ? u.getAlias() : null))
             .filter(u -> securityProvider.checkPermission(
                principal, ResourceType.SECURITY_USER, u.getIdentityID().convertToKey(), ResourceAction.ADMIN))
             .sorted()

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
@@ -925,7 +925,7 @@ public class ScheduleTaskService {
          model.idType(type);
 
          if(type == Identity.Type.USER.code()) {
-            model.idAlias(((User) task.getIdentity()).getAlias());
+            model.idAlias(SUtil.getUserAlias(task.getIdentity().getIdentityID()));
          }
       }
 

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -1535,7 +1535,7 @@ public class IdentityService {
       user.setRoles(model.roles().toArray(new IdentityID[0]));
       user.setGroups(memberNames.toArray(new String[0]));
       user.setEmails(emails);
-      user.setAlias(model.alias());
+      user.setAlias(!Tool.isEmptyString(model.alias()) ? model.alias() : null);
       user.setActive(model.status());
       user.setOrganization(model.organization());
       user.setGoogleSSOId(ouser.getGoogleSSOId());

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/options/task-options-pane.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/options/task-options-pane.component.ts
@@ -146,10 +146,10 @@ export class TaskOptionsPane implements OnInit {
    private getExecuteAsName(): void {
       let idName = this._model.owner;
 
-      if(this._model.idName != null) {
-         idName = this._model.idAlias == null ? this._model.idName : this._model.idAlias;
+      if(!!this._model.idName) {
+         idName = !this._model.idAlias ? this._model.idName : this._model.idAlias;
       }
-      else if(this._model.ownerAlias != null) {
+      else if(!!this._model.ownerAlias) {
          idName = this._model.ownerAlias;
       }
 


### PR DESCRIPTION
1. Avoid using an empty string as the user's alias.
2. Retrieving the latest user from the security provider and then obtaining the alias from the user ensures the alias is correct.