### PR TITLE
fix Bug #71709: when no permission to expand, should check permission in server

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/dialog/EmailDialogController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/dialog/EmailDialogController.java
@@ -359,6 +359,21 @@ public class EmailDialogController {
       String subject = Tool.defaultIfNull(emailPaneModel.subject(), "");
       String body = Tool.defaultIfNull(emailPaneModel.message(), "");
       boolean isSendLink = Tool.defaultIfNull(fileFormatPaneModel.sendLink(), false);
+
+      if((fileFormatPaneModel.expandEnabled() || fileFormatPaneModel.expandSelections() ||
+         fileFormatPaneModel.onlyDataComponents()) &&
+         !SecurityEngine.getSecurity().checkPermission(principal,
+         ResourceType.VIEWSHEET_TOOLBAR_ACTION, "ExportExpandComponents",
+         ResourceAction.READ))
+      {
+         return MessageDialogModel.builder()
+            .type(MessageCommand.Type.ERROR)
+            .success(false)
+            .message(Catalog.getCatalog().getString(
+               "viewer.viewsheet.email.noExpandPermission"))
+            .build();
+      }
+
       Catalog catalog = Catalog.getCatalog(principal);
 
       if(formatType == FileFormatInfo.EXPORT_TYPE_CSV) {

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -5270,6 +5270,7 @@ viewer.viewsheet.deleteBookmarkInSchedule=Bookmark "{0}" is used in the followin
 viewer.viewsheet.drillFilterTip=Select a dimension and click 'Drill Up Filter' to drill up.
 viewer.viewsheet.editPropertyFailed=Cannot edit properties of the assembly.
 viewer.viewsheet.editSelectionTree=Please add all higher levels of this dimension.
+viewer.viewsheet.email.noExpandPermission=Do not have permission to expand components.
 viewer.viewsheet.email.failed=Could not send to one or more of the recipients you specified.
 viewer.viewsheet.email.successful=Email delivered successfully.
 viewer.viewsheet.error=Failed to load the Dashboard.


### PR DESCRIPTION
fix Bug#71709
the bug is caused when no expand component permission, UI will disable expand option, but user can change html page to enable it, then select it to server, we should check permission in server and do not support it to o