### PR TITLE
fix Bug #71142, improve performance.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -1625,6 +1625,20 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
             // with full path between sub-vs. (61076)
             ChangedAssemblyList clist2 = new ChangedAssemblyList();
             reset(name, vs.getAssemblies(), clist2, initing, doOnLoad, null, toggleMaxMode);
+
+            clist2.getDataList().clear();
+            Viewsheet parent = vs.getViewsheet();
+            AssemblyEntry parentEntry = parent == null ? null :
+               new AssemblyEntry(parent.getName(), parent.getAbsoluteName(), parent.getAssemblyType());
+
+            // don't need to add sub entries when parent entry have already in data list,
+            // else will cause refresh duplicated times which will effect performance.
+            if(parentEntry == null || !clist.contains(parentEntry)) {
+               AssemblyEntry entry = new AssemblyEntry(arr[i].getName(), arr[i].getAbsoluteName(),
+                                                       arr[i].getAssemblyType());
+               clist2.getDataList().add(entry);
+            }
+
             // merge to main list. this may not be necessary but keep track of all changes
             // like before.
             clist.mergeCore(clist2);

--- a/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
@@ -1456,7 +1456,7 @@ public class CoreLifecycleService {
             addDeleteVSObject(rvs, (VSAssembly) infoObj, dispatcher);
          }
 
-         initTable(rvs, dispatcher, "", ((Viewsheet) assembly).getAssemblies(true, false));
+         initTable(rvs, dispatcher, "", ((Viewsheet) assembly).getAssemblies(false, false));
       }
       else {
          if(assembly.isEmbedded()) {


### PR DESCRIPTION
1. don't add sub viewsheet assembly entrise to main changed list when parent entry have already in data list, else will cause refresh duplicated times which will effect performance.
2. in refresh assembly logic, shouldn't to recursive to get all the assemblies to init tables, that will make assemblies in nested embedded viewsheet be refresh multi times.