### PR TITLE
fix Bug #71812. Fix the issue where assemblies using the "thisParameter" script collect incomplete parameters from sub viewsheets.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -1561,7 +1561,7 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
                {
                   executeView(entry.getName(), false, initing);
                }
-               else {
+               else if(!(info instanceof ViewsheetVSAssemblyInfo)) {
                   thisParameterScriptAssemblies.add(entry.getName());
                }
 


### PR DESCRIPTION
After the sub viewsheets are updated, execute the view for assemblies that use the "thisParameter" script to ensure they can get the parameters from the sub viewsheets.