### PR TITLE
Fix Bug #71556:If the task belongs to a ShareGroup, the user's name should not be added.

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskConditionService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskConditionService.java
@@ -84,26 +84,29 @@ public class ScheduleTaskConditionService {
    public void deleteTaskCondition(String taskName, int[] items, Principal principal)
       throws Exception
    {
-      taskName = scheduleService.getTaskName(Tool.byteDecode(taskName), principal);
+      String decodedTaskName  = scheduleService.getTaskName(Tool.byteDecode(taskName), principal);
       Catalog catalog = Catalog.getCatalog(principal);
 
-      if(taskName == null || "".equals(taskName)) {
+      if(Tool.isEmptyString(decodedTaskName)) {
          throw new Exception(catalog.getString("em.scheduler.emptyTaskName"));
       }
 
-      ScheduleTask task = scheduleManager.getScheduleTask(taskName);
+      ScheduleTask task = scheduleManager.getScheduleTask(decodedTaskName);
 
       if(task == null) {
          throw new Exception(catalog.getString(
-            "em.scheduler.taskNotFound", taskName));
+            "em.scheduler.taskNotFound", decodedTaskName));
       }
+
+      String saveTaskName = ScheduleManager.hasShareGroupPermission(task, principal) ?
+         taskName : decodedTaskName;
 
       for(int i = 0; i < items.length; i++) {
          int index = items[i];
          task.removeCondition(index);
       }
 
-      scheduleService.saveTask(taskName, task, principal);
+      scheduleService.saveTask(saveTaskName, task, principal);
    }
 
    public ScheduleConditionModel[] saveTaskCondition(String taskName, String oldTaskName,


### PR DESCRIPTION
When deleting a condition and fetching the taskName, if the current user does not match the task's owner, the user's name should be automatically appended. However, if the task belongs to a ShareGroup, the user's name should not be added.