### PR TITLE
fix Bug #72434, set correct z-index for the adhoc filter when the target assembly is max mode.

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerAdhocFilterService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerAdhocFilterService.java
@@ -467,7 +467,7 @@ public class ComposerAdhocFilterService {
          }
       }
 
-      info.setZIndex(object.getVSAssemblyInfo().getZIndex() + 1);
+      info.setZIndex(getFilterZIndex(object));
       int width =
          containerInfo.getLayoutSize() != null && containerInfo.isVisible() ?
             containerInfo.getLayoutSize().width : 2 * AssetUtil.defw;


### PR DESCRIPTION
set correct z-index for the adhoc filter when the target assembly is max mode.