### PR TITLE
Fix Bug #71943:Then retrieve the oldPassword from scheduleManager

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
@@ -1377,7 +1377,15 @@ public class ScheduleService {
             }
             else {
                abstractAction.setUseCredential(false);
-               abstractAction.setPassword(actionModel.password());
+               String password = actionModel.password();
+
+               if(oldAction instanceof ViewsheetAction oldViewsheetAction &&
+                  Util.PLACEHOLDER_PASSWORD.equals(password))
+               {
+                  password = oldViewsheetAction.getPassword();
+               }
+
+               abstractAction.setPassword(password);
             }
 
             if(abstractAction instanceof ViewsheetAction && "CSV".equals(actionModel.format())) {


### PR DESCRIPTION
The password in emailInfo should also follow the same logic as others by comparing it with PLACEHOLDER_PASSWORD, then retrieve the oldPassword from scheduleManager.