### PR TITLE
Bug #73022  For the chart image directive, do not set the image if the requested image changes before it returns

### DIFF
--- a/web/projects/portal/src/app/graph/objects/chart-image.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-image.directive.ts
@@ -46,13 +46,16 @@ export class ChartImageDirective {
             this.onLoading.emit();
          }
 
+         const requestedImage = this._chartImage;
+
          this.http.get(this.chartImage as string, { observe: "response", responseType: "blob" }).subscribe(
             response => {
                if(response.headers?.has("Retry-After")) {
                   const interval = parseInt(response.headers.get("Retry-After"), 10) * 1000;
                   setTimeout(() => this.loadImage(true), interval);
                }
-               else {
+               else if(requestedImage == this.chartImage) {
+                  // Do not set if image address changed before the request returned
                   this.renderer.setAttribute(this.element.nativeElement, "src", URL.createObjectURL(response.body));
                   this.onLoaded.emit();
                }


### PR DESCRIPTION
Before this change, the wrong image would load if the requested image rapidly alternates between two images.