### PR TITLE
Bug #71779  Fixed various issues with the 503 error page

### DIFF
--- a/web/projects/portal/src/app/reload/reload-page.component.ts
+++ b/web/projects/portal/src/app/reload/reload-page.component.ts
@@ -20,6 +20,7 @@ import { Component, NgZone, OnDestroy, OnInit } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { Subscription, throwError, timer } from "rxjs";
 import { mergeMap, retryWhen } from "rxjs/operators";
+import { StompClientService } from "../../../../shared/stomp/stomp-client.service";
 
 @Component({
    selector: "reload-page",
@@ -34,7 +35,7 @@ export class ReloadPageComponent implements OnInit, OnDestroy {
    protected redirectTo: string;
 
    constructor(private route: ActivatedRoute, private router: Router,
-               private http: HttpClient, private zone: NgZone)
+               private http: HttpClient, private zone: NgZone, private stompClientService: StompClientService)
    {
       this.route.queryParamMap.subscribe(params => {
          this.redirectTo = decodeURIComponent(params.get('redirectTo'));
@@ -43,6 +44,8 @@ export class ReloadPageComponent implements OnInit, OnDestroy {
    }
 
    ngOnInit(): void {
+      this.stompClientService.redirectToErrorPage();
+
       this.pingSubscription = this.http.get(this.pingUrl, { responseType: "text" }).pipe(
          retryWhen(errors =>
             errors.pipe(

--- a/web/projects/portal/src/app/widget/services/model.service.ts
+++ b/web/projects/portal/src/app/widget/services/model.service.ts
@@ -23,6 +23,7 @@ import {
    HttpResponse
 } from "@angular/common/http";
 import { Injectable } from "@angular/core";
+import { Router } from "@angular/router";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { Observable, throwError } from "rxjs";
 import { catchError } from "rxjs/operators";
@@ -36,7 +37,7 @@ export class ModelService {
    private readonly formHeaders: HttpHeaders;
    private _errorHandler: (error: any) => boolean;
 
-   constructor(private http: HttpClient, private modalService: NgbModal) {
+   constructor(private http: HttpClient, private modalService: NgbModal, private router: Router) {
       this.headers = new HttpHeaders({
          "Content-Type": "application/json",
          "X-Requested-With": "XMLHttpRequest",
@@ -127,6 +128,11 @@ export class ModelService {
          res.status != 502 && res.status != 503)
       {
          ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)", errMsg);
+      }
+
+      if(res.status == 502 || res.status == 503) {
+         this.router.navigate(['/reload'],
+            {queryParams: { redirectTo: this.router.url }, replaceUrl: true})
       }
 
       return throwError(errMsg);

--- a/web/projects/shared/stomp/stomp-client-channel.ts
+++ b/web/projects/shared/stomp/stomp-client-channel.ts
@@ -114,6 +114,10 @@ export class StompClientChannel {
       this.client.send(destination, headers, body);
    }
 
+   hasConnection(): boolean {
+      return !!this.client;
+   }
+
    private subscribeToTopic(destination: string, topic: StompTopic): Stomp.Subscription {
       return this.client.subscribe(destination, (message: Stomp.Frame) => {
          topic.subject.next({ frame: message });

--- a/web/projects/shared/stomp/stomp-client.service.ts
+++ b/web/projects/shared/stomp/stomp-client.service.ts
@@ -67,6 +67,12 @@ export class StompClientService {
       this.clients.forEach(v => v.reloadOnFailure = reload);
    }
 
+   public redirectToErrorPage() {
+      for(let client of this.clients.values()) {
+         client.redirectToErrorPage();
+      }
+   }
+
    private onDisconnect(endpoint: string) {
       this.clients.delete(endpoint);
       this.disconnectSubject.next();


### PR DESCRIPTION
The changes include stopping the stomp client from routing to the error page multiple times, removing the closed websockets remaining after refresh, and more coverage on when to redirect to the error page