### PR TITLE
fix Bug #70925:

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryDashboardService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryDashboardService.java
@@ -70,7 +70,7 @@ public class RepositoryDashboardService {
          permissionService.getTableModel(dashboardName, ResourceType.DASHBOARD,
                                          EnumSet.of(ResourceAction.ACCESS, ResourceAction.ADMIN), principal);
       Identity anonymous = new DefaultIdentity(XPrincipal.ANONYMOUS, Identity.USER);
-      Identity user = new DefaultIdentity(owner, Identity.USER);
+      Identity user = owner == null ? anonymous : new DefaultIdentity(owner, Identity.USER);
       final String dashName = dashboardName;
       boolean enable = Arrays.asList(dashboardManager.getDashboards(anonymous))
          .contains(dashboardName) ||


### PR DESCRIPTION
the bug is caused by bug#70778, it want to use owner to get dashboards from registry, should check owner is null, for global dashboard, its owner will be null, should using anonymous as identity.