### PR TITLE
fix Bug #72198: use right row height to expand table when export

### DIFF
--- a/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
@@ -2375,6 +2375,11 @@ public abstract class AbstractVSExporter implements VSExporter {
 
       for(int i = 0; i < rowCount; i++) {
          double rowHeight = info.getRowHeight(i);
+
+         if(Double.isNaN(rowHeight) && table instanceof VSTableLens) {
+            rowHeight = getCellHeight(i, (VSTableLens) table);
+         }
+
          expandedHeight += Double.isNaN(rowHeight) ? AssetUtil.defh : rowHeight;
       }
 
@@ -2384,6 +2389,17 @@ public abstract class AbstractVSExporter implements VSExporter {
       }
 
       return expandedHeight;
+   }
+
+   private int getCellHeight(int r, VSTableLens lens) {
+      // get cell height from table lens.
+      if(lens == null || lens.getRowHeights() == null || r >= lens.getRowHeights().length) {
+         return lens != null ? (int) lens.getRowHeightWithPadding(AssetUtil.defh, r) :
+            AssetUtil.defh;
+      }
+
+      int h = lens.getWrappedHeight(r, true);
+      return (int) lens.getRowHeightWithPadding(Double.isNaN(h) ? AssetUtil.defh : h, r);
    }
 
    private int getTotalHeight(TableDataVSAssemblyInfo info, XTable table) {


### PR DESCRIPTION
the bug is caused by when expand table in vs, it use default row height(20 pixel) to calculate its expand height, but the actual row height is 18, so its table will have some empty lines on the bottom. In fact, we should get row height from tablelens, the same as write table cell row.

old bug, 13.6 is also have the same bug.