### PR TITLE
Fix Bug #72090:The actionin annotationsdoes not require Reset Size, so it should not be added when creating the action.

### DIFF
--- a/web/projects/portal/src/app/vsobjects/action/chart-actions.ts
+++ b/web/projects/portal/src/app/vsobjects/action/chart-actions.ts
@@ -151,7 +151,7 @@ export class ChartActions extends AbstractVSActions<VSChartModel> implements Ann
                this.plotResizable && !this.isPopComponent() &&
                (!GraphTypes.isPolar(this.model.chartType) ||
                 this.model.facets && this.model.facets.length > 0) &&
-               this.isActionVisible("Reset Size")
+               this.isActionVisible("Reset Size") && !this.annotationsSelected
          },
       ]));
       groups.push(new AssemblyActionGroup([


### PR DESCRIPTION
The actionin annotationsdoes not require Reset Size, so it should not be added when creating the action.