### PR TITLE
fix Bug #71233, need not execute relation data assemblies when the  adhoc filter is removed

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerAdhocFilterController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerAdhocFilterController.java
@@ -505,7 +505,7 @@ public class ComposerAdhocFilterController {
          containerName = (String) list.getAhFilterProperty().get("_container");
 
          if(list.getSelectedObjects().isEmpty() && info.isCreatedByAdhoc()) {
-            coreLifecycleService.removeVSAssembly(rvs, linkUri, list, dispatcher, false, false);
+            VSEventUtil.removeVSObject(rvs, event.getName(), dispatcher);
             return;
          }
          else {
@@ -524,7 +524,7 @@ public class ComposerAdhocFilterController {
             final SelectionValue end = slist.getSelectionValue(slist.getSelectionValueCount() - 1);
 
             if(start.isSelected() && end.isSelected() && info.isCreatedByAdhoc()) {
-               coreLifecycleService.removeVSAssembly(rvs, linkUri, slider, dispatcher, false, false);
+               VSEventUtil.removeVSObject(rvs, event.getName(), dispatcher);
                return;
             }
             else {


### PR DESCRIPTION
need not execute relation data assemblies when the  adhoc filter is removed dhoc filter is removed because it is empty selected. applying selection has been executed when change selection status.