### PR TITLE
Bug #71333: should always show adhoc filter in client.

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/model/VSSelectionBaseModel.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/model/VSSelectionBaseModel.java
@@ -37,7 +37,8 @@ public abstract class VSSelectionBaseModel<T extends AbstractSelectionVSAssembly
         (SelectionBaseVSAssemblyInfo) assembly.getVSAssemblyInfo();
       FormatInfo finfo = assemblyInfo.getFormatInfo();
       String measure = assemblyInfo.getMeasure();
-      dropdown = assemblyInfo.getShowType() == SelectionVSAssemblyInfo.DROPDOWN_SHOW_TYPE;
+      dropdown = assemblyInfo.isAdhocFilter() ? false :
+         assemblyInfo.getShowType() == SelectionVSAssemblyInfo.DROPDOWN_SHOW_TYPE;
       singleSelection = assemblyInfo.isSingleSelection();
       showText = assemblyInfo.isShowText();
       showBar = assemblyInfo.isShowBar();


### PR DESCRIPTION
for adhoc filter, it should always show in client, but its show type maybe dropdown in container. So just show in client for adhoc filter. Do not change its server show type for, it should keep show/hide in container after apply adhoc filter.