### PR TITLE
fix Bug #71731: check create or edit by right path

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/datasources-database.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/datasources-database.component.ts
@@ -215,7 +215,7 @@ export class DatasourcesDatabaseComponent extends DataSourceSettingsPage impleme
    }
 
    isCreateDB(): boolean {
-      return this.originalModel.path == "/";
+      return this.originalModel.path == "" || this.originalModel.path == "/";
    }
 
    updateAdditionalList() {


### PR DESCRIPTION
when create db from tree, its origianal path is "/", when create new db from right pane action, its origianl path is "", when edit db,its path will be its folder+dbname, so we should check create rightly.