### PR TITLE
Bug #73151

### DIFF
--- a/core/src/main/java/inetsoft/uql/erm/ExpressionAttribute.java
+++ b/core/src/main/java/inetsoft/uql/erm/ExpressionAttribute.java
@@ -162,8 +162,6 @@ public class ExpressionAttribute extends XAttribute {
     *
     * @throws Exception if an error occurs while parsing the XML element.
     */
-
-
    @Override
    public void parseXML(Element tag) throws Exception {
       parseXML(tag, false);


### PR DESCRIPTION
override parseXML with siteAdminImport in ExpressionAttribute, otherwise mapping to XAttribute and losing expression