### PR TITLE
Fix Bug #70823：

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/EventAspect.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/EventAspect.java
@@ -398,7 +398,7 @@ public class EventAspect {
             continue;
          }
 
-         int delimiterIndex = objName.indexOf("~;~");
+         int delimiterIndex = objName.indexOf(IdentityID.KEY_DELIMITER);
 
          if(delimiterIndex != -1) {
             objName = objName.substring(0, delimiterIndex);

--- a/core/src/main/java/inetsoft/web/viewsheet/EventAspect.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/EventAspect.java
@@ -398,6 +398,12 @@ public class EventAspect {
             continue;
          }
 
+         int delimiterIndex = objName.indexOf("~;~");
+
+         if(delimiterIndex != -1) {
+            objName = objName.substring(0, delimiterIndex);
+         }
+
          nameBuilder.append(objName);
 
          if(i < objectParameters.size() - 1) {


### PR DESCRIPTION
When adding an audit entry, check if the objectName contains an organization name. If it does, remove the organization part.