### PR TITLE
Fix intermittent CSSDictionary test failures

### DIFF
--- a/core/src/main/java/inetsoft/util/css/CSSDictionary.java
+++ b/core/src/main/java/inetsoft/util/css/CSSDictionary.java
@@ -343,6 +343,10 @@ public class CSSDictionary {
             ConfigurationContext.getContext().get(DICTIONARIES_KEY);
 
          if(map != null) {
+            for(CSSDictionary dictionary : map.values()) {
+               dictionary.dmgr.clear();
+            }
+
             map.clear();
          }
       }

--- a/core/src/test/java/inetsoft/util/css/CSSDictionaryTest.java
+++ b/core/src/test/java/inetsoft/util/css/CSSDictionaryTest.java
@@ -118,8 +118,10 @@ public class CSSDictionaryTest {
       DataSpace space = DataSpace.getDataSpace();
 
       try {
-         space.withOutputStream("css", name, out ->
-            Tool.fileCopy(CSSDictionaryTest.class.getResourceAsStream(name), out));
+         if(!space.exists("css", name)) {
+            space.withOutputStream("css", name, out ->
+               Tool.fileCopy(CSSDictionaryTest.class.getResourceAsStream(name), out));
+         }
       }
       catch(IOException e) {
          throw new RuntimeException("Failed to copy the css file", e);


### PR DESCRIPTION
Remove change listeners when clearing the dictionary cache to prevent race conditions. A listener running on another thread can reinitialize the dictionary, causing null values to be returned during concurrent access.

Also, prevent re-copying a file to the data space if it already exists.