### PR TITLE
fix Bug #72059. Fix the provider list page loading issue caused by the lock failing to close due to being acquired multiple times by the same thread.

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/cluster/ClusterCache.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ClusterCache.java
@@ -178,7 +178,9 @@ public abstract class ClusterCache<E, L extends Serializable, S extends  Seriali
       int tryCount = 10;
 
       for(int i = 0; i < tryCount; i++) {
-         lock.lock();
+         if(i != 0) {
+            lock.lock();
+         }
 
          try {
             cluster.destroyLock(lockName);


### PR DESCRIPTION
When calling `destroyLock` for the first time, it's not necessary to acquire the lock again; otherwise, an exception will be thrown when closing the lock, which will cause repeated attempts to destroy the lock until the maximum retry limit is reached. Only if the first `destroyLock` fails and a retry is needed should the lock be acquired again.