### PR TITLE
Bug #74606, fix admin login failing when a custom security provider chain is active

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
+++ b/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
@@ -107,7 +107,6 @@ public class SecurityEngine implements SessionListener, MessageListener, AutoClo
 
          if(!authcChain.getProviders().isEmpty() && !authzChain.getProviders().isEmpty()) {
             provider = CompositeSecurityProvider.create(authcChain, authzChain);
-            migrateSiteAdminToChain(authcChain);
          }
          else {
             authcChain.tearDown();
@@ -204,9 +203,8 @@ public class SecurityEngine implements SessionListener, MessageListener, AutoClo
 
    /**
     * Ensures the virtual site admin ({@code admin^<defaultOrg>}) exists in the primary
-    * authentication provider of the given chain. This is a no-op after the first run because
-    * {@code getUser} returns non-null once the user has been stored. It handles legacy
-    * installations and chains created before this migration was added.
+    * authentication provider of the given chain so that admin login works when a custom
+    * security provider chain is active.
     */
    private void migrateSiteAdminToChain(AuthenticationChain authcChain) {
       if(vprovider == null || authcChain.getProviders().isEmpty()) {

--- a/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
+++ b/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
@@ -107,6 +107,7 @@ public class SecurityEngine implements SessionListener, MessageListener, AutoClo
 
          if(!authcChain.getProviders().isEmpty() && !authzChain.getProviders().isEmpty()) {
             provider = CompositeSecurityProvider.create(authcChain, authzChain);
+            migrateSiteAdminToChain(authcChain);
          }
          else {
             authcChain.tearDown();
@@ -219,7 +220,8 @@ public class SecurityEngine implements SessionListener, MessageListener, AutoClo
 
       IdentityID siteAdminId = new IdentityID("admin", Organization.getDefaultOrganizationID());
       boolean alreadyPresent = primary.getUser(siteAdminId) != null;
-      boolean envVarSet = System.getenv("INETSOFT_ADMIN_PASSWORD") != null;
+      String envVar = System.getenv("INETSOFT_ADMIN_PASSWORD");
+      boolean envVarSet = envVar != null && !envVar.isBlank();
 
       // When the env var is set it acts as a recovery mechanism: always update the File
       // provider so a corrupted or unknown password can be reset without wiping data.
@@ -266,6 +268,7 @@ public class SecurityEngine implements SessionListener, MessageListener, AutoClo
 
       if(!authcChain.getProviders().isEmpty() && !authzChain.getProviders().isEmpty()) {
          provider = CompositeSecurityProvider.create(authcChain, authzChain);
+         migrateSiteAdminToChain(authcChain);
          authcChain.addAuthenticationChangeListener(authzChain);
          authcChain.addAuthenticationChangeListener(this::fireAuthenticationChange);
       }

--- a/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
+++ b/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
@@ -107,6 +107,7 @@ public class SecurityEngine implements SessionListener, MessageListener, AutoClo
 
          if(!authcChain.getProviders().isEmpty() && !authzChain.getProviders().isEmpty()) {
             provider = CompositeSecurityProvider.create(authcChain, authzChain);
+            migrateSiteAdminToChain(authcChain);
          }
          else {
             authcChain.tearDown();
@@ -201,6 +202,39 @@ public class SecurityEngine implements SessionListener, MessageListener, AutoClo
       return result;
    }
 
+   /**
+    * Ensures the virtual site admin ({@code admin^<defaultOrg>}) exists in the primary
+    * authentication provider of the given chain. This is a no-op after the first run because
+    * {@code getUser} returns non-null once the user has been stored. It handles legacy
+    * installations and chains created before this migration was added.
+    */
+   private void migrateSiteAdminToChain(AuthenticationChain authcChain) {
+      if(vprovider == null || authcChain.getProviders().isEmpty()) {
+         return;
+      }
+
+      AuthenticationProvider primary = authcChain.getProviders().get(0);
+
+      if(!(primary instanceof EditableAuthenticationProvider editablePrimary)) {
+         return;
+      }
+
+      IdentityID siteAdminId = new IdentityID("admin", Organization.getDefaultOrganizationID());
+      boolean alreadyPresent = primary.getUser(siteAdminId) != null;
+      boolean envVarSet = System.getenv("INETSOFT_ADMIN_PASSWORD") != null;
+
+      // When the env var is set it acts as a recovery mechanism: always update the File
+      // provider so a corrupted or unknown password can be reset without wiping data.
+      // When not set, only add the admin if it is missing (first-time migration).
+      if(!alreadyPresent || envVarSet) {
+         User virtualAdmin = vprovider.getAuthenticationProvider().getUser(siteAdminId);
+
+         if(virtualAdmin != null) {
+            editablePrimary.addUser(virtualAdmin);
+         }
+      }
+   }
+
    public void newChain() {
       AuthenticationChain authcChain = new AuthenticationChain();
       List<AuthenticationProvider> authcProviders = authcChain.getProviderList();
@@ -208,6 +242,7 @@ public class SecurityEngine implements SessionListener, MessageListener, AutoClo
       authcProvider.setProviderName("Primary");
       authcProviders.add(authcProvider);
       authcChain.setProviders(authcProviders);
+      migrateSiteAdminToChain(authcChain);
 
       AuthorizationChain authzChain = new AuthorizationChain();
       List<AuthorizationProvider> authzProviders = authzChain.getProviderList();

--- a/core/src/main/java/inetsoft/sree/security/VirtualAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/VirtualAuthenticationProvider.java
@@ -91,6 +91,8 @@ public class VirtualAuthenticationProvider
       String algorithm =
          admin.getPasswordAlgorithm() == null ? "MD5" : admin.getPasswordAlgorithm();
       return Objects.equals(userIdentity.name, admin.getName()) &&
+         (userIdentity.orgID == null ||
+          Organization.getDefaultOrganizationID().equals(userIdentity.orgID)) &&
          Objects.equals(userid.name, admin.getName()) &&
          Tool.checkHashedPassword(
             admin.getPassword(), passwd, algorithm, admin.getPasswordSalt(),
@@ -137,7 +139,10 @@ public class VirtualAuthenticationProvider
     */
    @Override
    public User getUser(IdentityID userIdentity) {
-      if("admin".equals(userIdentity.name)) {
+      if("admin".equals(userIdentity.name) &&
+         (userIdentity.orgID == null ||
+          Organization.getDefaultOrganizationID().equals(userIdentity.orgID)))
+      {
          return admin;
       }
 
@@ -254,6 +259,22 @@ public class VirtualAuthenticationProvider
       catch(Exception ex) {
          LOG.error("Failed to load virtual security file: " + fileName, ex);
       }
+
+      // If INETSOFT_ADMIN_PASSWORD is set, sync the stored password to match the env var.
+      // This allows the env var to serve as a recovery mechanism when the stored password
+      // has become corrupted or is otherwise unknown.
+      String envPassword = System.getenv("INETSOFT_ADMIN_PASSWORD");
+
+      if(envPassword != null && !envPassword.isBlank()) {
+         try {
+            SUtil.setPassword(admin, AdminCredentialUtil.getRequiredAdminPassword());
+            save();
+            LOG.info("INETSOFT_ADMIN_PASSWORD is set; admin password synced from environment variable.");
+         }
+         catch(Exception e) {
+            LOG.warn("INETSOFT_ADMIN_PASSWORD is set but could not be applied: {}", e.getMessage());
+         }
+      }
    }
 
    /**
@@ -263,7 +284,9 @@ public class VirtualAuthenticationProvider
     */
    @Override
    public void addUser(User user) {
-      if(user.getName().equals("admin")) {
+      if(user.getName().equals("admin") &&
+         Organization.getDefaultOrganizationID().equals(user.getIdentityID().orgID))
+      {
          admin = (FSUser) user;
          save();
       }

--- a/core/src/main/java/inetsoft/sree/security/VirtualAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/VirtualAuthenticationProvider.java
@@ -269,10 +269,11 @@ public class VirtualAuthenticationProvider
          try {
             SUtil.setPassword(admin, AdminCredentialUtil.getRequiredAdminPassword());
             save();
-            LOG.info("INETSOFT_ADMIN_PASSWORD is set; admin password synced from environment variable.");
+            LOG.debug("INETSOFT_ADMIN_PASSWORD is set; admin password synced from environment variable.");
          }
          catch(Exception e) {
-            LOG.warn("INETSOFT_ADMIN_PASSWORD is set but could not be applied: {}", e.getMessage());
+            LOG.warn("INETSOFT_ADMIN_PASSWORD is set but could not be applied: {}. " +
+                     "Ensure the password meets strength requirements.", e.getMessage());
          }
       }
    }
@@ -285,7 +286,8 @@ public class VirtualAuthenticationProvider
    @Override
    public void addUser(User user) {
       if(user.getName().equals("admin") &&
-         Organization.getDefaultOrganizationID().equals(user.getIdentityID().orgID))
+         Organization.getDefaultOrganizationID().equals(user.getIdentityID().orgID) &&
+         user instanceof FSUser)
       {
          admin = (FSUser) user;
          save();

--- a/core/src/main/resources/inetsoft/web/resources/js/login.js
+++ b/core/src/main/resources/inetsoft/web/resources/js/login.js
@@ -16,6 +16,25 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 function initLoginView(requestedUrl, sessionExpired, defaultErrorMessage, gatewayErrorMessage, currentUser, onloadError) {
+   // Normalize requestedUrl to the current page's origin.  This handles the case where the
+   // server (behind a proxy that strips the subdomain) embeds a requestedUrl pointing to the
+   // host-org origin (e.g. localhost:8080) while the login page itself is served from
+   // org0.localhost:8080.  If left uncorrected the AJAX auth call and post-login redirect
+   // would both target the wrong origin, causing CORS failures and session loss.
+   try {
+      var _target = new URL(requestedUrl, window.location.href);
+
+      if(_target.origin !== window.location.origin) {
+         _target.protocol = window.location.protocol;
+         _target.hostname = window.location.hostname;
+         _target.port = window.location.port;
+         requestedUrl = _target.toString();
+      }
+   }
+   catch(e) {
+      // ignore — use requestedUrl as-is if URL parsing fails
+   }
+
    var $userNameField = $("#loginUserName");
    var $userNameError = $("#userNameError");
 


### PR DESCRIPTION
## Root Cause

Three interlocking issues caused the admin login to fail when a custom security provider chain was active:

**1. `VirtualAuthenticationProvider` matched admin for any org**
`authenticate()` and `getUser()` accepted any `IdentityID` with `name == "admin"` regardless of `orgID`. When a chained provider looked up `admin^<customOrg>`, the virtual provider incorrectly claimed to own that user, short-circuiting authentication before the real provider could handle it.

**2. `SecurityEngine` never seeded the virtual admin into the chain**
When `init()` constructed a security chain or `newChain()` was called, the virtual site admin (`admin^<defaultOrg>`) was never copied into the primary `EditableAuthenticationProvider`. The admin user was therefore invisible to the chain and authentication always failed.

**3. `login.js` sent the auth request to the wrong origin**
Behind a subdomain-stripping reverse proxy, the `requestedUrl` embedded in the login page pointed to the host origin (e.g. `localhost:8080`) while the login page itself was served from the org-subdomain origin (e.g. `org0.localhost:8080`). The AJAX auth call and post-login redirect both targeted the wrong origin, causing CORS failures and session loss.

## Fix

### `VirtualAuthenticationProvider`
- Guard `authenticate()`, `getUser()`, and `addUser()` to only match `admin^<defaultOrg>` (or `null` org for legacy callers that don't pass an org).
- On `loadFile()`, if `INETSOFT_ADMIN_PASSWORD` is set, sync the stored password from the env var so it acts as a recovery mechanism for corrupted or unknown passwords — without wiping any other data.

### `SecurityEngine`
- Add `migrateSiteAdminToChain(AuthenticationChain)`: copies the virtual admin user from `VirtualAuthenticationProvider` into the primary `EditableAuthenticationProvider` of the given chain. Called from both `init()` (for loaded chains) and `newChain()` (for newly constructed chains).
- After the first run this is a no-op because `getUser()` returns non-null once the user is stored.

### `login.js`
- At the top of `initLoginView()`, normalize `requestedUrl` to the current page's origin by replacing the protocol, hostname, and port with `window.location`'s values. This ensures the AJAX auth call and post-login redirect always target the correct subdomain origin regardless of what the server embedded in the URL.

## Test Plan
- [ ] Log in as `admin` with security disabled — should work unchanged
- [ ] Log in as `admin` with a single File security provider — should work unchanged
- [ ] Log in as `admin` with a custom security provider chain active — should now succeed
- [ ] Set `INETSOFT_ADMIN_PASSWORD` env var; restart server with an existing security chain — admin password should be synced from env var and login should succeed
- [ ] Multi-tenant setup with org subdomain behind reverse proxy — login page should redirect to correct origin after authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)