### PR TITLE
Merge forward fix for Bug #74684, fix chart dataset sort-by-value ordering overwritten by post-summary sort

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -2546,6 +2546,14 @@ public abstract class AssetQuery extends PreAssetQuery {
          AggregateRef aggregate = ginfo.getAggregate(sort);
 
          if(group != null) {
+            // if the group uses sort-by-value, the ordering is already applied
+            // by SummaryFilter via setSortByValInfo — do not re-sort here
+            OrderInfo oinfo = group.getOrderInfo();
+
+            if(oinfo != null && oinfo.isSortByVal()) {
+               continue;
+            }
+
             SortOrder comp = createDateSortOrder(group, order, false);
             cols.add(col);
             comps.add(comp);


### PR DESCRIPTION
In getSortSummaryTableLens, dimension sorts were being applied as a SortFilter after SummaryFilter processing, overwriting the value-based ordering (SORT_VALUE_DESC/ASC) that SummaryFilter had already applied via setSortByValInfo. Skip the re-sort for dimensions that use sort-by- value since SummaryFilter is solely responsible for their ordering.

Preserves the fix for Bug #61575 (non-sort-by-value dimension sorts on aggregated data blocks still apply), and the existing cube guard at the early-return condition is unchanged.