### PR TITLE
Bug #72935

### DIFF
--- a/web/projects/em/src/app/settings/security/security-settings-page/security-settings-page.component.html
+++ b/web/projects/em/src/app/settings/security/security-settings-page/security-settings-page.component.html
@@ -59,33 +59,38 @@
     <div class="tab-container" *ngIf="securityEnabled && isRefreshed">
       <nav mat-tab-nav-bar mat-stretch-tabs class="nav-tab" [tabPanel]="tabPanel">
         <a mat-tab-link label="securityLabel" *ngIf="securityProvidersVisible"
-           [routerLink]="['/settings/security/provider']"
+           [routerLink]="orgLoading ? null : ['/settings/security/provider']"
            routerLinkActive #providerActive="routerLinkActive"
-           [active]="providerActive.isActive">
+           [active]="providerActive.isActive"
+           [disabled]="orgLoading">
           _#(Security Providers)
         </a>
         <a mat-tab-link label="usersLabel" *ngIf="usersVisible"
-           [routerLink]="['/settings/security/users']"
+           [routerLink]="orgLoading ? null : ['/settings/security/users']"
            routerLinkActive #usersActive="routerLinkActive"
-           [active]="usersActive.isActive">
+           [active]="usersActive.isActive"
+           [disabled]="orgLoading">
           _#(Users)
         </a>
         <a mat-tab-link label="actionsLabel" *ngIf="actionsVisible"
-           [routerLink]="['/settings/security/actions']"
+           [routerLink]="orgLoading ? null : ['/settings/security/actions']"
            routerLinkActive #actionsActive="routerLinkActive"
-           [active]="actionsActive.isActive">
-          _#(Actions)
+           [active]="actionsActive.isActive"
+           [disabled]="orgLoading">
+        _#(Actions)
         </a>
         <a mat-tab-link *ngIf="ssoVisible"
-           [routerLink]="['/settings/security/sso']"
+           [routerLink]="orgLoading ? null : ['/settings/security/sso']"
            routerLinkActive #ssoActive="routerLinkActive"
-           [active]="ssoActive.isActive">
+           [active]="ssoActive.isActive"
+           [disabled]="orgLoading">
           _#(em.security.sso)
         </a>
         <a mat-tab-link *ngIf="googleSsoVisible"
-           [routerLink]="['/settings/security/googleSignIn']"
+           [routerLink]="orgLoading ? null : ['/settings/security/googleSignIn']"
            routerLinkActive #googleActive="routerLinkActive"
-           [active]="googleActive.isActive">
+           [active]="googleActive.isActive"
+           [disabled]="orgLoading">
           _#(Sign In With Google)
         </a>
       </nav>

--- a/web/projects/em/src/app/settings/security/security-settings-page/security-settings-page.component.ts
+++ b/web/projects/em/src/app/settings/security/security-settings-page/security-settings-page.component.ts
@@ -25,6 +25,7 @@ import { AuthorizationService } from "../../../authorization/authorization.servi
 import { MessageDialog, MessageDialogType } from "../../../common/util/message-dialog";
 import { PageHeaderService } from "../../../page-header/page-header.service";
 import { Secured } from "../../../secured";
+import { SecurityBusyService } from "../users/security-busy.service";
 import { SecurityEnabledEvent } from "./security-enabled-event";
 import { OrganizationDropdownService } from "../../../navbar/organization-dropdown.service";
 import { AppInfoService } from "../../../../../../shared/util/app-info.service";
@@ -57,6 +58,7 @@ export class SecuritySettingsPageComponent implements OnInit, OnDestroy {
    enterprise: boolean;
    orgIDPassOptions: string[] = ["domain", "path"];
    cloudPlatform = false;
+   orgLoading = false;
    private destroy$ = new Subject<void>();
 
    constructor(private pageTitle: PageHeaderService,
@@ -65,7 +67,8 @@ export class SecuritySettingsPageComponent implements OnInit, OnDestroy {
                private dialog: MatDialog,
                private appInfoService: AppInfoService,
                private httpClient: HttpClient,
-               private userService: ScheduleUsersService)
+               private userService: ScheduleUsersService,
+               private orgBusy: SecurityBusyService)
    {
    }
 
@@ -101,6 +104,8 @@ export class SecuritySettingsPageComponent implements OnInit, OnDestroy {
 
       this.httpClient.get("../api/em/security/get-enable-self-signup")
          .subscribe((event: SecurityEnabledEvent) => this.selfSignupEnabled = event.enable);
+
+      this.orgBusy.orgLoading$.subscribe(v => this.orgLoading = v);
    }
 
    ngOnDestroy(): void {

--- a/web/projects/em/src/app/settings/security/users/edit-identity-pane/edit-identity-pane.component.ts
+++ b/web/projects/em/src/app/settings/security/users/edit-identity-pane/edit-identity-pane.component.ts
@@ -23,6 +23,7 @@ import { MessageDialog, MessageDialogType } from "../../../../common/util/messag
 import {SecurityTreeNode} from "../../security-tree-view/security-tree-node";
 import {IdentityType} from "../../../../../../../shared/data/identity-type";
 import {convertToKey, IdentityId} from "../identity-id";
+import { SecurityBusyService } from "../security-busy.service";
 import {
    EditGroupPaneModel,
    EditIdentityPaneModel,
@@ -30,7 +31,7 @@ import {
    EditRolePaneModel,
    EditUserPaneModel
 } from "./edit-identity-pane.model";
-import {catchError} from "rxjs/operators";
+import {catchError, finalize } from "rxjs/operators";
 import {Tool} from "../../../../../../../shared/util/tool";
 
 @Component({
@@ -55,7 +56,7 @@ export class EditIdentityPaneComponent implements OnChanges {
    @Output() loadIdentityError = new EventEmitter<void>();
    public editModel$: Observable<EditIdentityPaneModel>;
 
-   constructor(private http: HttpClient, private dialog: MatDialog) {
+   constructor(private http: HttpClient, private dialog: MatDialog, private orgBusy: SecurityBusyService) {
    }
 
    ngOnChanges(changes: SimpleChanges): void {

--- a/web/projects/em/src/app/settings/security/users/edit-identity-view/edit-identity-view.component.ts
+++ b/web/projects/em/src/app/settings/security/users/edit-identity-view/edit-identity-view.component.ts
@@ -53,6 +53,7 @@ import {
 } from "../edit-identity-pane/edit-identity-pane.model";
 import {GetIdentityNameResponse} from "../get-identity-name-response";
 import { convertToKey, IdentityId } from "../identity-id";
+import { SecurityBusyService } from "../security-busy.service";
 
 interface IdentityTheme {
    id: string;
@@ -170,7 +171,8 @@ export class EditIdentityViewComponent implements OnInit, OnChanges, OnDestroy {
    constructor(private fb: UntypedFormBuilder,
                private http: HttpClient,
                private changeDetector: ChangeDetectorRef,
-               defaultErrorMatcher: ErrorStateMatcher)
+               defaultErrorMatcher: ErrorStateMatcher,
+               private orgBusy: SecurityBusyService)
    {
       this.passwordErrorMatcher = {
          isErrorState: (control: UntypedFormControl | null, form: FormGroupDirective | NgForm | null) =>
@@ -483,6 +485,7 @@ export class EditIdentityViewComponent implements OnInit, OnChanges, OnDestroy {
          this.groupSettingsChanged.emit(cmodel);
       }
       else if(this.type == IdentityType.ORGANIZATION) {
+         this.orgBusy.beginOrgSave();
          const cmodel = <EditOrganizationPaneModel> this.model;
          this.organizationSettingsChanged.emit(cmodel);
          this.identityEditable = false;

--- a/web/projects/em/src/app/settings/security/users/security-busy.service.ts
+++ b/web/projects/em/src/app/settings/security/users/security-busy.service.ts
@@ -1,0 +1,37 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class SecurityBusyService {
+   private _orgLoading = new BehaviorSubject<boolean>(false);
+   orgLoading$ = this._orgLoading.asObservable();
+
+   get orgLoading() {
+      return this._orgLoading.value;
+   }
+
+   beginOrgSave() {
+      this._orgLoading.next(true);
+   }
+
+   endOrgSave() {
+      this._orgLoading.next(false);
+   }
+}


### PR DESCRIPTION
Add orgLoading state service to disable security tabs during an organization update. Prevents stale data returning if action is edited before org update completes