### PR TITLE
Fix Bug #70816:

### DIFF
--- a/core/src/main/resources/inetsoft/web/resources/login.html
+++ b/core/src/main/resources/inetsoft/web/resources/login.html
@@ -131,13 +131,13 @@
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="activeSessoinTitle" data-th-text="#{Confirm}">Confirm</h5>
-        <button type="button" class="btn-close close" data-dismiss="modal" aria-label="Close">
+        <button type="button" class="btn-close close" data-bs-dismiss="modal" aria-label="Close">
         </button>
       </div>
       <div class="modal-body text-info" data-th-utext="#{login.warning.activeSession(${currentUser})}"></div>
       <div class="modal-footer">
         <button type="button" id="confirmLogin" class="btn btn-primary" data-th-text="#{Yes}">Yes</button>
-        <button type="button" class="btn btn-default" data-dismiss="modal" data-th-text="#{No}">No</button>
+        <button type="button" class="btn btn-default" data-bs-dismiss="modal" data-th-text="#{No}">No</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
In Bootstrap 5, the data-dismiss attribute has been deprecated and replaced with data-bs-dismiss.