### PR TITLE
fix Bug #71731: add parameter to split create db and edit db action

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryDataSourcesController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryDataSourcesController.java
@@ -21,15 +21,15 @@ import inetsoft.report.internal.Util;
 import inetsoft.sree.RepositoryEntry;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
+import inetsoft.uql.*;
 import inetsoft.uql.jdbc.SQLHelper;
 import inetsoft.uql.util.Config;
-import inetsoft.util.Tool;
+import inetsoft.util.*;
 import inetsoft.web.admin.content.database.DatabaseDefinition;
 import inetsoft.web.admin.content.database.DriverAvailability;
 import inetsoft.web.admin.content.database.types.CustomDatabaseType;
 import inetsoft.web.admin.security.ConnectionStatus;
 import inetsoft.web.factory.RemainingPath;
-import inetsoft.web.portal.data.DataSourceBrowserService;
 import inetsoft.web.security.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -114,12 +114,12 @@ public class RepositoryDataSourcesController {
     */
    @PostMapping("/api/data/databases")
    public ConnectionStatus setDataSourceModel(@RequestParam("path") String path,
+                                              @RequestParam("create") boolean create,
                                               @RequestBody() DataSourceSettingsModel model,
                                               Principal principal)
       throws Exception
    {
       ConnectionStatus status = null;
-
       String fullPath = this.databaseDatasourcesService.getDataSourceAuditPath(path,
          model.dataSource(), principal);
 
@@ -132,6 +132,15 @@ public class RepositoryDataSourcesController {
          if(database != null) {
             actionError = Tool.equals(database.getName(), database.getOldName()) ? null :
             "new Name:" + database.getName();
+         }
+
+         if(!create) {
+            XRepository repository = XFactory.getRepository();
+            XDataSource dataSource = repository.getDataSource(path);
+
+            if(dataSource == null) {
+               return new ConnectionStatus("Datasource Lost");
+            }
          }
 
          status = databaseDatasourcesService.saveDatabase(path,

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/datasources-database.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/datasources-database.component.ts
@@ -212,6 +212,10 @@ export class DatasourcesDatabaseComponent extends DataSourceSettingsPage impleme
       this.refreshDefaultTestQuery();
    }
 
+   isCreateDB(): boolean {
+      return this.originalModel.path == "/";
+   }
+
    updateAdditionalList() {
       if(this.additionalVisible) {
          this.additionalList = [];

--- a/web/projects/shared/util/datasource/data-source-settings-page.ts
+++ b/web/projects/shared/util/datasource/data-source-settings-page.ts
@@ -156,6 +156,10 @@ export abstract class DataSourceSettingsPage implements OnInit {
       return !this.database?.authentication?.useCredentialId;
    }
 
+   isCreateDB(): boolean {
+      return false;
+   }
+
    constructor(protected http: HttpClient) {
    }
 
@@ -271,7 +275,7 @@ export abstract class DataSourceSettingsPage implements OnInit {
     * Send request to save the database on the server then close page.
     */
    saveDatabase(): void {
-      let params = new HttpParams().set("path", this.model.path);
+      let params = new HttpParams().set("path", this.model.path).set("create", this.isCreateDB());
       let settingModel = Tool.clone(this.model.settings);
 
       if(!this.needSave()) {
@@ -298,6 +302,9 @@ export abstract class DataSourceSettingsPage implements OnInit {
          }
          else if(connection && connection.status === "Duplicate Folder") {
             this.showMessage("_#(js:em.data.databases.duplicateFolder)");
+         }
+         else if(connection && connection.status === "Datasource Lost") {
+            this.showMessage("_#(js:data.datasources.saveDataSourceLost)");
          }
          else {
             this.afterDatabaseSave();


### PR DESCRIPTION
for tabular db, it will send different request for create db and edit db, when edit one db is deleted, it will show warning for user.

for jdbc db, it will send the same request for create and edit, so when db is null, it maybe create or deleted, so we should show user same waring as tabular when edit db is deleted.