### PR TITLE
Bug #73117

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/DeployManagerService.java
+++ b/core/src/main/java/inetsoft/sree/internal/DeployManagerService.java
@@ -1606,8 +1606,9 @@ public class DeployManagerService {
                   }
                }
 
+               alias = jarInfo.getFolderAlias().get(entry.toIdentifier());
+
                if(selected) {
-                  alias = jarInfo.getFolderAlias().get(entry.toIdentifier());
                   desc = jarInfo.getFolderDescription().get(entry.getPath());
                }
                else {


### PR DESCRIPTION
Get alias from jarInfo alias map for all, not just selected asset, as required asset alias is stored here and lost otherwise