### PR TITLE
fix Bug #71112: fix assembly binding issue when embed vs for some layers

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/VSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/VSAQuery.java
@@ -1720,21 +1720,18 @@ public abstract class VSAQuery {
          return null;
       }
 
+      String baseAssembly = getAssembly().getAbsoluteName();
+
+      if(assemblyName.startsWith(Assembly.TABLE_VS_BOUND) && baseAssembly.contains(".")) {
+         int idx = baseAssembly.lastIndexOf(".");
+         String baseParent = baseAssembly.substring(0, idx + 1);
+         assemblyName = Assembly.TABLE_VS_BOUND + baseParent + assemblyName.substring(15);
+      }
+
       TableLens lens = box.getTableData(assemblyName);
 
       if(lens == null) {
-         String baseAssembly = getAssembly().getAbsoluteName();
-
-         if(assemblyName.startsWith(Assembly.TABLE_VS_BOUND) || baseAssembly.contains(".")) {
-            int idx = baseAssembly.lastIndexOf(".");
-            String baseParent = baseAssembly.substring(0, idx + 1);
-            assemblyName = Assembly.TABLE_VS_BOUND + baseParent + assemblyName.substring(15);
-            lens = box.getTableData(assemblyName);
-         }
-
-         if(lens == null) {
-            return null;
-         }
+        return null;
       }
 
       // meta data doesn't require all rows, which would cause conversion to calc problem

--- a/core/src/main/java/inetsoft/report/composition/execution/VSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/VSAQuery.java
@@ -1731,7 +1731,7 @@ public abstract class VSAQuery {
       TableLens lens = box.getTableData(assemblyName);
 
       if(lens == null) {
-        return null;
+         return null;
       }
 
       // meta data doesn't require all rows, which would cause conversion to calc problem

--- a/core/src/main/java/inetsoft/report/composition/execution/VSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/VSAQuery.java
@@ -1723,7 +1723,18 @@ public abstract class VSAQuery {
       TableLens lens = box.getTableData(assemblyName);
 
       if(lens == null) {
-         return null;
+         String baseAssembly = getAssembly().getAbsoluteName();
+
+         if(assemblyName.startsWith(Assembly.TABLE_VS_BOUND) || baseAssembly.contains(".")) {
+            int idx = baseAssembly.lastIndexOf(".");
+            String baseParent = baseAssembly.substring(0, idx + 1);
+            assemblyName = Assembly.TABLE_VS_BOUND + baseParent + assemblyName.substring(15);
+            lens = box.getTableData(assemblyName);
+         }
+
+         if(lens == null) {
+            return null;
+         }
       }
 
       // meta data doesn't require all rows, which would cause conversion to calc problem


### PR DESCRIPTION
The bug is caused by in embed vs, calc use assembly binding such as "viewsheet1.crosstab1", when execute calc in next layer vs(old vs as embed vs), then the assembly binding should add calc's parent on the before("viewsheet1.viewsheet1.crosstab"