### PR TITLE
merge from old version.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -6567,6 +6567,17 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
 
       if(vsAssemblyBinding) {
          name = VSUtil.getVSAssemblyBinding(name);
+
+         Viewsheet viewsheet = getViewsheet();
+
+         if(viewsheet != null && !Tool.isEmptyString(viewsheet.getAbsoluteName())) {
+            String vsName = viewsheet.getAbsoluteName();
+            Viewsheet mainViewsheet = getMainViewsheet(viewsheet);
+
+            if(mainViewsheet.getAssembly(vsName + "." + name) != null) {
+               name = vsName + "." + name;
+            }
+         }
       }
 
       TableLens lens = getFormTableLens(name);
@@ -6587,6 +6598,20 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
       }
 
       return lens;
+   }
+
+   private Viewsheet getMainViewsheet(Viewsheet viewsheet) {
+      while(viewsheet != null) {
+         Viewsheet parent = viewsheet.getViewsheet();
+
+         if(parent == null) {
+            return viewsheet;
+         }
+
+         viewsheet = parent;
+      }
+
+      return null;
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -5443,6 +5443,11 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
       if(index >= 0) {
          ViewsheetSandbox box = getSandbox(name.substring(0, index));
          name = name.substring(index + 1);
+
+         if(disposed) {
+            return;
+         }
+
          box.updateAssembly(name);
          return;
       }
@@ -6219,6 +6224,11 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
       if(index >= 0) {
          ViewsheetSandbox box = getSandbox(name.substring(0, index));
          name = name.substring(index + 1);
+
+         if(disposed) {
+            return null;
+         }
+
          return box.getVGraphPair(name, init, maxsize, export, scaleFont, forceExpand, ignoreSize);
       }
 

--- a/core/src/main/java/inetsoft/uql/jdbc/util/JDBCUtil.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/util/JDBCUtil.java
@@ -188,6 +188,12 @@ public class JDBCUtil {
                tables[i].getCatalog(), tables[i].getSchema());
             name = getUpperCaseName(tnode, name.toString(), sql);
             SelectTable ntable = sql.addTable(alias, name, loc, scroll);
+
+            // table already exists
+            if(ntable == null) {
+               continue;
+            }
+
             ntable.setCatalog(tables[i].getCatalog());
             ntable.setSchema(tables[i].getSchema());
          }

--- a/core/src/main/java/inetsoft/uql/viewsheet/AbstractVSAssembly.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/AbstractVSAssembly.java
@@ -832,6 +832,7 @@ public abstract class AbstractVSAssembly extends AbstractAssembly implements VSA
             if(assembly instanceof AnnotationVSAssembly) {
                ((BaseAnnotationVSAssemblyInfo) info).addAnnotation(
                   assembly.getName());
+               VSUtil.updateEmbeddedVSAnnotationZIndex((AnnotationVSAssembly) assembly, this);
             }
 
             // always set the data type annotation assembly visible to false

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VSUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VSUtil.java
@@ -8640,6 +8640,28 @@ public final class VSUtil {
       return flyovers;
    }
 
+   /**
+    * Update an annotation z-index if the annotation is for assembly of embedded vs.
+    *
+    * @param parentAssembly      the parent assembly of the annotation.
+    * @param annotation          the annotation assembly
+    */
+   public static void updateEmbeddedVSAnnotationZIndex(final AnnotationVSAssembly annotation,
+                                                       final VSAssembly parentAssembly)
+   {
+      if(annotation == null || parentAssembly == null) {
+         return;
+      }
+
+      if(annotation.getViewsheet() == parentAssembly.getViewsheet()) {
+         return;
+      }
+
+      if(annotation.getZIndex() < parentAssembly.getZIndex()) {
+         annotation.setZIndex(parentAssembly.getZIndex() + VSUtil.getZIndexGap(parentAssembly));
+      }
+   }
+
    public static boolean hideActionsForHostAssets(AssetEntry entry, Principal principal) {
       if(entry == null || principal == null) {
          return false;

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleCycleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleCycleService.java
@@ -23,6 +23,7 @@ import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.schedule.ScheduleCondition;
 import inetsoft.sree.schedule.TimeCondition;
 import inetsoft.sree.security.*;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
 import inetsoft.util.audit.ActionRecord;
@@ -75,6 +76,12 @@ public class ScheduleCycleService {
    public ScheduleCycleDialogModel getDialogModel(String cycleName, Principal principal)
       throws Exception
    {
+      if(!securityEngine.checkPermission(principal, ResourceType.SCHEDULE_CYCLE,
+                                         cycleName, ResourceAction.ACCESS))
+      {
+         throw new SecurityException(catalog.getString("em.scheduler.cycle.unauthorized", cycleName));
+      }
+
       int index = cycleName.indexOf(":");
       String label = index != -1 ? cycleName.substring(index + 1) : cycleName;
       String zoneName = Calendar.getInstance().getTimeZone().getDisplayName();
@@ -191,6 +198,13 @@ public class ScheduleCycleService {
 
       try {
          String oldName = model.name();
+
+         if(!securityEngine.checkPermission(principal, ResourceType.SCHEDULE_CYCLE,
+                                            oldName, ResourceAction.ACCESS))
+         {
+            catalog.getString("em.scheduler.cycle.unauthorized", oldName);
+         }
+
          String newName = model.label();
          String orgId = OrganizationManager.getInstance().getCurrentOrgID(principal);
          IdentityID identity = IdentityID.getIdentityIDFromKey(principal.getName());

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/HighlightDialogController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/HighlightDialogController.java
@@ -627,9 +627,26 @@ public class HighlightDialogController {
             .orElse(null);
       }
 
+      final String finalColName = colName;
+
+      if(ref == null) {
+         // make sure it's axis and not a node. (56974)
+         if(isAxis) {
+            List<VSDataRef> fields = new ArrayList<>(Arrays.asList(chartInfo.getXFields()));
+            fields.addAll(Arrays.asList(chartInfo.getYFields()));
+
+            ref = (ChartRef) fields.stream()
+               .filter(f -> f.getFullName().equals(finalColName))
+               .findFirst().orElse(null);
+         }
+         else {
+            ref = chartInfo.getFieldByName(colName, false);
+         }
+      }
+
       // relation highlights defined on source/target instead of textfield, which is
       // shared by source and target.
-      if(GraphTypeUtil.isWordCloud(chartInfo) || isText) {
+      if(ref != null && (GraphTypeUtil.isWordCloud(chartInfo) || isText)) {
          AestheticRef aref = null;
          boolean noTextBinding = chartInfo instanceof RelationChartInfo &&
             Tool.equals(ref, ((RelationChartInfo) chartInfo).getSourceField());
@@ -643,8 +660,6 @@ public class HighlightDialogController {
             ref = (ChartRef) aref.getDataRef();
          }
       }
-
-      final String finalColName = colName;
 
       if(GraphTypes.isTreemap(chartInfo.getRTChartType()) && !isAxis) {
          ChartRef[] groups = chartInfo.getGroupFields();
@@ -687,20 +702,6 @@ public class HighlightDialogController {
 
          if(ref == null && isSameRef(field, colName)) {
             ref = field;
-         }
-      }
-
-      if(ref == null) {
-         // make sure it's axis and not a node. (56974)
-         if(isAxis) {
-            List<VSDataRef> fields = new ArrayList<>(Arrays.asList(chartInfo.getXFields()));
-            fields.addAll(Arrays.asList(chartInfo.getYFields()));
-            ref = (ChartRef) fields.stream()
-               .filter(f -> f.getFullName().equals(finalColName))
-               .findFirst().orElse(null);
-         }
-         else {
-            ref = chartInfo.getFieldByName(colName, false);
          }
       }
 

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogController.java
@@ -776,6 +776,10 @@ public class ViewsheetPropertyDialogController {
                   continue;
                }
 
+               if(isEmbeddedVSAssemblySourceBinding(vs, oldSourceInfo)) {
+                  continue;
+               }
+
                ((DataVSAssembly) assembly).setSourceInfo(null);
 
                // for calc table, remove its layout's cell bindings.
@@ -799,6 +803,22 @@ public class ViewsheetPropertyDialogController {
             }
          }
       }
+   }
+
+   private boolean isEmbeddedVSAssemblySourceBinding(Viewsheet vs, SourceInfo oldSourceInfo) {
+      if(oldSourceInfo.getType() != XSourceInfo.VS_ASSEMBLY) {
+         return false;
+      }
+
+      String source = VSUtil.getVSAssemblyBinding(oldSourceInfo.getSource());
+
+      if(source == null) {
+         return false;
+      }
+
+      VSAssembly sourceAssembly = vs.getAssembly(source);
+
+      return sourceAssembly != null && sourceAssembly.getViewsheet() != vs;
    }
 
    private void removeCalcBinding(CalcTableVSAssembly calc) {

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/OpenViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/OpenViewsheetController.java
@@ -21,12 +21,12 @@ import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.analytic.composition.event.VSEventUtil;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.internal.LicenseException;
-import inetsoft.sree.security.OrganizationManager;
-import inetsoft.sree.security.SRPrincipal;
+import inetsoft.sree.security.*;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.ViewsheetInfo;
-import inetsoft.util.MessageException;
+import inetsoft.util.Catalog;
 import inetsoft.util.ThreadContext;
 import inetsoft.web.AutoSaveUtils;
 import inetsoft.web.composer.vs.VSObjectTreeNode;
@@ -132,6 +132,14 @@ public class OpenViewsheetController {
                              @LinkUri String linkUri)
       throws Exception
    {
+      if(!event.isViewer() &&
+         !SecurityEngine.getSecurity().checkPermission(principal,
+                                                       ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS))
+      {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.dashboard.authorization.permissionDenied"));
+      }
+
       if(licenseService.isCpuUnlicensed()) {
          throw new LicenseException(licenseService.getCpuUnlicensedMSG());
       }

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshController.java
@@ -403,6 +403,34 @@ public class VSRefreshController {
       updateUndoState(rvs, dispatcher);
    }
 
+   @MessageMapping("/vs/refresh/assembly/view")
+   public void refreshVsAssemblyView(RefreshVSAssemblyEvent event,
+                                     CommandDispatcher dispatcher,
+                                     @LinkUri String linkUri,
+                                     Principal principal)
+      throws Exception
+   {
+      String runtimeId = event.getVsRuntimeId();
+      RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
+
+      if(rvs == null) {
+         return;
+      }
+
+      Viewsheet vs = rvs.getViewsheet();
+      VSAssembly assembly = vs.getAssembly(event.getAssemblyName());
+
+      if(assembly != null) {
+         coreLifecycleService.refreshVSAssembly(rvs, assembly, dispatcher);
+
+         if(assembly instanceof TableDataVSAssembly) {
+            int rows = Math.max(assembly.getPixelSize().height / 16, 100);
+            BaseTableController.loadTableData(
+               rvs, assembly.getAbsoluteName(), 0, 0, rows, linkUri, dispatcher);
+         }
+      }
+   }
+
    /**
     * Refresh the assembly and reset dependencies.
     * @param rvs runtime viewsheet.

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshController.java
@@ -46,6 +46,8 @@ import inetsoft.web.viewsheet.event.RefreshVSAssemblyEvent;
 import inetsoft.web.viewsheet.event.VSRefreshEvent;
 import inetsoft.web.viewsheet.model.RuntimeViewsheetRef;
 import inetsoft.web.viewsheet.service.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -421,12 +423,17 @@ public class VSRefreshController {
       VSAssembly assembly = vs.getAssembly(event.getAssemblyName());
 
       if(assembly != null) {
-         coreLifecycleService.refreshVSAssembly(rvs, assembly, dispatcher);
+         try {
+            coreLifecycleService.refreshVSAssembly(rvs, assembly, dispatcher);
 
-         if(assembly instanceof TableDataVSAssembly) {
-            int rows = Math.max(assembly.getPixelSize().height / 16, 100);
-            BaseTableController.loadTableData(
-               rvs, assembly.getAbsoluteName(), 0, 0, rows, linkUri, dispatcher);
+            if(assembly instanceof TableDataVSAssembly) {
+               int rows = Math.max(assembly.getPixelSize().height / 16, 100);
+               BaseTableController.loadTableData(
+                  rvs, assembly.getAbsoluteName(), 0, 0, rows, linkUri, dispatcher);
+            }
+         }
+         catch(ExpiredSheetException e) {
+            LOG.warn("Viewsheet [{}] is expired.", runtimeId);
          }
       }
    }
@@ -528,4 +535,6 @@ public class VSRefreshController {
    private final VSChartDataHandler chartDataHandler;
    private final ParameterService parameterService;
    private final ConcurrentMap<String, Boolean> pending = new ConcurrentHashMap<>();
+
+   private static final Logger LOG = LoggerFactory.getLogger(VSRefreshController.class);
 }

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/annotation/VSAnnotationAddController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/annotation/VSAnnotationAddController.java
@@ -123,6 +123,7 @@ public class VSAnnotationAddController {
       // Create annotation
       final AnnotationVSAssembly annotation =
          (AnnotationVSAssembly) VSEventUtil.createVSAssembly(rvs, Viewsheet.ANNOTATION_ASSET);
+      VSUtil.updateEmbeddedVSAnnotationZIndex(annotation, parentAssembly);
       assert annotation != null;
       final AnnotationVSAssemblyInfo ainfo =
          (AnnotationVSAssemblyInfo) annotation.getVSAssemblyInfo();

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartAreasController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartAreasController.java
@@ -122,6 +122,10 @@ public class VSChartAreasController {
             model = new VSChartModel.VSChartModelFactory().createModel(
                state.getAssembly(), state.getRuntimeViewsheet());
          }
+         catch(ExpiredSheetException e) {
+            LOG.warn("Viewsheet [{}] is expired.", state.getRuntimeViewsheet().getID());
+            return;
+         }
          finally {
             box.unlockRead();
          }

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
@@ -667,7 +667,7 @@ export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
                         vsRuntimeId: this.vsInfo.runtimeId,
                         assemblyName: vsObject.absoluteName
                      };
-                     this.viewsheetClient.sendEvent("/events/vs/refresh/assembly", event);
+                     this.viewsheetClient.sendEvent("/events/vs/refresh/assembly/view", event);
                   }
 
                   this.renderedObjects.set(vsObject.absoluteName, newRendered);


### PR DESCRIPTION
fix Bug #71551, Refer to the getMeasure method of HyperlinkDialogController to fix the NPE.
fix Bug #71575, after render the vs assembly in viewer, just refresh the model of the assembly, need not to re-execute it.
fix Bug #71582, do not refresh the assembly when the current vs is disposed.
fix Bug #71615, find assembly by full absoluteName should use root viewsheet to find.
fix Bug #71618, after clear the source of vs, do not clean assemblies source that are binding embedded vs assembly.
Bug #71649,Update an annotation z-index if the annotation is for assembly of embedded vs to ensure annotation is above source assembly.
fix Bug #71677, check permission when edit the schedule cycle.
fix Bug #71706, check composer viewsheet permission when composer open a viewsheet.
fix NPE.