### PR TITLE
bug-74609: fix cloned org theme deleted when parent org theme is deleted

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
@@ -308,6 +308,7 @@ public abstract class AbstractEditableAuthenticationProvider
                if(t.getOrgID() != null) {
                   CustomTheme clone = (CustomTheme) t.clone();
                   clone.setOrgID(toOrgId);
+                  clone.setId(UUID.randomUUID().toString().replace("-", ""));
 
                   if(t.getOrganizations().contains(fromOrgId)) {
                      List<String> newOrgs = clone.getOrganizations();


### PR DESCRIPTION
## Summary

- When an organization is cloned, `copyThemes()` calls `CustomTheme.clone()` which preserves the original theme's `id` on the copy.
- `removeTheme()` deletes themes by ID globally across all orgs, so deleting a theme from the parent org inadvertently removed the identically-IDed clone in child orgs.
- Fix: assign a new `UUID` to each cloned theme in `copyThemes()` so that parent and child org themes have distinct IDs and deletions are properly scoped.

Fixes #74609.

## Test plan

- [ ] Create two themes in host-org (`host1`, `host2`) with "Visible to All Organizations" unchecked.
- [ ] Clone `organization0` from host-org; verify `host1` and `host2` appear in org0's theme pane.
- [ ] Clone `organization1` from org0; verify `host1`, `host2`, and `org0` themes appear in org1's theme pane.
- [ ] Delete `host1` from host-org; verify it still appears in org0 and org1 (no longer deleted).
- [ ] Delete `host2` from org0; verify it still appears in org1 (no longer deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)