### PR TITLE
fix Bug #71223, return null when the role do not exist during get role by IdentityID.

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/AbstractAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractAuthenticationProvider.java
@@ -21,6 +21,8 @@ import inetsoft.sree.SreeEnv;
 import inetsoft.uql.util.Identity;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
+
 /**
  * A skeletal implementation of an authentication provider.
  *
@@ -144,6 +146,25 @@ public abstract class AbstractAuthenticationProvider
    @Override
    public Role getRole(IdentityID roleIdentity) {
       return new Role(roleIdentity);
+   }
+
+   /**
+    * Check whether the role exist.
+    *
+    * @param roleIdentity role
+    */
+   protected boolean existRole(IdentityID roleIdentity) {
+      if(roleIdentity == null) {
+         return false;
+      }
+
+      IdentityID[] roles = getRoles();
+
+      if(roles == null) {
+         return false;
+      }
+
+      return Arrays.asList(roles).contains(roleIdentity);
    }
 
    /**

--- a/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationProvider.java
@@ -679,20 +679,6 @@ public class DatabaseAuthenticationProvider extends AbstractAuthenticationProvid
       return new Role(roleIdentity, "");
    }
 
-   private boolean existRole(IdentityID roleIdentity) {
-      if(roleIdentity == null) {
-         return false;
-      }
-
-      IdentityID[] roles = getRoles();
-
-      if(roles == null) {
-         return false;
-      }
-
-      return Arrays.asList(roles).contains(roleIdentity);
-   }
-
    private String parseOrgOrGlobalRole(String roleName, String userOrg) {
       return getRole(new IdentityID(roleName, userOrg)) == null ? null : userOrg;
    }

--- a/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
@@ -412,7 +412,7 @@ public abstract class LdapAuthenticationProvider
    @Override
    public final Role getRole(IdentityID roleid) {
       if(roleid != null) {
-         if("Organization Administrator".equals(roleid.getName())) {
+         if(!existRole(roleid)) {
             return null;
          }
 


### PR DESCRIPTION
return null when the role do not exist during get role by IdentityID.