### PR TITLE
fix Bug #72365: should calculate zindex for adhoc filter

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerAdhocFilterController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerAdhocFilterController.java
@@ -477,7 +477,7 @@ public class ComposerAdhocFilterController {
          }
       }
 
-      vs.addAssembly(vsassembly, false);
+      vs.addAssembly(vsassembly);
       coreLifecycleService.addDeleteVSObject(rvs, vsassembly, dispatcher);
    }
 


### PR DESCRIPTION
should calculate right zindex when add filter for table, caused by coding refactoring, for filter is not null it calculate zindex before, but other cases should calculate when add assembly.