### PR TITLE
fix Bug #71678. Fix the position of hyperlink item not right.

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-table-cell.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-table-cell.component.ts
@@ -471,8 +471,8 @@ export class VSTableCell implements OnInit, OnChanges, OnDestroy {
 
          this.onLinkClicked.emit({
             hyperlinks: this.cell.hyperlinks,
-            xPos: event.pageX,
-            yPos: event.pageY,
+            xPos: event.clientX,
+            yPos: event.clientY,
             numLinks: this.numLinks
          });
       }


### PR DESCRIPTION
pageX/pageY are coordinates that include the scrolling offset. For a dropdown menu, if the page is scrolled, using these will cause the menu to be positioned incorrectly. Therefore, clientX/clientY, which are based on the browser’s viewport, should be used to display the menu.