### PR TITLE
Bug #74484 - Fix slider label/format export issues in PDF

### DIFF
--- a/core/src/main/java/inetsoft/report/gui/viewsheet/VSFloatable.java
+++ b/core/src/main/java/inetsoft/report/gui/viewsheet/VSFloatable.java
@@ -109,8 +109,12 @@ public abstract class VSFloatable extends VSObject {
       int startx = Math.max(pos.x, 0);
       int starty = Math.max(pos.y, 0);
 
-      g.translate(startx, starty);
+      // Draw background at (0,0) before the content translate so it aligns
+      // with the border (which is also drawn at (0,0)). Drawing after the
+      // translate offset it by the border width, causing it to extend beyond
+      // the border's bottom-right corner.
       drawBackground(g);
+      g.translate(startx, starty);
       paintComponent(g);
       g.translate(-startx, -starty);
       drawBorders(g);

--- a/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
@@ -3723,7 +3723,9 @@ public abstract class AbstractVSExporter implements VSExporter {
 
       VSFormat udf = fmt.getUserDefinedFormat();
       Color savedBg = udf.getBackground();
+      boolean savedBgDefined = udf.isBackgroundDefined();
       Insets savedBorders = udf.getBorders();
+      boolean savedBordersDefined = udf.isBordersDefined();
       udf.setBackground(null);
       udf.setBorders(null);
 
@@ -3731,8 +3733,8 @@ public abstract class AbstractVSExporter implements VSExporter {
          return getInputImage(assembly, widgetSize);
       }
       finally {
-         udf.setBackground(savedBg);
-         udf.setBorders(savedBorders);
+         udf.setBackground(savedBg, savedBgDefined);
+         udf.setBorders(savedBorders, savedBordersDefined);
       }
    }
 

--- a/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
@@ -3661,12 +3661,31 @@ public abstract class AbstractVSExporter implements VSExporter {
          return;
       }
 
-      Rectangle2D widgetBounds = writeInputLabelText(info);
-
-      if(widgetBounds == null) {
+      if(!hasVisibleLabel(info)) {
          writePicture(assembly);
          return;
       }
+
+      CoordinateHelper helper = getHelper();
+
+      if(helper == null) {
+         return;
+      }
+
+      InputVSAssemblyInfo inputInfo = (InputVSAssemblyInfo) info;
+      LabelInfo labelInfo = inputInfo.getLabelInfo();
+      Rectangle2D fullBounds = expandBoundsForLabel(helper.getBounds(info), labelInfo);
+      Rectangle2D[] bounds = splitInputBounds(fullBounds, labelInfo);
+      Rectangle2D labelBounds = bounds[0];
+      Rectangle2D widgetBounds = bounds[1];
+
+      // Draw the assembly background and border around the full area (label + widget).
+      // In the browser the outer wrapper element carries the assembly format (background,
+      // border, round corner), so both the label and the widget share one visual boundary.
+      helper.drawTextBox(fullBounds, fullBounds, info.getFormat(), null, null, null, false);
+
+      // Draw the label text with its own label-specific format.
+      helper.drawTextBox(labelBounds, getLabelFormat(labelInfo), labelInfo.getLabelText());
 
       if(isZeroSize(widgetBounds)) {
          return;
@@ -3675,13 +3694,45 @@ public abstract class AbstractVSExporter implements VSExporter {
       Dimension widgetSize = new Dimension(
          (int) Math.round(widgetBounds.getWidth()),
          (int) Math.round(widgetBounds.getHeight()));
-      BufferedImage img = getInputImage(assembly, widgetSize);
+
+      // Render the widget without the assembly background/border — they were drawn above
+      // around the full (label + widget) bounds so the widget image must not repeat them.
+      BufferedImage img = getInputImageNoAssemblyStyle(assembly, info, widgetSize);
 
       if(img != null) {
-         getHelper().drawImage(img, widgetBounds);
+         helper.drawImage(img, widgetBounds);
       }
       else {
          LOG.warn("No image for input assembly: {}", assembly.getAbsoluteName());
+      }
+   }
+
+   /**
+    * Render a widget image with the assembly-level background and borders suppressed.
+    * Used by {@link #writeInputWithLabel} which draws those styles around the full
+    * (label + widget) bounds instead.
+    */
+   private BufferedImage getInputImageNoAssemblyStyle(VSAssembly assembly,
+      VSAssemblyInfo info, Dimension widgetSize)
+   {
+      VSCompositeFormat fmt = info.getFormat();
+
+      if(fmt == null) {
+         return getInputImage(assembly, widgetSize);
+      }
+
+      VSFormat udf = fmt.getUserDefinedFormat();
+      Color savedBg = udf.getBackground();
+      Insets savedBorders = udf.getBorders();
+      udf.setBackground(null);
+      udf.setBorders(null);
+
+      try {
+         return getInputImage(assembly, widgetSize);
+      }
+      finally {
+         udf.setBackground(savedBg);
+         udf.setBorders(savedBorders);
       }
    }
 


### PR DESCRIPTION
## Root Cause

### Error 1: Label and slider appear as independent entities

In the browser, the `vs-input-label-wrapper` host element receives the assembly's `background-color`, `border`, and `border-radius` — wrapping **both** the label and the slider content as one unified visual unit. In the PDF export, `writeInputWithLabel` only rendered the background/border inside the widget's `BufferedImage` (covering just the slider area), leaving the label visually disconnected with no border around the full assembly.

### Error 2: Background color extends beyond the border toward the lower-right corner

`VSFloatable.paint()` called `g.translate(startx, starty)` (where `startx/starty = border width`) **before** `drawBackground(g)`. This offset the background by the border width, so it was painted at `(borderWidth, borderWidth)` with `pixelSize` dimensions — extending `borderWidth` pixels beyond the border's bottom-right edge.

## Fix

### `AbstractVSExporter.writeInputWithLabel`

1. Draw the assembly's background + border around the **full bounds** (label + widget combined) via `helper.drawTextBox(fullBounds, ...)` — matching the browser's outer wrapper behaviour.
2. Draw the label text with its own `labelFormat` at `labelBounds`.
3. Render the widget image **without** the assembly background/border (new `getInputImageNoAssemblyStyle` method temporarily clears them from `userDefinedFormat`) — avoids double-drawing and a duplicate inner border on the widget.

### `VSFloatable.paint()`

Move `drawBackground(g)` to **before** the content-area translate, so the background fills `(0, 0)` to `(pixelWidth, pixelHeight)` — the same rectangle as the border. Previously the translate shifted the background by the border width, causing it to spill beyond the border's bottom-right corner.

## Test plan

- [ ] Import `label.vso`, open in composer, click preview, export to PDF
- [ ] Verify the label text and slider appear as one unified bordered box (single border around both)
- [ ] Verify the background color does not extend beyond the border at any corner
- [ ] Spot-check other labeled input assemblies (Checkbox, ComboBox, RadioButton, Spinner) for regressions
- [ ] Verify unlabeled sliders still render correctly via `writePicture`

🤖 Generated with [Claude Code](https://claude.com/claude-code)