### PR TITLE
fix Bug #71443. Fix the issue where custom log levels for Schedule Task do not take effect.

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/SUtil.java
+++ b/core/src/main/java/inetsoft/sree/internal/SUtil.java
@@ -2983,6 +2983,34 @@ public class SUtil {
    }
 
    /**
+    * Gets the task name for logging.
+    */
+   public static String getTaskNameForLogging(String taskId) {
+      if(Tool.isEmptyString(taskId)) {
+         return taskId;
+      }
+      else if(!taskId.contains(":")) {
+         return Tool.buildString(taskId, "^", OrganizationManager.getInstance().getCurrentOrgID());
+      }
+
+      int index = taskId.indexOf(':');
+      String userPart = taskId.substring(0, index);
+      String taskName = taskId.substring(index + 1);
+      String userName = userPart;
+      String orgId = Organization.getDefaultOrganizationID();
+
+      if(userPart.contains(IdentityID.KEY_DELIMITER)) {
+         IdentityID identityID = IdentityID.getIdentityIDFromKey(userPart);
+         userName = identityID.getName();
+         orgId = identityID.getOrgID();
+      }
+
+      String finalTaskName = Tool.buildString(userName, ":", taskName);
+      return LicenseManager.getInstance().isEnterprise() ?
+         Tool.buildString(finalTaskName, "^", orgId) : finalTaskName;
+   }
+
+   /**
     * Gets the task name that does not contain organization info.
     */
    public static String getTaskOrgName(String taskFullName, Principal principal) {

--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleServer.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleServer.java
@@ -26,6 +26,7 @@ import inetsoft.report.internal.license.LicenseManager;
 import inetsoft.sree.*;
 import inetsoft.sree.internal.RMICallThread;
 import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.security.OrganizationManager;
 import inetsoft.util.*;
 import inetsoft.util.health.HealthService;
 import inetsoft.util.health.HealthStatus;
@@ -115,8 +116,8 @@ public class ScheduleServer extends UnicastRemoteObject implements Schedule {
     */
    @Override
    public void runNow(String taskName) throws RemoteException {
-      String taskNameForLog = LicenseManager.getInstance().isEnterprise() ?
-         taskName : SUtil.getTaskNameWithoutOrg(taskName);
+      String taskNameForLog = Tool.buildString(
+         SUtil.getTaskNameWithoutOrg(taskName), "^", OrganizationManager.getInstance().getCurrentOrgID());
       MDC.put("SCHEDULE_TASK", taskNameForLog);
       LOG.debug(
          "Received start task [" + taskNameForLog + "] request on " +

--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleServer.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleServer.java
@@ -116,8 +116,9 @@ public class ScheduleServer extends UnicastRemoteObject implements Schedule {
     */
    @Override
    public void runNow(String taskName) throws RemoteException {
-      String taskNameForLog = Tool.buildString(
-         SUtil.getTaskNameWithoutOrg(taskName), "^", OrganizationManager.getInstance().getCurrentOrgID());
+      String taskNameWithoutOrg = SUtil.getTaskNameWithoutOrg(taskName);
+      String taskNameForLog = !LicenseManager.getInstance().isEnterprise() ? taskNameWithoutOrg :
+         Tool.buildString(taskNameWithoutOrg, "^", OrganizationManager.getInstance().getCurrentOrgID());
       MDC.put("SCHEDULE_TASK", taskNameForLog);
       LOG.debug(
          "Received start task [" + taskNameForLog + "] request on " +

--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleServer.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleServer.java
@@ -116,9 +116,7 @@ public class ScheduleServer extends UnicastRemoteObject implements Schedule {
     */
    @Override
    public void runNow(String taskName) throws RemoteException {
-      String taskNameWithoutOrg = SUtil.getTaskNameWithoutOrg(taskName);
-      String taskNameForLog = !LicenseManager.getInstance().isEnterprise() ? taskNameWithoutOrg :
-         Tool.buildString(taskNameWithoutOrg, "^", OrganizationManager.getInstance().getCurrentOrgID());
+      String taskNameForLog = SUtil.getTaskNameForLogging(taskName);
       MDC.put("SCHEDULE_TASK", taskNameForLog);
       LOG.debug(
          "Received start task [" + taskNameForLog + "] request on " +

--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
@@ -556,8 +556,8 @@ public class ScheduleTask implements Serializable, Cloneable, XMLSerializable {
                   }
 
                   String taskId = getTaskId();
-                  taskId = LicenseManager.getInstance().isEnterprise() ?
-                     taskId : SUtil.getTaskNameWithoutOrg(taskId);
+                  taskId = Tool.buildString(SUtil.getTaskNameWithoutOrg(taskId), "^",
+                                            OrganizationManager.getInstance().getCurrentOrgID());
                   MDC.put("SCHEDULE_TASK", taskId);
                   act.run(principal);
                   MDC.remove("SCHEDULE_TASK");

--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
@@ -556,10 +556,7 @@ public class ScheduleTask implements Serializable, Cloneable, XMLSerializable {
                   }
 
                   String taskId = getTaskId();
-                  String taskNameWithoutOrg = SUtil.getTaskNameWithoutOrg(taskId);
-                  taskId = !LicenseManager.getInstance().isEnterprise() ? taskNameWithoutOrg :
-                     Tool.buildString(taskNameWithoutOrg, "^",
-                                      OrganizationManager.getInstance().getCurrentOrgID());
+                  taskId = SUtil.getTaskNameForLogging(taskId);
                   MDC.put("SCHEDULE_TASK", taskId);
                   act.run(principal);
                   MDC.remove("SCHEDULE_TASK");

--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
@@ -556,8 +556,10 @@ public class ScheduleTask implements Serializable, Cloneable, XMLSerializable {
                   }
 
                   String taskId = getTaskId();
-                  taskId = Tool.buildString(SUtil.getTaskNameWithoutOrg(taskId), "^",
-                                            OrganizationManager.getInstance().getCurrentOrgID());
+                  String taskNameWithoutOrg = SUtil.getTaskNameWithoutOrg(taskId);
+                  taskId = !LicenseManager.getInstance().isEnterprise() ? taskNameWithoutOrg :
+                     Tool.buildString(taskNameWithoutOrg, "^",
+                                      OrganizationManager.getInstance().getCurrentOrgID());
                   MDC.put("SCHEDULE_TASK", taskId);
                   act.run(principal);
                   MDC.remove("SCHEDULE_TASK");

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
@@ -1748,8 +1748,7 @@ public class ScheduleService {
       }
       else {
          String taskNameWithoutOrg = SUtil.getTaskNameWithoutOrg(taskName);
-         String taskNameForLog = !LicenseManager.getInstance().isEnterprise() ?
-            taskNameWithoutOrg : Tool.buildString(taskNameWithoutOrg, "^", currentOrgID);
+         String taskNameForLog = SUtil.getTaskNameForLogging(taskName);
          MDC.put("SCHEDULE_TASK", taskNameForLog);
 
          if(task != null && !task.isEnabled()) {

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
@@ -1747,8 +1747,8 @@ public class ScheduleService {
          dumpException = false;
       }
       else {
-         String taskNameForLog = LicenseManager.getInstance().isEnterprise() ?
-            taskName : SUtil.getTaskNameWithoutOrg(taskName);
+         String taskNameForLog =
+            Tool.buildString(SUtil.getTaskNameWithoutOrg(taskName), "^", currentOrgID);
          MDC.put("SCHEDULE_TASK", taskNameForLog);
          String withoutOrg = SUtil.getTaskNameWithoutOrg(taskName);
 

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
@@ -1747,13 +1747,13 @@ public class ScheduleService {
          dumpException = false;
       }
       else {
-         String taskNameForLog =
-            Tool.buildString(SUtil.getTaskNameWithoutOrg(taskName), "^", currentOrgID);
+         String taskNameWithoutOrg = SUtil.getTaskNameWithoutOrg(taskName);
+         String taskNameForLog = !LicenseManager.getInstance().isEnterprise() ?
+            taskNameWithoutOrg : Tool.buildString(taskNameWithoutOrg, "^", currentOrgID);
          MDC.put("SCHEDULE_TASK", taskNameForLog);
-         String withoutOrg = SUtil.getTaskNameWithoutOrg(taskName);
 
          if(task != null && !task.isEnabled()) {
-            errorMsg = catalog.getString("em.scheduler.startDisabledTask", withoutOrg);
+            errorMsg = catalog.getString("em.scheduler.startDisabledTask", taskNameWithoutOrg);
          }
          else {
             try {
@@ -1762,7 +1762,7 @@ public class ScheduleService {
             catch(Throwable ex) {
                LOG.debug("Failed to run task {}: {}", taskNameForLog, ex.getMessage(), ex);
                errorMsg =
-                  catalog.getString("em.scheduler.startFailed", withoutOrg);
+                  catalog.getString("em.scheduler.startFailed", taskNameWithoutOrg);
             }
          }
 


### PR DESCRIPTION
Use the correct format of log level name to retrieve the log level. The correct format is: `UserName:TaskName^OrgId`.
For non-enterprise environments, the log level name without the organization ID is used. In this case, the correct format should be: `UserName:TaskName`.
