### PR TITLE
fix Bug #72174, overwrite the font.truetype.path property for docker image, linux font folder is '/usr/share/fonts/truetype/'.

### DIFF
--- a/docker/src/main/docker/Dockerfile
+++ b/docker/src/main/docker/Dockerfile
@@ -24,6 +24,7 @@ ENV JAVA_LOCALE_OPTS='-Duser.language=en -Duser.country=US -Djava.locale.provide
 ENV JAVA_CODECACHE_OPTS='-XX:InitialCodeCacheSize=100M -XX:ReservedCodeCacheSize=200m -XX:+UseCodeCacheFlushing'
 ENV JAVA_NETWORK_OPTS='-Djava.net.preferIPv4Stack=true'
 ENV JAVA_OPTS='-server $JAVA_MEMORY_OPTS $JAVA_GC_OPTS $JAVA_CODECACHE_OPTS $JAVA_LOCALE_OPTS $JAVA_NETWORK_OPTS -Djava.io.tmpdir=/var/lib/inetsoft/temp -Dinetsoft.log.dir=/var/lib/inetsoft/logs -Dinetsoft.metadata.dir=/var/lib/inetsoft/metadata'
+ENV INETSOFTENV_FONT_TRUETYPE_PATH='/usr/share/fonts/truetype/;$(sree.home)/fonts'
 ENV JAVA_CLASSPATH=''
 
 RUN apt-get update \


### PR DESCRIPTION
overwrite the font.truetype.path property for docker image, linux font folder is '/usr/share/fonts/truetype/'.