### PR TITLE
Bug #74542, DC chart previous-year lookup finds wrong quarter

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/calc/ValueOfColumn.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/calc/ValueOfColumn.java
@@ -424,7 +424,8 @@ public class ValueOfColumn extends AbstractColumn {
          List<XDimensionRef> ignoreList = dcTempGroups;
          boolean ndimIsPartDate = false;
 
-         if(ctype < ValueOfCalc.PREVIOUS_YEAR && ndim.equals(innerDim) && getDimensions() != null) {
+         if((ctype == ValueOfCalc.PREVIOUS || ctype == ValueOfCalc.NEXT)
+               && ndim.equals(innerDim) && getDimensions() != null) {
             String ndimBase = getDateColumnBase(ndim);
 
             if(ndimBase != null) {

--- a/core/src/main/java/inetsoft/report/composition/graph/calc/ValueOfColumn.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/calc/ValueOfColumn.java
@@ -418,13 +418,13 @@ public class ValueOfColumn extends AbstractColumn {
          // is a PART_DATE_GROUP, exclude any sibling PART_DATE_GROUP dimensions that share the
          // same base date column. This prevents zero rows when a part-level lookup crosses a
          // period boundary (e.g. April→March crosses Q2→Q1, so QuarterOfYear must be excluded).
-         // Do NOT exclude siblings when ndim is a full date group (e.g. Year): in that case the
-         // siblings (e.g. QuarterOfYear) must stay in the condition to find the correct period
-         // in the previous year (e.g. Q3 2019 when looking up previous year of Q3 2020).
+         // Only apply for PREVIOUS/NEXT: for PREVIOUS_YEAR and similar ctypes, the PART_DATE_GROUP
+         // sibling (e.g. QuarterOfYear) is the correct position discriminator and must remain in
+         // the condition to find the same quarter in the previous year.
          List<XDimensionRef> ignoreList = dcTempGroups;
          boolean ndimIsPartDate = false;
 
-         if(ndim.equals(innerDim) && getDimensions() != null) {
+         if(ctype < ValueOfCalc.PREVIOUS_YEAR && ndim.equals(innerDim) && getDimensions() != null) {
             String ndimBase = getDateColumnBase(ndim);
 
             if(ndimBase != null) {

--- a/core/src/test/java/inetsoft/report/composition/graph/calc/ValueOfColumnTest.java
+++ b/core/src/test/java/inetsoft/report/composition/graph/calc/ValueOfColumnTest.java
@@ -214,6 +214,54 @@ public class ValueOfColumnTest {
    }
 
    /**
+    * Regression test for Bug #74542: PREVIOUS_YEAR lookup must not exclude PART_DATE_GROUP
+    * sibling dimensions from the condition. The sibling (QuarterOfYear) is the position
+    * discriminator — without it the lookup always returns the first quarter of the previous
+    * year instead of the matching quarter.
+    */
+   @Test
+   void testPreviousYearKeepsPartDateGroupSiblingInCondition() {
+      valueOfColumn = new ValueOfColumn("id", "sum(id)");
+      valueOfColumn.setChangeType(ValueOfCalc.PREVIOUS_YEAR);
+      valueOfColumn.setDim("Year(Date)");
+      // innerDim == ndim triggers the sibling-detection branch
+      valueOfColumn.setInnerDim("Year(Date)");
+
+      DefaultTableLens tb = new DefaultTableLens(new Object[][]{
+         { "Year(Date)", "QuarterOfYear(Date)", "id" },
+         { toDate("2020-01-01"), 1, 5 },  // 2020 Q1
+         { toDate("2020-01-01"), 2, 3 },  // 2020 Q2
+         { toDate("2020-01-01"), 3, 4 },  // 2020 Q3
+         { toDate("2020-01-01"), 4, 2 },  // 2020 Q4
+         { toDate("2021-01-01"), 1, 4 },  // 2021 Q1
+         { toDate("2021-01-01"), 2, 7 },  // 2021 Q2 ← test row
+         { toDate("2021-01-01"), 3, 8 },  // 2021 Q3
+         { toDate("2021-01-01"), 4, 1 },  // 2021 Q4
+      });
+
+      VSDimensionRef yearVsRef = mock(VSDimensionRef.class);
+      when(yearVsRef.getFullName()).thenReturn("Year(Date)");
+      VSDimensionRef quarterVsRef = mock(VSDimensionRef.class);
+      when(quarterVsRef.getFullName()).thenReturn("QuarterOfYear(Date)");
+      vsDataSet = new VSDataSet(tb, new VSDataRef[] { yearVsRef, quarterVsRef });
+
+      // QuarterOfYear(Date) is a PART_DATE_GROUP sibling of Year(Date)
+      XDimensionRef quarterDimRef = mock(XDimensionRef.class);
+      when(quarterDimRef.getFullName()).thenReturn("QuarterOfYear(Date)");
+      when(quarterDimRef.getDateLevel()).thenReturn(XConstants.QUARTER_OF_YEAR_DATE_GROUP);
+      XDimensionRef yearDimRef = mock(XDimensionRef.class);
+      when(yearDimRef.getFullName()).thenReturn("Year(Date)");
+      when(yearDimRef.getDateLevel()).thenReturn(XConstants.YEAR_DATE_GROUP);
+      valueOfColumn.setDimensions(Arrays.asList(quarterDimRef, yearDimRef));
+
+      // Row 5 = 2021 Q2 (id=7). Correct previous-year value = 2020 Q2 (id=3).
+      // Regression: without the fix, QuarterOfYear is stripped from the condition so the
+      // lookup returns the first row of 2020 (Q1, id=5) instead of Q2 (id=3).
+      Object result = valueOfColumn.calculate(vsDataSet, 5, false, false);
+      assertEquals(3, result);
+   }
+
+   /**
     * check some basic functions
     */
    @Test


### PR DESCRIPTION
## Summary

- Regression introduced by #3375 (Bug #74367): the PART_DATE_GROUP sibling-exclusion block in `ValueOfColumn.getDataSetDynamicCalcValue()` ran for **all** ctype values including `PREVIOUS_YEAR`, incorrectly removing the quarter discriminator from DC chart year-over-year lookups.
- For a DC chart with Year-comparison-at-Quarter-granularity, `QuarterOfYear(Date)` was stripped from the lookup condition, leaving only `{Year=prevYear}`. All quarters of the previous year matched, and the first (Q1) was always returned regardless of the current row's quarter.
- Fix: guard the sibling-detection block with `ctype < ValueOfCalc.PREVIOUS_YEAR` so it only applies to PREVIOUS/NEXT lookups (where period-boundary crossing is a real issue), not to PREVIOUS_YEAR and similar date-period lookups (where the PART_DATE_GROUP sibling is the correct position discriminator).

## Test plan

- [ ] Import `Year_Quarter.zip` and open the DC chart on portal
- [ ] Verify "Change from previous year of Year(Date): Sum(Paid)" shows correct values (e.g. third value is -1, not 4)
- [ ] Verify the original Bug #74367 fix still works: a chart with MonthOfYear + QuarterOfYear using PREVIOUS lookup does not show INVALID for months that cross a quarter boundary (e.g. April→March)

🤖 Generated with [Claude Code](https://claude.com/claude-code)