### PR TITLE
Bug #72577 - Use runtime sheet counts to determine node protection

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/cluster/Cluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/Cluster.java
@@ -71,7 +71,7 @@ public interface Cluster extends AutoCloseable {
     * @return the cluster nodes.
     */
    default Set<String> getClusterNodes() {
-      return getClusterNodes(true);
+      return getClusterNodes(false);
    }
 
    /**
@@ -326,7 +326,7 @@ public interface Cluster extends AutoCloseable {
 
    void destroyMap(String name);
 
-   void addMapListener(String name, MapChangeListener<?, ?> l);
+   <K, V> void addMapListener(String name, MapChangeListener<K, V> l);
 
    void removeMapListener(String name, MapChangeListener<?, ?> l);
 

--- a/core/src/main/java/inetsoft/sree/internal/cluster/MapChangeListener.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/MapChangeListener.java
@@ -30,8 +30,4 @@ public interface MapChangeListener<K, V>  {
    default void entryExpired(EntryEvent<K, V> event) {
       // no-op
    }
-
-   default void entryEvicted(EntryEvent<K, V> event) {
-      // no-op
-   }
 }

--- a/core/src/main/java/inetsoft/sree/schedule/Scheduler.java
+++ b/core/src/main/java/inetsoft/sree/schedule/Scheduler.java
@@ -631,7 +631,7 @@ public class Scheduler {
       }
 
       Cluster cluster = Cluster.getInstance();
-      Set<String> clusterNodes = cluster.getClusterNodes();
+      Set<String> clusterNodes = cluster.getClusterNodes(true);
 
       if(clusterNodes == null) {
          return false;

--- a/core/src/main/java/inetsoft/web/admin/server/NodeProtectionCoordinatorTask.java
+++ b/core/src/main/java/inetsoft/web/admin/server/NodeProtectionCoordinatorTask.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.admin.server;
+
+import inetsoft.report.composition.RuntimeSheetCache;
+import inetsoft.sree.internal.cluster.Cluster;
+
+import java.io.Serializable;
+import java.util.*;
+
+/**
+ * Computes which nodes should have protection enabled based on the number of local
+ * runtime sheets
+ */
+public class NodeProtectionCoordinatorTask implements Runnable, Serializable {
+   private void init() {
+      if(cluster == null) {
+         cluster = Cluster.getInstance();
+      }
+
+      if(sheetCountMap == null) {
+         sheetCountMap = cluster.getReplicatedMap(RuntimeSheetCache.LOCAL_SHEET_COUNT);
+      }
+
+      if(nodeProtectionMap == null) {
+         nodeProtectionMap = cluster.getReplicatedMap(NodeProtectionService.NODE_PROTECTION_MAP);
+      }
+   }
+
+   @Override
+   public void run() {
+      init();
+
+      List<String> nodes = new ArrayList<>(cluster.getClusterNodes());
+      Collections.sort(nodes);
+
+      String minNode = null;
+      int min = Integer.MAX_VALUE;
+
+      // determine the min
+      for(String node : nodes) {
+         int value = sheetCountMap.getOrDefault(node, 0);
+
+         if(value < min) {
+            min = value;
+            minNode = node;
+         }
+
+         // no need to check further
+         if(min == 0) {
+            break;
+         }
+      }
+
+      // set node protections
+      for(String node : nodes) {
+         boolean oldValue = nodeProtectionMap.getOrDefault(node, false);
+         boolean newValue = !node.equals(minNode);
+
+         // reduce the number of update events
+         if(oldValue != newValue) {
+            nodeProtectionMap.put(node, newValue);
+         }
+      }
+   }
+
+   private transient Cluster cluster;
+   private transient Map<String, Integer> sheetCountMap;
+   private transient Map<String, Boolean> nodeProtectionMap;
+}

--- a/core/src/main/java/inetsoft/web/messaging/SessionConnectionService.java
+++ b/core/src/main/java/inetsoft/web/messaging/SessionConnectionService.java
@@ -50,12 +50,10 @@ public class SessionConnectionService {
    @Autowired
    public SessionConnectionService(IgniteSessionRepository sessionRepository,
                                    AuthenticationService authenticationService,
-                                   NodeProtectionService nodeProtectionService,
                                    ApplicationEventPublisher eventPublisher)
    {
       this.sessionRepository = sessionRepository;
       this.authenticationService = authenticationService;
-      this.nodeProtectionService = nodeProtectionService;
       this.eventPublisher = eventPublisher;
    }
 
@@ -73,7 +71,6 @@ public class SessionConnectionService {
 
    public void webSocketConnected(WebSocketSession session) {
       cleanReferences();
-      nodeProtectionService.updateNodeProtection(true);
 
       String wsSessionId = session.getId();
       eventPublisher.publishEvent(new WebsocketConnectionEvent(this, wsSessionId, true));
@@ -104,10 +101,6 @@ public class SessionConnectionService {
             }
 
             webSocketSessions.remove(wsSessionId);
-
-            if(webSocketSessions.isEmpty()) {
-               nodeProtectionService.updateNodeProtection(false);
-            }
          }
       }
    }
@@ -169,10 +162,6 @@ public class SessionConnectionService {
                      }
                   }
                }
-            }
-
-            if(webSocketSessions.isEmpty()) {
-               nodeProtectionService.updateNodeProtection(false);
             }
          }
       }
@@ -275,7 +264,6 @@ public class SessionConnectionService {
    private Cluster cluster;
    private final MessageListener listener = this::messageReceived;
    private final AuthenticationService authenticationService;
-   private final NodeProtectionService nodeProtectionService;
    private final IgniteSessionRepository sessionRepository;
    private final ApplicationEventPublisher eventPublisher;
    private final Map<String, WebSocketSessionRef> webSocketSessions = new HashMap<>();

--- a/core/src/main/java/inetsoft/web/session/IgniteSessionRepository.java
+++ b/core/src/main/java/inetsoft/web/session/IgniteSessionRepository.java
@@ -257,18 +257,18 @@ public class IgniteSessionRepository
    }
 
    @Override
-   public void entryEvicted(EntryEvent<String, MapSession> event) {
-      entryExpired(event);
-   }
-
-   @Override
    public void entryRemoved(EntryEvent<String, MapSession> event) {
       MapSession session = event.getValue();
 
       if(session != null) {
-         LOG.debug("Session deleted with ID: {}", session.getId());
-         sendApplicationEvent(new SessionDeletedEvent(this.getClass().getName(), session));
-         logout(session, "");
+         if(session.isExpired()) {
+            entryExpired(event);
+         }
+         else {
+            LOG.debug("Session deleted with ID: {}", session.getId());
+            sendApplicationEvent(new SessionDeletedEvent(this.getClass().getName(), session));
+            logout(session, "");
+         }
       }
    }
 

--- a/core/src/test/java/inetsoft/test/TestCluster.java
+++ b/core/src/test/java/inetsoft/test/TestCluster.java
@@ -247,7 +247,7 @@ public class TestCluster implements Cluster {
    }
 
    @Override
-   public void addMapListener(String name, MapChangeListener<?, ?> l) {
+   public <K, V> void addMapListener(String name, MapChangeListener<K, V> l) {
       mapListeners.computeIfAbsent(name, k -> new ArrayList<>()).add(l);
    }
 


### PR DESCRIPTION
Use runtime sheet counts to determine node protection.
Use continuous queries as a listener mechanism for distributed maps, but keep addMapListener/addMultiMapListener/addReplicatedMapListener since queries require a cache to exist and we might have to create the cache within the listener call.
Changed getClusterNodes to not include client nodes by default.