### PR TITLE
fix Bug #70916, Include the org ID in the resource key for isolation.

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/AbstractAuthorizationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractAuthorizationProvider.java
@@ -27,28 +27,28 @@ public abstract class AbstractAuthorizationProvider
    implements AuthorizationProvider
 {
    @Override
-   public void setPermission(ResourceType type, String resource, Permission perm) {
+   public void setPermission(ResourceType type, String resource, Permission perm, String orgID) {
    }
 
    @Override
-   public void setPermission(ResourceType type, IdentityID identityID, Permission perm) {
+   public void setPermission(ResourceType type, IdentityID identityID, Permission perm, String orgID) {
    }
 
    @Override
-   public void removePermission(ResourceType type, String resource) {
+   public void removePermission(ResourceType type, String resource, String orgID) {
    }
 
    @Override
-   public void removePermission(ResourceType type, IdentityID identityID) {
+   public void removePermission(ResourceType type, IdentityID identityID, String orgID) {
    }
 
    @Override
-   public Permission getPermission(ResourceType type, String resource) {
+   public Permission getPermission(ResourceType type, String resource, String orgID) {
       return null;
    }
 
    @Override
-   public Permission getPermission(ResourceType type, IdentityID identityID) {
+   public Permission getPermission(ResourceType type, IdentityID identityID, String orgID) {
       return null;
    }
 

--- a/core/src/main/java/inetsoft/sree/security/AbstractSecurityProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractSecurityProvider.java
@@ -18,7 +18,7 @@
 package inetsoft.sree.security;
 
 import inetsoft.uql.util.Identity;
-import inetsoft.util.Tuple3;
+import inetsoft.util.Tuple4;
 
 import java.security.Principal;
 import java.util.List;
@@ -293,37 +293,37 @@ public abstract class AbstractSecurityProvider implements SecurityProvider {
    }
 
    @Override
-   public void setPermission(ResourceType type, String resource, Permission perm) {
-      authorization.setPermission(type, resource, perm);
+   public void setPermission(ResourceType type, String resource, Permission perm, String orgID) {
+      authorization.setPermission(type, resource, perm, orgID);
    }
 
    @Override
-   public void setPermission(ResourceType type, IdentityID identityID, Permission perm) {
-      authorization.setPermission(type, identityID, perm);
+   public void setPermission(ResourceType type, IdentityID identityID, Permission perm, String orgID) {
+      authorization.setPermission(type, identityID, perm, orgID);
    }
 
    @Override
-   public void removePermission(ResourceType type, String resource) {
-      authorization.removePermission(type, resource);
+   public void removePermission(ResourceType type, String resource, String orgID) {
+      authorization.removePermission(type, resource, orgID);
    }
 
    @Override
-   public void removePermission(ResourceType type, IdentityID resource) {
-      authorization.removePermission(type, resource);
+   public void removePermission(ResourceType type, IdentityID resource, String orgID) {
+      authorization.removePermission(type, resource, orgID);
    }
 
    @Override
-   public Permission getPermission(ResourceType type, String resource) {
-      return authorization.getPermission(type, resource);
+   public Permission getPermission(ResourceType type, String resource, String orgID) {
+      return authorization.getPermission(type, resource, orgID);
    }
 
    @Override
-   public Permission getPermission(ResourceType type, IdentityID identityID) {
-      return authorization.getPermission(type, identityID);
+   public Permission getPermission(ResourceType type, IdentityID identityID, String orgID) {
+      return authorization.getPermission(type, identityID, orgID);
    }
 
    @Override
-   public List<Tuple3<ResourceType, String, Permission>> getPermissions() {
+   public List<Tuple4<ResourceType, String, String, Permission>> getPermissions() {
       return authorization.getPermissions();
    }
 

--- a/core/src/main/java/inetsoft/sree/security/AuthorizationChain.java
+++ b/core/src/main/java/inetsoft/sree/security/AuthorizationChain.java
@@ -17,7 +17,7 @@
  */
 package inetsoft.sree.security;
 
-import inetsoft.util.Tuple3;
+import inetsoft.util.Tuple4;
 
 import java.util.List;
 import java.util.Objects;
@@ -40,46 +40,71 @@ public class AuthorizationChain
 
    @Override
    public void setPermission(ResourceType type, String resource, Permission perm) {
+      setPermission(type, resource, perm, null);
+   }
+
+   @Override
+   public void setPermission(ResourceType type, String resource, Permission perm, String orgID) {
       for(AuthorizationProvider provider : getProviderList()) {
-         if(provider.getPermission(type, resource) != null) {
-            provider.setPermission(type, resource, perm);
+         if(provider.getPermission(type, resource, orgID) != null) {
+            provider.setPermission(type, resource, perm, orgID);
             return;
          }
       }
 
       // not found in any provider, set it on the first
-      getProviderList().get(0).setPermission(type, resource, perm);
+      getProviderList().get(0).setPermission(type, resource, perm, orgID);
    }
 
    @Override
    public void setPermission(ResourceType type, IdentityID identityID, Permission perm) {
+      setPermission(type, identityID, perm, null);
+   }
+
+   @Override
+   public void setPermission(ResourceType type, IdentityID identityID, Permission perm, String orgID) {
       for(AuthorizationProvider provider : getProviderList()) {
-         if(provider.getPermission(type, identityID) != null) {
-            provider.setPermission(type, identityID, perm);
+         if(provider.getPermission(type, identityID, orgID) != null) {
+            provider.setPermission(type, identityID, perm, orgID);
             return;
          }
       }
 
       // not found in any provider, set it on the first
-      getProviderList().get(0).setPermission(type, identityID, perm);
+      getProviderList().get(0).setPermission(type, identityID, perm, orgID);
    }
 
    @Override
    public void removePermission(ResourceType type, String resource) {
+      removePermission(type, resource, null);
+   }
+
+   @Override
+   public void removePermission(ResourceType type, String resource, String orgID) {
       stream()
-         .forEach(p -> p.removePermission(type, resource));
+         .forEach(p -> p.removePermission(type, resource, orgID));
    }
 
    @Override
    public void removePermission(ResourceType type, IdentityID resourceID) {
+      removePermission(type, resourceID, null);
+   }
+
+   @Override
+   public void removePermission(ResourceType type, IdentityID resourceID, String orgID) {
       stream()
-         .forEach(p -> p.removePermission(type, resourceID));
+         .forEach(p -> p.removePermission(type, resourceID, orgID));
    }
 
    @Override
    public Permission getPermission(ResourceType type, String resource) {
+      return getPermission(type, resource, null);
+   }
+
+   @Override
+   public Permission getPermission(ResourceType type, String resource, String orgID) {
       return stream()
-         .map(p -> p.getPermission(type, resource))
+         .map(p -> p.getPermission(type, resource, orgID))
          .filter(Objects::nonNull)
          .findFirst()
          .orElse(null);
@@ -87,15 +112,20 @@ public class AuthorizationChain
 
    @Override
    public Permission getPermission(ResourceType type, IdentityID identityID) {
+      return getPermission(type, identityID, null);
+   }
+
+   @Override
+   public Permission getPermission(ResourceType type, IdentityID identityID, String orgID) {
       return stream()
-         .map(p -> p.getPermission(type, identityID))
+         .map(p -> p.getPermission(type, identityID, orgID))
          .filter(Objects::nonNull)
          .findFirst()
          .orElse(null);
    }
 
    @Override
-   public List<Tuple3<ResourceType, String, Permission>> getPermissions() {
+   public List<Tuple4<ResourceType, String, String, Permission>> getPermissions() {
       for(AuthorizationProvider provider : getProviders()) {
          try {
             return provider.getPermissions();

--- a/core/src/main/java/inetsoft/sree/security/AuthorizationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AuthorizationProvider.java
@@ -17,7 +17,9 @@
  */
 package inetsoft.sree.security;
 
-import inetsoft.util.Tuple3;
+import inetsoft.sree.internal.SUtil;
+import inetsoft.util.Tool;
+import inetsoft.util.Tuple4;
 
 import java.util.List;
 
@@ -38,7 +40,18 @@ public interface AuthorizationProvider
     * @param resource the resource name, such as a replet register name or a saved report path.
     * @param perm     the granted permissions.
     */
-   void setPermission(ResourceType type, String resource, Permission perm);
+   default void setPermission(ResourceType type, String resource, Permission perm) {
+      setPermission(type, resource, perm, null);
+   }
+
+   /**
+    * Sets the permissions for the specified resource.
+    *
+    * @param type     the type of resource.
+    * @param resource the resource name, such as a replet register name or a saved report path.
+    * @param perm     the granted permissions.
+    */
+   void setPermission(ResourceType type, String resource, Permission perm, String orgID);
 
    /**
     * Sets the permissions for the specified identity.
@@ -47,7 +60,18 @@ public interface AuthorizationProvider
     * @param identityID the identity id to set permissions for
     * @param perm       the granted permissions.
     */
-   void setPermission(ResourceType type, IdentityID identityID, Permission perm);
+   default void setPermission(ResourceType type, IdentityID identityID, Permission perm) {
+      setPermission(type, identityID, perm, null);
+   }
+
+   /**
+    * Sets the permissions for the specified identity.
+    *
+    * @param type       the type of resource.
+    * @param identityID the identity id to set permissions for
+    * @param perm       the granted permissions.
+    */
+   void setPermission(ResourceType type, IdentityID identityID, Permission perm, String orgID);
 
    /**
     * Clears all permissions on the specified resource.
@@ -55,7 +79,17 @@ public interface AuthorizationProvider
     * @param type     the resource type.
     * @param resource the resource name, such as a replet path or a saved report path.
     */
-   void removePermission(ResourceType type, String resource);
+   default void removePermission(ResourceType type, String resource) {
+      removePermission(type, resource, null);
+   }
+
+   /**
+    * Clears all permissions on the specified resource.
+    *
+    * @param type     the resource type.
+    * @param resource the resource name, such as a replet path or a saved report path.
+    */
+   void removePermission(ResourceType type, String resource, String orgID);
 
    /**
     * Clears all permissions on the specified identity.
@@ -63,7 +97,17 @@ public interface AuthorizationProvider
     * @param type     the resource type.
     * @param identityID the identity, such as a specified user or role.
     */
-   void removePermission(ResourceType type, IdentityID identityID);
+   default void removePermission(ResourceType type, IdentityID identityID) {
+      removePermission(type, identityID, null);
+   }
+
+   /**
+    * Clears all permissions on the specified identity.
+    *
+    * @param type     the resource type.
+    * @param identityID the identity, such as a specified user or role.
+    */
+   void removePermission(ResourceType type, IdentityID identityID, String orgID);
 
    /**
     * Gets the permissions for the specified resource.
@@ -73,7 +117,11 @@ public interface AuthorizationProvider
     *
     * @return the granted permissions or {@code null} of none have been set.
     */
-   Permission getPermission(ResourceType type, String resource);
+   default Permission getPermission(ResourceType type, String resource) {
+      return getPermission(type, resource, null);
+   }
+
+   Permission getPermission(ResourceType type, String resource, String orgID);
 
    /**
     * Gets the permissions for the specified identity.
@@ -83,14 +131,26 @@ public interface AuthorizationProvider
     *
     * @return the granted permissions or {@code null} of none have been set.
     */
-   Permission getPermission(ResourceType type, IdentityID identityID);
+   default Permission getPermission(ResourceType type, IdentityID identityID) {
+      return getPermission(type, identityID, null);
+   }
+
+   /**
+    * Gets the permissions for the specified identity.
+    *
+    * @param type       the resource type.
+    * @param identityID the identity id.
+    *
+    * @return the granted permissions or {@code null} of none have been set.
+    */
+   Permission getPermission(ResourceType type, IdentityID identityID, String orgID);
 
    /**
     * Gets the permissions for all resources
     *
     * @return the list of tuples corresponding to the resource name, their types, and their permissions
     */
-   default List<Tuple3<ResourceType, String, Permission>> getPermissions() {
+   default List<Tuple4<ResourceType, String, String, Permission>> getPermissions() {
       throw new UnsupportedOperationException();
    }
 
@@ -103,4 +163,15 @@ public interface AuthorizationProvider
     * Tear down the security provider.
     */
    void tearDown();
+
+   default String getResourceOrgID(String orgID) {
+      if(!Tool.isEmptyString(orgID)) {
+         return orgID;
+      }
+
+      // still use default orgID when multi tenant is false
+      // to keep permission not changed after switching to multi tenant.
+      return SUtil.isMultiTenant() ?
+         OrganizationManager.getInstance().getCurrentOrgID() : Organization.getDefaultOrganizationID();
+   }
 }

--- a/core/src/main/java/inetsoft/sree/security/ResourceKey.java
+++ b/core/src/main/java/inetsoft/sree/security/ResourceKey.java
@@ -1,0 +1,102 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.sree.security;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.Objects;
+
+public class ResourceKey implements Serializable, Comparable<ResourceKey> {
+   public ResourceKey() {
+   }
+   public ResourceKey(ResourceType type, String path, String orgID) {
+      this.type = type;
+      this.path = path;
+      this.orgID = orgID;
+   }
+
+   public ResourceType getType() {
+      return type;
+   }
+
+   public void setType(ResourceType type) {
+      this.type = type;
+   }
+
+   public String getOrgID() {
+      return orgID;
+   }
+
+   public void setOrgID(String orgID) {
+      this.orgID = orgID;
+   }
+
+   public String getPath() {
+      return path;
+   }
+
+   public void setPath(String path) {
+      this.path = path;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      ResourceKey key = (ResourceKey) o;
+      return type == key.type && Objects.equals(orgID, key.orgID) && Objects.equals(path, key.path);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(type, path);
+   }
+
+   @Override
+   public String toString() {
+      return "Resource{" +
+         "type=" + type +
+         ", path='" + path + '\'' +
+         ", orgID='" + orgID + '\'' +
+         '}';
+   }
+
+   @Override
+   public int compareTo(ResourceKey o) {
+      if(o == null) {
+         return 1;
+      }
+
+      return Comparator.comparing(ResourceKey::getType)
+         .thenComparing(ResourceKey::getOrgID)
+         .thenComparing(ResourceKey::getPath).compare(this, o);
+   }
+
+   private ResourceType type;
+   private String path;
+   private String orgID;
+}

--- a/core/src/main/java/inetsoft/sree/security/VirtualAuthorizationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/VirtualAuthorizationProvider.java
@@ -59,9 +59,18 @@ public class VirtualAuthorizationProvider extends AbstractAuthorizationProvider 
       return userPermission;
    }
 
+   public Permission getPermission(ResourceType type, String resource, String orgID) {
+      return getPermission(type, resource);
+   }
+
    @Override
    public Permission getPermission(ResourceType type, IdentityID resource) {
       return userPermission;
+   }
+
+   @Override
+   public Permission getPermission(ResourceType type, IdentityID resource, String orgID) {
+      return getPermission(type, resource);
    }
 
    /**

--- a/core/src/main/java/inetsoft/util/Tuple4.java
+++ b/core/src/main/java/inetsoft/util/Tuple4.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util;
+
+import java.util.Objects;
+
+public class Tuple4<V1, V2, V3, V4> {
+   public Tuple4(V1 first, V2 second, V3 third, V4 forth) {
+      this.first = first;
+      this.second = second;
+      this.third = third;
+      this.forth = forth;
+   }
+
+   public V1 getFirst() {
+      return first;
+   }
+
+   public V2 getSecond() {
+      return second;
+   }
+
+   public V3 getThird() {
+      return third;
+   }
+
+   public V4 getForth() {
+      return forth;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      Tuple4<?, ?, ?, ?> Tuple4 = (Tuple4<?, ?, ?, ?>) o;
+      return Objects.equals(first, Tuple4.first) &&
+         Objects.equals(second, Tuple4.second) &&
+         Objects.equals(third, Tuple4.third) &&
+         Objects.equals(forth, Tuple4.forth);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(first, second, third, forth);
+   }
+
+   @Override
+   public String toString() {
+      return "Tuple4{" +
+         "first=" + first +
+         ", second=" + second +
+         ", third=" + third +
+         ", forth=" + forth +
+         '}';
+   }
+
+   private final V1 first;
+   private final V2 second;
+   private final V3 third;
+   private final V4 forth;
+}

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -1980,23 +1980,26 @@ public class IdentityService {
       Organization oldOrganization = oldOrgId == null || oldOrgId.isEmpty() ?
          null : provider.getOrganization(oldOrgId);
 
-      for(Tuple3<ResourceType, String, Permission> permissionSet : provider.getPermissions()) {
-         String second = permissionSet.getSecond();
-         Permission permission = permissionSet.getThird();
+      for(Tuple4<ResourceType, String, String, Permission> permissionSet : provider.getPermissions()) {
+         String resourceOrgID = permissionSet.getSecond();
+         String path = permissionSet.getThird();
+         Permission permission = permissionSet.getForth();
 
          if(permission == null) {
             continue;
          }
 
-         if(newName == null && second.contains(IdentityID.KEY_DELIMITER) && IdentityID.getIdentityIDFromKey(second).orgID != null &&
-               !Tool.equals(IdentityID.getIdentityIDFromKey(second).orgID,oldName.orgID) &&
-               !Tool.equals(IdentityID.getIdentityIDFromKey(second).orgID,oldOrgId)) {
+         if(newName == null && (resourceOrgID != null && !Tool.equals(resourceOrgID, oldOrgId) ||
+            path.contains(IdentityID.KEY_DELIMITER) && IdentityID.getIdentityIDFromKey(path).orgID != null &&
+               !Tool.equals(IdentityID.getIdentityIDFromKey(path).orgID,oldName.orgID) &&
+               !Tool.equals(IdentityID.getIdentityIDFromKey(path).orgID,oldOrgId)))
+         {
             //skip permissions not in this organization
             continue;
          }
 
-         if(containsOrgID(second, oldName.getOrgID()) && newName == null) {
-            provider.removePermission(permissionSet.getFirst(), second);
+         if(containsOrgID(path, oldName.getOrgID()) && newName == null) {
+            provider.removePermission(permissionSet.getFirst(), path, resourceOrgID);
          }
 
          for(ResourceAction action : ResourceAction.values()) {
@@ -2005,7 +2008,7 @@ public class IdentityService {
                   for(IdentityID granteeName : permission.getOrgScopedUserGrants(action, oldOrganization).toArray(new IdentityID[0])) {
                      if(oldName != null && oldName.name.equals(granteeName.name)) {
                         //rename old grantee to new name
-                        updateIdentityPermission(type, newName, oldName, oldOrganization, newOrgId, permission, action, permissionSet.getFirst(), second, doReplace);
+                        updateIdentityPermission(type, newName, oldName, oldOrganization, newOrgId, permission, action, permissionSet.getFirst(), path, doReplace);
                      }
                   }
                }
@@ -2013,7 +2016,7 @@ public class IdentityService {
                   for(IdentityID granteeName : permission.getOrgScopedGroupGrants(action, oldOrganization).toArray(new IdentityID[0])) {
                      if(oldName != null && oldName.name.equals(granteeName.name)) {
                         //rename old grantee to new name
-                        updateIdentityPermission(type, newName, oldName, oldOrganization, newOrgId, permission, action, permissionSet.getFirst(), second, doReplace);
+                        updateIdentityPermission(type, newName, oldName, oldOrganization, newOrgId, permission, action, permissionSet.getFirst(), path, doReplace);
                      }
                   }
                }
@@ -2021,7 +2024,7 @@ public class IdentityService {
                   for(IdentityID granteeName : permission.getOrgScopedRoleGrants(action, oldOrganization).toArray(new IdentityID[0])) {
                      if(oldName != null && oldName.name.equals(granteeName.name)) {
                         //rename old grantee to new name
-                        updateIdentityPermission(type, newName, oldName, oldOrganization, newOrgId, permission, action, permissionSet.getFirst(), second, doReplace);
+                        updateIdentityPermission(type, newName, oldName, oldOrganization, newOrgId, permission, action, permissionSet.getFirst(), path, doReplace);
                      }
                   }
                }
@@ -2051,32 +2054,33 @@ public class IdentityService {
    }
 
    private void updatePermission(SecurityProvider provider,
-                                 Tuple3<ResourceType, String, Permission> permissionSet,
+                                 Tuple4<ResourceType, String, String, Permission> permissionSet,
                                  String oIdentityName, String nIdentityName, String oorgId,
                                  String norgId, boolean doReplace, int changeIdentityType)
    {
       ResourceType type = permissionSet.getFirst();
-      String second = permissionSet.getSecond();
-      Permission permission = permissionSet.getThird();
+      String resourceOrgID = permissionSet.getSecond();
+      String path = permissionSet.getThird();
+      Permission permission = permissionSet.getForth();
       updateOrgEditedGrantAll(permission, oorgId, norgId);
-      String newPath = getNewPermissionPath(permissionSet.getFirst(), second, oorgId, norgId,
+      String newPath = getNewPermissionPath(permissionSet.getFirst(), path, oorgId, norgId,
          oIdentityName, nIdentityName, changeIdentityType);
 
       if(newPath != null) {
-         provider.setPermission(type, newPath, permission);
+         provider.setPermission(type, newPath, permission, norgId);
       }
       else {
-         provider.setPermission(type, second, permission);
+         provider.setPermission(type, path, permission, norgId);
       }
 
-      if(doReplace && !Tool.equals(oorgId, norgId) && !Tool.equals(newPath, second)) {
-         provider.removePermission(type, second);
+      if(doReplace && !Tool.equals(oorgId, norgId) && !Tool.equals(newPath, path)) {
+         provider.removePermission(type, path, resourceOrgID);
       }
    }
 
-   private boolean containsOrgID(String secondPath, String oorgID) {
-      if(secondPath != null && secondPath.contains(IdentityID.KEY_DELIMITER)) {
-         IdentityID identityID = IdentityID.getIdentityIDFromKey(secondPath);
+   private boolean containsOrgID(String path, String oorgID) {
+      if(path != null && path.contains(IdentityID.KEY_DELIMITER)) {
+         IdentityID identityID = IdentityID.getIdentityIDFromKey(path);
 
          return Tool.equals(oorgID, identityID.getOrgID());
       }
@@ -2084,12 +2088,12 @@ public class IdentityService {
       return false;
    }
 
-   private String getNewPermissionPath(ResourceType type, String secondPath,
+   private String getNewPermissionPath(ResourceType type, String path,
                                        String oorgID, String norgID, String oIdentityName,
                                        String nIdentityName, int changeIdentityType)
    {
       if(type == ResourceType.SECURITY_ORGANIZATION &&
-         Tool.equals(secondPath, new IdentityID(oIdentityName, oorgID).convertToKey()))
+         Tool.equals(path, new IdentityID(oIdentityName, oorgID).convertToKey()))
       {
          return new IdentityID(nIdentityName, norgID).convertToKey();
       }
@@ -2098,7 +2102,7 @@ public class IdentityService {
          if(changeIdentityType == Identity.USER) {
             IdentityID oldIdentityID = new IdentityID(oIdentityName, oorgID);
             IdentityID newIdentityID = new IdentityID(nIdentityName, norgID);
-            ScheduleTaskMetaData taskMetaData = ScheduleManager.getTaskMetaData(secondPath);
+            ScheduleTaskMetaData taskMetaData = ScheduleManager.getTaskMetaData(path);
 
             if(Tool.equals(taskMetaData.getTaskOwnerId(), oldIdentityID.convertToKey())) {
                taskMetaData.setTaskOwnerId(newIdentityID.convertToKey());
@@ -2107,7 +2111,7 @@ public class IdentityService {
             }
          }
          else if(changeIdentityType == Identity.ORGANIZATION) {
-            ScheduleTaskMetaData taskMetaData = ScheduleManager.getTaskMetaData(secondPath);
+            ScheduleTaskMetaData taskMetaData = ScheduleManager.getTaskMetaData(path);
             IdentityID ownerIdentityID = IdentityID.getIdentityIDFromKey(taskMetaData.getTaskOwnerId());
 
             if(ownerIdentityID != null && Tool.equals(ownerIdentityID.getOrgID(), oorgID)) {
@@ -2119,10 +2123,10 @@ public class IdentityService {
          }
       }
 
-      String newPath = secondPath;
+      String newPath = path;
 
-      if(containsOrgID(secondPath, oorgID) && !Tool.equals(oorgID, norgID)) {
-         IdentityID identityID = IdentityID.getIdentityIDFromKey(secondPath);
+      if(containsOrgID(path, oorgID) && !Tool.equals(oorgID, norgID)) {
+         IdentityID identityID = IdentityID.getIdentityIDFromKey(path);
          identityID.setOrgID(norgID);
          newPath = identityID.convertToKey();
       }


### PR DESCRIPTION
The bug occurs because resources with identical paths across different organizations share a single permission object, causing permission changes for one org to affect others. Two solutions were considered:

1. Adjust permission-setting/deletion logic everywhere.

2. Include the org ID in the resource key for isolation.

Though option 2 involves more interface changes, it’s more maintainable long-term, so I proceeded with it.