### PR TITLE
fix Bug #71774, should always use absolute name to get sandbox, because it always from root box to get.

### DIFF
--- a/core/src/main/java/inetsoft/report/script/viewsheet/ViewsheetVSAScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/viewsheet/ViewsheetVSAScriptable.java
@@ -67,7 +67,7 @@ public class ViewsheetVSAScriptable extends VSAScriptable {
       addProperty("viewsheetAlias", null);
 
       if(!ViewsheetScope.VIEWSHEET_SCRIPTABLE.equals(assembly)) {
-         ViewsheetSandbox myBox = box.getSandbox(assembly);
+         ViewsheetSandbox myBox = box.getSandbox(getVSAssembly().getAbsoluteName());
          // thisParameter points to parameters in the embedded vs instead of the containing vs
          addProperty("thisParameter", new VariableScriptable(myBox.getVariableTable()));
       }


### PR DESCRIPTION
should always use absolute name to get sandbox, because it always from root box to get.