### PR TITLE
Fix Bug #72666:Strategy for Preserving Tree Expansion State Across Different Export Layout Modes

### DIFF
--- a/core/src/main/java/inetsoft/report/io/viewsheet/VSSelectionTreeHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/VSSelectionTreeHelper.java
@@ -51,7 +51,10 @@ public class VSSelectionTreeHelper extends VSSelectionListHelper {
       writeObjectBackground(info);
       StringBuilder sTitle = new StringBuilder();
       List<SelectionValue> dispList = new ArrayList<>();
-      boolean expandAll = getExporter() == null || getExporter().isExpandSelections();
+      VSExporter exporter = getExporter();
+
+      boolean expandAll = exporter == null
+         || (exporter.isMatchLayout() ? info.isExpandAll() : exporter.isExpandSelections());
       String[] expandedPaths = assembly.getExpandedValues();
       prepareDisplayList(info, dispList, sTitle, false, expandAll, expandedPaths);
 

--- a/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLSelectionTreeHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLSelectionTreeHelper.java
@@ -107,7 +107,7 @@ public class HTMLSelectionTreeHelper extends VSSelectionTreeHelper{
       VSCompositeFormat fmt = info.getFormat();
       Vector dispList = new Vector();
       CompositeSelectionValue csv = info.getCompositeSelectionValue();
-      boolean expanded = getExporter() == null || getExporter().isExpandSelections();
+      boolean expanded = getExporter() == null || info.isExpandAll();
 
       info.visitCompositeChild(csv, dispList, true, expanded, expandedPaths);  // populate dispList
       slist.append("<div style='overflow:auto;width:100%;height:" + dataH + "'>");

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/ExcelSelectionTreeHelper.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/ExcelSelectionTreeHelper.java
@@ -19,8 +19,7 @@ package inetsoft.report.io.viewsheet.excel;
 
 import inetsoft.report.TableDataPath;
 import inetsoft.report.internal.Common;
-import inetsoft.report.io.viewsheet.VSSelectionListHelper;
-import inetsoft.report.io.viewsheet.VSSelectionTreeHelper;
+import inetsoft.report.io.viewsheet.*;
 import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.SelectionTreeVSAssemblyInfo;
@@ -64,8 +63,9 @@ public class ExcelSelectionTreeHelper extends VSSelectionTreeHelper {
 
       StringBuilder sTitle = new StringBuilder();
       List<SelectionValue> dispList = new ArrayList<>();
-
-      boolean expandAll = getExporter() == null || getExporter().isExpandSelections();
+      VSExporter exporter = getExporter();
+      boolean expandAll = exporter == null
+         || (exporter.isMatchLayout() ? info.isExpandAll() : exporter.isExpandSelections());
       String[] expandedPaths = assembly.getExpandedValues();
       prepareDisplayList(info, dispList, sTitle, true, expandAll, expandedPaths);
       writeTree(assembly, sheet, dispList);


### PR DESCRIPTION
If the user expands a selection tree in user portal and exports as "Match Layout" with current view, we should try to have the same expanded tree when exporting with "Match Layout".There is no Match Layout option in HTML, export directly according to the state of VS.