### PR TITLE
fix Bug #71253. Remove the property that is not needed by Community.

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -484,7 +484,6 @@
               <configDirectory>${project.build.directory}/server/config</configDirectory>
               <properties>
                 <log.level.org.apache.ignite>WARN</log.level.org.apache.ignite>
-                <security.login.orgLocation>domain</security.login.orgLocation>
               </properties>
             </configuration>
           </plugin>


### PR DESCRIPTION
Community does not support the 'security.login.orgLocation' property, so it has been removed.