### PR TITLE
Bug #74615, store email message as CDATA element to avoid XML attribute size limit

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/EmailInfo.java
+++ b/core/src/main/java/inetsoft/sree/schedule/EmailInfo.java
@@ -261,11 +261,7 @@ class EmailInfo implements Cloneable, Serializable, HttpXMLSerializable {
          }
       }
 
-      String message = getMessage();
-
-      if(message != null) {
-         message = isEncoding() ? message : Tool.escape(message);
-         writer.print(" message=\"" + byteEncode(message) + "\"");
+      if(messageHtml || getMessage() != null) {
          writer.print(" messageHtml=\"" + Boolean.toString(messageHtml) + "\"");
       }
 
@@ -295,6 +291,12 @@ class EmailInfo implements Cloneable, Serializable, HttpXMLSerializable {
       }
 
       writer.println(">");
+
+      String message = getMessage();
+
+      if(message != null) {
+         writer.println("<message><![CDATA[" + message.replace("]]>", "]]]]><![CDATA[>") + "]]></message>");
+      }
 
       if(query != null) {
          query.writeXML(writer);
@@ -342,8 +344,16 @@ class EmailInfo implements Cloneable, Serializable, HttpXMLSerializable {
          password = byteDecode(Tool.decryptPassword(password));
       }
 
-      message = tag.getAttribute("message");
-      message = byteDecode(message);
+      Element messageNode = Tool.getChildNodeByTagName(tag, "message");
+
+      if(messageNode != null) {
+         message = Tool.getValue(messageNode);
+      }
+      else {
+         // legacy: message was stored as an XML attribute before being moved to a child element
+         message = tag.getAttribute("message");
+         message = byteDecode(message);
+      }
 
       messageHtml = "true".equals(tag.getAttribute("messageHtml"));
 

--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleManager.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleManager.java
@@ -124,7 +124,7 @@ public class ScheduleManager {
          tasks.addAll(map.values());
       }
 
-      return tasks.stream().distinct().collect(Collectors.toList());
+      return tasks.stream().filter(Objects::nonNull).distinct().collect(Collectors.toList());
    }
 
    public ScheduleTaskMap getOrgTaskMap(String orgID) {

--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleTaskMap.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleTaskMap.java
@@ -90,8 +90,7 @@ class ScheduleTaskMap extends AbstractMap<String, ScheduleTask> {
          }
       }
       catch(Exception e) {
-         throw new RuntimeException(
-            "Failed to load schedule task: " + identifier, e);
+         LOG.error("Failed to load schedule task, skipping: {}", identifier, e);
       }
 
       return task;


### PR DESCRIPTION
## Summary
- **`EmailInfo`**: The `message` field is now written as a `<message>` CDATA child element instead of an XML attribute. Storing large HTML bodies (e.g. base64-encoded images embedded via CKEditor) as an attribute caused Woodstox's default 512 KB attribute size limit to be exceeded, triggering an `XMLStreamException` on read. `parseXML` reads from the element first and falls back to the legacy attribute for backward compatibility.
- **`ScheduleTaskMap`**: A task that fails to load now logs an error and returns `null` instead of rethrowing, so one corrupt task cannot break the entire schedule module for the org.
- **`ScheduleManager`**: `getAllScheduleTasks()` filters nulls to guard downstream code against skipped tasks.

## Test plan
- [ ] Create a schedule task with a delivery email action; paste a large image into the CKEditor message body so the HTML body exceeds 512 KB; save the task — it should succeed
- [ ] Verify the task list loads without error after saving
- [ ] Verify the schedule distribution chart endpoint (`/sree/api/em/schedule/distribution/chart`) returns 200
- [ ] Load an existing task saved with the old format (message as attribute) — message should round-trip correctly (backward compatibility)
- [ ] Verify tasks with no message, an empty message, and a message containing `]]>` all round-trip correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)