### PR TITLE
Bug #72072: fix date binding for range slider

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/JDBCHandler.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/JDBCHandler.java
@@ -907,6 +907,9 @@ public class JDBCHandler extends XHandler {
                               ((PreparedStatement) stmt).
                                  setString(inIdx, Tool.toString(val));
                            }
+                           else if(clickhouse && val instanceof java.sql.Date) {
+                              ((PreparedStatement) stmt).setDate(inIdx, (java.sql.Date) val);
+                           }
                            else if(clickhouse && val instanceof Timestamp) {
                               ((PreparedStatement) stmt).setObject(inIdx, Tool.toString(val));
                            }

--- a/core/src/main/java/inetsoft/uql/jdbc/JDBCHandler.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/JDBCHandler.java
@@ -908,7 +908,6 @@ public class JDBCHandler extends XHandler {
                               ((PreparedStatement) stmt).
                                  setString(inIdx, Tool.toString(val));
                            }
-
                            else if(clickhouse && val instanceof java.sql.Date) {
                               ((PreparedStatement) stmt).setDate(inIdx, (java.sql.Date) val);
                            }

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/RangeCondition.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/RangeCondition.java
@@ -21,6 +21,7 @@ import inetsoft.report.filter.ConditionGroup;
 import inetsoft.uql.ConditionItem;
 import inetsoft.uql.ConditionList;
 import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.viewsheet.*;
 
 import java.util.*;
@@ -62,7 +63,11 @@ public class RangeCondition {
 
    public static RangeCondition from(TimeSliderVSAssembly assembly, DataRef[] refs) {
       final Object[] mins = assembly.getSplitSelectedMinValues();
+      Object[] nmins = getFixedDateValues(mins, refs);
+
       final Object[] maxes = assembly.getSplitSelectedMaxValues();
+      Object[] nmaxes = getFixedDateValues(maxes, refs);
+
       final TimeInfo tinfo = assembly.getTimeInfo();
       // splitSelectedMax already accounts for upper inclusivity for composite time sliders
       final boolean upperInclusive =
@@ -70,8 +75,25 @@ public class RangeCondition {
       final boolean lowerInclusive = true;
       final boolean nullable = tinfo instanceof CompositeTimeInfo;
 
-      return new RangeCondition(mins, maxes, refs, lowerInclusive, upperInclusive, nullable,
+      return new RangeCondition(nmins, nmaxes, refs, lowerInclusive, upperInclusive, nullable,
                                 assembly.getName());
+   }
+
+   private static Object[] getFixedDateValues(Object[] values, DataRef[] refs) {
+      Object[] nvalues = new Object[values.length];
+
+      for(int i = 0; i < values.length; i++) {
+         if(refs != null && XSchema.DATE.equals(refs[i].getDataType()) &&
+            values[i] instanceof java.util.Date)
+         {
+            nvalues[i] = new java.sql.Date(((java.util.Date) values[i]).getTime());
+         }
+         else {
+            nvalues[i] = values[i];
+         }
+      }
+
+      return nvalues;
    }
 
    private RangeCondition(Object[] mins, Object[] maxes, DataRef[] refs, boolean lowerInclusive,


### PR DESCRIPTION
the bug is only exist for single binding, composite binding will change date to java.sql.Date when dataType of ref is "date", so just do the same issue for single binding. Should change condition value to java.sql.Date when create range condition, so it can split date and dateTime in JDBCHandler.execute.

for clickHouse db, date and dateTime should split to fix.

test for date type and dateTime type for clickHouse and normal db, they all works right.