### PR TITLE
Bug #71828: show user name for audit when change user password

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/ChangePasswordController.java
+++ b/core/src/main/java/inetsoft/web/admin/security/ChangePasswordController.java
@@ -56,7 +56,7 @@ public class ChangePasswordController {
          SUtil.setPassword((FSUser) user, request.password());
          ((EditableAuthenticationProvider) authc).addUser(user);
          ActionRecord record = SUtil.getActionRecord(principal, ActionRecord.ACTION_NAME_EDIT,
-             principal.getName(), ActionRecord.OBJECT_TYPE_PASSWORD);
+             SUtil.getUserName(principal), ActionRecord.OBJECT_TYPE_PASSWORD);
          Audit.getInstance().auditAction(record, principal);
       }
       else {


### PR DESCRIPTION
when change password for user, only show user name for object name in audit is ok. Only can edit user in current organzation.