### PR TITLE
fix Bug #71455: should only show horizontal for vs object container.

### DIFF
--- a/web/projects/portal/src/app/binding/editor/binding-editor.component.scss
+++ b/web/projects/portal/src/app/binding/editor/binding-editor.component.scss
@@ -71,7 +71,8 @@
 .object-view {
   margin-top: 5px;
   position: relative;
-  overflow: scroll;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .chart-max-mode {


### PR DESCRIPTION
should only show horizontal for table to show all columns, should hide vertical scrollbar for object container to show better, for table will have its vertical scrollbar to loading data according scrollbar. show two vertical scrollbar will be duplicate.