### PR TITLE
Merge forward changes for Bug #72342 - custom browse data query

### DIFF
--- a/core/src/main/java/inetsoft/uql/util/XUtil.java
+++ b/core/src/main/java/inetsoft/uql/util/XUtil.java
@@ -4793,6 +4793,36 @@ public final class XUtil {
       return null;
    }
 
+   public static boolean hasCustomBrowseDataQuery(XSourceInfo sourceInfo, DataRef column,
+                                                  Principal user)
+   {
+      XLogicalModel lmodel = XUtil.getLogicModel(sourceInfo, user);
+
+      if(lmodel == null) {
+         return false;
+      }
+
+      String entity = column.getEntity();
+      String attr = column.getAttribute();
+      int idx = attr == null ? -1 : attr.indexOf(":");
+
+      if(entity != null) {
+         attr = AssetUtil.trimEntity(attr, entity);
+      }
+      else if(idx != -1) {
+         entity = attr.substring(0, idx);
+         attr = attr.substring(idx + 1);
+      }
+
+      if(entity == null) {
+         return false;
+      }
+
+      XEntity xentity = lmodel.getEntity(entity);
+      XAttribute xattr = xentity.getAttribute(attr);
+      return xattr != null && xattr.getBrowseDataQuery() != null;
+   }
+
    private static final Map<Integer,String[]> DEFAULT_PATTERN = new HashMap<>();
 
    static {

--- a/core/src/main/java/inetsoft/web/composer/BrowseDataController.java
+++ b/core/src/main/java/inetsoft/web/composer/BrowseDataController.java
@@ -128,7 +128,7 @@ public class BrowseDataController {
             VSAQuery.appendCalcField((TableAssembly) assembly, name, true, viewsheet);
          }
 
-         model = executeByColumnCache(assembly);
+         model = executeByColumnCache(assembly, box.getBrowseUser());
 
          if(model == null) {
             model = executeByQuery(box, (TableAssembly) assembly);
@@ -169,9 +169,14 @@ public class BrowseDataController {
    /**
     * Execute data from column cache.
     */
-   private BrowseDataModel executeByColumnCache(Assembly assembly) {
+   private BrowseDataModel executeByColumnCache(Assembly assembly, Principal user) {
       if(sinfo == null && assembly instanceof BoundTableAssembly) {
-         sinfo = ((BoundTableAssembly) assembly).getSourceInfo();
+         SourceInfo modelSourceInfo = ((BoundTableAssembly) assembly).getSourceInfo();
+
+         // Bug #72342, use the model as source info only if it contains a custom browse query
+         if(XUtil.hasCustomBrowseDataQuery(modelSourceInfo, column, user)) {
+            sinfo = modelSourceInfo;
+         }
       }
 
       // only process model here, cause the column cache get data

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/VSConditionDialogController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/VSConditionDialogController.java
@@ -32,8 +32,7 @@ import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.erm.*;
 import inetsoft.uql.schema.XSchema;
-import inetsoft.uql.util.XNamedGroupInfo;
-import inetsoft.uql.util.XSourceInfo;
+import inetsoft.uql.util.*;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.uql.viewsheet.internal.*;
@@ -363,9 +362,15 @@ public class VSConditionDialogController {
       SourceInfo sourceInfo = null;
 
       if(wentry != null && wentry.isLogicModel()) {
-         sourceInfo = new SourceInfo(XSourceInfo.MODEL, wentry.getParentPath(), wentry.getName());
+         SourceInfo modelSourceInfo = new SourceInfo(XSourceInfo.MODEL, wentry.getParentPath(),
+                                                     wentry.getName());
+         // Bug #72342, use the model as source info only if it contains a custom browse query
+         if(XUtil.hasCustomBrowseDataQuery(modelSourceInfo, dataRef, principal)) {
+            sourceInfo = modelSourceInfo;
+         }
       }
-      else {
+
+      if(sourceInfo == null) {
          sourceInfo = assembly instanceof DataVSAssembly ?
             ((DataVSAssembly) assembly).getSourceInfo() : null;
       }


### PR DESCRIPTION
Use the model as source info only if it contains a custom browse query to get the browse data.