### PR TITLE
Merge forward changes for Bug #69919

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/VSBookmark.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/VSBookmark.java
@@ -227,12 +227,14 @@ public class VSBookmark implements XMLSerializable {
          writer.close();
          bmap.put(name, out.toByteArray());
          long ctime = System.currentTimeMillis();
+         VSBookmarkInfo info = bookmarksInfo.get(name);
 
-         if(bookmarksInfo.get(name) == null) {
+         if(info == null) {
             bookmarksInfo.put(name, new VSBookmarkInfo(name, type, user, readOnly, ctime, ctime, ctime));
          }
          else {
-            bookmarksInfo.put(name, new VSBookmarkInfo(name, type, user, readOnly, ctime));
+            bookmarksInfo.put(name, new VSBookmarkInfo(name, type, user, readOnly, ctime,
+                                                       info.getLastAccessed(), info.getCreateTime()));
          }
       }
       catch(Exception ex) {

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/VSBookmarkController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/VSBookmarkController.java
@@ -216,7 +216,6 @@ public class VSBookmarkController {
       }
 
       if("add".equals(action)) {
-         rvs.removeBookmark(name, ownerId, false);
          //add the bookmark
          bookmarkService.addBookmark(rvs, name, type, readOnly,
                                      !"add".equals(originalAction) || value.confirmed(), owner,

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
@@ -119,8 +119,8 @@ public class VSBookmarkService {
                                      !Tool.equals(rvs.getEntry() == null ? "" :
                                      rvs.getEntry().getOrgID(),((XPrincipal)principal).getOrgId());
 
-      if(!engine.checkPermission(principal, ResourceType.VIEWSHEET_TOOLBAR_ACTION,
-         "AddBookmark", ResourceAction.READ))
+      if(!engine.checkPermission(principal, ResourceType.VIEWSHEET_ACTION, "Bookmark",
+                                 ResourceAction.READ))
       {
          messageCommand.setMessage(catalog.getString("viewer.viewsheet.security.addbookmark"));
          messageCommand.setType(MessageCommand.Type.WARNING);


### PR DESCRIPTION
Don't remove a bookmark first before saving the current bookmark. This prevents the bookmark from going missing if there is a problem with adding the bookmark later. Check for the appropriate bookmark permission that can actually be set in the EM.