### PR TITLE
Fix Bug #72468:Only when the imageData is not null should the image data be written.

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/PresenterController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/PresenterController.java
@@ -101,7 +101,7 @@ public class PresenterController {
       BinaryTransfer imageData = presenterServiceProxy
          .getPresenterImage(runtimeId, assembly, width, height,layout, layoutRegion, principal);
 
-      if(binaryTransferService.isEmpty(imageData)) {
+      if(!binaryTransferService.isEmpty(imageData)) {
          response.setContentType("image/png");
          OutputStream out = response.getOutputStream();
          binaryTransferService.writeData(imageData, out);


### PR DESCRIPTION
Only when the imageData is not null should the image data be written.