### PR TITLE
fix Bug #72002. Fix the refresh issue of the provider list.

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/AuthenticationProviderService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/AuthenticationProviderService.java
@@ -772,7 +772,7 @@ public class AuthenticationProviderService extends BaseSubscribeChangHandler imp
          getSubscribers().stream()
             .filter(sub -> sub.getUser() instanceof XPrincipal)
             .forEach(sub -> {
-               this.debouncer.debounce(((XPrincipal) sub.getUser()).getCurrentOrgId(), 1L, TimeUnit.SECONDS,
+               this.debouncer.debounce(((XPrincipal) sub.getUser()).getSessionID(), 1L, TimeUnit.SECONDS,
                                        () -> sendToSubscriber(sub));
             });
       }


### PR DESCRIPTION
Using the organization ID as the debounce key can lead to event loss when multiple users from the same organization perform actions on providers at the same time. Since only one event would be processed during the debounce window, others may be ignored. To avoid this, the user session ID should be used as the debounce key instead.
