### PR TITLE
Bug #72707  Fix selection parameters from being set to null if any selected values were null

### DIFF
--- a/web/projects/portal/src/app/vsobjects/show-hyperlink.service.ts
+++ b/web/projects/portal/src/app/vsobjects/show-hyperlink.service.ts
@@ -114,8 +114,10 @@ export class ShowHyperlinkService extends HyperlinkService implements OnDestroy 
                params.set(model.name, [model.value]);
             }
 
-            extras.queryParams[model.name + ".__type__"] = model.type;
-            params.set(model.name + ".__type__", [model.type]);
+            if(extras.queryParams[model.name] == null || extras.queryParams[model.name] == "null") {
+               extras.queryParams[model.name + ".__type__"] = model.type;
+               params.set(model.name + ".__type__", [model.type]);
+            }
          });
       }
 


### PR DESCRIPTION
Related to Bug #49198
When setting the selection list type, we read the last selected value's type and set the entire selection list to that type.
In the case that the type was "null", the entire selection would be set to null.
This fix changes it to instead prioritize the first non-null type.