### PR TITLE
Bug #70780

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/Permission.java
+++ b/core/src/main/java/inetsoft/sree/security/Permission.java
@@ -145,6 +145,10 @@ public class Permission implements Serializable, Cloneable, XMLSerializable {
       return getGrants(action, Identity.ROLE);
    }
 
+   public Set<PermissionIdentity> getRoleGrants(ResourceAction action, String orgID) {
+      return getGrants(action, Identity.ROLE, orgID);
+   }
+
    public Set<PermissionIdentity> getAllRoleGrants(ResourceAction action) {
       return getGrants(action, Identity.ROLE, null);
    }

--- a/core/src/main/java/inetsoft/sree/security/Permission.java
+++ b/core/src/main/java/inetsoft/sree/security/Permission.java
@@ -774,6 +774,14 @@ public class Permission implements Serializable, Cloneable, XMLSerializable {
                 .anyMatch(o -> o.equals(orgId));
    }
 
+   public boolean hasChanges() {
+      return (userGrants != null && !userGrants.isEmpty())
+         || (roleGrants != null && !roleGrants.isEmpty())
+         || (groupGrants != null && !groupGrants.isEmpty())
+         || (organizationGrants != null && !organizationGrants.isEmpty())
+         || (orgUpdatedList != null && !orgUpdatedList.isEmpty());
+   }
+
    /**
     * clean any permissions belonging to the given organization
     * @param action the name of the granted action.

--- a/core/src/main/java/inetsoft/sree/security/Permission.java
+++ b/core/src/main/java/inetsoft/sree/security/Permission.java
@@ -774,14 +774,6 @@ public class Permission implements Serializable, Cloneable, XMLSerializable {
                 .anyMatch(o -> o.equals(orgId));
    }
 
-   public boolean hasChanges() {
-      return (userGrants != null && !userGrants.isEmpty())
-         || (roleGrants != null && !roleGrants.isEmpty())
-         || (groupGrants != null && !groupGrants.isEmpty())
-         || (organizationGrants != null && !organizationGrants.isEmpty())
-         || (orgUpdatedList != null && !orgUpdatedList.isEmpty());
-   }
-
    /**
     * clean any permissions belonging to the given organization
     * @param action the name of the granted action.

--- a/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
@@ -1679,6 +1679,11 @@ public class DataSourceRegistry implements MessageListener {
          newPermission.setUserGrants(action, currentOrgUserGrants);
          return true;
       }
+      else if(allUserGrants.size() > 1 && !currentOrgUserGrants.isEmpty() && allUserGrants.equals(currentOrgUserGrants)) {
+         permission.setUserGrants(action, newPermission.getAllUserGrants(action));
+         newPermission.setUserGrants(action, allUserGrants);
+         return true;
+      }
 
       return false;
    }
@@ -1695,6 +1700,11 @@ public class DataSourceRegistry implements MessageListener {
       }
       else if(allRoleGrants.size() > 0 && currentOrgRoleGrants.isEmpty()) {
          newPermission.setRoleGrants(action, currentOrgRoleGrants);
+         return true;
+      }
+      else if(allRoleGrants.size() > 1 && !currentOrgRoleGrants.isEmpty() && allRoleGrants.equals(currentOrgRoleGrants)) {
+         permission.setRoleGrants(action, newPermission.getAllRoleGrants(action));
+         newPermission.setRoleGrants(action, allRoleGrants);
          return true;
       }
 
@@ -1715,6 +1725,11 @@ public class DataSourceRegistry implements MessageListener {
          newPermission.setGroupGrants(action, currentOrgGroupGrants);
          return true;
       }
+      else if(allGroupGrants.size() > 1 && !currentOrgGroupGrants.isEmpty() && allGroupGrants.equals(currentOrgGroupGrants)) {
+         permission.setGroupGrants(action, newPermission.getAllGroupGrants(action));
+         newPermission.setGroupGrants(action, allGroupGrants);
+         return true;
+      }
 
       return false;
    }
@@ -1731,6 +1746,11 @@ public class DataSourceRegistry implements MessageListener {
       }
       else if(allOrganizationGrants.size() > 0 && currentOrgOrganizationGrants.isEmpty()) {
          newPermission.setOrganizationGrants(action, currentOrgOrganizationGrants);
+         return true;
+      }
+      else if(allOrganizationGrants.size() > 1 && !currentOrgOrganizationGrants.isEmpty() && allOrganizationGrants.equals(currentOrgOrganizationGrants)) {
+         permission.setOrganizationGrants(action, newPermission.getAllOrganizationGrants(action));
+         newPermission.setOrganizationGrants(action, allOrganizationGrants);
          return true;
       }
 

--- a/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
@@ -41,7 +41,6 @@ import java.beans.PropertyChangeListener;
 import java.io.Serializable;
 import java.lang.SecurityException;
 import java.lang.reflect.Method;
-import java.security.Principal;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
@@ -1670,11 +1669,20 @@ public class DataSourceRegistry implements MessageListener {
 
    private boolean moveOrgUserGrants(Permission permission, Permission newPermission, ResourceAction action, String orgID) {
       Set<Permission.PermissionIdentity> allUserGrants = permission.getAllUserGrants(action);
+      Set<Permission.PermissionIdentity> newAllUserGrants = newPermission.getAllUserGrants(action);
       Set<Permission.PermissionIdentity> currentOrgUserGrants = permission.getUserGrants(action, orgID);
 
       if(allUserGrants != null && currentOrgUserGrants != null && allUserGrants.size() > 0 && !currentOrgUserGrants.isEmpty()) {
          allUserGrants.removeAll(currentOrgUserGrants);
-         newPermission.setUserGrants(action, currentOrgUserGrants);
+
+         if(newAllUserGrants != null && !newAllUserGrants.isEmpty()) {
+            newAllUserGrants.addAll(currentOrgUserGrants);
+            newPermission.setUserGrants(action, newAllUserGrants);
+         }
+         else {
+            newPermission.setUserGrants(action, currentOrgUserGrants);
+         }
+
          permission.setUserGrants(action, allUserGrants);
          return !allUserGrants.isEmpty();
       }
@@ -1687,11 +1695,20 @@ public class DataSourceRegistry implements MessageListener {
 
    private boolean moveOrgRoleGrants(Permission permission, Permission newPermission, ResourceAction action, String orgID) {
       Set<Permission.PermissionIdentity> allRoleGrants = permission.getAllRoleGrants(action);
+      Set<Permission.PermissionIdentity> newAllRoleGrants = newPermission.getAllRoleGrants(action);
       Set<Permission.PermissionIdentity> currentOrgRoleGrants = permission.getRoleGrants(action, orgID);
 
       if(allRoleGrants != null && currentOrgRoleGrants != null && allRoleGrants.size() > 0 && !currentOrgRoleGrants.isEmpty()) {
          allRoleGrants.removeAll(currentOrgRoleGrants);
-         newPermission.setRoleGrants(action, currentOrgRoleGrants);
+
+         if(newAllRoleGrants != null && !newAllRoleGrants.isEmpty()) {
+            newAllRoleGrants.addAll(currentOrgRoleGrants);
+            newPermission.setRoleGrants(action, newAllRoleGrants);
+         }
+         else {
+            newPermission.setRoleGrants(action, currentOrgRoleGrants);
+         }
+
          permission.setRoleGrants(action, allRoleGrants);
          return !allRoleGrants.isEmpty();
       }
@@ -1704,11 +1721,20 @@ public class DataSourceRegistry implements MessageListener {
 
    private boolean moveOrgGroupGrants(Permission permission, Permission newPermission, ResourceAction action, String orgID) {
       Set<Permission.PermissionIdentity> allGroupGrants = permission.getAllGroupGrants(action);
+      Set<Permission.PermissionIdentity> newAllGroupGrants = newPermission.getAllGroupGrants(action);
       Set<Permission.PermissionIdentity> currentOrgGroupGrants = permission.getGroupGrants(action, orgID);
 
       if(allGroupGrants != null && currentOrgGroupGrants != null && allGroupGrants.size() > 0 && !currentOrgGroupGrants.isEmpty()) {
          allGroupGrants.removeAll(currentOrgGroupGrants);
-         newPermission.setGroupGrants(action, currentOrgGroupGrants);
+
+         if(newAllGroupGrants != null && !newAllGroupGrants.isEmpty()) {
+            newAllGroupGrants.addAll(currentOrgGroupGrants);
+            newPermission.setGroupGrants(action, newAllGroupGrants);
+         }
+         else {
+            newPermission.setGroupGrants(action, currentOrgGroupGrants);
+         }
+
          permission.setGroupGrants(action, allGroupGrants);
          return !allGroupGrants.isEmpty();
       }
@@ -1721,11 +1747,20 @@ public class DataSourceRegistry implements MessageListener {
 
    private boolean moveOrgOrganzaitionGrants(Permission permission, Permission newPermission, ResourceAction action, String orgID) {
       Set<Permission.PermissionIdentity> allOrganizationGrants = permission.getAllOrganizationGrants(action);
+      Set<Permission.PermissionIdentity> newAllOrganizationGrants = newPermission.getAllOrganizationGrants(action);
       Set<Permission.PermissionIdentity> currentOrgOrganizationGrants = permission.getOrganizationGrants(action, orgID);
 
       if(allOrganizationGrants != null && currentOrgOrganizationGrants != null && allOrganizationGrants.size() > 0 && !currentOrgOrganizationGrants.isEmpty()) {
          allOrganizationGrants.removeAll(currentOrgOrganizationGrants);
-         newPermission.setOrganizationGrants(action, currentOrgOrganizationGrants);
+
+         if(newAllOrganizationGrants != null && !newAllOrganizationGrants.isEmpty()) {
+            newAllOrganizationGrants.addAll(currentOrgOrganizationGrants);
+            newPermission.setOrganizationGrants(action, newAllOrganizationGrants);
+         }
+         else {
+            newPermission.setOrganizationGrants(action, currentOrgOrganizationGrants);
+         }
+
          permission.setOrganizationGrants(action, allOrganizationGrants);
          return !allOrganizationGrants.isEmpty();
       }

--- a/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
@@ -1660,7 +1660,7 @@ public class DataSourceRegistry implements MessageListener {
          }
          else {
             engine.removePermission(type, oldResource);
-            engine.setPermission(type, newResource, permission);
+            engine.setPermission(type, newResource, newPermission);
          }
       }
    }
@@ -1673,15 +1673,9 @@ public class DataSourceRegistry implements MessageListener {
          allUserGrants.removeAll(currentOrgUserGrants);
          newPermission.setUserGrants(action, currentOrgUserGrants);
          permission.setUserGrants(action, allUserGrants);
-         return true;
+         return !allUserGrants.isEmpty();
       }
       else if(allUserGrants.size() > 0 && currentOrgUserGrants.isEmpty()) {
-         newPermission.setUserGrants(action, currentOrgUserGrants);
-         return true;
-      }
-      else if(allUserGrants.size() > 1 && !currentOrgUserGrants.isEmpty() && allUserGrants.equals(currentOrgUserGrants)) {
-         permission.setUserGrants(action, newPermission.getAllUserGrants(action));
-         newPermission.setUserGrants(action, allUserGrants);
          return true;
       }
 
@@ -1696,15 +1690,9 @@ public class DataSourceRegistry implements MessageListener {
          allRoleGrants.removeAll(currentOrgRoleGrants);
          newPermission.setRoleGrants(action, currentOrgRoleGrants);
          permission.setRoleGrants(action, allRoleGrants);
-         return true;
+         return !allRoleGrants.isEmpty();
       }
       else if(allRoleGrants.size() > 0 && currentOrgRoleGrants.isEmpty()) {
-         newPermission.setRoleGrants(action, currentOrgRoleGrants);
-         return true;
-      }
-      else if(allRoleGrants.size() > 1 && !currentOrgRoleGrants.isEmpty() && allRoleGrants.equals(currentOrgRoleGrants)) {
-         permission.setRoleGrants(action, newPermission.getAllRoleGrants(action));
-         newPermission.setRoleGrants(action, allRoleGrants);
          return true;
       }
 
@@ -1719,15 +1707,9 @@ public class DataSourceRegistry implements MessageListener {
          allGroupGrants.removeAll(currentOrgGroupGrants);
          newPermission.setGroupGrants(action, currentOrgGroupGrants);
          permission.setGroupGrants(action, allGroupGrants);
-         return true;
+         return !allGroupGrants.isEmpty();
       }
       else if(allGroupGrants.size() > 0 && currentOrgGroupGrants.isEmpty()) {
-         newPermission.setGroupGrants(action, currentOrgGroupGrants);
-         return true;
-      }
-      else if(allGroupGrants.size() > 1 && !currentOrgGroupGrants.isEmpty() && allGroupGrants.equals(currentOrgGroupGrants)) {
-         permission.setGroupGrants(action, newPermission.getAllGroupGrants(action));
-         newPermission.setGroupGrants(action, allGroupGrants);
          return true;
       }
 
@@ -1742,15 +1724,9 @@ public class DataSourceRegistry implements MessageListener {
          allOrganizationGrants.removeAll(currentOrgOrganizationGrants);
          newPermission.setOrganizationGrants(action, currentOrgOrganizationGrants);
          permission.setOrganizationGrants(action, allOrganizationGrants);
-         return true;
+         return !allOrganizationGrants.isEmpty();
       }
       else if(allOrganizationGrants.size() > 0 && currentOrgOrganizationGrants.isEmpty()) {
-         newPermission.setOrganizationGrants(action, currentOrgOrganizationGrants);
-         return true;
-      }
-      else if(allOrganizationGrants.size() > 1 && !currentOrgOrganizationGrants.isEmpty() && allOrganizationGrants.equals(currentOrgOrganizationGrants)) {
-         permission.setOrganizationGrants(action, newPermission.getAllOrganizationGrants(action));
-         newPermission.setOrganizationGrants(action, allOrganizationGrants);
          return true;
       }
 
@@ -1763,7 +1739,7 @@ public class DataSourceRegistry implements MessageListener {
       if(orgUpdatedList.size() > 1 && permission.hasOrgEditedGrantAll(orgID)) {
          permission.removeGrantAllByOrg(orgID);
          newPermission.updateGrantAllByOrg(orgID, true);
-         return true;
+         return !orgUpdatedList.isEmpty();
       }
       else if(orgUpdatedList.size() > 0 && !permission.hasOrgEditedGrantAll(orgID)) {
          return true;

--- a/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
@@ -1640,17 +1640,16 @@ public class DataSourceRegistry implements MessageListener {
 
       Permission permission = engine.getPermission(type, oldResource);
       Permission newPermission = new Permission();
-      Principal principal = ThreadContext.getContextPrincipal();
-      IdentityID user = IdentityID.getIdentityIDFromKey(principal.getName());
+      String org = OrganizationManager.getInstance().getCurrentOrgID();
       boolean isRemovePermission = false;
 
       if(permission != null) {
          for(ResourceAction action : ResourceAction.values()) {
-            isRemovePermission |= moveOrgUserGrants(permission, newPermission, action, user.getOrgID());
-            isRemovePermission |= moveOrgRoleGrants(permission, newPermission, action, user.getOrgID());
-            isRemovePermission |= moveOrgGroupGrants(permission, newPermission, action, user.getOrgID());
-            isRemovePermission |= moveOrgOrganzaitionGrants(permission, newPermission, action, user.getOrgID());
-            isRemovePermission |= moveOrgOrgUpdatedList(permission, newPermission, user.getOrgID());
+            isRemovePermission |= moveOrgUserGrants(permission, newPermission, action, org);
+            isRemovePermission |= moveOrgRoleGrants(permission, newPermission, action, org);
+            isRemovePermission |= moveOrgGroupGrants(permission, newPermission, action, org);
+            isRemovePermission |= moveOrgOrganzaitionGrants(permission, newPermission, action, org);
+            isRemovePermission |= moveOrgOrgUpdatedList(permission, newPermission, org);
          }
       }
 
@@ -1676,7 +1675,7 @@ public class DataSourceRegistry implements MessageListener {
          permission.setUserGrants(action, allUserGrants);
          return true;
       }
-      else if(allUserGrants.size() == 1 && currentOrgUserGrants.isEmpty()) {
+      else if(allUserGrants.size() > 0 && currentOrgUserGrants.isEmpty()) {
          newPermission.setUserGrants(action, currentOrgUserGrants);
          return true;
       }
@@ -1694,7 +1693,7 @@ public class DataSourceRegistry implements MessageListener {
          permission.setRoleGrants(action, allRoleGrants);
          return true;
       }
-      else if(allRoleGrants.size() == 1 && currentOrgRoleGrants.isEmpty()) {
+      else if(allRoleGrants.size() > 0 && currentOrgRoleGrants.isEmpty()) {
          newPermission.setRoleGrants(action, currentOrgRoleGrants);
          return true;
       }
@@ -1712,7 +1711,7 @@ public class DataSourceRegistry implements MessageListener {
          permission.setGroupGrants(action, allGroupGrants);
          return true;
       }
-      else if(allGroupGrants.size() == 1 && currentOrgGroupGrants.isEmpty()) {
+      else if(allGroupGrants.size() > 0 && currentOrgGroupGrants.isEmpty()) {
          newPermission.setGroupGrants(action, currentOrgGroupGrants);
          return true;
       }
@@ -1730,7 +1729,7 @@ public class DataSourceRegistry implements MessageListener {
          permission.setOrganizationGrants(action, allOrganizationGrants);
          return true;
       }
-      else if(allOrganizationGrants.size() == 1 && currentOrgOrganizationGrants.isEmpty()) {
+      else if(allOrganizationGrants.size() > 0 && currentOrgOrganizationGrants.isEmpty()) {
          newPermission.setOrganizationGrants(action, currentOrgOrganizationGrants);
          return true;
       }
@@ -1746,7 +1745,7 @@ public class DataSourceRegistry implements MessageListener {
          newPermission.updateGrantAllByOrg(orgID, true);
          return true;
       }
-      else if(orgUpdatedList.size() == 1 && !permission.hasOrgEditedGrantAll(orgID)) {
+      else if(orgUpdatedList.size() > 0 && !permission.hasOrgEditedGrantAll(orgID)) {
          return true;
       }
 

--- a/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
@@ -1669,7 +1669,7 @@ public class DataSourceRegistry implements MessageListener {
       Set<Permission.PermissionIdentity> allUserGrants = permission.getAllUserGrants(action);
       Set<Permission.PermissionIdentity> currentOrgUserGrants = permission.getUserGrants(action, orgID);
 
-      if(allUserGrants != null && currentOrgUserGrants != null && allUserGrants.size() > 1 && !currentOrgUserGrants.isEmpty()) {
+      if(allUserGrants != null && currentOrgUserGrants != null && allUserGrants.size() > 0 && !currentOrgUserGrants.isEmpty()) {
          allUserGrants.removeAll(currentOrgUserGrants);
          newPermission.setUserGrants(action, currentOrgUserGrants);
          permission.setUserGrants(action, allUserGrants);
@@ -1686,7 +1686,7 @@ public class DataSourceRegistry implements MessageListener {
       Set<Permission.PermissionIdentity> allRoleGrants = permission.getAllRoleGrants(action);
       Set<Permission.PermissionIdentity> currentOrgRoleGrants = permission.getRoleGrants(action, orgID);
 
-      if(allRoleGrants != null && currentOrgRoleGrants != null && allRoleGrants.size() > 1 && !currentOrgRoleGrants.isEmpty()) {
+      if(allRoleGrants != null && currentOrgRoleGrants != null && allRoleGrants.size() > 0 && !currentOrgRoleGrants.isEmpty()) {
          allRoleGrants.removeAll(currentOrgRoleGrants);
          newPermission.setRoleGrants(action, currentOrgRoleGrants);
          permission.setRoleGrants(action, allRoleGrants);
@@ -1703,7 +1703,7 @@ public class DataSourceRegistry implements MessageListener {
       Set<Permission.PermissionIdentity> allGroupGrants = permission.getAllGroupGrants(action);
       Set<Permission.PermissionIdentity> currentOrgGroupGrants = permission.getGroupGrants(action, orgID);
 
-      if(allGroupGrants != null && currentOrgGroupGrants != null && allGroupGrants.size() > 1 && !currentOrgGroupGrants.isEmpty()) {
+      if(allGroupGrants != null && currentOrgGroupGrants != null && allGroupGrants.size() > 0 && !currentOrgGroupGrants.isEmpty()) {
          allGroupGrants.removeAll(currentOrgGroupGrants);
          newPermission.setGroupGrants(action, currentOrgGroupGrants);
          permission.setGroupGrants(action, allGroupGrants);
@@ -1720,7 +1720,7 @@ public class DataSourceRegistry implements MessageListener {
       Set<Permission.PermissionIdentity> allOrganizationGrants = permission.getAllOrganizationGrants(action);
       Set<Permission.PermissionIdentity> currentOrgOrganizationGrants = permission.getOrganizationGrants(action, orgID);
 
-      if(allOrganizationGrants != null && currentOrgOrganizationGrants != null && allOrganizationGrants.size() > 1 && !currentOrgOrganizationGrants.isEmpty()) {
+      if(allOrganizationGrants != null && currentOrgOrganizationGrants != null && allOrganizationGrants.size() > 0 && !currentOrgOrganizationGrants.isEmpty()) {
          allOrganizationGrants.removeAll(currentOrgOrganizationGrants);
          newPermission.setOrganizationGrants(action, currentOrgOrganizationGrants);
          permission.setOrganizationGrants(action, allOrganizationGrants);
@@ -1736,7 +1736,7 @@ public class DataSourceRegistry implements MessageListener {
    private boolean moveOrgOrgUpdatedList(Permission permission, Permission newPermission, String orgID) {
       Map<String, Boolean> orgUpdatedList = permission.getOrgEditedGrantAll();
 
-      if(orgUpdatedList.size() > 1 && permission.hasOrgEditedGrantAll(orgID)) {
+      if(orgUpdatedList.size() > 0 && permission.hasOrgEditedGrantAll(orgID)) {
          permission.removeGrantAllByOrg(orgID);
          newPermission.updateGrantAllByOrg(orgID, true);
          return !orgUpdatedList.isEmpty();

--- a/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
@@ -1639,7 +1639,7 @@ public class DataSourceRegistry implements MessageListener {
       }
 
       Permission permission = engine.getPermission(type, oldResource);
-      Permission newPermission = new Permission();
+      Permission newPermission = engine.getPermission(type, newResource);
       String org = OrganizationManager.getInstance().getCurrentOrgID();
       boolean isRemovePermission = false;
 
@@ -1653,7 +1653,7 @@ public class DataSourceRegistry implements MessageListener {
          }
       }
 
-      if(newPermission.hasChanges()) {
+      if(newPermission != null) {
          if(isRemovePermission) {
             engine.setPermission(type, newResource, newPermission);
             engine.setPermission(type, oldResource, permission);

--- a/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
@@ -1666,7 +1666,6 @@ public class DataSourceRegistry implements MessageListener {
       }
    }
 
-
    private boolean moveOrgUserGrants(Permission permission, Permission newPermission, ResourceAction action, String orgID) {
       Set<Permission.PermissionIdentity> allUserGrants = permission.getAllUserGrants(action);
       Set<Permission.PermissionIdentity> currentOrgUserGrants = permission.getUserGrants(action, orgID);
@@ -1753,7 +1752,6 @@ public class DataSourceRegistry implements MessageListener {
 
       return false;
    }
-
 
    /**
     * Helper method for getting the entries of all assets stored in the registry

--- a/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
@@ -1653,7 +1653,7 @@ public class DataSourceRegistry implements MessageListener {
          }
       }
 
-      if(permission != null) {
+      if(newPermission.hasChanges()) {
          if(isRemovePermission) {
             engine.setPermission(type, newResource, newPermission);
             engine.setPermission(type, oldResource, permission);

--- a/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
@@ -1641,9 +1641,14 @@ public class DataSourceRegistry implements MessageListener {
       Permission permission = engine.getPermission(type, oldResource);
       Permission newPermission = engine.getPermission(type, newResource);
       String org = OrganizationManager.getInstance().getCurrentOrgID();
-      boolean isRemovePermission = false;
 
       if(permission != null) {
+         boolean isRemovePermission = false;
+
+         if(newPermission == null) {
+            newPermission = new Permission();
+         }
+
          for(ResourceAction action : ResourceAction.values()) {
             isRemovePermission |= moveOrgUserGrants(permission, newPermission, action, org);
             isRemovePermission |= moveOrgRoleGrants(permission, newPermission, action, org);
@@ -1651,9 +1656,7 @@ public class DataSourceRegistry implements MessageListener {
             isRemovePermission |= moveOrgOrganzaitionGrants(permission, newPermission, action, org);
             isRemovePermission |= moveOrgOrgUpdatedList(permission, newPermission, org);
          }
-      }
 
-      if(newPermission != null) {
          if(isRemovePermission) {
             engine.setPermission(type, newResource, newPermission);
             engine.setPermission(type, oldResource, permission);


### PR DESCRIPTION
The bug occurred because, when renaming a folder in the cloned organization, the permission key was directly modified. For example, if the current key is DataSourceFolder:f1, the corresponding value (the permission object) contains permissions not only for the original organization but also for the cloned organization. When renaming a folder under the cloned organization, the original key should not be deleted. Instead, only the permissions related to the cloned organization within the original key’s value should be removed. After that, a new key should be created and the corresponding permissions stored under it. This will properly resolve the issue.