### PR TITLE
Bug #72865 - fix web socket subscription key collisions

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/plugins/PluginChangeController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/plugins/PluginChangeController.java
@@ -61,9 +61,9 @@ public class PluginChangeController {
    @SubscribeMapping(CHANGE_TOPIC)
    public void subscribeToTopic(StompHeaderAccessor header, Principal principal) {
       final MessageHeaders messageHeaders = header.getMessageHeaders();
-      final String subscriptionId =
-         (String) messageHeaders.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
-      subscriptions.put(subscriptionId, principal);
+      final String sessionId =
+         (String) messageHeaders.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
+      subscriptions.put(sessionId, principal);
    }
 
    @EventListener
@@ -79,11 +79,11 @@ public class PluginChangeController {
    private void removeSubscription(AbstractSubProtocolEvent event) {
       final Message<byte[]> message = event.getMessage();
       final MessageHeaders headers = message.getHeaders();
-      final String subscriptionId =
-         (String) headers.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
+      final String sessionId =
+         (String) headers.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
 
-      if(subscriptionId != null) {
-         subscriptions.remove(subscriptionId);
+      if(sessionId != null) {
+         subscriptions.remove(sessionId);
       }
    }
 

--- a/core/src/main/java/inetsoft/web/admin/content/repository/MVChangeController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/MVChangeController.java
@@ -70,9 +70,9 @@ public class MVChangeController implements MessageListener {
    @SubscribeMapping(CHANGE_TOPIC)
    public void subscribeToTopic(StompHeaderAccessor header, Principal principal) throws Exception {
       final MessageHeaders messageHeaders = header.getMessageHeaders();
-      final String subscriptionId =
-         (String) messageHeaders.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
-      subscriptions.put(subscriptionId, principal);
+      final String sessionId =
+         (String) messageHeaders.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
+      subscriptions.put(sessionId, principal);
    }
 
    @EventListener
@@ -88,11 +88,11 @@ public class MVChangeController implements MessageListener {
    private void removeSubscription(AbstractSubProtocolEvent event) {
       final Message<byte[]> message = event.getMessage();
       final MessageHeaders headers = message.getHeaders();
-      final String subscriptionId =
-         (String) headers.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
+      final String sessionId =
+         (String) headers.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
 
-      if(subscriptionId != null) {
-         subscriptions.remove(subscriptionId);
+      if(sessionId != null) {
+         subscriptions.remove(sessionId);
       }
    }
 

--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryChangeController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryChangeController.java
@@ -111,9 +111,9 @@ public class RepositoryChangeController {
    @SubscribeMapping(CHANGE_TOPIC)
    public void subscribeToTopic(StompHeaderAccessor header, Principal principal) throws Exception {
       final MessageHeaders messageHeaders = header.getMessageHeaders();
-      final String subscriptionId =
-         (String) messageHeaders.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
-      subscriptions.put(subscriptionId, principal);
+      final String sessionId =
+         (String) messageHeaders.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
+      subscriptions.put(sessionId, principal);
       IdentityID pId = principal == null ? null : IdentityID.getIdentityIDFromKey(principal.getName());
 
       if(principal != null) {
@@ -150,11 +150,11 @@ public class RepositoryChangeController {
    private void removeSubscription(AbstractSubProtocolEvent event) {
       final Message<byte[]> message = event.getMessage();
       final MessageHeaders headers = message.getHeaders();
-      final String subscriptionId =
-         (String) headers.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
+      final String sessionId =
+         (String) headers.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
 
-      if(subscriptionId != null) {
-         Principal principal = subscriptions.remove(subscriptionId);
+      if(sessionId != null) {
+         Principal principal = subscriptions.remove(sessionId);
 
          if(principal != null) {
             PropertyChangeListener listener = adminReportListeners.remove(principal);

--- a/core/src/main/java/inetsoft/web/admin/monitoring/MonitoringDataService.java
+++ b/core/src/main/java/inetsoft/web/admin/monitoring/MonitoringDataService.java
@@ -18,7 +18,7 @@
 package inetsoft.web.admin.monitoring;
 
 import inetsoft.util.*;
-import inetsoft.web.service.BaseSubscribeChangHandler;
+import inetsoft.web.service.BaseSubscribeChangeHandler;
 import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +48,7 @@ import java.util.stream.Stream;
  */
 @Service
 @Lazy(false)
-public class MonitoringDataService extends BaseSubscribeChangHandler {
+public class MonitoringDataService extends BaseSubscribeChangeHandler {
    @Autowired
    public MonitoringDataService(SimpUserRegistry userRegistry,
                                 SimpMessagingTemplate messageTemplate)

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskChangeController.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskChangeController.java
@@ -78,17 +78,17 @@ public class ScheduleTaskChangeController {
    @SubscribeMapping(PORTAL_TOPIC)
    public synchronized void subscribePortal(StompHeaderAccessor header, Principal principal) {
       final MessageHeaders messageHeaders = header.getMessageHeaders();
-      final String subscriptionId =
-         (String) messageHeaders.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
-      portalSubscribers.put(subscriptionId, principal);
+      final String sessionId =
+         (String) messageHeaders.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
+      portalSubscribers.put(sessionId, principal);
    }
 
    @SubscribeMapping(ADMIN_TOPIC)
    public synchronized void subscribeAdmin(StompHeaderAccessor header, Principal principal) {
       final MessageHeaders messageHeaders = header.getMessageHeaders();
-      final String subscriptionId =
-         (String) messageHeaders.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
-      adminSubscribers.put(subscriptionId, principal);
+      final String sessionId =
+         (String) messageHeaders.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
+      adminSubscribers.put(sessionId, principal);
    }
 
    @EventListener
@@ -104,12 +104,12 @@ public class ScheduleTaskChangeController {
    private void removeSubscription(AbstractSubProtocolEvent event) {
       final Message<byte[]> message = event.getMessage();
       final MessageHeaders headers = message.getHeaders();
-      final String subscriptionId =
-         (String) headers.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
+      final String sessionId =
+         (String) headers.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
 
-      if(subscriptionId != null) {
-         adminSubscribers.remove(subscriptionId);
-         portalSubscribers.remove(subscriptionId);
+      if(sessionId != null) {
+         adminSubscribers.remove(sessionId);
+         portalSubscribers.remove(sessionId);
       }
    }
 

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskFolderChangeController.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskFolderChangeController.java
@@ -61,17 +61,17 @@ public class ScheduleTaskFolderChangeController {
    @SubscribeMapping(FOLDER_TOPIC)
    public synchronized void subscribeFolderChange(StompHeaderAccessor header, Principal principal) {
       final MessageHeaders messageHeaders = header.getMessageHeaders();
-      final String subscriptionId =
-         (String) messageHeaders.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
-      folderSubscriptions.put(subscriptionId, principal);
+      final String sessionId =
+         (String) messageHeaders.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
+      folderSubscriptions.put(sessionId, principal);
    }
 
    @SubscribeMapping(EM_FOLDER_TOPIC)
    public synchronized void subscribeEmFolderChange(StompHeaderAccessor header, Principal principal) {
       final MessageHeaders messageHeaders = header.getMessageHeaders();
-      final String subscriptionId =
-         (String) messageHeaders.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
-      emFolderSubscriptions.put(subscriptionId, principal);
+      final String sessionId =
+         (String) messageHeaders.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
+      emFolderSubscriptions.put(sessionId, principal);
    }
 
    private void folderChanged(AssetChangeEvent event) {

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleUsersChangeService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleUsersChangeService.java
@@ -24,7 +24,7 @@ import inetsoft.uql.XPrincipal;
 import inetsoft.util.DefaultDebouncer;
 import inetsoft.util.Tool;
 import inetsoft.web.admin.security.*;
-import inetsoft.web.service.BaseSubscribeChangHandler;
+import inetsoft.web.service.BaseSubscribeChangeHandler;
 import jakarta.annotation.PreDestroy;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.EventListener;
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 
 @Service
 @Lazy(false)
-public class ScheduleUsersChangeService extends BaseSubscribeChangHandler implements MessageListener {
+public class ScheduleUsersChangeService extends BaseSubscribeChangeHandler implements MessageListener {
    public ScheduleUsersChangeService(SimpMessagingTemplate messageTemplate) {
       super(messageTemplate);
       Cluster.getInstance().addMessageListener(this);
@@ -77,9 +77,9 @@ public class ScheduleUsersChangeService extends BaseSubscribeChangHandler implem
          .get(DestinationPatternsMessageCondition.LOOKUP_DESTINATION_HEADER);
       final String subscriptionId =
          (String) messageHeaders.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
-      final BaseSubscribeChangHandler.BaseSubscriber subscriber =
-         new BaseSubscribeChangHandler.BaseSubscriber(sessionId, subscriptionId,
-            lookupDestination, destination, headerAccessor.getUser());
+      final BaseSubscribeChangeHandler.BaseSubscriber subscriber =
+         new BaseSubscribeChangeHandler.BaseSubscriber(sessionId, subscriptionId,
+                                                       lookupDestination, destination, headerAccessor.getUser());
 
       return addSubscriber(subscriber);
    }

--- a/core/src/main/java/inetsoft/web/admin/security/AuthenticationProviderService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/AuthenticationProviderService.java
@@ -31,7 +31,7 @@ import inetsoft.uql.util.Identity;
 import inetsoft.util.*;
 import inetsoft.util.audit.ActionRecord;
 import inetsoft.util.data.MapModel;
-import inetsoft.web.service.BaseSubscribeChangHandler;
+import inetsoft.web.service.BaseSubscribeChangeHandler;
 import inetsoft.web.viewsheet.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +55,7 @@ import java.util.stream.Collectors;
 
 @Service
 @EnableAspectJAutoProxy(proxyTargetClass = true)
-public class AuthenticationProviderService extends BaseSubscribeChangHandler implements MessageListener {
+public class AuthenticationProviderService extends BaseSubscribeChangeHandler implements MessageListener {
    @Autowired
    public AuthenticationProviderService(SecurityEngine securityEngine, ObjectMapper objectMapper,
                                         SimpMessagingTemplate messageTemplate)
@@ -90,9 +90,9 @@ public class AuthenticationProviderService extends BaseSubscribeChangHandler imp
          .get(DestinationPatternsMessageCondition.LOOKUP_DESTINATION_HEADER);
       final String subscriptionId =
          (String) messageHeaders.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
-      final BaseSubscribeChangHandler.BaseSubscriber subscriber =
-         new BaseSubscribeChangHandler.BaseSubscriber(sessionId, subscriptionId,
-                                                      lookupDestination, destination, headerAccessor.getUser());
+      final BaseSubscribeChangeHandler.BaseSubscriber subscriber =
+         new BaseSubscribeChangeHandler.BaseSubscriber(sessionId, subscriptionId,
+                                                       lookupDestination, destination, headerAccessor.getUser());
 
       return addSubscriber(subscriber);
    }

--- a/core/src/main/java/inetsoft/web/composer/AssetTreeRefreshController.java
+++ b/core/src/main/java/inetsoft/web/composer/AssetTreeRefreshController.java
@@ -96,9 +96,9 @@ public class AssetTreeRefreshController {
    @SubscribeMapping("/asset-changed")
    public void subscribeToTopic(StompHeaderAccessor header, Principal principal) {
       final MessageHeaders messageHeaders = header.getMessageHeaders();
-      final String subscriptionId =
-         (String) messageHeaders.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
-      subscriptions.put(subscriptionId, principal);
+      final String sessionId =
+         (String) messageHeaders.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
+      subscriptions.put(sessionId, principal);
 
       if(principal instanceof XPrincipal) {
          String orgId = ((XPrincipal) principal).getCurrentOrgId();
@@ -119,11 +119,11 @@ public class AssetTreeRefreshController {
    private void removeSubscription(AbstractSubProtocolEvent event) {
       final Message<byte[]> message = event.getMessage();
       final MessageHeaders headers = message.getHeaders();
-      final String subscriptionId =
-         (String) headers.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
+      final String sessionId =
+         (String) headers.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
 
-      if(subscriptionId != null) {
-         subscriptions.remove(subscriptionId);
+      if(sessionId != null) {
+         subscriptions.remove(sessionId);
       }
    }
 

--- a/core/src/main/java/inetsoft/web/composer/RuntimeSheetTransformController.java
+++ b/core/src/main/java/inetsoft/web/composer/RuntimeSheetTransformController.java
@@ -322,9 +322,9 @@ public class RuntimeSheetTransformController implements MessageListener {
    @SubscribeMapping("/dependency-changed")
    public void subscribeToDependency(StompHeaderAccessor header, Principal principal) {
       final MessageHeaders messageHeaders = header.getMessageHeaders();
-      final String subscriptionId =
-         (String) messageHeaders.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
-      subscriptions.put(subscriptionId, principal);
+      final String sessionId =
+         (String) messageHeaders.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
+      subscriptions.put(sessionId, principal);
    }
 
    @EventListener
@@ -340,11 +340,11 @@ public class RuntimeSheetTransformController implements MessageListener {
    private void removeSubscription(AbstractSubProtocolEvent event) {
       final Message<byte[]> message = event.getMessage();
       final MessageHeaders headers = message.getHeaders();
-      final String subscriptionId =
-         (String) headers.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
+      final String sessionId =
+         (String) headers.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
 
-      if(subscriptionId != null) {
-         subscriptions.remove(subscriptionId);
+      if(sessionId != null) {
+         subscriptions.remove(sessionId);
       }
    }
 

--- a/core/src/main/java/inetsoft/web/portal/controller/RepositoryTreeChangeController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/RepositoryTreeChangeController.java
@@ -86,9 +86,9 @@ public class RepositoryTreeChangeController {
    @SubscribeMapping(COMMANDS_TOPIC)
    public void subscribeToTopic(StompHeaderAccessor header, Principal principal) throws Exception {
       final MessageHeaders messageHeaders = header.getMessageHeaders();
-      final String subscriptionId =
-         (String) messageHeaders.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
-      subscriptions.put(subscriptionId, principal);
+      final String sessionId =
+         (String) messageHeaders.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
+      subscriptions.put(sessionId, principal);
 
       if(principal != null) {
          IdentityID pId = IdentityID.getIdentityIDFromKey(principal.getName());
@@ -111,11 +111,11 @@ public class RepositoryTreeChangeController {
    private void removeSubscription(AbstractSubProtocolEvent event) {
       final Message<byte[]> message = event.getMessage();
       final MessageHeaders headers = message.getHeaders();
-      final String subscriptionId =
-         (String) headers.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
+      final String sessionId =
+         (String) headers.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
 
-      if(subscriptionId != null) {
-         Principal principal = subscriptions.remove(subscriptionId);
+      if(sessionId != null) {
+         Principal principal = subscriptions.remove(sessionId);
 
          if(principal != null) {
             PropertyChangeListener listener = reportListeners.remove(principal);

--- a/core/src/main/java/inetsoft/web/service/BaseSubscribeChangeHandler.java
+++ b/core/src/main/java/inetsoft/web/service/BaseSubscribeChangeHandler.java
@@ -34,8 +34,8 @@ import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-public abstract class BaseSubscribeChangHandler {
-   public BaseSubscribeChangHandler(SimpMessagingTemplate messageTemplate) {
+public abstract class BaseSubscribeChangeHandler {
+   public BaseSubscribeChangeHandler(SimpMessagingTemplate messageTemplate) {
       this.messageTemplate = messageTemplate;
    }
 
@@ -45,19 +45,9 @@ public abstract class BaseSubscribeChangHandler {
    public void handleUnsubscribe(SessionUnsubscribeEvent event) {
       final Message<byte[]> message = event.getMessage();
       final MessageHeaders headers = message.getHeaders();
-      final String subscriptionId =
-         (String) headers.get(SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER);
-
-      if(subscriptionId != null) {
-         lock.lock();
-
-         try {
-            subscribers.removeIf(sub -> subscriptionId.equals(sub.getSubscriptionId()));
-         }
-         finally {
-            lock.unlock();
-         }
-      }
+      final String sessionId =
+         (String) headers.get(SimpMessageHeaderAccessor.SESSION_ID_HEADER);
+      removeSubscription(sessionId);
    }
 
    /**
@@ -65,7 +55,10 @@ public abstract class BaseSubscribeChangHandler {
     */
    public void handleDisconnect(SessionDisconnectEvent event) {
       final String sessionId = event.getSessionId();
+      removeSubscription(sessionId);
+   }
 
+   private void removeSubscription(String sessionId) {
       if(sessionId != null) {
          lock.lock();
 
@@ -224,5 +217,5 @@ public abstract class BaseSubscribeChangHandler {
    private final SimpMessagingTemplate messageTemplate;
    private final Set<BaseSubscriber> subscribers = new HashSet<>();
    private final Lock lock = new ReentrantLock();
-   private static final Logger LOG = LoggerFactory.getLogger(BaseSubscribeChangHandler.class);
+   private static final Logger LOG = LoggerFactory.getLogger(BaseSubscribeChangeHandler.class);
 }


### PR DESCRIPTION
Don't use simpSubscriptionId as the key for the subscribers map as it's not unique and causes collisions between different users and http sessions. It is also not available when the web socket disconnects. Use simpSessionId instead.