### PR TITLE
Fix Bug #71963:Use userName (instead of format) to identify the old serverPathInfo, as format is mutable.

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
@@ -1225,10 +1225,12 @@ public class ScheduleService {
 
             Arrays.stream(viewsheetAction.getSaveFormats())
                .forEach(format -> viewsheetAction.setFilePath(format, (ServerPathInfo) null));
-            Map<Integer, ServerPathInfo> clone = new HashMap<>();
+           List <ServerPathInfo> clone = new ArrayList<>();
 
-            if(oldAction instanceof ViewsheetAction oldViewsheetAction) {
-               clone.putAll(oldViewsheetAction.getFilePathsMap());
+            if(oldAction instanceof ViewsheetAction oldViewsheetAction &&
+               !oldViewsheetAction.getFilePathsMap().isEmpty())
+            {
+               clone.addAll(oldViewsheetAction.getFilePathsMap().values());
             }
 
             if(Tool.defaultIfNull(actionModel.saveToServerEnabled(), false)) {
@@ -1241,12 +1243,13 @@ public class ScheduleService {
                   int format = Integer.parseInt(saveFormats[i]);
                   ServerPathInfoModel pModel = serverFilePaths.get(i);
                   String password = pModel.password();
-                  ServerPathInfo oldInfo = clone.get(format);
 
-                  if(Util.PLACEHOLDER_PASSWORD.equals(password) && oldInfo != null &&
-                     oldInfo.getUsername().equals(pModel.username()) && !clone.isEmpty())
-                  {
-                     password = oldInfo.getPassword();
+                  for(ServerPathInfo serverPathInfo : clone) {
+                     if(Util.PLACEHOLDER_PASSWORD.equals(password) &&
+                        Tool.equals(serverPathInfo.getUsername(), pModel.username()))
+                     {
+                        password = serverPathInfo.getPassword();
+                     }
                   }
 
                   if(pModel.ftp()) {

--- a/core/src/main/java/inetsoft/web/admin/schedule/model/GeneralActionModel.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/model/GeneralActionModel.java
@@ -133,6 +133,11 @@ public abstract class GeneralActionModel extends ScheduleActionModel {
       return new String[0];
    }
 
+   @Value.Default
+   public String[] oldSaveFormats() {
+      return new String[0];
+   }
+
    @Nullable
    public abstract Boolean emailMatchLayout();
 


### PR DESCRIPTION
The old serverPathInfo cannot be retrieved based on the format type because the format type is modifiable. Instead, it should be determined by the userName.