### PR TITLE
Merge changes for Bug #72770 - make ReplaceAllKeyValueTask and RenameKeyValueTask safer

### DIFF
--- a/core/src/main/java/inetsoft/storage/RenameKeyValueTask.java
+++ b/core/src/main/java/inetsoft/storage/RenameKeyValueTask.java
@@ -50,14 +50,14 @@ public class RenameKeyValueTask<T extends Serializable>
 
    @Override
    public T call() throws Exception {
+      // first deserialize before removing anything
+      T newValue = deserializeValue(data);
       T value = getEngine().remove(getId(), oldKey);
 
       if(value == null) {
          throw new Exception
             (oldKey + " does not exist in " + getId() + ", cannot rename to " + newKey);
       }
-
-      T newValue = deserializeValue(data);
 
       if(newValue != null) {
          value = newValue;


### PR DESCRIPTION
The ReplaceAllKeyValueTask previously removed all existing key-value pairs from the storage before inserting new ones. If deserialization failed or the process terminated unexpectedly, all key-value pairs could be lost. The logic now inserts new key-value pairs first and removes only those not present in the new set.
Also changed RenameKeyValueTask to deserialize first before removing from the storage.