### PR TITLE
fix Bug #71460, improve performance

### DIFF
--- a/core/src/main/java/inetsoft/report/filter/TextComparer.java
+++ b/core/src/main/java/inetsoft/report/filter/TextComparer.java
@@ -20,6 +20,7 @@ package inetsoft.report.filter;
 import inetsoft.report.Comparer;
 import inetsoft.util.Tool;
 
+import java.nio.charset.StandardCharsets;
 import java.text.Collator;
 
 /**
@@ -75,7 +76,19 @@ public class TextComparer implements Comparer {
          v2 = v2 != null ? v2.toString() : null;
       }
 
+      if(v1 == v2) {
+         return 0;
+      }
+
       if(collator != null) {
+         if(v1 instanceof String && v2 instanceof String &&
+            isAsciiOnly((String) v1) && isAsciiOnly((String) v2))
+         {
+            // If both strings are ASCII only, we can use the default comparison
+            // which is faster than using a collator.
+            return Tool.compare(v1, v2, caseSensitive, true);
+         }
+
          try {
             return collator.compare((String) v1, (String) v2);
          }
@@ -87,6 +100,15 @@ public class TextComparer implements Comparer {
       }
 
       return Tool.compare(v1, v2, caseSensitive, true);
+   }
+
+   private boolean isAsciiOnly(String str) {
+      if (str == null) {
+         return false;
+      }
+
+      byte[] bytes = str.getBytes(StandardCharsets.US_ASCII);
+      return bytes.length == str.length();
    }
 
    /**


### PR DESCRIPTION
The bug occurred because the JVM parameter -Duser.language=en was not used, causing the system's default locale to be applied instead. When performing string comparisons, the behavior depends on the locale, specifically by using RuleBasedCollator, which considers linguistic rules—a relatively time-consuming approach. Also, testing on JDK 1.8 and JDK 21 revealed that JDK 21 is nearly twice as slow as JDK 1.8, which are the two root causes of this bug.

To optimize performance, we improved the compare method in TextComparer. If both strings are ASCII-only, the default string comparison is used instead, reducing the execution time from 45s to 12s.