### PR TITLE
Bug 71065

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/sync/DependencyTransformer.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/DependencyTransformer.java
@@ -1534,9 +1534,9 @@ public abstract class DependencyTransformer {
     *
     * @return extend Model DependencyInfo
     */
-   public static RenameDependencyInfo createExtendModelDepInfoForFolderChanged(XLogicalModel model,
-                                                                               String oldFolderName,
-                                                                               String newFolderName)
+   public static RenameDependencyInfo createExtendModelDepInfoForFolderChanged(
+      RenameDependencyInfo renameDependencyInfo, XLogicalModel model, String oldFolderName,
+      String newFolderName)
    {
       if(model == null) {
          return null;
@@ -1548,7 +1548,6 @@ public abstract class DependencyTransformer {
          return null;
       }
 
-      RenameDependencyInfo renameDependencyInfo = new RenameDependencyInfo();
       String datasource = model.getDataSource();
       String baseModelName = model.getName();
       String pathSpliter = XUtil.DATAMODEL_PATH_SPLITER;

--- a/core/src/main/java/inetsoft/web/portal/controller/database/DatabaseModelBrowserService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/DatabaseModelBrowserService.java
@@ -397,15 +397,9 @@ public class DatabaseModelBrowserService {
             dinfo.addRenameInfo(obj, rinfo);
          }
 
+         DependencyTransformer.createExtendModelDepInfoForFolderChanged(dinfo, logicalModel,
+            oldFolder, folder);
          RenameTransformHandler.getTransformHandler().addTransformTask(dinfo);
-         RenameDependencyInfo extendModelDependencyInfo =
-            DependencyTransformer.createExtendModelDepInfoForFolderChanged(logicalModel, oldFolder, folder);
-
-         if(extendModelDependencyInfo != null &&
-            !ArrayUtils.isEmpty(extendModelDependencyInfo.getAssetObjects()))
-         {
-            RenameTransformHandler.getTransformHandler().addTransformTask(extendModelDependencyInfo);
-         }
       }
       catch(Exception ex) {
          actionRecord.setActionError(ex.getMessage() + ", Target Entry: " + newPath);
@@ -677,8 +671,8 @@ public class DatabaseModelBrowserService {
             List<AssetObject> entries = DependencyTransformer.getDependencies(oentry.toIdentifier());
 
             if(entries == null) {
-               DependencyTransformer.createExtendModelDepInfoForFolderChanged(logicalModel, oldName,
-                  folderName);
+               DependencyTransformer.createExtendModelDepInfoForFolderChanged(dinfo, logicalModel,
+                  oldName, folderName);
                continue;
             }
 
@@ -686,8 +680,8 @@ public class DatabaseModelBrowserService {
                dinfo.addRenameInfo(obj, rinfo);
             }
 
-            DependencyTransformer.createExtendModelDepInfoForFolderChanged(logicalModel, oldName,
-               folderName);
+            DependencyTransformer.createExtendModelDepInfoForFolderChanged(dinfo, logicalModel,
+               oldName, folderName);
          }
 
          for(String partitionName : dataModel.getPartitionNames()) {

--- a/core/src/main/java/inetsoft/web/portal/controller/database/DatabaseModelBrowserService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/DatabaseModelBrowserService.java
@@ -677,12 +677,17 @@ public class DatabaseModelBrowserService {
             List<AssetObject> entries = DependencyTransformer.getDependencies(oentry.toIdentifier());
 
             if(entries == null) {
+               DependencyTransformer.createExtendModelDepInfoForFolderChanged(logicalModel, oldName,
+                  folderName);
                continue;
             }
 
             for(AssetObject obj : entries) {
                dinfo.addRenameInfo(obj, rinfo);
             }
+
+            DependencyTransformer.createExtendModelDepInfoForFolderChanged(logicalModel, oldName,
+               folderName);
          }
 
          for(String partitionName : dataModel.getPartitionNames()) {
@@ -708,12 +713,17 @@ public class DatabaseModelBrowserService {
             List<AssetObject> entries = DependencyTransformer.getDependencies(oentry.toIdentifier());
 
             if(entries == null) {
+               DependencyTransformer.createExtendViewDepInfoForFolderChanged(dinfo,
+                  partitionModel, opath, npath, rinfo, oentry.getPath());
                continue;
             }
 
             for(AssetObject obj : entries) {
                dinfo.addRenameInfo(obj, rinfo);
             }
+
+            DependencyTransformer.createExtendViewDepInfoForFolderChanged(dinfo,
+               partitionModel, opath, npath, rinfo, oentry.getPath());
          }
 
          Permission permission = securityEngine.getPermission(


### PR DESCRIPTION
when rename data model folder, not only create rename info for models and views, also should create rename info for extend models and extend views.

coding refactory, should using one rename dependency info when one rename action, merge all rename info together to run task.