### PR TITLE
fix Bug #71019:

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/sync/TaskAssetDependencyTransformer.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/TaskAssetDependencyTransformer.java
@@ -353,7 +353,7 @@ public class TaskAssetDependencyTransformer extends DependencyTransformer {
                replaceCDATANode(item, value.replace(info.getOldName(), info.getNewName()));
             }
             else if(Tool.equals(value, info.getOldName())) {
-               replaceCDATANode(item, info.alias ? info.getNewName() : newColName2);
+               replaceCDATANode(item, info.alias || newColName2 == null ? info.getNewName() : newColName2);
             }
             else if(Tool.equals(value, oldColName2)) {
                replaceCDATANode(item, newColName2);


### PR DESCRIPTION
when rename alias, it should change alias from old name to newname, but if rename name not alias, it should change new name to entity+newname, but if not entity, should using newname. So add check for newColName is null, should using newname as parameter value.