### PR TITLE
Fix Bug #72432: code review

### DIFF
--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/presentation-themes-view.component.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/presentation-themes-view.component.ts
@@ -185,10 +185,12 @@ export class PresentationThemesViewComponent implements OnInit {
                result.global = this.isSiteAdmin && this.orgId == "host-org";
 
                if(!!result) {
-                  const newThemes = this.themes.slice();
-                  newThemes.push(result);
-                  this.setThemes(newThemes);
-                  this.onThemeSelected(result.id);
+                  this.http.post<CustomThemeModel>("../api/em/settings/presentation/themes", result).subscribe(model => {
+                     const newThemes = this.themes.slice();
+                     newThemes.push(model);
+                     this.setThemes(newThemes);
+                     this.setSelection(model)
+                  });
                }
             });
          });


### PR DESCRIPTION
Roll back the previous changes. The API for adding a theme should not be deleted. Instead, after adding, the newly created theme should be directly added to the frontend's setSelection without needing to fetch it again.