### PR TITLE
Fix Bug #71471:Adjust the size of the "More" icon

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.html
@@ -231,6 +231,7 @@
                [safeFont]="othersFormat?.font"
                [style.width.px]="model.objectFormat.width">
             <i class="plus-box-outline-icon icon-size1 show-others-icon" aria-hidden="true"
+               [class.mobile-max-mode-icon]="mobile && model.maxMode"
                [style.color]="othersFormat?.foreground"
                (click)="expandList($event)"></i>
             <span>_#(More) ({{selectionValues.length - visibleValues}})</span>


### PR DESCRIPTION
Adjust the size of the "More" icon on mobile to match the other selection list cells.