### PR TITLE
fix Bug #71269: should check table style and script exist or not when run backup task

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/IndividualAssetBackupAction.java
+++ b/core/src/main/java/inetsoft/sree/schedule/IndividualAssetBackupAction.java
@@ -142,14 +142,14 @@ public class IndividualAssetBackupAction implements ScheduleAction, HttpXMLSeria
             String id = ((TableStyleAsset) asset).getStyleID();
 
             if(LibManager.getManager().getTableStyle(id) == null) {
-               throw new RuntimeException("Error retrieving tablestyle from lib manager: " + id);
+               failedAssets.add(asset);
             }
          }
          else if(asset instanceof ScriptAsset) {
             String name = asset.getPath();
 
             if(LibManager.getManager().getScript(name) == null) {
-               throw new RuntimeException("Error retrieving tablestyle from lib manager: " + name);
+               failedAssets.add(asset);
             }
          }
       }


### PR DESCRIPTION
when run backup file to backup assets, if assets is tablestyle or script, should also check if them are existed, should throw exception to run failed if tablestyle and script do not existed.