### PR TITLE
 fix Bug #72234, reset counter and destroy necesarry distributed map.

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationCacheServiceImp.java
+++ b/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationCacheServiceImp.java
@@ -51,35 +51,7 @@ public class DatabaseAuthenticationCacheServiceImp implements DatabaseAuthentica
             }
          }
 
-         if(cluster != null) {
-            if(lists != null) {
-               cluster.destroyMap(prefix + ".lists");
-            }
-
-            if(orgNames != null) {
-               cluster.destroyMap(prefix + ".orgNames");
-            }
-
-            if(orgMembers != null) {
-               cluster.destroyMap(prefix + ".orgMembers");
-            }
-
-            if(orgRoles != null) {
-               cluster.destroyMap(prefix + ".orgRoles");
-            }
-
-            if(groupUsers != null) {
-               cluster.destroyMap(prefix + ".groupUsers");
-            }
-
-            if(userRoles != null) {
-               cluster.destroyMap(prefix + ".userRoles");
-            }
-
-            if(userEmails != null) {
-               cluster.destroyMap(prefix + ".userEmails");
-            }
-         }
+         clientCount.decrementAndGet();
       }
    }
 
@@ -134,6 +106,52 @@ public class DatabaseAuthenticationCacheServiceImp implements DatabaseAuthentica
          if(cluster != null) {
             cluster.undeploySingletonService(prefix);
          }
+
+         destroyCache();
+      }
+   }
+
+   private void destroyCache() {
+      if(cluster != null) {
+         if(lists != null) {
+            cluster.destroyMap(prefix + ".lists");
+         }
+
+         if(orgNames != null) {
+            cluster.destroyMap(prefix + ".orgNames");
+         }
+
+         if(orgMembers != null) {
+            cluster.destroyMap(prefix + ".orgMembers");
+         }
+
+         if(orgRoles != null) {
+            cluster.destroyMap(prefix + ".orgRoles");
+         }
+
+         if(groupUsers != null) {
+            cluster.destroyMap(prefix + ".groupUsers");
+         }
+
+         if(userRoles != null) {
+            cluster.destroyMap(prefix + ".userRoles");
+         }
+
+         if(userEmails != null) {
+            cluster.destroyMap(prefix + ".userEmails");
+         }
+      }
+
+      if(loadingCount != null) {
+         loadingCount.set(0L);
+      }
+
+      if(lastLoadTime != null) {
+         lastLoadTime.set(0L);
+      }
+
+      if(lastFailureTime != null) {
+         lastFailureTime.set(0L);
       }
    }
 


### PR DESCRIPTION
 By reading the source code of IgniteServiceProcessor, the scenarios that trigger Service.cancel include: undeploy, redeploy, onKernalStop, and onDeActivate processor. Therefore, I think it might be better to destroy the distributed map when disconnecting the service, also should perform clientCount.decrementAndGet() in the cancel function.