### PR TITLE
fix Bug #71932. Set the audit start time within one day before the end time.

### DIFF
--- a/web/projects/em/src/app/auditing/audit-table-view/audit-table-view.component.ts
+++ b/web/projects/em/src/app/auditing/audit-table-view/audit-table-view.component.ts
@@ -99,6 +99,10 @@ export class AuditTableViewComponent<R> implements OnInit, AfterViewInit {
                this._startDate = this.minDate;
                this._endDate = this.maxDate;
                this.initDate = this.maxDate;
+
+               if(this._startDate < this._endDate - 24 * 60 * 60 * 1000) {
+                  this._startDate = this._endDate - 24 * 60 * 60 * 1000;
+               }
             }
 
             this.onParameterChange();


### PR DESCRIPTION
When initially opening the audit page, restrict the log's start time to be within one day before the end time.