### PR TITLE
fix Bug #72026. Fix 400 – Bad Request error.

### DIFF
--- a/web/projects/portal/src/app/composer/gui/vs/composer-object.service.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/composer-object.service.ts
@@ -670,8 +670,19 @@ export class ComposerObjectService {
    }
 
    checkTableTransferDataType(viewsheetService: ViewsheetClientService, tableData: TableTransfer) {
+      let runtimeId: string = viewsheetService.runtimeId;
+      let lastSlashIdx: number = runtimeId.lastIndexOf("/");
+
+      if(lastSlashIdx > 0) {
+         let folder: string = runtimeId.substring(0, lastSlashIdx + 1);
+         runtimeId = folder + encodeURIComponent(runtimeId.substring(lastSlashIdx + 1));
+      }
+      else {
+         runtimeId = encodeURIComponent(runtimeId);
+      }
+
       return this.modelService.sendModel<any>("../api/composer/viewsheet/objects/getTableTransferDataType/" +
-         encodeURIComponent(viewsheetService.runtimeId), tableData);
+         runtimeId, tableData);
    }
 
    applyChangeBinding(viewsheetService: ViewsheetClientService, objectName: string,


### PR DESCRIPTION
Only the actual `runtimeId` should be encoded, not the path portion. Encoding the path will result in a 400 error: `Message Invalid URI: [The encoded slash character is not allowed]`.
