### PR TITLE
Bug #72609 - track status of a schedule task across nodes

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleStatusDao.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleStatusDao.java
@@ -17,7 +17,6 @@
  */
 package inetsoft.sree.schedule;
 
-import inetsoft.sree.schedule.quartz.JobCompletionListener;
 import inetsoft.storage.KeyValueStorage;
 import inetsoft.util.SingletonManager;
 import org.slf4j.Logger;

--- a/core/src/main/java/inetsoft/sree/schedule/quartz/JobCompletionListener.java
+++ b/core/src/main/java/inetsoft/sree/schedule/quartz/JobCompletionListener.java
@@ -71,6 +71,11 @@ public class JobCompletionListener extends JobListenerSupport {
          TaskActivity activity = new TaskActivity(taskName);
          Scheduler scheduler = Scheduler.getScheduler();
          Catalog catalog = Catalog.getCatalog();
+
+         boolean runNow = context.getMergedJobDataMap().getBoolean("runNow");
+         ScheduleStatusDao dao = ScheduleStatusDao.getInstance();
+         dao.setStatus(taskName, Scheduler.Status.STARTED, context.getFireTime().getTime(),
+                       0L, null, runNow);
          scheduler.updateRunning(jobKey, activity, null, context, catalog);
          scheduler.updateNextRun(jobKey, activity, true, catalog);
          TaskActivityMessage message = new TaskActivityMessage();


### PR DESCRIPTION
Record a STARTED status in distributed storage before schedule task execution to track running tasks across nodes