### PR TITLE
fix Bug #71386. Fix the issue where the custom log level does not take effect.

### DIFF
--- a/core/src/main/java/inetsoft/util/log/LogContext.java
+++ b/core/src/main/java/inetsoft/util/log/LogContext.java
@@ -116,7 +116,7 @@ public enum LogContext {
    }
 
    private String fixOrgScopeResourceName(String name) {
-      if(!SUtil.isMultiTenant() || Tool.equals(ORGANIZATION.getPrefix(), getPrefix()) ||
+      if(Tool.equals(ORGANIZATION.getPrefix(), getPrefix()) ||
          Tool.equals(CATEGORY.getPrefix(), getPrefix()))
       {
          return name;

--- a/core/src/main/java/inetsoft/util/log/LogManager.java
+++ b/core/src/main/java/inetsoft/util/log/LogManager.java
@@ -175,14 +175,6 @@ public final class LogManager implements AutoCloseable, MessageListener {
     * @return the log level or <tt>Level.OFF</tt> if the default should be used.
     */
    private LogLevel getContextLevel(LogContext context, String name) {
-      if(!SUtil.isMultiTenant() && name != null) {
-         int orgIndex = name.lastIndexOf(Organization.getDefaultOrganizationID());
-
-         if(orgIndex > 0) {
-            name = name.substring(0, orgIndex - 1);
-         }
-      }
-
       return contextLevels.get(context).get(name);
    }
 


### PR DESCRIPTION
Unify the naming convention for log levels so that the organization ID is always included, regardless of whether the system is multi-tenant. This ensures that switching tenants does not affect the retrieval of log levels.