### PR TITLE
fix Bug #71176: should not remove asset header for auto save files

### DIFF
--- a/core/src/main/java/inetsoft/util/migrate/MigrateDocumentTask.java
+++ b/core/src/main/java/inetsoft/util/migrate/MigrateDocumentTask.java
@@ -93,7 +93,7 @@ public abstract class MigrateDocumentTask implements MigrateTask {
             AssetEntry newEntry = entry.cloneAssetEntry((Organization) getNewOrganization());
             String newKey = newEntry.toIdentifier(true);
 
-            if(document.getChildNodes().getLength() == 2 &&
+            if(this.document == null && document.getChildNodes().getLength() == 2 &&
                document.getFirstChild().getNodeValue().indexOf(oldKey) > 0)
             {
                document.removeChild(document.getFirstChild());


### PR DESCRIPTION
the bug is caused by bug#70788, it removed old document's inetsoft-asset child node becaused putDocument will create new node for it. But for auto save file, it will not put, so should get old node to change to new organization node. so should split them.