### PR TITLE
fix Bug #71829, clear sql string of jdbc query before execute it.

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
@@ -1704,17 +1704,18 @@ public class QueryManagerService {
       RuntimeQueryService.RuntimeXQuery runtimeQuery =
          runtimeQueryService.getRuntimeQuery(runtimeId);
       JDBCQuery query = runtimeQuery.getQuery();
+
+      if(sqlString != null) {
+         parseSqlString(runtimeId, sqlString, false, true, principal);
+         query = runtimeQuery.getQuery();
+      }
+
       UniformSQL sql = (UniformSQL) query.getSQLDefinition();
 
       if(sql.isParseSQL() && !sql.isLossy()) {
          query = query.clone();
          sql = (UniformSQL) query.getSQLDefinition();
          sql.clearSQLString();
-      }
-
-      if(sqlString != null) {
-         parseSqlString(runtimeId, sqlString, false, true, principal);
-         query = runtimeQuery.getQuery();
       }
 
       VariableTable vtable = runtimeQuery.getVariables();


### PR DESCRIPTION
clear sql string of jdbc query after the query has been parsed without lose any information. if condition parameter value is null, it will be removed before execute sql, this operation just for sql string as null sql.