### PR TITLE
Bug #74593 - Use runtime-aware bottomTabs accessor in layout and export paths

### DIFF
--- a/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
+++ b/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
@@ -1269,7 +1269,7 @@ public final class VSEventUtil {
          throws Exception
    {
       VSAssemblyInfo tabInfo = (VSAssemblyInfo) assembly.getInfo();
-      boolean bottomTabs = ((TabVSAssemblyInfo) tabInfo).getBottomTabsValue();
+      boolean bottomTabs = ((TabVSAssemblyInfo) tabInfo).isBottomTabs();
 
       // for bottom tabs, getLayoutPosition() returns the tab bar position
       // (set by AbstractLayout.applyTab as npos.y + contentHeight)

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
@@ -573,7 +573,9 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
     * Returns the effective bottomTabs value, reflecting the runtime value if set,
     * otherwise the design-time value. Callers in the Composer (design-time) context
     * should prefer {@link #getBottomTabsValue()} to avoid reading a stale runtime
-    * override.
+    * override, except for layout/export paths (e.g. {@code VSLayoutService},
+    * {@code AbstractLayout}, {@code VSEventUtil}) which need the runtime-effective
+    * value even in the composer.
     */
    public boolean isBottomTabs() {
       Object rval = bottomTabs.getRValue();

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
@@ -570,12 +570,11 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
    }
 
    /**
-    * Returns the effective bottomTabs value, reflecting the runtime value if set,
-    * otherwise the design-time value. Callers in the Composer (design-time) context
-    * should prefer {@link #getBottomTabsValue()} to avoid reading a stale runtime
-    * override, except for layout/export paths (e.g. {@code VSLayoutService},
-    * {@code AbstractLayout}, {@code VSEventUtil}) which need the runtime-effective
-    * value even in the composer.
+    * Returns the effective {@code bottomTabs} value: the runtime (script-set) value
+    * if present, otherwise the design-time value. Use this method in all layout,
+    * export, and rendering paths. Callers that specifically need the raw design-time
+    * value (e.g. property dialog editors) should use {@link #getBottomTabsValue()}
+    * instead.
     */
    public boolean isBottomTabs() {
       Object rval = bottomTabs.getRValue();

--- a/core/src/main/java/inetsoft/uql/viewsheet/vslayout/AbstractLayout.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/vslayout/AbstractLayout.java
@@ -408,7 +408,7 @@ public abstract class AbstractLayout implements AssetObject {
     */
    private void applyTab(TabVSAssembly vsassembly, Point npos, Dimension nsize) {
       TabVSAssemblyInfo tabInfo = (TabVSAssemblyInfo) vsassembly.getVSAssemblyInfo();
-      boolean bottomTabs = tabInfo.getBottomTabsValue();
+      boolean bottomTabs = tabInfo.isBottomTabs();
       Dimension tabSize = getSize(vsassembly);
       Dimension osize = getComponentSize(vsassembly);
       int contentHeight = nsize.height - tabSize.height;

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
@@ -421,7 +421,6 @@ public class VSLayoutService {
 
       VSObjectModel objectModel = null;
       boolean isBottomTabs = assembly instanceof TabVSAssembly &&
-
          ((TabVSAssemblyInfo) assembly.getInfo()).isBottomTabs();
 
       if(assembly != null) {
@@ -430,8 +429,8 @@ public class VSLayoutService {
 
          // sync dValue on the clone so VSTabModel (which reads dValue in
          // composer mode) is consistent with the positioning logic
-         if(isBottomTabs) {
-            ((TabVSAssemblyInfo) assembly.getInfo()).setBottomTabsValue(true);
+         if(assembly instanceof TabVSAssembly) {
+            ((TabVSAssemblyInfo) assembly.getInfo()).setBottomTabsValue(isBottomTabs);
          }
 
          objectModel = objectModelService.createModel(assembly, rvs);

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
@@ -420,8 +420,7 @@ public class VSLayoutService {
       }
 
       VSObjectModel objectModel = null;
-      boolean isBottomTabs = assembly instanceof TabVSAssembly &&
-         ((TabVSAssemblyInfo) assembly.getInfo()).isBottomTabs();
+      boolean isBottomTabs = false;
 
       if(assembly != null) {
          assembly.getInfo().setVisible(true);
@@ -429,8 +428,11 @@ public class VSLayoutService {
 
          // sync dValue on the clone so VSTabModel (which reads dValue in
          // composer mode) is consistent with the positioning logic
-         if(assembly instanceof TabVSAssembly) {
-            ((TabVSAssemblyInfo) assembly.getInfo()).setBottomTabsValue(isBottomTabs);
+         if(assembly instanceof TabVSAssembly tabAssembly) {
+            TabVSAssemblyInfo tabInfoClone =
+               (TabVSAssemblyInfo) tabAssembly.getInfo();
+            isBottomTabs = tabInfoClone.isBottomTabs();
+            tabInfoClone.setBottomTabsValue(isBottomTabs);
          }
 
          objectModel = objectModelService.createModel(assembly, rvs);

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
@@ -421,11 +421,19 @@ public class VSLayoutService {
 
       VSObjectModel objectModel = null;
       boolean isBottomTabs = assembly instanceof TabVSAssembly &&
-         ((TabVSAssemblyInfo) assembly.getInfo()).getBottomTabsValue();
+
+         ((TabVSAssemblyInfo) assembly.getInfo()).isBottomTabs();
 
       if(assembly != null) {
          assembly.getInfo().setVisible(true);
          rvs.getViewsheet().getLayoutInfo().getPrintLayout();
+
+         // sync dValue on the clone so VSTabModel (which reads dValue in
+         // composer mode) is consistent with the positioning logic
+         if(isBottomTabs) {
+            ((TabVSAssemblyInfo) assembly.getInfo()).setBottomTabsValue(true);
+         }
+
          objectModel = objectModelService.createModel(assembly, rvs);
 
          if(assembly instanceof TabVSAssembly ||

--- a/core/src/test/java/inetsoft/web/composer/vs/controller/VSLayoutServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/controller/VSLayoutServiceTest.java
@@ -186,6 +186,42 @@ class VSLayoutServiceTest {
    }
 
    @Test
+   void scriptOverrideToNonBottomTabsPositionedCorrectly() {
+      Viewsheet vs = new Viewsheet();
+
+      // dValue=true (UI), rValue=false (script override)
+      TabVSAssembly tab = new TabVSAssembly(vs, "Tab1");
+      TabVSAssemblyInfo tabInfo = (TabVSAssemblyInfo) tab.getInfo();
+      tabInfo.setBottomTabsValue(true);
+      tabInfo.setBottomTabs(false);
+
+      TextVSAssembly child = new TextVSAssembly(vs, "Text1");
+      vs.addAssembly(child);
+      vs.addAssembly(tab);
+      tab.setAssemblies(new String[]{"Text1"});
+
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      VSObjectModel tabModel = mockObjectModel();
+      VSObjectModel childModel = mockObjectModel();
+      childModel.getObjectFormat().setPositions(0, 0, 200, 80);
+
+      when(objectModelService.createModel(any(TabVSAssembly.class), eq(rvs))).thenReturn(tabModel);
+      when(objectModelService.createModel(any(TextVSAssembly.class), eq(rvs)))
+         .thenReturn(childModel);
+
+      int layoutY = 300;
+      VSAssemblyLayout layout = new VSAssemblyLayout(
+         "Tab1", new Point(50, layoutY), new Dimension(400, 30));
+
+      VSLayoutObjectModel result = service.createObjectModel(rvs, layout, objectModelService);
+
+      // rValue=false overrides dValue=true, so top tabs behavior
+      assertEquals(layoutY, result.top(),
+         "model top should not be shifted for script-overridden non-bottom tabs");
+   }
+
+   @Test
    void nonBottomTabsTopNotShifted() {
       Viewsheet vs = new Viewsheet();
 

--- a/core/src/test/java/inetsoft/web/composer/vs/controller/VSLayoutServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/controller/VSLayoutServiceTest.java
@@ -219,6 +219,10 @@ class VSLayoutServiceTest {
       // rValue=false overrides dValue=true, so top tabs behavior
       assertEquals(layoutY, result.top(),
          "model top should not be shifted for script-overridden non-bottom tabs");
+
+      // children should not be repositioned for non-bottom-tabs
+      assertEquals(0, (int) childModel.getObjectFormat().getTop(),
+         "child top should not be changed for non-bottom-tabs");
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/composer/vs/controller/VSLayoutServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/controller/VSLayoutServiceTest.java
@@ -146,6 +146,46 @@ class VSLayoutServiceTest {
    }
 
    @Test
+   void scriptSetBottomTabsPositionedCorrectly() {
+      Viewsheet vs = new Viewsheet();
+
+      // tab assembly with bottomTabs set via script (rValue only, dValue=false)
+      TabVSAssembly tab = new TabVSAssembly(vs, "Tab1");
+      TabVSAssemblyInfo tabInfo = (TabVSAssemblyInfo) tab.getInfo();
+      tabInfo.setBottomTabs(true);
+
+      TextVSAssembly child = new TextVSAssembly(vs, "Text1");
+      vs.addAssembly(child);
+      vs.addAssembly(tab);
+      tab.setAssemblies(new String[]{"Text1"});
+
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      int childHeight = 80;
+      VSObjectModel tabModel = mockObjectModel();
+      VSObjectModel childModel = mockObjectModel();
+      childModel.getObjectFormat().setPositions(0, 0, 200, childHeight);
+
+      when(objectModelService.createModel(any(TabVSAssembly.class), eq(rvs))).thenReturn(tabModel);
+      when(objectModelService.createModel(any(TextVSAssembly.class), eq(rvs)))
+         .thenReturn(childModel);
+
+      int layoutX = 100;
+      int layoutY = 300;
+      VSAssemblyLayout layout = new VSAssemblyLayout(
+         "Tab1", new Point(layoutX, layoutY), new Dimension(400, 30));
+
+      VSLayoutObjectModel result = service.createObjectModel(rvs, layout, objectModelService);
+
+      assertEquals(layoutY, result.top());
+      assertEquals(layoutX, result.left());
+
+      // child positioned at the visual top, same as dValue-set bottom tabs
+      assertEquals(layoutX, (int) childModel.getObjectFormat().getLeft());
+      assertEquals(layoutY, (int) childModel.getObjectFormat().getTop());
+   }
+
+   @Test
    void nonBottomTabsTopNotShifted() {
       Viewsheet vs = new Viewsheet();
 


### PR DESCRIPTION
Three layout/export code paths read the design-time value (getBottomTabsValue) for the bottomTabs property, ignoring script-set runtime values:

- AbstractLayout.applyTab() — print layout application
- VSEventUtil.applyTabScale() — device layout scale-to-screen
- VSLayoutService.createObjectModel() — composer print layout preview

Switched all three to isBottomTabs(), which checks the runtime value first and falls back to the design-time value. In createObjectModel(), the clone's dValue is synced to match the effective value so VSTabModel (which reads dValue in composer mode) stays consistent with the positioning logic.

Added a test verifying correct positioning when bottomTabs is set via script (rValue) with the design-time value left as default.