### PR TITLE
fix Bug #72275: fix XTrinaryCondition when it is in XSet to get right types

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/JDBCQuery.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/JDBCQuery.java
@@ -576,7 +576,7 @@ public class JDBCQuery extends XQuery {
          return;
       }
 
-      if(xFilterNode instanceof XBinaryCondition ) {
+      if(xFilterNode instanceof XBinaryCondition) {
          fixConditionVariable((XBinaryCondition) xFilterNode, selection);
       }
       else if(xFilterNode instanceof XTrinaryCondition trinaryCondition) {
@@ -594,6 +594,9 @@ public class JDBCQuery extends XQuery {
             }
             else if(condition instanceof XSet) {
                fixXFilterVariable((XSet) condition, selection);
+            }
+            else if(condition instanceof XTrinaryCondition) {
+               fixConditionVariable((XTrinaryCondition) condition, selection);
             }
          }
       }


### PR DESCRIPTION
should fixed XTrinaryCondition to get right types from column when XTrinaryCondition is in XSet, if not in XSet, it is already fixed.