### PR TITLE
fix Bug #72178, sync expression status to avoid quote expression field.

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/util/JDBCUtil.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/util/JDBCUtil.java
@@ -491,6 +491,7 @@ public class JDBCUtil {
          newSelect.setDescription(path, select.getDescription(path));
          newSelect.setTable(path, select.getTable(path));
          newSelect.setXMetaInfo(aidx, select.getXMetaInfo(i));
+         newSelect.setExpression(aidx, select.isExpression(i));
       }
 
       sql.setSelection(newSelect);


### PR DESCRIPTION
sync expression status to avoid quote expression field.(see SQLHelper.generateSelectClause line1310).