### PR TITLE
fix Bug #71421. Fix the syntax error that occurs when performing a drill-down on date values in a crosstab using a cube data source.

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/TableConditionUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/TableConditionUtil.java
@@ -496,7 +496,7 @@ public class TableConditionUtil {
          }
 
          // number in xmla query causes exception, needs to be string
-         if(xmla) {
+         if(xmla && !(val instanceof Date)) {
             val = Tool.toString(val);
          }
 


### PR DESCRIPTION
Do not convert values of type `Date` to `String`, as this will cause the conversion to a unique name of the member to fail. Please refer to the `CubeQuery.convertCondition()` method.