### PR TITLE
fix Bug #72331: should not syncUserDashboards(identity) for ANONYMOUS user

### DIFF
--- a/core/src/main/java/inetsoft/sree/web/dashboard/DashboardManager.java
+++ b/core/src/main/java/inetsoft/sree/web/dashboard/DashboardManager.java
@@ -100,7 +100,9 @@ public class DashboardManager implements AutoCloseable {
    public synchronized String[] getDashboards(Identity identity, boolean sync) {
       init();
 
-      if(identity.getType() == Identity.USER && sync) {
+      if(identity.getType() == Identity.USER && sync &&
+         !ClientInfo.ANONYMOUS.equals(identity.getName()))
+      {
          try {
             syncUserDashboards(identity);
          }


### PR DESCRIPTION
the bug is caused by changes of Bug #70778, it changed type of ClientInfo.ANONYMOUS to user not role, but getDashboards will call syncUserDashboards, the method will get Dashboards of role type and to override user type to save for ANONYMOUS. In fact, we should not syncUserDashboards(identity) for ANONYMOUS user. It can get its dashboard from its user type key directly.