### PR TITLE
Bug #74582, fix change-from-previous returning empty for string dimensions

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/calc/ValueOfColumn.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/calc/ValueOfColumn.java
@@ -375,50 +375,12 @@ public class ValueOfColumn extends AbstractColumn {
          Object val = data.getData(ndim, row);
          Object tval = null;
 
-         if(ctype >= ValueOfCalc.PREVIOUS_YEAR) {
-            if(ctype != ValueOfCalc.PREVIOUS_RANGE) {
-               VSDataSet vsDataSet = getVSDataset(data);
-
-               if(vsDataSet != null && vsDataSet.isOthers(ndim, String.valueOf(val))) {
-                  return INVALID;
-               }
-
-               if(!(val instanceof Date)) {
-                  return INVALID;
-               }
-
-               tval = getPreviousDate(val);
-            }
-            else {
-               tval = getPreRange(val);
-            }
-         }
-         else {
-            // In a facet chart each facet is backed by a DataSetFilter containing only that
-            // facet's rows. The router built from a per-facet dataset only knows values within
-            // that facet, so navigating to a previous/next period that falls in a different facet
-            // returns INVALID. Use getRootDataSet() when ndim is the inner dimension so the
-            // router can traverse values across all facets.
-            DataSet routerData = (ndim.equals(innerDim) && data instanceof DataSetFilter)
-               ? ((DataSetFilter) data).getRootDataSet() : data;
-            Router router = getRouter(routerData, ndim);
-            tval = router.getValue(val, ctype == ValueOfCalc.PREVIOUS ? -1 : 1);
-         }
-
-         if(tval == DATE_INVALID || tval == Router.INVALID || tval == Router.NOT_EXIST) {
-            return INVALID;
-         }
-
-         // The first year in the dataset should not assume the previous year (which is not in
-         // the dataset) to be 0 when calculating change.
-         if(tval instanceof Date && getMinDate(data).after((Date) tval)) {
-            return INVALID;
-         }
-
-         // When ndim is the innermost dimension (no outer-dimension sub-grouping) AND ndim itself
-         // is a PART_DATE_GROUP, exclude any sibling PART_DATE_GROUP dimensions that share the
-         // same base date column. This prevents zero rows when a part-level lookup crosses a
-         // period boundary (e.g. April→March crosses Q2→Q1, so QuarterOfYear must be excluded).
+         // Pre-compute ndimIsPartDate before router construction so both the router selection
+         // and the sub-dataset lookup use consistent logic.
+         // A PART_DATE_GROUP inner dim (e.g. MonthOfYear) in a facet chart needs the
+         // root-dataset router to find cross-facet values (e.g. April→March crosses Q2→Q1).
+         // Non-date/non-PART_DATE_GROUP inner dims (e.g. plain string dimensions) must use
+         // the sorted dataset for the router so that previous/next follows chart sort order.
          // Only apply for PREVIOUS/NEXT: for PREVIOUS_YEAR and similar ctypes, the PART_DATE_GROUP
          // sibling (e.g. QuarterOfYear) is the correct position discriminator and must remain in
          // the condition to find the same quarter in the previous year.
@@ -452,6 +414,48 @@ public class ValueOfColumn extends AbstractColumn {
                   }
                }
             }
+         }
+
+         if(ctype >= ValueOfCalc.PREVIOUS_YEAR) {
+            if(ctype != ValueOfCalc.PREVIOUS_RANGE) {
+               VSDataSet vsDataSet = getVSDataset(data);
+
+               if(vsDataSet != null && vsDataSet.isOthers(ndim, String.valueOf(val))) {
+                  return INVALID;
+               }
+
+               if(!(val instanceof Date)) {
+                  return INVALID;
+               }
+
+               tval = getPreviousDate(val);
+            }
+            else {
+               tval = getPreRange(val);
+            }
+         }
+         else {
+            // In a facet chart, a PART_DATE_GROUP inner dimension (e.g. MonthOfYear) is backed
+            // by a per-facet DataSetFilter containing only that facet's rows (e.g. months 4-6
+            // for Q2). The router built from this sub-dataset cannot find the previous value
+            // that crosses a facet boundary (April→March is in Q1). Use getRootDataSet() so
+            // the router can traverse values across all facets.
+            // For non-PART_DATE_GROUP inner dimensions (e.g. plain string dimensions), use
+            // data (the sorted dataset) so that previous/next navigation follows chart sort order.
+            DataSet routerData = (ndimIsPartDate && data instanceof DataSetFilter)
+               ? ((DataSetFilter) data).getRootDataSet() : data;
+            Router router = getRouter(routerData, ndim);
+            tval = router.getValue(val, ctype == ValueOfCalc.PREVIOUS ? -1 : 1);
+         }
+
+         if(tval == DATE_INVALID || tval == Router.INVALID || tval == Router.NOT_EXIST) {
+            return INVALID;
+         }
+
+         // The first year in the dataset should not assume the previous year (which is not in
+         // the dataset) to be 0 when calculating change.
+         if(tval instanceof Date && getMinDate(data).after((Date) tval)) {
+            return INVALID;
          }
 
          Map<String, Object> cond = createCond(data, ndim, row, ignoreList, tval);

--- a/core/src/test/java/inetsoft/report/composition/graph/calc/ValueOfColumnTest.java
+++ b/core/src/test/java/inetsoft/report/composition/graph/calc/ValueOfColumnTest.java
@@ -19,6 +19,7 @@
 package inetsoft.report.composition.graph.calc;
 
 import inetsoft.graph.data.CalcColumn;
+import inetsoft.graph.data.SortedDataSet;
 import inetsoft.report.composition.graph.*;
 import inetsoft.report.filter.*;
 import inetsoft.report.lens.DefaultTableLens;
@@ -259,6 +260,50 @@ public class ValueOfColumnTest {
       // lookup returns the first row of 2020 (Q1, id=5) instead of Q2 (id=3).
       Object result = valueOfColumn.calculate(vsDataSet, 5, false, false);
       assertEquals(3, result);
+   }
+
+   /**
+    * Regression test for Bug #74582: PREVIOUS on a plain string dimension must use the
+    * sorted dataset's router (not the root VSDataSet's router) when data is a DataSetFilter.
+    *
+    * Original data order: C, A, B (intentionally non-alphabetical).
+    * Sorted (chart) order: A, B, C.
+    *
+    * With the bug (root-dataset router, iteration C → A → B):
+    *   getValue("A", -1) = "C" (A is at index 1, previous = C at index 0) → returns id=30 (wrong).
+    * With the fix (sorted-dataset router, iteration A → B → C):
+    *   getValue("A", -1) = INVALID (A is first) → correctly returns INVALID.
+    */
+   @Test
+   void testChangePreviousWithStringDimension_RouterUsesSortedOrder() {
+      valueOfColumn = new ValueOfColumn("id", "sum(id)");
+      valueOfColumn.setChangeType(ValueOfCalc.PREVIOUS);
+      valueOfColumn.setDim("name");
+      valueOfColumn.setInnerDim("name");
+
+      // Original row order: C=30, A=10, B=20 (intentionally NOT alphabetical)
+      DefaultTableLens tb = new DefaultTableLens(new Object[][]{
+         { "name", "id" },
+         { "C", 30 },
+         { "A", 10 },
+         { "B", 20 }
+      });
+
+      VSDimensionRef mockDRef = mock(VSDimensionRef.class);
+      when(mockDRef.getFullName()).thenReturn("name");
+      vsDataSet = new VSDataSet(tb, new VSDataRef[]{ mockDRef });
+
+      // SortedDataSet (forceSort=true) sorts "name" alphabetically: A(id=10), B(id=20), C(id=30)
+      SortedDataSet sortedDataSet = new SortedDataSet(vsDataSet, "name");
+      sortedDataSet.setForceSort(true);
+
+      // Row 0 in sorted order = "A" — first alphabetically, so no previous → INVALID
+      Object result = valueOfColumn.calculate(sortedDataSet, 0, true, false);
+      assertEquals(CalcColumn.INVALID, result);
+
+      // Row 1 in sorted order = "B" — previous in sorted order is "A" (id=10)
+      result = valueOfColumn.calculate(sortedDataSet, 1, false, false);
+      assertEquals(10, result);
    }
 
    /**


### PR DESCRIPTION
## Bug Cause

`getDataSetDynamicCalcValue()` in `ValueOfColumn` builds a `DataSetRouter` for `PREVIOUS`/`NEXT` navigation. Bug #74367 changed the router to always use the root `VSDataSet` whenever `ndim == innerDim && data instanceof DataSetFilter`, intending to fix cross-facet lookups for PART_DATE_GROUP dimensions (e.g. MonthOfYear). Bug #74542 later added a `ndimIsPartDate` guard for the **sub-dataset lookup** phase, but left the **router** switch un-guarded.

For a plain string dimension (`ndimIsPartDate = false`), the `DataSetRouter` was being built from the root `VSDataSet`, which iterates rows in original insertion order. The chart's `SortedDataSet` wrapper presents rows in sort order, so if the insertion order differs from the sort order, `router.getValue(val, -1)` finds the wrong predecessor:

- Original insertion order: C → A → B
- Chart sorted order: A → B → C
- With the bug: `getValue("A", -1)` in insertion order [C, A, B] = "C" (A is at index 1, predecessor is C) → wrong lookup, returns id of "C" row instead of INVALID
- With the fix: `getValue("A", -1)` in sorted order [A, B, C] = INVALID (A is first) → correct

This caused the "Change from previous [String]" calculated column to show wrong values or appear blank when the dimension's chart sort order differed from the data's original insertion order.

## Fix

Pre-compute `ndimIsPartDate` **before** the router is constructed (moved earlier in the method), then gate the root-dataset router switch on `ndimIsPartDate` — the same guard already used for the sub-dataset lookup:

```java
// Before (too broad — switches router to root for all inner-dim DataSetFilter cases):
DataSet routerData = (ndim.equals(innerDim) && data instanceof DataSetFilter)
    ? ((DataSetFilter) data).getRootDataSet() : data;

// After (only switch to root when ndim is a PART_DATE_GROUP date dimension):
DataSet routerData = (ndimIsPartDate && data instanceof DataSetFilter)
    ? ((DataSetFilter) data).getRootDataSet() : data;
```

PART_DATE_GROUP inner dims (e.g. MonthOfYear in a facet chart) still use the root-dataset router so cross-facet lookups continue to work (original Bug #74367 fix preserved). Non-PART_DATE_GROUP inner dims (plain strings, full date groups) now use `data` (the sorted DataSetFilter), restoring correct sort-order navigation.

## Test Plan

- [ ] Import `previousstring.zip` and open in portal; verify "Change from previous [String]" column shows correct values in Show Data and renders correctly in chart
- [ ] Regression: open a chart with PART_DATE_GROUP dimension (MonthOfYear + QuarterOfYear); verify "Change from previous" across quarter boundaries still works (Bug #74367 not regressed)
- [ ] Regression: open a DC chart with Year + QuarterOfYear; verify PREVIOUS_YEAR lookup returns correct quarter (Bug #74542 not regressed)
- [ ] `ValueOfColumnTest#testChangePreviousWithStringDimension_RouterUsesSortedOrder` — new regression test passes
- [ ] `ValueOfColumnTest` and `ChangeColumnTest` — all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)