### PR TITLE
fix Bug #71355. Fix the issue where `custom log level - role` does not work in non-multi-tenant mode.

### DIFF
--- a/core/src/main/java/inetsoft/util/log/LogManager.java
+++ b/core/src/main/java/inetsoft/util/log/LogManager.java
@@ -20,8 +20,7 @@ package inetsoft.util.log;
 import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.internal.cluster.*;
-import inetsoft.sree.security.SecurityEngine;
-import inetsoft.sree.security.SecurityProvider;
+import inetsoft.sree.security.*;
 import inetsoft.util.*;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.*;
@@ -176,6 +175,14 @@ public final class LogManager implements AutoCloseable, MessageListener {
     * @return the log level or <tt>Level.OFF</tt> if the default should be used.
     */
    private LogLevel getContextLevel(LogContext context, String name) {
+      if(!SUtil.isMultiTenant() && name != null) {
+         int orgIndex = name.lastIndexOf(Organization.getDefaultOrganizationID());
+
+         if(orgIndex > 0) {
+            name = name.substring(0, orgIndex - 1);
+         }
+      }
+
       return contextLevels.get(context).get(name);
    }
 


### PR DESCRIPTION
When not in multi-tenant mode, retrieving the context level should ignore the organization part in the custom log level name.
