### PR TITLE
fix Bug #71262.  Fix the failure of 'rtrim' execution.

### DIFF
--- a/core/src/main/java/inetsoft/util/script/JavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/JavaScriptEngine.java
@@ -1611,6 +1611,10 @@ public class JavaScriptEngine {
          }
       }
 
+      if(idx < 0) {
+         return "";
+      }
+
       return str.substring(0, idx);
    }
 


### PR DESCRIPTION
Fix the issue where `rtrim` fails when the input string is empty or consists entirely of whitespace characters.