### PR TITLE
Bug #74501 - Fix slider script labelVisible property targeting tick labels instead of component label

### DIFF
--- a/core/src/main/java/inetsoft/report/script/viewsheet/SliderVSAScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/viewsheet/SliderVSAScriptable.java
@@ -67,7 +67,7 @@ public class SliderVSAScriptable extends InputVSAScriptable {
                   boolean.class, info.getClass(), info);
       addProperty("currentVisible", "isCurrentVisible", "setCurrentVisible",
                   boolean.class, info.getClass(), info);
-      addProperty("labelVisible", "isLabelVisible", "setLabelVisible",
+      addProperty("tickLabelVisible", "isLabelVisible", "setLabelVisible",
                   boolean.class, info.getClass(), info);
       addProperty("snap", "isSnap", "setSnap",
                   boolean.class, info.getClass(), info);

--- a/core/src/test/java/inetsoft/report/script/viewsheet/SliderVSAScriptableTest.java
+++ b/core/src/test/java/inetsoft/report/script/viewsheet/SliderVSAScriptableTest.java
@@ -21,6 +21,7 @@ package inetsoft.report.script.viewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.uql.viewsheet.SliderVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.LabelInfo;
 import inetsoft.uql.viewsheet.internal.SliderVSAssemblyInfo;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -73,7 +74,7 @@ public class SliderVSAScriptableTest {
                    sliderVSAScriptable.get("increment", sliderVSAScriptable));
 
       String[] keys = {"minVisible", "maxVisible", "tickVisible",
-                       "currentVisible", "labelVisible", "snap"};
+                       "currentVisible", "labelVisible", "tickLabelVisible", "snap"};
 
       for (String key : keys) {
          assert sliderVSAScriptable.get(key, null) instanceof Boolean;
@@ -97,6 +98,22 @@ public class SliderVSAScriptableTest {
    void testGetSetMaxValue(){
       sliderVSAScriptable.setMaxValue("200");
       assertEquals("200.0", sliderVSAScriptable.getMax());
+   }
+
+   @Test
+   void testLabelVisibleTargetsComponentLabel() {
+      sliderVSAScriptable.addProperties();
+      LabelInfo labelInfo = sliderVSAssemblyInfo.getLabelInfo();
+
+      // labelVisible should control the component label (LabelInfo), not tick labels
+      assertFalse(labelInfo.isLabelVisible());
+      sliderVSAScriptable.put("labelVisible", sliderVSAScriptable, true);
+      assertTrue(labelInfo.isLabelVisible());
+
+      // tickLabelVisible should control the tick labels (SliderVSAssemblyInfo)
+      assertTrue(sliderVSAssemblyInfo.isLabelVisible());
+      sliderVSAScriptable.put("tickLabelVisible", sliderVSAScriptable, false);
+      assertFalse(sliderVSAssemblyInfo.isLabelVisible());
    }
 
    @Test


### PR DESCRIPTION
SliderVSAScriptable registered "labelVisible" pointing to SliderVSAssemblyInfo (tick labels), overwriting the parent
InputVSAScriptable registration that points to LabelInfo (component label). This prevented scripts like Slider1.labelVisible=true from making the component label visible.

Rename the slider tick-label script property from "labelVisible" to "tickLabelVisible" so the parent's LabelInfo registration survives.
Slider1.labelVisible now controls the component label, consistent with all other input assemblies.