### PR TITLE
fix Bug #71478: user renamed should update some tasks of other user if it used current user's task as condition.

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleManager.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleManager.java
@@ -1054,6 +1054,7 @@ public class ScheduleManager {
                   Tool.equals(IdentityID.getIdentityIDFromKey(userName).name, oname.getName()))
                {
                   completeCondition.setTaskName(taskName.replace(oname.getName(), name));
+                  changedTasks.add(task);
                }
             }
          }


### PR DESCRIPTION
when change one user, tasks of this user will update, but other user's task maybe used this user's task, then we should update it and resave to new use name.