### PR TITLE
Fix Bug #72605:

### DIFF
--- a/core/src/main/java/inetsoft/sree/ClientInfo.java
+++ b/core/src/main/java/inetsoft/sree/ClientInfo.java
@@ -77,6 +77,10 @@ public class ClientInfo implements Cloneable, Serializable, XMLSerializable {
       this.locale = locale;
    }
 
+   public ClientInfo getCacheKey() {
+      return new ClientInfo(userID, addr, session, locale);
+   }
+
    /**
     * Returns the user name.
     *

--- a/core/src/main/java/inetsoft/sree/security/AuthenticationService.java
+++ b/core/src/main/java/inetsoft/sree/security/AuthenticationService.java
@@ -125,7 +125,6 @@ public class AuthenticationService {
                }
 
                ClientInfo clientInfo = new ClientInfo(userName, remoteAddr, sessionId, clientLocale);
-               clientInfo.setLoginUserName(userId);
                DefaultTicket ticket = new DefaultTicket(userId, password);
                principal = authenticate(clientInfo, ticket);
 

--- a/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
+++ b/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
@@ -366,7 +366,7 @@ public class SecurityEngine implements SessionListener, MessageListener, AutoClo
                   principal.setProperty("__internal__", "true");
                   users.remove(user);
                   principal.setProperty("login.user", "true");
-                  users.put(user, principal);
+                  users.put(user.getCacheKey(), principal);
                   ConnectionProcessor.getInstance().setAdditionalDatasource(principal);
                }
             }
@@ -410,7 +410,7 @@ public class SecurityEngine implements SessionListener, MessageListener, AutoClo
 
                users.remove(user);
                principal.setProperty("login.user", "true");
-               users.put(user, principal);
+               users.put(user.getCacheKey(), principal);
             }
          }
       }
@@ -1379,6 +1379,11 @@ public class SecurityEngine implements SessionListener, MessageListener, AutoClo
          }
 
          SRPrincipal srPrincipal2 = users.get(srPrincipal.getUser());
+
+         ClientInfo k1 = srPrincipal.getUser();
+         for(ClientInfo k2 : users.keySet()) {
+            System.out.println("equals? " + k1.equals(k2) + ", hash1=" + k1.hashCode() + ", hash2=" + k2.hashCode());
+         }
 
          if(srPrincipal2 == null) {
             // anonymous users are not added to the users map. allow anonymous users if they exist


### PR DESCRIPTION
Research has found that when using a map for get in Ignite, duplicate objects are only written once. Therefore, if loginUser and userId are the same, only one entry will be stored, which results in failing to retrieve the value. Moreover, since loginUser is not a core part of getUser(), it does not need to be added to usersMap.