### PR TITLE
Bug #70934

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/ContentRepositoryTreeService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/ContentRepositoryTreeService.java
@@ -47,7 +47,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.io.File;
 import java.security.Principal;
 import java.util.*;
 import java.util.concurrent.*;
@@ -825,7 +824,7 @@ public class ContentRepositoryTreeService {
    {
       String description = "";
       String icon = null;
-      String label = entry.getLabel();
+      String label = shouldShowEntryAlias(entry) ? entry.getLabel() : entry.getName();
       long lastModifiedTime = 0;
 
       if(entry.getType() == RepositoryEntry.WORKSHEET) {
@@ -2002,6 +2001,12 @@ public class ContentRepositoryTreeService {
 
       return securityProvider.checkPermission(
          principal, ResourceType.SECURITY_USER, user.convertToKey(), ResourceAction.ADMIN);
+   }
+
+   private boolean shouldShowEntryAlias(RepositoryEntry entry) {
+      String name = entry.getName();
+      return SUtil.MY_DASHBOARD.equals(name) || Tool.MY_DASHBOARD.equals(name) ||
+         RepositoryEntry.USERS_FOLDER.equals(name) || RepositoryEntry.WORKSHEETS_FOLDER.equals(name);
    }
 
 //   private boolean checkOrgID(String user, String orgID) {


### PR DESCRIPTION
Except for the program-specific names, other entries should display the name instead of the alias on the EM side.