### PR TITLE
Bug #73167 - check for empty set or map in removeAll() and putAll()

### DIFF
--- a/utils/inetsoft-storage-mapdb/src/main/java/inetsoft/storage/mapdb/MapDBKeyValueEngine.java
+++ b/utils/inetsoft-storage-mapdb/src/main/java/inetsoft/storage/mapdb/MapDBKeyValueEngine.java
@@ -161,11 +161,19 @@ public class MapDBKeyValueEngine implements KeyValueEngine {
 
    @Override
    public <T> void putAll(String id, Map<String, T> keyValueMap) {
+      if(keyValueMap.isEmpty()) {
+         return;
+      }
+
       updateAll(id, keyValueMap, null);
    }
 
    @Override
    public void removeAll(String id, Set<String> keys) {
+      if(keys.isEmpty()) {
+         return;
+      }
+
       updateAll(id, null, keys);
    }
 


### PR DESCRIPTION
Make sure that the set or map is not empty before performing removeAll() or putAll() bulk operations.