### PR TITLE
Bug #72673

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
@@ -1139,7 +1139,7 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
       Set<AssemblyRef> set = new HashSet<>();
 
       for(Assembly assemblyItem : getAssemblies()) {
-         if(!(assemblyItem instanceof AbstractContainerVSAssembly)) {
+         if(!(assemblyItem instanceof AbstractVSAssembly)) {
             continue;
          }
 


### PR DESCRIPTION
revert to check when AbstractVSAssembly, otherwise getScriptDependings() skips assemblies with scripts relating to change