### PR TITLE
fix Bug #71507. Fix condition issue for crosstab-structured table column headers.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -2332,6 +2332,28 @@ public abstract class AssetQuery extends PreAssetQuery {
             }
          }
 
+         ConditionListWrapper postConditionList = getPostConditionList();
+         AggregateInfo aggInfo = getTable().getAggregateInfo();
+
+         if(!postConditionList.isEmpty() && aggInfo != null && aggInfo.isCrosstab()) {
+            stable.setConditionOnColHeader(true);
+            stable.setCondition(new ConditionGroup(postConditionList.getConditionList(), (name) -> {
+               for(int i = 0; i < groups.length; i++) {
+                  if(groups[i].getName().equals(name)) {
+                     return i;
+                  }
+               }
+
+               for(int i = 0; i < aggregates.length; i++) {
+                  if(aggregates[i].getName().equals(name)) {
+                     return i + groups.length;
+                  }
+               }
+
+               return -1;
+            }));
+         }
+
          // apply sort order
          for(int i = 0; i < colist.size(); i++) {
             SortOrder order = colist.get(i);

--- a/core/src/main/java/inetsoft/report/filter/CrossTabFilter.java
+++ b/core/src/main/java/inetsoft/report/filter/CrossTabFilter.java
@@ -2804,7 +2804,9 @@ public class CrossTabFilter extends AbstractTableLens
                }
             }
 
-            boolean eval = condition.evaluate(values);
+            boolean eval = !isConditionOnColHeader() ?
+               condition.evaluate(values) :
+               condition.evaluate(ArrayUtils.addAll(ctuple.getRow(), rtuple.getRow(), values));
 
             if(eval) {
                rdvec.add(rtuple);
@@ -6695,6 +6697,14 @@ public class CrossTabFilter extends AbstractTableLens
       this.calcTotal = calcTotal;
    }
 
+   public boolean isConditionOnColHeader() {
+      return conditionOnColHeader;
+   }
+
+   public void setConditionOnColHeader(boolean conditionOnColHeader) {
+      this.conditionOnColHeader = conditionOnColHeader;
+   }
+
    /**
     * Crosstab data descriptor.
     */
@@ -7201,6 +7211,7 @@ public class CrossTabFilter extends AbstractTableLens
    private int dcDataRefHeaderIndex = -1;
    private List<CalcColumn> calcs = null;
    private boolean calcTotal;
+   private boolean conditionOnColHeader = false; // Flag for applying condition to crosstab column header
    private Map<String, String> calcMeasureMap = new HashMap<>();
    private transient Map<Integer, CalcColumn> aggCalcMap = new HashMap<>();
 


### PR DESCRIPTION
Fix the issue where column headers in crosstab-structured tables within the worksheet do not apply conditions when a condition is set.