### PR TITLE
fix Bug #71098. Fix NPE.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
@@ -1897,6 +1897,10 @@ public class RuntimeViewsheet extends RuntimeSheet {
     * Refresh the tip views or pop components of the runtime viewsheet.
     */
    public void refreshAllTipViewOrPopComponentTable() {
+      if(vs == null) {
+         return;
+      }
+
       Assembly[] arr = vs.getAssemblies();
 
       if(mode != VIEWSHEET_RUNTIME_MODE) {

--- a/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
@@ -2734,8 +2734,11 @@ public class CoreLifecycleService {
          }
 
          final Viewsheet vs = rvs.getViewsheet();
-         final VSAssemblyInfo vsAssemblyInfo = vs.getVSAssemblyInfo();
-         permissions.addAll(vsAssemblyInfo.getActionNames());
+
+         if(vs != null) {
+            final VSAssemblyInfo vsAssemblyInfo = vs.getVSAssemblyInfo();
+            permissions.addAll(vsAssemblyInfo.getActionNames());
+         }
       }
 
       return permissions;


### PR DESCRIPTION
Reproduce this bug by closing the preview pane before the preview viewsheet finishes. Since the preview pane is closed prematurely, the viewsheet gets disposed. Considering that this behavior is uncommon and the issue also existed in previous versions, just fix the NPE.