### PR TITLE
fix Bug #71197, when select node by drag start, if the current node is in tree selection keep the selection, if it not in selection just select the current node.

### DIFF
--- a/web/projects/em/src/app/common/util/tree/multi-select-tree-node.directive.ts
+++ b/web/projects/em/src/app/common/util/tree/multi-select-tree-node.directive.ts
@@ -59,7 +59,7 @@ export class MultiSelectTreeNodeDirective {
          if(!newSelection.some((n) => n.label === nodeData.label &&
             n.data === nodeData.data))
          {
-            newSelection.push(nodeData);
+            newSelection = [nodeData];
          }
       }
       else if(!event.ctrlKey && !event.metaKey && !event.shiftKey) {


### PR DESCRIPTION
when select node by drag start, if the current node is in tree selection keep the selection, if it not in selection just select the current node.