### PR TITLE
fix Bug #72132: clear no used calc fields wen do not create chart by wizard

### DIFF
--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSCloseObjectWizardController.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSCloseObjectWizardController.java
@@ -148,6 +148,10 @@ public class VSCloseObjectWizardController {
             return;
          }
 
+         if(!(info instanceof ChartVSAssemblyInfo)) {
+            WizardRecommenderUtil.removeRangeTotalColumn(vs, null);
+         }
+
          if(info instanceof ChartVSAssemblyInfo && originalAssembly instanceof ChartVSAssembly) {
             ((ChartVSAssemblyInfo) info).setMaxSize(null);
             vs.setMaxMode(false);

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/WizardRecommenderUtil.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/WizardRecommenderUtil.java
@@ -851,13 +851,17 @@ public final class WizardRecommenderUtil {
          getUsedAutoCreatedCal(newInfo, used);
       }
 
+      removeRangeTotalColumn(vs, used);
+   }
+
+   public static void removeRangeTotalColumn(Viewsheet vs, Set<String> used) {
       for(String source : vs.getCalcFieldSources()) {
          CalculateRef[] crefs = vs.getCalcFields(source);
 
          if(crefs != null) {
             for(CalculateRef cref : crefs) {
                if((cref.getName().startsWith("Total@") || cref.getName().startsWith("Range@"))
-                  && !used.contains(source + ":" + cref.getName()))
+                  && (used == null || !used.contains(source + ":" + cref.getName())))
                {
                   vs.removeCalcField(source, cref.getName());
                }


### PR DESCRIPTION
when goto wizard select one aggregate, it will create Range@ or Total@ column for some cases, but after select other assemblies not chart, should clear them.