### PR TITLE
Bug #72692  When resetting parameters, clear the variable table before getting parameters

### DIFF
--- a/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
+++ b/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
@@ -1514,11 +1514,11 @@ public final class VSEventUtil {
 //         return;
 //      }
 
-      VariableTable vart = box.getVariableTable();
-
       if(reset) {
          box.resetVariableTable();
       }
+
+      VariableTable vart = box.getVariableTable();
 
       UserVariable[] vars = AssetEventUtil.executeVariables(
          engine, box, vart, null, vsName, null, initvars, varNameOnly);


### PR DESCRIPTION
Currently, the variable table is cleared after we get the parameters.
This means that the execution will only get a list of variables that exist, but are not defined yet in the variable table.
This list of parameters is prompted and inserted in to the empty variable table later on, but the variables that were originally in the table never get prompted, until it is reset again.