### PR TITLE
fix Bug #72638, Fix a bunch of broken issues in the viewsheet wizard.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
@@ -613,6 +613,14 @@ public abstract class RuntimeSheet {
       }
    }
 
+   public long getModified() {
+      return modified;
+   }
+
+   public void setModified(long modified) {
+      this.modified = modified;
+   }
+
    static final class XSwappableSheetList {
       public XSwappableSheetList(XPrincipal contextPrincipal) {
          this.values = new LinkedList<>();
@@ -901,6 +909,7 @@ public abstract class RuntimeSheet {
    private long heartbeat = System.currentTimeMillis(); // heartbeat timestamp
    private Map<String, Object> prop = new HashMap<>();
    private String previousURL;
+   private long modified;
 
    private static final Logger LOG =
       LoggerFactory.getLogger(RuntimeSheet.class);

--- a/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
@@ -4000,7 +4000,7 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
          writer.println("<assemblies>");
 
          for(Assembly assembly : assemblies) {
-            writer.println("<oneAssembly>");
+            writer.println("<oneAssembly isLatestTemp=\"" + (latestTemp == assembly)+ "\">");
             assembly.writeXML(writer);
             writer.println("</oneAssembly>");
          }
@@ -4166,6 +4166,10 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
 
          if(assembly == null) {
             continue;
+         }
+
+         if("true".equalsIgnoreCase(Tool.getAttribute(onenode, "isLatestTemp"))) {
+            latestTemp = assembly;
          }
 
          // parse state content may have been added the assembly

--- a/core/src/main/java/inetsoft/web/binding/service/VSBindingService.java
+++ b/core/src/main/java/inetsoft/web/binding/service/VSBindingService.java
@@ -1820,6 +1820,7 @@ public class VSBindingService {
          orvs.addCheckpoint(nvs.prepareCheckpoint());
       }
 
+      engine.flushRuntimeSheet(oid == null ? nid : oid);
       engine.closeViewsheet(nid, principal);
 
       return oid;

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartLegendsVisibilityService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartLegendsVisibilityService.java
@@ -79,7 +79,9 @@ public class VSChartLegendsVisibilityService extends VSChartControllerService<VS
                RuntimeViewsheet rtv = getViewsheetEngine().getViewsheet(runtimeId, principal);
                VSTemporaryInfo temporaryInfo = temporaryInfoService.getVSTemporaryInfo(rtv);
                temporaryInfo.setShowLegend(!event.isHide());
-            } catch (Exception ex) {
+               getViewsheetEngine().flushRuntimeSheet(runtimeId);
+            }
+            catch (Exception ex) {
                throw new RuntimeException(ex);
             }
          }

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSCloseObjectWizardService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSCloseObjectWizardService.java
@@ -26,6 +26,7 @@ import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.uql.asset.AggregateRef;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.*;
+import inetsoft.util.Tool;
 import inetsoft.web.viewsheet.command.UpdateUndoStateCommand;
 import inetsoft.web.viewsheet.model.VSObjectModel;
 import inetsoft.web.viewsheet.model.VSObjectModelFactoryService;
@@ -85,6 +86,9 @@ public class VSCloseObjectWizardService {
          return null;
       }
 
+      System.err.println("\n----0---closeobject wizard---" + vsId +"----"
+                            + rvs.getViewsheet().getAssemblies().length  + "---" + rvs.hashCode() + "---" + Tool.getIP());
+
       ViewsheetSandbox box = rvs.getViewsheetSandbox();
       // shouldn't hold up save/close a vs by a long running query/filter since the
       // saved info doesn't need the runtime data.
@@ -129,6 +133,11 @@ public class VSCloseObjectWizardService {
                updateAllCalcField(vs, orvs.getViewsheet());
             }
 
+            System.err.println("\n----1---closeobject wizard---" + vsId +"----"
+                                  + rvs.getViewsheet().getAssemblies().length  + "---" + rvs.hashCode() + "---" + Tool.getIP());
+
+
+            viewsheetService.flushRuntimeSheet(vsId);
             return null;
          }
 
@@ -198,6 +207,9 @@ public class VSCloseObjectWizardService {
 
          model = objectModelService.createModel(tempAssembly, orvs);
          orvs.addCheckpoint(orvs.getViewsheet().prepareCheckpoint());
+         String orid = rvs.getOriginalID();
+         orid = orid == null ? vsId : orid;
+         viewsheetService.flushRuntimeSheet(vsId);
 
          UpdateUndoStateCommand command = new UpdateUndoStateCommand();
          command.setPoints(orvs.size());

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardBindingService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardBindingService.java
@@ -169,6 +169,7 @@ public class VSWizardBindingService {
          }
          else {
             refreshBindingRefs(id, event, dispatcher, principal, linkUri);
+            viewsheetService.flushRuntimeSheet(id);
          }
       }
       finally {
@@ -264,6 +265,7 @@ public class VSWizardBindingService {
       }
       finally {
          box.unlockWrite();
+         viewsheetService.flushRuntimeSheet(id);
       }
 
       return null;
@@ -307,6 +309,7 @@ public class VSWizardBindingService {
       }
       finally {
          box.unlockWrite();
+         viewsheetService.flushRuntimeSheet(id);
       }
 
       return null;

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardDialogService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardDialogService.java
@@ -99,6 +99,7 @@ public class VSWizardDialogService {
       }
       finally {
          box.unlockWrite();
+         viewsheetService.flushRuntimeSheet(runtimeId);
       }
 
       SaveSheetCommand command = SaveSheetCommand.builder()

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardFormatService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardFormatService.java
@@ -103,6 +103,7 @@ public class VSWizardFormatService {
       }
       finally {
          box.unlockRead();
+         viewsheetService.flushRuntimeSheet(id);
       }
 
       return null;

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardObjectService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardObjectService.java
@@ -214,6 +214,7 @@ public class VSWizardObjectService {
          }
 
          box.unlockWrite();
+         viewsheetService.flushRuntimeSheet(vsId);
       }
 
       return null;
@@ -390,6 +391,7 @@ public class VSWizardObjectService {
       }
       finally {
          box.unlockRead();
+         viewsheetService.flushRuntimeSheet(id);
       }
 
       return null;
@@ -472,6 +474,7 @@ public class VSWizardObjectService {
       }
       finally {
          box.unlockWrite();
+         viewsheetService.flushRuntimeSheet(rid);
       }
 
       return null;
@@ -510,6 +513,7 @@ public class VSWizardObjectService {
       }
       finally {
          box.unlockRead();
+         viewsheetService.flushRuntimeSheet(id);
       }
 
       return null;

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardObjectToolbarService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardObjectToolbarService.java
@@ -85,6 +85,8 @@ public class VSWizardObjectToolbarService {
          {
             assembly.setPixelSize(originalAssembly.getPixelSize());
          }
+
+         viewsheetService.flushRuntimeSheet(id);
       }
 
       return null;

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardPreviewService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardPreviewService.java
@@ -65,6 +65,7 @@ public class VSWizardPreviewService {
       vsTemporaryInfo.setDescription(event.getText());
       VSAssembly latestAssembly = WizardRecommenderUtil.getTempAssembly(rvs.getViewsheet());
       bindingHandler.updateTitle(rvs, latestAssembly);
+      viewsheetService.flushRuntimeSheet(id);
 
       return null;
    }
@@ -89,6 +90,8 @@ public class VSWizardPreviewService {
          bindingHandler.fixTempAssemblySize(latestAssembly.getVSAssemblyInfo(), rvs);
          coreLifecycleService.refreshVSAssembly(rvs, latestAssembly, dispatcher);
       }
+
+      viewsheetService.flushRuntimeSheet(id);
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardVisualizationService.java
@@ -119,6 +119,7 @@ public class VSWizardVisualizationService {
       }
       finally {
          box.unlockWrite();
+         viewsheetService.flushRuntimeSheet(id);
       }
 
       return null;

--- a/core/src/main/java/inetsoft/web/vswizard/controller/WizardDeleteObjectService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/WizardDeleteObjectService.java
@@ -62,6 +62,7 @@ public class WizardDeleteObjectService {
       }
       finally {
          box.unlockWrite();
+         engine.flushRuntimeSheet(vsId);
       }
 
       return null;

--- a/core/src/main/java/inetsoft/web/vswizard/controller/WizardInsertObjectService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/WizardInsertObjectService.java
@@ -58,6 +58,7 @@ public class WizardInsertObjectService {
       }
       finally {
          box.unlockWrite();
+         engine.flushRuntimeSheet(vId);
       }
 
       return null;

--- a/core/src/main/java/inetsoft/web/vswizard/controller/WizardObjectMoveService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/WizardObjectMoveService.java
@@ -62,6 +62,7 @@ public class WizardObjectMoveService {
       }
       finally {
          box.unlockWrite();
+         engine.flushRuntimeSheet(vId);
       }
 
       return null;
@@ -86,6 +87,7 @@ public class WizardObjectMoveService {
       }
       finally {
          box.unlockWrite();
+         engine.flushRuntimeSheet(vId);
       }
 
       return null;

--- a/core/src/main/java/inetsoft/web/vswizard/controller/WizardObjectResizeService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/WizardObjectResizeService.java
@@ -59,6 +59,7 @@ public class WizardObjectResizeService {
       }
       finally {
          box.unlockRead();
+         engine.flushRuntimeSheet(vID);
       }
 
       return null;

--- a/core/src/main/java/inetsoft/web/vswizard/controller/WizardPaneService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/WizardPaneService.java
@@ -24,6 +24,7 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.WorksheetEngine;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.util.Tool;
 import inetsoft.web.viewsheet.service.CommandDispatcher;
 import inetsoft.web.vswizard.service.WizardViewsheetService;
 import org.springframework.stereotype.Service;
@@ -64,6 +65,7 @@ public class WizardPaneService {
       }
       finally {
          box.unlockRead();
+         viewsheetService.flushRuntimeSheet(vsId);
       }
 
       return null;

--- a/core/src/main/java/inetsoft/web/vswizard/controller/WizardUploadImageService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/WizardUploadImageService.java
@@ -80,6 +80,9 @@ public class WizardUploadImageService {
       catch(Exception ex) {
          LoggerFactory.getLogger(ImagePreviewPaneController.class).debug("Failed to get uploaded file data", ex);
       }
+      finally {
+         viewsheetService.flushRuntimeSheet(runtimeId);
+      }
 
       return objectModelService.createModel(assembly, rvs);
    }


### PR DESCRIPTION
1. add modified time for RuntimeSheet, and modify update local map logic of ContinuousQuery in RuntimeSheetCache. (1)don't overwrite the latest changes with outdated versions. (2)don't overwrite local map value with same version value(event caused by operation of same node), avoid losing runtime changes during flush.

2. Change flush to a synchronous operation to ensure that asynchronous tasks can retrieve the latest values from remote nodes.

3. update latestTemp for viewsheet when read data from RuntimeViewsheetState, else wizard temp assembly will be lost, see Viewsheet.getAssemblies function.

4. flush runtime sheet changes after each wizard operation.