### PR TITLE
Bug #72510, fix chart DND binding error.

### DIFF
--- a/core/src/main/java/inetsoft/web/binding/dnd/controller/VSSourceChangeController.java
+++ b/core/src/main/java/inetsoft/web/binding/dnd/controller/VSSourceChangeController.java
@@ -52,5 +52,4 @@ public class VSSourceChangeController {
    }
 
    private VSSourceChangeServiceProxy vsSourceChangeServiceProxy;
-
 }

--- a/core/src/main/java/inetsoft/web/binding/dnd/controller/VSSourceChangeController.java
+++ b/core/src/main/java/inetsoft/web/binding/dnd/controller/VSSourceChangeController.java
@@ -33,7 +33,6 @@ public class VSSourceChangeController {
    public VSSourceChangeController(VSSourceChangeServiceProxy vsSourceChangeServiceProxy,
                                    VSAssemblyInfoHandler handler)
    {
-      this.handler = handler;
       this.vsSourceChangeServiceProxy = vsSourceChangeServiceProxy;
    }
 
@@ -49,9 +48,9 @@ public class VSSourceChangeController {
       @RequestParam("table") String table, Principal principal)
       throws Exception
    {
-      return vsSourceChangeServiceProxy.checkSourceChanged(vsId, aname, table, handler, principal);
+      return vsSourceChangeServiceProxy.checkSourceChanged(vsId, aname, table, principal);
    }
 
    private VSSourceChangeServiceProxy vsSourceChangeServiceProxy;
-   private final VSAssemblyInfoHandler handler;
+
 }

--- a/core/src/main/java/inetsoft/web/binding/dnd/controller/VSSourceChangeService.java
+++ b/core/src/main/java/inetsoft/web/binding/dnd/controller/VSSourceChangeService.java
@@ -34,13 +34,14 @@ import java.security.Principal;
 @ClusterProxy
 public class VSSourceChangeService {
 
-   public VSSourceChangeService(ViewsheetService viewsheetService) {
+   public VSSourceChangeService(ViewsheetService viewsheetService, VSAssemblyInfoHandler handler) {
       this.viewsheetService = viewsheetService;
+      this.handler = handler;
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
-   public SourceChangeMessage checkSourceChanged(@ClusterProxyKey String vsId, String aname, String table,
-                                                         VSAssemblyInfoHandler handler, Principal principal)
+   public SourceChangeMessage checkSourceChanged(@ClusterProxyKey String vsId, String aname,
+                                                 String table, Principal principal)
       throws Exception
    {
       ViewsheetService engine = viewsheetService;
@@ -63,4 +64,5 @@ public class VSSourceChangeService {
 
 
    private ViewsheetService viewsheetService;
+   private final VSAssemblyInfoHandler handler;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/SourceChangeMessage.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/SourceChangeMessage.java
@@ -17,7 +17,9 @@
  */
 package inetsoft.web.composer.model.vs;
 
-public class SourceChangeMessage {
+import java.io.Serializable;
+
+public class SourceChangeMessage implements Serializable {
 
    public boolean getChanged() {
       return changed;


### PR DESCRIPTION
1, VSAssemblyInfoHandler should not be serialized, because it is a spring bean. 
2, SourceChangeMessage should support Serialization, it will send between node.