### PR TITLE
Bug #71723, limit inserted rows from runaway expanding headerRowCount

### DIFF
--- a/core/src/main/java/inetsoft/report/lens/DefaultTableLens.java
+++ b/core/src/main/java/inetsoft/report/lens/DefaultTableLens.java
@@ -322,7 +322,7 @@ public class DefaultTableLens extends AttributeTableLens {
       insertRow(fontmap, row, n);
 
       // adjust header/trailer row count if necessary
-      if(row < getHeaderRowCount() && row + n <= getHeaderRowCount()) {
+      if(row + n <= getHeaderRowCount()) {
          setHeaderRowCount(getHeaderRowCount() + n);
       }
 


### PR DESCRIPTION
Bug #71723, limit inserted rows from runaway expanding headerRowCount by checking if inserted rows still fall within previously asserted header region(merge from 13.7)