### PR TITLE
Fix portal appearing disabled after presentation settings reset

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/presentation/PortalIntegrationViewSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/presentation/PortalIntegrationViewSettingsService.java
@@ -189,7 +189,7 @@ public class PortalIntegrationViewSettingsService {
                case "Dashboard":
                   index = 0;
                   break;
-               case "Repository":
+               case "Report":
                   index = 1;
                   break;
                case "Schedule":
@@ -200,6 +200,7 @@ public class PortalIntegrationViewSettingsService {
                   break;
                }
 
+               tab.setVisible(true);
                index = newPortalTabs.size() > index ? index : newPortalTabs.size();
                newPortalTabs.add(index, tab);
             }


### PR DESCRIPTION
## Summary

- When a site admin resets global presentation settings in EM, built-in portal tabs (Dashboard, Report, Schedule, Data) had their `visible` flag preserved at their pre-reset state instead of being restored to the default `visible=true`
- If any tabs were previously hidden, they remained hidden after reset, causing the portal navigation tabs to appear disabled to users
- Also fixes an incorrect switch case using `"Repository"` instead of `"Report"` that caused the Report tab to always be sorted to position 0 instead of position 1

**Root cause:** `PortalIntegrationViewSettingsService.resetSettings()` iterated over existing portal tabs and added non-editable built-in tabs to the new tab list without setting `tab.setVisible(true)`. A reset-to-default should restore each built-in tab to its default visible state.

**Fix:** Added `tab.setVisible(true)` for each built-in tab during global reset, and corrected `"Repository"` → `"Report"` in the ordering switch statement.

Fixes Bug #74528.

## Test plan

- [ ] In EM → Presentation Settings (Global), go to Portal Integration section and hide one or more built-in tabs (e.g. Dashboard), apply
- [ ] Click "Reset to Default"
- [ ] Access the portal — verify all built-in tabs (Dashboard, Report, Schedule, Data) are visible and not disabled
- [ ] Verify Reset to Default from Export Menu section also restores portal tabs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)