### PR TITLE
fix Bug #71278: cube date should not set date level and option to get browse data.

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/BrowseDataController.java
+++ b/core/src/main/java/inetsoft/web/composer/BrowseDataController.java
@@ -281,7 +281,8 @@ public class BrowseDataController {
       // the none date group column in the columnselection and lossing date option information,
       // so here add date option prefix to avoid issue (50186).
       if(column.getDataRef() instanceof DateRangeRef &&
-         ((DateRangeRef) column.getDataRef()).getDataRef() != null)
+         ((DateRangeRef) column.getDataRef()).getDataRef() != null &&
+         !(table instanceof CubeTableAssembly))
       {
          DateRangeRef range = (DateRangeRef) column.getDataRef();
          DataRef attr = range.getDataRef();


### PR DESCRIPTION
for normal date column, should using its date level and option to get right range column to browse data. But for cube data, we should not fix it, when cube data column set as date, it using deta level and option will get wrong column and can not get right browse data, should using orginal column to get right data.