### PR TITLE
fix Bug #70910, do not set the updateGrantAllByOrg as true when do not set any identity to the new folder permission.

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryObjectService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryObjectService.java
@@ -758,7 +758,7 @@ public class RepositoryObjectService {
          perm.setUserGrantsForOrg(action, userGrants, currentOrgID);
       }
 
-      perm.updateGrantAllByOrg(currentOrgID, true);
+      perm.updateGrantAllByOrg(currentOrgID, !userGrants.isEmpty());
       authz.setPermission(type, name, perm);
    }
 


### PR DESCRIPTION
do not set the updateGrantAllByOrg as true when do not set any identity to the new folder permission.