### PR TITLE
bug-71028 when add same datasource to backup of schedule,list show repeat datasource

### DIFF
--- a/web/projects/em/src/app/settings/schedule/task-action-pane/backup-file/backup-file.component.ts
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/backup-file/backup-file.component.ts
@@ -251,11 +251,14 @@ export class BackupFileComponent implements OnDestroy {
    }
 
    isSameType(entityType: number, nodeType: number): boolean {
-      if((entityType & RepositoryEntryType.DATA_SOURCE) == RepositoryEntryType.DATA_SOURCE) {
-         return (nodeType & RepositoryEntryType.FOLDER) == RepositoryEntryType.FOLDER;
+      const isEntityDataSource = (entityType & RepositoryEntryType.DATA_SOURCE) === RepositoryEntryType.DATA_SOURCE;
+      const isNodeDataSource = (nodeType & RepositoryEntryType.DATA_SOURCE) === RepositoryEntryType.DATA_SOURCE;
+
+      if(isEntityDataSource && isNodeDataSource) {
+         return true;
       }
 
-      return entityType == nodeType;
+      return entityType === nodeType;
    }
 
    getExportableLabel(node: RepositoryTreeNode): string {

--- a/web/projects/em/src/app/settings/schedule/task-action-pane/backup-file/backup-file.component.ts
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/backup-file/backup-file.component.ts
@@ -235,7 +235,7 @@ export class BackupFileComponent implements OnDestroy {
       const assetEntities = this.exportableNodes
          .filter((node) =>
             !this.selectedEntities.some((entity) =>
-               entity.path == node.data.path && entity.type == node.data.type))
+               entity.path == node.data.path && this.isSameType(entity.type, node.data.type)))
          .map((node) => <SelectedAssetModel>{
             label: this.getExportableLabel(node.data),
             path: node.data.path ? node.data.path : node.data.label,
@@ -248,6 +248,10 @@ export class BackupFileComponent implements OnDestroy {
          });
 
       this.filterEntities(assetEntities);
+   }
+
+   isSameType(entityType: number, nodeType: number): boolean {
+      return (entityType & nodeType) === entityType || (nodeType & entityType) === nodeType;
    }
 
    getExportableLabel(node: RepositoryTreeNode): string {

--- a/web/projects/em/src/app/settings/schedule/task-action-pane/backup-file/backup-file.component.ts
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/backup-file/backup-file.component.ts
@@ -251,7 +251,11 @@ export class BackupFileComponent implements OnDestroy {
    }
 
    isSameType(entityType: number, nodeType: number): boolean {
-      return (entityType & nodeType) === entityType || (nodeType & entityType) === nodeType;
+      if((entityType & RepositoryEntryType.DATA_SOURCE) == RepositoryEntryType.DATA_SOURCE) {
+         return (nodeType & RepositoryEntryType.FOLDER) == RepositoryEntryType.FOLDER;
+      }
+
+      return entityType == nodeType;
    }
 
    getExportableLabel(node: RepositoryTreeNode): string {


### PR DESCRIPTION
Because entity. type = 1024 and node.data.type = 1025, reopening the page allows adding the same datasource again.  Bitwise comparison shows that both include DATA_SOURCE, but 1025 is actually 1024 | 1, meaning it also includes FOLDER. Therefore, even though they refer to the same resource, the types are not exactly equal, which leads to them being treated as different objects. Using a "bitwise contains" check instead of "strict equality"—to be consistent with the service—can resolve this issue.