### PR TITLE
fix Bug #71455: add scroll bar for object view  to show total content when table with large columns

### DIFF
--- a/web/projects/portal/src/app/binding/editor/binding-editor.component.scss
+++ b/web/projects/portal/src/app/binding/editor/binding-editor.component.scss
@@ -71,7 +71,7 @@
 .object-view {
   margin-top: 5px;
   position: relative;
-  overflow: visible;
+  overflow: scroll;
 }
 
 .chart-max-mode {


### PR DESCRIPTION
Should add scrollbar for object view when object view have table with more columns can not show