### PR TITLE
Fix Bug #72399:Prevent redundant tree refreshes in distributed environment

### DIFF
--- a/web/projects/em/src/app/settings/schedule/schedule-folder-tree/schedule-folder-tree.component.ts
+++ b/web/projects/em/src/app/settings/schedule/schedule-folder-tree/schedule-folder-tree.component.ts
@@ -88,10 +88,11 @@ export class ScheduleFolderTreeComponent implements OnInit, OnDestroy {
    ngOnInit(): void {
       this.refreshTree(true, this._path);
       this.subscriptions.add(
-         this.scheduleChangeService.onFolderChange.subscribe(() => {
-            if(!this.suppressFolderChange) {
-               this.refreshTree();
-            }
+         this.scheduleChangeService.onFolderChange.pipe(
+            filter(() => !this.suppressFolderChange),
+            debounceTime(500)
+         ).subscribe(() => {
+            this.refreshTree();
          })
       );
    }


### PR DESCRIPTION
In a distributed environment, folder change events are broadcast multiple times, causing refreshTree() to run repeatedly and refresh the tree unnecessarily. Using RxJS debounceTime and suppressFolderChange ensures the tree refreshes only when needed.