### PR TITLE
fix Bug #71718. Fix the issue where moving a folder under User\_Scope prompts a permission error.

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/data/DataSetService.java
+++ b/core/src/main/java/inetsoft/web/portal/data/DataSetService.java
@@ -815,7 +815,8 @@ public class DataSetService {
                ActionRecord.OBJECT_TYPE_FOLDER, new Timestamp(System.currentTimeMillis()),
                ActionRecord.ACTION_STATUS_SUCCESS, actionMessage);
 
-            if(!securityProvider.checkPermission(principal, ResourceType.ASSET,
+            if(scope != AssetRepository.USER_SCOPE &&
+               !securityProvider.checkPermission(principal, ResourceType.ASSET,
                                                 items[i].getPath(), ResourceAction.WRITE))
             {
                String label = items[i].getPath();


### PR DESCRIPTION
When a user operates on assets under the USER_SCOPE, there is no need to check whether they have permission for the asset they are operating on.