### PR TITLE
fix Bug #72176: for addional db, should set its name as inputname not include folder of base source.

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/DatabaseDatasourcesService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/DatabaseDatasourcesService.java
@@ -1050,7 +1050,7 @@ public class DatabaseDatasourcesService {
       DatabaseType databaseType = databaseTypeService.getDatabaseType(type);
 
       JDBCDataSource xds = new JDBCDataSource();
-      xds.setName(name);
+      xds.setName(isAdditionalSource ? definition.getName() : name);
       xds.setDescription(definition.getDescription());
       xds.setDriver(databaseType.getDriverClass(definition.getInfo()));
       xds.setRequireLogin(definition.getAuthentication().isRequired());


### PR DESCRIPTION
for addional db, should set its name as inputname not include folder of base source.