### PR TITLE
Bug #71960: add logic for databricks to fix map key in db, the same as clickmouse

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/UniformSQL.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/UniformSQL.java
@@ -3631,7 +3631,9 @@ public class UniformSQL implements SQLDefinition, Cloneable, XMLSerializable {
    }
 
    private String getQuotedSqlString(String sql) {
-      if(dataSource != null && dataSource.getDatabaseType() == JDBCDataSource.JDBC_CLICKHOUSE) {
+      if(dataSource != null && (dataSource.getDatabaseType() == JDBCDataSource.JDBC_CLICKHOUSE ||
+         "databricks".equals(SQLHelper.getProductName(dataSource))))
+      {
          return JDBCUtil.quoteMapKeyAccessForParsing(sql);
       }
 


### PR DESCRIPTION
for databricks and clickmouse db, it should fix map key for column, clickmouse is fixed on bug71915, so fix the same issue to databricks