### PR TITLE
Fix Bug #72105:Reverting to the default position: static.

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-crosstab.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-crosstab.component.html
@@ -32,7 +32,6 @@
      [style.top.px]="(viewer || embeddedVS) && !model.maxMode && !isBinding ?
      model.objectFormat.top : null"
      [style.left.px]="(viewer || embeddedVS) && !model.maxMode && !isBinding ? model.objectFormat.left : null"
-     [style.position]="viewer || embeddedVS ? 'absolute' : 'relative'"
      [style.width.px]="getObjectWidth()"
      [style.height.px]="getObjectHeight()"
      (onClick)="showPagingControl()">


### PR DESCRIPTION
The position: relative property establishes a new stacking context, potentially causing irregularities in scroll computation. In cases where the parent container employs overflow: auto, relative positioning forces additional layout calculations. By reverting to the default position: static, these supplementary calculations are eliminated.