### PR TITLE
Revert "Bug #72983, handle import as Site Admin for viewsheet hyperlinks"

### DIFF
--- a/core/src/main/java/inetsoft/report/Hyperlink.java
+++ b/core/src/main/java/inetsoft/report/Hyperlink.java
@@ -22,13 +22,11 @@ import inetsoft.report.filter.DCMergeCell;
 import inetsoft.report.filter.GroupedTable;
 import inetsoft.report.internal.Util;
 import inetsoft.report.internal.table.RuntimeCalcTableLens;
-import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.OrganizationManager;
 import inetsoft.uql.DrillPath;
 import inetsoft.uql.DrillSubQuery;
 import inetsoft.uql.asset.AssetEntry;
-import inetsoft.uql.tabular.View;
 import inetsoft.uql.viewsheet.DynamicValue;
 import inetsoft.uql.viewsheet.internal.VSUtil;
 import inetsoft.util.*;
@@ -774,14 +772,6 @@ public class Hyperlink implements XMLSerializable, Serializable, Cloneable {
     */
    @Override
    public void parseXML(Element tag) throws Exception {
-      parseXML(tag, false);
-   }
-
-   /**
-    * Method to parse an xml segment.
-    */
-   @Override
-   public void parseXML(Element tag, boolean isSiteAdminImport) throws Exception {
       String attr;
 
       if((attr = Tool.getAttribute(tag, "LinkType")) != null) {
@@ -789,18 +779,7 @@ public class Hyperlink implements XMLSerializable, Serializable, Cloneable {
       }
 
       if((attr = Tool.getAttribute(tag, "Link")) != null) {
-         if(getLinkType() == Hyperlink.VIEWSHEET_LINK) {
-            attr = SUtil.handleViewsheetLinkOrgMismatch(attr);
-         }
-
-         setLink(attr);
-
-         if(isSiteAdminImport && linkType == Hyperlink.VIEWSHEET_LINK) {
-            String linkPath = this.getLink();
-            linkPath = linkPath.substring(0, linkPath.lastIndexOf("^") + 1) + OrganizationManager.getInstance().getCurrentOrgID();
-            setLink(linkPath);
-         }
-      }
+         setLink(handleAssetLinkOrgMismatch(attr, getLinkType()));      }
 
       if((attr = Tool.getAttribute(tag, "TargetFrame")) != null) {
          setTargetFrame(attr);
@@ -865,6 +844,32 @@ public class Hyperlink implements XMLSerializable, Serializable, Cloneable {
          setParameterLabel(name, label);
          setParameterType(name, type);
       }
+   }
+
+   /**
+    * In cases that hyperlink linked asset does not match current orgID, replace orgID to match
+    */
+   public static String handleAssetLinkOrgMismatch(String link, int isAssetLink) {
+      if(isAssetLink == VIEWSHEET_LINK) {
+         String curOrgId = OrganizationManager.getInstance().getCurrentOrgID();
+         int orgIdx = link.lastIndexOf("^");
+
+         //handle import assets from older version without org identifier
+         boolean hasOrgDelim = link.chars().filter(ch -> ch == '^').count() > 3;
+
+         if(orgIdx > 0 && hasOrgDelim) {
+            String linkOrg = link.substring(orgIdx + 1);
+
+            if(!Tool.equals(linkOrg, curOrgId)) {
+               return link.substring(0, orgIdx + 1) + curOrgId;
+            }
+         }
+         else if(!hasOrgDelim) {
+            link = link + "^" + curOrgId;
+         }
+      }
+
+      return link;
    }
 
    /**
@@ -1663,32 +1668,15 @@ public class Hyperlink implements XMLSerializable, Serializable, Cloneable {
        * Parse and recreate a Hyperlink.
        */
       @Override
-      public void parseXML(Element element) throws IOException{
-         parseXML(element, false);
-      }
-
-      @Override
-      public void parseXML(Element tag, boolean isSiteAdminImport) throws IOException {
+      public void parseXML(Element tag) throws IOException {
          String attr;
 
          if((attr = Tool.getAttribute(tag, "Name")) != null) {
             name = attr;
          }
 
-         if((attr = Tool.getAttribute(tag, "LinkType")) != null) {
-            linkType = Integer.parseInt(attr);
-         }
-
          if((attr = Tool.getAttribute(tag, "Link")) != null) {
-            if(linkType == VIEWSHEET_LINK) {
-               attr = SUtil.handleViewsheetLinkOrgMismatch(attr);
-            }
-
-            if(isSiteAdminImport && linkType == Hyperlink.VIEWSHEET_LINK) {
-               String linkPath = this.getLink();
-               linkPath = linkPath.substring(0, linkPath.lastIndexOf("^") + 1) + OrganizationManager.getInstance().getCurrentOrgID();
-               setLink(linkPath);
-            }
+            setLink(attr);
          }
 
          if((attr = Tool.getAttribute(tag, "Query")) != null) {
@@ -1709,6 +1697,10 @@ public class Hyperlink implements XMLSerializable, Serializable, Cloneable {
 
          if((attr = Tool.getAttribute(tag, "BookmarkUser")) != null) {
             setBookmarkUser(attr);
+         }
+
+         if((attr = Tool.getAttribute(tag, "LinkType")) != null) {
+            linkType = Integer.parseInt(attr);
          }
 
          if((attr = Tool.getAttribute(tag, "SendReportParameters")) != null) {

--- a/core/src/main/java/inetsoft/sree/RepletEngine.java
+++ b/core/src/main/java/inetsoft/sree/RepletEngine.java
@@ -2027,7 +2027,7 @@ public class RepletEngine extends AbstractAssetEngine
     */
    @Override
    public AbstractSheet getSheet(AssetEntry entry, Principal user,
-                                 boolean permission, AssetContent ctype, boolean isSiteAdminImport)
+                                 boolean permission, AssetContent ctype)
       throws Exception
    {
       // @by larryl, we call this with null user from many places. Calling
@@ -2037,7 +2037,7 @@ public class RepletEngine extends AbstractAssetEngine
          checkAccess(user);
       }
 
-      return super.getSheet(entry, user, permission, ctype, isSiteAdminImport);
+      return super.getSheet(entry, user, permission, ctype);
    }
 
    /**

--- a/core/src/main/java/inetsoft/sree/internal/SUtil.java
+++ b/core/src/main/java/inetsoft/sree/internal/SUtil.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.sree.internal;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.mv.fs.*;
 import inetsoft.report.Hyperlink;
@@ -3435,38 +3436,6 @@ public class SUtil {
       }
 
       return orgID;
-   }
-
-   /**
-    * In cases that hyperlink linked asset does not match current orgID, replace orgID to match
-    */
-   public static String handleViewsheetLinkOrgMismatch(String link) {
-      String curOrgId = OrganizationManager.getInstance().getCurrentOrgID();
-      int orgIdx = link.lastIndexOf("^");
-
-      //handle import assets from older version without org identifier
-      boolean hasOrgDelim = link.chars().filter(ch -> ch == '^').count() > 3;
-
-      if(orgIdx > 0 && hasOrgDelim) {
-         String linkOrg = link.substring(orgIdx + 1);
-
-         if(!Tool.equals(linkOrg, curOrgId)) {
-            link = link.substring(0, orgIdx + 1) + curOrgId;
-         }
-      }
-      else if(!hasOrgDelim) {
-         link = link + "^" + curOrgId;
-      }
-
-      for(String pathSection : link.split("\\^")) {
-         if(pathSection.contains(IdentityID.KEY_DELIMITER)) {
-            IdentityID updatedUser = IdentityID.getIdentityIDFromKey(pathSection);
-            updatedUser.orgID = OrganizationManager.getInstance().getCurrentOrgID();
-            link = link.replace(pathSection, updatedUser.convertToKey());
-         }
-      }
-
-      return link;
    }
 
    private static boolean isIpHost(String host) {

--- a/core/src/main/java/inetsoft/sree/schedule/ViewsheetAction.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ViewsheetAction.java
@@ -194,10 +194,10 @@ public class ViewsheetAction extends AbstractAction implements ViewsheetSupport 
       parseXML(action, false);
    }
 
-   public void parseXML(Element action, boolean isSiteAdminImport) throws Exception {
-      viewsheet = SUtil.handleViewsheetLinkOrgMismatch(byteDecode(action.getAttribute("viewsheet")));
+   public void parseXML(Element action, boolean isImportSiteAdmin) throws Exception {
+      viewsheet = byteDecode(action.getAttribute("viewsheet"));
 
-      if(isSiteAdminImport) {
+      if(isImportSiteAdmin) {
          viewsheet = viewsheet.substring(0,viewsheet.lastIndexOf("^")+1) +
                      OrganizationManager.getInstance().getCurrentOrgID();
 
@@ -226,7 +226,7 @@ public class ViewsheetAction extends AbstractAction implements ViewsheetSupport 
             bookmarkNames[i] = bookmark.getAttribute("name");
             bookmarkUsers[i] = IdentityID.getIdentityIDFromKey(bookmark.getAttribute("user"));
 
-            if(isSiteAdminImport) {
+            if(isImportSiteAdmin) {
                bookmarkUsers[i] = bookmarkUsers[i] == null || bookmarkUsers[i].getOrgID() == null ? bookmarkUsers[i] :
                                   new IdentityID(bookmarkUsers[i].getName(), OrganizationManager.getInstance().getCurrentOrgID());
             }
@@ -240,7 +240,7 @@ public class ViewsheetAction extends AbstractAction implements ViewsheetSupport 
          String bookmarkName = action.getAttribute("bookmarkName");
          IdentityID bookmarkUser = IdentityID.getIdentityIDFromKey(action.getAttribute("bookmarkUser"));
 
-         if(isSiteAdminImport) {
+         if(isImportSiteAdmin) {
             bookmarkUser = bookmarkUser == null || bookmarkUser.getOrgID() == null ? bookmarkUser :
                            new IdentityID(bookmarkUser.getName(), OrganizationManager.getInstance().getCurrentOrgID());
          }

--- a/core/src/main/java/inetsoft/uql/DrillPath.java
+++ b/core/src/main/java/inetsoft/uql/DrillPath.java
@@ -17,7 +17,6 @@
  */
 package inetsoft.uql;
 
-import inetsoft.report.Hyperlink;
 import inetsoft.sree.security.OrganizationManager;
 import inetsoft.util.*;
 import org.slf4j.Logger;
@@ -544,32 +543,15 @@ public class DrillPath implements XMLSerializable, Serializable, Cloneable {
     */
    @Override
    public void parseXML(Element tag) throws Exception {
-      parseXML(tag, false);
-   }
-
-   public void parseXML(Element tag, boolean isSiteAdminImport) throws Exception {
       String attr;
 
       if((attr = Tool.getAttribute(tag, "name")) != null) {
          setName(attr);
       }
 
-      if((attr = Tool.getAttribute(tag, "linkType")) != null) {
-         setLinkType(Integer.parseInt(attr));
-      }
-
       if((attr = Tool.getAttribute(tag, "link")) != null) {
-         if(linkType == VIEWSHEET_LINK) {
-            attr = handleDrillLinkOrgMismatch(attr);
-         }
-
+         attr = handleDrillLinkOrgMismatch(attr);
          setLink(attr);
-      }
-
-      if(isSiteAdminImport && linkType == Hyperlink.VIEWSHEET_LINK) {
-         String linkPath = this.getLink();
-         linkPath = linkPath.substring(0, linkPath.lastIndexOf("^") + 1) + OrganizationManager.getInstance().getCurrentOrgID();
-         setLink(linkPath);
       }
 
       if((attr = Tool.getAttribute(tag, "targetFrame")) != null) {
@@ -578,6 +560,10 @@ public class DrillPath implements XMLSerializable, Serializable, Cloneable {
 
       if((attr = Tool.getAttribute(tag, "toolTip")) != null) {
          setToolTip(attr);
+      }
+
+      if((attr = Tool.getAttribute(tag, "linkType")) != null) {
+         setLinkType(Integer.parseInt(attr));
       }
 
       Element qnode = Tool.getChildNodeByTagName(tag, "subquery");

--- a/core/src/main/java/inetsoft/uql/XDrillInfo.java
+++ b/core/src/main/java/inetsoft/uql/XDrillInfo.java
@@ -253,17 +253,13 @@ public class XDrillInfo implements XMLSerializable, Serializable, Cloneable {
     */
    @Override
    public void parseXML(Element tag) throws Exception {
-      parseXML(tag, false);
-   }
-
-   public void parseXML(Element tag, boolean isSiteAdminImport) throws Exception {
       NodeList list = Tool.getChildNodesByTagName(tag, "drillPath");
 
       for(int i = 0; i < list.getLength(); i++) {
          Element elem = (Element) list.item(i);
 
          DrillPath path = new DrillPath("");
-         path.parseXML(elem, isSiteAdminImport);
+         path.parseXML(elem);
 
          addDrillPath(path);
       }

--- a/core/src/main/java/inetsoft/uql/asset/AbstractAssembly.java
+++ b/core/src/main/java/inetsoft/uql/asset/AbstractAssembly.java
@@ -109,12 +109,8 @@ public abstract class AbstractAssembly implements Assembly {
     * @param elem the specified xml element.
     */
    protected void parseContents(Element elem) throws Exception {
-      parseContents(elem, false);
-   }
-
-   protected void parseContents(Element elem, boolean isSiteAdminImport) throws Exception {
       Element inode = Tool.getChildNodeByTagName(elem, "assemblyInfo");
-      getInfo().parseXML(inode, isSiteAdminImport);
+      getInfo().parseXML(inode);
    }
 
    /**
@@ -123,13 +119,8 @@ public abstract class AbstractAssembly implements Assembly {
     */
    @Override
    public final void parseXML(Element elem) throws Exception {
-      parseXML(elem, false);
-   }
-
-   @Override
-   public final void parseXML(Element elem, boolean isSiteAdminImport) throws Exception {
       parseAttributes(elem);
-      parseContents(elem, isSiteAdminImport);
+      parseContents(elem);
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/asset/internal/AssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/asset/internal/AssemblyInfo.java
@@ -262,23 +262,14 @@ public abstract class AssemblyInfo implements AssetObject, DataSerializable {
       name = Tool.getChildValueByTagName(elem, "name");
    }
 
-   protected void parseContents(Element elem, boolean isSiteAdminImport) throws Exception {
-      name = Tool.getChildValueByTagName(elem, "name");
-   }
-
    /**
     * Method to parse an xml segment.
     * @param elem the specified xml element.
     */
    @Override
    public final void parseXML(Element elem) throws Exception {
-      parseXML(elem, false);
-   }
-
-   @Override
-   public final void parseXML(Element elem, boolean isSiteAdminImport) throws Exception {
       parseAttributes(elem);
-      parseContents(elem, isSiteAdminImport);
+      parseContents(elem);
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/asset/sync/DependencyTransformer.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/DependencyTransformer.java
@@ -19,8 +19,8 @@ package inetsoft.uql.asset.sync;
 
 import inetsoft.report.Hyperlink;
 import inetsoft.report.composition.RuntimeWorksheet;
-import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.internal.cluster.Cluster;
+import inetsoft.sree.security.Organization;
 import inetsoft.sree.security.OrganizationManager;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
@@ -1387,7 +1387,7 @@ public abstract class DependencyTransformer {
 
                   if(link != null) {
                      ((Element) linkList.item(i)).setAttribute("Link",
-                                linkType == Hyperlink.VIEWSHEET_LINK ? SUtil.handleViewsheetLinkOrgMismatch(link) : link);
+                        Hyperlink.handleAssetLinkOrgMismatch(link, linkType));
                   }
                }
             }
@@ -1401,7 +1401,7 @@ public abstract class DependencyTransformer {
 
                if(link != null && (Hyperlink.VIEWSHEET_LINK + "").equals(linkType)) {
                   ((Element) dirllList.item(i)).setAttribute("link",
-                     SUtil.handleViewsheetLinkOrgMismatch(link));
+                     Hyperlink.handleAssetLinkOrgMismatch(link, Integer.parseInt(linkType)));
                }
             }
 

--- a/core/src/main/java/inetsoft/uql/asset/sync/UpdateDependencyHandler.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/UpdateDependencyHandler.java
@@ -897,7 +897,7 @@ public final class UpdateDependencyHandler {
          }
 
          if(linkType == Hyperlink.VIEWSHEET_LINK) {
-            dependencies.add(AssetEntry.createAssetEntry(SUtil.handleViewsheetLinkOrgMismatch(linkName)));
+            dependencies.add(AssetEntry.createAssetEntry(Hyperlink.handleAssetLinkOrgMismatch(linkName, linkType)));
          }
       }
    }

--- a/core/src/main/java/inetsoft/uql/schema/XTypeNode.java
+++ b/core/src/main/java/inetsoft/uql/schema/XTypeNode.java
@@ -357,11 +357,6 @@ public class XTypeNode extends XNode implements Comparable, XMLSerializable {
     */
    @Override
    public void parseXML(Element root) {
-      parseXML(root, false);
-   }
-
-   @Override
-   public void parseXML(Element root, boolean isSiteAdminImport) {
       NamedNodeMap map = root.getAttributes();
 
       for(int i = 0; i < map.getLength(); i++) {
@@ -397,7 +392,7 @@ public class XTypeNode extends XNode implements Comparable, XMLSerializable {
             if(name != null && type != null) {
                XTypeNode attrnode = XSchema.createPrimitiveType(type);
                attrnode.setName(name);
-               attrnode.parseXML(elem, isSiteAdminImport);
+               attrnode.parseXML(elem);
                addAttribute(attrnode);
             }
          }

--- a/core/src/main/java/inetsoft/uql/viewsheet/AbstractVSAssembly.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/AbstractVSAssembly.java
@@ -53,19 +53,13 @@ public abstract class AbstractVSAssembly extends AbstractAssembly implements VSA
    public static VSAssembly createVSAssembly(Element elem, Viewsheet vs)
       throws Exception
    {
-      return createVSAssembly(elem, vs, false);
-   }
-
-   public static VSAssembly createVSAssembly(Element elem, Viewsheet vs, boolean isSiteAdminImport)
-      throws Exception
-   {
       String cls = Tool.getAttribute(elem, "class");
       VSAssembly assembly = null;
 
       try {
          assembly = (VSAssembly) Class.forName(cls).newInstance();
          assembly.setViewsheet(vs);
-         assembly.parseXML(elem, isSiteAdminImport);
+         assembly.parseXML(elem);
       }
       catch(InstantiationException ex) {
          // sometimes CalcTableVSAQuery.CrosstabVSAssembly may be not removed
@@ -576,13 +570,8 @@ public abstract class AbstractVSAssembly extends AbstractAssembly implements VSA
     */
    @Override
    protected final void parseContents(Element elem) throws Exception {
-      parseContents(elem, false);
-   }
-
-   @Override
-   protected final void parseContents(Element elem, boolean isSiteAdminImport) throws Exception {
       Element inode = Tool.getChildNodeByTagName(elem, "assemblyInfo");
-      getInfo().parseXML(inode, isSiteAdminImport);
+      getInfo().parseXML(inode);
       parseStateContent(elem, false);
    }
 

--- a/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
@@ -4140,11 +4140,6 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
     */
    @Override
    public void parseXML(Element elem) throws Exception {
-      parseXML(elem, false);
-   }
-
-   @Override
-   public void parseXML(Element elem, boolean isSiteAdminImport) throws Exception {
       // form 10.3 ViewsheetAsset begin to write "viewsheet" for root, so
       // VS10_2Transformer need to append "viewsheet" node, but when open
       // an old version viewsheet directly, we should not contain the viewsheet
@@ -4167,7 +4162,7 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
          }
 
          VSAssembly assembly =
-            AbstractVSAssembly.createVSAssembly(anode, this, isSiteAdminImport);
+            AbstractVSAssembly.createVSAssembly(anode, this);
 
          if(assembly == null) {
             continue;

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/GaugeVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/GaugeVSAssemblyInfo.java
@@ -161,12 +161,7 @@ public class GaugeVSAssemblyInfo extends RangeOutputVSAssemblyInfo implements De
     */
    @Override
    protected void parseContents(Element elem) throws Exception {
-      parseContents(elem, false);
-   }
-
-   @Override
-   protected void parseContents(Element elem, boolean isSiteAdminImport) throws Exception {
-      super.parseContents(elem, isSiteAdminImport);
+      super.parseContents(elem);
 
       vfColorValue.setDValue(Tool.getChildValueByTagName(elem, "valueFill"));
    }

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/OutputVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/OutputVSAssemblyInfo.java
@@ -536,12 +536,7 @@ public abstract class OutputVSAssemblyInfo extends VSAssemblyInfo
     */
    @Override
    protected void parseContents(Element elem) throws Exception {
-      parseContents(elem, false);
-   }
-
-   @Override
-   protected void parseContents(Element elem, boolean isSiteAdminImport) throws Exception {
-      super.parseContents(elem, isSiteAdminImport);
+      super.parseContents(elem);
 
       Element bnode = Tool.getChildNodeByTagName(elem, "bindingInfo");
 

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/RangeOutputVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/RangeOutputVSAssemblyInfo.java
@@ -772,12 +772,7 @@ public class RangeOutputVSAssemblyInfo extends OutputVSAssemblyInfo {
     */
    @Override
    protected void parseContents(Element elem) throws Exception {
-      parseContents(elem, false);
-   }
-
-   @Override
-   protected void parseContents(Element elem, boolean isSiteAdminImport) throws Exception {
-      super.parseContents(elem, isSiteAdminImport);
+      super.parseContents(elem);
 
       double[] resetValues = getResetValues();
       boolean isReset = resetValues != null;

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VSAssemblyInfo.java
@@ -989,11 +989,6 @@ public class VSAssemblyInfo extends AssemblyInfo implements FloatableVSAssemblyI
     */
    @Override
    protected void parseContents(Element elem) throws Exception {
-      parseContents(elem, false);
-   }
-
-   @Override
-   protected void parseContents(Element elem, boolean isSiteAdminImport) throws Exception {
       super.parseContents(elem);
       Element dnode = Tool.getChildNodeByTagName(elem, "description");
 
@@ -1041,7 +1036,7 @@ public class VSAssemblyInfo extends AssemblyInfo implements FloatableVSAssemblyI
 
       if(lnode != null) {
          Hyperlink link = new Hyperlink();
-         link.parseXML((Element) lnode.getFirstChild(), isSiteAdminImport);
+         link.parseXML((Element) lnode.getFirstChild());
          linkValue.setDValue(link);
       }
 
@@ -1049,7 +1044,7 @@ public class VSAssemblyInfo extends AssemblyInfo implements FloatableVSAssemblyI
 
       if(rnode != null) {
          ref = new Hyperlink.Ref();
-         ref.parseXML((Element) rnode.getFirstChild(), isSiteAdminImport);
+         ref.parseXML((Element) rnode.getFirstChild());
       }
 
       Element sNode = Tool.getChildNodeByTagName(elem, "script");

--- a/core/src/main/java/inetsoft/util/XMLSerializable.java
+++ b/core/src/main/java/inetsoft/util/XMLSerializable.java
@@ -39,9 +39,5 @@ public interface XMLSerializable {
     * Method to parse an xml segment.
     */
    public void parseXML(Element tag) throws Exception;
-
-   public default void parseXML(Element tag, boolean isSiteAdminImport) throws Exception {
-      parseXML(tag);
-   }
 }
 

--- a/core/src/main/java/inetsoft/util/dep/AbstractSheetAsset.java
+++ b/core/src/main/java/inetsoft/util/dep/AbstractSheetAsset.java
@@ -51,7 +51,7 @@ public abstract class AbstractSheetAsset extends AbstractXAsset {
     * Parse content of the specified asset from input stream.
     */
    @Override
-   public synchronized void parseContent(InputStream input, XAssetConfig config, boolean isImport, boolean isSiteAdminImport)
+   public synchronized void parseContent(InputStream input, XAssetConfig config, boolean isImport, boolean isSiteAdmin)
       throws Exception
    {
       Document doc = Tool.parseXML(input);
@@ -72,9 +72,9 @@ public abstract class AbstractSheetAsset extends AbstractXAsset {
       boolean overwriting = config != null && config.isOverwriting();
       AbstractSheet sheet0 = getSheet();
       AssetEntry entry = getAssetEntry();
-      parseSheet(sheet0, root, config, entry.getOrgID(), isSiteAdminImport);
+      parseSheet(sheet0, root, config, entry.getOrgID());
 
-      if(isImport && sheet0 != null && isSiteAdminImport) {
+      if(isImport && sheet0 != null && isSiteAdmin) {
          for(AssetEntry dep : sheet0.getOuterDependencies()) {
             dep.setOrgID(entry.getOrgID());
 
@@ -399,16 +399,6 @@ public abstract class AbstractSheetAsset extends AbstractXAsset {
     */
    protected void parseSheet(AbstractSheet sheet, Element elem,
                              XAssetConfig config, String orgId)
-      throws Exception
-   {
-      parseSheet(sheet, elem, config, orgId, false);
-   }
-
-   /**
-    * Parse sheet.
-    */
-   protected void parseSheet(AbstractSheet sheet, Element elem,
-                             XAssetConfig config, String orgId, boolean isSiteAdminImport)
       throws Exception
    {
       sheet.parseXML(elem);

--- a/core/src/main/java/inetsoft/util/dep/ViewsheetAsset.java
+++ b/core/src/main/java/inetsoft/util/dep/ViewsheetAsset.java
@@ -542,20 +542,13 @@ public class ViewsheetAsset extends AbstractSheetAsset implements FolderChangeab
    protected void parseSheet(AbstractSheet sheet, Element elem, XAssetConfig config, String orgId)
       throws Exception
    {
-      parseSheet(sheet, elem, config, orgId, false);
-   }
-
-   @Override
-   protected void parseSheet(AbstractSheet sheet, Element elem, XAssetConfig config, String orgId, boolean isSiteAdminImport)
-      throws Exception
-   {
       if("viewsheet".equals(elem.getNodeName()) &&
          Tool.getChildNodeByTagName(elem, "viewsheet") != null)
       {
          elem = Tool.getChildNodeByTagName(elem, "viewsheet");
       }
 
-      sheet.parseXML(elem, isSiteAdminImport);
+      sheet.parseXML(elem);
 
       Viewsheet vs = (Viewsheet) sheet;
 


### PR DESCRIPTION
This change is incomplete. There are multiple classes that override `parseContents` and these need to be modified to reflect the changed signature.