### PR TITLE
Fix Bug #71100:

### DIFF
--- a/core/src/main/java/inetsoft/report/internal/StyleCore.java
+++ b/core/src/main/java/inetsoft/report/internal/StyleCore.java
@@ -1575,7 +1575,8 @@ public abstract class StyleCore extends AbstractAssetEngine
       }
 
       String elemId = elem.getID();
-      String elemLogName = getSheetName() + "." + elemId;
+      String elemLogName = getSheetName() == null || getSheetName().equals("null") ? elemId :
+         getSheetName() + "." + elemId;
       Catalog catalog = Catalog.getCatalog();
       String warningMsg = null;
       String logMsg = null;


### PR DESCRIPTION
The name field is not used when creating and using the layout, so it is not saved when the layout is saved, resulting in name being null. When using it, you need to check for null.