### PR TITLE
Fix Bug #71747:When checking permissions, it is also necessary to consider whether "Modify By Owner Only" is selected.

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/ScheduleTaskController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/ScheduleTaskController.java
@@ -182,10 +182,11 @@ public class ScheduleTaskController {
       ScheduleTask task = scheduleManager.getScheduleTask(taskName);
 
       if(!(SecurityEngine.getSecurity().checkPermission(principal, ResourceType.SCHEDULE_TASK, taskName,
-            ResourceAction.WRITE) || (task != null && ScheduleManager.hasShareGroupPermission(task, principal))))
+            ResourceAction.WRITE) || (task != null && scheduleTaskService.canDeleteTask(task, principal))))
       {
          return;
       }
+
       boolean enabled = !scheduleTaskService.isTaskEnabled(taskName);
       scheduleTaskService.setTaskEnabled(taskName, enabled, principal);
    }


### PR DESCRIPTION
When checking permissions, it is also necessary to consider whether "Modify By Owner Only" is selected. If enabled, only the owner can delete it.