### PR TITLE
fix Bug #70825, use SecurityEngine insteadof SecurityProvider to chec…

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/data/DatasourcesService.java
+++ b/core/src/main/java/inetsoft/web/portal/data/DatasourcesService.java
@@ -17,7 +17,7 @@
  */
 package inetsoft.web.portal.data;
 
-import inetsoft.sree.security.SecurityProvider;
+import inetsoft.sree.security.SecurityEngine;
 import inetsoft.uql.XDataSource;
 import inetsoft.uql.XRepository;
 import inetsoft.uql.tabular.TabularUtil;
@@ -32,10 +32,10 @@ import org.springframework.stereotype.Service;
 public class DatasourcesService extends DatasourcesBaseService {
    @Autowired
    public DatasourcesService(XRepository repository,
-                             SecurityProvider securityProvider,
+                             SecurityEngine SecurityEngine,
                              DataSourceStatusService dataSourceStatusService)
    {
-      super(repository, securityProvider, dataSourceStatusService);
+      super(repository, SecurityEngine, dataSourceStatusService);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/portal/service/datasource/XmlaDatasourceService.java
+++ b/core/src/main/java/inetsoft/web/portal/service/datasource/XmlaDatasourceService.java
@@ -21,7 +21,7 @@ import inetsoft.report.TableLens;
 import inetsoft.report.XSessionManager;
 import inetsoft.report.lens.DefaultTableLens;
 import inetsoft.report.lens.xnode.XNodeTableLens;
-import inetsoft.sree.security.SecurityProvider;
+import inetsoft.sree.security.SecurityEngine;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.ColumnRef;
 import inetsoft.uql.asset.DependencyHandler;
@@ -51,10 +51,10 @@ import java.util.stream.Collectors;
 
 @Service
 public class XmlaDatasourceService extends DatasourcesBaseService {
-   public XmlaDatasourceService(XRepository repository, SecurityProvider securityProvider,
+   public XmlaDatasourceService(XRepository repository, SecurityEngine securityEngine,
                                 DataSourceStatusService dataSourceStatusService)
    {
-      super(repository, securityProvider, dataSourceStatusService);
+      super(repository, securityEngine, dataSourceStatusService);
    }
 
    public DataSourceXmlaDefinition getNewDataSourceModel(String parentPath) throws Exception {


### PR DESCRIPTION
 use SecurityEngine insteadof SecurityProvider to check permission, to make sure parent permission be checked if there's no permission defined for current resource.