### PR TITLE
fix Bug #72225, should delete plugin file after reset db provider connection, because provider is used plugin.

### DIFF
--- a/core/src/main/java/inetsoft/util/Plugins.java
+++ b/core/src/main/java/inetsoft/util/Plugins.java
@@ -569,8 +569,8 @@ public final class Plugins implements BlobStorage.Listener<Plugin.Descriptor>, A
       Drivers.getInstance().pluginRemoved(pluginId);
       DataSourceRegistry.getRegistry().clearCache();
       plugin.getClassLoader().close();
-      delete(plugin.getFolder());
       resetDBProviderConnection();
+      delete(plugin.getFolder());
 
       LOG.info("Removed plugin {}:{}", plugin.getId(), plugin.getVersion());
    }


### PR DESCRIPTION
should delete plugin file after reset db provider connection, because provider is used plugin.