### PR TITLE
fix Bug #71969. When toggling MaxMode, the adhoc filter should be hidden.

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartController.java
@@ -26,7 +26,7 @@ import inetsoft.report.composition.graph.VSDataSet;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.graph.*;
-import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.*;
 import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
 import inetsoft.web.viewsheet.command.MessageCommand;
@@ -259,19 +259,28 @@ public abstract class VSChartController<T extends VSChartEvent> {
                                       boolean refreshData)
    {
       Assembly[] assemblies = vs.getAssemblies();
-      
+
       for(int i = 0; i < assemblies.length; i++) {
          Assembly other = assemblies[i];
-         
+
          if(other instanceof Viewsheet) {
             reloadOtherAssemblies(rvs, (Viewsheet) other, priorAssembly, uri, dispatcher, refreshData);
             continue;
          }
-         
+
          if(Tool.equals(other.getAbsoluteName(), priorAssembly)) {
             continue;
          }
-         
+
+         if(other instanceof SelectionVSAssembly) {
+            SelectionVSAssemblyInfo info =
+               (SelectionVSAssemblyInfo) ((SelectionVSAssembly) other).getVSAssemblyInfo();
+
+            if(info.isCreatedByAdhoc() && info.isAdhocFilter()) {
+               continue;
+            }
+         }
+
          reloadVSAssembly((VSAssembly) other, rvs, uri, dispatcher, refreshData, priorAssembly);
       }
    }


### PR DESCRIPTION
When toggling MaxMode, the adhoc filter does not need to reload. When entering MaxMode, the filter will be hidden. If the adhoc filter reloads, it may cause the AddVSObjectCommand to execute later than the RemoveVSObjectCommand due to execution order issues, resulting in the adhoc filter not disappearing.