### PR TITLE
Fix Bug #71298:

### DIFF
--- a/web/projects/em/src/app/auditing/audit-identity-info/audit-identity-info.component.html
+++ b/web/projects/em/src/app/auditing/audit-identity-info/audit-identity-info.component.html
@@ -21,7 +21,7 @@
     <mat-form-field *ngIf="organizationFilter == true" appearance="outline" color="accent" class="flex">
       <mat-label>_#(Identity Organizations)</mat-label>
       <mat-select formControlName="selectedOrganizations" multiple>
-        <mat-option *ngFor="let org of organizations; let i = index" [value]="org">{{organizationNames[i]}}</mat-option>
+        <mat-option *ngFor="let org of organizations; let i = index" [value]="org.orgID">{{organizations[i].name}}</mat-option>
       </mat-select>
     </mat-form-field>
     <mat-form-field appearance="outline" color="accent" class="flex margin-left">

--- a/web/projects/em/src/app/auditing/audit-identity-info/audit-identity-info.component.ts
+++ b/web/projects/em/src/app/auditing/audit-identity-info/audit-identity-info.component.ts
@@ -26,6 +26,7 @@ import { ContextHelp } from "../../context-help";
 import { PageHeaderService } from "../../page-header/page-header.service";
 import { Searchable } from "../../searchable";
 import { Secured } from "../../secured";
+import { IdentityId } from "../../settings/security/users/identity-id";
 import { AuditTableViewComponent } from "../audit-table-view/audit-table-view.component";
 import { IdentityInfo, IdentityInfoList, IdentityInfoParameters } from "./identity-info";
 
@@ -54,8 +55,7 @@ export class AuditIdentityInfoComponent implements OnInit, OnDestroy {
    actions = [ "c", "d", "m", "r" ];
    states = [ "0", "1", "2" ];
    hosts: string[] = [];
-   organizations: string[] = [];
-   organizationNames: string[] = [];
+   organizations: IdentityId[] = [];
    orgNames: string[] = [];
    form: FormGroup;
    systemAdministrator = false;
@@ -124,7 +124,6 @@ export class AuditIdentityInfoComponent implements OnInit, OnDestroy {
                types: [],
                hosts: [],
                organizations: [],
-               organizationNames: [],
                organizationFilter: true,
                systemAdministrator: false,
                startTime: 0,
@@ -132,7 +131,6 @@ export class AuditIdentityInfoComponent implements OnInit, OnDestroy {
             }))),
             tap(params => {
                this.organizations = params.organizations;
-               this.organizationNames = params.organizationNames;
                this.organizationFilter = params.organizationFilter;
                this.hosts = params.hosts;
             }));

--- a/web/projects/em/src/app/auditing/audit-identity-info/identity-info.ts
+++ b/web/projects/em/src/app/auditing/audit-identity-info/identity-info.ts
@@ -20,7 +20,7 @@ import {IdentityId} from "../../settings/security/users/identity-id";
 
 export interface IdentityInfoParameters extends AuditRecordParameters {
    hosts: string[];
-   organizations: string[];
+   organizations: IdentityId[];
    organizationFilter: boolean;
    systemAdministrator: boolean;
 }


### PR DESCRIPTION
The current implementation stores organization names (orgName) and organization identifiers (orgID) in separate array structures. This storage approach cannot guarantee index consistency between the two datasets, which may lead to misalignment between identifiers and their corresponding names.