### PR TITLE
fix Bug #70949: rollback changes(should load columns when init sheet for oneDrive db)

### DIFF
--- a/connectors/inetsoft-onedrive/src/main/java/inetsoft/uql/onedrive/OneDriveQuery.java
+++ b/connectors/inetsoft-onedrive/src/main/java/inetsoft/uql/onedrive/OneDriveQuery.java
@@ -86,6 +86,12 @@ public class OneDriveQuery extends SelectableTabularQuery  {
     */
    public void setExcelSheet(String excelSheet) {
       this.excelSheet = excelSheet;
+
+      try {
+         this.loadColumns();
+      }
+      catch(Exception e) {
+      }
    }
 
    /**


### PR DESCRIPTION
the bug is caused by Bug#69653, it remove loadColumns when init the one drive query, it is wrong, should rollback it. After testing, the old bug can not reproduce and works right.