### PR TITLE
Fix Bug #72196: Rounding Replaces Truncation.

### DIFF
--- a/core/src/main/java/inetsoft/report/gui/viewsheet/VSCalendar.java
+++ b/core/src/main/java/inetsoft/report/gui/viewsheet/VSCalendar.java
@@ -640,7 +640,7 @@ public class VSCalendar extends VSFloatable {
       int tx = x;
 
       if(center) {
-         tx = x + (w - fm.stringWidth(txt)) / 2;
+         tx = x + Math.round((w - fm.stringWidth(txt)) / 2.0f);
       }
       // default right align
       else {


### PR DESCRIPTION
The original calculation method only retained the integer part, but importing or exporting involved scaling up and down. If the scaling ratio was too large, it would lead to significant errors. Therefore, rounding was adopted to minimize the errors.