### PR TITLE
Bug #70705 - fix chart loading icon that doesn't want to go away

### DIFF
--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
@@ -469,6 +469,10 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
    }
 
    public updateChartObject(): void {
+      if(this.chartObject && (!this.chartObject.tiles || this.chartObject.tiles.length == 0)) {
+         this.fireOnLoad();
+      }
+
       const context = this.getContext();
 
       if(context) {


### PR DESCRIPTION
If there are no tiles to load then mark the plot area as loaded