### PR TITLE
Bug #74367, fix interval chart bars empty on previous-year trend charts

### DIFF
--- a/core/src/main/java/inetsoft/graph/data/AbstractDataSet.java
+++ b/core/src/main/java/inetsoft/graph/data/AbstractDataSet.java
@@ -810,15 +810,6 @@ public abstract class AbstractDataSet implements DataSet {
       idxmap = null;
    }
 
-   /**
-    * Invalidate the cached column count so the next call to getColCount() recomputes it.
-    * Subclasses should call this whenever their getColCount0() result may have changed
-    * without going through addCalcColumn/removeCalcColumns/removeCalcValues.
-    */
-   protected void invalidateCachedColCount() {
-      cachedColCount = -1;
-   }
-
    @Override
    public Object clone() {
       return clone(false);

--- a/core/src/main/java/inetsoft/graph/data/AbstractDataSet.java
+++ b/core/src/main/java/inetsoft/graph/data/AbstractDataSet.java
@@ -340,6 +340,16 @@ public abstract class AbstractDataSet implements DataSet {
    }
 
    /**
+    * Reset the cached column count so the next call to getColCount() recomputes it.
+    * Subclasses that change the effective column count outside of the standard calc-column
+    * add/remove paths (e.g. IntervalDataSet.initColumns) must call this to keep
+    * getColCount() consistent. (74367)
+    */
+   protected void invalidateCachedColCount() {
+      cachedColCount = -1;
+   }
+
+   /**
     * Return the number of columns in the data set.
     */
    @Override

--- a/core/src/main/java/inetsoft/report/composition/graph/IntervalDataSet.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/IntervalDataSet.java
@@ -48,12 +48,25 @@ public class IntervalDataSet extends TopDataSet {
       // info is still valid. (53628)
       if(this.bcols != getDataSet().getColCount()) {
          this.bcols = getDataSet().getColCount();
+         DataSet ds = getDataSet();
+         // Use all=true so that calc column indices are resolved even when calcvals is
+         // temporarily null (e.g. after removeCalcValues). The indices are based on
+         // getColCount0() which is stable regardless of calcvals state. (74367)
          baseIntervals = intervalCols.stream()
-            .map(pair -> new int[]{ getDataSet().indexOfHeader(pair[0]),
-                                    getDataSet().indexOfHeader(pair[1]) })
+            .map(pair -> new int[]{
+               ds instanceof AbstractDataSet
+                  ? ((AbstractDataSet) ds).indexOfHeader(pair[0], true)
+                  : ds.indexOfHeader(pair[0]),
+               ds instanceof AbstractDataSet
+                  ? ((AbstractDataSet) ds).indexOfHeader(pair[1], true)
+                  : ds.indexOfHeader(pair[1])
+            })
             .collect(Collectors.toList());
          // bcols changed so getColCount0() result changed; invalidate so getColCount()
-         // recomputes instead of returning a stale value. (74492)
+         // recomputes instead of returning a stale value. Also ensures outer
+         // IntervalDataSet wrappers see the correct inner colCount rather than a stale
+         // value, preventing wrong intervalIdx offsets and null data for interval bars.
+         // (74492, 74367)
          invalidateCachedColCount();
       }
    }

--- a/core/src/main/java/inetsoft/report/composition/graph/calc/ValueOfColumn.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/calc/ValueOfColumn.java
@@ -408,8 +408,6 @@ public class ValueOfColumn extends AbstractColumn {
             return INVALID;
          }
 
-         // the first year in the dataset should not assume the previous year (which is not in
-         // the dataset) to be 0 when calculating change.
          if(tval instanceof Date && getMinDate(data).after((Date) tval)) {
             return INVALID;
          }
@@ -463,18 +461,20 @@ public class ValueOfColumn extends AbstractColumn {
          // (e.g. QuarterOfYear=3) and switching to root causes the sub-dataset index to be
          // rebuilt unnecessarily and can return wrong rows.
          // When ndim != innerDim: always switch (original pre-bug behavior).
-         if(data instanceof DataSetFilter && (ndimIsPartDate || !ndim.equals(innerDim))) {
-            data = ((DataSetFilter) data).getRootDataSet();
+         DataSet lookupData = data;
+
+         if(lookupData instanceof DataSetFilter && (ndimIsPartDate || !ndim.equals(innerDim))) {
+            lookupData = ((DataSetFilter) lookupData).getRootDataSet();
          }
 
-         data = getSubDataSet(data, cond);
-         int rcnt = ((AbstractDataSet) data).getRowCountUnprojected();
+         DataSet sub = getSubDataSet(lookupData, cond);
+         int rcnt = ((AbstractDataSet) sub).getRowCountUnprojected();
 
-         if(data.getRowCount() <= 0) {
+         if(sub.getRowCount() <= 0) {
             return INVALID;
          }
 
-         return data.getData(field, (ctype == ValueOfCalc.PREVIOUS) ? rcnt - 1 : 0);
+         return sub.getData(field, (ctype == ValueOfCalc.PREVIOUS) ? rcnt - 1 : 0);
       }
    }
 

--- a/core/src/main/java/inetsoft/report/composition/graph/calc/ValueOfColumn.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/calc/ValueOfColumn.java
@@ -394,10 +394,11 @@ public class ValueOfColumn extends AbstractColumn {
             }
          }
          else {
-            // When ndim == innerDim and data is a facet sub-dataset, the sub-dataset only
-            // contains the rows for this facet (e.g. Q2 = months 4-6). The previous value
-            // may belong to a different facet (e.g. April → March, which is in Q1). Use the
-            // root dataset so the router can find cross-facet previous/next values.
+            // In a facet chart each facet is backed by a DataSetFilter containing only that
+            // facet's rows. The router built from a per-facet dataset only knows values within
+            // that facet, so navigating to a previous/next period that falls in a different facet
+            // returns INVALID. Use getRootDataSet() when ndim is the inner dimension so the
+            // router can traverse values across all facets.
             DataSet routerData = (ndim.equals(innerDim) && data instanceof DataSetFilter)
                ? ((DataSetFilter) data).getRootDataSet() : data;
             Router router = getRouter(routerData, ndim);
@@ -408,6 +409,8 @@ public class ValueOfColumn extends AbstractColumn {
             return INVALID;
          }
 
+         // The first year in the dataset should not assume the previous year (which is not in
+         // the dataset) to be 0 when calculating change.
          if(tval instanceof Date && getMinDate(data).after((Date) tval)) {
             return INVALID;
          }
@@ -479,6 +482,9 @@ public class ValueOfColumn extends AbstractColumn {
    }
 
    // Extract the base column name from a date function expression, e.g. "MonthOfYear(Date)" -> "Date".
+   // Assumes the format "Function(ColumnName)" with no nesting — for a nested expression like
+   // "MonthOfYear(Year(Date))" this returns "Year(Date)", not "Date". Nested date functions are
+   // not currently used in dimension full names, so this is sufficient in practice.
    private String getDateColumnBase(String dimName) {
       if(dimName == null) {
          return null;


### PR DESCRIPTION
## Root Causes and Fixes

This PR fixes five related issues that together caused interval chart bars (with Value of Previous calculations) to render empty.

### Fix 1 — Wrong sub-dataset lookup target in `ValueOfColumn`

`createCond()` was called without the target date (`tval`), so the lookup condition matched the current row's date rather than the previous period. Zero rows were found for every lookup.

**Fix:** Pass `tval` to `createCond()`.

### Fix 2 — PART_DATE_GROUP siblings breaking period-boundary lookups

When `MonthOfYear` is the innermost dimension and `QuarterOfYear` is also in the chart, `createCond()` included `QuarterOfYear` in the lookup condition. A cross-quarter lookup (e.g. April→March: Q2→Q1) found zero rows and returned INVALID for those data points.

**Fix:** Detect PART_DATE_GROUP sibling dimensions sharing the same base date column and add them to the `createCond()` ignore list.

### Fix 3 — Cross-facet previous values not found in per-facet datasets

In a facet chart, each facet has its own sub-dataset containing only its rows. When looking up "previous period" across a facet boundary (e.g. April in the Q2 facet needs March which is in the Q1 facet), the per-facet sub-dataset had zero matching rows, returning INVALID.

**Fix:** When `data` is a `DataSetFilter` (sub-dataset), use `getRootDataSet()` for both the router and the sub-dataset lookup so cross-facet rows are reachable. Also refactored to use a separate `lookupData` variable instead of mutating `data`, preserving it for `getMinDate()` and other downstream uses.

### Fix 4 — Stale `baseIntervals` indices when calcvals temporarily null

`IntervalDataSet.initColumns()` called `indexOfHeader()` with `all=false`, which excludes calc columns when `calcvals` is null (e.g. right after `removeCalcValues()`). This returned -1 for the base/interval column indices, so `getIntervalData()` returned null for every bar until the next `prepareCalc()`.

**Fix:** Use `indexOfHeader(col, all=true)` so indices are resolved from `getColCount0()` regardless of `calcvals` state.

### Fix 5 — Stale `cachedColCount` in double-IDS wrapping (core fix)

When two `IntervalDataSet` instances are nested (outer IDS → inner IDS → `SubDataSet`), the outer IDS uses `getColCount()` on the inner IDS to detect when `bcols` needs updating. `AbstractDataSet.getColCount()` caches its result in `cachedColCount`. When the inner IDS's `initColumns()` updated `bcols` and rebuilt `baseIntervals`, it did not reset `cachedColCount`, so `getColCount()` on the inner IDS returned the stale pre-update value. The outer IDS saw no change and kept its own stale `bcols`.

Consequently `intervalIdx = col - bcols` was computed with the wrong offset, causing `intervalIdx >= baseIntervals.size()` and null returns for all bars.

**Fix:** Added `AbstractDataSet.invalidateCachedColCount()` and call it at the end of `IntervalDataSet.initColumns()` whenever `bcols` changes, ensuring the outer IDS always sees the correct inner `colCount` on the next call.

## Files Changed

- `core/.../graph/data/AbstractDataSet.java` — add `protected invalidateCachedColCount()` method
- `core/.../report/composition/graph/IntervalDataSet.java` — `all=true` for indexOfHeader + call `invalidateCachedColCount()` when bcols changes
- `core/.../report/composition/graph/calc/ValueOfColumn.java` — fixes 1–3 above

## Test Plan

- [ ] Open a viewsheet with an interval/range bar chart using "Value of Previous" or "Change from Previous" calculation
- [ ] Verify chart bars paint correctly for all periods, including months that cross quarter boundaries (e.g. April in a chart grouped by QuarterOfYear)
- [ ] Verify facet/trellis layout interval charts paint correctly (cross-facet previous values)
- [ ] Verify non-facet interval charts are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)