### PR TITLE
Bug #74541 - Input assembly resets to original value on first change after rename

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyService.java
@@ -819,6 +819,8 @@ public class VSObjectPropertyService {
 
       if(vs.renameAssembly(oldName, newName)) {
          rvs.getViewsheetSandbox().resetRuntime();
+         // prevent applyParameterToInput() from overwriting input values after rename
+         rvs.getViewsheetSandbox().markParametersApplied();
          commandDispatcher.sendCommand(containerName, new RenameVSObjectCommand(oldName, newName));
          renameChildAssemblies(oldNames, newName, vs);
          ViewsheetSandbox box = rvs.getViewsheetSandbox();


### PR DESCRIPTION
When an input assembly (slider, combobox, etc.) is renamed via the property dialog, resetRuntime() clears the parametersApplied flag. The subsequent processChange cycle runs reset(initing=true), which causes applyParameterToInput() to overwrite the assembly's selected value with a stale variable-table entry. The second change works because parametersApplied is set by then.

Fix: call markParametersApplied() after resetRuntime() in the rename path, matching the existing pattern in VSBindingService and RuntimeViewsheet.restoreCheckpoint0().