### PR TITLE
Bug #74659, enforce SCHEDULE_OPTION permissions server-side when saving schedule tasks

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
@@ -606,10 +606,10 @@ public class ScheduleTaskService {
    void sanitizeConditions(ScheduleTask task, ScheduleTask originalTask,
                            Principal principal)
    {
-      boolean canSetStartTime = securityProvider.checkPermission(
-         principal, ResourceType.SCHEDULE_OPTION, "startTime", ResourceAction.READ);
-      boolean canUseTimeRange = securityProvider.checkPermission(
-         principal, ResourceType.SCHEDULE_OPTION, "timeRange", ResourceAction.READ);
+      boolean canSetStartTime = scheduleService.checkPermission(
+         principal, ResourceType.SCHEDULE_OPTION, "startTime");
+      boolean canUseTimeRange = scheduleService.checkPermission(
+         principal, ResourceType.SCHEDULE_OPTION, "timeRange");
 
       if(canSetStartTime && canUseTimeRange) {
          return;

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
@@ -542,7 +542,7 @@ public class ScheduleTaskService {
 
       if(!internalTask) {
          for(int i = 0; i < model.actions().size(); i++) {
-            ScheduleAction scheduleAction = task.getActionCount() > i ? task.getAction(i) : null;
+            ScheduleAction scheduleAction = originalTask.getActionCount() > i ? originalTask.getAction(i) : null;
             ScheduleAction action =
                scheduleService.getActionFromModel(model.actions().get(i), scheduleAction, principal, linkURI);
 
@@ -712,6 +712,8 @@ public class ScheduleTaskService {
             vsa.setOnlyDataComponents(origVsa.isOnlyDataComponents());
             vsa.setExportAllTabbedTables(origVsa.isExportAllTabbedTables());
             vsa.setEmailCSVConfig(origVsa.getEmailCSVConfig());
+            vsa.setAttachmentName(origVsa.getAttachmentName());
+            vsa.setCompressFile(origVsa.isCompressFile());
          }
          else {
             vsa.setEmails(null);
@@ -728,6 +730,8 @@ public class ScheduleTaskService {
             vsa.setOnlyDataComponents(false);
             vsa.setExportAllTabbedTables(false);
             vsa.setEmailCSVConfig(null);
+            vsa.setAttachmentName(null);
+            vsa.setCompressFile(false);
          }
       }
 

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
@@ -518,6 +518,10 @@ public class ScheduleTaskService {
             "Unauthorized access to resource \"%s\" by %s", task.getName(), principal));
       }
 
+      // Snapshot the server-side task before applying client changes so that sanitizeConditions
+      // and sanitizeAction can restore any fields the principal is not permitted to change.
+      ScheduleTask originalTask = task.clone();
+
       Set<TimeRange> ranges = new HashSet<>();
 
       for(int i = 0; i < model.conditions().size(); i++) {
@@ -534,6 +538,8 @@ public class ScheduleTaskService {
          task.removeCondition(i);
       }
 
+      sanitizeConditions(task, originalTask, principal);
+
       if(!internalTask) {
          for(int i = 0; i < model.actions().size(); i++) {
             ScheduleAction scheduleAction = task.getActionCount() > i ? task.getAction(i) : null;
@@ -543,6 +549,8 @@ public class ScheduleTaskService {
             if(action == null) {
                continue;
             }
+
+            sanitizeAction(action, scheduleAction, principal);
 
             if(action instanceof IndividualAssetBackupAction) {
                IndividualAssetBackupAction backupAction = (IndividualAssetBackupAction) action;
@@ -593,6 +601,159 @@ public class ScheduleTaskService {
       }
 
       return getDialogModel(taskName, principal, em);
+   }
+
+   void sanitizeConditions(ScheduleTask task, ScheduleTask originalTask,
+                           Principal principal)
+   {
+      boolean canSetStartTime = securityProvider.checkPermission(
+         principal, ResourceType.SCHEDULE_OPTION, "startTime", ResourceAction.READ);
+      boolean canUseTimeRange = securityProvider.checkPermission(
+         principal, ResourceType.SCHEDULE_OPTION, "timeRange", ResourceAction.READ);
+
+      if(canSetStartTime && canUseTimeRange) {
+         return;
+      }
+
+      for(int i = task.getConditionCount() - 1; i >= 0; i--) {
+         if(!(task.getCondition(i) instanceof TimeCondition tc)) {
+            continue;
+         }
+
+         TimeCondition origTc = i < originalTask.getConditionCount() &&
+            originalTask.getCondition(i) instanceof TimeCondition o ? o : null;
+         boolean sameType = origTc != null && origTc.getType() == tc.getType();
+
+         if(!canSetStartTime) {
+            if(tc.getType() == TimeCondition.AT || tc.getType() == TimeCondition.EVERY_HOUR) {
+               // These types are not available without startTime permission.
+               // Restore only if the server had the same type; otherwise discard.
+               if(sameType) {
+                  task.setCondition(i, origTc);
+               }
+               else {
+                  task.removeCondition(i);
+               }
+
+               continue;
+            }
+
+            // For other types, restore time fields only when the type matches.
+            // If the type differs or there is no original, apply defaults.
+            if(sameType) {
+               tc.setHour(origTc.getHour());
+               tc.setMinute(origTc.getMinute());
+               tc.setSecond(origTc.getSecond());
+            }
+            else {
+               tc.setHour(1);
+               tc.setMinute(30);
+               tc.setSecond(0);
+            }
+         }
+
+         if(!canUseTimeRange) {
+            TimeRange origRange = sameType ? origTc.getTimeRange() : null;
+
+            if(!Objects.equals(tc.getTimeRange(), origRange)) {
+               tc.setTimeRange(origRange);
+            }
+         }
+      }
+   }
+
+   void sanitizeAction(ScheduleAction action, ScheduleAction originalAction,
+                       Principal principal)
+   {
+      if(!(action instanceof ViewsheetAction vsa)) {
+         return;
+      }
+
+      boolean canSetNotificationEmail = scheduleService.checkPermission(
+         principal, ResourceType.SCHEDULE_OPTION, "notificationEmail");
+      boolean canSaveToDisk = scheduleService.checkPermission(
+         principal, ResourceType.SCHEDULE_OPTION, "saveToDisk");
+      boolean canDeliverEmail = scheduleService.checkPermission(
+         principal, ResourceType.SCHEDULE_OPTION, "emailDelivery");
+
+      // Only preserve admin-set values when the action targets the same dashboard.
+      // If the sheet changed, treat it as a new action and apply restrictions unconditionally.
+      ViewsheetAction origVsa = originalAction instanceof ViewsheetAction o &&
+         Objects.equals(o.getViewsheet(), vsa.getViewsheet()) ? o : null;
+
+      if(!canSetNotificationEmail) {
+         if(origVsa != null && origVsa.getNotifications() != null &&
+            !origVsa.getNotifications().isEmpty())
+         {
+            vsa.setNotifications(origVsa.getNotifications());
+            vsa.setNotifyError(origVsa.isNotifyError());
+            vsa.setLink(origVsa.isLink());
+         }
+         else {
+            vsa.setNotifications(null);
+            vsa.setNotifyError(false);
+            vsa.setLink(false);
+         }
+      }
+
+      if(!canDeliverEmail) {
+         if(origVsa != null && origVsa.getEmails() != null && !origVsa.getEmails().isEmpty()) {
+            vsa.setEmails(origVsa.getEmails());
+            vsa.setCCAddresses(origVsa.getCCAddresses());
+            vsa.setBCCAddresses(origVsa.getBCCAddresses());
+            vsa.setFrom(origVsa.getFrom());
+            vsa.setSubject(origVsa.getSubject());
+            vsa.setMessage(origVsa.getMessage());
+            vsa.setMessageHtml(origVsa.isMessageHtml());
+            vsa.setFileFormat(origVsa.getFileFormat());
+            vsa.setDeliverLink(origVsa.isDeliverLink());
+            vsa.setMatchLayout(origVsa.isMatchLayout());
+            vsa.setExpandSelections(origVsa.isExpandSelections());
+            vsa.setOnlyDataComponents(origVsa.isOnlyDataComponents());
+            vsa.setExportAllTabbedTables(origVsa.isExportAllTabbedTables());
+            vsa.setEmailCSVConfig(origVsa.getEmailCSVConfig());
+         }
+         else {
+            vsa.setEmails(null);
+            vsa.setCCAddresses(null);
+            vsa.setBCCAddresses(null);
+            vsa.setFrom(null);
+            vsa.setSubject(null);
+            vsa.setMessage(null);
+            vsa.setMessageHtml(false);
+            vsa.setFileFormat(null);
+            vsa.setDeliverLink(false);
+            vsa.setMatchLayout(false);
+            vsa.setExpandSelections(false);
+            vsa.setOnlyDataComponents(false);
+            vsa.setExportAllTabbedTables(false);
+            vsa.setEmailCSVConfig(null);
+         }
+      }
+
+      if(!canSaveToDisk) {
+         for(int fmt : vsa.getSaveFormats()) {
+            vsa.setFilePath(fmt, (ServerPathInfo) null);
+         }
+
+         vsa.setSaveCSVConfig(null);
+         vsa.setSaveToServerMatch(false);
+         vsa.setSaveToServerExpandSelections(false);
+         vsa.setSaveToServerOnlyDataComponents(false);
+         vsa.setSaveExportAllTabbedTables(false);
+
+         if(origVsa != null && origVsa.getSaveFormats().length > 0) {
+            for(Map.Entry<Integer, ServerPathInfo> e : origVsa.getFilePathsMap().entrySet()) {
+               vsa.setFilePath(e.getKey(), e.getValue());
+            }
+
+            vsa.setSaveCSVConfig(origVsa.getSaveCSVConfig());
+            vsa.setSaveToServerMatch(origVsa.isSaveToServerMatch());
+            vsa.setSaveToServerExpandSelections(origVsa.isSaveToServerExpandSelections());
+            vsa.setSaveToServerOnlyDataComponents(origVsa.isSaveToServerOnlyDataComponents());
+            vsa.setSaveExportAllTabbedTables(origVsa.isSaveExportAllTabbedTables());
+         }
+      }
    }
 
    private void renameBackupAction(IndividualAssetBackupAction action, String path, String oid, String nid) {

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/dialog/ScheduleDialogController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/dialog/ScheduleDialogController.java
@@ -497,10 +497,10 @@ public class ScheduleDialogController {
          action.setCCAddresses(emailInfoModel.ccAddresses());
          action.setBCCAddresses(emailInfoModel.bccAddresses());
          action.setExportAllTabbedTables(emailInfoModel.exportAllTabbedTables());
-      }
 
-      if(emailInfoModel.formatType() == FileFormatInfo.EXPORT_TYPE_CSV) {
-         action.setCompressFile(true);
+         if(emailInfoModel.formatType() == FileFormatInfo.EXPORT_TYPE_CSV) {
+            action.setCompressFile(true);
+         }
       }
 
       TimeCondition condition = new TimeCondition();

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/dialog/ScheduleDialogController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/dialog/ScheduleDialogController.java
@@ -462,6 +462,14 @@ public class ScheduleDialogController {
          return;
       }
 
+      SecurityEngine security = SecurityEngine.getSecurity();
+      boolean canDeliverEmail = security.checkPermission(
+         principal, ResourceType.SCHEDULE_OPTION, "emailDelivery", ResourceAction.READ);
+      boolean canSetStartTime = security.checkPermission(
+         principal, ResourceType.SCHEDULE_OPTION, "startTime", ResourceAction.READ);
+      boolean canUseTimeRange = security.checkPermission(
+         principal, ResourceType.SCHEDULE_OPTION, "timeRange", ResourceAction.READ);
+
       ViewsheetAction action = new ViewsheetAction();
 
       action.setBookmarks(new String[]{Optional.ofNullable(viewsheetActionModel.bookmarkName()).orElse("")});
@@ -471,39 +479,54 @@ public class ScheduleDialogController {
       action.setViewsheet(
          Optional.ofNullable(viewsheetActionModel.viewsheet()).orElse(entry.toIdentifier()));
 
-      action.setFileFormat(getEmailFormat(emailInfoModel.formatType()));
-      action.setEmailCSVConfig(new CSVConfig(emailInfoModel.csvConfigModel()));
-      action.setEmails(Optional.ofNullable(emailInfoModel.emails()).orElse(""));
-      action.setFrom(Optional.ofNullable(emailInfoModel.fromAddress())
-         .orElse(SreeEnv.getProperty("mail.from.address")));
-      action.setAttachmentName(
-         Optional.ofNullable(emailInfoModel.attachmentName()).orElse(entry.getName()));
-      action.setSubject(
-         Optional.ofNullable(emailInfoModel.subject()).orElse(getEntryMessage(entry)));
-      action.setMessage(
-         Optional.ofNullable(emailInfoModel.message()).orElse(getEntryMessage(entry)));
-      action.setMatchLayout(emailInfoModel.matchLayout());
-      action.setExpandSelections(emailInfoModel.expandSelections());
-      action.setOnlyDataComponents(emailInfoModel.onlyDataComponents());
-      action.setCCAddresses(emailInfoModel.ccAddresses());
-      action.setBCCAddresses(emailInfoModel.bccAddresses());
-      action.setExportAllTabbedTables(emailInfoModel.exportAllTabbedTables());
+      if(canDeliverEmail) {
+         action.setFileFormat(getEmailFormat(emailInfoModel.formatType()));
+         action.setEmailCSVConfig(new CSVConfig(emailInfoModel.csvConfigModel()));
+         action.setEmails(Optional.ofNullable(emailInfoModel.emails()).orElse(""));
+         action.setFrom(Optional.ofNullable(emailInfoModel.fromAddress())
+            .orElse(SreeEnv.getProperty("mail.from.address")));
+         action.setAttachmentName(
+            Optional.ofNullable(emailInfoModel.attachmentName()).orElse(entry.getName()));
+         action.setSubject(
+            Optional.ofNullable(emailInfoModel.subject()).orElse(getEntryMessage(entry)));
+         action.setMessage(
+            Optional.ofNullable(emailInfoModel.message()).orElse(getEntryMessage(entry)));
+         action.setMatchLayout(emailInfoModel.matchLayout());
+         action.setExpandSelections(emailInfoModel.expandSelections());
+         action.setOnlyDataComponents(emailInfoModel.onlyDataComponents());
+         action.setCCAddresses(emailInfoModel.ccAddresses());
+         action.setBCCAddresses(emailInfoModel.bccAddresses());
+         action.setExportAllTabbedTables(emailInfoModel.exportAllTabbedTables());
+      }
 
       if(emailInfoModel.formatType() == FileFormatInfo.EXPORT_TYPE_CSV) {
          action.setCompressFile(true);
       }
 
       TimeCondition condition = new TimeCondition();
-      condition.setHour(Optional.ofNullable(timeConditionModel.hour())
-                           .filter(h -> h > 0)
-                           .orElse(1));
-      condition.setMinute(Optional.ofNullable(timeConditionModel.minute())
-                             .filter(h -> h > 0)
-                             .orElse(30));
-      condition.setSecond(Optional.ofNullable(timeConditionModel.second())
-                             .filter(h -> h > 0)
-                             .orElse(0));
-      condition.setType(timeConditionModel.type());
+
+      if(canSetStartTime) {
+         condition.setHour(Optional.ofNullable(timeConditionModel.hour())
+                              .filter(h -> h > 0)
+                              .orElse(1));
+         condition.setMinute(Optional.ofNullable(timeConditionModel.minute())
+                                .filter(h -> h > 0)
+                                .orElse(30));
+         condition.setSecond(Optional.ofNullable(timeConditionModel.second())
+                                .filter(h -> h > 0)
+                                .orElse(0));
+         condition.setType(timeConditionModel.type());
+      }
+      else {
+         // Principal cannot set the scheduled time: use system defaults and
+         // fall back to EVERY_DAY if the submitted type was AT or EVERY_HOUR.
+         condition.setHour(1);
+         condition.setMinute(30);
+         condition.setSecond(0);
+         int type = timeConditionModel.type();
+         condition.setType(type == TimeCondition.AT || type == TimeCondition.EVERY_HOUR
+            ? TimeCondition.EVERY_DAY : type);
+      }
 
       if(condition.getType() == TimeCondition.EVERY_DAY) {
          condition.setWeekdayOnly(timeConditionModel.weekdayOnly());
@@ -533,7 +556,7 @@ public class ScheduleDialogController {
          }
       }
 
-      if(timeConditionModel.timeRange() != null) {
+      if(timeConditionModel.timeRange() != null && canUseTimeRange) {
          TimeRangeModel range = timeConditionModel.timeRange();
          condition.setTimeRange(new TimeRange(
             range.name(), range.startTime(), range.endTime(), range.defaultRange()));

--- a/core/src/test/java/inetsoft/web/admin/schedule/ScheduleTaskServiceSanitizeTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/ScheduleTaskServiceSanitizeTest.java
@@ -18,7 +18,8 @@
 package inetsoft.web.admin.schedule;
 
 import inetsoft.sree.schedule.*;
-import inetsoft.sree.security.*;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
 import inetsoft.uql.viewsheet.FileFormatInfo;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,16 +39,13 @@ class ScheduleTaskServiceSanitizeTest {
    @Mock
    private ScheduleService scheduleService;
    @Mock
-   private SecurityProvider securityProvider;
-   @Mock
    private Principal principal;
 
    private ScheduleTaskService service;
 
    @BeforeEach
    void setUp() {
-      service = new ScheduleTaskService(null, null, scheduleService, null,
-                                        securityProvider, null);
+      service = new ScheduleTaskService(null, null, scheduleService, null, null, null);
    }
 
    // ── sanitizeConditions ────────────────────────────────────────────────────
@@ -152,6 +150,34 @@ class ScheduleTaskServiceSanitizeTest {
 
       // client sends AT but original at index 0 is EVERY_DAY
       ScheduleTask task = taskWithAt(new Date());
+      ScheduleTask original = taskWithEveryDay(9, 0, 0);
+
+      service.sanitizeConditions(task, original, principal);
+
+      assertEquals(0, task.getConditionCount());
+   }
+
+   @Test
+   void sanitizeConditions_noStartTime_everyHourSameIndex_restoresOriginal() {
+      denyStartTime();
+      allowTimeRange();
+
+      ScheduleTask task = taskWithEveryHour(10, 0);
+      ScheduleTask original = taskWithEveryHour(9, 15);
+      TimeCondition origTc = (TimeCondition) original.getCondition(0);
+
+      service.sanitizeConditions(task, original, principal);
+
+      assertEquals(1, task.getConditionCount());
+      assertSame(origTc, task.getCondition(0));
+   }
+
+   @Test
+   void sanitizeConditions_noStartTime_everyHourTypeMismatch_removesCondition() {
+      denyStartTime();
+      allowTimeRange();
+
+      ScheduleTask task = taskWithEveryHour(10, 0);
       ScheduleTask original = taskWithEveryDay(9, 0, 0);
 
       service.sanitizeConditions(task, original, principal);
@@ -405,6 +431,16 @@ class ScheduleTaskServiceSanitizeTest {
       return task;
    }
 
+   private ScheduleTask taskWithEveryHour(int hour, int minute) {
+      ScheduleTask task = new ScheduleTask();
+      TimeCondition tc = new TimeCondition();
+      tc.setType(TimeCondition.EVERY_HOUR);
+      tc.setHour(hour);
+      tc.setMinute(minute);
+      task.addCondition(tc);
+      return task;
+   }
+
    private ScheduleTask taskWithAt(Date date) {
       ScheduleTask task = new ScheduleTask();
       TimeCondition tc = TimeCondition.at(date);
@@ -419,26 +455,26 @@ class ScheduleTaskServiceSanitizeTest {
    }
 
    private void allowStartTime() {
-      when(securityProvider.checkPermission(eq(principal),
-         eq(ResourceType.SCHEDULE_OPTION), eq("startTime"), eq(ResourceAction.READ)))
+      when(scheduleService.checkPermission(eq(principal),
+         eq(ResourceType.SCHEDULE_OPTION), eq("startTime")))
          .thenReturn(true);
    }
 
    private void denyStartTime() {
-      when(securityProvider.checkPermission(eq(principal),
-         eq(ResourceType.SCHEDULE_OPTION), eq("startTime"), eq(ResourceAction.READ)))
+      when(scheduleService.checkPermission(eq(principal),
+         eq(ResourceType.SCHEDULE_OPTION), eq("startTime")))
          .thenReturn(false);
    }
 
    private void allowTimeRange() {
-      when(securityProvider.checkPermission(eq(principal),
-         eq(ResourceType.SCHEDULE_OPTION), eq("timeRange"), eq(ResourceAction.READ)))
+      when(scheduleService.checkPermission(eq(principal),
+         eq(ResourceType.SCHEDULE_OPTION), eq("timeRange")))
          .thenReturn(true);
    }
 
    private void denyTimeRange() {
-      when(securityProvider.checkPermission(eq(principal),
-         eq(ResourceType.SCHEDULE_OPTION), eq("timeRange"), eq(ResourceAction.READ)))
+      when(scheduleService.checkPermission(eq(principal),
+         eq(ResourceType.SCHEDULE_OPTION), eq("timeRange")))
          .thenReturn(false);
    }
 

--- a/core/src/test/java/inetsoft/web/admin/schedule/ScheduleTaskServiceSanitizeTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/ScheduleTaskServiceSanitizeTest.java
@@ -382,9 +382,58 @@ class ScheduleTaskServiceSanitizeTest {
    }
 
    @Test
+   void sanitizeAction_noEmailDelivery_differentSheet_clears() {
+      allowNotificationEmail();
+      allowSaveToDisk();
+      denyEmailDelivery();
+
+      ViewsheetAction original = vsActionWithSheet("vs1");
+      original.setEmails("admin@example.com");
+      original.setCCAddresses("cc@example.com");
+      original.setSubject("Server subject");
+      original.setAttachmentName("report.pdf");
+      original.setCompressFile(true);
+
+      ViewsheetAction action = vsActionWithSheet("vs2");
+      action.setEmails("hacker@evil.com");
+      action.setCCAddresses("hacker2@evil.com");
+      action.setSubject("Hacker subject");
+      action.setAttachmentName("evil.pdf");
+      action.setCompressFile(true);
+
+      service.sanitizeAction(action, original, principal);
+
+      assertNull(action.getEmails());
+      assertNull(action.getCCAddresses());
+      assertNull(action.getSubject());
+      assertNull(action.getAttachmentName());
+      assertFalse(action.isCompressFile());
+   }
+
+   @Test
+   void sanitizeAction_noSaveToDisk_differentSheet_clears() {
+      allowNotificationEmail();
+      denySaveToDisk();
+      allowEmailDelivery();
+
+      ViewsheetAction original = vsActionWithSheet("vs1");
+      original.setFilePath(FileFormatInfo.EXPORT_TYPE_PDF, new ServerPathInfo("/reports/report.pdf"));
+      original.setSaveToServerMatch(true);
+
+      ViewsheetAction action = vsActionWithSheet("vs2");
+      action.setFilePath(FileFormatInfo.EXPORT_TYPE_PDF, new ServerPathInfo("/evil/path.pdf"));
+      action.setSaveToServerMatch(true);
+
+      service.sanitizeAction(action, original, principal);
+
+      assertEquals(0, action.getSaveFormats().length);
+      assertFalse(action.isSaveToServerMatch());
+   }
+
+   @Test
    void sanitizeAction_noSaveToDisk_sameSheet_origHadSave_restoresSaveSettings() {
       allowNotificationEmail();
-      denyDisk();
+      denySaveToDisk();
       allowEmailDelivery();
 
       ViewsheetAction original = vsActionWithSheet("vs1");
@@ -403,7 +452,7 @@ class ScheduleTaskServiceSanitizeTest {
    @Test
    void sanitizeAction_noSaveToDisk_sameSheet_origHadNoSave_clearsSaveSettings() {
       allowNotificationEmail();
-      denyDisk();
+      denySaveToDisk();
       allowEmailDelivery();
 
       ViewsheetAction action = vsActionWithSheet("vs1");
@@ -496,7 +545,7 @@ class ScheduleTaskServiceSanitizeTest {
          .thenReturn(true);
    }
 
-   private void denyDisk() {
+   private void denySaveToDisk() {
       when(scheduleService.checkPermission(eq(principal),
          eq(ResourceType.SCHEDULE_OPTION), eq("saveToDisk")))
          .thenReturn(false);

--- a/core/src/test/java/inetsoft/web/admin/schedule/ScheduleTaskServiceSanitizeTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/ScheduleTaskServiceSanitizeTest.java
@@ -1,0 +1,480 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.schedule;
+
+import inetsoft.sree.schedule.*;
+import inetsoft.sree.security.*;
+import inetsoft.uql.viewsheet.FileFormatInfo;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ScheduleTaskServiceSanitizeTest {
+
+   @Mock
+   private ScheduleService scheduleService;
+   @Mock
+   private SecurityProvider securityProvider;
+   @Mock
+   private Principal principal;
+
+   private ScheduleTaskService service;
+
+   @BeforeEach
+   void setUp() {
+      service = new ScheduleTaskService(null, null, scheduleService, null,
+                                        securityProvider, null);
+   }
+
+   // ── sanitizeConditions ────────────────────────────────────────────────────
+
+   @Test
+   void sanitizeConditions_hasAllPermissions_conditionsUnchanged() {
+      allowStartTime();
+      allowTimeRange();
+
+      ScheduleTask task = taskWithEveryDay(10, 0, 0);
+      ScheduleTask original = taskWithEveryDay(9, 30, 0);
+
+      service.sanitizeConditions(task, original, principal);
+
+      TimeCondition tc = (TimeCondition) task.getCondition(0);
+      assertEquals(10, tc.getHour());
+   }
+
+   @Test
+   void sanitizeConditions_noStartTime_everyDaySameIndex_restoresTime() {
+      denyStartTime();
+      allowTimeRange();
+
+      ScheduleTask task = taskWithEveryDay(10, 0, 0);
+      ScheduleTask original = taskWithEveryDay(9, 30, 0);
+
+      service.sanitizeConditions(task, original, principal);
+
+      assertEquals(1, task.getConditionCount());
+      TimeCondition tc = (TimeCondition) task.getCondition(0);
+      assertEquals(TimeCondition.EVERY_DAY, tc.getType());
+      assertEquals(9, tc.getHour());
+      assertEquals(30, tc.getMinute());
+      assertEquals(0, tc.getSecond());
+   }
+
+   @Test
+   void sanitizeConditions_noStartTime_everyDayNoOriginalAtIndex_appliesDefaults() {
+      denyStartTime();
+      allowTimeRange();
+
+      ScheduleTask task = taskWithEveryDay(10, 15, 0);
+      ScheduleTask original = new ScheduleTask();   // no conditions
+
+      service.sanitizeConditions(task, original, principal);
+
+      assertEquals(1, task.getConditionCount());
+      TimeCondition tc = (TimeCondition) task.getCondition(0);
+      assertEquals(TimeCondition.EVERY_DAY, tc.getType());
+      assertEquals(1, tc.getHour());
+      assertEquals(30, tc.getMinute());
+      assertEquals(0, tc.getSecond());
+   }
+
+   @Test
+   void sanitizeConditions_noStartTime_everyDayTypeMismatch_appliesDefaults() {
+      denyStartTime();
+      allowTimeRange();
+
+      // client sends EVERY_DAY but original at same index is EVERY_WEEK
+      ScheduleTask task = taskWithEveryDay(10, 0, 0);
+      ScheduleTask original = new ScheduleTask();
+      TimeCondition origTc = new TimeCondition();
+      origTc.setType(TimeCondition.EVERY_WEEK);
+      origTc.setHour(8);
+      origTc.setMinute(0);
+      original.addCondition(origTc);
+
+      service.sanitizeConditions(task, original, principal);
+
+      // EVERY_DAY condition is kept (not removed), but time is defaulted
+      assertEquals(1, task.getConditionCount());
+      TimeCondition tc = (TimeCondition) task.getCondition(0);
+      assertEquals(TimeCondition.EVERY_DAY, tc.getType());
+      assertEquals(1, tc.getHour());
+      assertEquals(30, tc.getMinute());
+   }
+
+   @Test
+   void sanitizeConditions_noStartTime_atConditionSameIndex_restoresOriginal() {
+      denyStartTime();
+      allowTimeRange();
+
+      Calendar cal = Calendar.getInstance();
+      cal.set(2025, Calendar.JANUARY, 1, 9, 0, 0);
+      Date date = cal.getTime();
+
+      ScheduleTask task = taskWithAt(date);
+      ScheduleTask original = taskWithAt(date);
+      TimeCondition origTc = (TimeCondition) original.getCondition(0);
+
+      service.sanitizeConditions(task, original, principal);
+
+      assertEquals(1, task.getConditionCount());
+      assertSame(origTc, task.getCondition(0));
+   }
+
+   @Test
+   void sanitizeConditions_noStartTime_atConditionTypeMismatch_removesCondition() {
+      denyStartTime();
+      allowTimeRange();
+
+      // client sends AT but original at index 0 is EVERY_DAY
+      ScheduleTask task = taskWithAt(new Date());
+      ScheduleTask original = taskWithEveryDay(9, 0, 0);
+
+      service.sanitizeConditions(task, original, principal);
+
+      assertEquals(0, task.getConditionCount());
+   }
+
+   @Test
+   void sanitizeConditions_noStartTime_atConditionBeyondOriginal_removesCondition() {
+      denyStartTime();
+      allowTimeRange();
+
+      ScheduleTask task = taskWithAt(new Date());
+      ScheduleTask original = new ScheduleTask();   // empty
+
+      service.sanitizeConditions(task, original, principal);
+
+      assertEquals(0, task.getConditionCount());
+   }
+
+   @Test
+   void sanitizeConditions_noTimeRange_sameTypeSameIndex_restoresTimeRange() {
+      allowStartTime();
+      denyTimeRange();
+
+      ScheduleTask task = taskWithEveryDay(9, 0, 0);
+      TimeCondition tc = (TimeCondition) task.getCondition(0);
+      tc.setTimeRange(new TimeRange("client-range", "08:00", "09:00", false));
+
+      ScheduleTask original = taskWithEveryDay(9, 0, 0);
+      TimeRange origRange = new TimeRange("server-range", "10:00", "11:00", true);
+      ((TimeCondition) original.getCondition(0)).setTimeRange(origRange);
+
+      service.sanitizeConditions(task, original, principal);
+
+      assertEquals(1, task.getConditionCount());
+      TimeCondition result = (TimeCondition) task.getCondition(0);
+      assertEquals(TimeCondition.EVERY_DAY, result.getType());
+      assertEquals(9, result.getHour());   // hour unchanged since startTime is allowed
+      assertEquals(origRange, result.getTimeRange());
+   }
+
+   @Test
+   void sanitizeConditions_noTimeRange_typeMismatch_clearsTimeRange() {
+      allowStartTime();
+      denyTimeRange();
+
+      ScheduleTask task = taskWithEveryDay(9, 0, 0);
+      ((TimeCondition) task.getCondition(0))
+         .setTimeRange(new TimeRange("client-range", "08:00", "09:00", false));
+
+      ScheduleTask original = new ScheduleTask();
+      TimeCondition origTc = new TimeCondition();
+      origTc.setType(TimeCondition.EVERY_WEEK);
+      original.addCondition(origTc);
+
+      service.sanitizeConditions(task, original, principal);
+
+      // EVERY_DAY condition is kept (not removed), but time range is cleared
+      assertEquals(1, task.getConditionCount());
+      TimeCondition result = (TimeCondition) task.getCondition(0);
+      assertEquals(TimeCondition.EVERY_DAY, result.getType());
+      assertNull(result.getTimeRange());
+   }
+
+   // ── sanitizeAction ────────────────────────────────────────────────────────
+
+   @Test
+   void sanitizeAction_notViewsheetAction_noOp() {
+      // BatchAction is an AbstractAction but not a ViewsheetAction
+      BatchAction action = mock(BatchAction.class);
+      service.sanitizeAction(action, null, principal);
+      verifyNoInteractions(scheduleService);
+   }
+
+   @Test
+   void sanitizeAction_hasAllPermissions_actionUnchanged() {
+      allowNotificationEmail();
+      allowSaveToDisk();
+      allowEmailDelivery();
+
+      ViewsheetAction action = vsActionWithSheet("vs1");
+      action.setNotifications("user@example.com");
+      action.setEmails("a@b.com");
+
+      service.sanitizeAction(action, vsActionWithSheet("vs1"), principal);
+
+      assertEquals("user@example.com", action.getNotifications());
+      assertEquals("a@b.com", action.getEmails());
+   }
+
+   @Test
+   void sanitizeAction_noNotificationEmail_sameSheet_origHadNotifications_restores() {
+      denyNotificationEmail();
+      allowSaveToDisk();
+      allowEmailDelivery();
+
+      ViewsheetAction original = vsActionWithSheet("vs1");
+      original.setNotifications("admin@example.com");
+      original.setNotifyError(true);
+      original.setLink(true);
+
+      ViewsheetAction action = vsActionWithSheet("vs1");
+      action.setNotifications("hacker@evil.com");
+      action.setNotifyError(false);
+      action.setLink(false);
+
+      service.sanitizeAction(action, original, principal);
+
+      assertEquals("admin@example.com", action.getNotifications());
+      assertTrue(action.isNotifyError());
+      assertTrue(action.isLink());
+   }
+
+   @Test
+   void sanitizeAction_noNotificationEmail_sameSheet_origHadNoNotifications_clears() {
+      denyNotificationEmail();
+      allowSaveToDisk();
+      allowEmailDelivery();
+
+      ViewsheetAction action = vsActionWithSheet("vs1");
+      action.setNotifications("hacker@evil.com");
+      action.setNotifyError(true);
+      action.setLink(true);
+
+      service.sanitizeAction(action, vsActionWithSheet("vs1"), principal);
+
+      assertNull(action.getNotifications());
+      assertFalse(action.isNotifyError());
+      assertFalse(action.isLink());
+   }
+
+   @Test
+   void sanitizeAction_noNotificationEmail_differentSheet_clears() {
+      denyNotificationEmail();
+      allowSaveToDisk();
+      allowEmailDelivery();
+
+      ViewsheetAction original = vsActionWithSheet("vs1");
+      original.setNotifications("admin@example.com");
+      original.setNotifyError(true);
+      original.setLink(true);
+
+      ViewsheetAction action = vsActionWithSheet("vs2");
+      action.setNotifications("hacker@evil.com");
+      action.setNotifyError(true);
+      action.setLink(true);
+
+      service.sanitizeAction(action, original, principal);
+
+      assertNull(action.getNotifications());
+      assertFalse(action.isNotifyError());
+      assertFalse(action.isLink());
+   }
+
+   @Test
+   void sanitizeAction_noEmailDelivery_sameSheet_origHadEmails_restoresAllFields() {
+      allowNotificationEmail();
+      allowSaveToDisk();
+      denyEmailDelivery();
+
+      ViewsheetAction original = vsActionWithSheet("vs1");
+      original.setEmails("admin@example.com");
+      original.setCCAddresses("cc@example.com");
+      original.setSubject("Server subject");
+      original.setMessage("Server body");
+
+      ViewsheetAction action = vsActionWithSheet("vs1");
+      action.setEmails("hacker@evil.com");
+      action.setCCAddresses("hacker2@evil.com");
+      action.setSubject("Hacker subject");
+      action.setMessage("Hacker body");
+
+      service.sanitizeAction(action, original, principal);
+
+      assertEquals("admin@example.com", action.getEmails());
+      assertEquals("cc@example.com", action.getCCAddresses());
+      assertEquals("Server subject", action.getSubject());
+      assertEquals("Server body", action.getMessage());
+   }
+
+   @Test
+   void sanitizeAction_noEmailDelivery_sameSheet_origHadNoEmails_clearsAllFields() {
+      allowNotificationEmail();
+      allowSaveToDisk();
+      denyEmailDelivery();
+
+      ViewsheetAction action = vsActionWithSheet("vs1");
+      action.setEmails("hacker@evil.com");
+      action.setCCAddresses("cc@evil.com");
+      action.setBCCAddresses("bcc@evil.com");
+      action.setSubject("Subject");
+      action.setMessage("Body");
+
+      service.sanitizeAction(action, vsActionWithSheet("vs1"), principal);
+
+      assertNull(action.getEmails());
+      assertNull(action.getCCAddresses());
+      assertNull(action.getBCCAddresses());
+      assertNull(action.getSubject());
+      assertNull(action.getMessage());
+   }
+
+   @Test
+   void sanitizeAction_noSaveToDisk_sameSheet_origHadSave_restoresSaveSettings() {
+      allowNotificationEmail();
+      denyDisk();
+      allowEmailDelivery();
+
+      ViewsheetAction original = vsActionWithSheet("vs1");
+      original.setFilePath(FileFormatInfo.EXPORT_TYPE_PDF, new ServerPathInfo("/reports/report.pdf"));
+      original.setSaveToServerMatch(true);
+
+      ViewsheetAction action = vsActionWithSheet("vs1");
+      action.setFilePath(FileFormatInfo.EXPORT_TYPE_PDF, new ServerPathInfo("/evil/path.pdf"));
+
+      service.sanitizeAction(action, original, principal);
+
+      assertEquals("/reports/report.pdf", action.getFilePath(FileFormatInfo.EXPORT_TYPE_PDF));
+      assertTrue(action.isSaveToServerMatch());
+   }
+
+   @Test
+   void sanitizeAction_noSaveToDisk_sameSheet_origHadNoSave_clearsSaveSettings() {
+      allowNotificationEmail();
+      denyDisk();
+      allowEmailDelivery();
+
+      ViewsheetAction action = vsActionWithSheet("vs1");
+      action.setFilePath(FileFormatInfo.EXPORT_TYPE_PDF, new ServerPathInfo("/evil/path.pdf"));
+      action.setSaveToServerMatch(true);
+      action.setSaveToServerExpandSelections(true);
+
+      service.sanitizeAction(action, vsActionWithSheet("vs1"), principal);
+
+      assertEquals(0, action.getSaveFormats().length);
+      assertFalse(action.isSaveToServerMatch());
+      assertFalse(action.isSaveToServerExpandSelections());
+   }
+
+   // ── helpers ───────────────────────────────────────────────────────────────
+
+   private ScheduleTask taskWithEveryDay(int hour, int minute, int second) {
+      ScheduleTask task = new ScheduleTask();
+      TimeCondition tc = new TimeCondition();
+      tc.setType(TimeCondition.EVERY_DAY);
+      tc.setHour(hour);
+      tc.setMinute(minute);
+      tc.setSecond(second);
+      task.addCondition(tc);
+      return task;
+   }
+
+   private ScheduleTask taskWithAt(Date date) {
+      ScheduleTask task = new ScheduleTask();
+      TimeCondition tc = TimeCondition.at(date);
+      task.addCondition(tc);
+      return task;
+   }
+
+   private ViewsheetAction vsActionWithSheet(String sheet) {
+      ViewsheetAction action = new ViewsheetAction();
+      action.setViewsheet(sheet);
+      return action;
+   }
+
+   private void allowStartTime() {
+      when(securityProvider.checkPermission(eq(principal),
+         eq(ResourceType.SCHEDULE_OPTION), eq("startTime"), eq(ResourceAction.READ)))
+         .thenReturn(true);
+   }
+
+   private void denyStartTime() {
+      when(securityProvider.checkPermission(eq(principal),
+         eq(ResourceType.SCHEDULE_OPTION), eq("startTime"), eq(ResourceAction.READ)))
+         .thenReturn(false);
+   }
+
+   private void allowTimeRange() {
+      when(securityProvider.checkPermission(eq(principal),
+         eq(ResourceType.SCHEDULE_OPTION), eq("timeRange"), eq(ResourceAction.READ)))
+         .thenReturn(true);
+   }
+
+   private void denyTimeRange() {
+      when(securityProvider.checkPermission(eq(principal),
+         eq(ResourceType.SCHEDULE_OPTION), eq("timeRange"), eq(ResourceAction.READ)))
+         .thenReturn(false);
+   }
+
+   private void allowNotificationEmail() {
+      when(scheduleService.checkPermission(eq(principal),
+         eq(ResourceType.SCHEDULE_OPTION), eq("notificationEmail")))
+         .thenReturn(true);
+   }
+
+   private void denyNotificationEmail() {
+      when(scheduleService.checkPermission(eq(principal),
+         eq(ResourceType.SCHEDULE_OPTION), eq("notificationEmail")))
+         .thenReturn(false);
+   }
+
+   private void allowSaveToDisk() {
+      when(scheduleService.checkPermission(eq(principal),
+         eq(ResourceType.SCHEDULE_OPTION), eq("saveToDisk")))
+         .thenReturn(true);
+   }
+
+   private void denyDisk() {
+      when(scheduleService.checkPermission(eq(principal),
+         eq(ResourceType.SCHEDULE_OPTION), eq("saveToDisk")))
+         .thenReturn(false);
+   }
+
+   private void allowEmailDelivery() {
+      when(scheduleService.checkPermission(eq(principal),
+         eq(ResourceType.SCHEDULE_OPTION), eq("emailDelivery")))
+         .thenReturn(true);
+   }
+
+   private void denyEmailDelivery() {
+      when(scheduleService.checkPermission(eq(principal),
+         eq(ResourceType.SCHEDULE_OPTION), eq("emailDelivery")))
+         .thenReturn(false);
+   }
+}


### PR DESCRIPTION
Users with restricted SCHEDULE_OPTION sub-resources (startTime, timeRange, notificationEmail, saveToDisk, emailDelivery) could bypass the UI and submit crafted requests to save disallowed values.

ScheduleTaskService.saveTask():
- Snapshot the server-side task before applying client changes
- sanitizeConditions(): for AT and EVERY_HOUR conditions, restore the original or remove if the principal lacks startTime permission; for other recurring types restore the original time fields or apply defaults on type mismatch; restore or clear the timeRange field accordingly
- sanitizeAction(): for ViewsheetAction, restore all notification fields (addresses, notifyIfFailed, includeLink), all email delivery fields, and all save-to-disk fields from the server-side original when the same dashboard was previously configured; clear them otherwise

ScheduleDialogController.scheduleVS():
- Block EVERY_HOUR in addition to AT when startTime permission is denied, falling back to EVERY_DAY
- Guard all email delivery fields (from, to, cc, bcc, subject, message, format, layout options) behind the emailDelivery permission, not just the to-address

Add ScheduleTaskServiceSanitizeTest covering the key permission enforcement cases for sanitizeConditions() and sanitizeAction().