### PR TITLE
fix Bug #72372, add session id for principal created by token.

### DIFF
--- a/core/src/main/java/inetsoft/web/security/JWTFilter.java
+++ b/core/src/main/java/inetsoft/web/security/JWTFilter.java
@@ -25,8 +25,7 @@ import inetsoft.web.security.auth.UnauthorizedAccessException;
 import inetsoft.web.security.auth.MissingTokenException;
 import inetsoft.web.security.auth.JwtService;
 import jakarta.servlet.*;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.*;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
@@ -86,8 +85,10 @@ public class JWTFilter extends AbstractSecurityFilter {
          }
 
          try {
+            final HttpSession session = httpRequest.getSession(false);
+            String sessionId = session != null ? session.getId() : null;
             SRPrincipal principal = service.getPrincipal(
-               request.getRemoteHost(), header, request.getLocale());
+               request.getRemoteHost(), header, sessionId, request.getLocale());
             httpRequest = new AuthenticatedRequest(httpRequest, principal);
             ThreadContext.setContextPrincipal(principal);
             ThreadContext.setLocale(principal.getLocale());


### PR DESCRIPTION
add session id for client info to make sure can get value from IgniteDistributedMap with serializabled data.