### PR TITLE
fix Bug #71225:

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
@@ -1474,11 +1474,21 @@ public class ScheduleService {
       if(value instanceof Object[]) {
          Object[] array = (Object[]) value;
 
-         if(array != null && Tool.DATE.equals(type)) {
-            for(int i = 0; i < array.length; i++) {
-               if(array[i] instanceof java.util.Date) {
-                  java.util.Date odate = (java.util.Date) array[i];
-                  array[i] = new java.sql.Date(odate.getTime());
+         if(array != null) {
+            if(Tool.DATE.equals(type)) {
+               for(int i = 0; i < array.length; i++) {
+                  if(array[i] instanceof java.util.Date) {
+                     java.util.Date odate = (java.util.Date) array[i];
+                     array[i] = new java.sql.Date(odate.getTime());
+                  }
+               }
+            }
+            else if(Tool.TIME.equals(type)) {
+               for(int i = 0; i < array.length; i++) {
+                  if(array[i] instanceof java.util.Date) {
+                     java.util.Date odate = (java.util.Date) array[i];
+                     array[i] = new java.sql.Time(odate.getTime());
+                  }
                }
             }
          }


### PR DESCRIPTION
when create parameter from client for task, it will using java.util.date type when parameter is date/time/timeInstant, so should split date and time to java.sql.date and java.sql.time to avoid type is wrong.