### PR TITLE
Fix a circular dependency issue

### DIFF
--- a/core/src/main/java/inetsoft/web/binding/VSFormulaService.java
+++ b/core/src/main/java/inetsoft/web/binding/VSFormulaService.java
@@ -67,7 +67,7 @@ public class VSFormulaService {
          tableName = tableName == null ? assembly.getTableName() : tableName;
 
          ColumnSelection selection = columnHandler.getColumnSelection(
-            rvs, viewsheetService, assemblyName, tableName, null,
+            rvs, assemblyName, tableName, null,
             false, true, false, false, false, true);
 
          List<DataRefModel> columnFields = new ArrayList<>();

--- a/core/src/main/java/inetsoft/web/binding/controller/VSTableLayoutService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/VSTableLayoutService.java
@@ -500,7 +500,7 @@ public class VSTableLayoutService {
          return null;
       }
 
-      ColumnSelection cols = columnsHandler.getColumnSelection(rvs, viewsheetService, name,
+      ColumnSelection cols = columnsHandler.getColumnSelection(rvs, name,
                                                                sinfo.getSource(), null, false, true, false, false, false, false);
       AssetRepository rep = AssetUtil.getAssetRepository(false);
 

--- a/core/src/main/java/inetsoft/web/binding/handler/VSColumnHandler.java
+++ b/core/src/main/java/inetsoft/web/binding/handler/VSColumnHandler.java
@@ -30,13 +30,22 @@ import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.util.XUtil;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.VSUtil;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+import java.util.Objects;
 
 @Component
 public class VSColumnHandler {
+   @Autowired
+   public VSColumnHandler(ViewsheetService viewsheetService) {
+      this.viewsheetService = viewsheetService;
+   }
+
    /** GetColumnSelectionEvent */
    public ColumnSelection getColumnSelection(
-      RuntimeViewsheet rvs, ViewsheetService viewsheetService, String assembly, String tableName,
+      RuntimeViewsheet rvs, String assembly, String tableName,
       String dimensionOf, boolean measureOnly, boolean includeCalc, boolean exclude,
       boolean ignoreToCheckPerm, boolean embedded, boolean includeAggregate) throws Exception
    {
@@ -150,6 +159,175 @@ public class VSColumnHandler {
    }
 
    /**
+    * Called by selection list editor
+    * @param rvs        RuntimeViewsheet instance
+    * @param table      table
+    * @param principal  the principal user
+    * @return the column selection
+    * @throws Exception if can't retrieve columns
+    */
+   public ColumnSelection getTableColumns(RuntimeViewsheet rvs, String table,
+                                          Principal principal)
+      throws Exception
+   {
+      return getTableColumns(rvs, table, null, null, null, false,
+                             false, false, false, false, false, principal);
+   }
+
+   /**
+    * Called by data input pane
+    * @param rvs        RuntimeViewsheet instance
+    * @param table      table
+    * @param embedded   get embedded tables
+    * @param principal  the principal user
+    * @return the column selection
+    * @throws Exception if can't retrieve columns
+    */
+   public ColumnSelection getTableColumns(RuntimeViewsheet rvs, String table,
+                                          boolean embedded, Principal principal)
+      throws Exception
+   {
+      return getTableColumns(rvs, table, null, null, null, embedded,
+                             false, false, false, false, false, principal);
+   }
+
+   /**
+    * Get the Column Selection for a table, Mimic of GetColumnSelectionEvent
+    * @param rvs                    Runtime Viewsheet instance
+    * @param table                  the table
+    * @param assembly               assembly name
+    * @param vsName                 viewsheet name
+    * @param dimensionOf            dimension name
+    * @param embedded               get embedded tables
+    * @param measureOnly            only get measures
+    * @param includeCalc            include calc columns
+    * @param ignoreToCheckPerm      ignore check ?
+    * @param includeAggregate       include aggregate columns
+    * @param excludeAggregateCalc   exclude aggregate calc columns
+    * @param principal              principal user
+    * @return the ColumnSelection
+    * @throws Exception if can't retrieve the columns
+    */
+   public ColumnSelection getTableColumns(RuntimeViewsheet rvs, String table, String assembly,
+                                          String vsName, String dimensionOf, boolean embedded,
+                                          boolean measureOnly, boolean includeCalc,
+                                          boolean ignoreToCheckPerm, boolean includeAggregate,
+                                          boolean excludeAggregateCalc, Principal principal)
+      throws Exception
+   {
+      Viewsheet vs = rvs.getViewsheet();
+
+      if(vs == null) {
+         return new ColumnSelection();
+      }
+
+      if(vsName == null && assembly != null && assembly.indexOf('.') > 0) {
+         vsName = assembly.substring(0, assembly.lastIndexOf('.'));
+      }
+
+      // get the real viewsheet name, if this event is fired by an embedded vs
+      if(vsName != null) {
+         vs = (Viewsheet) vs.getAssembly(vsName);
+      }
+
+      if(vs == null) {
+         return new ColumnSelection();
+      }
+
+      Worksheet ws = vs.getBaseWorksheet();
+      ColumnSelection selection;
+
+      if(ws != null && ignoreToCheckPerm ||
+         VSEventUtil.checkBaseWSPermission(vs, principal, viewsheetService.getAssetRepository(), ResourceAction.READ))
+      {
+         Assembly wsobj = Objects.requireNonNull(ws).getAssembly(table);
+
+         if(!(wsobj instanceof TableAssembly tableAssembly)) {
+            return new ColumnSelection();
+         }
+
+         TableAssembly tableAssembly0 = tableAssembly;
+
+         while(tableAssembly0 instanceof MirrorTableAssembly) {
+            tableAssembly0 =
+               ((MirrorTableAssembly) tableAssembly0).getTableAssembly();
+         }
+
+         // still get the original column selection, otherwise the column selection will not match
+         // the runtime column selection and things like TableVSAQuery.getQueryData() may fail
+         selection = table == null ? new ColumnSelection() :
+            tableAssembly.getColumnSelection(true).clone();
+         XUtil.addDescriptionsFromSource(tableAssembly0, selection);
+         AggregateInfo dimonly = null;
+
+         if(dimensionOf != null) {
+            Assembly obj = vs.getAssembly(dimensionOf);
+
+            if(obj instanceof CubeVSAssembly) {
+               dimonly = ((CubeVSAssembly) obj).getAggregateInfo();
+            }
+         }
+
+         for(int i = selection.getAttributeCount() - 1; i >= 0; i--) {
+            ColumnRef ref = (ColumnRef) selection.getAttribute(i);
+            boolean excludeCalc = !includeCalc && ref instanceof CalculateRef;
+            boolean excludeAggCalc = excludeAggregateCalc && VSUtil.isAggregateCalc(ref);
+
+            if(VSUtil.isPreparedCalcField(ref) || embedded && ref.isExpression() || measureOnly &&
+               (ref.getRefType() & DataRef.CUBE) == DataRef.CUBE &&
+               (ref.getRefType() & DataRef.MEASURE) != DataRef.MEASURE ||
+               dimonly != null && !isDimensionRef(ref, dimonly) ||
+               excludeCalc || excludeAggCalc ||
+               ref instanceof CalculateRef && ((CalculateRef) ref).isDcRuntime())
+            {
+               selection.removeAttribute(i);
+            }
+         }
+
+         if(includeCalc) {
+            CalculateRef[] calcs = vs.getCalcFields(table);
+
+            if(calcs != null && calcs.length > 0) {
+               for(CalculateRef ref : calcs) {
+                  if(VSUtil.isPreparedCalcField(ref)) {
+                     continue;
+                  }
+
+                  if(!ref.isDcRuntime() && (!excludeAggregateCalc || ref.isBaseOnDetail()) &&
+                     !(selection.containsAttribute(ref) ||
+                        selection.getAttribute(ref.getName()) != null))
+                  {
+                     selection.addAttribute(ref);
+                  }
+               }
+            }
+         }
+
+         selection = VSUtil.getVSColumnSelection(selection);
+         selection = VSUtil.sortColumns(selection);
+
+         if(includeAggregate) {
+            ColumnSelection aggregate = VSEventUtil.getAggregateColumnSelection(vs, table);
+
+            for(int i = 0; i < aggregate.getAttributeCount(); i++) {
+               selection.addAttribute(aggregate.getAttribute(i), false);
+            }
+         }
+
+         AssetQuery query = AssetUtil.handleMergeable(rvs.getRuntimeWorksheet(), tableAssembly);
+
+         if(tableAssembly != null && query != null) {
+            selection.setProperty("sqlMergeable", query.isQueryMergeable(false));
+         }
+      }
+      else {
+         selection = new ColumnSelection();
+      }
+
+      return selection;
+   }
+
+   /**
     * Check if ref is a group in the aggregate info.
     */
    private boolean isDimensionRef(ColumnRef ref, AggregateInfo ainfo) {
@@ -169,4 +347,6 @@ public class VSColumnHandler {
 
       return !VSEventUtil.isMeasure(ref);
    }
+
+   private final ViewsheetService viewsheetService;
 }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/SelectionListService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/SelectionListService.java
@@ -18,17 +18,17 @@
 
 package inetsoft.web.composer.vs.dialog;
 
+import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.cluster.*;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.WorksheetEngine;
 import inetsoft.uql.ColumnSelection;
 import inetsoft.uql.asset.ColumnRef;
 import inetsoft.uql.erm.DataRef;
-import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.util.Tool;
 import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.binding.handler.VSAssemblyInfoHandler;
-import inetsoft.web.viewsheet.service.VSInputService;
+import inetsoft.web.binding.handler.VSColumnHandler;
 import org.springframework.stereotype.Service;
 
 import java.security.Principal;
@@ -38,10 +38,10 @@ import java.util.*;
 @ClusterProxy
 public class SelectionListService {
 
-   public SelectionListService(VSInputService vsInputService, ViewsheetService viewsheetService,
-                                                              VSAssemblyInfoHandler infoHandler)
+   public SelectionListService(VSColumnHandler vsColumnHandler, ViewsheetService viewsheetService,
+                               VSAssemblyInfoHandler infoHandler)
    {
-      this.vsInputService = vsInputService;
+      this.vsColumnHandler = vsColumnHandler;
       this.viewsheetService = viewsheetService;
       this.infoHandler = infoHandler;
    }
@@ -52,12 +52,12 @@ public class SelectionListService {
    {
 
       RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
-      ColumnSelection selection = this.vsInputService.getTableColumns(rvs, table, principal);
+      ColumnSelection selection = vsColumnHandler.getTableColumns(rvs, table, principal);
       String[] columns = selection.stream().map(DataRef::getName).toArray(String[]::new);
       String[] tooltips = new String[selection.getAttributeCount()];
       String[] dataTypes = new String[selection.getAttributeCount()];
 
-      for(int i = 0; i < columns.length; i ++) {
+      for(int i = 0; i < columns.length; i++) {
          if(columns[i].isEmpty()) {
             columns[i] = "Column [" + i + "]";
          }
@@ -99,6 +99,6 @@ public class SelectionListService {
    }
 
    private ViewsheetService viewsheetService;
-   private final VSInputService vsInputService;
+   private final VSColumnHandler vsColumnHandler;
    private final VSAssemblyInfoHandler infoHandler;
 }

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyService.java
@@ -46,6 +46,7 @@ import inetsoft.util.*;
 import inetsoft.util.script.ScriptEnv;
 import inetsoft.util.script.ScriptException;
 import inetsoft.web.binding.handler.VSAssemblyInfoHandler;
+import inetsoft.web.binding.handler.VSColumnHandler;
 import inetsoft.web.composer.model.vs.*;
 import inetsoft.web.composer.vs.VSObjectTreeNode;
 import inetsoft.web.composer.vs.VSObjectTreeService;
@@ -82,7 +83,7 @@ public class VSObjectPropertyService {
    @Autowired
    public VSObjectPropertyService(
       CoreLifecycleService coreLifecycleService,
-      VSInputService vsInputService,
+      VSColumnHandler vsColumnHandler,
       VSObjectTreeService vsObjectTreeService,
       VSAssemblyInfoHandler infoHander,
       ViewsheetService viewsheetService,
@@ -91,7 +92,7 @@ public class VSObjectPropertyService {
       SharedFilterService sharedFilterService)
    {
       this.coreLifecycleService = coreLifecycleService;
-      this.vsInputService = vsInputService;
+      this.vsColumnHandler = vsColumnHandler;
       this.vsObjectTreeService = vsObjectTreeService;
       this.infoHander = infoHander;
       this.viewsheetService = viewsheetService;
@@ -1637,7 +1638,7 @@ public class VSObjectPropertyService {
                                                         RuntimeViewsheet rvs, Principal principal)
       throws Exception
    {
-      ColumnSelection selection = vsInputService.getTableColumns(
+      ColumnSelection selection = vsColumnHandler.getTableColumns(
          rvs, table, null, null, dimensionOf, false, false, true, false, false, true, principal);
       List<OutputColumnRefModel> columnList = new ArrayList<>();
 
@@ -2140,7 +2141,7 @@ public class VSObjectPropertyService {
 
 
    private final CoreLifecycleService coreLifecycleService;
-   private final VSInputService vsInputService;
+   private final VSColumnHandler vsColumnHandler;
    private final VSObjectTreeService vsObjectTreeService;
    private final VSAssemblyInfoHandler infoHander;
    private final ViewsheetService viewsheetService;

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSOutputService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSOutputService.java
@@ -32,6 +32,7 @@ import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.VSUtil;
 import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
+import inetsoft.web.binding.handler.VSColumnHandler;
 import inetsoft.web.composer.model.TreeNodeModel;
 import inetsoft.web.composer.model.vs.OutputColumnRefModel;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,10 +47,8 @@ public class VSOutputService {
     * Created a new instance of VSOutputService
     */
    @Autowired
-   public VSOutputService(
-      VSInputService vsInputService,
-      ViewsheetService viewsheetService) {
-      this.vsInputService = vsInputService;
+   public VSOutputService(VSColumnHandler vsColumnHandler, ViewsheetService viewsheetService) {
+      this.vsColumnHandler = vsColumnHandler;
       this.viewsheetService = viewsheetService;
    }
 
@@ -596,8 +595,8 @@ public class VSOutputService {
                                                 boolean includeCalc, Principal principal)
       throws Exception
    {
-      return vsInputService.getTableColumns(rvs, table, null, null, null, false,
-                                            false, includeCalc, false, false, false, principal);
+      return vsColumnHandler.getTableColumns(rvs, table, null, null, null, false,
+                                             false, includeCalc, false, false, false, principal);
    }
 
    /**
@@ -613,10 +612,8 @@ public class VSOutputService {
                                                     boolean measureOnly, Principal principal)
       throws Exception
    {
-      ColumnSelection columnSelection = vsInputService.getTableColumns(rvs, table, null, null, null, false,
-                                            measureOnly, true, false, false, false, principal);
-
-      return columnSelection;
+      return vsColumnHandler.getTableColumns(rvs, table, null, null, null, false, measureOnly,
+                                             true, false, false, false, principal);
    }
 
    private String getEntryType(AssetEntry entry) {
@@ -638,6 +635,6 @@ public class VSOutputService {
       return table;
    }
 
-   private final VSInputService vsInputService;
+   private final VSColumnHandler vsColumnHandler;
    private final ViewsheetService viewsheetService;
 }

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/ImagePropertyDialogControllerTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/ImagePropertyDialogControllerTest.java
@@ -31,6 +31,7 @@ import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.ImageVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
 import inetsoft.web.binding.handler.VSAssemblyInfoHandler;
+import inetsoft.web.binding.handler.VSColumnHandler;
 import inetsoft.web.composer.model.vs.ImagePropertyDialogModel;
 import inetsoft.web.composer.vs.VSObjectTreeService;
 import inetsoft.web.composer.vs.controller.VSLayoutService;
@@ -69,7 +70,7 @@ class ImagePropertyDialogControllerTest {
                                                   vsLayoutService, parameterService);
       temporaryInfoService = new VSWizardTemporaryInfoService(viewsheetService);
       vsObjectPropertyService = spy(new VSObjectPropertyService(coreLifecycleService,
-                                                                vsInputService,
+                                                                vsColumnHandler,
                                                                 vsObjectTreeService,
                                                                 infoHandler, viewsheetEngine,
                                                                 temporaryInfoService,
@@ -136,7 +137,7 @@ class ImagePropertyDialogControllerTest {
    @Mock SharedFilterService sharedFilterService;
 
    private CoreLifecycleService coreLifecycleService;
-   @Mock VSInputService vsInputService;
+   @Mock VSColumnHandler vsColumnHandler;
    private VSObjectPropertyService vsObjectPropertyService;
    private ImagePropertyDialogController controller;
    private VSTrapService trapService;

--- a/core/src/test/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyServiceTest.java
@@ -22,6 +22,7 @@ import inetsoft.test.SreeHome;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.web.binding.handler.VSAssemblyInfoHandler;
+import inetsoft.web.binding.handler.VSColumnHandler;
 import inetsoft.web.composer.vs.VSObjectTreeService;
 import inetsoft.web.viewsheet.service.*;
 import inetsoft.web.vswizard.service.VSWizardTemporaryInfoService;
@@ -42,7 +43,7 @@ class VSObjectPropertyServiceTest {
    @BeforeEach
    void setup() throws Exception {
       controller = new VSObjectPropertyService(coreLifecycleService,
-                                               vsInputService,
+                                               vsColumnHandler,
                                                vsObjectTreeService,
                                                infoHandler, viewsheetEngine,
                                                temporaryInfoService,
@@ -68,9 +69,8 @@ class VSObjectPropertyServiceTest {
       assertEquals(popComponents[0], selectionListAssemblyName);
    }
 
-   @Mock
-   CoreLifecycleService coreLifecycleService;
-   @Mock VSInputService vsInputService;
+   @Mock CoreLifecycleService coreLifecycleService;
+   @Mock VSColumnHandler vsColumnHandler;
    @Mock VSObjectTreeService vsObjectTreeService;
    @Mock VSAssemblyInfoHandler infoHandler;
    @Mock ViewsheetEngine viewsheetEngine;


### PR DESCRIPTION
VSInputService -> VSObjectPropertyService -> VSInputService
Move getTableColumns() from VSInputService to VSColumnHandler