### PR TITLE
add  DistributedLockProxy  to support retry mechanisms for lock acquisition

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/DistributedLockProxy.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/DistributedLockProxy.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.sree.internal.cluster.ignite;
+
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.locks.*;
+
+public class DistributedLockProxy implements Lock {
+   public DistributedLockProxy(String lockName) {
+      this.lockName = lockName;
+   }
+
+   public void setRealLock(Lock lock) {
+      this.realLock = lock;
+   }
+
+   @Override
+   public void lock() {
+      Exception exception = null;
+
+      for(int i = 0; i < MAX_TRY_COUNT; i++) {
+         try {
+            realLock.lock();
+            return;
+         }
+         catch(Exception ex) {
+            exception = ex;
+            LOG.debug("Failed to acquire {} lock for {} attempts: ", lockName, i, ex);
+         }
+
+         try {
+            Thread.sleep(3_000);
+         }
+         catch(InterruptedException ignore) {
+         }
+      }
+
+      throw new RuntimeException("Failed to acquire target lock after " + MAX_TRY_COUNT + " attempts: " + lockName, exception);
+   }
+
+   @Override
+   public void lockInterruptibly() throws InterruptedException {
+      realLock.lockInterruptibly();
+   }
+
+   @Override
+   public boolean tryLock() {
+      return realLock.tryLock();
+   }
+
+   @Override
+   public boolean tryLock(long time, @NotNull java.util.concurrent.TimeUnit unit) throws InterruptedException {
+      return realLock.tryLock(time, unit);
+   }
+
+   @Override
+   public void unlock() {
+      realLock.unlock();
+   }
+
+   @NotNull
+   @Override
+   public Condition newCondition() {
+      return realLock.newCondition();
+   }
+
+   private Lock realLock;
+   private String lockName;
+   private static final int MAX_TRY_COUNT = 10;
+   private static final Logger LOG = LoggerFactory.getLogger(DistributedLockProxy.class);
+}


### PR DESCRIPTION
Google Cloud Logs showed numerous lock acquisition failures caused by node left. The DistributedLockProxy was implemented to support retry mechanisms for lock acquisition, preventing task failures.

following is one exception in the log:
025-05-07 15:42:09,820 ERROR 192.168.2.164 [] o.a.i.i.p.d.GridCacheLockImpl: <ignite-sys-atomic-cache@default-volatile-ds-group@volatileDsMemPlc> Failed to compare and set: o.a.i.i.processors.datastructures.GridCacheLockImpl$Sync$1@1ac8243f
org.apache.ignite.internal.cluster.ClusterTopologyCheckedException: Failed to acquire lock for keys (primary node left grid, retry transaction if possible) [keys=[UserKeyCacheObjectImpl [part=80, val=GridCacheInternalKeyImpl [name=inetsoft.sree.schedule.ScheduleManager.extensionLock, grpName=default-volatile-ds-group@volatileDsMemPlc], hasValBytes=false]], node=d82034be-f6fc-4e8d-890d-98002b3fba6f]
  at org.apache.ignite.internal.processors.cache.distributed.dht.colocated.GridDhtColocatedLockFuture.newTopologyException(GridDhtColocatedLockFuture.java:1461)
  at org.apache.ignite.internal.processors.cache.distributed.dht.colocated.GridDhtColocatedLockFuture.map(GridDhtColocatedLockFuture.java:1443)
  at org.apache.ignite.internal.processors.cache.distributed.dht.colocated.GridDhtColocatedLockFuture.map0(GridDhtColocatedLockFuture.java:972)
  at org.apache.ignite.internal.processors.cache.distributed.dht.colocated.GridDhtColocatedLockFuture.map(GridDhtColocatedLockFuture.java:923)
  at org.apache.ignite.internal.processors.cache.distributed.dht.colocated.GridDhtColocatedLockFuture.map(GridDhtColocatedLockFuture.java:811)
  at org.apache.ignite.internal.processors.cache.distributed.dht.colocated.GridDhtColocatedCache.lockAllAsync(GridDhtColocatedCache.java:718)
  at org.apache.ignite.internal.processors.cache.distributed.GridDistributedCacheAdapter.txLockAsync(GridDistributedCacheAdapter.java:110)
  at org.apache.ignite.internal.processors.cache.distributed.near.GridNearTxLocal.putAsync0(GridNearTxLocal.java:658)
  at org.apache.ignite.internal.processors.cache.distributed.near.GridNearTxLocal.putAsync(GridNearTxLocal.java:478)
  at org.apache.ignite.internal.processors.cache.GridCacheAdapter$20.op(GridCacheAdapter.java:2458)
  at org.apache.ignite.internal.processors.cache.GridCacheAdapter$20.op(GridCacheAdapter.java:2456)
  at org.apache.ignite.internal.processors.cache.GridCacheAdapter.syncOp(GridCacheAdapter.java:4268)
  at org.apache.ignite.internal.processors.cache.GridCacheAdapter.put0(GridCacheAdapter.java:2456)
  at org.apache.ignite.internal.processors.cache.GridCacheAdapter.put(GridCacheAdapter.java:2434)
  at org.apache.ignite.internal.processors.cache.GridCacheAdapter.put(GridCacheAdapter.java:2413)
  at org.apache.ignite.internal.processors.cache.GridCacheProxyImpl.put(GridCacheProxyImpl.java:524)
  at org.apache.ignite.internal.processors.datastructures.GridCacheLockImpl$Sync$1.call(GridCacheLockImpl.java:547)
  at org.apache.ignite.internal.processors.datastructures.GridCacheLockImpl$Sync$1.call(GridCacheLockImpl.java:514)
  at org.apache.ignite.internal.processors.cache.GridCacheUtils.retryTopologySafe(GridCacheUtils.java:1396)
  at org.apache.ignite.internal.processors.datastructures.GridCacheLockImpl$Sync.compareAndSetGlobalState(GridCacheLockImpl.java:514)
  at org.apache.ignite.internal.processors.datastructures.GridCacheLockImpl$Sync.tryAcquire(GridCacheLockImpl.java:395)
  at org.apache.ignite.internal.processors.datastructures.GridCacheLockImpl$Sync.tryAcquire(GridCacheLockImpl.java:432)
  at java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:989)
  at org.apache.ignite.internal.processors.datastructures.GridCacheLockImpl$Sync.lock(GridCacheLockImpl.java:427)
  at org.apache.ignite.internal.processors.datastructures.GridCacheLockImpl.lock(GridCacheLockImpl.java:1186)
  at inetsoft.sree.schedule.ScheduleManager.getScheduleTasks(ScheduleManager.java:308)
  at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
  at java.base/java.lang.reflect.Method.invoke(Method.java:580)