### PR TITLE
Fix Bug #71469:Use fullNameinstead of name.

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/database/DataSourceService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/DataSourceService.java
@@ -750,7 +750,7 @@ public class DataSourceService {
    {
       DefaultMetaDataProvider meta = metaDataProviders.stream()
          .filter(p -> Tool.equals(ds, p.getDataSource()) && ds != null &&
-            Tool.equals(ds.getName(), p.getDataSource().getName()))
+            Tool.equals(ds.getFullName(), p.getDataSource().getFullName()))
          .findFirst().orElse(null);
 
       if(meta == null) {


### PR DESCRIPTION
When determining whether the dataSource in the old meta is the same as the new dataSource, it should be based on fullName, because fullName includes the folder name, to avoid still fetching the old meta after renaming the folder.