### PR TITLE
fix Bug #71405. Fix performance issue.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/event/AssetEventUtil.java
+++ b/core/src/main/java/inetsoft/report/composition/event/AssetEventUtil.java
@@ -1997,7 +1997,21 @@ public class AssetEventUtil {
       AssetQuery query = AssetQuery.createAssetQuery(
          tassembly, AssetQuerySandbox.RUNTIME_MODE, box, false, -1L, true, false);
       VariableTable vtable = (VariableTable) box.getVariableTable().clone();
-      TableLens table = query.getTableLens(vtable);
+      TableLens table = null;
+
+      try {
+         if(ws != null) {
+            ws.getWorksheetInfo().setTempMaxRow(BrowseDataController.MAX_ROW_COUNT);
+         }
+
+         table = query.getTableLens(vtable);
+      }
+      finally {
+         if(ws != null) {
+            ws.getWorksheetInfo().setTempMaxRow(-1);
+         }
+      }
+
       int index = vattr == null ? 0 : AssetUtil.findColumn(table, vcol);
 
       // table changed? return
@@ -2019,6 +2033,7 @@ public class AssetEventUtil {
          AssetUtil.getXTableValues(table, lindex);
       var.setValues(values);
       var.setChoices(labels);
+      var.setDataTruncated(table.moreRows(BrowseDataController.MAX_ROW_COUNT));
    }
 
    /**


### PR DESCRIPTION
In this bug, the reason the worksheet pane kept loading was that the collected variable values included millions of records, which caused rendering issues in the browser. In practical use, such a large number of values is not meaningful for variable dropdowns. After reviewing how variables are handled in "Browse Data" and "Condition" in VS, we decided to limit the number of variable values to 1000. To achieve this, a temporary `maxrow` was set in the worksheet info to construct a `MaxRowsTablelens` with `MaxRow` set to 1000, thereby resolving the issue.
