### PR TITLE
fix Bug #71119: fix duplicate alias with other column name

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerVSTableController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerVSTableController.java
@@ -146,6 +146,14 @@ public class ComposerVSTableController {
                   dispatcher.sendCommand(command);
                   return;
                }
+
+               if(ref.getAlias() == null && ref.getName().equals(event.getText())) {
+                  MessageCommand command = new MessageCommand();
+                  command.setType(MessageCommand.Type.ERROR);
+                  command.setMessage(Catalog.getCatalog().getString("common.conflictingColumnAttribute", ref.getName()));
+                  dispatcher.sendCommand(command);
+                  return;
+               }
             }
 
             ColumnRef column = (ColumnRef) columns.getAttribute(getActualColIndex(columns, col));


### PR DESCRIPTION
the same as worksheet column, column alias should not the same as other column name, if the same, show warning for user.