### PR TITLE
Bug #71860: should check upload-drivers permission for upload action

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/upload/UploadController.java
+++ b/core/src/main/java/inetsoft/web/admin/upload/UploadController.java
@@ -98,8 +98,6 @@ public class UploadController {
    private boolean checkPermission(Principal principal) {
       try {
          return securityEngine.checkPermission(
-            principal, ResourceType.EM, "*", ResourceAction.ACCESS) &&
-            securityEngine.checkPermission(
                principal, ResourceType.UPLOAD_DRIVERS, "*", ResourceAction.ACCESS);
       }
       catch(SecurityException e) {


### PR DESCRIPTION
the bug is caused by Bug #71636, old bug case only check have em permission so return permission for upload, should check permission for upload-drivers. In fact, we should only check upload-drivers for upload action.