### PR TITLE
fix Bug #72149: fix null for attribute when no attribute in formula

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/database/LogicalModelController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/LogicalModelController.java
@@ -395,7 +395,10 @@ public class LogicalModelController {
          String entityName = ((XAttributeModel) model).getParentEntity();
          XEntity entity = logicalModel.getEntity(entityName);
          XAttribute attribute = entity.getAttribute(name);
-         ex = attribute.getDependencyException();
+
+         if(attribute != null) {
+            ex = attribute.getDependencyException();
+         }
       }
 
       if(ex != null) {


### PR DESCRIPTION
when do formula no attribute, should not throw dependency exception.