### PR TITLE
Fix Bug #71882: Add a check for this.shareConfig.

### DIFF
--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -3512,31 +3512,31 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
    }
 
    isShareEmailDisabled(): boolean {
-      return !(this.shareConfig && this.shareConfig.emailEnabled);
+      return !this.shareConfig?.emailEnabled;
    }
 
    isShareFacebookDisabled(): boolean {
-      return !(this.shareConfig && this.shareConfig.facebookEnabled);
+      return !this.shareConfig?.facebookEnabled;
    }
 
    isShareHangoutsDisabled(): boolean {
-      return !(this.shareConfig && this.shareConfig.googleChatEnabled);
+      return !this.shareConfig?.googleChatEnabled;
    }
 
    isShareLinkedInDisabled(): boolean {
-      return !(this.shareConfig && this.shareConfig.linkedinEnabled);
+      return !this.shareConfig?.linkedinEnabled;
    }
 
    isShareSlackDisabled(): boolean {
-      return !(this.shareConfig && this.shareConfig.slackEnabled);
+      return !this.shareConfig?.slackEnabled;
    }
 
    isShareTwitterDisabled(): boolean {
-      return !(this.shareConfig && this.shareConfig.twitterEnabled);
+      return !this.shareConfig?.twitterEnabled;
    }
 
    isShareLinkDisabled(): boolean {
-      return !(this.shareConfig && this.shareConfig.linkEnabled);
+      return !this.shareConfig?.linkEnabled;
    }
 
    isScheduleVisible(): boolean {


### PR DESCRIPTION
Because Firefox may trigger the this check earlier in certain cases (such as ES6 modules or strict mode), causing this.shareConfig to be accessed before initialization, we also need to add a check for this.shareConfig.