### PR TITLE
Bug 72220 don't call Ignite service internal methods directly.

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationCache.java
+++ b/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationCache.java
@@ -50,7 +50,6 @@ class DatabaseAuthenticationCache implements AutoCloseable {
                this.service = cluster.getSingletonService(
                   prefix, DatabaseAuthenticationCacheService.class,
                   () -> new DatabaseAuthenticationCacheServiceImp(provider.getProviderName()));
-               service.init();
                service.connect();
                this.lists = cluster.getReplicatedMap(prefix + ".lists");
                this.orgNames = cluster.getReplicatedMap(prefix + ".orgNames");


### PR DESCRIPTION
Don't call the init(), cancel(), execute() methods directly. They are for internal use by Ignite to manage the services lifecycle when it is deployed and undeployed.

I put a stack trace in the init() method and verified that it was called at server startup as expected and was able to log into the EM with a database user.

```
java.lang.Exception: Stack trace
        at java.base/java.lang.Thread.dumpStack(Thread.java:2210)
        at inetsoft.sree.security.db.DatabaseAuthenticationCacheServiceImp.init(DatabaseAuthenticationCacheServiceImp.java:88)
        at org.apache.ignite.services.Service.init(Service.java:158)
        at org.apache.ignite.internal.processors.service.IgniteServiceProcessor.redeploy(IgniteServiceProcessor.java:1327)
        at org.apache.ignite.internal.processors.service.ServiceDeploymentTask.lambda$processDeploymentActions$5(ServiceDeploymentTask.java:317)
        at java.base/java.util.HashMap.forEach(HashMap.java:1429)
        at java.base/java.util.Collections$UnmodifiableMap.forEach(Collections.java:1707)
        at org.apache.ignite.internal.processors.service.ServiceDeploymentTask.processDeploymentActions(ServiceDeploymentTask.java:301)
        at org.apache.ignite.internal.processors.service.ServiceDeploymentTask.init(ServiceDeploymentTask.java:261)
        at org.apache.ignite.internal.processors.service.ServiceDeploymentManager$ServicesDeploymentWorker.body(ServiceDeploymentManager.java:475)
        at org.apache.ignite.internal.util.worker.GridWorker.run(GridWorker.java:125)
        at java.base/java.lang.Thread.run(Thread.java:1583)
   ```