### PR TITLE
Fix Bug #70960:

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-table-cell.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-table-cell.component.ts
@@ -91,6 +91,7 @@ export class VSTableCell implements OnInit, OnChanges, OnDestroy {
    @Input() isFlyOnClick: boolean = false;
    @Input() width: number = 0;
    @Input() height: number = 0;
+   @Input() lastStart: number = 0;
    @Input() linkUri: string;
    @Input() isRendered: boolean = true;
    @Input() selectedDataIndex;
@@ -270,7 +271,7 @@ export class VSTableCell implements OnInit, OnChanges, OnDestroy {
 
       //Cell will be focused on enter key if it's the first one below current selected data cell
       if(changes.selectedDataIndex && this.selectedDataIndex && this.dataCellIndex) {
-         if(this.selectedDataIndex.row + 1 == this.dataCellIndex.row &&
+         if(this.selectedDataIndex.row - this.lastStart + 1 == this.dataCellIndex.row &&
             this.selectedDataIndex.column == this.dataCellIndex.column)
          {
             this.nextCellChanged.emit(this.cell);

--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.html
@@ -216,6 +216,7 @@
                 [width]="tableCellDisplayWidth(j)"
                 [height]="getRowHeight(indexToRow(i))"
                 [selectedDataIndex]="selectedDataIndex"
+                [lastStart]="lastStart"
                 [dataCellIndex]="{row: i, column: j}"
                 [isRendered]="!firstRow || loadedRows.start > 0"
                 (nextCellChanged)="nextCellChange($event)"

--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.ts
@@ -504,7 +504,7 @@ export class VSTable extends BaseTable<VSTableModel> implements OnInit, OnDestro
       let c = event.col;
 
       if(r < this.model.rowCount - 1) {
-         this.nextCell = this.tableData[r + 1][c];
+         this.nextCell = this.tableData[r - this.lastStart + 1][c];
       }
       else if(r == this.model.rowCount - 1) {
          this.nextCell = this.tableData[0][c];


### PR DESCRIPTION
The table loads data in batches (group by group), and tableData only contains one batch of data. To determine which row within this batch is selected, simply subtract the starting index from the selected row number.