### PR TITLE
Bug #72644: fix null assets to continue when rename, it will generate tasks for new assets after later refresh.

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/DataCycleManager.java
+++ b/core/src/main/java/inetsoft/sree/internal/DataCycleManager.java
@@ -251,6 +251,10 @@ public class DataCycleManager
                continue;
             }
 
+            if(asset == null) {
+               continue;
+            }
+
             DataCycleId cycle = new DataCycleId(asset.getName(), asset.getOrgId());
             IdentityID identityID = new IdentityID(XPrincipal.SYSTEM, orgId);
             ScheduleTask task = new ScheduleTask(


### PR DESCRIPTION
should check null for asset because when rename, the cycle name will be changed by rename thread, so it can get null for old name, but after update to new asset, it will generateTasks for new assets, so just check null for old cases.