### PR TITLE
Merge forward bug fixes for web components

### DIFF
--- a/core/src/main/java/inetsoft/report/LibManager.java
+++ b/core/src/main/java/inetsoft/report/LibManager.java
@@ -856,13 +856,12 @@ public class LibManager implements AutoCloseable {
    public static final class Reference extends SingletonManager.Reference<LibManager> {
       @Override
       public LibManager get(Object ... parameters) {
-         boolean doInit = false;
          lock.lock();
 
          try {
             if(manager == null) {
-               doInit = true;
                manager = new LibManager(new NoopLibrarySecurity());
+               manager.init(null);
             }
             else {
                // Init storage for org if it isn't initialized yet
@@ -871,10 +870,6 @@ public class LibManager implements AutoCloseable {
          }
          finally {
             lock.unlock();
-         }
-
-         if(doInit) {
-            manager.init(null);
          }
 
          return manager;

--- a/core/src/main/java/inetsoft/report/composition/execution/MirrorQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/MirrorQuery.java
@@ -235,6 +235,8 @@ public class MirrorQuery extends AssetQuery {
          return null;
       }
 
+      table = new TableFilter2(table);
+
       for(int i = 0; i < table.getColCount(); i++) {
          String header = AssetUtil.format(XUtil.getHeader(table, i));
          String originalIdentifier = table.getColumnIdentifier(i);

--- a/core/src/main/java/inetsoft/report/composition/execution/TableFilter2.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/TableFilter2.java
@@ -655,19 +655,8 @@ public class TableFilter2 extends AbstractTableLens
     */
    @Override
    public String getColumnIdentifier(int col) {
-      return table.getColumnIdentifier(col);
-   }
-
-   /**
-    * Set the column identifier of a column.
-    * @param col the specified column index.
-    * @param identifier the column indentifier of the column. The identifier
-    * might be different from the column name, for it may contain more
-    * locating information than the column name.
-    */
-   @Override
-   public void setColumnIdentifier(int col, String identifier) {
-      table.setColumnIdentifier(col, identifier);
+      String identifier = super.getColumnIdentifier(col);
+      return identifier == null ? table.getColumnIdentifier(col) : identifier;
    }
 
    // SortedTable interface, allows sorting info to be passed up

--- a/web/projects/portal/src/app/embed/viewer/embed-viewer.component.html
+++ b/web/projects/portal/src/app/embed/viewer/embed-viewer.component.html
@@ -18,12 +18,13 @@
 
 <div #embedViewer class="embed-viewer"
      [class.data-tip-pop-component-visible]="dataTipPopComponentVisible">
-  <viewer-app *ngIf="assetId && connected && !showError"
+  <viewer-app #viewerApp *ngIf="assetId && connected && !showError"
               [assetId]="assetId"
               [queryParameters]="queryParams"
               [hideToolbar]="hideToolbar"
               [hideMiniToolbar]="hideMiniToolbar"
               [globalLoadingIndicator]="globalLoadingIndicator"
+              [viewerOffsetFunc]="viewerOffsetFunc"
               (onEmbedError)="onEmbedError($event)"
               (onLoadingStateChanged)="onLoadingStateChanged($event)"
               (onDataTipPopComponentVisible)="onDataTipPopComponentVisible($event)">

--- a/web/projects/portal/src/app/embed/viewer/embed-viewer.component.scss
+++ b/web/projects/portal/src/app/embed/viewer/embed-viewer.component.scss
@@ -22,7 +22,6 @@
     height: 100%;
     position: relative;
     overflow: hidden;
-    z-index: 1;
 
     &.data-tip-pop-component-visible {
       overflow: visible;

--- a/web/projects/portal/src/app/embed/viewer/embed-viewer.component.ts
+++ b/web/projects/portal/src/app/embed/viewer/embed-viewer.component.ts
@@ -21,6 +21,7 @@ import {
    ChangeDetectorRef,
    Component,
    ElementRef,
+   HostListener,
    Injector,
    Input,
    OnDestroy,
@@ -43,6 +44,7 @@ import { DialogService } from "../../widget/slide-out/dialog-service.service";
 import { TooltipService } from "../../widget/tooltip/tooltip.service";
 import { ShadowDomService } from "../shadow-dom.service";
 import { EMBED_VIEWER_URL_MATCHER } from "./embed-viewer-url-matcher";
+import { ViewerAppComponent } from "../../vsobjects/viewer-app.component";
 
 declare const window: any;
 
@@ -103,6 +105,7 @@ export class EmbedViewerComponent implements OnInit, OnDestroy, AfterViewInit {
    dataTipPopComponentVisible: boolean;
    private loadingSet: Set<string> = new Set<string>();
    @ViewChild("embedViewer") embedViewer: ElementRef;
+   @ViewChild("viewerApp") viewerApp: ViewerAppComponent;
 
    private subscriptions: Subscription = new Subscription();
 
@@ -191,6 +194,7 @@ export class EmbedViewerComponent implements OnInit, OnDestroy, AfterViewInit {
       this.showError = !!message;
 
       if(this.showError) {
+         this.loading = false;
          console.error(message);
       }
    }
@@ -222,5 +226,23 @@ export class EmbedViewerComponent implements OnInit, OnDestroy, AfterViewInit {
 
    onDataTipPopComponentVisible(visible: boolean) {
       this.dataTipPopComponentVisible = visible;
+   }
+
+   viewerOffsetFunc = () => {
+      let embedViewerRect = this.embedViewer.nativeElement.getBoundingClientRect();
+
+      return {
+         x: embedViewerRect.left,
+         y: embedViewerRect.top,
+         width: window.innerWidth - embedViewerRect.left,
+         height: window.innerHeight - embedViewerRect.top,
+         scrollLeft: 0,
+         scrollTop: 0
+      };
+   };
+
+   @HostListener("mouseleave", ["$event"])
+   onMouseLeave(event: MouseEvent): void {
+      this.viewerApp?.clearDataTipPopComponents();
    }
 }

--- a/web/projects/portal/src/app/vsobjects/action/chart-actions.ts
+++ b/web/projects/portal/src/app/vsobjects/action/chart-actions.ts
@@ -90,7 +90,7 @@ export class ChartActions extends AbstractVSActions<VSChartModel> implements Ann
             enabled: () => true,
             visible: () => !this.preview && !this.isPopComponent() && !this.mobileDevice &&
                this.isActionVisibleInViewer("Format") && !this.annotationsSelected &&
-               !this.showFormatPaneDisabled()
+               !this.showFormatPaneDisabled() && !this.embed
          },
          {
             id: () => "chart hide-title",

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -340,6 +340,7 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
    @Input() hideToolbar: boolean = false;
    @Input() hideMiniToolbar: boolean = false;
    @Input() globalLoadingIndicator: boolean = false;
+   @Input() viewerOffsetFunc: () => { x: number, y: number, width: number, height: number, scrollLeft: number, scrollTop: number };
    @Output() onAnnotationChanged = new EventEmitter<boolean>();
    @Output() runtimeIdChange = new EventEmitter<string>();
    @Output() socket = new EventEmitter<ViewsheetClientService>();
@@ -2948,18 +2949,8 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
    }
 
    setDataTipOffsets(): { x: number, y: number, width: number, height: number, scrollLeft: number, scrollTop: number } {
-      if(this.embed) {
-         const el = document.documentElement;
-         const rect = el.getBoundingClientRect();
-
-         return {
-            x: rect.x,
-            y: rect.y,
-            width: rect.width,
-            height: rect.height,
-            scrollLeft: el.scrollLeft || document.body.scrollLeft,
-            scrollTop: el.scrollTop || document.body.scrollTop
-         };
+      if(this.viewerOffsetFunc) {
+         return this.viewerOffsetFunc();
       }
 
       let originRect = this.viewerRoot.nativeElement.getBoundingClientRect();
@@ -4003,6 +3994,11 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
             this.dataTipService.isDataTipVisible(this.dataTipService.dataTipName)) ||
          (!!this.popComponentService.getPopComponent() &&
             this.popComponentService.isPopComponentVisible(this.popComponentService.getPopComponent()));
+   }
+
+   public clearDataTipPopComponents(): void {
+      this.dataTipService.hideDataTip(true);
+      this.popComponentService.hidePopComponent();
    }
 
    private updateScrollViewport(): void {


### PR DESCRIPTION
Bug #71351
Fix popover component positioning.
Since TableFilter2 is cloned when retrieved from the cache, store the column identifier in TableFilter2 instead of passing it down to the base table lens to avoid issues when a table lens is shared across different viewsheets. Move LibManager initialization inside the lock to avoid uninitialized usage by other threads.

Bug #71396
Stop loading on error

Bug #71468
Fix dialogs, dropdowns, data tips and pop components from showing behind other web components. Format pane doesn't render well inside the web component so hide the action.