### PR TITLE
fix Bug #71503. Fix the issue where the data displayed in a crosstab-structured mirror table does not apply the conditions from the base table.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/MirrorQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/MirrorQuery.java
@@ -125,8 +125,8 @@ public class MirrorQuery extends AssetQuery {
          }
       }
 
-      this.query = AssetQuery.createAssetQuery(mirror, fixSubQueryMode(mode),
-                                               box, true, ts, false, metadata);
+      this.query = AssetQuery.createAssetQuery(mirror, fixSubQueryMode(mode), box, true, ts, false,
+                                               fixSubQueryMetadataState(table, metadata));
       this.query.setSubQuery(true);
       this.query.plan = this.plan;
       this.query.parentSQLExpressions.addAll(getSQLExpressions());

--- a/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
@@ -70,6 +70,16 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
       return mode;
    }
 
+   public static boolean fixSubQueryMetadataState(AbstractTableAssembly table, boolean metadata) {
+      AggregateInfo aggInfo = table.getAggregateInfo();
+
+      if(metadata && aggInfo != null && aggInfo.isCrosstab()) {
+         metadata = false;
+      }
+
+      return metadata;
+   }
+
    /**
     * Create an asset query.
     */


### PR DESCRIPTION
If the mirror table has a crosstab structure, it relies on the actual data in the base table to generate the column headers. Therefore, in the subquery of the mirror query, it should not be in the metadata state; otherwise, the conditions set on the base table will not be applied during the execution of the subquery.
