### PR TITLE
Performance fixes: cache XSwapper bean lookups and throttle CSS disk checks

### DIFF
--- a/core/src/main/java/inetsoft/mv/data/DefaultTableBlock.java
+++ b/core/src/main/java/inetsoft/mv/data/DefaultTableBlock.java
@@ -73,9 +73,11 @@ public final class DefaultTableBlock implements XTableBlock, Cloneable {
       this.file = new CacheBlockFile("mvcolswap", "dat");
       isTemp = true;
 
+      XSwapper swapper = XSwapper.getSwapper();
+
       for(int i = 0; i < dcnt; i++) {
          XDimDictionary dict = cinfos[i].getDictionary();
-         XSwapper.getSwapper().waitForMemory();
+         swapper.waitForMemory();
          dcols[i] = new MVDimColumn(dict.size(), rcnt, true);
          dcols[i].setRangeMin(dict.getRangeMin());
          dcols[i].setContainsNull(dict.containsNull());
@@ -84,7 +86,7 @@ public final class DefaultTableBlock implements XTableBlock, Cloneable {
       long[] pos = {0};
 
       for(int i = 0; i < mcnt; i++) {
-         XSwapper.getSwapper().waitForMemory();
+         swapper.waitForMemory();
          mcols[i] = createMeasureColumn(types[i + dcnt], mvcols[i + dcnt],
             columnNames, cinfos[i + dcnt].getMin(), cinfos[i + dcnt].getMax(), pos);
       }

--- a/core/src/main/java/inetsoft/mv/data/DimValueList.java
+++ b/core/src/main/java/inetsoft/mv/data/DimValueList.java
@@ -243,7 +243,7 @@ public class DimValueList {
             return 0;
          }
 
-         return getAgePriority(XSwapper.getSwapper().cur - accessed, alive * 2L);
+         return getAgePriority(getSwapper().cur - accessed, alive * 2L);
       }
 
       @Override
@@ -264,7 +264,7 @@ public class DimValueList {
       @Override
       public synchronized boolean swap() {
          arr = null;
-         XSwapper.getSwapper().deregister(this);
+         getSwapper().deregister(this);
          return true;
       }
 
@@ -283,7 +283,7 @@ public class DimValueList {
             }
          }
 
-         accessed = XSwapper.getSwapper().cur;
+         accessed = getSwapper().cur;
          return arr[idx];
       }
 
@@ -292,13 +292,14 @@ public class DimValueList {
          SeekableByteChannel channel = null;
 
          try {
-            XSwapper.getSwapper().waitForMemory();
+            XSwapper s = getSwapper();
+            s.waitForMemory();
             channel = channelProvider.newReadChannel();
             channel.position(segpos[n]);
 
             arr = MVTool.readObjects(channel, true);
-            accessed = XSwapper.getSwapper().cur;
-            XSwapper.getSwapper().register(this);
+            accessed = s.cur;
+            s.register(this);
          }
          catch(Exception ex) {
             LOG.error("Failed to read fragment: {}", n, ex);

--- a/core/src/main/java/inetsoft/mv/data/MVDecimalColumn.java
+++ b/core/src/main/java/inetsoft/mv/data/MVDecimalColumn.java
@@ -342,8 +342,9 @@ public abstract class MVDecimalColumn extends AbstractMeasureColumn {
          this.index = index;
          this.size = size;
          this.newbuf = newbuf;
-         XSwapper.getSwapper().cur = System.currentTimeMillis();
-         this.iaccessed = XSwapper.getSwapper().cur;
+         XSwapper s = getSwapper();
+         s.cur = System.currentTimeMillis();
+         this.iaccessed = s.cur;
       }
 
       public abstract ByteBuffer copyToBuffer(ByteBuffer buf);
@@ -370,7 +371,7 @@ public abstract class MVDecimalColumn extends AbstractMeasureColumn {
             return 0;
          }
 
-         return getAgePriority(XSwapper.getSwapper().cur - iaccessed, alive * 2L);
+         return getAgePriority(getSwapper().cur - iaccessed, alive * 2L);
       }
 
       @Override

--- a/core/src/main/java/inetsoft/mv/data/MVDimColumn.java
+++ b/core/src/main/java/inetsoft/mv/data/MVDimColumn.java
@@ -79,7 +79,7 @@ public final class MVDimColumn extends DictDimIndex implements XMVColumn {
     * Get the value at the specified index.
     */
    public final int getValue(int idx) {
-      accessed = XSwapper.getSwapper().cur;
+      accessed = getSwapper().cur;
       return dimbuf.getValue(idx);
    }
 

--- a/core/src/main/java/inetsoft/mv/data/MVDoubleColumn.java
+++ b/core/src/main/java/inetsoft/mv/data/MVDoubleColumn.java
@@ -235,7 +235,7 @@ public class MVDoubleColumn extends MVDecimalColumn {
       @Override
       public void setValue(int index, double val) {
          if(arr == null) {
-            XSwapper.getSwapper().waitForMemory();
+            getSwapper().waitForMemory();
             arr = new double[size];
          }
 
@@ -263,14 +263,14 @@ public class MVDoubleColumn extends MVDecimalColumn {
       }
 
       private double[] access() {
-         iaccessed = XSwapper.getSwapper().cur;
+         iaccessed = getSwapper().cur;
          double[] arr = this.arr;
 
          if(arr != null) {
             return arr;
          }
 
-         XSwapper.getSwapper().waitForMemory();
+         getSwapper().waitForMemory();
 
          synchronized(this) {
             arr = this.arr;

--- a/core/src/main/java/inetsoft/mv/data/MVFloatColumn.java
+++ b/core/src/main/java/inetsoft/mv/data/MVFloatColumn.java
@@ -257,7 +257,7 @@ public class MVFloatColumn extends MVDecimalColumn {
       @Override
       public void setValue(int index, double val) {
          if(arr == null) {
-            XSwapper.getSwapper().waitForMemory();
+            getSwapper().waitForMemory();
             arr = new float[size];
          }
 
@@ -285,14 +285,14 @@ public class MVFloatColumn extends MVDecimalColumn {
       }
 
       protected float[] access() {
-         iaccessed = XSwapper.getSwapper().cur;
+         iaccessed = getSwapper().cur;
          float[] arr = this.arr;
 
          if(arr != null) {
             return arr;
          }
 
-         XSwapper.getSwapper().waitForMemory();
+         getSwapper().waitForMemory();
 
          synchronized(this) {
             arr = this.arr;

--- a/core/src/main/java/inetsoft/mv/data/MVIntColumn.java
+++ b/core/src/main/java/inetsoft/mv/data/MVIntColumn.java
@@ -51,7 +51,7 @@ public class MVIntColumn extends DictDimIndex implements MVMeasureColumn {
          max = max0.intValue();
       }
 
-      XSwapper.getSwapper().waitForMemory();
+      getSwapper().waitForMemory();
       dimbuf.setSize(size, true);
    }
 
@@ -132,7 +132,7 @@ public class MVIntColumn extends DictDimIndex implements MVMeasureColumn {
    @Override
    public final double getValue(int idx) {
       int result = dimbuf.getValue(idx);
-      accessed = XSwapper.getSwapper().cur;
+      accessed = getSwapper().cur;
 
       if(hasMin) {
          if(result == 0) {

--- a/core/src/main/java/inetsoft/mv/data/MVRangeIntColumn.java
+++ b/core/src/main/java/inetsoft/mv/data/MVRangeIntColumn.java
@@ -420,7 +420,7 @@ public class MVRangeIntColumn extends MVDecimalColumn {
       @Override
       public void setValue(int index, double val) {
          if(arr == null) {
-            XSwapper.getSwapper().waitForMemory();
+            getSwapper().waitForMemory();
             arr = new int[size];
          }
 
@@ -449,14 +449,14 @@ public class MVRangeIntColumn extends MVDecimalColumn {
       }
 
       protected int[] access() {
-         iaccessed = XSwapper.getSwapper().cur;
+         iaccessed = getSwapper().cur;
          int[] arr = this.arr;
 
          if(arr != null) {
             return arr;
          }
 
-         XSwapper.getSwapper().waitForMemory();
+         getSwapper().waitForMemory();
 
          synchronized(this) {
             arr = this.arr;

--- a/core/src/main/java/inetsoft/mv/data/MVUIntColumn.java
+++ b/core/src/main/java/inetsoft/mv/data/MVUIntColumn.java
@@ -404,7 +404,7 @@ public class MVUIntColumn extends MVDecimalColumn {
       @Override
       public void setValue(int index, double val) {
          if(arr == null) {
-            XSwapper.getSwapper().waitForMemory();
+            getSwapper().waitForMemory();
             arr = new int[size];
          }
 
@@ -433,14 +433,14 @@ public class MVUIntColumn extends MVDecimalColumn {
       }
 
       protected int[] access() {
-         iaccessed = XSwapper.getSwapper().cur;
+         iaccessed = getSwapper().cur;
          int[] arr = this.arr;
 
          if(arr != null) {
             return arr;
          }
 
-         XSwapper.getSwapper().waitForMemory();
+         getSwapper().waitForMemory();
 
          synchronized(this) {
             arr = this.arr;

--- a/core/src/main/java/inetsoft/mv/data/XDimDictionary.java
+++ b/core/src/main/java/inetsoft/mv/data/XDimDictionary.java
@@ -102,8 +102,9 @@ public class XDimDictionary extends XSwappable implements Cloneable {
       valid = true;
       completed = false;
       disposed = false;
-      XSwapper.getSwapper().cur = System.currentTimeMillis();
-      accessed = XSwapper.getSwapper().cur;
+      XSwapper s = getSwapper();
+      s.cur = System.currentTimeMillis();
+      accessed = s.cur;
    }
 
    /**
@@ -375,7 +376,7 @@ public class XDimDictionary extends XSwappable implements Cloneable {
     * Access this dim dictionary.
     */
    private final Object[] access() {
-      accessed = XSwapper.getSwapper().cur;
+      accessed = getSwapper().cur;
       Object[] values = this.values;
 
       if(values != null) {
@@ -669,7 +670,7 @@ public class XDimDictionary extends XSwappable implements Cloneable {
     * Load from binary storage.
     */
    private void read0(ReadableByteChannel channel) throws IOException {
-      XSwapper.getSwapper().waitForMemory();
+      getSwapper().waitForMemory();
 
       ByteBuffer buf = ByteBuffer.allocate(28);
       channel.read(buf);
@@ -774,7 +775,7 @@ public class XDimDictionary extends XSwappable implements Cloneable {
          return 0;
       }
 
-      return getAgePriority(XSwapper.getSwapper().cur - accessed, alive * 2L);
+      return getAgePriority(getSwapper().cur - accessed, alive * 2L);
    }
 
    /**
@@ -1112,8 +1113,9 @@ public class XDimDictionary extends XSwappable implements Cloneable {
          dict.completed = false;
          dict.disposed = false;
          dict.hashCode = 0;
-         XSwapper.getSwapper().cur = System.currentTimeMillis();
-         dict.accessed = XSwapper.getSwapper().cur;
+         XSwapper s = dict.getSwapper();
+         s.cur = System.currentTimeMillis();
+         dict.accessed = s.cur;
          return dict;
       }
       catch(Exception ex) {

--- a/core/src/main/java/inetsoft/mv/data/XDimIndex.java
+++ b/core/src/main/java/inetsoft/mv/data/XDimIndex.java
@@ -53,8 +53,9 @@ public abstract class XDimIndex extends XSwappable {
       valid = true;
       completed = false;
       disposed = false;
-      XSwapper.getSwapper().cur = System.currentTimeMillis();
-      accessed = XSwapper.getSwapper().cur;
+      XSwapper s = getSwapper();
+      s.cur = System.currentTimeMillis();
+      accessed = s.cur;
    }
 
    /**
@@ -144,7 +145,7 @@ public abstract class XDimIndex extends XSwappable {
    }
 
    protected void touch() {
-      accessed = XSwapper.getSwapper().cur;
+      accessed = getSwapper().cur;
 
       if(!completed) {
          access();
@@ -156,7 +157,7 @@ public abstract class XDimIndex extends XSwappable {
     */
    protected void access() {
       if(!completed && (channel != null || file != null)) {
-         XSwapper.getSwapper().waitForMemory();
+         getSwapper().waitForMemory();
 
          synchronized(this) {
             SeekableInputStream channel = this.channel;
@@ -196,7 +197,7 @@ public abstract class XDimIndex extends XSwappable {
 
       // invalid? validate it
       if(!valid) {
-         XSwapper.getSwapper().waitForMemory();
+         getSwapper().waitForMemory();
 
          synchronized(this) {
             validate();
@@ -436,7 +437,7 @@ public abstract class XDimIndex extends XSwappable {
          return 0;
       }
 
-      return getAgePriority(XSwapper.getSwapper().cur - accessed, alive * 2L);
+      return getAgePriority(getSwapper().cur - accessed, alive * 2L);
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/filter/SummaryFilter.java
+++ b/core/src/main/java/inetsoft/report/filter/SummaryFilter.java
@@ -2345,6 +2345,14 @@ public class SummaryFilter extends AbstractGroupedTable
       this.cube = cube;
    }
 
+   private XSwapper getSwapper() {
+      if(swapper == null) {
+         swapper = XSwapper.getSwapper();
+      }
+
+      return swapper;
+   }
+
    // base class for MergedGroupNode and UnionGroupNode
    private class CombinedGroupNode extends GroupNode {
       @Override
@@ -2558,7 +2566,7 @@ public class SummaryFilter extends AbstractGroupedTable
             // GroupNode (vals and sum) can be relatively heavy. when the number explodes
             // in deeply nested grouping, it can create a large surge in memory demand.
             if(row % 500 == 0) {
-               XSwapper.getSwapper().waitForMemory();
+               getSwapper().waitForMemory();
             }
 
             node = new GroupNode();
@@ -3389,6 +3397,7 @@ public class SummaryFilter extends AbstractGroupedTable
    private List<OrderInfo> orderInfo = new ArrayList<>();
    UserMessage userMsg = null;
    private transient DefaultComparator defaultComparator = new DefaultComparator(true);
+   private transient XSwapper swapper;
 
    private static final Logger LOG = LoggerFactory.getLogger(SummaryFilter.class);
 }

--- a/core/src/main/java/inetsoft/report/internal/paging/PageGroup.java
+++ b/core/src/main/java/inetsoft/report/internal/paging/PageGroup.java
@@ -44,14 +44,15 @@ public class PageGroup extends XSwappable {
       this.swapfile = swapfile;
       this.proc = processor;
       this.pages = new StylePage[max_pages];
-      XSwapper.getSwapper().cur = System.currentTimeMillis();
-      this.accessed = XSwapper.getSwapper().cur;
+      XSwapper s = getSwapper();
+      s.cur = System.currentTimeMillis();
+      this.accessed = s.cur;
       this.valid = true;
       this.ioneoff = proc == null ? false : proc.isInitialOneOff();
       this.interactive = false;// proc == null ? true : proc.isInteractive();
       this.batch = proc == null ? false : proc.isBatchWaiting();
       this.lcompleted = UNKNOWN;
-      this.monitor = XSwapper.getSwapper().getMonitor();
+      this.monitor = s.getMonitor();
 
       if(this.monitor != null) {
          isCountHM = monitor.isLevelQualified(XSwappableMonitor.HITS);
@@ -63,7 +64,7 @@ public class PageGroup extends XSwappable {
     * Access the page group.
     */
    private synchronized void access(int n) {
-      accessed = XSwapper.getSwapper().cur;
+      accessed = getSwapper().cur;
 
       if(disposed) {
          return;
@@ -83,7 +84,7 @@ public class PageGroup extends XSwappable {
       long livePeriod = !interactive && proc != null && proc.isBatchWaiting() &&
          !proc.isCompleted() ? 200 : alive;
 
-      return getAgePriority(XSwapper.getSwapper().cur - accessed, livePeriod);
+      return getAgePriority(getSwapper().cur - accessed, livePeriod);
    }
 
    /**
@@ -237,7 +238,7 @@ public class PageGroup extends XSwappable {
          return;
       }
 
-      XSwapper.getSwapper().waitForMemory();
+      getSwapper().waitForMemory();
       valid = true;
 
       try {

--- a/core/src/main/java/inetsoft/sree/web/HttpServiceRequest.java
+++ b/core/src/main/java/inetsoft/sree/web/HttpServiceRequest.java
@@ -851,11 +851,12 @@ public class HttpServiceRequest implements ServiceRequest {
          byte[] bytes = new byte[1024];
 
          OutputStream output = new ByteArrayOutputStream();
+         XSwapper swapper = XSwapper.getSwapper();
 
          while((read = input.read(bytes)) >= 0) {
             if(file == null && length + read > 1024 * 1024) {
                // cache posts longer than 1M to file
-               file = FileSystemService.getInstance().getCacheFile(XSwapper.getSwapper().getPrefix() + ".tdat");
+               file = FileSystemService.getInstance().getCacheFile(swapper.getPrefix() + ".tdat");
                file.deleteOnExit();
 
                OutputStream foutput = new FileOutputStream(file);

--- a/core/src/main/java/inetsoft/uql/erm/AbstractDataRef.java
+++ b/core/src/main/java/inetsoft/uql/erm/AbstractDataRef.java
@@ -215,12 +215,6 @@ public abstract class AbstractDataRef implements DataRef {
     * @param writer the output stream to which to write the XML data.
     */
    protected void writeContents(PrintWriter writer) {
-      // for flash side
-      if(!Tool.isCompact()) {
-         writer.print("<view>");
-         writer.print("<![CDATA[" + Encode.forCDATA(toView()) + "]]>");
-         writer.println("</view>");
-      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/erm/AbstractDataRef.java
+++ b/core/src/main/java/inetsoft/uql/erm/AbstractDataRef.java
@@ -222,13 +222,6 @@ public abstract class AbstractDataRef implements DataRef {
     * @param dos the output stream to which to write the OutputStream data.
     */
    protected void writeContents2(DataOutputStream dos) {
-      // for flash side
-      try {
-         dos.writeUTF(toView());
-      }
-      catch (IOException e) {
-         // ignore
-      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/table/XTableFragment.java
+++ b/core/src/main/java/inetsoft/uql/table/XTableFragment.java
@@ -55,8 +55,9 @@ public final class XTableFragment extends XSwappable {
 
       this.files = new ArrayList<>();
       this.columns = columns;
-      XSwapper.getSwapper().cur = System.currentTimeMillis();
-      this.iaccessed = XSwapper.getSwapper().cur;
+      XSwapper s = getSwapper();
+      s.cur = System.currentTimeMillis();
+      this.iaccessed = s.cur;
       this.valid = valid;
    }
 
@@ -66,7 +67,7 @@ public final class XTableFragment extends XSwappable {
          return 0;
       }
 
-      return getAgePriority(XSwapper.getSwapper().cur - iaccessed, alive);
+      return getAgePriority(getSwapper().cur - iaccessed, alive);
    }
 
    /**
@@ -396,7 +397,7 @@ public final class XTableFragment extends XSwappable {
     * Called when the columns are used.
     */
    private void access() {
-      iaccessed = XSwapper.getSwapper().cur;
+      iaccessed = getSwapper().cur;
       valid = true; // column access (isNull, get...) will swap in data
    }
 

--- a/core/src/main/java/inetsoft/uql/viewsheet/SelectionList.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/SelectionList.java
@@ -800,12 +800,12 @@ public class SelectionList extends XSwappable implements AssetObject, DataSerial
       // given the current usage, where a SelectionValue would be updated immediately
       // after swapping, it should be safe. we will need to make SelectionValue
       // immutable to make it completely safe.
-      if(!completed || !valid || XSwapper.getSwapper().cur < lastAccess + 5000) {
+      if(!completed || !valid || getSwapper().cur < lastAccess + 5000) {
          return 0;
       }
 
       // allow SelectionList to be swapped. but don't do it unless really necessary.
-      return getAgePriority(XSwapper.getSwapper().cur - lastAccess, alive * 3L);
+      return getAgePriority(getSwapper().cur - lastAccess, alive * 3L);
    }
 
    @Override
@@ -890,7 +890,7 @@ public class SelectionList extends XSwappable implements AssetObject, DataSerial
 
    private List<SelectionValue> getList() {
       ArrayList<SelectionValue> list = this.list;
-      lastAccess = XSwapper.getSwapper().cur;
+      lastAccess = getSwapper().cur;
 
       if(!valid) {
          synchronized(this) {

--- a/core/src/main/java/inetsoft/util/css/CSSDictionary.java
+++ b/core/src/main/java/inetsoft/util/css/CSSDictionary.java
@@ -189,9 +189,9 @@ public class CSSDictionary {
       if(dictionary != null) {
          long now = System.currentTimeMillis();
 
-         // optimization, avoid repeatedly checking for last modified time. allow 3s for
+         // optimization, avoid repeatedly checking for last modified time. allow 10s for
          // css dictionary change to become effective.
-         if(dictionary.lastCheck + 3000 < now) {
+         if(dictionary.lastCheck + 10000 < now) {
             long lastModified = getLastModified(cssDir, cssFile, isReport);
             dictionary.lastCheck = now;
 
@@ -251,8 +251,16 @@ public class CSSDictionary {
          return System.currentTimeMillis();
       }
 
+      String orgID = OrganizationManager.getInstance().getCurrentOrgID();
+      long now = System.currentTimeMillis();
+      Long lastCheck = ORG_LAST_CHECK.get(orgID);
+
+      if(lastCheck != null && now - lastCheck <= 10000) {
+         return ORG_LAST_MODIFIED.getOrDefault(orgID, -1L);
+      }
+
       Map<String, String> cssEntries = PortalThemesManager.getManager().getCssEntries();
-      String orgFile = cssEntries.get(OrganizationManager.getInstance().getCurrentOrgID());
+      String orgFile = cssEntries.get(orgID);
       List<String> otherFiles = new ArrayList<>();
 
       if(orgFile != null) {
@@ -260,13 +268,19 @@ public class CSSDictionary {
       }
 
       if(!Tool.equals(otherFiles, dict.otherFiles)) {
-         return System.currentTimeMillis();
+         ORG_LAST_CHECK.put(orgID, now);
+         ORG_LAST_MODIFIED.put(orgID, now);
+         return now;
       }
 
       long orgLastModified = getLastModified(dict.cssDir, orgFile, false);
       long globalLastModified = getLastModified(dict.cssDir, "format.css", false);
+      long result = Math.max(orgLastModified, globalLastModified);
 
-      return Math.max(orgLastModified, globalLastModified);
+      ORG_LAST_CHECK.put(orgID, now);
+      ORG_LAST_MODIFIED.put(orgID, result);
+
+      return result;
    }
 
    // get css file last modified time
@@ -2265,6 +2279,8 @@ public class CSSDictionary {
    private static final ReadWriteLock DICTIONARIES_LOCK =
       new ReentrantReadWriteLock(true);
    private static Map<String, CascadingStyleSheet> styleSheets = new ConcurrentHashMap<>();
+   private static final ConcurrentHashMap<String, Long> ORG_LAST_CHECK = new ConcurrentHashMap<>();
+   private static final ConcurrentHashMap<String, Long> ORG_LAST_MODIFIED = new ConcurrentHashMap<>();
 
    private static final Logger LOG = LoggerFactory.getLogger(CSSDictionary.class);
 }

--- a/core/src/main/java/inetsoft/util/swap/ByteBufferPool.java
+++ b/core/src/main/java/inetsoft/util/swap/ByteBufferPool.java
@@ -130,7 +130,7 @@ public final class ByteBufferPool {
             }
          }
 
-         XSwapper.getSwapper().deregister(this);
+         getSwapper().deregister(this);
       }
 
       public ByteBuffer getByteBuffer() {

--- a/core/src/main/java/inetsoft/util/swap/XIntFragment.java
+++ b/core/src/main/java/inetsoft/util/swap/XIntFragment.java
@@ -47,10 +47,11 @@ public final class XIntFragment extends XSwappable {
 
    private XIntFragment() {
       super();
-      XSwapper.getSwapper().cur = System.currentTimeMillis();
-      this.iaccessed = XSwapper.getSwapper().cur;
+      XSwapper s = getSwapper();
+      s.cur = System.currentTimeMillis();
+      this.iaccessed = s.cur;
       this.valid = true;
-      this.monitor = XSwapper.getSwapper().getMonitor();
+      this.monitor = s.getMonitor();
 
       if(monitor != null) {
          isCountHM = monitor.isLevelQualified(XSwappableMonitor.HITS);
@@ -73,7 +74,7 @@ public final class XIntFragment extends XSwappable {
     * Access the int fragment.
     */
    public final void access() {
-      iaccessed = XSwapper.getSwapper().cur;
+      iaccessed = getSwapper().cur;
 
       if(isCountHM) {
          if(valid && !lastValid) {
@@ -98,7 +99,7 @@ public final class XIntFragment extends XSwappable {
          return 0;
       }
 
-      return getAgePriority(XSwapper.getSwapper().cur - iaccessed, alive);
+      return getAgePriority(getSwapper().cur - iaccessed, alive);
    }
 
    /**
@@ -276,7 +277,7 @@ public final class XIntFragment extends XSwappable {
          if(!file.exists()) {
             fout = new RandomAccessFile(file, "rw");
             channel = fout.getChannel();
-            XSwapper.getSwapper().waitForMemory();
+            getSwapper().waitForMemory();
             buf = ByteBuffer.allocate((int) len);
          }
 

--- a/core/src/main/java/inetsoft/util/swap/XObjectFragment.java
+++ b/core/src/main/java/inetsoft/util/swap/XObjectFragment.java
@@ -49,8 +49,9 @@ public final class XObjectFragment<T> extends XSwappable {
       this.size = size;
       this.pos = 0;
       this.arr = new Object[isize];
-      XSwapper.getSwapper().cur = System.currentTimeMillis();
-      this.iaccessed = XSwapper.getSwapper().cur;
+      XSwapper s = getSwapper();
+      s.cur = System.currentTimeMillis();
+      this.iaccessed = s.cur;
       this.valid = true;
 
       if(getMonitor() != null) {
@@ -64,7 +65,7 @@ public final class XObjectFragment<T> extends XSwappable {
     */
    public final Object[] access() {
       Object[] arr = this.arr;
-      iaccessed = XSwapper.getSwapper().cur;
+      iaccessed = getSwapper().cur;
 
       if(isCountHM) {
          if(valid && !lastValid) {
@@ -80,7 +81,7 @@ public final class XObjectFragment<T> extends XSwappable {
       if(!valid || arr == null) {
          DEBUG_LOG.debug("Validate swapped data: %s", this);
 
-         XSwapper.getSwapper().waitForMemory();
+         getSwapper().waitForMemory();
 
          synchronized(this) {
             if(!valid || arr == null) {
@@ -98,7 +99,7 @@ public final class XObjectFragment<T> extends XSwappable {
          return 0;
       }
 
-      return getAgePriority(XSwapper.getSwapper().cur - iaccessed, alive);
+      return getAgePriority(getSwapper().cur - iaccessed, alive);
    }
 
    /**
@@ -283,7 +284,7 @@ public final class XObjectFragment<T> extends XSwappable {
       File file = getFile(prefix + "_0.tdat");
 
       if(length() != 0 && !file.exists()) {
-         XSwapper.getSwapper().waitForMemory();
+         getSwapper().waitForMemory();
       }
 
       synchronized(this) {
@@ -532,7 +533,7 @@ public final class XObjectFragment<T> extends XSwappable {
       }
 
       if(!valid) {
-         XSwapper.getSwapper().waitForMemory();
+         getSwapper().waitForMemory();
 
          synchronized(this) {
             if(!valid) {
@@ -720,7 +721,7 @@ public final class XObjectFragment<T> extends XSwappable {
          // @by jasons, monitor is now transient, so we need to look it up on
          // demand so a deserialized version works.
          if(monitor == null) {
-            monitor = XSwapper.getSwapper().getMonitor();
+            monitor = getSwapper().getMonitor();
          }
       }
 

--- a/core/src/main/java/inetsoft/util/swap/XStringFragment.java
+++ b/core/src/main/java/inetsoft/util/swap/XStringFragment.java
@@ -42,12 +42,13 @@ public final class XStringFragment extends XSwappable {
    public XStringFragment(String val, long interval) {
       super();
       this.interval = interval;
-      XSwapper.getSwapper().cur = System.currentTimeMillis();
-      this.iaccessed = XSwapper.getSwapper().cur;
+      XSwapper s = getSwapper();
+      s.cur = System.currentTimeMillis();
+      this.iaccessed = s.cur;
       value = val;
       len = value == null ? 0 : value.length();
       this.valid = true;
-      this.monitor = XSwapper.getSwapper().getMonitor();
+      this.monitor = s.getMonitor();
 
       if(monitor != null) {
          isCountHM = monitor.isLevelQualified(XSwappableMonitor.HITS);
@@ -106,7 +107,7 @@ public final class XStringFragment extends XSwappable {
     * Access the int fragment.
     */
    public final void access() {
-      iaccessed = XSwapper.getSwapper().cur;
+      iaccessed = getSwapper().cur;
 
       if(isCountHM) {
          if(valid && !lastValid) {
@@ -121,7 +122,7 @@ public final class XStringFragment extends XSwappable {
 
       if(!valid) {
          DEBUG_LOG.debug("Validate swapped data: %s", this);
-         XSwapper.getSwapper().waitForMemory();
+         getSwapper().waitForMemory();
 
          synchronized(this) {
             if(!valid) {
@@ -155,7 +156,7 @@ public final class XStringFragment extends XSwappable {
          return;
       }
 
-      XSwapper.getSwapper().deregister(this);
+      getSwapper().deregister(this);
       disposed = true;
       value = null;
       File file = getFile(prefix + ".tdat");
@@ -188,7 +189,7 @@ public final class XStringFragment extends XSwappable {
          return 0;
       }
 
-      return getAgePriority(XSwapper.getSwapper().cur - iaccessed, interval);
+      return getAgePriority(getSwapper().cur - iaccessed, interval);
    }
 
    /**
@@ -279,7 +280,7 @@ public final class XStringFragment extends XSwappable {
          int len = 0;
 
          if(fout != null) {
-	    XSwapper.getSwapper().waitForMemory();
+	    getSwapper().waitForMemory();
             byte[] buf = value.getBytes("UTF-8");
             len = buf.length;
             fout.write(buf);

--- a/core/src/main/java/inetsoft/util/swap/XSwappable.java
+++ b/core/src/main/java/inetsoft/util/swap/XSwappable.java
@@ -100,8 +100,16 @@ public abstract class XSwappable implements Serializable {
       initPrefix();
    }
 
+   protected XSwapper getSwapper() {
+      if(swapper == null) {
+         swapper = XSwapper.getSwapper();
+      }
+
+      return swapper;
+   }
+
    private void initPrefix() {
-      this.prefix = XSwapper.getSwapper().getPrefix();
+      this.prefix = getSwapper().getPrefix();
    }
 
    /**
@@ -143,7 +151,7 @@ public abstract class XSwappable implements Serializable {
     * This method should be called when the object is ready to be swapped.
     */
    public void complete() {
-      XSwapper.getSwapper().register(this);
+      getSwapper().register(this);
    }
 
    @Override
@@ -193,6 +201,7 @@ public abstract class XSwappable implements Serializable {
    protected static final int alive =
       Integer.parseInt(SreeEnv.getProperty("swappable.alive.period", "1500"));
    protected String prefix;
+   protected transient XSwapper swapper;
    private transient double priority;
    private transient Comparator comp;
 }

--- a/core/src/main/java/inetsoft/util/swap/XSwappableIntList.java
+++ b/core/src/main/java/inetsoft/util/swap/XSwappableIntList.java
@@ -214,7 +214,7 @@ public class XSwappableIntList implements Serializable {
     */
    public final int add(int val) {
       if((count & BLOCK_SIZE) == 0) {
-         XSwapper.getSwapper().waitForMemory();
+         getSwapper().waitForMemory();
 
          if(fragment != null) {
             fragment.complete();
@@ -342,6 +342,14 @@ public class XSwappableIntList implements Serializable {
       return true;
    }
 
+   private XSwapper getSwapper() {
+      if(swapper == null) {
+         swapper = XSwapper.getSwapper();
+      }
+
+      return swapper;
+   }
+
    private static final int BLOCK_BITS = 15;
    private static final int BLOCK_SIZE = 0x7fff;
 
@@ -353,6 +361,7 @@ public class XSwappableIntList implements Serializable {
    private boolean disposed = false; // list disposed
    private int count; // data count
    private transient XIntFragment fragment; // current list fragment
+   private transient XSwapper swapper;
    private static final Logger LOG =
       LoggerFactory.getLogger(XSwappableIntList.class);
 }

--- a/core/src/main/java/inetsoft/util/swap/XSwappableObjectList.java
+++ b/core/src/main/java/inetsoft/util/swap/XSwappableObjectList.java
@@ -152,7 +152,7 @@ public final class XSwappableObjectList<T> implements Serializable {
 
       // wait for memory outside (before) synchronized to avoid deadlock
       if((waitCnt++ & 0x1f) == 0) {
-         XSwapper.getSwapper().waitForMemory();
+         getSwapper().waitForMemory();
       }
 
       return fragments[tidx].getSafely(ridx);
@@ -201,7 +201,7 @@ public final class XSwappableObjectList<T> implements Serializable {
 
       // wait for memory outside (before) synchronized to avoid deadlock
       if((waitCnt++ & 0x1f) == 0) {
-         XSwapper.getSwapper().waitForMemory();
+         getSwapper().waitForMemory();
       }
 
       return fragments[fidx].getArray();
@@ -227,7 +227,7 @@ public final class XSwappableObjectList<T> implements Serializable {
     */
    public int add(Object obj) {
       if((count & BLOCK_SIZE) == 0) {
-         XSwapper.getSwapper().waitForMemory();
+         getSwapper().waitForMemory();
 
          if(fragment != null) {
             fragment.complete();
@@ -442,6 +442,14 @@ public final class XSwappableObjectList<T> implements Serializable {
       private Object[] fragment;
    }
 
+   private XSwapper getSwapper() {
+      if(swapper == null) {
+         swapper = XSwapper.getSwapper();
+      }
+
+      return swapper;
+   }
+
    private static final int BLOCK_BITS = 13;
    private static final int BLOCK_SIZE = 0x1fff;
 
@@ -455,6 +463,7 @@ public final class XSwappableObjectList<T> implements Serializable {
    private Class kryoClass;
    private transient short waitCnt = 0;
    private transient XObjectFragment fragment; // current list fragment
+   private transient XSwapper swapper;
    private transient boolean debug =
       "true".equals(SreeEnv.getProperty("filter.debug", "false"));
    private static final Logger LOG =

--- a/core/src/main/java/inetsoft/util/swap/XSwapper.java
+++ b/core/src/main/java/inetsoft/util/swap/XSwapper.java
@@ -850,7 +850,7 @@ public final class XSwapper {
 
    private long cts = System.currentTimeMillis();
    private long scount = 0L;
-   private int cachedState = GOOD_MEM;
+   private volatile int cachedState = GOOD_MEM;
    private volatile long stateTS = 0;
 
    private boolean stopped = false;

--- a/core/src/main/java/inetsoft/util/swap/XSwapper.java
+++ b/core/src/main/java/inetsoft/util/swap/XSwapper.java
@@ -140,13 +140,13 @@ public final class XSwapper {
     * Get memory state at no more than a certain interval.
     */
    public int getMemoryState() {
-      XSwapper s = getSwapper();
       long now = System.currentTimeMillis();
-      if(now - s.stateTS > 200) {
-         s.stateTS = now;
-         s.cachedState = getMemoryState0();
+
+      if(now - stateTS > 200) {
+         stateTS = now;
+         cachedState = getMemoryState0();
       }
-      return s.cachedState;
+      return cachedState;
    }
 
    /**


### PR DESCRIPTION
- XSwappable: add protected transient `swapper` field with lazy getter so subclasses (XStringFragment, XObjectFragment, XIntFragment, XTableFragment, SelectionList, DimValueList, MVDecimalColumn, XDimIndex, XDimDictionary, MVUIntColumn, MVRangeIntColumn, MVIntColumn, MVFloatColumn, MVDoubleColumn, MVDimColumn, PageGroup) use the cached instance instead of calling XSwapper.getSwapper() on every hot-path invocation
- Non-XSwappable classes with repeated calls get the same private transient field+getter pattern: XSwappableObjectList, XSwappableIntList, SummaryFilter
- DefaultTableBlock, HttpServiceRequest: hoist getSwapper() above inner loops to avoid redundant Spring bean lookups per iteration
- XSwapper.getMemoryState(): use instance fields directly instead of re-entering getSwapper() on every 200ms cache-miss
- CSSDictionary.getOrgScopedCSSLastModified(): add per-org 10-second debounce using ConcurrentHashMap to avoid hitting DataSpace on every CSS property access
- AbstractDataRef.writeContents(): remove dead Flash-era <view> write that was never read back by the base class parser