### PR TITLE
Bug #72556, fix error when change select list value for cube source.

### DIFF
--- a/core/src/main/java/inetsoft/report/filter/CubeTableFilter.java
+++ b/core/src/main/java/inetsoft/report/filter/CubeTableFilter.java
@@ -125,7 +125,7 @@ public class CubeTableFilter extends DefaultTableFilter {
    /**
     * Indexed comparator compares objects by index.
     */
-   private class IndexedComparator implements Comparator, Serializable {
+   private static class IndexedComparator implements Comparator, Serializable {
       public IndexedComparator(Map<Object, Integer> map) {
          super();
          this.map = map;


### PR DESCRIPTION
 change CubeTableFilter#IndexedComparator class to static to avoid  serialize CubeTableFilter when serialize IndexedComparator