### PR TITLE
fix Bug 71859, fix issue that some org user get host-org resource in AKS

### DIFF
--- a/core/src/main/java/inetsoft/util/BlobIndexedStorage.java
+++ b/core/src/main/java/inetsoft/util/BlobIndexedStorage.java
@@ -76,6 +76,10 @@ public class BlobIndexedStorage extends AbstractIndexedStorage {
    @Override
    public XMLSerializable getXMLSerializable(String key, TransformListener trans, String orgID) throws Exception {
       try {
+         if(!Tool.isEmptyString(orgID) && !cachedOrgIDs.contains(orgID)) {
+            throw new RuntimeException("The target organization does not exist: " + orgID);
+         }
+
          BlobStorage<Metadata> storage = getMetadataStorage(orgID);
          Metadata metadata = storage.getMetadata(key);
          AssetEntry entry = AssetEntry.createAssetEntry(key);
@@ -164,6 +168,10 @@ public class BlobIndexedStorage extends AbstractIndexedStorage {
    @Override
    public Document getDocument(String key, String orgID) {
       try {
+         if(!Tool.isEmptyString(orgID) && !cachedOrgIDs.contains(orgID)) {
+            throw new RuntimeException("The target organization does not exist: " + orgID);
+         }
+
          Metadata metadata = getMetadataStorage(orgID).getMetadata(key);
 
          if(metadata.getFolder() != null) {
@@ -241,6 +249,10 @@ public class BlobIndexedStorage extends AbstractIndexedStorage {
    }
 
    public byte[] get(String key, String orgID) throws Exception {
+      if(!Tool.isEmptyString(orgID) && !cachedOrgIDs.contains(orgID)) {
+         throw new RuntimeException("The target organization does not exist: " + orgID);
+      }
+
       try(InputStream input = getMetadataStorage(orgID).getInputStream(key)) {
          return IOUtils.toByteArray(input);
       }

--- a/core/src/main/java/inetsoft/web/admin/schedule/EMScheduleTaskFolderController.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/EMScheduleTaskFolderController.java
@@ -185,14 +185,16 @@ public class EMScheduleTaskFolderController {
       ScheduleTaskModel[] taskModels = request.getTasks();
       ScheduleManager scheduleManager = ScheduleManager.getScheduleManager();
 
-      for(ScheduleTaskModel taskModel : taskModels) {
-         ScheduleTask task = scheduleManager.getScheduleTask(taskModel.name());
+      if(taskModels != null) {
+         for(ScheduleTaskModel taskModel : taskModels) {
+            ScheduleTask task = scheduleManager.getScheduleTask(taskModel.name());
 
-         if(!(SecurityEngine.getSecurity().checkPermission(principal,
-            ResourceType.SCHEDULE_TASK, taskModel.name(), ResourceAction.WRITE) ||
-            (task != null && scheduleTaskService.canDeleteTask(task, principal))))
-         {
-            return;
+            if(!(SecurityEngine.getSecurity().checkPermission(principal,
+               ResourceType.SCHEDULE_TASK, taskModel.name(), ResourceAction.WRITE) ||
+               (task != null && scheduleTaskService.canDeleteTask(task, principal))))
+            {
+               return;
+            }
          }
       }
 

--- a/web/projects/em/src/app/settings/content/drivers-and-plugins/plugins-view/plugins-view.component.ts
+++ b/web/projects/em/src/app/settings/content/drivers-and-plugins/plugins-view/plugins-view.component.ts
@@ -193,7 +193,7 @@ export class PluginsViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
    private connectSocket(): void {
       if(!this.connecting && !this.connection) {
-         this.client.connect("../vs-events").subscribe(
+         this.client.connect("../vs-events", true).subscribe(
             (connection) => {
                this.connecting = false;
                this.connection = connection;

--- a/web/projects/em/src/app/settings/content/materialized-views/mv-management-view/mv-change.service.ts
+++ b/web/projects/em/src/app/settings/content/materialized-views/mv-management-view/mv-change.service.ts
@@ -37,7 +37,7 @@ export class MVChangeService implements OnDestroy {
 
    private connectSocket(): void {
       if(!this.connecting && !this.connection) {
-         this.client.connect("../vs-events").subscribe(
+         this.client.connect("../vs-events", true).subscribe(
             (connection) => {
                this.connecting = false;
                this.connection = connection;

--- a/web/projects/em/src/app/settings/content/repository/repository-tree-data-source.ts
+++ b/web/projects/em/src/app/settings/content/repository/repository-tree-data-source.ts
@@ -148,7 +148,7 @@ export class RepositoryTreeDataSource
 
    private connectSocket(init?: boolean): void {
       if(!this.connecting && !this.connection) {
-         this.client.connect("../vs-events").subscribe(
+         this.client.connect("../vs-events", true).subscribe(
             (connection) => {
                this.connecting = false;
                this.connection = connection;

--- a/web/projects/em/src/app/settings/schedule/schedule-task-list/em-schedule-change.service.ts
+++ b/web/projects/em/src/app/settings/schedule/schedule-task-list/em-schedule-change.service.ts
@@ -29,7 +29,7 @@ export class EmScheduleChangeService implements OnDestroy {
   onFolderChange = new EventEmitter();
 
   constructor(private stompClient: StompClientService, private zone: NgZone) {
-    this.stompClient.connect("../vs-events").subscribe(
+    this.stompClient.connect("../vs-events", true).subscribe(
        (connection) => {
          this.connection = connection;
          this.subscriptions.add(connection.subscribe(

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-query/database-query.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-query/database-query.component.html
@@ -92,7 +92,8 @@
           <sql-query-preview-pane class="tab-pane-content"
                                   [runtimeId]="runtimeId"
                                   [sqlString]="queryModel?.freeFormSQLPaneModel?.sqlString"
-                                  [tableCount]="queryModel?.linkPaneModel?.tables?.length">
+                                  [tableCount]="queryModel?.linkPaneModel?.tables?.length"
+                                  (goBackToPreviousTab)="updateTab(oldTab)">
           </sql-query-preview-pane>
         </ng-template>
       </ng-container>

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-query/database-query.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-query/database-query.component.ts
@@ -82,7 +82,7 @@ export class DatabaseQueryComponent implements OnDestroy {
       if(!!model?.freeFormSQLPaneModel.sqlString &&
          model?.freeFormSQLPaneModel.parseResult == ParseResult.PARSE_FAILED)
       {
-         this.activeTab = DatabaseQueryTabs.SQL_STRING;
+         this.updateTab(DatabaseQueryTabs.SQL_STRING)
       }
 
       this.oldSqlString = model.freeFormSQLPaneModel.sqlString;
@@ -92,6 +92,7 @@ export class DatabaseQueryComponent implements OnDestroy {
    @Input() sessionOperations: OperationModel[];
    @ViewChild("queryConditionsPane") queryConditionsPane: QueryConditionsPaneComponent;
    activeTab: string = DatabaseQueryTabs.LINKS;
+   oldTab: string = this.activeTab;
    private subscriptions: Subscription = new Subscription();
    private oldSqlString: string;
 
@@ -147,15 +148,15 @@ export class DatabaseQueryComponent implements OnDestroy {
       let nextTab = event.nextId;
 
       if(this.activeTab == DatabaseQueryTabs.FIELDS) {
-         this.updateQuery(DatabaseQueryTabs.FIELDS, () => this.activeTab = nextTab);
+         this.updateQuery(DatabaseQueryTabs.FIELDS, () => this.updateTab(nextTab));
       }
       else if(this.activeTab == DatabaseQueryTabs.CONDITIONS) {
          this.queryConditionsPane.checkDirtyConditions().then(() => {
-            this.updateQuery(DatabaseQueryTabs.CONDITIONS, () => this.activeTab = nextTab);
+            this.updateQuery(DatabaseQueryTabs.CONDITIONS, () => this.updateTab(nextTab));
          });
       }
       else if(this.activeTab == DatabaseQueryTabs.SORT) {
-         this.updateQuery(DatabaseQueryTabs.SORT, () => this.activeTab = nextTab);
+         this.updateQuery(DatabaseQueryTabs.SORT, () => this.updateTab(nextTab));
       }
       else if(this.activeTab == DatabaseQueryTabs.GROUPING) {
          this.switchFromGroupingTab(nextTab);
@@ -168,10 +169,18 @@ export class DatabaseQueryComponent implements OnDestroy {
             });
       }
       else if(this.activeTab == DatabaseQueryTabs.LINKS && nextTab == DatabaseQueryTabs.SQL_STRING) {
-         this.queryModelService.emitModelChange(() => this.activeTab = nextTab);
+         this.queryModelService.emitModelChange(() => this.updateTab(nextTab));
       }
       else {
-         this.activeTab = nextTab;
+         this.updateTab(nextTab);
+      }
+   }
+
+   updateTab(tab: string) {
+      this.activeTab = tab;
+
+      if(tab != DatabaseQueryTabs.PREVIEW) {
+         this.oldTab = this.activeTab;
       }
    }
 
@@ -207,7 +216,7 @@ export class DatabaseQueryComponent implements OnDestroy {
                   {"yes": "_#(js:Yes)", "no": "_#(js:No)"})
             .then((response) => {
                if(response == "yes") {
-                  this.activeTab = nextTab;
+                  this.updateTab(nextTab);
                }
             });
          }
@@ -222,22 +231,22 @@ export class DatabaseQueryComponent implements OnDestroy {
             ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)", msg);
          }
          else {
-            this.activeTab = nextTab;
+            this.updateTab(nextTab);
          }
       }
       else {
-         this.activeTab = nextTab;
+         this.updateTab(nextTab);
       }
    }
 
    switchFromGroupingTab(nextTab: any): void {
       if(this.validGroupBy) {
          if(this.queryGroupingPane.isGroupByPane()) {
-            this.updateQuery(DatabaseQueryTabs.GROUPING, () => this.activeTab = nextTab);
+            this.updateQuery(DatabaseQueryTabs.GROUPING, () => this.updateTab(nextTab));
          }
          else {
             this.queryGroupingPane.havingConditionsPane.checkDirtyConditions().then(() => {
-               this.updateQuery(DatabaseQueryTabs.GROUPING, () => this.activeTab = nextTab);
+               this.updateQuery(DatabaseQueryTabs.GROUPING, () => this.updateTab(nextTab));
             });
          }
       }
@@ -275,7 +284,7 @@ export class DatabaseQueryComponent implements OnDestroy {
    }
 
    public resetActiveTab(): void {
-      this.activeTab = DatabaseQueryTabs.LINKS;
+      this.updateTab(DatabaseQueryTabs.LINKS);
    }
 
    public checkQuery(): Promise<void> {

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-query/query-preview/sql-query-preview-pane.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-query/query-preview/sql-query-preview-pane.component.ts
@@ -15,7 +15,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { Component, ElementRef, Input, OnDestroy, OnInit } from "@angular/core";
+import {
+   Component,
+   ElementRef,
+   EventEmitter,
+   Input,
+   OnDestroy,
+   OnInit,
+   Output
+} from "@angular/core";
 import { HttpClient, HttpParams } from "@angular/common/http";
 import { Rectangle } from "../../../../../../common/data/rectangle";
 import { GuiTool } from "../../../../../../common/util/gui-tool";
@@ -35,6 +43,7 @@ export class SqlQueryPreviewPaneComponent implements OnDestroy, OnInit {
    @Input() sqlString: string;
    @Input() tableCount: number;
    @Input() sqlEdited: boolean;
+   @Output() goBackToPreviousTab = new EventEmitter<void>();
    previewPending: boolean = false;
    tableData: string[][];
    scrollbarWidth: number;
@@ -94,6 +103,7 @@ export class SqlQueryPreviewPaneComponent implements OnDestroy, OnInit {
       },
       () => {
          this.previewPending = false;
+         this.goBackToPreviousTab.emit();
       });
    }
 

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/datasources-database.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/datasources-database.component.ts
@@ -406,13 +406,13 @@ export class DatasourcesDatabaseComponent extends DataSourceSettingsPage impleme
             let message: string = "";
 
             if(this.model.settings.dataSource.name == value.trim()) {
-               message = "_#(js:common.datasource.nameInvalid)";
+               message = Tool.formatCatalogString("_#(js:common.datasource.nameInvalid)", [value]);
                duplicate = true;
             }
             else if(!!this.additionalDataSources && this.additionalDataSources.map(
                (source) => source.name).indexOf(value.trim()) != -1)
             {
-               message = "_#(js:common.datasource.nameExists)";
+               message = Tool.formatCatalogString("_#(js:common.datasource.nameExists)", [value]);
                duplicate = true;
             }
 
@@ -444,7 +444,6 @@ export class DatasourcesDatabaseComponent extends DataSourceSettingsPage impleme
          .subscribe((response) =>
       {
          if(!!response && !!response.datasources && response.datasources.length > 0) {
-            console.log(response.datasources.join());
             ComponentTool.showConfirmDialog(this.modalService, "_#(js:Confirm)",
                Tool.formatCatalogString("_#(js:common.datasource.connectionUsedByExtendedModel)",
                   [response.datasources.join()]))
@@ -496,13 +495,13 @@ export class DatasourcesDatabaseComponent extends DataSourceSettingsPage impleme
       let message: string = "";
 
       if(this.model.settings.dataSource.name == value.trim()) {
-         message = "_#(js:common.datasource.nameInvalid)";
+         message = Tool.formatCatalogString("_#(js:common.datasource.nameInvalid)", [value]);
          duplicate = true;
       }
       else if(!!this.additionalDataSources && this.getSelectedAdditional()[0].name != value.trim()
          && this.additionalDataSources.map((source) => source.name).indexOf(value.trim()) != -1)
       {
-         message = "_#(js:common.datasource.nameExists)";
+         message = Tool.formatCatalogString("_#(js:common.datasource.nameExists)", [value]);
          duplicate = true;
       }
 

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -3196,8 +3196,28 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
             height += 19;
          }
 
+         if(!!this.viewerToolbar) {
+            width = Math.max(width, this.getMinimumToolbarWidth(this.viewerToolbar));
+         }
+
          this.onViewerSizeChanged.emit({width: this.fitToWidth ? null : width, height: height});
       }
+   }
+
+   private getMinimumToolbarWidth(toolbar: ElementRef): number {
+      let toolbarWidth = 0;
+
+      toolbar.nativeElement.childNodes.forEach((child: HTMLElement) => {
+         if(!child?.getBoundingClientRect || !child?.getBoundingClientRect() ||
+            child?.classList?.contains("hidden-input"))
+         {
+            return;
+         }
+
+         toolbarWidth += child.getBoundingClientRect().width;
+      });
+
+      return toolbarWidth;
    }
 
    /**

--- a/web/projects/portal/src/app/widget/dialog/sql-query-dialog/simple-query-pane.component.html
+++ b/web/projects/portal/src/app/widget/dialog/sql-query-dialog/simple-query-pane.component.html
@@ -129,7 +129,8 @@
                                 [runtimeId]="runtimeId"
                                 [sqlString]="model?.sqlString"
                                 [tableCount]="tableCount"
-                                [sqlEdited]="model.sqlEdited">
+                                [sqlEdited]="model.sqlEdited"
+                                (goBackToPreviousTab)="goBackToPreviousTab()">
         </sql-query-preview-pane>
       </ng-template>
     </ng-container>

--- a/web/projects/portal/src/app/widget/dialog/sql-query-dialog/simple-query-pane.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/sql-query-dialog/simple-query-pane.component.ts
@@ -154,6 +154,7 @@ export class SimpleQueryPaneComponent {
    conditionDialogModel: VPMConditionDialogModel;
    selectedConditionIndex: number = -1;
    private _defaultTab: string = this.editTab;
+   private _oldTab: string = this._defaultTab;
 
    get defaultTab(): string {
       return this._defaultTab;
@@ -643,6 +644,11 @@ export class SimpleQueryPaneComponent {
       }
       else {
          this._defaultTab = next;
+         this._oldTab = this._defaultTab;
       }
+   }
+
+   goBackToPreviousTab(): void {
+      this._defaultTab = this._oldTab;
    }
 }

--- a/web/projects/shared/schedule/schedule-users.service.ts
+++ b/web/projects/shared/schedule/schedule-users.service.ts
@@ -50,7 +50,7 @@ export class ScheduleUsersService implements OnDestroy {
          this.url = "../api/portal/schedule/users-model";
       }
 
-      this.stompClient.connect("../vs-events", true).subscribe(connection => {
+      this.stompClient.connect("../vs-events", !portal).subscribe(connection => {
          this.connection = connection;
 
          this.subscription.add(connection.subscribe("/user/schedule/users-change",


### PR DESCRIPTION
fix Bug #71850, Bug #71859,
Based on the code analysis, the issue likely occurs due to limited cloud service resources causing slow request responses. When deleting an organization, if someone simultaneously requests resources from that organization, cause get null object from storage, then continue to get host org resource if exposeDefaultOrg is true(see DatasourceRegister.getObject and AbstractAssetEngine.getWorksheetEntries), resulting in the described bug.

To fix this, throw runtime exception if the organization doesn't exist when get resource from storage instead of returning null, preventing other organizations from erroneously accessing the host org's resources.