### PR TITLE
Bug #74535, fix embedded viewsheet showing blank after import to target folder

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/DeployManagerService.java
+++ b/core/src/main/java/inetsoft/sree/internal/DeployManagerService.java
@@ -747,12 +747,13 @@ public class DeployManagerService {
                   continue;
                }
 
-               changeAssetMap.put(supportEntry, getAssetObjectByAsset(newAsset));
+               AssetObject newEntry = getAssetObjectByAsset(newAsset);
+               changeAssetMap.put(supportEntry, newEntry);
 
                if(supportEntry instanceof AssetEntry) {
                   AssetObject currOrgEntry = ((AssetEntry) supportEntry).cloneAssetEntry(
                                              new Organization(OrganizationManager.getInstance().getCurrentOrgID()));
-                  changeAssetMap.put(currOrgEntry, getAssetObjectByAsset(newAsset));
+                  changeAssetMap.put(currOrgEntry, newEntry);
                }
 
             }

--- a/core/src/main/java/inetsoft/uql/asset/sync/UpdateDependencyHandler.java
+++ b/core/src/main/java/inetsoft/uql/asset/sync/UpdateDependencyHandler.java
@@ -304,8 +304,7 @@ public final class UpdateDependencyHandler {
          }
       }
 
-      list = getChildNodes(doc,
-         "./assembly/assemblies/oneAssembly/assembly/assemblyInfo/viewsheetEntry/assetEntry");
+      list = getChildNodes(doc, "./assembly//viewsheetEntry/assetEntry");
 
       for(int i = 0; i < list.getLength(); i++) {
          Element ele = (Element) list.item(i);


### PR DESCRIPTION
## Root Cause

When importing a viewsheet containing a `VSEmbedAssembly` (embedded viewsheet) into a target folder, the embedded VS path reference inside the outer viewsheet was not updated to include the new folder prefix, causing the outer viewsheet to display blank.

The dependency scanner `addEmbeddedVSDependencies()` used a rigid XPath:
```
./assembly/assemblies/oneAssembly/assembly/assemblyInfo/viewsheetEntry/assetEntry
```
This path did not match the actual XML structure of `VSEmbedAssembly` nodes, so the embedded VS was never added to the outer viewsheet's dependency set. With no dependency entry, `createRenameInfos()` never produced a `RenameInfo` for the embedded reference, and `AssetEmbedDependencyTransformer.renameEmbedVS()` was never invoked to rewrite the path.

## Fix

Changed the XPath in `addEmbeddedVSDependencies()` to:
```
./assembly//viewsheetEntry/assetEntry
```
This uses the same recursive search scope that `AssetEmbedDependencyTransformer.renameEmbedVS()` already uses when performing the actual rename, ensuring the embedded VS dependency is always detected regardless of nesting depth in the assembly XML.

## Test Plan
- [ ] New org + org admin user with Organization Administrator role
- [ ] EM → Content → Repository → switch to the new org
- [ ] Import zip containing an outer viewsheet with an embedded viewsheet, selecting a target folder (e.g. `f1`)
- [ ] Login to portal as org admin, open the outer viewsheet — should render correctly (not blank)
- [ ] Import the same zip without selecting a target folder — should still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)