### PR TITLE
Fix Bug #71962:Use two distinct attributes/properties to differentiate smtpAuthentication

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/general/EmailSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/general/EmailSettingsService.java
@@ -34,7 +34,8 @@ public class EmailSettingsService {
          .ssl(SreeEnv.getBooleanProperty("mail.ssl"))
          .tls(SreeEnv.getBooleanProperty("mail.tls"))
          .jndiUrl(SreeEnv.getProperty("mail.jndi.url"))
-         .smtpAuthentication(SMTPAuthType.forValue(SreeEnv.getProperty("mail.smtp.auth")))
+         .smtpAuthentication("true".equals(SreeEnv.getProperty("mail.smtp.authbox")))
+         .smtpAuthenticationType(SMTPAuthType.forValue(SreeEnv.getProperty("mail.smtp.auth")))
          .smtpUser(SreeEnv.getProperty("mail.smtp.user"))
          .smtpSecretId(Tool.isCloudSecrets() ? SreeEnv.getProperty("mail.smtp.pass") : null)
          .smtpPassword(!Tool.isCloudSecrets() ? SreeEnv.getPassword("mail.smtp.pass") : null)
@@ -64,13 +65,14 @@ public class EmailSettingsService {
                         @SuppressWarnings("unused") @AuditUser Principal principal)
       throws Exception
    {
-      SreeEnv.setProperty("mail.smtp.auth", model.smtpAuthentication().value());
+      SreeEnv.setProperty("mail.smtp.authbox", model.smtpAuthentication() + "");
+      SreeEnv.setProperty("mail.smtp.auth", model.smtpAuthenticationType().value());
 
-      if(model.smtpAuthentication() == SMTPAuthType.SMTP_AUTH) {
+      if(model.smtpAuthenticationType() == SMTPAuthType.SMTP_AUTH) {
          SreeEnv.setProperty("mail.smtp.user", model.smtpUser());SreeEnv.setPassword(
             "mail.smtp.pass", Tool.isCloudSecrets() ? model.smtpSecretId() :model.smtpPassword());
       }
-      else if(model.smtpAuthentication() == SMTPAuthType.SASL_XOAUTH2 || model.smtpAuthentication() == SMTPAuthType.GOOGLE_AUTH) {
+      else if(model.smtpAuthenticationType() == SMTPAuthType.SASL_XOAUTH2 || model.smtpAuthenticationType() == SMTPAuthType.GOOGLE_AUTH) {
          SreeEnv.setProperty("mail.smtp.user", model.smtpUser());
 
          SreeEnv.setProperty("mail.smtp.clientId", model.smtpClientId());
@@ -79,7 +81,7 @@ public class EmailSettingsService {
          SreeEnv.setPassword("mail.smtp.refreshToken", model.smtpRefreshToken());
          SreeEnv.setProperty("mail.smtp.tokenExpiration", model.tokenExpiration());
 
-         if(model.smtpAuthentication() == SMTPAuthType.SASL_XOAUTH2) {
+         if(model.smtpAuthenticationType() == SMTPAuthType.SASL_XOAUTH2) {
             SreeEnv.setProperty("mail.smtp.authUri", model.smtpAuthUri());
             SreeEnv.setProperty("mail.smtp.tokenUri", model.smtpTokenUri());
             SreeEnv.setProperty("mail.smtp.oauthScopes", model.smtpOAuthScopes());

--- a/core/src/main/java/inetsoft/web/admin/general/model/EmailSettingsModel.java
+++ b/core/src/main/java/inetsoft/web/admin/general/model/EmailSettingsModel.java
@@ -40,7 +40,9 @@ public interface EmailSettingsModel {
    @Nullable
    String jndiUrl();
 
-   SMTPAuthType smtpAuthentication();
+   boolean smtpAuthentication();
+
+   SMTPAuthType smtpAuthenticationType();
 
    @Nullable
    String smtpUser();

--- a/web/projects/em/src/app/settings/general/email-settings-view/email-settings-model.ts
+++ b/web/projects/em/src/app/settings/general/email-settings-view/email-settings-model.ts
@@ -20,7 +20,8 @@ export interface EmailSettingsModel {
    ssl: boolean;
    tls: boolean;
    jndiUrl: string;
-   smtpAuthentication: SMTPAuthType;
+   smtpAuthentication: boolean;
+   smtpAuthenticationType: SMTPAuthType;
    smtpUser: string;
    smtpPassword: string;
    smtpSecretId: string;

--- a/web/projects/em/src/app/settings/general/email-settings-view/email-settings-view.component.html
+++ b/web/projects/em/src/app/settings/general/email-settings-view/email-settings-view.component.html
@@ -45,7 +45,7 @@
 
         <mat-form-field appearance="outline" color="accent">
           <mat-label>_#(SMTP Authentication Type)</mat-label>
-          <mat-select formControlName="smtpAuthentication" placeholder="_#(SMTP Authentication Type)">
+          <mat-select formControlName="smtpAuthenticationType" placeholder="_#(SMTP Authentication Type)">
             <mat-option [value]="SMTPAuthType.NONE">_#(None)</mat-option>
             <mat-option [value]="SMTPAuthType.SMTP_AUTH">_#(SMTP Authentication)</mat-option>
             <mat-option [value]="SMTPAuthType.SASL_XOAUTH2">_#(SASL XOAuth2)</mat-option>

--- a/web/projects/em/src/app/settings/general/email-settings-view/email-settings-view.component.ts
+++ b/web/projects/em/src/app/settings/general/email-settings-view/email-settings-view.component.ts
@@ -145,6 +145,7 @@ export class EmailSettingsViewComponent implements OnDestroy {
             tls: [""],
             jndiUrl: [""],
             smtpAuthentication: [""],
+            smtpAuthenticationType: [""],
             smtpUser: ["", Validators.required],
             historyEnabled: [""],
             fromAddress: ["", [Validators.required, FormValidators.emailSpecialCharacters]],
@@ -176,14 +177,14 @@ export class EmailSettingsViewComponent implements OnDestroy {
    updateForm() {
       this.model.confirmSmtpPassword = this.model.smtpPassword;
       this.form.patchValue(this.model, {emitEvent: false});
-      this.smtpAuthenticationChanged(this.model.smtpAuthentication);
+      this.smtpAuthenticationChanged(this.model.smtpAuthenticationType);
 
       this.subscriptions.add(this.form.valueChanges.subscribe(formVal => {
          if(!this.valueChanged(formVal)) {
             return;
          }
 
-         if(formVal.smtpAuthentication == SMTPAuthType.GOOGLE_AUTH) {
+         if(formVal.smtpAuthenticationType == SMTPAuthType.GOOGLE_AUTH) {
             if(formVal.smtpUser != this.model.smtpUser) {
                formVal.fromAddress = formVal.smtpUser;
                this.form.get("fromAddress").setValue(formVal.smtpUser, {emitEvent: false});

--- a/web/projects/em/src/app/settings/properties/property-settings-view/properties-tool.ts
+++ b/web/projects/em/src/app/settings/properties/property-settings-view/properties-tool.ts
@@ -35,7 +35,7 @@ export namespace PropertiesTool {
       "graph.script.action.support", "html.close.button", "html.image.scale",
       "htmlpresenter.fitline", "hyperlink.indicator", "image.antialias",
       "image.filtered", "image.png.alpha", "mail.ssl", "log.output.stderr",
-      "mail.smtp.auth", "map.selection.enabled", "mv.detail.data",
+      "mail.smtp.authbox", "map.selection.enabled", "mv.detail.data",
       "mv.ignore.nestedSelection", "mv.double.precision", "mv.outer.moveUp", "mv.union.moveUp",
       "olap.table.originalContent", "output.null.to.zero", "pdf.compress.image",
       "pdf.compress.text", "pdf.embed.cmap", "pdf.embed.font", "pdf.generate.links",


### PR DESCRIPTION
Since SMTP Authentication and SMTP Authentication Type are two separate components, they should not be represented by a single property and must be distinguished accordingly.