### PR TITLE
fix Bug #71524. Fix some embeddedvs show empty.

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
@@ -670,7 +670,9 @@ export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
                      this.viewsheetClient.sendEvent("/events/vs/refresh/assembly", event);
                   }
 
-                  this.renderedObjects.set(vsObject.absoluteName, newRendered);
+                  if(newRendered) {
+                     this.renderedObjects.set(vsObject.absoluteName, newRendered);
+                  }
                }
             }
          });


### PR DESCRIPTION
Only assemblies within the scroll viewport should be added to `renderedObjects`; otherwise, the assemblies will not be rendered.