### PR TITLE
Feature #72688, support manual input color mapping dialog

### DIFF
--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -2738,6 +2738,7 @@ Swapping=Swapping
 Swapping\ Size=Swapping Size
 Switch\ To\ Comparison\ Mode=Switch To Comparison Mode
 Switch\ To\ Date\ Range\ Mode=Switch To Date Range Mode
+Switch\ To\ Manual\ Input=Switch To Manual Input
 Switch\ To\ Month\ View=Switch To Month View
 Switch\ To\ Range=Switch To Range
 Switch\ To\ Simple\ View=Switch To Simple View

--- a/web/projects/portal/src/app/binding/editor/chart/color-mapping-dialog.component.html
+++ b/web/projects/portal/src/app/binding/editor/chart/color-mapping-dialog.component.html
@@ -34,14 +34,18 @@
                  aria-hidden="true"></i>
             </button>
           </div>
+          <div class="form-check col-auto px-0">
+            <input class="mx-0" type="checkbox" title="_#(Switch To Manual Input)"
+                   [(ngModel)]="colorMap.manualInput" [ngModelOptions]="{standalone: true}">
+          </div>
           <div class="col">
-            <select class="form-control" *ngIf="truncatedDimensionData?.length > 0"
+            <select class="form-control" *ngIf="truncatedDimensionData?.length > 0 && !colorMap.manualInput"
                     [(ngModel)]="colorMap.option" [ngModelOptions]="{standalone: true}">
               <option [value]="data.value"
                       *ngFor="let data of truncatedDimensionData">{{data.label}}
               </option>
             </select>
-            <input class="form-control" *ngIf="truncatedDimensionData?.length == 0"
+            <input class="form-control" *ngIf="truncatedDimensionData?.length == 0 || colorMap.manualInput"
                    [ngModelOptions]="{standalone: true}"
                    [(ngModel)]="colorMap.option">
           </div>


### PR DESCRIPTION
Allow user to input manual option on color mapping dialog which may not appear in current field resultset