### PR TITLE
fix Bug #71261: fix date type parameter for task

### DIFF
--- a/core/src/main/java/inetsoft/sree/RepletRequest.java
+++ b/core/src/main/java/inetsoft/sree/RepletRequest.java
@@ -1126,7 +1126,7 @@ public class RepletRequest implements java.io.Serializable, Cloneable, HttpXMLSe
       }
       else if(ptype.equals("Date")) {
          try {
-            Date val = dateFmt.parse(pvalue);
+            java.sql.Date val = new java.sql.Date(dateFmt.parse(pvalue).getTime());
 
             if(parameterValue != null) {
                parameterValue.setValue(val);


### PR DESCRIPTION
when task create date parameters, it will put variable table it as this: "^Date^2015-01-01", then it will parse it to java.util.Date. So when using script to set the parameter value to text, it show util date with time. But we should parse it to java.sql.Date similar to the time will parse to java.sql.time.