### PR TITLE
Bug #72813  In ColumnMapFilter, serialize string headers

### DIFF
--- a/core/src/main/java/inetsoft/report/filter/ColumnMapFilter.java
+++ b/core/src/main/java/inetsoft/report/filter/ColumnMapFilter.java
@@ -141,6 +141,8 @@ public class ColumnMapFilter extends AbstractTableLens
       // optimization
       headerRows = (short) table.getHeaderRowCount();
       headers = null;
+      stringHeaders = null;
+
       resetIdentifiers();
    }
 
@@ -625,6 +627,15 @@ public class ColumnMapFilter extends AbstractTableLens
          }
 
          headers[c] = v;
+
+         if(v instanceof String) {
+            if(stringHeaders == null) {
+               stringHeaders = new String[map.length];
+            }
+
+            stringHeaders[c] = (String) v;
+         }
+
          return;
       }
 
@@ -739,7 +750,15 @@ public class ColumnMapFilter extends AbstractTableLens
    @Serial
    private void readObject(ObjectInputStream in) throws ClassNotFoundException, IOException {
       in.defaultReadObject();
+      String[] oldStringHeaders = stringHeaders;
+
       setTable(table);
+
+      if(oldStringHeaders != null) {
+         stringHeaders = oldStringHeaders;
+         headers = new Object[map.length];
+         System.arraycopy(stringHeaders, 0, headers, 0, map.length);
+      }
    }
 
    /**
@@ -968,6 +987,7 @@ public class ColumnMapFilter extends AbstractTableLens
 
    private TableLens table;
    private int[] map; // column mapping
+   private String[] stringHeaders;  // serializable string headers
    private transient Object[] headers; // column header
    private transient String[] identifiers;
    private transient int[] duptimes; // header's duplicated times


### PR DESCRIPTION
When the calcfield is added to the table, if it is effectively just an alias, we would optimize if by using a ColumnMapFilter instead of a full FormulaTableLens. In this case, though, the we rely on the ColumnMapFilter to use the header array to get the right name for the header. My change ensures that the string header names are kept when the ColumnMapFilter is deserialized.