### PR TITLE
Fix Bug #71140:

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/MergedVSChartInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/MergedVSChartInfo.java
@@ -230,7 +230,6 @@ public class MergedVSChartInfo extends VSChartInfo implements MergedChartInfo {
          list.add(rtflds[i]);
       }
 
-
       VSDataRef[] arr = new VSDataRef[list.size()];
       list.toArray(arr);
       return arr;

--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/MergedVSChartInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/MergedVSChartInfo.java
@@ -203,21 +203,6 @@ public class MergedVSChartInfo extends VSChartInfo implements MergedChartInfo {
       DataRef[] xyflds = super.getRTFields(true, false, false, false);
       DataRef[] rtflds = super.getRTFields(false, true, true, true);
 
-      if(this instanceof VSMapInfo) {
-         ChartRef[] geoRefs = ((VSMapInfo) this).getGeoFields();
-
-         for(int i = 0; i < geoRefs.length; i++) {
-            if(geoRefs[i] instanceof VSChartGeoRef && getHyperlink() != null) {
-               VSChartGeoRef ngeoRef = ((VSChartGeoRef) geoRefs[i]).clone();
-               ngeoRef.setHyperlink(getHyperlink());
-               list.add(ngeoRef);
-            }
-            else {
-               list.add(geoRefs[i]);
-            }
-         }
-      }
-
       for(int i = 0; i < xyflds.length; i++) {
          list.add(xyflds[i]);
       }

--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/MergedVSChartInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/MergedVSChartInfo.java
@@ -203,6 +203,21 @@ public class MergedVSChartInfo extends VSChartInfo implements MergedChartInfo {
       DataRef[] xyflds = super.getRTFields(true, false, false, false);
       DataRef[] rtflds = super.getRTFields(false, true, true, true);
 
+      if(this instanceof VSMapInfo) {
+         ChartRef[] geoRefs = ((VSMapInfo) this).getGeoFields();
+
+         for(int i = 0; i < geoRefs.length; i++) {
+            if(geoRefs[i] instanceof VSChartGeoRef && getHyperlink() != null) {
+               VSChartGeoRef ngeoRef = ((VSChartGeoRef) geoRefs[i]).clone();
+               ngeoRef.setHyperlink(getHyperlink());
+               list.add(ngeoRef);
+            }
+            else {
+               list.add(geoRefs[i]);
+            }
+         }
+      }
+
       for(int i = 0; i < xyflds.length; i++) {
          list.add(xyflds[i]);
       }
@@ -214,6 +229,7 @@ public class MergedVSChartInfo extends VSChartInfo implements MergedChartInfo {
       for(int i = 0; i < rtflds.length; i++) {
          list.add(rtflds[i]);
       }
+
 
       VSDataRef[] arr = new VSDataRef[list.size()];
       list.toArray(arr);

--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/VSMapInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/VSMapInfo.java
@@ -556,17 +556,10 @@ public class VSMapInfo extends MergedVSChartInfo implements MapInfo {
    @Override
    public VSDataRef[] getRTFields() {
       List list = new ArrayList(Arrays.asList(super.getRTFields().clone()));
-      ChartRef[] geoRefs = getGeoFields();
+      ChartRef[] geoRefs = getRTGeoFields();
 
       for(int i = 0; i < geoRefs.length; i++) {
-         if(geoRefs[i] instanceof VSChartGeoRef && getHyperlink() != null) {
-            VSChartGeoRef ngeoRef = ((VSChartGeoRef) geoRefs[i]).clone();
-            ngeoRef.setHyperlink(getHyperlink());
-            list.add(ngeoRef);
-         }
-         else {
-            list.add(geoRefs[i]);
-         }
+         list.add(geoRefs[i]);
       }
 
       VSDataRef[] arr = new VSDataRef[list.size()];

--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/VSMapInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/VSMapInfo.java
@@ -553,6 +553,27 @@ public class VSMapInfo extends MergedVSChartInfo implements MapInfo {
       return list.toArray(new ChartRef[list.size()]);
    }
 
+   @Override
+   public VSDataRef[] getRTFields() {
+      List list = new ArrayList(Arrays.asList(super.getRTFields().clone()));
+      ChartRef[] geoRefs = getGeoFields();
+
+      for(int i = 0; i < geoRefs.length; i++) {
+         if(geoRefs[i] instanceof VSChartGeoRef && getHyperlink() != null) {
+            VSChartGeoRef ngeoRef = ((VSChartGeoRef) geoRefs[i]).clone();
+            ngeoRef.setHyperlink(getHyperlink());
+            list.add(ngeoRef);
+         }
+         else {
+            list.add(geoRefs[i]);
+         }
+      }
+
+      VSDataRef[] arr = new VSDataRef[list.size()];
+      list.toArray(arr);
+      return arr;
+   }
+
    private ArrayList<VSChartGeoRef> geoRefs = new ArrayList<>();
    private VSChartRef[] rGeoRefs;
    private static final Logger LOG =

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
@@ -1456,7 +1456,8 @@ public class VsToReportConverter {
             ChartRef[] rGeoRefs = ((VSMapInfo) vinfo).getRTGeoFields();
 
             for(int i = 0; i < rGeoRefs.length; i++) {
-               ((MapInfo) rinfo).addGeoField(rGeoRefs[i]);
+               ((VSMapInfo) rinfo).addGeoField(rGeoRefs[i]);
+               ((VSMapInfo) rinfo).addRTGeoField(rGeoRefs[i]);
             }
          }
       }


### PR DESCRIPTION
When collecting all runtime fields, if the object is a Map type, geographic fields should be included (consistent with the previous Report processing logic). Additionally, any hyperlink fields should also be added to the geographic fields collection.