### PR TITLE
fix Bug #71332. Fix the issue where the node was not selected.

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/model/TreeNodeModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/TreeNodeModel.java
@@ -81,8 +81,7 @@ public interface TreeNodeModel extends Comparable<TreeNodeModel> {
 
    @Nullable String cssClass();
 
-   @Value.Default
-   default boolean defaultOrgAsset() { return false; }
+   @Nullable Boolean defaultOrgAsset();
 
    @Value.Default
    default boolean disabled() {

--- a/web/projects/portal/src/app/widget/tree/tree-dropdown.component.ts
+++ b/web/projects/portal/src/app/widget/tree/tree-dropdown.component.ts
@@ -95,8 +95,7 @@ export class TreeDropdownComponent extends TreeDataPane {
             {
                label: this.currentLabel,
                data: !!this.currentNodeData ? this.currentNodeData : this.currentLabel,
-               type: this.selectedType,
-               defaultOrgAsset: false
+               type: this.selectedType
             };
 
          return [selectedNode, ...(this.initSelectedNodes ? this.initSelectedNodes : [])];


### PR DESCRIPTION
The `defaultOrgAsset` property should be nullable because in many cases this property may not be needed for validation. For example, in the current case, the node mismatch was caused by the absence of this property.