### PR TITLE
Bug #72587: we should just init runtime entry for vs when new RuntimViewsheet

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
@@ -212,6 +212,8 @@ public class RuntimeViewsheet extends RuntimeSheet {
          embedAssemblyInfo = loadJson(EmbedAssemblyInfo.class, state.getEmbedAssemblyInfo(), mapper);
       }
 
+      setEntry(entry);
+
       // load base worksheet and create asset query sandbox
       resetRuntime();
    }


### PR DESCRIPTION
the bug is caused by the runtime asset entry is lost when preview because we will not write runtime asset entry and parse it, we should just init it when new RuntimViewsheet