### PR TITLE
Fix Bug #72207:The z-index should not be increased on the binding interface.

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartMaxModeController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartMaxModeController.java
@@ -18,6 +18,7 @@
 package inetsoft.web.viewsheet.controller.chart;
 
 import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
@@ -72,6 +73,8 @@ public class VSChartMaxModeController extends VSChartController<VSChartEvent> {
     */
    private int toggleMaxMode(VSChartStateInfo chartState, Dimension maxSize) {
       final ChartVSAssemblyInfo info = chartState.getChartAssemblyInfo();
+      RuntimeViewsheet runtimeViewsheet = chartState.getRuntimeViewsheet();
+      boolean isBinding = runtimeViewsheet.isBinding();
       info.setMaxSize(maxSize);
       chartState.getViewsheet().setMaxMode(maxSize != null);
 
@@ -89,7 +92,7 @@ public class VSChartMaxModeController extends VSChartController<VSChartEvent> {
 
       if(maxSize != null) {
          final Assembly[] assemblies = viewsheet.getAssemblies(true, true);
-         int parentZAdjust = embeddedViewsheet ? zAdjust : 0;
+         int parentZAdjust = embeddedViewsheet && !isBinding ? zAdjust : 0;
 
          if(assemblies != null) {
             final VSAssembly topAssembly = (VSAssembly) assemblies[assemblies.length - 1];

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/table/VSTableMaxModeController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/table/VSTableMaxModeController.java
@@ -62,6 +62,7 @@ public class VSTableMaxModeController {
       String name = event.tableName();
       TableDataVSAssembly tableAssembly = (TableDataVSAssembly) vs.getAssembly(name);
       Dimension maxSize = event.maxSize();
+      boolean isBinding = rvs.isBinding();
 
       if(tableAssembly == null) {
          return;
@@ -90,7 +91,7 @@ public class VSTableMaxModeController {
 
       if(maxSize != null) {
          final Assembly[] assemblies = vs.getAssemblies(true, true);
-         int parentZAdjust = embeddedViewsheet ? zAdjust : 0;
+         int parentZAdjust = embeddedViewsheet && !isBinding ? zAdjust : 0;
 
          if(assemblies != null) {
             final VSAssembly topAssembly = (VSAssembly) assemblies[assemblies.length - 1];

--- a/core/src/main/java/inetsoft/web/viewsheet/service/MaxModeAssemblyService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/MaxModeAssemblyService.java
@@ -40,6 +40,7 @@ public class MaxModeAssemblyService {
       Viewsheet vs = rvs.getViewsheet();
       VSAssembly ass = vs.getAssembly(assemblyName);
       int oldShowTypeValue = -1;
+      boolean isBinding = rvs.isBinding();
 
       if(!(ass instanceof MaxModeSupportAssembly)) {
          return;
@@ -84,7 +85,7 @@ public class MaxModeAssemblyService {
 
       if(maxSize != null) {
          final Assembly[] assemblies = vs.getAssemblies(true, true);
-         int parentZAdjust = embeddedViewsheet ? zAdjust : 0;
+         int parentZAdjust = embeddedViewsheet && !isBinding ? zAdjust : 0;
 
          if(assemblies != null) {
             final VSAssembly topAssembly = (VSAssembly) assemblies[assemblies.length - 1];


### PR DESCRIPTION
The issue is that after modification #70528, all embedded sheets in maxmode have an increased z-index to overlay other components. However, on the binding interface, there is only this single component, and an excessively high z-index can block other dialogs. Therefore, the z-index should not be increased on the binding interface.