### PR TITLE
fix Bug #72168: use table name to check cube source

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
@@ -1575,7 +1575,7 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
 
          if(vstr.toString().equals(mobj) || caption.toString().equals(mobj) ||
             cellData != null && cellData.toString().equals(mobj) &&
-            assembly.getSourceType() == (SourceInfo.DATASOURCE | SourceInfo.CUBE) ||
+            assembly.getTableName().startsWith(Assembly.CUBE_VS) ||
             memberObj != null && memberObj.isIdentity(mobj))
          {
             pos = counter;


### PR DESCRIPTION
check cube source by tablename, cube will have spefic prefix for table name