### PR TITLE
Bug #73012

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/sync/AssetWSDependencyTransformer.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/AssetWSDependencyTransformer.java
@@ -64,6 +64,11 @@ public class AssetWSDependencyTransformer extends AssetHyperlinkDependencyTransf
          String npath = nentry.getPath();
          String oldUser = oentry.getUser() == null ? null : oentry.getUser().convertToKey();
 
+         //if importing from older version, raw user does not contain organization
+         if(user != null && !user.contains(IdentityID.KEY_DELIMITER) && oldUser != null && oldUser.contains(IdentityID.KEY_DELIMITER)) {
+            oldUser = IdentityID.getIdentityIDFromKey(oldUser).getName();
+         }
+
          if(Tool.equals(val, opath) && Tool.equals(user, oldUser) &&
             Tool.equals(scope, oentry.getScope() + ""))
          {


### PR DESCRIPTION
Match raw user value from old versions to updated IdentityID name when processing dependency rename so correct asset is found to rename dependency path