### PR TITLE
fix Bug #71461: should add size measure to MDX to get right drillthrough result for MDX

### DIFF
--- a/core/src/main/java/inetsoft/analytic/composition/event/ChartVSSelectionUtil.java
+++ b/core/src/main/java/inetsoft/analytic/composition/event/ChartVSSelectionUtil.java
@@ -132,7 +132,8 @@ public abstract class ChartVSSelectionUtil {
 
             if(cinfo.getChartType() == GraphTypes.CHART_SUNBURST ||
                cinfo.getChartType() == GraphTypes.CHART_CIRCLE_PACKING ||
-               cinfo.getChartType() == GraphTypes.CHART_ICICLE)
+               cinfo.getChartType() == GraphTypes.CHART_ICICLE ||
+               cinfo.getChartType() == GraphTypes.CHART_TREEMAP)
             {
                treeFields = new HashSet<>();
                ChartRef[] treeDims = cinfo.getRTGroupFields();
@@ -402,7 +403,8 @@ public abstract class ChartVSSelectionUtil {
 
             if(cinfo.getChartType() == GraphTypes.CHART_SUNBURST ||
                cinfo.getChartType() == GraphTypes.CHART_CIRCLE_PACKING ||
-               cinfo.getChartType() == GraphTypes.CHART_ICICLE)
+               cinfo.getChartType() == GraphTypes.CHART_ICICLE ||
+               cinfo.getChartType() == GraphTypes.CHART_TREEMAP)
             {
                addMeasuresToSelection(selection, points, lens, headers, header, false);
             }


### PR DESCRIPTION
should add measure ref in size field for treemap so it can get right MDX to drillthrough and then to get right data for show detail.