### PR TITLE
Bug 71162, shouldn't add permission for the new created resource.

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryObjectService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryObjectService.java
@@ -748,9 +748,10 @@ public class RepositoryObjectService {
       AuthorizationProvider authz = securityProvider.getAuthorizationProvider();
       Permission perm = new Permission();
       String currentOrgID = OrganizationManager.getInstance().getCurrentOrgID();
+      String userOrgID = ((XPrincipal) principal).getOrgId();
       Set<String> userGrants = new HashSet<>();
 
-      if(principal instanceof XPrincipal && Tool.equals(((XPrincipal) principal).getOrgId(), currentOrgID)) {
+      if(principal instanceof XPrincipal && Organization.getSelfOrganizationID().equals(userOrgID)) {
          userGrants.add(IdentityID.getIdentityIDFromKey(principal.getName()).name);
       }
 

--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryObjectService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryObjectService.java
@@ -715,9 +715,6 @@ public class RepositoryObjectService {
             }
          }
 
-         setResourcePermission(isWorksheetFolder ? ResourceType.ASSET :
-                                  type == RepositoryEntry.DATA_SOURCE_FOLDER ?
-                                     ResourceType.DATA_SOURCE_FOLDER : ResourceType.REPORT, principal, folderName);
          actionRecord.setObjectName(Util.getObjectFullPath(isWorksheetFolder ?
              RepositoryEntry.WORKSHEET_FOLDER : type, folderName, principal, user));
 
@@ -743,26 +740,6 @@ public class RepositoryObjectService {
          }
       }
    }
-
-   private void setResourcePermission(ResourceType type, Principal principal, String name) {
-      AuthorizationProvider authz = securityProvider.getAuthorizationProvider();
-      Permission perm = new Permission();
-      String currentOrgID = OrganizationManager.getInstance().getCurrentOrgID();
-      String userOrgID = ((XPrincipal) principal).getOrgId();
-      Set<String> userGrants = new HashSet<>();
-
-      if(principal instanceof XPrincipal && Organization.getSelfOrganizationID().equals(userOrgID)) {
-         userGrants.add(IdentityID.getIdentityIDFromKey(principal.getName()).name);
-      }
-
-      for(ResourceAction action : ResourceAction.values()) {
-         perm.setUserGrantsForOrg(action, userGrants, currentOrgID);
-      }
-
-      perm.updateGrantAllByOrg(currentOrgID, !userGrants.isEmpty());
-      authz.setPermission(type, name, perm);
-   }
-
 
    private void removeFolder(TreeNodeInfo node, RepletRegistry registry) throws Exception {
       final String folder = node.path();


### PR DESCRIPTION
Except for the self user, the current user should not be added to the user grants for newly created resources. The tracking log shows that it was added when bug # 27925 was resolved on 13.1, but it is unclear what the reason was at that time, the modification seems to not match the description of the bug. Considering that self users do not have permission to log in to EM, fix by deleting the logic of setting permisson for the new created resource.