### PR TITLE
fix Bug #71387. Fix display issue of assembly when tab visibility is script-controlled.

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
@@ -1518,6 +1518,16 @@ public class CoreLifecycleService {
                   addDeleteVSObject(rvs, child, dispatcher);
                }
             }
+            else if(info instanceof TabVSAssemblyInfo) {
+               String selectedAssembly = ((TabVSAssemblyInfo) info).getSelected();
+
+               if(!Tool.isEmptyString(selectedAssembly)) {
+                  VSAssembly child = rvs.getViewsheet().getAssembly(selectedAssembly);
+                  VSAssemblyInfo childInfo = VSEventUtil.getAssemblyInfo(rvs, child);
+                  child.setVSAssemblyInfo(childInfo);
+                  addDeleteVSObject(rvs, child, dispatcher);
+               }
+            }
          }
          finally {
             box.unlockWrite();

--- a/web/projects/portal/src/app/vsobjects/objects/tab/vs-tab.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/tab/vs-tab.component.ts
@@ -120,7 +120,6 @@ export class VSTab extends NavigationComponent<VSTabModel> implements OnChanges,
          this.vsInfo.vsObjects
             .filter(obj => obj.absoluteName == this.model.selected && obj.objectType == "VSChart")
             .forEach(obj => (<VSChartModel> obj).chartSelection.regions = []);
-         console.log("change:", this.vsInfo);
          this.viewsheetClientService.sendEvent(target, event);
       }
 


### PR DESCRIPTION
When a tab container's visibility is changed at runtime (e.g. in a script), the children have not been added in the client. Need to call addDeleteVSObject to make sure the selected assembly is added to the client app if necessary.