### PR TITLE
Bug #71827: should split createdb and editdb to different check

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/datasources-database.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/datasources-database.component.ts
@@ -117,6 +117,7 @@ export class DatasourcesDatabaseComponent extends DataSourceSettingsPage impleme
    selectedProperty: any[] = [];
    private routeParamSubscription: Subscription;
    enterprise: boolean;
+   _createDB: boolean = false;
 
    searchFunc: (text: Observable<string>) => Observable<any[]> = (text: Observable<string>) =>
       text.pipe(
@@ -154,6 +155,8 @@ export class DatasourcesDatabaseComponent extends DataSourceSettingsPage impleme
                const listingName = routeParams.get("listingName");
 
                if(listingName) {
+                  this._createDB = true;
+
                   return this.httpClient.get("../api/data/database/listing/"
                      + Tool.encodeURIComponentExceptSlash(listingName));
                }
@@ -215,7 +218,7 @@ export class DatasourcesDatabaseComponent extends DataSourceSettingsPage impleme
    }
 
    isCreateDB(): boolean {
-      return this.originalModel.path == "" || this.originalModel.path == "/";
+      return this._createDB;
    }
 
    updateAdditionalList() {


### PR DESCRIPTION
should split create new datasource and edit new datasource by different route, if create new datasource it will select listing db names and to edit db page, but edit will to edit db page directly.