### PR TITLE
fix Bug #71331. Fix ColumnNotFoundException and fix the chart/rangeslider's inability to show metadata.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/CubeVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/CubeVSAQuery.java
@@ -29,6 +29,7 @@ import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.VSUtil;
+import inetsoft.uql.xmla.XMLAUtil;
 import inetsoft.util.Catalog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -422,7 +423,7 @@ public abstract class CubeVSAQuery extends DataVSAQuery {
          table = getBaseTable(table);
       }
 
-      return new VSCubeTableLens(lens, table.getColumnSelection(true));
+      return new VSCubeTableLens(lens, table.getColumnSelection(true), XMLAUtil.isMetadata(box));
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
@@ -36,8 +36,7 @@ import inetsoft.uql.util.XEmbeddedTable;
 import inetsoft.uql.util.XSourceInfo;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.*;
-import inetsoft.uql.xmla.CubeDate;
-import inetsoft.uql.xmla.MemberObject;
+import inetsoft.uql.xmla.*;
 import inetsoft.util.MessageFormat;
 import inetsoft.util.*;
 import inetsoft.util.audit.ExecutionBreakDownRecord;
@@ -648,7 +647,7 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
       TableLens lens = super.getTableLens(table);
 
       if(lens != null && !isWorksheetCube() && AssetUtil.isCubeTable(table)) {
-         lens = new VSCubeTableLens(lens, table.getColumnSelection(true));
+         lens = new VSCubeTableLens(lens, table.getColumnSelection(true), XMLAUtil.isMetadata(box));
       }
 
       Object min = tinfo.getMin();

--- a/core/src/main/java/inetsoft/report/composition/execution/VSCubeTableLens.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/VSCubeTableLens.java
@@ -50,8 +50,19 @@ public class VSCubeTableLens extends DefaultTableFilter
     * @param columns the corresponding table column selection.
     */
    public VSCubeTableLens(TableLens lens, ColumnSelection columns) {
+      this(lens, columns, false);
+   }
+
+   /**
+    * Create a copy of a table lens.
+    * @param lens contained base table lens.
+    * @param columns the corresponding table column selection.
+    * @param metadata true if using metadata, false otherwise.
+    */
+   public VSCubeTableLens(TableLens lens, ColumnSelection columns, boolean metadata) {
       super(lens);
       this.columns = columns;
+      this.metadata = metadata;
 
       dimtypes = new int[lens.getColCount()];
 
@@ -216,7 +227,12 @@ public class VSCubeTableLens extends DefaultTableFilter
       Object obj = super.getObject(r, c);
 
       if(r < getHeaderRowCount()) {
-         // dimension name should be kept for headers
+         // Dimension name should be kept for headers, except in metadata mode.
+         // In metadata mode, brackets `[` and `]` should be removed from headers
+         // to match the binding column.
+         if(metadata) {
+            return getDisplayFullValue(Tool.toString(obj));
+         }
       }
       else if(obj instanceof MemberObject || obj instanceof String) {
          return getDisplayValue(obj, dimtypes[c]);
@@ -316,4 +332,5 @@ public class VSCubeTableLens extends DefaultTableFilter
 
    private ColumnSelection columns;
    private int[] dimtypes;
+   private boolean metadata;
 }

--- a/core/src/main/java/inetsoft/uql/xmla/XMLAUtil.java
+++ b/core/src/main/java/inetsoft/uql/xmla/XMLAUtil.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.uql.xmla;
 
+import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.sree.SreeEnv;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
@@ -935,6 +936,17 @@ public class XMLAUtil {
    public static boolean isDisplayFullCaption() {
       return "true".equals(SreeEnv.getProperty(
          "olap.table.originalContent", "false"));
+   }
+
+   /**
+    * Check whether the viewsheet is in metadata mode.
+    */
+   public static boolean isMetadata(ViewsheetSandbox box) {
+      if(box.getViewsheet() != null) {
+         return box.getViewsheet().getViewsheetInfo().isMetadata();
+      }
+
+      return false;
    }
 
    /**


### PR DESCRIPTION
For cube tablelens in metadata mode, brackets `[` and `]` should be removed from headers to match the binding column.