### PR TITLE
Merge forward fix for Bug #71869 - web socket reconnect

### DIFF
--- a/core/src/main/java/inetsoft/util/Debouncer.java
+++ b/core/src/main/java/inetsoft/util/Debouncer.java
@@ -91,4 +91,9 @@ public interface Debouncer<T> extends AutoCloseable {
     */
    <V> Future<V> debounce(T key, long interval, TimeUnit intervalUnit, Callable<V> task,
                           BinaryOperator<Callable<V>> reducer);
+
+   /**
+    * Cancels a task
+    */
+   void cancel(T key);
 }

--- a/core/src/main/java/inetsoft/web/composer/ComposerDisconnectListener.java
+++ b/core/src/main/java/inetsoft/web/composer/ComposerDisconnectListener.java
@@ -19,14 +19,14 @@ package inetsoft.web.composer;
 
 import inetsoft.web.viewsheet.service.RuntimeViewsheetManager;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.*;
 
 import java.security.Principal;
 
 @Component
-public class ComposerDisconnectListener implements ApplicationListener<SessionDisconnectEvent> {
+public class ComposerDisconnectListener {
    @Autowired
    public ComposerDisconnectListener(RuntimeViewsheetManager runtimeViewsheetManager) {
       this.runtimeViewsheetManager = runtimeViewsheetManager;
@@ -36,10 +36,15 @@ public class ComposerDisconnectListener implements ApplicationListener<SessionDi
     * On websocket disconnect, attempts to clean up the socket's runtime sheet if it has
     * not been closed already.
     */
-   @Override
-   public void onApplicationEvent(SessionDisconnectEvent sessionDisconnectEvent) {
+   @EventListener
+   public void sessionDisconnected(SessionDisconnectEvent sessionDisconnectEvent) {
       Principal principal = sessionDisconnectEvent.getUser();
       runtimeViewsheetManager.sessionEnded(principal);
+   }
+
+   @EventListener
+   public void sessionConnected(SessionConnectEvent event) {
+      runtimeViewsheetManager.sessionConnected(event.getUser());
    }
 
    private final RuntimeViewsheetManager runtimeViewsheetManager;

--- a/web/projects/portal/src/app/common/test/test-utils.ts
+++ b/web/projects/portal/src/app/common/test/test-utils.ts
@@ -825,6 +825,7 @@ export namespace TestUtils {
    export function createMockStompClientService(): any {
       const stompMessages = new Subject<StompMessage>();
       const whenDisconnected = new Subject<void>();
+      const reconnectError = new Subject<void>();
       const stompConnection = {
          subscribe: jest.fn(),
          send: jest.fn(),
@@ -836,7 +837,8 @@ export namespace TestUtils {
       });
       return {
          connect: jest.fn(() => observableOf(stompConnection)),
-         whenDisconnected: jest.fn(() => observableOf(whenDisconnected))
+         whenDisconnected: jest.fn(() => observableOf(whenDisconnected)),
+         reconnectError: jest.fn(() => observableOf(reconnectError))
       };
    }
 

--- a/web/projects/portal/src/app/common/viewsheet-client/viewsheet-client.service.ts
+++ b/web/projects/portal/src/app/common/viewsheet-client/viewsheet-client.service.ts
@@ -88,6 +88,9 @@ export class ViewsheetClientService implements OnDestroy {
          this.client.whenDisconnected().subscribe(() => {
             this.connectionErrorSubject.next("Client disconnected!");
          });
+         this.client.reconnectError().subscribe((error) => {
+            this.connectionErrorSubject.next(error);
+         });
          this.client.connect("../vs-events", false, customElement).subscribe(
             (connection) => {
                this.commandSubject.forceAsync = connection.transport !== "websocket";

--- a/web/projects/portal/src/app/embed/viewer/embed-viewer.component.html
+++ b/web/projects/portal/src/app/embed/viewer/embed-viewer.component.html
@@ -20,7 +20,8 @@
      [class.data-tip-pop-component-visible]="dataTipPopComponentVisible"
      [style.width.px]="width ? width : null"
      [style.height.px]="height ? height : null">
-  <viewer-app #viewerApp *ngIf="assetId && connected && !showError"
+  <viewer-app #viewerApp *ngIf="assetId && connected"
+              [style.visibility]="showError ? 'hidden' : 'visible'"
               [assetId]="assetId"
               [queryParameters]="queryParams"
               [hideToolbar]="hideToolbar"

--- a/web/projects/portal/src/app/embed/viewer/embed-viewer.component.ts
+++ b/web/projects/portal/src/app/embed/viewer/embed-viewer.component.ts
@@ -201,6 +201,8 @@ export class EmbedViewerComponent implements OnInit, OnDestroy, AfterViewInit {
          this.loading = false;
          console.error(message);
       }
+
+      this.cdRef.detectChanges();
    }
 
    onLoadingStateChanged(event: { name: string, loading: boolean }) {

--- a/web/projects/shared/stomp/stomp-client.service.ts
+++ b/web/projects/shared/stomp/stomp-client.service.ts
@@ -33,6 +33,7 @@ import { BaseHrefService } from "../../portal/src/app/common/services/base-href.
 export class StompClientService {
    private clients: Map<string, StompClient> = new Map<string, StompClient>();
    private disconnectSubject = new Subject<void>();
+   private reconnectErrorSubject = new Subject<string>();
    private _reloadOnFailure: boolean = false;
 
    constructor(private zone: NgZone, private ssoHeartbeatService: SsoHeartbeatService,
@@ -48,6 +49,7 @@ export class StompClientService {
          if(!client) {
             client = new StompClient(
                endpoint, (key) => this.onDisconnect(key),
+               (error) => this.onReconnectError(error),
                this.ssoHeartbeatService, this.logoutService, em, this.baseHrefService.getBaseHref(),
                customElement);
             this.clients.set(endpoint, client);
@@ -67,7 +69,15 @@ export class StompClientService {
       this.disconnectSubject.next();
    }
 
+   private onReconnectError(error: string) {
+      this.reconnectErrorSubject.next(error);
+   }
+
    whenDisconnected(): Observable<void> {
       return this.disconnectSubject.asObservable();
+   }
+
+   reconnectError(): Observable<string> {
+      return this.reconnectErrorSubject.asObservable();
    }
 }


### PR DESCRIPTION
Allow the web socket to reconnect. Don't close the viewsheets right away. 
On error just hide the viewer-app instead of destroying it as that doesn't allow the web socket to reconnect and would require the page to be reloaded.