### PR TITLE
fix Bug #72242: should not add localize for bookmark name when filter bookmark

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSExportService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSExportService.java
@@ -382,7 +382,7 @@ public class VSExportService {
 
       for(VSBookmarkInfo vsBookmarkInfo : allBookmarks) {
          if(vsBookmarkInfo.getName().equals(VSBookmark.HOME_BOOKMARK)) {
-            allBookmarkNames.add(Catalog.getCatalog().getString(vsBookmarkInfo.getName()));
+            allBookmarkNames.add(vsBookmarkInfo.getName());
          }
          else if(vsBookmarkInfo.getOwner() == null ||
             principal != null && Tool.equals(vsBookmarkInfo.getOwner().convertToKey(), principal.getName()))


### PR DESCRIPTION
should not localize the bookmark name when export, after localize make the bookmark not find in bookmark list and will export null image