### PR TITLE
fix Bug #71957, clear the use message thread local values before handle the request

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/EventAspect.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/EventAspect.java
@@ -162,6 +162,7 @@ public class EventAspect {
                    "|| within(inetsoft.web.binding.controller.ChangeChartTypeController))")
    public Object sendUserMessage(ProceedingJoinPoint pjp) throws Throwable {
       try {
+         Tool.clearUserMessage();
          return pjp.proceed();
       }
       finally {


### PR DESCRIPTION
clear the use message thread local values before handle the request, avoid the last time process this thread do not clear.