### PR TITLE
Bug #71814: return right tablelens for rangeslider binding cube

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
@@ -465,7 +465,7 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
          checkMaxRowLimit(table);
 
          if(unit == TimeInfo.MEMBER || cubeData) {
-            if(table.getRowCount() < 2 || table.getColCount() != 1) {
+            if(table.getRowCount() < 2 || !cubeData && table.getColCount() != 1) {
                return null;
             }
 


### PR DESCRIPTION
should not return null for cube binding, for cube source will return all binding column in vs as sourcetable, so its column maybe more than one. Should return its tablelens and to get min and max values.