### PR TITLE
Bug #74541 - Fix ComboBox selection resets on first change after bind…

### DIFF
--- a/core/src/main/java/inetsoft/web/binding/service/VSBindingService.java
+++ b/core/src/main/java/inetsoft/web/binding/service/VSBindingService.java
@@ -894,6 +894,17 @@ public class VSBindingService {
       }
 
       orvs.setViewsheet(nvs);
+      // setViewsheet() triggers resetRuntime() which clears parametersApplied.
+      // Mark parameters as already applied so that applyParameterToInput() does
+      // not overwrite input-assembly selections with stale variable-table entries
+      // on the next reset(initing=true) cycle (e.g. combobox selection change).
+      // Same pattern as the undo/redo fix in RuntimeViewsheet.restoreCheckpoint0().
+      ViewsheetSandbox box = orvs.getViewsheetSandbox();
+
+      if(box != null) {
+         box.markParametersApplied();
+      }
+
       orvs.setBindingID(null);
       orvs.getViewsheet().setMaxMode(false);
 


### PR DESCRIPTION
…ing pane commit

When a ComboBox variable is bound to a chart's color, shape, size, or text binding, the first ComboBox selection change after closing the binding pane reverts to the previous value. This happens because VSBindingService.finishEdit() calls setViewsheet() which triggers resetRuntime(), clearing the parametersApplied flag. No subsequent reset(initing=true) runs to restore it, so the next selection change triggers applyParameterToInput() which overwrites the new selection with the stale variable-table entry.

The fix calls markParametersApplied() after setViewsheet() in finishEdit(), matching the existing pattern in RuntimeViewsheet.restoreCheckpoint0() (Bug #74220).