### PR TITLE
Fix Bug #72167:Add null pointer check (NPE protection).

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/jobstore/ClusterJobStore.java
+++ b/core/src/main/java/inetsoft/sree/schedule/jobstore/ClusterJobStore.java
@@ -554,10 +554,11 @@ public class ClusterJobStore implements JobStore, Serializable {
    @Override
    public void resumeTrigger(TriggerKey triggerKey) throws JobPersistenceException {
       triggersByKey.lock(triggerKey, 5, TimeUnit.MINUTES);
+      TriggerWrapper oldTrigger = triggersByKey.get(triggerKey);
 
       try {
-         if(schedulerRunning) {
-            TriggerWrapper newTrigger = newTriggerWrapper(triggersByKey.get(triggerKey), NORMAL);
+         if(schedulerRunning && oldTrigger != null) {
+            TriggerWrapper newTrigger = newTriggerWrapper(oldTrigger, NORMAL);
             triggersByKey.set(newTrigger.key, newTrigger);
          }
       }


### PR DESCRIPTION
If another thread or process removes the trigger without the current thread's awareness, get(triggerKey) may return null. Hence, an NPE (NullPointerException) check is required.