### PR TITLE
Fix Bug #71474:Add logRecordName to the table's Properties.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/SQLBoundQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/SQLBoundQuery.java
@@ -62,6 +62,11 @@ public class SQLBoundQuery extends BoundQuery {
       this.oquery = (JDBCQuery) nquery.clone();
       this.xquery = (JDBCQuery) nquery.clone();
 
+      if(box.getWSEntry() != null) {
+         table.setProperty("logRecordName", Tool.buildString(box.getWSEntry().getPath(), ".",
+                           getTableDescription(table.getName())));
+      }
+
       if(nquery != null) {
          nquery.setName(box.getWSName() + "." +
                         getTableDescription(table.getName()));
@@ -189,17 +194,9 @@ public class SQLBoundQuery extends BoundQuery {
    @Override
    protected Collection<?> getLogRecord() {
       if(table != null) {
-         String worksheetName = MDC.get(LogContext.WORKSHEET.name());
+         String name = table.getProperty("logRecordName") != null ?
+            table.getProperty("logRecordName") : null;
 
-         if(LicenseManager.getInstance().isEnterprise() && worksheetName != null &&
-            worksheetName.contains("^"))
-         {
-            worksheetName = worksheetName.substring(0, worksheetName.indexOf('^'));
-         }
-
-         String queryName = table.getProperty("queryOriginalName") != null ?
-            table.getProperty("queryOriginalName") : table.getAbsoluteName();
-         String name = Tool.buildString(worksheetName, ".", queryName);
          return Collections.singleton(LogContext.QUERY.getRecord(name));
       }
       else if(xquery != null) {

--- a/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
@@ -5224,7 +5224,6 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
 
       table.setVisible(false);
       table.getInfo().setName(nname);
-      table.setProperty("queryOriginalName", tname);
       MirrorTableAssembly mirror = new MirrorTableAssembly(ws, tname, table);
       mirror.setVisible(!VSUtil.isVSAssemblyBinding(tname));
       mirror.setVisibleTable(table.isVisibleTable());


### PR DESCRIPTION
If a script in the viewsheet is used to fetch data values, the MDC (Mapped Diagnostic Context) will not contain worksheet information. Therefore, relying on the MDC to retrieve the worksheetName is unreliable. Instead, when constructing the SQLBoundQuery, we can set the worksheet and query names into its Properties.