### PR TITLE
Bug #73056 - lingering principals

### DIFF
--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/AbstractRestRuntime.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/AbstractRestRuntime.java
@@ -40,7 +40,8 @@ public abstract class AbstractRestRuntime extends TabularRuntime {
    public XTableNode runQuery(TabularQuery tabularQuery, VariableTable params) {
       final AbstractRestQuery query = (AbstractRestQuery) tabularQuery;
       QueryManager manager = (QueryManager) query.getProperty("queryManager");
-      ExecutorService executor = Executors.newSingleThreadExecutor(GroupedThread::new);
+      ExecutorService executor = Executors.newSingleThreadExecutor(
+         r -> new GroupedThread(r, ThreadContext.getContextPrincipal()));
       boolean cancelled = false;
       XTableNode result = null;
 

--- a/core/src/main/java/inetsoft/mv/MVCompositeDispatcher.java
+++ b/core/src/main/java/inetsoft/mv/MVCompositeDispatcher.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.security.Principal;
 import java.util.List;
 import java.util.UUID;
 
@@ -43,9 +44,10 @@ class MVCompositeDispatcher extends MVDispatcher implements Runnable {
    /**
     * Create an instanceof MVCompositeDispatcher.
     */
-   public MVCompositeDispatcher(MVDef def, VariableTable vars) {
+   public MVCompositeDispatcher(MVDef def, VariableTable vars, Principal principal) {
       super(def);
       this.vars = vars;
+      this.principal = principal;
    }
 
    @Override
@@ -67,6 +69,8 @@ class MVCompositeDispatcher extends MVDispatcher implements Runnable {
    @Override
    public void run() {
       try {
+         ThreadContext.setContextPrincipal(principal);
+
          synchronized(lock) {
             try {
                dispatch0();
@@ -79,6 +83,9 @@ class MVCompositeDispatcher extends MVDispatcher implements Runnable {
       }
       catch(Exception ex) {
          exception = ex;
+      }
+      finally {
+         ThreadContext.setContextPrincipal(null);
       }
    }
 
@@ -245,6 +252,7 @@ class MVCompositeDispatcher extends MVDispatcher implements Runnable {
    private VariableTable vars;
    private boolean completed = false;
    private Exception exception;
+   private Principal principal;
    private transient Object lock = new Object();
    private static final Logger LOG =
       LoggerFactory.getLogger(MVCompositeDispatcher.class);

--- a/core/src/main/java/inetsoft/mv/MVDispatcher.java
+++ b/core/src/main/java/inetsoft/mv/MVDispatcher.java
@@ -249,7 +249,7 @@ public class MVDispatcher {
                }
 
                MVCompositeDispatcher dispatcher =
-                  new MVCompositeDispatcher(def, vars);
+                  new MVCompositeDispatcher(def, vars, ThreadContext.getContextPrincipal());
                dispatcher.number = this.number;
                dispatcher.isDate = this.isDate;
                dispatcher.isDateTime = this.isDateTime;

--- a/core/src/main/java/inetsoft/mv/MVManager.java
+++ b/core/src/main/java/inetsoft/mv/MVManager.java
@@ -252,7 +252,7 @@ public final class MVManager implements MessageListener {
 
                String orgID = OrganizationManager.getInstance().getCurrentOrgID();
 
-               (new GroupedThread() {
+               (new GroupedThread(ThreadContext.getContextPrincipal()) {
                   @Override
                   protected void doRun() {
                      try {

--- a/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
+++ b/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
@@ -513,6 +513,20 @@ public class WorksheetEngine extends SheetLibraryEngine implements WorksheetServ
     * @return the runtime sheet if any.
     */
    public final RuntimeSheet getSheet(String id, Principal user, boolean touch) {
+      return getSheet(id, user, touch, false);
+   }
+
+   /**
+    * Get the runtime sheet.
+    * @param id the specified sheet id.
+    * @param user the specified user.
+    * @param touch <code>true</code> to update the access time and heartbeat.
+    * @param peek <code>true</code> to only check for runtime sheet entry and skip cache update
+    * @return the runtime sheet if any.
+    */
+   public final RuntimeSheet getSheet(String id, Principal user, boolean touch,
+                                      boolean peek)
+   {
       if(!isLocal(id)) {
          LOG.error("Getting sheet from non-owner: {}", id, new Exception("Stack trace"));
       }
@@ -535,16 +549,27 @@ public class WorksheetEngine extends SheetLibraryEngine implements WorksheetServ
          }
       }
 
-      Principal principal = ThreadContext.getContextPrincipal();
-
-      if(user != null && principal == null) {
+      if(user != null && ThreadContext.getContextPrincipal() == null) {
          ThreadContext.setContextPrincipal(user);
       }
 
-      // debounce and execute in a different thread the call to accessSheet as it
-      // serializes the runtime sheet and saves it in the distributed cache
-      debouncer.debounce("accessSheet_" + id, 1L,
-                         TimeUnit.SECONDS, () -> accessSheet(id, touch));
+      // only save the runtime sheet to the distributed cache if it's not a peek
+      if(!peek) {
+         final Principal principal = ThreadContext.getContextPrincipal();
+
+         // debounce and execute in a different thread the call to accessSheet as it
+         // serializes the runtime sheet and saves it in the distributed cache
+         debouncer.debounce("accessSheet_" + id, 1L, TimeUnit.SECONDS, () -> {
+            try {
+               ThreadContext.setContextPrincipal(principal);
+               accessSheet(id, touch);
+            }
+            finally {
+               ThreadContext.setContextPrincipal(null);
+            }
+         });
+      }
+
       return rs;
    }
 

--- a/core/src/main/java/inetsoft/report/composition/WorksheetService.java
+++ b/core/src/main/java/inetsoft/report/composition/WorksheetService.java
@@ -116,6 +116,8 @@ public interface WorksheetService {
 
    RuntimeSheet getSheet(String id, Principal user, boolean touch);
 
+   RuntimeSheet getSheet(String id, Principal user, boolean touch, boolean peek);
+
    /**
     * Save the worksheet.
     * @param ws the specified worksheet.

--- a/core/src/main/java/inetsoft/report/composition/execution/ConcatenatedQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ConcatenatedQuery.java
@@ -762,6 +762,7 @@ public class ConcatenatedQuery extends AssetQuery {
       public Thread newThread(Runnable r) {
          GroupedThread thread = new GroupedThread(r);
          thread.setDaemon(true);
+         thread.setPrincipal(ThreadContext.getContextPrincipal());
          return thread;
       }
    }

--- a/core/src/main/java/inetsoft/report/composition/execution/JoinQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/JoinQuery.java
@@ -1030,6 +1030,7 @@ public class JoinQuery extends AssetQuery {
       @Override
       public Thread newThread(Runnable r) {
          GroupedThread thread = new GroupedThread(r);
+         thread.setPrincipal(ThreadContext.getContextPrincipal());
          thread.setDaemon(true);
          return thread;
       }

--- a/core/src/main/java/inetsoft/report/lens/CrossJoinTableLens.java
+++ b/core/src/main/java/inetsoft/report/lens/CrossJoinTableLens.java
@@ -886,7 +886,7 @@ public class CrossJoinTableLens extends AbstractBinaryTableFilter implements Can
     */
    private class WaitingThread extends GroupedThread {
       public WaitingThread(boolean left) {
-         super();
+         super(ThreadContext.getContextPrincipal());
 
          this.left = left;
       }

--- a/core/src/main/java/inetsoft/sree/internal/ProcessReader.java
+++ b/core/src/main/java/inetsoft/sree/internal/ProcessReader.java
@@ -17,8 +17,7 @@
  */
 package inetsoft.sree.internal;
 
-import inetsoft.sree.security.IdentityID;
-import inetsoft.sree.security.OrganizationManager;
+import inetsoft.sree.security.*;
 import inetsoft.uql.XPrincipal;
 import inetsoft.util.*;
 import inetsoft.util.log.*;
@@ -110,7 +109,9 @@ public class ProcessReader {
 
                if(logLine) {
                   if(firstRecord) {
-                     setPrincipal(SUtil.getPrincipal(new IdentityID(XPrincipal.SYSTEM, OrganizationManager.getInstance().getCurrentOrgID()), null, false));
+                     setPrincipal(SUtil.getPrincipal(
+                        new IdentityID(XPrincipal.SYSTEM, Organization.getDefaultOrganizationID()),
+                        null, false));
                      addRecord("External process");
                      firstRecord = false;
                   }

--- a/core/src/main/java/inetsoft/sree/internal/SUtil.java
+++ b/core/src/main/java/inetsoft/sree/internal/SUtil.java
@@ -2465,6 +2465,11 @@ public class SUtil {
       try {
          Principal principal = null;
          HttpSession session = req.getSession(create);
+
+         if(session == null) {
+            return null;
+         }
+
          boolean isEmRequest = Tool.equals("true", req.getHeader(RepletRepository.EM_CLIENT)) ||
             "websocket".equals(req.getHeader("Upgrade")) &&
                Tool.equals("true", req.getParameter(RepletRepository.EM_CLIENT));

--- a/core/src/main/java/inetsoft/sree/security/OrganizationContextHolder.java
+++ b/core/src/main/java/inetsoft/sree/security/OrganizationContextHolder.java
@@ -42,5 +42,5 @@ public class OrganizationContextHolder {
       THREAD_LOCAL.remove();
    }
 
-   private static final InheritableThreadLocal<StringWrapper> THREAD_LOCAL = new InheritableThreadLocal<>();
+   private static final ThreadLocal<StringWrapper> THREAD_LOCAL = new ThreadLocal<>();
 }

--- a/core/src/main/java/inetsoft/uql/asset/sync/DependencyTransformer.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/DependencyTransformer.java
@@ -29,8 +29,7 @@ import inetsoft.uql.service.DataSourceRegistry;
 import inetsoft.uql.tabular.TabularDataSource;
 import inetsoft.uql.util.XUtil;
 import inetsoft.uql.xmla.XMLADataSource;
-import inetsoft.util.GroupedThread;
-import inetsoft.util.Tool;
+import inetsoft.util.*;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,7 +97,9 @@ public abstract class DependencyTransformer {
          for(int i = 0; i < nthread; i++) {
             List<AssetObject> list = DependencyTool.getThreadAssets(i, count, entries);
 
-            executors.execute((new GroupedThread("AssetTransformerThread_" + i) {
+            executors.execute((new GroupedThread("AssetTransformerThread_" + i,
+                                                 ThreadContext.getContextPrincipal())
+            {
                {
                   setDaemon(true);
                }

--- a/core/src/main/java/inetsoft/uql/service/XEngine.java
+++ b/core/src/main/java/inetsoft/uql/service/XEngine.java
@@ -71,7 +71,7 @@ public class XEngine implements XRepository, XQueryRepository {
     * Load data source meta data in background.
     */
    private void loadMetaData(final String dx) {
-      GroupedThread thread = new GroupedThread() {
+      GroupedThread thread = new GroupedThread(ThreadContext.getContextPrincipal()) {
          @Override
          protected void doRun() {
             setPrincipal(ThreadContext.getContextPrincipal());
@@ -1782,7 +1782,7 @@ public class XEngine implements XRepository, XQueryRepository {
       }
 
       MetaDataLoader loader = new MetaDataLoader(session, dx, mtype, clone);
-      new GroupedThread(loader).start();
+      new GroupedThread(loader, ThreadContext.getContextPrincipal()).start();
       long last = System.currentTimeMillis();
       String msg = "";
 
@@ -1978,7 +1978,7 @@ public class XEngine implements XRepository, XQueryRepository {
    private void writeMetaDataCache(final String key, final XNode meta) {
       metaDataCache.put(key, meta);
 
-      (new GroupedThread() {
+      (new GroupedThread(ThreadContext.getContextPrincipal()) {
          {
             setPriority(Thread.MIN_PRIORITY);
          }

--- a/core/src/main/java/inetsoft/uql/util/XNodeTable.java
+++ b/core/src/main/java/inetsoft/uql/util/XNodeTable.java
@@ -448,7 +448,12 @@ public class XNodeTable implements XTable {
             init(table.getColumnCreators());
 
             if(bgproc) {
-               ThreadPool.addOnDemand(() -> load(table));
+               ThreadPool.addOnDemand(new ThreadPool.AbstractContextRunnable() {
+                  @Override
+                  public void run() {
+                     load(table);
+                  }
+               });
             }
             else {
                load(table);
@@ -465,7 +470,12 @@ public class XNodeTable implements XTable {
             // root is a sequence node now
             if(bgproc) {
                final XNode root2 = root;
-               ThreadPool.addOnDemand(() -> load(root2));
+               ThreadPool.addOnDemand(new ThreadPool.AbstractContextRunnable() {
+                  @Override
+                  public void run() {
+                     load(root2);
+                  }
+               });
             }
             else {
                load(root);
@@ -580,20 +590,23 @@ public class XNodeTable implements XTable {
          boolean bgproc = prop.equalsIgnoreCase("true");
 
          if(bgproc) {
-            ThreadPool.addOnDemand(() -> {
-               try {
-                  loadTable0();
-               }
-               catch(ClassCastException ex) {
-                  loadDataException = ex;
-               }
-               catch(Exception ex) {
-                  cancelled = true;
-                  loadDataException = ex;
-                  LOG.debug("Failed to load XTableNode", ex);
-               }
-               finally {
-                  complete();
+            ThreadPool.addOnDemand(new ThreadPool.AbstractContextRunnable() {
+               @Override
+               public void run() {
+                  try {
+                     loadTable0();
+                  }
+                  catch(ClassCastException ex) {
+                     loadDataException = ex;
+                  }
+                  catch(Exception ex) {
+                     cancelled = true;
+                     loadDataException = ex;
+                     LOG.debug("Failed to load XTableNode", ex);
+                  }
+                  finally {
+                     complete();
+                  }
                }
             });
          }

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VSUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VSUtil.java
@@ -6978,9 +6978,16 @@ public final class VSUtil {
       {
          String debounceKey = VSBookmark.getLockKey(bookmark.getIdentifier(), bookmarkInfo.getOwner().convertToKey())
             + "_" + bookmarkName;
+         final Principal contextPrincipal = ThreadContext.getContextPrincipal();
          getDebouncer().debounce(debounceKey, 2L, TimeUnit.SECONDS, () -> {
-            updateBookmarkLastAccessedTime(bookmark.getIdentifier(), bookmarkName,
-                                           bookmarkInfo.getOwner(), rep);
+            try {
+               ThreadContext.setContextPrincipal(contextPrincipal);
+               updateBookmarkLastAccessedTime(bookmark.getIdentifier(), bookmarkName,
+                                              bookmarkInfo.getOwner(), rep);
+            }
+            finally {
+               ThreadContext.setContextPrincipal(null);
+            }
          });
       }
 

--- a/core/src/main/java/inetsoft/util/GroupedThread.java
+++ b/core/src/main/java/inetsoft/util/GroupedThread.java
@@ -41,7 +41,7 @@ public class GroupedThread extends Thread {
     * Create a thread that is in the same thread group as its creator.
     */
    public GroupedThread() {
-      this(ThreadContext.getContextPrincipal());
+      this((Principal) null);
    }
 
    /**
@@ -50,7 +50,7 @@ public class GroupedThread extends Thread {
     * @param name the name of the thread.
     */
    public GroupedThread(String name) {
-      this(name, ThreadContext.getContextPrincipal());
+      this(name, null);
    }
 
    /**
@@ -79,11 +79,6 @@ public class GroupedThread extends Thread {
       this.records = new LinkedHashSet<>();
       this.user = user;
 
-      // if user is null, try getting principal from context
-      if(this.user == null) {
-         this.user = ThreadContext.getContextPrincipal();
-      }
-
       if(Thread.currentThread() instanceof GroupedThread) {
          GroupedThread pthread = (GroupedThread) Thread.currentThread();
          parentStackTrace = pthread.stackTrace;
@@ -96,7 +91,7 @@ public class GroupedThread extends Thread {
     * @param runnable a Runnable instance
     */
    public GroupedThread(Runnable runnable) {
-      this(runnable, ThreadContext.getContextPrincipal());
+      this(runnable, (Principal) null);
    }
 
    /**
@@ -106,7 +101,7 @@ public class GroupedThread extends Thread {
     * @param name     the name of the thread.
     */
    public GroupedThread(Runnable runnable, String name) {
-      this(runnable, name, ThreadContext.getContextPrincipal());
+      this(runnable, name, null);
    }
 
    /**
@@ -136,11 +131,6 @@ public class GroupedThread extends Thread {
       this.stackTrace = Thread.currentThread().getStackTrace();
       this.records = new LinkedHashSet<>();
       this.user = user;
-
-      // if user is null, try getting principal from context
-      if(this.user == null) {
-         this.user = ThreadContext.getContextPrincipal();
-      }
 
       if(Thread.currentThread() instanceof GroupedThread) {
          GroupedThread pthread = (GroupedThread) Thread.currentThread();

--- a/core/src/main/java/inetsoft/util/ThreadContext.java
+++ b/core/src/main/java/inetsoft/util/ThreadContext.java
@@ -197,8 +197,8 @@ public final class ThreadContext {
       }
    }
 
-   private static final ThreadLocal<Principal> PRINCIPAL = new InheritableThreadLocal<>();
-   private static final ThreadLocal<Locale> LOCALE = new InheritableThreadLocal<>();
+   private static final ThreadLocal<Principal> PRINCIPAL = new ThreadLocal<>();
+   private static final ThreadLocal<Locale> LOCALE = new ThreadLocal<>();
    private static final Map<Thread,Map<String,Object>> sessionInfos = new WeakHashMap<>();
    private static final Logger LOG = LoggerFactory.getLogger(ThreadContext.class);
 }

--- a/core/src/main/java/inetsoft/util/ThreadPool.java
+++ b/core/src/main/java/inetsoft/util/ThreadPool.java
@@ -18,10 +18,8 @@
 package inetsoft.util;
 
 import inetsoft.report.internal.license.*;
-import inetsoft.sree.security.OrganizationContextHolder;
 import org.slf4j.*;
 
-import java.lang.reflect.*;
 import java.security.Principal;
 import java.util.*;
 import java.util.concurrent.*;

--- a/core/src/main/java/inetsoft/util/Tool.java
+++ b/core/src/main/java/inetsoft/util/Tool.java
@@ -4777,7 +4777,7 @@ public final class Tool extends CoreTool {
                future.completeExceptionally(e);
             }
          }
-      });
+      }, ThreadContext.getContextPrincipal());
       reference.set(thread);
       thread.start();
       return future;

--- a/core/src/main/java/inetsoft/web/ThreadLocalCleanupFilter.java
+++ b/core/src/main/java/inetsoft/web/ThreadLocalCleanupFilter.java
@@ -18,12 +18,14 @@
 
 package inetsoft.web;
 
+import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.security.OrganizationContextHolder;
-import inetsoft.util.GroupedThread;
 import inetsoft.util.ThreadContext;
 import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
 
 import java.io.IOException;
+import java.security.Principal;
 
 public class ThreadLocalCleanupFilter implements Filter {
    @Override
@@ -31,14 +33,17 @@ public class ThreadLocalCleanupFilter implements Filter {
       throws IOException, ServletException
    {
       try {
+         Principal principal = SUtil.getPrincipal((HttpServletRequest) request);
+
+         if(principal != null) {
+            ThreadContext.setContextPrincipal(principal);
+         }
+
          chain.doFilter(request, response);
       }
       finally {
-         if(Thread.currentThread() instanceof GroupedThread groupedThread) {
-            groupedThread.setPrincipal(null);
-         }
-
          ThreadContext.setContextPrincipal(null);
+         ThreadContext.setPrincipal(null);
          OrganizationContextHolder.clear();
          ThreadContext.setLocale(null);
       }

--- a/core/src/main/java/inetsoft/web/admin/content/repository/ExportAssetController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/ExportAssetController.java
@@ -67,6 +67,8 @@ public class ExportAssetController {
       session.setAttribute(PERM_ATTR, future);
 
       ThreadPool.addOnDemand(() -> {
+         Principal oldPrincipal = ThreadContext.getContextPrincipal();
+
          try {
             ThreadContext.setPrincipal(principal);
             SelectedAssetModelList list = deployService.filterEntities(assets, principal);
@@ -77,6 +79,7 @@ public class ExportAssetController {
          }
          finally {
             session.setAttribute(PERM_ATTR, future);
+            ThreadContext.setPrincipal(oldPrincipal);
          }
       });
    }
@@ -105,6 +108,8 @@ public class ExportAssetController {
       session.setAttribute(DEPS_ATTR, future);
 
       ThreadPool.addOnDemand(() -> {
+         Principal oldPrincipal = ThreadContext.getPrincipal();
+
          try {
             ThreadContext.setPrincipal(principal);
             RequiredAssetModelList list =
@@ -116,6 +121,7 @@ public class ExportAssetController {
          }
          finally {
             session.setAttribute(DEPS_ATTR, future);
+            ThreadContext.setPrincipal(oldPrincipal);
          }
       });
    }

--- a/core/src/main/java/inetsoft/web/admin/content/repository/ImportAssetService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/ImportAssetService.java
@@ -173,8 +173,9 @@ public class ImportAssetService {
             catch(Exception e) {
                future.completeExceptionally(e);
             }
-
-            ThreadContext.setPrincipal(oPrincipal);
+            finally {
+               ThreadContext.setPrincipal(oPrincipal);
+            }
          });
       }
 

--- a/core/src/main/java/inetsoft/web/admin/viewsheet/ViewsheetService.java
+++ b/core/src/main/java/inetsoft/web/admin/viewsheet/ViewsheetService.java
@@ -447,7 +447,7 @@ public class ViewsheetService
          throw new IllegalStateException("The viewsheet engine has not been initialized");
       }
 
-      if(service.getSheet(id, null) == null) {
+      if(service.getSheet(id, null, false, true) == null) {
          throw new IllegalArgumentException("No viewsheet with ID \"" + id + "\" exists");
       }
    }

--- a/core/src/main/java/inetsoft/web/portal/service/datasource/DataSourceStatusService.java
+++ b/core/src/main/java/inetsoft/web/portal/service/datasource/DataSourceStatusService.java
@@ -53,7 +53,7 @@ public class DataSourceStatusService {
       for(int i = 0; i < paths.size(); i++) {
          final int idx = i;
 
-         final Thread thread = new Thread(() -> {
+         final Thread thread = new GroupedThread(() -> {
             XDataSource.Status status = null;
             LogContext.setUser(ThreadContext.getContextPrincipal());
             MDC.put("DATA_SOURCE", paths.get(idx));
@@ -68,7 +68,7 @@ public class DataSourceStatusService {
             }
 
             statuses[idx] = status;
-         });
+         }, principal);
 
          thread.start();
          threads.add(thread);

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardBindingService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardBindingService.java
@@ -282,7 +282,7 @@ public class VSWizardBindingService {
       VSTemporaryInfo vsTemporaryInfo = temporaryInfoService.getVSTemporaryInfo(rvs);
       // The calculation of cardinality should start as early as possible
       WizardRecommenderUtil.calcCardinalities(box, (VSTemporaryInfo) vsTemporaryInfo.clone(),
-                                              event.getSelectedNodes());
+                                              event.getSelectedNodes(), principal);
 
       box.cancel(true);
       box.lockWrite();

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/WizardRecommenderUtil.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/WizardRecommenderUtil.java
@@ -30,8 +30,7 @@ import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.graph.*;
 import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.VSUtil;
-import inetsoft.util.GroupedThread;
-import inetsoft.util.Tool;
+import inetsoft.util.*;
 import inetsoft.web.vswizard.RecommendSequentialContext;
 import inetsoft.web.vswizard.model.recommender.*;
 import inetsoft.web.vswizard.recommender.execution.*;
@@ -40,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
+import java.security.Principal;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -404,7 +404,7 @@ public final class WizardRecommenderUtil {
    }
 
    public static void calcCardinalities(ViewsheetSandbox box, VSTemporaryInfo tempInfo,
-                                        AssetEntry[] dimEntries)
+                                        AssetEntry[] dimEntries, Principal principal)
    {
       if(dimEntries == null || dimEntries.length == 0) {
          return;
@@ -415,7 +415,7 @@ public final class WizardRecommenderUtil {
       for(int i = 0; i < dimEntries.length; i++) {
          AssetEntry entry = dimEntries[i];
 
-         new GroupedThread() {
+         new GroupedThread(principal) {
             @Override
             protected void doRun() {
                try {


### PR DESCRIPTION
Replaced InheritableThreadLocal with regular ThreadLocal to prevent principal objects from lingering in threads and being used incorrectly. Identified the places where new threads are spawned to determine where the context principal should be explicitly passed. Avoided setting a principal in GroupedThread unless required to prevent unknown principals from persisting for the lifetime of the thread, especially in thread pools.

Prevented unnecessary writes of the runtime sheet to the cache when being checked for existence in ViewsheetService.checkVSExisted().