### PR TITLE
Bug #74555 - Fix input label positioning in bottom tabs for script and composer

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -4874,6 +4874,20 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
 
          executeScript(assembly);
 
+         // reposition input child in bottom-tab container after script may
+         // have changed label properties (visible, position, gap, font)
+         if(assembly instanceof InputVSAssembly &&
+            assembly.getContainer() instanceof TabVSAssembly tabContainer)
+         {
+            TabVSAssemblyInfo tabInfo =
+               (TabVSAssemblyInfo) tabContainer.getVSAssemblyInfo();
+
+            if(tabInfo.isBottomTabs()) {
+               TabVSAssemblyInfo.repositionChildForBottomTabs(
+                  tabInfo, assembly.getVSAssemblyInfo(), assembly.getPixelSize());
+            }
+         }
+
          // by yanie: bug1412619712845
          // updateHighlight after script execution to make sure the value set
          // via script can be used in highlight in time.

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
@@ -459,7 +459,8 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
     * alters a child's effective height and only that child needs to be
     * adjusted without recalculating the entire tab layout.</p>
     *
-    * @param tabInfo  the bottom-tab info (must have a non-null pixel offset)
+    * @param tabInfo  the bottom-tab info; caller must verify
+    *                 {@code getBottomTabsValue()} is true
     * @param childInfo the child assembly's info to reposition
     * @param childSize the child assembly's pixel size
     */

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
@@ -452,6 +452,42 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
    }
 
    /**
+    * Reposition a single child assembly so its visual bottom edge is flush
+    * with the tab bar's top edge. The tab bar itself is not moved.
+    *
+    * <p>This is useful when a property change (label, show type, size, etc.)
+    * alters a child's effective height and only that child needs to be
+    * adjusted without recalculating the entire tab layout.</p>
+    *
+    * @param tabInfo  the bottom-tab info (must have a non-null pixel offset)
+    * @param childInfo the child assembly's info to reposition
+    * @param childSize the child assembly's pixel size
+    */
+   public static void repositionChildForBottomTabs(TabVSAssemblyInfo tabInfo,
+                                                   VSAssemblyInfo childInfo,
+                                                   Dimension childSize)
+   {
+      Point tabPos = tabInfo.getPixelOffset();
+      int childHeight = getBottomTabChildHeight(childInfo, childSize);
+
+      if(tabPos == null || childHeight <= 0) {
+         return;
+      }
+
+      int newChildY = tabPos.y - childHeight;
+      Point childPos = childInfo.getPixelOffset();
+
+      if(childPos != null && newChildY != childPos.y) {
+         int dy = newChildY - childPos.y;
+         childInfo.setPixelOffset(new Point(childPos.x, newChildY));
+
+         if(childInfo.getLayoutPosition() != null) {
+            childInfo.getLayoutPosition().translate(0, dy);
+         }
+      }
+   }
+
+   /**
     * Get the effective height for positioning a child in bottom tabs.
     * Dropdown components only show the title bar, so use title height
     * instead of the collapsed pixel height.

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
@@ -459,8 +459,8 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
     * alters a child's effective height and only that child needs to be
     * adjusted without recalculating the entire tab layout.</p>
     *
-    * @param tabInfo  the bottom-tab info; caller must verify
-    *                 {@code getBottomTabsValue()} is true
+    * @param tabInfo  the tab info; caller must verify the tab is in
+    *                 bottom-tab mode before calling
     * @param childInfo the child assembly's info to reposition
     * @param childSize the child assembly's pixel size
     */

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyService.java
@@ -342,6 +342,9 @@ public class VSObjectPropertyService {
          TabVSAssemblyInfo tabInfo =
             (TabVSAssemblyInfo) tabContainer.getVSAssemblyInfo();
 
+         // post-setVSAssemblyInfo the assembly info has no rValues, so
+         // runtime-aware accessors in getBottomTabChildHeight are equivalent
+         // to design-time ones here
          if(tabInfo.getBottomTabsValue() && inputLabelHeightChanged(oinfo, info)) {
             TabVSAssemblyInfo.repositionChildForBottomTabs(
                tabInfo, assembly.getVSAssemblyInfo(), assembly.getPixelSize());

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyService.java
@@ -333,7 +333,9 @@ public class VSObjectPropertyService {
       // if script contains binding change, re-process data
       hint = assembly instanceof SelectionVSAssembly ? (hint | hintScript) : hint;
 
-      // reposition bottom tabs when an input child's label affects its visual height
+      // reposition this child in the bottom-tab container when a label
+      // property change alters its effective height. setVSAssemblyInfo uses
+      // copyInfo (not reference storage), so we modify the assembly's own info.
       if(assembly instanceof InputVSAssembly &&
          assembly.getContainer() instanceof TabVSAssembly tabContainer)
       {
@@ -341,7 +343,8 @@ public class VSObjectPropertyService {
             (TabVSAssemblyInfo) tabContainer.getVSAssemblyInfo();
 
          if(tabInfo.getBottomTabsValue() && inputLabelHeightChanged(oinfo, info)) {
-            TabVSAssemblyInfo.repositionForBottomTabs(tabInfo, vs, true);
+            TabVSAssemblyInfo.repositionChildForBottomTabs(
+               tabInfo, assembly.getVSAssemblyInfo(), assembly.getPixelSize());
          }
       }
 

--- a/core/src/main/java/inetsoft/web/viewsheet/model/VSInputModel.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/model/VSInputModel.java
@@ -35,12 +35,17 @@ public abstract class VSInputModel<T extends InputVSAssembly> extends VSObjectMo
 
       LabelInfo labelInfo = assemblyInfo.getLabelInfo();
 
-      if (labelInfo != null) {
+      if(labelInfo != null) {
+         boolean runtime = rvs != null && rvs.isRuntime();
          labelModel = new VSInputLabelModel();
-         labelModel.setShowLabel(labelInfo.isLabelVisible());
-         labelModel.setLabelText(labelInfo.getLabelText());
-         labelModel.setLabelPosition(labelInfo.getLabelPosition());
-         labelModel.setLabelGap(labelInfo.getLabelGap());
+         labelModel.setShowLabel(runtime ? labelInfo.isLabelVisible()
+                                         : labelInfo.getLabelVisibleValue());
+         labelModel.setLabelText(runtime ? labelInfo.getLabelText()
+                                         : labelInfo.getLabelTextValue());
+         labelModel.setLabelPosition(runtime ? labelInfo.getLabelPosition()
+                                              : labelInfo.getLabelPositionValue());
+         labelModel.setLabelGap(runtime ? labelInfo.getLabelGap()
+                                         : labelInfo.getLabelGapValue());
          labelModel.setLabelFormat(new VSFormatModel(labelInfo.getLabelFormat()));
       }
    }

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
@@ -185,6 +185,70 @@ class TabVSAssemblyInfoTest {
       assertEquals(20, TabVSAssemblyInfo.getBottomTabChildHeight(info, size));
    }
 
+   @Test
+   void repositionChildForBottomTabsMovesChildUp() {
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setPixelOffset(new Point(50, 200));
+
+      TextInputVSAssemblyInfo childInfo = new TextInputVSAssemblyInfo();
+      childInfo.setPixelOffset(new Point(50, 170));
+      Dimension childSize = new Dimension(200, 30);
+
+      // no label, child height = 30, tab at 200 → child should be at 170
+      TabVSAssemblyInfo.repositionChildForBottomTabs(tabInfo, childInfo, childSize);
+      assertEquals(170, childInfo.getPixelOffset().y);
+
+      // add top label: child height increases, child should move up
+      LabelInfo labelInfo = childInfo.getLabelInfo();
+      labelInfo.setLabelVisibleValue("true");
+      labelInfo.setLabelPositionValue(LabelInfo.TOP);
+      labelInfo.setLabelGapValue(5);
+      int labelHeight = labelInfo.getRenderedHeight();
+
+      TabVSAssemblyInfo.repositionChildForBottomTabs(tabInfo, childInfo, childSize);
+      assertEquals(200 - (30 + labelHeight + 5), childInfo.getPixelOffset().y);
+
+      // tab bar position unchanged
+      assertEquals(200, tabInfo.getPixelOffset().y);
+   }
+
+   @Test
+   void repositionChildForBottomTabsNoopWhenAligned() {
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setPixelOffset(new Point(50, 150));
+
+      TextInputVSAssemblyInfo childInfo = new TextInputVSAssemblyInfo();
+      childInfo.setPixelOffset(new Point(50, 120));
+      Dimension childSize = new Dimension(200, 30);
+
+      // already aligned: 120 + 30 = 150 = tab y
+      TabVSAssemblyInfo.repositionChildForBottomTabs(tabInfo, childInfo, childSize);
+      assertEquals(120, childInfo.getPixelOffset().y);
+   }
+
+   @Test
+   void repositionChildForBottomTabsUpdatesLayoutPosition() {
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setPixelOffset(new Point(50, 200));
+
+      TextInputVSAssemblyInfo childInfo = new TextInputVSAssemblyInfo();
+      childInfo.setPixelOffset(new Point(50, 180));
+      childInfo.setLayoutPosition(new Point(50, 180));
+      Dimension childSize = new Dimension(200, 30);
+
+      // add label to create height mismatch
+      LabelInfo labelInfo = childInfo.getLabelInfo();
+      labelInfo.setLabelVisibleValue("true");
+      labelInfo.setLabelPositionValue(LabelInfo.BOTTOM);
+      labelInfo.setLabelGapValue(3);
+      int labelHeight = labelInfo.getRenderedHeight();
+      int expectedY = 200 - (30 + labelHeight + 3);
+
+      TabVSAssemblyInfo.repositionChildForBottomTabs(tabInfo, childInfo, childSize);
+      assertEquals(expectedY, childInfo.getPixelOffset().y);
+      assertEquals(expectedY, childInfo.getLayoutPosition().y);
+   }
+
    private VSAssembly mockChild(String name, SelectionBaseVSAssemblyInfo info,
                                 Point offset, Dimension size, int showType)
    {

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
@@ -24,6 +24,7 @@ import org.mockito.Mockito;
 import java.awt.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
 class TabVSAssemblyInfoTest {
@@ -247,6 +248,47 @@ class TabVSAssemblyInfoTest {
       TabVSAssemblyInfo.repositionChildForBottomTabs(tabInfo, childInfo, childSize);
       assertEquals(expectedY, childInfo.getPixelOffset().y);
       assertEquals(expectedY, childInfo.getLayoutPosition().y);
+   }
+
+   @Test
+   void repositionChildForBottomTabsNullTabOffset() {
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setPixelOffset(null);
+
+      TextInputVSAssemblyInfo childInfo = new TextInputVSAssemblyInfo();
+      childInfo.setPixelOffset(new Point(50, 170));
+      Dimension childSize = new Dimension(200, 30);
+
+      TabVSAssemblyInfo.repositionChildForBottomTabs(tabInfo, childInfo, childSize);
+      // child unchanged when tab offset is null
+      assertEquals(170, childInfo.getPixelOffset().y);
+   }
+
+   @Test
+   void repositionChildForBottomTabsNullChildOffset() {
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setPixelOffset(new Point(50, 200));
+
+      TextInputVSAssemblyInfo childInfo = new TextInputVSAssemblyInfo();
+      childInfo.setPixelOffset(null);
+      Dimension childSize = new Dimension(200, 30);
+
+      // no NPE, silently skipped
+      TabVSAssemblyInfo.repositionChildForBottomTabs(tabInfo, childInfo, childSize);
+      assertNull(childInfo.getPixelOffset());
+   }
+
+   @Test
+   void repositionChildForBottomTabsZeroHeight() {
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setPixelOffset(new Point(50, 200));
+
+      TextInputVSAssemblyInfo childInfo = new TextInputVSAssemblyInfo();
+      childInfo.setPixelOffset(new Point(50, 170));
+
+      // null size results in zero height, early return
+      TabVSAssemblyInfo.repositionChildForBottomTabs(tabInfo, childInfo, null);
+      assertEquals(170, childInfo.getPixelOffset().y);
    }
 
    private VSAssembly mockChild(String name, SelectionBaseVSAssemblyInfo info,


### PR DESCRIPTION
- Use design-time label accessors in composer model (VSInputModel) so script-set rValues don't override UI checkbox state in the composer
- Reposition input child after script execution in ViewsheetSandbox so script-set label properties (visible, position, gap) are reflected in the child's position within bottom-tab containers