### PR TITLE
Bug #72506: should not Serializable for AssetRepository 

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/AssetTreeController.java
+++ b/core/src/main/java/inetsoft/web/composer/AssetTreeController.java
@@ -68,7 +68,7 @@ public class AssetTreeController {
       @RequestBody(required = false) AssetEntry entry,
       Principal principal) throws Exception
    {
-      return assetTreeServiceProxy.getConnectionParameters(rid, cubeData, entry, assetRepository, principal);
+      return assetTreeServiceProxy.getConnectionParameters(rid, cubeData, entry, principal);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/composer/AssetTreeService.java
+++ b/core/src/main/java/inetsoft/web/composer/AssetTreeService.java
@@ -46,13 +46,14 @@ import java.util.stream.Collectors;
 @ClusterProxy
 public class AssetTreeService {
 
-   public AssetTreeService(ViewsheetService viewsheetService) {
+   public AssetTreeService(ViewsheetService viewsheetService, AssetRepository assetRepository) {
       this.viewsheetService = viewsheetService;
+      this.assetRepository = assetRepository;
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public LoadAssetTreeNodesValidator getConnectionParameters(@ClusterProxyKey String rid, String cubeData, AssetEntry entry,
-                                                              AssetRepository assetRepository, Principal principal) throws Exception
+                                                              Principal principal) throws Exception
    {
       if(rid == null || "".equals(rid)) {
          return null;
@@ -129,4 +130,5 @@ public class AssetTreeService {
    }
 
    private ViewsheetService viewsheetService;
+   private AssetRepository assetRepository;
 }


### PR DESCRIPTION
Bug #72506: the bug is caused by assetRepository.getSession will throw null point, because the AssetRepository should not be seariable to other object, should inject through the service's constructor