### PR TITLE
fix Bug #70770, runtime sheet id may be a worksheet id, for global share assets, just switch to org for the vs, user just can open the shared vs.

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VSUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VSUtil.java
@@ -8669,9 +8669,11 @@ public final class VSUtil {
       ViewsheetService service = SingletonManager.getInstance(ViewsheetService.class);
 
       try {
-         RuntimeViewsheet runtimeSheet = service.getViewsheet(sheetRuntimeId, principal);
+         RuntimeSheet runtimeSheet = service.getSheet(sheetRuntimeId, principal);
 
-         if(runtimeSheet == null || runtimeSheet.getEntry() == null) {
+         if(runtimeSheet == null || runtimeSheet.getEntry() == null ||
+            !(runtimeSheet instanceof RuntimeViewsheet))
+         {
             return false;
          }
 


### PR DESCRIPTION
runtime sheet id may be a worksheet id, for global share assets, just switch to org for the vs, user just can open the shared vs.