### PR TITLE
fix Bug #71850, Bug #71859,  fix issue that other org user get host org resource

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/AbstractAssetEngine.java
+++ b/core/src/main/java/inetsoft/uql/asset/AbstractAssetEngine.java
@@ -386,24 +386,26 @@ public abstract class AbstractAssetEngine implements AssetRepository, AutoClosea
       }
 
       String orgID = OrganizationManager.getInstance().getCurrentOrgID();
+      String hostOrgID = Organization.getDefaultOrganizationID();
+
       //pass default org global repository if inside global visible folder
       if(SUtil.isDefaultVSGloballyVisible(user) &&
-         Tool.equals(entry.getOrgID(), Organization.getDefaultOrganizationID()) &&
+         Tool.equals(entry.getOrgID(), hostOrgID) &&
          Tool.equals(entry.getPath(), OrganizationManager.getGlobalDefOrgFolderName()))
       {
          identifier = "1^4097^__NULL__^/^host-org";
-         orgID = Organization.getDefaultOrganizationID();
+         orgID = hostOrgID;
       }
+
       XMLSerializable obj = storage.getXMLSerializable(identifier, null, orgID);
 
       //catch default org folder by checking as host org
       if(obj == null && SUtil.isDefaultVSGloballyVisible(user) &&
+         Tool.equals(entry.getOrgID(), hostOrgID) &&
          !Tool.equals(identifier, "1^4097^__NULL__^/^"+Organization.getSelfOrganizationID()) &&
-         !Tool.equals(identifier, "1^1^__NULL__^/^"+Organization.getSelfOrganizationID())
-      ) {
-         AssetEntry tmp = (AssetEntry) entry.clone();
-         tmp.setOrgID(Organization.getDefaultOrganizationID());
-         obj = storage.getXMLSerializable(tmp.toIdentifier(true), null, Organization.getDefaultOrganizationID());
+         !Tool.equals(identifier, "1^1^__NULL__^/^"+Organization.getSelfOrganizationID()))
+      {
+         obj = storage.getXMLSerializable(identifier, null, hostOrgID);
       }
 
       if(obj instanceof AssetFolder) {

--- a/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
@@ -1526,15 +1526,14 @@ public class DataSourceRegistry implements MessageListener {
             }
          }
 
+         String hostOrgID = Organization.getDefaultOrganizationID();
+
          //if object is null, retry with host-org when global default visible
          if(result == null && SUtil.isDefaultVSGloballyVisible() && !ignoreGlobalShare() &&
-                              !Tool.equals(orgId, Organization.getDefaultOrganizationID())) {
-            orgId = Organization.getDefaultOrganizationID();
-            AssetEntry hentry = (AssetEntry) entry.clone();
-            hentry.setOrgID(orgId);
-
+            !Tool.equals(orgId, hostOrgID) && Tool.equals(entry.getOrgID(), hostOrgID))
+         {
             try {
-               result = indexedStorage.getXMLSerializable(hentry.toIdentifier(true), null, orgId);
+               result = indexedStorage.getXMLSerializable(identifier, null, hostOrgID);
             }
             catch(Exception e) {
                LOG.error("Failed to get object: {}", entry.getPath(), e);


### PR DESCRIPTION
According to the code analysis, the issue is likely due to limited cloud service resources causing slow response times. When deleting an organization, if someone simultaneously requests resources from that organization may get host org resources.

The solution is to ensure that the AssetEntry used to obtain resources holds the correct orgID. Specifically, when an org user accesses shared global resources, the AssetEntry's orgID should be set to the host organization's ID.