### PR TITLE
fix Bug #71406, 

### DIFF
--- a/web/projects/portal/src/app/composer/gui/ws/editor/schema/schema-column.component.ts
+++ b/web/projects/portal/src/app/composer/gui/ws/editor/schema/schema-column.component.ts
@@ -70,7 +70,7 @@ export class SchemaColumnComponent implements OnInit, AfterViewInit, OnDestroy {
    ngOnInit(): void {
       this.tableColumn = {column: this.column, table: this.schemaTable.name};
       this.columnHeader = this.schemaTable.colInfos
-         .find(colInfo => colInfo.name == this.column.name).header;
+         .find(colInfo => colInfo.name == this.column.name)?.header || this.column.name;
 
       this.connSub = this.schemaThumbnailService.getConnectingColumnSubject()
          .subscribe((tableColumn) => {


### PR DESCRIPTION
When in live data mode, if a column is not found in the column infos (which are based on the table data), use the column name as the column header. Note that in live data mode, table data is limited to 200 columns by default, which means some columns in the original data might not be included in the column infos.