### PR TITLE
Bug #71847: when task folder do not have tasks, should check task model for null

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/EMScheduleTaskFolderController.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/EMScheduleTaskFolderController.java
@@ -185,14 +185,16 @@ public class EMScheduleTaskFolderController {
       ScheduleTaskModel[] taskModels = request.getTasks();
       ScheduleManager scheduleManager = ScheduleManager.getScheduleManager();
 
-      for(ScheduleTaskModel taskModel : taskModels) {
-         ScheduleTask task = scheduleManager.getScheduleTask(taskModel.name());
+      if(taskModels != null) {
+         for(ScheduleTaskModel taskModel : taskModels) {
+            ScheduleTask task = scheduleManager.getScheduleTask(taskModel.name());
 
-         if(!(SecurityEngine.getSecurity().checkPermission(principal,
-            ResourceType.SCHEDULE_TASK, taskModel.name(), ResourceAction.WRITE) ||
-            (task != null && scheduleTaskService.canDeleteTask(task, principal))))
-         {
-            return;
+            if(!(SecurityEngine.getSecurity().checkPermission(principal,
+               ResourceType.SCHEDULE_TASK, taskModel.name(), ResourceAction.WRITE) ||
+               (task != null && scheduleTaskService.canDeleteTask(task, principal))))
+            {
+               return;
+            }
          }
       }
 


### PR DESCRIPTION
the bug is caused by move empty folder, so its taskModels will be null, so should check null for models.