### PR TITLE
Bug #72670: should not localize identity type for mv

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/MVService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/MVService.java
@@ -112,9 +112,8 @@ public class MVService {
 
          if(def.getUsers() != null) {
             for(Identity identity : def.getUsers()) {
-               buffer.append(catalog.getString(
-                  identity.getType() == Identity.GROUP ? "Group" :
-                     identity.getType() == Identity.ROLE ? "Role" : "User"))
+               buffer.append(identity.getType() == Identity.GROUP ? "Group" :
+                  identity.getType() == Identity.ROLE ? "Role" : "User")
                   .append(":").append(identity.getName()).append(" ");
             }
          }


### PR DESCRIPTION
should not add Identity Type to localized, for it will create MaterializedViewUser by it, then it will throw error to do not find type. should using type not localized and it will works right.

the bug exist on main branch and session branch, so just commit it to main