### PR TITLE
Fix Bug #72546:Ignite distributed calls require that the return object must be serializable.

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/model/dialog/schedule/SimpleScheduleDialogModel.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/model/dialog/schedule/SimpleScheduleDialogModel.java
@@ -27,6 +27,7 @@ import inetsoft.web.viewsheet.model.dialog.ImmutableEmailAddrDialogModel;
 import org.immutables.value.Value;
 
 import javax.annotation.Nullable;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,7 +37,7 @@ import java.util.List;
 @Value.Immutable
 @JsonSerialize(as = ImmutableSimpleScheduleDialogModel.class)
 @JsonDeserialize(as = ImmutableSimpleScheduleDialogModel.class)
-public abstract class SimpleScheduleDialogModel {
+public abstract class SimpleScheduleDialogModel implements Serializable {
    @Nullable
    public abstract Boolean userDialogEnabled();
 


### PR DESCRIPTION
Ignite distributed calls require that the return object must be serializable.