### PR TITLE
Bug #71364 - optimization fixes for the sorting dialog

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/model/vs/VSSortRefModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/VSSortRefModel.java
@@ -18,16 +18,23 @@
 package inetsoft.web.composer.model.vs;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import inetsoft.web.binding.drm.DataRefModel;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class VSSortRefModel {
-   public DataRefModel getDataRefModel() {
-      return dataRefModel;
+   public String getName() {
+      return name;
    }
 
-   public void setDataRefModel(DataRefModel dataRefModel) {
-      this.dataRefModel = dataRefModel;
+   public void setName(String name) {
+      this.name = name;
+   }
+
+   public String getView() {
+      return view;
+   }
+
+   public void setView(String view) {
+      this.view = view;
    }
 
    public int getOrder() {
@@ -38,6 +45,7 @@ public class VSSortRefModel {
       this.order = order;
    }
 
-   private DataRefModel dataRefModel;
+   private String name;
+   private String view;
    private int order;
 }

--- a/web/projects/portal/src/app/composer/data/vs/vs-sort-ref-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/vs-sort-ref-model.ts
@@ -15,9 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { DataRef } from "../../../common/data/data-ref";
 
 export interface VSSortRefModel {
-   dataRefModel: DataRef;
+   name: string;
+   view: string;
    order: number;
 }

--- a/web/projects/portal/src/app/composer/dialog/vs/vs-sorting-dialog.component.ts
+++ b/web/projects/portal/src/app/composer/dialog/vs/vs-sorting-dialog.component.ts
@@ -34,6 +34,8 @@ export class VSSortingDialog {
    }
 
    ok() {
-      this.onCommit.emit(this.model);
+      const result = Object.assign({}, this.model);
+      delete result.vsSortingPaneModel.columnNoneList;
+      this.onCommit.emit(result);
    }
 }

--- a/web/projects/portal/src/app/composer/dialog/vs/vs-sorting-pane.component.html
+++ b/web/projects/portal/src/app/composer/dialog/vs/vs-sorting-pane.component.html
@@ -33,7 +33,7 @@
         <button class="sort-button sort-descending-icon" *ngSwitchCase="SortEnum.DESC"
                 title="_#(Descending)"
              (click)="_col.order = SortEnum.NONE; move(_i, model.columnSortList, model.columnNoneList);" style="padding: 0px"></button>
-        <div style="padding-left: 6px">{{_col.dataRefModel.view || _col.dataRefModel.name}}</div>
+        <div style="padding-left: 6px">{{_col.view || _col.name}}</div>
       </div>
       <div *ngFor="let _col of model.columnNoneList; let _i = index" class="sort-row p-1 mb-1 bd-gray"
            [class.selected]="_col == selectedField"
@@ -42,7 +42,7 @@
         <button class="sort-button sort-icon icon-size-sm"
                 title="_#(Sort)"
                 (click)="_col.order = SortEnum.ASC; move(_i, model.columnNoneList, model.columnSortList);" style="padding: 0px"></button>
-        <div style="padding-left: 6px">{{_col.dataRefModel.view || _col.dataRefModel.name}} </div>
+        <div style="padding-left: 6px">{{_col.view || _col.name}} </div>
       </div>
     </div>
     <ng-container largeFieldButtons>


### PR DESCRIPTION
Don't send data ref objects to the client. Column names are sufficient.
Exclude unsorted columns from the final result sent to the server, as they are never accessed.