### PR TITLE
for Bug #70859, add ResourceNotFoundException

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/SUtil.java
+++ b/core/src/main/java/inetsoft/sree/internal/SUtil.java
@@ -2131,8 +2131,8 @@ public class SUtil {
          try {
             asset.parseIdentifier(path, user);
          }
-         catch(Exception ex) {
-            LOG.warn(String.format("Failed to parse identifier with path %s for %s.", path, asset.getClass().getName()), ex);
+         catch(ResourceNotFoundException ex) {
+            LOG.warn(String.format("Ignore the not exist resource %s with path %s", type, path), ex);
             asset = null;
          }
       }

--- a/core/src/main/java/inetsoft/util/dep/ResourceNotFoundException.java
+++ b/core/src/main/java/inetsoft/util/dep/ResourceNotFoundException.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.util.dep;
+
+public class ResourceNotFoundException extends RuntimeException  {
+   public ResourceNotFoundException() {
+      super();
+   }
+
+   public ResourceNotFoundException(String msg) {
+      super(msg);
+   }
+}

--- a/core/src/main/java/inetsoft/util/dep/TableStyleAsset.java
+++ b/core/src/main/java/inetsoft/util/dep/TableStyleAsset.java
@@ -123,7 +123,7 @@ public class TableStyleAsset extends AbstractXAsset {
       XTableStyle tableStyle = manager.getTableStyle(path);
 
       if(tableStyle == null) {
-         throw new RuntimeException("Cannot find table style with path: " + path);
+         throw new ResourceNotFoundException("Cannot find table style with path: " + path);
       }
 
       style = tableStyle.getID();


### PR DESCRIPTION
table style is a special resource, for table with a tablestyle which alreay have not exist should not effect the dashboard execution, so add ResourceNotFoundException, and only ignore ResourceNotFoundException when doing export.