### PR TITLE
Fix Bug #71139:

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/VSBookmarkController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/VSBookmarkController.java
@@ -315,10 +315,10 @@ public class VSBookmarkController {
             bookmarkService.processBookmark(VSBookmark.HOME_BOOKMARK, IdentityID.getIdentityIDFromKey(principal.getName()),
                                             rvs, (XPrincipal) principal, value, linkUri,
                                             rvs.getID(), commandDispatcher);
-         }
 
-         Cluster.getInstance().sendMessage(new ViewsheetBookmarkChangedEvent(rvs,
-                                           true, currBookmark.getName()));
+            Cluster.getInstance().sendMessage(new ViewsheetBookmarkChangedEvent(rvs,
+               true, currBookmark.getName()));
+         }
       }
       catch(MessageException ex) {
          MessageCommand command = new MessageCommand();


### PR DESCRIPTION
Fix NullPointerException: Only notify other sessions when the currently opened bookmark is confirmed to be non-null, ensuring safe deletion.