### PR TITLE
fix Bug #72321: should save runtimePartition after addTable

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalModelManagerService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalModelManagerService.java
@@ -695,9 +695,9 @@ public class PhysicalModelManagerService {
 
       if(table != null) {
          tableName = physicalModelService.addPartitionTable(partition, table);
-         runtimePartitionService.saveRuntimePartition(rp);
 
          if(fixBounds) {
+            runtimePartitionService.saveRuntimePartition(rp);
             fixTableBounds(rp.getId(), partition, tableName);
          }
       }

--- a/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalModelManagerService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalModelManagerService.java
@@ -695,6 +695,7 @@ public class PhysicalModelManagerService {
 
       if(table != null) {
          tableName = physicalModelService.addPartitionTable(partition, table);
+         runtimePartitionService.saveRuntimePartition(rp);
 
          if(fixBounds) {
             fixTableBounds(rp.getId(), partition, tableName);


### PR DESCRIPTION
the bug is caused by the RuntimeXPartition will save before add table, so when fixTableBounds it will not get tables and popup null point exception. So after addtable to RuntimeXPartition, we should save it. Then fixTableBounds will get latest tables and works well(it will get runtime partition by runtimePartitionService.getRuntimePartition(runtimeId)).