### PR TITLE
bug-71238 script parameter value can't display in print layout

### DIFF
--- a/core/src/main/java/inetsoft/report/script/viewsheet/ViewsheetScope.java
+++ b/core/src/main/java/inetsoft/report/script/viewsheet/ViewsheetScope.java
@@ -128,6 +128,10 @@ public class ViewsheetScope extends ScriptableObject implements Cloneable, Dynam
       }
    }
 
+   public void prepareVariables(VariableTable vtable) {
+      setVariableTable(vtable);
+   }
+
    /**
     * Execute a query.
     * @param name query name.

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSExportService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSExportService.java
@@ -720,6 +720,7 @@ public class VSExportService {
                exportBox =
                   new ViewsheetSandbox(cviewsheet, vmode, rbox.getUser(), rbox.getAssetEntry());
                exportBox.prepareMVCreation();
+               exportBox.getScope().prepareVariables(rbox.getVariableTable());
 
                for(int i = 0; exportBox != null && i < assemblies.length; i++) {
                   VSAssembly assembly = (VSAssembly) assemblies[i];


### PR DESCRIPTION
The bug occurred because when a new ViewsheetSandbox object was created, the original VariableTable was also reset. However, executing the script requires values from the parameter, and since the parameter did not contain any data (e.g., date: 2024-01-24), the script execution resulted in the text component displaying its default value. To fix this, the original VariableTable should be set into the new ViewsheetSandbox object after it is created. This ensures that the script executes successfully and the text component can retrieve the correct value.