### PR TITLE
Bug #72936

### DIFF
--- a/core/src/main/java/inetsoft/web/vswizard/handler/VSWizardBindingHandler.java
+++ b/core/src/main/java/inetsoft/web/vswizard/handler/VSWizardBindingHandler.java
@@ -2379,7 +2379,6 @@ public class VSWizardBindingHandler {
             // font is set on text and should not be carried to other components (e.g. table)
             if(format.getUserDefinedFormat().isFontValueDefined()) {
                formatObj = (VSFormat) formatObj.clone();
-               formatObj.setFontValue(format.getFontValue());
             }
          }
 


### PR DESCRIPTION
Should not pass fontValue format on update, instead force reload of default or user defined down the line to prevent holding stale format from other type