### PR TITLE
fix Bug #72188:for Databricks, "default" should not the keyword, the same as clickmouse

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/DatabricksHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/DatabricksHelper.java
@@ -92,4 +92,18 @@ public class DatabricksHelper extends SQLHelper {
 
       return super.getOrderByColumn(field);
    }
+
+   /**
+    * Check if a word is a keyword.
+    * @param word the specified keyword.
+    * @return <tt>true</tt> is a keyword, <tt>false</tt> otherwise.
+    */
+   @Override
+   public boolean isKeyword(String word) {
+      if(word.equals("default")) {
+         return false;
+      }
+
+      return super.isKeyword(word);
+   }
 }


### PR DESCRIPTION
for Databricks, "default" should not the keyword, the same as clickmouse