### PR TITLE
fix Bug #70887

### DIFF
--- a/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.ts
+++ b/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.ts
@@ -376,11 +376,13 @@ export class UsersSettingsPageComponent implements OnInit, OnDestroy {
                this.snackBar.open("_#(js:em.security.userNameChangeWarning)", "_#(js:Close)", {duration: Tool.SNACKBAR_DURATION});
             }
 
+            const selectProvider = !!identities.find(node => node.type == IdentityType.ORGANIZATION);
+
             if(sameTypeNode != null && this.isSysAdmin) {
                this.refreshTree(sameTypeNode.identityID, sameTypeNode.type);
             }
             else {
-               this.refreshTree();
+               this.refreshTree(null, null, false, selectProvider);
             }
          });
    }


### PR DESCRIPTION
When deleting an organization identity, the organization dropdown should be refreshed.