### PR TITLE
bug-71204 multiple delete menu pop up, they have coverage.

### DIFF
--- a/web/projects/portal/src/app/widget/fixed-dropdown/fixed-dropdown.component.ts
+++ b/web/projects/portal/src/app/widget/fixed-dropdown/fixed-dropdown.component.ts
@@ -70,8 +70,18 @@ export class FixedDropdownComponent implements OnInit, AfterViewInit, OnDestroy 
       // component may not have bubbled to the document layer yet
       this.listenerTick = setTimeout(
          () => {
+            if(this.container && this.container.tagName === 'FORM') {
+               this.listeners.push(
+                  this.renderer.listen(this.container, "mousedown", (e) => this.documentMousedown(e)),
+               )
+            }
+            else {
+               this.listeners.push(
+                  this.renderer.listen("document", "mousedown", (e) => this.documentMousedown(e)),
+               )
+            }
+
             this.listeners.push(
-               this.renderer.listen("document", "mousedown", (e) => this.documentMousedown(e)),
                this.renderer.listen("document", "click", (e) => this.documentClick(e)),
                this.renderer.listen("document", "keyup.esc", (e) => this.closeFromOutsideEsc(e)),
                this.renderer.listen("window", "resize", (e) => this.closeFromWindowResize(e)),

--- a/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.html
+++ b/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.html
@@ -20,7 +20,7 @@
    [cshid]="'CreatingExpression'">
 </modal-header>
 <div class="modal-body" blockMouse>
-  <form [formGroup]="form" class="container-fluid" [class.flex-col-container]="canResize">
+  <form #formElement [formGroup]="form" class="container-fluid" [class.flex-col-container]="canResize">
     <div *ngIf="isCalc && !isCube" class="calc-type-pane">
       <h5>_#(Calculate Field From)</h5>
       <div class="container">

--- a/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.ts
+++ b/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.ts
@@ -165,6 +165,7 @@ export class FormulaEditorDialog extends BaseResizeableDialogComponent implement
    @Output() aggregateModify: EventEmitter<any> = new EventEmitter<any>();
    @Output() aggregateDelete: EventEmitter<any> = new EventEmitter<any>();
    @ViewChild("newAggrDialog") newAggrDialog: TemplateRef<any>;
+   @ViewChild("formElement") formElementRef: ElementRef<HTMLFormElement>;
    private _scriptDefinitions: any = null;
    _aggregates: DataRef[] = [];
    public static DATE_PART_COLUMN: string = "date_part_column";
@@ -1239,6 +1240,7 @@ export class FormulaEditorDialog extends BaseResizeableDialogComponent implement
       let options: DropdownOptions = {
          position: {x: event[0].clientX + 2, y: event[0].clientY + 2},
          contextmenu: true,
+         container: this.formElementRef.nativeElement,
       };
 
       let contextmenu: ActionsContextmenuComponent = this.dropdownService


### PR DESCRIPTION
The bug occurs because the event listener is attached to the document level, but in the formula-editor-dialog component, blockMouse is applied to the body, which prevents event bubbling. As a result, the event does not reach the document and is not captured. By attaching the listener directly to the form element under the body, the event is not blocked, which resolves the issue.