### PR TITLE
Fix Bug #71992:Some Column's DataRefs are script-based (not plain AttributeRefs), so they cannot be cast directly.

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/SQLQueryDialogController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/SQLQueryDialogController.java
@@ -669,18 +669,21 @@ public class SQLQueryDialogController extends WorksheetController {
          DataRef ref = conditionItem.getAttribute();
          ColumnRef colRef = getColumnRef(ref);
 
-         if(colRef != null && colRef instanceof ColumnRef) {
-            AttributeRef attRef = (AttributeRef) colRef.getDataRef();
-            String attr = attRef.getAttribute();
-            String newAlias = aliasMapping.get(attr);
-            DataRef newCol = selection.getAttribute(newAlias);
+         if(colRef != null) {
+            DataRef dataRef = colRef.getDataRef();
 
-            if(ref instanceof ColumnRef) {
-               conditionItem.setAttribute(newCol);
-            }
-            else {
-               updateColumnRef(ref, (ColumnRef) newCol);
-               conditionItem.setAttribute(ref);
+            if(dataRef instanceof AttributeRef attRef) {
+               String attr = attRef.getAttribute();
+               String newAlias = aliasMapping.get(attr);
+               DataRef newCol = selection.getAttribute(newAlias);
+
+               if(ref instanceof ColumnRef) {
+                  conditionItem.setAttribute(newCol);
+               }
+               else {
+                  updateColumnRef(ref, (ColumnRef) newCol);
+                  conditionItem.setAttribute(ref);
+               }
             }
          }
       }


### PR DESCRIPTION
When modifying SQL queries, we need to update all bound assemblies in the SQL. Some Column's DataRefs are script-based (not plain AttributeRefs), so they cannot be cast directly.