### PR TITLE
fix Bug #71370: legend content should paint right height to do not show gap in bottom

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/VGraphPair.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/VGraphPair.java
@@ -2240,7 +2240,7 @@ public class VGraphPair {
     * Get the image for the specified legend.
     * @param isTitle true if paint title.
     */
-   private Graphics2D getLegendGraphic(int idx, boolean isTitle, int row, int col, double titleHeight) {
+   private Graphics2D getLegendGraphic(int idx, boolean isTitle, int row, int col, double tileHeight) {
       final VGraph vgraph = this.vgraph;
       // use the real size legend to paint
       final Legend legend = vgraph.getLegendGroup() == null ?
@@ -2270,7 +2270,7 @@ public class VGraphPair {
       LegendSpec spec = legend.getVisualFrame().getLegendSpec();
 
       SVGSupport.getInstance().setCanvasSize(
-         g, new Dimension((int) bounds.getWidth(), (int) Math.min(titleHeight, 1024)));
+         g, new Dimension((int) bounds.getWidth(), (int) Math.min(tileHeight, 1024)));
       // background for legend is drawn in gui instead of in image. force it to
       // not draw in legend so semi-transparent colors aren't on top of each other
       legend.setPaintBackground(false);

--- a/core/src/main/java/inetsoft/report/composition/graph/VGraphPair.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/VGraphPair.java
@@ -2225,22 +2225,22 @@ public class VGraphPair {
     * @param idx legend index.
     */
    public Graphics2D getLegendTitleGraphic(int idx, int row, int col) {
-      return getLegendGraphic(idx, true, row, col);
+      return getLegendGraphic(idx, true, row, col, 0);
    }
 
    /**
     * Get the image for the specified legend.
     * @param idx legend index.
     */
-   public Graphics2D getLegendContentGraphic(int idx, int row, int col) {
-      return getLegendGraphic(idx, false, row, col);
+   public Graphics2D getLegendContentGraphic(int idx, int row, int col, double height) {
+      return getLegendGraphic(idx, false, row, col, height);
    }
 
    /**
     * Get the image for the specified legend.
     * @param isTitle true if paint title.
     */
-   private Graphics2D getLegendGraphic(int idx, boolean isTitle, int row, int col) {
+   private Graphics2D getLegendGraphic(int idx, boolean isTitle, int row, int col, double titleHeight) {
       final VGraph vgraph = this.vgraph;
       // use the real size legend to paint
       final Legend legend = vgraph.getLegendGroup() == null ?
@@ -2270,7 +2270,7 @@ public class VGraphPair {
       LegendSpec spec = legend.getVisualFrame().getLegendSpec();
 
       SVGSupport.getInstance().setCanvasSize(
-         g, new Dimension((int) bounds.getWidth(), (int) Math.min(bounds.getHeight(), 1024)));
+         g, new Dimension((int) bounds.getWidth(), (int) Math.min(titleHeight, 1024)));
       // background for legend is drawn in gui instead of in image. force it to
       // not draw in legend so semi-transparent colors aren't on top of each other
       legend.setPaintBackground(false);

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/AssemblyImageService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/AssemblyImageService.java
@@ -311,7 +311,7 @@ public class AssemblyImageService {
                   }
 
                   if(svg) {
-                     svgGraphics = getChartSVG(aname, row, col, index, pair, box, name);
+                     svgGraphics = getChartSVG(aname, row, col, index, pair, box, name, height);
 
                      if(svgGraphics == null) {
                         image = getChartImage(aname, row, col, index, pair, box, name, dpi * scale);
@@ -492,7 +492,7 @@ public class AssemblyImageService {
     * Get chart image.
     */
    private Graphics2D getChartSVG(String aname, int row, int col, int index, VGraphPair pair,
-                                     ViewsheetSandbox box, String name)
+                                     ViewsheetSandbox box, String name, double titleHeight)
    {
       Graphics2D image = null;
 
@@ -577,7 +577,7 @@ public class AssemblyImageService {
          image = pair.getLegendTitleGraphic(index, row, col);
       }
       else if("legend_content".equals(aname)) {
-         image = pair.getLegendContentGraphic(index, row, col);
+         image = pair.getLegendContentGraphic(index, row, col, titleHeight);
       }
 
       return image;

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/AssemblyImageService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/AssemblyImageService.java
@@ -492,7 +492,7 @@ public class AssemblyImageService {
     * Get chart image.
     */
    private Graphics2D getChartSVG(String aname, int row, int col, int index, VGraphPair pair,
-                                     ViewsheetSandbox box, String name, double titleHeight)
+                                     ViewsheetSandbox box, String name, double tileHeight)
    {
       Graphics2D image = null;
 
@@ -577,7 +577,7 @@ public class AssemblyImageService {
          image = pair.getLegendTitleGraphic(index, row, col);
       }
       else if("legend_content".equals(aname)) {
-         image = pair.getLegendContentGraphic(index, row, col, titleHeight);
+         image = pair.getLegendContentGraphic(index, row, col, tileHeight);
       }
 
       return image;


### PR DESCRIPTION
for legends with large data, it will caused to use two images, the second image have only serval legend should using title height to paint to do not show some gap in legend place.