### PR TITLE
Bug #74412, revert incorrect mobile layout fallback in bookmark navigation

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
@@ -837,56 +837,8 @@ public class RuntimeViewsheet extends RuntimeSheet {
 
       // Apply the updated viewsheet
       if(processedViewsheet != null) {
-         ViewsheetLayout layoutToApply = rvsLayout;
-
-         if(layoutToApply == null) {
-            // rvsLayout is null when no layout matched the current device (e.g. a
-            // mobile-only layout opened from a non-mobile browser). For bookmark
-            // navigation we still need to apply a layout so that the stored positions
-            // are rendered correctly. Re-run the width match treating the device as
-            // mobile so that mobile-only layouts are considered as a fallback.
-            // Bug #74412
-            String displayWidthStr = getEntry().getProperty("_device_display_width");
-
-            if(displayWidthStr != null) {
-               LayoutInfo layoutInfo = vs.getLayoutInfo();
-               layoutToApply = layoutInfo.matchLayout(Integer.parseInt(displayWidthStr), true);
-
-               if(layoutToApply != null) {
-                  String pixelDensityStr = getEntry().getProperty("_device_pixel_density");
-                  double dpi;
-
-                  if(pixelDensityStr != null) {
-                     int pixelDensity = Integer.parseInt(pixelDensityStr);
-
-                     if(pixelDensity < 200) {
-                        dpi = 160D;
-                     }
-                     else if(pixelDensity <= 280) {
-                        dpi = 240D;
-                     }
-                     else if(pixelDensity <= 400) {
-                        dpi = 320D;
-                     }
-                     else if(pixelDensity <= 560) {
-                        dpi = 480D;
-                     }
-                     else {
-                        dpi = 640D;
-                     }
-                  }
-                  else {
-                     // don't scale HTML
-                     dpi = 160D;
-                  }
-
-                  layoutToApply = layoutInfo.matchDPI(dpi, layoutToApply);
-               }
-            }
-         }
-
-         if(layoutToApply != null) {
-            processedViewsheet = layoutToApply.apply(processedViewsheet);
+         if(rvsLayout != null) {
+            processedViewsheet = rvsLayout.apply(processedViewsheet);
          }
 
          setOpenedBookmark(bookmark == null ? null : bookmark.getBookmarkInfo(name));


### PR DESCRIPTION
## Summary

- Reverts the incorrect fix from PR #3381 which applied mobile-only layouts on non-mobile devices during bookmark navigation
- The previous fix called `matchLayout(width, true)` with `mobile=true` as a fallback when `rvsLayout` was null, which caused mobile-only layouts to be applied on non-mobile devices
- Per the correct behavior: when "Mobile Only" is checked on a layout, that layout must not apply to non-mobile devices, even when restoring bookmarks

## Test plan

- [ ] Import the `annotation.zip` test case viewsheet
- [ ] Open viewsheet `annotation` in the portal and select bookmark `annotation` — verify mobile layout is applied
- [ ] Open the viewsheet in Composer → Dashboard Options → Layout tab → edit `layout1` → check "Mobile Only" → save
- [ ] Open viewsheet in portal (from a non-mobile browser) and select bookmark `annotation` — verify the mobile layout is **not** applied (expected behavior per Redmine #74412 feedback)
- [ ] Open viewsheet in portal from a mobile browser and select bookmark `annotation` — verify the mobile layout **is** applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)