### PR TITLE
Bug #73055  Fix backwards compatibility issue in EmbeddedTableStorage Metadata

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/EmbeddedTableStorage.java
+++ b/core/src/main/java/inetsoft/uql/asset/EmbeddedTableStorage.java
@@ -128,6 +128,10 @@ public class EmbeddedTableStorage implements AutoCloseable {
    }
 
    public static final class Metadata implements Serializable {
+      public Metadata() {
+         this.temp = false;
+      }
+
       public Metadata(boolean temp) {
          this.temp = temp;
       }


### PR DESCRIPTION
Restoring a backup from a previous version of 14.0 would have issues restoring the EmbeddedTableStorage Metadata since it was missing the constructor for the serialization