### PR TITLE
Silence spurious WARN when security chain is empty in EM security provider pages

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/AuthenticationProviderService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/AuthenticationProviderService.java
@@ -216,7 +216,7 @@ public class AuthenticationProviderService extends BaseSubscribeChangHandler imp
       SecurityProviderStatusList.Builder builder = SecurityProviderStatusList.builder();
 
       if(chain.isEmpty()) {
-         LOG.warn("The authentication chain has not been initialized.");
+         LOG.debug("The authentication chain has not been initialized.");
       }
       else {
          chain.get().stream()

--- a/core/src/main/java/inetsoft/web/admin/security/AuthorizationProviderService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/AuthorizationProviderService.java
@@ -44,7 +44,7 @@ public class AuthorizationProviderService {
       SecurityProviderStatusList.Builder builder = SecurityProviderStatusList.builder();
 
       if(!chain.isPresent()) {
-         LOG.warn("The authorization chain has not been initialized.");
+         LOG.debug("The authorization chain has not been initialized.");
       }
       else {
          chain.get().stream()


### PR DESCRIPTION
## Summary

- `AuthenticationProviderService.getProviderListModel()` and `AuthorizationProviderService.getProviderListModel()` logged a `WARN` whenever `getAuthenticationChain()` / `getAuthorizationChain()` returned `Optional.empty()`
- This fires on every navigation to EM → Security → Providers when the chain is in a valid empty state: security just enabled but no providers configured yet, providers failed to instantiate at startup (already logged as `ERROR` in `SecurityChain.loadConfiguration`), or the system is mid-restart
- In all these cases the `VirtualAuthenticationProvider` handles login and the response is correctly an empty list — the warning is misleading noise
- Downgrade both to `DEBUG` so the message is available for diagnostics without polluting production logs

## Test plan

- [ ] Navigate to EM → Security → Authentication Providers with no providers configured — no WARN in logs
- [ ] Navigate to EM → Security → Authorization Providers with no providers configured — no WARN in logs
- [ ] Verify the provider list page still shows correctly (empty list, then providers after adding one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)