### PR TITLE
Bug #72330  Remove cluster restriction when uploading drivers in the portal

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/DatabaseDatasourcesService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/DatabaseDatasourcesService.java
@@ -850,9 +850,7 @@ public class DatabaseDatasourcesService {
 
    public boolean isUploadEnabled(Principal principal) {
       try {
-         boolean cluster = "server_cluster".equals(SreeEnv.getProperty("server.type")) ||
-            ScheduleClient.getScheduleClient().isCluster();
-         return !cluster && securityEngine.checkPermission(
+         return securityEngine.checkPermission(
             principal, ResourceType.UPLOAD_DRIVERS, "*", ResourceAction.ACCESS);
       }
       catch(SecurityException e) {


### PR DESCRIPTION
In Bug #67196 the cluster restriction for uploading drivers in the em was removed.
Uploading drivers in the portal uses the same em endpoint to upload the files, so I don't see any reason why to have different requirements in the portal, as long as the user has the correct permissions.