### PR TITLE
remove duplicate context for worksheet prompt

### DIFF
--- a/web/projects/shared/ai-assistant/ai-assistant.service.ts
+++ b/web/projects/shared/ai-assistant/ai-assistant.service.ts
@@ -271,7 +271,8 @@ export class AiAssistantService {
       this.resetContextMap();
       this.setContextTypeFieldValue(ContextType.WORKSHEET);
       let context = getWorksheetContext(ws);
-      this.setContextField("tableSchemas", context);}
+      this.setContextField("tableSchemas", context);
+   }
 
    setWorksheetScriptContext(fields: TreeNodeModel[]): void {
       if(!fields || fields.length === 0) {


### PR DESCRIPTION
tableSchemas and dataContext is the same, so remove dataContext, only leave the tableSchemas for prompt to use