### PR TITLE
Bug #72065: should check file exists or not when delete file

### DIFF
--- a/core/src/main/java/inetsoft/uql/erm/XPartition.java
+++ b/core/src/main/java/inetsoft/uql/erm/XPartition.java
@@ -2960,7 +2960,7 @@ public class XPartition implements Cloneable, Serializable, XMLSerializable, XML
          File dir = fileSystemService.getMetadataDirectory();
          File file = fileSystemService.getFile(dir, key);
 
-         if(!file.delete()) {
+         if(file.exists() && !file.delete()) {
             LOG.warn("Failed to delete meta-data file: {}", file);
          }
       }


### PR DESCRIPTION
should check file exists and delete failed, then show warning for user. If do not exists, indicate it do not create meta for it, should not show warning for user.