### PR TITLE
fix Bug #71642. Fix the issue where the filter moves with scrolling.

### DIFF
--- a/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.html
+++ b/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.html
@@ -77,6 +77,7 @@
         <ng-container *ngFor="let vsObject of vs.vsObjects; trackBy: trackByFn;">
           <editable-object-container #container
                                      [class.max-mode-view]="vsObject.absoluteName == maxModeAssembly"
+                                     [class.max-mode-view-filter]="isFilterInMaxModeView(vsObject)"
                                      [vsPaneRef]="vsPane"
                                      [containerBounds]="vsPaneBounds"
                                      [viewsheet]="vs" [vsObjectModel]="vsObject" [touchDevice]="touchDevice"

--- a/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.scss
+++ b/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.scss
@@ -150,6 +150,11 @@ div.vs-pane .bl-selected {
   z-index: 1000;
 }
 
+.max-mode-view-filter {
+  position: fixed;
+  z-index: 9910 !important;
+}
+
 .javascript-icon {
   cursor: pointer;
 }

--- a/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.ts
@@ -2680,4 +2680,8 @@ export class VSPane extends CommandProcessor implements OnInit, OnDestroy, After
       let assetEntry: AssetEntry = createAssetEntry(this.vs.id);
       return assetEntry?.organization != this.orgInfo?.key;
    }
+
+   isFilterInMaxModeView(vsObject: VSObjectModel): boolean {
+      return !!this.maxModeAssembly && (<any> vsObject).adhocFilter;
+   }
 }


### PR DESCRIPTION
Fixed the issue where the filter component triggered by the 'Filter' action on the chart in maxMode scrolls along with the vs-pane-container scrollbar.