### PR TITLE
Fix Bug #71258:

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
@@ -2958,7 +2958,7 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
          return null;
       }
 
-      int index = name.indexOf('.');
+      int index = name.lastIndexOf('.');
 
       if(index >= 0) {
          Viewsheet vs = null;


### PR DESCRIPTION
Due to the changes in #71174, when fetching the Assembly, the logic was modified from directly retrieving the innermost chart to getting the outermost viewsheet and then searching layer by layer downwards. However, this approach can only reach the second layer and will fail with multiple nested layers. Therefore, it should be changed to search in reverse (from inner to outer).