### PR TITLE
Bug #73040 - fix state not getting parsed in a deeply embedded vs

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -198,7 +198,7 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
       this.vs = vs;
       this.vs.addActionListener(this);
       this.vs.addActionListener(metarep);
-      updateRootSandboxMap(vs.getName(), vs);
+      updateRootSandboxMap(vs.getAbsoluteName(), vs);
 
       if(resetRuntime) {
          ViewsheetSandbox[] boxes = getSandboxes();
@@ -287,11 +287,29 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
          return;
       }
 
-      Viewsheet parent = root.getViewsheet();
+      Viewsheet rootViewsheet = root.getViewsheet();
+      Viewsheet parentViewsheet = null;
+      String name = null;
+      int index = vname.lastIndexOf('.');
 
-      if(parent.containsAssembly(vname) && root.bmap.get(vname) == this) {
-         parent.removeAssembly(vname, false, true);
-         parent.addAssembly(vs, false, false, false);
+      if(index >= 0) {
+         ViewsheetSandbox parentBox = root.bmap.get(vname.substring(0, index));
+
+         if(parentBox != null) {
+            parentViewsheet = parentBox.getViewsheet();
+            name = vname.substring(index + 1);
+         }
+      }
+      else {
+         parentViewsheet = rootViewsheet;
+         name = vname;
+      }
+
+      if(parentViewsheet != null && parentViewsheet.containsAssembly(name) &&
+         root.bmap.get(vname) == this)
+      {
+         parentViewsheet.removeAssembly(name, false, true);
+         parentViewsheet.addAssembly(vs, false, false, false);
       }
    }
 
@@ -301,7 +319,7 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
             continue;
          }
 
-         ViewsheetSandbox box = bmap.get(assembly.getName());
+         ViewsheetSandbox box = bmap.get(assembly.getAbsoluteName());
 
          if(box != null) {
             box.setViewsheet((Viewsheet) assembly, false);

--- a/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
@@ -617,7 +617,6 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
                      tvs.parseState(element);
                      updateVSAssembly((VSAssembly) assemblies.get(i), tvs);
                      clearCache();
-                     tvs.setLastModified(System.currentTimeMillis());
                      in.close();
 
                      // clear cached absolute name since the base viewsheet doesn't


### PR DESCRIPTION
Fix the logic for updating sandboxes which ended up placing an embedded VS inside of a root sandbox.
Don't update the last modified time of embedded viewsheets after parsing. This caused the state to not be parsed in a deeply embedded VS because of the recursive nature of the update call. It doesn't seem to have an effect for Bug #25028 for which this change was added.