### PR TITLE
fix Bug #71286. When searching tree nodes, folder nodes should be in the expanded state.

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/RepositoryTreeSearchController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/RepositoryTreeSearchController.java
@@ -319,6 +319,7 @@ public class RepositoryTreeSearchController {
          .addAllChildren(folderNodes)
          .addAllChildren(fileNodes)
          .leaf(false)
+         .expanded(true)
          .build();
    }
 


### PR DESCRIPTION
When searching tree nodes, folder nodes should be in the expanded state.