### PR TITLE
fix Bug #71547. Fix the issue where updating one of the viewsheets doesn't recalculate the bounds of the embedded group.

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
@@ -2469,6 +2469,12 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
 
       resetCorners();
 
+      for(Assembly assembly : getAssemblies()) {
+         if(assembly instanceof ContainerVSAssembly) {
+            ((ContainerVSAssembly) assembly).layout();
+         }
+      }
+
       if(isEmbedded()) {
          info.setPixelSize(getSize0());
       }


### PR DESCRIPTION
After `resetCorners`, it means the upper-left and bottom-right corners of the viewsheet have been recalculated and are up-to-date. Then, all `ContainerVSAssembly` instances should perform layout to apply the latest bounds of the viewsheet.