### PR TITLE
fix Bug #72326, don't wrap ExpiredSheetException by RuntimeException

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
@@ -937,11 +937,11 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
          try {
             return job.call();
          }
-         catch(ExpiredSheetException ex) {
+         catch(RuntimeException ex) {
             throw ex;
          }
-         catch(Exception e) {
-            throw new RuntimeException(e);
+         catch(Exception ex) {
+            throw new RuntimeException(ex);
          }
       }
 


### PR DESCRIPTION
don't wrap ExpiredSheetException by RuntimeException, to let ignore ExpiredSheetException logic can work.