### PR TITLE
fix Bug #70587

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/cluster/ClusterCache.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ClusterCache.java
@@ -144,6 +144,8 @@ public abstract class ClusterCache<E, L extends Serializable, S extends  Seriali
 
       if(lock.tryLock(10L, TimeUnit.SECONDS)) {
          try {
+            lastInstance = referenceCounter.decrementAndGet() == 0;
+
             if(lastInstance) {
                cluster.destroyLong(prefix + "timestamp");
                cluster.destroyLong(prefix + "lastLoad");


### PR DESCRIPTION
Get the value of `lastInstance` again before destroying the cache to avoid the cache being destroyed prematurely.