### PR TITLE
Bug #74564, don't error when user revokes their own repository folder ADMIN permission

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryFolderService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryFolderService.java
@@ -202,6 +202,10 @@ public class RepositoryFolderService {
                permissionService.updateResourcePermissions(oldPath, newPath, resourceType);
             }
 
+            if(!hasPermission(newPath, resourceType, ResourceAction.ADMIN, principal)) {
+               return null;
+            }
+
             return getSettings(newPath, true, owner, principal);
          }
          finally {
@@ -228,6 +232,10 @@ public class RepositoryFolderService {
          if(actionRecord != null) {
             Audit.getInstance().auditAction(actionRecord, principal);
          }
+      }
+
+      if(!hasPermission(newPath, resourceType, ResourceAction.ADMIN, principal)) {
+         return null;
       }
 
       return getSettings(newPath, false, owner, principal);

--- a/web/projects/em/src/app/settings/content/repository/content-repository-page/content-repository.service.ts
+++ b/web/projects/em/src/app/settings/content/repository/content-repository-page/content-repository.service.ts
@@ -494,6 +494,9 @@ export class ContentRepositoryService implements OnDestroy {
                   return of(null);
                }),
                map(folderModel => {
+                  if(!folderModel) {
+                     return null;
+                  }
 
                   folderModel.folderMeta = this.getEditNodeMetaMap(data);
 

--- a/web/projects/em/src/app/settings/content/repository/content-repository-page/content-repository.service.ts
+++ b/web/projects/em/src/app/settings/content/repository/content-repository-page/content-repository.service.ts
@@ -441,6 +441,10 @@ export class ContentRepositoryService implements OnDestroy {
                   return of(null);
                }),
                map(model => {
+                  if(!model) {
+                     return null;
+                  }
+
                   model.folderMeta = this.getEditNodeMetaMap(data);
 
                   return <ScheduleTaskFolderEditorModel>{
@@ -465,6 +469,10 @@ export class ContentRepositoryService implements OnDestroy {
                   return of(null);
                }),
                map(model => {
+                  if(!model) {
+                     return null;
+                  }
+
                   model.folderMeta = this.getEditNodeMetaMap(data);
 
                   return <DataSourceFolderEditorModel>{


### PR DESCRIPTION
After saving a permission change that removed the caller's own ADMIN access, applySettings() called getSettings() which then failed with a misleading "Permission denied to delete: /" popup. Return null instead so the frontend closes the pane gracefully.

Also fix a pre-existing TypeError when getEditor() mapped a null folderModel.