### PR TITLE
bug-71169  setting ldap at first, switch to actions pane and add permission, some role load duplicate

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
@@ -412,6 +412,10 @@ public abstract class LdapAuthenticationProvider
    @Override
    public final Role getRole(IdentityID roleid) {
       if(roleid != null) {
+         if("Organization Administrator".equals(roleid.getName())) {
+            return null;
+         }
+
          if(Organization.getDefaultOrganizationID().equals(roleid.getOrgID()) || roleid.getOrgID() == null) {
             return getCache().getRole(roleid.getName());
          }

--- a/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
@@ -411,11 +411,7 @@ public abstract class LdapAuthenticationProvider
     */
    @Override
    public final Role getRole(IdentityID roleid) {
-      if(roleid != null && !SUtil.isMultiTenant()) {
-         if("Organization Administrator".equals(roleid.getName())) {
-            return null;
-         }
-
+      if(roleid != null) {
          if(Organization.getDefaultOrganizationID().equals(roleid.getOrgID()) || roleid.getOrgID() == null) {
             return getCache().getRole(roleid.getName());
          }

--- a/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.internal.cluster.*;
 import inetsoft.sree.security.*;
 import inetsoft.uql.util.Identity;
@@ -410,7 +411,17 @@ public abstract class LdapAuthenticationProvider
     */
    @Override
    public final Role getRole(IdentityID roleid) {
-      return getCache().getRole(roleid.getName());
+      if(roleid != null && !SUtil.isMultiTenant()) {
+         if("Organization Administrator".equals(roleid.getName())) {
+            return null;
+         }
+
+         if(Organization.getDefaultOrganizationID().equals(roleid.getOrgID()) || roleid.getOrgID() == null) {
+            return getCache().getRole(roleid.getName());
+         }
+      }
+
+      return null;
    }
 
    protected Role doGetRole(String name) {


### PR DESCRIPTION
For the LDAP provider, organizations are not supported. Therefore, when retrieving roles, any role that does not belong to the "host-org" or has a null organization ID should be filtered out. Since organization support is not available, roles like "org-admin" should also be excluded.