### PR TITLE
fix Bug #70991,

### DIFF
--- a/core/src/main/java/inetsoft/mv/MVManager.java
+++ b/core/src/main/java/inetsoft/mv/MVManager.java
@@ -1101,7 +1101,7 @@ public final class MVManager {
       migrateStorageData(oorg, norg, true);
    }
 
-   private void migrateStorageData(Organization oorg, Organization norg, boolean copy)
+   public void migrateStorageData(Organization oorg, Organization norg, boolean copy)
       throws Exception
    {
       mvs.initRoot(norg.getOrganizationID());
@@ -1159,7 +1159,7 @@ public final class MVManager {
             defName = def.getName();
             mv.setDef(def);
             mv.save(MVStorage.getFile(def.getName()), storeId, false);
-            fsys.rename(oldDefName, oorgId, defName, norgId, copy);
+            fsys.rename(oldDefName, oorgId, defName, norgId);
          }
          catch(IOException e) {
             throw new RuntimeException(e);

--- a/core/src/main/java/inetsoft/mv/fs/FSService.java
+++ b/core/src/main/java/inetsoft/mv/fs/FSService.java
@@ -219,6 +219,7 @@ public final class FSService {
 
       if(removeNode != null) {
          removeNode.getFSystem().dispose();
+         datas.remove(orgId);
       }
    }
 

--- a/core/src/main/java/inetsoft/mv/fs/XFileSystem.java
+++ b/core/src/main/java/inetsoft/mv/fs/XFileSystem.java
@@ -83,7 +83,7 @@ public interface XFileSystem {
    /**
     * Rename one XFile.
     */
-   boolean rename(String from, String fromOrgId, String to, String toOrgId, boolean keepGlobalFile);
+   boolean rename(String from, String fromOrgId, String to, String toOrgId);
 
    /**
     * Remove the XFile for the given name.

--- a/core/src/main/java/inetsoft/mv/fs/internal/BlockFileStorage.java
+++ b/core/src/main/java/inetsoft/mv/fs/internal/BlockFileStorage.java
@@ -84,6 +84,10 @@ public class BlockFileStorage implements AutoCloseable {
    }
 
    public void rename(BlockFile oldFile, BlockFile newFile) throws IOException {
+      rename(null, oldFile, newFile);
+   }
+
+   public void rename(String orgId, BlockFile oldFile, BlockFile newFile) throws IOException {
       if((oldFile instanceof CacheBlockFile) && (newFile instanceof CacheBlockFile)) {
          FileSystemService fs = FileSystemService.getInstance();
          File source = fs.getCacheFile(oldFile.getName());
@@ -99,7 +103,7 @@ public class BlockFileStorage implements AutoCloseable {
          copy(oldFile, newFile);
       }
       else if((oldFile instanceof StorageBlockFile) && (newFile instanceof StorageBlockFile)) {
-         getStorage().rename(oldFile.getName(), newFile.getName());
+         getStorage(orgId).rename(oldFile.getName(), newFile.getName());
       }
    }
 

--- a/core/src/main/java/inetsoft/mv/fs/internal/DefaultBlockSystem.java
+++ b/core/src/main/java/inetsoft/mv/fs/internal/DefaultBlockSystem.java
@@ -177,7 +177,7 @@ public final class DefaultBlockSystem implements XBlockSystem, XMLSerializable {
             nblock.setPhysicalLen(oldFile.length(fromOrgId));
 
             if(rename) {
-               BlockFileStorage.getInstance().rename(oldFile, newFile);
+               BlockFileStorage.getInstance().rename(orgId, oldFile, newFile);
             }
             else {
                BlockFileStorage.getInstance().copy(oldFile, fromOrgId, newFile, toOrgId);
@@ -560,6 +560,7 @@ public final class DefaultBlockSystem implements XBlockSystem, XMLSerializable {
    public void dispose() {
       try {
          blocks.close();
+         lastLoad.set(0L);
       }
       catch(Exception e) {
          LOG.warn("Failed to close distributed map", e);

--- a/core/src/main/java/inetsoft/mv/fs/internal/LocalFileSystem.java
+++ b/core/src/main/java/inetsoft/mv/fs/internal/LocalFileSystem.java
@@ -330,14 +330,14 @@ public final class LocalFileSystem extends AbstractFileSystem {
    @Override
    public boolean rename(String from, String to) {
       String currentOrgID = OrganizationManager.getInstance().getCurrentOrgID();
-      return rename(from, currentOrgID, to, currentOrgID, false);
+      return rename(from, currentOrgID, to, currentOrgID);
    }
 
    /**
     * Copy one XFile.
     */
    @Override
-   public boolean rename(String from, String fromOrgId, String to, String toOrgId, boolean keepGlobalFile) {
+   public boolean rename(String from, String fromOrgId, String to, String toOrgId) {
       if(bsys == null) {
          return false;
       }
@@ -382,9 +382,7 @@ public final class LocalFileSystem extends AbstractFileSystem {
                SBlock nsblock = new SBlock(to, blkid);
                nsblock.setLength(sblock.getLength());
 
-               NBlock renamedfileBlock = !keepGlobalFile ?
-                                         bsys.rename(sblock, nsblock, fromOrgId, toOrgId) :
-                                         bsys.copy(sblock, fromOrgId, nsblock, toOrgId) ;
+               NBlock renamedfileBlock = bsys.rename(sblock, nsblock, fromOrgId, toOrgId);
 
                if(renamedfileBlock == null) {
                   LOG.warn(Tool.convertUserLogInfo(
@@ -398,9 +396,7 @@ public final class LocalFileSystem extends AbstractFileSystem {
                   SNBlock targetSNBlock = new SNBlock(to, blkid);
                   targetSNBlock.setLength(sourceSNBlock.getLength());
 
-                  NBlock renamedBlock = !keepGlobalFile ?
-                                        bsys.rename(sourceSNBlock, targetSNBlock, fromOrgId, toOrgId) :
-                                        bsys.copy(sourceSNBlock, fromOrgId, targetSNBlock, toOrgId);
+                  NBlock renamedBlock = bsys.rename(sourceSNBlock, targetSNBlock, fromOrgId, toOrgId);
 
                   if(renamedBlock == null) {
                      LOG.warn(Tool.convertUserLogInfo(

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -926,12 +926,12 @@ public class IdentityService {
          updateLibraryStorage(oOrg.getId(), nOrg.getId(), true);
          IndexedStorage.getIndexedStorage().copyStorageData(oOrg, nOrg, rename);
 
-         FSService.copyServerNode(oOrg.getId(), nOrg.getId(), true);
-         //updateBlobStorageName("__mvBlock", oOrg.getId(), nOrg.getId(), BlockFileStorage.Metadata.class, true);
+         //FSService.copyServerNode(oOrg.getId(), nOrg.getId(), true);
          updateBlobStorageName("__mvws", oOrg.getId(), nOrg.getId(), BlockFileStorage.Metadata.class, true);
          updateBlobStorageName("__pdata", oOrg.getId(), nOrg.getId(), BlockFileStorage.Metadata.class, true);
          updateBlobStorageName("__autoSave", oOrg.getId(), nOrg.getId(), BlockFileStorage.Metadata.class, true);
-         MVManager.getManager().copyStorageData(oOrg, nOrg);
+         updateBlobStorageName("__mvBlock", oOrg.getId(), nOrg.getId(), BlockFileStorage.Metadata.class, true);
+         MVManager.getManager().migrateStorageData(oOrg, nOrg, !rename);
 
          addNewOrgTaskToScheduleServer(nOrg.getOrganizationID());
       }


### PR DESCRIPTION
1, fix mv data migrate logic to make it work well. 
step1: clone or rename fs.xml and bs.xml.
step2: clone or rename the mvBlock storage file.
step3: process MVManager.getManager().migrateStorageData to update the mv and block file name to new org. 

2, when update new org XFileSystem item, just rename it, need`t to copied, because fs.xml, bs.xml，mvBlock storage file have been updated. new org has copy data from old org. 

3, need`t copy server node data by FSService.copyServerNode, fs.xml, bs.xml have been copied, and have updated at MVManager.getManager().migrateStorageData.