### PR TITLE
Bug 71680(tooltip show in left when maxmode) and  Bug #71670(adhoc filter apply when change max mode)

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
@@ -88,6 +88,7 @@ import { ShowHyperlinkService } from "../../show-hyperlink.service";
 import { ViewerResizeService } from "../../util/viewer-resize.service";
 import { VSUtil } from "../../util/vs-util";
 import { AbstractVSObject } from "../abstract-vsobject.component";
+import { AdhocFilterService } from "../data-tip/adhoc-filter.service";
 import { DataTipService } from "../data-tip/data-tip.service";
 import { SelectableObject } from "../selectable-object";
 import { DetailDndInfo } from "../table/detail-dnd-info";
@@ -369,7 +370,8 @@ export class VSChart extends AbstractVSObject<VSChartModel>
                private tabService: VSTabService,
                protected zone: NgZone,
                private richTextService: RichTextService,
-               private fullScreenService: FullScreenService)
+               private fullScreenService: FullScreenService,
+               private adhocFilterService: AdhocFilterService)
    {
       super(viewsheetClient, zone, contextProvider, dataTipService);
       this.resetShowEmptyAreaStatus();
@@ -553,6 +555,7 @@ export class VSChart extends AbstractVSObject<VSChartModel>
       }, 100);
 
       this.dataTipService.hideDataTip();
+      this.adhocFilterService.hideAdhocFilter();
       this.model.selectedAnnotations = [];
    }
 
@@ -561,6 +564,7 @@ export class VSChart extends AbstractVSObject<VSChartModel>
       this.viewsheetClient.sendEvent(CHART_MAX_MODE_URL, chartEvent);
       this.maxModeChange.emit({assembly: this.model.absoluteName, maxMode: false});
       this.dataTipService.hideDataTip();
+      this.adhocFilterService.hideAdhocFilter();
       this.onScroll(new Point(0, 0));
    }
 

--- a/web/projects/portal/src/app/vsobjects/objects/data-tip/adhoc-filter.service.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/data-tip/adhoc-filter.service.ts
@@ -29,6 +29,8 @@ export class AdhocFilterService {
    private listener = null;
    private filterName: string = null;
 
+   private close: any = null;
+
 
    constructor(private renderer: Renderer2,
                private changeRef: ChangeDetectorRef,
@@ -44,6 +46,7 @@ export class AdhocFilterService {
    {
       this._adhocFilterShowing = true;
       this.filterName = absoluteName;
+      this.close = closed;
 
       this.listener = this.renderer.listen("document", "click", (event: MouseEvent) => {
          if(!elementRef.nativeElement.contains(event.target) &&
@@ -52,7 +55,6 @@ export class AdhocFilterService {
             (!acceptClose || acceptClose()))
          {
             this.hideAdhocFilter();
-            closed();
          }
       });
 
@@ -77,5 +79,6 @@ export class AdhocFilterService {
       this.listener();
       this._adhocFilterShowing = false;
       this.filterName = null;
+      this.close();
    }
 }

--- a/web/projects/portal/src/app/vsobjects/objects/data-tip/adhoc-filter.service.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/data-tip/adhoc-filter.service.ts
@@ -26,6 +26,9 @@ import { GuiTool } from "../../../common/util/gui-tool";
 @Injectable()
 export class AdhocFilterService {
    private _adhocFilterShowing: boolean = false;
+   private listener = null;
+   private filterName: string = null;
+
 
    constructor(private renderer: Renderer2,
                private changeRef: ChangeDetectorRef,
@@ -40,29 +43,39 @@ export class AdhocFilterService {
               acceptClose: () => boolean): () => any
    {
       this._adhocFilterShowing = true;
+      this.filterName = absoluteName;
 
-      const listener = this.renderer.listen("document", "click", (event: MouseEvent) => {
+      this.listener = this.renderer.listen("document", "click", (event: MouseEvent) => {
          if(!elementRef.nativeElement.contains(event.target) &&
             !GuiTool.parentContainsClass(<Element> event.target, "mini-toolbar") &&
             !GuiTool.parentContainsClass(<Element> event.target, "mobile-toolbar") &&
             (!acceptClose || acceptClose()))
          {
-            const vsevent: VSObjectEvent = new VSObjectEvent(absoluteName);
-
-            // delay so change is applied before temp assembly is removed
-            setTimeout(() => {
-               this.viewsheetClient.sendEvent("/events/composer/viewsheet/moveAdhocFilter",
-                                              vsevent);
-            }, 500);
-
-            // remove the listener
-            listener();
+            this.hideAdhocFilter();
             closed();
-            this._adhocFilterShowing = false;
          }
       });
 
       this.changeRef.detectChanges();
-      return listener;
+      return this.listener;
+   }
+
+   hideAdhocFilter() {
+      if(this.filterName == null) {
+         return;
+      }
+
+      const vsevent: VSObjectEvent = new VSObjectEvent(this.filterName);
+
+      // delay so change is applied before temp assembly is removed
+      setTimeout(() => {
+         this.viewsheetClient.sendEvent("/events/composer/viewsheet/moveAdhocFilter",
+            vsevent);
+      }, 500);
+
+      // remove the listener
+      this.listener();
+      this._adhocFilterShowing = false;
+      this.filterName = null;
    }
 }

--- a/web/projects/portal/src/app/vsobjects/objects/table/base-table.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/base-table.ts
@@ -72,6 +72,7 @@ import { ShowHyperlinkService } from "../../show-hyperlink.service";
 import { CheckFormDataService } from "../../util/check-form-data.service";
 import { ViewerResizeService } from "../../util/viewer-resize.service";
 import { AbstractVSObject } from "../abstract-vsobject.component";
+import { AdhocFilterService } from "../data-tip/adhoc-filter.service";
 import { DataTipService } from "../data-tip/data-tip.service";
 import { SelectableObject } from "../selectable-object";
 import { DetailDndInfo } from "./detail-dnd-info";
@@ -291,7 +292,8 @@ export abstract class BaseTable<T extends BaseTableModel> extends AbstractVSObje
                protected pagingControlService: PagingControlService,
                protected zone: NgZone,
                protected tabService: VSTabService,
-               @Optional() protected viewerResizeService: ViewerResizeService)
+               @Optional() protected viewerResizeService: ViewerResizeService,
+               protected adhocFilterService: AdhocFilterService)
    {
       super(viewsheetClient, zone, contextProvider, dataTipService);
       this.isBinding = contextProvider.binding;
@@ -348,6 +350,7 @@ export abstract class BaseTable<T extends BaseTableModel> extends AbstractVSObje
       this.viewsheetClient.sendEvent(TABLE_MAX_MODE_URL, maxTableEvent);
       this.maxModeChange.emit({assembly: this.model.absoluteName, maxMode: true});
       this.dataTipService.hideDataTip();
+      this.adhocFilterService.hideAdhocFilter();
       this.model.selectedAnnotations = [];
    }
 
@@ -365,6 +368,7 @@ export abstract class BaseTable<T extends BaseTableModel> extends AbstractVSObje
       this.viewsheetClient.sendEvent(TABLE_MAX_MODE_URL, maxTableEvent);
       this.maxModeChange.emit({assembly: this.model.absoluteName, maxMode: false});
       this.dataTipService.hideDataTip();
+      this.adhocFilterService.hideAdhocFilter();
    }
 
    protected abstract showPagingControl(): void;

--- a/web/projects/portal/src/app/vsobjects/objects/table/base-table.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/base-table.ts
@@ -1903,7 +1903,7 @@ export abstract class BaseTable<T extends BaseTableModel> extends AbstractVSObje
          let placement: string;
 
          // change placement if the tooltip is out of bounds
-         if(x <= (window.innerWidth || document.documentElement.clientWidth)) {
+         if(x <= (window.innerWidth || document.documentElement.clientWidth) && !this.model.maxMode) {
             placement = "right";
          }
          else {

--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-calctable.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-calctable.component.ts
@@ -54,6 +54,7 @@ import { ShowHyperlinkService } from "../../show-hyperlink.service";
 import { CheckFormDataService } from "../../util/check-form-data.service";
 import { ViewerResizeService } from "../../util/viewer-resize.service";
 import { VSUtil } from "../../util/vs-util";
+import { AdhocFilterService } from "../data-tip/adhoc-filter.service";
 import { DataTipService } from "../data-tip/data-tip.service";
 import { BaseTable } from "./base-table";
 import { VSFormatModel } from "../../model/vs-format-model";
@@ -208,12 +209,13 @@ export class VSCalcTable extends BaseTable<VSCalcTableModel> implements OnDestro
                zone: NgZone,
                protected tabService: VSTabService,
                @Optional() viewerResizeService: ViewerResizeService,
-               private richTextService: RichTextService)
+               private richTextService: RichTextService,
+               protected adhocFilterService: AdhocFilterService)
    {
       super(viewsheetClient, dropdownService, downloadService, renderer, changeDetectorRef,
             contextProvider, formDataService, debounceService, scaleService, hyperlinkService,
             http, dataTipService, popComponentService, pagingControlService,
-            zone, tabService, viewerResizeService);
+            zone, tabService, viewerResizeService, adhocFilterService);
    }
 
    protected updateTableHeight(): void {

--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-crosstab.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-crosstab.component.ts
@@ -71,6 +71,7 @@ import { ShowHyperlinkService } from "../../show-hyperlink.service";
 import { CheckFormDataService } from "../../util/check-form-data.service";
 import { ViewerResizeService } from "../../util/viewer-resize.service";
 import { VSUtil } from "../../util/vs-util";
+import { AdhocFilterService } from "../data-tip/adhoc-filter.service";
 import { DataTipService } from "../data-tip/data-tip.service";
 import { BaseTable } from "./base-table";
 import { VSTableCell } from "./vs-table-cell.component";
@@ -293,12 +294,13 @@ export class VSCrosstab extends BaseTable<VSCrosstabModel> implements OnInit, On
                zone: NgZone,
                protected tabService: VSTabService,
                @Optional() viewerResizeService: ViewerResizeService,
-               private richTextService: RichTextService)
+               private richTextService: RichTextService,
+               protected adhocFilterService: AdhocFilterService)
    {
       super(viewsheetClient, dropdownService, downloadService, renderer, changeDetectorRef,
             contextProvider, formDataService, debounceService, scaleService, hyperlinkService,
             http, dataTipService, popComponentService, pagingControlService,
-            zone, tabService, viewerResizeService);
+            zone, tabService, viewerResizeService, adhocFilterService);
       this.crosstabActionHandler =
          new CrosstabActionHandler(modelService, viewsheetClient, dialogService, contextProvider);
    }

--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.ts
@@ -73,6 +73,7 @@ import { ShowHyperlinkService } from "../../show-hyperlink.service";
 import { CheckFormDataService } from "../../util/check-form-data.service";
 import { ViewerResizeService } from "../../util/viewer-resize.service";
 import { VSUtil } from "../../util/vs-util";
+import { AdhocFilterService } from "../data-tip/adhoc-filter.service";
 import { DataTipService } from "../data-tip/data-tip.service";
 import { BaseTable } from "./base-table";
 import { PopComponentService } from "../data-tip/pop-component.service";
@@ -282,12 +283,13 @@ export class VSTable extends BaseTable<VSTableModel> implements OnInit, OnDestro
                zone: NgZone,
                protected tabService: VSTabService,
                @Optional() viewerResizeService: ViewerResizeService,
-               private richTextService: RichTextService)
+               private richTextService: RichTextService,
+               protected adhocFilterService: AdhocFilterService)
    {
       super(viewsheetClient, dropdownService, downloadService, renderer,
             changeDetectorRef, contextProvider, formDataService, debounceService,
             scaleService, hyperlinkService, http, dataTipService, popComponentService,
-            pagingControlService, zone, tabService, viewerResizeService);
+            pagingControlService, zone, tabService, viewerResizeService, adhocFilterService);
    }
 
    public ngOnInit(): void {


### PR DESCRIPTION
fix Bug #71680, when maxmode, should always show scrollbar's tooltip on left, for chart will in full screen to overlap the tip

Bug #71670:
when open max mode or close max mode, should hide adhoc filter(if filter have data filter, it will move it to container, if do not have data, it will remove)