### PR TITLE
fix Bug #71500, fix brush issue for complex chart

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartBrushController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartBrushController.java
@@ -85,10 +85,6 @@ public class VSChartBrushController extends VSChartController<VSChartBrushEvent>
             LOG.error("Failed to brush: " + e, e);
             throw new RuntimeException(e);
          }
-         finally {
-            // clear chart loading mask after brush finished
-            dispatcher.sendCommand(event.getChartName(), new ClearChartLoadingCommand());
-         }
       });
    }
 

--- a/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.html
@@ -182,7 +182,7 @@
                    (mouseSelect)="selectAnnotation($event)">
     </vs-annotation>
   </ng-container>
-  <vs-loading-display *ngIf="model && model?.sourceType != -1 && chartLoading && chartLoadingIcon && (isBinding || !model.maxMode) && !globalLoadingIndicator"
+  <vs-loading-display *ngIf="model && model?.sourceType != -1 && chartLoading && chartLoadingIcon && !globalLoadingIndicator && !viewsheetLoading"
                       [allowInteraction]="true"
                       [assemblyLoading]="true"></vs-loading-display>
 </div>

--- a/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
@@ -142,6 +142,7 @@ export class VSChart extends AbstractVSObject<VSChartModel>
       return this._selected;
    }
 
+   @Input() viewsheetLoading: boolean = false;
    @Output() public onOpenEditPane = new EventEmitter<any>();
    @Output() public maxModeChange = new EventEmitter<{assembly: string, maxMode: boolean}>();
    @Output() public onOpenFormatPane = new EventEmitter<VSChartModel>();

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.html
@@ -84,6 +84,7 @@
                 [variableValues]="variableValues"
                 [container]="containerRef"
                 [popupShowing]="popupShowing"
+                [viewsheetLoading]="viewsheetLoading"
                 [globalLoadingIndicator]="globalLoadingIndicator"
                 (removeAnnotations)="removeAnnotations.emit()"
                 (onOpenEditPane)="onEditChart.emit($event)"

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
@@ -80,6 +80,7 @@ export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
    @Input() hideMiniToolbar: boolean = false;
    @Input() globalLoadingIndicator: boolean = false;
    @Input() virtualScrolling = false;
+   @Input() viewsheetLoading = false;
    @Output() public openContextMenu = new EventEmitter<{
       actions: AbstractVSActions<any>,
       event: MouseEvent

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.html
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.html
@@ -429,6 +429,7 @@
         [guideType]="guideType"
         [hideMiniToolbar]="hideMiniToolbar"
         [globalLoadingIndicator]="globalLoadingIndicator"
+        [viewsheetLoading]="viewsheetLoading"
         (onSubmit)="submitData()"
         (onLoadingStateChanged)="onLoadingStateChanged.emit($event)"
         [virtualScrolling]="virtualScroll && !(scaleToScreen && !fitToWidth && !showScroll && !embed)"


### PR DESCRIPTION
This bug reproduces when the chart has thousands of plot items and dimension labels. fix by following logic:
1. Don't send ClearChartLoadingCommand after finishing brush. This is because if the graph is too complex, even though the brush operation has ended, the refresh of the chart area is slow, resulting in a situation where neither the loading indicator is shown nor the brushed chart area is immediately displayed. The logic to send ClearChartLoadingCommand after brushing was originally added to fix Bug #25716. However, since SetChartAreasCommand (which ends chart loading) is sent after the chart area refresh completes, removing this logic is acceptable.

2. Support showing chart loading in max mode. Originally, disabled chart loading in max mode is added to fix Bug #39759. The solution now is to use viewsheetLoading to avoid simultaneously showing both the vs loading and chart loading indicators.