### PR TITLE
Bug #72708  Do not use the runtime viewsheet's init var table if fullScreenId is null

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
@@ -2795,19 +2795,23 @@ public class CoreLifecycleService {
 
       ChangedAssemblyList clist = createList(true, event, dispatcher, null, uri);
 
-      rvs.getEntry().setProperty("bookmarkIndex", bookmarkIndex);
-      // optimization, this shouldn't be needed for new vs since the
-      // RuntimeViewsheet cstr calls updateVSBookmark through setEntry
-      rvs.updateVSBookmark();
-      // @by davyc, if full screen viewsheet, keep its variables
-      // fix bug1366833082660
-      VariableTable temp = rvs.getViewsheetSandbox().getVariableTable();
+      String fullScreenId = event.getFullScreenId();
 
-      if(temp != null) {
-         temp.addAll(variables);
+      if(fullScreenId != null && fullScreenId.length() > 0) {
+         rvs.getEntry().setProperty("bookmarkIndex", bookmarkIndex);
+         // optimization, this shouldn't be needed for new vs since the
+         // RuntimeViewsheet cstr calls updateVSBookmark through setEntry
+         rvs.updateVSBookmark();
+         // @by davyc, if full screen viewsheet, keep its variables
+         // fix bug1366833082660
+         VariableTable temp = rvs.getViewsheetSandbox().getVariableTable();
+
+         if(temp != null) {
+            temp.addAll(variables);
+         }
+
+         variables = temp;
       }
-
-      variables = temp;
 
       VSEventUtil.syncEmbeddedTableVSAssembly(rvs.getViewsheet());
       rvs.setEmbeddedID(eid);


### PR DESCRIPTION
Before the stateless session changes, the runtime viewsheet id was determined solely if fullScreenId was defined.
So before, this section of code had an condition block checking if the rvsId was null.

Now, the id always needs to be defined since this is inside a proxied method and the condition block was removed.
However, this particular logic should still only execute if fullScreenId is defined.