### PR TITLE
Bug #72833 - add affinityCallAsync to prevent timeout exceptions

### DIFF
--- a/build-tools/cluster-proxy-annotations/src/main/java/inetsoft/cluster/ClusterProxyMethod.java
+++ b/build-tools/cluster-proxy-annotations/src/main/java/inetsoft/cluster/ClusterProxyMethod.java
@@ -30,6 +30,4 @@ public @interface ClusterProxyMethod {
     * The name of the cache that is used for the colocation of the method invocation.
     */
    String value();
-
-   boolean async() default false;
 }

--- a/build-tools/cluster-proxy-annotations/src/main/java/inetsoft/cluster/apt/ClusterAnnotationProcessor.java
+++ b/build-tools/cluster-proxy-annotations/src/main/java/inetsoft/cluster/apt/ClusterAnnotationProcessor.java
@@ -82,7 +82,6 @@ public class ClusterAnnotationProcessor extends AbstractProcessor {
       String callableClassName = getCallableClassName(methodName, callableClasses);
       String returnType = methodElement.getReturnType().toString();
       String cacheName = methodElement.getAnnotation(ClusterProxyMethod.class).value();
-      boolean async = methodElement.getAnnotation(ClusterProxyMethod.class).async();
       List<String> exceptions = MoreElements.asExecutable(methodElement).getThrownTypes().stream()
          .map(TypeMirror::toString)
          .toList();
@@ -116,8 +115,7 @@ public class ClusterAnnotationProcessor extends AbstractProcessor {
       }
 
       ProxyMethod proxyMethod = new ProxyMethod(
-         methodName, callableClassName, returnType, cacheName, keyParam, params, exceptions,
-         async);
+         methodName, callableClassName, returnType, cacheName, keyParam, params, exceptions);
       proxyClass.getMethods().add(proxyMethod);
    }
 

--- a/build-tools/cluster-proxy-annotations/src/main/java/inetsoft/cluster/apt/ProxyMethod.java
+++ b/build-tools/cluster-proxy-annotations/src/main/java/inetsoft/cluster/apt/ProxyMethod.java
@@ -25,8 +25,7 @@ import java.util.Objects;
 
 public final class ProxyMethod {
    public ProxyMethod(String name, String callableClassName, String returnType, String cacheName,
-                      String keyParam, List<ProxyParameter> parameters, List<String> exceptions,
-                      boolean async)
+                      String keyParam, List<ProxyParameter> parameters, List<String> exceptions)
    {
       this.name = name;
       this.callableClassName = callableClassName;
@@ -36,7 +35,6 @@ public final class ProxyMethod {
       this.keyParam = keyParam;
       this.parameters = new DecoratedCollection<>(parameters);
       this.exceptions = new DecoratedCollection<>(exceptions);
-      this.async = async;
    }
 
    public String getName() {
@@ -71,10 +69,6 @@ public final class ProxyMethod {
       return exceptions;
    }
 
-   public boolean isAsync() {
-      return async;
-   }
-
    @Override
    public boolean equals(Object o) {
       if(o == null || getClass() != o.getClass()) {
@@ -87,14 +81,12 @@ public final class ProxyMethod {
          Objects.equals(returnType, that.returnType) &&
          Objects.equals(cacheName, that.cacheName) &&
          Objects.equals(keyParam, that.keyParam) &&
-         Objects.equals(parameters, that.parameters) &&
-         async == that.async;
+         Objects.equals(parameters, that.parameters);
    }
 
    @Override
    public int hashCode() {
-      return Objects.hash(name, callableClassName, returnType, cacheName, keyParam, parameters,
-                          async);
+      return Objects.hash(name, callableClassName, returnType, cacheName, keyParam, parameters);
    }
 
    @Override
@@ -106,7 +98,6 @@ public final class ProxyMethod {
          ", cacheName='" + cacheName + '\'' +
          ", keyParam='" + keyParam + '\'' +
          ", parameters=" + parameters +
-         ", async=" + async +
          '}';
    }
 
@@ -118,5 +109,4 @@ public final class ProxyMethod {
    private final String keyParam;
    private final DecoratedCollection<ProxyParameter> parameters;
    private final DecoratedCollection<String> exceptions;
-   private final boolean async;
 }

--- a/build-tools/cluster-proxy-annotations/src/main/resources/inetsoft/cluster/apt/Proxy.java.mustache
+++ b/build-tools/cluster-proxy-annotations/src/main/resources/inetsoft/cluster/apt/Proxy.java.mustache
@@ -30,7 +30,6 @@ public class {{proxySimpleName}} {
       }
    }
 
-   {{^async}}
    public {{{returnType}}} {{name}}({{#parameters}}{{^first}}, {{/first}}{{{value.type}}} {{value.name}}{{/parameters}}){{#exceptions}}{{#first}} throws {{/first}}{{^first}}, {{/first}}{{value}}{{/exceptions}} {
       inetsoft.sree.internal.cluster.Cluster _cluster = inetsoft.sree.internal.cluster.Cluster.getInstance();
       {{#worksheetCache}}
@@ -60,9 +59,8 @@ public class {{proxySimpleName}} {
          _serviceProxyCallable.serviceProxyContext.apply();
       }
    }
-   {{/async}}
-   {{#async}}
-   public java.util.concurrent.Future<{{{returnType}}}> {{name}}({{#parameters}}{{^first}}, {{/first}}{{{value.type}}} {{value.name}}{{/parameters}}){{#exceptions}}{{#first}} throws {{/first}}{{^first}}, {{/first}}{{value}}{{/exceptions}} {
+
+   public java.util.concurrent.Future<{{{returnType}}}> {{name}}Async({{#parameters}}{{^first}}, {{/first}}{{{value.type}}} {{value.name}}{{/parameters}}){{#exceptions}}{{#first}} throws {{/first}}{{^first}}, {{/first}}{{value}}{{/exceptions}} {
       inetsoft.sree.internal.cluster.Cluster _cluster = inetsoft.sree.internal.cluster.Cluster.getInstance();
       {{#worksheetCache}}
       inetsoft.report.composition.WorksheetService _wsService = inetsoft.report.composition.WorksheetEngine.getWorksheetService();
@@ -82,6 +80,5 @@ public class {{proxySimpleName}} {
          _serviceProxyCallable.serviceProxyContext.apply();
       }
    }
-   {{/async}}
 {{/methods}}
 }

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
@@ -976,7 +976,7 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
       }
 
       try {
-         return future.get(60L, TimeUnit.SECONDS);
+         return future.get(5L, TimeUnit.MINUTES);
       }
       catch(RuntimeException ex) {
          throw ex;

--- a/core/src/main/java/inetsoft/web/viewsheet/EventAspect.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/EventAspect.java
@@ -193,7 +193,8 @@ public class EventAspect {
          if(commandDispatcher.isPresent() && principal.isPresent() &&
             runtimeViewsheetRef.getRuntimeId() != null)
          {
-            eventAspectServiceProxy.updateViewsheet(runtimeViewsheetRef.getRuntimeId(), commandDispatcher.get(), principal.get());
+            eventAspectServiceProxy.updateViewsheetAsync(runtimeViewsheetRef.getRuntimeId(),
+                                                         commandDispatcher.get(), principal.get());
          }
       }
    }

--- a/core/src/main/java/inetsoft/web/viewsheet/EventAspectService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/EventAspectService.java
@@ -42,7 +42,7 @@ public class EventAspectService {
       this.coreLifecycleService = coreLifecycleService;
    }
 
-   @ClusterProxyMethod(value = WorksheetEngine.CACHE_NAME, async = true)
+   @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void updateViewsheet(@ClusterProxyKey String runtimeId, CommandDispatcher commandDispatcher, Principal principal) throws Exception{
       RuntimeSheet rts = viewsheetService.getSheet(runtimeId, principal);
 

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshController.java
@@ -55,8 +55,8 @@ public class VSRefreshController {
                                 CommandDispatcher commandDispatcher,
                                 @LinkUri String linkUri) throws Exception
    {
-      vsRefreshServiceProxy.refreshViewsheet(this.runtimeViewsheetRef.getRuntimeId(),
-                                             event, principal, commandDispatcher, linkUri);
+      vsRefreshServiceProxy.refreshViewsheetAsync(this.runtimeViewsheetRef.getRuntimeId(),
+                                                  event, principal, commandDispatcher, linkUri);
 
    }
 

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshService.java
@@ -101,7 +101,7 @@ public class VSRefreshService {
       return null;
    }
 
-   @ClusterProxyMethod(value = WorksheetEngine.CACHE_NAME, async = true)
+   @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void refreshViewsheet(@ClusterProxyKey String id, VSRefreshEvent event, Principal principal,
                                 CommandDispatcher commandDispatcher, String linkUri) throws Exception
    {


### PR DESCRIPTION
Add affinityCallAsync so that requests don't have to wait for execution to finish and prevent timeout exceptions.