### PR TITLE
Bug #74614, navigate away from cycle editor page on load error

### DIFF
--- a/web/projects/em/src/app/settings/schedule/schedule-cycle-editor-page/schedule-cycle-editor-page.component.ts
+++ b/web/projects/em/src/app/settings/schedule/schedule-cycle-editor-page/schedule-cycle-editor-page.component.ts
@@ -110,6 +110,9 @@ export class ScheduleCycleEditorPageComponent implements OnInit, OnDestroy {
                this.model.timeZoneOptions, null);
             this.originalModel = Tool.clone(model);
             this.updateList();
+         },
+         () => {
+            this.close();
          });
    }
 

--- a/web/projects/em/src/app/settings/schedule/schedule-cycle-editor-page/schedule-cycle-editor-page.component.ts
+++ b/web/projects/em/src/app/settings/schedule/schedule-cycle-editor-page/schedule-cycle-editor-page.component.ts
@@ -111,8 +111,20 @@ export class ScheduleCycleEditorPageComponent implements OnInit, OnDestroy {
             this.originalModel = Tool.clone(model);
             this.updateList();
          },
-         () => {
-            this.close();
+         (error: HttpErrorResponse) => {
+            if(error.error?.message) {
+               this.dialog.open(MessageDialog, {
+                  width: "500px",
+                  data: {
+                     title: "_#(js:Error)",
+                     content: error.error.message,
+                     type: MessageDialogType.ERROR
+                  }
+               }).afterClosed().subscribe(() => this.close());
+            }
+            else {
+               this.close();
+            }
          });
    }
 


### PR DESCRIPTION
- When a user navigates to the cycle editor page (/settings/schedule/cycles/:cycle) and loses access to the Data Cycles permission (e.g. admin unchecks "Derive Permissions from Parent"), refreshing the page results in a failed API call with no error handling, leaving the page empty.
- Added an error handler to loadModel() in ScheduleCycleEditorPageComponent that calls close() on failure, navigating back to /settings/schedule/cycles. AuthorizationGuard then redirects to the first permitted schedule tab.
- This mirrors the existing error handling behavior in ScheduleTaskEditorPageComponent.