### PR TITLE
fix Bug #71068:

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-data-model-browser/data-model-browser.service.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-data-model-browser/data-model-browser.service.ts
@@ -465,7 +465,7 @@ export class DataModelBrowserService {
                create: true,
                desc: "",
                parent: parent,
-               folder: folder
+               folder: folder == null ? "" : folder
             };
 
             if(!isDefault) {


### PR DESCRIPTION
The bug is extend view will not transform in task, so when rename source, it will be lost in task backup list. It caused by saved wrong folder for extend view when no folder, its folder should be null, not "null",  is add extend model parameters should set folder to "" to avoid it add "null" to url.