### PR TITLE
fix Bug #71987, fix parsed sql can not execute for oracle.

### DIFF
--- a/core/src/main/antlr/inetsoft/uql/util/sqlparser/SQLParser.g
+++ b/core/src/main/antlr/inetsoft/uql/util/sqlparser/SQLParser.g
@@ -2295,7 +2295,25 @@ derived_column [JDBCSelection selection, UniformSQL sql]
               sql.getDataSource().getDatabaseType() == JDBCDataSource.JDBC_ORACLE &&
               exp.getType().equals(XExpression.FIELD))
        {
-              tmp = tmp.toUpperCase();
+              String[] parts = Tool.splitWithDelim(tmp, ".", '"');
+              StringBuilder builder = new StringBuilder();
+
+              for(int i = 0; i < parts.length; i++) {
+                String part = parts[i];
+
+                if(part.startsWith("\"") && part.endsWith("\"")) {
+                  builder.append(part);
+                }
+                else {
+                  builder.append(part.toUpperCase());
+                }
+
+                if(i < parts.length - 1) {
+                  builder.append('.');
+                }
+              }
+
+              tmp = builder.toString();
            }
 
            selection.addColumn(tmp);

--- a/core/src/main/java/inetsoft/util/Tool.java
+++ b/core/src/main/java/inetsoft/util/Tool.java
@@ -398,9 +398,7 @@ public final class Tool extends CoreTool {
     * @param delim the delimiter to be used in splitting the string.
     * @param escape the escape character.
     */
-   public static String[] splitWithQuote(String str, String delim,
-                                         char escape)
-   {
+   public static String[] splitWithQuote(String str, String delim, char escape) {
 
       String[] strs = splitWithDelim(str, delim, escape);;
 
@@ -414,8 +412,7 @@ public final class Tool extends CoreTool {
       return strs;
    }
 
-   public static String[] splitWithDelim(String str, String delim,
-                                         char escape) {
+   public static String[] splitWithDelim(String str, String delim, char escape) {
       if(str == null || str.length() == 0) {
          return new String[] {};
       }

--- a/core/src/main/java/inetsoft/util/Tool.java
+++ b/core/src/main/java/inetsoft/util/Tool.java
@@ -399,6 +399,22 @@ public final class Tool extends CoreTool {
     * @param escape the escape character.
     */
    public static String[] splitWithQuote(String str, String delim,
+                                         char escape)
+   {
+
+      String[] strs = splitWithDelim(str, delim, escape);;
+
+      // strip quotes
+      for(int i = 0; i < strs.length; i++) {
+         if(strs[i].startsWith("\"") && strs[i].endsWith("\"")) {
+            strs[i] = strs[i].substring(1, strs[i].length() - 1);
+         }
+      }
+
+      return strs;
+   }
+
+   public static String[] splitWithDelim(String str, String delim,
                                          char escape) {
       if(str == null || str.length() == 0) {
          return new String[] {};
@@ -416,13 +432,6 @@ public final class Tool extends CoreTool {
 
       String[] strs = new String[v.size()];
       v.copyInto(strs);
-
-      // strip quotes
-      for(int i = 0; i < strs.length; i++) {
-         if(strs[i].startsWith("\"") && strs[i].endsWith("\"")) {
-            strs[i] = strs[i].substring(1, strs[i].length() - 1);
-         }
-      }
 
       return strs;
    }


### PR DESCRIPTION
for oracle, should not convert the table or column name to uppercase when it is quoted, because quoted column or table name is case-sensitive.