### PR TITLE
fix Bug #71975. Avoid sending duplicate requests.

### DIFF
--- a/web/projects/em/src/app/common/util/editor-panel/editor-panel.component.ts
+++ b/web/projects/em/src/app/common/util/editor-panel/editor-panel.component.ts
@@ -116,6 +116,7 @@ export class EditorPanelComponent implements OnChanges, AfterViewInit, AfterCont
    }
 
    handleClick(event: MouseEvent) {
+      this.applyDisabled = true;
       this.applyClickSubject.next(event);
    }
 }


### PR DESCRIPTION
After clicking the Apply button, it should be immediately disabled to avoid exceptions caused by multiple repeated requests. In the cloud environment, due to slower response times, this issue is easily triggered. Debounce cannot solve this problem, because if the response is slow, repeated clicks on Apply can still send the same request multiple times, and the page will also refresh repeatedly when each request completes. Therefore, the Apply button should be disabled immediately after clicking it.