### PR TITLE
Bug #73091 - fix checking whether assembly is a data tip or pop component

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
@@ -1574,13 +1574,11 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
       }
 
       try {
-         Viewsheet rootVS = getRootViewsheet(this);
-
          for(Assembly assemblyItem : getAssemblies(false, false, true, false, true)) {
             VSAssembly assembly = (VSAssembly) assemblyItem;
             String assemblyName = assembly.getAbsoluteName();
-            boolean isFloat = VSUtil.isPopComponent(assemblyName, rootVS) ||
-               VSUtil.isTipView(assemblyName, rootVS);
+            boolean isFloat = VSUtil.isPopComponent(assemblyName, this) ||
+               VSUtil.isTipView(assemblyName, this);
 
             if(!includeAnnotation) {
                if(assembly instanceof AnnotationVSAssembly ||


### PR DESCRIPTION
Revert the change for Bug #70697 which breaks the logic for checking whether an assembly is a data tip or pop component. The original issue described there is not reproducible.