### PR TITLE
Bug #72391

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/TouchAssetController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/TouchAssetController.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.viewsheet.controller;
 
+import inetsoft.util.Tool;
 import inetsoft.web.viewsheet.event.TouchAssetEvent;
 import inetsoft.web.viewsheet.model.RuntimeViewsheetRef;
 import inetsoft.web.viewsheet.service.CommandDispatcher;
@@ -40,8 +41,12 @@ public class TouchAssetController {
                           CommandDispatcher commandDispatcher, @LinkUri String linkUri)
       throws Exception
    {
-         touchAssetServiceProxy.touchAsset(runtimeViewsheetRef.getRuntimeId(), event, principal,
-                                           commandDispatcher, linkUri);
+      String runtimeId = runtimeViewsheetRef.getRuntimeId();
+
+      if(!Tool.isEmptyString(runtimeId)) {
+         touchAssetServiceProxy.touchAsset(runtimeId, event, principal,
+                                             commandDispatcher, linkUri);
+      }
    }
 
    private RuntimeViewsheetRef runtimeViewsheetRef;


### PR DESCRIPTION
Check for null before call to proxied touchAsset to prevent stale call to touch deleted asset from throwing error