### PR TITLE
Fix Bug #71959:Additionally, the oldServerPath should be obtained from the scheduleManager.

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/ServerPathInfo.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ServerPathInfo.java
@@ -55,10 +55,7 @@ public class ServerPathInfo implements Cloneable, Serializable, HttpXMLSerializa
          }
          else {
             this.username = model.username();
-
-            if(!Util.PLACEHOLDER_PASSWORD.equals(model.password())) {
-               this.password = model.password();
-            }
+            this.password = model.password();
          }
       }
 

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
@@ -1406,10 +1406,16 @@ public class ScheduleService {
          backupAction.setPaths(Tool.defaultIfNull(backupActionModel.backupPathsEnabled(), false) ? backupActionModel
             .backupPath() : null);
          ServerPathInfo oldServerPath = backupAction.getServerPath();
+
+         if(oldAction instanceof IndividualAssetBackupAction oldBackupAction) {
+            oldServerPath = oldBackupAction.getServerPath();
+         }
+
          ServerPathInfo newServerPathInfo = Tool.defaultIfNull(backupActionModel.backupPathsEnabled(), false) ?
             new ServerPathInfo(backupActionModel.backupServerPath()) : null;
 
          if(oldServerPath != null && newServerPathInfo != null &&
+            newServerPathInfo.getUsername().equals(oldServerPath.getUsername()) &&
             Util.PLACEHOLDER_PASSWORD.equals(newServerPathInfo.getPassword()))
          {
             newServerPathInfo.setPassword(oldServerPath.getPassword());

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
@@ -1415,7 +1415,7 @@ public class ScheduleService {
             new ServerPathInfo(backupActionModel.backupServerPath()) : null;
 
          if(oldServerPath != null && newServerPathInfo != null &&
-            newServerPathInfo.getUsername().equals(oldServerPath.getUsername()) &&
+            Tool.equals(newServerPathInfo.getUsername(), oldServerPath.getUsername()) &&
             Util.PLACEHOLDER_PASSWORD.equals(newServerPathInfo.getPassword()))
          {
             newServerPathInfo.setPassword(oldServerPath.getPassword());


### PR DESCRIPTION
Since setServerPaths() already includes a check for passwords with PLACEHOLDER_PASSWORD, there's no need to filter the password field again in new ServerPathInfo(). Additionally, the oldServerPath should be obtained from the scheduleManager.