### PR TITLE
Bug #74510 - Fix selection overlay mismatch on stacked bars with roun…

### DIFF
--- a/core/src/main/java/inetsoft/graph/visual/BarVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/BarVO.java
@@ -938,10 +938,12 @@ public class BarVO extends ElementVO {
       // ensure the cache is populated
       getPath();
       // use pre-rounding bounds so the region rectangle matches the original
-      // segment, allowing the frontend to reconstruct rounding from metadata
+      // segment, allowing the frontend to reconstruct rounding from metadata.
+      // for non-stacked rounded bars, pre-rounding bounds equals the path's
+      // bounding box (rounding only clips corners, doesn't change the bbox).
       CachedShape cached = this.cachedShape.get();
 
-      if(cached != null && cached.roundingApplied && cached.preRoundingBounds != null) {
+      if(cached != null && cached.roundingApplied) {
          return new Shape[] {cached.preRoundingBounds};
       }
 
@@ -1331,9 +1333,10 @@ public class BarVO extends ElementVO {
     * Used for region metadata so the frontend can reconstruct the correct rounded shape.
     */
    public Rectangle2D getPreRoundingBounds() {
+      getPath(); // ensure cache is populated
       CachedShape cached = this.cachedShape.get();
 
-      if(cached != null && cached.roundingApplied && cached.preRoundingBounds != null) {
+      if(cached != null && cached.roundingApplied) {
          return cached.preRoundingBounds;
       }
 

--- a/core/src/main/java/inetsoft/graph/visual/BarVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/BarVO.java
@@ -212,6 +212,10 @@ public class BarVO extends ElementVO {
 
          path0 = transformShape(path0, getScreenTransform());
 
+         // cache pre-rounding bounds for region/metadata computation
+         Rectangle2D preRounding = path0.getBounds2D();
+         boolean roundingApplied = false;
+
          IntervalElement ielem = (IntervalElement) ((ElementGeometry) getGeometry()).getElement();
          double r = ielem.getCornerRadius();
 
@@ -219,6 +223,7 @@ public class BarVO extends ElementVO {
             IntervalGeometry geom = (IntervalGeometry) getGeometry();
             boolean stdOrientation = GTool.isHorizontal(getScreenTransform());
             int openDir = stdOrientation ? (negative ? 0 : 1) : (negative ? 3 : 2);
+            roundingApplied = true;
 
             if(!ielem.isStack()) {
                boolean roundAll = ielem.isRoundAllCorners();
@@ -230,7 +235,8 @@ public class BarVO extends ElementVO {
             }
          }
 
-         this.cachedShape = new SoftReference<>(new CachedShape(trans0, path0));
+         this.cachedShape = new SoftReference<>(
+            new CachedShape(trans0, path0, preRounding, roundingApplied));
       }
 
       return path0;
@@ -929,6 +935,16 @@ public class BarVO extends ElementVO {
     */
    @Override
    public Shape[] getShapes() {
+      // ensure the cache is populated
+      getPath();
+      // use pre-rounding bounds so the region rectangle matches the original
+      // segment, allowing the frontend to reconstruct rounding from metadata
+      CachedShape cached = this.cachedShape.get();
+
+      if(cached != null && cached.roundingApplied && cached.preRoundingBounds != null) {
+         return new Shape[] {cached.preRoundingBounds};
+      }
+
       return new Shape[] {getPath()};
    }
 
@@ -1288,13 +1304,19 @@ public class BarVO extends ElementVO {
    }
 
    private static class CachedShape {
-      public CachedShape(AffineTransform trans, Shape shape) {
+      public CachedShape(AffineTransform trans, Shape shape,
+                         Rectangle2D preRoundingBounds, boolean roundingApplied)
+      {
          this.trans = trans;
          this.path = shape;
+         this.preRoundingBounds = preRoundingBounds;
+         this.roundingApplied = roundingApplied;
       }
 
       AffineTransform trans; // transform as of last path0
       Shape path; // transformed shape ready for drawing
+      Rectangle2D preRoundingBounds; // bounds before rounding was applied
+      boolean roundingApplied; // true if corner rounding changed the shape
    }
 
    /**
@@ -1302,6 +1324,20 @@ public class BarVO extends ElementVO {
     */
    public boolean isNegative() {
       return negative;
+   }
+
+   /**
+    * Get the screen-space bounds of the bar before corner rounding was applied.
+    * Used for region metadata so the frontend can reconstruct the correct rounded shape.
+    */
+   public Rectangle2D getPreRoundingBounds() {
+      CachedShape cached = this.cachedShape.get();
+
+      if(cached != null && cached.roundingApplied && cached.preRoundingBounds != null) {
+         return cached.preRoundingBounds;
+      }
+
+      return getBounds();
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/graph/GraphBuilder.java
+++ b/core/src/main/java/inetsoft/web/graph/GraphBuilder.java
@@ -1364,7 +1364,7 @@ public class GraphBuilder {
                   double totalStackInterval = geom.getTotalStackInterval();
 
                   if(totalStackInterval > 0 && geom.getInterval() != 0) {
-                     Rectangle2D barBounds = barVO.getBounds();
+                     Rectangle2D barBounds = barVO.getPreRoundingBounds();
                      double segDim = stdOrientation
                         ? barBounds.getHeight() : barBounds.getWidth();
                      double barWidth = stdOrientation


### PR DESCRIPTION
…ded corners

GraphBuilder and VisualObjectArea were using post-rounding bounding boxes for region bounds and arc metadata, while BarVO.applyStackRounding used pre-rounding bounds. For segments near the rounded edge, the post-rounding bounding box is narrower, causing the frontend to reconstruct a different shape than what was rendered.

Cache the pre-rounding screen-space bounds in BarVO and use them for region extraction (getShapes) and metadata computation (GraphBuilder). The change is scoped to bars where rounding was actually applied via a roundingApplied flag, so non-rounded bars are unaffected.