### PR TITLE
fix Bug #71489. Fix NPE and condition application issues.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/CubeQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/CubeQuery.java
@@ -246,6 +246,14 @@ public class CubeQuery extends AssetQuery {
 
          if(item.getAttribute() instanceof ColumnRef) {
             column = (ColumnRef) item.getAttribute();
+
+            if(column.getDataRef() instanceof RangeRef) {
+               DataRef dataRef = ((RangeRef) column.getDataRef()).getDataRef();
+
+               if(dataRef instanceof AttributeRef) {
+                  column = new ColumnRef(dataRef);
+               }
+            }
          }
          else if(item.getAttribute() instanceof GroupRef){
             GroupRef gref = (GroupRef) item.getAttribute();


### PR DESCRIPTION
For cube worksheets, all conditions are post-processed. If a condition depends on a range column, should add its base attribute to the query instead of the range column itself.