### PR TITLE
Bug #72624,  fix error during init the ViewsheetSandbox  when vs has DynamicValue.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
@@ -164,10 +164,10 @@ public class RuntimeViewsheet extends RuntimeSheet {
       mode = state.getMode();
 
       if(state.getBoxRid() != null) {
-         box = new ViewsheetSandbox(vs, mode, getUser(), entry, state.getBoxRid());
+         box = new ViewsheetSandbox(vs, mode, getUser(), false, entry, state.getBoxRid());
       }
       else {
-         box = new ViewsheetSandbox(vs, mode, getUser(), entry);
+         box = new ViewsheetSandbox(vs, mode, getUser(), false, entry);
       }
 
       box.setOriginalID(state.getOriginalId());

--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -92,6 +92,12 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
       this(null, vs, vmode, user, true, entry, null, boxRid);
    }
 
+   public ViewsheetSandbox(Viewsheet vs, int vmode, Principal user, boolean reset, AssetEntry entry,
+                           String boxRid)
+   {
+      this(null, vs, vmode, user, reset, entry, null, boxRid);
+   }
+
    /**
     * Constructor.
     * @param vs the specified viewsheet.


### PR DESCRIPTION
for restore RuntimeViewsheet, should not reset the ViewsheetSandbox when create it, it will reset after update vs, init to update it will case error, because ws of vs do not exist.