### PR TITLE
Bug #71861

### DIFF
--- a/web/projects/portal/src/app/vs-wizard/gui/object-wizard/wizard-binding-tree.component.ts
+++ b/web/projects/portal/src/app/vs-wizard/gui/object-wizard/wizard-binding-tree.component.ts
@@ -299,7 +299,11 @@ export class WizardBindingTree extends CommandProcessor implements OnInit, OnDes
             .filter(node => !!node && !!node.data)
             .map((node) => node.data),
          false, tableName, null, !!reload);
-      this.viewsheetClient.sendEvent(REFRESH_BINDING_NODES_CHANGED_URI, event);
+
+      //Don't refresh bindings if !reload to prevent cancelling executing queries
+      if(!(tableName == null && reload == false)) {
+         this.viewsheetClient.sendEvent(REFRESH_BINDING_NODES_CHANGED_URI, event);
+      }
    }
 
    /**


### PR DESCRIPTION
Check before refreshing binding to prevent cancelling executing queries from second call to refresh bindings on select node