### PR TITLE
Fix Bug #71470:Modify the UI display and value storage/retrieval.

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/logviewer/LogSettingService.java
+++ b/core/src/main/java/inetsoft/web/admin/logviewer/LogSettingService.java
@@ -210,9 +210,11 @@ public class LogSettingService {
          orgId = provider.getOrgIdFromName(orgName);
       }
 
-      if(Tool.isEmptyString(orgId) && context != LogContext.ORGANIZATION &&
-         context != LogContext.CATEGORY)
-      {
+      if(context == LogContext.ORGANIZATION) {
+         return provider.getOrgIdFromName(name);
+      }
+
+      if(Tool.isEmptyString(orgId) && context != LogContext.CATEGORY) {
          orgId = Organization.getDefaultOrganizationID();
       }
 

--- a/web/projects/em/src/app/settings/logging/add-logging-level-dialog/add-logging-level-dialog.component.ts
+++ b/web/projects/em/src/app/settings/logging/add-logging-level-dialog/add-logging-level-dialog.component.ts
@@ -78,12 +78,14 @@ export class AddLoggingLevelDialogComponent implements OnInit {
       }
 
       if(this.model.context == "ORGANIZATION" && !this.model.orgName) {
-         this.model.orgName = this.model.name;
+         this.form.get("orgName").setValue(this.model.name);
+      }
+      else {
+         this.form.get("orgName").setValue(this.model.orgName);
       }
 
       this.form.get("context").setValue(this.model.context);
       this.form.get("name").setValue(this.model.name);
-      this.form.get("orgName").setValue(this.model.orgName);
       this.form.get("level").setValue(this.model.level);
    }
 
@@ -96,7 +98,7 @@ export class AddLoggingLevelDialogComponent implements OnInit {
 
       if(this.model.context == "ORGANIZATION") {
          this.model.name = this.form.get("orgName").value;
-         this.model.orgName = this.model.name;
+         this.model.orgName = null;
       }
       else {
          this.model.name = this.form.get("name").value.trim();


### PR DESCRIPTION
To modify the two issues:
1.When the Log type is organization, the name and organization fields both display the organization name, causing duplication. It should only display in the name field. 
2.On the backend, both storing values in contextLevels and retrieving values from MDC should be based solely on the orgID.