### PR TITLE
Bug #74535, fix embedded viewsheet blank after import to target folder for org admin

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/DeployManagerService.java
+++ b/core/src/main/java/inetsoft/sree/internal/DeployManagerService.java
@@ -749,7 +749,7 @@ public class DeployManagerService {
 
                changeAssetMap.put(supportEntry, getAssetObjectByAsset(newAsset));
 
-               if(OrganizationManager.getInstance().isSiteAdmin(principal) && supportEntry instanceof AssetEntry) {
+               if(supportEntry instanceof AssetEntry) {
                   AssetObject currOrgEntry = ((AssetEntry) supportEntry).cloneAssetEntry(
                                              new Organization(OrganizationManager.getInstance().getCurrentOrgID()));
                   changeAssetMap.put(currOrgEntry, getAssetObjectByAsset(newAsset));


### PR DESCRIPTION
## Root Cause

When importing a viewsheet containing embedded viewsheets (e.g., tab-container VSes) to a target folder, the import engine needs to update the embedded VS path references inside the outer viewsheet's XML. For example, if `bottom label2` embeds `pvs_alias` and both are moved to folder `f1`, the reference from `bottom label2` to `pvs_alias` must be rewritten to `f1/pvs_alias`.

This rewrite relies on `createRenameInfos()` finding the moved asset in `changeAssetMap`. That map is keyed by `AssetEntry`, and `AssetEntry.equals()` compares `orgID`. The map keys get their `orgID` from the export ZIP file. The dependency objects collected by `addEmbeddedVSDependencies()` always have `orgID` set to `getCurrentOrgID()` (the importing org's ID).

When the ZIP was exported from a community environment (orgID = `null`) and imported into an organization (orgID = `"org1"`), the key and lookup entry have mismatched `orgID` values → `HashMap.get()` returns `null` → no `RenameInfo` is created for the embedded VS → the path reference is never updated → the embedded viewsheet is at `f1/pvs_alias` but the outer viewsheet still points to `pvs_alias` → blank.

A prior fix (Bug #73145) already addressed this for **site admin** imports by adding an extra `changeAssetMap` entry cloned with `getCurrentOrgID()`. That fix was gated behind `isSiteAdmin(principal)` and so never applied to **org admin** imports.

## Fix

In `DeployManagerService.importAssets0()`, the first loop that pre-populates `changeAssetMap` with target-folder renames now unconditionally adds the `currentOrgID`-keyed entry for every `AssetEntry`, not just when the principal is a site admin. This ensures `createRenameInfos()` can find the mapping regardless of what `orgID` was stored in the export ZIP.

**File changed:** `core/src/main/java/inetsoft/sree/internal/DeployManagerService.java`

```java
// Before:
if(OrganizationManager.getInstance().isSiteAdmin(principal) && supportEntry instanceof AssetEntry) {

// After:
if(supportEntry instanceof AssetEntry) {
```

## Test plan

- [ ] Create `organization1`, create an org admin user
- [ ] In EM → Content → Repository for `organization1`, import the attached `embedded vs.zip`
- [ ] In the import dialog, click **Target Location**, select Repository and create folder `f1`, click OK then Finish
- [ ] Log in to Portal as the org admin of `organization1`
- [ ] Open viewsheet `bottom label2` from folder `f1`
- [ ] Verify the viewsheet renders correctly (not blank)
- [ ] Repeat the import **without** selecting a target folder and confirm it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)