### PR TITLE
fix Bug #71786, return cloned object for NthMostFrequentFormula.

### DIFF
--- a/core/src/main/java/inetsoft/mv/formula/NthMostFrequentFormula.java
+++ b/core/src/main/java/inetsoft/mv/formula/NthMostFrequentFormula.java
@@ -210,11 +210,12 @@ public class NthMostFrequentFormula
          NthMostFrequentFormula nmf = (NthMostFrequentFormula) super.clone();
          nmf.def = def;
          nmf.map = new Double2IntOpenHashMap(map);
+
+         return nmf;
       }
       catch(Exception e) {
          LOG.error("Failed to clone object", e);
       }
-
 
       return null;
    }


### PR DESCRIPTION
return cloned object for NthMostFrequentFormula.