### PR TITLE
fix Bug #71910, NPE check

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/AuthenticationChain.java
+++ b/core/src/main/java/inetsoft/sree/security/AuthenticationChain.java
@@ -101,6 +101,7 @@ public class AuthenticationChain
       }
 
       return stream()
+         .filter(p -> p.getOrganizationIDs() != null)
          .flatMap(p -> Arrays.stream(p.getOrganizationIDs()))
          .distinct()
          .toArray(String[]::new);


### PR DESCRIPTION
cannot guess what operations AWS performed that caused the provider's organizationId array to be empty, so just add NPE check.