### PR TITLE
fix Bug #72104. Fix the issue of the page not refreshing due to route reuse.

### DIFF
--- a/web/projects/em/src/app/app.module.ts
+++ b/web/projects/em/src/app/app.module.ts
@@ -31,6 +31,7 @@ import { MatTableModule } from "@angular/material/table";
 import { MatToolbarModule } from "@angular/material/toolbar";
 import { BrowserModule, HammerModule } from "@angular/platform-browser";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { RouteReuseStrategy } from "@angular/router";
 import { EmClientInterceptor } from "../../../portal/src/app/common/services/emclient-interceptor";
 import { HttpParamsCodecInterceptor } from "../../../portal/src/app/common/services/http-params-codec-interceptor";
 import { RequestedWithInterceptor } from "../../../portal/src/app/common/services/requested-with-interceptor";
@@ -45,6 +46,7 @@ import { AppComponent } from "./app.component";
 import { MessageDialogModule } from "./common/util/message-dialog.module";
 import { ModalHeaderModule } from "./common/util/modal-header/modal-header.module";
 import { CsrfInterceptor } from "./csrf-interceptor";
+import { CustomRouteReuseStrategy } from "./custom-route-reuse-strategy";
 import { InvalidSessionInterceptor } from "./invalid-session-interceptor";
 import { ManageFavoritesComponent } from "./manage-favorites/manage-favorites.component";
 import { NavbarComponent } from "./navbar/navbar.component";
@@ -93,7 +95,8 @@ export const httpInterceptorProviders = [
       SsoHeartbeatService,
       httpInterceptorProviders,
       ScheduleUsersService,
-      ScheduleTaskNamesService
+      ScheduleTaskNamesService,
+      { provide: RouteReuseStrategy, useClass: CustomRouteReuseStrategy }
    ],
    declarations: [
       AppComponent,

--- a/web/projects/em/src/app/custom-route-reuse-strategy.ts
+++ b/web/projects/em/src/app/custom-route-reuse-strategy.ts
@@ -1,0 +1,59 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { ActivatedRouteSnapshot, DetachedRouteHandle, RouteReuseStrategy } from "@angular/router";
+import { Injectable } from "@angular/core";
+
+/**
+ * Custom RouteReuseStrategy to control route reuse behavior.
+ *
+ * This strategy disables route reuse temporarily when `forceNoReuse` is set to true,
+ * forcing Angular to destroy and recreate the component on the next navigation.
+ *
+ * By default, it follows Angular's standard behavior of reusing routes
+ * only if the route configuration (`routeConfig`) is the same.
+ */
+@Injectable()
+export class CustomRouteReuseStrategy implements RouteReuseStrategy {
+   public static forceNoReuse = false;
+
+   shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
+      if(CustomRouteReuseStrategy.forceNoReuse) {
+         CustomRouteReuseStrategy.forceNoReuse = false;
+         return false;
+      }
+
+      // Default behavior: reuse only when the routeConfig is the same
+      return future.routeConfig === curr.routeConfig;
+   }
+
+   shouldDetach(): boolean {
+      return false;
+   }
+
+   store(): void {
+   }
+
+   shouldAttach(): boolean {
+      return false;
+   }
+
+   retrieve(): DetachedRouteHandle | null {
+      return null;
+   }
+}

--- a/web/projects/em/src/app/page-header/page-header.component.ts
+++ b/web/projects/em/src/app/page-header/page-header.component.ts
@@ -29,6 +29,7 @@ import { BehaviorSubject, Subscription } from "rxjs";
 import { debounceTime, distinctUntilChanged } from "rxjs/operators";
 import { ScheduleUsersService } from "../../../../shared/schedule/schedule-users.service";
 import { AppInfoService } from "../../../../shared/util/app-info.service";
+import { CustomRouteReuseStrategy } from "../custom-route-reuse-strategy";
 import { OrganizationDropdownService } from "../navbar/organization-dropdown.service";
 import { EmPageHeaderModel } from "./em-page-header-model";
 import { PageHeaderService } from "./page-header.service";
@@ -157,10 +158,11 @@ export class PageHeaderComponent implements OnInit, OnDestroy {
 
       this.ngZone.run(() => {
          this.router.navigateByUrl("/", { skipLocationChange: true }).then(() => {
+            CustomRouteReuseStrategy.forceNoReuse = true;
+
             if(index != -1) {
                this.ngZone.run(() => {
                   this.router.navigate([currRoute], {fragment: fragment, replaceUrl: true});
-
                });
             }
             else {


### PR DESCRIPTION
Implement a custom RouteReuseStrategy to avoid route reuse on the next navigation. This prevents the page from not refreshing when re-routing to the current page due to organization changes caused by route reuse.
