### PR TITLE
Fix Bug #71647:Prevent F12 from modifying button properties to interfere with subsequent operations.

### DIFF
--- a/web/projects/portal/src/app/portal/dashboard/dashboard-tab.component.html
+++ b/web/projects/portal/src/app/portal/dashboard/dashboard-tab.component.html
@@ -24,7 +24,7 @@
     <ul class="nav nav-inline ms-auto">
       <li class="nav-item tab" [class.disabled]="!model.editable" *ngIf="!mobile">
         <a class="nav-icon icon-size-medium icon-hover-bg nav-link"
-           [fixedDropdown]="settingsDropdown"
+           [fixedDropdown]="model.editable ? settingsDropdown : null"
            title="_#(Dashboard Configuration)" dropdownPlacement="bottom"
            aria-haspopup="true" tabindex="-1" role="button" enterClick>
           <i class="setting-icon" aria-hidden="true"></i>


### PR DESCRIPTION
The display of the dropdown menu is determined by permission checks, which prevents users from opening the dialog via F12 (Developer Tools) and performing subsequent unauthorized operations