### PR TITLE
fix Bug #71263, clear the data level examples of data ref when the ref is not date type.

### DIFF
--- a/web/projects/portal/src/app/composer/dialog/ws/aggregate-pane.component.ts
+++ b/web/projects/portal/src/app/composer/dialog/ws/aggregate-pane.component.ts
@@ -240,6 +240,7 @@ export class AggregatePane {
    }
 
    populateOptions(row: Row, index: number): void {
+      this.dateLevelExamples[index] = null;
       let num = 0;
       this.groups[index] = [
          ...this.baseGroups,


### PR DESCRIPTION
clear the data level examples of data ref when the ref is not date type.