### PR TITLE
fix Bug #71170: split date and timeinstant type value in task embed parameters

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
@@ -1432,6 +1432,7 @@ public class ScheduleService {
                         if(parameter.array()) {
                            value = scheduleConditionService
                               .getParamValueAsArray(parameter.type(), parameter.value().getValue().toString());
+                           value = fixDateArrayValue(value, parameter.type());
                         }
                         else if(value instanceof DynamicValueModel) {
                            value = ((DynamicValueModel) value).convertParameterValue();
@@ -1464,6 +1465,26 @@ public class ScheduleService {
       }
 
       return action;
+   }
+
+   // For date and timeInstant type values as array, their values will the same type(java.util.date)
+   // so it will change to timeInstant time when using Tool.getDataString, so we should change date
+   // to java.sql.date to split them using right type.
+   private Object fixDateArrayValue(Object value, String type) {
+      if(value instanceof Object[]) {
+         Object[] array = (Object[]) value;
+
+         if(array != null && Tool.DATE.equals(type)) {
+            for(int i = 0; i < array.length; i++) {
+               if(array[i] instanceof java.util.Date) {
+                  java.util.Date odate = (java.util.Date) array[i];
+                  array[i] = new java.sql.Date(odate.getTime());
+               }
+            }
+         }
+      }
+
+      return value;
    }
 
    private String trimEmailSpaces(String emails) {


### PR DESCRIPTION
in old version, it will change timeInstant value without time to date.

In stylebi, it will change date to timeInstant value.

The two issue becaused date and timeInstant in client will all change to java.util.Date, and  in 13.8, it check value is date or timeinstant according with time or not, in stylebi, it will change all java.util.date object to timeInstant by using Tool.getDataString method.

In fact, we should split right types to avoid the two issues. For date type value should using java.sql.Date to save value, timeInstant keep old type.