### PR TITLE
fix Bug #71749：show right warning for no expand permission for schedule vs

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/dialog/ScheduleDialogController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/dialog/ScheduleDialogController.java
@@ -406,7 +406,7 @@ public class ScheduleDialogController {
       {
          Catalog catalog = Catalog.getCatalog(principal);
          MessageCommand messageCommand = new MessageCommand();
-         messageCommand.setMessage(catalog.getString("common.nopermission"));
+         messageCommand.setMessage(catalog.getString("em.schedule.task.noExpandPermission"));
          messageCommand.setType(MessageCommand.Type.ERROR);
          commandDispatcher.sendCommand(messageCommand);
          return;

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -4428,6 +4428,7 @@ em.schedule.task.archiveRequiresConfiguration=You must choose an archive storage
 em.schedule.task.dependencyFailed=Failed to check task dependency.
 em.schedule.task.disableFailed=Failed to disable selected task.
 em.schedule.task.duplicateName=The specified task name exists.
+em.schedule.task.noExpandPermission=You do not have permission to Expand Components.
 em.schedule.task.failedRun=Failed to run task "{0}".
 em.schedule.task.failedStop=Failed to stop task "{0}".
 em.schedule.task.folderEdit=Scheduled Task Folder


### PR DESCRIPTION
when schedule vs, if do not have expand component permission, should show user a proper warning.