### PR TITLE
Fix Bug #71748:Based on conditional checks, block dialog pop-ups

### DIFF
--- a/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.ts
@@ -814,6 +814,10 @@ export class ScheduleTaskListComponent implements OnInit, OnDestroy, AfterConten
    }
 
    public moveTasks(): void {
+      if(this.showTasksAsList || !this.removeEnable()) {
+         return;
+      }
+
       let moveFolderRequest: PortalMoveTaskFolderRequest = <PortalMoveTaskFolderRequest>{
          target: null,
          tasks: this.getSelectedTaskModels(),


### PR DESCRIPTION
Based on conditional checks, block dialog pop-ups to prevent modifying button properties via F12 (DevTools) and subsequent unauthorized operations.