### PR TITLE
fix Bug #71462: should not quote variable in sql parser

### DIFF
--- a/core/src/main/antlr/inetsoft/uql/util/sqlparser/SQLParser.g
+++ b/core/src/main/antlr/inetsoft/uql/util/sqlparser/SQLParser.g
@@ -357,7 +357,9 @@ String quoteDot(String str) {
    SQLHelper helper = SQLHelper.getSQLHelper(dx, (Principal) null);
    String quote = helper != null ? helper.getQuote() : "\"";
 
-   if(str.indexOf(".") > 0 || preferQuote && XUtil.isSpecialName(str, true, helper)) {
+   if(str.indexOf(".") > 0 || preferQuote && XUtil.isSpecialName(str, true, helper) &&
+      !XUtil.shouldNotQuote(str))
+   {
       return quote + strip(str) + quote;
    }
 

--- a/core/src/main/java/inetsoft/uql/util/XUtil.java
+++ b/core/src/main/java/inetsoft/uql/util/XUtil.java
@@ -766,6 +766,14 @@ public final class XUtil {
       return length > 0 && Character.isDigit(str.charAt(0));
    }
 
+   public static final boolean shouldNotQuote(String str) {
+      if(str.startsWith("$(") && str.endsWith(")")) {
+         return true;
+      }
+
+      return false;
+   }
+
    /**
     * Quote one name segment.
     * @param name the specified table/column name.


### PR DESCRIPTION
for varaible in sql, should not quote it for it will replace to right value when executequery(replacevariables)