### PR TITLE
Fix Bug #71535:Exclude empty strings ("") and undefined.

### DIFF
--- a/web/projects/portal/src/app/widget/condition/top-n-editor.component.ts
+++ b/web/projects/portal/src/app/widget/condition/top-n-editor.component.ts
@@ -62,7 +62,7 @@ export class TopNEditor implements OnChanges {
 
    ngOnChanges(changes: SimpleChanges) {
       if(changes.hasOwnProperty("value")) {
-         if(this.value != null) {
+         if(this.value) {
             this.n = this.value.n;
             this.dataRef = this.value.dataRef;
          }


### PR DESCRIPTION
In frontend development, you cannot simply check if a value equals null - you must also exclude empty strings ("") and undefined.