### PR TITLE
fix Bug #70892

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
@@ -911,10 +911,6 @@ public class UserTreeService {
          List<String> localesList = localizationSettingsService.getModel().locales()
             .stream().map(LocalizationModel::label).collect(Collectors.toList());
 
-         //update to this organization
-         String newOrgID = identity.getId();
-         OrganizationManager.getInstance().setCurrentOrgID(newOrgID);
-
          return EditOrganizationPaneModel.builder()
             .name(identity.getName())
             .id(identity.getId())
@@ -930,6 +926,7 @@ public class UserTreeService {
       catch(Exception e) {
          actionRecord.setActionStatus(ActionRecord.ACTION_STATUS_FAILURE);
          actionRecord.setActionError(e.getMessage());
+         newOrgId = null;
          throw e;
       }
       finally {
@@ -938,6 +935,11 @@ public class UserTreeService {
 
          if(identityInfoRecord != null) {
             Audit.getInstance().auditIdentityInfo(identityInfoRecord, principal);
+         }
+
+         //update to new organization
+         if(newOrgId != null) {
+            OrganizationManager.getInstance().setCurrentOrgID(newOrgId);
          }
       }
    }


### PR DESCRIPTION
Fixed the issue of not switching to the new organization after creation. 
In the `try{}` block, it's not guaranteed that the `principal` in `ThreadContext` remains the currently logged-in user because it could be set to something else during the process of copying the organization. Therefore, the old `principal` is restored to `ThreadContext` in the `finally{}` block, and then the `curr_org_id` property is updated to the newly created organization.