### PR TITLE
Bug #72809 -  close viewsheets on session expiration

### DIFF
--- a/core/src/test/java/inetsoft/test/ControllersExtension.java
+++ b/core/src/test/java/inetsoft/test/ControllersExtension.java
@@ -90,7 +90,7 @@ public class ControllersExtension extends MockMessageExtension {
          }
       };
 
-      runtimeViewsheetManager = new RuntimeViewsheetManager(viewsheetService, worksheetService);
+      runtimeViewsheetManager = new RuntimeViewsheetManager(viewsheetService);
       List<VSObjectModelFactory<?, ?>> modelFactories = Arrays.asList(
          new VSCalcTableModel.VSCalcTableModelFactory(),
          new VSCheckBoxModel.VSCheckBoxModelFactory(),


### PR DESCRIPTION
Don't listen for websocket disconnection as that doesn't fit well with distributed sessions. Listen for SessionDeletedEvent and SessionExpiredEvent instead and close the viewsheets on the right node.