### PR TITLE
Support incremental worksheet and viewsheet construction in wiz

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/wiz/service/AddVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/composer/wiz/service/AddVisualizationService.java
@@ -23,9 +23,9 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.WorksheetEngine;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
-import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.*;
+import inetsoft.web.composer.ws.WsMergeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -46,17 +46,13 @@ import java.util.List;
 @ClusterProxy
 public class AddVisualizationService {
 
-   /**
-    * Property key set on every MirrorTableAssembly that was created by the wiz merge process.
-    * Used to identify wiz-managed mirrors without relying on name prefixes.
-    */
-   static final String PROP_WIZ_MERGED = "wiz.merged";
-
    public AddVisualizationService(ViewsheetService viewsheetService,
-                                  AssetRepository assetRepository)
+                                  AssetRepository assetRepository,
+                                  WsMergeService wsMergeService)
    {
       this.viewsheetService = viewsheetService;
       this.assetRepository = assetRepository;
+      this.wsMergeService = wsMergeService;
    }
 
    /**
@@ -157,7 +153,7 @@ public class AddVisualizationService {
       Map<String, String> vsRenameMap = new HashMap<>();
 
       // Step 1: merge worksheet (returns vizWS-name → dashWS-name mapping)
-      Map<String, String> wsRenameMap = mergeWorksheet(vizWS, dashWS, vizSuffix, vsRenameMap);
+      Map<String, String> wsRenameMap = wsMergeService.mergeWorksheet(vizWS, dashWS, vizSuffix, vsRenameMap);
 
       // Apply deferred VS binding redirects accumulated during WS merge
       for(Map.Entry<String, String> e : vsRenameMap.entrySet()) {
@@ -174,193 +170,6 @@ public class AddVisualizationService {
       assetRepository.setSheet(dashVS.getBaseEntry(), dashWS, principal, true);
 
       return null;
-   }
-
-   // ---------------------------------------------------------------------------
-   // Step 1: Worksheet merge
-   // ---------------------------------------------------------------------------
-
-   /**
-    * Merges all WSAssemblies from {@code vizWS} into {@code dashWS} and returns a map of
-    * old assembly names (in vizWS) to their effective names in dashWS after merging.
-    */
-   private Map<String, String> mergeWorksheet(Worksheet vizWS, Worksheet dashWS,
-                                              String vizSuffix,
-                                              Map<String, String> vsRenameMap)
-   {
-      Map<String, String> wsRenameMap = new HashMap<>();
-      List<WSAssembly> sorted = topologicalSort(vizWS);
-
-      for(WSAssembly srcAssembly : sorted) {
-         // Situation A: BoundTableAssembly with same data source as an existing one
-         if(srcAssembly instanceof BoundTableAssembly srcBound) {
-            BoundTableAssembly existingTable = findMergeableTable(dashWS, srcBound);
-
-            if(existingTable != null) {
-               // Ensure the existing table has a "prev" mirror (first-merge promotion).
-               // Any VS binding redirects are collected into vsRenameMap and applied later.
-               ensureBaseHasPrevMirror(dashWS, existingTable, vsRenameMap);
-               // Expand the base with any new columns from srcBound
-               mergeColumns(existingTable, srcBound);
-               // Create a new mirror for this visualization's column/condition view
-               String curMirrorName = createVizMirror(dashWS, existingTable, srcBound);
-               wsRenameMap.put(srcBound.getName(), curMirrorName);
-               continue;
-            }
-         }
-
-         // Situation B: everything else — clone and resolve name conflicts
-         // Note: if this assembly (e.g. MirrorTableAssembly, CompositeTableAssembly) references
-         // a BoundTableAssembly that was already processed under Situation A, the rename
-         // (srcBound → curMirrorName) is already in wsRenameMap. The renameDepended loop below
-         // will correctly update the child reference, because topological order guarantees the
-         // BoundTableAssembly entry is in wsRenameMap before this downstream assembly is reached.
-         WSAssembly cloned = (WSAssembly) srcAssembly.clone();
-         String originalName = srcAssembly.getName();
-         String targetName = originalName;
-
-         if(dashWS.getAssembly(targetName) != null) {
-            targetName = resolveNameConflict(originalName, vizSuffix, dashWS);
-            cloned.getWSAssemblyInfo().setName(targetName);
-            wsRenameMap.put(originalName, targetName);
-         }
-
-         // addAssembly sets cloned.ws = dashWS, enabling correct renameDepended behaviour
-         dashWS.addAssembly(cloned);
-
-         // Apply accumulated renames to update child references within this assembly
-         for(Map.Entry<String, String> entry : wsRenameMap.entrySet()) {
-            cloned.renameDepended(entry.getKey(), entry.getValue());
-         }
-      }
-
-      return wsRenameMap;
-   }
-
-   /**
-    * Returns the BoundTableAssembly in {@code dashWS} that shares the same data source
-    * (type + datasource prefix + physical table/query name) as {@code srcTable}, or
-    * {@code null} if none exists.
-    */
-   private BoundTableAssembly findMergeableTable(Worksheet dashWS,
-                                                 BoundTableAssembly srcTable)
-   {
-      SourceInfo srcInfo = srcTable.getSourceInfo();
-
-      if(srcInfo == null || srcInfo.isEmpty()) {
-         return null;
-      }
-
-      for(Assembly a : dashWS.getAssemblies()) {
-         if(!(a instanceof BoundTableAssembly candidate)) {
-            continue;
-         }
-
-         SourceInfo candidateInfo = candidate.getSourceInfo();
-
-         if(candidateInfo == null || candidateInfo.isEmpty()) {
-            continue;
-         }
-
-         if(srcInfo.getType() == candidateInfo.getType() &&
-            Objects.equals(srcInfo.getPrefix(), candidateInfo.getPrefix()) &&
-            Objects.equals(srcInfo.getSource(), candidateInfo.getSource()))
-         {
-            return candidate;
-         }
-      }
-
-      return null;
-   }
-
-   /**
-    * If {@code existingTable} does not yet have a wiz mirror pointing to it, promotes it
-    * to a "base" table: strips its conditions/aggregation (moving them to a new mirror
-    * that takes its original role), and updates dashVS VS bindings to point at the mirror.
-    */
-   private void ensureBaseHasPrevMirror(Worksheet dashWS,
-                                        BoundTableAssembly existingTable,
-                                        Map<String, String> vsRenameMap)
-   {
-      String baseName = existingTable.getName();
-
-      // Check if any wiz mirror already targets this base
-      boolean hasMirror = Arrays.stream(dashWS.getAssemblies())
-         .anyMatch(a -> a instanceof MirrorTableAssembly m &&
-            "true".equals(m.getProperty(PROP_WIZ_MERGED)) &&
-            Objects.equals(m.getAssemblyName(), baseName));
-
-      if(hasMirror) {
-         return; // already promoted in a previous merge
-      }
-
-      // Save the original semantics that belong to the first visualization
-      ConditionListWrapper preconds = existingTable.getPreConditionList();
-      ConditionListWrapper postconds = existingTable.getPostConditionList();
-      AggregateInfo aggr = (AggregateInfo) existingTable.getAggregateInfo().clone();
-      ColumnSelection origCols = existingTable.getColumnSelection(true).clone();
-
-      // Strip conditions/aggregation from the base so it becomes a "full data" query
-      existingTable.setPreConditionList(new ConditionList());
-      existingTable.setPostConditionList(new ConditionList());
-      existingTable.setAggregateInfo(new AggregateInfo());
-
-      // Create a mirror that restores the original viz's view
-      String prevMirrorName = ensureUniqueName(baseName, dashWS);
-      MirrorTableAssembly prevMirror = new MirrorTableAssembly(dashWS, prevMirrorName, existingTable);
-      prevMirror.setColumnSelection(origCols, true);
-      prevMirror.setPreConditionList(preconds);
-      prevMirror.setPostConditionList(postconds);
-      prevMirror.setAggregateInfo(aggr);
-      prevMirror.setProperty(PROP_WIZ_MERGED, "true");
-      dashWS.addAssembly(prevMirror);
-
-      // Collect the redirect (existingTable → prevMirror) so the caller can apply it to dashVS
-      // after the full WS merge is complete, rather than touching VS assemblies mid-merge.
-      vsRenameMap.put(baseName, prevMirrorName);
-   }
-
-   /**
-    * Expands {@code base}'s public column selection with any columns from {@code srcTable}
-    * that are not already present.
-    */
-   private void mergeColumns(BoundTableAssembly base, BoundTableAssembly srcTable) {
-      ColumnSelection baseColumns = base.getColumnSelection(true);
-      ColumnSelection srcColumns = srcTable.getColumnSelection(true);
-
-      for(int i = 0; i < srcColumns.getAttributeCount(); i++) {
-         DataRef col = srcColumns.getAttribute(i);
-
-         if(baseColumns.getAttribute(col.getName()) == null) {
-            baseColumns.addAttribute(col);
-         }
-      }
-
-      base.setColumnSelection(baseColumns, true);
-   }
-
-   /**
-    * Creates a MirrorTableAssembly in {@code dashWS} that points at {@code base} and exposes
-    * only the columns (and conditions/aggregation) of {@code srcTable}.
-    *
-    * @return the name of the created mirror assembly.
-    */
-   private String createVizMirror(Worksheet dashWS, BoundTableAssembly base,
-                                  BoundTableAssembly srcTable)
-   {
-      String mirrorName = ensureUniqueName(base.getName(), dashWS);
-
-      ColumnSelection vizCols = srcTable.getColumnSelection(true).clone();
-
-      MirrorTableAssembly mirror = new MirrorTableAssembly(dashWS, mirrorName, base);
-      mirror.setColumnSelection(vizCols, true);
-      mirror.setPreConditionList((ConditionListWrapper) srcTable.getPreConditionList().clone());
-      mirror.setPostConditionList((ConditionListWrapper) srcTable.getPostConditionList().clone());
-      mirror.setAggregateInfo((AggregateInfo) srcTable.getAggregateInfo().clone());
-      mirror.setProperty(PROP_WIZ_MERGED, "true");
-      dashWS.addAssembly(mirror);
-
-      return mirrorName;
    }
 
    // ---------------------------------------------------------------------------
@@ -488,130 +297,9 @@ public class AddVisualizationService {
    }
 
    /**
-    * Performs a topological sort of the assemblies in {@code ws} so that dependencies are
-    * processed before the assemblies that depend on them (sources before sinks).
-    * Uses Kahn's algorithm on the dependency graph derived from
-    * {@link WSAssembly#getDependeds(Set)}.
-    */
-   private List<WSAssembly> topologicalSort(Worksheet ws) {
-      Assembly[] all = ws.getAssemblies();
-
-      // deps: assembly name → names of WS assemblies it depends on
-      // revDeps: assembly name → names of WS assemblies that depend on it
-      Map<String, Set<String>> deps = new HashMap<>();
-      Map<String, Set<String>> revDeps = new HashMap<>();
-
-      for(Assembly a : all) {
-         deps.put(a.getName(), new HashSet<>());
-         revDeps.put(a.getName(), new HashSet<>());
-      }
-
-      for(Assembly a : all) {
-         Set<AssemblyRef> depRefs = new HashSet<>();
-         ((WSAssembly) a).getDependeds(depRefs);
-
-         for(AssemblyRef ref : depRefs) {
-            String depName = ref.getEntry().getName();
-
-            if(deps.containsKey(depName)) {
-               deps.get(a.getName()).add(depName);
-               revDeps.get(depName).add(a.getName());
-            }
-         }
-      }
-
-      // Compute in-degree (number of dependencies each assembly has within this WS)
-      Map<String, Integer> inDegree = new HashMap<>();
-
-      for(Map.Entry<String, Set<String>> e : deps.entrySet()) {
-         inDegree.put(e.getKey(), e.getValue().size());
-      }
-
-      // Seed queue with root nodes (no WS-internal dependencies)
-      Queue<String> queue = new LinkedList<>();
-
-      for(Map.Entry<String, Integer> e : inDegree.entrySet()) {
-         if(e.getValue() == 0) {
-            queue.add(e.getKey());
-         }
-      }
-
-      List<WSAssembly> sorted = new ArrayList<>(all.length);
-
-      while(!queue.isEmpty()) {
-         String name = queue.poll();
-         WSAssembly node = (WSAssembly) ws.getAssembly(name);
-
-         if(node != null) {
-            sorted.add(node);
-         }
-
-         for(String downstream : revDeps.getOrDefault(name, Collections.emptySet())) {
-            if(inDegree.merge(downstream, -1, Integer::sum) == 0) {
-               queue.add(downstream);
-            }
-         }
-      }
-
-      // Append any assemblies not reached (e.g. cycles or disconnected nodes)
-      Set<String> visited = new HashSet<>();
-
-      for(WSAssembly a : sorted) {
-         visited.add(a.getName());
-      }
-
-      for(Assembly a : all) {
-         if(!visited.contains(a.getName())) {
-            sorted.add((WSAssembly) a);
-         }
-      }
-
-      return sorted;
-   }
-
-   /**
-    * Generates a unique name for a new assembly in {@code ws} by appending {@code "_" + vizSuffix},
-    * then a counter if still conflicting.
-    */
-   private String resolveNameConflict(String originalName, String vizSuffix, Worksheet ws) {
-      String candidate = originalName + "_" + vizSuffix;
-
-      if(ws.getAssembly(candidate) == null) {
-         return candidate;
-      }
-
-      int counter = 2;
-
-      while(ws.getAssembly(candidate) != null) {
-         candidate = originalName + "_" + vizSuffix + "_" + counter++;
-      }
-
-      return candidate;
-   }
-
-   /**
-    * Returns {@code name} if it does not already exist in {@code ws}, otherwise appends
-    * an incrementing counter until a free name is found.
-    */
-   private String ensureUniqueName(String name, Worksheet ws) {
-      if(ws.getAssembly(name) == null) {
-         return name;
-      }
-
-      int counter = 1;
-      String candidate = name + "_" + counter;
-
-      while(ws.getAssembly(candidate) != null) {
-         candidate = name + "_" + (++counter);
-      }
-
-      return candidate;
-   }
-
-   /**
     * Computes a short, unique name suffix for this visualization by sanitizing the entry
-    * name (keep alphanumeric + underscore, max 20 chars) and appending a counter if the
-    * same suffix has already been used in dashVS.
+    * name (keep alphanumeric + underscore, max 20 chars) and appending a counter based on
+    * how many visualizations have already been merged into dashVS.
     */
    private String computeUniqueSuffix(String vizName, Viewsheet dashVS) {
       String base = vizName.replaceAll("[^A-Za-z0-9_]", "_");
@@ -628,6 +316,7 @@ public class AddVisualizationService {
 
    private final ViewsheetService viewsheetService;
    private final AssetRepository assetRepository;
+   private final WsMergeService wsMergeService;
 
    private static final Logger LOG = LoggerFactory.getLogger(AddVisualizationService.class);
 }

--- a/core/src/main/java/inetsoft/web/composer/wiz/service/AddVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/composer/wiz/service/AddVisualizationService.java
@@ -25,7 +25,7 @@ import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.*;
-import inetsoft.web.composer.ws.WsMergeService;
+import inetsoft.web.wiz.service.WsMergeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;

--- a/core/src/main/java/inetsoft/web/composer/wiz/service/AddVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/composer/wiz/service/AddVisualizationService.java
@@ -191,10 +191,11 @@ public class AddVisualizationService {
       int offsetX = (int) (xOffset / scale);
       int offsetY = (int) (yOffset / scale);
 
-      // Pass 1: clone every assembly and compute its final name, building vsRenameMap
+      // Pass 1: clone every assembly and compute its final name, building vsConflictRenameMap
       //         so that intra-visualization cross-references can be patched in pass 2.
+      //         (distinct from the outer vsRenameMap which tracks WS base→mirror renames)
       List<VSAssembly> clones = new ArrayList<>();
-      Map<String, String> vsRenameMap = new HashMap<>();
+      Map<String, String> vsConflictRenameMap = new HashMap<>();
 
       for(Assembly a : vizVS.getAssemblies()) {
          if(!(a instanceof VSAssembly srcAssembly)) {
@@ -225,7 +226,7 @@ public class AddVisualizationService {
 
          if(!targetName.equals(originalName)) {
             cloned.getVSAssemblyInfo().setName(targetName);
-            vsRenameMap.put(originalName, targetName);
+            vsConflictRenameMap.put(originalName, targetName);
          }
 
          clones.add(cloned);
@@ -237,7 +238,7 @@ public class AddVisualizationService {
          applyWsRenameToVSAssembly(cloned, wsRenameMap);
 
          // Patch VS-level cross-references (container children, linked/selection assemblies)
-         for(Map.Entry<String, String> e : vsRenameMap.entrySet()) {
+         for(Map.Entry<String, String> e : vsConflictRenameMap.entrySet()) {
             cloned.renameDepended(e.getKey(), e.getValue());
          }
 

--- a/core/src/main/java/inetsoft/web/composer/ws/WsMergeService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/WsMergeService.java
@@ -1,0 +1,361 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.ws;
+
+import inetsoft.uql.*;
+import inetsoft.uql.asset.*;
+import inetsoft.uql.erm.DataRef;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+/**
+ * Worksheet-level merge utilities shared by AddVisualizationService and GenerateWsService.
+ *
+ * <p>Core rule: each {@link BoundTableAssembly} appears only once in the target worksheet.
+ * Different queries that share the same physical table each get their own
+ * {@link MirrorTableAssembly} (tagged with {@link #PROP_WIZ_MERGED}) that carries
+ * independent column selections, conditions, and aggregation.</p>
+ */
+@Service
+public class WsMergeService {
+
+   /**
+    * Property key set on every MirrorTableAssembly created by the wiz merge process.
+    * Used to identify wiz-managed mirrors without relying on name prefixes.
+    */
+   public static final String PROP_WIZ_MERGED = "wiz.merged";
+
+   /**
+    * Merges all WSAssemblies from {@code vizWS} into {@code dashWS} and returns a map of
+    * old assembly names (in vizWS) to their effective names in dashWS after merging.
+    *
+    * <p>For each {@link BoundTableAssembly} in vizWS:</p>
+    * <ul>
+    *   <li>If a matching table already exists in dashWS (same data source): expand the base
+    *       with any new columns, ensure it has a "prev" mirror for the first visualization,
+    *       and create a new mirror for the current visualization.</li>
+    *   <li>Otherwise: clone the assembly, resolve name conflicts, and add it directly.</li>
+    * </ul>
+    *
+    * @param vizWS      source worksheet (the new query being added)
+    * @param dashWS     target worksheet (accumulates all queries)
+    * @param vizSuffix  unique suffix used to resolve name conflicts
+    * @param vsRenameMap out-parameter: accumulates base→prevMirror renames that the caller
+    *                   should propagate to any VS-level bindings (may be ignored when there
+    *                   is no associated viewsheet)
+    * @return map of vizWS assembly name → final name in dashWS
+    */
+   public Map<String, String> mergeWorksheet(Worksheet vizWS, Worksheet dashWS,
+                                             String vizSuffix,
+                                             Map<String, String> vsRenameMap)
+   {
+      Map<String, String> wsRenameMap = new HashMap<>();
+      List<WSAssembly> sorted = topologicalSort(vizWS);
+
+      for(WSAssembly srcAssembly : sorted) {
+         // Situation A: BoundTableAssembly with same data source as an existing one
+         if(srcAssembly instanceof BoundTableAssembly srcBound) {
+            BoundTableAssembly existingTable = findMergeableTable(dashWS, srcBound);
+
+            if(existingTable != null) {
+               ensureBaseHasPrevMirror(dashWS, existingTable, vsRenameMap);
+               mergeColumns(existingTable, srcBound);
+               String curMirrorName = createVizMirror(dashWS, existingTable, srcBound);
+               wsRenameMap.put(srcBound.getName(), curMirrorName);
+               continue;
+            }
+         }
+
+         // Situation B: everything else — clone and resolve name conflicts
+         WSAssembly cloned = (WSAssembly) srcAssembly.clone();
+         String originalName = srcAssembly.getName();
+         String targetName = originalName;
+
+         if(dashWS.getAssembly(targetName) != null) {
+            targetName = resolveNameConflict(originalName, vizSuffix, dashWS);
+            cloned.getWSAssemblyInfo().setName(targetName);
+            wsRenameMap.put(originalName, targetName);
+         }
+
+         // addAssembly sets cloned.ws = dashWS, enabling correct renameDepended behaviour
+         dashWS.addAssembly(cloned);
+
+         // Apply accumulated renames to update child references within this assembly
+         for(Map.Entry<String, String> entry : wsRenameMap.entrySet()) {
+            cloned.renameDepended(entry.getKey(), entry.getValue());
+         }
+      }
+
+      return wsRenameMap;
+   }
+
+   /**
+    * Generates a unique suffix for this merge pass based on the given name and the current
+    * number of assemblies in the target worksheet.
+    */
+   public String computeUniqueSuffix(String name, Worksheet ws) {
+      String base = name.replaceAll("[^A-Za-z0-9_]", "_");
+
+      if(base.length() > 20) {
+         base = base.substring(0, 20);
+      }
+
+      int count = ws.getAssemblies().length;
+      return base + "_" + count;
+   }
+
+   /**
+    * Returns the BoundTableAssembly in {@code dashWS} that shares the same data source
+    * (type + datasource prefix + physical table/query name) as {@code srcTable}, or
+    * {@code null} if none exists.
+    */
+   private BoundTableAssembly findMergeableTable(Worksheet dashWS, BoundTableAssembly srcTable) {
+      SourceInfo srcInfo = srcTable.getSourceInfo();
+
+      if(srcInfo == null || srcInfo.isEmpty()) {
+         return null;
+      }
+
+      for(Assembly a : dashWS.getAssemblies()) {
+         if(!(a instanceof BoundTableAssembly candidate)) {
+            continue;
+         }
+
+         SourceInfo candidateInfo = candidate.getSourceInfo();
+
+         if(candidateInfo == null || candidateInfo.isEmpty()) {
+            continue;
+         }
+
+         if(srcInfo.getType() == candidateInfo.getType() &&
+            Objects.equals(srcInfo.getPrefix(), candidateInfo.getPrefix()) &&
+            Objects.equals(srcInfo.getSource(), candidateInfo.getSource()))
+         {
+            return candidate;
+         }
+      }
+
+      return null;
+   }
+
+   /**
+    * If {@code existingTable} does not yet have a wiz mirror pointing to it, promotes it
+    * to a "base" table: strips its conditions/aggregation (moving them to a new mirror
+    * that takes its original role), and records the rename in {@code vsRenameMap} so the
+    * caller can redirect any VS-level bindings.
+    */
+   private void ensureBaseHasPrevMirror(Worksheet dashWS,
+                                        BoundTableAssembly existingTable,
+                                        Map<String, String> vsRenameMap)
+   {
+      String baseName = existingTable.getName();
+
+      // Check if any wiz mirror already targets this base
+      boolean hasMirror = Arrays.stream(dashWS.getAssemblies())
+         .anyMatch(a -> a instanceof MirrorTableAssembly m &&
+            "true".equals(m.getProperty(PROP_WIZ_MERGED)) &&
+            Objects.equals(m.getAssemblyName(), baseName));
+
+      if(hasMirror) {
+         return; // already promoted in a previous merge
+      }
+
+      // Save the original semantics that belong to the first visualization
+      ConditionListWrapper preconds = existingTable.getPreConditionList();
+      ConditionListWrapper postconds = existingTable.getPostConditionList();
+      AggregateInfo aggr = (AggregateInfo) existingTable.getAggregateInfo().clone();
+      ColumnSelection origCols = existingTable.getColumnSelection(true).clone();
+
+      // Strip conditions/aggregation from the base so it becomes a "full data" query
+      existingTable.setPreConditionList(new ConditionList());
+      existingTable.setPostConditionList(new ConditionList());
+      existingTable.setAggregateInfo(new AggregateInfo());
+
+      // Create a mirror that restores the original viz's view
+      String prevMirrorName = ensureUniqueName(baseName, dashWS);
+      MirrorTableAssembly prevMirror = new MirrorTableAssembly(dashWS, prevMirrorName, existingTable);
+      prevMirror.setColumnSelection(origCols, true);
+      prevMirror.setPreConditionList(preconds);
+      prevMirror.setPostConditionList(postconds);
+      prevMirror.setAggregateInfo(aggr);
+      prevMirror.setProperty(PROP_WIZ_MERGED, "true");
+      dashWS.addAssembly(prevMirror);
+
+      // Collect the redirect so the caller can apply it to VS bindings if needed
+      vsRenameMap.put(baseName, prevMirrorName);
+   }
+
+   /**
+    * Expands {@code base}'s public column selection with any columns from {@code srcTable}
+    * that are not already present (judged by column name).
+    */
+   private void mergeColumns(BoundTableAssembly base, BoundTableAssembly srcTable) {
+      ColumnSelection baseColumns = base.getColumnSelection(true);
+      ColumnSelection srcColumns = srcTable.getColumnSelection(true);
+
+      for(int i = 0; i < srcColumns.getAttributeCount(); i++) {
+         DataRef col = srcColumns.getAttribute(i);
+
+         if(baseColumns.getAttribute(col.getName()) == null) {
+            baseColumns.addAttribute(col);
+         }
+      }
+
+      base.setColumnSelection(baseColumns, true);
+   }
+
+   /**
+    * Creates a MirrorTableAssembly in {@code dashWS} that points at {@code base} and
+    * carries only the columns/conditions/aggregation of {@code srcTable}.
+    *
+    * @return the name of the created mirror assembly
+    */
+   private String createVizMirror(Worksheet dashWS, BoundTableAssembly base,
+                                   BoundTableAssembly srcTable)
+   {
+      String mirrorName = ensureUniqueName(base.getName(), dashWS);
+      ColumnSelection vizCols = srcTable.getColumnSelection(true).clone();
+
+      MirrorTableAssembly mirror = new MirrorTableAssembly(dashWS, mirrorName, base);
+      mirror.setColumnSelection(vizCols, true);
+      mirror.setPreConditionList((ConditionListWrapper) srcTable.getPreConditionList().clone());
+      mirror.setPostConditionList((ConditionListWrapper) srcTable.getPostConditionList().clone());
+      mirror.setAggregateInfo((AggregateInfo) srcTable.getAggregateInfo().clone());
+      mirror.setProperty(PROP_WIZ_MERGED, "true");
+      dashWS.addAssembly(mirror);
+
+      return mirrorName;
+   }
+
+   /**
+    * Performs a topological sort of the assemblies in {@code ws} so that dependencies are
+    * processed before the assemblies that depend on them (sources before sinks).
+    * Uses Kahn's algorithm on the dependency graph derived from
+    * {@link WSAssembly#getDependeds(Set)}.
+    */
+   private List<WSAssembly> topologicalSort(Worksheet ws) {
+      Assembly[] all = ws.getAssemblies();
+      Map<String, Set<String>> deps = new HashMap<>();
+      Map<String, Set<String>> revDeps = new HashMap<>();
+
+      for(Assembly a : all) {
+         deps.put(a.getName(), new HashSet<>());
+         revDeps.put(a.getName(), new HashSet<>());
+      }
+
+      for(Assembly a : all) {
+         Set<AssemblyRef> depRefs = new HashSet<>();
+         ((WSAssembly) a).getDependeds(depRefs);
+
+         for(AssemblyRef ref : depRefs) {
+            String depName = ref.getEntry().getName();
+
+            if(deps.containsKey(depName)) {
+               deps.get(a.getName()).add(depName);
+               revDeps.get(depName).add(a.getName());
+            }
+         }
+      }
+
+      Map<String, Integer> inDegree = new HashMap<>();
+
+      for(Map.Entry<String, Set<String>> e : deps.entrySet()) {
+         inDegree.put(e.getKey(), e.getValue().size());
+      }
+
+      Queue<String> queue = new LinkedList<>();
+
+      for(Map.Entry<String, Integer> e : inDegree.entrySet()) {
+         if(e.getValue() == 0) {
+            queue.add(e.getKey());
+         }
+      }
+
+      List<WSAssembly> sorted = new ArrayList<>(all.length);
+
+      while(!queue.isEmpty()) {
+         String name = queue.poll();
+         WSAssembly node = (WSAssembly) ws.getAssembly(name);
+
+         if(node != null) {
+            sorted.add(node);
+         }
+
+         for(String downstream : revDeps.getOrDefault(name, Collections.emptySet())) {
+            if(inDegree.merge(downstream, -1, Integer::sum) == 0) {
+               queue.add(downstream);
+            }
+         }
+      }
+
+      // Append any assemblies not reached (e.g. cycles or disconnected nodes)
+      Set<String> visited = new HashSet<>();
+
+      for(WSAssembly a : sorted) {
+         visited.add(a.getName());
+      }
+
+      for(Assembly a : all) {
+         if(!visited.contains(a.getName())) {
+            sorted.add((WSAssembly) a);
+         }
+      }
+
+      return sorted;
+   }
+
+   /**
+    * Generates a unique name by appending {@code "_" + vizSuffix}, then an incrementing
+    * counter if still conflicting.
+    */
+   private String resolveNameConflict(String originalName, String vizSuffix, Worksheet ws) {
+      String candidate = originalName + "_" + vizSuffix;
+
+      if(ws.getAssembly(candidate) == null) {
+         return candidate;
+      }
+
+      int counter = 2;
+
+      while(ws.getAssembly(candidate) != null) {
+         candidate = originalName + "_" + vizSuffix + "_" + counter++;
+      }
+
+      return candidate;
+   }
+
+   /**
+    * Returns {@code name} if it does not already exist in {@code ws}, otherwise appends
+    * an incrementing counter until a free name is found.
+    */
+   private String ensureUniqueName(String name, Worksheet ws) {
+      if(ws.getAssembly(name) == null) {
+         return name;
+      }
+
+      int counter = 1;
+      String candidate = name + "_" + counter;
+
+      while(ws.getAssembly(candidate) != null) {
+         candidate = name + "_" + (++counter);
+      }
+
+      return candidate;
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetConstructionModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetConstructionModel.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class WorksheetConstructionModel {
    private String name; // ws table name
+   private String worksheetId; // nullable; when set, merge into existing worksheet instead of creating new
    private List<QueryField> fields;
    private List<JoinPath> joinPaths;
    private List<TableSetOperation> tableSetOperations;
@@ -38,6 +39,14 @@ public class WorksheetConstructionModel {
 
    public void setName(String name) {
       this.name = name;
+   }
+
+   public String getWorksheetId() {
+      return worksheetId;
+   }
+
+   public void setWorksheetId(String worksheetId) {
+      this.worksheetId = worksheetId;
    }
 
    public List<QueryField> getFields() {

--- a/core/src/main/java/inetsoft/web/wiz/service/CreateVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/CreateVsService.java
@@ -121,8 +121,14 @@ public class CreateVsService {
             targetVs.syncWizData(vs);
          }
          else {
-            // Incremental: reuse the existing viewsheet; update the base entry if needed.
+            // Incremental: reuse the existing viewsheet; update the base entry only if it differs.
             targetVs = vs;
+         }
+
+         // Snapshot the previous base entry before any mutation so we can restore it on failure.
+         AssetEntry previousBaseEntry = targetVs.getBaseEntry();
+
+         if(!createdRuntimeId && !sourceWs.equals(previousBaseEntry)) {
             targetVs.setBaseEntry(sourceWs);
          }
 
@@ -178,9 +184,10 @@ public class CreateVsService {
             rvs.setViewsheet(previousVs);
 
             if(!createdRuntimeId) {
-               // In incremental mode targetVs == previousVs, so also remove the assembly
-               // that was just added to leave the viewsheet in its original state.
+               // In incremental mode targetVs == previousVs; remove the assembly and restore
+               // the base entry to leave the viewsheet in exactly its pre-call state.
                previousVs.removeAssembly(assembly.getName());
+               previousVs.setBaseEntry(previousBaseEntry);
             }
 
             throw e;

--- a/core/src/main/java/inetsoft/web/wiz/service/CreateVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/CreateVsService.java
@@ -111,19 +111,33 @@ public class CreateVsService {
             throw new IllegalStateException("Worksheet has no primary assembly");
          }
 
-         Viewsheet newVs = new Viewsheet(sourceWs);
-         newVs.syncWizData(vs);
-         VSAssembly assembly = createAssembly(newVs, model.getVisualizationType(), title, config, primaryAssembly.getName());
+         // Incremental mode: when runtimeId was supplied by the caller, add the new assembly
+         // to the existing viewsheet rather than replacing it wholesale.
+         final Viewsheet targetVs;
+
+         if(createdRuntimeId) {
+            // Fresh viewsheet: create a new one bound to the source worksheet.
+            targetVs = new Viewsheet(sourceWs);
+            targetVs.syncWizData(vs);
+         }
+         else {
+            // Incremental: reuse the existing viewsheet; update the base entry if needed.
+            targetVs = vs;
+            targetVs.setBaseEntry(sourceWs);
+         }
+
+         VSAssembly assembly = createAssembly(targetVs, model.getVisualizationType(), title, config, primaryAssembly.getName());
 
          if(assembly == null) {
             throw new RuntimeException("Unsupported visualization type: " + model.getVisualizationType());
          }
 
-         newVs.addAssembly(assembly);
+         targetVs.addAssembly(assembly);
          assembly.setPrimary(true);
 
+         // Always call setViewsheet so the sandbox picks up the updated viewsheet object.
          Viewsheet previousVs = rvs.getViewsheet();
-         rvs.setViewsheet(newVs);
+         rvs.setViewsheet(targetVs);
 
          try {
             // Execute the assembly view after the viewsheet is set so that dynamic values are
@@ -160,7 +174,15 @@ public class CreateVsService {
             return result;
          }
          catch(Exception e) {
+            // Rollback: restore the previous viewsheet state.
             rvs.setViewsheet(previousVs);
+
+            if(!createdRuntimeId) {
+               // In incremental mode targetVs == previousVs, so also remove the assembly
+               // that was just added to leave the viewsheet in its original state.
+               previousVs.removeAssembly(assembly.getName());
+            }
+
             throw e;
          }
       }

--- a/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
@@ -211,7 +211,14 @@ public class GenerateWsService {
 
       if(model.getWorksheetId() != null) {
          // Incremental path: merge the new query into the existing worksheet
-         AssetEntry existingEntry = AssetEntry.createAssetEntry(model.getWorksheetId());
+         AssetEntry existingEntry;
+
+         try {
+            existingEntry = AssetEntry.createAssetEntry(model.getWorksheetId());
+         }
+         catch(Exception e) {
+            throw new IllegalArgumentException("Invalid worksheetId: " + model.getWorksheetId(), e);
+         }
          Worksheet dashWS = (Worksheet) viewsheetService.getAssetRepository()
             .getSheet(existingEntry, user, false, AssetContent.ALL);
 
@@ -244,18 +251,18 @@ public class GenerateWsService {
       Assembly[] assemblies = worksheet.getAssemblies();
       int[] heights = new int[assemblies.length];
       int[] widths = new int[assemblies.length];
-      String[] tablas = new String[assemblies.length];
+      String[] tables = new String[assemblies.length];
 
       for(int i = 0; i < assemblies.length; i++) {
          Assembly assembly = assemblies[i];
          heights[i] = 62;
          widths[i] = 150;
-         tablas[i] = assembly.getName();
+         tables[i] = assembly.getName();
       }
 
       builder.heights(heights);
       builder.widths(widths);
-      builder.names(tablas);
+      builder.names(tables);
       layoutGraphService.layoutGraph(worksheet, builder.build());
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
@@ -33,6 +33,7 @@ import inetsoft.uql.jdbc.JDBCDataSource;
 import inetsoft.uql.jdbc.util.SQLTypes;
 import inetsoft.util.Tool;
 import inetsoft.web.composer.ws.LayoutGraphService;
+import inetsoft.web.composer.ws.WsMergeService;
 import inetsoft.web.composer.ws.event.WSLayoutGraphEvent;
 import inetsoft.web.composer.ws.joins.InnerJoinService;
 import org.springframework.stereotype.Service;
@@ -45,12 +46,14 @@ public class GenerateWsService {
    public GenerateWsService(ViewsheetService viewsheetService, MetadataApiService metadataApiService,
                             InnerJoinService innerJoinService,
                             LayoutGraphService layoutGraphService,
+                            WsMergeService wsMergeService,
                             ObjectMapper objectMapper)
    {
       this.viewsheetService = viewsheetService;
       this.metadataApiService = metadataApiService;
       this.innerJoinService = innerJoinService;
       this.layoutGraphService = layoutGraphService;
+      this.wsMergeService = wsMergeService;
       this.objectMapper = objectMapper;
    }
 
@@ -198,8 +201,7 @@ public class GenerateWsService {
          throw new RuntimeException("can not generate worksheet");
       }
 
-      worksheet.setPrimaryAssembly(table.getName());
-
+      // Apply conditions and sort to the new table before persisting or merging
       if(model.getFilters() != null) {
          applyCondition(table, model.getFilters());
       }
@@ -207,10 +209,32 @@ public class GenerateWsService {
          applyOrderBy(table, model.getOrderBy());
       }
 
-      layoutGraph(worksheet);
-      AssetEntry assetEntry = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, model.getName(), null);
-      viewsheetService.setWorksheet(worksheet, assetEntry, user, true, true);
-      generateWsResponse.setWsId(assetEntry.toIdentifier());
+      if(model.getWorksheetId() != null) {
+         // Incremental path: merge the new query into the existing worksheet
+         AssetEntry existingEntry = AssetEntry.createAssetEntry(model.getWorksheetId());
+         Worksheet dashWS = (Worksheet) viewsheetService.getAssetRepository()
+            .getSheet(existingEntry, user, false, AssetContent.ALL);
+
+         if(dashWS == null) {
+            throw new IllegalArgumentException("Worksheet not found: " + model.getWorksheetId());
+         }
+
+         String vizSuffix = wsMergeService.computeUniqueSuffix(model.getName(), dashWS);
+         Map<String, String> wsRenameMap = wsMergeService.mergeWorksheet(worksheet, dashWS, vizSuffix, new HashMap<>());
+         String finalTableName = wsRenameMap.getOrDefault(table.getName(), table.getName());
+         dashWS.setPrimaryAssembly(finalTableName);
+         layoutGraph(dashWS);
+         viewsheetService.getAssetRepository().setSheet(existingEntry, dashWS, user, true);
+         generateWsResponse.setWsId(existingEntry.toIdentifier());
+      }
+      else {
+         // New worksheet path
+         worksheet.setPrimaryAssembly(table.getName());
+         layoutGraph(worksheet);
+         AssetEntry assetEntry = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, model.getName(), null);
+         viewsheetService.setWorksheet(worksheet, assetEntry, user, true, true);
+         generateWsResponse.setWsId(assetEntry.toIdentifier());
+      }
 
       return generateWsResponse;
    }
@@ -727,5 +751,6 @@ public class GenerateWsService {
    private final MetadataApiService metadataApiService;
    private final InnerJoinService innerJoinService;
    private final LayoutGraphService layoutGraphService;
+   private final WsMergeService wsMergeService;
    private final ObjectMapper objectMapper;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
@@ -33,7 +33,6 @@ import inetsoft.uql.jdbc.JDBCDataSource;
 import inetsoft.uql.jdbc.util.SQLTypes;
 import inetsoft.util.Tool;
 import inetsoft.web.composer.ws.LayoutGraphService;
-import inetsoft.web.composer.ws.WsMergeService;
 import inetsoft.web.composer.ws.event.WSLayoutGraphEvent;
 import inetsoft.web.composer.ws.joins.InnerJoinService;
 import org.springframework.stereotype.Service;
@@ -219,16 +218,22 @@ public class GenerateWsService {
          catch(Exception e) {
             throw new IllegalArgumentException("Invalid worksheetId: " + model.getWorksheetId(), e);
          }
-         Worksheet dashWS = (Worksheet) viewsheetService.getAssetRepository()
+         AbstractSheet sheet = viewsheetService.getAssetRepository()
             .getSheet(existingEntry, user, false, AssetContent.ALL);
 
-         if(dashWS == null) {
-            throw new IllegalArgumentException("Worksheet not found: " + model.getWorksheetId());
+         if(!(sheet instanceof Worksheet dashWS)) {
+            throw new IllegalArgumentException(
+               sheet == null
+                  ? "Worksheet not found: " + model.getWorksheetId()
+                  : "worksheetId does not reference a worksheet: " + model.getWorksheetId());
          }
 
          String vizSuffix = wsMergeService.computeUniqueSuffix(model.getName(), dashWS);
          Map<String, String> wsRenameMap = wsMergeService.mergeWorksheet(worksheet, dashWS, vizSuffix, new HashMap<>());
          String finalTableName = wsRenameMap.getOrDefault(table.getName(), table.getName());
+         // By design, the primary assembly always tracks the most recently added query.
+         // Callers (e.g. CreateVsService) bind to the primary assembly name returned in
+         // the response, so downstream VS bindings remain consistent with the last request.
          dashWS.setPrimaryAssembly(finalTableName);
          layoutGraph(dashWS);
          viewsheetService.getAssetRepository().setSheet(existingEntry, dashWS, user, true);

--- a/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package inetsoft.web.composer.ws;
+package inetsoft.web.wiz.service;
 
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
@@ -176,9 +176,12 @@ public class WsMergeService {
          return; // already promoted in a previous merge
       }
 
-      // Save the original semantics that belong to the first visualization
-      ConditionListWrapper preconds = existingTable.getPreConditionList();
-      ConditionListWrapper postconds = existingTable.getPostConditionList();
+      // Save the original semantics that belong to the first visualization.
+      // Guard against null: freshly constructed tables may return null condition lists.
+      ConditionListWrapper preconds = existingTable.getPreConditionList() != null
+         ? existingTable.getPreConditionList() : new ConditionList();
+      ConditionListWrapper postconds = existingTable.getPostConditionList() != null
+         ? existingTable.getPostConditionList() : new ConditionList();
       AggregateInfo aggr = (AggregateInfo) existingTable.getAggregateInfo().clone();
       ColumnSelection origCols = existingTable.getColumnSelection(true).clone();
 
@@ -234,8 +237,10 @@ public class WsMergeService {
 
       MirrorTableAssembly mirror = new MirrorTableAssembly(dashWS, mirrorName, base);
       mirror.setColumnSelection(vizCols, true);
-      mirror.setPreConditionList((ConditionListWrapper) srcTable.getPreConditionList().clone());
-      mirror.setPostConditionList((ConditionListWrapper) srcTable.getPostConditionList().clone());
+      ConditionListWrapper srcPre = srcTable.getPreConditionList();
+      ConditionListWrapper srcPost = srcTable.getPostConditionList();
+      mirror.setPreConditionList(srcPre != null ? (ConditionListWrapper) srcPre.clone() : new ConditionList());
+      mirror.setPostConditionList(srcPost != null ? (ConditionListWrapper) srcPost.clone() : new ConditionList());
       mirror.setAggregateInfo((AggregateInfo) srcTable.getAggregateInfo().clone());
       mirror.setProperty(PROP_WIZ_MERGED, "true");
       dashWS.addAssembly(mirror);


### PR DESCRIPTION
Extract worksheet merge logic from AddVisualizationService into a shared WsMergeService. Add worksheetId field to WorksheetConstructionModel so GenerateWsService can merge new queries into an existing worksheet instead of always creating a fresh one. Update CreateVsService to append assemblies to an existing runtime viewsheet when a runtimeId is already provided,rather than replacing the viewsheet on every call.