### PR TITLE
Fix Bug #72207:Revert #72162 - dropdownMenu z-index change redundant (binding pane's embedded z-index already fixed), prevents dialog overlap.

### DIFF
--- a/web/projects/portal/src/app/binding/editor/chart/field/chart-fieldmc.component.html
+++ b/web/projects/portal/src/app/binding/editor/chart/field/chart-fieldmc.component.html
@@ -28,7 +28,7 @@
     </dynamic-combo-box>
     <div class="fieldEditIcon" *ngIf="isEditMeasure()"
          (openChange)="openChange($event)" [fixedDropdown]="dropdownMenu"
-         [disabled]="!isEnabled" [autoClose]="false" [zIndex]="110000"
+         [disabled]="!isEnabled" [autoClose]="false" [zIndex]="10000"
          [closeOnOutsideClick]="!dialogOpened"
          [attr.data-test]="cellLabel + ' measure dropdown'">
       <i class="icon-size-small btn-icon no-caret"


### PR DESCRIPTION
Roll back the changes of #72162, as the z-index of embedded in the binding pane has already been reduced, so there is no longer a need to modify the z-index of dropdownMenu separately, otherwise it will override the dialog.