### PR TITLE
fix Bug #71047: fix issue of bookmarks can not saved for task

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
@@ -845,7 +845,7 @@ public class ScheduleTaskService {
                for(int j = 0; bookmarkTypes != null && j < bookmarkTypes.length; j++) {
                   if(bookmarkTypes[j] == VSBookmarkInfo.ALLSHARE ||
                      (bookmarkTypes[j] == VSBookmarkInfo.GROUPSHARE && groupShare) ||
-                     Tool.equals(identityID, bookmarkUsers[j]))
+                     Tool.equals(modelID, bookmarkUsers[j]))
                   {
                      bookmarkList.add(bookmarks[j]);
                      bookmarkUserList.add(bookmarkUsers[j]);


### PR DESCRIPTION
the bug is caused by when task's identity is null, it will not match with bookmark user, so should using modelID to check, modelID will set to owner id when identity is null.