### PR TITLE
Bug #74532, fix NPE when opening logical model after importing datasource to folder

### DIFF
--- a/core/src/main/java/inetsoft/uql/util/DefaultMetaDataProvider.java
+++ b/core/src/main/java/inetsoft/uql/util/DefaultMetaDataProvider.java
@@ -1185,6 +1185,10 @@ public class DefaultMetaDataProvider implements MetaDataProvider {
       String[] names = pname.split(":");
       XPartition partition = getDataModel().getPartition(names[0]);
 
+      if(partition == null) {
+         return;
+      }
+
       if(names.length > 1) {
          partition = partition.getPartition(names[1]);
       }


### PR DESCRIPTION
## Root Cause

`DefaultMetaDataProvider.refreshMetaData(String pname, ...)` splits `pname` on `":"` to handle sub-partition names (e.g. `"partition:(Default Connection)"`):

```java
String[] names = pname.split(":");
XPartition partition = getDataModel().getPartition(names[0]);

if(names.length > 1) {
    partition = partition.getPartition(names[1]);  // NPE if partition is null
}

if(partition == null) {  // too late — already crashed above
    return;
}
```

When a datasource is imported into a subfolder (`Data Source/Examples/Orders/Data Model/f1/lm`), the physical model (partition) is stored under a different path. The logical model's `getPartition(names[0])` lookup fails to find it, returning `null`. The existing null guard was placed **after** the sub-partition dereference, so when `names.length > 1`, calling `partition.getPartition(names[1])` throws NPE.

## Fix

Moved the `partition == null` check to immediately after `getDataModel().getPartition(names[0])`, before the sub-partition dereference. The second null check for the sub-partition result is retained.

## Test Plan

- [ ] Import a datasource zip into a subfolder (e.g. `Data Source/f1`), open its extended logical model — should load without NPE
- [ ] Open a logical model on a datasource imported to the root level — unaffected
- [ ] Open a logical model with a `(Default Connection)` sub-partition — still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)