### PR TITLE
Bug #70964  List all organization scoped properties in the organization editor pane

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
@@ -966,10 +966,20 @@ public class UserTreeService {
       String[] propertyNames = {"max.row.count", "max.col.count", "max.cell.size", "max.user.count"};
       List<PropertyModel> properties = new ArrayList<>();
       IdentityID pId = IdentityID.getIdentityIDFromKey(principal.getName());
+      Set<Object> keyset = SreeEnv.getProperties().keySet();
+      String orgPrefix = "inetsoft.org." + orgID.getOrgID() + ".";
 
-      for(String key : propertyNames) {
-         if(SreeEnv.getProperty(key, false, true) != null) {
-            properties.add(PropertyModel.builder().name(key).value(SreeEnv.getProperty(key, false, true)).build());
+      for(Object key : keyset) {
+         String propName = (String) key;
+
+         if(!(propName).startsWith(orgPrefix)) {
+            continue;
+         }
+
+         propName = propName.substring(orgPrefix.length());
+
+         if(SreeEnv.getProperty(propName, false, true) != null) {
+            properties.add(PropertyModel.builder().name(propName).value(SreeEnv.getProperty(propName, false, true)).build());
          }
       }
 

--- a/web/projects/em/src/app/settings/security/property-table-view/property-table-view.component.html
+++ b/web/projects/em/src/app/settings/security/property-table-view/property-table-view.component.html
@@ -29,6 +29,7 @@
           </th>
           <td mat-cell *matCellDef="let row" class="selected-cell">
             <mat-checkbox (click)="$event.stopPropagation()"
+                          [disabled]="!isEditableProperty(row.name)"
                           (change)="$event ? toggleRow(row) : null"
                           [checked]="selection.isSelected(row)">
             </mat-checkbox>
@@ -37,17 +38,17 @@
         <ng-container [matColumnDef]="'name'">
           <ng-container class="detail-cell">
             <th mat-header-cell *matHeaderCellDef>_#(Name)</th>
-            <td mat-cell *matCellDef="let row">{{getLabel(row.name)}}</td>
+            <td mat-cell [class.disabled]="!isEditableProperty(row.name)" *matCellDef="let row">{{getLabel(row.name)}}</td>
           </ng-container>
         </ng-container>
         <ng-container [matColumnDef]="'value'">
           <ng-container class="detail-cell">
             <th mat-header-cell *matHeaderCellDef>_#(Value)</th>
-            <td mat-cell *matCellDef="let row"> {{row.value}}</td>
+            <td mat-cell [class.disabled]="!isEditableProperty(row.name)" *matCellDef="let row"> {{row.value}}</td>
           </ng-container>
         </ng-container>
         <tr mat-header-row *matHeaderRowDef="displayColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayColumns;" (click)="selection.toggle(row)"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayColumns;" (click)="toggleSelection(row)"></tr>
       </table>
       <mat-paginator [pageSizeOptions]="[10, 25, 100]" [showFirstLastButtons]="true"></mat-paginator>
     </div>

--- a/web/projects/em/src/app/settings/security/property-table-view/property-table-view.component.scss
+++ b/web/projects/em/src/app/settings/security/property-table-view/property-table-view.component.scss
@@ -24,3 +24,7 @@ table {
   overflow-y: auto;
   margin-bottom: 1em;
 }
+
+.disabled {
+  opacity: 0.7;
+}

--- a/web/projects/em/src/app/settings/security/property-table-view/property-table-view.component.ts
+++ b/web/projects/em/src/app/settings/security/property-table-view/property-table-view.component.ts
@@ -34,16 +34,27 @@ import { PropertyModel } from "./property-model";
    styleUrls: ["./property-table-view.component.scss"]
 })
 export class PropertyTableViewComponent implements OnChanges, AfterViewInit {
+   @Input() get dataSource(): PropertyModel[] {
+      return this._dataSource;
+   }
+
+   set dataSource(value: PropertyModel[]) {
+      this._dataSource = value;
+      this.editableProperties = value.filter(prop => this.isEditableProperty(prop.name));
+   }
+
+   _dataSource: PropertyModel[] = [];
+   editableProperties = [];
    @Input() name: string;
    @Input() type: number;
    @Input() label: string;
-   @Input() dataSource: PropertyModel[] = [];
    @Input() editable: boolean = true;
    @Output() addProperties = new EventEmitter<PropertyModel[]>();
    @Output() removeProperties = new EventEmitter<PropertyModel[]>();
    @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
    matTableDataSource: MatTableDataSource<PropertyModel>;
    displayColumns: string[] = ["selected", "name", "value"];
+   orgProperties: string[] = ["max.row.count", "max.col.count", "max.cell.size", "max.user.count"];
    selection = new SelectionModel<PropertyModel>(true, []);
 
    constructor(private dialog: MatDialog) { }
@@ -118,7 +129,7 @@ export class PropertyTableViewComponent implements OnChanges, AfterViewInit {
    }
 
    isAllSelected(): boolean {
-      return this.selection.selected.length === this.matTableDataSource.data.length;
+      return this.selection.selected.length === this.editableProperties.length;
    }
 
    toggleRow(row) {
@@ -128,6 +139,18 @@ export class PropertyTableViewComponent implements OnChanges, AfterViewInit {
    masterToggle() {
       this.isAllSelected() ?
          this.selection.clear() :
-         this.matTableDataSource.data.forEach(row => this.selection.select(row));
+         this.matTableDataSource.data
+            .filter(prop => this.isEditableProperty(prop.name))
+            .forEach(row => this.selection.select(row));
+   }
+
+   toggleSelection(row :PropertyModel) {
+      if(this.isEditableProperty(row.name)) {
+         this.selection.toggle(row);
+      }
+   }
+
+   isEditableProperty(property: string): boolean {
+      return this.orgProperties.indexOf(property) != -1;
    }
 }


### PR DESCRIPTION
I don't think users should be allowed to manually edit all the org properties from here, since that would require permission to the properties component. I've added the remaining org properties to the list as uneditable rows.