### PR TITLE
Bug #73116  When processing changes for an embedded viewsheet assembly, only refresh the viewsheet if a selection was changed

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/ChangedAssemblyList.java
+++ b/core/src/main/java/inetsoft/report/composition/ChangedAssemblyList.java
@@ -174,6 +174,10 @@ public class ChangedAssemblyList implements Serializable {
       return val == null ? 0 : val;
    }
 
+   public boolean hasProcessedSelections() {
+      return !smap.isEmpty();
+   }
+
    /**
     * Add a ready assembly.
     * @param assembly the specified assembly.

--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -1902,7 +1902,10 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
          ViewsheetSandbox box = getSandbox(name.substring(0, index));
          String embeddedName = name.substring(index + 1);
          box.processChange(embeddedName, hint, clist, type);
-         name = name.substring(0, index);
+
+         if(clist.hasProcessedSelections()) {
+            name = name.substring(0, index);
+         }
       }
 
       if((hint & VSAssembly.OUTPUT_DATA_CHANGED) == VSAssembly.OUTPUT_DATA_CHANGED) {


### PR DESCRIPTION
Currently when a datatip inside an embedded viewsheet would normally pop up, it would first need to process the embedded assembly, which leads to processing the embedded viewsheet, which leads to the viewsheet refreshing.
This would interfere with the datatip popping up.

This change is intended to limit the scope of the change made for Bug #71373, which introduced the embedded viewsheet processing when a selection is changed.