### PR TITLE
fix Bug #71501. Fix the issue where selection list and selection tree using cube data sources did not apply formatting.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/SelectionTreeVSAQuery2.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/SelectionTreeVSAQuery2.java
@@ -508,7 +508,7 @@ public class SelectionTreeVSAQuery2 extends SelectionTreeVSAQuery {
     * Get selection value data by the data type.
     */
    @Override
-   protected Object getSelectionValueData(SelectionValue svalue, DataRef ref) {
+   protected Object getSelectionValueData(SelectionValue svalue, DataRef ref, int rtype) {
       SelectionTreeVSAssembly assembly =
          (SelectionTreeVSAssembly) getAssembly();
       SelectionTreeVSAssemblyInfo sinfo =


### PR DESCRIPTION
Allow formatting of values in cube data sources. If the data source is a cube, the value retrieved should be the `originalLabel` from the `SelectionValue` instead of the `value`, because `value` is a reference to the cube source value (e.g., `[Account].[Account].&[1]`), not the actual display value.