### PR TITLE
fix Bug #71377: none date level should not create default format according to level, should use source format

### DIFF
--- a/core/src/main/java/inetsoft/report/filter/CrossTabFilter.java
+++ b/core/src/main/java/inetsoft/report/filter/CrossTabFilter.java
@@ -5516,7 +5516,7 @@ public class CrossTabFilter extends AbstractTableLens
       if(sc == null) {
          return sections;
       }
-      
+
       sections.sort(sc);
       return sections;
    }
@@ -6174,6 +6174,10 @@ public class CrossTabFilter extends AbstractTableLens
                (!Tool.isNumberClass(table.getColType(col0)) ||
                (level & SortOrder.PART_DATE_GROUP) == 0))
             {
+               continue;
+            }
+
+            if(Tool.isDateClass(table.getColType(col0)) && level == 0) {
                continue;
             }
 


### PR DESCRIPTION
when date group for crosstab, it will create default format according to deta level, but if level is none, should not set default format for it and then make to use source format.