### PR TITLE
Fix Bug #72554:Restore the hyperlink-related logic in the layout to ensure compatibility with the TableElementDef changes.

### DIFF
--- a/core/src/main/java/inetsoft/report/internal/TableElementDef.java
+++ b/core/src/main/java/inetsoft/report/internal/TableElementDef.java
@@ -23,6 +23,7 @@ import inetsoft.report.filter.*;
 import inetsoft.report.internal.binding.*;
 import inetsoft.report.internal.info.*;
 import inetsoft.report.internal.table.*;
+import inetsoft.report.io.viewsheet.ExportUtil;
 import inetsoft.report.lens.*;
 import inetsoft.report.lens.xnode.XNodeTableLens;
 import inetsoft.report.painter.PresenterPainter;
@@ -85,6 +86,22 @@ public class TableElementDef extends BaseElement
 
       // default to grow
       setProperty(GROW, "true");
+   }
+
+   public boolean containsLink() {
+      if(getVSTableLens() != null) {
+         return getVSTableLens().isHyperlinkEnabled();
+      }
+
+      return false;
+   }
+
+   public Hyperlink.Ref getHyperlink(int row, int col) {
+      if(getVSTableLens() != null) {
+         return ExportUtil.getTableCellHyperLink(getVSTableLens(), row, col, null);
+      }
+
+      return null;
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/internal/TablePaintable.java
+++ b/core/src/main/java/inetsoft/report/internal/TablePaintable.java
@@ -161,8 +161,9 @@ public class TablePaintable extends BasePaintable {
       }
 
       boolean hasDrill = lens.containsDrill();
+      boolean hasLink = telem.containsLink();
 
-      if(hasDrill) {
+      if(hasDrill || hasLink) {
          VariableTable vars = getReportParameters();
 
          // find all cell specific hyperlinks
@@ -174,6 +175,18 @@ public class TablePaintable extends BasePaintable {
             for(int c = 0; c < reg.x + reg.width; c++) {
                if(c >= headerC && c < reg.x) {
                   continue;
+               }
+
+               if(hasLink) {
+                  int c2 = c;
+                  int r2 = getBaseRow(r);
+                  Hyperlink.Ref link = telem.getHyperlink(r2, c2);
+
+                  if(link != null) {
+                     Util.mergeParameters(link, vars);
+                     Util.updateLink(link);
+                     setHyperlink(r, c, link);
+                  }
                }
 
                // @by davyc, r2 and c2 is lens's base table's row and column value,


### PR DESCRIPTION
Since the previous deletion of the report logic removed the hyperlink-related functionality in TableElementDef, but the layout still requires it, the hyperlink-related logic should be restored in the layout.