### PR TITLE
Bug #72093,  fix Clickhouse to date logic when generate sql string.

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/ClickhouseHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/ClickhouseHelper.java
@@ -42,13 +42,13 @@ public class ClickhouseHelper extends SQLHelper {
          Pattern pattern = Pattern.compile("\\{ts\\s*'(.*?)'\\}");
          Matcher matcher = pattern.matcher(str);
 
-         return "toDateTime(" + matcher.replaceAll("'$1'") + ")";
+         return matcher.replaceAll("toDateTime('$1')");
       }
       else if(str.startsWith("{d") || str.startsWith("({d") ) {
          Pattern pattern = Pattern.compile("\\{d\\s*'(.*?)'\\}");
          Matcher matcher = pattern.matcher(str);
 
-         return "toDate(" + matcher.replaceAll("'$1'") + ")";
+         return matcher.replaceAll("toDate('$1')");
       }
       else {
          return super.transformDate(str);


### PR DESCRIPTION
({d '2025-01-01'},{d '2025-03-20'}) should convert to (toDate('2025-01-01'), toDate('2025-03-20')) not toDate(('2025-01-01', '2025-03-20'))