### PR TITLE
fix Bug #71643. Fix NPE.

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/RangeSliderPropertyDialogController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/RangeSliderPropertyDialogController.java
@@ -372,6 +372,8 @@ public class RangeSliderPropertyDialogController {
                             RangeSliderDataPaneModel rangeSliderDataPaneModel,
                             RangeSliderSizePaneModel rangeSliderSizePaneModel)
    {
+      TimeInfo oldTimeInfo =
+         assemblyInfo.getTimeInfo() != null ? (TimeInfo) assemblyInfo.getTimeInfo().clone() : null;
       OutputColumnRefModel[] columns = rangeSliderDataPaneModel.getSelectedColumns();
 
       if(rangeSliderDataPaneModel.isComposite()) {
@@ -448,6 +450,10 @@ public class RangeSliderPropertyDialogController {
       }
 
       assemblyInfo.setSubmitOnChangeValue(rangeSliderSizePaneModel.isSubmitOnChange());
+
+      if(!Tool.equals(oldTimeInfo, assemblyInfo.getTimeInfo())) {
+         assemblyInfo.setTimeSliderSelection(new TimeSliderSelection());
+      }
    }
 
    private final VSObjectPropertyService vsObjectPropertyService;

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerBindingController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerBindingController.java
@@ -451,6 +451,8 @@ public class ComposerBindingController {
       else if(info instanceof TimeSliderVSAssemblyInfo && ref != null) {
          String title = ref.getName();
          TimeSliderVSAssemblyInfo assemblyinfo = (TimeSliderVSAssemblyInfo) info;
+         TimeInfo oldTimeInfo =
+            assemblyinfo.getTimeInfo() != null ? (TimeInfo) assemblyinfo.getTimeInfo().clone() : null;
          DataRef[] dataRefs = bindings.stream()
                                       .map(bindingService::createDataRef)
                                       .toArray(DataRef[]::new);
@@ -491,6 +493,10 @@ public class ComposerBindingController {
          assemblyinfo.setTimeInfo(tinfo);
          assemblyinfo.setTableName(table);
          assemblyinfo.setTitleValue(title);
+
+         if(!Tool.equals(oldTimeInfo, tinfo)) {
+            assemblyinfo.setTimeSliderSelection(new TimeSliderSelection());
+         }
 
          if(bindings != null && bindings.size() > 0) {
             String sourceType = bindings.get(0).getProperty("type");


### PR DESCRIPTION
The cause of the bug is that `TimeSliderSelection` in `TimeSliderVSAssemblyInfo` was not cleared, so `DateFormat` attempted to format a non-date string, resulting in `null` and leading to an NPE. The solution is to clear `TimeSliderSelection` when the range slider is bound to a `Composite` column.