### PR TITLE
fix Bug #70804, wait for mv to refresh chart.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -6202,7 +6202,14 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
             }
          }
 
-         if(pair == null || !pair.isCompleted() && pair.isCancelled()) {
+         XPrincipal principal = ThreadContext.getContextPrincipal() == null ?
+            null : (XPrincipal)ThreadContext.getContextPrincipal();
+
+         if(pair == null || !pair.isCompleted() && pair.isCancelled() ||
+            // init to throw CheckMissingMVEvent to make sure client display progress bar to
+            // wait for mv insteadof always loading becauseof an empty graph.
+            init && MVManager.getManager().isPending(getAssetEntry(), principal))
+         {
             pair = new VGraphPair();
             needInit = true;
             pairs.put(name, pair);


### PR DESCRIPTION
init to throw CheckMissingMVEvent to make sure client display progress bar to wait for mv insteadof always loading becauseof an empty graph.