### PR TITLE
fix Bug #71314: olap date group only can create post condition

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/AssemblyConditionDialogController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/AssemblyConditionDialogController.java
@@ -31,7 +31,6 @@ import inetsoft.uql.viewsheet.internal.VSUtil;
 import inetsoft.util.Tool;
 import inetsoft.web.binding.VSScriptableController;
 import inetsoft.web.binding.drm.*;
-import inetsoft.web.binding.model.DateRangeRefModel;
 import inetsoft.web.binding.model.GroupRefModel;
 import inetsoft.web.binding.service.DataRefModelFactoryService;
 import inetsoft.web.composer.BrowseDataController;

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/AssemblyConditionDialogController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/AssemblyConditionDialogController.java
@@ -31,6 +31,7 @@ import inetsoft.uql.viewsheet.internal.VSUtil;
 import inetsoft.util.Tool;
 import inetsoft.web.binding.VSScriptableController;
 import inetsoft.web.binding.drm.*;
+import inetsoft.web.binding.model.DateRangeRefModel;
 import inetsoft.web.binding.model.GroupRefModel;
 import inetsoft.web.binding.service.DataRefModelFactoryService;
 import inetsoft.web.composer.BrowseDataController;
@@ -168,6 +169,20 @@ public class AssemblyConditionDialogController extends WorksheetController {
             preAggregateFields[idx] = groupFields[i];
          }
       }
+
+      List<DataRefModel> newPreAggregates = new ArrayList<>();
+
+      for(int i = 0; i < preAggregateFields.length; i++) {
+         DataRefModel nagg = preAggregateFields[i];
+         boolean postAgg = nagg instanceof GroupRefModel &&
+            nagg.getRefType() == DataRef.CUBE_TIME_DIMENSION;
+
+         if(!postAgg) {
+            newPreAggregates.add(nagg);
+         }
+      }
+
+      preAggregateFields = newPreAggregates.toArray(new DataRefModel[0]);
 
       for(int i = 0, j = aggregateInfo.getGroupCount(); i < aggregateInfo.getAggregateCount();
           i++, j++)

--- a/web/projects/portal/src/app/composer/dialog/ws/assembly-condition-dialog.component.ts
+++ b/web/projects/portal/src/app/composer/dialog/ws/assembly-condition-dialog.component.ts
@@ -25,6 +25,7 @@ import { ConditionValueType } from "../../../common/data/condition/condition-val
 import { JunctionOperator } from "../../../common/data/condition/junction-operator";
 import { JunctionOperatorType } from "../../../common/data/condition/junction-operator-type";
 import { DataRef } from "../../../common/data/data-ref";
+import { DataRefType } from "../../../common/data/data-ref-type";
 import { XSchema } from "../../../common/data/xschema";
 import { isValidConditionList } from "../../../common/util/condition.util";
 import { LocalStorage } from "../../../common/util/local-storage.util";
@@ -270,6 +271,11 @@ export class AssemblyConditionDialog implements OnInit {
             // check if the condition belongs to the post-aggregate conditions
             else if(condition.field.classType === "AggregateRef"
                || condition.field.formulaName)
+            {
+               this.addCondition(condition, this.model.postAggregateConditionList);
+            }
+            else if(condition.field.classType === "GroupRef" &&
+               condition.field.refType == DataRefType.CUBE_TIME_DIMENSION)
             {
                this.addCondition(condition, this.model.postAggregateConditionList);
             }


### PR DESCRIPTION
1 for olap column set as date, it can do date level group to column, and then it can only do pre condition for original column, but can post condition for group columns. 

2 for pre-condition pane, should not load cube columns in list(maybe table from olap and normal to join, so should check cube type for every field, field list maybe have different columns mixed) 

3 when add simple condition to list, should change olap orginal column to pre condition, date group for olap time dimension should push to post conditions