### PR TITLE
Merge forward Bug #71081 - fuzzy column matching

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/internal/AssetUtil.java
+++ b/core/src/main/java/inetsoft/uql/asset/internal/AssetUtil.java
@@ -3296,7 +3296,6 @@ public class AssetUtil {
       }
 
       ColumnIndexMap columnIndexMap = new ColumnIndexMap(table);
-      ColumnIndexMap fuzzyColumnIndexMap = new ColumnIndexMap(table, true);
 
       for(int i = 0; i < columns.getAttributeCount(); i++) {
          ColumnRef column = (ColumnRef) columns.getAttribute(i);
@@ -3308,10 +3307,10 @@ public class AssetUtil {
          int col;
 
          if(column.getEntity() == null || column.getEntity().isEmpty()) {
-            col = Util.findColumn(fuzzyColumnIndexMap, column.getAttribute());
+            col = Util.findColumn(columnIndexMap, column.getAttribute());
          }
          else {
-            col = Util.findColumn(fuzzyColumnIndexMap,
+            col = Util.findColumn(columnIndexMap,
                column.getEntity() + "." + column.getAttribute());
          }
 


### PR DESCRIPTION
Don't do fuzzy matching when trying to find an aliased column. Adjust the logic which was originally added for Bug #38624.