### PR TITLE
fix Bug #71622: can not open worsheet to edit when no worksheet permission

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/data/DataSetService.java
+++ b/core/src/main/java/inetsoft/web/portal/data/DataSetService.java
@@ -140,6 +140,7 @@ public class DataSetService {
                  .deletable(false)
                  .materialized(false)
                  .canMaterialize(false)
+                 .canWorksheet(false)
                  .hasSubFolder(hasSubDataSetFolder(privateWsFolder, movingFolders, principal))
                  .workSheetType(-1)
                  .build());
@@ -233,6 +234,7 @@ public class DataSetService {
          .deletable(false)
          .materialized(false)
          .canMaterialize(false)
+         .canWorksheet(false)
          .hasSubFolder(hasSubDataSetFolder(privateWsFolder, null, principal))
          .workSheetType(-1)
          .build();
@@ -420,6 +422,7 @@ public class DataSetService {
          .deletable(admin || checkAssetPermission(principal, entry, ResourceAction.DELETE))
          .materialized(false)
          .canMaterialize(false)
+         .canWorksheet(false)
          .parentPath(parentPath)
          .hasSubFolder(hasSubDataSetFolder(entry, movingFolders, principal))
          .workSheetType(-1)
@@ -463,6 +466,8 @@ public class DataSetService {
       boolean canMaterialize = SreeEnv.getBooleanProperty("ws.mv.enabled") &&
          editable && securityProvider.checkPermission(principal, ResourceType.MATERIALIZATION,
                                                       "*", ResourceAction.ACCESS);
+      boolean canWorksheet = securityProvider.checkPermission(
+         principal, ResourceType.WORKSHEET, "*", ResourceAction.ACCESS);
       String modifiedDateLabel = entry.getModifiedDate() == null ? "" :
          new SimpleDateFormat(SreeEnv.getProperty("format.date.time")).format(entry.getModifiedDate());
       String createdDateLabel = entry.getCreatedDate() == null ? "" :
@@ -499,6 +504,7 @@ public class DataSetService {
          .deletable(deletable)
          .materialized(AssetTreeController.getMaterialized(entry, principal))
          .canMaterialize(canMaterialize)
+         .canWorksheet(canWorksheet)
          .parentPath(parentPath)
          .hasSubFolder(hasSubDataSetFolder(entry, movingFolders, principal))
          .workSheetType(getWorksheetType(entry))

--- a/core/src/main/java/inetsoft/web/portal/data/WorksheetBrowserInfo.java
+++ b/core/src/main/java/inetsoft/web/portal/data/WorksheetBrowserInfo.java
@@ -47,6 +47,7 @@ public interface WorksheetBrowserInfo {
    boolean deletable();
    boolean materialized();
    boolean canMaterialize();
+   boolean canWorksheet();
    @Nullable
    String parentPath();
    boolean hasSubFolder();


### PR DESCRIPTION
If no worksheet permission, only can not edit worksheet but can rename and move, rename and move only check asset permission, but edit ws should open composer so should have worksheet permission in compose