### PR TITLE
fix Bug #71999. Fix TypeError: cannot access "minuteOffset" when result is undefined

### DIFF
--- a/web/projects/shared/util/date-type-formatter.ts
+++ b/web/projects/shared/util/date-type-formatter.ts
@@ -143,6 +143,10 @@ export class DateTypeFormatter {
    }
 
    public static getMinuteOffset(tz: string, timeZoneOptions: TimeZoneModel[]): number {
+      if(!tz) {
+         return 0;
+      }
+
       let result = timeZoneOptions.find((opt) => opt.timeZoneId == tz &&
          opt.minuteOffset != null);
 


### PR DESCRIPTION
If the time zone is not set, directly returning 0 means there is no offset.