### PR TITLE
fix Bug #71378. Fix the issue where logs cannot be filtered by the 'ORGANIZATION' log level.

### DIFF
--- a/core/src/main/java/inetsoft/util/log/LogContext.java
+++ b/core/src/main/java/inetsoft/util/log/LogContext.java
@@ -148,8 +148,11 @@ public enum LogContext {
          MDC.remove(LogContext.USER.name());
          MDC.remove(LogContext.GROUP.name());
          MDC.remove(LogContext.ROLE.name());
+         MDC.remove(LogContext.ORGANIZATION.name());
       }
       else {
+         MDC.put(LogContext.ORGANIZATION.name(), ((XPrincipal) user).getOrgId());
+
          boolean enterprise = LicenseManager.getInstance().isEnterprise();
          IdentityID userIdentity = IdentityID.getIdentityIDFromKey(user.getName());
 


### PR DESCRIPTION
Add organization information to the MDC, so that logs can be filtered based on the custom log level of type 'ORGANIZATION'.