### PR TITLE
Fix Bug #71187:

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/dialog/ScheduleDialogController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/dialog/ScheduleDialogController.java
@@ -431,9 +431,15 @@ public class ScheduleDialogController {
       }
 
       TimeCondition condition = new TimeCondition();
-      condition.setHour(Optional.ofNullable(timeConditionModel.hour()).orElse(1));
-      condition.setMinute(Optional.ofNullable(timeConditionModel.minute()).orElse(30));
-      condition.setSecond(Optional.ofNullable(timeConditionModel.second()).orElse(0));
+      condition.setHour(Optional.ofNullable(timeConditionModel.hour())
+                           .filter(h -> h > 0)
+                           .orElse(1));
+      condition.setMinute(Optional.ofNullable(timeConditionModel.minute())
+                             .filter(h -> h > 0)
+                             .orElse(30));
+      condition.setSecond(Optional.ofNullable(timeConditionModel.second())
+                             .filter(h -> h > 0)
+                             .orElse(0));
       condition.setType(timeConditionModel.type());
 
       if(condition.getType() == TimeCondition.EVERY_DAY) {


### PR DESCRIPTION
Under the condition of no cache, the startTime will be assigned the default value of -1. When saving data on the backend, only null values were handled, but negative numbers were not processed. Simply add logic to handle negative numbers.