### PR TITLE
Bug #73034

### DIFF
--- a/web/projects/portal/src/app/binding/editor/binding-editor.component.scss
+++ b/web/projects/portal/src/app/binding/editor/binding-editor.component.scss
@@ -122,6 +122,7 @@
 
 .dc-applied-indicator {
   color: darkgray;
+  z-index: 10000;
 }
 
 .binding-border {


### PR DESCRIPTION
set dc-applied mask to large z index to ensure it shows above chart and other components