### PR TITLE
Bug #72066

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/cluster/ClusterCache.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ClusterCache.java
@@ -670,7 +670,8 @@ public abstract class ClusterCache<E, L extends Serializable, S extends  Seriali
                }
                catch(ClusterTopologyCheckedException clusterException) {
                   LOG.warn("Failed to acquire lock due to cluster topology change");
-               }            }
+               }
+            }
 
             long interval = loadInterval;
 


### PR DESCRIPTION
Add catch for ClusterTopologyCheckedException to prevent breaking processTasks() when cluster is unstable