### PR TITLE
fix Bug #70847:

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
@@ -225,7 +225,7 @@ public abstract class AbstractEditableAuthenticationProvider
 
       addOrganization(newOrg);
 
-      identityService.copyStorages(fromOrganization, newOrg);
+      identityService.copyStorages(fromOrganization, newOrg, replace);
       identityService.copyRepletRegistry(fromOrgId, newOrgID);
 
       if(!replace) {

--- a/core/src/main/java/inetsoft/uql/asset/AssetEntry.java
+++ b/core/src/main/java/inetsoft/uql/asset/AssetEntry.java
@@ -1330,6 +1330,10 @@ public class AssetEntry implements AssetObject, Comparable<AssetEntry>, DataSeri
       favoritesUser.remove(favoritesUser0);
    }
 
+   public void clearFavoritesUser() {
+      favoritesUser.clear();
+   }
+
    /**
     * Get the description without localization.
     * @return the description.

--- a/core/src/main/java/inetsoft/util/AbstractIndexedStorage.java
+++ b/core/src/main/java/inetsoft/util/AbstractIndexedStorage.java
@@ -587,7 +587,7 @@ public abstract class AbstractIndexedStorage implements IndexedStorage {
    }
 
    @Override
-   public void copyStorageData(Organization oOrg, Organization nOrg) throws Exception {
+   public void copyStorageData(Organization oOrg, Organization nOrg, boolean rename) throws Exception {
       // no-op
    }
 

--- a/core/src/main/java/inetsoft/util/BlobIndexedStorage.java
+++ b/core/src/main/java/inetsoft/util/BlobIndexedStorage.java
@@ -434,7 +434,7 @@ public class BlobIndexedStorage extends AbstractIndexedStorage {
 
    @Override
    public void migrateStorageData(AbstractIdentity oorg, AbstractIdentity norg) throws Exception  {
-      migrateStorageData(oorg, norg, true);
+      migrateStorageData(oorg, norg, true, true);
    }
 
    @Override
@@ -564,7 +564,8 @@ public class BlobIndexedStorage extends AbstractIndexedStorage {
       }
    }
 
-   private void migrateStorageData(AbstractIdentity oorg, AbstractIdentity norg, boolean removeOld)
+   private void migrateStorageData(AbstractIdentity oorg, AbstractIdentity norg, boolean removeOld,
+                                   boolean rename)
       throws Exception
    {
       String oId = oorg instanceof Organization ? ((Organization) oorg).getId() :
@@ -622,6 +623,10 @@ public class BlobIndexedStorage extends AbstractIndexedStorage {
                }
 
                for(AssetEntry newEntry : newEntries) {
+                  if(!rename) {
+                     newEntry.clearFavoritesUser();
+                  }
+
                   folder.addEntry(newEntry);
                }
             }
@@ -648,8 +653,8 @@ public class BlobIndexedStorage extends AbstractIndexedStorage {
    }
 
    @Override
-   public void copyStorageData(Organization oOrg, Organization nOrg) throws Exception {
-      migrateStorageData(oOrg, nOrg, false);
+   public void copyStorageData(Organization oOrg, Organization nOrg, boolean rename) throws Exception {
+      migrateStorageData(oOrg, nOrg, false, rename);
    }
 
    @Override

--- a/core/src/main/java/inetsoft/util/IndexedStorage.java
+++ b/core/src/main/java/inetsoft/util/IndexedStorage.java
@@ -367,10 +367,11 @@ public interface IndexedStorage {
     *
     * @param oOrg the oOrg used for the old storage
     * @param nOrg the nOrg used for the old storage
+    * @param rename rename or copy org
     *
     * @since 14.0
     */
-   void copyStorageData(Organization oOrg, Organization nOrg) throws Exception;
+   void copyStorageData(Organization oOrg, Organization nOrg, boolean rename) throws Exception;
 
    /**
     * Deletes an indexed storage store

--- a/core/src/main/java/inetsoft/util/IndexedStorageWrapper.java
+++ b/core/src/main/java/inetsoft/util/IndexedStorageWrapper.java
@@ -408,8 +408,8 @@ public class IndexedStorageWrapper implements IndexedStorage {
    }
 
    @Override
-   public void copyStorageData(Organization oOrg, Organization nOrg) throws Exception {
-      storage.copyStorageData(oOrg, nOrg);
+   public void copyStorageData(Organization oOrg, Organization nOrg, boolean rename) throws Exception {
+      storage.copyStorageData(oOrg, nOrg, rename);
    }
 
    @Override

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -887,13 +887,13 @@ public class IdentityService {
       removeBlobStorage("__autoSave", orgID, LibManager.Metadata.class);
    }
 
-   public void copyStorages(Organization oOrg, Organization nOrg) {
+   public void copyStorages(Organization oOrg, Organization nOrg, boolean rename) {
       try {
          DashboardManager.getManager().copyStorageData(oOrg.getId(), nOrg.getId());
          DependencyStorageService.getInstance().copyStorageData(oOrg, nOrg);
          RecycleBin.getRecycleBin().copyStorageData(oOrg.getId(), nOrg.getId());
          updateLibraryStorage(oOrg.getId(), nOrg.getId(), true);
-         IndexedStorage.getIndexedStorage().copyStorageData(oOrg, nOrg);
+         IndexedStorage.getIndexedStorage().copyStorageData(oOrg, nOrg, rename);
 
          FSService.copyServerNode(oOrg.getId(), nOrg.getId(), true);
          //updateBlobStorageName("__mvBlock", oOrg.getId(), nOrg.getId(), BlockFileStorage.Metadata.class, true);


### PR DESCRIPTION
when rename organzation, its favoritesUser should keep for asset folder, if copy organization to create new org, should clear favorite users.

In fact, vs's favorite user will save in its asset folder in storage, so when copy org not rename org, we should clear favoritessUser for all asset folders.