### PR TITLE
Bug #74554 - Keep tab bar position when input label changes in bottom tabs

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
@@ -459,7 +459,8 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
     * alters a child's effective height and only that child needs to be
     * adjusted without recalculating the entire tab layout.</p>
     *
-    * @param tabInfo  the bottom-tab info (must have a non-null pixel offset)
+    * @param tabInfo  the bottom-tab info; caller must verify
+    *                 {@code getBottomTabsValue()} is true
     * @param childInfo the child assembly's info to reposition
     * @param childSize the child assembly's pixel size
     */

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
@@ -452,6 +452,42 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
    }
 
    /**
+    * Reposition a single child assembly so its visual bottom edge is flush
+    * with the tab bar's top edge. The tab bar itself is not moved.
+    *
+    * <p>This is useful when a property change (label, show type, size, etc.)
+    * alters a child's effective height and only that child needs to be
+    * adjusted without recalculating the entire tab layout.</p>
+    *
+    * @param tabInfo  the bottom-tab info (must have a non-null pixel offset)
+    * @param childInfo the child assembly's info to reposition
+    * @param childSize the child assembly's pixel size
+    */
+   public static void repositionChildForBottomTabs(TabVSAssemblyInfo tabInfo,
+                                                   VSAssemblyInfo childInfo,
+                                                   Dimension childSize)
+   {
+      Point tabPos = tabInfo.getPixelOffset();
+      int childHeight = getBottomTabChildHeight(childInfo, childSize);
+
+      if(tabPos == null || childHeight <= 0) {
+         return;
+      }
+
+      int newChildY = tabPos.y - childHeight;
+      Point childPos = childInfo.getPixelOffset();
+
+      if(childPos != null && newChildY != childPos.y) {
+         int dy = newChildY - childPos.y;
+         childInfo.setPixelOffset(new Point(childPos.x, newChildY));
+
+         if(childInfo.getLayoutPosition() != null) {
+            childInfo.getLayoutPosition().translate(0, dy);
+         }
+      }
+   }
+
+   /**
     * Get the effective height for positioning a child in bottom tabs.
     * Dropdown components only show the title bar, so use title height
     * instead of the collapsed pixel height.

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyService.java
@@ -333,7 +333,9 @@ public class VSObjectPropertyService {
       // if script contains binding change, re-process data
       hint = assembly instanceof SelectionVSAssembly ? (hint | hintScript) : hint;
 
-      // reposition bottom tabs when an input child's label affects its visual height
+      // reposition this child in the bottom-tab container when a label
+      // property change alters its effective height. setVSAssemblyInfo uses
+      // copyInfo (not reference storage), so we modify the assembly's own info.
       if(assembly instanceof InputVSAssembly &&
          assembly.getContainer() instanceof TabVSAssembly tabContainer)
       {
@@ -341,7 +343,8 @@ public class VSObjectPropertyService {
             (TabVSAssemblyInfo) tabContainer.getVSAssemblyInfo();
 
          if(tabInfo.getBottomTabsValue() && inputLabelHeightChanged(oinfo, info)) {
-            TabVSAssemblyInfo.repositionForBottomTabs(tabInfo, vs, true);
+            TabVSAssemblyInfo.repositionChildForBottomTabs(
+               tabInfo, assembly.getVSAssemblyInfo(), assembly.getPixelSize());
          }
       }
 

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
@@ -185,6 +185,70 @@ class TabVSAssemblyInfoTest {
       assertEquals(20, TabVSAssemblyInfo.getBottomTabChildHeight(info, size));
    }
 
+   @Test
+   void repositionChildForBottomTabsMovesChildUp() {
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setPixelOffset(new Point(50, 200));
+
+      TextInputVSAssemblyInfo childInfo = new TextInputVSAssemblyInfo();
+      childInfo.setPixelOffset(new Point(50, 170));
+      Dimension childSize = new Dimension(200, 30);
+
+      // no label, child height = 30, tab at 200 → child should be at 170
+      TabVSAssemblyInfo.repositionChildForBottomTabs(tabInfo, childInfo, childSize);
+      assertEquals(170, childInfo.getPixelOffset().y);
+
+      // add top label: child height increases, child should move up
+      LabelInfo labelInfo = childInfo.getLabelInfo();
+      labelInfo.setLabelVisibleValue("true");
+      labelInfo.setLabelPositionValue(LabelInfo.TOP);
+      labelInfo.setLabelGapValue(5);
+      int labelHeight = labelInfo.getRenderedHeight();
+
+      TabVSAssemblyInfo.repositionChildForBottomTabs(tabInfo, childInfo, childSize);
+      assertEquals(200 - (30 + labelHeight + 5), childInfo.getPixelOffset().y);
+
+      // tab bar position unchanged
+      assertEquals(200, tabInfo.getPixelOffset().y);
+   }
+
+   @Test
+   void repositionChildForBottomTabsNoopWhenAligned() {
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setPixelOffset(new Point(50, 150));
+
+      TextInputVSAssemblyInfo childInfo = new TextInputVSAssemblyInfo();
+      childInfo.setPixelOffset(new Point(50, 120));
+      Dimension childSize = new Dimension(200, 30);
+
+      // already aligned: 120 + 30 = 150 = tab y
+      TabVSAssemblyInfo.repositionChildForBottomTabs(tabInfo, childInfo, childSize);
+      assertEquals(120, childInfo.getPixelOffset().y);
+   }
+
+   @Test
+   void repositionChildForBottomTabsUpdatesLayoutPosition() {
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setPixelOffset(new Point(50, 200));
+
+      TextInputVSAssemblyInfo childInfo = new TextInputVSAssemblyInfo();
+      childInfo.setPixelOffset(new Point(50, 180));
+      childInfo.setLayoutPosition(new Point(50, 180));
+      Dimension childSize = new Dimension(200, 30);
+
+      // add label to create height mismatch
+      LabelInfo labelInfo = childInfo.getLabelInfo();
+      labelInfo.setLabelVisibleValue("true");
+      labelInfo.setLabelPositionValue(LabelInfo.BOTTOM);
+      labelInfo.setLabelGapValue(3);
+      int labelHeight = labelInfo.getRenderedHeight();
+      int expectedY = 200 - (30 + labelHeight + 3);
+
+      TabVSAssemblyInfo.repositionChildForBottomTabs(tabInfo, childInfo, childSize);
+      assertEquals(expectedY, childInfo.getPixelOffset().y);
+      assertEquals(expectedY, childInfo.getLayoutPosition().y);
+   }
+
    private VSAssembly mockChild(String name, SelectionBaseVSAssemblyInfo info,
                                 Point offset, Dimension size, int showType)
    {

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
@@ -24,6 +24,7 @@ import org.mockito.Mockito;
 import java.awt.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
 class TabVSAssemblyInfoTest {
@@ -247,6 +248,47 @@ class TabVSAssemblyInfoTest {
       TabVSAssemblyInfo.repositionChildForBottomTabs(tabInfo, childInfo, childSize);
       assertEquals(expectedY, childInfo.getPixelOffset().y);
       assertEquals(expectedY, childInfo.getLayoutPosition().y);
+   }
+
+   @Test
+   void repositionChildForBottomTabsNullTabOffset() {
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setPixelOffset(null);
+
+      TextInputVSAssemblyInfo childInfo = new TextInputVSAssemblyInfo();
+      childInfo.setPixelOffset(new Point(50, 170));
+      Dimension childSize = new Dimension(200, 30);
+
+      TabVSAssemblyInfo.repositionChildForBottomTabs(tabInfo, childInfo, childSize);
+      // child unchanged when tab offset is null
+      assertEquals(170, childInfo.getPixelOffset().y);
+   }
+
+   @Test
+   void repositionChildForBottomTabsNullChildOffset() {
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setPixelOffset(new Point(50, 200));
+
+      TextInputVSAssemblyInfo childInfo = new TextInputVSAssemblyInfo();
+      childInfo.setPixelOffset(null);
+      Dimension childSize = new Dimension(200, 30);
+
+      // no NPE, silently skipped
+      TabVSAssemblyInfo.repositionChildForBottomTabs(tabInfo, childInfo, childSize);
+      assertNull(childInfo.getPixelOffset());
+   }
+
+   @Test
+   void repositionChildForBottomTabsZeroHeight() {
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setPixelOffset(new Point(50, 200));
+
+      TextInputVSAssemblyInfo childInfo = new TextInputVSAssemblyInfo();
+      childInfo.setPixelOffset(new Point(50, 170));
+
+      // null size results in zero height, early return
+      TabVSAssemblyInfo.repositionChildForBottomTabs(tabInfo, childInfo, null);
+      assertEquals(170, childInfo.getPixelOffset().y);
    }
 
    private VSAssembly mockChild(String name, SelectionBaseVSAssemblyInfo info,


### PR DESCRIPTION
- Fix bottom-tab child repositioning so the tab bar stays in place and only the affected input component shifts when a label property changes (visibility, position, gap, or font)
- Fix `setVSAssemblyInfo` uses `copyInfo` (field copy), so post-call modifications to the parameter object had no effect — now modifies the assembly's own stored info
- Extract `TabVSAssemblyInfo.repositionChildForBottomTabs()` static helper for single-child repositioning without recalculating the entire tab layout