### PR TITLE
fix Bug #71048, don't sync empty permission incase the permission wit…

### DIFF
--- a/core/src/main/java/inetsoft/sree/RepletEngine.java
+++ b/core/src/main/java/inetsoft/sree/RepletEngine.java
@@ -1706,12 +1706,11 @@ public class RepletEngine extends AbstractAssetEngine
          if(!SUtil.isMyReport(oname)) {
             SecurityEngine security = getSecurity();
 
-            if(security != null) {
-               security.setPermission(
-                  ResourceType.REPORT, nname,
-                  security.getPermission(ResourceType.REPORT, oname));
+            if(security != null && !Tool.equals(nname, oname)) {
+               Permission perm = security.getPermission(ResourceType.REPORT, oname);
 
-               if(!Tool.equals(nname, oname)) {
+               if(perm != null) {
+                  security.setPermission(ResourceType.REPORT, nname, perm);
                   security.removePermission(ResourceType.REPORT, oname);
                }
             }


### PR DESCRIPTION
don't sync empty permission incase the permission with npath have already be updated and old path permission have already be removed.