### PR TITLE
Bug #74550 - Scope empty plot hyperlink to plot rectangle in PDF exports

### DIFF
--- a/core/src/main/java/inetsoft/report/internal/ChartElementDef.java
+++ b/core/src/main/java/inetsoft/report/internal/ChartElementDef.java
@@ -612,9 +612,11 @@ public class ChartElementDef extends PainterElementDef
    }
 
    /**
-    * Set element-level hyperlink without propagating to chart data refs.
+    * Set the fallback element-level hyperlink used when the plot is empty
+    * (no rendered visuals). Unlike {@link #setHyperlink(Hyperlink)}, this
+    * does not propagate to chart data refs.
     */
-   public void setPlotAreaHyperlink(Hyperlink link) {
+   public void setEmptyPlotHyperlink(Hyperlink link) {
       super.setHyperlink(link);
    }
 
@@ -712,6 +714,14 @@ public class ChartElementDef extends PainterElementDef
    */
    public void setVGraph(VGraph vgraph) {
       this.vgraph = vgraph;
+   }
+
+   /**
+    * Get the VGraph set via {@link #setVGraph(VGraph)} for vs-converted reports.
+    * May be null when the element is not produced from a vs chart.
+    */
+   public VGraph getVGraph() {
+      return vgraph;
    }
 
    @Override

--- a/core/src/main/java/inetsoft/report/internal/ChartPainterPaintable.java
+++ b/core/src/main/java/inetsoft/report/internal/ChartPainterPaintable.java
@@ -82,7 +82,7 @@ public class ChartPainterPaintable extends LinkedShapePainterPaintable {
          }
          else {
             // no VGraph, fall back to whole-paintable bounds
-            LOG.debug("Empty-plot link on whole paintable, VGraph unavailable");
+            LOG.debug("Falling back to whole-paintable bounds for empty-plot link (no VGraph)");
             setHyperlink(new Hyperlink.Ref(elementLink));
          }
       }

--- a/core/src/main/java/inetsoft/report/internal/ChartPainterPaintable.java
+++ b/core/src/main/java/inetsoft/report/internal/ChartPainterPaintable.java
@@ -17,7 +17,9 @@
  */
 package inetsoft.report.internal;
 
+import inetsoft.graph.VGraph;
 import inetsoft.graph.data.*;
+import inetsoft.graph.internal.GTool;
 import inetsoft.report.*;
 import inetsoft.report.composition.graph.GraphUtil;
 import inetsoft.report.composition.graph.IntervalDataSet;
@@ -30,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.awt.*;
+import java.awt.geom.Rectangle2D;
 import java.util.Enumeration;
 import java.util.Map;
 
@@ -67,7 +70,21 @@ public class ChartPainterPaintable extends LinkedShapePainterPaintable {
       Hyperlink elementLink = ((PainterElement) elem).getHyperlink();
 
       if(elementLink != null) {
-         setHyperlink(new Hyperlink.Ref(elementLink));
+         // scope link to plot rectangle; per-region links added below overlay on top
+         VGraph vgraph = elem instanceof ChartElementDef
+            ? ((ChartElementDef) elem).getVGraph() : null;
+
+         if(vgraph != null) {
+            Rectangle2D plot = vgraph.getPlotBounds();
+            Rectangle2D hitArea = GTool.getFlipYTransform(vgraph)
+               .createTransformedShape(plot).getBounds2D();
+            setHyperlink(hitArea, new Hyperlink.Ref(elementLink));
+         }
+         else {
+            // no VGraph, fall back to whole-paintable bounds
+            LOG.debug("Empty-plot link on whole paintable, VGraph unavailable");
+            setHyperlink(new Hyperlink.Ref(elementLink));
+         }
       }
 
       ChartPainter cpainter = (ChartPainter) painter;

--- a/core/src/main/java/inetsoft/report/internal/LinkedShapePainterPaintable.java
+++ b/core/src/main/java/inetsoft/report/internal/LinkedShapePainterPaintable.java
@@ -75,7 +75,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
     */
    public Hyperlink.Ref getHyperlink(Shape shape) {
       if(map == null) {
-         map = Collections.synchronizedMap(new LinkedHashMap<>());
+         map = new LinkedHashMap<>();
       }
 
       return map.get(shape);
@@ -86,7 +86,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
     */
    public void setHyperlink(Shape shape, Hyperlink.Ref link) {
       if(map == null) {
-         map = Collections.synchronizedMap(new LinkedHashMap<>());
+         map = new LinkedHashMap<>();
       }
 
       if(link == null) {
@@ -102,7 +102,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
     */
    protected Hyperlink.Ref[] getDrillHyperlinks(Shape shape) {
       if(dmap == null) {
-         dmap = Collections.synchronizedMap(new LinkedHashMap<>());
+         dmap = new LinkedHashMap<>();
       }
 
       Hyperlink.Ref[] refs = dmap.get(shape) == null ?
@@ -120,7 +120,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
       }
 
       if(dmap == null) {
-         dmap = Collections.synchronizedMap(new LinkedHashMap<>());
+         dmap = new LinkedHashMap<>();
       }
 
       if(links == null) {
@@ -137,7 +137,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
     */
    public Hyperlink.Ref[] getHyperlinks(Shape shape) {
       if(dmap == null) {
-         dmap = Collections.synchronizedMap(new LinkedHashMap<>());
+         dmap = new LinkedHashMap<>();
       }
 
       Hyperlink.Ref href = getHyperlink(shape);
@@ -244,7 +244,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
       Object obj = s.readObject();
 
       if(obj instanceof Integer) {
-         map = Collections.synchronizedMap(new LinkedHashMap<>());
+         map = new LinkedHashMap<>();
          int linkcnt = ((Integer) obj).intValue();
 
          for(int i = 0; i < linkcnt; i++) {
@@ -269,7 +269,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
     */
    private void writeObject(ObjectOutputStream stream) throws IOException {
       if(map == null) {
-         map = Collections.synchronizedMap(new LinkedHashMap<>());
+         map = new LinkedHashMap<>();
       }
 
       // @by jasons, if the background is transparent (null), we need to store
@@ -325,7 +325,8 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
       }
    }
 
-   // synchronized LinkedHashMap preserves insertion order for deterministic PDF link emission
+   // LinkedHashMap preserves insertion order for deterministic PDF link emission.
+   // not synchronized: paintables are accessed single-threadedly during report rendering.
    protected transient Map<Shape, Hyperlink.Ref> map;
    protected transient Map<Shape, Hyperlink.Ref[]> dmap;
 

--- a/core/src/main/java/inetsoft/report/internal/LinkedShapePainterPaintable.java
+++ b/core/src/main/java/inetsoft/report/internal/LinkedShapePainterPaintable.java
@@ -75,10 +75,10 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
     */
    public Hyperlink.Ref getHyperlink(Shape shape) {
       if(map == null) {
-         map = new LinkedHashMap();
+         map = Collections.synchronizedMap(new LinkedHashMap<>());
       }
 
-      return (Hyperlink.Ref) map.get(shape);
+      return map.get(shape);
    }
 
    /**
@@ -86,7 +86,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
     */
    public void setHyperlink(Shape shape, Hyperlink.Ref link) {
       if(map == null) {
-         map = new LinkedHashMap();
+         map = Collections.synchronizedMap(new LinkedHashMap<>());
       }
 
       if(link == null) {
@@ -102,11 +102,11 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
     */
    protected Hyperlink.Ref[] getDrillHyperlinks(Shape shape) {
       if(dmap == null) {
-         dmap = new LinkedHashMap();
+         dmap = Collections.synchronizedMap(new LinkedHashMap<>());
       }
 
       Hyperlink.Ref[] refs = dmap.get(shape) == null ?
-         new Hyperlink.Ref[0] : (Hyperlink.Ref[]) dmap.get(shape);
+         new Hyperlink.Ref[0] : dmap.get(shape);
 
       return refs;
    }
@@ -120,7 +120,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
       }
 
       if(dmap == null) {
-         dmap = new LinkedHashMap();
+         dmap = Collections.synchronizedMap(new LinkedHashMap<>());
       }
 
       if(links == null) {
@@ -137,26 +137,26 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
     */
    public Hyperlink.Ref[] getHyperlinks(Shape shape) {
       if(dmap == null) {
-         dmap = new LinkedHashMap();
+         dmap = Collections.synchronizedMap(new LinkedHashMap<>());
       }
 
       Hyperlink.Ref href = getHyperlink(shape);
       Hyperlink.Ref[] drefs = getDrillHyperlinks(shape);
 
-      Map map = new OrderedMap();
+      Map<String, Hyperlink.Ref> linkMap = new OrderedMap<>();
 
       if(href != null) {
-         map.put(href.getName(), href);
+         linkMap.put(href.getName(), href);
       }
 
       for(int i = 0; i < drefs.length; i++) {
-         if(!map.containsKey(drefs[i].getName())) {
-            map.put(drefs[i].getName(), drefs[i]);
+         if(!linkMap.containsKey(drefs[i].getName())) {
+            linkMap.put(drefs[i].getName(), drefs[i]);
          }
       }
 
-      Hyperlink.Ref[] links = new Hyperlink.Ref[map.size()];
-      map.values().toArray(links);
+      Hyperlink.Ref[] links = new Hyperlink.Ref[linkMap.size()];
+      linkMap.values().toArray(links);
 
       return links;
    }
@@ -244,7 +244,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
       Object obj = s.readObject();
 
       if(obj instanceof Integer) {
-         map = new LinkedHashMap();
+         map = Collections.synchronizedMap(new LinkedHashMap<>());
          int linkcnt = ((Integer) obj).intValue();
 
          for(int i = 0; i < linkcnt; i++) {
@@ -259,7 +259,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
                obj2 = new Ellipse2D.Double(x, y, w, h);
             }
 
-           map.put(obj2, s.readObject());
+           map.put((Shape) obj2, (Hyperlink.Ref) s.readObject());
          }
       }
    }
@@ -269,7 +269,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
     */
    private void writeObject(ObjectOutputStream stream) throws IOException {
       if(map == null) {
-         map = new LinkedHashMap();
+         map = Collections.synchronizedMap(new LinkedHashMap<>());
       }
 
       // @by jasons, if the background is transparent (null), we need to store
@@ -286,10 +286,10 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
       stream.writeObject(elem);
 
       stream.writeObject(Integer.valueOf(map.size()));
-      Iterator keys = map.keySet().iterator();
+      Iterator<Shape> keys = map.keySet().iterator();
 
       while(keys.hasNext()) {
-         Object obj = keys.next();
+         Shape obj = keys.next();
 
          if(obj instanceof Ellipse2D) {
             double x = 0, y = 0, w = 0, h = 0;
@@ -325,11 +325,11 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
       }
    }
 
-   // LinkedHashMap preserves insertion order for deterministic PDF link emission
-   protected transient LinkedHashMap map;
-   protected transient LinkedHashMap dmap;
+   // synchronized LinkedHashMap preserves insertion order for deterministic PDF link emission
+   protected transient Map<Shape, Hyperlink.Ref> map;
+   protected transient Map<Shape, Hyperlink.Ref[]> dmap;
 
-   private class AreaEnumeration implements Enumeration {
+   private class AreaEnumeration implements Enumeration<Shape> {
       private AreaEnumeration() {
          if(map != null) {
             shapes.addAll(map.keySet());
@@ -346,11 +346,11 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
       }
 
       @Override
-      public Object nextElement() {
+      public Shape nextElement() {
          return shapes.get(idx++);
       }
 
       private int idx = 0;
-      ArrayList shapes = new ArrayList();
+      ArrayList<Shape> shapes = new ArrayList<>();
    }
 }

--- a/core/src/main/java/inetsoft/report/internal/LinkedShapePainterPaintable.java
+++ b/core/src/main/java/inetsoft/report/internal/LinkedShapePainterPaintable.java
@@ -75,7 +75,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
     */
    public Hyperlink.Ref getHyperlink(Shape shape) {
       if(map == null) {
-         map = new Hashtable();
+         map = new LinkedHashMap();
       }
 
       return (Hyperlink.Ref) map.get(shape);
@@ -86,7 +86,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
     */
    public void setHyperlink(Shape shape, Hyperlink.Ref link) {
       if(map == null) {
-         map = new Hashtable();
+         map = new LinkedHashMap();
       }
 
       if(link == null) {
@@ -102,7 +102,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
     */
    protected Hyperlink.Ref[] getDrillHyperlinks(Shape shape) {
       if(dmap == null) {
-         dmap = new Hashtable();
+         dmap = new LinkedHashMap();
       }
 
       Hyperlink.Ref[] refs = dmap.get(shape) == null ?
@@ -120,7 +120,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
       }
 
       if(dmap == null) {
-         dmap = new Hashtable();
+         dmap = new LinkedHashMap();
       }
 
       if(links == null) {
@@ -137,7 +137,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
     */
    public Hyperlink.Ref[] getHyperlinks(Shape shape) {
       if(dmap == null) {
-         dmap = new Hashtable();
+         dmap = new LinkedHashMap();
       }
 
       Hyperlink.Ref href = getHyperlink(shape);
@@ -244,7 +244,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
       Object obj = s.readObject();
 
       if(obj instanceof Integer) {
-         map = new Hashtable();
+         map = new LinkedHashMap();
          int linkcnt = ((Integer) obj).intValue();
 
          for(int i = 0; i < linkcnt; i++) {
@@ -269,7 +269,7 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
     */
    private void writeObject(ObjectOutputStream stream) throws IOException {
       if(map == null) {
-         map = new Hashtable();
+         map = new LinkedHashMap();
       }
 
       // @by jasons, if the background is transparent (null), we need to store
@@ -286,10 +286,10 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
       stream.writeObject(elem);
 
       stream.writeObject(Integer.valueOf(map.size()));
-      Enumeration keys = map.keys();
+      Iterator keys = map.keySet().iterator();
 
-      while(keys.hasMoreElements()) {
-         Object obj = keys.nextElement();
+      while(keys.hasNext()) {
+         Object obj = keys.next();
 
          if(obj instanceof Ellipse2D) {
             double x = 0, y = 0, w = 0, h = 0;
@@ -325,8 +325,9 @@ public abstract class LinkedShapePainterPaintable extends PainterPaintable {
       }
    }
 
-   protected transient Hashtable map;
-   protected transient Hashtable dmap;
+   // LinkedHashMap preserves insertion order for deterministic PDF link emission
+   protected transient LinkedHashMap map;
+   protected transient LinkedHashMap dmap;
 
    private class AreaEnumeration implements Enumeration {
       private AreaEnumeration() {

--- a/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
@@ -1379,37 +1379,39 @@ public abstract class AbstractVSExporter implements VSExporter {
                   boolean imgOnly = exportChartAsImage(chart);
                   data = data == null && pair != null ? pair.getData() : data;
 
+                  VGraph graph = null;
+
                   if(data != null && !(data.getRowCount() <= 0 && data.getColCount() <= 0)) {
-                     VGraph graph = !isMatchLayout() && supportChartSlices() ?
+                     graph = !isMatchLayout() && supportChartSlices() ?
                         pair.getExpandedVGraph() : pair.getRealSizeVGraph();
+                  }
 
-                     if(graph != null) {
-                        Rectangle2D bounds = graph.getBounds();
-                        // chart not included in onlyDataComponents. (59989)
-                        boolean needSlice = !isMatchLayout() && !isOnlyDataComponents() &&
-                           bounds.getWidth() * bounds.getHeight() > EXPORT_SIZE * EXPORT_SIZE;
+                  Hyperlink emptyPlotLink = info.getEmptyPlotLinkValue();
 
-                        Hyperlink emptyPlotLink = info.getEmptyPlotLinkValue();
+                  // emit before writeChart so per-region links overlay on top
+                  if(emptyPlotLink != null) {
+                     int titleHeight = info.isTitleVisible() ? info.getTitleHeight() : 0;
+                     Insets padding = info.getPadding();
+                     Insets2D border = getBorderOffset(info.getFormat());
+                     Rectangle2D chartBounds = new Rectangle2D.Double(
+                        pos.x + padding.left + border.left,
+                        pos.y + padding.top + border.top + titleHeight,
+                        size.width - padding.left - padding.right - border.left - border.right,
+                        size.height - padding.top - padding.bottom - border.top - border.bottom - titleHeight);
+                     writeEmptyPlotHyperlink(new Hyperlink.Ref(emptyPlotLink), graph, chartBounds);
+                  }
 
-                        // emit before writeChart so per-region links overlay on top
-                        if(emptyPlotLink != null) {
-                           int titleHeight = info.isTitleVisible() ? info.getTitleHeight() : 0;
-                           Insets padding = info.getPadding();
-                           Insets2D border = getBorderOffset(info.getFormat());
-                           Rectangle2D chartBounds = new Rectangle2D.Double(
-                              pos.x + padding.left + border.left,
-                              pos.y + padding.top + border.top + titleHeight,
-                              size.width - padding.left - padding.right - border.left - border.right,
-                              size.height - padding.top - padding.bottom - border.top - border.bottom - titleHeight);
-                           writeEmptyPlotHyperlink(new Hyperlink.Ref(emptyPlotLink), graph, chartBounds);
-                        }
+                  if(graph != null) {
+                     Rectangle2D bounds = graph.getBounds();
+                     // chart not included in onlyDataComponents. (59989)
+                     boolean needSlice = !isMatchLayout() && !isOnlyDataComponents() &&
+                        bounds.getWidth() * bounds.getHeight() > EXPORT_SIZE * EXPORT_SIZE;
 
-                        if(!needSlice) {
-                           writeChart(chart, graph, data, imgOnly);
-                        }
-                        else {
-                           writeSliceChart(chart, data, pair, isMatchLayout(), imgOnly);
-                        }
+                     if(!needSlice) {
+                        writeChart(chart, graph, data, imgOnly);
+                     }
+                     else {
+                        writeSliceChart(chart, data, pair, isMatchLayout(), imgOnly);
                      }
                   }
 

--- a/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
@@ -1374,20 +1374,6 @@ public abstract class AbstractVSExporter implements VSExporter {
                      }
                   }
 
-                  Hyperlink emptyPlotLink = info.getEmptyPlotLinkValue();
-
-                  if(emptyPlotLink != null) {
-                     int titleHeight = info.isTitleVisible() ? info.getTitleHeight() : 0;
-                     Insets padding = info.getPadding();
-                     Insets2D border = getBorderOffset(info.getFormat());
-                     Rectangle2D plotBounds = new Rectangle2D.Double(
-                        pos.x + padding.left + border.left,
-                        pos.y + padding.top + border.top + titleHeight,
-                        size.width - padding.left - padding.right - border.left - border.right,
-                        size.height - padding.top - padding.bottom - border.top - border.bottom - titleHeight);
-                     writeEmptyPlotHyperlink(new Hyperlink.Ref(emptyPlotLink), plotBounds);
-                  }
-
                   VGraphPair pair = box.getVGraphPair(name, true, null, true, 1);
                   DataSet data = (DataSet) box.getData(name);
                   boolean imgOnly = exportChartAsImage(chart);
@@ -1402,6 +1388,21 @@ public abstract class AbstractVSExporter implements VSExporter {
                         // chart not included in onlyDataComponents. (59989)
                         boolean needSlice = !isMatchLayout() && !isOnlyDataComponents() &&
                            bounds.getWidth() * bounds.getHeight() > EXPORT_SIZE * EXPORT_SIZE;
+
+                        Hyperlink emptyPlotLink = info.getEmptyPlotLinkValue();
+
+                        // emit before writeChart so per-region links overlay on top
+                        if(emptyPlotLink != null) {
+                           int titleHeight = info.isTitleVisible() ? info.getTitleHeight() : 0;
+                           Insets padding = info.getPadding();
+                           Insets2D border = getBorderOffset(info.getFormat());
+                           Rectangle2D chartBounds = new Rectangle2D.Double(
+                              pos.x + padding.left + border.left,
+                              pos.y + padding.top + border.top + titleHeight,
+                              size.width - padding.left - padding.right - border.left - border.right,
+                              size.height - padding.top - padding.bottom - border.top - border.bottom - titleHeight);
+                           writeEmptyPlotHyperlink(new Hyperlink.Ref(emptyPlotLink), graph, chartBounds);
+                        }
 
                         if(!needSlice) {
                            writeChart(chart, graph, data, imgOnly);
@@ -3444,7 +3445,19 @@ public abstract class AbstractVSExporter implements VSExporter {
       }
    }
 
-   protected void writeEmptyPlotHyperlink(Hyperlink.Ref ref, Rectangle2D bounds) {
+   /**
+    * Emit the empty-plot hyperlink. The link should be registered on the plot
+    * rectangle only (not the axes or legends). Default is a no-op; subclasses
+    * override.
+    *
+    * @param ref          the hyperlink reference
+    * @param vgraph       the rendered VGraph; use {@code vgraph.getPlotBounds()}
+    *                     (graph-local coords) to derive the actual plot rectangle
+    * @param chartBounds  on-page chart rectangle excluding title, padding and border
+    */
+   protected void writeEmptyPlotHyperlink(Hyperlink.Ref ref, VGraph vgraph,
+                                          Rectangle2D chartBounds)
+   {
       // subclasses override to emit the link
    }
 

--- a/core/src/main/java/inetsoft/report/io/viewsheet/pdf/PDFVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/pdf/PDFVSExporter.java
@@ -46,6 +46,7 @@ import org.w3c.dom.Element;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.*;
@@ -251,10 +252,9 @@ public class PDFVSExporter extends AbstractVSExporter {
          return;
       }
 
-      float pH = helper.getPrinter().getPageSize().height * 72;
       LinkArea area = new LinkArea(shape,
          GTool.getFlipYTransform(vgraph), bounds.getX(),
-         bounds.getY(), pH);
+         bounds.getY(), getPageHeightPts());
       helper.setLinks(area, hyperlink);
    }
 
@@ -262,18 +262,24 @@ public class PDFVSExporter extends AbstractVSExporter {
    protected void writeEmptyPlotHyperlink(Hyperlink.Ref ref, VGraph vgraph,
                                           Rectangle2D chartBounds)
    {
-      if(!genLink || ref == null || ref.getLinkType() != Hyperlink.WEB_LINK ||
-         vgraph == null)
-      {
+      if(!genLink || ref == null || ref.getLinkType() != Hyperlink.WEB_LINK) {
          return;
       }
 
-      // map plot bounds to PDF page coords same as per-region chart links
-      Rectangle2D plot = vgraph.getPlotBounds();
-      float pH = helper.getPrinter().getPageSize().height * 72;
-      LinkArea area = new LinkArea(plot, GTool.getFlipYTransform(vgraph),
-                                   chartBounds.getX(), chartBounds.getY(), pH);
-      helper.setLinks(area, ref);
+      float pH = getPageHeightPts();
+
+      if(vgraph != null) {
+         // map plot bounds to PDF page coords same as per-region chart links
+         Rectangle2D plot = vgraph.getPlotBounds();
+         LinkArea area = new LinkArea(plot, GTool.getFlipYTransform(vgraph),
+                                      chartBounds.getX(), chartBounds.getY(), pH);
+         helper.setLinks(area, ref);
+      }
+      else {
+         // no VGraph (empty dataset), fall back to chart content area
+         LinkArea area = new LinkArea(chartBounds, new AffineTransform(), 0, 0, pH);
+         helper.setLinks(area, ref);
+      }
    }
 
    /**
@@ -1128,7 +1134,7 @@ public class PDFVSExporter extends AbstractVSExporter {
       }
 
       helper.write();
-      float pageH = helper.getPrinter().getPageSize().height * 72;
+      float pageH = getPageHeightPts();
 
       if(genLink) {
          for(int i = 0; i <= helper.getPage(); i++) {
@@ -1189,6 +1195,11 @@ public class PDFVSExporter extends AbstractVSExporter {
       }
 
       return !Tool.equals(fmt.getBackground(), parentFmt.getBackground());
+   }
+
+   // page height in PDF points (1 inch = 72 points)
+   private float getPageHeightPts() {
+      return helper.getPrinter().getPageSize().height * 72;
    }
 
    private PDFCoordinateHelper helper;

--- a/core/src/main/java/inetsoft/report/io/viewsheet/pdf/PDFVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/pdf/PDFVSExporter.java
@@ -259,10 +259,21 @@ public class PDFVSExporter extends AbstractVSExporter {
    }
 
    @Override
-   protected void writeEmptyPlotHyperlink(Hyperlink.Ref ref, Rectangle2D bounds) {
-      if(genLink && ref != null && ref.getLinkType() == Hyperlink.WEB_LINK) {
-         helper.setLinks(bounds, ref);
+   protected void writeEmptyPlotHyperlink(Hyperlink.Ref ref, VGraph vgraph,
+                                          Rectangle2D chartBounds)
+   {
+      if(!genLink || ref == null || ref.getLinkType() != Hyperlink.WEB_LINK ||
+         vgraph == null)
+      {
+         return;
       }
+
+      // map plot bounds to PDF page coords same as per-region chart links
+      Rectangle2D plot = vgraph.getPlotBounds();
+      float pH = helper.getPrinter().getPageSize().height * 72;
+      LinkArea area = new LinkArea(plot, GTool.getFlipYTransform(vgraph),
+                                   chartBounds.getX(), chartBounds.getY(), pH);
+      helper.setLinks(area, ref);
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/pdf/PDF3Generator.java
+++ b/core/src/main/java/inetsoft/report/pdf/PDF3Generator.java
@@ -620,7 +620,9 @@ public class PDF3Generator extends inetsoft.report.io.AbstractGenerator {
             (LinkedShapePainterPaintable) pt;
          Enumeration areas = pt2.getHyperlinkAreas();
          Rectangle base = pt2.getBounds();
-         Map<Hyperlink.Ref, Rectangle> maps = new HashMap<>();
+         // LinkedHashMap preserves paintable insertion order for /Annots emission.
+         // Replaces bug1300957927646 sort which was dead code (sorted unused array).
+         Map<Hyperlink.Ref, Rectangle> maps = new LinkedHashMap<>();
 
          while(areas.hasMoreElements()) {
             Shape shape = (Shape) areas.nextElement();
@@ -636,28 +638,6 @@ public class PDF3Generator extends inetsoft.report.io.AbstractGenerator {
                maps.put(hlink, box);
             }
          }
-
-         // fix bug1300957927646 sort the hyperlink area
-         Object[] values = maps.values().toArray();
-
-         Arrays.sort(values, new Comparator<Object>() {
-            @Override
-            public int compare(Object obj1, Object obj2) {
-               Rectangle r1 = (Rectangle) obj1;
-               Rectangle r2 = (Rectangle) obj2;
-
-               if(r1.intersects(r2)) {
-                  return r1.height > r2.height ? 1 : 0;
-               }
-
-               return r2.contains(r1) ? 1 : 0;
-            }
-
-            @Override
-            public boolean equals(Object obj) {
-               return true;
-            }
-         });
 
          for(Hyperlink.Ref hlink : maps.keySet()) {
             Integer linkId = getPrinter().addLink(

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
@@ -1455,7 +1455,7 @@ public class VsToReportConverter {
       Hyperlink emptyPlotLink = cinfo.getEmptyPlotLinkValue();
 
       if(emptyPlotLink != null) {
-         chartelem.setPlotAreaHyperlink(emptyPlotLink);
+         chartelem.setEmptyPlotHyperlink(emptyPlotLink);
       }
    }
 


### PR DESCRIPTION
Constrain the empty-plot hyperlink clickable area from the full chart content area (including axes/legends) to VGraph.getPlotBounds().

Direct PDF: emit link after VGraph is obtained using LinkArea with GTool.getFlipYTransform, matching per-region chart link mapping.

Layout PDF: register as shape-keyed entry so it emits before per-region links in /Annots. Switch Hashtable/HashMap to LinkedHashMap in LinkedShapePainterPaintable and PDF3Generator to preserve insertion order. Remove dead sort in PDF3Generator (bug1300957927646).