### PR TITLE
Fix Bug #71031:

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/selection/selection-list-cell.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/selection-list-cell.component.ts
@@ -149,10 +149,6 @@ export class SelectionListCell implements OnInit, OnChanges {
       this.measureTextVAlign = GuiTool.getFlexVAlign(this.measureTextFormat.vAlign);
       this.isParentIDTree = model.objectType === "VSSelectionTree" && (<VSSelectionTreeModel> model).mode == MODE.ID;
 
-      if(this.mobile) {
-         this.cellFormat.font = "15px Roboto, roboto, arial, helvetica, sans-serif"
-      }
-
       switch(this.measureTextFormat.vAlign) {
       case "top":
          this.barY = this.sanitization.bypassSecurityTrustStyle("2px");


### PR DESCRIPTION
To maintain consistency with other content, only the icons should be enlarged in mobile mode, not the text.