### PR TITLE
fix Bug #71763, for XNodeTable, when the base table canceled cause the current table process break, cancel current table.

### DIFF
--- a/core/src/main/java/inetsoft/uql/util/XNodeTable.java
+++ b/core/src/main/java/inetsoft/uql/util/XNodeTable.java
@@ -651,7 +651,7 @@ public class XNodeTable implements XTable {
          finally {
             complete();
 
-            if(!baseTableCancelBreakLoad) {
+            if(baseTableCancelBreakLoad) {
                cancelled = true;
             }
 


### PR DESCRIPTION
for XNodeTable, when the base table canceled cause the current table process break, cancel current table.