### PR TITLE
fix Bug #70337:

### DIFF
--- a/web/projects/em/src/app/settings/schedule/task-action-pane/backup-file/backup-file.component.ts
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/backup-file/backup-file.component.ts
@@ -387,10 +387,8 @@ export class BackupFileComponent implements OnDestroy {
             if(node.label !== "_#(js:Data Model)" &&
                ((type & RepositoryEntryType.FOLDER) != RepositoryEntryType.FOLDER ||
                   (type & RepositoryEntryType.DATA_SOURCE) == RepositoryEntryType.DATA_SOURCE ||
-                  ((type & RepositoryEntryType.LOGIC_MODEL) == RepositoryEntryType.LOGIC_MODEL &&
-                     node.children.length === 0) ||
-                  ((type & RepositoryEntryType.PARTITION) == RepositoryEntryType.PARTITION &&
-                     node.children.length === 0))) {
+                  (type & RepositoryEntryType.LOGIC_MODEL) == RepositoryEntryType.LOGIC_MODEL ||
+                  (type & RepositoryEntryType.PARTITION) == RepositoryEntryType.PARTITION)) {
                assets.push(<SelectedAssetModel>{
                   label: label,
                   path: path,


### PR DESCRIPTION
fix Bug #70953:
the bug is caused by when logicmodel and partition, only add the node when no children. In fact, when backup file, we should backup logicmodel and partitaion and its children.