### PR TITLE
fix Bug #71303. Fix NPE.

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/OnClickController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/OnClickController.java
@@ -387,7 +387,7 @@ public class OnClickController {
          return box0;
       }
 
-      int index = name.indexOf(".");
+      int index = name.lastIndexOf(".");
       String vsName = name.substring(0, index);
       box0 = box0.getSandbox(vsName);
 


### PR DESCRIPTION
When there are multiple levels of nested viewsheets, obtain the `ViewsheetSandbox` based on the name of the innermost viewsheet to ensure it can be retrieved correctly.