### PR TITLE
fix Bug #71916. Users with admin permissions over the task owner should be allowed to edit the task.

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
@@ -228,8 +228,19 @@ public class ScheduleTaskService {
       }
 
       OrganizationManager organizationManager = OrganizationManager.getInstance();
+      boolean adminPermission = false;
 
-      if(organizationManager.isSiteAdmin(principal) || organizationManager.isOrgAdmin(principal)) {
+      try {
+         SecurityEngine securityEngine = SecurityEngine.getSecurity();
+         adminPermission = securityEngine.checkPermission(
+            principal, ResourceType.SECURITY_USER, task.getOwner(), ResourceAction.ADMIN);
+      }
+      catch(Exception ignore) {
+      }
+
+      if(organizationManager.isSiteAdmin(principal) || organizationManager.isOrgAdmin(principal) ||
+         adminPermission)
+      {
          return true;
       }
 


### PR DESCRIPTION
If the current user has admin permissions over the task’s owner, they should have edit permissions on the task even if the 'Modify By Owner Only' option is set to true.