### PR TITLE
fix Bug #71324, 

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskFolderService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskFolderService.java
@@ -805,14 +805,7 @@ public class ScheduleTaskFolderService {
    public EditTaskFolderDialogModel getFolderEditModel(String folderPath, Principal principal) throws Exception {
       EditTaskFolderDialogModel.Builder model = EditTaskFolderDialogModel.builder();
       AssetEntry entry = getFolderEntry(folderPath);
-      List<IdentityID> owners = getOwners(principal);
-      model.users(owners);
       model.oldPath(folderPath);
-
-      if(owners.size() > 0) {
-         model.adminName(principal.getName());
-      }
-
       setFolderNameAndOwner(model, entry);
       model.securityEnabled(isSecurityEnabled());
 


### PR DESCRIPTION
do not load uses for EditTaskFolderDialogModel, because now it do not support change owner, task folder is global. please see Bug #43793.