### PR TITLE
Merge changes for Bug #72744 - sub query condition

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/SubQueryValue.java
+++ b/core/src/main/java/inetsoft/uql/asset/SubQueryValue.java
@@ -542,11 +542,7 @@ public class SubQueryValue implements AssetObject {
    }
 
    private boolean containsSubQueryAttribute(ColumnSelection columns, DataRef ref) {
-      if(columns.containsAttribute(ref)) {
-         return true;
-      }
-
-      return ref.isEntityBlank() && columns.getAttribute(ref.getName(), query) != null;
+      return columns.containsAttribute(ref) || columns.getAttribute(ref.getName()) != null;
    }
 
    private DataRef ref = null;


### PR DESCRIPTION
Make checkValidity logic less restrictive. Just check if a column name exists instead of trying to match entities which might contain "_O" suffix.