### PR TITLE
Fix Bug #72194:Now, it has been uniformly modified to orgid__additionalDatabase^_^Database

### DIFF
--- a/core/src/main/java/inetsoft/uql/AdditionalConnectionDataSource.java
+++ b/core/src/main/java/inetsoft/uql/AdditionalConnectionDataSource.java
@@ -136,7 +136,7 @@ public abstract class AdditionalConnectionDataSource<SELF extends AdditionalConn
          repository = XFactory.getRepository();
 
          if(repository instanceof XEngine) {
-            ((XEngine) repository).removeMetaDataFiles(getFullName() + "__" + name);
+            ((XEngine) repository).removeMetaDataFiles(getFullName() + "^_^" + name);
          }
       }
       catch(RemoteException ex) {

--- a/core/src/main/java/inetsoft/uql/service/XEngine.java
+++ b/core/src/main/java/inetsoft/uql/service/XEngine.java
@@ -663,7 +663,7 @@ public class XEngine implements XRepository, XQueryRepository {
          String[] names = jds.getDataSourceNames();
 
          for(String name : names) {
-            removeMetaDataFiles(dsname + "__" + name);
+            removeMetaDataFiles(dsname + "^_^" + name);
          }
       }
 
@@ -1530,17 +1530,19 @@ public class XEngine implements XRepository, XQueryRepository {
          dx = odx;
       }
 
-      String key = OrganizationManager.getInstance().getCurrentOrgID() + "__" + dx.getFullName();
+      String key = dx.getFullName();
       boolean mysql = false;
 
       if(dx instanceof AdditionalConnectionDataSource &&
          ((AdditionalConnectionDataSource<?>) dx).getBaseDatasource() != null)
       {
          key = ((AdditionalConnectionDataSource<?>) dx).getBaseDatasource().getFullName() +
-            "__" + key;
+            "^_^" + key;
          mysql = (dx instanceof JDBCDataSource) &&
             ((JDBCDataSource) dx).getDatabaseType() == JDBCDataSource.JDBC_MYSQL;
       }
+
+      key = OrganizationManager.getInstance().getCurrentOrgID() + "__" + key;
 
       boolean cache = true;
       XNode node;

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/datasources-database.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/datasources-database.component.ts
@@ -815,7 +815,13 @@ export class DatasourcesDatabaseComponent extends DataSourceSettingsPage impleme
    }
 
    refreshMetadata() {
-      const params = new HttpParams().set("dataSource", this.databasePath);
+      let dataSource = this.databasePath;
+
+      if(!this.additionalVisible && this.primaryDatabasePath) {
+         dataSource = this.primaryDatabasePath + "/" + this.database.name;
+      }
+
+      const params = new HttpParams().set("dataSource", dataSource);
       this.http.get<boolean>(PORTAL_DATABASE_REFRESH, {params}).subscribe(success =>
       {
          if(success) {


### PR DESCRIPTION
The reason the refresh is not effective is that the path concatenation in removeMetaDataFiles for "Additional" is inconsistent with the local storage. Now, it has been uniformly modified to orgid__additionalDatabase^_^Database, ensuring consistency between put and remove.