### PR TITLE
Fix Bug #72013: The aspect needs to be added to the method that is directly called by the Spring proxy.

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/ResourcePermissionService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/ResourcePermissionService.java
@@ -243,6 +243,10 @@ public class ResourcePermissionService {
       setResourcePermissions0(path, resourceType, tableModel, principal);
    }
 
+   @Audited(
+      actionName = ActionRecord.ACTION_NAME_EDIT,
+      objectType = ActionRecord.OBJECT_TYPE_OBJECTPERMISSION
+   )
    public void setResourcePermissions(String path, ResourceType resourceType,
                                       @SuppressWarnings("unused") @AuditObjectName String auditPath,
                                       ResourcePermissionModel tableModel,


### PR DESCRIPTION
Because if this method is called internally within the same class (rather than through the Spring proxy object), AOP will not take effect. Therefore, the aspect needs to be added to the method that is directly called by the Spring proxy.