### PR TITLE
fix Bug #71753. Avoid directly exposing the datasource password in the response to the frontend.

### DIFF
--- a/core/src/main/java/inetsoft/report/internal/Util.java
+++ b/core/src/main/java/inetsoft/report/internal/Util.java
@@ -3402,6 +3402,7 @@ public class Util implements inetsoft.report.StyleConstants {
 
    private static final Font WATER_FONT = new StyleFont(StyleFont.DEFAULT_FONT_FAMILY, Font.BOLD, 22);
    public static final String DATE_PART_COLUMN = "date_part_column";
+   public static final String PLACEHOLDER_PASSWORD = "**********";
 
    private static final int MAX_ROW_COUNT = 0;
    private static final int MAX_COLUMN_COUNT = 200;

--- a/core/src/main/java/inetsoft/uql/jdbc/util/JDBCUtil.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/util/JDBCUtil.java
@@ -18,6 +18,7 @@
 package inetsoft.uql.jdbc.util;
 
 import inetsoft.analytic.composition.ViewsheetEngine;
+import inetsoft.report.internal.Util;
 import inetsoft.uql.erm.vpm.VpmProcessor;
 import inetsoft.sree.SreeEnv;
 import inetsoft.sree.security.ResourceAction;
@@ -948,7 +949,8 @@ public class JDBCUtil {
 
          if(!jdbcDataSource.isUseCredentialId()) {
             result.getAuthentication().setUserName(jdbcDataSource.getUser());
-            result.getAuthentication().setPassword(jdbcDataSource.getPassword());
+            result.getAuthentication().setPassword(
+               Tool.isEmptyString(jdbcDataSource.getPassword()) ? "" : Util.PLACEHOLDER_PASSWORD);
          }
          else {
             result.getAuthentication().setCredentialId(jdbcDataSource.getCredentialId());

--- a/core/src/main/java/inetsoft/web/admin/content/repository/DatabaseDatasourcesService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/DatabaseDatasourcesService.java
@@ -1058,7 +1058,23 @@ public class DatabaseDatasourcesService {
          if(!Tool.isCloudSecrets() || !definition.getAuthentication().isUseCredentialId()) {
             xds.initCredential(true);
             xds.setUser(definition.getAuthentication().getUserName());
-            xds.setPassword(definition.getAuthentication().getPassword());
+            String oldName = definition.getOldName();
+            String password = definition.getAuthentication().getPassword();
+
+            if(!Tool.isEmptyString(oldName) && Tool.equals(password, Util.PLACEHOLDER_PASSWORD)) {
+               try {
+                  path = Tool.isEmptyString(path) ? oldName : path;
+                  XDataSource dataSource = repository.getDataSource(path);
+
+                  if(dataSource instanceof JDBCDataSource) {
+                     password = ((JDBCDataSource) dataSource).getPassword();
+                  }
+               }
+               catch(Exception ignore){
+               }
+            }
+
+            xds.setPassword(password);
          }
          else {
             String credentialId = definition.getAuthentication().getCredentialId();

--- a/web/projects/shared/util/datasource/data-source-settings-page.ts
+++ b/web/projects/shared/util/datasource/data-source-settings-page.ts
@@ -306,7 +306,8 @@ export abstract class DataSourceSettingsPage implements OnInit {
    }
 
    testDatabase(): void {
-      let params = new HttpParams().set("path", this.primaryDatabasePath);
+      let path = !!this.primaryDatabasePath ? this.primaryDatabasePath : this.model?.path;
+      let params = new HttpParams().set("path", !!path ? path : "");
       this.http.post<ConnectionStatus>(TEST_ADDITIONAL, this.database, {params}).pipe(
          catchError((error: HttpErrorResponse) => {
             if(this.showTestMessage) {


### PR DESCRIPTION
Hide the password of the `JdbcDatasource` when reopening after saving the datasource.