### PR TITLE
fix Bug #71865, fix  widht and height error for viewer size change event.

### DIFF
--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -3190,6 +3190,12 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
             width += this.allAssemblyBounds.left;
          }
 
+         // see GuiTool.getChartMaxModeSize, 19px is for scrollbar of table data assembly.
+         if(this.vsObjects?.length > 0 && this.vsObjects[0]?.sheetMaxMode) {
+            width += 19;
+            height += 19;
+         }
+
          this.onViewerSizeChanged.emit({width: this.fitToWidth ? null : width, height: height});
       }
    }


### PR DESCRIPTION
during emit viewer size change event,if vs is max mode, width and height should add 19 px, it is for scrollbar of table data assembly.