### PR TITLE
fix Bug #71849. Normalize the runtime ID when touching the file.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/event/AssetEventUtil.java
+++ b/core/src/main/java/inetsoft/report/composition/event/AssetEventUtil.java
@@ -1573,7 +1573,13 @@ public class AssetEventUtil {
     * @param table the specified table.
     */
    public static void initColumnSelection(RuntimeWorksheet rws,
-                                          TableAssembly table) throws Exception {
+                                          TableAssembly table)
+      throws Exception
+   {
+      if(rws.isDisposed()) {
+         return;
+      }
+
       initColumnSelection(rws.getAssetQuerySandbox(), table);
    }
 

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/ImportCSVDialogController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/ImportCSVDialogController.java
@@ -227,7 +227,8 @@ public class ImportCSVDialogController extends WorksheetController {
    @ResponseBody
    public void touchFile(@PathVariable("runtimeId") String runtimeId) throws IOException {
       String cdir = FileSystemService.getInstance().getCacheDirectory();
-      fileCache.get(cdir + Tool.byteDecode(runtimeId) + "_csv");
+      runtimeId = Tool.normalizeFileName(Tool.byteDecode(runtimeId));
+      fileCache.get(cdir + runtimeId + "_csv");
    }
 
    @MessageMapping("/ws/dialog/import-csv-dialog-model")


### PR DESCRIPTION
When uploading the file, the runtime ID in the cache key is normalized, so the same normalization should be applied when touching the file.