### PR TITLE
Fix Bug #71827:ParentPath can be used for judgment

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/datasources-database.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/datasources-database.component.ts
@@ -215,7 +215,7 @@ export class DatasourcesDatabaseComponent extends DataSourceSettingsPage impleme
    }
 
    isCreateDB(): boolean {
-      return this.originalModel.path == "" || this.originalModel.path == "/";
+      return this.parentPath != null || this.parentPath == "" || this.parentPath == "/";
    }
 
    updateAdditionalList() {


### PR DESCRIPTION
Determining whether it's a "new" operation based on this.originalModel.path is not accurate enough, because if there is a folder, this.originalModel.path will contain the folder name. Instead, parentPath can be used for judgment, since parentPath is derived from the URL—it is only assigned a value in "new" mode, whereas in "edit" mode, it remains null. Additionally, if it's the root directory, the tree view displays it as "/", while the right-side view shows it as an empty string "".