### PR TITLE
Bug #72107: add “supportCatalog” for db to get right columns first time 

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/database/QueryGraphModelService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/QueryGraphModelService.java
@@ -613,6 +613,11 @@ public class QueryGraphModelService {
          entry.getProperty("catalogSep"), xds,
          entry.getProperty(XSourceInfo.CATALOG),
          entry.getProperty(XSourceInfo.SCHEMA));
+
+      if(entry.getProperty("supportCatalog") != null) {
+         node.setAttribute("supportCatalog", entry.getProperty("supportCatalog"));
+      }
+
       DefaultMetaDataProvider metaDataProvider = getMetaDataProvider(database);
       TableNode tableNode = metaDataProvider.getTableMetaData(node);
 


### PR DESCRIPTION
the bug is caused by when first time to loading physical table columns from sql query pane, it lost supportCatalog attribute. loading from other places is right. So just add right parameter when get table columns.

It will occur for all db have catalog, and will occur only first time open by sql query dialog. After have right metadata, it will works right.