### PR TITLE
Bug 71174. Find the assembly to avoid NPE.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -3675,9 +3675,7 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
       // of the target embedded table
       if(assembly instanceof InputVSAssembly) {
          InputVSAssembly iassembly = (InputVSAssembly) assembly;
-
-
-         new InputVSAQuery(this, iassembly.getName()).resetEmbeddedData(initing);
+         new InputVSAQuery(this, iassembly.getAbsoluteName()).resetEmbeddedData(initing);
          updateAssembly(iassembly);
          refreshVariable(iassembly, initing, clist);
       }

--- a/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
@@ -2944,7 +2944,7 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
          return ws == null ? null : ws.getAssembly(entry.getName());
       }
 
-      return getAssembly(entry.getName());
+      return getAssembly(entry.getAbsoluteName());
    }
 
    /**


### PR DESCRIPTION
Use the absolute name to find an assembly in embedded viewsheet.