### PR TITLE
Bug #74545, Fix New Query being incorrectly disabled in the portal data tab left tree for users without data source write permission

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-navigation-tree/data-sources-tree-view.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-navigation-tree/data-sources-tree-view.component.ts
@@ -1363,7 +1363,7 @@ export class DataSourcesTreeViewComponent extends CommandProcessor implements On
             icon: () => "",
             visible: () => node.type === PortalDataType.DATABASE ||
                node.type === PortalDataType.DATA_SOURCE,
-            enabled: () => this.canCreateChildren(node) && this.canCreateQuery(node),
+            enabled: () => this.canCreateQuery(node),
             action: () => this.createQuery(node)
          },
          {


### PR DESCRIPTION
Consistent with the right-pane behavior which only requires read and physical table access permissions