### PR TITLE
fix Bug #72178, don't quote expression column.

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
@@ -1794,6 +1794,14 @@ public class QueryManagerService {
                : fullname.substring(fullname.lastIndexOf('.') + 1);
             AttributeRef attributeRef = new AttributeRef(name);
             ColumnRef ref = new ColumnRef(attributeRef);
+
+            if(selection.isExpression(i)) {
+               ExpressionRef expressionRef = new ExpressionRef();
+               expressionRef.setName(name);
+               expressionRef.setExpression(fullname);
+               ref.setDataRef(expressionRef);
+            }
+
             ref.setDataType(selection.getType(fullname));
             String oldAlias = getOriginalAlias(aliasMapping, alias);
             DataRef oldRef = getOldAttributeRef(oldAlias, fullname, oldColumns, selection);


### PR DESCRIPTION
 should create ExpressionRef for expression field to avoid quote the expression field as normal field when expression field contains keyword(see SQLHelper.generateSelectClause line1310).