### PR TITLE
Fix Bug #71433:Modify the storage of query in MDC.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/SQLBoundQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/SQLBoundQuery.java
@@ -188,7 +188,8 @@ public class SQLBoundQuery extends BoundQuery {
    @Override
    protected Collection<?> getLogRecord() {
       if(table != null) {
-         String name = Tool.buildString(MDC.get(LogContext.WORKSHEET.name()), ".", table.getAbsoluteName());
+         String name = Tool.buildString(MDC.get(LogContext.WORKSHEET.name()), ".",
+            table.getInfo().getAbsoluteName());
          return Collections.singleton(LogContext.QUERY.getRecord(name));
       }
       else if(xquery != null) {

--- a/core/src/main/java/inetsoft/uql/asset/internal/SQLBoundTableAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/asset/internal/SQLBoundTableAssemblyInfo.java
@@ -66,6 +66,19 @@ public class SQLBoundTableAssemblyInfo extends BoundTableAssemblyInfo {
       return this.query;
    }
 
+   public String getOriginalName() {
+      return originalName;
+   }
+
+   public void setOriginalName(String originalName) {
+      this.originalName = originalName;
+   }
+
+   @Override
+   public String getAbsoluteName() {
+      return getOriginalName();
+   }
+
    /**
     * Write contents.
     * @param writer the specified writer.
@@ -136,6 +149,7 @@ public class SQLBoundTableAssemblyInfo extends BoundTableAssemblyInfo {
    }
 
    private JDBCQuery query;
+   private String originalName;
 
    private static final Logger LOG =
       LoggerFactory.getLogger(SQLBoundTableAssemblyInfo.class);

--- a/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
@@ -5230,6 +5230,10 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
       mirror.setProperty(VS_MIRROR_TABLE, "true");
       ws.addAssembly(mirror);
 
+      if(table.getInfo() instanceof SQLBoundTableAssemblyInfo) {
+         ((SQLBoundTableAssemblyInfo) table.getInfo()).setOriginalName(tname);
+      }
+
       return true;
    }
 

--- a/core/src/main/java/inetsoft/util/GroupedThread.java
+++ b/core/src/main/java/inetsoft/util/GroupedThread.java
@@ -450,6 +450,11 @@ public class GroupedThread extends Thread {
          if(context != null) {
             key = context.name();
             value = context.getRecordName(record);
+
+            if(context == LogContext.QUERY) {
+               String[] parts = value.split("\\.");
+               value = parts.length == 2 ? parts[1] : value;
+            }
          }
       }
       else if(record instanceof QueryRecord) {


### PR DESCRIPTION
The name defined in the custom configuration corresponds to the value stored in the MDC (Mapped Diagnostic Context). However, when storing the value, the table name is modified by MirrorQuery—it adds a suffix and may include other prefixes. Therefore, we need to: 1.Store the original name (before any modifications by MirrorQuery). 2.Extract only the query name(removing any added prefixes/suffixes).