### PR TITLE
bug-71322  delete table styles folder, style always display in table

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryObjectService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryObjectService.java
@@ -18,6 +18,7 @@
 package inetsoft.web.admin.content.repository;
 
 import inetsoft.report.LibManager;
+import inetsoft.report.composition.event.AssetEventUtil;
 import inetsoft.report.internal.Util;
 import inetsoft.report.style.XTableStyle;
 import inetsoft.sree.RepletRegistry;
@@ -388,7 +389,7 @@ public class RepositoryObjectService {
                LibManager.getManager().save();
                break;
             case RepositoryEntry.TABLE_STYLE | RepositoryEntry.FOLDER:
-               LibManager.getManager().removeTableStyleFolder(node.path());
+               AssetEventUtil.removeStyleFolder(node.path(), LibManager.getManager());
                LibManager.getManager().save();
                break;
             case RepositoryEntry.FOLDER:


### PR DESCRIPTION
The bug occurred because when deleting the style folder on the EM side, only the current folder was deleted without removing all the table styles under it. To fix this, all styles and subfolders within the folder should also be deleted.