### PR TITLE
Fix Bug #72363, avoid partitioning Spring Web-related caches on scheduler node

### DIFF
--- a/build-tools/cluster-proxy-annotations/src/main/resources/inetsoft/cluster/apt/Proxy.java.mustache
+++ b/build-tools/cluster-proxy-annotations/src/main/resources/inetsoft/cluster/apt/Proxy.java.mustache
@@ -33,7 +33,7 @@ public class {{proxySimpleName}} {
    public {{{returnType}}} {{name}}({{#parameters}}{{^first}}, {{/first}}{{{value.type}}} {{value.name}}{{/parameters}}){{#exceptions}}{{#first}} throws {{/first}}{{^first}}, {{/first}}{{value}}{{/exceptions}} {
       inetsoft.sree.internal.cluster.Cluster cluster = inetsoft.sree.internal.cluster.Cluster.getInstance();
 
-      if(cluster.isLocalCacheKey("{{cacheName}}", {{keyParam}})) {
+      if(cluster.isLocalCacheKey("{{cacheName}}", {{keyParam}}) || cluster.isLocalCall()) {
          {{targetClass}} service = inetsoft.util.ConfigurationContext.getContext().getSpringBean({{targetClass}}.class);
          return service.{{name}}({{#parameters}}{{^first}}, {{/first}}{{value.name}}{{/parameters}});
       }

--- a/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
+++ b/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
@@ -67,6 +67,7 @@ public class WorksheetEngine extends SheetLibraryEngine implements WorksheetServ
     */
    public WorksheetEngine(AssetRepository engine) throws RemoteException {
       Cluster cluster = Cluster.getInstance();
+      Cluster.getInstance().registerSpringProxyPartitionedCache(CACHE_NAME);
       amap = new RuntimeSheetCache(CACHE_NAME);
       emap = new ConcurrentHashMap<>();
       executionMap = new ExecutionMap();

--- a/core/src/main/java/inetsoft/sree/internal/cluster/Cluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/Cluster.java
@@ -254,6 +254,29 @@ public interface Cluster extends AutoCloseable {
    <K> boolean isLocalCacheKey(String cache, K key);
 
    /**
+    * Determines if should make the call local.
+    *
+    * @return {@code true} if make the call local or {@code false} if not.
+    */
+   <K> boolean isLocalCall();
+
+   /**
+    * Registers a cache name as a Spring Web / proxy related partitioned cache.
+    *
+    * <p>
+    * Caches registered via this method will be treated as "affinity-sensitive":
+    * when creating these caches in Ignite, the scheduler nodes will be excluded
+    * from holding any primary or backup partitions. This ensures that tasks
+    * triggered via Spring Web proxies or affinity calls are never dispatched
+    * to scheduler nodes, avoiding potential issues such as missing
+    * ApplicationContext or NPEs.
+    * </p>
+    *
+    * @param cacheName the name of the cache to register as a Spring Web / proxy partitioned cache.
+    */
+   void registerSpringProxyPartitionedCache(String cacheName);
+
+   /**
     * Executes given job on the node where data for provided affinity key is located.
     *
     * @param cache the name of the cache.

--- a/core/src/main/java/inetsoft/web/admin/content/repository/ImportAssetService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/ImportAssetService.java
@@ -54,6 +54,7 @@ public class ImportAssetService {
          .expireAfterAccess(10L, TimeUnit.MINUTES)
          .maximumSize(1000L)
          .build();
+      Cluster.getInstance().registerSpringProxyPartitionedCache(CACHE_NAME);
       this.contexts = Cluster.getInstance().getMap(CACHE_NAME);
    }
 

--- a/core/src/test/java/inetsoft/test/TestCluster.java
+++ b/core/src/test/java/inetsoft/test/TestCluster.java
@@ -541,6 +541,15 @@ public class TestCluster implements Cluster {
    }
 
    @Override
+   public <K> boolean isLocalCall() {
+      return true;
+   }
+
+   @Override
+   public void registerSpringProxyPartitionedCache(String cacheName) {
+   }
+
+   @Override
    public <T> T affinityCall(String cache, String key, AffinityCallable<T> job) {
       try {
          return job.call();


### PR DESCRIPTION
Avoid partitioning Spring Web-related caches on scheduler node to prevent them from becoming primary nodes for these caches. This eliminates NPE exceptions when calling ConfigurationContext.getContext().getSpringBean during AffinityCallable execution on scheduler nodes.

For client or scheduler operations, should use local calls.