### PR TITLE
Fix Bug #71298:The modified logic checks orgID equality if multi-tenancy is enabled, otherwise verifies EM access permissions.

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/deploy/DeployService.java
+++ b/core/src/main/java/inetsoft/web/admin/deploy/DeployService.java
@@ -343,7 +343,12 @@ public class DeployService {
       boolean siteAdmin = manager.isSiteAdmin(principal);
 
       for(PartialDeploymentJarInfo.SelectedAsset entry : info.getSelectedEntries()) {
-         if(!siteAdmin && !Tool.equals(entry.getUser().orgID, manager.getCurrentOrgID())) {
+         boolean accessViolation = SUtil.isMultiTenant() ?
+            !Tool.equals(entry.getUser().orgID, manager.getCurrentOrgID()) :
+            !securityEngine.checkPermission(principal, ResourceType.EM, "*", ResourceAction.ACCESS);
+
+         if(!siteAdmin && accessViolation)
+         {
             ArrayList<String> errors = new ArrayList<>();
             errors.add(Catalog.getCatalog().getString("em.import.ignoreOtherOrgAssetsForOrgAdmin"));
             return ImportAssetResponse.builder()


### PR DESCRIPTION
The modified logic checks orgID equality if multi-tenancy is enabled, otherwise verifies EM access permissions.