### PR TITLE
Bug #72668

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/controller/ComposerViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/ComposerViewsheetController.java
@@ -144,8 +144,11 @@ public class ComposerViewsheetController {
                                 @LinkUri String linkUri) throws Exception
    {
       runtimeViewsheetRef.setRuntimeId(event.getRuntimeViewsheetId());
-      composerViewsheetService.previewViewsheet(runtimeViewsheetRef.getRuntimeId(),
+      String previewRuntimeID = composerViewsheetService.previewViewsheet(runtimeViewsheetRef.getRuntimeId(),
                                                 event, principal, dispatcher, linkUri);
+
+      composerViewsheetService.refreshPreviewViewsheet(previewRuntimeID, event,
+                                                       principal, dispatcher, linkUri, true);
    }
 
    /**
@@ -168,7 +171,7 @@ public class ComposerViewsheetController {
       String id = runtimeViewsheetRef.getRuntimeId();
 
       if(composerViewsheetService.refreshPreviewViewsheet(id, event,
-                                                          principal, commandDispatcher, linkUri))
+                                                          principal, commandDispatcher, linkUri, false))
       {
          runtimeViewsheetRef.setLastModified(System.currentTimeMillis());
       }

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/ExportController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/ExportController.java
@@ -47,14 +47,13 @@ import java.io.OutputStream;
 import java.security.Principal;
 import java.util.*;
 
-import static inetsoft.web.viewsheet.controller.GetImageController.processImageRenderResult;
-
 @Controller
 public class ExportController {
    @Autowired
    public ExportController(VSLifecycleService lifecycleService,
                            BinaryTransferService binaryTransferService,
                            AssemblyImageServiceProxy assemblyImageServiceProxy,
+                           AssemblyImageService imageService,
                            VSExportService exportService,
                            ExportControllerServiceProxy exportControllerServiceProxy)
    {
@@ -63,6 +62,7 @@ public class ExportController {
       this.serviceProxy = assemblyImageServiceProxy;
       this.exportService = exportService;
       this.exportControllerServiceProxy = exportControllerServiceProxy;
+      this.imageService = imageService;
    }
 
    @GetMapping("/export/check/**")
@@ -285,7 +285,7 @@ public class ExportController {
                                                                                          chartSize.getHeight(), chartSize.getWidth(),
                                                                                          chartSize.getHeight(), svg, principal);
 
-      processImageRenderResult(result, request, response);
+      imageService.processImageRenderResult(result, request, response);
    }
 
    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
@@ -341,6 +341,7 @@ public class ExportController {
    private final AssemblyImageServiceProxy serviceProxy;
    private final VSExportService exportService;
    private final ExportControllerServiceProxy exportControllerServiceProxy;
+   private final AssemblyImageService imageService;
 
    private static final Logger LOG = LoggerFactory.getLogger(ExportController.class);
 }


### PR DESCRIPTION
Preview viewsheet is created under key for composer viewsheet, so node specific maps are not populated correctly later, updated to call refreshViewsheet on previewViewsheet with its own key for proxied methods so correct values are stored, also clean up BinaryTransfer