### PR TITLE
Resolving the Duplicate AI Assistant Panel Issue When Viewsheet is Embedded in Portal

### DIFF
--- a/web/projects/portal/src/app/viewer/viewer-root.component.html
+++ b/web/projects/portal/src/app/viewer/viewer-root.component.html
@@ -17,4 +17,4 @@
   -->
 <router-outlet></router-outlet>
 <dl-download-target (downloadStarted)="downloadStarted($event)"></dl-download-target>
-<ai-assistant-panel></ai-assistant-panel>
+<ai-assistant-panel *ngIf="!inPortal"></ai-assistant-panel>

--- a/web/projects/portal/src/app/viewer/viewer-root.component.ts
+++ b/web/projects/portal/src/app/viewer/viewer-root.component.ts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { Component, OnDestroy, OnInit } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { StompClientConnection } from "../../../../shared/stomp/stomp-client-connection";
 import { StompClientService } from "../common/viewsheet-client";
@@ -27,12 +28,16 @@ import { ComponentTool } from "../common/util/component-tool";
    styleUrls: ["viewer-root.component.scss"]
 })
 export class ViewerRootComponent implements OnInit, OnDestroy {
+   inPortal: boolean = false;
    private connection: StompClientConnection;
 
-   constructor(private socket: StompClientService, private modalService: NgbModal) {
+   constructor(private socket: StompClientService, private modalService: NgbModal,
+               private route: ActivatedRoute) {
    }
 
    ngOnInit(): void {
+      this.inPortal = !!this.route.snapshot.data["inPortal"];
+
       if(document.body.className.indexOf("app-loaded") == -1) {
          document.body.className += " app-loaded";
          const splash = document.querySelector<HTMLElement>(".loading-splash");


### PR DESCRIPTION
When Viewsheet is lazily loaded and embedded into Portal through routing, both Portal and Viewer render their own <ai-assistant-panel> in the DOM. Since they share the same singleton service AiAssistantService, clicking to open or collapse the AI assistant causes both panels to respond to state changes simultaneously. The solution is to let Portal's panel handle all Portal scenarios (including cases where Viewer is embedded), while Viewer's panel is rendered only when Viewer is accessed independently (not embedded in Portal).