### PR TITLE
Bug #72608 - MV min/max range issue with multi-threaded creation

### DIFF
--- a/core/src/main/java/inetsoft/mv/DateMVColumn.java
+++ b/core/src/main/java/inetsoft/mv/DateMVColumn.java
@@ -137,13 +137,6 @@ public final class DateMVColumn extends MVColumn implements XDynamicMVColumn {
    }
 
    /**
-    * Get the range date option.
-    */
-   public static final int getRangeDateOption() {
-      return RANGE_INTERVAL;
-   }
-
-   /**
     * Create one date mv column.
     */
    private static DateMVColumn create(MVColumn col, TableAssembly table, int dtype) {
@@ -225,12 +218,15 @@ public final class DateMVColumn extends MVColumn implements XDynamicMVColumn {
          return null;
       }
 
-      if(level == RANGE_INTERVAL) {
+      if(level == DateRangeRef.YEAR_INTERVAL || level == DateRangeRef.MONTH_INTERVAL ||
+         level == DateRangeRef.DAY_INTERVAL || level == DateRangeRef.HOUR_INTERVAL ||
+         level == DateRangeRef.MINUTE_INTERVAL)
+      {
          if(min0 == null) {
             min0 = (Date) obj;
             max0 = (Date) obj;
          }
-         else if(obj != null) {
+         else {
             Date dval = (Date) obj;
 
             if(min0.compareTo(dval) > 0) {
@@ -403,7 +399,6 @@ public final class DateMVColumn extends MVColumn implements XDynamicMVColumn {
       return this.real;
    }
 
-   private static final int RANGE_INTERVAL = DateRangeRef.YEAR_INTERVAL;
    private int level = 0;
    private MVColumn base = null;
    private Date max0 = null;

--- a/core/src/main/java/inetsoft/mv/MVCreatorUtil.java
+++ b/core/src/main/java/inetsoft/mv/MVCreatorUtil.java
@@ -636,8 +636,8 @@ public class MVCreatorUtil {
          cinfo.setMax(max);
 
          if(min instanceof Date && max instanceof Date) {
-            mvcol.setMin((Date) min);
-            mvcol.setMax((Date) max);
+            mvcol.convert(min);
+            mvcol.convert(max);
          }
       }
    }

--- a/core/src/main/java/inetsoft/mv/MVDispatcher.java
+++ b/core/src/main/java/inetsoft/mv/MVDispatcher.java
@@ -782,10 +782,8 @@ public class MVDispatcher {
             Date dmax = dcol.getMax();
             Date dmin = dcol.getMin();
             DateMVColumn dpcol = (DateMVColumn) pcol;
-            Date dpmax = dcol.getMax();
-            Date dpmin = dcol.getMin();
-            dpcol.convert(dpmin);
-            dpcol.convert(dpmax);
+            dpcol.convert(dmin);
+            dpcol.convert(dmax);
          }
       }
 


### PR DESCRIPTION
Handle multi-threaded MV creation issue. Ensure min/max are updated only when new values are smaller/larger than existing ones.