### PR TITLE
Bug #74579, Bug #74576 fix unauthorized access when EM user uploads/deletes custom shapes

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceFolderSettingsController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceFolderSettingsController.java
@@ -318,9 +318,9 @@ public class DataSpaceFolderSettingsController {
       String orgShapesDir = ImageShapes.getShapesDirectory();
 
       if(path.equals(globalShapesDir) || path.startsWith(globalShapesDir + "/")) {
-         // Only the exact sentinel path "portal/shapes" with global=false is redirected
-         // to the org shapes dir; sub-paths always write to the global dir
-         if(path.equals(globalShapesDir) && !global) {
+         // When the frontend sends the sentinel path with global=false, the user is
+         // uploading org-scoped shapes, so org-settings permission is sufficient.
+         if(path.equals(globalShapesDir) && !global && SUtil.isMultiTenant()) {
             return securityEngine.checkPermission(principal, ResourceType.EM_COMPONENT,
                   "settings/presentation/settings", ResourceAction.ACCESS) ||
                securityEngine.checkPermission(principal, ResourceType.EM_COMPONENT,

--- a/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceFolderSettingsController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceFolderSettingsController.java
@@ -19,9 +19,6 @@ package inetsoft.web.admin.content.dataspace;
 
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.security.*;
-import inetsoft.uql.XPrincipal;
-import inetsoft.uql.asset.ConfirmException;
-import inetsoft.uql.util.XSessionService;
 import inetsoft.uql.viewsheet.graph.aesthetic.ImageShapes;
 import inetsoft.util.*;
 import inetsoft.util.audit.ActionRecord;
@@ -321,8 +318,9 @@ public class DataSpaceFolderSettingsController {
       String orgShapesDir = ImageShapes.getShapesDirectory();
 
       if(path.equals(globalShapesDir) || path.startsWith(globalShapesDir + "/")) {
-         // global=false means the actual destination is the org shapes dir
-         if(!global) {
+         // Only the exact sentinel path "portal/shapes" with global=false is redirected
+         // to the org shapes dir; sub-paths always write to the global dir
+         if(path.equals(globalShapesDir) && !global) {
             return securityEngine.checkPermission(principal, ResourceType.EM_COMPONENT,
                   "settings/presentation/settings", ResourceAction.ACCESS) ||
                securityEngine.checkPermission(principal, ResourceType.EM_COMPONENT,

--- a/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceFolderSettingsController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceFolderSettingsController.java
@@ -317,12 +317,23 @@ public class DataSpaceFolderSettingsController {
          return false;
       }
 
-      if(ImageShapes.getGlobalShapesDirectory().equals(path)) {
-         if(global) {
+      String globalShapesDir = ImageShapes.getGlobalShapesDirectory();
+      String orgShapesDir = ImageShapes.getShapesDirectory();
+
+      if(path.equals(globalShapesDir) || path.startsWith(globalShapesDir + "/")) {
+         // global=false means the actual destination is the org shapes dir
+         if(!global) {
             return securityEngine.checkPermission(principal, ResourceType.EM_COMPONENT,
-               "settings/presentation/settings", ResourceAction.ACCESS);
+                  "settings/presentation/settings", ResourceAction.ACCESS) ||
+               securityEngine.checkPermission(principal, ResourceType.EM_COMPONENT,
+                  "settings/presentation/org-settings", ResourceAction.ACCESS);
          }
 
+         return securityEngine.checkPermission(principal, ResourceType.EM_COMPONENT,
+            "settings/presentation/settings", ResourceAction.ACCESS);
+      }
+
+      if(path.equals(orgShapesDir) || path.startsWith(orgShapesDir + "/")) {
          return securityEngine.checkPermission(principal, ResourceType.EM_COMPONENT,
                "settings/presentation/settings", ResourceAction.ACCESS) ||
             securityEngine.checkPermission(principal, ResourceType.EM_COMPONENT,

--- a/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceFolderSettingsController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceFolderSettingsController.java
@@ -18,6 +18,7 @@
 package inetsoft.web.admin.content.dataspace;
 
 import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.security.*;
 import inetsoft.uql.XPrincipal;
 import inetsoft.uql.asset.ConfirmException;
 import inetsoft.uql.util.XSessionService;
@@ -25,8 +26,6 @@ import inetsoft.uql.viewsheet.graph.aesthetic.ImageShapes;
 import inetsoft.util.*;
 import inetsoft.util.audit.ActionRecord;
 import inetsoft.util.audit.Audit;
-import inetsoft.sree.security.ResourceAction;
-import inetsoft.sree.security.ResourceType;
 import inetsoft.web.adhoc.DecodeParam;
 import inetsoft.web.admin.content.dataspace.model.DataSpaceFolderSettingsModel;
 import inetsoft.web.admin.content.dataspace.model.DataSpaceFolderUploadModel;
@@ -35,6 +34,7 @@ import inetsoft.web.admin.upload.UploadedFile;
 import inetsoft.web.security.RequiredPermission;
 import inetsoft.web.security.Secured;
 import inetsoft.web.security.auth.ResourceExistsException;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.io.IOUtils;
@@ -55,11 +55,13 @@ public class DataSpaceFolderSettingsController {
    public DataSpaceFolderSettingsController(
       DataSpaceContentSettingsService dataSpaceContentSettingsService,
       DataSpaceFolderSettingsService dataSpaceFolderSettingsService,
-      UploadService uploadService)
+      UploadService uploadService,
+      SecurityEngine securityEngine)
    {
       this.dataSpaceContentSettingsService = dataSpaceContentSettingsService;
       this.dataSpaceFolderSettingsService = dataSpaceFolderSettingsService;
       this.uploadService = uploadService;
+      this.securityEngine = securityEngine;
    }
 
    @Secured(
@@ -152,18 +154,17 @@ public class DataSpaceFolderSettingsController {
       this.dataSpaceContentSettingsService.deleteDataSpaceNode(path, true);
    }
 
-   @Secured(
-      @RequiredPermission(
-         resourceType = ResourceType.EM_COMPONENT,
-         resource = "settings/content/data-space",
-         actions = ResourceAction.ACCESS
-      )
-   )
    @PostMapping("/api/em/content/data-space/folder/upload")
    public void uploadDataSpaceFiles(@RequestBody DataSpaceFolderUploadModel model,
-                                    Principal principal)
+                                    Principal principal,
+                                    HttpServletRequest request)
       throws Exception
    {
+      if(!checkUploadPermission(principal, model.path(), model.global())) {
+         throw new inetsoft.sree.security.SecurityException(
+            "Unauthorized access to resource \"" + request.getRequestURI() + "\" by user " + principal);
+      }
+
       String dir = model.path();
 
       if("portal/shapes".equals(model.path())) {
@@ -306,7 +307,34 @@ public class DataSpaceFolderSettingsController {
       zip.finish();
    }
 
+   private boolean checkUploadPermission(Principal principal, String path, boolean global)
+      throws inetsoft.sree.security.SecurityException
+   {
+      boolean hasEMAccess = securityEngine.checkPermission(
+         principal, ResourceType.EM, "*", ResourceAction.ACCESS);
+
+      if(!hasEMAccess) {
+         return false;
+      }
+
+      if(ImageShapes.getGlobalShapesDirectory().equals(path)) {
+         if(global) {
+            return securityEngine.checkPermission(principal, ResourceType.EM_COMPONENT,
+               "settings/presentation/settings", ResourceAction.ACCESS);
+         }
+
+         return securityEngine.checkPermission(principal, ResourceType.EM_COMPONENT,
+               "settings/presentation/settings", ResourceAction.ACCESS) ||
+            securityEngine.checkPermission(principal, ResourceType.EM_COMPONENT,
+               "settings/presentation/org-settings", ResourceAction.ACCESS);
+      }
+
+      return securityEngine.checkPermission(principal, ResourceType.EM_COMPONENT,
+         "settings/content/data-space", ResourceAction.ACCESS);
+   }
+
    private final DataSpaceContentSettingsService dataSpaceContentSettingsService;
    private final DataSpaceFolderSettingsService dataSpaceFolderSettingsService;
    private final UploadService uploadService;
+   private final SecurityEngine securityEngine;
 }

--- a/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceTreeController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceTreeController.java
@@ -17,24 +17,29 @@
  */
 package inetsoft.web.admin.content.dataspace;
 
-import inetsoft.sree.security.ResourceAction;
-import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.*;
+import inetsoft.uql.viewsheet.graph.aesthetic.ImageShapes;
 import inetsoft.util.MessageException;
 import inetsoft.web.adhoc.DecodeParam;
 import inetsoft.web.admin.content.dataspace.model.*;
 import inetsoft.web.security.RequiredPermission;
 import inetsoft.web.security.Secured;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.Principal;
 import java.util.List;
 
 @RestController
 public class DataSpaceTreeController {
    @Autowired
-   public DataSpaceTreeController(DataSpaceContentSettingsService dataSpaceContentSettingsService) {
+   public DataSpaceTreeController(DataSpaceContentSettingsService dataSpaceContentSettingsService,
+                                   SecurityEngine securityEngine)
+   {
       this.dataSpaceContentSettingsService = dataSpaceContentSettingsService;
+      this.securityEngine = securityEngine;
    }
 
    @Secured(
@@ -101,21 +106,22 @@ public class DataSpaceTreeController {
    /**
     * Delete the selected repository entry
     */
-   @Secured(
-      @RequiredPermission(
-         resourceType = ResourceType.EM_COMPONENT,
-         resource = "settings/content/data-space",
-         actions = ResourceAction.ACCESS
-      )
-   )
    @PostMapping("api/em/content/data-space/tree/delete")
-   public void deleteNodes(@RequestBody DeleteDataSpaceTreeNodesRequest deleteRequest)
-      throws MessageException
+   public void deleteNodes(@RequestBody DeleteDataSpaceTreeNodesRequest deleteRequest,
+                           Principal principal, HttpServletRequest request)
+      throws Exception
    {
       DataSpaceTreeNodeInfo[] nodes = deleteRequest.nodes();
 
       if(nodes == null) {
          return;
+      }
+
+      for(DataSpaceTreeNodeInfo node : nodes) {
+         if(!checkDeletePermission(principal, node.path())) {
+            throw new inetsoft.sree.security.SecurityException(
+               "Unauthorized access to resource \"" + request.getRequestURI() + "\" by user " + principal);
+         }
       }
 
       for(DataSpaceTreeNodeInfo node : nodes) {
@@ -127,5 +133,32 @@ public class DataSpaceTreeController {
       }
    }
 
+   private boolean checkDeletePermission(Principal principal, String path)
+      throws inetsoft.sree.security.SecurityException
+   {
+      if(!securityEngine.checkPermission(principal, ResourceType.EM, "*", ResourceAction.ACCESS)) {
+         return false;
+      }
+
+      String globalShapesDir = ImageShapes.getGlobalShapesDirectory();
+      String orgShapesDir = ImageShapes.getShapesDirectory();
+
+      if(path.equals(globalShapesDir) || path.startsWith(globalShapesDir + "/")) {
+         return securityEngine.checkPermission(principal, ResourceType.EM_COMPONENT,
+            "settings/presentation/settings", ResourceAction.ACCESS);
+      }
+
+      if(path.equals(orgShapesDir) || path.startsWith(orgShapesDir + "/")) {
+         return securityEngine.checkPermission(principal, ResourceType.EM_COMPONENT,
+               "settings/presentation/settings", ResourceAction.ACCESS) ||
+            securityEngine.checkPermission(principal, ResourceType.EM_COMPONENT,
+               "settings/presentation/org-settings", ResourceAction.ACCESS);
+      }
+
+      return securityEngine.checkPermission(principal, ResourceType.EM_COMPONENT,
+         "settings/content/data-space", ResourceAction.ACCESS);
+   }
+
    private final DataSpaceContentSettingsService dataSpaceContentSettingsService;
+   private final SecurityEngine securityEngine;
 }


### PR DESCRIPTION
Users with presentation settings permissions (settings/presentation/settings or settings/presentation/org-settings) were blocked from uploading and deleting custom shapes because the data-space endpoints required the settings/content/data-space permission.

Replace @Secured annotations on the upload and delete endpoints with manual permission checks that allow presentation-permissioned users to act on shape paths, while still requiring settings/content/data-space for all other data-space operations. Global shape uploads/deletes require settings/presentation/settings; org-level shapes accept either presentation permission.