### PR TITLE
Fix Bug #71085:

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/PortalController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/PortalController.java
@@ -50,6 +50,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -287,7 +289,6 @@ public class PortalController {
    public GlobalParameterModel getGlobalParameters(@PathVariable("type") String type,
                                                    @RemainingPath String path, Principal principal)
    {
-      path = Tool.byteDecode(path);
       String providerClassName = SreeEnv.getProperty("global.parameter.provider", (String) null);
       ParameterPageModel model = null;
 

--- a/web/projects/shared/util/guard/global-parameter-guard.service.ts
+++ b/web/projects/shared/util/guard/global-parameter-guard.service.ts
@@ -96,7 +96,7 @@ export class GlobalParameterGuard implements CanActivate {
    }
 
    private getGlobalParameters(path: string, type: string): Observable<GlobalParameterModel> {
-      path = Tool.byteEncode(path);
+      path = encodeURI(path);
       const url = `../api/portal/global-parameters/${type}/${path}`;
       return this.http.get<GlobalParameterModel>(url);
    }


### PR DESCRIPTION
Because different systems may interpret special characters differently, using encodeURI is sufficient as it only encodes the necessary special characters.