### PR TITLE
fix Bug #71382:  crosstab in embed vs drill issue.

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/handler/crosstab/CrosstabDrillHandler.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/handler/crosstab/CrosstabDrillHandler.java
@@ -154,7 +154,7 @@ public class CrosstabDrillHandler
       RuntimeViewsheet rvs = viewsheetService.getViewsheet(
          runtimeViewsheetRef.getRuntimeId(), principal);
       final ViewsheetSandbox box = rvs.getViewsheetSandbox();
-      VSTableLens lens = box.getVSTableLens(table.getName(), false);
+      VSTableLens lens = box.getVSTableLens(table.getAbsoluteName(), false);
 
       for(String field : drillFilterAction.getFields()) { // for chart
          drillAllField(true, drillFilterAction.isDrillUp(), field,


### PR DESCRIPTION
not only occor for olap, normal db have same issue. for embed crosstab to drill, should using its abosolute name not name to get tablelens. for normal assemblies, they are same, for crosstab in embed vs, they are different.