### PR TITLE
fix Bug #72209: remove dulicate loading for security provider page

### DIFF
--- a/web/projects/em/src/app/settings/security/security-list-view/security-list-view.component.html
+++ b/web/projects/em/src/app/settings/security/security-list-view/security-list-view.component.html
@@ -15,7 +15,6 @@
   ~ You should have received a copy of the GNU Affero General Public License
   ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   -->
-<mat-spinner color="accent" *ngIf="!providers"></mat-spinner>
 <mat-list>
   <mat-list-item class="list-item"
                  *ngFor="let provider of providers; let i = index; let first = first; let last = last;"


### PR DESCRIPTION
the bug is caused by Bug72001, it add loading for security-page when page loading, so there is no need for providers to loading in the same page. After page loaded, provider are loaded too.