### PR TITLE
Fix login page displayed on portal when security is not enabled

### DIFF
--- a/core/src/main/java/inetsoft/web/messaging/SessionConnectionService.java
+++ b/core/src/main/java/inetsoft/web/messaging/SessionConnectionService.java
@@ -124,20 +124,22 @@ public class SessionConnectionService implements MapSessionRepository.SessionExp
             // don't redirect if already coming from the logout filter
             boolean fromLogout = Boolean.TRUE.equals(
                httpSession.getAttribute(AbstractLogoutFilter.LOGGED_OUT));
+            // don't redirect to login if security is not enabled - allow to reconnect
+            boolean securityEnabled = SecurityEngine.getSecurity().isSecurityEnabled();
 
             // redirect to login page if not anonymous, otherwise, allow to reconnect
             CloseStatus status;
 
-            if(!fromLogout && authenticated) {
+            if(!fromLogout && authenticated && securityEnabled) {
                // redirect to the login page with session timeout message
                status = new CloseStatus(4002, "Session timeout");
             }
-            else if(authenticated) {
+            else if(fromLogout && authenticated) {
                // redirect to the login page without the session timeout message
                status = new CloseStatus(4001, "Logged out");
             }
             else {
-               // allow to reconnect if anonymous
+               // allow to reconnect if anonymous or if security is not enabled
                status = CloseStatus.NORMAL;
             }
 

--- a/core/src/main/java/inetsoft/web/security/AbstractLogoutFilter.java
+++ b/core/src/main/java/inetsoft/web/security/AbstractLogoutFilter.java
@@ -71,7 +71,8 @@ public abstract class AbstractLogoutFilter extends AbstractSecurityFilter {
       boolean securityEnabled = getSecurityEngine().isSecurityEnabled();
 
       // SSO need login in login page of sso.
-      if((guestLogin || fromEm || !securityEnabled) && !isSSO()) {
+      // When security is not enabled, don't redirect to the login page — just go back to portal.
+      if(securityEnabled && (guestLogin || fromEm) && !isSSO()) {
          redirectUri = LinkUriArgumentResolver.getLinkUri(request) +
             DefaultAuthorizationFilter.LOGIN_PAGE +
             "?requestedUrl=" + URLEncoder.encode(redirectUri, "UTF-8");


### PR DESCRIPTION
## Summary

- When security is not enabled and a session expires (or the server is restarted with the portal open in a browser), the WebSocket close handler no longer sends code 4002 ("Session timeout") — which would trigger `logoutService.sessionExpired()` on the client. Instead, it sends NORMAL close (code 1000), allowing the STOMP client to reconnect as an anonymous user.
- The logout/session-expired redirect no longer targets `login.html` when security is disabled. Instead it redirects directly to `app/portal`, so users are taken back to the portal rather than shown a login form they cannot meaningfully use.

## Root cause

Two cooperating issues:
1. **`SessionConnectionService.sessionExpired()`** — code 4002 was sent for any authenticated (non-anonymous) session that expired, regardless of whether security was enabled. With security disabled, users can still hold non-anonymous sessions (e.g. logged in via virtual provider), so they received 4002 on session timeout/restart, which drove the browser to `../sessionexpired`.
2. **`AbstractLogoutFilter.getLogoutRedirectUri()`** — the `!securityEnabled` clause unconditionally redirected to `login.html` on any logout/expiry when security was off. The login page then displayed a login form the user couldn't meaningfully fill in.

## Test plan

- [ ] Start server with security disabled; open portal; let session expire (or restart server); verify browser reconnects to portal, not login page.
- [ ] Start server with security enabled; open portal; let session expire; verify browser is redirected to login page as before.
- [ ] Verify explicit logout with security disabled redirects to portal.
- [ ] Verify explicit logout with security enabled redirects to login page.

Fixes #74533

🤖 Generated with [Claude Code](https://claude.com/claude-code)