### PR TITLE
fix Bug #71300. Add a check for `null` values when collect 'runQuery' script dependencies.

### DIFF
--- a/core/src/main/java/inetsoft/util/dep/ViewsheetAsset.java
+++ b/core/src/main/java/inetsoft/util/dep/ViewsheetAsset.java
@@ -289,9 +289,12 @@ public class ViewsheetAsset extends AbstractSheetAsset implements FolderChangeab
          public void nextElement(ScriptIterator.Token token, ScriptIterator.Token pref,
                                  ScriptIterator.Token cref)
          {
-            if(token.isRef() && pref != null && "runQuery".equals(pref.val) )
-            {
-               list.add(createAssetEntry(token.val));
+            if(token.isRef() && pref != null && "runQuery".equals(pref.val)) {
+               AssetEntry assetEntry = createAssetEntry(token.val);
+
+               if(assetEntry != null) {
+                  list.add(assetEntry);
+               }
             }
          }
       };


### PR DESCRIPTION
Due to an incorrect way of referencing the worksheet in the 'runQuery' script, a `null` was added to the dependency list. Therefore, add a check for `null` values.