### PR TITLE
Fix Bug #71636:Modify the relationship of permission checks.

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/upload/UploadController.java
+++ b/core/src/main/java/inetsoft/web/admin/upload/UploadController.java
@@ -98,7 +98,7 @@ public class UploadController {
    private boolean checkPermission(Principal principal) {
       try {
          return securityEngine.checkPermission(
-            principal, ResourceType.EM, "*", ResourceAction.ACCESS) ||
+            principal, ResourceType.EM, "*", ResourceAction.ACCESS) &&
             securityEngine.checkPermission(
                principal, ResourceType.UPLOAD_DRIVERS, "*", ResourceAction.ACCESS);
       }


### PR DESCRIPTION
The permission for file upload requires both client-side access rights and upload privileges, so the relationship between them should be "&&" rather than "||"