### PR TITLE
Bug #72254

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
@@ -1820,7 +1820,7 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
          p2 = getRowCol(position.x + size.width, position.y + size.height, bottom);
 
          // ensure the bottom row is exclusive so the last item in larger lists can render
-         if (info instanceof SelectionTreeVSAssemblyInfo) {
+         if(info instanceof SelectionTreeVSAssemblyInfo) {
             p2.y = p2.y + 1;
          }
       }


### PR DESCRIPTION
ensure bottom row count does not match exclusive anchor height in large selection trees by manually increasing by 1