### PR TITLE
fix Bug #72341. Fix task execution failure caused by the isLogin check not passing.

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/SUtil.java
+++ b/core/src/main/java/inetsoft/sree/internal/SUtil.java
@@ -725,7 +725,7 @@ public class SUtil {
     */
    public static SRPrincipal getPrincipal(IdentityID remoteUser, String remoteAddr, boolean fireEvent) {
       SRPrincipal principal = getPrincipal(remoteUser, remoteAddr, (String) null, fireEvent, null);
-      principal.setProperty("skipLoginCheck", "true");
+      principal.setIgnoreLogin(true);
       return principal;
    }
 

--- a/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
+++ b/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
@@ -1384,8 +1384,7 @@ public class SecurityEngine implements SessionListener, MessageListener, AutoClo
             return XPrincipal.SYSTEM.equals(identity.getName()) ||
                (ClientInfo.ANONYMOUS.equals(identity.getName()) &&
                (provider == null || provider.getAuthenticationProvider().isVirtual() ||
-                  containsAnonymous(identity.getOrgID()))) ||
-               "true".equals(((SRPrincipal) principal).getProperty("skipLoginCheck"));
+                  containsAnonymous(identity.getOrgID())));
          }
 
          ClientInfo user1 = srPrincipal.getUser();


### PR DESCRIPTION
When using the principal obtained from the `getPrincipal` method for permission validation, the login check should be skipped.