### PR TITLE
Fix Bug #71401:Add a click event listener to the form on the page.

### DIFF
--- a/web/projects/portal/src/app/widget/fixed-dropdown/fixed-dropdown.component.ts
+++ b/web/projects/portal/src/app/widget/fixed-dropdown/fixed-dropdown.component.ts
@@ -73,16 +73,17 @@ export class FixedDropdownComponent implements OnInit, AfterViewInit, OnDestroy 
             if(this.container && this.container.tagName === 'FORM') {
                this.listeners.push(
                   this.renderer.listen(this.container, "mousedown", (e) => this.documentMousedown(e)),
+                  this.renderer.listen(this.container, "click", (e) => this.documentClick(e)),
                )
             }
             else {
                this.listeners.push(
                   this.renderer.listen("document", "mousedown", (e) => this.documentMousedown(e)),
+                  this.renderer.listen("document", "click", (e) => this.documentClick(e)),
                )
             }
 
             this.listeners.push(
-               this.renderer.listen("document", "click", (e) => this.documentClick(e)),
                this.renderer.listen("document", "keyup.esc", (e) => this.closeFromOutsideEsc(e)),
                this.renderer.listen("window", "resize", (e) => this.closeFromWindowResize(e)),
             );


### PR DESCRIPTION
Add a click event listener to the form on the page, allowing it to trigger the documentClick method and close after clicking.