### PR TITLE
fix Bug #71295. Handle errors caused by request messages exceeding the WebSocket size limit.

### DIFF
--- a/web/projects/portal/src/app/vsobjects/dialog/graph/hyperlink-dialog.component.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/graph/hyperlink-dialog.component.ts
@@ -304,24 +304,27 @@ export class HyperlinkDialog implements OnInit {
          }
       }
 
+      const { fields, ...modelClone } = this.model;
+      const model: HyperlinkDialogModel = { ...modelClone, fields: [] };
+
       // Check trap
       const trapInfo = new TrapInfo(CHECK_TRAP_REST_URI, this.objectName, this.runtimeId,
                                     this.model);
 
       this.trapService.checkTrap(trapInfo, () => {
          if(commit) {
-            this.onCommit.emit(this.model);
+            this.onCommit.emit(model);
          }
          else {
-            this.onApply.emit({collapse: collapse, result: this.model});
+            this.onApply.emit({collapse: collapse, result: model});
          }
       }, () => {
       }, () => {
          if(commit) {
-            this.onCommit.emit(this.model);
+            this.onCommit.emit(model);
          }
          else {
-            this.onApply.emit({collapse: collapse, result: this.model});
+            this.onApply.emit({collapse: collapse, result: model});
          }
       });
    }


### PR DESCRIPTION
The `fields` property is used when adding a parameter of type "field" for a hyperlink. It is not used when sending a request to set the hyperlink. If there are too many fields, it may exceed the WebSocket request size limit. Therefore, the `fields` property value is not included when submitting the hyperlink model.
