### PR TITLE
Bug #73051 - copy storage using the wrong metadata class

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -939,7 +939,7 @@ public class IdentityService {
       removeBlobStorage("__mvBlock", orgID, BlockFileStorage.Metadata.class);
       removeBlobStorage("__pdata", orgID, EmbeddedTableStorage.Metadata.class);
       removeBlobStorage("__library", orgID, LibManager.Metadata.class);
-      removeBlobStorage("__autoSave", orgID, LibManager.Metadata.class);
+      removeBlobStorage("__autoSave", orgID, AutoSaveUtils.Metadata.class);
       EmbeddedDataCacheHandler.clearOrgCache(orgID);
    }
 
@@ -952,9 +952,9 @@ public class IdentityService {
          IndexedStorage.getIndexedStorage().copyStorageData(oOrg, nOrg, rename);
 
          //FSService.copyServerNode(oOrg.getId(), nOrg.getId(), true);
-         updateBlobStorageName("__mvws", oOrg.getId(), nOrg.getId(), BlockFileStorage.Metadata.class, true);
-         updateBlobStorageName("__pdata", oOrg.getId(), nOrg.getId(), BlockFileStorage.Metadata.class, true);
-         updateBlobStorageName("__autoSave", oOrg.getId(), nOrg.getId(), BlockFileStorage.Metadata.class, true);
+         updateBlobStorageName("__mvws", oOrg.getId(), nOrg.getId(), MVWorksheetStorage.Metadata.class, true);
+         updateBlobStorageName("__pdata", oOrg.getId(), nOrg.getId(), EmbeddedTableStorage.Metadata.class, true);
+         updateBlobStorageName("__autoSave", oOrg.getId(), nOrg.getId(), AutoSaveUtils.Metadata.class, true);
          updateBlobStorageName("__mvBlock", oOrg.getId(), nOrg.getId(), BlockFileStorage.Metadata.class, true);
          MVManager.getManager().migrateStorageData(oOrg, nOrg, !rename);
 


### PR DESCRIPTION
Use the appropriate metadata class when copying storages