### PR TITLE
Bug #72911  Enable formatting when selecting an assembly inside a container

### DIFF
--- a/web/projects/portal/src/app/vsobjects/format/vs-formats-pane.component.ts
+++ b/web/projects/portal/src/app/vsobjects/format/vs-formats-pane.component.ts
@@ -358,8 +358,14 @@ export class VSFormatsPane implements OnInit, OnChanges {
             return false;
          }
 
+         let parentContainers = new Set(this._focusedAssemblies
+            .map((assembly) => assembly.container)
+            .filter(container => !!container));
+         let nonGroupAssemblies = this._focusedAssemblies
+            .filter(assembly => !parentContainers.has(assembly.absoluteName));
+
          //disabled if textInput, calendar comboBox, or shape is focused
-         return !!this._focusedAssemblies.find((object) => {
+         return !!nonGroupAssemblies.find((object) => {
             return object.objectType == "VSTextInput" || object.objectType == "VSLine" ||
                object.objectType == "VSGroupContainer" || object.objectType == "VSTab" ||
                object.objectType == "VSRectangle" || object.objectType == "VSOval" ||


### PR DESCRIPTION
When an assembly inside a group container is selected, it selects the group container as well.
This change will make it so that the group containers that are parents of the intended selected assembly are ignored when it comes to disabling the format options.