### PR TITLE
fix Bug #71898, change label of the mv that has parent vs.

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/MVService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/MVService.java
@@ -301,13 +301,13 @@ public class MVService {
       List<String> parentVsIds = def.getParentVsIds();
       String parentVsIdsStr = parentVsIds != null && !parentVsIds.isEmpty() ?
          parentVsIds.stream()
-            .map(id -> AssetEntry.createAssetEntry(id).getPath())
+            .map(id -> Tool.buildString("\"", AssetEntry.createAssetEntry(id).getPath(), "\""))
             .collect(Collectors.joining(" -> "))
          : null;
       return Arrays.stream(data.getRegisteredSheets())
          .map(id -> AssetEntry.createAssetEntry(id).getPath())
          .filter(path -> (!path.startsWith(RECYCLE_BIN_FOLDER)))
-         .map(path -> parentVsIdsStr != null ? parentVsIdsStr + " -> " + path : path)
+         .map(path -> parentVsIdsStr != null ? parentVsIdsStr + " -> " + Tool.buildString("\"", path, "\"")  : path)
          .collect(Collectors.joining(","));
    }
 


### PR DESCRIPTION
if vs mv has parent vs, change label from parent -> child to "parent" -> "child", because other vs can be renamed to parent -> child, in mv list, it is no way to distinguish.