### PR TITLE
Bug #73207, Minor optimization. If there is no datasource name, don't…

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/internal/AssetUtil.java
+++ b/core/src/main/java/inetsoft/uql/asset/internal/AssetUtil.java
@@ -2284,6 +2284,10 @@ public class AssetUtil {
          }
       }
 
+      if(prefix == null) {
+         return null;
+      }
+
       try {
          XRepository repository = XFactory.getRepository();
          XDomain domain = repository.getDomain(prefix);


### PR DESCRIPTION
This is a minor improvement to avoid hitting synchronized code when the result is always null