### PR TITLE
Database Security Provider Lost After GKE Node Restart

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/SecurityChain.java
+++ b/core/src/main/java/inetsoft/sree/security/SecurityChain.java
@@ -198,6 +198,14 @@ public abstract class SecurityChain<T extends JsonConfigurableProvider & Cachabl
                         failureCount, getConfigFile());
                   }
                   else {
+                     if(failureCount > 0) {
+                        LOG.warn(
+                           "{} of {} security provider(s) failed to load from '{}'; " +
+                           "the remaining providers have been applied but security " +
+                           "configuration may be incomplete",
+                           failureCount, list.size() + failureCount, getConfigFile());
+                     }
+
                      clear();
                      setProviderList(list);
                   }

--- a/core/src/main/java/inetsoft/sree/security/SecurityChain.java
+++ b/core/src/main/java/inetsoft/sree/security/SecurityChain.java
@@ -164,6 +164,7 @@ public abstract class SecurityChain<T extends JsonConfigurableProvider & Cachabl
 
                   ArrayNode providersArray = (ArrayNode) root.get("providers");
                   List<T> list = new ArrayList<>();
+                  int failureCount = 0;
 
                   for(int i = 0; i < providersArray.size(); i++) {
                      ObjectNode wrapperNode = (ObjectNode) providersArray.get(i);
@@ -180,13 +181,26 @@ public abstract class SecurityChain<T extends JsonConfigurableProvider & Cachabl
                         list.add(provider);
                      }
                      catch(Exception e) {
+                        failureCount++;
                         LOG.error(
                            "Failed to create instance of security provider: {}", providerClass, e);
                      }
                   }
 
-                  clear();
-                  setProviderList(list);
+                  // If the config file specified providers but ALL of them failed to instantiate,
+                  // retain the existing runtime providers rather than wiping them. This prevents a
+                  // corrupted or temporarily unreadable config (e.g. after a GKE node restart) from
+                  // clearing all security providers and locking out every user.
+                  if(list.isEmpty() && failureCount > 0) {
+                     LOG.error(
+                        "All {} security provider(s) failed to load from '{}'; retaining " +
+                        "existing providers to prevent loss of security configuration",
+                        failureCount, getConfigFile());
+                  }
+                  else {
+                     clear();
+                     setProviderList(list);
+                  }
                }
             }
          }

--- a/core/src/main/java/inetsoft/sree/security/SecurityChain.java
+++ b/core/src/main/java/inetsoft/sree/security/SecurityChain.java
@@ -160,8 +160,6 @@ public abstract class SecurityChain<T extends JsonConfigurableProvider & Cachabl
                      root = (ObjectNode) mapper.readTree(input);
                   }
 
-                  timestamp = dataSpace.getLastModified(null, getConfigFile());
-
                   ArrayNode providersArray = (ArrayNode) root.get("providers");
                   List<T> list = new ArrayList<>();
                   int failureCount = 0;
@@ -191,6 +189,8 @@ public abstract class SecurityChain<T extends JsonConfigurableProvider & Cachabl
                   // retain the existing runtime providers rather than wiping them. This prevents a
                   // corrupted or temporarily unreadable config (e.g. after a GKE node restart) from
                   // clearing all security providers and locking out every user.
+                  // Do NOT update timestamp on total failure – allow the next dataChanged() to retry
+                  // when the transient condition clears, without requiring a manual config edit.
                   if(list.isEmpty() && failureCount > 0) {
                      LOG.error(
                         "All {} security provider(s) failed to load from '{}'; retaining " +
@@ -206,6 +206,7 @@ public abstract class SecurityChain<T extends JsonConfigurableProvider & Cachabl
                            failureCount, list.size() + failureCount, getConfigFile());
                      }
 
+                     timestamp = dataSpace.getLastModified(null, getConfigFile());
                      clear();
                      setProviderList(list);
                   }

--- a/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationCache.java
+++ b/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationCache.java
@@ -43,6 +43,12 @@ class DatabaseAuthenticationCache implements AutoCloseable {
          return false;
       }
 
+      // Exponential backoff: don't hammer the cluster when the security provider is unavailable
+      // (e.g. immediately after a GKE node restart before SecurityEngine has loaded providers).
+      if(System.currentTimeMillis() < nextRetryTime) {
+         return false;
+      }
+
       serviceLock.lock();
 
       try {
@@ -62,10 +68,19 @@ class DatabaseAuthenticationCache implements AutoCloseable {
                   prefix, DatabaseAuthenticationCacheService.class,
                   () -> new DatabaseAuthenticationCacheServiceImpl(provider.getProviderName()));
                service.connect();
+               // Reset backoff on success
+               currentRetryDelayMs = INITIAL_RETRY_DELAY_MS;
+               nextRetryTime = 0L;
             }
             catch(Exception ex) {
                service = null;
-               LOG.error("Failed to initialize service for provider: " + provider.getProviderName(), ex);
+               nextRetryTime = System.currentTimeMillis() + currentRetryDelayMs;
+               currentRetryDelayMs = Math.min(currentRetryDelayMs * 2, MAX_RETRY_DELAY_MS);
+               LOG.warn(
+                  "Failed to initialize service for provider '{}', will retry in {}s: {}",
+                  provider.getProviderName(), currentRetryDelayMs / 1000,
+                  ex.getMessage());
+               LOG.debug("Service initialization failure detail", ex);
                return false;
             }
          }
@@ -348,6 +363,9 @@ class DatabaseAuthenticationCache implements AutoCloseable {
          groupUsers = null;
          userRoles = null;
          userEmails = null;
+         // Reset backoff so the next access retries immediately
+         currentRetryDelayMs = INITIAL_RETRY_DELAY_MS;
+         nextRetryTime = 0L;
       }
       finally {
          serviceLock.unlock();
@@ -365,9 +383,16 @@ class DatabaseAuthenticationCache implements AutoCloseable {
    private DistributedMap<IdentityID, IdentityArray> userRoles;
    private DistributedMap<IdentityID, String[]> userEmails;
 
+   // Exponential backoff state for initialize() failures
+   private volatile long nextRetryTime = 0L;
+   private volatile long currentRetryDelayMs = INITIAL_RETRY_DELAY_MS;
+
    private static final Logger LOG = LoggerFactory.getLogger(DatabaseAuthenticationCache.class);
    private static final String ORG_LIST = "orgs";
    private static final String USER_LIST = "users";
    private static final String GROUP_LIST = "groups";
    private static final String ROLE_LIST = "roles";
+   // Initial backoff after a failed initialize(): 10 seconds, doubling up to 5 minutes
+   private static final long INITIAL_RETRY_DELAY_MS = 10_000L;
+   private static final long MAX_RETRY_DELAY_MS = 300_000L;
 }

--- a/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationCache.java
+++ b/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationCache.java
@@ -43,15 +43,15 @@ class DatabaseAuthenticationCache implements AutoCloseable {
          return false;
       }
 
-      // Exponential backoff: don't hammer the cluster when the security provider is unavailable
-      // (e.g. immediately after a GKE node restart before SecurityEngine has loaded providers).
-      if(System.currentTimeMillis() < nextRetryTime) {
-         return false;
-      }
-
       serviceLock.lock();
 
       try {
+         // Exponential backoff: don't hammer the cluster when the security provider is unavailable
+         // (e.g. immediately after a GKE node restart before SecurityEngine has loaded providers).
+         if(System.currentTimeMillis() < nextRetryTime) {
+            return false;
+         }
+
          if(service == null) {
             try {
                Cluster cluster = Cluster.getInstance();
@@ -74,11 +74,12 @@ class DatabaseAuthenticationCache implements AutoCloseable {
             }
             catch(Exception ex) {
                service = null;
-               nextRetryTime = System.currentTimeMillis() + currentRetryDelayMs;
+               long retryDelayMs = currentRetryDelayMs;
+               nextRetryTime = System.currentTimeMillis() + retryDelayMs;
                currentRetryDelayMs = Math.min(currentRetryDelayMs * 2, MAX_RETRY_DELAY_MS);
                LOG.warn(
                   "Failed to initialize service for provider '{}', will retry in {}s: {}",
-                  provider.getProviderName(), currentRetryDelayMs / 1000,
+                  provider.getProviderName(), retryDelayMs / 1000,
                   ex.getMessage());
                LOG.debug("Service initialization failure detail", ex);
                return false;


### PR DESCRIPTION
After a node restart, when SecurityChain reloads the authc-chain.json file, if all provider instantiations fail, it would still call clear() to remove the running providers, resulting in complete loss of security configuration. Fix: Skip the replacement when all providers fail to load, preserving the existing state.

Additionally, when DatabaseAuthenticationCache fails to initialize, it would retry indefinitely without rate limiting and log an ERROR on every attempt. Fix: Implement exponential backoff (starting at 10 seconds, up to a maximum of 5 minutes) and downgrade the log level to WARN.