### PR TITLE
fix Bug #71705: check duplicate child for tab when exporting

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
@@ -1700,10 +1700,13 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
          }
 
          if(isExportAllTabbedTables()) {
+            String exportedAssembly = isMatchLayout() ? null : assembly.getSelected();
             String[] assemblies = assembly.getAssemblies();
 
             for(String cassemblyName : assemblies) {
-               writeAllExpandTable(vs.getAssembly(cassemblyName));
+               if(!Tool.equals(exportedAssembly, cassemblyName)) {
+                  writeAllExpandTable(vs.getAssembly(cassemblyName));
+               }
             }
          }
       }
@@ -2481,7 +2484,7 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
             else {
                end = htmlContent.length();
             }
-            
+
             if(end > 0) {
                end = "font-size:".equals(attrName) ? end - 2: end;
             }


### PR DESCRIPTION
when export vs use expand component mode,it will export tab's selected assembly, then select export all tab tables will export tab's selected assembly second time, so should check to avoid exporting one tab child for two times.