### PR TITLE
Bug #72429: shoud add listener for empty repository path since repository maybe change by other nodes

### DIFF
--- a/core/src/main/java/inetsoft/sree/web/dashboard/DashboardRegistry.java
+++ b/core/src/main/java/inetsoft/sree/web/dashboard/DashboardRegistry.java
@@ -627,9 +627,7 @@ public class DashboardRegistry implements SessionListener {
          }
          else {
             try {
-               if(space.exists(null, path)) {
-                  dmgr.addChangeListener(space, null, path, changeListener);
-               }
+               dmgr.addChangeListener(space, null, path, changeListener);
             }
             catch(Exception ex) {
                String msg = "Merge Dashboard failed!";


### PR DESCRIPTION
the bug is only occor when first time open server and server have no security and no dashboards. (only occur for server nodes config)

when first time load registry, the repository is null, it will not add changeListener for dataspace change. So after first node to add dashboard, the second node will not dispatch changeListener and will not clear cache to reload dashboard from data space.

in fact, we should add change listener for every registry when load registry.(because registry will be changed by other nodes)