### PR TITLE
bug-71181 permission prompts is wrong

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/data/DataSourceBrowserService.java
+++ b/core/src/main/java/inetsoft/web/portal/data/DataSourceBrowserService.java
@@ -631,14 +631,11 @@ public class DataSourceBrowserService {
                   item.getPath(), ResourceAction.WRITE))
             {
                String path = item.getPath();
+               String name = item.getName();
 
-               if(!path.isEmpty()) {
-                  path = path.replace(item.getName(), "");
-                  char last = path.charAt(path.length() - 1);
-
-                  if(last == '/' || last == '\\') {
-                     path = path.substring(0, path.length() - 1);
-                  }
+               if(path.length() > name.length() && path.endsWith("/" + item.getName())) {
+                  int index = path.length() - name.length() - 1;
+                  path = path.substring(0, index);
                }
 
                throw new MessageException(Catalog.getCatalog()

--- a/core/src/main/java/inetsoft/web/portal/data/DataSourceBrowserService.java
+++ b/core/src/main/java/inetsoft/web/portal/data/DataSourceBrowserService.java
@@ -630,8 +630,15 @@ public class DataSourceBrowserService {
             if(!securityEngine.checkPermission(principal, ResourceType.DATA_SOURCE_FOLDER,
                   item.getPath(), ResourceAction.WRITE))
             {
+               String path = item.getPath();
+
+               if(path != null) {
+                  path = path.replace(item.getName(), "");
+                  path = path.replaceAll("[\\\\/]+$", "");
+               }
+
                throw new MessageException(Catalog.getCatalog()
-                  .getString("common.writeAuthority", item.getPath()));
+                  .getString("common.writeAuthority", path));
             }
 
             if(PortalDataType.DATA_SOURCE_FOLDER.name().equals(item.getType())) {

--- a/core/src/main/java/inetsoft/web/portal/data/DataSourceBrowserService.java
+++ b/core/src/main/java/inetsoft/web/portal/data/DataSourceBrowserService.java
@@ -632,9 +632,13 @@ public class DataSourceBrowserService {
             {
                String path = item.getPath();
 
-               if(path != null) {
+               if(!path.isEmpty()) {
                   path = path.replace(item.getName(), "");
-                  path = path.replaceAll("[\\\\/]+$", "");
+                  char last = path.charAt(path.length() - 1);
+
+                  if(last == '/' || last == '\\') {
+                     path = path.substring(0, path.length() - 1);
+                  }
                }
 
                throw new MessageException(Catalog.getCatalog()

--- a/core/src/main/java/inetsoft/web/portal/data/DataSourceBrowserService.java
+++ b/core/src/main/java/inetsoft/web/portal/data/DataSourceBrowserService.java
@@ -633,7 +633,7 @@ public class DataSourceBrowserService {
                String path = item.getPath();
                String name = item.getName();
 
-               if(path.length() > name.length() && path.endsWith("/" + item.getName())) {
+               if(path.endsWith("/" + item.getName())) {
                   int index = path.length() - name.length() - 1;
                   path = path.substring(0, index);
                }


### PR DESCRIPTION
For folders without permission, only the parent path should be displayed during the move operation, rather than showing the path as if the current data source has already been moved into the new location. Otherwise, it may give a misleading impression that the move has already been completed.