### PR TITLE
bug-71020

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/sync/TaskAssetDependencyTransformer.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/TaskAssetDependencyTransformer.java
@@ -223,7 +223,7 @@ public class TaskAssetDependencyTransformer extends DependencyTransformer {
 
          Element user = getChildNode(item, "user");
 
-         if(!Tool.equals(ouser, Tool.getValue(user))) {
+         if(!Tool.equals(ouser.convertToKey(), Tool.getValue(user))) {
             continue;
          }
 

--- a/core/src/main/java/inetsoft/uql/asset/sync/TaskAssetDependencyTransformer.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/TaskAssetDependencyTransformer.java
@@ -223,7 +223,7 @@ public class TaskAssetDependencyTransformer extends DependencyTransformer {
 
          Element user = getChildNode(item, "user");
 
-         if(!Tool.equals(ouser.convertToKey(), Tool.getValue(user))) {
+         if(!Tool.equals(ouser == null ? null : ouser.convertToKey(), Tool.getValue(user))) {
             continue;
          }
 


### PR DESCRIPTION
During the table rename process, since ouser is an IdentityID object and Tool.getValue(user) is a string (e.g., "admin~;~host-org"), the comparison always returns false. As a result, the logic to update the path in the document was not executed, which caused the current issue. Converting ouser to a string before comparison would resolve this problem.