### PR TITLE
Bug #72636, fix npe during edit ws join.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeWorksheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeWorksheet.java
@@ -115,12 +115,15 @@ public class RuntimeWorksheet extends RuntimeSheet
          vars = loadJson(VariableTable.class, state.getVars(), mapper);
       }
 
-      box = new AssetQuerySandbox(ws, (XPrincipal) getUser(), vars);
-      box.setWSName(entry.getSheetName());
-      box.setWSEntry(entry);
-      box.setBaseUser(user);
-      box.setActive(true);
-      box.setQueryManager(new QueryManager());
+      if(entry != null) {
+         box = new AssetQuerySandbox(ws, (XPrincipal) getUser(), vars);
+         box.setWSName(entry.getSheetName());
+         box.setWSEntry(entry);
+         box.setBaseUser(user);
+         box.setActive(true);
+         box.setQueryManager(new QueryManager());
+      }
+
       preview = state.isPreview();
       gettingStarted = state.isGettingStarted();
       pid = state.getPid();


### PR DESCRIPTION
need not to init the AssetQuerySandbox if the entry of RuntimeWorksheet is null. just joinWs entry is null.