### PR TITLE
Bug #74175, fix MV creation producing empty data in non-host organizations

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/MVSupportService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/MVSupportService.java
@@ -1091,7 +1091,17 @@ public class MVSupportService {
             error = e;
          }
 
-         updateStatus(results, error);
+         // Set the principal so persistAndClearWorksheet() reads embedded table
+         // data from the correct org rather than the host org.
+         Principal oldPrincipal = ThreadContext.getContextPrincipal();
+         ThreadContext.setContextPrincipal(principal);
+
+         try {
+            updateStatus(results, error);
+         }
+         finally {
+            ThreadContext.setContextPrincipal(oldPrincipal);
+         }
       }
 
       public List<MVStatus> call() {


### PR DESCRIPTION
Set the task's principal before calling updateStatus() so that embedded data is retrieved from the correct org.