### PR TITLE
Merge forward fix for Bug #71144 - color browser autofill

### DIFF
--- a/web/projects/portal/src/app/widget/color-picker/cp-color-pane.component.ts
+++ b/web/projects/portal/src/app/widget/color-picker/cp-color-pane.component.ts
@@ -60,7 +60,7 @@ export class ColorPane implements OnInit {
 
    setColorValue(value: string) {
       if(!value) {
-         this.selectColor(value);
+         setTimeout(() => this.selectColor(value), 0);
       }
       else {
          this.colorValue = getColorHex("#" + value);
@@ -68,7 +68,7 @@ export class ColorPane implements OnInit {
          if(/^[0-9a-fA-F]{6}$/.test(value)) {
             this.color = "#" + value;
             this.recentColorService.colorSelected(this.color);
-            this.colorChanged.emit(this.color);
+            setTimeout(() => this.colorChanged.emit(this.color), 0);
          }
       }
    }


### PR DESCRIPTION
Wait briefly to let browser autofill capture the input value before emitting the new color and closing the dropdown.