### PR TITLE
fix Bug #71175: split user create aggregates and binding create aggregates in calc pane

### DIFF
--- a/core/src/main/java/inetsoft/web/binding/VSFormulaController.java
+++ b/core/src/main/java/inetsoft/web/binding/VSFormulaController.java
@@ -66,9 +66,18 @@ public class VSFormulaController {
          List<DataRefModel> aggregateFields = new ArrayList<>();
          List<DataRefModel> allcolumns = new ArrayList<>();
          List<String> calcFieldsGroup = new ArrayList<>();
+         List<String> userAggNames = new ArrayList<>();
 
          populateSelection(selection, columnFields, aggregateFields,
                            allcolumns, calcFieldsGroup, tableName);
+
+         AggregateRef[] userAggs = viewsheet.getAggrFields(tableName);
+
+         if(userAggs != null) {
+            for(int i = 0; i < userAggs.length; i++) {
+               userAggNames.add(userAggs[i].toString());
+            }
+         }
 
          Map<String, Object> result = new HashMap<>();
          result.put("columnFields", columnFields);
@@ -76,6 +85,7 @@ public class VSFormulaController {
          result.put("allcolumns", allcolumns);
          result.put("calcFieldsGroup", calcFieldsGroup);
          result.put("sqlMergeable", selection.getProperty("sqlMergeable"));
+         result.put("userAggNames", userAggNames);
          boolean isWS = viewsheet.getBaseEntry() != null && viewsheet.getBaseEntry() .isWorksheet();
          DataRefModel[] grayedOutFields = assemblyInfoHandler.getGrayedOutFields(rvs);
 

--- a/web/projects/portal/src/app/binding/widget/binding-tree/vs-binding-tree-actions.ts
+++ b/web/projects/portal/src/app/binding/widget/binding-tree/vs-binding-tree-actions.ts
@@ -277,6 +277,7 @@ export class VSBindingTreeActions extends ContextMenuActions {
          calcDialog.columns = <DataRef[]> fieldsInfo.columnFields;
          calcDialog.aggregates = <DataRef[]> fieldsInfo.aggregateFields;
          calcDialog.calcFieldsGroup = <string[]> fieldsInfo.calcFieldsGroup;
+         calcDialog.grayedOutFields = <DataRef[]> fieldsInfo.grayedOutFields;
          calcDialog.userAggNames = <string[]> fieldsInfo.userAggNames;
          calcDialog.dataType = "string";
          calcDialog.aggregateModify.subscribe((result: any) => {

--- a/web/projects/portal/src/app/binding/widget/binding-tree/vs-binding-tree-actions.ts
+++ b/web/projects/portal/src/app/binding/widget/binding-tree/vs-binding-tree-actions.ts
@@ -277,7 +277,7 @@ export class VSBindingTreeActions extends ContextMenuActions {
          calcDialog.columns = <DataRef[]> fieldsInfo.columnFields;
          calcDialog.aggregates = <DataRef[]> fieldsInfo.aggregateFields;
          calcDialog.calcFieldsGroup = <string[]> fieldsInfo.calcFieldsGroup;
-         calcDialog.grayedOutFields = <DataRef[]> fieldsInfo.grayedOutFields;
+         calcDialog.userAggNames = <string[]> fieldsInfo.userAggNames;
          calcDialog.dataType = "string";
          calcDialog.aggregateModify.subscribe((result: any) => {
             this.modifyAggregateField(tableName, result.nref, result.oref, calcDialog, tableName);

--- a/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.ts
+++ b/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.ts
@@ -127,6 +127,7 @@ export class FormulaEditorDialog extends BaseResizeableDialogComponent implement
    @Input() isCondition: boolean = false;
 
    @Input() grayedOutFields: DataRef[];
+   @Input() userAggNames: string[];
    @Input() selfVisible: boolean = true;
    @Input() checkDuplicatesInColumnTree: boolean = true;
 
@@ -686,6 +687,8 @@ export class FormulaEditorDialog extends BaseResizeableDialogComponent implement
                useragg: "true",
                data: this.getAggrExpression(aggregateRef)
             };
+
+            this.userAggNames.push(this.getFullName(aggregateRef));
             let anode: TreeNodeModel = this.createTreeNode(
                this.getFullName(aggregateRef), properties, true, null);
 
@@ -926,7 +929,7 @@ export class FormulaEditorDialog extends BaseResizeableDialogComponent implement
                parentName: column.data.name,
                parentLabel: column.label,
                parentData: column.data.data,
-               useragg: "true"
+               useragg: this.userAggNames.indexOf(this.getFullName(field)) >= 0 ? "true" : "false"
             }
          };
 


### PR DESCRIPTION
the bug is caused by user create agg and binding agg do not split and we should only support to delete user agg, binding agg should not delete from calc pane.

check agg is user agg or not according to get it from aggregatemap in viewsheet.