### PR TITLE
fix Bug #71566. Fix spinner always showing.

### DIFF
--- a/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.html
+++ b/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.html
@@ -91,7 +91,7 @@
           <mat-error *ngIf="optionsForm.controls['owner'].errors && optionsForm.controls['owner'].errors['invalid']">
             _#(Invalid user)
           </mat-error>
-          <mat-spinner matSuffix *ngIf="adminName == ''" mode="indeterminate" diameter="17"></mat-spinner>
+          <mat-spinner matSuffix *ngIf="isAdminNameLoading" mode="indeterminate" diameter="17"></mat-spinner>
         </mat-form-field>
         <mat-form-field appearance="outline" color="accent">
           <mat-label>_#(Execute As)</mat-label>
@@ -99,7 +99,7 @@
                  formControlName="executeAs"
                  (change)="fireModelChanged()">
           <div class="flex-row" matSuffix>
-            <mat-spinner *ngIf="adminName == ''" mode="indeterminate" diameter="17"></mat-spinner>
+            <mat-spinner *ngIf="isAdminNameLoading" mode="indeterminate" diameter="17"></mat-spinner>
             <button mat-icon-button (click)="openExecuteAsDialog()" matTooltip="_#(Select User)" [disabled]="!adminName">
               <mat-icon fontSet="ineticons" fontIcon="edit-icon"></mat-icon>
             </button>

--- a/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.ts
+++ b/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.ts
@@ -128,6 +128,7 @@ export class TaskOptionsPane {
    private _model: TaskOptionsPaneModel;
    private owners: IdentityIdWithLabel[];
    public adminName: string = "";
+   public isAdminNameLoading: boolean = true;
    private _executeAs: string;
    public groupErrorState = new GroupErrorState();
    public static DEFAULT_LOCALE: string = "Default";
@@ -164,6 +165,7 @@ export class TaskOptionsPane {
       usersService.getAdminName().subscribe(
          value => {
             this.adminName = value;
+            this.isAdminNameLoading = false;
             this.updateDisabledState();
          }
       );


### PR DESCRIPTION
The visibility of the loading spinner should not directly depend on whether `adminName` has a value, because for non-administrator users like `user0`, `adminName` will be `null`   Therefore, whether the spinner is shown should depend on when the subscription for `adminName` responds with a result.