### PR TITLE
Fix Bug #71280:

### DIFF
--- a/web/projects/portal/src/app/binding/editor/data-editor.component.scss
+++ b/web/projects/portal/src/app/binding/editor/data-editor.component.scss
@@ -17,6 +17,8 @@
  */
 .field-list-pane {
   min-height: 36px;
+  max-height: 116px;
+  overflow-y: auto;
   padding: 0px;
   display: flex;
 }


### PR DESCRIPTION
Since the table binding area can accommodate many fields, it is necessary to set a maximum display height of three rows of data, with a scrollbar appearing for any overflow content.