### PR TITLE
Bug #74509, fix NPE in Scheduler.getSchedulerStatus() when healthCheckFuture is null

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/Scheduler.java
+++ b/core/src/main/java/inetsoft/sree/schedule/Scheduler.java
@@ -719,7 +719,8 @@ public class Scheduler {
       long lastCheck = SchedulerHealthService.getInstance().getLastCheck();
       long nextCheck = healthCheckFuture == null ?
          0L : healthCheckFuture.getDelay(TimeUnit.MILLISECONDS);
-      Future.State checkState = healthCheckFuture.state();
+      Future.State checkState = healthCheckFuture == null ?
+         Future.State.CANCELLED : healthCheckFuture.state();
       int executingCount = 0;
       int threadCount = 0;
 


### PR DESCRIPTION
## Root Cause

In `Scheduler.getSchedulerStatus()` (line 722), `healthCheckFuture.state()` was called unconditionally, but `healthCheckFuture` can be `null` when the scheduler's health check executor has not yet been initialized (e.g., during startup or before the first health check cycle begins).

The method already guarded against `null` on the immediately preceding line for `getDelay()`:

```java
long nextCheck = healthCheckFuture == null ?
    0L : healthCheckFuture.getDelay(TimeUnit.MILLISECONDS);
Future.State checkState = healthCheckFuture.state();  // ← NPE here
```

This race condition is more likely to surface in cloud/AKS environments where health probes hit the scheduler endpoint very early in the pod lifecycle, before the scheduler has fully started and scheduled its health check task.

## Stack Trace

```
java.lang.NullPointerException: Cannot invoke "java.util.concurrent.ScheduledFuture.state()" because "this.healthCheckFuture" is null
    at inetsoft.sree.schedule.Scheduler.getSchedulerStatus(Scheduler.java:722)
    at inetsoft.util.health.SchedulerHealthService.getStatus(SchedulerHealthService.java:34)
    at inetsoft.util.health.HealthService.getStatus(HealthService.java:43)
    at inetsoft.sree.schedule.ScheduleServer.getHealth(ScheduleServer.java:245)
    at inetsoft.sree.schedule.CloudRunnerServerScheduleClient.getHealthStatus(CloudRunnerServerScheduleClient.java:117)
```

## Fix

Added the same null guard already present for `getDelay()` to the `state()` call, returning `Future.State.CANCELLED` as a safe fallback when `healthCheckFuture` has not yet been initialized:

```java
Future.State checkState = healthCheckFuture == null ?
    Future.State.CANCELLED : healthCheckFuture.state();
```

`CANCELLED` is semantically appropriate here — it indicates no active health check is running, which is accurate when the scheduler hasn't started yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)