### PR TITLE
Fix Bug #71180:

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -648,7 +648,11 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
       pairs.clear();
       images.clear();
 
-      // dispose sandbox
+      disposeSandbox();
+   }
+
+   // dispose sandbox
+   public void disposeSandbox() {
       List<String> list = new ArrayList<>(bmap.keySet());
 
       for(String name : list) {

--- a/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
@@ -1288,6 +1288,11 @@ public class CoreLifecycleService {
       if(manualRefresh && refreshParent) {
          // make sure that any embedded viewsheets have their contents updated
          sheet.update(rvs.getAssetRepository(), null, rvs.getUser());
+         ViewsheetSandbox box = rvs.getViewsheetSandbox();
+
+         if(box != null) {
+            box.disposeSandbox();
+         }
       }
 
       Assembly[] assemblies = sheet.getAssemblies(false, true);


### PR DESCRIPTION
When obtaining the content of the text, it is retrieved based on the viewsheet stored in the sandbox's bmap (used to store EmbeddedViewsheet). When we perform a refresh, the viewsheet in the sandbox is updated, but the viewsheet in the bmap is not. Therefore, when assigning a value to the text, it only updates the viewsheet in the bmap and does not update the current runtimeViewsheet. Thus, during a manual refresh, the content of the bmap should be cleared.