### PR TITLE
Merge forward changes for Bug #73000 - column aliases

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -480,7 +480,16 @@ public abstract class AssetQuery extends PreAssetQuery {
          if(filter.getTable() instanceof TableFilter2 ||
             filter.getTable() instanceof AssetQuery.FormatTableLens)
          {
+            // Bug #73000, keep the headers (aliases)
+            Object[] headers = filter.getHeaders();
             filter.setTable(shuckOffFormat(filter.getTable()));
+
+            if(headers != null) {
+               for(int i = 0; i < headers.length; i++) {
+                  filter.setObject(0, i, headers[i]);
+               }
+            }
+
             return filter;
          }
       }

--- a/core/src/main/java/inetsoft/report/filter/ColumnMapFilter.java
+++ b/core/src/main/java/inetsoft/report/filter/ColumnMapFilter.java
@@ -731,6 +731,10 @@ public class ColumnMapFilter extends AbstractTableLens
       return type != null ? type : table != null ? table.getReportType() : null;
    }
 
+   public Object[] getHeaders() {
+      return headers;
+   }
+
    /**
     * ColumnMapFilter data descriptor.
     */


### PR DESCRIPTION
Don't lose column aliases when removing the FormatTableLens