### PR TITLE
fix Bug #72025, fix ignite waring.

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/cluster/ClusterCache.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ClusterCache.java
@@ -252,7 +252,9 @@ public abstract class ClusterCache<E, L extends Serializable, S extends  Seriali
                            Map map = entrySet.stream()
                               .filter(entry -> entry.getKey() != null)
                               .filter(entry -> entry.getValue() != null)
-                              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+                                                        (o1, o2) -> o2,
+                                                        TreeMap::new));
                            e.getValue().putAll(map);
                         }
                      }


### PR DESCRIPTION
for ignite waring "Unordered map java.util.HashMap is used for putAll operation on cache DatabaseSecurityCache:db.organizationName. This can lead to a distributed deadlock. Switch to a sorted map like TreeMap instead." use tree map to replace the hashmap.