### PR TITLE
fix Bug #72265: should get class from plugin if catch exception from default class loader and its class loader is plugin 

### DIFF
--- a/core/src/main/java/inetsoft/util/CoreTool.java
+++ b/core/src/main/java/inetsoft/util/CoreTool.java
@@ -3741,7 +3741,7 @@ public class CoreTool {
          Method func = cls.getMethod(method, params == null ? new Class[] {} : params);
          return func.invoke(obj, args == null ? new Object[] {} : args);
       }
-      catch(ClassNotFoundException e) {
+      catch(Exception e) {
          try {
             if(obj == null || !(obj.getClass().getClassLoader() instanceof Plugin.PluginClassLoader)) {
                return null;


### PR DESCRIPTION
The tool.call used to call methods for db drivers, in old verion, it will cause classNotfound exception so it will get class from plugin. But in stylebi, we will get theses class from default classloader, but it will have methodAccestor for the methods, so it can not invoke method rightly. If catch exception, we should check if obj's class load is plugin class loader, if yes, should get method from plugin and then to invke it