### PR TITLE
Bug #74527, fix NPE when importing schedule task with null CompletionCondition task name

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
@@ -1463,6 +1463,11 @@ public class ScheduleTask implements Serializable, Cloneable, XMLSerializable {
    private void updateConditionTaskPath(CompletionCondition condition) {
       String currOrgID = OrganizationManager.getInstance().getCurrentOrgID();
       String path = condition.getTaskName();
+
+      if(path == null || path.indexOf(":") < 0) {
+         return;
+      }
+
       String pathUserID = path.substring(0, path.indexOf(":"));
       String remaining = path.substring(path.indexOf(":"));
       IdentityID userID = IdentityID.getIdentityIDFromKey(pathUserID);


### PR DESCRIPTION
## Root Cause

When a schedule task exported from one organization is imported into another, `ScheduleTask.parseXML()` calls `updateConditionTaskPath()` for each `CompletionCondition` to rewrite the org ID in the dependent task name.

`CompletionCondition.parseXML()` sets `taskname` from the `task` XML attribute via `Tool.getAttribute()`. If the attribute is absent or the condition was saved without an org-qualified name (e.g. created on `organization0` before multi-tenancy was fully applied), `getTaskName()` returns `null`.

`updateConditionTaskPath()` then calls `path.indexOf(":")` on the null value:

```java
String path = condition.getTaskName();  // null
String pathUserID = path.substring(0, path.indexOf(":"));  // NPE
```

## Fix

Added a null/format guard at the top of `updateConditionTaskPath()` — if the task name is `null` or does not contain a `:` separator (i.e. it is not an org-qualified identity key), return early. There is nothing to rewrite in either case.

## Test Plan

- [ ] Export a schedule task with a `CompletionCondition` from `organization0`, import into `organization1` — task imports successfully without NPE
- [ ] Export and import a schedule task with no `CompletionCondition` — unaffected
- [ ] Export and import a schedule task with a properly org-qualified `CompletionCondition` — org ID is still rewritten correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)