### PR TITLE
Bug #72798 - handle data for SnapshotEmbeddedTable

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeWorksheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeWorksheet.java
@@ -452,21 +452,28 @@ public class RuntimeWorksheet extends RuntimeSheet
    @Override
    RuntimeWorksheetState saveState(ObjectMapper mapper) {
       RuntimeWorksheetState state = new RuntimeWorksheetState();
-      super.saveState(state, mapper);
 
-      state.setWs(saveXml(ws));
+      try {
+         Worksheet.setIsTEMP(true);
+         super.saveState(state, mapper);
 
-      if(box != null && box.getVariableTable() != null) {
-         state.setVars(saveJson(box.getVariableTable(), mapper));
+         state.setWs(saveXml(ws));
+
+         if(box != null && box.getVariableTable() != null) {
+            state.setVars(saveJson(box.getVariableTable(), mapper));
+         }
+
+         state.setPreview(preview);
+         state.setGettingStarted(gettingStarted);
+         state.setPid(pid);
+         state.setSyncData(syncData);
+
+         if(joinWS != null) {
+            state.setJoinWS(joinWS.saveState(mapper));
+         }
       }
-
-      state.setPreview(preview);
-      state.setGettingStarted(gettingStarted);
-      state.setPid(pid);
-      state.setSyncData(syncData);
-
-      if(joinWS != null) {
-         state.setJoinWS(joinWS.saveState(mapper));
+      finally {
+         Worksheet.setIsTEMP(false);
       }
 
       return state;

--- a/core/src/main/java/inetsoft/uql/asset/AbstractTableAssembly.java
+++ b/core/src/main/java/inetsoft/uql/asset/AbstractTableAssembly.java
@@ -2327,6 +2327,11 @@ public abstract class AbstractTableAssembly extends AbstractWSAssembly implement
       }
    }
 
+   @Override
+   public void pasted() {
+      id = UUID.randomUUID().toString();
+   }
+
    private static final Logger LOG = LoggerFactory.getLogger(AbstractTableAssembly.class);
    private static final Set<String> IGNORED = new HashSet<>();
 

--- a/core/src/main/java/inetsoft/web/ServerLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/ServerLifecycleService.java
@@ -19,6 +19,7 @@ package inetsoft.web;
 
 import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.SUtil;
+import inetsoft.uql.asset.EmbeddedTableStorage;
 import inetsoft.util.*;
 import inetsoft.web.service.LicenseService;
 import jakarta.annotation.PostConstruct;
@@ -27,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -65,6 +67,11 @@ public class ServerLifecycleService implements ApplicationContextAware {
    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
       StatusDumpService.getInstance().setApplicationContext(applicationContext);
       ConfigurationContext.getContext().setApplicationContext(applicationContext);
+   }
+
+   @Scheduled(fixedRate = 10800000L)
+   public void removeExpiredTempTables() {
+      EmbeddedTableStorage.getInstance().removeExpiredTempTables();
    }
 
    private final LicenseService licenseService;

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/SaveWorksheetDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/SaveWorksheetDialogService.java
@@ -308,6 +308,7 @@ public class SaveWorksheetDialogService extends WorksheetControllerService {
             }
 
             WorksheetEventUtil.updateWorksheetMode(rws);
+            ensureWorksheetDistinct(rws);
             engine.setWorksheet(rws.getWorksheet(), entry, principal, true, !model.updateDep());
             actionRecord.setActionStatus(ActionRecord.ACTION_STATUS_SUCCESS);
             SaveWorksheetService.initWorksheetOldName(rws);
@@ -356,6 +357,20 @@ public class SaveWorksheetDialogService extends WorksheetControllerService {
       rws.getWorksheet().setLastModified(date.getTime());
 
       return null;
+   }
+
+   private void ensureWorksheetDistinct(RuntimeWorksheet rws) {
+      Worksheet worksheet = rws.getWorksheet();
+
+      if(worksheet != null) {
+         for(Assembly obj : worksheet.getAssemblies()) {
+            if(obj instanceof AbstractWSAssembly) {
+               // calls pasted which resets the table ids and renames the data files
+               // so that two worksheets remain distinct after a "save as" operation
+              ((AbstractWSAssembly) obj).pasted();
+            }
+         }
+      }
    }
 
    private final Catalog catalog = Catalog.getCatalog();


### PR DESCRIPTION
Prevent SnapshotEmbeddedTable data from being deleted unexpectedly. Handle copy/undo/save-as operations by making sure that the data files are saved to new files instead of sharing with the original assembly.
Mark tables as temp until the worksheet is explicitly saved. Clean up expired temp tables after 2 weeks (longer than auto save files) to make sure they don't stay in the storage forever.