### PR TITLE
Bug 72438: Apply Button Enable Logic Fix

### DIFF
--- a/web/projects/em/src/app/settings/content/repository/dashboard/repository-dashboard-settings-view/repository-dashboard-settings-view.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/dashboard/repository-dashboard-settings-view/repository-dashboard-settings-view.component.ts
@@ -156,6 +156,7 @@ export class RepositoryDashboardSettingsViewComponent implements OnChanges, OnIn
       oldModel.oname = "";
       const currModel = Tool.clone(this.model);
       currModel.oname = "";
+      console.log(this.form.invalid ,!this.form.valid, Tool.isEquals(oldModel, currModel), !this.dashboardChanged);
       return this.form.invalid || !this.form.valid || Tool.isEquals(oldModel, currModel) || !this.dashboardChanged;
    }
 
@@ -172,6 +173,7 @@ export class RepositoryDashboardSettingsViewComponent implements OnChanges, OnIn
 
    apply() {
       this.dashboardChanged = false;
+      this._oldModel = Tool.clone(this.model);
       this.dashboardSettingsChanged.emit(this.model);
    }
 

--- a/web/projects/em/src/app/settings/content/repository/dashboard/repository-dashboard-settings-view/repository-dashboard-settings-view.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/dashboard/repository-dashboard-settings-view/repository-dashboard-settings-view.component.ts
@@ -156,7 +156,6 @@ export class RepositoryDashboardSettingsViewComponent implements OnChanges, OnIn
       oldModel.oname = "";
       const currModel = Tool.clone(this.model);
       currModel.oname = "";
-      console.log(this.form.invalid ,!this.form.valid, Tool.isEquals(oldModel, currModel), !this.dashboardChanged);
       return this.form.invalid || !this.form.valid || Tool.isEquals(oldModel, currModel) || !this.dashboardChanged;
    }
 


### PR DESCRIPTION
Since this component directly assigns values based on the model, the oldModel should be reassigned after clicking "Apply". Otherwise, the oldModel will remain the initially opened model, which affects the disabling of the "Apply" button.