### PR TITLE
fix Bug #71097: should only update Home bookmark to current vs when updateHome is true

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
@@ -183,7 +183,7 @@ public class RuntimeViewsheet extends RuntimeSheet {
          VSBookmark bookmark = getVSBookmark(getUserName());
          List<VSBookmarkInfo> visibleBookmarks = getUserVisibleBookmarks(pId);
 
-         if(bookmark != null && !containsHomeBookmark(visibleBookmarks)) {
+         if(bookmark != null && !containsHomeBookmark(visibleBookmarks) && updateHome) {
             bookmark.addHomeBookmark(vs, true);
          }
          // fix Bug #24338, should update the home bookmark when preview the viewsheet.


### PR DESCRIPTION
the bug is caused by after rename any bookmark, the home bookmark will changed to current bookmark state because rename will send event to update bookmarks to latest. In fact, we should only update home bookmark when updateHome is true.