### PR TITLE
fix Bug #72020. Hide "Show Actual Size" action for selection list/tree in a selection container.

### DIFF
--- a/web/projects/portal/src/app/vsobjects/action/selection-list-actions.ts
+++ b/web/projects/portal/src/app/vsobjects/action/selection-list-actions.ts
@@ -194,7 +194,7 @@ export class SelectionListActions extends AbstractVSActions<VSSelectionListModel
    }
 
    private get closeMaxModeVisible():  boolean {
-      return this.model.maxMode && (GuiTool.isMobileDevice() ||
+      return this.model.maxMode && !this.inSelectionContainer && (GuiTool.isMobileDevice() ||
          ((!this.binding && this.model.maxMode &&
             this.isActionVisibleInViewer("Close Max Mode") && !this.isDataTip() &&
             !this.isPopComponent()) && this.isActionVisibleInViewer("Show Actual Size")));

--- a/web/projects/portal/src/app/vsobjects/action/selection-tree-actions.ts
+++ b/web/projects/portal/src/app/vsobjects/action/selection-tree-actions.ts
@@ -178,7 +178,7 @@ export class SelectionTreeActions extends AbstractVSActions<VSSelectionTreeModel
    }
 
    private get closeMaxModeVisible():  boolean {
-      return this.model.maxMode && (this.mobileDevice ||
+      return this.model.maxMode && !this.inSelectionContainer && (this.mobileDevice ||
          ((!this.binding && this.model.maxMode &&
             this.isActionVisibleInViewer("Close Max Mode") && !this.isDataTip() &&
             !this.isPopComponent()) && this.isActionVisibleInViewer("Show Actual Size")));


### PR DESCRIPTION
If the selection list/tree is inside a selection container, "Show Enlarged" and "Show Actual Size" are not supported.