### PR TITLE
Bug #74565, renaming a data cycle loses access for non-admin creators

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleCycleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleCycleService.java
@@ -232,6 +232,13 @@ public class ScheduleCycleService {
                }
             }
 
+            // Copy old permission to the new name before removing it, so that the renamed
+            // cycle retains its original permissions. Non-admin users are filtered out of the
+            // permission model returned to the client, so relying solely on the submitted model
+            // would lose their access grants.
+            Permission oldPermission =
+               securityEngine.getPermission(ResourceType.SCHEDULE_CYCLE, getCyclePermissionID(oldName, orgId));
+            securityEngine.setPermission(ResourceType.SCHEDULE_CYCLE, getCyclePermissionID(newName, orgId), oldPermission);
             removeCyclePermission(oldName, orgId);
          }
          else if(newName == null || "".equals(newName)) {
@@ -261,8 +268,7 @@ public class ScheduleCycleService {
          dataCycleManager.setCycleInfo(newName, orgId, cycleInfo);
          dataCycleManager.save();
 
-         if(model.permissionModel() != null &&
-            (model.permissionModel().changed() || !newName.equals(oldName))) {
+         if(model.permissionModel() != null && model.permissionModel().changed()) {
             permissionService.setResourcePermissions(getCyclePermissionID(newName, orgId), ResourceType.SCHEDULE_CYCLE,
                                                      model.permissionModel(), principal);
          }


### PR DESCRIPTION
When a non-admin user renamed a data cycle, the renamed cycle became inaccessible. The permission model returned to the client had an empty grants list (non-admin users are filtered out of the permission table by isIdentityAuthorized), so setResourcePermissions cleared all grants for the new name while the old permission had already been removed.

Fix: copy the old permission directly to the new name before removing it, preserving all grants regardless of client visibility. Only call setResourcePermissions when the user explicitly changed permissions (changed() == true).