### PR TITLE
Bug #74543, ComboBox TOP label not shown in PDF / print layout

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
@@ -1802,8 +1802,24 @@ public class VsToReportConverter {
       if(contentBounds.height <= 0) {
          switch(position) {
             case LabelInfo.TOP:
-               // Cannot grow the section upward; overlap label at the widget's top edge
-               // instead of trying to place it above the allocated band.
+               // For a TOP label, try to place the label in the section that covers the space
+               // immediately above the widget (bounds.y - labelH .. bounds.y). This is typically
+               // the filler section created to preserve vertical spacing before the first assembly.
+               // Returning early skips the addElement0 call below so the label is not double-added.
+               if(bounds.y >= labelH) {
+                  String aboveSection = findSectionContaining(bounds.y - 1);
+
+                  if(aboveSection != null) {
+                     Rectangle topLabelBounds =
+                        new Rectangle(bounds.x, bounds.y - labelH, bounds.width, labelH);
+                     addElement0(topLabelBounds, textbox, aboveSection);
+                     return new Rectangle(bounds.x, bounds.y, bounds.width, bounds.height);
+                  }
+               }
+
+               // No section above to absorb the label; fall back to overlapping the label
+               // with the widget at its top edge (label will be visible if the widget image
+               // is transparent or the report renderer respects element order).
                labelBounds = new Rectangle(bounds.x, bounds.y, bounds.width, labelH);
                break;
             case LabelInfo.BOTTOM:
@@ -2878,6 +2894,23 @@ public class VsToReportConverter {
       for(LayoutSection layout : contentSections) {
          if(name.equals(layout.section.getID())) {
             return layout.bounds;
+         }
+      }
+
+      return null;
+   }
+
+   /**
+    * Find the ID of the content section whose absolute-pixel bounds contain the given
+    * y-coordinate. Returns {@code null} if no section covers that position.
+    */
+   private String findSectionContaining(int absoluteY) {
+      for(LayoutSection layout : contentSections) {
+         int sectionTop = layout.bounds.y;
+         int sectionBottom = layout.bounds.y + layout.bounds.height;
+
+         if(absoluteY >= sectionTop && absoluteY < sectionBottom) {
+            return layout.section.getID();
          }
       }
 

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
@@ -799,6 +799,7 @@ public class VsToReportConverter {
             SectionElementDef filler = createReportSection();
             getSectionContent(filler).setHeight(y / 72f);
             addSection(filler, new Rectangle(0, 0, pwidth, y));
+            fillerSectionIds.add(filler.getID());
             bounds = new Rectangle(0, 0, pwidth, y + height);
          }
 
@@ -838,6 +839,7 @@ public class VsToReportConverter {
                int fillh = y - bounds.y - bounds.height;
                getSectionContent(filler).setHeight(fillh / 72f);
                addSection(filler, new Rectangle(0, bounds.y + bounds.height, pwidth, fillh));
+               fillerSectionIds.add(filler.getID());
             }
 
             innersection = createReportSection();
@@ -1812,14 +1814,15 @@ public class VsToReportConverter {
                   if(aboveSection != null) {
                      Rectangle topLabelBounds =
                         new Rectangle(bounds.x, bounds.y - labelH, bounds.width, labelH);
+                     expandSectionForLabel(aboveSection, topLabelBounds);
                      addElement0(topLabelBounds, textbox, aboveSection);
                      return new Rectangle(bounds.x, bounds.y, bounds.width, bounds.height);
                   }
                }
 
-               // No section above to absorb the label; fall back to overlapping the label
-               // with the widget at its top edge (label will be visible if the widget image
-               // is transparent or the report renderer respects element order).
+               // No filler section found above to absorb the label; fall back to overlapping
+               // the label with the widget at the same bounds. The label will likely be covered
+               // by the opaque widget image (the original bug), but there is no safe alternative.
                labelBounds = new Rectangle(bounds.x, bounds.y, bounds.width, labelH);
                break;
             case LabelInfo.BOTTOM:
@@ -2901,14 +2904,24 @@ public class VsToReportConverter {
    }
 
    /**
-    * Find the ID of the content section whose absolute-pixel bounds contain the given
-    * y-coordinate. Returns {@code null} if no section covers that position.
+    * Find the ID of the filler section (one of the empty spacing sections created by
+    * {@link #createReportSections} to preserve vertical gaps between assemblies) whose
+    * absolute-pixel bounds contain the given y-coordinate.
+    * Returns {@code null} if no filler section covers that position.
+    * Content sections (those holding assembly elements) are intentionally excluded to
+    * prevent a label from being placed inside another assembly's section.
     */
    private String findSectionContaining(int absoluteY) {
       for(LayoutSection layout : contentSections) {
+         if(!fillerSectionIds.contains(layout.section.getID())) {
+            continue;
+         }
+
          int sectionTop = layout.bounds.y;
          int sectionBottom = layout.bounds.y + layout.bounds.height;
 
+         // Sections are abutted with a half-open interval [sectionTop, sectionBottom).
+         // Use (absoluteY < sectionBottom) rather than (<=) to match this convention.
          if(absoluteY >= sectionTop && absoluteY < sectionBottom) {
             return layout.section.getID();
          }
@@ -3028,6 +3041,8 @@ public class VsToReportConverter {
    private TabularSheet report = new TabularSheet();
    // sections used to hold content elements
    private List<LayoutSection> contentSections = new ArrayList<>();
+   // IDs of filler sections (empty spacing sections, not bound to any assembly)
+   private Set<String> fillerSectionIds = new HashSet<>();
    private SectionElementDef headerSection = null; // section of header.
    private SectionElementDef footerSection = null; // section of footer.
    private static HashMap<String, PrintLayout> tempLayouts = new HashMap<>();


### PR DESCRIPTION
## Summary

- When a ComboBox with a TOP-positioned label is exported to PDF (or viewed in print layout), the label was invisible because both the label text box and the widget image were placed at identical coordinates — the opaque widget image rendered second, covering the label.
- Root cause: in `VsToReportConverter.addInputLabel()`, when `contentBounds.height ≤ 0` (widget layout height equals the label height, e.g. the default 20 px), the TOP-label zero-height fallback set `labelBounds = bounds` (same as the widget), so the widget image always covered it.
- Fix: for the TOP label zero-height case, find the report section that spans `bounds.y - labelH .. bounds.y` (the filler section created by `createReportSections()` to preserve vertical spacing above the first assembly) and place the label there instead. Added `findSectionContaining()` helper to locate that section. Falls back to the prior overlap behaviour if no such section exists.

## Test plan

- [ ] Open `combobox_label` viewsheet (has ComboBox with TOP label in print layout).
- [ ] Export to PDF — verify "ComboBox1 laebl" label text appears above the combo widget.
- [ ] Open Print Layout preview — verify label appears above the widget there too.
- [ ] Verify ComboBoxes without labels still export correctly.
- [ ] Verify LEFT/RIGHT/BOTTOM label positions are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)