### PR TITLE
Fix Bug #71044:

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/viewsheet/vs-viewsheet.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/viewsheet/vs-viewsheet.component.html
@@ -31,7 +31,7 @@
       <i class="viewsheet-link viewsheet-icon" [style.height.px]="iconHeight"></i>
     </a>
   </div>
-  <div *ngIf="composer" class="composer-overlay"></div>
+  <div *ngIf="composer" class="composer-overlay" [style.z-index]="getOverlayZIndex()"></div>
   <div class="embedded-viewsheet"
        *ngIf="vsInfo0"
        [class.prevent-scroll]="maxMode"

--- a/web/projects/portal/src/app/vsobjects/objects/viewsheet/vs-viewsheet.component.scss
+++ b/web/projects/portal/src/app/vsobjects/objects/viewsheet/vs-viewsheet.component.scss
@@ -38,7 +38,6 @@
 }
 
 .composer-overlay {
-  z-index: 9998;
   position: absolute;
   top: 0;
   left: 0;

--- a/web/projects/portal/src/app/vsobjects/objects/viewsheet/vs-viewsheet.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/viewsheet/vs-viewsheet.component.ts
@@ -364,4 +364,8 @@ export class VSViewsheet extends NavigationComponent<VSViewsheetModel> implement
    getEmbeddedVSBounds() {
       return Rectangle.fromClientRect(<any> this.model.objectFormat);
    }
+
+   getOverlayZIndex(): number {
+      return 9998 - this.model.objectFormat.zIndex;
+   }
 }


### PR DESCRIPTION
The event is not being triggered because the parent component (or another higher-level component) is intercepting it. When child and parent components have the same z-index, the child components stack on top of the parent. Therefore, in cases of multi-level nesting, the z-index of child components should be reduced by 1 to ensure proper event propagation.