### PR TITLE
Bug #71966: when do adhoc filter on embed vs, should fix RemoveCommand in vs-viewsheet

### DIFF
--- a/web/projects/portal/src/app/common/viewsheet-client/command-processor.ts
+++ b/web/projects/portal/src/app/common/viewsheet-client/command-processor.ts
@@ -17,6 +17,7 @@
  */
 import { Input, NgZone } from "@angular/core";
 import { Subscription } from "rxjs";
+import { RemoveVSObjectCommand } from "../../vsobjects/command/remove-vs-object-command";
 import { ViewsheetClientService } from "./viewsheet-client.service";
 import { ViewsheetCommandMessage } from "./viewsheet-command-message";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
@@ -76,7 +77,9 @@ export abstract class CommandProcessor {
          (message: ViewsheetCommandMessage) => {
             if(handleGlobal && !message.assembly ||
                !handleGlobal && this.getAssemblyName() &&
-               this.getAssemblyName() === message.assembly)
+               (this.getAssemblyName() === message.assembly ||
+               message.type == "RemoveVSObjectCommand" &&
+               (message.command as RemoveVSObjectCommand).name.startsWith(this.getAssemblyName())))
             {
                const method: string = "process" + message.type;
 


### PR DESCRIPTION
for embed vs, when do filter on assembly in embed vs and do not filter any data, then click other places, the filter do not hide, becaused the removeVSObjectCommand do not execute on embed vs, add condition to fix it.