### PR TITLE
Fix Bug #71117:

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
@@ -305,6 +305,14 @@ public class ScheduleTask implements Serializable, Cloneable, XMLSerializable {
       }
    }
 
+   public void addAction(ScheduleAction action, String linkUrl) {
+      if(action instanceof AbstractAction) {
+         ((AbstractAction) action).setLinkURI(linkUrl);
+      }
+
+      addAction(action);
+   }
+
    /**
     * Get the number of conditions.
     */


### PR DESCRIPTION
Use the @LinkURL annotation to extract the URL and add it when creating the ViewSheet action. The shell-side issue has been resolved by #71125.