### PR TITLE
fix Bug #72458: should clone user's login user when clone client info

### DIFF
--- a/core/src/main/java/inetsoft/sree/ClientInfo.java
+++ b/core/src/main/java/inetsoft/sree/ClientInfo.java
@@ -223,7 +223,10 @@ public class ClientInfo implements Cloneable, Serializable, XMLSerializable {
     */
    @Override
    public Object clone() {
-      return new ClientInfo(userID, addr, session, locale);
+      ClientInfo newClient = new ClientInfo(userID, addr, session, locale);
+      newClient.loginUser = loginUser;
+
+      return newClient;
    }
 
    /**


### PR DESCRIPTION
should clone user's login user when clone client info, so it can check  user login to get right result