### PR TITLE
Bug #74549, block org-settings access when multi-tenancy is disabled

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/authz/ComponentAuthorizationController.java
+++ b/core/src/main/java/inetsoft/web/admin/authz/ComponentAuthorizationController.java
@@ -80,6 +80,10 @@ public class ComponentAuthorizationController {
       boolean authorized = component.available() && checkPermission(resource, principal);
       boolean multiTenancyHidden = false;
 
+      if(component.requiresMultiTenancy() && !SUtil.isMultiTenant()) {
+         return false;
+      }
+
       if(component.hiddenForMultiTenancy() && SUtil.isMultiTenant()) {
          multiTenancyHidden = !OrganizationManager.getInstance().isSiteAdmin(principal);
       }

--- a/core/src/main/java/inetsoft/web/admin/authz/ViewComponent.java
+++ b/core/src/main/java/inetsoft/web/admin/authz/ViewComponent.java
@@ -42,6 +42,11 @@ public interface ViewComponent {
       return false;
    }
 
+   @Value.Default
+   default boolean requiresMultiTenancy() {
+      return false;
+   }
+
    @Value.Lazy
    @JsonIgnore
    default boolean available() {

--- a/core/src/main/java/inetsoft/web/security/SecuredAspect.java
+++ b/core/src/main/java/inetsoft/web/security/SecuredAspect.java
@@ -266,16 +266,16 @@ public class SecuredAspect {
    }
 
    private boolean isComponentAccessible(String resource, Principal user) {
-      if(!SUtil.isMultiTenant()) {
-         return true;
-      }
-
       ViewComponent component = componentAuthorizationService.getComponent(resource);
 
       if(component == null) {
          LOG.warn("EM component '{}' not found in view-components.json; defaulting to deny. " +
                   "Check for a misspelled or unregistered @Secured resource path.", resource);
          return false;
+      }
+
+      if(!SUtil.isMultiTenant()) {
+         return !component.requiresMultiTenancy();
       }
 
       return !component.hiddenForMultiTenancy() ||

--- a/web/gulp/em-metadata.js
+++ b/web/gulp/em-metadata.js
@@ -69,6 +69,7 @@ const generateMetadata = function() {
                   child.label = entry.label;
                   child.requiredLicenses = entry.requiredLicenses;
                   child.hiddenForMultiTenancy = entry.hiddenForMultiTenancy;
+                  child.requiresMultiTenancy = entry.requiresMultiTenancy;
                } else {
                   parent = child;
                }
@@ -85,8 +86,8 @@ const generateMetadata = function() {
 
       if(match != null) {
          const addEntries = (md => {
-            const {route, label, requiredLicenses, children, hiddenForMultiTenancy} = md;
-            securityEntries.push({route, label, requiredLicenses, hiddenForMultiTenancy});
+            const {route, label, requiredLicenses, children, hiddenForMultiTenancy, requiresMultiTenancy} = md;
+            securityEntries.push({route, label, requiredLicenses, hiddenForMultiTenancy, requiresMultiTenancy});
 
             if(children) {
                children.forEach(c => addEntries(c));

--- a/web/projects/em/src/app/secured.ts
+++ b/web/projects/em/src/app/secured.ts
@@ -43,6 +43,11 @@ export interface SecuredDescriptor {
     * Whether hide the view for multi tenancy
     */
    hiddenForMultiTenancy?: boolean
+
+   /**
+    * Whether the view requires multi-tenancy to be enabled
+    */
+   requiresMultiTenancy?: boolean
 }
 
 /**

--- a/web/projects/em/src/app/settings/presentation/presentation-settings-view/presentation-org-settings-view.component.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-settings-view/presentation-org-settings-view.component.ts
@@ -22,7 +22,8 @@ import { PresentationSettingsViewComponent } from "./presentation-settings-view.
 
 @Secured({
    route: "/settings/presentation/org-settings",
-   label: "Presentation Org Settings"
+   label: "Presentation Org Settings",
+   requiresMultiTenancy: true
 })
 @ContextHelp({
    route: "/settings/presentation/org-settings",


### PR DESCRIPTION
When multi-tenancy is disabled, the org-settings EM component was never explicitly denied (it's hidden from the permission tree), so the security engine defaulted to allowing it. Direct URL and API access bypassed the nav-level filtering.

Added a `requiresMultiTenancy` flag to `ViewComponent`/`SecuredDescriptor`, set it on `PresentationOrgSettingsViewComponent`, and enforced it in both `SecuredAspect.isComponentAccessible` (API layer) and `ComponentAuthorizationController.componentAvailable` (authz query layer).