### PR TITLE
Merge forward Bug #70746 - Update the last modified time of the logical model

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/LocalDependencyHandler.java
+++ b/core/src/main/java/inetsoft/uql/asset/LocalDependencyHandler.java
@@ -278,7 +278,7 @@ public class LocalDependencyHandler implements DependencyHandler {
 
       if(logical != null) {
          updateAttributesDependency(logical, columns, entry, add, cache);
-         xdm.addLogicalModel(logical, false);
+         xdm.addLogicalModel(logical, true);
          xrep.updateDataModel(xdm.clone());
       }
    }
@@ -1127,7 +1127,7 @@ public class LocalDependencyHandler implements DependencyHandler {
                 logicalModel.addLogicalModel(logical, false);
             }
             else {
-               xdm.addLogicalModel(logical, false);
+               xdm.addLogicalModel(logical, true);
             }
 
             xrep.updateDataModel(xdm.clone());


### PR DESCRIPTION
Update the last modified time of the logical model when the dependencies are updated. This ensures that the resulting blob digest also changes. Without this, there’s a risk that a previously seen digest could reappear, leading to a race condition where the blob is being removed and added at the same time.