### PR TITLE
Fix Bug #71472:Uniformly use user's name + '/' + sheet's path for logging.

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/ws/OpenWorksheetController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/OpenWorksheetController.java
@@ -89,13 +89,24 @@ public class OpenWorksheetController extends WorksheetController {
       ThreadContext.setPrincipal(principal);
       String id = event.id();
       AssetEntry entry = AssetEntry.createAssetEntry(id);
+      String entryPath;
 
       if(entry == null || entry.getType() != AssetEntry.Type.WORKSHEET) {
          return;
       }
 
+      if(entry.getScope() == AssetRepository.USER_SCOPE &&
+         entry.getUser() != null && entry.getPath() != null)
+      {
+         String userName = entry.getUser().getName();
+         entryPath = userName + "/" + entry.getPath();
+      }
+      else {
+         entryPath = entry.getPath();
+      }
+
       GroupedThread.withGroupedThread(groupedThread -> {
-         groupedThread.addRecord(LogContext.WORKSHEET, entry.getPath());
+         groupedThread.addRecord(LogContext.WORKSHEET, entryPath);
       });
 
       if(!event.openAutoSavedFile()) {

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSLifecycleService.java
@@ -117,8 +117,9 @@ public class VSLifecycleService {
                entryPath = entry.getPath();
             }
 
-            if(entry.getScope() == AssetRepository.USER_SCOPE) {
-               entryPath = Tool.MY_DASHBOARD + "/" + entryPath;
+            if(entry.getScope() == AssetRepository.USER_SCOPE && entry.getUser() != null) {
+               String userName = entry.getUser().getName();
+               entryPath = userName + "/" + entryPath;
             }
 
             ((GroupedThread) Thread.currentThread())


### PR DESCRIPTION
When adding log records, to distinguish between resources under different organizations and private spaces, we uniformly use the format:user's name + "/" + sheet's path.