### PR TITLE
fix Bug #71499: olap as date column should apply db format

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -3795,7 +3795,7 @@ public abstract class AssetQuery extends PreAssetQuery {
          setMeasureNames(mheaders);
          this.cgroup = cgroup;
          groups = new HashMap<>();
-         this.cube = cube;
+         setCube(cube);
       }
 
       /**
@@ -3819,7 +3819,7 @@ public abstract class AssetQuery extends PreAssetQuery {
        */
       @Override
       protected void resetOrder(List<GroupNode> nodes0, List<GroupNode> nodes1, int gidx) {
-         if(!cube) {
+         if(!isCube()) {
             return;
          }
 
@@ -3836,7 +3836,6 @@ public abstract class AssetQuery extends PreAssetQuery {
 
       private ConditionGroup cgroup;
       private Map<Integer, DataRef> groups;
-      private final boolean cube;
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/filter/SummaryFilter.java
+++ b/core/src/main/java/inetsoft/report/filter/SummaryFilter.java
@@ -1710,7 +1710,7 @@ public class SummaryFilter extends AbstractGroupedTable
          // fix bug1261032688280
          // not date type, not part date level?
          if(!dcol[col] && !(Tool.isNumberClass(table.getColType(col)) &&
-            (level & SortOrder.PART_DATE_GROUP) != 0))
+            (level & SortOrder.PART_DATE_GROUP) != 0) || isCube())
          {
             minfos[col] = null;
             continue;
@@ -2335,6 +2335,14 @@ public class SummaryFilter extends AbstractGroupedTable
     */
    public boolean isSortTopN() {
       return sortTopN;
+   }
+
+   public boolean isCube() {
+      return cube;
+   }
+
+   public void setCube(boolean cube) {
+      this.cube = cube;
    }
 
    // base class for MergedGroupNode and UnionGroupNode
@@ -3327,6 +3335,7 @@ public class SummaryFilter extends AbstractGroupedTable
    private static final String TOTAL_LABEL = Catalog.getCatalog().getString("Total");
 
    private XSwappableTable sumrows = null;
+   private boolean cube = false;
    private TableLens table;
    private boolean def;
    private final int[] cols; // sorting columns


### PR DESCRIPTION
olap as date column can not apply its output format because in SummaryFilter, it get default format accordong to date level, but for olap date it should not apply date level and we should use the db format as default format. Crosstab and chart will be ok.