### PR TITLE
fix Bug #71024

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/sync/UpdateDependencyHandler.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/UpdateDependencyHandler.java
@@ -189,6 +189,7 @@ public final class UpdateDependencyHandler {
          String prefix = null;
          String entryPaths = null;
          boolean physicalTable = false;
+         boolean worksheetType = false;
 
          for(int j = 0; j < propertyList.getLength(); j++) {
             Element property = (Element) propertyList.item(j);
@@ -214,9 +215,12 @@ public final class UpdateDependencyHandler {
                Element valE = Tool.getChildNodeByTagName(property, "value");
                entryPaths = Tool.getValue(valE);
             }
+            else if(AssetEntry.WORKSHEET_TYPE.equals(key)) {
+               worksheetType = true;
+            }
          }
 
-         if("worksheet".equals(type)) {
+         if("worksheet".equals(type) || type == null && worksheetType) {
             int scope = AssetRepository.GLOBAL_SCOPE;
 
             try {


### PR DESCRIPTION
example vs "Construction Dashboard" binding asset entry do not have "mainType" property, so can not know source is worksheet, so can not transform binding info during import to target folder. to ensure work well, if binding have AssetEntry.WORKSHEET_TYPE property, think it binding worksheet source.