### PR TITLE
Bug #72999

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/AbstractContainerVSAssembly.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/AbstractContainerVSAssembly.java
@@ -225,15 +225,20 @@ public abstract class AbstractContainerVSAssembly extends AbstractVSAssembly
     */
    @Override
    public void calcChildZIndex() {
+      calcChildZIndex(this.getZIndex());
+   }
+
+   @Override
+   public void calcChildZIndex(int zIndex) {
       String[] arr = getAssemblies();
       Assembly[] assemblies = new Assembly[arr.length];
-      VSUtil.calcChildZIndex(assemblies, this.getZIndex());
+      VSUtil.calcChildZIndex(assemblies, zIndex);
 
       for(int i = 0; i < arr.length; i++) {
          assemblies[i] = getViewsheet().getAssembly(arr[i]);
 
          if(assemblies[i] instanceof ContainerVSAssembly) {
-            ((ContainerVSAssembly) assemblies[i]).calcChildZIndex();
+            ((ContainerVSAssembly) assemblies[i]).calcChildZIndex(zIndex);
          }
       }
    }

--- a/core/src/main/java/inetsoft/uql/viewsheet/ContainerVSAssembly.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/ContainerVSAssembly.java
@@ -63,6 +63,11 @@ public interface ContainerVSAssembly extends VSAssembly {
    public void calcChildZIndex();
 
    /**
+    * Calc the sub component z index with calculated z index
+    */
+   public void calcChildZIndex(int zIndex);
+
+   /**
     * Layout the Container Assembly.
     * @return the names of the assemblies relocated.
     */

--- a/core/src/main/java/inetsoft/uql/viewsheet/GroupContainerVSAssembly.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/GroupContainerVSAssembly.java
@@ -125,6 +125,11 @@ public class GroupContainerVSAssembly extends AbstractContainerVSAssembly {
     */
    @Override
    public void calcChildZIndex() {
+      calcChildZIndex(info.getZIndex());
+   }
+
+   @Override
+   public void calcChildZIndex(int zIndex) {
       String[] arr = getAssemblies();
       Assembly[] assemblies = new Assembly[arr.length];
 
@@ -132,7 +137,7 @@ public class GroupContainerVSAssembly extends AbstractContainerVSAssembly {
          assemblies[i] = getViewsheet().getAssembly(arr[i]);
       }
 
-      VSUtil.calcChildZIndex(assemblies, info.getZIndex());
+      VSUtil.calcChildZIndex(assemblies, zIndex);
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
@@ -3356,7 +3356,7 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
 
       for(Assembly assembly : assemblies) {
          if(assembly instanceof ContainerVSAssembly) {
-            ((ContainerVSAssembly) assembly).calcChildZIndex();
+            ((ContainerVSAssembly) assembly).calcChildZIndex(((ContainerVSAssembly) assembly).getZIndex());
          }
       }
    }


### PR DESCRIPTION
, pass calculated z index of parent directly to child index calculations rather than relying on pulling assemblyinfo again to ensure correct z index ordering