### PR TITLE
fix Bug #70955

### DIFF
--- a/web/projects/em/src/app/settings/content/repository/import-export/selected-asset-list/selected-asset-list.component.html
+++ b/web/projects/em/src/app/settings/content/repository/import-export/selected-asset-list/selected-asset-list.component.html
@@ -18,7 +18,7 @@
 <table mat-table matSort [dataSource]="dataSource">
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>_#(Name)</th>
-    <td mat-cell *matCellDef="let row" [title]="row.label"> {{ getLabel(row.label) }}</td>
+    <td mat-cell *matCellDef="let row; let i = index" [title]="row.label"> {{ getLabel(row.label, i) }}</td>
   </ng-container>
   <ng-container matColumnDef="type">
     <th mat-header-cell *matHeaderCellDef class="type-column">_#(Type)</th>
@@ -26,7 +26,7 @@
   </ng-container>
   <ng-container matColumnDef="appliedTargetLabel">
     <th [style.display]="selectedTargetFolder ? '' : 'none'" mat-header-cell *matHeaderCellDef>_#(Imported Path)</th>
-    <td [style.display]="selectedTargetFolder ? '' : 'none'" mat-cell *matCellDef="let row" [title]="row.appliedTargetLabel"> {{ getLabel(row.appliedTargetLabel) }}</td>
+    <td [style.display]="selectedTargetFolder ? '' : 'none'" mat-cell *matCellDef="let row; let i = index" [title]="row.appliedTargetLabel"> {{ getLabel(row.appliedTargetLabel, i) }}</td>
   </ng-container>
   <ng-container matColumnDef="lastModifiedTime">
     <th mat-header-cell *matHeaderCellDef class="type-column">_#(Last Modified Time)</th>

--- a/web/projects/em/src/app/settings/content/repository/import-export/selected-asset-list/selected-asset-list.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/import-export/selected-asset-list/selected-asset-list.component.ts
@@ -77,7 +77,13 @@ export class SelectedAssetListComponent implements OnInit {
       return this.selection.selected.length === this.assets.length;
    }
 
-   getLabel(path: string) {
+   getLabel(path: string, index: number) {
+      const assetType = this.assets[index]?.typeName;
+
+      if(assetType != "AUTOSAVEVS" && assetType != "AUTOSAVEWS") {
+         return path;
+      }
+
       if(path != null && path.indexOf("^") != -1) {
          let paths = path.split("^");
 


### PR DESCRIPTION
Fixed the issue where the names of the extended model/view were not displayed correctly in the selected-asset-list.  I checked the previous version, and the `getLabel()` method was added to handle the autosave file, please refer to  `https://repo.inetsoft.com/svn/product/changeset/127760`.