### PR TITLE
fix Bug #71012, rollback Bug #70630 modify and refix it

### DIFF
--- a/core/src/main/java/inetsoft/util/dep/TableStyleAsset.java
+++ b/core/src/main/java/inetsoft/util/dep/TableStyleAsset.java
@@ -119,14 +119,21 @@ public class TableStyleAsset extends AbstractXAsset {
     */
    @Override
    public void parseIdentifier(String path, IdentityID userIdentity) {
+      style = path;
+   }
+
+   /**
+    * Get table style id by path
+    */
+   public String getStyleID() {
       LibManager manager = LibManager.getManager();
-      XTableStyle tableStyle = manager.getTableStyle(path);
+      XTableStyle tableStyle = manager.getTableStyle(style);
 
       if(tableStyle == null) {
-         throw new ResourceNotFoundException("Cannot find table style with path: " + path);
+         throw new ResourceNotFoundException("Cannot find table style with path: " + style);
       }
 
-      style = tableStyle.getID();
+      return tableStyle.getID();
    }
 
    public String getLabel() {

--- a/core/src/main/java/inetsoft/web/admin/deploy/DeployService.java
+++ b/core/src/main/java/inetsoft/web/admin/deploy/DeployService.java
@@ -845,6 +845,10 @@ public class DeployService {
       IdentityID user = entityUser == null || "__NULL__".equals(entityUser.name) ? null : entityUser;
       XAsset asset = SUtil.getXAsset(type, entityName, user);
 
+      if(asset instanceof TableStyleAsset style) {
+         asset = SUtil.getXAsset(type, style.getStyleID(), user);
+      }
+
       if(model.lastModifiedTime() != null) {
          asset.setLastModifiedTime(model.lastModifiedTime().longValue());
       }


### PR DESCRIPTION
parseIdentifier should not check table style exist, during import assets, fist step is get asset list by identifier, if check exist at there, will cause error.