### PR TITLE
Fix Bug #71884:Add a unique identifier to prevent radio button selection errors.

### DIFF
--- a/web/projects/portal/src/app/portal/dialog/vpm-condition-dialog/vpm-condition-pane/vpm-condition-pane.component.html
+++ b/web/projects/portal/src/app/portal/dialog/vpm-condition-dialog/vpm-condition-pane/vpm-condition-pane.component.html
@@ -36,7 +36,7 @@
       </div>
       <div class="form-check">
         <label class="form-check-label">
-          <input type="radio" name="vpm-andOrButtons"
+          <input type="radio" name="vpm-andOrButtons-{{uniquePageId}}"
                  class="form-check-input"
                  [(ngModel)]="conjunction.conjunction"
                  [value]="ConjunctionTypes.AND"
@@ -47,7 +47,7 @@
       </div>
       <div class="form-check">
         <label class="form-check-label">
-          <input type="radio" name="vpm-andOrButtons"
+          <input type="radio" name="vpm-andOrButtons-{{uniquePageId}}"
                  class="form-check-input"
                  [(ngModel)]="conjunction.conjunction"
                  [value]="ConjunctionTypes.OR"

--- a/web/projects/portal/src/app/portal/dialog/vpm-condition-dialog/vpm-condition-pane/vpm-condition-pane.component.ts
+++ b/web/projects/portal/src/app/portal/dialog/vpm-condition-dialog/vpm-condition-pane/vpm-condition-pane.component.ts
@@ -55,6 +55,7 @@ export class VPMConditionPane implements OnInit {
    ConjunctionTypes = ConjunctionTypes;
    private _conditionList: ConditionItemModel[]; // even indexes contain conditions, odd contain junctions
    private _condition: ClauseModel;
+   uniquePageId = Math.random().toString(36).substring(2);
 
    /**
     * Input for conditionList. If condition list is empty, create and select a new empty clause.


### PR DESCRIPTION
Because the same component is opened twice and their radio buttons have the same name, they are automatically rendered on the first page. Therefore, adding a unique identifier to the name can avoid this issue.