### PR TITLE
fix Bug #71914, fix CloudFront timeout for create mv.

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/MVController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/MVController.java
@@ -17,6 +17,8 @@
  */
 package inetsoft.web.admin.content.repository;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import inetsoft.mv.trans.UserInfo;
 import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.DataCycleManager;
@@ -35,9 +37,10 @@ import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
 import java.security.Principal;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @RestController
@@ -50,6 +53,10 @@ public class MVController {
       this.mvService = mvService;
       this.support = support;
       this.securityProvider = securityProvider;
+      this.createMVCache = Caffeine.newBuilder()
+         .expireAfterAccess(10L, TimeUnit.MINUTES)
+         .maximumSize(1000L)
+         .build();
    }
 
    @PostMapping("/api/em/content/repository/mv/analyze")
@@ -121,9 +128,54 @@ public class MVController {
    }
 
    @PostMapping("/api/em/content/repository/mv/create")
-   public void create(HttpServletRequest req,
+   public CreateMVResponse create(HttpServletRequest req,
+                      @RequestParam(name = "createId", required = false) String createId,
                       @RequestBody CreateUpdateMVRequest createUpdateMVRequest,
                       Principal principal) throws Throwable
+   {
+      if(createId != null) {
+         CompletableFuture<CreateMVResponse> future = createMVCache.getIfPresent(createId);
+
+         if(future != null) {
+            if(future.isDone()) {
+               createMVCache.invalidate(createId);
+               return future.get();
+            }
+            else {
+               return CreateMVResponse.builder().complete(false).build();
+            }
+         }
+      }
+
+      if(createId == null) {
+         create0(req, createUpdateMVRequest, principal);
+         return CreateMVResponse.builder().complete(true).build();
+      }
+      else if(createMVCache.getIfPresent(createId) == null) {
+         CompletableFuture<CreateMVResponse> future = new CompletableFuture<>();
+         createMVCache.put(createId, future);
+         ThreadPool.addOnDemand(() -> {
+            Principal oPrincipal = ThreadContext.getPrincipal();
+            ThreadContext.setPrincipal(principal);
+
+            try {
+               create0(req, createUpdateMVRequest, principal);
+               future.complete(CreateMVResponse.builder().complete(true).build());
+            }
+            catch(Throwable e) {
+               future.completeExceptionally(e);
+            }
+
+            ThreadContext.setPrincipal(oPrincipal);
+         });
+      }
+
+      return CreateMVResponse.builder().complete(false).build();
+   }
+
+   public void create0(HttpServletRequest req, CreateUpdateMVRequest createUpdateMVRequest,
+                       Principal principal)
+      throws Throwable
    {
       ActionRecord actionRecord = SUtil.getActionRecord(
          principal, ActionRecord.ACTION_NAME_CREATE,
@@ -294,4 +346,5 @@ public class MVController {
    private final MVService mvService;
    private final MVSupportService support;
    private final SecurityProvider securityProvider;
+   private final Cache<String, CompletableFuture<CreateMVResponse>> createMVCache;
 }

--- a/core/src/main/java/inetsoft/web/admin/content/repository/model/CreateMVResponse.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/model/CreateMVResponse.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.admin.content.repository.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableCreateMVResponse.class)
+public interface CreateMVResponse {
+   @Value.Default
+   default boolean failed() { return false; }
+
+   @Value.Default
+   default boolean complete() {
+      return true;
+   }
+
+   static CreateMVResponse.Builder builder() {
+      return new CreateMVResponse.Builder();
+   }
+
+   final class Builder extends ImmutableCreateMVResponse.Builder {
+   }
+}

--- a/web/projects/shared/util/model/mv/create-mv-response.ts
+++ b/web/projects/shared/util/model/mv/create-mv-response.ts
@@ -1,0 +1,22 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export interface CreateMvResponse {
+   failed?: boolean;
+   complete?: boolean;
+}


### PR DESCRIPTION
    In AWS, when using CloudFront, the response has a time out period with a maximum of 60 seconds. If the MV execution is slow, the request will timeout. 
    For MV creation requests, add a creation ID. The server creates a separate thread for each creation ID to execute the MV, and the client polls the MV creation status at 2-second intervals to avoid a single request taking too long.