### PR TITLE
fix Bug #70111:

### DIFF
--- a/web/projects/portal/src/app/portal/report/tree/repository-tree-view.component.ts
+++ b/web/projects/portal/src/app/portal/report/tree/repository-tree-view.component.ts
@@ -17,7 +17,7 @@
  */
 import { HttpClient, HttpParams } from "@angular/common/http";
 import {
-   AfterViewInit,
+   AfterViewInit, ChangeDetectorRef,
    Component,
    EventEmitter,
    Input,
@@ -98,7 +98,8 @@ export class RepositoryTreeViewComponent implements OnInit, AfterViewInit, OnDes
    private currOrgID: string = null;
 
    constructor(private http: HttpClient, private modal: NgbModal,
-               private pageTabService: PageTabService)
+               private pageTabService: PageTabService,
+               private changeDetectorRef: ChangeDetectorRef)
    {
       this.http.get<string>("../api/em/navbar/organization").subscribe((org)=>{
          this.currOrgID = org;
@@ -205,6 +206,7 @@ export class RepositoryTreeViewComponent implements OnInit, AfterViewInit, OnDes
             (node) => {
                this.searchRootNode = node;
                this.searchMode = true;
+               this.changeDetectorRef.detectChanges();
             },
             (error) => ComponentTool.showHttpError("Failed to search assets", error, this.modal)
          );


### PR DESCRIPTION
the bug is caused by when seach to server, it will get new root nodes of search result, its all nodes is right for client, but client tree will not refresh to new nodes. If you click some action, it will refresh and get right nodes. In fact, we should refresh tree when search is finished.