### PR TITLE
Bug #72312  Change behavior of the vpm "one of" condition pane to match the regular "one of" condition pane

### DIFF
--- a/web/projects/portal/src/app/portal/dialog/vpm-condition-dialog/vpm-condition-pane/vpm-condition-item-pane/vpm-condition-editor/one-of-vpm-condition-editor.component.ts
+++ b/web/projects/portal/src/app/portal/dialog/vpm-condition-dialog/vpm-condition-pane/vpm-condition-item-pane/vpm-condition-editor/one-of-vpm-condition-editor.component.ts
@@ -81,6 +81,10 @@ export class OneOfVpmConditionEditor implements OnChanges {
 
       let model = Tool.clone(this._valueModel);
       this.editingModel = model;
+
+      if(this.editorType == ClauseValueTypes.VALUE) {
+         this.editingModel.expression = null;
+      }
    }
 
    private updateValues(): void {


### PR DESCRIPTION
When selecting a "one of" condition statement, it should not add the whole list of values to the textbox, since it could be accidentally appended to the list as another value.