### PR TITLE
fix Bug #72135: should use scaledShape to get right points to calculate position of annotation

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/AnnotationVSUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/AnnotationVSUtil.java
@@ -1224,7 +1224,7 @@ public final class AnnotationVSUtil {
             if(isMap && regions != null && regions.length > 0 &&
                regions[0] instanceof PolygonRegion) {
                PolygonRegion pregion = getMaxRegion(regions);
-               Shape shape = pregion.createShape();
+               Shape shape = pregion.createScaledShape();
 
                if(shape instanceof Polygon) {
                   Point center = getPolygonCenter((Polygon) shape);


### PR DESCRIPTION
should use scaledShape to get right points to calculate position of annotation