### PR TITLE
fix Bug #70788:

### DIFF
--- a/core/src/main/java/inetsoft/util/migrate/MigrateDocumentTask.java
+++ b/core/src/main/java/inetsoft/util/migrate/MigrateDocumentTask.java
@@ -83,6 +83,13 @@ public abstract class MigrateDocumentTask implements MigrateTask {
             processAssemblies(document.getDocumentElement());
             AssetEntry newEntry = entry.cloneAssetEntry((Organization) getNewOrganization());
             String newKey = newEntry.toIdentifier(true);
+
+            if(document.getChildNodes().getLength() == 2 &&
+               document.getFirstChild().getNodeValue().indexOf(oldKey) > 0)
+            {
+               document.removeChild(document.getFirstChild());
+            }
+
             setDocument(((Organization) getNewOrganization()).getId(), newKey, document);
          }
       }


### PR DESCRIPTION
when copy organzation we will migate sheets and its document children is right, but inetsoft-asset node is create by cloned org, if clone from host to org0, the inetsoft-asset will be host, we should remove it and it will create new node for it in BlobIndexStorage.putDocument