### PR TITLE
fix Bug #71365. Fix can't add aggregate.

### DIFF
--- a/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.ts
+++ b/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.ts
@@ -127,7 +127,7 @@ export class FormulaEditorDialog extends BaseResizeableDialogComponent implement
    @Input() isCondition: boolean = false;
 
    @Input() grayedOutFields: DataRef[];
-   @Input() userAggNames: string[];
+   @Input() userAggNames: string[] = [];
    @Input() selfVisible: boolean = true;
    @Input() checkDuplicatesInColumnTree: boolean = true;
 


### PR DESCRIPTION
The bug was caused by assigning a value to an undefined object when closing `newAggrDialog`, so a default value is assigned to the `userAggNames` object.