### PR TITLE
bug-70891

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-table-tree/physical-model-table-tree.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-table-tree/physical-model-table-tree.component.ts
@@ -51,6 +51,10 @@ export class PhysicalModelTableTreeComponent {
    selectNode(node: TreeNodeModel): void {
       this.selectedNodes = this.selectedNodes == null ? [] : this.selectedNodes;
       this.selectedNodes.push(node);
+
+      if(this.selectedNodes != null && this.selectedNodes.length == 1) {
+         this.selectNode0(this.selectedNodes);
+      }
    }
 
    selectNode0(node: TreeNodeModel[]) {


### PR DESCRIPTION
When only one node in the right pane is selected, if there is content in Outgoing Joins, it should be displayed.