### PR TITLE
Bug #73974 Hide 'Labels on Opposite Side' for marimekko charts

### DIFF
--- a/core/src/main/java/inetsoft/web/graph/model/dialog/AxisPropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/graph/model/dialog/AxisPropertyDialogModel.java
@@ -95,6 +95,9 @@ public class AxisPropertyDialogModel {
          maxMode ? axisDesc.isMaxModeLabelVisible() : axisDesc.isLabelVisible());
       axisLabelPaneModel.setShowAxisLabelEnabled(showAxisLabelEnabled);
       axisLabelPaneModel.setLabelOnSecondaryAxis(axisDesc.isLabelOnSecondaryAxis());
+      axisLabelPaneModel.setSecondary("right_y_axis".equals(axisType) ||
+         GraphTypes.isRadar(cInfo.getRTChartType()) ||
+         GraphTypes.isMekko(cInfo.getRTChartType()));
 
       RotationRadioGroupModel rotationRadioGroupModel = new RotationRadioGroupModel();
       CompositeTextFormat textFormat;


### PR DESCRIPTION
Cherry-pick of PR #2910 from the epic-70095 branch.

Hides the 'Labels on Opposite Side' option for marimekko (mekko) chart types, as this option is not applicable for those chart types.