### PR TITLE
Bug #72720: when no source for assembly, add no binding to assistant to use different prompt for script

### DIFF
--- a/web/projects/shared/ai-assistant/ai-assistant.service.ts
+++ b/web/projects/shared/ai-assistant/ai-assistant.service.ts
@@ -204,6 +204,9 @@ export class AiAssistantService {
 
       if(bindingContext) {
          this.setContextField("bindingContext", bindingContext);
+         let noBinding: boolean = objectModel.source == null || objectModel.source.source == null
+            || objectModel.source.source.length == 0;
+         this.setContextField("noBinding", noBinding ? "true": "false");
       }
    }
 


### PR DESCRIPTION
when no source for assembly, add no binding to assistant to use different prompt for script