### PR TITLE
Bug #74597, fix EM repository permission check for user-scoped assets

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/ContentRepositoryTreeService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/ContentRepositoryTreeService.java
@@ -2005,8 +2005,29 @@ public class ContentRepositoryTreeService {
       };
    }
 
-   public boolean checkUserPermission(IdentityID user, Principal principal) {
-      if(principal == null) {
+   void checkSheetPermission(int scope, IdentityID ownerID, String path,
+                             ResourceType nonUserScopeType, Principal principal)
+      throws inetsoft.sree.security.SecurityException
+   {
+      if(scope == AssetRepository.USER_SCOPE) {
+         if(!checkUserPermission(ownerID, principal) ||
+            !SecurityEngine.getSecurity().checkPermission(
+               principal, ResourceType.MY_DASHBOARDS, "*", ResourceAction.READ))
+         {
+            throw new MessageException(Catalog.getCatalog().getString(
+               "em.common.security.no.permission", path));
+         }
+      }
+      else if(!SecurityEngine.getSecurity().checkPermission(
+                 principal, nonUserScopeType, path, ResourceAction.ADMIN))
+      {
+         throw new MessageException(Catalog.getCatalog().getString(
+            "em.common.security.no.permission", path));
+      }
+   }
+
+   private boolean checkUserPermission(IdentityID user, Principal principal) {
+      if(principal == null || user == null) {
          return false;
       }
 

--- a/core/src/main/java/inetsoft/web/admin/content/repository/ContentRepositoryTreeService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/ContentRepositoryTreeService.java
@@ -2005,7 +2005,7 @@ public class ContentRepositoryTreeService {
       };
    }
 
-   private boolean checkUserPermission(IdentityID user, Principal principal) {
+   public boolean checkUserPermission(IdentityID user, Principal principal) {
       if(principal == null) {
          return false;
       }

--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryViewsheetController.java
@@ -19,7 +19,6 @@ package inetsoft.web.admin.content.repository;
 
 import inetsoft.sree.security.*;
 import inetsoft.uql.asset.AssetEntry;
-import inetsoft.uql.asset.AssetRepository;
 import inetsoft.util.*;
 import inetsoft.web.adhoc.DecodeParam;
 import inetsoft.web.security.RequiredPermission;
@@ -66,21 +65,7 @@ public class RepositoryViewsheetController {
       IdentityID ownerID = IdentityID.getIdentityIDFromKey(owner);
       path = treeService.getUnscopedPath(path);
 
-      if(scope == AssetRepository.USER_SCOPE) {
-         if(!treeService.checkUserPermission(ownerID, principal) ||
-            !SecurityEngine.getSecurity().checkPermission(
-               principal, ResourceType.MY_DASHBOARDS, "*", ResourceAction.READ))
-         {
-            throw new MessageException(Catalog.getCatalog().getString(
-               "em.common.security.no.permission", path));
-         }
-      }
-      else if(!SecurityEngine.getSecurity().checkPermission(principal, ResourceType.REPORT, path,
-                                                            ResourceAction.ADMIN))
-      {
-         throw new MessageException(Catalog.getCatalog().getString(
-            "em.common.security.no.permission", path));
-      }
+      treeService.checkSheetPermission(scope, ownerID, path, ResourceType.REPORT, principal);
 
       final AssetEntry entry = new AssetEntry(scope, AssetEntry.Type.VIEWSHEET, path, ownerID);
       return sheetService.getSheetSettings(entry, ResourceType.REPORT, timeZone, owner, principal);
@@ -104,21 +89,7 @@ public class RepositoryViewsheetController {
       path = treeService.getUnscopedPath(path);
       IdentityID ownerID = IdentityID.getIdentityIDFromKey(owner);
 
-      if(scope == AssetRepository.USER_SCOPE) {
-         if(!treeService.checkUserPermission(ownerID, principal) ||
-            !SecurityEngine.getSecurity().checkPermission(
-               principal, ResourceType.MY_DASHBOARDS, "*", ResourceAction.READ))
-         {
-            throw new MessageException(Catalog.getCatalog().getString(
-               "em.common.security.no.permission", path));
-         }
-      }
-      else if(!SecurityEngine.getSecurity().checkPermission(principal, ResourceType.REPORT, path,
-                                                            ResourceAction.ADMIN))
-      {
-         throw new MessageException(Catalog.getCatalog().getString(
-            "em.common.security.no.permission", path));
-      }
+      treeService.checkSheetPermission(scope, ownerID, path, ResourceType.REPORT, principal);
 
       final AssetEntry oldEntry = new AssetEntry(scope, AssetEntry.Type.VIEWSHEET, path, ownerID);
       final AssetEntry newEntry =

--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryViewsheetController.java
@@ -19,6 +19,7 @@ package inetsoft.web.admin.content.repository;
 
 import inetsoft.sree.security.*;
 import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
 import inetsoft.util.*;
 import inetsoft.web.adhoc.DecodeParam;
 import inetsoft.web.security.RequiredPermission;
@@ -62,16 +63,25 @@ public class RepositoryViewsheetController {
       }
 
       int scope = treeService.getAssetScope(path);
+      IdentityID ownerID = IdentityID.getIdentityIDFromKey(owner);
       path = treeService.getUnscopedPath(path);
 
-      if(!SecurityEngine.getSecurity().checkPermission(principal, ResourceType.REPORT, path,
-                                                       ResourceAction.ADMIN))
+      if(scope == AssetRepository.USER_SCOPE) {
+         if(!treeService.checkUserPermission(ownerID, principal) ||
+            !SecurityEngine.getSecurity().checkPermission(
+               principal, ResourceType.MY_DASHBOARDS, "*", ResourceAction.READ))
+         {
+            throw new MessageException(Catalog.getCatalog().getString(
+               "em.common.security.no.permission", path));
+         }
+      }
+      else if(!SecurityEngine.getSecurity().checkPermission(principal, ResourceType.REPORT, path,
+                                                            ResourceAction.ADMIN))
       {
          throw new MessageException(Catalog.getCatalog().getString(
             "em.common.security.no.permission", path));
       }
 
-      IdentityID ownerID = IdentityID.getIdentityIDFromKey(owner);
       final AssetEntry entry = new AssetEntry(scope, AssetEntry.Type.VIEWSHEET, path, ownerID);
       return sheetService.getSheetSettings(entry, ResourceType.REPORT, timeZone, owner, principal);
    }
@@ -94,8 +104,17 @@ public class RepositoryViewsheetController {
       path = treeService.getUnscopedPath(path);
       IdentityID ownerID = IdentityID.getIdentityIDFromKey(owner);
 
-      if(!SecurityEngine.getSecurity().checkPermission(principal, ResourceType.REPORT, path,
-                                                       ResourceAction.ADMIN))
+      if(scope == AssetRepository.USER_SCOPE) {
+         if(!treeService.checkUserPermission(ownerID, principal) ||
+            !SecurityEngine.getSecurity().checkPermission(
+               principal, ResourceType.MY_DASHBOARDS, "*", ResourceAction.READ))
+         {
+            throw new MessageException(Catalog.getCatalog().getString(
+               "em.common.security.no.permission", path));
+         }
+      }
+      else if(!SecurityEngine.getSecurity().checkPermission(principal, ResourceType.REPORT, path,
+                                                            ResourceAction.ADMIN))
       {
          throw new MessageException(Catalog.getCatalog().getString(
             "em.common.security.no.permission", path));

--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryWorksheetController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryWorksheetController.java
@@ -21,6 +21,7 @@ import inetsoft.report.internal.Util;
 import inetsoft.sree.RepositoryEntry;
 import inetsoft.sree.security.*;
 import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
 import inetsoft.util.*;
 import inetsoft.web.adhoc.DecodeParam;
 import inetsoft.web.security.RequiredPermission;
@@ -64,6 +65,7 @@ public class RepositoryWorksheetController {
       }
 
       final int scope = treeService.getAssetScope(path);
+      IdentityID ownerID = IdentityID.getIdentityIDFromKey(owner);
       path = treeService.getUnscopedPath(path);
 
       if(owner != null) {
@@ -74,14 +76,22 @@ public class RepositoryWorksheetController {
          }
       }
 
-      if(!SecurityEngine.getSecurity().checkPermission(principal, ResourceType.ASSET, path,
-                                                       ResourceAction.ADMIN))
+      if(scope == AssetRepository.USER_SCOPE) {
+         if(!treeService.checkUserPermission(ownerID, principal) ||
+            !SecurityEngine.getSecurity().checkPermission(
+               principal, ResourceType.MY_DASHBOARDS, "*", ResourceAction.READ))
+         {
+            throw new MessageException(Catalog.getCatalog().getString(
+               "em.common.security.no.permission", path));
+         }
+      }
+      else if(!SecurityEngine.getSecurity().checkPermission(principal, ResourceType.ASSET, path,
+                                                            ResourceAction.ADMIN))
       {
          throw new MessageException(Catalog.getCatalog().getString(
             "em.common.security.no.permission", path));
       }
 
-      IdentityID ownerID = IdentityID.getIdentityIDFromKey(owner);
       final AssetEntry entry = new AssetEntry(scope, AssetEntry.Type.WORKSHEET, path, ownerID);
       return sheetService.getSheetSettings(entry, ResourceType.ASSET, timeZone, owner, principal);
    }
@@ -105,12 +115,24 @@ public class RepositoryWorksheetController {
       IdentityID ownerID = IdentityID.getIdentityIDFromKey(owner);
       final int scope = treeService.getAssetScope(path);
       path = treeService.getUnscopedPath(path);
-      final AssetEntry entry = new AssetEntry(scope, AssetEntry.Type.WORKSHEET, path, ownerID);
 
-      if(!SecurityEngine.getSecurity().checkPermission(principal, ResourceType.ASSET, path, ResourceAction.ADMIN)) {
+      if(scope == AssetRepository.USER_SCOPE) {
+         if(!treeService.checkUserPermission(ownerID, principal) ||
+            !SecurityEngine.getSecurity().checkPermission(
+               principal, ResourceType.MY_DASHBOARDS, "*", ResourceAction.READ))
+         {
+            throw new MessageException(Catalog.getCatalog().getString(
+               "em.common.security.no.permission", path));
+         }
+      }
+      else if(!SecurityEngine.getSecurity().checkPermission(principal, ResourceType.ASSET, path,
+                                                            ResourceAction.ADMIN))
+      {
          throw new MessageException(Catalog.getCatalog().getString(
             "em.common.security.no.permission", path));
       }
+
+      final AssetEntry entry = new AssetEntry(scope, AssetEntry.Type.WORKSHEET, path, ownerID);
 
       if(model.permissionTableModel() != null && model.permissionTableModel().changed()) {
          String fullPath = Util.getObjectFullPath(

--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryWorksheetController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryWorksheetController.java
@@ -21,7 +21,6 @@ import inetsoft.report.internal.Util;
 import inetsoft.sree.RepositoryEntry;
 import inetsoft.sree.security.*;
 import inetsoft.uql.asset.AssetEntry;
-import inetsoft.uql.asset.AssetRepository;
 import inetsoft.util.*;
 import inetsoft.web.adhoc.DecodeParam;
 import inetsoft.web.security.RequiredPermission;
@@ -76,21 +75,7 @@ public class RepositoryWorksheetController {
          }
       }
 
-      if(scope == AssetRepository.USER_SCOPE) {
-         if(!treeService.checkUserPermission(ownerID, principal) ||
-            !SecurityEngine.getSecurity().checkPermission(
-               principal, ResourceType.MY_DASHBOARDS, "*", ResourceAction.READ))
-         {
-            throw new MessageException(Catalog.getCatalog().getString(
-               "em.common.security.no.permission", path));
-         }
-      }
-      else if(!SecurityEngine.getSecurity().checkPermission(principal, ResourceType.ASSET, path,
-                                                            ResourceAction.ADMIN))
-      {
-         throw new MessageException(Catalog.getCatalog().getString(
-            "em.common.security.no.permission", path));
-      }
+      treeService.checkSheetPermission(scope, ownerID, path, ResourceType.ASSET, principal);
 
       final AssetEntry entry = new AssetEntry(scope, AssetEntry.Type.WORKSHEET, path, ownerID);
       return sheetService.getSheetSettings(entry, ResourceType.ASSET, timeZone, owner, principal);
@@ -116,21 +101,7 @@ public class RepositoryWorksheetController {
       final int scope = treeService.getAssetScope(path);
       path = treeService.getUnscopedPath(path);
 
-      if(scope == AssetRepository.USER_SCOPE) {
-         if(!treeService.checkUserPermission(ownerID, principal) ||
-            !SecurityEngine.getSecurity().checkPermission(
-               principal, ResourceType.MY_DASHBOARDS, "*", ResourceAction.READ))
-         {
-            throw new MessageException(Catalog.getCatalog().getString(
-               "em.common.security.no.permission", path));
-         }
-      }
-      else if(!SecurityEngine.getSecurity().checkPermission(principal, ResourceType.ASSET, path,
-                                                            ResourceAction.ADMIN))
-      {
-         throw new MessageException(Catalog.getCatalog().getString(
-            "em.common.security.no.permission", path));
-      }
+      treeService.checkSheetPermission(scope, ownerID, path, ResourceType.ASSET, principal);
 
       final AssetEntry entry = new AssetEntry(scope, AssetEntry.Type.WORKSHEET, path, ownerID);
 


### PR DESCRIPTION
Private viewsheets and worksheets failed with a 500 error when opened in the EM content repository because the permission check used the stripped path (after removing "My Dashboards/") against REPORT/ASSET resources, which never resolved correctly for USER_SCOPE assets.

Mirror the checkAssetPermission0 pattern from AbstractAssetEngine: for USER_SCOPE, check that the principal is the owner or has ADMIN over the owner (via ContentRepositoryTreeService.checkUserPermission) and has READ on MY_DASHBOARDS; for all other scopes, keep the existing REPORT/ASSET admin check on the unscoped path.