### PR TITLE
fix Bug #72198, get correct table expand row count, now export use real row height not AssetUtil.defh.

### DIFF
--- a/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
@@ -2367,7 +2367,7 @@ public abstract class AbstractVSExporter implements VSExporter {
             hrow = vsinfo != null ? Math.max(1, vsinfo.getRuntimeColHeaders().length) : 0;
          }
 
-         int tableLineCount = getExpandTableLineCount(table, obj, titleRow, hrow, match);;
+         int tableLineCount = table.getRowCount() - hrow;
          rowCount = Math.min(tableLineCount, getMaxRow(ypos));
       }
 


### PR DESCRIPTION
get correct table expand row count, now export use real row height not AssetUtil.defh.