### PR TITLE
Bug #72503 - don't store MV analysis in a session attribute

### DIFF
--- a/core/src/main/java/inetsoft/mv/MVDef.java
+++ b/core/src/main/java/inetsoft/mv/MVDef.java
@@ -26,7 +26,6 @@ import inetsoft.report.composition.QueryTreeModel.QueryNode;
 import inetsoft.report.composition.WorksheetWrapper;
 import inetsoft.report.composition.execution.*;
 import inetsoft.sree.internal.SUtil;
-import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.OrganizationManager;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
@@ -485,7 +484,7 @@ public final class MVDef implements Comparable, XMLSerializable, Serializable, C
    /**
     * Get all removed columns.
     */
-   public List<MVColumn> getRemovedColumns() {
+   private List<MVColumn> getRemovedColumns() {
       MVContainer container = getContainer();
       return container == null ? Collections.emptyList() : container.rcolumns;
    }
@@ -828,21 +827,11 @@ public final class MVDef implements Comparable, XMLSerializable, Serializable, C
          }
 
          container = this.container;
-
          // release memory in time, container pointed to by cref (weak ref)
          this.container = null;
       }
 
       return container;
-   }
-
-   public void restoreContainer(Worksheet ws, List<MVColumn> columns, List<MVColumn> rcolumns) {
-      if(getContainer() == null) {
-         this.container = new MVContainer(columns, ws);
-         this.container.rcolumns = rcolumns;
-         this.incremental = checkIncremental(ws);
-         this.containerRef = new SoftReference<>(container);
-      }
    }
 
    public MVMetaData getMetaData() {
@@ -2711,7 +2700,7 @@ public final class MVDef implements Comparable, XMLSerializable, Serializable, C
    // true if disable MV when VPM exists
    public static final ThreadLocal<Boolean> REJECT_VPM = ThreadLocal.withInitial(() -> false);
 
-   transient MVContainer container = null;
+   MVContainer container = null;
    private transient SoftReference<MVContainer> containerRef = new SoftReference<>(null);
    private String plan = null; // query plan of the mvDef
    private String mvname = null; // name of this mv

--- a/core/src/main/java/inetsoft/web/admin/content/repository/model/AnalyzeMVResponse.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/model/AnalyzeMVResponse.java
@@ -55,6 +55,8 @@ public interface AnalyzeMVResponse {
    @Value.Default
    default boolean runInBackground() { return false; }
 
+   String analysisId();
+
     static AnalyzeMVResponse.Builder builder() {
         return new AnalyzeMVResponse.Builder();
     }

--- a/core/src/main/java/inetsoft/web/portal/controller/PortalMVController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/PortalMVController.java
@@ -24,12 +24,11 @@ import inetsoft.uql.XPrincipal;
 import inetsoft.util.Tool;
 import inetsoft.web.admin.content.repository.MVService;
 import inetsoft.web.admin.content.repository.MVSupportService;
+import inetsoft.web.admin.content.repository.model.AnalyzeMVResponse;
 import inetsoft.web.admin.content.repository.model.MVManagementModel;
 import inetsoft.web.factory.DecodePathVariable;
 import inetsoft.web.portal.model.AnalyzeMVPortalRequest;
 import inetsoft.web.portal.model.MVTreeModel;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -46,14 +45,16 @@ public class PortalMVController {
    }
 
    @PostMapping("/api/portal/content/repository/mv/analyze")
-   public void analyze(@RequestBody AnalyzeMVPortalRequest analyzeMVPortalRequest,
-                       HttpServletRequest req, Principal principal)
+   public AnalyzeMVResponse analyze(@RequestBody AnalyzeMVPortalRequest analyzeMVPortalRequest,
+                                    Principal principal)
       throws Exception
    {
-      HttpSession session = req.getSession(true);
-      MVSupportService.AnalysisResult jobs =
+      MVSupportService.AnalysisResult analysisResult =
          portalMVService.analyze(analyzeMVPortalRequest, principal);
-      session.setAttribute("mv_jobs", jobs);
+      return AnalyzeMVResponse.builder()
+         .completed(false)
+         .analysisId(analysisResult.getId())
+         .build();
    }
 
    @PostMapping("/api/portal/content/materialized-view/info")

--- a/web/projects/em/src/app/settings/content/materialized-views/mv-management-view/mv-management-view.component.ts
+++ b/web/projects/em/src/app/settings/content/materialized-views/mv-management-view/mv-management-view.component.ts
@@ -271,7 +271,7 @@ export class MvManagementViewComponent implements OnInit, OnDestroy {
                });
             }
             else {
-               this.analysisCompleted();
+               this.analysisCompleted(response.analysisId);
             }
          }, () => this.loading = false);
    }
@@ -285,10 +285,10 @@ export class MvManagementViewComponent implements OnInit, OnDestroy {
          });
    }
 
-   private analysisCompleted(): void {
-      this.http.get("../api/em/content/materialized-view/check-analysis").subscribe((response: AnalyzeMVResponse) => {
+   private analysisCompleted(analysisId: string): void {
+      this.http.get("../api/em/content/materialized-view/check-analysis/" + analysisId).subscribe((response: AnalyzeMVResponse) => {
          if(!response.completed) {
-            setTimeout(() => this.analysisCompleted(), 5000);
+            setTimeout(() => this.analysisCompleted(analysisId), 5000);
             return;
          }
 
@@ -297,7 +297,7 @@ export class MvManagementViewComponent implements OnInit, OnDestroy {
          this.loading = false;
 
          if(response.exception) {
-            this.http.get("../api/em/content/repository/mv/exceptions").subscribe(
+            this.http.get("../api/em/content/repository/mv/exceptions/" + analysisId).subscribe(
                (exceptions: MVExceptionResponse) =>
                {
                   // open the exception dialog

--- a/web/projects/shared/util/model/mv/analyze-mv-response.ts
+++ b/web/projects/shared/util/model/mv/analyze-mv-response.ts
@@ -27,4 +27,5 @@ export interface AnalyzeMVResponse {
    defaultCycle?: string;
    runInBackground?: boolean;
    dateFormat?: string;
+   analysisId: string;
 }


### PR DESCRIPTION
Don't store MV analysis in a session attribute. Add it to a distributed map instead and pass an analysis identifier to retrieve it. Reverted the changes for restoring MVContainer. Just make it serializable and there is no need for this additional logic.