### PR TITLE
clear method of ignite cache can not call in transaction, replace with removeAll.

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/cluster/DistributedMap.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/DistributedMap.java
@@ -61,4 +61,9 @@ public interface DistributedMap<K, V> extends Map<K, V> {
     * @param keys
     */
    void removeAll(Set<? extends K> keys);
+
+   /**
+    * Removes all entries from the map.
+    */
+   void removeAll();
 }

--- a/core/src/main/java/inetsoft/sree/internal/cluster/LocalClusterMap.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/LocalClusterMap.java
@@ -119,6 +119,12 @@ public class LocalClusterMap<K, V>
    }
 
    @Override
+   public void removeAll() {
+      local.clear();
+      distributedMap.removeAll();
+   }
+
+   @Override
    public void putAll(Map<? extends K, ? extends V> m) {
       local.putAll(m);
       distributedMap.putAll(m);

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteDistributedMap.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteDistributedMap.java
@@ -89,6 +89,14 @@ public class IgniteDistributedMap<K, V> implements DistributedMap<K, V> {
       });
    }
 
+   @Override
+   public void removeAll() {
+      executeWithRetry(() -> {
+         cache.removeAll();
+         return null;
+      });
+   }
+
    public void delete(K key) {
       executeWithRetry(() -> {
          cache.remove(key);

--- a/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationCache.java
+++ b/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationCache.java
@@ -157,18 +157,18 @@ class DatabaseAuthenticationCache implements AutoCloseable {
             roles.clear();
             roles.addAll(Arrays.asList(newRoles.result()));
 
-            orgNames.clear();
+            orgNames.removeAll();
             orgNames.putAll(newOrgNames);
 
-            orgMembers.clear();
+            orgMembers.removeAll();
             orgMembers.putAll(newOrgMembers);
 
-            orgRoles.clear();
+            orgRoles.removeAll();
             orgRoles.putAll(newOrgRoles);
 
-            groupUsers.clear();
-            userRoles.clear();
-            userEmails.clear();
+            groupUsers.removeAll();
+            userRoles.removeAll();
+            userEmails.removeAll();
 
             tx.commit();
             lastLoad.set(System.currentTimeMillis());

--- a/core/src/test/java/inetsoft/test/TestCluster.java
+++ b/core/src/test/java/inetsoft/test/TestCluster.java
@@ -763,6 +763,11 @@ public class TestCluster implements Cluster {
       }
 
       @Override
+      public void removeAll() {
+         delegate.clear();
+      }
+
+      @Override
       public void putAll(@NotNull Map<? extends K, ? extends V> m) {
          for(Map.Entry<? extends K, ? extends V> e : m.entrySet()) {
             put(e.getKey(), e.getValue());


### PR DESCRIPTION
clear method of ignite cache can not call in transaction, replace with removeAll.