### PR TITLE
fix Bug #72162, increase the z-index of chart fieldmc drop down, because chart z-index will increase by 100,000 in max mode.

### DIFF
--- a/web/projects/portal/src/app/binding/editor/chart/field/chart-fieldmc.component.html
+++ b/web/projects/portal/src/app/binding/editor/chart/field/chart-fieldmc.component.html
@@ -28,7 +28,7 @@
     </dynamic-combo-box>
     <div class="fieldEditIcon" *ngIf="isEditMeasure()"
          (openChange)="openChange($event)" [fixedDropdown]="dropdownMenu"
-         [disabled]="!isEnabled" [autoClose]="false" [zIndex]="10000"
+         [disabled]="!isEnabled" [autoClose]="false" [zIndex]="110000"
          [closeOnOutsideClick]="!dialogOpened"
          [attr.data-test]="cellLabel + ' measure dropdown'">
       <i class="icon-size-small btn-icon no-caret"


### PR DESCRIPTION
increase the z-index of chart fieldmc drop down, because chart z-index will increase by 100,000 in max mode.