### PR TITLE
fix Bug #71058, remove the listener from runtimeAssetRepository before destroy AssetTreeRefreshController.

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/AssetTreeRefreshController.java
+++ b/core/src/main/java/inetsoft/web/composer/AssetTreeRefreshController.java
@@ -56,6 +56,12 @@ public class AssetTreeRefreshController {
    public void preDestroy() throws Exception {
       assetRepository.removeAssetChangeListener(listener);
       LibManager.getManager().removeActionListener(libraryListener);
+      AssetRepository runtimeAssetRepository = AssetUtil.getAssetRepository(false);
+
+      if(runtimeAssetRepository != null && runtimeAssetRepository != assetRepository) {
+         runtimeAssetRepository.removeAssetChangeListener(listener);
+      }
+
       this.debouncer.close();
    }
 


### PR DESCRIPTION
remove the listener from runtimeAssetRepository before destroy AssetTreeRefreshController.