### PR TITLE
fix Bug #70983

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/RepositoryTreeController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/RepositoryTreeController.java
@@ -394,7 +394,7 @@ public class RepositoryTreeController {
             analyticRepository.renameRepositoryEntry(entry, newPath, principal);
          }
          else {
-            boolean reAlias = assetEntry.getAlias() != null || containsSpecialChars(newName);
+            boolean reAlias = !Tool.isEmptyString(assetEntry.getAlias()) || containsSpecialChars(newName);
             String name = assetEntry.getScope() == AssetRepository.USER_SCOPE ?
                newPath.substring(Tool.MY_DASHBOARD.length() + 1) : newPath;
             AssetEntry nentry = new AssetEntry(assetEntry.getScope(),


### PR DESCRIPTION
Validate the case where the alias is an empty string. If the alias is null or an empty string, renaming the viewsheet should modify the viewsheet's name, not the alias.