### PR TITLE
Bug 70898

### DIFF
--- a/core/src/main/java/inetsoft/mv/MVManager.java
+++ b/core/src/main/java/inetsoft/mv/MVManager.java
@@ -1512,7 +1512,7 @@ public final class MVManager {
          for(int i = 0; roles != null && i < roles.length; i++) {
             id = new DefaultIdentity(roles[i], Identity.ROLE);
 
-            if(def.containsUser(id) || id.getName().equals("Organization Administrator")) {
+            if(def.containsUser(id)) {
                return true;
             }
          }

--- a/core/src/main/java/inetsoft/mv/MVManager.java
+++ b/core/src/main/java/inetsoft/mv/MVManager.java
@@ -1512,7 +1512,7 @@ public final class MVManager {
          for(int i = 0; roles != null && i < roles.length; i++) {
             id = new DefaultIdentity(roles[i], Identity.ROLE);
 
-            if(def.containsUser(id)) {
+            if(def.containsUser(id) || id.getName().equals("Organization Administrator")) {
                return true;
             }
          }

--- a/core/src/main/java/inetsoft/web/admin/content/repository/MVSupportService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/MVSupportService.java
@@ -1123,7 +1123,7 @@ public class MVSupportService {
             }
 
             // user enable security, but without any permission, default to administrator
-            if(!SecurityEngine.getSecurity().getSecurityProvider().isVirtual())
+            if(!SecurityEngine.getSecurity().getSecurityProvider().isVirtual() && MVDef.REJECT_VPM.get())
             {
                String orgID = Optional.ofNullable(entry.getOrgID()).orElse(Organization.getDefaultOrganizationID());
                List<IdentityID> orgAdminUsers = OrganizationManager.getInstance().orgAdminUsers(orgID);


### PR DESCRIPTION
A user with organization administrator privileges should be added to the identities list when creating the materialized view (MV).  It should not rely on checking if identities is empty or lacks permissions to add the user afterward.