### PR TITLE
fix Bug #71168. Fix the NameNotFoundException caused by incorrect group directory.

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.internal.cluster.*;
 import inetsoft.sree.security.*;
 import inetsoft.uql.util.Identity;
@@ -270,6 +269,23 @@ public abstract class LdapAuthenticationProvider
          name.append(getGroupAttribute()).append('=').append(group);
 
          if(getGroupBase() != null && !getGroupBase().isEmpty()) {
+            String middleGroup = doGetGroups().get(group);
+
+            if(middleGroup != null) {
+               int baseGroupIndex = Math.max(0, middleGroup.indexOf(getGroupBase()));
+
+               if(middleGroup.startsWith(name.toString()) && baseGroupIndex > name.length() + 1) {
+                  middleGroup = middleGroup.substring(name.length() + 1, baseGroupIndex - 1);
+               }
+               else {
+                  middleGroup = null;
+               }
+
+               if(!Tool.isEmptyString(middleGroup)) {
+                  name.append(",").append(middleGroup);
+               }
+            }
+
             return Arrays.stream(getGroupBases(getGroupBase()))
                .map(g -> name.append(",").append(g).toString())
                .flatMap(g -> searchDirectory(g, filter, scope, attr).stream())


### PR DESCRIPTION
Fix the issue caused by the missing intermediate directory level in the group path.
Before the fix: `ou=Support,ou=people`
After the fix (correct): `ou=Support,ou=IT,ou=people`

Exception trace:
Caused by: javax.naming.NameNotFoundException: [LDAP: error code 32 - No Such Object]
        at java.naming/com.sun.jndi.ldap.LdapCtx.mapErrorCode(LdapCtx.java:3285) ~[na:na]
        at java.naming/com.sun.jndi.ldap.LdapCtx.processReturnCode(LdapCtx.java:3206) ~[na:na]
        at java.naming/com.sun.jndi.ldap.LdapCtx.processReturnCode(LdapCtx.java:2997) ~[na:na]
        at java.naming/com.sun.jndi.ldap.LdapCtx.searchAux(LdapCtx.java:1876) ~[na:na]
        at java.naming/com.sun.jndi.ldap.LdapCtx.c_search(LdapCtx.java:1799) ~[na:na]
        at java.naming/com.sun.jndi.toolkit.ctx.ComponentDirContext.p_search(ComponentDirContext.java:392) ~[na:na]
        at java.naming/com.sun.jndi.toolkit.ctx.PartialCompositeDirContext.search(PartialCompositeDirContext.java:358) ~[na:na]
        at java.naming/com.sun.jndi.toolkit.ctx.PartialCompositeDirContext.search(PartialCompositeDirContext.java:341) ~[na:na]
        at java.naming/javax.naming.directory.InitialDirContext.search(InitialDirContext.java:346) ~[na:na]
        at inetsoft.sree.security.ldap.LdapAuthenticationProvider.searchDirectory(LdapAuthenticationProvider.java:1170) ~[classes/:na]
        at inetsoft.sree.security.ldap.LdapAuthenticationProvider.searchDirectory(LdapAuthenticationProvider.java:1067) ~[classes/:na]