### PR TITLE
fix Bug #71767, show filter context menu when table is expanded. This shows a pop-up selection component so it is ok that the selection container is not visible.

### DIFF
--- a/web/projects/portal/src/app/vsobjects/action/calc-table-actions.ts
+++ b/web/projects/portal/src/app/vsobjects/action/calc-table-actions.ts
@@ -92,7 +92,6 @@ export class CalcTableActions extends BaseTableActions<VSCalcTableModel> {
             enabled: () => true,
             visible: () => !this.annotationsSelected &&
                !this.binding && !this.model.titleSelected && this.oneCellSelected &&
-               !this.model.maxMode &&
                (!(this.viewer || this.preview) || this.model.adhocFilterEnabled) &&
                this.model.sourceType !== SourceInfoType.VS_ASSEMBLY &&
                this.selectedCellBindingType === 2 // not text nor formula

--- a/web/projects/portal/src/app/vsobjects/action/crosstab-actions.ts
+++ b/web/projects/portal/src/app/vsobjects/action/crosstab-actions.ts
@@ -710,7 +710,7 @@ export class CrosstabActions extends BaseTableActions<VSCrosstabModel> {
 
    private get filterVisible(): boolean {
       if(this.binding || !this.oneCellSelected || this.model.titleSelected ||
-         this.model.maxMode || !this.model.selectedRegions ||
+         !this.model.selectedRegions ||
          this.model.selectedRegions.length === 0 ||
          this.model.sourceType === SourceInfoType.VS_ASSEMBLY)
       {

--- a/web/projects/portal/src/app/vsobjects/action/table-actions.ts
+++ b/web/projects/portal/src/app/vsobjects/action/table-actions.ts
@@ -349,7 +349,7 @@ export class TableActions extends BaseTableActions<VSTableModel> {
 
    private get filterVisible(): boolean {
       return !this.binding && (!this.viewer && !this.preview || this.model.adhocFilterEnabled) &&
-         !this.model.maxMode && !this.model.titleSelected && this.oneCellSelected &&
+         !this.model.titleSelected && this.oneCellSelected &&
          !this.model.form && !this.model.embedded &&
          this.model.sourceType !== SourceInfoType.VS_ASSEMBLY;
    }

--- a/web/projects/portal/src/app/vsobjects/objects/abstract-vsobject.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/abstract-vsobject.component.ts
@@ -111,6 +111,10 @@ export abstract class AbstractVSObject<T extends VSObjectModel> extends CommandP
          if(maxObj && this.model.container && this.model.container == maxObj.absoluteName) {
             return true;
          }
+
+         if(maxObj && !!(this.model as any).adhocFilter) {
+            return true;
+         }
       }
 
       return !this.viewer && !this.embeddedVS || this.model.visible &&


### PR DESCRIPTION
 Bug #71590, show filter context menu when table is expanded. This shows a pop-up selection component so it is ok that the selection container is not visible.