### PR TITLE
Bug 70747, performance issue.

### DIFF
--- a/core/src/main/java/inetsoft/mv/MVDef.java
+++ b/core/src/main/java/inetsoft/mv/MVDef.java
@@ -1798,7 +1798,9 @@ public final class MVDef implements Comparable, XMLSerializable, Serializable, C
       if(ws != null) {
          if(separateWS) {
             try {
+               ws.setWsID(wsId);
                writeWorksheet(ws);
+               ws.setWsID(null);
             }
             catch(Exception ex) {
                LOG.error("Failed to write worksheet", ex);

--- a/core/src/main/java/inetsoft/mv/MVWorksheetStorage.java
+++ b/core/src/main/java/inetsoft/mv/MVWorksheetStorage.java
@@ -84,12 +84,11 @@ public class MVWorksheetStorage implements AutoCloseable {
    }
 
    private BlobStorage<Metadata> getStorage() {
-      String storeID = OrganizationManager.getInstance().getCurrentOrgID().toLowerCase() + "__" + "mvws";
-      return SingletonManager.getInstance(BlobStorage.class, storeID, false);
+      return getStorage(OrganizationManager.getInstance().getCurrentOrgID());
    }
 
    private BlobStorage<Metadata> getStorage(String orgID) {
-      String storeID = orgID.toLowerCase() + "__" + "mvws";
+      String storeID =  Tool.buildString(orgID.toLowerCase(), "__", "mvws");
       return SingletonManager.getInstance(BlobStorage.class, storeID, false);
    }
 

--- a/core/src/main/java/inetsoft/mv/fs/internal/BlockFileStorage.java
+++ b/core/src/main/java/inetsoft/mv/fs/internal/BlockFileStorage.java
@@ -129,7 +129,7 @@ public class BlockFileStorage implements AutoCloseable {
 
    public BlobStorage<Metadata> getStorage(String orgID) {
       orgID = orgID == null ? OrganizationManager.getInstance().getCurrentOrgID() : orgID;
-      String storeID = orgID.toLowerCase() + "__" + "mvBlock";
+      String storeID = Tool.buildString(orgID.toLowerCase(), "__", "mvBlock");
       return SingletonManager.getInstance(BlobStorage.class, storeID, true);
    }
 

--- a/core/src/main/java/inetsoft/uql/asset/AbstractAssetEngine.java
+++ b/core/src/main/java/inetsoft/uql/asset/AbstractAssetEngine.java
@@ -3117,6 +3117,7 @@ public abstract class AbstractAssetEngine implements AssetRepository, AutoClosea
 
       if(!Objects.equals(oidentifier, nidentifier)) {
          ostorage.remove(oidentifier);
+         EmbeddedDataCacheHandler.clearWSCache(oidentifier);
       }
 
       npfolder.addEntry(nentry);

--- a/core/src/main/java/inetsoft/uql/asset/EmbeddedDataCacheHandler.java
+++ b/core/src/main/java/inetsoft/uql/asset/EmbeddedDataCacheHandler.java
@@ -1,0 +1,281 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.uql.asset;
+
+import inetsoft.uql.util.XEmbeddedTable;
+import inetsoft.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.nio.file.*;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class EmbeddedDataCacheHandler {
+   public EmbeddedDataCacheHandler(EmbeddedTableAssembly assembly) {
+      this.assembly = assembly;
+   }
+
+   public void writeEmbeddedData(PrintWriter writer) {
+      XEmbeddedTable xdata = assembly.getEmbeddedData();
+      String folder = getAssemblyCacheFolder();
+
+      System.err.println("\n-------cachefolder: " + folder);
+      System.err.println("-------worksheet: " + assembly.getWorksheet().getWsID());
+      System.err.println("-------getAssemblyEntry: " + assembly.getAssemblyEntry());
+
+      try {
+         if(!writeEmbeddedDataWithCache(writer)) {
+            xdata.reset();
+            int blockIndex = 0;
+
+            while(xdata.hasNextBlock()) {
+               Path blockPath = getCacheFilePath(folder, blockIndex);
+               ByteArrayOutputStream buf = new ByteArrayOutputStream();
+
+               // write cache blob files
+               try(DataOutputStream out = new DataOutputStream(buf)) {
+                  xdata.writeData(out, true);
+                  byte[] encoded = Base64.getEncoder().encode(buf.toByteArray());
+                  writeToCacheAtomically(blockPath, encoded);
+               }
+
+               // write embedded data from cache
+               try(BufferedReader reader = Files.newBufferedReader(blockPath)) {
+                  reader.lines().forEach(writer::println);
+               }
+
+               blockIndex++;
+            }
+         }
+      }
+      catch(IOException e) {
+         Catalog catalog = Catalog.getCatalog();
+         String wsId = assembly.getWorksheet().getWsID();
+         String wsName = AssetEntry.createAssetEntry(wsId).getName();
+         throw new RuntimeException(catalog.getString("Cache operation for {0} in worksheet {1} failed",
+                                                      assembly.getAbsoluteName(), wsName), e);
+      }
+   }
+
+   /**
+    * Write embedded data by read block caches.
+    */
+   private boolean writeEmbeddedDataWithCache(PrintWriter writer) throws IOException {
+      String folder = getAssemblyCacheFolder();
+
+      Path cachePath = getCacheFilePath(folder);
+      boolean existed = Files.exists(cachePath);
+
+      if(!existed) {
+         return false;
+      }
+
+      File dir = cachePath.toFile();
+
+      if(dir.isDirectory()) {
+         List<File> files = sortedCacheBlocks(dir);
+         System.err.println("=======existCache: " + files.size());
+         for(int i = 0; i < files.size(); i++) {
+            try(BufferedReader reader = Files.newBufferedReader(files.get(i).toPath())) {
+               reader.lines().forEach(writer::println);
+            }
+         }
+      }
+
+      return true;
+   }
+
+   /**
+    * Make sure the blocked files are in asc order.
+    */
+   private List<File> sortedCacheBlocks(File directory) {
+      if (!directory.isDirectory()) {
+         throw new IllegalArgumentException("Provided file is not a directory");
+      }
+
+      File[] files = directory.listFiles();
+
+      if (files == null) {
+         throw new RuntimeException("Failed to list directory files");
+      }
+
+      return Arrays.stream(files)
+         .filter(File::isFile)
+         .sorted(Comparator.comparingInt(file -> {
+            try {
+               return Integer.parseInt(file.getName());
+            }
+            catch(NumberFormatException e) {
+               return Integer.MAX_VALUE;
+            }
+         }))
+         .collect(Collectors.toList());
+   }
+
+   /**
+    * Get the cache folder for current worksheet.
+    */
+   private static String getWorksheetCacheFolder(String wsIdenfifier) {
+      AssetEntry entry = AssetEntry.createAssetEntry(wsIdenfifier);
+
+      if(!Tool.isEmptyString(entry.getOrgID())) {
+         return Tool.buildString(getOrganizationCacheFolder(entry.getOrgID()),
+                                 File.separator, bytesToHex(wsIdenfifier.getBytes()));
+      }
+
+      return bytesToHex(wsIdenfifier.getBytes());
+   }
+
+   private static String getOrganizationCacheFolder(String orgID) {
+      return orgID;
+   }
+
+   /**
+    * Get the cache folder for emebdded table.
+    */
+   private String getAssemblyCacheFolder() {
+      String wsIdentifier = assembly.getWorksheet().getWsID();
+      String tableName = assembly.getAbsoluteName();
+      tableName = bytesToHex(tableName.getBytes());
+
+
+      return Tool.buildString(getWorksheetCacheFolder(wsIdentifier), File.separator, tableName);
+   }
+
+   private static String bytesToHex(byte[] bytes) {
+      StringBuilder sb = new StringBuilder();
+
+      for(byte b : bytes) {
+         sb.append(String.format("%02x", b));
+      }
+
+      return sb.toString();
+   }
+
+   /**
+    * Write block cache file.
+    */
+   private void writeToCacheAtomically(Path targetPath, byte[] data) throws IOException {
+      Path tempPath = targetPath.resolveSibling(targetPath.getFileName() + ".tmp");
+      getCacheFile(tempPath, false);
+
+      try (BufferedWriter writer = Files.newBufferedWriter(tempPath,
+                                                           StandardOpenOption.CREATE,
+                                                           StandardOpenOption.TRUNCATE_EXISTING))
+      {
+         writer.write("<embeddedDatas><![CDATA[");
+         writer.newLine();
+         writer.write(new String(data));
+         writer.newLine();
+         writer.write("]]></embeddedDatas>");
+      }
+
+      Files.move(tempPath, targetPath, StandardCopyOption.ATOMIC_MOVE);
+   }
+
+   private Path getCacheFilePath(String folder, int blockIndex) {
+      return getCacheFilePath(Tool.buildString(folder, File.separator, blockIndex));
+   }
+
+   /**
+    * Get path in the file system cache.
+    */
+   private static Path getCacheFilePath(String path) {
+      try {
+         String dir = FileSystemService.getInstance().getCacheDirectory();
+         dir = Tool.buildString(dir, File.separator, EMBEDDED_CACHE_FOLDER);
+
+         return Paths.get(dir, path);
+      }
+      catch(IOException e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   /**
+    * Get or create cache file.
+    */
+   public File getCacheFile(Path tempFile, boolean folder) {
+      try {
+         Path parent = tempFile.getParent();
+
+         if(parent != null && !Files.exists(parent)) {
+            getCacheFile(parent, true);
+         }
+
+         if(Files.exists(tempFile)) {
+            return tempFile.toFile();
+         }
+
+         if(folder) {
+            Files.createDirectory(tempFile);
+         }
+         else {
+            Files.createFile(tempFile);
+         }
+      }
+      catch(Exception ex) {
+         LOG.error("Failed to create temp file: " + tempFile.getFileName(), ex);
+         return null;
+      }
+
+      return tempFile.toFile();
+   }
+
+   /**
+    * Remove worksheet caches when deleting/renaming ws.
+    */
+   public static void clearWSCache(String identifier) {
+      if(Tool.isEmptyString(identifier)) {
+         return;
+      }
+
+      clearOrgCache(getWorksheetCacheFolder(identifier));
+   }
+
+   /**
+    * Remove organization caches when deleting/renaming organization id.
+    */
+   public static void clearOrgCache(String orgID) {
+      if(Tool.isEmptyString(orgID)) {
+         return;
+      }
+
+      removeCache(getOrganizationCacheFolder(orgID));
+   }
+
+   private static void removeCache(String folder) {
+      Path path = getCacheFilePath(folder);
+
+      if(path.toFile().exists()) {
+         try {
+            FileSystemService.getInstance().deleteFile(path.toFile().getAbsolutePath());
+         }
+         catch(IOException e) {
+            throw new RuntimeException(e);
+         }
+      }
+   }
+
+   private EmbeddedTableAssembly assembly;
+   private static final String EMBEDDED_CACHE_FOLDER = "EmbeddedData";
+   private static final Logger LOG = LoggerFactory.getLogger(EmbeddedDataCacheHandler.class);
+}

--- a/core/src/main/java/inetsoft/uql/asset/EmbeddedDataCacheHandler.java
+++ b/core/src/main/java/inetsoft/uql/asset/EmbeddedDataCacheHandler.java
@@ -37,10 +37,6 @@ public class EmbeddedDataCacheHandler {
       XEmbeddedTable xdata = assembly.getEmbeddedData();
       String folder = getAssemblyCacheFolder();
 
-      System.err.println("\n-------cachefolder: " + folder);
-      System.err.println("-------worksheet: " + assembly.getWorksheet().getWsID());
-      System.err.println("-------getAssemblyEntry: " + assembly.getAssemblyEntry());
-
       try {
          if(!writeEmbeddedDataWithCache(writer)) {
             xdata.reset();
@@ -92,7 +88,7 @@ public class EmbeddedDataCacheHandler {
 
       if(dir.isDirectory()) {
          List<File> files = sortedCacheBlocks(dir);
-         System.err.println("=======existCache: " + files.size());
+
          for(int i = 0; i < files.size(); i++) {
             try(BufferedReader reader = Files.newBufferedReader(files.get(i).toPath())) {
                reader.lines().forEach(writer::println);

--- a/core/src/main/java/inetsoft/uql/asset/EmbeddedTableAssembly.java
+++ b/core/src/main/java/inetsoft/uql/asset/EmbeddedTableAssembly.java
@@ -29,8 +29,7 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.*;
 
 import java.io.*;
-import java.util.Base64;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -174,6 +173,16 @@ public class EmbeddedTableAssembly extends AbstractTableAssembly {
     * @param writer the specified writer.
     */
    protected synchronized void writeEmbeddedData(PrintWriter writer) {
+      if(getWorksheet().getWsID() != null) {
+         EmbeddedDataCacheHandler handler = new EmbeddedDataCacheHandler(this);
+         handler.writeEmbeddedData(writer);
+      }
+      else {
+         writeEmbeddedData0(writer);
+      }
+   }
+
+   protected synchronized void writeEmbeddedData0(PrintWriter writer) {
       XEmbeddedTable xdata = getEmbeddedData();
       xdata.reset();
 

--- a/core/src/main/java/inetsoft/uql/asset/SnapshotEmbeddedTableAssembly.java
+++ b/core/src/main/java/inetsoft/uql/asset/SnapshotEmbeddedTableAssembly.java
@@ -348,7 +348,7 @@ public class SnapshotEmbeddedTableAssembly extends EmbeddedTableAssembly
          stable.moreRows(XTable.EOT);
          rowCnt = stable.getRowCount();
 
-         writer.println("<sembeddedData row=\"" + rowCnt + "\">");
+         writer.println(Tool.buildString("<sembeddedData row=\"", rowCnt, "\">"));
 
          if(columns != null) {
             columns.writeXML(writer);
@@ -359,8 +359,7 @@ public class SnapshotEmbeddedTableAssembly extends EmbeddedTableAssembly
          if(dataPaths != null) {
             for(String dataPath : dataPaths) {
                if(dataPathsLoadVersion.get(dataPath) != null) {
-                  writer.println("<path loadVersion=\"" + dataPathsLoadVersion.get(dataPath) +
-                                    "\"><![CDATA[");
+                  writer.println(Tool.buildString("<path loadVersion=\"", dataPathsLoadVersion.get(dataPath), "\"><![CDATA["));
                }
                else {
                   writer.println("<path><![CDATA[");
@@ -418,10 +417,10 @@ public class SnapshotEmbeddedTableAssembly extends EmbeddedTableAssembly
             writer.print("<header ");
 
             if(headers[i] != null) {
-               writer.print("name=\"" + Tool.escape(headers[i].toString()) + "\" ");
+               writer.print(Tool.buildString("name=\"", Tool.escape(headers[i].toString()), "\" ") );
             }
 
-            writer.println("creator=\"" + creators[i] + "\" lflag=\"" + lflags[i] + "\"/>");
+            writer.println(Tool.buildString("creator=\"", creators[i],  "\" lflag=\"", lflags[i], "\"/>"));
          }
 
          writer.println("</headers>");

--- a/core/src/main/java/inetsoft/uql/asset/Worksheet.java
+++ b/core/src/main/java/inetsoft/uql/asset/Worksheet.java
@@ -1370,6 +1370,14 @@ public class Worksheet extends AbstractSheet implements VariableProvider {
       }
    }
 
+   public String getWsID() {
+      return wsID;
+   }
+
+   public void setWsID(String wsID) {
+      this.wsID = wsID;
+   }
+
    private static final Logger LOG = LoggerFactory.getLogger(Worksheet.class);
    private static ThreadLocal<Boolean> temp = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
@@ -1381,4 +1389,5 @@ public class Worksheet extends AbstractSheet implements VariableProvider {
    private WorksheetInfo winfo; // viewsheet info
    private boolean offline;
    private transient Map<String, WSAssembly> amap;
+   private transient String wsID = null; // for mv cache
 }

--- a/core/src/main/java/inetsoft/util/CoreTool.java
+++ b/core/src/main/java/inetsoft/util/CoreTool.java
@@ -58,6 +58,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static inetsoft.util.Tool.buildString;
 import static inetsoft.util.Tool.isNumberClass;
 
 /**
@@ -2972,7 +2973,7 @@ public class CoreTool {
             }
             break;
          case Element.ENTITY_REFERENCE_NODE:
-            String val = "&" + child.getNodeName() + ";";
+            String val = buildString("&", child.getNodeName(), ";");
             String eval = decoding.get(val);
 
             if(eval != null) {

--- a/core/src/main/java/inetsoft/util/Tool.java
+++ b/core/src/main/java/inetsoft/util/Tool.java
@@ -4976,11 +4976,11 @@ public final class Tool extends CoreTool {
       }
    }
 
-   public static String buildString(String... strs) {
+   public static String buildString(Object... strs) {
       return buildString(50, strs);
    }
 
-   public static String buildString(int capacity, String... strs) {
+   public static String buildString(int capacity, Object... strs) {
       if(strs == null || strs.length == 0) {
          return "";
       }

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -916,6 +916,7 @@ public class IdentityService {
       removeBlobStorage("__pdata", orgID, EmbeddedTableStorage.Metadata.class);
       removeBlobStorage("__library", orgID, LibManager.Metadata.class);
       removeBlobStorage("__autoSave", orgID, LibManager.Metadata.class);
+      EmbeddedDataCacheHandler.clearOrgCache(orgID);
    }
 
    public void copyStorages(Organization oOrg, Organization nOrg, boolean rename) {


### PR DESCRIPTION
According to the dump file, it was found that the issue was caused by `XSwapper.getSwapper().waitForMemory();` consumes a significant amount of time.", which prevented the current process from completing in a timely manner. By inspecting real-time memory objects, it was discovered that millions of `byte[]` instances and hundreds of thousands of `String` instances existed, leading to high memory usage. Analysis of the case revealed that many worksheet contained embedded tables, and repeatedly creating materialized views (MV) would repeatedly write embedded data, resulting in the generation of a massive number of instances. Therefore, the following optimizations were implemented:  

1. Added cache files for embedded data blocks for MV to utilize disk caching and avoid generating a large number of instances.  And clear cache once remove ws and org 

2. Used `StringBuilder` instead of the `+` operator for string concatenation whenever possible.