### PR TITLE
fix Bug #71438: add type check for Crosstab Query

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AbstractCrosstabVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AbstractCrosstabVSAQuery.java
@@ -66,8 +66,10 @@ public abstract class AbstractCrosstabVSAQuery extends CubeVSAQuery
    public AbstractCrosstabVSAQuery(ViewsheetSandbox box, String crosstab, boolean detail) {
       super(box, crosstab, detail);
 
-      CrosstabDataVSAssembly cassembly = (CrosstabDataVSAssembly) getAssembly();
-      groupInfo = cassembly.getAggregateInfo();
+      if(getAssembly() != null) {
+         CrosstabDataVSAssembly cassembly = (CrosstabDataVSAssembly) getAssembly();
+         groupInfo = cassembly.getAggregateInfo();
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/composition/execution/CrosstabVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/CrosstabVSAQuery.java
@@ -342,6 +342,14 @@ public class CrosstabVSAQuery extends AbstractCrosstabVSAQuery {
       return cols;
    }
 
+   protected VSAssembly getAssembly() {
+      if(!(getViewsheet().getAssembly(vname) instanceof CrosstabVSAssembly)) {
+         return null;
+      }
+
+      return getViewsheet().getAssembly(vname);
+   }
+
    private boolean columnLimit = true;
 
    public static class CrossTabSortFilter extends SortFilter {


### PR DESCRIPTION
the bug is caused by specifi case, when home save id vschart1 as a chart assembly, but in other bookmark using the same id as a crosstab, then to remove the bookmark, it will refresh to execute the crosstab, but the query is larger, bebore query finish, the viewsheet change to home bookmark, so the query will get chart assembly for the crosstab query, so we should check type for crosstab query.