### PR TITLE
Bug #74573: Fix Ignite NPE causing thread deadlock when distributed lock times out

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/cluster/DistributedMap.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/DistributedMap.java
@@ -33,11 +33,12 @@ public interface DistributedMap<K, V> extends Map<K, V> {
    void lock(K key);
 
    /**
-    * Acquires the lock for the specified key for the specified lease time.
+    * Acquires the lock for the specified key, waiting up to the specified timeout.
+    * Throws {@link IllegalStateException} if the lock cannot be acquired within the timeout.
     *
     * @param key       the key to lock
-    * @param leaseTime time to wait before releasing the lock
-    * @param timeUnit  unit of time to specify lease time
+    * @param leaseTime maximum time to wait to acquire the lock
+    * @param timeUnit  unit of time for the timeout
     */
    void lock(K key, long leaseTime, TimeUnit timeUnit);
 

--- a/core/src/main/java/inetsoft/sree/internal/cluster/MultiMap.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/MultiMap.java
@@ -150,11 +150,12 @@ public interface MultiMap<K, V> {
    void lock(K key);
 
    /**
-    * Acquires the lock for the specified key for the specified lease time.
+    * Acquires the lock for the specified key, waiting up to the specified timeout.
+    * Throws {@link IllegalStateException} if the lock cannot be acquired within the timeout.
     *
     * @param key       the key to lock
-    * @param leaseTime time to wait before releasing the lock
-    * @param timeUnit  unit of time for the lease time
+    * @param leaseTime maximum time to wait to acquire the lock
+    * @param timeUnit  unit of time for the timeout
     */
    void lock(K key, long leaseTime, TimeUnit timeUnit);
 

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteDistributedMap.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteDistributedMap.java
@@ -164,7 +164,7 @@ public class IgniteDistributedMap<K, V> implements DistributedMap<K, V> {
       // properly, leaving the waiting thread blocked indefinitely.
       while(!lock.tryLock()) {
          if(System.nanoTime() >= deadlineNs) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                "Lock acquisition timed out after " + leaseTime + " " + timeUnit +
                " for key: " + key);
          }

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteDistributedMap.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteDistributedMap.java
@@ -154,10 +154,28 @@ public class IgniteDistributedMap<K, V> implements DistributedMap<K, V> {
 
    @Override
    public void lock(K key, long leaseTime, TimeUnit timeUnit) {
-      try {
-         getLock(key).tryLock(leaseTime, timeUnit);
-      }
-      catch(InterruptedException e) {
+      long deadlineNs = System.nanoTime() + timeUnit.toNanos(leaseTime);
+      Lock lock = getLock(key);
+
+      // Use tryLock() (zero timeout) in a polling loop instead of tryLock(time, unit).
+      // tryLock(time > 0) creates a GridDhtLockFuture with a LockTimeoutObject whose
+      // onTimeout() has a NullPointerException bug in Ignite 2.17.0 when tx is null
+      // (i.e., no active transaction). The NPE prevents the timeout from being handled
+      // properly, leaving the waiting thread blocked indefinitely.
+      while(!lock.tryLock()) {
+         if(System.nanoTime() >= deadlineNs) {
+            throw new RuntimeException(
+               "Lock acquisition timed out after " + leaseTime + " " + timeUnit +
+               " for key: " + key);
+         }
+
+         try {
+            Thread.sleep(LOCK_POLL_INTERVAL_MS);
+         }
+         catch(InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Lock acquisition interrupted for key: " + key, e);
+         }
       }
    }
 
@@ -166,7 +184,18 @@ public class IgniteDistributedMap<K, V> implements DistributedMap<K, V> {
    }
 
    public boolean tryLock(K key, long time, TimeUnit timeunit) throws InterruptedException {
-      return getLock(key).tryLock(time, timeunit);
+      long deadlineNs = System.nanoTime() + timeunit.toNanos(time);
+      Lock lock = getLock(key);
+
+      while(!lock.tryLock()) {
+         if(System.nanoTime() >= deadlineNs) {
+            return false;
+         }
+
+         Thread.sleep(LOCK_POLL_INTERVAL_MS);
+      }
+
+      return true;
    }
 
    @Override
@@ -284,4 +313,5 @@ public class IgniteDistributedMap<K, V> implements DistributedMap<K, V> {
    private final IgniteCache<K, V> cache;
    private final ThreadLocal<Map<K, Lock>> lockMap = ThreadLocal.withInitial(HashMap::new);
    private static final int MAX_RETRIES = 5;
+   private static final long LOCK_POLL_INTERVAL_MS = 200L;
 }

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteMultiMap.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteMultiMap.java
@@ -216,10 +216,28 @@ public class IgniteMultiMap<K, V> implements MultiMap<K, V> {
 
    @Override
    public void lock(K key, long leaseTime, TimeUnit timeUnit) {
-      try {
-         getLock(key).tryLock(leaseTime, timeUnit);
-      }
-      catch(InterruptedException e) {
+      long deadlineNs = System.nanoTime() + timeUnit.toNanos(leaseTime);
+      Lock lock = getLock(key);
+
+      // Use tryLock() (zero timeout) in a polling loop instead of tryLock(time, unit).
+      // tryLock(time > 0) creates a GridDhtLockFuture with a LockTimeoutObject whose
+      // onTimeout() has a NullPointerException bug in Ignite 2.17.0 when tx is null
+      // (i.e., no active transaction). The NPE prevents the timeout from being handled
+      // properly, leaving the waiting thread blocked indefinitely.
+      while(!lock.tryLock()) {
+         if(System.nanoTime() >= deadlineNs) {
+            throw new RuntimeException(
+               "Lock acquisition timed out after " + leaseTime + " " + timeUnit +
+               " for key: " + key);
+         }
+
+         try {
+            Thread.sleep(LOCK_POLL_INTERVAL_MS);
+         }
+         catch(InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Lock acquisition interrupted for key: " + key, e);
+         }
       }
    }
 
@@ -230,7 +248,18 @@ public class IgniteMultiMap<K, V> implements MultiMap<K, V> {
 
    @Override
    public boolean tryLock(K key, long time, TimeUnit timeunit) throws InterruptedException {
-      return getLock(key).tryLock(time, timeunit);
+      long deadlineNs = System.nanoTime() + timeunit.toNanos(time);
+      Lock lock = getLock(key);
+
+      while(!lock.tryLock()) {
+         if(System.nanoTime() >= deadlineNs) {
+            return false;
+         }
+
+         Thread.sleep(LOCK_POLL_INTERVAL_MS);
+      }
+
+      return true;
    }
 
    @Override
@@ -286,4 +315,5 @@ public class IgniteMultiMap<K, V> implements MultiMap<K, V> {
    private final IgniteCache<K, Collection<V>> cache;
    private final ThreadLocal<Map<K, Lock>> lockMap = ThreadLocal.withInitial(HashMap::new);
    private static final int MAX_RETRIES = 5;
+   private static final long LOCK_POLL_INTERVAL_MS = 200L;
 }

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteMultiMap.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteMultiMap.java
@@ -226,7 +226,7 @@ public class IgniteMultiMap<K, V> implements MultiMap<K, V> {
       // properly, leaving the waiting thread blocked indefinitely.
       while(!lock.tryLock()) {
          if(System.nanoTime() >= deadlineNs) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                "Lock acquisition timed out after " + leaseTime + " " + timeUnit +
                " for key: " + key);
          }


### PR DESCRIPTION
## Summary

- Calling `cache.lock(key).tryLock(time > 0, unit)` on a TRANSACTIONAL Ignite 2.17.0 cache creates a `GridDhtLockFuture` with `tx=null` (no active transaction) and registers a `LockTimeoutObject`. When the timeout fires, `onTimeout()` calls `dumpPendingLocks()` which accesses `tx.getClass()` at line 1174 — NPE because `tx` is null.
- The NPE propagates out of `onTimeout()` before `onComplete()` executes, leaving the waiting thread permanently blocked. This surfaces as a user-visible error popup when creating a dashboard.
- Fix: replace `tryLock(time, unit)` with a polling loop using `tryLock()` (zero-timeout). With `timeout=0`, Ignite creates `GridDhtLockFuture` without a `LockTimeoutObject`, bypassing the buggy `onTimeout()` path entirely. Applied to `IgniteDistributedMap` and `IgniteMultiMap`.

Same root cause as #74099 (fix only reached certain feature branches, never merged to main).

## Test plan

- [ ] New user0 & user1, add both to group0
- [ ] Content → Repository: grant group0 R permission
- [ ] Security → Action: grant user1 dashboard tab permission
- [ ] Login portal as user1, switch to dashboard tab
- [ ] New dashboard → select examples/projection → click OK
- [ ] Verify no NPE in server log and no error popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)