### PR TITLE
fix Bug #71812. Use the correct VS name to obtain the ViewsheetSandbox.

### DIFF
--- a/core/src/main/java/inetsoft/report/script/viewsheet/ViewsheetVSAScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/viewsheet/ViewsheetVSAScriptable.java
@@ -67,7 +67,9 @@ public class ViewsheetVSAScriptable extends VSAScriptable {
       addProperty("viewsheetAlias", null);
 
       if(!ViewsheetScope.VIEWSHEET_SCRIPTABLE.equals(assembly)) {
-         ViewsheetSandbox myBox = box.getSandbox(getVSAssembly().getAbsoluteName());
+         String vsName =
+            getVSAssembly().getViewsheet() == null ? assembly : getVSAssembly().getAbsoluteName();
+         ViewsheetSandbox myBox = box.getSandbox(vsName);
          // thisParameter points to parameters in the embedded vs instead of the containing vs
          addProperty("thisParameter", new VariableScriptable(myBox.getVariableTable()));
       }


### PR DESCRIPTION
If the viewsheet obtained through the `getVSAssembly()` method is the top-level viewsheet, the `assembly` should still be used instead of calling `getAbsoluteName()` on the viewsheet.