### PR TITLE
Translate the following into English: "Read the `synonyms` attribute from `tableData` and wrap it into `ai_context`."

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -117,6 +117,14 @@ public class MetadataApiService {
       dataset.setSource(source);
       dataset.setCustomExtensions(List.of(buildDatasetExtension(dsName, catalog, schema, source)));
 
+      Object synonyms = tableData.getAttribute("synonyms");
+
+      if(synonyms != null) {
+         Map<String, Object> aiContext = new LinkedHashMap<>();
+         aiContext.put("synonyms", synonyms);
+         dataset.setAiContext(aiContext);
+      }
+
       List<String> primaryKeys = new ArrayList<>();
       List<OsiField> fields = new ArrayList<>();
 

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -126,14 +126,6 @@ public class MetadataApiService {
       dataset.setCustomExtensions(List.of(buildDatasetExtension(dsName, catalog, schema, source)));
 
       Object synonyms = tableData.getAttribute("synonyms");
-
-      if(synonyms != null) {
-         Map<String, Object> aiContext = new LinkedHashMap<>();
-         aiContext.put("synonyms", synonyms);
-         dataset.setAiContext(aiContext);
-      }
-
-      Object synonyms = tableData.getAttribute("synonyms");
       boolean hasSynonyms = synonyms instanceof String s ? !s.isEmpty()
          : synonyms instanceof Collection<?> c ? !c.isEmpty()
          : synonyms != null;

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -133,6 +133,17 @@ public class MetadataApiService {
          dataset.setAiContext(aiContext);
       }
 
+      Object synonyms = tableData.getAttribute("synonyms");
+      boolean hasSynonyms = synonyms instanceof String s ? !s.isEmpty()
+         : synonyms instanceof Collection<?> c ? !c.isEmpty()
+         : synonyms != null;
+
+      if(hasSynonyms) {
+         Map<String, Object> aiContext = new LinkedHashMap<>();
+         aiContext.put("synonyms", synonyms);
+         dataset.setAiContext(aiContext);
+      }
+
       List<String> primaryKeys = new ArrayList<>();
       List<OsiField> fields = new ArrayList<>();
 


### PR DESCRIPTION
After constructing the `OsiDataset`, read the `synonyms` attribute from `tableData` (table-level metadata `XNode`). If it is not empty, wrap it into `ai_context`.