### PR TITLE
Bug #74583, fix MV analysis permission check for private viewsheets/worksheets

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/MVSupportService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/MVSupportService.java
@@ -184,12 +184,26 @@ public class MVSupportService {
          AssetEntry candidateEntry = getEntry(candidate.id);
 
          if(candidateEntry != null) {
-            ResourceType resourceType = candidateEntry.isWorksheet() ?
-               ResourceType.ASSET : ResourceType.REPORT;
+            boolean hasPermission;
 
-            if(!SecurityEngine.getSecurity().checkPermission(
-               principal, resourceType, candidateEntry.getPath(), ResourceAction.WRITE))
-            {
+            if(candidateEntry.getScope() == AssetRepository.USER_SCOPE) {
+               IdentityID entryUser = candidateEntry.getUser();
+               hasPermission = entryUser != null && principal != null &&
+                  (principal.getName().equals(entryUser.convertToKey()) ||
+                   SecurityEngine.getSecurity().checkPermission(
+                      principal, ResourceType.SECURITY_USER, entryUser.convertToKey(),
+                      ResourceAction.ADMIN)) &&
+                  SecurityEngine.getSecurity().checkPermission(
+                     principal, ResourceType.MY_DASHBOARDS, "*", ResourceAction.READ);
+            }
+            else {
+               ResourceType resourceType = candidateEntry.isWorksheet() ?
+                  ResourceType.ASSET : ResourceType.REPORT;
+               hasPermission = SecurityEngine.getSecurity().checkPermission(
+                  principal, resourceType, candidateEntry.getPath(), ResourceAction.WRITE);
+            }
+
+            if(!hasPermission) {
                throw new MessageException(Catalog.getCatalog().getString(
                   "em.common.security.no.permission", candidateEntry.getPath()));
             }

--- a/core/src/main/java/inetsoft/web/admin/content/repository/MVSupportService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/MVSupportService.java
@@ -184,29 +184,7 @@ public class MVSupportService {
          AssetEntry candidateEntry = getEntry(candidate.id);
 
          if(candidateEntry != null) {
-            boolean hasPermission;
-
-            if(candidateEntry.getScope() == AssetRepository.USER_SCOPE) {
-               IdentityID entryUser = candidateEntry.getUser();
-               hasPermission = entryUser != null && principal != null &&
-                  (principal.getName().equals(entryUser.convertToKey()) ||
-                   SecurityEngine.getSecurity().checkPermission(
-                      principal, ResourceType.SECURITY_USER, entryUser.convertToKey(),
-                      ResourceAction.ADMIN)) &&
-                  SecurityEngine.getSecurity().checkPermission(
-                     principal, ResourceType.MY_DASHBOARDS, "*", ResourceAction.READ);
-            }
-            else {
-               ResourceType resourceType = candidateEntry.isWorksheet() ?
-                  ResourceType.ASSET : ResourceType.REPORT;
-               hasPermission = SecurityEngine.getSecurity().checkPermission(
-                  principal, resourceType, candidateEntry.getPath(), ResourceAction.WRITE);
-            }
-
-            if(!hasPermission) {
-               throw new MessageException(Catalog.getCatalog().getString(
-                  "em.common.security.no.permission", candidateEntry.getPath()));
-            }
+            checkAssetPermission(candidateEntry, principal);
          }
       }
 
@@ -1444,6 +1422,48 @@ public class MVSupportService {
          return Boolean.compare(mv1.getDefinition().isAssociationMV(),
                                 mv2.getDefinition().isAssociationMV());
       }
+   }
+
+   private static void checkAssetPermission(AssetEntry entry, Principal principal)
+      throws inetsoft.sree.security.SecurityException
+   {
+      boolean hasPermission;
+
+      if(entry.getScope() == AssetRepository.USER_SCOPE) {
+         hasPermission = hasUserScopePermission(entry, principal);
+      }
+      else {
+         ResourceType resourceType = entry.isWorksheet() ?
+            ResourceType.ASSET : ResourceType.REPORT;
+         hasPermission = SecurityEngine.getSecurity().checkPermission(
+            principal, resourceType, entry.getPath(), ResourceAction.WRITE);
+      }
+
+      if(!hasPermission) {
+         throw new MessageException(Catalog.getCatalog().getString(
+            "em.common.security.no.permission", entry.getPath()));
+      }
+   }
+
+   private static boolean hasUserScopePermission(AssetEntry entry, Principal principal)
+      throws inetsoft.sree.security.SecurityException
+   {
+      IdentityID entryUser = entry.getUser();
+
+      // Intentionally fail-closed: deny access when the owning user is unknown.
+      // AbstractAssetEngine.checkAssetPermission() returns true in this case, but
+      // MV analysis must not proceed without a verifiable owner.
+      if(entryUser == null || principal == null) {
+         return false;
+      }
+
+      boolean isSameUser = principal.getName().equals(entryUser.convertToKey());
+      boolean isAdmin = SecurityEngine.getSecurity().checkPermission(
+         principal, ResourceType.SECURITY_USER, entryUser, ResourceAction.ADMIN);
+
+      return (isSameUser || isAdmin) &&
+         SecurityEngine.getSecurity().checkPermission(
+            principal, ResourceType.MY_DASHBOARDS, "*", ResourceAction.READ);
    }
 
    private final ExecutorService analyzePool =

--- a/core/src/main/java/inetsoft/web/admin/content/repository/MVSupportService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/MVSupportService.java
@@ -1458,7 +1458,7 @@ public class MVSupportService {
       }
 
       boolean isSameUser = principal.getName().equals(entryUser.convertToKey());
-      boolean isAdmin = SecurityEngine.getSecurity().checkPermission(
+      boolean isAdmin = !isSameUser && SecurityEngine.getSecurity().checkPermission(
          principal, ResourceType.SECURITY_USER, entryUser, ResourceAction.ADMIN);
 
       return (isSameUser || isAdmin) &&


### PR DESCRIPTION
For USER_SCOPE assets, verify the principal is the asset owner (or has ADMIN over the owner) and has MY_DASHBOARDS READ permission; retain the existing REPORT/ASSET WRITE check for all other scopes.