### PR TITLE
fix Bug #72183, fix databricks can not get table meta.

### DIFF
--- a/core/src/main/java/inetsoft/uql/util/DefaultMetaDataProvider.java
+++ b/core/src/main/java/inetsoft/uql/util/DefaultMetaDataProvider.java
@@ -21,8 +21,7 @@ import inetsoft.report.composition.execution.AssetDataCache;
 import inetsoft.uql.*;
 import inetsoft.uql.erm.XDataModel;
 import inetsoft.uql.erm.XPartition;
-import inetsoft.uql.jdbc.JDBCDataSource;
-import inetsoft.uql.jdbc.SQLHelper;
+import inetsoft.uql.jdbc.*;
 import inetsoft.uql.jdbc.util.JDBCUtil;
 import inetsoft.uql.jdbc.util.XMetaDataNode;
 import inetsoft.uql.schema.XSchema;
@@ -1196,6 +1195,10 @@ public class DefaultMetaDataProvider implements MetaDataProvider {
 
       metadataCache.put(getDataModel().getDataSource() + "::" +
          pname, getMetaData(partition, sortChildren, additional));
+   }
+
+   public XNode getRootMetaData(String additional) throws Exception {
+      return new JDBCHandler().getRootMetaData((JDBCDataSource) getDataSource(), "DBPROPERTIES", additional);
    }
 
    private boolean portalData = false;

--- a/core/src/main/java/inetsoft/web/portal/controller/database/QueryGraphModelService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/QueryGraphModelService.java
@@ -618,6 +618,18 @@ public class QueryGraphModelService {
          node.setAttribute("supportCatalog", entry.getProperty("supportCatalog"));
       }
 
+      SQLHelper helper = SQLHelper.getSQLHelper(xds);
+
+      if(helper != null && "databricks".equals(helper.getSQLHelperType())) {
+         String quote = helper.getQuote();
+
+         // for databricks, default is not keyword, default schema should not be quoted.
+         if(Tool.equals(node.getAttribute("schema"), Tool.buildString(quote, "default", quote))) {
+            node.setAttribute("schema", "default");
+         }
+      }
+
+
       DefaultMetaDataProvider metaDataProvider = getMetaDataProvider(database);
       TableNode tableNode = metaDataProvider.getTableMetaData(node);
 

--- a/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
@@ -2189,7 +2189,7 @@ public class QueryManagerService {
 
       UniformSQL sql = (UniformSQL) query.getSQLDefinition();
       SelectTable[] selectTables = sql.getSelectTable();
-      XNode root = null;
+      XNode root = metaData.getRootMetaData(XUtil.OUTER_MOSE_LAYER_DATABASE);
 
       for(SelectTable selectTable : selectTables) {
          Object name = selectTable.getName();
@@ -2203,14 +2203,6 @@ public class QueryManagerService {
          else {
             tableName = String.valueOf(selectTable.getName());
             XNode node = metaData.getTable(tableName, XUtil.OUTER_MOSE_LAYER_DATABASE);
-
-            if(node != null && root == null) {
-               root = node;
-
-               while(root.getParent() != null) {
-                  root = root.getParent();
-               }
-            }
 
             if(node != null) {
                tablePath = JDBCUtil.getTablePath(jdbcDataSource, node);


### PR DESCRIPTION
1, get datasource root metadata by data source.
2,for databricks, default is not keyword, default schema should not be quoted.