### PR TITLE
fix Bug #72133, fix Unordered map java.util.HashMap is used for putAll operation on cache DatabaseSecurityCache:db.organizationName. This can lead to a distributed deadlock. Switch to a sorted map like TreeMap instead. warning

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/cluster/ClusterCache.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ClusterCache.java
@@ -761,7 +761,7 @@ public abstract class ClusterCache<E, L extends Serializable, S extends  Seriali
                   e.getValue().clear();
 
                   if(data.containsKey(e.getKey())) {
-                     e.getValue().putAll(data.get(e.getKey()));
+                     e.getValue().putAll(new TreeMap<>(data.get(e.getKey())));
                   }
                }
 


### PR DESCRIPTION
for ignite waring "Unordered map java.util.HashMap is used for putAll operation on cache DatabaseSecurityCache:db.organizationName. This can lead to a distributed deadlock. Switch to a sorted map like TreeMap instead." use tree map to replace the hashmap.