### PR TITLE
Fix Bug #71527:The comparison should be made between the old alias and the Expression.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQueryCacheNormalizer.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQueryCacheNormalizer.java
@@ -319,6 +319,8 @@ public class AssetQueryCacheNormalizer {
       }
 
       Pattern pattern = Pattern.compile(table.getName() + "\\[[\"|']" + alias + "(@.*)?]");
+      String olderAlias = table.getProperty(alias + ".oldAlias");
+      Pattern olderPattern = Pattern.compile(table.getName() + "\\[[\"|']" + olderAlias + "(@.*)?]");;
 
       // check if the alias is referenced in other assemblies
       for(Assembly assembly : box.getWorksheet().getAssemblies()) {
@@ -337,8 +339,9 @@ public class AssetQueryCacheNormalizer {
 
             ExpressionRef ref = (ExpressionRef) col.getDataRef();
             Matcher matcher = pattern.matcher(ref.getExpression());
+            Matcher matcher2 = olderPattern.matcher(ref.getExpression());
 
-            if(matcher.find())
+            if(matcher.find() || matcher2.find())
             {
                return false;
             }

--- a/core/src/main/java/inetsoft/web/composer/ws/RenameColumnController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/RenameColumnController.java
@@ -251,6 +251,8 @@ public class RenameColumnController extends WorksheetController {
       final ColumnRef originalCol = (ColumnRef) Tool.clone(ocolumn);
       ColumnSelection columns = table.getColumnSelection(false);
       int index = columns.indexOfAttribute(ocolumn);
+      String oldAlias = ocolumn.getAlias();
+      table.setProperty(alias + ".oldAlias", oldAlias == null ? "" : oldAlias);
 
       if(index < 0) {
          if(columns.getAttribute(ocolumn.getAttribute()) != null) {


### PR DESCRIPTION
If we modify the information in the expression after the live data has passed, then the comparison should be made against the old alias at that point.