### PR TITLE
fix Bug #71487. Fix some exception issues related to cube under MV.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
@@ -1915,7 +1915,7 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
    private ConditionList removeAggregateCondition(ConditionList conds,
                                                   AggregateInfo ainfo)
    {
-      if(getCubeType(getAssembly()) != null || ainfo == null || ainfo.isEmpty() ||
+      if(ainfo == null || ainfo.isEmpty() ||
          ainfo.getAggregateCount() == 0 || !ainfo.isAggregated())
       {
          return conds;

--- a/core/src/main/java/inetsoft/uql/asset/internal/AssetUtil.java
+++ b/core/src/main/java/inetsoft/uql/asset/internal/AssetUtil.java
@@ -449,7 +449,7 @@ public class AssetUtil {
       int type = source.getType();
 
       if(type == SourceInfo.MODEL || type == SourceInfo.PHYSICAL_TABLE ||
-        type == SourceInfo.DATASOURCE)
+        type == SourceInfo.DATASOURCE || type == (SourceInfo.DATASOURCE | SourceInfo.CUBE))
       {
          String name = source.getPrefix();
          XRepository repository = XFactory.getRepository();


### PR DESCRIPTION
1. Cube datasource is also a type of source and should continue to retrieve the datasource instead of throwing an "Unsupported type found" exception.
2. Even for cube types, when showing details, aggregates in the condition should be removed; otherwise, an `inetsoft.mv.MVExecutionException: Dimension not found` error will be thrown because it attempts to find the aggregate in the dimensions. Regarding this error, I have checked that it also exists in previous versions.