### PR TITLE
Bug #72899 - z-index issue of the background div in vs-image

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/output/image/vs-image.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/output/image/vs-image.component.html
@@ -30,46 +30,48 @@
      [style.left.px]="viewer || embeddedVS ? model.objectFormat.left : null"
      [style.position]="viewer || embeddedVS ? 'absolute' : 'relative'"
      [style.width.px]="model.objectFormat.width"
-     [style.height.px]="model.objectFormat.height"
-     [style.background-color]="model.objectFormat.background"
-     [style.border-bottom]="model.objectFormat.border.bottom"
-     [style.border-top]="model.objectFormat.border.top"
-     [style.border-left]="model.objectFormat.border.left"
-     [style.border-right]="model.objectFormat.border.right"
-     [style.border-radius.px]="model.objectFormat.roundCorner">
-  <div class="image-container"
-       [style.align-items]="model.objectFormat.alignItems"
-       [style.justify-content]="model.objectFormat.justifyContent"
+     [style.height.px]="model.objectFormat.height">
+  <div class="border-div"
        [style.z-index]="viewer ? model.objectFormat.zIndex : null"
-       [class.cursor-pointer]="viewer && (model.hyperlinks && model.hyperlinks.length || model.hasOnClick || model.popComponent)">
-    <ng-container *ngIf="!model.noImageFlag && vsInfo?.linkUri">
-      <img #imageElement *ngIf="!model.scaleInfo.tiled" class="image-content"
+       [style.background-color]="model.objectFormat.background"
+       [style.border-bottom]="model.objectFormat.border.bottom"
+       [style.border-top]="model.objectFormat.border.top"
+       [style.border-left]="model.objectFormat.border.left"
+       [style.border-right]="model.objectFormat.border.right"
+       [style.border-radius.px]="model.objectFormat.roundCorner">
+    <div class="image-container"
+         [style.align-items]="model.objectFormat.alignItems"
+         [style.justify-content]="model.objectFormat.justifyContent"
+         [class.cursor-pointer]="viewer && (model.hyperlinks && model.hyperlinks.length || model.hasOnClick || model.popComponent)">
+      <ng-container *ngIf="!model.noImageFlag && vsInfo?.linkUri">
+        <img #imageElement *ngIf="!model.scaleInfo.tiled" class="image-content"
+             (click)="clicked($event)"
+             (load)="onImageLoad()" (error)="finishLoad()"
+             [class.image-content-shadow]="model.shadow && model.animateGif"
+             [style.width.px]="imageSize.width"
+             [style.height.px]="imageSize.height"
+             [style.opacity]="opacity"
+             [attr.src]="src">
+        <div *ngIf="model.scaleInfo.tiled"
+             [ngStyle]="{'background': 'url(' + src + ') repeat'}"
+             (click)="clicked($event)"
+             class="image-content-tiled"
+             [style.opacity]="opacity">
+        </div>
+      </ng-container>
+      <div *ngIf="model.noImageFlag"
+           [innerText]="'_#(Image)'"
            (click)="clicked($event)"
-           (load)="onImageLoad()" (error)="finishLoad()"
-           [class.image-content-shadow]="model.shadow && model.animateGif"
+           class="image-no-content"
            [style.width.px]="imageSize.width"
            [style.height.px]="imageSize.height"
-           [style.opacity]="opacity"
-           [attr.src]="src">
-      <div *ngIf="model.scaleInfo.tiled"
-           [ngStyle]="{'background': 'url(' + src + ') repeat'}"
-           (click)="clicked($event)"
-           class="image-content-tiled"
-           [style.opacity]="opacity">
+           [style.background]="model.objectFormat.background"
+           [style.border-radius.px]="model.objectFormat.roundCorner"
+           [style.line-height]="model.objectFormat.height +'px'">
       </div>
-    </ng-container>
-    <div *ngIf="model.noImageFlag"
-         [innerText]="'_#(Image)'"
-         (click)="clicked($event)"
-         class="image-no-content"
-         [style.width.px]="imageSize.width"
-         [style.height.px]="imageSize.height"
-         [style.background]="model.objectFormat.background"
-         [style.border-radius.px]="model.objectFormat.roundCorner"
-         [style.line-height]="model.objectFormat.height +'px'">
-    </div>
-    <div class="annotation-hidden-container" *ngIf="viewer">
-      <vs-hidden-annotation [annotations]="model.assemblyAnnotationModels"></vs-hidden-annotation>
+      <div class="annotation-hidden-container" *ngIf="viewer">
+        <vs-hidden-annotation [annotations]="model.assemblyAnnotationModels"></vs-hidden-annotation>
+      </div>
     </div>
   </div>
   <ng-container *ngIf="viewer">

--- a/web/projects/portal/src/app/vsobjects/objects/output/image/vs-image.component.scss
+++ b/web/projects/portal/src/app/vsobjects/objects/output/image/vs-image.component.scss
@@ -61,3 +61,9 @@ div {
   top: 0;
   left: 0;
 }
+
+.border-div {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
Change in Bug #69952 broke annotations which was then reverted in Bug #72836, reintroducing the original issue.
Add a border-div container and set the z-index there, similar to other assemblies so that the background div displays in the correct stacking order and is not hidden by other elements.