### PR TITLE
passing the correct em flag when the stomp client connects.

### DIFF
--- a/web/projects/em/src/app/settings/content/drivers-and-plugins/plugins-view/plugins-view.component.ts
+++ b/web/projects/em/src/app/settings/content/drivers-and-plugins/plugins-view/plugins-view.component.ts
@@ -193,7 +193,7 @@ export class PluginsViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
    private connectSocket(): void {
       if(!this.connecting && !this.connection) {
-         this.client.connect("../vs-events").subscribe(
+         this.client.connect("../vs-events", true).subscribe(
             (connection) => {
                this.connecting = false;
                this.connection = connection;

--- a/web/projects/em/src/app/settings/content/materialized-views/mv-management-view/mv-change.service.ts
+++ b/web/projects/em/src/app/settings/content/materialized-views/mv-management-view/mv-change.service.ts
@@ -37,7 +37,7 @@ export class MVChangeService implements OnDestroy {
 
    private connectSocket(): void {
       if(!this.connecting && !this.connection) {
-         this.client.connect("../vs-events").subscribe(
+         this.client.connect("../vs-events", true).subscribe(
             (connection) => {
                this.connecting = false;
                this.connection = connection;

--- a/web/projects/em/src/app/settings/content/repository/repository-tree-data-source.ts
+++ b/web/projects/em/src/app/settings/content/repository/repository-tree-data-source.ts
@@ -148,7 +148,7 @@ export class RepositoryTreeDataSource
 
    private connectSocket(init?: boolean): void {
       if(!this.connecting && !this.connection) {
-         this.client.connect("../vs-events").subscribe(
+         this.client.connect("../vs-events", true).subscribe(
             (connection) => {
                this.connecting = false;
                this.connection = connection;

--- a/web/projects/em/src/app/settings/schedule/schedule-task-list/em-schedule-change.service.ts
+++ b/web/projects/em/src/app/settings/schedule/schedule-task-list/em-schedule-change.service.ts
@@ -29,7 +29,7 @@ export class EmScheduleChangeService implements OnDestroy {
   onFolderChange = new EventEmitter();
 
   constructor(private stompClient: StompClientService, private zone: NgZone) {
-    this.stompClient.connect("../vs-events").subscribe(
+    this.stompClient.connect("../vs-events", true).subscribe(
        (connection) => {
          this.connection = connection;
          this.subscriptions.add(connection.subscribe(

--- a/web/projects/shared/schedule/schedule-users.service.ts
+++ b/web/projects/shared/schedule/schedule-users.service.ts
@@ -50,7 +50,7 @@ export class ScheduleUsersService implements OnDestroy {
          this.url = "../api/portal/schedule/users-model";
       }
 
-      this.stompClient.connect("../vs-events", true).subscribe(connection => {
+      this.stompClient.connect("../vs-events", !portal).subscribe(connection => {
          this.connection = connection;
 
          this.subscription.add(connection.subscribe("/user/schedule/users-change",


### PR DESCRIPTION
During testing, our colleague observed in AKS that a certain organization's audit log contained records from other organizations' resources. Based on code analysis, this issue may occur because the correct em flag was not passed when establishing the WebSocket connection. When a site admin is simultaneously logged into both EM and Portal with a shared session, the system retrieves an incorrect principal, leading to the wrong orgId being fetched.