### PR TITLE
bug-70898

### DIFF
--- a/core/src/main/java/inetsoft/mv/MVManager.java
+++ b/core/src/main/java/inetsoft/mv/MVManager.java
@@ -1512,7 +1512,7 @@ public final class MVManager {
          for(int i = 0; roles != null && i < roles.length; i++) {
             id = new DefaultIdentity(roles[i], Identity.ROLE);
 
-            if(def.containsUser(id)) {
+            if(def.containsUser(id) || id.getName().equals("Organization Administrator")) {
                return true;
             }
          }


### PR DESCRIPTION
The issue arises because permissions were granted to a Repository Tree Group (e.g., group0).  When executing the getIsMaterializedFilter method, the current user is inferred from the group identity (group0), while the user logged into the portal is actually a guest.

As a result, the filter compares this internal group-based identity against the portal's logged-in user (guest), causing a mismatch and ultimately filtering out views that should be visible.