### PR TITLE
Bug #73078

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
@@ -2775,7 +2775,7 @@ public class CoreLifecycleService {
       RuntimeViewsheet rvs;
 
       try {
-         rvs = viewsheetService.getViewsheet(id, user);
+         rvs = viewsheetService.getViewsheet(id, user); //race condition? hits as expires
       }
       catch(Exception e) {
          LoggerFactory.getLogger(getClass()).warn("Missing viewsheet {}", id, new Exception("Stack trace"));
@@ -2972,6 +2972,12 @@ public class CoreLifecycleService {
                                 CommandDispatcher dispatcher, AssetRepository assetRepository,
                                 Principal principal) throws Exception {
       boolean auditFinish = true;
+
+      if(rvs.getViewsheet() == null) {
+         LOG.warn(Catalog.getCatalog().getString("portal.viewsheetClosedAfterOpening", rvs.getID()));
+         return false;
+      }
+
       setExportType(rvs, dispatcher);
       setPermission(rvs, principal, dispatcher);
 

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -5024,6 +5024,7 @@ portal.schedule.tastchanged=Task Changed
 portal.schedule.isSaving.warning=The current task save operation has not finished yet. Please wait until it is completed before switching the condition type.
 portal.schedule.unsave.confirm=The task has unsaved changes, close anyway?
 portal.schedule.task.action.duplicateFormat=That format is already in the list. Override? If not, please choose another format.
+portal.viewsheetClosedAfterOpening=Viewsheet {0} has expired while processing. This usually indicates the viewsheet was closed before loading completed
 post=post
 pre=pre
 preview=preview


### PR DESCRIPTION
Swallow missing rvs.viewsheet while processing openViewsheet as it previously asserts rvs.viewsheet exists, so this only occurs if user closes a viewsheet immediately after opening