### PR TITLE
Bug #74529 - Silence SecurityException for org admins on plugin change subscription

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/plugins/PluginChangeController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/plugins/PluginChangeController.java
@@ -60,7 +60,11 @@ public class PluginChangeController {
       if(!SecurityEngine.getSecurity().getSecurityProvider().checkPermission(
          principal, ResourceType.EM_COMPONENT, "settings/content/drivers-and-plugins", ResourceAction.ACCESS))
       {
-         throw new SecurityException("Unauthorized access to plugin changes by user " + principal.getName());
+         // User lacks plugin management access (e.g. Organization Administrator). Silently
+         // ignore the subscription rather than throwing — the portal subscribes to this topic
+         // to refresh driver availability when editing datasources, and an unauthorized user
+         // simply won't receive plugin-change notifications.
+         return;
       }
 
       this.principal = principal;


### PR DESCRIPTION
## Summary

- When an Organization Administrator selects a datasource in the portal, the datasource settings page (`datasources-database.component.ts`) subscribes to the `/em-plugin-changed` WebSocket topic on `ngOnInit()`.
- The security hardening in #74401 added a permission check to `PluginChangeController.subscribeToTopic()` that **throws** a `SecurityException` when the user lacks the `settings/content/drivers-and-plugins` EM permission.
- Organization Administrators don't have that permission, so a `SecurityException` is logged and an error dialog appears every time they open a datasource — even though the datasource access itself is authorized.

## Fix

Changed `subscribeToTopic()` to **silently return** (instead of throwing) when the user lacks plugin management access. Users without the permission simply won't receive real-time plugin-change push notifications, which is acceptable since they cannot install plugins.

## Test plan

- [ ] Create an Organization Administrator user in a cloned organization
- [ ] Log in as that org admin and navigate to Data Source → Examples → Orders
- [ ] Confirm no `SecurityException` appears in the browser console or as an error dialog
- [ ] Log in as a global site admin, open the Drivers & Plugins page — confirm plugin change notifications still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)