### PR TITLE
Fix Bug #72361:

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
@@ -285,8 +285,10 @@ public class VSBookmarkService {
                                             rvs.getID(), commandDispatcher);
          }
 
-         Cluster.getInstance().sendMessage(new ViewsheetBookmarkChangedEvent(rvs,
-                                                                             true, currBookmark.getName()));
+         if(currBookmark != null) {
+            Cluster.getInstance().sendMessage(new ViewsheetBookmarkChangedEvent(rvs,
+                                                                                true, currBookmark.getName()));
+         }
       }
       catch(MessageException ex) {
          MessageCommand command = new MessageCommand();


### PR DESCRIPTION
Because the value of currBookmark is the currently opened bookmark, if it is not opened, it will be null, which may cause a NullPointerException. Therefore, it is necessary to add null checks to prevent NPE.