### PR TITLE
bug-74589: PORTAL InjectionToken duplicate issue

### DIFF
--- a/web/projects/shared/schedule/schedule-task-names.service.ts
+++ b/web/projects/shared/schedule/schedule-task-names.service.ts
@@ -17,12 +17,11 @@
  */
 
 import { HttpClient } from "@angular/common/http";
-import { Inject, Injectable, InjectionToken, OnDestroy, Optional } from "@angular/core";
+import { Inject, Injectable, OnDestroy, Optional } from "@angular/core";
 import { BehaviorSubject, Observable } from "rxjs";
 import { NameLabelTuple } from "../util/name-label-tuple";
 import { ScheduleTaskNamesModel } from "./model/schedule-task-names-model";
-
-export const PORTAL = new InjectionToken<boolean>("PORTAL");
+import { PORTAL } from "./schedule-users.service";
 
 @Injectable()
 export class ScheduleTaskNamesService implements OnDestroy {


### PR DESCRIPTION
Bug Cause:
  schedule-task-names.service.ts declared a duplicate PORTAL InjectionToken, causing injection failure and the portal
  incorrectly calling the restricted EM endpoint.

Solution:  Removed the duplicate PORTAL token definition from schedule-task-names.service.ts and imported it from
  schedule-users.service.ts instead, so the portal correctly calls the authorized /api/portal/schedule/task-names
  endpoint.