### PR TITLE
fix Bug #70867:

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleConditionService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleConditionService.java
@@ -230,7 +230,8 @@ public class ScheduleConditionService {
          }
 
          if(array) {
-            type = getParameterType(repRequest, paramName, vals.length > 0 ? vals[0] : null);
+            type = vals.length > 0 ? Tool.getDataType(vals[0]) :
+               getParameterType(repRequest, paramName, vals.length > 0 ? vals[0] : null);
          }
 
          AddParameterDialogModel paramModel = AddParameterDialogModel.builder()
@@ -264,7 +265,8 @@ public class ScheduleConditionService {
       }
       else if("array".equals(type)) {
          Object[] vals = (Object[]) value;
-         type = getParameterType(repRequest, paramName, vals.length > 0 ? vals[0] : null);
+         type = vals.length > 0 ? Tool.getDataType(vals[0]) :
+            getParameterType(repRequest, paramName, vals.length > 0 ? vals[0] : null);
          StringBuilder builder = new StringBuilder();
 
          for(int i = 0; i < vals.length; i++) {


### PR DESCRIPTION
when data is array, it will not dynamic value, but its value will have its data type such as "timeInstant~2025-01-01 00:00:00", so we can get its actual type from value.

this logic will be used for vs parameters and batch actions in tasks, test for them all works right. For array, its type will be array, so its inner data type will in value strings to save, we just get it to parse and show right when reopen.