### PR TITLE
Bug #72795  Fix the default parameter selection when the value is a comma separated list of values

### DIFF
--- a/web/projects/portal/src/app/widget/dialog/variable-collection-selector/variable-collection-selector.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/variable-collection-selector/variable-collection-selector.component.ts
@@ -67,6 +67,22 @@ export class VariableCollectionSelector implements OnInit {
          this.value.splice(0);
          this.value.push(...temp);
       }
+      else if(this.style === StyleType.LIST &&
+         this.value.length == 1 && this.values.indexOf(this.value[0]) === -1)
+      {
+         // Look for selection options in the combined string
+         let valueString = this.value[0];
+         let temp: any[] = [];
+
+         for(let i = 0; i < this.values.length; i++) {
+            if(valueString.indexOf(this.values[i]) >= 0) {
+               temp[i] = this.values[i];
+            }
+         }
+
+         this.value.splice(0);
+         this.value.push(...temp);
+      }
    }
 
    change(value: any) {


### PR DESCRIPTION
When the variables are first passed in, the value array is combined back together into a single comma separated list of values.
This is because we may have accidentally separated an actual string with a comma into it into two different pieces.

My change works around that by populated the selected value list with only values that appear in the full values list.
First it checks each option to see if it is present in the comma separated selected value string, and adds it to the selection if it is present. That way, even if the option string has a comma in it, it will still be present in the comma separated string list.