### PR TITLE
fix Bug #70996

### DIFF
--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/task-action-pane.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/task-action-pane.component.ts
@@ -380,26 +380,15 @@ export class TaskActionPane implements OnInit {
       ComponentTool.showConfirmDialog(this.modalService, "_#(js:Confirm)", message).then(
          (result: string) => {
             if(result === "ok") {
-               const params = new HttpParams()
-                  .set("name", Tool.byteEncode(this.oldTaskName))
-                  .set("owner", Tool.byteEncode(this.taskOwner));
                const actions: number[] = Tool.clone(this.selectedActions);
                actions.sort();
-               actions.reverse();
 
-               this.http.post(ACTION_URI + "/delete", actions, { params })
-                  .subscribe(() => {
-                     actions.sort();
+               for(let i = actions.length - 1; i >= 0; i--) {
+                  this._model.actions.splice(actions[i], 1);
+               }
 
-                     for(let i = actions.length - 1; i >= 0; i--) {
-                        this._model.actions.splice(actions[i], 1);
-                     }
-
-                     this.selectedActions = [];
-                  },
-                     (error: string) => {
-                        // Error
-                     });
+               this.selectedActions = [];
+               this.actionIndex = this._model.actions.length - 1;
             }
          });
    }

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.component.ts
@@ -626,23 +626,16 @@ export class TaskConditionPane implements OnInit, OnChanges {
       ComponentTool.showConfirmDialog(this.modalService, "_#(js:Confirm)", message).then(
          (result: string) => {
             if(result === "ok") {
-               const params = new HttpParams().set("name", Tool.byteEncode(this.oldTaskName));
                const conditions: number[] = Tool.clone(this.selectedConditions);
                conditions.sort();
                conditions.reverse();
 
-               this.http.post(TASK_URI + "/delete", conditions, { params: params })
-                  .subscribe(() => {
-                        for(let index of conditions) {
-                           this._model.conditions.splice(index, 1);
-                        }
+               for(let index of conditions) {
+                  this._model.conditions.splice(index, 1);
+               }
 
-                        this.selectedConditions = [];
-                        this.conditionIndex = this._model.conditions.length - 1;
-                     },
-                     () => {
-                        // Error
-                     });
+               this.selectedConditions = [];
+               this.conditionIndex = this._model.conditions.length - 1;
             }
          });
    }


### PR DESCRIPTION
When deleting a task condition or task action, do not directly request to delete it. All modifications to the task should be temporary, and changes should only be saved when the "save" button is clicked. This approach ensures consistency with the behavior on the EM side.