### PR TITLE
fix Bug #71285, return quarter of year is interval is "q" as document describes.

### DIFF
--- a/core/src/main/java/inetsoft/util/script/JavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/JavaScriptEngine.java
@@ -1366,6 +1366,9 @@ public class JavaScriptEngine {
                int startDayOfYear = cal.get(Calendar.DAY_OF_YEAR);
 
                return endDayOfYear - startDayOfYear + 1;
+            case "q":
+               int month = cal.get(Calendar.MONTH);
+               return (month / 3) + 1;
             default:
                int field = getDateInterval(interval);
 


### PR DESCRIPTION
this is an old bug, return quarter of year is interval is "q" as document describes.