### PR TITLE
Bug #72712 - thread stuck when deserializing a table

### DIFF
--- a/core/src/main/java/inetsoft/uql/avro/AvroXTableSerializer.java
+++ b/core/src/main/java/inetsoft/uql/avro/AvroXTableSerializer.java
@@ -188,6 +188,8 @@ public class AvroXTableSerializer {
          table.addRow(values);
       }
 
+      table.complete();
+
       try {
          for(int i = 0; i < table.getColCount(); i++) {
             Object header = table.getObject(0, i);
@@ -202,7 +204,6 @@ public class AvroXTableSerializer {
       catch(Exception ignore) {
       }
 
-      table.complete();
       return table;
    }
 


### PR DESCRIPTION
Complete the table first before calling setXMetaInfo(). Otherwise it may cause the thread to get stuck.