### PR TITLE
Merge forward Bug #72270 - dashboard refresh script function

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuerySandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuerySandbox.java
@@ -917,8 +917,9 @@ public class AssetQuerySandbox implements Serializable, Cloneable, ActionListene
             : (TableAssembly) table.clone();
 
          AssetQueryCacheNormalizer cacheNormalizer = new AssetQueryCacheNormalizer(table2, this, mode);
+         long touchTime = vsbox != null ? vsbox.getTouchTimestamp() : -1L;
          AssetQuery query = AssetQuery.createAssetQuery(
-            table2, mode, this, false, -1L, true, false);
+            table2, mode, this, false, touchTime, true, false);
 
          try {
             VariableTable vars2;

--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -538,7 +538,7 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
     */
    public long getTouchTimestamp() {
       if(root != null) {
-         return root.touchTS;
+         return Math.max(touchTS, root.touchTS);
       }
 
       return touchTS;

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VSUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VSUtil.java
@@ -40,6 +40,7 @@ import inetsoft.report.internal.table.*;
 import inetsoft.report.io.viewsheet.CoordinateHelper;
 import inetsoft.report.painter.PresenterPainter;
 import inetsoft.report.script.ReportJavaScriptEngine;
+import inetsoft.report.script.viewsheet.ViewsheetScope;
 import inetsoft.report.style.TableStyle;
 import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.SUtil;
@@ -1515,6 +1516,28 @@ public final class VSUtil {
          if(!token.isRef()) {
             parseText(token.val);
             return;
+         }
+
+         if(vs instanceof Viewsheet && ctoken != null && "refresh".equals(ctoken.val)) {
+            Viewsheet vsToRefresh = null;
+
+            // thisViewsheet, refresh this viewsheet
+            if(ViewsheetScope.VIEWSHEET_SCRIPTABLE.equals(token.val)) {
+               vsToRefresh = (Viewsheet) vs;
+            }
+            else {
+               Assembly assembly = vs.getAssembly(token.val);
+
+               if(assembly instanceof Viewsheet) {
+                  vsToRefresh = (Viewsheet) assembly;
+               }
+            }
+
+            if(vsToRefresh != null) {
+               for(Assembly assembly : vsToRefresh.getAssemblies(true)) {
+                  dset.add(new AssemblyRef(AssemblyRef.OUTPUT_DATA, assembly.getAssemblyEntry()));
+               }
+            }
          }
 
          Assembly assembly = vs.getAssembly(token.val);

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/OnClickController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/OnClickController.java
@@ -23,8 +23,8 @@ import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.report.internal.license.LicenseManager;
 import inetsoft.report.script.viewsheet.VSPropertyDescriptor;
 import inetsoft.report.script.viewsheet.ViewsheetScope;
-import inetsoft.uql.asset.AssemblyEntry;
-import inetsoft.uql.asset.AssemblyRef;
+import inetsoft.uql.asset.*;
+import inetsoft.uql.asset.internal.ScriptIterator;
 import inetsoft.uql.asset.internal.WSExecution;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.*;
@@ -33,7 +33,7 @@ import inetsoft.util.UserMessage;
 import inetsoft.web.binding.event.VSOnClickEvent;
 import inetsoft.web.viewsheet.LoadingMask;
 import inetsoft.web.viewsheet.Undoable;
-import inetsoft.web.viewsheet.command.MessageCommand;
+import inetsoft.web.viewsheet.command.*;
 import inetsoft.web.viewsheet.event.InputValue;
 import inetsoft.web.viewsheet.event.VSSubmitEvent;
 import inetsoft.web.viewsheet.model.RuntimeViewsheetRef;
@@ -46,6 +46,7 @@ import org.springframework.stereotype.Controller;
 
 import java.security.Principal;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Controller
 public class OnClickController {
@@ -62,7 +63,6 @@ public class OnClickController {
    }
 
    @Undoable
-   @LoadingMask
    @MessageMapping("/onclick/{name}/{x}/{y}/{isConfirm}")
    public void onConfirm(@DestinationVariable("name") String name,
                        @DestinationVariable("x") String x,
@@ -123,7 +123,6 @@ public class OnClickController {
    }
 
    @Undoable
-   @LoadingMask
    @MessageMapping("/onclick/{name}/{x}/{y}")
    public void onClick(@DestinationVariable("name") String name,
                        @DestinationVariable("x") String x,
@@ -157,12 +156,24 @@ public class OnClickController {
                                                            principal);
 
       WSExecution.setAssetQuerySandbox(rvs.getViewsheetSandbox().getAssetQuerySandbox());
+      Viewsheet vs = rvs.getViewsheet();
+      VSAssembly assembly = vs != null ? vs.getAssembly(name) : null;
+      String script = getScript(assembly);
+      boolean loadingMask = shouldShowLoadingMask(assembly, script, vs);
 
       try {
+         if(loadingMask) {
+            dispatcher.sendCommand(new ShowLoadingMaskCommand());
+         }
+
          process0(rvs, name, x, y, linkUri, isConfirm, usrmsg, principal, dispatcher);
       }
       finally {
          WSExecution.setAssetQuerySandbox(null);
+
+         if(loadingMask) {
+            dispatcher.sendCommand(new ClearLoadingCommand());
+         }
       }
    }
 
@@ -197,14 +208,7 @@ public class OnClickController {
 
       ViewsheetSandbox box0 = getVSBox(name, box);
       ViewsheetScope scope = box0.getScope();
-      String script = null;
-
-      if(assembly.getInfo() instanceof ClickableOutputVSAssemblyInfo) {
-         script = ((ClickableOutputVSAssemblyInfo) assembly.getInfo()).getOnClick();
-      }
-      else {
-         script = ((ClickableInputVSAssemblyInfo) assembly.getInfo()).getOnClick();
-      }
+      String script = getScript(assembly);
 
       if(xstr != null && ystr != null) {
          scope.put("mouseX", scope, xstr);
@@ -393,6 +397,59 @@ public class OnClickController {
       box0 = box0.getSandbox(vsName);
 
       return getVSBox(name.substring(index + 1, name.length()), box0);
+   }
+
+   private String getScript(VSAssembly assembly) {
+      if(assembly == null || !assembly.getVSAssemblyInfo().isScriptEnabled()) {
+         return null;
+      }
+
+      String script = null;
+
+      if(assembly.getInfo() instanceof ClickableOutputVSAssemblyInfo) {
+         script = ((ClickableOutputVSAssemblyInfo) assembly.getInfo()).getOnClick();
+      }
+      else if(assembly.getInfo() instanceof ClickableInputVSAssemblyInfo) {
+         script = ((ClickableInputVSAssemblyInfo) assembly.getInfo()).getOnClick();
+      }
+
+      return script;
+   }
+
+   private boolean shouldShowLoadingMask(VSAssembly assembly, String script, Viewsheet vs) {
+      AtomicBoolean loadingMask = new AtomicBoolean(true);
+
+      if(!(assembly instanceof SubmitVSAssembly) ||
+         !((SubmitVSAssemblyInfo) assembly.getInfo()).isRefresh())
+      {
+         ScriptIterator iterator = new ScriptIterator(script);
+         ScriptIterator.ScriptListener listener = (token, pref, cref) -> {
+            if(cref != null && "refresh".equals(cref.val)) {
+               Viewsheet vsToRefresh = null;
+
+               // thisViewsheet
+               if(ViewsheetScope.VIEWSHEET_SCRIPTABLE.equals(token.val)) {
+                  vsToRefresh = assembly.getViewsheet();
+               }
+               else {
+                  Assembly vsAssembly = vs.getAssembly(token.val);
+
+                  if(vsAssembly instanceof Viewsheet) {
+                     vsToRefresh = (Viewsheet) vsAssembly;
+                  }
+               }
+
+               if(vsToRefresh != null) {
+                  loadingMask.set(false);
+               }
+            }
+         };
+
+         iterator.addScriptListener(listener);
+         iterator.iterate();
+      }
+
+      return loadingMask.get();
    }
 
    private final RuntimeViewsheetRef runtimeViewsheetRef;


### PR DESCRIPTION
Add a script function to refresh a dashboard.
Make sure that data in script also uses fresh data on refresh. Use the touch timestamp of the viewsheet sandbox when available such as when executing script in viewsheets. Don't show the loading mask when using the script refresh function so that it doesn't appear as if the entire viewsheet is loading.