### PR TITLE
Bug #74480, remove portal usage of EM organization endpoints

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/user/OrganizationController.java
+++ b/core/src/main/java/inetsoft/web/admin/security/user/OrganizationController.java
@@ -106,22 +106,6 @@ public class OrganizationController {
       return Arrays.stream(SecurityEngine.getSecurity().getSecurityProvider().getOrganizationNames()).toList();
    }
 
-   // No @Secured: non-site-admins are scoped to their own org below, so no data is leaked.
-   @GetMapping("/api/em/security/users/get-all-organization-ids/")
-   public List<String> getAllOrganizationIDs(Principal principal)
-   {
-      if(!SUtil.isMultiTenant()) {
-         return new ArrayList<>();
-      }
-
-      if(!OrganizationManager.getInstance().isSiteAdmin(principal)) {
-         String orgID = OrganizationManager.getInstance().getCurrentOrgID(principal);
-         return orgID != null ? List.of(orgID) : new ArrayList<>();
-      }
-
-      return Arrays.stream(SecurityEngine.getSecurity().getSecurityProvider().getOrganizationIDs()).toList();
-   }
-
    @Secured(
       @RequiredPermission(
          resourceType = ResourceType.EM_COMPONENT,

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-vpm/vpm-hidden-columns/vpm-hidden-columns.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-vpm/vpm-hidden-columns/vpm-hidden-columns.component.ts
@@ -34,6 +34,7 @@ import { AttributeRef } from "../../../../../../common/data/attribute-ref";
 import { DataRef } from "../../../../../../common/data/data-ref";
 import { DatabaseTreeNodeType } from "../../../../model/datasources/database/database-tree-node-type";
 import { Tool } from "../../../../../../../../../shared/util/tool";
+import { CurrentUserService } from "../../../../../../../../../shared/util/current-user.service";
 import { ComponentTool } from "../../../../../../common/util/component-tool";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { DataItem } from "../../../../model/datasources/database/vpm/test-data-model";
@@ -69,13 +70,13 @@ export class VPMHiddenColumnsComponent implements OnInit {
    filterStr: string = "";
    currOrg: string = "";
 
-   constructor(private httpClient: HttpClient, private modalService: NgbModal) {
+   constructor(private httpClient: HttpClient, private modalService: NgbModal,
+               private currentUserService: CurrentUserService) {
    }
 
    ngOnInit(): void {
       this.initDataSourceTree();
-      this.httpClient.get<string>("../api/em/navbar/organization")
-         .subscribe((org) => this.currOrg = org);
+      this.currentUserService.getPortalCurrentUser().subscribe(user => this.currOrg = user?.name?.orgID ?? "");
    }
 
    get selectedColumns(): TreeNodeModel[] {

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-vpm/vpm-hidden-columns/vpm-hidden-columns.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-vpm/vpm-hidden-columns/vpm-hidden-columns.component.ts
@@ -22,10 +22,11 @@ import {
    EventEmitter,
    ViewEncapsulation,
    OnInit,
+   OnDestroy,
    ViewChild
 } from "@angular/core";
 import { TreeNodeModel } from "../../../../../../widget/tree/tree-node-model";
-import { Observable, of } from "rxjs";
+import { Observable, of, Subscription } from "rxjs";
 import { DatabaseTreeNodeModel } from "../../../../model/datasources/database/physical-model/database-tree-node-model";
 import { HttpClient } from "@angular/common/http";
 import { HiddenColumnsModel } from "../../../../model/datasources/database/vpm/hidden-columns-model";
@@ -51,7 +52,7 @@ const MAX_HIDDEN_COLUMN = 500;
    styleUrls: ["vpm-hidden-columns.component.scss"],
    encapsulation: ViewEncapsulation.None
 })
-export class VPMHiddenColumnsComponent implements OnInit {
+export class VPMHiddenColumnsComponent implements OnInit, OnDestroy {
    @Input() hidden: HiddenColumnsModel;
    @Input() databaseName: string;
    @Input() availableRoles: DataItem[];
@@ -69,6 +70,7 @@ export class VPMHiddenColumnsComponent implements OnInit {
    loadingTree: boolean = false;
    filterStr: string = "";
    currOrg: string = "";
+   private subscriptions = new Subscription();
 
    constructor(private httpClient: HttpClient, private modalService: NgbModal,
                private currentUserService: CurrentUserService) {
@@ -76,7 +78,11 @@ export class VPMHiddenColumnsComponent implements OnInit {
 
    ngOnInit(): void {
       this.initDataSourceTree();
-      this.currentUserService.getPortalCurrentUser().subscribe(user => this.currOrg = user?.name?.orgID ?? "");
+      this.subscriptions.add(this.currentUserService.getPortalCurrentUser().subscribe(user => this.currOrg = user?.name?.orgID ?? ""));
+   }
+
+   ngOnDestroy(): void {
+      this.subscriptions.unsubscribe();
    }
 
    get selectedColumns(): TreeNodeModel[] {

--- a/web/projects/portal/src/app/portal/report/tree/repository-tree-view.component.ts
+++ b/web/projects/portal/src/app/portal/report/tree/repository-tree-view.component.ts
@@ -103,7 +103,7 @@ export class RepositoryTreeViewComponent implements OnInit, AfterViewInit, OnDes
                private changeDetectorRef: ChangeDetectorRef,
                private currentUserService: CurrentUserService)
    {
-      this.currentUserService.getPortalCurrentUser().subscribe(user => this.currOrgID = user?.name?.orgID ?? null);
+      this.subscriptions.add(this.currentUserService.getPortalCurrentUser().subscribe(user => this.currOrgID = user?.name?.orgID ?? null));
 
       this.subscriptions.add(this.pageTabService.onRefreshPage.subscribe((tab: TabInfoModel) => {
          let entry = createAssetEntry(tab.id);

--- a/web/projects/portal/src/app/portal/report/tree/repository-tree-view.component.ts
+++ b/web/projects/portal/src/app/portal/report/tree/repository-tree-view.component.ts
@@ -39,6 +39,7 @@ import { RepositoryTreeComponent } from "../../../widget/repository-tree/reposit
 import { TreeNodeModel } from "../../../widget/tree/tree-node-model";
 import { ReportTabModel } from "../report-tab-model";
 import { Tool } from "../../../../../../shared/util/tool";
+import { CurrentUserService } from "../../../../../../shared/util/current-user.service";
 
 const SEARCH_URI = "../api/portal/tree/search";
 const GET_PORTAL_TREE_FOLDER = "../api/portal/tree";
@@ -99,11 +100,10 @@ export class RepositoryTreeViewComponent implements OnInit, AfterViewInit, OnDes
 
    constructor(private http: HttpClient, private modal: NgbModal,
                private pageTabService: PageTabService,
-               private changeDetectorRef: ChangeDetectorRef)
+               private changeDetectorRef: ChangeDetectorRef,
+               private currentUserService: CurrentUserService)
    {
-      this.http.get<string>("../api/em/navbar/organization").subscribe((org)=>{
-         this.currOrgID = org;
-      });
+      this.currentUserService.getPortalCurrentUser().subscribe(user => this.currOrgID = user?.name?.orgID ?? null);
 
       this.subscriptions.add(this.pageTabService.onRefreshPage.subscribe((tab: TabInfoModel) => {
          let entry = createAssetEntry(tab.id);

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -569,7 +569,7 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
       ngbDatepickerConfig.maxDate = {year: 2099, month: 12, day: 31};
       this.embed = this.contextProvider.embed;
 
-      this.currentUserService.getPortalCurrentUser().subscribe(user => this.currOrgID = user?.name?.orgID ?? null);
+      this.subscriptions.add(this.currentUserService.getPortalCurrentUser().subscribe(user => this.currOrgID = user?.name?.orgID ?? null));
    }
 
    getAssemblyName(): string {

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -202,6 +202,7 @@ import { VSUtil } from "./util/vs-util";
 import { VsToolbarButtonDirective } from "./vs-toolbar-button.directive";
 import { BaseHrefService } from "../common/services/base-href.service";
 import { DashboardTabModel } from "../portal/dashboard/dashboard-tab-model";
+import { CurrentUserService } from "../../../../shared/util/current-user.service";
 
 declare const window: any;
 declare var globalPostParams: { [name: string]: string[] } | null;
@@ -547,7 +548,8 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
                private miniToolbarService: MiniToolbarService,
                private assetLoadingService: AssetLoadingService,
                private viewContainerRef: ViewContainerRef,
-               private baseHrefService: BaseHrefService)
+               private baseHrefService: BaseHrefService,
+               private currentUserService: CurrentUserService)
    {
       super(viewsheetClient, zone, true);
       tooltipConfig.tooltipClass = "top-tooltip";
@@ -567,7 +569,7 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
       ngbDatepickerConfig.maxDate = {year: 2099, month: 12, day: 31};
       this.embed = this.contextProvider.embed;
 
-      this.http.get<string>("../api/em/navbar/organization").subscribe((org)=>{this.currOrgID = org;});
+      this.currentUserService.getPortalCurrentUser().subscribe(user => this.currOrgID = user?.name?.orgID ?? null);
    }
 
    getAssemblyName(): string {

--- a/web/projects/portal/src/app/vsobjects/viewer-app.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.spec.ts
@@ -39,7 +39,6 @@ import {
 import { of as observableOf } from "rxjs";
 import { DownloadService } from "../../../../shared/download/download.service";
 import { AppInfoService } from "../../../../shared/util/app-info.service";
-import { CurrentUserService } from "../../../../shared/util/current-user.service";
 import { AssetLoadingService } from "../common/services/asset-loading.service";
 import { BaseHrefService } from "../common/services/base-href.service";
 import { FirstDayOfWeekService } from "../common/services/first-day-of-week.service";
@@ -371,6 +370,7 @@ describe("ViewerApp Unit Tests", () => {
    it("should remove the vsobject's actions when removing the vsobject", () => {
       const httpClient = TestBed.inject(HttpClient);
       const baseHrefService = TestBed.inject(BaseHrefService);
+      const currentUserService = { getPortalCurrentUser: jest.fn().mockReturnValue(observableOf(null)) };
       const viewerApp = new ViewerAppComponent(
          viewsheetClientService, null, null, null, null, null, null, null,
          new NgbDatepickerConfig(), null, actionFactory, httpClient, null, formDataService,
@@ -380,7 +380,7 @@ describe("ViewerApp Unit Tests", () => {
          richTextService, viewerToolbarMessageService, mobileToolbarService, mockDocument, composerRecentService,
          pageTabService, pagingControlService, selectionMobileService,
          assetLoadingService, viewContainerRef, baseHrefService,
-         TestBed.inject(CurrentUserService));
+         currentUserService as any);
       const mockChart = TestUtils.createMockVSChartModel("Mock Chart");
       const mockTable = TestUtils.createMockVSTableModel("Mock Table");
       const mockCrosstab = TestUtils.createMockVSCrosstabModel("Mock Crosstab");

--- a/web/projects/portal/src/app/vsobjects/viewer-app.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.spec.ts
@@ -39,6 +39,7 @@ import {
 import { of as observableOf } from "rxjs";
 import { DownloadService } from "../../../../shared/download/download.service";
 import { AppInfoService } from "../../../../shared/util/app-info.service";
+import { CurrentUserService } from "../../../../shared/util/current-user.service";
 import { AssetLoadingService } from "../common/services/asset-loading.service";
 import { BaseHrefService } from "../common/services/base-href.service";
 import { FirstDayOfWeekService } from "../common/services/first-day-of-week.service";
@@ -378,7 +379,8 @@ describe("ViewerApp Unit Tests", () => {
          firstDayOfWeekService, new NgbTooltipConfig(new NgbConfig()), shareService, null,
          richTextService, viewerToolbarMessageService, mobileToolbarService, mockDocument, composerRecentService,
          pageTabService, pagingControlService, selectionMobileService,
-         assetLoadingService, viewContainerRef, baseHrefService);
+         assetLoadingService, viewContainerRef, baseHrefService,
+         TestBed.inject(CurrentUserService));
       const mockChart = TestUtils.createMockVSChartModel("Mock Chart");
       const mockTable = TestUtils.createMockVSTableModel("Mock Table");
       const mockCrosstab = TestUtils.createMockVSCrosstabModel("Mock Crosstab");

--- a/web/projects/portal/src/app/widget/asset-tree/asset-tree.component.ts
+++ b/web/projects/portal/src/app/widget/asset-tree/asset-tree.component.ts
@@ -15,7 +15,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { HttpClient } from "@angular/common/http";
 import {
    ChangeDetectionStrategy,
    ChangeDetectorRef,
@@ -32,7 +31,7 @@ import {
    ViewChild
 } from "@angular/core";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
-import { forkJoin, merge as observableMerge, Observable, throwError } from "rxjs";
+import { merge as observableMerge, Observable, throwError } from "rxjs";
 import { catchError, finalize, map } from "rxjs/operators";
 import { AssetEntry } from "../../../../../shared/data/asset-entry";
 import { AssetType } from "../../../../../shared/data/asset-type";
@@ -52,6 +51,7 @@ import { LoadAssetTreeNodesEvent } from "./load-asset-tree-nodes-event";
 import { LoadAssetTreeNodesValidator } from "./load-asset-tree-nodes-validator";
 import { VirtualScrollTreeComponent } from "../tree/virtual-scroll-tree/virtual-scroll-tree.component";
 import { TreeTool } from "../../common/util/tree-tool";
+import { CurrentUserService } from "../../../../../shared/util/current-user.service";
 
 const isDataSource = (node: TreeNodeModel) => {
    const entry = node.data as AssetEntry;
@@ -124,7 +124,6 @@ export class AssetTreeComponent implements OnInit, OnDestroy, OnChanges {
    };
    private loadDataSourcesAfterLoadRoot;
    private currOrgID: string = "";
-   private organizations: string[];
 
    get searchMode(): boolean {
       return this.root != this.activeRoot;
@@ -135,22 +134,18 @@ export class AssetTreeComponent implements OnInit, OnDestroy, OnChanges {
                private assetClientService: AssetClientService,
                private modalService: NgbModal,
                private debounceService: DebounceService,
-               private zone: NgZone, private http: HttpClient)
+               private zone: NgZone,
+               private currentUserService: CurrentUserService)
    {
    }
 
    ngOnInit() {
       this.setupAssetClientService();
 
-      //Use forkJoin to wait for multiple HTTP requests to complete simultaneously.
-      forkJoin({
-         org: this.http.get<string>("../api/em/navbar/organization"),
-         orgIDList: this.http.get<string[]>("../api/em/security/users/get-all-organization-ids/")
-      }).subscribe(({ org, orgIDList }) => {
-            this.currOrgID = org;
-            this.organizations = orgIDList;
-            this.loadAssetTree();
-         });
+      this.currentUserService.getPortalCurrentUser().subscribe((user) => {
+         this.currOrgID = user?.name?.orgID ?? "";
+         this.loadAssetTree();
+      });
    }
 
    loadAssetTree() {
@@ -289,13 +284,6 @@ export class AssetTreeComponent implements OnInit, OnDestroy, OnChanges {
    }
 
    private handleAssetChangeEvent(event: AssetChangeEvent) {
-      //check asset's organization and only refresh if this organization is changed
-      let eventOrgID = event.newIdentifier?.split("^").pop();
-
-      if(this.organizations?.includes(eventOrgID) && !(this.currOrgID == eventOrgID)) {
-         return;
-      }
-
       if(event.parentEntry == null) {
          this.refreshFromRoot();
          return;

--- a/web/projects/portal/src/app/widget/asset-tree/asset-tree.component.ts
+++ b/web/projects/portal/src/app/widget/asset-tree/asset-tree.component.ts
@@ -31,7 +31,7 @@ import {
    ViewChild
 } from "@angular/core";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
-import { merge as observableMerge, Observable, throwError } from "rxjs";
+import { merge as observableMerge, Observable, Subscription, throwError } from "rxjs";
 import { catchError, finalize, map } from "rxjs/operators";
 import { AssetEntry } from "../../../../../shared/data/asset-entry";
 import { AssetType } from "../../../../../shared/data/asset-type";
@@ -124,6 +124,7 @@ export class AssetTreeComponent implements OnInit, OnDestroy, OnChanges {
    };
    private loadDataSourcesAfterLoadRoot;
    private currOrgID: string = "";
+   private subscriptions = new Subscription();
 
    get searchMode(): boolean {
       return this.root != this.activeRoot;
@@ -142,10 +143,10 @@ export class AssetTreeComponent implements OnInit, OnDestroy, OnChanges {
    ngOnInit() {
       this.setupAssetClientService();
 
-      this.currentUserService.getPortalCurrentUser().subscribe((user) => {
+      this.subscriptions.add(this.currentUserService.getPortalCurrentUser().subscribe((user) => {
          this.currOrgID = user?.name?.orgID ?? "";
          this.loadAssetTree();
-      });
+      }));
    }
 
    loadAssetTree() {
@@ -217,6 +218,7 @@ export class AssetTreeComponent implements OnInit, OnDestroy, OnChanges {
 
    ngOnDestroy() {
       this.assetClientService.disconnect();
+      this.subscriptions.unsubscribe();
    }
 
    ngOnChanges(changes: SimpleChanges): void {

--- a/web/projects/portal/src/app/widget/email-dialog/email-addr-dialog.spec.ts
+++ b/web/projects/portal/src/app/widget/email-dialog/email-addr-dialog.spec.ts
@@ -24,6 +24,7 @@ import { of as observableOf } from "rxjs";
 import { IdentityTreeComponent } from "../identity-tree/identity-tree.component";
 import { DragService } from "../services/drag.service";
 import { ModelService } from "../services/model.service";
+import { CurrentUserService } from "../../../../../shared/util/current-user.service";
 import { ShuffleListComponent } from "../shuffle-list/shuffle-list.component";
 import { TreeNodeComponent } from "../tree/tree-node.component";
 import { TreeSearchPipe } from "../tree/tree-search.pipe";
@@ -63,11 +64,12 @@ describe("Email Addr Dialog Unit Test", () => {
    let emailAddrDialog: EmailAddrDialog;
 
    let changeDetectorRef = { detectChanges: jest.fn() };
-   let modelService = { getModel: jest.fn(), getCurrentOrganization: jest.fn() };
+   let modelService = { getModel: jest.fn() };
+   let currentUserService = { getPortalCurrentUser: jest.fn() };
    let dragService = { reset: jest.fn(), put: jest.fn() };
    beforeEach(() => {
       modelService.getModel.mockImplementation(() => observableOf([]));
-      modelService.getCurrentOrganization.mockImplementation(() => observableOf());
+      currentUserService.getPortalCurrentUser.mockImplementation(() => observableOf(null));
       TestBed.configureTestingModule({
          imports: [
             FormsModule, ReactiveFormsModule, NgbModule
@@ -80,6 +82,9 @@ describe("Email Addr Dialog Unit Test", () => {
          },
          {
             provide: ModelService, useValue: modelService
+         },
+         {
+            provide: CurrentUserService, useValue: currentUserService
          },
          {
             provide: DragService, useValue: dragService

--- a/web/projects/portal/src/app/widget/email-dialog/embedded-email-pane.component.ts
+++ b/web/projects/portal/src/app/widget/email-dialog/embedded-email-pane.component.ts
@@ -26,7 +26,7 @@ import { debounceTime, distinctUntilChanged } from "rxjs/operators";
 import { IdentityModel } from "../../../../../em/src/app/settings/security/security-table-view/identity-model";
 import { SearchComparator } from "../tree/search-comparator";
 import { FormValidators } from "../../../../../shared/util/form-validators";
-import { Subject } from "rxjs";
+import { Subject, Subscription } from "rxjs";
 import { GuiTool } from "../../common/util/gui-tool";
 import { ModelService } from "../services/model.service";
 import { HttpParams } from "@angular/common/http";
@@ -71,6 +71,7 @@ export class EmbeddedEmailPane implements OnInit, OnDestroy {
    usersNode: TreeNodeModel[] = [];
    private searchTextchanges$ = new Subject<string>();
    private searchIdentitychanges$ = new Subject<string>();
+   private subscriptions = new Subscription();
    mobile: boolean;
    currOrg: string;
 
@@ -92,7 +93,7 @@ export class EmbeddedEmailPane implements OnInit, OnDestroy {
          .set("name", "Users")
          .set("type", String(IdentityType.USERS));
 
-      this.currentUserService.getPortalCurrentUser().subscribe(user => this.currOrg = user?.name?.orgID ?? null);
+      this.subscriptions.add(this.currentUserService.getPortalCurrentUser().subscribe(user => this.currOrg = user?.name?.orgID ?? null));
 
       this.modelService.getModel(EXPAND_IDENTITY_NODE_URI, params)
          .subscribe(
@@ -143,6 +144,7 @@ export class EmbeddedEmailPane implements OnInit, OnDestroy {
    ngOnDestroy(): void {
       this.searchTextchanges$.unsubscribe();
       this.searchIdentitychanges$.unsubscribe();
+      this.subscriptions.unsubscribe();
    }
 
    updateSearchText(str: string) {

--- a/web/projects/portal/src/app/widget/email-dialog/embedded-email-pane.component.ts
+++ b/web/projects/portal/src/app/widget/email-dialog/embedded-email-pane.component.ts
@@ -30,6 +30,7 @@ import { Subject } from "rxjs";
 import { GuiTool } from "../../common/util/gui-tool";
 import { ModelService } from "../services/model.service";
 import { HttpParams } from "@angular/common/http";
+import { CurrentUserService } from "../../../../../shared/util/current-user.service";
 import { equalsIdentity, IdentityId } from "../../../../../em/src/app/settings/security/users/identity-id";
 
 const EXPAND_IDENTITY_NODE_URI = "../api/vs/expand-identity-node";
@@ -85,12 +86,13 @@ export class EmbeddedEmailPane implements OnInit, OnDestroy {
       return this._addresses;
    }
 
-   constructor(private modelService: ModelService) {
+   constructor(private modelService: ModelService,
+               private currentUserService: CurrentUserService) {
       let params = new HttpParams()
          .set("name", "Users")
          .set("type", String(IdentityType.USERS));
 
-      this.modelService.getCurrentOrganization().subscribe((org)=>{this.currOrg=org;});
+      this.currentUserService.getPortalCurrentUser().subscribe(user => this.currOrg = user?.name?.orgID ?? null);
 
       this.modelService.getModel(EXPAND_IDENTITY_NODE_URI, params)
          .subscribe(

--- a/web/projects/portal/src/app/widget/services/model.service.ts
+++ b/web/projects/portal/src/app/widget/services/model.service.ts
@@ -58,11 +58,6 @@ export class ModelService {
       this._errorHandler = handler;
    }
 
-   getCurrentOrganization(): Observable<string> {
-      return this.http.get<string>("../api/em/navbar/organization");
-
-   }
-
    getOrgMVGlobalResource(org: string): Observable<boolean> {
       return this.http.get<boolean>("../api/portal/content/materialized-view/isOrgAccessGlobalMV/"+org);
    }


### PR DESCRIPTION
Replace portal's direct calls to EM organization endpoints with CurrentUserService.getPortalCurrentUser(), which already provides the current org ID via the portal's own API. Also remove the now-unused get-all-organization-ids backend endpoint and a redundant client-side cross-org event filter that the server already handles.