### PR TITLE
Fix Bug #71384:

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -2600,7 +2600,7 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
       // script will be executed before onLoad
       //executeScript((OutputVSAssembly) assembly);
 
-      Object data = getData(entry.getName());
+      Object data = getData(entry.getAbsoluteName());
       OutputVSAssemblyInfo outputInfo = (OutputVSAssemblyInfo)
          assembly.getInfo();
       BindingInfo binding = outputInfo.getBindingInfo();


### PR DESCRIPTION
Due to the changes in bug#70423, the previous embedded viewsheet would only query the values once, but now it queries twice—the first time for the inner viewsheet and the second time for the complete viewsheet. Therefore, it is necessary to retrieve the values based on the AbsoluteName of the entry.