### PR TITLE
Bug #74523 - Fix bottom tabs positioning in device layouts with scale…

### DIFF
--- a/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
+++ b/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
@@ -1270,6 +1270,9 @@ public final class VSEventUtil {
    {
       VSAssemblyInfo tabInfo = (VSAssemblyInfo) assembly.getInfo();
       boolean bottomTabs = ((TabVSAssemblyInfo) tabInfo).getBottomTabsValue();
+
+      // for bottom tabs, getLayoutPosition() returns the tab bar position
+      // (set by AbstractLayout.applyTab as npos.y + contentHeight)
       Point tabPos = tabInfo.getLayoutPosition();
       Dimension tabSize = tabInfo.getLayoutSize();
       String[] assemblies = assembly.getAssemblies();

--- a/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
+++ b/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
@@ -1269,6 +1269,7 @@ public final class VSEventUtil {
          throws Exception
    {
       VSAssemblyInfo tabInfo = (VSAssemblyInfo) assembly.getInfo();
+      boolean bottomTabs = ((TabVSAssemblyInfo) tabInfo).getBottomTabsValue();
       Point tabPos = tabInfo.getLayoutPosition();
       Dimension tabSize = tabInfo.getLayoutSize();
       String[] assemblies = assembly.getAssemblies();
@@ -1291,8 +1292,10 @@ public final class VSEventUtil {
                (int) Math.floor(size.height * sizeScale.y + repairH);
             scaleSize.height = Math.max(0, scaleSize.height);
 
-            info.setScaledPosition(
-               new Point(tabPos.x, tabPos.y + tabSize.height));
+            // top tabs: children below tab bar; bottom tabs: children above tab bar
+            int childY = bottomTabs ?
+               tabPos.y - scaleSize.height : tabPos.y + tabSize.height;
+            info.setScaledPosition(new Point(tabPos.x, childY));
             info.setScaledSize(scaleSize);
 
             if(child instanceof CurrentSelectionVSAssembly) {
@@ -1310,19 +1313,22 @@ public final class VSEventUtil {
                   sheet, viewSize, scaleSize.width, scaleSize.height, mobile
                );
 
-               // temporarily set the origin of the viewsheet so that the scaled
-               // viewsheet contents are positioned relative to the tab bar
+               // temporarily offset the viewsheet origin so scaled contents
+               // are positioned relative to the tab content area
                int vsOffsetX = (int) Math.round(-1 * viewBounds.x * vsScaleRatio.x);
                int vsOffsetY = (int) Math.round(-1 * viewBounds.y * vsScaleRatio.y);
+               int vsChildY = bottomTabs ?
+                  tabPos.y - scaleSize.height + vsOffsetY :
+                  tabPos.y + tabSize.height + vsOffsetY;
                info.setScaledPosition(
-                  new Point(tabPos.x + vsOffsetX, tabPos.y + tabSize.height + vsOffsetY));
+                  new Point(tabPos.x + vsOffsetX, vsChildY));
 
-               // scale the viewsheet contents
                applyScale(sheet, vsScaleRatio, mobile, userAgent, scaleSize.width, box);
 
-               // set the viewsheet position to the tab bar's position so that
-               // the edit button is positioned correctly.
-               info.setScaledPosition(new Point(tabPos.x, tabPos.y + tabSize.height));
+               // reset to final position so the edit button is placed correctly
+               int finalChildY = bottomTabs ?
+                  tabPos.y - scaleSize.height : tabPos.y + tabSize.height;
+               info.setScaledPosition(new Point(tabPos.x, finalChildY));
             }
          }
       }

--- a/core/src/main/java/inetsoft/uql/viewsheet/vslayout/AbstractLayout.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/vslayout/AbstractLayout.java
@@ -404,7 +404,7 @@ public abstract class AbstractLayout implements AssetObject {
    }
 
    /**
-    * Apply tab assembly layout.
+    * Apply tab assembly layout. npos is the visual top of the full tab area.
     */
    private void applyTab(TabVSAssembly vsassembly, Point npos, Dimension nsize) {
       TabVSAssemblyInfo tabInfo = (TabVSAssemblyInfo) vsassembly.getVSAssemblyInfo();
@@ -426,17 +426,17 @@ public abstract class AbstractLayout implements AssetObject {
             childSize =
                new Dimension((int) (childSize.width * scaleRadio.x),
                              (int) (childSize.height * scaleRadio.y));
-            // for bottom tabs, the layout position (npos) is the tab bar at the
-            // bottom; children sit above it, each positioned by its own height
             Point childPos = bottomTabs ?
-               new Point(npos.x, npos.y - childSize.height) :
+               new Point(npos.x, npos.y) :
                new Point(npos.x, npos.y + tabSize.height);
             applyAssembly(child, childPos, childSize);
          }
       }
 
       tabSize.width = (int) (tabSize.width * scaleRadio.x);
-      applyBaseAssembly(vsassembly, npos, tabSize);
+      Point tabPos = bottomTabs ?
+         new Point(npos.x, npos.y + contentHeight) : npos;
+      applyBaseAssembly(vsassembly, tabPos, tabSize);
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/viewsheet/vslayout/AbstractLayout.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/vslayout/AbstractLayout.java
@@ -434,6 +434,10 @@ public abstract class AbstractLayout implements AssetObject {
       }
 
       tabSize.width = (int) (tabSize.width * scaleRadio.x);
+
+      // for bottom tabs, store the tab bar position (visual top + contentHeight)
+      // in tabInfo via applyBaseAssembly; VSEventUtil.applyTabScale reads this
+      // to position children above the tab bar
       Point tabPos = bottomTabs ?
          new Point(npos.x, npos.y + contentHeight) : npos;
       applyBaseAssembly(vsassembly, tabPos, tabSize);

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
@@ -421,7 +421,7 @@ public class VSLayoutService {
 
       VSObjectModel objectModel = null;
       boolean isBottomTabs = assembly instanceof TabVSAssembly &&
-         ((TabVSAssemblyInfo) assembly.getInfo()).isBottomTabs();
+         ((TabVSAssemblyInfo) assembly.getInfo()).getBottomTabsValue();
 
       if(assembly != null) {
          assembly.getInfo().setVisible(true);

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
@@ -180,16 +180,6 @@ public class VSLayoutService {
 
       if(info instanceof TabVSAssemblyInfo) {
          size = getVSTabSize(viewsheet, assembly);
-
-         // for bottom tabs, the stored position represents the tab bar (at the
-         // bottom of the content area). The drop position is the visual top, so
-         // shift it down by maxChildHeight to match the convention used by
-         // createObjectModel and the frontend move/resize handler.
-         if(((TabVSAssemblyInfo) info).getBottomTabsValue()) {
-            int tabBarHeight = viewsheet.getPixelSize(info).height;
-            int maxChildHeight = size.height - tabBarHeight;
-            position.y += Math.max(0, maxChildHeight);
-         }
       }
       else if(assembly instanceof Viewsheet) {
          Viewsheet cloneAssembly = ((Viewsheet) assembly).clone();
@@ -444,31 +434,18 @@ public class VSLayoutService {
             getChildAssemblies((ContainerVSAssembly) assembly, rvs,
                                childModels, objectModelService);
 
-            // for bottom tabs, children sit above the tab bar — position each
-            // child at its own height above the layout position (only one is
-            // visible at a time, so differing heights don't overlap)
+            // for bottom tabs, position children at the visual top of the
+            // layout area (the stored position is the visual top)
             if(isBottomTabs) {
                Point layoutPos = assemblyLayout.getPosition();
 
                for(VSObjectModel childModel : childModels) {
                   VSFormatModel fmt = childModel.getObjectFormat();
                   fmt.setPositions(
-                     layoutPos.x, Math.max(0, layoutPos.y - fmt.getHeight()),
+                     layoutPos.x, layoutPos.y,
                      fmt.getWidth(), fmt.getHeight());
                }
             }
-         }
-      }
-
-      // for bottom tabs, shift top to visual top (children above tab bar).
-      // childModels is empty when assembly is null (editable overlay), so
-      // maxChildHeight stays 0 and top is unchanged.
-      int maxChildHeight = 0;
-
-      if(isBottomTabs) {
-         for(VSObjectModel childModel : childModels) {
-            maxChildHeight = Math.max(maxChildHeight,
-               (int) childModel.getObjectFormat().getHeight());
          }
       }
 
@@ -480,7 +457,7 @@ public class VSLayoutService {
          .width(assemblyLayout.getSize().width)
          .height(assemblyLayout.getSize().height)
          .left(assemblyLayout.getPosition().x)
-         .top(Math.max(0, assemblyLayout.getPosition().y - maxChildHeight))
+         .top(assemblyLayout.getPosition().y)
          .tableLayout(assemblyLayout.getTableLayout())
          .supportTableLayout(supportTableLayout(assembly))
          .build();

--- a/core/src/test/java/inetsoft/web/composer/vs/controller/VSLayoutServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/controller/VSLayoutServiceTest.java
@@ -47,7 +47,7 @@ class VSLayoutServiceTest {
    }
 
    @Test
-   void bottomTabsChildrenPositionedAboveTabBar() {
+   void bottomTabsChildrenPositionedAtVisualTop() {
       Viewsheet vs = new Viewsheet();
 
       // tab assembly with bottomTabs enabled
@@ -84,20 +84,20 @@ class VSLayoutServiceTest {
 
       VSLayoutObjectModel result = service.createObjectModel(rvs, layout, objectModelService);
 
-      // top should be shifted up by the max child height
-      assertEquals(layoutY - childHeight, result.top(),
-         "model top should be shifted up by max child height");
+      // top is the visual top of the tab area (no shift for bottom tabs)
+      assertEquals(layoutY, result.top(),
+         "model top should be the visual top (layout position)");
       assertEquals(layoutX, result.left());
 
-      // child format repositioned above tab bar, clamped to canvas origin
+      // child positioned at the visual top of the layout area
       assertEquals(layoutX, (int) childFmt.getLeft(),
          "child left should match layout position");
-      assertEquals(Math.max(0, layoutY - childHeight), (int) childFmt.getTop(),
-         "child top should be positioned above tab bar, clamped to 0");
+      assertEquals(layoutY, (int) childFmt.getTop(),
+         "child top should be at the visual top of the layout area");
    }
 
    @Test
-   void bottomTabsTopShiftUsesMaxChildHeight() {
+   void bottomTabsMultipleChildrenAllAtVisualTop() {
       Viewsheet vs = new Viewsheet();
 
       TabVSAssembly tab = new TabVSAssembly(vs, "Tab1");
@@ -132,17 +132,17 @@ class VSLayoutServiceTest {
 
       VSLayoutObjectModel result = service.createObjectModel(rvs, layout, objectModelService);
 
-      // top offset should use the max of the two child heights
-      assertEquals(layoutY - child2Height, result.top(),
-         "model top should be shifted by the tallest child height");
+      // top is the visual top (no shift), same for all tab types
+      assertEquals(layoutY, result.top(),
+         "model top should be the visual top (layout position)");
 
-      // each child positioned at its own height above tab bar, clamped to 0
-      assertEquals(Math.max(0, layoutY - child1Height),
+      // both children positioned at the visual top of the layout area
+      assertEquals(layoutY,
          (int) childModel1.getObjectFormat().getTop(),
-         "child1 top should be its own height above tab bar, clamped to 0");
-      assertEquals(Math.max(0, layoutY - child2Height),
+         "child1 top should be at the visual top of the layout area");
+      assertEquals(layoutY,
          (int) childModel2.getObjectFormat().getTop(),
-         "child2 top should be its own height above tab bar, clamped to 0");
+         "child2 top should be at the visual top of the layout area");
    }
 
    @Test

--- a/web/projects/portal/src/app/composer/gui/vs/layouts/layout-object.component.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/layouts/layout-object.component.ts
@@ -279,11 +279,9 @@ export class LayoutObject implements OnInit, OnDestroy {
    }
 
    private updateDimensions0(): void {
-      // for bottom tabs, model.top is the visual top (shifted up by backend);
-      // add back the child height to send the stored tab bar position
       let event: MoveResizeLayoutObjectsEvent = new MoveResizeLayoutObjectsEvent(
          this.layout.name, [this.model.name], [this.model.left],
-         [this.model.top + this.bottomTabsChildHeight],
+         [this.model.top],
          [this.model.width], [this.model.height]);
       event.region = this.layout.currentPrintSection;
 


### PR DESCRIPTION
…-to-screen

The scale-to-screen code path (VSEventUtil.applyTabScale) hardcoded child positions below the tab bar, ignoring the bottom tabs setting. Also simplify the stored layout position convention for bottom tabs to always represent the visual top of the tab area, consistent with all other assembly types.

- AbstractLayout.applyTab(): treat npos as visual top; place tab bar at npos.y + contentHeight for bottom tabs instead of treating npos as the tab bar position
- VSEventUtil.applyTabScale(): position children above the tab bar (tabPos.y - childHeight) for bottom tabs instead of always below
- VSLayoutService: remove shift/un-shift protocol that was needed by the old convention
- layout-object.component.ts: send model.top directly (no shift add-back)