### PR TITLE
AI Assistant Panel Dynamically Fetches Latest Branding Configuration on Each Open

### DIFF
--- a/web/projects/shared/ai-assistant/ai-assistant-dialog.component.ts
+++ b/web/projects/shared/ai-assistant/ai-assistant-dialog.component.ts
@@ -48,6 +48,7 @@ export class AiAssistantDialogComponent implements OnInit, OnDestroy {
    }
 
    ngOnInit(): void {
+      this.aiAssistantService.refreshBranding();
       this.contextSub = this.aiAssistantService.contextChange$.subscribe(() => {
          this.context = this.aiAssistantService.getFullContext();
       });

--- a/web/projects/shared/ai-assistant/ai-assistant.service.ts
+++ b/web/projects/shared/ai-assistant/ai-assistant.service.ts
@@ -95,6 +95,10 @@ export class AiAssistantService {
          this.styleBIUrl = url || "";
       });
 
+      this.refreshBranding();
+   }
+
+   refreshBranding(): void {
       this.http.get<{title: string, vendorName: string, logoUrl: string}>(
          "../api/assistant/get-branding").pipe(
          catchError(() => of(null))


### PR DESCRIPTION
Every time a user opens the AI assistant panel, it re-fetches the latest Title, Vendor Name, and Logo URL from /api/assistant/get-branding, without requiring a browser refresh.