### PR TITLE
Fix Bug #71469:Add the judgment of "name"

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/database/DataSourceService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/DataSourceService.java
@@ -749,7 +749,8 @@ public class DataSourceService {
       throws Exception
    {
       DefaultMetaDataProvider meta = metaDataProviders.stream()
-         .filter(p -> Tool.equals(ds, p.getDataSource()))
+         .filter(p -> Tool.equals(ds, p.getDataSource()) &&
+            Tool.equals(ds.getName(), p.getDataSource().getName()))
          .findFirst().orElse(null);
 
       if(meta == null) {

--- a/core/src/main/java/inetsoft/web/portal/controller/database/DataSourceService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/DataSourceService.java
@@ -749,7 +749,7 @@ public class DataSourceService {
       throws Exception
    {
       DefaultMetaDataProvider meta = metaDataProviders.stream()
-         .filter(p -> Tool.equals(ds, p.getDataSource()) &&
+         .filter(p -> Tool.equals(ds, p.getDataSource()) && ds != null &&
             Tool.equals(ds.getName(), p.getDataSource().getName()))
          .findFirst().orElse(null);
 


### PR DESCRIPTION
In the self organization, each role operates independently, so the dataSource is not public. However, dataSource names must remain unique across different roles. Therefore, we can add a name-based check to determine which meta data to reference, and subsequently, which cache to retrieve.