### PR TITLE
Fix Bug #71232:

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
@@ -4217,6 +4217,11 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
             field = new XExpression(col, XExpression.FIELD);
          }
 
+         if(item.getAttribute() instanceof  ColumnRef) {
+            int sqlType = ((ColumnRef) item.getAttribute()).getSqlType();
+            field.setSqlType(sqlType);
+         }
+
          XFilterNode node = createCondNode(cond, field, vars);
          return new XFilterNodeItem(node, item.getLevel());
       }

--- a/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
@@ -4217,7 +4217,7 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
             field = new XExpression(col, XExpression.FIELD);
          }
 
-         if(item.getAttribute() instanceof  ColumnRef) {
+         if(item.getAttribute() instanceof ColumnRef) {
             int sqlType = ((ColumnRef) item.getAttribute()).getSqlType();
             field.setSqlType(sqlType);
          }

--- a/core/src/main/java/inetsoft/uql/jdbc/XExpression.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/XExpression.java
@@ -28,6 +28,7 @@ import org.w3c.dom.NodeList;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.sql.Types;
 import java.util.Vector;
 
 /**
@@ -165,6 +166,14 @@ public class XExpression implements Cloneable, Serializable, XMLSerializable {
     */
    public String getType() {
       return type;
+   }
+
+   public int getSqlType() {
+      return sqlType;
+   }
+
+   public void setSqlType(int sqlType) {
+      this.sqlType = sqlType;
    }
 
    public String toString() {
@@ -363,6 +372,7 @@ public class XExpression implements Cloneable, Serializable, XMLSerializable {
    private int quote = QUOTE_NONE;
    private Object value = "";
    private String type = FIELD;
+   private int sqlType = Types.VARCHAR;
 
    private static Vector opList = new Vector();
    private static Vector functionNameList = new Vector();

--- a/core/src/main/java/inetsoft/uql/jdbc/util/ConditionListHandler.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/util/ConditionListHandler.java
@@ -21,6 +21,7 @@ import inetsoft.uql.*;
 import inetsoft.uql.asset.internal.ConditionUtil;
 import inetsoft.uql.erm.*;
 import inetsoft.uql.jdbc.*;
+import inetsoft.util.CoreTool;
 import inetsoft.util.Queue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -468,9 +469,11 @@ public class ConditionListHandler {
                                          cond.isEqual() ? ">=" : ">");
          break;
       default: // EQUAL_TO
-         condnode = new XBinaryCondition(field,
-                                         getExpression(cond, cond.getValue(0), vars, true),
-                                         "=");
+         Object condValue = cond.getValue(0);
+         String sqlType = SQLTypes.getSQLTypes(null).convertToXType(field.getSqlType());
+         condValue = CoreTool.getData(sqlType, condValue);
+         condnode = new XBinaryCondition(field, getExpression(cond, CoreTool.getData(sqlType, condValue),
+                                                              vars, true), "=");
          break;
       }
 

--- a/core/src/main/java/inetsoft/uql/jdbc/util/ConditionListHandler.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/util/ConditionListHandler.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Time;
+import java.sql.Types;
 import java.util.*;
 
 /**
@@ -470,10 +471,15 @@ public class ConditionListHandler {
          break;
       default: // EQUAL_TO
          Object condValue = cond.getValue(0);
-         String sqlType = SQLTypes.getSQLTypes(null).convertToXType(field.getSqlType());
-         condValue = CoreTool.getData(sqlType, condValue);
-         condnode = new XBinaryCondition(field, getExpression(cond, CoreTool.getData(sqlType, condValue),
-                                                              vars, true), "=");
+
+         if(field != null && (field.getSqlType() == Types.BOOLEAN ||
+            field.getSqlType() == Types.VARCHAR || field.getSqlType() == Types.INTEGER))
+         {
+            String sqlType = SQLTypes.getSQLTypes(null).convertToXType(field.getSqlType());
+            condValue = CoreTool.getData(sqlType, condValue);
+         }
+
+         condnode = new XBinaryCondition(field, getExpression(cond, condValue, vars, true), "=");
          break;
       }
 


### PR DESCRIPTION
When performing queries, the attribute types should be consistent with the database. Therefore, the type of a Variable cannot be changed according to the column type. However, considering the application of Variables in other contexts, we should modify the type of the Variable to match the type of the attribute being queried in the database when constructing the SQL statement.