### PR TITLE
fix Bug #71118. Fix OutOfMemoryError.

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/TaskBalancer.java
+++ b/core/src/main/java/inetsoft/sree/schedule/TaskBalancer.java
@@ -230,7 +230,7 @@ public class TaskBalancer {
       int hardCoded = slots.stream()
          .mapToInt(BitSet::cardinality)
          .sum();
-      int slotsPerThread = duration / interval;
+      int slotsPerThread = Math.max(1, duration / interval);
       int requiredThreads =
          Math.max(1, (int) Math.ceil((conditions.size() + hardCoded) / (float) slotsPerThread));
       int conditionIndex = 0;


### PR DESCRIPTION
The value of `slotsPerThread` should be at least 1. The cause of the bug is that the start and end times become equal after rounding, which results in a duration of 0. When the duration is 0, `slotsPerThread` becomes 0, leading to the calculation of `requiredThreads` as `Integer.MAX_VALUE`, which ultimately causes continuous object creation and results in an `OutOfMemoryError`.