### PR TITLE
Bug #72001. Avoid displaying blank during page rendering.

### DIFF
--- a/web/projects/em/src/app/settings/settings-sidenav/settings-sidenav.component.html
+++ b/web/projects/em/src/app/settings/settings-sidenav/settings-sidenav.component.html
@@ -47,3 +47,4 @@
     </mat-sidenav-content>
   </mat-sidenav-container>
 </div>
+<em-loading-spinner [loading]="loading"></em-loading-spinner>

--- a/web/projects/em/src/app/settings/settings-sidenav/settings-sidenav.component.ts
+++ b/web/projects/em/src/app/settings/settings-sidenav/settings-sidenav.component.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { BreakpointObserver } from "@angular/cdk/layout";
-import { Component, NgZone, OnDestroy, OnInit, ViewChild } from "@angular/core";
+import { AfterViewInit, Component, NgZone, OnDestroy, OnInit, ViewChild } from "@angular/core";
 import { MatSidenav } from "@angular/material/sidenav";
 import { Router } from "@angular/router";
 import { Subject } from "rxjs";
@@ -35,7 +35,7 @@ const SMALL_WIDTH_BREAKPOINT = 720;
    templateUrl: "./settings-sidenav.component.html",
    styleUrls: ["./settings-sidenav.component.scss"]
 })
-export class SettingsSidenavComponent implements OnInit, OnDestroy {
+export class SettingsSidenavComponent implements OnInit, AfterViewInit, OnDestroy {
    @ViewChild(MatSidenav, { static: true }) sidenav: MatSidenav;
    searchText: string;
    generalVisible = false;
@@ -45,6 +45,7 @@ export class SettingsSidenavComponent implements OnInit, OnDestroy {
    presentationVisible = false;
    loggingVisible = false;
    propertiesVisible = false;
+   loading = true;
 
    private destroy$ = new Subject<void>();
 
@@ -70,6 +71,12 @@ export class SettingsSidenavComponent implements OnInit, OnDestroy {
          this.presentationVisible = p.permissions.presentation;
          this.loggingVisible = p.permissions.logging;
          this.propertiesVisible = p.permissions.properties;
+      });
+   }
+
+   ngAfterViewInit() {
+      setTimeout(() => {
+         this.loading = false;
       });
    }
 

--- a/web/projects/em/src/app/settings/settings.module.ts
+++ b/web/projects/em/src/app/settings/settings.module.ts
@@ -33,6 +33,7 @@ import { SearchModule } from "../search/search.module";
 import { TopScrollModule } from "../top-scroll/top-scroll.module";
 import { SettingsRoutingModule } from "./settings-routing.module";
 import { SettingsSidenavComponent } from "./settings-sidenav/settings-sidenav.component";
+import { LoadingSpinnerModule } from "../common/util/loading-spinner/loading-spinner.module";
 
 @NgModule({
    imports: [
@@ -50,7 +51,8 @@ import { SettingsSidenavComponent } from "./settings-sidenav/settings-sidenav.co
       PageHeaderModule,
       SettingsRoutingModule,
       SearchModule,
-      TopScrollModule
+      TopScrollModule,
+      LoadingSpinnerModule
    ],
    declarations: [SettingsSidenavComponent],
    providers: [


### PR DESCRIPTION
Add a loading spinner to fill the blank during page rendering, and hide the loading spinner after all child components have finished rendering.