### PR TITLE
Fix Bug #72009: Change detection needs to be manually triggered.

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/selection/services/selection-container-children.service.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/services/selection-container-children.service.ts
@@ -17,11 +17,13 @@
  */
 import { Injectable } from "@angular/core";
 import { Observable ,  ReplaySubject ,  Subject } from "rxjs";
+import { VSSelectionContainerModel } from "../../../model/vs-selection-container-model";
 import { SelectionContainerChildDragModel } from "../selection-container-child-drag-model";
 
 @Injectable()
 export class SelectionContainerChildrenService {
    private childUpdated: Subject<number> = new Subject<number>();
+   private childModelUpdated: Subject<VSSelectionContainerModel> = new Subject<VSSelectionContainerModel>();
    private subject: ReplaySubject<SelectionContainerChildDragModel> =
       new ReplaySubject<SelectionContainerChildDragModel>(1);
    private dragModel: SelectionContainerChildDragModel =
@@ -34,6 +36,14 @@ export class SelectionContainerChildrenService {
 
    public updateChild(childIndex: number): void {
       this.childUpdated.next(childIndex);
+   }
+
+   public get onChildModelUpdate(): Observable<VSSelectionContainerModel> {
+      return this.childModelUpdated.asObservable();
+   }
+
+   public updateChildModel(model: VSSelectionContainerModel): void {
+      this.childModelUpdated.next(model);
    }
 
    public get dragModelSubject(): ReplaySubject<SelectionContainerChildDragModel> {

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection-container-children.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection-container-children.component.ts
@@ -146,6 +146,10 @@ export class VSSelectionContainerChildren extends CommandProcessor implements On
             this.actionFactory.createActions(this.vsObject.childObjects[index]);
       });
 
+      this.selectionContainerChildrenService.onChildModelUpdate.subscribe((model) => {
+         this.vsObject = model
+      });
+
       if(this.vsObject.childObjects) {
          this.childActions = [];
 
@@ -169,6 +173,8 @@ export class VSSelectionContainerChildren extends CommandProcessor implements On
                this.actionFactory.createCurrentSelectionActions(model));
          }
       }
+
+      this.changeRef.detectChanges();
    }
 
    get vsObject(): VSSelectionContainerModel {

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection-container.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection-container.component.ts
@@ -284,6 +284,7 @@ export class VSSelectionContainer extends AbstractVSObject<VSSelectionContainerM
             this.model.childObjects[i] =
                VSUtil.replaceObject(this.model.childObjects[i], command.info);
             this.selectionContainerChildrenService.updateChild(i);
+            this.selectionContainerChildrenService.updateChildModel(this.model);
             this.updateFocus(this.model.childObjects[i]);
             break;
          }


### PR DESCRIPTION
Due to Angular's change detection mechanism being set to OnPush, when modifying the properties of this._vsObject, if the object reference itself does not change, Angular's change detection may not trigger the child component's @Input() setter. Therefore, change detection needs to be manually triggered.