### PR TITLE
bug-70773

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
@@ -100,7 +100,7 @@ public class VSBookmarkService {
          return messageCommand;
       }
 
-      vs.getRuntimeEntry().setProperty("keepAnnonVis", "true");
+      vs.getRuntimeEntry().setProperty("keepAnnoVis", "true");
       rvs.addBookmark(bookmarkName, type,
                       principal.getName() == null ? new IdentityID("admin", OrganizationManager.getInstance().getCurrentOrgID()) :
                       IdentityID.getIdentityIDFromKey(principal.getName()), readOnly);


### PR DESCRIPTION
The bug occurred because in the set property, keepAnnoVis was incorrectly written as keepAnnonVis. As a result, the keepAnnoVisible method always retrieved a null value for keepAnnonVis. Correcting it to keepAnnoVis resolves the issue.