### PR TITLE
Bug #74484, fix double-layer border in slider/input PDF export

### DIFF
--- a/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
@@ -3726,6 +3726,17 @@ public abstract class AbstractVSExporter implements VSExporter {
     * Render a widget image with the assembly-level background and borders suppressed.
     * Used by {@link #writeInputWithLabel} which draws those styles around the full
     * (label + widget) bounds instead.
+    *
+    * <p>Both the runtime value (rValue) and the design-time value (dValue) must be
+    * cleared for the suppression to take effect:
+    * <ul>
+    *   <li>{@code ClazzHolder.getRValue()} (used by borders) falls back to dValue
+    *       when rValue is null, so setting rValue to null alone leaves the border
+    *       visible.</li>
+    *   <li>{@code DynamicValue.getRValue()} (used by background) auto-assigns dValue
+    *       to rValue when rValue is null and dValue is a literal string, so setting
+    *       rValue to null alone allows dValue to re-appear on the next read.</li>
+    * </ul>
     */
    private BufferedImage getInputImageNoAssemblyStyle(VSAssembly assembly,
       VSAssemblyInfo info, Dimension widgetSize)
@@ -3739,17 +3750,28 @@ public abstract class AbstractVSExporter implements VSExporter {
       VSFormat udf = fmt.getUserDefinedFormat();
       Color savedBg = udf.getBackground();
       boolean savedBgDefined = udf.isBackgroundDefined();
+      String savedBgValue = udf.getBackgroundValue();
+      boolean savedBgValDefined = udf.isBackgroundValueDefined();
       Insets savedBorders = udf.getBorders();
       boolean savedBordersDefined = udf.isBordersDefined();
+      Insets savedBordersValue = udf.getBordersValue();
+      boolean savedBordersValDefined = udf.isBordersValueDefined();
+
+      // Clear both rValue and dValue so neither ClazzHolder nor DynamicValue
+      // can resurrect the original value during widget image rendering.
       udf.setBackground(null);
+      udf.setBackgroundValue(null);
       udf.setBorders(null);
+      udf.setBordersValue(null);
 
       try {
          return getInputImage(assembly, widgetSize);
       }
       finally {
          udf.setBackground(savedBg, savedBgDefined);
+         udf.setBackgroundValue(savedBgValue, savedBgValDefined);
          udf.setBorders(savedBorders, savedBordersDefined);
+         udf.setBordersValue(savedBordersValue, savedBordersValDefined);
       }
    }
 


### PR DESCRIPTION
## Root Cause

`getInputImageNoAssemblyStyle` was designed to suppress the assembly-level
background and border while rendering the slider/input widget as an image,
because `writeInputWithLabel` already draws those styles around the full
(label + widget) area.  The method cleared the *runtime* value via
`setBorders(null)` / `setBackground(null)`, but two separate fallback
mechanisms in the value-holder classes caused the original values to
reappear during rendering:

### 1 — `ClazzHolder.getRValue()` falls back to `dValue` (borders)

`bordersValue` is a `ClazzHolder<Insets>`.  Its `getRValue()` is:

```java
public T getRValue() {
    return rvalue != null ? rvalue : dvalue;   // falls back to dvalue!
}
```

`setBorders(null)` calls `ClazzHolder.setRValue(null)`, making `rvalue = null`.
On the very next `getRValue()` call the holder returns `dvalue` — the
design-time `Insets(4098, 4098, 4098, 4098)` loaded from XML.

`VSCompositeFormat.getBorders()` therefore returned the full medium-line
border even after the suppression call, and `VSObject.drawBorders()` drew
the orange border onto the widget image.

### 2 — `DynamicValue.getRValue()` auto-assigns `dValue` to `rValue` (background)

`bgval` is a `DynamicValue`.  Its `getRValue()` contains:

```java
if (!isVariable(dvalue) && !isScript(dvalue) && rvalue == null && dvalue != null) {
    rvalue = dvalue;   // silently restores rvalue from dvalue
}
return rvalue;
```

`setBackground(null)` calls `DynamicValue.setRValue(null)`, making
`rvalue = null`.  On the next `getRValue()` call the method auto-assigns
`dvalue` (the literal `"#f9c8cb"` string loaded from XML) back to `rvalue`
and returns it.  `VSFormat.getBackground()` therefore returned the original
pink colour, and `VSFloatable.drawBackground()` painted a solid fill over
the widget image.

### Visible symptom

`writeInputWithLabel` draws **one** outer orange border around
`fullBounds` (label + widget).  Because suppression failed, the widget
image also drew its own border around `widgetBounds` (widget only).  The
narrower inner rectangle was visible inside the outer one in the exported
PDF — reported as a **double-layer border**.

## Fix

Save and clear **both** the runtime value *and* the design-time value for
background and borders before rendering the widget image, then restore both
in the `finally` block.

```java
// --- save ---
Color  savedBg             = udf.getBackground();
boolean savedBgDefined     = udf.isBackgroundDefined();
String  savedBgValue       = udf.getBackgroundValue();       // ← NEW
boolean savedBgValDefined  = udf.isBackgroundValueDefined(); // ← NEW
Insets  savedBorders       = udf.getBorders();
boolean savedBordersDefined = udf.isBordersDefined();
Insets  savedBordersValue  = udf.getBordersValue();          // ← NEW
boolean savedBordersValDefined = udf.isBordersValueDefined();// ← NEW

// --- suppress ---
udf.setBackground(null);
udf.setBackgroundValue(null);   // ← NEW: clears DynamicValue.dValue
udf.setBorders(null);
udf.setBordersValue(null);      // ← NEW: clears ClazzHolder.dValue

// --- restore ---
udf.setBackground(savedBg, savedBgDefined);
udf.setBackgroundValue(savedBgValue, savedBgValDefined);     // ← NEW
udf.setBorders(savedBorders, savedBordersDefined);
udf.setBordersValue(savedBordersValue, savedBordersValDefined); // ← NEW
```

With both the runtime and design-time values cleared, `ClazzHolder.getRValue()`
returns `null` (no dValue to fall back to) and `DynamicValue.getRValue()` has
nothing to auto-assign, so the composite format returns `null` for both
background and borders during widget image rendering.  Only one border —
the outer one drawn by `writeInputWithLabel` around the full bounds — remains
visible in the exported PDF.

## Test plan

- [ ] Import `label.vso`, open in Composer, preview, export as PDF
- [ ] Verify the slider shows **one** orange border around the full label+widget area — no double/inner border
- [ ] Verify the background colour is correct (pink `#f9c8cb`) and not duplicated
- [ ] Repeat for Spinner, CheckBox, RadioButton, and ComboBox assemblies that have labels and assembly-level formatting
- [ ] Verify assemblies **without** labels still export correctly via `writePicture`

🤖 Generated with [Claude Code](https://claude.com/claude-code)