### PR TITLE
fix Bug #71917. Fix NPE.

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/JDBCHandler.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/JDBCHandler.java
@@ -3534,12 +3534,14 @@ public class JDBCHandler extends XHandler {
    }
 
    public void resetConnection() {
-      try {
-         reset();
-         xds = null;
-      }
-      catch(Exception ex) {
-         LOG.error("Failed to reset JDBC handler on data source change", ex);
+      synchronized(metaLock) {
+         try {
+            reset();
+            xds = null;
+         }
+         catch(Exception ex) {
+            LOG.error("Failed to reset JDBC handler on data source change", ex);
+         }
       }
    }
 


### PR DESCRIPTION
Avoid resetting 'xds' to null while the 'getMetaData' method is executing.