### PR TITLE
Fix Bug #72583:When modifying the content in the cache, it should be saved promptly to avoid retrieving outdated information later.

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalGraphModelService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalGraphModelService.java
@@ -107,6 +107,7 @@ public class PhysicalGraphModelService {
 
       GraphViewModel graphModel = physicalGraphModel.getGraphViewModel();
       new PhysicalGraphLayout(graphModel, rPartition, colPriority).layout();
+      this.partitionService.saveRuntimePartition(rPartition);
    }
 
    public void createAlias(String runtimeId, String table, String alias) throws Exception {


### PR DESCRIPTION
When modifying the content in the cache, it should be saved promptly to avoid retrieving outdated information later.