### PR TITLE
fix Bug #71727: check null to avoid worksheet query can not execute

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -2919,7 +2919,7 @@ public abstract class AssetQuery extends PreAssetQuery {
                   }
 
                   if(!(baseRef instanceof CalculateRef)) {
-                     if(box.getViewsheetSandbox().isRuntime()) {
+                     if(box.getViewsheetSandbox() != null && box.getViewsheetSandbox().isRuntime()) {
                         LOG.warn(Catalog.getCatalog().getString(
                            "viewer.worksheet.columnMissing", column.getAttribute()));
                      }


### PR DESCRIPTION
when execute worksheet query, should check null for viewsheetsandbox to void query can not execute.