### PR TITLE
fix Bug #70834

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
@@ -332,7 +332,7 @@ export class VSChart extends AbstractVSObject<VSChartModel>
                   this.dropdownService, []);
                break;
             default:
-               propertiesHandler.handleEvent(event, this.variableValues(this.getAssemblyName()), null);
+               propertiesHandler.handleEvent(event, this.variableValues(this.getAssemblyName()), (<any> this.vsInfo).id);
             }
          });
          this.clickAction = value.clickAction;


### PR DESCRIPTION
Pass the asset ID to avoid a npe when initializing palettes in `b-categorical-color-pane`.