### PR TITLE
Bug #73096  Update chart maxmode state when auto refresh is disabled

### DIFF
--- a/web/projects/portal/src/app/vsview/view/vs-object-view.component.ts
+++ b/web/projects/portal/src/app/vsview/view/vs-object-view.component.ts
@@ -129,6 +129,11 @@ export class VSObjectView extends CommandProcessor implements OnDestroy, OnInit,
    onChartMaxModeChange($event: {assembly: string, maxMode: boolean}) {
       this.chartMaxMode = $event.maxMode;
       this.chartMaxModeChange.emit($event);
+
+      if(this._model.objectType == "VSChart" && !!(this._model as VSChartModel).notAuto) {
+         (this._model as VSChartModel).maxMode = this.chartMaxMode;
+      }
+
       LocalStorage.setItem("chart-edit-max-mode", this.chartMaxMode ? "true" : "");
    }
 


### PR DESCRIPTION
This doesn't actually fix any issues with the maxmode chart image. Instead of a cropped image, it will instead display a blank image, but at least the maxmode state in the toolbar will be updated.
To fix the image itself, you will need to do a manual refresh on the chart to get the new image.