### PR TITLE
bug-71095 image setting alpha layout header,it can not applied

### DIFF
--- a/core/src/main/java/inetsoft/report/io/viewsheet/pdf/PDFVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/pdf/PDFVSExporter.java
@@ -42,6 +42,7 @@ import inetsoft.util.graphics.SVGSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 import javax.swing.*;
 import java.awt.*;
@@ -357,6 +358,20 @@ public class PDFVSExporter extends AbstractVSExporter {
                   Document doc =
                      SVGSupport.getInstance().createSVGDocument(new ByteArrayInputStream(svg));
                   Graphics2D g2 = (Graphics2D) g.create();
+                  Element root = doc.getDocumentElement();
+                  String alphaStr = info.getImageAlpha();
+
+                  if(alphaStr != null && !alphaStr.equals("100")) {
+                     try {
+                        float alpha = Integer.parseInt(alphaStr) / 100.0f;
+                        root.setAttribute("fill-opacity", String.valueOf(alpha));
+                        root.setAttribute("stroke-opacity", String.valueOf(alpha));
+                     }
+                     catch(NumberFormatException e) {
+                        root.setAttribute("fill-opacity", "1.0");
+                        root.setAttribute("stroke-opacity", "1.0");
+                     }
+                  }
 
                   MetaImage.printSVG(g2, x, y, width, height, doc);
                   g2.dispose();


### PR DESCRIPTION
The bug occurs because the SVG image does not properly handle transparency. Using the opacity attribute may sometimes have no effect, as some SVG renderers ignore the <svg> element's opacity when converting to PDF or printing. Therefore, using fill-opacity and stroke-opacity, which directly affect the drawing properties, can effectively achieve the desired transparency.