### PR TITLE
Bug #74548, show confirm password error when password field is edited

### DIFF
--- a/web/projects/em/src/app/settings/security/users/edit-identity-view/edit-identity-view.component.ts
+++ b/web/projects/em/src/app/settings/security/users/edit-identity-view/edit-identity-view.component.ts
@@ -185,7 +185,9 @@ export class EditIdentityViewComponent implements OnInit, OnChanges, OnDestroy {
    {
       this.passwordErrorMatcher = {
          isErrorState: (control: UntypedFormControl | null, form: FormGroupDirective | NgForm | null) =>
-            (!!control?.dirty || !!control?.touched) && !!this.pwForm.errors && !!this.pwForm.errors.passwordsMatch ||
+            (!!control?.dirty || !!control?.touched || !!form?.submitted ||
+             !!(this.pwForm.controls.password?.dirty || this.pwForm.controls.password?.touched)) &&
+            !!this.pwForm.errors?.passwordsMatch ||
             defaultErrorMatcher.isErrorState(control, form)
       };
    }


### PR DESCRIPTION
When creating a new user, the confirm password field now turns red as soon as the user fills in the password field, making it clear that the confirm password field still needs to be filled in.