### PR TITLE
fix Bug #70885, skip the physicalTablePermission check when creating …a query, since JDBC queries already handle that during the queryCreatable initialization.

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/data-datasource-browser.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/data-datasource-browser.component.ts
@@ -725,9 +725,7 @@ export class DataDatasourceBrowserComponent extends CommandProcessor implements 
     * Create Query.
     */
    createQuery(datasource: DataSourceInfo): void {
-      if(!datasource.queryCreatable || !this.physicalTablePermission ||
-         !datasource.childrenCreatable)
-      {
+      if(!datasource.queryCreatable || !datasource.childrenCreatable) {
          return;
       }
 


### PR DESCRIPTION
skip the physicalTablePermission check when creating …a query, since JDBC queries already handle that during the queryCreatable initialization.