### PR TITLE
Bug #74526, fix DC chart Y2 axis not rendering when all change-column values are null

### DIFF
--- a/core/src/main/java/inetsoft/graph/scale/LinearScale.java
+++ b/core/src/main/java/inetsoft/graph/scale/LinearScale.java
@@ -112,10 +112,17 @@ public class LinearScale extends Scale {
       double[] pair = calc.calculate(data, cols, getGraphDataSelector());
 
       // NaN signals no column data was found in this subset (e.g. a facet cell that has
-      // dataset rows but none for this particular measure). Skip the merge entirely so
-      // empty cells don't contaminate the shared min/max across the facet.
+      // dataset rows but none for this particular measure). When the scale has already been
+      // initialized with real data from other init() calls, skip the merge so empty cells
+      // don't contaminate the shared min/max across facet cells. However, if the scale is
+      // completely uninitialized (no real data seen yet), fall through with pair={0,0} so
+      // the [0,0]→[0,1] guard below gives the axis a usable default range — this preserves
+      // the prior behavior for measures like DC change values whose rows are all null. (74526)
       if(Double.isNaN(pair[0]) || Double.isNaN(pair[1])) {
-         return;
+         if(minc.get() != null || maxc.get() != null) {
+            return;
+         }
+         pair = new double[]{0, 0};
       }
 
       // use explicitly set min


### PR DESCRIPTION
## Summary

- In Date Comparison (isValuePlus=true) charts, `ChangeColumn` returns `INVALID` for all rows in the current period because there is no prior period to compare against. `AbstractDataSet.prepareCalc()` converts `INVALID` → `null`, so `LinearRange.calculate()` finds no non-null values and returns `{NaN, NaN}`.
- Commit `3b18fa682` (LinearRange/LinearScale NaN sentinel) made `LinearScale.init()` unconditionally `return` on NaN, leaving the Y2 axis scale completely uninitialized. The change-value series became invisible.
- Fix: when the NaN pair arrives but the scale has never been initialized (both `minc` and `maxc` are null), fall through with `pair={0,0}` so the existing `[0,0]→[0,1]` guard gives the axis a usable default range. When the scale already has real data from another `init()` call (facet scenario), keep the early return to prevent empty-cell contamination.

## Test plan

- [ ] Import `dcplot.vso` and open the DC chart on the portal — Y2 axis and change-value points/lines should render correctly
- [ ] Verify that facet charts with empty cells still do not have their axis range contaminated by zero values from empty facet cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)