### PR TITLE
Bug #74566, prevent MV info request when user lacks MV permission

### DIFF
--- a/web/projects/em/src/app/settings/content/repository/repository-viewsheet-settings-view/repository-viewsheet-settings-view.component.html
+++ b/web/projects/em/src/app/settings/content/repository/repository-viewsheet-settings-view/repository-viewsheet-settings-view.component.html
@@ -38,7 +38,9 @@
       </ng-template>
     </mat-tab>
     <mat-tab #mvTab [disabled]="!hasMVPermission" label="_#(MV)">
-      <em-analyze-mv-page #mvPage [nodesToAnalyze]="[editingNode]" (mvChanged)="mvChanged.emit($event)"></em-analyze-mv-page>
+      <ng-template matTabContent>
+        <em-analyze-mv-page #mvPage [nodesToAnalyze]="[editingNode]" (mvChanged)="mvChanged.emit($event)"></em-analyze-mv-page>
+      </ng-template>
     </mat-tab>
   </mat-tab-group>
   <ng-container em-editor-panel-actions>


### PR DESCRIPTION
The em-analyze-mv-page component in the viewsheet settings MV tab was not wrapped in ng-template matTabContent, causing it to instantiate eagerly and fire a POST to /api/em/content/materialized-view/info even when the tab was disabled due to missing MV permission, resulting in a 500 error. Wrap the component in matTabContent for lazy initialization, consistent with the other tabs on this panel.