### PR TITLE
fix Bug #72001. Display a loading spinner while the provider page is loading.

### DIFF
--- a/web/projects/em/src/app/common/util/loading-spinner/loading-spinner.service.ts
+++ b/web/projects/em/src/app/common/util/loading-spinner/loading-spinner.service.ts
@@ -1,0 +1,36 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Injectable } from "@angular/core";
+import { BehaviorSubject } from "rxjs";
+
+@Injectable({
+   providedIn: "root"
+})
+export class LoadingSpinnerService {
+   private subject = new BehaviorSubject<boolean>(true);
+   loading$ = this.subject.asObservable();
+
+   show() {
+      this.subject.next(true);
+   }
+
+   hide() {
+      this.subject.next(false);
+   }
+}

--- a/web/projects/em/src/app/settings/security/security-provider/security-provider-page/security-provider-page.component.ts
+++ b/web/projects/em/src/app/settings/security/security-provider/security-provider-page/security-provider-page.component.ts
@@ -15,8 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { Component, OnInit } from "@angular/core";
-import { AuthorizationService } from "../../../../authorization/authorization.service";
+import { AfterViewInit, Component, OnInit } from "@angular/core";
+import { LoadingSpinnerService } from "../../../../common/util/loading-spinner/loading-spinner.service";
 import { PageHeaderService } from "../../../../page-header/page-header.service";
 import { Secured } from "../../../../secured";
 
@@ -30,11 +30,19 @@ import { Secured } from "../../../../secured";
    templateUrl: "./security-provider-page.component.html",
    styleUrls: ["./security-provider-page.component.scss"]
 })
-export class SecurityProviderPageComponent implements OnInit {
-   constructor(private pageTitle: PageHeaderService) {
+export class SecurityProviderPageComponent implements OnInit, AfterViewInit {
+   constructor(private pageTitle: PageHeaderService,
+               private loadingSpinnerService: LoadingSpinnerService) {
    }
 
    ngOnInit() {
       this.pageTitle.title = "_#(js:Security Settings Provider)";
+      this.loadingSpinnerService.show();
+   }
+
+   ngAfterViewInit() {
+      setTimeout(() => {
+         this.loadingSpinnerService.hide();
+      }, 200);
    }
 }


### PR DESCRIPTION
Child components rendered through `<router-outlet>` are loaded asynchronously, so ending the loading spinner in the parent component's `ngAfterViewInit` is inappropriate. Instead, the child component should notify the parent once its rendering is complete, allowing the parent to properly stop the loading spinner at the right time.