### PR TITLE
Bug #72460

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetDataCache.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetDataCache.java
@@ -478,6 +478,8 @@ public class AssetDataCache extends DataCache<DataKey, TableLens> {
                }
                catch(Exception e) {
                   LOG.warn("Failed to load table lens from distributed table cache store", e);
+
+                  cache.remove(key);
                }
             }
          }


### PR DESCRIPTION
clear cache entry on failed load to prevent persistently stored outdated and invalid data