### PR TITLE
For Bug #73065, adjust query timeout checking for tabular bound query.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/TabularBoundQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/TabularBoundQuery.java
@@ -96,4 +96,13 @@ public class TabularBoundQuery extends BoundQuery {
          }
       }
    }
+
+   @Override
+   protected int getQueryTimeOut() {
+      if(xquery != null) {
+         return xquery.getTimeout();
+      }
+
+      return super.getQueryTimeOut();
+   }
 }


### PR DESCRIPTION
Override getQueryTimeout in TabularBoundQuery as it is not accurate to get the timeout from default BoundQuery logic.
BoundQuery always checks the individual query timeout and if not set, uses the global timeout settings.