### PR TITLE
Bug #73124, set ExpressionAttribute.expr to empty string by default 

### DIFF
--- a/core/src/main/java/inetsoft/uql/erm/ExpressionAttribute.java
+++ b/core/src/main/java/inetsoft/uql/erm/ExpressionAttribute.java
@@ -361,7 +361,7 @@ public class ExpressionAttribute extends XAttribute {
       this.parseable = parseable;
    }
 
-   private String expr;
+   private String expr = "";
    private boolean aggr = false;
    private boolean parseable = true;
 }


### PR DESCRIPTION
to prevent NPE if expression is never updated