### PR TITLE
Bug #72455 - fix session handling when SSO is enabled

### DIFF
--- a/core/src/main/java/inetsoft/web/security/AbstractLogoutFilter.java
+++ b/core/src/main/java/inetsoft/web/security/AbstractLogoutFilter.java
@@ -51,14 +51,15 @@ public abstract class AbstractLogoutFilter extends AbstractSecurityFilter {
    protected String getLogoutRedirectUri(HttpServletRequest request)
       throws UnsupportedEncodingException
    {
-      String redirectUri = SreeEnv.getProperty(
-         "portal.logout.url", LinkUriArgumentResolver.getLinkUri(request) + REDIRECT_URI);
+      String defRedirectUri = LinkUriArgumentResolver.getLinkUri(request) + REDIRECT_URI;
+      String redirectUri = SreeEnv.getProperty("portal.logout.url", defRedirectUri);
       Map<String, String[]> queryParameters = getQueryParameters(request);
       boolean fromEm = isFromEm(queryParameters);
       boolean showLogin = isShowLogin(queryParameters);
       boolean guestLogin = isGuestLogin(request, showLogin);
 
-      if(fromEm) {
+      // for SSO only redirect to EM when portal.logout.url is not set
+      if(fromEm && (!isSSO() || redirectUri.equals(defRedirectUri))) {
          if("GET".equals(request.getMethod()) && request.getParameter("redirectUri") != null) {
             redirectUri = request.getParameter("redirectUri");
          }

--- a/core/src/main/java/inetsoft/web/security/AbstractSecurityFilter.java
+++ b/core/src/main/java/inetsoft/web/security/AbstractSecurityFilter.java
@@ -165,7 +165,7 @@ public abstract class AbstractSecurityFilter
    /**
     * Create a session and add an audit login record when logging in with SSO
     */
-   protected void createSSOSession(HttpServletRequest request,
+   protected SRPrincipal createSSOSession(HttpServletRequest request,
                                    SRPrincipal principal) throws AuthenticationFailureException
    {
       final IdentityID pId = principal == null ? null : IdentityID.getIdentityIDFromKey(principal.getName());
@@ -178,10 +178,12 @@ public abstract class AbstractSecurityFilter
       final IdentityID[] newRoles =
          Stream.concat(Arrays.stream(defRoles), Arrays.stream(currentRoles)).toArray(IdentityID[]::new);
       principal.setRoles(newRoles);
-      createSession(request, principal);
       final ClientInfo info = createClientInfo(principal.getIdentityID(), request);
+      principal = new SRPrincipal(principal, info);
+      createSession(request, principal);
       AuthenticationService.getInstance().authenticate(info, principal);
       SUtil.loginRecord(request, pId, true, null);
+      return principal;
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/security/InvalidateSessionFilter.java
+++ b/core/src/main/java/inetsoft/web/security/InvalidateSessionFilter.java
@@ -44,7 +44,7 @@ public class InvalidateSessionFilter extends AbstractSecurityFilter {
       HttpServletRequest httpRequest = (HttpServletRequest) request;
       HttpSession session = httpRequest.getSession(false);
 
-      if(session != null && !isSSO() && !isPublicResource(httpRequest) &&
+      if(session != null && !isPublicResource(httpRequest) &&
          !isPublicApi(httpRequest))
       {
          SRPrincipal principal = (SRPrincipal) SUtil.getPrincipal(httpRequest);


### PR DESCRIPTION
Make sure that the session is released on sso logout and redirected properly when using the portal.logout.url property.
Fix session invalidation issues due to client info mismatch when SSO is enabled.
Ensure that the client info in the Principal object matches the users map in SecurityEngine to prevent sessions from being invalidated immediately and to allow proper session cleanup.