### PR TITLE
Fix Bug #71459:

### DIFF
--- a/core/src/main/java/inetsoft/util/script/JSObject.java
+++ b/core/src/main/java/inetsoft/util/script/JSObject.java
@@ -249,7 +249,7 @@ public class JSObject extends NativeJavaObject {
                Number x = (Number) get(obj, "x");
                Number y = (Number) get(obj, "y");
                Number width = (Number) get(obj, "width");
-               Number height = (Number) get(obj, "x");
+               Number height = (Number) get(obj, "height");
 
                if(stype != null && stype.equals("ellipse")) {
                   return new Ellipse2D.Double(x.intValue(), y.intValue(),


### PR DESCRIPTION
When obtaining the value of height, it should be retrieved based on the name being "height".