### PR TITLE
fix Bug #71772: use match layout to check select expand components or not

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/dialog/EmailDialogController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/dialog/EmailDialogController.java
@@ -360,7 +360,7 @@ public class EmailDialogController {
       String body = Tool.defaultIfNull(emailPaneModel.message(), "");
       boolean isSendLink = Tool.defaultIfNull(fileFormatPaneModel.sendLink(), false);
 
-      if((fileFormatPaneModel.expandEnabled() || fileFormatPaneModel.expandSelections() ||
+      if((!fileFormatPaneModel.matchLayout() || fileFormatPaneModel.expandSelections() ||
          fileFormatPaneModel.onlyDataComponents()) &&
          !SecurityEngine.getSecurity().checkPermission(principal,
          ResourceType.VIEWSHEET_TOOLBAR_ACTION, "ExportExpandComponents",


### PR DESCRIPTION
if select "expand components", match layout will be false, then if no expand permission should show uer warning