### PR TITLE
fix Bug #72396: the getCurrentDate2 should be nullable because user can only select currentDate1

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/event/calendar/CalendarSelectionEvent.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/event/calendar/CalendarSelectionEvent.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 public abstract class CalendarSelectionEvent {
    public abstract String getCurrentDate1();
 
+   @Nullable
    public abstract String getCurrentDate2();
 
    @Nullable


### PR DESCRIPTION
for calendar, the getCurrentDate2 should be nullable because user can only select currentDate1