### PR TITLE
bug-71204 multiple delete menu pop up, they have coverage.

### DIFF
--- a/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.html
+++ b/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.html
@@ -19,7 +19,7 @@
    (onCancel)="cancel()"
    [cshid]="'CreatingExpression'">
 </modal-header>
-<div class="modal-body" blockMouse>
+<div class="modal-body" [blockMouse]="false">
   <form [formGroup]="form" class="container-fluid" [class.flex-col-container]="canResize">
     <div *ngIf="isCalc && !isCube" class="calc-type-pane">
       <h5>_#(Calculate Field From)</h5>

--- a/web/projects/portal/src/app/widget/mouse-event/block-mouse.directive.ts
+++ b/web/projects/portal/src/app/widget/mouse-event/block-mouse.directive.ts
@@ -29,7 +29,6 @@ export class BlockMouseDirective implements OnInit {
    ngOnInit(): void {
       const handler = (event: MouseEvent) => {
          if(this.isBlockMouse) {
-            console.trace(1);
             event.stopPropagation();
          }
       };

--- a/web/projects/portal/src/app/widget/mouse-event/block-mouse.directive.ts
+++ b/web/projects/portal/src/app/widget/mouse-event/block-mouse.directive.ts
@@ -21,7 +21,7 @@ import { Input, Directive, NgZone, ElementRef, OnInit } from "@angular/core";
    selector: "[blockMouse]"
 })
 export class BlockMouseDirective implements OnInit {
-   @Input() isBlockMouse: boolean = true;
+   @Input("blockMouse") isBlockMouse: boolean = true;
 
    constructor(private _ngZone: NgZone, private el: ElementRef) {
    }
@@ -29,6 +29,7 @@ export class BlockMouseDirective implements OnInit {
    ngOnInit(): void {
       const handler = (event: MouseEvent) => {
          if(this.isBlockMouse) {
+            console.trace(1);
             event.stopPropagation();
          }
       };


### PR DESCRIPTION
The bug occurs because the event listener did not capture the event, resulting in the previously created action not being closed. The reason it wasn't captured is that this.renderer.listen("document", "mousedown", (e) => this.documentMousedown(e)) binds the listener in the bubbling phase by default. This means that if event.stopPropagation() is called elsewhere on the page, it can prevent the event from reaching the listener. Therefore, in the formula-editor-dialog, the blockMouse directive should be set to false to avoid stopping event propagation, which will resolve the issue.