### PR TITLE
Bug #74683 - Fix Twitter 401 after ~2h by honoring server-returned expires_in

### DIFF
--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/twitter/TwitterDataSource.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/twitter/TwitterDataSource.java
@@ -151,8 +151,19 @@ public class TwitterDataSource extends OAuthEndpointJsonDataSource<TwitterDataSo
    public void updateTokens(Tokens tokens) {
       setAccessToken(tokens.accessToken());
       setRefreshToken(tokens.refreshToken());
-      // expiresIn not returned by oauth server, all tokens expire in 24 hours
-      setTokenExpiration(tokens.issued() + TimeUnit.MILLISECONDS.convert(24L, TimeUnit.HOURS));
+      long now = System.currentTimeMillis();
+      long expiration = tokens.expiration();
+
+      if(expiration <= now) {
+         // fallback when expires_in missing
+         expiration = now + TimeUnit.MILLISECONDS.convert(2L, TimeUnit.HOURS);
+      }
+      else {
+         // buffer against clock skew
+         expiration -= TimeUnit.MILLISECONDS.convert(30L, TimeUnit.SECONDS);
+      }
+
+      setTokenExpiration(expiration);
    }
 
    @Override

--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/twitter/TwitterDataSource.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/twitter/TwitterDataSource.java
@@ -155,11 +155,11 @@ public class TwitterDataSource extends OAuthEndpointJsonDataSource<TwitterDataSo
       long expiration = tokens.expiration();
 
       if(expiration <= now) {
-         // fallback when expires_in missing
+         // fallback: expiration missing or already-expired
          expiration = now + TimeUnit.MILLISECONDS.convert(2L, TimeUnit.HOURS);
       }
       else {
-         // buffer against clock skew
+         // clock-skew buffer; tokens.expiration() is an absolute timestamp with no server-side margin
          expiration -= TimeUnit.MILLISECONDS.convert(30L, TimeUnit.SECONDS);
       }
 


### PR DESCRIPTION
X returns expires_in: 7200, but updateTokens() hardcoded 24 hours, so isTokenValid() reported the token valid for 22 hours after it had actually expired, causing every request to 401.

Use tokens.expiration() (populated from upstream expires_in via the data-auth-server intermediary), with a now + 2h fallback if the value is missing/past, plus a 30s buffer for clock skew.

Existing datasources self-heal on next re-auth or once their stale 24h window elapses.