### PR TITLE
Bug #74553, LEFT label overlaps widget in Excel export when gap is 0

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
@@ -744,7 +744,7 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
       // For LEFT-positioned labels the widget starts immediately to the right, so cap the
       // extra by the gap to prevent the text box from overlapping the widget when gap is small.
       double extra = LabelInfo.LEFT.equals(labelInfo.getLabelPosition())
-         ? Math.min(30, Math.max(0, labelInfo.getLabelGap()))
+         ? Math.min(30, labelInfo.getLabelGap())
          : 30;
       Rectangle2D padded = new Rectangle2D.Double(
          pixelBounds.getX(), pixelBounds.getY(),

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
@@ -741,9 +741,14 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
    private void writeLabelTextBox(LabelInfo labelInfo, Rectangle2D pixelBounds) {
       // Add extra width so Excel's font metrics (Calibri) don't cause the text to wrap.
       // getLabelDimensions uses Java AWT string width which is narrower than Excel's rendering.
+      // For LEFT-positioned labels the widget starts immediately to the right, so cap the
+      // extra by the gap to prevent the text box from overlapping the widget when gap is small.
+      double extra = LabelInfo.LEFT.equals(labelInfo.getLabelPosition())
+         ? Math.min(30, Math.max(0, labelInfo.getLabelGap()))
+         : 30;
       Rectangle2D padded = new Rectangle2D.Double(
          pixelBounds.getX(), pixelBounds.getY(),
-         pixelBounds.getWidth() + 30, pixelBounds.getHeight());
+         pixelBounds.getWidth() + extra, pixelBounds.getHeight());
       XSSFClientAnchor anchor = (XSSFClientAnchor) getAnchorFromPixelRect(padded);
       XSSFTextBox tb = patriarch.createTextbox(anchor);
       // Default to vertical center to match browser flex-layout; applyFormat overrides if set.


### PR DESCRIPTION
## Summary

- When an input assembly (Slider, Spinner, ComboBox, TextInput) has a LEFT-positioned label with `gap=0` and is exported to Excel, the label text box overlapped the widget image.
- Root cause: `writeLabelTextBox()` unconditionally added 30 px of extra width to compensate for Excel's wider Calibri font metrics. With `gap=0` the widget starts at exactly `labelBounds.maxX`, so the 30 px extension reached 30 px into the widget area.
- Fix: for LEFT-positioned labels, cap the extra width at `Math.min(30, gap)`. With `gap=0` no extra width is added; with `gap ≥ 30` the full 30 px buffer is preserved. RIGHT/TOP/BOTTOM labels are unaffected — their extra width extends away from the widget.

## Test plan

- [ ] Open `label_left` viewsheet (Slider3/Spinner3/ComboBox3/TextInput3 each have LEFT label with `gap=0`).
- [ ] Export to Excel — verify label and widget are adjacent with no overlap.
- [ ] Test with `gap=10` — verify label gets up to 10 px of extra width (no overlap, slight font-metric buffer).
- [ ] Test with `gap=30+` — verify full 30 px buffer is applied.
- [ ] Verify RIGHT/TOP/BOTTOM label positions are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)