### PR TITLE
Bug #72574, fix open mv vs error.

### DIFF
--- a/core/src/main/java/inetsoft/mv/data/DetailMergedTableBlock.java
+++ b/core/src/main/java/inetsoft/mv/data/DetailMergedTableBlock.java
@@ -48,7 +48,7 @@ public final class DetailMergedTableBlock extends MergedTableBlock {
       this.intcols = intcols;
       this.tscols = tscols;
       
-      tbl = new PagedTableLens() {};
+      tbl = new MVQuery.PagedTableLens0();
       // bigdecimal is stored as double mv column. map the types to avoid class exception
       // when double is added to a XBDDoubleColumn
       Class[] types2 = Arrays.stream(types)

--- a/core/src/main/java/inetsoft/mv/data/MergedTableBlock.java
+++ b/core/src/main/java/inetsoft/mv/data/MergedTableBlock.java
@@ -29,6 +29,7 @@ import inetsoft.uql.util.XUtil;
 import inetsoft.uql.viewsheet.internal.VSUtil;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.List;
@@ -39,7 +40,7 @@ import java.util.List;
  * @author InetSoft Technology
  * @since  10.2
  */
-public abstract class MergedTableBlock implements XTableBlock {
+public abstract class MergedTableBlock implements XTableBlock, Serializable {
    /**
     * Constructor.
     */
@@ -282,5 +283,5 @@ public abstract class MergedTableBlock implements XTableBlock {
    final FormulaInfo[] infos;
    private boolean detail;
    boolean dimAggregate;
-   protected MVQuery query;
+   protected transient MVQuery query;
 }

--- a/core/src/main/java/inetsoft/mv/data/MergedTableBlock.java
+++ b/core/src/main/java/inetsoft/mv/data/MergedTableBlock.java
@@ -29,7 +29,6 @@ import inetsoft.uql.util.XUtil;
 import inetsoft.uql.viewsheet.internal.VSUtil;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.List;
@@ -40,7 +39,7 @@ import java.util.List;
  * @author InetSoft Technology
  * @since  10.2
  */
-public abstract class MergedTableBlock implements XTableBlock, Serializable {
+public abstract class MergedTableBlock implements XTableBlock {
    /**
     * Constructor.
     */
@@ -283,5 +282,5 @@ public abstract class MergedTableBlock implements XTableBlock, Serializable {
    final FormulaInfo[] infos;
    private boolean detail;
    boolean dimAggregate;
-   protected transient MVQuery query;
+   protected MVQuery query;
 }


### PR DESCRIPTION
fix tablelens serialize error after crete mv. make  MergedTableBlock is Serializable and ignore MVQuery, because MVQuery just use during execute.