### PR TITLE
fix Bug #711515: olap calc rename should rename its rankingcol with total

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/CrosstabVSAssembly.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/CrosstabVSAssembly.java
@@ -746,6 +746,9 @@ public class CrosstabVSAssembly extends CrossBaseVSAssembly implements
             if(VSUtil.matchRefName(rankname, oname)) {
                dref.setRankingColValue(VSUtil.getMatchRefName(rankname, nname));
             }
+            else if(rankname != null && rankname.endsWith(": " + oname)) {
+               dref.setRankingColValue(rankname.substring(0, rankname.length() - oname.length()) + nname);
+            }
          }
 
          DataRef[] rows = cinfo.getDesignRowHeaders();
@@ -760,6 +763,9 @@ public class CrosstabVSAssembly extends CrossBaseVSAssembly implements
 
             if(VSUtil.matchRefName(rankname, oname)) {
                dref.setRankingColValue(VSUtil.getMatchRefName(rankname, nname));
+            }
+            else if(rankname != null && rankname.endsWith(": " + oname)) {
+               dref.setRankingColValue(rankname.substring(0, rankname.length() - oname.length()) + nname);
             }
          }
       }


### PR DESCRIPTION
when rename calc fields, should rename its ranking col value, if ranking value have total, should rename column name after ":"