### PR TITLE
Bug #71828: only show user name for change password record

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/ChangePasswordController.java
+++ b/core/src/main/java/inetsoft/web/admin/security/ChangePasswordController.java
@@ -56,7 +56,7 @@ public class ChangePasswordController {
          SUtil.setPassword((FSUser) user, request.password());
          ((EditableAuthenticationProvider) authc).addUser(user);
          ActionRecord record = SUtil.getActionRecord(principal, ActionRecord.ACTION_NAME_EDIT,
-             SUtil.getUserName(principal), ActionRecord.OBJECT_TYPE_PASSWORD);
+             user.getName(), ActionRecord.OBJECT_TYPE_PASSWORD);
          Audit.getInstance().auditAction(record, principal);
       }
       else {


### PR DESCRIPTION
should show user name in audit for change password action, only can edit users in current org, so org info should ignore.