### PR TITLE
 fix Bug #71207, improve performance

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerRangeSliderController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerRangeSliderController.java
@@ -115,7 +115,7 @@ public class ComposerRangeSliderController {
       info.setEditable(assembly.isEditable());
       VSEventUtil.copyFormat(assembly, newAssembly);
       initCellFormat(newAssembly);
-      coreLifecycleService.removeVSAssembly(rvs, linkUri, assembly, dispatcher, false, false);
+      coreLifecycleService.removeVSAssemblies(rvs, linkUri, dispatcher, false, false, false, false, assembly);
       containerAssembly.setAssemblies(assemblies);
       viewsheet.addAssembly(newAssembly);
       coreLifecycleService.addDeleteVSObject(rvs, newAssembly, dispatcher);

--- a/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
@@ -1866,7 +1866,16 @@ public class CoreLifecycleService {
    public void removeVSAssemblies(RuntimeViewsheet rvs, String uri, CommandDispatcher dispatcher,
                                   boolean replace, boolean layout, boolean fireEvent,
                                   VSAssembly ...assemblies)
-      throws Exception {
+      throws Exception
+   {
+      removeVSAssemblies(rvs, uri, dispatcher, replace, layout, fireEvent, true, assemblies);
+   }
+
+   public void removeVSAssemblies(RuntimeViewsheet rvs, String uri, CommandDispatcher dispatcher,
+                                  boolean replace, boolean layout, boolean fireEvent,
+                                  boolean refreshData, VSAssembly ...assemblies)
+      throws Exception
+   {
       final String id = rvs.getID();
       Viewsheet vs = rvs.getViewsheet();
       ViewsheetSandbox box = rvs.getViewsheetSandbox();
@@ -2226,7 +2235,7 @@ public class CoreLifecycleService {
       }
 
       // reprocess associated assemblies
-      if(!relatedSelections.isEmpty()) {
+      if(refreshData && !relatedSelections.isEmpty()) {
          try {
             int hint = VSAssembly.OUTPUT_DATA_CHANGED;
 


### PR DESCRIPTION
Optimizations were implemented across three key areas: 
1. While JDK 21 enhances security, certain functionalities exhibited performance degradation—particularly string comparisons. This issue was addressed when I fixed Bug #71460, resulting in an improvement from 20s to 9s.

 2. The initial setting -XX:ReservedCodeCacheSize=100m proved insufficient. Reverting to the default 240 MB further reduced execution time from 9s to 8s.

 3. Avoided unnecessary data refresh during assembly deletion. Given that the crosstab data source in the test case contained tens of thousands of rows, the original row-by-row group, summarize, and sort operations were highly time-consuming. This optimization reduced processing time from 8s to 7s.