### PR TITLE
fix Bug #71305: fix rangslider binding olap column which setting as date attribute

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
@@ -36,6 +36,7 @@ import inetsoft.uql.util.XEmbeddedTable;
 import inetsoft.uql.util.XSourceInfo;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.*;
+import inetsoft.uql.xmla.CubeDate;
 import inetsoft.uql.xmla.MemberObject;
 import inetsoft.util.MessageFormat;
 import inetsoft.util.*;
@@ -464,7 +465,7 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
          table.moreRows(Integer.MAX_VALUE);
          checkMaxRowLimit(table);
 
-         if(unit == TimeInfo.MEMBER) {
+         if(unit == TimeInfo.MEMBER || cubeData) {
             if(table.getRowCount() < 2 || table.getColCount() != 1) {
                return null;
             }
@@ -1532,6 +1533,11 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
             String str = obj == null ? CoreTool.FAKE_NULL : AbstractCondition.getValueString(obj,
                refs[idx].getDataType(), false);
             objs[idx] = obj;
+
+            if(obj instanceof CubeDate && ((CubeDate) obj).getMemberObject() != null) {
+               str = ((CubeDate) obj).getMemberObject().getCaption();
+            }
+
             vstr.append(str);
 
             if(obj instanceof MemberObject) {


### PR DESCRIPTION
for rangslider binding cube date(cube string column define as date to be a date column), it will treat unit as Month and using min and max date to get all dates in them. should fix it as this
1.  when cube data, should return tablelens for rangslider and get values from tablelens.

2. when value is CubeDate(as date for olap column), should get its MemberObj and to get its caption to as value, then it will using the value to create right condition in MDX.