### PR TITLE
Fix Bug #72108: It should be ensured that the children within the current group (or indirectly contained tabs) are excluded from each other

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerGroupController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerGroupController.java
@@ -124,6 +124,10 @@ public class ComposerGroupController {
                String[] subChilds = selGroup.getAssemblies();
 
                for(int j = 0; j < subChilds.length; j++) {
+                  if(viewsheet.getAssembly(subChilds[j]) instanceof TabVSAssembly) {
+                     continue;
+                  }
+
                   childs.add(subChilds[j]);
                }
             }


### PR DESCRIPTION
When creating a group, it should be ensured that the children within the current group (or indirectly contained tabs) are excluded from each other. Therefore, when adding childrenName, such cases should be explicitly filtered out. Otherwise, it may lead to an infinite loop.