### PR TITLE
Fix Bug #71336:When a column cannot be found, a warning pops up but the operation cannot proceed.

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/VSDimensionRef.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/VSDimensionRef.java
@@ -1390,7 +1390,21 @@ public class VSDimensionRef extends AbstractDataRef implements ContentObject, XD
 
          String gtext = Tool.toString(arr[i]);
          DataRef group = columns.getAttribute(gtext);
-         VSDimensionRef ref = this.clone();
+
+         if(group == null && !gtext.equals("null") && !gtext.equals("")) {
+            // don't throw an exception so the rendering can complete without
+            // generating a broken chart image
+            LOG.warn("Column not found: " + groupValue + " (" + columns + ")");
+
+            if(groupValue.getDValue().startsWith("=")) {
+               CoreTool.addUserMessage(Catalog.getCatalog().getString(
+                  "common.viewsheet.expressionColumn", groupValue));
+            }
+
+            continue;
+         }
+
+         VSDimensionRef ref = (VSDimensionRef) this.clone();
 
          if(group instanceof ColumnRef) {
             ColumnRef col = (ColumnRef) group;


### PR DESCRIPTION
Due to the changes in #70201, when a column cannot be found, a warning pops up but the operation cannot proceed, so the previous code that did not invoke the old events and commands is being added back.