### PR TITLE
Bug #70816

### DIFF
--- a/core/src/main/resources/inetsoft/web/resources/css/login.css
+++ b/core/src/main/resources/inetsoft/web/resources/css/login.css
@@ -52,7 +52,7 @@ div.loading-indicator {
   top: 0;
 }
 
-.close {
+.modal-header .close {
   margin-left: auto;
 }
 

--- a/core/src/main/resources/inetsoft/web/resources/login.html
+++ b/core/src/main/resources/inetsoft/web/resources/login.html
@@ -129,9 +129,11 @@
   <div class="modal fade" id="activeSession" tabindex="-1" aria-labelledby="activeSessionTitle" aria-hidden="true" style="display: none">
   <div class="modal-dialog">
     <div class="modal-content">
-      <modal-header
-        [title]="'_#(Confirm)'">
-      </modal-header>
+      <div class="modal-header">
+        <h5 class="modal-title" id="activeSessoinTitle" data-th-text="#{Confirm}">Confirm</h5>
+        <button type="button" class="btn-close close" data-dismiss="modal" aria-label="Close">
+        </button>
+      </div>
       <div class="modal-body text-info" data-th-utext="#{login.warning.activeSession(${currentUser})}"></div>
       <div class="modal-footer">
         <button type="button" id="confirmLogin" class="btn btn-primary" data-th-text="#{Yes}">Yes</button>


### PR DESCRIPTION
Since login.html is under the java directory, it cannot recognize the modal-header component located under the web directory. As a result, the title does not appear.

To roll back the code:
Previously, the close icon appeared on the left because the .close style was not applied—it was likely overridden by other styles such as .btn-close. To fix this, you need to increase the specificity of the .close style so that it takes effect.