### PR TITLE
Bug #72986 - prevent swap file from being deleted

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
@@ -853,6 +853,12 @@ public abstract class RuntimeSheet {
       }
 
       @Override
+      public File[] getSwapFiles() {
+         File file = getFile(prefix + ".tdat");
+         return new File[]{ file };
+      }
+
+      @Override
       public synchronized void dispose() {
          if(disposed) {
             return;


### PR DESCRIPTION
Mark the swap file as in use to prevent it from being deleted when cleaning up the cache