### PR TITLE
fix Bug #71436. Fix incorrect value calculation in the `CALC.time()` script function.

### DIFF
--- a/core/src/main/java/inetsoft/util/script/CalcDateTime.java
+++ b/core/src/main/java/inetsoft/util/script/CalcDateTime.java
@@ -435,19 +435,22 @@ public class CalcDateTime {
     * 0:00:00 (12:00:00 AM) to 23:59:59 (11:59:59 P.M.).
     */
    public static double time(int hour, int minute, int second) {
-      hour = hour % 24;
-      minute = minute % 60;
-      second = second % 60;
+      int totalSeconds = hour * 3600 + minute * 60 + second;
+      totalSeconds = totalSeconds % (24 * 60 * 60);
+
+      hour = totalSeconds / 3600;
+      minute = (totalSeconds % 3600) / 60;
+      second = totalSeconds % 60;
 
       Calendar start = CoreTool.calendar.get();
       start.clear();
-      start.set(Calendar.HOUR, 0);
+      start.set(Calendar.HOUR_OF_DAY, 0);
       start.set(Calendar.MINUTE, 0);
       start.set(Calendar.SECOND, 0);
 
       Calendar cal = CoreTool.calendar2.get();
       cal.clear();
-      cal.set(Calendar.HOUR, hour);
+      cal.set(Calendar.HOUR_OF_DAY, hour);
       cal.set(Calendar.MINUTE, minute);
       cal.set(Calendar.SECOND, second);
 


### PR DESCRIPTION
Fix the issue in the `CALC.time()` script function where the result is incorrect when the hour, minute, or second parameters exceed their valid ranges. The cause was that the overflow part of these values was discarded in the code, whereas Excel applies carry-over logic in such cases.