### PR TITLE
fix Bug #70912

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationProvider.java
@@ -1243,7 +1243,7 @@ public class DatabaseAuthenticationProvider extends AbstractAuthenticationProvid
              connectionLastTested.isBefore(Instant.now().minusMillis(connectionRetryInterval));
    }
 
-   private void resetConnection() {
+   public void resetConnection() {
       poolLock.lock();
 
       try {


### PR DESCRIPTION
When the driver is uninstalled or installed, reset the database provider's connection and cache to ensure that the next time accessing the database provider's data, it can re-establish the connection and retrieve the data.