### PR TITLE
Fix Bug #71222: Modify multi-layer nested embedded viewsheet execution script.

### DIFF
--- a/core/src/main/java/inetsoft/report/script/viewsheet/ViewsheetVSAScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/viewsheet/ViewsheetVSAScriptable.java
@@ -89,12 +89,6 @@ public class ViewsheetVSAScriptable extends VSAScriptable {
    }
 
    protected VSAssemblyInfo getVSAssemblyInfo() {
-      Viewsheet vs = box.getViewsheet();
-
-      if(vs.isEmbedded()) {
-         return vs.getVSAssemblyInfo();
-      }
-
       return super.getVSAssemblyInfo();
    }
 


### PR DESCRIPTION
If a multi-level nested embedded viewsheet correctly obtains its scope during script execution, there is no need to repeatedly search for the embedded viewsheet during the process, as doing so may lead to incorrect script execution hierarchy.