### PR TITLE
Bug #74577, fix NPE when uninstalling multiple plugins with one failure

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/plugins/PluginsService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/plugins/PluginsService.java
@@ -170,31 +170,24 @@ public class PluginsService {
       ArrayList<PluginModel> pluginsList = new ArrayList<>(model.plugins());
       String actionName = ActionRecord.ACTION_NAME_DELETE;
       String objectType = ActionRecord.OBJECT_TYPE_PLUG;
-      Timestamp actionTimestamp = new Timestamp(System.currentTimeMillis());
-      ActionRecord actionRecord = new ActionRecord(SUtil.getUserName(principal), actionName, null,
-                                                   objectType, actionTimestamp,
-                                                   ActionRecord.ACTION_STATUS_FAILURE, null);
 
       for(PluginModel plugin : pluginsList) {
-         if(actionRecord != null) {
-            String objectName = plugin.name() == null ? "" : plugin.name();
-            actionRecord.setObjectName(objectName);
-         }
+         String objectName = plugin.name() == null ? "" : plugin.name();
+         Timestamp actionTimestamp = new Timestamp(System.currentTimeMillis());
+         ActionRecord actionRecord = new ActionRecord(SUtil.getUserName(principal), actionName,
+                                                      objectName, objectType, actionTimestamp,
+                                                      ActionRecord.ACTION_STATUS_FAILURE, null);
 
          try {
             Config.removePlugin(plugins.getPlugin(plugin.id()));
             plugins.uninstallPlugin(plugin.id());
             actionRecord.setActionStatus(ActionRecord.ACTION_STATUS_SUCCESS);
-
          }
          catch(IOException e) {
-            actionRecord = null;
             LOG.warn("There was an error uninstalling plugin: " + plugin.name());
          }
          finally {
-            if(actionRecord != null) {
-               Audit.getInstance().auditAction(actionRecord, principal);
-            }
+            Audit.getInstance().auditAction(actionRecord, principal);
          }
       }
    }


### PR DESCRIPTION
When uninstalling a list of plugins, an IOException on one plugin set the shared actionRecord to null. Subsequent iterations then hit a NPE calling actionRecord.setActionStatus() without a null check.

Fix by creating a per-plugin ActionRecord inside the loop so each uninstall is audited independently and a failure on one plugin does not affect the others.