### PR TITLE
fix Bug #72127: use acutal data to compare for cube data binding 

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
@@ -19,8 +19,7 @@ package inetsoft.report.composition.execution;
 
 import inetsoft.graph.internal.GTool;
 import inetsoft.mv.*;
-import inetsoft.report.MemberObjectTableLens;
-import inetsoft.report.TableLens;
+import inetsoft.report.*;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.internal.Util;
 import inetsoft.report.internal.table.TableFormat;
@@ -1505,6 +1504,7 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
          StringBuilder caption = new StringBuilder();
          Object[] objs = new Object[refs.length];
          MemberObject memberObj = null;
+         Object cellData = null;
 
          for(int idx = 0; idx < refs.length; idx++) {
             int j = Util.findColumn(data, refs[idx], columnIndexMap);
@@ -1522,6 +1522,10 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
             Object obj = data instanceof MemberObjectTableLens ?
                ((MemberObjectTableLens) data).getMemberObject(i, j) :
                data.getObject(i, j);
+
+            if(data instanceof DataTableLens) {
+               cellData = ((DataTableLens) data).getData(i, j);
+            }
 
             if(refs[idx].getRefType() == DataRef.CUBE_MODEL_DIMENSION &&
                refs[idx] instanceof ColumnRef && obj != null)
@@ -1570,7 +1574,9 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
          }
 
          if(vstr.toString().equals(mobj) || caption.toString().equals(mobj) ||
-           memberObj != null && memberObj.isIdentity(mobj))
+            cellData != null && cellData.toString().equals(mobj) &&
+            assembly.getSourceType() == (SourceInfo.DATASOURCE | SourceInfo.CUBE) ||
+            memberObj != null && memberObj.isIdentity(mobj))
          {
             pos = counter;
          }


### PR DESCRIPTION
when time slider binding cube data, its selectedMin value is uname of memberObject, but it getObject(i,j) will return its caption, so we should using getData to get its actual data to compare with it, it will match, only change cube binding.