### PR TITLE
Bug #74477, fix AI assistant branding not working after initial fix

### DIFF
--- a/core/src/main/java/inetsoft/web/assistant/AIAssistantController.java
+++ b/core/src/main/java/inetsoft/web/assistant/AIAssistantController.java
@@ -201,7 +201,7 @@ public class AIAssistantController {
       return healthClient.sendAsync(req, HttpResponse.BodyHandlers.discarding())
          .thenApply(r -> ResponseEntity.ok(r.statusCode() < 500))
          .exceptionally(e -> {
-            LOG.debug("AI assistant health check failed for {}: {}", url, e.getMessage());
+            LOG.warn("AI assistant health check failed for {}: {}", url, e.getMessage());
             return ResponseEntity.ok(false);
          });
    }

--- a/web/projects/shared/ai-assistant/ai-assistant-dialog.component.html
+++ b/web/projects/shared/ai-assistant/ai-assistant-dialog.component.html
@@ -5,7 +5,7 @@
                 [attr.chat-app-server-url]="chatAppServerUrl"
                 [attr.stylebi-url]="styleBIUrl"
                 [attr.new-chat]="newChat || null"
-                [attr.title]="chatAppTitle"
+                [attr.app-title]="chatAppTitle"
                 [attr.vendor-name]="chatAppVendorName"
                 [attr.logo-url]="chatAppLogoUrl"
                 [attr.theme]="theme"></ai-assistant>


### PR DESCRIPTION
## Root cause

The original #74477 fix added EM settings and Angular bindings for `title`, `vendor-name`, `logo-url`, and `theme`, but two problems remained:

**1. AI Assistant Title used as a browser tooltip (not the sidebar title)**

`[attr.title]="chatAppTitle"` sets the native HTML `title` attribute on the `<ai-assistant>` custom element. Browsers treat the `title` attribute as a tooltip — shown on hover over the entire element — so the configured title text appeared as a tooltip popup rather than as the history sidebar heading.

Fix: rename to `[attr.app-title]`, which maps to the `appTitle` prop the web component exposes for the sidebar title.

**2. Health check connection failures silently returned `false`**

When the Java `HttpClient` could not connect to the AI assistant server (e.g. wrong URL scheme — `http://` instead of `https://`), the exception was logged at DEBUG level. In practice this meant the error was invisible in production logs, leaving admins no indication of why the assistant showed "unavailable". The URL scheme mismatch itself is easy to get wrong since the EM field has no hint about HTTPS being required.

Fix: promote the log statement from `LOG.debug` to `LOG.warn` so the actual exception message appears in the log at default log levels.

## Changes

| File | Change |
|---|---|
| `ai-assistant-dialog.component.html` | `[attr.title]` → `[attr.app-title]` |
| `AIAssistantController.java` | `LOG.debug` → `LOG.warn` for health check failures |

## Dependency

The full branding fix (vendor name, logo, sidebar title, theme) also requires a new `@inetsoft-technology/ai-assistant` npm package that registers `appTitle`, `vendorName`, `logoUrl`, and `theme` as observed attributes on the `<ai-assistant>` web component. That change is tracked in a separate PR in the `assistant` repo and will be followed by a package version bump here once published.