### PR TITLE
fix Bug #71861, in live mode, if runtime tablelens can not be executed successfully, will create a metadata data, do not put it as a valid data cache.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetDataCache.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetDataCache.java
@@ -23,11 +23,12 @@ import inetsoft.report.TableFilter;
 import inetsoft.report.TableLens;
 import inetsoft.report.composition.WorksheetService;
 import inetsoft.report.filter.BinaryTableFilter;
+import inetsoft.report.internal.Util;
+import inetsoft.report.internal.XNodeMetaTable;
 import inetsoft.report.internal.table.CancellableTableLens;
 import inetsoft.report.lens.SetTableLens;
 import inetsoft.sree.SreeEnv;
-import inetsoft.uql.VariableTable;
-import inetsoft.uql.XPrincipal;
+import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.service.DataSourceRegistry;
 import inetsoft.uql.util.QueryManager;
@@ -113,11 +114,26 @@ public class AssetDataCache extends DataCache<DataKey, TableLens> {
 
       TableFilter2 filter = (TableFilter2) cache.get(key, ts);
 
-      if(filter != null && (filter.isChanged() || isCancelled(filter))) {
+      if(filter != null && (filter.isChanged() || isCancelled(filter) ||
+         isFailedQueryDefaultMetaTable(filter)))
+      {
          filter = null;
       }
 
       return filter == null ? null : (TableFilter2) filter.clone();
+   }
+
+   private static boolean isFailedQueryDefaultMetaTable(XTable lens) {
+      List<XTable> metaTables = new ArrayList<>();
+      Util.listNestedTable(lens, XNodeMetaTable.class, metaTables);
+
+      for(XTable table : metaTables) {
+         if(table instanceof XNodeMetaTable metaTable && metaTable.isFailedQueryDefault()) {
+            return true;
+         }
+      }
+
+      return false;
    }
 
    // Check if table or sub-table cancelled

--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -716,7 +716,7 @@ public abstract class AssetQuery extends PreAssetQuery {
 
                if(base == null) {
                   if(AssetQuerySandbox.isLiveMode(mode)) {
-                     base = getDesignTableLens(vars);
+                     base = getDesignTableLens(vars, true);
                   }
 
                   return base;
@@ -1018,6 +1018,16 @@ public abstract class AssetQuery extends PreAssetQuery {
     * @param vars the specified variable table.
     */
    protected TableLens getDesignTableLens(VariableTable vars) throws Exception {
+      return getDesignTableLens(vars, false);
+   }
+
+   /**
+    * Get the design mode table lens.
+    * @param vars the specified variable table.
+    */
+   protected TableLens getDesignTableLens(VariableTable vars, boolean failedQueryDefault)
+      throws Exception
+   {
       AggregateInfo group = getAggregateInfo();
       boolean embedded = AssetQuerySandbox.isEmbeddedMode(mode);
       boolean pub = !group.isEmpty() || embedded || gmerged ||
@@ -1058,7 +1068,7 @@ public abstract class AssetQuery extends PreAssetQuery {
 
       XTypeNode output = getXTypeNode(columns);
 
-      TableLens base = new XNodeMetaTable(output);
+      TableLens base = new XNodeMetaTable(output, failedQueryDefault);
       TableDataDescriptor desc = base.getDescriptor();
       XNodeMetaTable.TableDataDescriptor2 desc2 =
          desc instanceof XNodeMetaTable.TableDataDescriptor2

--- a/core/src/main/java/inetsoft/report/internal/XNodeMetaTable.java
+++ b/core/src/main/java/inetsoft/report/internal/XNodeMetaTable.java
@@ -47,6 +47,14 @@ public class XNodeMetaTable extends AbstractTableLens {
    /**
     * Create a table meta data model from a tree definition.
     */
+   public XNodeMetaTable(XTypeNode root, boolean failedQueryDefault) {
+      this(false, root, false);
+      this.failedQueryDefault = failedQueryDefault;
+   }
+
+   /**
+    * Create a table meta data model from a tree definition.
+    */
    public XNodeMetaTable(boolean multirow, XTypeNode root) {
       this(multirow, root, false);
    }
@@ -273,6 +281,13 @@ public class XNodeMetaTable extends AbstractTableLens {
    }
 
    /**
+    * Check if the query is a failed query default data.
+    */
+   public boolean isFailedQueryDefault() {
+      return failedQueryDefault;
+   }
+
+   /**
     * Table data descriptor.
     */
    public final class TableDataDescriptor2 extends DefaultTableDataDescriptor {
@@ -374,4 +389,5 @@ public class XNodeMetaTable extends AbstractTableLens {
    private Map mmap = null;
    private Object[] examplers;
    private TableDataDescriptor descriptor;
+   private boolean failedQueryDefault;
 }


### PR DESCRIPTION
in live mode, if runtime tablelens can not be executed successfully, will create a metadata data, do not put it as a valid data cache.