### PR TITLE
Bug #72793 Bug #72861 - merge forward viewer web component changes

### DIFF
--- a/web/gulp/viewer-element.js
+++ b/web/gulp/viewer-element.js
@@ -53,6 +53,8 @@ gulp.task("viewer-element:sass", function () {
       .pipe(sass())
       .pipe(replace("inetsoft-viewer :root", "inetsoft-viewer"))
       .pipe(replace("inetsoft-viewer body", "inetsoft-viewer"))
+      .pipe(replace("#inetsoft-viewer-overlay :root", "#inetsoft-viewer-overlay"))
+      .pipe(replace("#inetsoft-viewer-overlay body", "#inetsoft-viewer-overlay"))
       .pipe(postcss([cssnano()]))
       .pipe(gulp.dest("target/generated-resources/gulp/inetsoft/web/resources/app/"));
 });

--- a/web/projects/portal/src/app/embed/viewer/embed-viewer.component.html
+++ b/web/projects/portal/src/app/embed/viewer/embed-viewer.component.html
@@ -26,7 +26,7 @@
               [queryParameters]="queryParams"
               [hideToolbar]="hideToolbar"
               [hideMiniToolbar]="hideMiniToolbar"
-              [globalLoadingIndicator]="globalLoadingIndicator"
+              [globalLoadingIndicator]="globalLoadingIndicator || hideLoadingIndicator"
               [viewerOffsetFunc]="getViewerOffsetFunc()"
               [embedViewer]="true"
               (onEmbedError)="onEmbedError($event)"
@@ -40,7 +40,7 @@
     </span>
   </div>
 
-  <vs-loading-display *ngIf="globalLoadingIndicator && loading"
+  <vs-loading-display *ngIf="globalLoadingIndicator && loading && !hideLoadingIndicator"
                       [allowInteraction]="true"
                       [justShowIcon]="true">
   </vs-loading-display>

--- a/web/projects/portal/src/app/embed/viewer/embed-viewer.component.ts
+++ b/web/projects/portal/src/app/embed/viewer/embed-viewer.component.ts
@@ -76,6 +76,15 @@ export class EmbedViewerComponent implements OnInit, OnDestroy, AfterViewInit {
    }
 
    @Input()
+   set hideLoadingIndicator(value: boolean | string) {
+      this._hideLoadingIndicator = this.isTrue(value);
+   }
+
+   get hideLoadingIndicator(): boolean {
+      return this._hideLoadingIndicator;
+   }
+
+   @Input()
    set hideMiniToolbar(value: boolean | string) {
       this._hideMiniToolbar = this.isTrue(value);
    }
@@ -105,6 +114,7 @@ export class EmbedViewerComponent implements OnInit, OnDestroy, AfterViewInit {
    private _hideToolbar: boolean = true;
    private _hideMiniToolbar: boolean = true;
    private _globalLoadingIndicator: boolean = true;
+   private _hideLoadingIndicator: boolean = false;
    private _scale: boolean = false;
    assetId: string;
    queryParams: Map<string, string[]>;
@@ -119,6 +129,7 @@ export class EmbedViewerComponent implements OnInit, OnDestroy, AfterViewInit {
    private loadingSet: Set<string> = new Set<string>();
    @ViewChild("embedViewer") embedViewer: ElementRef;
    @ViewChild("viewerApp") viewerApp: ViewerAppComponent;
+   overlayContainer: HTMLElement;
 
    private subscriptions: Subscription = new Subscription();
 
@@ -185,15 +196,17 @@ export class EmbedViewerComponent implements OnInit, OnDestroy, AfterViewInit {
             }
          });
       }
+
+      this.createOverlayContainer();
    }
 
    ngAfterViewInit(): void {
-      this.tooltipService.container = this.embedViewer.nativeElement;
-      this.modalConfig.container = this.embedViewer.nativeElement;
-      this.dropdownService.container = this.embedViewer.nativeElement;
+      this.tooltipService.container = this.overlayContainer;
+      this.modalConfig.container = this.overlayContainer;
+      this.dropdownService.container = this.overlayContainer;
       // handle dropdown in a dialog outside the bounds of the element
       this.dropdownService.allowPositionOutsideContainer = true;
-      this.dialogService.container = this.embedViewer.nativeElement;
+      this.dialogService.container = this.overlayContainer;
    }
 
    ngOnDestroy() {
@@ -278,5 +291,15 @@ export class EmbedViewerComponent implements OnInit, OnDestroy, AfterViewInit {
    onViewerSizeChanged(size: {width: number, height: number}) {
       this.width = size.width;
       this.height = size.height;
+   }
+
+   private createOverlayContainer() {
+      this.overlayContainer = document.getElementById("inetsoft-viewer-overlay");
+
+      if(!this.overlayContainer) {
+         this.overlayContainer = document.createElement("div");
+         this.overlayContainer.id = "inetsoft-viewer-overlay";
+         document.body.appendChild(this.overlayContainer);
+      }
    }
 }

--- a/web/projects/portal/src/app/vsobjects/objects/output/text/vs-text.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/output/text/vs-text.component.ts
@@ -375,6 +375,7 @@ export class VSText extends AbstractVSObject<VSTextModel>
 
             // If can not add one characters, should only return old string.
             if(actualH >= textH) {
+               window.document.body.removeChild(test);
                return lastString + "...";
             }
 

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -367,7 +367,10 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
 
    set runtimeId(value: string) {
       this._runtimeId = value;
-      this.dialogService.container = `.viewer-container[runtime-id="${value}"]`;
+
+      if(!this.embed) {
+         this.dialogService.container = `.viewer-container[runtime-id="${value}"]`;
+      }
    }
 
    name: string;
@@ -672,6 +675,11 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
 
       if(this.embed) {
          this.handleDataTipPopComponentChanges();
+         const overlayContainer = document.getElementById("inetsoft-viewer-overlay");
+
+         if(overlayContainer) {
+            this.dialogService.container = overlayContainer;
+         }
       }
 
       // Feed to trigger scroll viewport sizing when the root is visible. For example, if the

--- a/web/projects/portal/src/viewer-element.scss
+++ b/web/projects/portal/src/viewer-element.scss
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-inetsoft-viewer {
+inetsoft-viewer, #inetsoft-viewer-overlay {
   @import "target/generated-resources/gulp/inetsoft/web/resources/viewer-element/concat-viewer-element";
 
   range-slider {
@@ -59,5 +59,22 @@ inetsoft-viewer {
     .vs-range-slider .thumb-middle {
       background-image: url('assets/default/timeslider/thumb_middle_up.png') !important;
     }
+  }
+}
+
+#inetsoft-viewer-overlay {
+  position: fixed;
+  width: 100vw;
+  height: 100vh;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: none;
+  pointer-events: none;
+  z-index: 100;
+
+  * {
+    pointer-events: auto;
   }
 }


### PR DESCRIPTION
Bug #72793
Add hide-loading-indicator attribute in the viewer web component to hide all loading indicators

Bug #72861
Add an overlay container to the document body for tooltips, dialogs, and dropdowns. This ensures they are not affected by transforms or other css applied to the web component.
Remove ellipsis text node from the dom after being measured.