### PR TITLE
fix Bug #72086. Fix incorrect gray overlay state in embedded viewsheet.

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/data-tip/data-tip.service.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/data-tip/data-tip.service.ts
@@ -58,6 +58,7 @@ export class DataTipService {
    private _dataTipsVisible: Map<string, boolean> = new Map<string, boolean>();
    private inited = {}; // track if data tip has been initialized
    private _dataTipChanged = new Subject<void>();
+   private _showHideDataTip = new Subject<void>();
 
    constructor(private viewsheetClient: ViewsheetClientService, private zone: NgZone)
    {
@@ -210,6 +211,8 @@ export class DataTipService {
          condition: condition,
          dataTipAlpha: alpha
       };
+
+      this.showHideDataTip.next();
    }
 
    /**
@@ -228,6 +231,7 @@ export class DataTipService {
       this._parentName = null;
       this._condition = null;
       this._lastDataTip = null;
+      this.showHideDataTip.next();
    }
 
    public clearDataTip() {
@@ -297,5 +301,9 @@ export class DataTipService {
 
    get dataTipChanged(): Subject<void> {
       return this._dataTipChanged;
+   }
+
+   get showHideDataTip(): Subject<void> {
+      return this._showHideDataTip;
    }
 }

--- a/web/projects/portal/src/app/vsobjects/objects/data-tip/pop-component.service.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/data-tip/pop-component.service.ts
@@ -278,6 +278,7 @@ export class PopComponentService {
       this.clearPopViewerOffset();
       this.popComponent = null;
       this._popComponentSource = null;
+      this._componentPop.next(null);
    }
 
    // Check if this component should be visible. Either it's not a popcomponent or its popped up.

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
@@ -179,6 +179,11 @@ export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
 
       this.subscriptions.add(this.popService.componentPop.subscribe((name) => {
          this.resetAssemblyAction(name);
+         this.changeDetectorRef.detectChanges();
+      }));
+
+      this.subscriptions.add(this.dataTipService.showHideDataTip.subscribe(() => {
+         this.changeDetectorRef.detectChanges();
       }));
    }
 


### PR DESCRIPTION
Fix the issue where the embedded viewsheet's gray overlay layer has an incorrect state due to failure to promptly detect the visibility status of the popup or datatip components.