### PR TITLE
Fix Bug #71945:Modify the email subject when a task fails in Community edition to exclude organization information.

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
@@ -629,13 +629,12 @@ public class ScheduleTask implements Serializable, Cloneable, XMLSerializable {
                   // send task failed mail
                   if(SreeEnv.getBooleanProperty("schedule.options.taskFailed", "true", "CHECKED"))
                   {
-                     boolean isMultiTenant = SUtil.isMultiTenant();
                      String subject = Catalog.getCatalog().getString(
                         "em.scheduler.notification.taskFailedSub.community", getName(),
                         (new SimpleDateFormat("hh:mma yyyy-MM-dd"))
                            .format(new Date()));
 
-                     if(isMultiTenant) {
+                     if(SUtil.isMultiTenant()) {
                         subject = Catalog.getCatalog().getString(
                            "em.scheduler.notification.taskFailedSub",
                            SUtil.getTaskNameWithoutOrg(getTaskId()),

--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
@@ -629,13 +629,13 @@ public class ScheduleTask implements Serializable, Cloneable, XMLSerializable {
                   // send task failed mail
                   if(SreeEnv.getBooleanProperty("schedule.options.taskFailed", "true", "CHECKED"))
                   {
-                     boolean isEnterprise = LicenseManager.getInstance().isEnterprise();
+                     boolean isMultiTenant = SUtil.isMultiTenant();
                      String subject = Catalog.getCatalog().getString(
                         "em.scheduler.notification.taskFailedSub.community", getName(),
                         (new SimpleDateFormat("hh:mma yyyy-MM-dd"))
                            .format(new Date()));
 
-                     if(isEnterprise) {
+                     if(isMultiTenant) {
                         subject = Catalog.getCatalog().getString(
                            "em.scheduler.notification.taskFailedSub",
                            SUtil.getTaskNameWithoutOrg(getTaskId()),

--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
@@ -629,11 +629,21 @@ public class ScheduleTask implements Serializable, Cloneable, XMLSerializable {
                   // send task failed mail
                   if(SreeEnv.getBooleanProperty("schedule.options.taskFailed", "true", "CHECKED"))
                   {
+                     boolean isEnterprise = LicenseManager.getInstance().isEnterprise();
                      String subject = Catalog.getCatalog().getString(
-                        "em.scheduler.notification.taskFailedSub",
-                        SUtil.getTaskNameWithoutOrg(getTaskId()), SUtil.getTaskOrgName(getTaskId(), principal),
+                        "em.scheduler.notification.taskFailedSub.community", getName(),
                         (new SimpleDateFormat("hh:mma yyyy-MM-dd"))
-                        .format(new Date()));
+                           .format(new Date()));
+
+                     if(isEnterprise) {
+                        subject = Catalog.getCatalog().getString(
+                           "em.scheduler.notification.taskFailedSub",
+                           SUtil.getTaskNameWithoutOrg(getTaskId()),
+                           SUtil.getTaskOrgName(getTaskId(), principal),
+                           (new SimpleDateFormat("hh:mma yyyy-MM-dd"))
+                              .format(new Date()));
+                     }
+
                      String body = Catalog.getCatalog().getString(
                         "em.scheduler.notification.taskFailedBody",
                         exceptions.get(i));

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -4489,6 +4489,7 @@ em.scheduler.notification.note4=Scheduled Dashboard ''{0}'' has been executed.
 em.scheduler.notification.note5=Execution successful for scheduled Dashboard.
 em.scheduler.notification.taskFailedBody=Task failed due to the following error\: {0}.
 em.scheduler.notification.taskFailedSub=Task {0} of {1} organization failed at {2}
+em.scheduler.notification.taskFailedSub.community=Task ({0}) Failed at {1}
 em.scheduler.options.stopDateIsEarlierError=The stop date should not be earlier than the start date.
 em.scheduler.renameCycleError=Could not rename this cycle since materialized view uses it.
 em.scheduler.servertimezone=server time zone


### PR DESCRIPTION
Modify the email subject when a task fails in Community edition to exclude organization information.