### PR TITLE
fix Bug #71526. Fix chained task can't be triggered after rename user.

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleManager.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleManager.java
@@ -1069,6 +1069,7 @@ public class ScheduleManager {
                Tool.equals(IdentityID.getIdentityIDFromKey(userName).name, oname.getName()))
             {
                task.renameDependency(taskDep, taskDep.replace(oname.getName(), name));
+               changedTasks.add(task);
             }
          }
 


### PR DESCRIPTION
Fix the issue where chained tasks were not executed. When the "Run After" task in the chained condition changes, add the current task to the `changedTasks` set to ensure it gets saved.