### PR TITLE
fix Bug #72331: should set runtime id to  runtimeViewsheetRef when preview

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/controller/ComposerViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/ComposerViewsheetController.java
@@ -143,6 +143,7 @@ public class ComposerViewsheetController {
                                 CommandDispatcher dispatcher,
                                 @LinkUri String linkUri) throws Exception
    {
+      runtimeViewsheetRef.setRuntimeId(event.getRuntimeViewsheetId());
       composerViewsheetService.previewViewsheet(runtimeViewsheetRef.getRuntimeId(),
                                                 event, principal, dispatcher, linkUri);
    }


### PR DESCRIPTION
the bug is caused by Feature#70119, runtimeViewsheetRef.getRuntimeId() will be null when preview, should set right value when preview