### PR TITLE
Bug #72718: add source tables and columns to data context when no binding for assembly.

### DIFF
--- a/core/src/main/java/inetsoft/web/binding/model/BindingModel.java
+++ b/core/src/main/java/inetsoft/web/binding/model/BindingModel.java
@@ -92,8 +92,79 @@ public class BindingModel {
       this.type = type;
    }
 
+   public void setTables(List<SourceTable> tables) {
+      this.tables = tables;
+   }
+
+   public List<SourceTable> getTables() {
+      return tables;
+   }
+
+   public class SourceTable {
+      public SourceTable() {
+      }
+
+      public String getName() {
+         return name;
+      }
+
+      public void setName(String name) {
+         this.name = name;
+      }
+
+      public List<SourceTableColumn> getColumns() {
+         return columns;
+      }
+
+      /**
+       * Set type.
+       */
+      public void setColumns(List<SourceTableColumn> columns) {
+         this.columns = columns;
+      }
+
+      private String name;
+      private List<SourceTableColumn> columns;
+   }
+
+   public class SourceTableColumn {
+      public SourceTableColumn(String name, String type) {
+         this.name = name;
+         this.dataType = type;
+      }
+
+      public String getName() {
+         return name;
+      }
+
+      public void setName(String name) {
+         this.name = name;
+      }
+
+      public String getDescription() {
+         return description;
+      }
+
+      public void setDescription(String description) {
+         this.description = description;
+      }
+
+      public String getDataType() {
+         return dataType;
+      }
+
+      public void setDataType(String type) {
+         this.dataType = type;
+      }
+
+      private String name;
+      private String dataType;
+      private String description;
+   }
+
    private SourceInfo source;
    private List<DataRefModel> availableFields;
+   private List<SourceTable> tables;
    private boolean sqlMergeable = true;
    private String type;
 }

--- a/web/projects/portal/src/app/binding/data/binding-model.ts
+++ b/web/projects/portal/src/app/binding/data/binding-model.ts
@@ -23,4 +23,16 @@ export class BindingModel {
    sqlMergeable: boolean;
    availableFields: Array<DataRef>;
    type: string;
+   tables: Array<SourceTable>;
+}
+
+export class SourceTable {
+   name: string;
+   columns: Array<SourceTableColumn>;
+}
+
+export class SourceTableColumn {
+   name: string;
+   dataType: string;
+   description: string;
 }

--- a/web/projects/portal/src/app/binding/services/assistant/available-fields-helper.ts
+++ b/web/projects/portal/src/app/binding/services/assistant/available-fields-helper.ts
@@ -17,11 +17,13 @@
  */
 
 import { DataRef } from "../../../common/data/data-ref";
+import { SourceTable, SourceTableColumn } from "../../data/binding-model";
 import { Field } from "./types/field";
+import { Table } from "./types/table";
 
-export function getAvailableFields(availableFields: DataRef[]): string {
-   if(!availableFields) {
-      return "";
+export function getAvailableFields(tables: SourceTable[], availableFields: DataRef[]): string {
+   if(!availableFields || availableFields.length == 0) {
+      return getTableFields(tables);
    }
 
    let fields: Field[] = [];
@@ -45,4 +47,40 @@ export function getAvailableFields(availableFields: DataRef[]): string {
    });
 
    return JSON.stringify(fields);
+}
+
+export function getTableFields(sourceTables: SourceTable[]): string {
+   if(!sourceTables || sourceTables.length == 0) {
+      return "";
+   }
+
+   let tables: Table[] = [];
+
+   sourceTables.forEach(table => {
+      tables.push({
+         table_name: table.name,
+         columns: getTableColumns(table.columns)
+      });
+   });
+
+   return JSON.stringify(tables);
+}
+
+export function getTableColumns(columns: SourceTableColumn[]): Field[] {
+   let fields: Field[] = [];
+
+   if(!columns || columns.length == 0) {
+      return fields;
+   }
+
+   columns.forEach(column => {
+      fields.push({
+         field_name: column.name,
+         data_type: column.dataType,
+         is_calcfield: false, // for source table column will not include calc columns
+         description: column.description
+      });
+   });
+
+   return fields;
 }

--- a/web/projects/shared/ai-assistant/ai-assistant.service.ts
+++ b/web/projects/shared/ai-assistant/ai-assistant.service.ts
@@ -212,7 +212,7 @@ export class AiAssistantService {
          return;
       }
 
-      let dataContext = getAvailableFields(bindingModel.availableFields);
+      let dataContext = getAvailableFields(bindingModel.tables, bindingModel.availableFields);
 
       if(dataContext) {
          this.setContextField("dataContext", dataContext);


### PR DESCRIPTION
add source tables and columns to data context when no binding for assembly.

when no source for assembly, its available fields will be null, so we should list all source table's columns for user to select