### PR TITLE
Bug-71074 <mobile-selectionlist>"others"icon should adjust larger 

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/selection/selection-list-cell.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/selection-list-cell.component.html
@@ -54,7 +54,7 @@
       <div class="icon-label-content"
            tooltipIf [disableTooltipIf]="toggleEnabled">
         <div [ngClass]="getTreeIconClass()"
-             [class.mobile-max-model-icon]="mobile && maxMode"
+             [class.mobile-max-mode-icon]="mobile && maxMode"
              [style.color]="cellFormat.foreground"
              *ngIf="isFolder()" (click)="toggleFolder($event)"
              [style.padding-left.px]="nodeIndent - indent"
@@ -64,7 +64,7 @@
              class="selection-list-icon-layout"
              [ngClass]="getIconClass()"
              [title]="getCellTooltip()"
-             [class.mobile-max-model-icon]="mobile && maxMode"
+             [class.mobile-max-mode-icon]="mobile && maxMode"
              [style.padding-left.px]="isFolder() ? 1 : nodeIndent"
              [style.color]="cellFormat.foreground"
              (click)="click($event)">

--- a/web/projects/portal/src/app/vsobjects/objects/selection/selection-list-cell.component.scss
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/selection-list-cell.component.scss
@@ -35,7 +35,7 @@
         display: flex;
         align-items: center;
 
-        .mobile-max-model-icon {
+        .mobile-max-mode-icon {
           font-size: 24px !important;
         }
 

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.html
@@ -242,6 +242,7 @@
                [style.background]="othersFormat?.background"
                [safeFont]="othersFormat?.font">
             <i class="plus-box-outline-icon icon-size1 show-others-icon"
+               [class.mobile-max-model-icon]="mobile && model.maxMode"
                [style.color]="othersFormat?.foreground"
                (click)="showAllValues($event)"></i>
             _#(Others)...

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.html
@@ -242,7 +242,7 @@
                [style.background]="othersFormat?.background"
                [safeFont]="othersFormat?.font">
             <i class="plus-box-outline-icon icon-size1 show-others-icon"
-               [class.mobile-max-model-icon]="mobile && model.maxMode"
+               [class.mobile-max-mode-icon]="mobile && model.maxMode"
                [style.color]="othersFormat?.foreground"
                (click)="showAllValues($event)"></i>
             _#(Others)...

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.scss
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.scss
@@ -262,3 +262,7 @@
 .separator-visible {
   border-right: 1px solid;
 }
+
+.mobile-max-model-icon {
+  font-size: 24px !important;
+}

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.scss
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.scss
@@ -263,6 +263,6 @@
   border-right: 1px solid;
 }
 
-.mobile-max-model-icon {
+.mobile-max-mode-icon {
   font-size: 24px !important;
 }

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
@@ -185,6 +185,7 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
    headerBorderBottomColor: string;
    headerSeparatorBorderColor: string;
    private searchPending: boolean = false;
+   mobile: boolean = GuiTool.isMobileDevice();
 
    // Number of values displayed when the selection list is first loaded as well as the number
    // of values to show when click 'More' to show values not displayed


### PR DESCRIPTION
Adjust the size of the "others" icon on mobile to match the other selection list cells.