### PR TITLE
Bug #72280,

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleControllerService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleControllerService.java
@@ -263,7 +263,7 @@ public class CoreLifecycleControllerService {
          auditFinish = processSheet(rvs, event, uri, dispatcher, rvs.getAssetRepository(), user);
       }
 
-      return new ProcessSheetResult(id, auditFinish, coreLifecycleService.getPermissions(rvs, user));
+      return new ProcessSheetResult(id, auditFinish);
    }
 
    private boolean processSheet(RuntimeViewsheet rvs, OpenViewsheetEvent event, String linkUri,
@@ -555,16 +555,10 @@ public class CoreLifecycleControllerService {
    public static final class ProcessSheetResult implements Serializable {
       private String id;
       private boolean auditFinish;
-      private Set<String> dispatchPermissions;
-
-      public ProcessSheetResult(String id, boolean auditFinish, Set<String> dispatchPermissions) {
-         this.id = id;
-         this.auditFinish = auditFinish;
-         this.dispatchPermissions = dispatchPermissions;
-      }
 
       public ProcessSheetResult(String id, boolean auditFinish) {
-         this(id, auditFinish, null);
+         this.id = id;
+         this.auditFinish = auditFinish;
       }
 
       public String getId() {
@@ -581,14 +575,6 @@ public class CoreLifecycleControllerService {
 
       public void setAuditFinish(boolean auditFinish) {
          this.auditFinish = auditFinish;
-      }
-
-      public Set<String> getDispatchPermissions() {
-         return dispatchPermissions;
-      }
-
-      public void setDispatchPermissions(Set<String> dispatchPermissions) {
-         this.dispatchPermissions = dispatchPermissions;
       }
    }
 

--- a/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
@@ -116,11 +116,6 @@ public class CoreLifecycleService {
             id, eid, execSessionId, null, bookmarkIndex, drillFrom, entry, viewer, uri, variables,
             event, dispatcher, user);
          id = result.getId();
-
-         if(id != null && !id.isEmpty()) {
-            dispatcher.sendCommand(
-               null, new SetRuntimeIdCommand(id, result.getDispatchPermissions()));
-         }
       }
       else {
          id = engine.openViewsheet(entry, user, viewer);
@@ -138,11 +133,6 @@ public class CoreLifecycleService {
 
       if(runtimeViewsheetManager != null && result.getId() != null) {
          runtimeViewsheetManager.sheetOpened(user, result.getId());
-      }
-
-      if(result.getId() != null && !result.getId().isEmpty()) {
-         dispatcher.sendCommand(
-            null, new SetRuntimeIdCommand(result.getId(), result.getDispatchPermissions()));
       }
 
       return result;


### PR DESCRIPTION
Don't send SetRuntimeIdCommand after handleOpenSheet, breaks SetPermissionsCommand and is extraneous because call occurs in handleOpenSheet