### PR TITLE
Bug #74524. Fix DC chart DataGroup appearing on top x-axis with custom periods.

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonInfo.java
@@ -996,6 +996,12 @@ public class DateComparisonInfo implements Cloneable, XMLSerializable {
    }
 
    public boolean isCompareAll() {
+      // For custom periods, only granularity applies; the interval level concept
+      // (YEAR_TO_DATE, etc.) is not applicable to manually-defined date ranges.
+      if(!isStdPeriod()) {
+         return true;
+      }
+
       int level = dcInterval.getLevel();
       return level == ALL;
    }


### PR DESCRIPTION
When customPeriod=true, interval level (e.g. YEAR_TO_DATE) is not applicable — only granularity matters. isCompareAll() now returns true for non-standard periods so convertToCustomPartMap() is always used, preventing DataGroup from being placed on the x2 axis.