### PR TITLE
Bug #74644, hide Schedule Tasks node in EM content tree for users without scheduler permission

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/ContentRepositoryTreeService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/ContentRepositoryTreeService.java
@@ -1384,6 +1384,10 @@ public class ContentRepositoryTreeService {
    }
 
    private List<ContentRepositoryTreeNode> getSchedulerNodes(Principal principal) {
+      if(!securityProvider.checkPermission(principal, ResourceType.SCHEDULER, "*", ResourceAction.ACCESS)) {
+         return Collections.emptyList();
+      }
+
       List<ContentRepositoryTreeNode> result = new ArrayList<>();
       List<ContentRepositoryTreeNode> children = getScheduleTaskNodeChildren(principal);
 


### PR DESCRIPTION
Check ResourceType.SCHEDULER ACCESS permission in getSchedulerNodes() before building the scheduler content tree, so users who lack scheduler privileges no longer see the schedule tasks node in the EM repository tree.