### PR TITLE
Merge forward changes for Bug #72356 - selector locking

### DIFF
--- a/core/src/main/java/inetsoft/report/script/formula/FormulaFunctions.java
+++ b/core/src/main/java/inetsoft/report/script/formula/FormulaFunctions.java
@@ -1373,7 +1373,7 @@ public class FormulaFunctions {
       TableRangeProcessor proc = new TableRangeProcessor(table, scope);
       Vector locs = new Vector();
       NamedCellRange range = new NamedCellRange(spec);
-      Map groups = range.getRuntimeGroups();
+      Map<String, NamedCellRange.GroupSpec> groups = range.getRuntimeGroups();
       String expr = range.getColumn();
 
       RangeSelector selector = null;

--- a/core/src/main/java/inetsoft/report/script/formula/NamedCellRange.java
+++ b/core/src/main/java/inetsoft/report/script/formula/NamedCellRange.java
@@ -258,7 +258,7 @@ public class NamedCellRange extends CellRange {
    /**
     * Resolve the variables and index in group specification.
     */
-   public Map getRuntimeGroups() {
+   public Map<String, GroupSpec> getRuntimeGroups() {
       Map<String, GroupSpec> groups = new HashMap<>(groupspecs);
       RuntimeCalcTableLens calc = null;
       XTable table = (XTable) FormulaContext.getTable();
@@ -352,7 +352,7 @@ public class NamedCellRange extends CellRange {
       }
 
       if(groupspecs.size() > 0) {
-         Map specs = getRuntimeGroups();
+         Map<String, GroupSpec> specs = getRuntimeGroups();
          GroupRowSelector groupsel = new GroupRowSelector(table, specs);
 
          if(summary) {
@@ -385,7 +385,7 @@ public class NamedCellRange extends CellRange {
       }
 
       Vector cells = new Vector();
-      Map specs = getRuntimeGroups();
+      Map<String, GroupSpec> specs = getRuntimeGroups();
       RangeSelector selector = CrosstabGroupSelector.getSelector(
               Tool.replaceAll(colexpr, LayoutTool.SCRIPT_ESCAPED_COLON, ":"), table, specs);
       CrosstabRangeProcessor proc = new CrosstabRangeProcessor(table, FormulaContext.getScope());
@@ -401,7 +401,7 @@ public class NamedCellRange extends CellRange {
     */
    private Collection getCalcCells(RuntimeCalcTableLens table, boolean position) {
       Vector cells = new Vector();
-      Map specs = getRuntimeGroups();
+      Map<String, GroupSpec> specs = getRuntimeGroups();
       RangeSelector selector = new CalcGroupSelector(table, specs);
       CalcRangeProcessor proc = new CalcRangeProcessor(table, FormulaContext.getScope());
 
@@ -431,7 +431,7 @@ public class NamedCellRange extends CellRange {
 
          try {
             if(groupspecs.size() > 0) {
-               Map specs = getRuntimeGroups();
+               Map<String, GroupSpec> specs = getRuntimeGroups();
                //selector = new ValueRowSelector(table, specs);
                // optimization
                selector = CachedRowSelector.getSelector(table, specs);
@@ -459,7 +459,7 @@ public class NamedCellRange extends CellRange {
    /**
     * Group value specification, an index or a group value.
     */
-   static class GroupSpec {
+   public static class GroupSpec {
       public GroupSpec(String str) {
          if(str.startsWith("\"") && str.endsWith("\"") ||
             str.startsWith("'") && str.endsWith("'"))

--- a/core/src/main/java/inetsoft/report/script/formula/RangeSelector.java
+++ b/core/src/main/java/inetsoft/report/script/formula/RangeSelector.java
@@ -21,7 +21,7 @@ import inetsoft.report.internal.FastDouble2String;
 import inetsoft.uql.XTable;
 import inetsoft.util.Tool;
 
-import java.util.ArrayList;
+import java.util.*;
 
 /**
  * An interface for selecting rows.
@@ -102,6 +102,31 @@ public abstract class RangeSelector {
          obj = toGroupString(obj);
          return super.add(obj);
       }
+   }
+
+   static class SelectorKey {
+      SelectorKey(XTable table, Set<String> groupKeys) {
+         this.tableId = System.identityHashCode(table);
+         this.groupKeys = new HashSet<>(groupKeys);
+      }
+
+      @Override
+      public boolean equals(Object obj) {
+         if(!(obj instanceof SelectorKey)) {
+            return false;
+         }
+
+         SelectorKey other = (SelectorKey) obj;
+         return tableId == other.tableId && groupKeys.equals(other.groupKeys);
+      }
+
+      @Override
+      public int hashCode() {
+         return Objects.hash(tableId, groupKeys);
+      }
+
+      private final int tableId;
+      private final Set<String> groupKeys;
    }
 
    protected boolean processCalc = false;


### PR DESCRIPTION
Don't use a class level lock. Lock on the selector key to allow other threads with other tables to proceed.