### PR TITLE
Fix Bug #71205:

### DIFF
--- a/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.ts
+++ b/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.ts
@@ -1255,7 +1255,7 @@ export class FormulaEditorDialog extends BaseResizeableDialogComponent implement
                label: () => "_#(js:Delete)",
                icon: () => null,
                enabled: () => true,
-               visible: () => node?.data?.useragg,
+               visible: () => node?.data?.useragg == "true",
                action: () => this.deleteAggregate(node)
             }
          ])


### PR DESCRIPTION
Only newly created aggregates have a delete menu; the original ones should not be displayed. The reason for the display is that node?.data?.useragg is a string-type value, which should be compared with true to return a boolean value.