### PR TITLE
fix Bug #71873. Go back to the previous tab when the parameter collection dialog is cancelled.

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-query/database-query.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-query/database-query.component.html
@@ -92,7 +92,8 @@
           <sql-query-preview-pane class="tab-pane-content"
                                   [runtimeId]="runtimeId"
                                   [sqlString]="queryModel?.freeFormSQLPaneModel?.sqlString"
-                                  [tableCount]="queryModel?.linkPaneModel?.tables?.length">
+                                  [tableCount]="queryModel?.linkPaneModel?.tables?.length"
+                                  (goBackToPreviousTab)="updateTab(oldTab)">
           </sql-query-preview-pane>
         </ng-template>
       </ng-container>

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-query/database-query.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-query/database-query.component.ts
@@ -82,7 +82,7 @@ export class DatabaseQueryComponent implements OnDestroy {
       if(!!model?.freeFormSQLPaneModel.sqlString &&
          model?.freeFormSQLPaneModel.parseResult == ParseResult.PARSE_FAILED)
       {
-         this.activeTab = DatabaseQueryTabs.SQL_STRING;
+         this.updateTab(DatabaseQueryTabs.SQL_STRING)
       }
 
       this.oldSqlString = model.freeFormSQLPaneModel.sqlString;
@@ -92,6 +92,7 @@ export class DatabaseQueryComponent implements OnDestroy {
    @Input() sessionOperations: OperationModel[];
    @ViewChild("queryConditionsPane") queryConditionsPane: QueryConditionsPaneComponent;
    activeTab: string = DatabaseQueryTabs.LINKS;
+   oldTab: string = this.activeTab;
    private subscriptions: Subscription = new Subscription();
    private oldSqlString: string;
 
@@ -147,15 +148,15 @@ export class DatabaseQueryComponent implements OnDestroy {
       let nextTab = event.nextId;
 
       if(this.activeTab == DatabaseQueryTabs.FIELDS) {
-         this.updateQuery(DatabaseQueryTabs.FIELDS, () => this.activeTab = nextTab);
+         this.updateQuery(DatabaseQueryTabs.FIELDS, () => this.updateTab(nextTab));
       }
       else if(this.activeTab == DatabaseQueryTabs.CONDITIONS) {
          this.queryConditionsPane.checkDirtyConditions().then(() => {
-            this.updateQuery(DatabaseQueryTabs.CONDITIONS, () => this.activeTab = nextTab);
+            this.updateQuery(DatabaseQueryTabs.CONDITIONS, () => this.updateTab(nextTab));
          });
       }
       else if(this.activeTab == DatabaseQueryTabs.SORT) {
-         this.updateQuery(DatabaseQueryTabs.SORT, () => this.activeTab = nextTab);
+         this.updateQuery(DatabaseQueryTabs.SORT, () => this.updateTab(nextTab));
       }
       else if(this.activeTab == DatabaseQueryTabs.GROUPING) {
          this.switchFromGroupingTab(nextTab);
@@ -168,10 +169,18 @@ export class DatabaseQueryComponent implements OnDestroy {
             });
       }
       else if(this.activeTab == DatabaseQueryTabs.LINKS && nextTab == DatabaseQueryTabs.SQL_STRING) {
-         this.queryModelService.emitModelChange(() => this.activeTab = nextTab);
+         this.queryModelService.emitModelChange(() => this.updateTab(nextTab));
       }
       else {
-         this.activeTab = nextTab;
+         this.updateTab(nextTab);
+      }
+   }
+
+   updateTab(tab: string) {
+      this.activeTab = tab;
+
+      if(tab != DatabaseQueryTabs.PREVIEW) {
+         this.oldTab = this.activeTab;
       }
    }
 
@@ -207,7 +216,7 @@ export class DatabaseQueryComponent implements OnDestroy {
                   {"yes": "_#(js:Yes)", "no": "_#(js:No)"})
             .then((response) => {
                if(response == "yes") {
-                  this.activeTab = nextTab;
+                  this.updateTab(nextTab);
                }
             });
          }
@@ -222,22 +231,22 @@ export class DatabaseQueryComponent implements OnDestroy {
             ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)", msg);
          }
          else {
-            this.activeTab = nextTab;
+            this.updateTab(nextTab);
          }
       }
       else {
-         this.activeTab = nextTab;
+         this.updateTab(nextTab);
       }
    }
 
    switchFromGroupingTab(nextTab: any): void {
       if(this.validGroupBy) {
          if(this.queryGroupingPane.isGroupByPane()) {
-            this.updateQuery(DatabaseQueryTabs.GROUPING, () => this.activeTab = nextTab);
+            this.updateQuery(DatabaseQueryTabs.GROUPING, () => this.updateTab(nextTab));
          }
          else {
             this.queryGroupingPane.havingConditionsPane.checkDirtyConditions().then(() => {
-               this.updateQuery(DatabaseQueryTabs.GROUPING, () => this.activeTab = nextTab);
+               this.updateQuery(DatabaseQueryTabs.GROUPING, () => this.updateTab(nextTab));
             });
          }
       }
@@ -275,7 +284,7 @@ export class DatabaseQueryComponent implements OnDestroy {
    }
 
    public resetActiveTab(): void {
-      this.activeTab = DatabaseQueryTabs.LINKS;
+      this.updateTab(DatabaseQueryTabs.LINKS);
    }
 
    public checkQuery(): Promise<void> {

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-query/query-preview/sql-query-preview-pane.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-query/query-preview/sql-query-preview-pane.component.ts
@@ -15,7 +15,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { Component, ElementRef, Input, OnDestroy, OnInit } from "@angular/core";
+import {
+   Component,
+   ElementRef,
+   EventEmitter,
+   Input,
+   OnDestroy,
+   OnInit,
+   Output
+} from "@angular/core";
 import { HttpClient, HttpParams } from "@angular/common/http";
 import { Rectangle } from "../../../../../../common/data/rectangle";
 import { GuiTool } from "../../../../../../common/util/gui-tool";
@@ -35,6 +43,7 @@ export class SqlQueryPreviewPaneComponent implements OnDestroy, OnInit {
    @Input() sqlString: string;
    @Input() tableCount: number;
    @Input() sqlEdited: boolean;
+   @Output() goBackToPreviousTab = new EventEmitter<void>();
    previewPending: boolean = false;
    tableData: string[][];
    scrollbarWidth: number;
@@ -94,6 +103,7 @@ export class SqlQueryPreviewPaneComponent implements OnDestroy, OnInit {
       },
       () => {
          this.previewPending = false;
+         this.goBackToPreviousTab.emit();
       });
    }
 

--- a/web/projects/portal/src/app/widget/dialog/sql-query-dialog/simple-query-pane.component.html
+++ b/web/projects/portal/src/app/widget/dialog/sql-query-dialog/simple-query-pane.component.html
@@ -129,7 +129,8 @@
                                 [runtimeId]="runtimeId"
                                 [sqlString]="model?.sqlString"
                                 [tableCount]="tableCount"
-                                [sqlEdited]="model.sqlEdited">
+                                [sqlEdited]="model.sqlEdited"
+                                (goBackToPreviousTab)="goBackToPreviousTab()">
         </sql-query-preview-pane>
       </ng-template>
     </ng-container>

--- a/web/projects/portal/src/app/widget/dialog/sql-query-dialog/simple-query-pane.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/sql-query-dialog/simple-query-pane.component.ts
@@ -154,6 +154,7 @@ export class SimpleQueryPaneComponent {
    conditionDialogModel: VPMConditionDialogModel;
    selectedConditionIndex: number = -1;
    private _defaultTab: string = this.editTab;
+   private _oldTab: string = this._defaultTab;
 
    get defaultTab(): string {
       return this._defaultTab;
@@ -643,6 +644,11 @@ export class SimpleQueryPaneComponent {
       }
       else {
          this._defaultTab = next;
+         this._oldTab = this._defaultTab;
       }
+   }
+
+   goBackToPreviousTab(): void {
+      this._defaultTab = this._oldTab;
    }
 }


### PR DESCRIPTION
When switching to the preview pane, if parameter collection is cancelled during the process, return to the previous tab instead of staying on the preview tab.
