### PR TITLE
fix Bug #71329. Throw an exception if either number is negative when computing the GCD.

### DIFF
--- a/core/src/main/java/inetsoft/util/script/CalcMath.java
+++ b/core/src/main/java/inetsoft/util/script/CalcMath.java
@@ -296,6 +296,12 @@ public class CalcMath {
          throw new RuntimeException("Array should at least contain one number");
       }
 
+      for(int i = 0; i < nos.length; i++) {
+         if(nos[i] < 0) {
+            throw new RuntimeException("All numbers should be non-negative");
+         }
+      }
+
       int gcd;
 
       if(nos.length == 1) {


### PR DESCRIPTION
When calculating the greatest common divisor of two numbers, an exception should be thrown if either number is negative.