### PR TITLE
fix Bug #72034, just load host org shapes when org user edit global share vs at viewer.

### DIFF
--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/shape-field-mc.component.html
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/shape-field-mc.component.html
@@ -60,7 +60,7 @@
   <div *ngIf="editPaneId" class="dropdown-pane">
     <div *ngIf="frames" [ngSwitch]="editPaneId">
       <div *ngSwitchCase="'StaticShape'">
-        <static-shape-pane [shapeStr]="shapeFrame?.shape"
+        <static-shape-pane [shapeStr]="shapeFrame?.shape" [assetId]="assetId"
           [nilSupported]="nilSupported"
           (shapeChanged)="shapeFrame.shape = $event; openChanged(false)">
         </static-shape-pane>


### PR DESCRIPTION
just load host org shapes when org user edit global share vs at viewer.