### PR TITLE
Feature #70313 - fix serialization tests that were failing randomly

### DIFF
--- a/core/src/main/java/inetsoft/report/lens/CrossJoinTableLens.java
+++ b/core/src/main/java/inetsoft/report/lens/CrossJoinTableLens.java
@@ -200,7 +200,7 @@ public class CrossJoinTableLens extends AbstractBinaryTableFilter implements Can
     * Validate the cross join lens.
     */
    private synchronized void validate() {
-      if(lthread != null) {
+      if(lthread != null || isCompleted()) {
          return;
       }
 

--- a/core/src/main/java/inetsoft/util/css/CSSDictionary.java
+++ b/core/src/main/java/inetsoft/util/css/CSSDictionary.java
@@ -254,7 +254,10 @@ public class CSSDictionary {
       Map<String, String> cssEntries = PortalThemesManager.getManager().getCssEntries();
       String orgFile = cssEntries.get(OrganizationManager.getInstance().getCurrentOrgID());
       List<String> otherFiles = new ArrayList<>();
-      otherFiles.add(orgFile);
+
+      if(orgFile != null) {
+         otherFiles.add(orgFile);
+      }
 
       if(!Tool.equals(otherFiles, dict.otherFiles)) {
          return System.currentTimeMillis();


### PR DESCRIPTION
Fix VSFormatTableLensTest and CrossJoinTableLensTest. 
In CrossJoinTableLens don't recreate the left and right threads in the deserialized table when the processing has already been completed.
 In CSSDictionary check if the file isn't null before adding it to the list to test equality. Otherwise lastModified always returns System.currentTimeMillis().