### PR TITLE
Bug #74560, fix navigation loop and distribution permission handling in schedule

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/authz/ComponentAuthorizationController.java
+++ b/core/src/main/java/inetsoft/web/admin/authz/ComponentAuthorizationController.java
@@ -106,11 +106,18 @@ public class ComponentAuthorizationController {
                principal, ResourceType.MATERIALIZATION, "*", ResourceAction.ACCESS);
          }
          else if(authorized && ("settings/schedule/tasks".equals(resource) ||
-            "settings/schedule/cycles".equals(resource))) {
+            "settings/schedule/cycles".equals(resource) ||
+            "settings/schedule/distribution".equals(resource))) {
             // Don't allow access to the tasks tab if they don't have the general scheduler
             // permission. Not a real-world use case, but the testers check it.
             authorized = securityEngine.checkPermission(
                principal, ResourceType.SCHEDULER, "*", ResourceAction.ACCESS);
+
+            if(authorized && "settings/schedule/distribution".equals(resource)) {
+               // Distribution is shown within the tasks page, so tasks must also be permitted.
+               authorized = securityEngine.checkPermission(
+                  principal, ResourceType.EM_COMPONENT, "settings/schedule/tasks", ResourceAction.ACCESS);
+            }
          }
          else if(("settings/presentation/themes".equals(resource) ||
             "settings/security/sso".equals(resource) ||

--- a/core/src/main/java/inetsoft/web/admin/authz/ComponentAuthorizationController.java
+++ b/core/src/main/java/inetsoft/web/admin/authz/ComponentAuthorizationController.java
@@ -108,8 +108,8 @@ public class ComponentAuthorizationController {
          else if(authorized && ("settings/schedule/tasks".equals(resource) ||
             "settings/schedule/cycles".equals(resource) ||
             "settings/schedule/distribution".equals(resource))) {
-            // Don't allow access to the tasks tab if they don't have the general scheduler
-            // permission. Not a real-world use case, but the testers check it.
+            // Don't allow access to schedule sub-tabs (tasks, cycles, distribution) if they
+            // don't have the general scheduler permission. Not a real-world use case, but the testers check it.
             authorized = securityEngine.checkPermission(
                principal, ResourceType.SCHEDULER, "*", ResourceAction.ACCESS);
 

--- a/web/projects/em/src/app/authorization/authorization-guard.service.ts
+++ b/web/projects/em/src/app/authorization/authorization-guard.service.ts
@@ -44,6 +44,7 @@ export class AuthorizationGuard implements CanActivate {
 
             if(!allowed) {
                // find first permitted child and redirect to that
+               // "notification" and "distribution" are API-only permission keys with no Angular route; skip them
                const redirect = Object.keys(p).find(
                   name => p[name] === true && name != "notification" && name != "distribution");
 

--- a/web/projects/em/src/app/authorization/authorization-guard.service.ts
+++ b/web/projects/em/src/app/authorization/authorization-guard.service.ts
@@ -44,7 +44,8 @@ export class AuthorizationGuard implements CanActivate {
 
             if(!allowed) {
                // find first permitted child and redirect to that
-               const redirect = Object.keys(p).find(name => p[name] === true && name != "notification");
+               const redirect = Object.keys(p).find(
+                  name => p[name] === true && name != "notification" && name != "distribution");
 
                if(redirect) {
                   //force orgAdmin redirect to a page that is not external logs

--- a/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.html
+++ b/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.html
@@ -171,7 +171,7 @@
   </mat-card-actions>
 </mat-card>
 
-<mat-card appearance="outlined">
+<mat-card appearance="outlined" *ngIf="distributionVisible">
   <mat-card-header>
     <div class="distribution-title">
       <div>_#(Distribution)</div>

--- a/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.ts
+++ b/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.ts
@@ -280,9 +280,6 @@ export class ScheduleTaskListComponent implements OnInit, AfterViewInit, OnDestr
    }
 
    ngAfterViewInit(): void {
-      if(this.distributionVisible) {
-         this.loadDistributionChart();
-      }
    }
 
    ngOnDestroy(): void {
@@ -893,6 +890,10 @@ export class ScheduleTaskListComponent implements OnInit, AfterViewInit, OnDestr
    }
 
    private loadDistributionChart(): void {
+      if(!this.distributionVisible || !this.chartDiv) {
+         return;
+      }
+
       this.loadingChart = true;
       switch(this.distributionType) {
       case DistributionType.WEEK:

--- a/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.ts
+++ b/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.ts
@@ -49,6 +49,7 @@ import { DomSanitizer, SafeResourceUrl } from "@angular/platform-browser";
 import { ActivatedRoute, ParamMap, Router } from "@angular/router";
 import { Observable, of as observableOf, Subject, throwError, timer } from "rxjs";
 import { catchError, finalize, map, takeUntil, tap } from "rxjs/operators";
+import { AuthorizationService } from "../../../authorization/authorization.service";
 import { GuiTool } from "../../../../../../portal/src/app/common/util/gui-tool";
 import { DownloadService } from "../../../../../../shared/download/download.service";
 import { ScheduleTaskChange } from "../../../../../../shared/schedule/model/schedule-task-change";
@@ -143,13 +144,14 @@ export enum DistributionType {
    ]
 })
 export class ScheduleTaskListComponent implements OnInit, AfterViewInit, OnDestroy {
-   @ViewChild("chartDiv", { static: true }) chartDiv: ElementRef;
+   @ViewChild("chartDiv", { static: false }) chartDiv: ElementRef;
    @ViewChild("redistributeParams") redistributeParams: TemplateRef<any>;
    @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
    @ViewChild(MatSort, { static: true }) sort: MatSort;
    @ViewChild("folderTree") folderTree: ScheduleFolderTreeComponent;
 
    loading: boolean = true;
+   distributionVisible = false;
    tasks: ScheduleTaskModel[] = [];
    expandedElement: ScheduleTaskModel | null;
    selectedNodes: RepositoryFlatNode[] = [];
@@ -210,7 +212,8 @@ export class ScheduleTaskListComponent implements OnInit, AfterViewInit, OnDestr
                private bottomSheet: MatBottomSheet, fb: UntypedFormBuilder,
                defaultErrorMatcher: ErrorStateMatcher,
                private downloadService: DownloadService,
-               private dragService: ScheduleTaskDragService)
+               private dragService: ScheduleTaskDragService,
+               private authzService: AuthorizationService)
    {
       this.redistributeForm = fb.group(
          {
@@ -239,6 +242,14 @@ export class ScheduleTaskListComponent implements OnInit, AfterViewInit, OnDestr
 
    ngOnInit() {
       this.pageTitle.title = "_#(js:Schedule Tasks)";
+
+      this.authzService.getPermissions("settings/schedule").subscribe(p => {
+         this.distributionVisible = !!p.permissions["distribution"];
+
+         if(this.distributionVisible) {
+            setTimeout(() => this.loadDistributionChart());
+         }
+      });
 
       this.http.get(CHANGE_SHOW_TYPE_URI).subscribe(
          (showTasksAsList) => {
@@ -269,7 +280,9 @@ export class ScheduleTaskListComponent implements OnInit, AfterViewInit, OnDestr
    }
 
    ngAfterViewInit(): void {
-      this.loadDistributionChart();
+      if(this.distributionVisible) {
+         this.loadDistributionChart();
+      }
    }
 
    ngOnDestroy(): void {


### PR DESCRIPTION
- Exclude "distribution" from AuthorizationGuard redirect candidates since it is an API-only permission key with no corresponding Angular route, preventing an infinite navigation loop when a user lacks schedule access

- Require SCHEDULER permission and tasks access before marking distribution as authorized in ComponentAuthorizationController, preventing the schedule menu item from appearing when the user only has the distribution API permission

- Hide the distribution chart card in ScheduleTaskListComponent when the user lacks the distribution permission, avoiding a 500 error from the chart API