### PR TITLE
fix Bug #72223, break deadlock

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationCacheServiceImp.java
+++ b/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationCacheServiceImp.java
@@ -84,7 +84,6 @@ public class DatabaseAuthenticationCacheServiceImp implements DatabaseAuthentica
 
    @Override
    public void init() throws Exception {
-      provider = getProvider(providerName);
       cluster = Cluster.getInstance();
       prefix = "DatabaseSecurity:" + providerName;
       this.lists = cluster.getReplicatedMap(prefix + ".lists");
@@ -125,6 +124,7 @@ public class DatabaseAuthenticationCacheServiceImp implements DatabaseAuthentica
    }
 
    public void connect() {
+      provider = getProvider(providerName);
       clientCount.incrementAndGet();
    }
 

--- a/core/src/main/java/inetsoft/web/admin/security/user/SecurityTreeServer.java
+++ b/core/src/main/java/inetsoft/web/admin/security/user/SecurityTreeServer.java
@@ -87,7 +87,7 @@ public class SecurityTreeServer {
          currOrgID = currOrgID == null ? Organization.getDefaultOrganizationID() : currOrgID;
          String[] orgIds = provider.getOrganizationIDs();
 
-         if(orgIds.length == 0) {
+         if(isMultiTenant && orgIds.length == 0) {
             throw new MessageException(Catalog.getCatalog().getString("em.security.provider.db.noOrg"));
          }
 
@@ -95,7 +95,7 @@ public class SecurityTreeServer {
             throw new InvalidOrgException(Catalog.getCatalog().getString("em.security.invalidOrganizationPassed"));
          }
 
-         String currOrgName = provider.getOrgNameFromID(currOrgID);
+         String currOrgName = orgIds.length > 0 ? provider.getOrgNameFromID(currOrgID) : Organization.getDefaultOrganizationName();
          boolean isEnterprise = LicenseManager.getInstance().isEnterprise();
          isMultiTenant = isEnterprise && isMultiTenant;
 


### PR DESCRIPTION
1. don't pop up no org warning for non multitenat.
2. break deadlock 
"http-nio-8080-exec-10@24364" tid=0x10d nid=NA waiting
  java.lang.Thread.State: WAITING
     at jdk.internal.misc.Unsafe.park(Unsafe.java:-1)
     at java.util.concurrent.locks.LockSupport.park(LockSupport.java:371)
     at org.apache.ignite.internal.util.future.GridFutureAdapter.get0(GridFutureAdapter.java:181)
     at org.apache.ignite.internal.util.future.GridFutureAdapter.get(GridFutureAdapter.java:144)
     at org.apache.ignite.internal.AsyncSupportAdapter.saveOrGet(AsyncSupportAdapter.java:109)
     at org.apache.ignite.internal.IgniteServicesImpl.deployAll(IgniteServicesImpl.java:245)
     at org.apache.ignite.internal.IgniteServicesImpl.deploy(IgniteServicesImpl.java:228)
     at inetsoft.sree.internal.cluster.ignite.IgniteCluster.getSingletonService(IgniteCluster.java:1361)
     at inetsoft.sree.security.db.DatabaseAuthenticationCache.initialize(DatabaseAuthenticationCache.java:61)
     at inetsoft.sree.security.db.DatabaseAuthenticationCache.isLoading(DatabaseAuthenticationCache.java:241)
     at inetsoft.sree.security.db.DatabaseAuthenticationProvider.getCache(DatabaseAuthenticationProvider.java:778)
     at inetsoft.sree.security.db.DatabaseAuthenticationProvider.getCache(DatabaseAuthenticationProvider.java:757)
     at inetsoft.sree.security.db.DatabaseAuthenticationProvider.clearCache(DatabaseAuthenticationProvider.java:405)
     at inetsoft.web.admin.security.AuthenticationProviderService.editAuthenticationProvider(AuthenticationProviderService.java:202)
     at inetsoft.web.admin.security.AuthenticationProviderController.editAuthenticationProvider(AuthenticationProviderController.java:78)      // waiting for services-deployment-worker-#95@24295"

"services-deployment-worker-#95@24295" tid=0x96 nid=NA waiting
  java.lang.Thread.State: WAITING
     at jdk.internal.misc.Unsafe.park(Unsafe.java:-1)
     at java.util.concurrent.locks.LockSupport.park(LockSupport.java:221)
     at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:754)
     at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireShared(AbstractQueuedSynchronizer.java:1079)
     at java.util.concurrent.locks.ReentrantReadWriteLock$ReadLock.lock(ReentrantReadWriteLock.java:738)
     //locked by AuthenticationProviderController.editAuthenticationProvider
     at inetsoft.sree.security.SecurityChain.getProviders(SecurityChain.java:91)
     at inetsoft.sree.security.db.DatabaseAuthenticationCacheServiceImp.getProvider(DatabaseAuthenticationCacheServiceImp.java:294)
     at inetsoft.sree.security.db.DatabaseAuthenticationCacheServiceImp.init(DatabaseAuthenticationCacheServiceImp.java:87)
     at org.apache.ignite.services.Service.init(Service.java:158)
     at org.apache.ignite.internal.processors.service.IgniteServiceProcessor.redeploy(IgniteServiceProcessor.java:1327)
     at org.apache.ignite.internal.processors.service.ServiceDeploymentTask.lambda$processDeploymentActions$5(ServiceDeploymentTask.java:317)
     at org.apache.ignite.internal.processors.service.ServiceDeploymentTask$$Lambda/0x000002024d53ce48.accept(Unknown Source:-1)
     at java.util.HashMap.forEach(HashMap.java:1429)
     at java.util.Collections$UnmodifiableMap.forEach(Collections.java:1707)
     at org.apache.ignite.internal.processors.service.ServiceDeploymentTask.processDeploymentActions(ServiceDeploymentTask.java:301)
     at org.apache.ignite.internal.processors.service.ServiceDeploymentTask.init(ServiceDeploymentTask.java:261)
     at org.apache.ignite.internal.processors.service.ServiceDeploymentManager$ServicesDeploymentWorker.body(ServiceDeploymentManager.java:475)
     at org.apache.ignite.internal.util.worker.GridWorker.run(GridWorker.java:125)
     at java.lang.Thread.runWith(Thread.java:1596)
     at java.lang.Thread.run(Thread.java:1583)

  break deadlock, edit db provider -> 获取 SecurityChain.writeLock -> DatabaseAuthenticationCache.initialize ->