### PR TITLE
fix Bug #71376. Retrieve the log level using a key in the same format.

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/IdentityID.java
+++ b/core/src/main/java/inetsoft/sree/security/IdentityID.java
@@ -112,9 +112,16 @@ public class IdentityID implements Comparable<IdentityID>, Serializable, XMLSeri
       }
    }
 
+   public String getLabelWithCaretDelimiter() {
+      boolean enterprise = LicenseManager.getInstance().isEnterprise();
+      return enterprise ?
+         Tool.buildString(name, "^", orgID == null ? GLOBAL_ORG_KEY : orgID) : name;
+   }
+
    public String getLabel() {
       boolean enterprise = LicenseManager.getInstance().isEnterprise();
-      return enterprise ? (name + "(" + (orgID == null ? GLOBAL_ORG_KEY : orgID) + ")") : name;
+      return enterprise ?
+         Tool.buildString(name, "(", orgID == null ? GLOBAL_ORG_KEY : orgID, ")") : name;
    }
 
    @Override

--- a/core/src/main/java/inetsoft/util/log/LogContext.java
+++ b/core/src/main/java/inetsoft/util/log/LogContext.java
@@ -152,19 +152,25 @@ public enum LogContext {
       else {
          boolean enterprise = LicenseManager.getInstance().isEnterprise();
          IdentityID userIdentity = IdentityID.getIdentityIDFromKey(user.getName());
-         String name = userIdentity != null ? userIdentity.getLabel() : user.getName();
 
-         MDC.put(LogContext.USER.name(), name);
+         if(userIdentity == null) {
+            userIdentity = IdentityID.getIdentityIDFromKey(user.getName());
+         }
+
+         MDC.put(LogContext.USER.name(), userIdentity.getLabelWithCaretDelimiter());
 
          if(user instanceof XPrincipal principal) {
+            IdentityID finalUserIdentity = userIdentity;
             String groups = String.join(",",
                                         Arrays.stream(principal.getGroups())
                                            .map(g -> enterprise ?
-                                              new IdentityID(g, userIdentity.getOrgID()).getLabel() : g)
+                                              new IdentityID(g, finalUserIdentity.getOrgID())
+                                                 .getLabelWithCaretDelimiter() : g)
                                            .toArray(String[]::new));
             String roles = String.join(",",
                                        Arrays.stream(principal.getRoles())
-                                          .map(r -> enterprise ? r.getLabel() : r.getName())
+                                          .map(r -> enterprise ?
+                                             r.getLabelWithCaretDelimiter() : r.getName())
                                           .toArray(String[]::new));
 
             if(!groups.equals("")) {


### PR DESCRIPTION
Custom log level is stored in key-value format, where the key follows the format `Identity^OrgID`. Therefore, when retrieving the log level, the key should also follow this format.