### PR TITLE
Bug 72524, fix assset tree refresh error after change an asset name.

### DIFF
--- a/core/src/main/java/inetsoft/report/lib/logical/AbstractLogicalLibrary.java
+++ b/core/src/main/java/inetsoft/report/lib/logical/AbstractLogicalLibrary.java
@@ -58,6 +58,7 @@ public abstract class AbstractLogicalLibrary<T> implements LogicalLibrary<T> {
 
    @Override
    public List<String> toSecureList() {
+      ReentrantReadWriteLock lock = getOrgLock(null);
       lock.readLock().lock();
 
       try {
@@ -72,6 +73,7 @@ public abstract class AbstractLogicalLibrary<T> implements LogicalLibrary<T> {
 
    @Override
    public Enumeration<String> toSecureEnumeration() {
+      ReentrantReadWriteLock lock = getOrgLock(null);
       lock.readLock().lock();
 
       try {
@@ -90,6 +92,7 @@ public abstract class AbstractLogicalLibrary<T> implements LogicalLibrary<T> {
    }
 
    protected Map<String, LogicalLibraryEntry<T>> toMap() {
+      ReentrantReadWriteLock lock = getOrgLock(null);
       lock.readLock().lock();
 
       try {
@@ -103,6 +106,7 @@ public abstract class AbstractLogicalLibrary<T> implements LogicalLibrary<T> {
    @Override
    public String caseInsensitiveFindName(String name, boolean secure) {
       final HashSet<String> temp;
+      ReentrantReadWriteLock lock = getOrgLock(null);
       lock.readLock().lock();
 
       try {
@@ -232,6 +236,7 @@ public abstract class AbstractLogicalLibrary<T> implements LogicalLibrary<T> {
    public int put(String name, T asset) {
       final int id;
       final TransactionType transactionType;
+      ReentrantReadWriteLock lock = getOrgLock(null);
       lock.writeLock().lock();
 
       try {
@@ -297,6 +302,7 @@ public abstract class AbstractLogicalLibrary<T> implements LogicalLibrary<T> {
    }
 
    public LogicalLibraryEntry getLogicalLibraryEntry(String name, String orgID) {
+      ReentrantReadWriteLock lock = getOrgLock(null);
       lock.readLock().lock();
 
       try {
@@ -342,6 +348,7 @@ public abstract class AbstractLogicalLibrary<T> implements LogicalLibrary<T> {
             "Permission denied to delete " + getEntryName()));
       }
 
+      ReentrantReadWriteLock lock = getOrgLock(null);
       lock.writeLock().lock();
 
       try {
@@ -442,6 +449,7 @@ public abstract class AbstractLogicalLibrary<T> implements LogicalLibrary<T> {
             "Permission denied to modify " + getEntryName()));
       }
 
+      ReentrantReadWriteLock lock = getOrgLock(null);
       lock.writeLock().lock();
 
       try {
@@ -580,15 +588,13 @@ public abstract class AbstractLogicalLibrary<T> implements LogicalLibrary<T> {
       }
    }
 
-   private ReentrantReadWriteLock getOrgLock(String orgId) {
+   protected ReentrantReadWriteLock getOrgLock(String orgId) {
       orgId = orgId == null ? OrganizationManager.getInstance().getCurrentOrgID() : orgId;
 
       return lockMap.computeIfAbsent(orgId, k -> new ReentrantReadWriteLock());
    }
 
    private final LibrarySecurity security;
-
-   protected final ReadWriteLock lock = new ReentrantReadWriteLock();
    private final Map<String, Map<String, LogicalLibraryEntry<T>>> nameToEntryMaps = new HashMap<>();
    protected final Deque<Transaction<LogicalLibraryEntry<T>>> transactions = new ArrayDeque<>();
    private final ConcurrentHashMap<String, ReentrantReadWriteLock> lockMap = new ConcurrentHashMap<>();

--- a/core/src/main/java/inetsoft/report/lib/logical/ScriptLogicalLibrary.java
+++ b/core/src/main/java/inetsoft/report/lib/logical/ScriptLogicalLibrary.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
 import java.util.*;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class ScriptLogicalLibrary extends AbstractLogicalLibrary<ScriptEntry> {
    protected ScriptLogicalLibrary(LibrarySecurity security) {
@@ -35,6 +36,7 @@ public class ScriptLogicalLibrary extends AbstractLogicalLibrary<ScriptEntry> {
 
    @Override
    public Enumeration<String> toSecureEnumeration() {
+      ReentrantReadWriteLock lock = getOrgLock(null);
       lock.readLock().lock();
 
       try {

--- a/core/src/main/java/inetsoft/report/lib/logical/ScriptLogicalLibrary.java
+++ b/core/src/main/java/inetsoft/report/lib/logical/ScriptLogicalLibrary.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
 import java.util.*;
+import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class ScriptLogicalLibrary extends AbstractLogicalLibrary<ScriptEntry> {
@@ -36,7 +37,7 @@ public class ScriptLogicalLibrary extends AbstractLogicalLibrary<ScriptEntry> {
 
    @Override
    public Enumeration<String> toSecureEnumeration() {
-      ReentrantReadWriteLock lock = getOrgLock(null);
+      ReadWriteLock lock = getOrgLock(null);
       lock.readLock().lock();
 
       try {

--- a/core/src/main/java/inetsoft/report/lib/logical/TableStyleFolderLogicalLibrary.java
+++ b/core/src/main/java/inetsoft/report/lib/logical/TableStyleFolderLogicalLibrary.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.lang.SecurityException;
 import java.lang.invoke.MethodHandles;
 import java.util.*;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 public class TableStyleFolderLogicalLibrary extends AbstractLogicalLibrary<String> {
@@ -85,6 +86,7 @@ public class TableStyleFolderLogicalLibrary extends AbstractLogicalLibrary<Strin
 
    public List<String> getTableStyleFolders(String folder, boolean filterAudit) {
       final boolean root = folder == null;
+      ReentrantReadWriteLock lock = getOrgLock(null);
       lock.readLock().lock();
 
       try {
@@ -170,6 +172,7 @@ public class TableStyleFolderLogicalLibrary extends AbstractLogicalLibrary<Strin
                .build());
       }
 
+      ReentrantReadWriteLock lock = getOrgLock(null);
       lock.writeLock().lock();
 
       try {
@@ -189,6 +192,7 @@ public class TableStyleFolderLogicalLibrary extends AbstractLogicalLibrary<Strin
     * name-value mapping is not necessary.
     */
    public void add(String folderName) {
+      ReentrantReadWriteLock lock = getOrgLock(null);
       lock.writeLock().lock();
 
       try {

--- a/core/src/main/java/inetsoft/report/lib/logical/TableStyleFolderLogicalLibrary.java
+++ b/core/src/main/java/inetsoft/report/lib/logical/TableStyleFolderLogicalLibrary.java
@@ -31,7 +31,7 @@ import java.io.InputStream;
 import java.lang.SecurityException;
 import java.lang.invoke.MethodHandles;
 import java.util.*;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.ReadWriteLock;
 import java.util.stream.Collectors;
 
 public class TableStyleFolderLogicalLibrary extends AbstractLogicalLibrary<String> {
@@ -86,7 +86,7 @@ public class TableStyleFolderLogicalLibrary extends AbstractLogicalLibrary<Strin
 
    public List<String> getTableStyleFolders(String folder, boolean filterAudit) {
       final boolean root = folder == null;
-      ReentrantReadWriteLock lock = getOrgLock(null);
+      ReadWriteLock lock = getOrgLock(null);
       lock.readLock().lock();
 
       try {
@@ -172,7 +172,7 @@ public class TableStyleFolderLogicalLibrary extends AbstractLogicalLibrary<Strin
                .build());
       }
 
-      ReentrantReadWriteLock lock = getOrgLock(null);
+      ReadWriteLock lock = getOrgLock(null);
       lock.writeLock().lock();
 
       try {
@@ -192,7 +192,7 @@ public class TableStyleFolderLogicalLibrary extends AbstractLogicalLibrary<Strin
     * name-value mapping is not necessary.
     */
    public void add(String folderName) {
-      ReentrantReadWriteLock lock = getOrgLock(null);
+      ReadWriteLock lock = getOrgLock(null);
       lock.writeLock().lock();
 
       try {

--- a/core/src/main/java/inetsoft/report/lib/logical/TableStyleLogicalLibrary.java
+++ b/core/src/main/java/inetsoft/report/lib/logical/TableStyleLogicalLibrary.java
@@ -31,7 +31,7 @@ import java.lang.SecurityException;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.ReadWriteLock;
 import java.util.stream.Collectors;
 
 public class TableStyleLogicalLibrary extends AbstractLogicalLibrary<XTableStyle> {
@@ -103,7 +103,7 @@ public class TableStyleLogicalLibrary extends AbstractLogicalLibrary<XTableStyle
 
    public List<XTableStyle> getTableStyles(String folder, boolean filterAudit) {
       final boolean root = folder == null;
-      ReentrantReadWriteLock lock = getOrgLock(null);
+      ReadWriteLock lock = getOrgLock(null);
       lock.readLock().lock();
 
       try {
@@ -138,7 +138,7 @@ public class TableStyleLogicalLibrary extends AbstractLogicalLibrary<XTableStyle
       final int id;
       final TransactionType transactionType;
       final String styleName = style.getName();
-      ReentrantReadWriteLock lock = getOrgLock(null);
+      ReadWriteLock lock = getOrgLock(null);
       lock.writeLock().lock();
 
       try {
@@ -205,7 +205,7 @@ public class TableStyleLogicalLibrary extends AbstractLogicalLibrary<XTableStyle
    }
 
    public String rename(String oldName, String newName, String oid) {
-      ReentrantReadWriteLock lock = getOrgLock(null);
+      ReadWriteLock lock = getOrgLock(null);
       lock.writeLock().lock();
 
       try {
@@ -257,7 +257,7 @@ public class TableStyleLogicalLibrary extends AbstractLogicalLibrary<XTableStyle
    @Override
    protected boolean checkPermission(ResourceType type, String name, ResourceAction action) {
       if(type == ResourceType.TABLE_STYLE) {
-         ReentrantReadWriteLock lock = getOrgLock(null);
+         ReadWriteLock lock = getOrgLock(null);
          lock.readLock().lock();
 
          try {
@@ -297,7 +297,7 @@ public class TableStyleLogicalLibrary extends AbstractLogicalLibrary<XTableStyle
 
       int idx = name.lastIndexOf(LibManager.SEPARATOR);
       name = idx >= 0 ? name.substring(idx + 1) : name;
-      ReentrantReadWriteLock lock = getOrgLock(null);
+      ReadWriteLock lock = getOrgLock(null);
       lock.readLock().lock();
 
       try {

--- a/core/src/main/java/inetsoft/report/lib/logical/TableStyleLogicalLibrary.java
+++ b/core/src/main/java/inetsoft/report/lib/logical/TableStyleLogicalLibrary.java
@@ -31,6 +31,7 @@ import java.lang.SecurityException;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 public class TableStyleLogicalLibrary extends AbstractLogicalLibrary<XTableStyle> {
@@ -102,6 +103,7 @@ public class TableStyleLogicalLibrary extends AbstractLogicalLibrary<XTableStyle
 
    public List<XTableStyle> getTableStyles(String folder, boolean filterAudit) {
       final boolean root = folder == null;
+      ReentrantReadWriteLock lock = getOrgLock(null);
       lock.readLock().lock();
 
       try {
@@ -136,6 +138,7 @@ public class TableStyleLogicalLibrary extends AbstractLogicalLibrary<XTableStyle
       final int id;
       final TransactionType transactionType;
       final String styleName = style.getName();
+      ReentrantReadWriteLock lock = getOrgLock(null);
       lock.writeLock().lock();
 
       try {
@@ -202,6 +205,7 @@ public class TableStyleLogicalLibrary extends AbstractLogicalLibrary<XTableStyle
    }
 
    public String rename(String oldName, String newName, String oid) {
+      ReentrantReadWriteLock lock = getOrgLock(null);
       lock.writeLock().lock();
 
       try {
@@ -253,6 +257,7 @@ public class TableStyleLogicalLibrary extends AbstractLogicalLibrary<XTableStyle
    @Override
    protected boolean checkPermission(ResourceType type, String name, ResourceAction action) {
       if(type == ResourceType.TABLE_STYLE) {
+         ReentrantReadWriteLock lock = getOrgLock(null);
          lock.readLock().lock();
 
          try {
@@ -292,6 +297,7 @@ public class TableStyleLogicalLibrary extends AbstractLogicalLibrary<XTableStyle
 
       int idx = name.lastIndexOf(LibManager.SEPARATOR);
       name = idx >= 0 ? name.substring(idx + 1) : name;
+      ReentrantReadWriteLock lock = getOrgLock(null);
       lock.readLock().lock();
 
       try {


### PR DESCRIPTION
1, add lock to load lib assets logic to ensure nodes data are consistent.
2, lower the lock level, make it scope is org.