### PR TITLE
Fix Test Cases for ComposerViewsheetApiController

### DIFF
--- a/core/src/test/java/inetsoft/web/composer/vs/controller/ComposerViewsheetApiControllerTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/controller/ComposerViewsheetApiControllerTest.java
@@ -24,7 +24,9 @@ import inetsoft.test.SreeHome;
 import inetsoft.uql.XPrincipal;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.VSUtil;
 import inetsoft.uql.viewsheet.vslayout.LayoutInfo;
+import inetsoft.util.ConfigurationContext;
 import inetsoft.web.composer.vs.VSObjectTreeService;
 import inetsoft.web.composer.vs.command.PopulateVSObjectTreeCommand;
 import inetsoft.web.composer.vs.event.NewViewsheetEvent;
@@ -33,12 +35,11 @@ import inetsoft.web.viewsheet.event.OpenPreviewViewsheetEvent;
 import inetsoft.web.viewsheet.model.RuntimeViewsheetRef;
 import inetsoft.web.viewsheet.model.VSObjectModelFactoryService;
 import inetsoft.web.viewsheet.service.*;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InOrder;
-import org.mockito.Mock;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
 
 import static org.mockito.Mockito.*;
 
@@ -47,9 +48,31 @@ import static org.mockito.Mockito.*;
 class ComposerViewsheetApiControllerTest {
    @BeforeEach
    void setup() throws Exception {
+      staticConfigurationContext = Mockito.mockStatic(ConfigurationContext.class);
+      staticConfigurationContext.when(ConfigurationContext::getContext)
+         .thenReturn(configurationContext);
+      vsutil = Mockito.mockStatic(VSUtil.class);
+      ComposerViewsheetService composerViewsheetService =
+         new ComposerViewsheetService(runtimeViewsheetManager,
+                                      coreLifecycleService,
+                                      viewsheetService,
+                                      vsObjectTreeService,
+                                      refreshController,
+                                      vsLayoutService,
+                                      objectModelService,
+                                      vsCompositionService);
+      ComposerViewsheetServiceProxy composerViewsheetServiceProxy = new ComposerViewsheetServiceProxy();
+      Mockito.when(configurationContext.getSpringBean(inetsoft.web.composer.vs.controller.ComposerViewsheetService.class))
+         .thenReturn(composerViewsheetService);
       controller = new ComposerViewsheetController(runtimeViewsheetRef,
                                                    viewsheetService,
-                                                   composerViewsheetService);
+                                                   composerViewsheetServiceProxy);
+   }
+
+   @AfterEach
+   void afterEach() throws Exception {
+      staticConfigurationContext.close();
+      vsutil.close();
    }
 
    // Bug #10686 Make sure permissions are set for preview viewsheets
@@ -92,7 +115,6 @@ class ComposerViewsheetApiControllerTest {
    @Mock
    CoreLifecycleService coreLifecycleService;
    @Mock ViewsheetService viewsheetService;
-   @Mock ComposerViewsheetServiceProxy composerViewsheetService;
    @Mock RuntimeViewsheet rvs;
    @Mock ViewsheetSandbox box;
    @Mock Viewsheet viewsheet;
@@ -106,7 +128,10 @@ class ComposerViewsheetApiControllerTest {
    @Mock VSLayoutService vsLayoutService;
    @Mock VSObjectModelFactoryService objectModelService;
    @Mock VSCompositionService vsCompositionService;
-
+   @Mock ApplicationContext applicationContext;
+   @Mock ConfigurationContext configurationContext;
+   MockedStatic<ConfigurationContext> staticConfigurationContext;
+   MockedStatic<VSUtil> vsutil;
 
    private ComposerViewsheetController controller;
 }


### PR DESCRIPTION
The ComposerViewsheetServiceProxy creates the ComposerViewsheetService by getting the bean from the configuration context.
In the test case, we have to mock the getBean method on the configuration context to return a new instance of the ComposerViewsheetService  that we created in the setup method.