### PR TITLE
fix Bug #72071, distingush viewsheets from organization and the host

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/AssetEntry.java
+++ b/core/src/main/java/inetsoft/uql/asset/AssetEntry.java
@@ -1931,10 +1931,14 @@ public class AssetEntry implements AssetObject, Comparable<AssetEntry>, DataSeri
       return identifier;
    }
 
+   public String getSheetName() {
+      return getSheetName(false);
+   }
+
    /**
     * If the entry is sheet, get fullpath and scope as the sheet name.
     */
-   public String getSheetName() {
+   public String getSheetName(boolean sharedGlobal) {
       if(type == null || !isSheet()) {
          return "";
       }
@@ -1949,7 +1953,7 @@ public class AssetEntry implements AssetObject, Comparable<AssetEntry>, DataSeri
       }
 
       if(scope == AssetRepository.GLOBAL_SCOPE) {
-         root.append("(Global Scope) ");
+         root.append(sharedGlobal ? "(Shared Host Global Scope) " : "(Global Scope) ");
       }
       else if(scope == AssetRepository.REPORT_SCOPE) {
          root.append("(Report Scope) ");

--- a/core/src/main/java/inetsoft/web/admin/viewsheet/ViewsheetModel.java
+++ b/core/src/main/java/inetsoft/web/admin/viewsheet/ViewsheetModel.java
@@ -20,10 +20,11 @@ package inetsoft.web.admin.viewsheet;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import inetsoft.report.composition.RuntimeViewsheet;
-import inetsoft.sree.security.IdentityID;
-import inetsoft.sree.security.OrganizationManager;
+import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.security.*;
 import inetsoft.uql.XPrincipal;
 import inetsoft.util.ThreadContext;
+import inetsoft.util.Tool;
 import org.immutables.serial.Serial;
 import org.immutables.value.Value;
 
@@ -78,8 +79,18 @@ public interface ViewsheetModel extends Serializable {
          monitorUser(user);
          dateCreated(rvs.getDateCreated());
          dateAccessed(rvs.getLastAccessed());
+         String sheet = null;
 
-         String sheet = rvs.getEntry().getSheetName();
+         if(SUtil.isDefaultVSGloballyVisible() &&
+            !Tool.equals(user.getOrgID(), OrganizationManager.getInstance().getCurrentOrgID()) &&
+            Tool.equals(user.getOrgID(), Organization.getDefaultOrganizationID()))
+         {
+            sheet = rvs.getEntry().getSheetName(true);
+         }
+         else {
+            sheet = rvs.getEntry().getSheetName();
+         }
+
          String prefix = "Viewsheet: ";
          int idx = sheet == null ? -1 : sheet.indexOf(prefix);
 


### PR DESCRIPTION
 add "(Shared Host Global Scope) " prefix for sheet name of the shared host vs when create ViewsheetModel, to distingush viewsheets from organization and the host, to avoid users mistakenly thinking they have seen monitor data  of  other organizations.

To minimize the impact of changes, only handle them in ViewsheetModel instead of directly modifying AssetEntry. getSheetName, because when calling AssetEntry. getSheetName, we are unsure if we have set the orgid for threadlocal.