### PR TITLE
Fix Bug #71962:The checkbox is redundant and should be removed.

### DIFF
--- a/web/projects/em/src/app/settings/general/email-settings-view/email-settings-view.component.html
+++ b/web/projects/em/src/app/settings/general/email-settings-view/email-settings-view.component.html
@@ -36,13 +36,6 @@
           <mat-label>_#(Mail Session JNDI URL)</mat-label>
           <input matInput placeholder="_#(Mail Session JNDI URL)" formControlName="jndiUrl">
         </mat-form-field>
-        <mat-checkbox class="mat-checkbox-field" formControlName="smtpAuthentication">
-          _#(SMTP Authentication)
-        </mat-checkbox>
-
-        <ng-container *ngIf="model?.smtpAuthentication">
-        </ng-container>
-
         <mat-form-field appearance="outline" color="accent">
           <mat-label>_#(SMTP Authentication Type)</mat-label>
           <mat-select formControlName="smtpAuthentication" placeholder="_#(SMTP Authentication Type)">


### PR DESCRIPTION
Since the dropdown already has a "None" option, the checkbox is redundant and should be removed.