### PR TITLE
Bug #72963  When drill back up to previous ref, keep time series value

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/handler/chart/VSChartDrillHandler.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/handler/chart/VSChartDrillHandler.java
@@ -575,10 +575,6 @@ public class VSChartDrillHandler extends BaseDrillHandler<ChartVSAssembly, Chart
       if(nref != null) {
          nref = (VSDimensionRef) nref.clone();
 
-         if(!exist) {
-            nref.setTimeSeries(((VSDimensionRef) ref).isTimeSeries());
-         }
-
          info.decrementDrillLevel();
 
          // reset format if new ref, see bug1332539939927


### PR DESCRIPTION
When drilling down, the next level ref retrieved in VSUtil.getNextLevelRef() will always set timeSeries to false.
So when drilling back up, it would always set this timeSeries value in the previous ref.