### PR TITLE
fix Bug #70099:

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/sync/ViewsheetBookmarkChangedEvent.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/ViewsheetBookmarkChangedEvent.java
@@ -17,7 +17,9 @@
  */
 package inetsoft.uql.asset.sync;
 
+import at.favre.lib.bytes.BytesValidator;
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.IdentityID;
 import inetsoft.uql.asset.AssetChangedEvent;
 import inetsoft.uql.asset.AssetEntry;
 
@@ -28,9 +30,21 @@ public class ViewsheetBookmarkChangedEvent extends AssetChangedEvent {
 
    public ViewsheetBookmarkChangedEvent(RuntimeViewsheet rvs, boolean deleted, String bookmark) {
       super(rvs.getEntry());
+
       rvsID = rvs.getID();
       this.deleted = deleted;
       this.bookmark = bookmark;
+   }
+
+   public ViewsheetBookmarkChangedEvent(RuntimeViewsheet rvs, String oname, String nname,
+                                        IdentityID owner) {
+      super(rvs.getEntry());
+
+      rvsID = rvs.getID();
+      this.deleted = false;
+      this.oldBookmark = oname;
+      this.bookmark = nname;
+      this.owner = owner;
    }
 
    public String getID() {
@@ -41,6 +55,14 @@ public class ViewsheetBookmarkChangedEvent extends AssetChangedEvent {
       return bookmark;
    }
 
+   public String getOldBookmark() {
+      return oldBookmark;
+   }
+
+   public IdentityID getOwner() {
+      return owner;
+   }
+
    public boolean isDeleted() {
       return deleted;
    }
@@ -48,4 +70,6 @@ public class ViewsheetBookmarkChangedEvent extends AssetChangedEvent {
    public String rvsID;
    public boolean deleted = false;
    public String bookmark = "";
+   public String oldBookmark = null;
+   public IdentityID owner = null;
 }

--- a/core/src/main/java/inetsoft/web/composer/RuntimeSheetTransformController.java
+++ b/core/src/main/java/inetsoft/web/composer/RuntimeSheetTransformController.java
@@ -84,7 +84,7 @@ public class RuntimeSheetTransformController implements MessageListener {
             String oname = ((ViewsheetBookmarkChangedEvent) event.getMessage()).getOldBookmark();
             String nname = ((ViewsheetBookmarkChangedEvent) event.getMessage()).getBookmark();
             IdentityID owner = ((ViewsheetBookmarkChangedEvent) event.getMessage()).getOwner();
-            handleRameBookmark(asset, id, oname, nname, owner);
+            handleRenameBookmark(asset, id, oname, nname, owner);
          }
       }
       else if(event.getMessage() instanceof RenameTransformFinishedEvent) {
@@ -196,7 +196,7 @@ public class RuntimeSheetTransformController implements MessageListener {
          });
    }
 
-   private void handleRameBookmark(AssetEntry entry, String id, String oname, String nname,
+   private void handleRenameBookmark(AssetEntry entry, String id, String oname, String nname,
                                           IdentityID owner) {
       RuntimeViewsheet[] sheets = null;
 

--- a/core/src/main/java/inetsoft/web/composer/RuntimeSheetTransformController.java
+++ b/core/src/main/java/inetsoft/web/composer/RuntimeSheetTransformController.java
@@ -84,7 +84,7 @@ public class RuntimeSheetTransformController implements MessageListener {
             String oname = ((ViewsheetBookmarkChangedEvent) event.getMessage()).getOldBookmark();
             String nname = ((ViewsheetBookmarkChangedEvent) event.getMessage()).getBookmark();
             IdentityID owner = ((ViewsheetBookmarkChangedEvent) event.getMessage()).getOwner();
-            handleMessageForBookmarks(asset, id, oname, nname, owner);
+            handleRameBookmark(asset, id, oname, nname, owner);
          }
       }
       else if(event.getMessage() instanceof RenameTransformFinishedEvent) {
@@ -196,7 +196,7 @@ public class RuntimeSheetTransformController implements MessageListener {
          });
    }
 
-   private void handleMessageForBookmarks(AssetEntry entry, String id, String oname, String nname,
+   private void handleRameBookmark(AssetEntry entry, String id, String oname, String nname,
                                           IdentityID owner) {
       RuntimeViewsheet[] sheets = null;
 
@@ -221,36 +221,6 @@ public class RuntimeSheetTransformController implements MessageListener {
             }
          }
       }
-   }
-
-   private void handleRameBookmark(AssetEntry entry, String id, String bookmark, boolean reload) {
-      RuntimeViewsheet[] sheets = null;
-
-      if(viewsheetService instanceof ViewsheetEngine) {
-         ViewsheetEngine engine = (ViewsheetEngine) viewsheetService;
-
-         if(entry.isViewsheet()) {
-            sheets = engine.getAllRuntimeViewsheets();
-         }
-      }
-
-      if(sheets == null || sheets.length == 0) {
-         return;
-      }
-
-      Arrays.stream(sheets)
-         .filter(sheet -> Tool.equals(entry, sheet.getEntry()) && !Tool.equals(sheet.getID(), id))
-         .filter(sheet -> sheet.getOpenedBookmark() != null &&
-            Tool.equals(sheet.getOpenedBookmark().getName(), bookmark))
-         .forEach(sheet -> {
-            RenameEventModel model = RenameEventModel.builder()
-               .id(sheet.getID())
-               .bookmark(bookmark)
-               .reload(reload)
-               .entry(entry)
-               .build();
-            messagingTemplate.convertAndSendToUser(destination, "/dependency-changed", model);
-         });
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/VSBookmarkController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/VSBookmarkController.java
@@ -460,7 +460,7 @@ public class VSBookmarkController {
       AuditRecordUtils.executeEditBookmarkRecord(rvs, origBookmarkInfo, name, owner);
 
       if(!Tool.equals(name, oldName)) {
-         Cluster.getInstance().sendMessage(new ViewsheetBookmarkChangedEvent(rvs.getEntry()));
+         Cluster.getInstance().sendMessage(new ViewsheetBookmarkChangedEvent(rvs, oldName, name, owner));
       }
    }
 


### PR DESCRIPTION
the bug is caused by different browse open the same bookmark of the same vs, one user to rename the bookmark, the other browse refresh to new bookmarks but do not select new bookmark.

1  when rename bookmark, add bookmark old name, nname, owner to the event.

2  when browse get bookmark rename event, if opened bookmark is renamed bookmark, should update to new bookmark name.

coding review for it