### PR TITLE
fix Bug #71928, do not wait the current thread when sql is not parse SQL.

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
@@ -1487,7 +1487,7 @@ public class QueryManagerService {
          sql.setSQLString(sqlString);
 
          // it is waiting for the parser finish parsing the sql string.
-         if(!Tool.equals(sqlString, sql.getSQLString())) {
+         if(!Tool.equals(sqlString, sql.getSQLString()) && sql.isParseSQL()) {
             try {
                sql.wait();
             }
@@ -1605,11 +1605,13 @@ public class QueryManagerService {
       synchronized(sql) {
          sql.setSQLString(nsqlString);
 
-         // it is waiting for the parser finish parsing the sql string.
-         try {
-            sql.wait();
-         }
-         catch(InterruptedException e) {
+         if(sql.isParseSQL()) {
+            // it is waiting for the parser finish parsing the sql string.
+            try {
+               sql.wait();
+            }
+            catch(InterruptedException e) {
+            }
          }
       }
 


### PR DESCRIPTION
if it is not parse SQL the sql string will not auto parse, so need not wait parse finish.