### PR TITLE
fix Bug #71412, import performance

### DIFF
--- a/web/projects/portal/src/app/binding/editor/sort-option.component.ts
+++ b/web/projects/portal/src/app/binding/editor/sort-option.component.ts
@@ -401,6 +401,10 @@ export class SortOption implements OnInit {
                this.valueLabelList = this.valueLabelList == null ? [] : this.valueLabelList;
                let existingList = null;
 
+               if(this.valueLabelList.length > 5001) {
+                  this.valueLabelList = this.valueLabelList.slice(0, 5001);
+               }
+
                if(this.dimension.manualOrder) {
                   existingList = this.dimension.manualOrder
                      .map(v => v || "")


### PR DESCRIPTION
import performance, don't send useless datas to server by websocket since manual order is limited to 5000 distinct values.