### PR TITLE
Bug #70864

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/BatchAction.java
+++ b/core/src/main/java/inetsoft/sree/schedule/BatchAction.java
@@ -310,7 +310,14 @@ public class BatchAction extends AbstractAction {
             DynamicParameterValue parameterValue = (DynamicParameterValue) val;
             writer.print("<dynamicParameterValue>");
             writer.print("<value>");
-            writer.print("<![CDATA[" + Tool.getDataString(parameterValue.getValue()) + "]]>");
+
+            if(parameterValue.getValue() != null && parameterValue.isArray() && parameterValue.getValue() instanceof Object[]) {
+               writer.print("<![CDATA[" + Tool.getDataString((Object[]) parameterValue.getValue()) + "]]>");
+            }
+            else {
+               writer.print("<![CDATA[" + Tool.getDataString(parameterValue.getValue()) + "]]>");
+            }
+
             writer.print("</value>");
             writer.print("<type>");
             writer.print("<![CDATA[" + parameterValue.getType() + "]]>");
@@ -318,6 +325,9 @@ public class BatchAction extends AbstractAction {
             writer.print("<valueType>");
             writer.print("<![CDATA[" + parameterValue.getDataType() + "]]>");
             writer.print("</valueType>");
+            writer.print("<array>");
+            writer.print("<![CDATA[" + parameterValue.isArray() + "]]>");
+            writer.print("</array>");
             writer.print("</dynamicParameterValue>");
          }
          else {
@@ -352,10 +362,14 @@ public class BatchAction extends AbstractAction {
             Element valNode = Tool.getChildNodeByTagName(dynamicParameterValue, "value");
             Element typeNode = Tool.getChildNodeByTagName(dynamicParameterValue, "type");
             Element dataTypeNode = Tool.getChildNodeByTagName(dynamicParameterValue, "valueType");
+            Element arrayNode = Tool.getChildNodeByTagName(dynamicParameterValue, "array");
             String value = Tool.getValue(valNode);
             String type = Tool.getValue(typeNode);
             String dataType = Tool.getValue(dataTypeNode);
-            map.put(key, new DynamicParameterValue(value, type, dataType));
+            String array = Tool.getValue(arrayNode);
+
+            Boolean isArray = "true".equals(array) ? true : false;
+            map.put(key, new DynamicParameterValue(value, type, dataType, isArray));
          }
          else {
             Element valNode = Tool.getChildNodeByTagName(propNode, "value");

--- a/core/src/main/java/inetsoft/util/CoreTool.java
+++ b/core/src/main/java/inetsoft/util/CoreTool.java
@@ -1283,12 +1283,26 @@ public class CoreTool {
       return getDataString(val, true, false);
    }
 
+   public static String getDataString(Object[] val) {
+      return getDataString(val, true, false);
+   }
+
    /**
     * Get a string representation of a value.
     * @param val the object to get a string representation of.
     */
    public static String getDataString(Object val, boolean keepBlank) {
       return getDataString(val, keepBlank, false);
+   }
+
+   public static String getDataString(Object[] val, boolean keepBlank, boolean strictNull) {
+      StringBuilder buffer = new StringBuilder();
+
+      for(int i = 0; i < val.length; i++) {
+         buffer.append(i != 0 ? "," : "").append(getDataString(val[i], true, strictNull));
+      }
+
+      return buffer.toString();
    }
 
    /**
@@ -1342,6 +1356,8 @@ public class CoreTool {
          return val.toString();
       }
    }
+
+
 
    /**
     * Get the string data.

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleConditionService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleConditionService.java
@@ -208,6 +208,24 @@ public class ScheduleConditionService {
          String paramName = (String) paramNames.nextElement();
          Object value = repRequest.getParameter(paramName);
          String type = getParameterType(repRequest, paramName, value);
+
+         if(!type.equals("array") && value instanceof DynamicParameterValue) {
+            boolean array = ((DynamicParameterValue) value).isArray();
+
+            if(array) {
+               AddParameterDialogModel paramModel = AddParameterDialogModel.builder()
+                  .name(paramName)
+                  .type(type)
+                  .array(array)
+                  .value(value instanceof DynamicValueModel ? (DynamicValueModel) value
+                            : new DynamicValueModel(((DynamicParameterValue) value).getValue(), DynamicValueModel.VALUE, type, array))
+                  .build();
+
+               paramModels.add(paramModel);
+               continue;
+            }
+         }
+
          value = decodeParameter(value, "array".equals(type));
          boolean array = "array".equals(type);
          Object[] vals = null;

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
@@ -1430,8 +1430,14 @@ public class ScheduleService {
                         Object value = parameter.value();
 
                         if(parameter.array()) {
-                           value = scheduleConditionService
+                           value = ((DynamicValueModel) value).convertParameterValue();
+                           Object val = scheduleConditionService
                               .getParamValueAsArray(parameter.type(), parameter.value().getValue().toString());
+
+                           if(value instanceof DynamicParameterValue) {
+                              ((DynamicParameterValue) value).setValue(val);
+                              ((DynamicParameterValue) value).setArray(true);
+                           }
                         }
                         else if(value instanceof DynamicValueModel) {
                            value = ((DynamicValueModel) value).convertParameterValue();


### PR DESCRIPTION
1.When array is enabled, the value obtained through getParamValueAsArray should be set to the value property of the DynamicParameterValue object.

2.Since the DynamicParameterValue class contains an array property, both writerXml and parseXml need to include this array attribute.

3.When array is enabled, the value property in the DynamicParameterValue object becomes an Object[]. According to the original logic in writerXml, if it's an array of Integer values like 1 and 2, it would be serialized as integer~1^integer~2. However, in the UI, the display should show the actual values (i.e., 1,2). Therefore, a dedicated getDataString method was added to handle Object[] parameters correctly.

4.When adding a model to AddParameterDialogModel, if the datatype is not array but the array property in DynamicParameterValue is true, it indicates that all parameters in the DynamicParameterValue object are already correctly set and can be directly added to AddParameterDialogModel without any additional handling.