### PR TITLE
Bug #74544, Slider LEFT/RIGHT label not centered vertically in PDF export

### DIFF
--- a/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
@@ -3881,13 +3881,19 @@ public abstract class AbstractVSExporter implements VSExporter {
             Math.max(0, fullH - labelH - gap));
          break;
       case LabelInfo.RIGHT:
-         labelBounds = new Rectangle2D.Double(x + fullW - labelW, y, labelW, fullH);
+         // Center the label text vertically relative to the widget height,
+         // matching the Angular preview which uses flexbox vertical centering.
+         labelBounds = new Rectangle2D.Double(x + fullW - labelW,
+            y + (fullH - labelH) / 2.0, labelW, labelH);
          widgetBounds = new Rectangle2D.Double(x, y,
             Math.max(0, fullW - labelW - gap), fullH);
          break;
       case LabelInfo.LEFT:
       default:
-         labelBounds = new Rectangle2D.Double(x, y, labelW, fullH);
+         // Center the label text vertically relative to the widget height,
+         // matching the Angular preview which uses flexbox vertical centering.
+         labelBounds = new Rectangle2D.Double(x, y + (fullH - labelH) / 2.0,
+            labelW, labelH);
          widgetBounds = new Rectangle2D.Double(x + labelW + gap, y,
             Math.max(0, fullW - labelW - gap), fullH);
          break;

--- a/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
@@ -3884,7 +3884,7 @@ public abstract class AbstractVSExporter implements VSExporter {
          // Center the label text vertically relative to the widget height,
          // matching the Angular preview which uses flexbox vertical centering.
          labelBounds = new Rectangle2D.Double(x + fullW - labelW,
-            y + (fullH - labelH) / 2.0, labelW, labelH);
+            y + Math.max(0, (fullH - labelH) / 2.0), labelW, labelH);
          widgetBounds = new Rectangle2D.Double(x, y,
             Math.max(0, fullW - labelW - gap), fullH);
          break;
@@ -3892,7 +3892,7 @@ public abstract class AbstractVSExporter implements VSExporter {
       default:
          // Center the label text vertically relative to the widget height,
          // matching the Angular preview which uses flexbox vertical centering.
-         labelBounds = new Rectangle2D.Double(x, y + (fullH - labelH) / 2.0,
+         labelBounds = new Rectangle2D.Double(x, y + Math.max(0, (fullH - labelH) / 2.0),
             labelW, labelH);
          widgetBounds = new Rectangle2D.Double(x + labelW + gap, y,
             Math.max(0, fullW - labelW - gap), fullH);


### PR DESCRIPTION
## Summary

- When a Slider (or other input widget) has a LEFT or RIGHT label and is exported to PDF, the label text appeared at the **top** of the widget's bounds instead of vertically centered, because `AbstractVSExporter.splitInputBounds()` gave the label a full-height rectangle.
- In the Angular preview, LEFT/RIGHT labels are centered by CSS flexbox (`align-items: center`). The PDF exporter had no equivalent centering.
- Fix: for LEFT and RIGHT positions in `splitInputBounds()`, compute a label bounds rectangle that is `labelH` tall and offset by `(fullH - labelH) / 2` from the top, placing the text at the vertical midpoint of the widget — matching the browser preview.

## Test plan

- [ ] Open `slider_label` viewsheet (Slider3 has LEFT label "Slider3 label", Slider4 has RIGHT label "Slider4 label").
- [ ] Export to PDF — verify both labels appear vertically centered next to the slider widget.
- [ ] Verify TOP and BOTTOM label positions are unaffected.
- [ ] Verify ComboBox and other input widgets with LEFT/RIGHT labels also center correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)