### PR TITLE
fix Bug #72022. Fix filter not displaying due to incorrect zIndex.

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/service/MaxModeAssemblyService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/MaxModeAssemblyService.java
@@ -58,16 +58,25 @@ public class MaxModeAssemblyService {
          vs = (Viewsheet) vs.getAssembly(assemblyName.substring(0, index));
       }
 
+      boolean adhocFilter = ass.getVSAssemblyInfo() instanceof SelectionBaseVSAssemblyInfo &&
+         ((SelectionBaseVSAssemblyInfo) ass.getVSAssemblyInfo()).isAdhocFilter();
+
+      if(!adhocFilter) {
+         vs.setMaxMode(maxSize != null);
+      }
+
       int zAdjust = maxSize == null ? -100000 : 100000;
-      vs.setMaxMode(maxSize != null);
       boolean embeddedViewsheet = false;
 
       while(vs.getViewsheet() != null) {
          // make sure embedded vs is on top when maximizing chart inside
          vs.setZIndex(vs.getZIndex() + zAdjust);
          vs = vs.getViewsheet();
-         vs.setMaxMode(maxSize != null);
          embeddedViewsheet = true;
+
+         if(!adhocFilter) {
+            vs.setMaxMode(maxSize != null);
+         }
       }
 
       MaxModeSupportAssemblyInfo assemblyInfo = assembly.getMaxModeInfo();


### PR DESCRIPTION
The bug manifests as the filter not being displayed, caused by an incorrect `maxMode` state in the viewsheet, which leads to an incorrect `zIndex` calculation for the filter.
For `adhocFilter`, it should not affect the `maxMode` state of the viewsheet, because the `maxMode` state is already determined by the component that triggers the filter before the filter is shown.
