### PR TITLE
merge from sr13_7 for 73088

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/ExpandableDataSet.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/ExpandableDataSet.java
@@ -291,6 +291,16 @@ public class ExpandableDataSet extends AbstractDataSetFilter {
       return data;
    }
 
+   /**
+    * Create a new ExpandableDataSet with the same additional dimensions and measure.s
+    */
+   public ExpandableDataSet create(DataSet base) {
+      ExpandableDataSet data = new ExpandableDataSet(base);
+      data.map = new OrderedMap<>(this.map);
+      data.measures = new HashMap<>(this.measures);
+      return data;
+   }
+
    private int bcol;
    private int brow;
    private OrderedMap<String, Object> map;

--- a/core/src/main/java/inetsoft/report/composition/graph/VGraphPair.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/VGraphPair.java
@@ -482,7 +482,13 @@ public class VGraphPair {
                // do nothing
             }
             else if(nset != null) {
-               this.data = nset;
+               // make sure added dimensions and measures are not lost. (73088)
+               if(this.data instanceof ExpandableDataSet) {
+                  this.data = ((ExpandableDataSet) this.data).create(nset);
+               }
+               else {
+                  this.data = nset;
+               }
             }
 
             // for script chart, if multi-element is defined but no color frame,


### PR DESCRIPTION
The fake measure added to ExpandableDataSet is lost when a script touches the dataset. Changed to make a 'copy' of the ExpandableDataSet when changing the base dataset instead of straight replacement.