### PR TITLE
Bug #72900 - prevent data files that are in use from being deleted on clean up

### DIFF
--- a/core/src/main/java/inetsoft/util/FileSystemService.java
+++ b/core/src/main/java/inetsoft/util/FileSystemService.java
@@ -21,6 +21,7 @@ import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.cluster.Cluster;
 import inetsoft.sree.internal.cluster.ignite.IgniteCluster;
 import inetsoft.uql.DriverCache;
+import inetsoft.uql.asset.SnapshotEmbeddedTableAssembly;
 import inetsoft.util.swap.XSwapper;
 import inetsoft.web.service.LocalizationService;
 import org.slf4j.Logger;
@@ -586,12 +587,14 @@ public class FileSystemService {
 
                try {
                   Map<String, Integer> map = cluster.getMap(XSwapper.SWAP_FILE_MAP);
+                  Map<String, Integer> snapshotMap = cluster.getMap(SnapshotEmbeddedTableAssembly.FILE_REFERENCES_MAP);
 
                   for(int i = 0; files != null && i < files.length; i++) {
                      if(!files[i].isDirectory() &&
                         !files[i].getName().startsWith(Tool.PERSISTENT_PREFIX) &&
                         !files[i].getName().startsWith(DriverCache.DRIVER_CACHE_FILE_NAME) &&
-                        !map.containsKey(files[i].getAbsolutePath()))
+                        !map.containsKey(files[i].getAbsolutePath()) &&
+                        !snapshotMap.containsKey(files[i].getAbsolutePath()))
                      {
                         Path path = files[i].toPath();
 

--- a/core/src/main/java/inetsoft/util/swap/XSwapper.java
+++ b/core/src/main/java/inetsoft/util/swap/XSwapper.java
@@ -899,7 +899,7 @@ public final class XSwapper {
    public static final String SWAP_FILE_MAP_LOCK = "inetsoft.swap.file.map.lock";
 
    public static final class XSwappableReference extends Cleaner.Reference<XSwappable> {
-      XSwappableReference(XSwappable referent, File[] files) {
+      public XSwappableReference(XSwappable referent, File[] files) {
          super(referent);
          Cluster cluster = Cluster.getInstance();
          Map<String, Integer> map = cluster.getMap(SWAP_FILE_MAP);


### PR DESCRIPTION
Merge missing changes from Bug #67725.
  Don't remove swap or snapshot files that are still in use.
  Increase data timeout.
  Change the snapshot file references table to use a distributed map instead.
Mark the swap file in XTableFragment as in use when not being called through the XSwapper.
Implement hashcode() in SnapshotEmbeddedTableAssembly to prevent subsequent instances overwriting the previous asset change listeners of the same type in asset repository.