### PR TITLE
Bug #74494 - Fix dropdown selection gap with bottom-tabs set via script

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
@@ -223,6 +223,9 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
             return popDown ? this.model.objectFormat.top : this.model.objectFormat.top - bodyHeight;
          }
          else if(this.model.dropdown && inBottomTab) {
+            // applies whether the dropdown is collapsed or expanded; the collapsed
+            // case is critical because it's where objectFormat.top would be stale
+            // when bottomTabs is toggled via script.
             const expanded = !SelectionBaseController.isHidden(this.model);
             return VSUtil.computeBottomTabSelectionTop(
                bottomTab.objectFormat.top, this.model.titleFormat.height,

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
@@ -209,7 +209,8 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
    private _columnShiftCleanup: (() => void) | null = null;
 
    get topPosition(): number {
-      const inBottomTab = VSUtil.isInBottomTabContainer(this.model, this.vsInfo?.vsObjects);
+      const bottomTab = VSUtil.getBottomTabContainer(this.model, this.vsInfo?.vsObjects);
+      const inBottomTab = !!bottomTab;
 
       if((this.viewer || this.embeddedVS) && !this.model.maxMode && !this.inContainer) {
          if(this.atBottom && this.model.dropdown &&
@@ -221,11 +222,11 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
 
             return popDown ? this.model.objectFormat.top : this.model.objectFormat.top - bodyHeight;
          }
-         else if(this.model.dropdown && !SelectionBaseController.isHidden(this.model)
-            && inBottomTab)
-         {
-            let searchBarHeight = this.model.searchDisplayed ? this.model.titleFormat.height : 0;
-            return this.model.objectFormat.top - this.getBodyHeight() - searchBarHeight;
+         else if(this.model.dropdown && inBottomTab) {
+            const expanded = !SelectionBaseController.isHidden(this.model);
+            return VSUtil.computeBottomTabSelectionTop(
+               bottomTab.objectFormat.top, this.model.titleFormat.height,
+               expanded, this.getBodyHeight(), this.model.searchDisplayed);
          }
          else {
             return this.model.objectFormat.top;

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.spec.ts
@@ -311,4 +311,59 @@ describe("VSSelection Test", () => {
       // non-dropdown: objectFormat.top already accounts for full component height
       expect(fixture.componentInstance.topPosition).toBe(300);
    });
+
+   // Bug #74494 — dropdown selection in a bottom-tabs tab must derive its Y
+   // from the parent tab's objectFormat.top, not its own (possibly stale)
+   // objectFormat.top. Stale values occur when Tab.bottomTabs is toggled via
+   // script and the child pixelOffset update doesn't reach the client.
+   it("should anchor collapsed dropdown selection to parent tab top, ignoring stale objectFormat.top", () => {
+      let listModel = createListModel();
+      listModel.dropdown = true;
+      listModel.hidden = true;                 // dropdown panel collapsed
+      listModel.searchDisplayed = false;
+      listModel.objectFormat.top = 9999;       // stale; must be ignored
+      listModel.titleFormat.height = 20;
+      listModel.containerType = "VSTab";
+      listModel.container = "Tab1";
+
+      let tabModel = Object.assign(
+         { bottomTabs: true },
+         TestUtils.createMockVSObjectModel("VSTab", "Tab1")
+      );
+      tabModel.objectFormat.top = 544;
+
+      contextService.viewer = true;
+      fixture.componentInstance.model = listModel;
+      fixture.componentInstance.vsInfo = { vsObjects: [tabModel] } as any;
+
+      // title flush with tab bar: 544 - titleHeight(20) = 524
+      expect(fixture.componentInstance.topPosition).toBe(524);
+   });
+
+   it("should shift expanded dropdown selection above parent tab by body height", () => {
+      let listModel = createListModel();
+      listModel.dropdown = true;
+      listModel.searchDisplayed = false;
+      listModel.objectFormat.top = 9999;       // stale; must be ignored
+      listModel.titleFormat.height = 20;
+      listModel.cellHeight = 18;
+      listModel.listHeight = 5;                // getBodyHeight → 18 * 5 = 90
+      listModel.containerType = "VSTab";
+      listModel.container = "Tab1";
+
+      let tabModel = Object.assign(
+         { bottomTabs: true },
+         TestUtils.createMockVSObjectModel("VSTab", "Tab1")
+      );
+      tabModel.objectFormat.top = 544;
+
+      contextService.viewer = true;
+      fixture.componentInstance.model = listModel;
+      // model setter forces hidden=true for new dropdown models; flip after assignment
+      fixture.componentInstance.model.hidden = false;
+      fixture.componentInstance.vsInfo = { vsObjects: [tabModel] } as any;
+
+      // tabTop(544) - titleHeight(20) - bodyHeight(90) = 434
+      expect(fixture.componentInstance.topPosition).toBe(434);
+   });
 });

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
@@ -523,6 +523,9 @@ export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
                   return popDown ? obj?.objectFormat?.top : obj?.objectFormat?.top - bodyHeight;
                }
                else if(selModel.dropdown && inBottomTab) {
+                  // applies whether the dropdown is collapsed or expanded; the collapsed
+                  // case is critical because it's where objectFormat.top would be stale
+                  // when bottomTabs is toggled via script.
                   const expanded = !SelectionBaseController.isHidden(selModel);
                   return VSUtil.computeBottomTabSelectionTop(
                      bottomTab.objectFormat.top, selModel.titleFormat.height,

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
@@ -508,25 +508,25 @@ export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
             if((this.viewer || this.embeddedVS) && !(<VSSelectionBaseModel> obj).maxMode
                && obj.containerType !== "VSSelectionContainer")
             {
-               const inBottomTab = VSUtil.isInBottomTabContainer(obj, this.vsInfo?.vsObjects);
+               const bottomTab = VSUtil.getBottomTabContainer(obj, this.vsInfo?.vsObjects);
+               const inBottomTab = !!bottomTab;
+               const selModel = <VSSelectionBaseModel> obj;
 
-               if(this.isAtBottom(i, true) && (<VSSelectionBaseModel> obj).dropdown &&
-                  !SelectionBaseController.isHidden(<VSSelectionBaseModel> obj) &&
+               if(this.isAtBottom(i, true) && selModel.dropdown &&
+                  !SelectionBaseController.isHidden(selModel) &&
                   !inBottomTab)
                {
-                  let bodyHeight = this.getSelectionBodyHeight(<VSSelectionBaseModel> obj);
+                  let bodyHeight = this.getSelectionBodyHeight(selModel);
                   let popDown = this.containerBounds?.height - obj?.objectFormat?.top -
-                     (<VSSelectionBaseModel> obj)?.titleFormat?.height - bodyHeight > 0;
+                     selModel?.titleFormat?.height - bodyHeight > 0;
 
                   return popDown ? obj?.objectFormat?.top : obj?.objectFormat?.top - bodyHeight;
                }
-               else if((<VSSelectionBaseModel> obj).dropdown &&
-                  !SelectionBaseController.isHidden(<VSSelectionBaseModel> obj) &&
-                  inBottomTab)
-               {
-                  let bodyHeight = this.getSelectionBodyHeight(<VSSelectionBaseModel> obj);
-                  let searchBarHeight = (<VSSelectionBaseModel> obj).searchDisplayed ? (<VSSelectionBaseModel> obj).titleFormat.height : 0;
-                  return obj?.objectFormat?.top - bodyHeight - searchBarHeight;
+               else if(selModel.dropdown && inBottomTab) {
+                  const expanded = !SelectionBaseController.isHidden(selModel);
+                  return VSUtil.computeBottomTabSelectionTop(
+                     bottomTab.objectFormat.top, selModel.titleFormat.height,
+                     expanded, this.getSelectionBodyHeight(selModel), selModel.searchDisplayed);
                }
                else {
                   return obj?.objectFormat?.top;

--- a/web/projects/portal/src/app/vsobjects/util/vs-util.ts
+++ b/web/projects/portal/src/app/vsobjects/util/vs-util.ts
@@ -588,11 +588,33 @@ export namespace VSUtil {
    export const CALENDAR_BODY_HEIGHT = CALENDAR_ROW_HEIGHT * CALENDAR_BODY_ROWS;
 
    export function isInBottomTabContainer(obj: VSObjectModel, vsObjects: VSObjectModel[]): boolean {
+      return !!getBottomTabContainer(obj, vsObjects);
+   }
+
+   export function getBottomTabContainer(obj: VSObjectModel, vsObjects: VSObjectModel[]): VSTabModel | null {
       if(obj.containerType !== "VSTab" || !obj.container) {
-         return false;
+         return null;
       }
 
-      const parentTab = vsObjects?.find(o => o.absoluteName === obj.container);
-      return !!parentTab && (parentTab as VSTabModel).bottomTabs === true;
+      const parentTab = vsObjects?.find(o => o.absoluteName === obj.container) as VSTabModel;
+      return parentTab && parentTab.bottomTabs === true ? parentTab : null;
+   }
+
+   /**
+    * Compute Y for a dropdown selection flush with the top of a bottom-tabs tab bar.
+    * Derives position from the parent tab's top rather than the selection's own
+    * objectFormat.top, which may be stale when bottomTabs is toggled via script
+    * (child pixelOffset refreshes aren't guaranteed to reach the client).
+    *
+    * - collapsed (expanded=false): title sits directly above the tab bar.
+    * - expanded: wrapper shifts further up by bodyHeight (+ searchBarHeight) so the
+    *   body pops above the title.
+    */
+   export function computeBottomTabSelectionTop(tabTop: number, titleHeight: number,
+                                                expanded: boolean, bodyHeight: number,
+                                                searchDisplayed: boolean): number {
+      const body = expanded ? bodyHeight : 0;
+      const searchBar = expanded && searchDisplayed ? titleHeight : 0;
+      return tabTop - titleHeight - body - searchBar;
    }
 }

--- a/web/projects/portal/src/app/vsobjects/util/vs-util.ts
+++ b/web/projects/portal/src/app/vsobjects/util/vs-util.ts
@@ -591,7 +591,9 @@ export namespace VSUtil {
       return !!getBottomTabContainer(obj, vsObjects);
    }
 
-   export function getBottomTabContainer(obj: VSObjectModel, vsObjects: VSObjectModel[]): VSTabModel | null {
+   export function getBottomTabContainer(obj: VSObjectModel,
+                                          vsObjects: VSObjectModel[] | undefined): VSTabModel | null
+   {
       if(obj.containerType !== "VSTab" || !obj.container) {
          return null;
       }
@@ -606,7 +608,9 @@ export namespace VSUtil {
     * objectFormat.top, which may be stale when bottomTabs is toggled via script
     * (child pixelOffset refreshes aren't guaranteed to reach the client).
     *
-    * - collapsed (expanded=false): title sits directly above the tab bar.
+    * - collapsed (expanded=false): title sits directly above the tab bar; this
+    *   branch also covers the script-stale case, anchoring the title correctly
+    *   regardless of the selection's own (possibly stale) objectFormat.top.
     * - expanded: wrapper shifts further up by bodyHeight (+ searchBarHeight) so the
     *   body pops above the title.
     */
@@ -614,6 +618,7 @@ export namespace VSUtil {
                                                 expanded: boolean, bodyHeight: number,
                                                 searchDisplayed: boolean): number {
       const body = expanded ? bodyHeight : 0;
+      // selection's search bar height matches the title bar height
       const searchBar = expanded && searchDisplayed ? titleHeight : 0;
       return tabTop - titleHeight - body - searchBar;
    }


### PR DESCRIPTION
When Tab.bottomTabs is toggled via script, the server repositions child pixelOffsets flush with the tab bar, but the updated selection model isn't pushed to the client — the title renders at its stale position with a gap to the tab strip.

Derive the dropdown selection's Y on the client from the parent tab's objectFormat.top instead of the selection's own (possibly stale) value. Extract the formula to VSUtil.computeBottomTabSelectionTop and add VSUtil.getBottomTabContainer so both vs-selection and vs-object-container share a single definition.