### PR TITLE
fix Bug #71328. The factorial of 0 is generally defined to be 1.

### DIFF
--- a/core/src/main/java/inetsoft/util/script/CalcUtil.java
+++ b/core/src/main/java/inetsoft/util/script/CalcUtil.java
@@ -497,8 +497,12 @@ public class CalcUtil {
     */
    public static long factorialdouble(long n) {
       // Base Case:
+      // If n == 0 then n! = 1
+      if(n == 0) {
+         return 1;
+      }
       // If n == 1 or n ==2 then n! = n.
-      if(n == 1 || n == 2) {
+      else if(n == 1 || n == 2) {
          return n;
       }
       // Recursive Case:


### PR DESCRIPTION
The constant case of 0 was not handled when calculating the double factorial, which led to infinite recursion of the `factorialdouble` method and eventually caused a `StackOverflowError`. However, it is generally accepted that the factorial of 0 is 1.