### PR TITLE
fix Bug #70959

### DIFF
--- a/core/src/main/java/inetsoft/util/migrate/MigrateScheduleTask.java
+++ b/core/src/main/java/inetsoft/util/migrate/MigrateScheduleTask.java
@@ -283,7 +283,7 @@ public class MigrateScheduleTask extends MigrateDocumentTask {
    private void syncIdentityAttribute(Element task, String attrName) {
       String user = task.getAttribute(attrName);
 
-      if(user == null) {
+      if(Tool.isEmptyString(user)) {
          return;
       }
 


### PR DESCRIPTION
Handle the case where the user is an empty string. In the previous logic, this would result in creating an incorrect user.