### PR TITLE
fix Bug #71927, fix not create right columnselection after getting columninfo by sqlstring.

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
@@ -1777,8 +1777,9 @@ public class QueryManagerService {
       UniformSQL sql = (UniformSQL) query.getSQLDefinition();
       ColumnSelection columns = new ColumnSelection();
 
-      if(sql.getParseResult() == UniformSQL.PARSE_SUCCESS ||
-         sql.getParseResult() == UniformSQL.PARSE_PARTIALLY)
+      if((sql.getParseResult() == UniformSQL.PARSE_SUCCESS ||
+         sql.getParseResult() == UniformSQL.PARSE_PARTIALLY) &&
+         sql.getSelection().getColumnCount() > 0)
       {
          JDBCSelection selection = (JDBCSelection) sql.getSelection();
 


### PR DESCRIPTION
caused by parseresult be changed when set sqlstring. fix by checking selection column count when create columnselection by uniformsql since column count should larger than 0 if really PARSE_SUCCESS or  PARSE_PARTIALLY