### PR TITLE
fix Bug #71134. Avoid letting `ViewSheet` get the `TableLens` cached by `Worksheet`.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetDataCache.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetDataCache.java
@@ -379,15 +379,7 @@ public class AssetDataCache extends DataCache<DataKey, TableLens> {
       }
 
       if(box.getAdditionalVariableProvider() != null) {
-         VariableTable varTable = new VariableTable();
-         varTable.put("additionalVarProvider", true);
-
-         try {
-            vtable.addAll(varTable);
-         }
-         catch(Exception e) {
-            // ignore
-         }
+         vtable.put("additionalVarProvider", true);
       }
 
       try {


### PR DESCRIPTION
Avoid letting `ViewSheet` get the `TableLens` cached by `Worksheet`.