### PR TITLE
Bug 72362: Adding null checks can prevent the NPE.

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VSUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VSUtil.java
@@ -6778,6 +6778,10 @@ public final class VSUtil {
     * Get viewsheet bookmark owner alias.
     */
    public static String getUserAlias(IdentityID owner) {
+      if(owner == null) {
+         return null;
+      }
+
       SecurityProvider securityProvider = SecurityEngine.getSecurity().getSecurityProvider();
 
       if(securityProvider == null || securityProvider.isVirtual()) {

--- a/core/src/main/java/inetsoft/web/portal/controller/PortalController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/PortalController.java
@@ -199,7 +199,7 @@ public class PortalController {
       }
 
       IdentityID pId = principal == null ? null :IdentityID.getIdentityIDFromKey(principal.getName());
-      String alias = VSUtil.getUserAlias(pId);
+      String alias = pId == null ? null : VSUtil.getUserAlias(pId);
 
       return CurrentUserModel.builder()
          .anonymous(principal == null || pId.name.equals(XPrincipal.ANONYMOUS))

--- a/core/src/main/java/inetsoft/web/portal/controller/PortalController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/PortalController.java
@@ -199,7 +199,7 @@ public class PortalController {
       }
 
       IdentityID pId = principal == null ? null :IdentityID.getIdentityIDFromKey(principal.getName());
-      String alias = pId == null ? null : VSUtil.getUserAlias(pId);
+      String alias = VSUtil.getUserAlias(pId);
 
       return CurrentUserModel.builder()
          .anonymous(principal == null || pId.name.equals(XPrincipal.ANONYMOUS))


### PR DESCRIPTION
During SSO login, the principal may be null, so pId would also be null. Therefore, retrieving the Alias based on pId would trigger a NullPointerException (NPE). Adding null checks can prevent the NPE.