### PR TITLE
Bug #71631 -  fix npe due to a null data space resource

### DIFF
--- a/core/src/main/java/inetsoft/web/DataSpaceProtocolResolver.java
+++ b/core/src/main/java/inetsoft/web/DataSpaceProtocolResolver.java
@@ -53,11 +53,7 @@ public class DataSpaceProtocolResolver implements ProtocolResolver {
          file = path.substring(index + 1);
       }
 
-      if(dataSpace.exists(dir, file)) {
-         return new DataSpaceResource(dir, file, dataSpace);
-      }
-
-      return null;
+      return new DataSpaceResource(dir, file, dataSpace);
    }
 
    private static final String PROTOCOL = "dataspace:";
@@ -89,7 +85,7 @@ public class DataSpaceProtocolResolver implements ProtocolResolver {
 
       @Override
       public boolean isReadable() {
-         return true;
+         return exists();
       }
 
       @Override


### PR DESCRIPTION
Fix npe. Return a data space resource object even if it doesn't exist as spring then calls isReadable() on it which will throw an npe if the object is null.