### PR TITLE
bug-71302 open combox has default value,pop up error 

### DIFF
--- a/web/projects/portal/src/app/vsobjects/dialog/combo-box-editor.component.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/combo-box-editor.component.ts
@@ -131,7 +131,7 @@ export class ComboBoxEditor implements OnInit, OnChanges {
                   }
                }
 
-               this.model.defaultValue = value[0].value;
+               this.model.defaultValue = value.length > 0 ? value[0].value : null;
             }
          });
       }


### PR DESCRIPTION
This bug occurs because value is an empty array ([]), so value[0] is undefined. As a result, accessing value[0].value causes an error. You need to handle this case separately—only access value[0].value when value has at least one element.