### PR TITLE
fix Bug #71746. Fix IllegalStateException.

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/data/WorksheetBrowserInfo.java
+++ b/core/src/main/java/inetsoft/web/portal/data/WorksheetBrowserInfo.java
@@ -47,7 +47,12 @@ public interface WorksheetBrowserInfo {
    boolean deletable();
    boolean materialized();
    boolean canMaterialize();
-   boolean canWorksheet();
+
+   @Value.Default
+   default boolean canWorksheet() {
+      return false;
+   }
+
    @Nullable
    String parentPath();
    boolean hasSubFolder();


### PR DESCRIPTION
Fix the error caused by the missing `canWorksheet` property when constructing `WorksheetBrowserInfo`.