### PR TITLE
Bug #74562, fix Materialize permission check to use WRITE instead of ADMIN

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/MVSupportService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/MVSupportService.java
@@ -188,7 +188,7 @@ public class MVSupportService {
                ResourceType.ASSET : ResourceType.REPORT;
 
             if(!SecurityEngine.getSecurity().checkPermission(
-               principal, resourceType, candidateEntry.getPath(), ResourceAction.ADMIN))
+               principal, resourceType, candidateEntry.getPath(), ResourceAction.WRITE))
             {
                throw new MessageException(Catalog.getCatalog().getString(
                   "em.common.security.no.permission", candidateEntry.getPath()));


### PR DESCRIPTION
MVSupportService.analyze() was checking ResourceAction.ADMIN on each candidate viewsheet/worksheet asset, but the portal only requires WRITE to show the Materialize menu option. Users with repository WRITE access could see the menu item but got a permission error on nested viewsheets they didn't have ADMIN on.