### PR TITLE
fix Bug #72206. Fix the abnormal behavior issue of expression fields in the query.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
@@ -1306,7 +1306,7 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
       String alias = getAlias(column);
       alias = Tool.equals(col, alias) ? null : alias;
       int index = nselection.addColumn(col);
-      nselection.setExpression(index, column.isExpression());
+      nselection.setExpression(index, column.isExpression() || column.isQueryExpressionField());
 
       if(alias != null) {
          nselection.setAlias(index, alias, getColumnAliasQuote());
@@ -1424,7 +1424,7 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
          }
 
          int index = nselection.addColumn(col);
-         nselection.setExpression(index, column.isExpression());
+         nselection.setExpression(index, column.isExpression() || column.isQueryExpressionField());
          nselection.setAlias(index, alias);
          ((JDBCSelection) nselection).setAggregate(col, true);
          String ocol = getColumn(column);
@@ -2409,7 +2409,7 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
 
          if(!found) {
             int index = selection2.addColumn(col);
-            selection2.setExpression(index, column.isExpression());
+            selection2.setExpression(index, column.isExpression() || column.isQueryExpressionField());
 
             if(alias != null) {
                selection2.setAlias(index, alias);

--- a/core/src/main/java/inetsoft/uql/asset/ColumnRef.java
+++ b/core/src/main/java/inetsoft/uql/asset/ColumnRef.java
@@ -574,6 +574,12 @@ public class ColumnRef extends AbstractDataRef implements AssetObject, DataRefWr
          writer.print(aalias);
          writer.print("\"");
       }
+
+      if(queryExpressionField) {
+         writer.print(" queryExpressionField=\"");
+         writer.print(queryExpressionField);
+         writer.print("\"");
+      }
    }
 
    /**
@@ -589,6 +595,7 @@ public class ColumnRef extends AbstractDataRef implements AssetObject, DataRefWr
          dos.writeBoolean(sql);
          dos.writeUTF(dtype != null ? dtype : XSchema.STRING);
          dos.writeInt(sqlType);
+         dos.writeBoolean(queryExpressionField);
          // transient
          //dos.writeBoolean(aalias);
       }
@@ -648,6 +655,12 @@ public class ColumnRef extends AbstractDataRef implements AssetObject, DataRefWr
          catch(NumberFormatException ex) {
             sqlType = Types.VARCHAR;
          }
+      }
+
+      val = Tool.getAttribute(tag, "queryExpressionField");
+
+      if(val != null) {
+         queryExpressionField = "true".equals(val);
       }
    }
 
@@ -815,6 +828,7 @@ public class ColumnRef extends AbstractDataRef implements AssetObject, DataRefWr
             col2.oldName = oldName;
             col2.lastOldName = lastOldName;
             col2.chash = Integer.MIN_VALUE;
+            col2.queryExpressionField = queryExpressionField;
          }
 
          return col2;
@@ -917,6 +931,14 @@ public class ColumnRef extends AbstractDataRef implements AssetObject, DataRefWr
       return oldName;
    }
 
+   public boolean isQueryExpressionField() {
+      return queryExpressionField;
+   }
+
+   public void setQueryExpressionField(boolean queryExpressionField) {
+      this.queryExpressionField = queryExpressionField;
+   }
+
    private DataRef ref = null;
    private String alias = null;
    private byte width = 1;
@@ -929,6 +951,7 @@ public class ColumnRef extends AbstractDataRef implements AssetObject, DataRefWr
    private String desc = null;
    private String oldName = null;
    private String lastOldName = null; // using last old name to undo to next action before save.
+   private boolean queryExpressionField = false; // Used to identify an expression column generated in the query's fields.
 
    private transient boolean processed = false;
    private transient boolean aalias = true;

--- a/core/src/main/java/inetsoft/uql/erm/DataRef.java
+++ b/core/src/main/java/inetsoft/uql/erm/DataRef.java
@@ -107,6 +107,13 @@ public interface DataRef
    }
 
    /**
+    * Check whether the attribute is an expression column generated in a query’s fields.
+    */
+   default boolean isQueryExpressionField() {
+      return false;
+   }
+
+   /**
     * Check if the data ref is blank.
     * @return <tt>true</tt> if blank, <tt>false</tt> otherwise.
     */

--- a/core/src/main/java/inetsoft/uql/jdbc/UniformSQL.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/UniformSQL.java
@@ -714,6 +714,17 @@ public class UniformSQL implements SQLDefinition, Cloneable, XMLSerializable {
          if(child != null) {
             selection.setDescription(columnName, Tool.getValue(child));
          }
+
+         list = Tool.getChildNodesByTagName(column, "isExp");
+
+         if(list.getLength() > 0) {
+            child = (Element) list.item(0);
+         }
+
+         if(child != null) {
+            selection.setExpression(selection.getColumnCount() - 1,
+               "true".equals(Tool.getValue(child)));
+         }
       }
 
       nlist = Tool.getChildNodesByTagName(node, "where");
@@ -999,6 +1010,7 @@ public class UniformSQL implements SQLDefinition, Cloneable, XMLSerializable {
          String type = selection.getType(column);
          String tname = selection.getTable(column);
          String desc = selection.getDescription(column);
+         boolean isExp = selection.isExpression(column);
 
          if(full && tname == null && alias != null) {
             tname = selection.getTable(alias);
@@ -1013,6 +1025,7 @@ public class UniformSQL implements SQLDefinition, Cloneable, XMLSerializable {
                         "]]></table>");
          writer.println("<description><![CDATA[" + (desc == null ? "" : desc) +
                         "]]></description>");
+         writer.println("<isExp><![CDATA[" + isExp + "]]></isExp>");
          writer.println("</column>");
       }
 

--- a/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
@@ -1794,14 +1794,7 @@ public class QueryManagerService {
                : fullname.substring(fullname.lastIndexOf('.') + 1);
             AttributeRef attributeRef = new AttributeRef(name);
             ColumnRef ref = new ColumnRef(attributeRef);
-
-            if(selection.isExpression(i)) {
-               ExpressionRef expressionRef = new ExpressionRef();
-               expressionRef.setName(name);
-               expressionRef.setExpression(fullname);
-               ref.setDataRef(expressionRef);
-            }
-
+            ref.setQueryExpressionField(selection.isExpression(i));
             ref.setDataType(selection.getType(fullname));
             String oldAlias = getOriginalAlias(aliasMapping, alias);
             DataRef oldRef = getOldAttributeRef(oldAlias, fullname, oldColumns, selection);


### PR DESCRIPTION
Use the `queryExpressionField` attribute to distinguish between expressions defined in the query fields and those created via the 'Create Expression' button in the ws-details-pane.
Add expression serialization to ensure the expression state in `UniformSQL` is not lost.