### PR TITLE
fix Bug #71059, should not decrement the reference count again in the Cluster cache destroy method.

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/cluster/ClusterCache.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ClusterCache.java
@@ -144,7 +144,7 @@ public abstract class ClusterCache<E, L extends Serializable, S extends  Seriali
 
       if(lock.tryLock(10L, TimeUnit.SECONDS)) {
          try {
-            lastInstance = referenceCounter.decrementAndGet() == 0;
+            lastInstance = referenceCounter.get() == 0;
 
             if(lastInstance) {
                cluster.destroyLong(prefix + "timestamp");


### PR DESCRIPTION
should not decrement the reference count again in the Cluster cache destroy method.