### PR TITLE
Merge forward fix for Bug #71924 - cache images

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
@@ -2463,6 +2463,10 @@ public class RuntimeViewsheet extends RuntimeSheet {
       }
    }
 
+   public ImageHashService getImageHashService() {
+      return imageHashService;
+   }
+
    private String bindingID;
    private Viewsheet vs; // viewsheet
    private Viewsheet originalVs;
@@ -2491,6 +2495,7 @@ public class RuntimeViewsheet extends RuntimeSheet {
    private VSTemporaryInfo temporaryInfo;
    private boolean wizardViewsheet = false;
    private EmbedAssemblyInfo embedAssemblyInfo;
+   private final ImageHashService imageHashService = new ImageHashService();
 
    private static final Logger LOG =
       LoggerFactory.getLogger(RuntimeViewsheet.class);

--- a/core/src/main/java/inetsoft/util/ImageHashService.java
+++ b/core/src/main/java/inetsoft/util/ImageHashService.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2025, InetSoft Technology Corp, All Rights Reserved.
+ *
+ * The software and information contained herein are copyrighted and
+ * proprietary to InetSoft Technology Corp. This software is furnished
+ * pursuant to a written license agreement and may be used, copied,
+ * transmitted, and stored only in accordance with the terms of such
+ * license and with the inclusion of the above copyright notice. Please
+ * refer to the file "COPYRIGHT" for further copyright and licensing
+ * information. This software and information or any other copies
+ * thereof may not be provided or otherwise made available to any other
+ * person.
+ */
+
+package inetsoft.util;
+
+import inetsoft.analytic.composition.VSPortalHelper;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.*;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.awt.Dimension;
+import java.awt.Image;
+import java.awt.image.BufferedImage;
+import java.security.MessageDigest;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Creates a hash for an image and stores the image information so that the image can
+ * be later retrieved given the hash
+ */
+public class ImageHashService {
+   public String getImageHash(VSAssembly assembly) {
+      VSAssemblyInfo assemblyInfo = assembly.getVSAssemblyInfo();
+      Viewsheet vs = assembly.getViewsheet();
+      String assemblyName = null;
+      String imagePath = null;
+      boolean rawBytes = shouldSendRawBytes(assembly);
+      int width = -1;
+      int height = -1;
+
+      if(assemblyInfo instanceof ImageVSAssemblyInfo) {
+         ImageVSAssemblyInfo imageVSAssemblyInfo = (ImageVSAssemblyInfo) assemblyInfo;
+
+         // only include assemblyName when using rawImage (script set image)
+         if(imageVSAssemblyInfo.getRawImage() != null) {
+            assemblyName = assemblyInfo.getName();
+         }
+
+         imagePath = imageVSAssemblyInfo.getImage();
+      }
+
+      if(Tool.isEmptyString(imagePath)) {
+         return null;
+      }
+
+      boolean svg = imagePath.endsWith(".svg");
+      boolean presenter = imagePath.startsWith("java:presenter:");
+
+      // only include width and height when absolutely necessary
+      if(!rawBytes && (svg || presenter)) {
+         Dimension size = assemblyInfo.getLayoutSize();
+
+         if(size == null || size.width == 0 || size.height == 0) {
+            size = assemblyInfo.getPixelSize();
+         }
+
+         width = size.width;
+         height = size.height;
+      }
+
+      ImageInfo imageInfo = new ImageInfo(imagePath, width, height, rawBytes, assemblyName);
+
+      if(infoToHash.containsKey(imageInfo)) {
+         return infoToHash.get(imageInfo);
+      }
+
+      String hash = getImageHash(imageInfo, vs);
+
+      if(hash != null) {
+         infoToHash.put(imageInfo, hash);
+         hashToInfo.put(hash, imageInfo);
+      }
+
+      return hash;
+   }
+
+   public void sendImageResponse(String hash, Viewsheet viewsheet, HttpServletRequest request,
+                                 HttpServletResponse response)
+      throws Exception
+   {
+      ImageInfo imageInfo = hashToInfo.get(hash);
+
+      if(imageInfo == null) {
+         return;
+      }
+
+      response.setHeader("Cache-Control", "public, max-age=86400"); // 1 day
+      response.setHeader("Pragma", "");
+
+      byte[] buf = getImageBytes(imageInfo, viewsheet);
+      boolean svg = imageInfo.path != null && imageInfo.path.endsWith(".svg");
+
+      if(svg) {
+         response.setContentType("image/svg+xml");
+      }
+      else {
+         response.setContentType("image/png");
+      }
+
+      final String encodingTypes = request.getHeader("Accept-Encoding");
+      final ServletOutputStream outputStream = response.getOutputStream();
+
+      if(encodingTypes != null && encodingTypes.contains("gzip")) {
+         try(final GZIPOutputStream out = new GZIPOutputStream(outputStream)) {
+            response.addHeader("Content-Encoding", "gzip");
+            out.write(buf);
+         }
+      }
+      else {
+         outputStream.write(buf);
+      }
+   }
+
+   private String getImageHash(ImageInfo imageInfo, Viewsheet vs) {
+      byte[] imageBytes = null;
+
+      try {
+         imageBytes = getImageBytes(imageInfo, vs);
+      }
+      catch(Exception e) {
+         throw new RuntimeException(e);
+      }
+
+      if(imageBytes != null) {
+         try {
+            return computeImageMD5Hash(imageBytes);
+         }
+         catch(Exception e) {
+            return null;
+         }
+      }
+
+      return null;
+   }
+
+   private byte[] getImageBytes(ImageInfo imageInfo, Viewsheet vs) throws Exception {
+      if(imageInfo == null) {
+         return null;
+      }
+
+      Image rawImage = null;
+
+      if(imageInfo.assemblyName != null) {
+         VSAssembly vsAssembly = vs.getAssembly(imageInfo.assemblyName);
+
+         if(vsAssembly instanceof ImageVSAssembly) {
+            rawImage = ((ImageVSAssemblyInfo) vsAssembly.getVSAssemblyInfo()).getRawImage();
+         }
+      }
+
+      byte[] buf;
+
+      if(imageInfo.rawBytes) {
+         buf = VSUtil.getVSImageBytes(rawImage, imageInfo.path, vs, imageInfo.width,
+                                      imageInfo.height, null, vsPortalHelper);
+      }
+      else {
+         final int dpi = 72;
+         Image image = VSUtil.getVSImage(rawImage, imageInfo.path, vs, imageInfo.width,
+                                         imageInfo.height, null, vsPortalHelper);
+
+         if(image == null) {
+            image = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
+            ((BufferedImage) image).setRGB(0, 0, 0xffffff);
+         }
+
+         buf = VSUtil.getImageBytes(image, dpi);
+      }
+
+      return buf;
+   }
+
+   private String computeImageMD5Hash(byte[] imageBytes) throws Exception {
+      // Compute MD5 hash
+      MessageDigest md = MessageDigest.getInstance("MD5");
+      byte[] digest = md.digest(imageBytes);
+
+      // Convert hash bytes to hex string
+      StringBuilder hexString = new StringBuilder();
+
+      for(byte b : digest) {
+         hexString.append(String.format("%02x", b));
+      }
+
+      return hexString.toString();
+   }
+
+   private boolean shouldSendRawBytes(Assembly assembly) {
+      if(assembly instanceof ImageVSAssembly) {
+         ImageVSAssemblyInfo info = (ImageVSAssemblyInfo) assembly.getInfo();
+         boolean isGIF = info.isAnimateGIF();
+         boolean isSVG = info.getImage() != null && info.getImage().endsWith(".svg");
+
+         if(isGIF) {
+            return true;
+         }
+
+         if(isSVG) {
+            return !info.isScaleImageValue() || info.isMaintainAspectRatioValue();
+         }
+      }
+
+      return false;
+   }
+
+   /**
+    * Image info that can be used to get the actual image
+    */
+   private static class ImageInfo {
+      public ImageInfo(String path, int width, int height, boolean rawBytes, String assemblyName) {
+         this.path = path;
+         this.width = width;
+         this.height = height;
+         this.rawBytes = rawBytes;
+         this.assemblyName = assemblyName;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if(this == o) {
+            return true;
+         }
+
+         if(o == null || getClass() != o.getClass()) {
+            return false;
+         }
+
+         ImageInfo imageInfo = (ImageInfo) o;
+         return width == imageInfo.width && height == imageInfo.height &&
+            rawBytes == imageInfo.rawBytes && Objects.equals(path, imageInfo.path) &&
+            Objects.equals(assemblyName, imageInfo.assemblyName);
+      }
+
+      @Override
+      public int hashCode() {
+         return Objects.hash(path, width, height, rawBytes, assemblyName);
+      }
+
+      private final String path;
+      private final int width;
+      private final int height;
+      private final boolean rawBytes;
+      private final String assemblyName;
+   }
+
+   private final ConcurrentHashMap<ImageInfo, String> infoToHash = new ConcurrentHashMap<>();
+   private final ConcurrentHashMap<String, ImageInfo> hashToInfo = new ConcurrentHashMap<>();
+   private final VSPortalHelper vsPortalHelper = new VSPortalHelper();
+}

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/GetImageController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/GetImageController.java
@@ -124,6 +124,25 @@ public class GetImageController {
    }
 
    /**
+    * Get image given the supplied hash
+    *
+    * @param vid        The runtime viewsheet id.
+    * @param hash       The image hash.
+    * @param principal  The user which is logged into the browser.
+    */
+   @GetMapping(value = "/getImageFromHash/{vid}/{hash}")
+   @InGroupedThread
+   public void processGetImageFromHash(
+      @PathVariable("vid") String vid,
+      @PathVariable("hash") String hash,
+      Principal principal,
+      HttpServletRequest request,
+      HttpServletResponse response) throws Exception
+   {
+      imageService.processImageFromHash(vid, hash, principal, request, response);
+   }
+
+   /**
     * Gets the image requested, and puts it into the response.  Only called directly
     * by Chart, the other image-using assets all call the 4-parameter version above.
     *

--- a/core/src/main/java/inetsoft/web/viewsheet/model/VSImageModel.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/model/VSImageModel.java
@@ -22,6 +22,7 @@ import inetsoft.report.Hyperlink;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.viewsheet.ImageVSAssembly;
 import inetsoft.uql.viewsheet.internal.ImageVSAssemblyInfo;
+import inetsoft.util.ImageHashService;
 import inetsoft.web.composer.model.vs.HyperlinkModel;
 import org.springframework.stereotype.Component;
 
@@ -57,6 +58,11 @@ public class VSImageModel extends VSOutputModel<ImageVSAssembly> {
             hyperlinks[i] = HyperlinkModel.createHyperlinkModel(hrefs[i]);
          }
       }
+
+      if(assembly.getImage() != null) {
+         ImageHashService imageHashService = rvs.getImageHashService();
+         imageHash = imageHashService.getImageHash(assembly);
+      }
    }
 
    public boolean getNoImageFlag() {
@@ -87,6 +93,10 @@ public class VSImageModel extends VSOutputModel<ImageVSAssembly> {
       return hyperlinks;
    }
 
+   public String getImageHash() {
+      return imageHash;
+   }
+
    private boolean noImageFlag;
    private String alpha;
    private boolean locked;
@@ -94,6 +104,7 @@ public class VSImageModel extends VSOutputModel<ImageVSAssembly> {
    private boolean shadow;
    private final HyperlinkModel[] hyperlinks;
    private final ScaleInfoModel scaleInfo;
+   private String imageHash;
 
    @Component
    public static final class VSImageModelFactory

--- a/web/projects/portal/src/app/common/test/test-utils.ts
+++ b/web/projects/portal/src/app/common/test/test-utils.ts
@@ -1256,7 +1256,8 @@ export namespace TestUtils {
             scaleImage: false,
             tiled: false,
             preserveAspectRatio: false
-         }
+         },
+         imageHash: null
       }, createMockVSObjectModel("VSImage", name));
    }
 

--- a/web/projects/portal/src/app/vsobjects/model/output/vs-image-model.ts
+++ b/web/projects/portal/src/app/vsobjects/model/output/vs-image-model.ts
@@ -27,4 +27,5 @@ export interface VSImageModel extends VSOutputModel {
    animateGif: boolean;
    shadow: boolean;
    scaleInfo: ScaleInfoModel;
+   imageHash: string;
 }

--- a/web/projects/portal/src/app/vsobjects/objects/output/image/vs-image.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/output/image/vs-image.component.html
@@ -41,9 +41,9 @@
   <div class="image-container"
        [class.cursor-pointer]="viewer && (model.hyperlinks && model.hyperlinks.length || model.hasOnClick || model.popComponent)">
     <ng-container *ngIf="!model.noImageFlag && vsInfo?.linkUri">
-      <img *ngIf="!model.scaleInfo.tiled" class="image-content"
+      <img #imageElement *ngIf="!model.scaleInfo.tiled" class="image-content"
            (click)="clicked($event)"
-           (load)="onImageLoad($event)" (error)="finishLoad()"
+           (load)="onImageLoad()" (error)="finishLoad()"
            [class.image-content-shadow]="model.shadow && model.animateGif"
            [style.width.px]="imageSize.width"
            [style.height.px]="imageSize.height"

--- a/web/projects/portal/src/app/vsobjects/objects/output/image/vs-image.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/output/image/vs-image.component.ts
@@ -18,6 +18,7 @@
 import {
    ChangeDetectorRef,
    Component,
+   ElementRef,
    EventEmitter,
    Input,
    NgZone,
@@ -26,7 +27,8 @@ import {
    OnInit,
    Output,
    SimpleChange,
-   SimpleChanges
+   SimpleChanges,
+   ViewChild
 } from "@angular/core";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { AssemblyActionEvent } from "../../../../common/action/assembly-action-event";
@@ -55,6 +57,7 @@ export class VSImage extends AbstractImageComponent<VSImageModel>
    @Input() layoutRegion: string = "CONTENT";
    @Input() layoutName: string;
    @Output() onOpenFormatPane = new EventEmitter<VSImageModel>();
+   @ViewChild("imageElement") imageElement: ElementRef;
    imageSize = new Dimension(null, null);
    tooltip: string = "";
    opacity: any;
@@ -126,6 +129,7 @@ export class VSImage extends AbstractImageComponent<VSImageModel>
          () => {
             this.opacity = this.getOpacity();
             this.src = this.getSrc();
+            this.onImageLoad();
             this.changeRef.detectChanges();
 
             if(this.model.scaleInfo.tiled) {
@@ -165,6 +169,11 @@ export class VSImage extends AbstractImageComponent<VSImageModel>
             "/" + this.model.objectFormat.width +
             "/" + this.model.objectFormat.height +
             "?" + this.model.genTime;
+      }
+      else if(this.model.imageHash) {
+         newSrc = this.vsInfo.linkUri + "/getImageFromHash" +
+            "/" + Tool.byteEncodeURLComponent(this.viewsheetClient.runtimeId) +
+            "/" + Tool.byteEncodeURLComponent(this.model.imageHash);
       }
       else {
          newSrc = this.vsInfo.linkUri + "getAssemblyImage" +
@@ -233,7 +242,7 @@ export class VSImage extends AbstractImageComponent<VSImageModel>
       return this.contextProvider.composer;
    }
 
-   onImageLoad(event: UIEvent) {
+   onImageLoad() {
       this.imageSize = new Dimension(null, null);
       this.changeRef.detectChanges();
 
@@ -241,8 +250,8 @@ export class VSImage extends AbstractImageComponent<VSImageModel>
          let size = new Dimension(this.model.objectFormat.width, this.model.objectFormat.height);
 
          if(this.model.scaleInfo.preserveAspectRatio) {
-            const image = event.target as HTMLImageElement;
-            size = size.getScaledDimension(image.width / image.height);
+            size = size.getScaledDimension(
+               this.imageElement.nativeElement.width / this.imageElement.nativeElement.height);
          }
 
          size.width -= Tool.getMarginSize(this.model.objectFormat.border.left);


### PR DESCRIPTION
Create a hash for an image and then retrieve the image using the hash. Make sure that the browser caches the image response so that subsequent requests just retrieve the image from the browser cache.