### PR TITLE
fix Bug #72433, ignore NoSuchFileException during delete blob cache file. because it may be deleted by the DeleteBlobTask.

### DIFF
--- a/core/src/main/java/inetsoft/storage/BlobCache.java
+++ b/core/src/main/java/inetsoft/storage/BlobCache.java
@@ -110,8 +110,12 @@ public class BlobCache {
    }
 
    protected void remove(String storeId, String digest, Path file) throws IOException {
-      if(file.toFile().exists()) {
-         Files.delete(file);
+      try {
+         if(file.toFile().exists()) {
+            Files.delete(file);
+         }
+      }
+      catch(NoSuchFileException ignore) {
       }
    }
 


### PR DESCRIPTION
ignore NoSuchFileException during delete blob cache file. because it may be deleted by the DeleteBlobTask.