### PR TITLE
Bug #74594 - Fix search bar overlap with bottom tab strip on collapsed dropdown

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
@@ -238,12 +238,16 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
 
       // composer mode: shift up relative to wrapper.
       // non-dropdown case is handled by editable-object-container.getTopPosition()
-      if(!(this.viewer || this.embeddedVS)
-         && this.model.dropdown && !SelectionBaseController.isHidden(this.model)
-         && inBottomTab)
-      {
-         let searchBarHeight = this.model.searchDisplayed ? this.model.titleFormat.height : 0;
-         return -this.getBodyHeight() - searchBarHeight;
+      if(!(this.viewer || this.embeddedVS) && this.model.dropdown && inBottomTab) {
+         const expanded = !SelectionBaseController.isHidden(this.model);
+         const searchBarHeight = this.model.searchDisplayed ? this.model.titleFormat.height : 0;
+
+         // collapsed-with-search still needs an upward shift because the search bar
+         // ([hidden], not *ngIf) renders below the title and would overlap the tab strip.
+         if(expanded || searchBarHeight > 0) {
+            const bodyHeight = expanded ? this.getBodyHeight() : 0;
+            return -bodyHeight - searchBarHeight;
+         }
       }
 
       return null;

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.spec.ts
@@ -373,6 +373,7 @@ describe("VSSelection Test", () => {
    it("should shift collapsed dropdown selection up by an extra titleHeight when search bar is displayed (viewer)", () => {
       let listModel = createListModel();
       listModel.dropdown = true;
+      listModel.hidden = true;                 // dropdown panel collapsed
       listModel.searchDisplayed = true;
       listModel.objectFormat.top = 9999;       // stale; must be ignored
       listModel.titleFormat.height = 20;
@@ -386,16 +387,44 @@ describe("VSSelection Test", () => {
       tabModel.objectFormat.top = 544;
 
       contextService.viewer = true;
-      fixture.componentInstance.model = listModel;        // model setter forces hidden=true
+      fixture.componentInstance.model = listModel;
       fixture.componentInstance.vsInfo = { vsObjects: [tabModel] } as any;
 
       // tabTop(544) - titleHeight(20) - searchBar(20) = 504
       expect(fixture.componentInstance.topPosition).toBe(504);
    });
 
+   it("should shift expanded dropdown selection above parent tab when search bar is displayed (viewer)", () => {
+      let listModel = createListModel();
+      listModel.dropdown = true;
+      listModel.searchDisplayed = true;
+      listModel.objectFormat.top = 9999;       // stale; must be ignored
+      listModel.titleFormat.height = 20;
+      listModel.cellHeight = 18;
+      listModel.listHeight = 5;                // getBodyHeight → 18*5 - searchBar(20) = 70
+      listModel.containerType = "VSTab";
+      listModel.container = "Tab1";
+
+      let tabModel = Object.assign(
+         { bottomTabs: true },
+         TestUtils.createMockVSObjectModel("VSTab", "Tab1")
+      );
+      tabModel.objectFormat.top = 544;
+
+      contextService.viewer = true;
+      fixture.componentInstance.model = listModel;
+      // model setter forces hidden=true for new dropdown models; flip after assignment
+      fixture.componentInstance.model.hidden = false;
+      fixture.componentInstance.vsInfo = { vsObjects: [tabModel] } as any;
+
+      // tabTop(544) - titleHeight(20) - bodyHeight(70) - searchBar(20) = 434
+      expect(fixture.componentInstance.topPosition).toBe(434);
+   });
+
    it("should shift collapsed dropdown selection up by searchBar height in composer when search bar is displayed", () => {
       let listModel = createListModel();
       listModel.dropdown = true;
+      listModel.hidden = true;                 // dropdown panel collapsed
       listModel.searchDisplayed = true;
       listModel.titleFormat.height = 20;
       listModel.containerType = "VSTab";
@@ -407,7 +436,7 @@ describe("VSSelection Test", () => {
       );
 
       contextService.viewer = false;
-      fixture.componentInstance.model = listModel;        // model setter forces hidden=true
+      fixture.componentInstance.model = listModel;
       fixture.componentInstance.vsInfo = { vsObjects: [tabModel] } as any;
 
       // composer returns relative offset: -bodyHeight(0, collapsed) - searchBar(20) = -20
@@ -417,6 +446,7 @@ describe("VSSelection Test", () => {
    it("should not shift collapsed dropdown selection in composer when search bar is hidden", () => {
       let listModel = createListModel();
       listModel.dropdown = true;
+      listModel.hidden = true;                 // dropdown panel collapsed
       listModel.searchDisplayed = false;
       listModel.titleFormat.height = 20;
       listModel.containerType = "VSTab";
@@ -428,7 +458,7 @@ describe("VSSelection Test", () => {
       );
 
       contextService.viewer = false;
-      fixture.componentInstance.model = listModel;        // model setter forces hidden=true
+      fixture.componentInstance.model = listModel;
       fixture.componentInstance.vsInfo = { vsObjects: [tabModel] } as any;
 
       // composer collapsed-no-search: no shift, fall through to null

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.spec.ts
@@ -366,4 +366,72 @@ describe("VSSelection Test", () => {
       // tabTop(544) - titleHeight(20) - bodyHeight(90) = 434
       expect(fixture.componentInstance.topPosition).toBe(434);
    });
+
+   // Bug #74594 — collapsed dropdown with the search bar enabled must shift up
+   // an extra titleHeight so the search bar (rendered via [hidden], not *ngIf)
+   // doesn't overlap the bottom tab strip.
+   it("should shift collapsed dropdown selection up by an extra titleHeight when search bar is displayed (viewer)", () => {
+      let listModel = createListModel();
+      listModel.dropdown = true;
+      listModel.searchDisplayed = true;
+      listModel.objectFormat.top = 9999;       // stale; must be ignored
+      listModel.titleFormat.height = 20;
+      listModel.containerType = "VSTab";
+      listModel.container = "Tab1";
+
+      let tabModel = Object.assign(
+         { bottomTabs: true },
+         TestUtils.createMockVSObjectModel("VSTab", "Tab1")
+      );
+      tabModel.objectFormat.top = 544;
+
+      contextService.viewer = true;
+      fixture.componentInstance.model = listModel;        // model setter forces hidden=true
+      fixture.componentInstance.vsInfo = { vsObjects: [tabModel] } as any;
+
+      // tabTop(544) - titleHeight(20) - searchBar(20) = 504
+      expect(fixture.componentInstance.topPosition).toBe(504);
+   });
+
+   it("should shift collapsed dropdown selection up by searchBar height in composer when search bar is displayed", () => {
+      let listModel = createListModel();
+      listModel.dropdown = true;
+      listModel.searchDisplayed = true;
+      listModel.titleFormat.height = 20;
+      listModel.containerType = "VSTab";
+      listModel.container = "Tab1";
+
+      let tabModel = Object.assign(
+         { bottomTabs: true },
+         TestUtils.createMockVSObjectModel("VSTab", "Tab1")
+      );
+
+      contextService.viewer = false;
+      fixture.componentInstance.model = listModel;        // model setter forces hidden=true
+      fixture.componentInstance.vsInfo = { vsObjects: [tabModel] } as any;
+
+      // composer returns relative offset: -bodyHeight(0, collapsed) - searchBar(20) = -20
+      expect(fixture.componentInstance.topPosition).toBe(-20);
+   });
+
+   it("should not shift collapsed dropdown selection in composer when search bar is hidden", () => {
+      let listModel = createListModel();
+      listModel.dropdown = true;
+      listModel.searchDisplayed = false;
+      listModel.titleFormat.height = 20;
+      listModel.containerType = "VSTab";
+      listModel.container = "Tab1";
+
+      let tabModel = Object.assign(
+         { bottomTabs: true },
+         TestUtils.createMockVSObjectModel("VSTab", "Tab1")
+      );
+
+      contextService.viewer = false;
+      fixture.componentInstance.model = listModel;        // model setter forces hidden=true
+      fixture.componentInstance.vsInfo = { vsObjects: [tabModel] } as any;
+
+      // composer collapsed-no-search: no shift, fall through to null
+      expect(fixture.componentInstance.topPosition).toBeNull();
+   });
 });

--- a/web/projects/portal/src/app/vsobjects/util/vs-util.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/util/vs-util.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { VSUtil } from "./vs-util";
+
+describe("VSUtil.computeBottomTabSelectionTop", () => {
+   const tabTop = 500;
+   const titleHeight = 20;
+   const bodyHeight = 100;
+
+   it("collapsed without search bar: shifts up by titleHeight only", () => {
+      expect(VSUtil.computeBottomTabSelectionTop(tabTop, titleHeight, false, bodyHeight, false))
+         .toBe(tabTop - titleHeight);
+   });
+
+   it("collapsed with search bar: shifts up by titleHeight + searchBar so search clears the tab strip", () => {
+      expect(VSUtil.computeBottomTabSelectionTop(tabTop, titleHeight, false, bodyHeight, true))
+         .toBe(tabTop - titleHeight - titleHeight);
+   });
+
+   it("expanded without search bar: shifts up by titleHeight + bodyHeight", () => {
+      expect(VSUtil.computeBottomTabSelectionTop(tabTop, titleHeight, true, bodyHeight, false))
+         .toBe(tabTop - titleHeight - bodyHeight);
+   });
+
+   it("expanded with search bar: shifts up by titleHeight + bodyHeight + searchBar", () => {
+      expect(VSUtil.computeBottomTabSelectionTop(tabTop, titleHeight, true, bodyHeight, true))
+         .toBe(tabTop - titleHeight - bodyHeight - titleHeight);
+   });
+});

--- a/web/projects/portal/src/app/vsobjects/util/vs-util.ts
+++ b/web/projects/portal/src/app/vsobjects/util/vs-util.ts
@@ -608,9 +608,13 @@ export namespace VSUtil {
     * objectFormat.top, which may be stale when bottomTabs is toggled via script
     * (child pixelOffset refreshes aren't guaranteed to reach the client).
     *
-    * - collapsed (expanded=false): title sits directly above the tab bar; this
-    *   branch also covers the script-stale case, anchoring the title correctly
-    *   regardless of the selection's own (possibly stale) objectFormat.top.
+    * The search bar renders via [hidden] (not *ngIf), so it occupies space whenever
+    * searchDisplayed is true — including when the dropdown is collapsed. Account
+    * for it in both states so it never overlaps the tab strip.
+    *
+    * - collapsed: title sits above the tab bar; if the search bar is shown, the
+    *   wrapper shifts up an additional titleHeight so the search bar also clears
+    *   the tab bar.
     * - expanded: wrapper shifts further up by bodyHeight (+ searchBarHeight) so the
     *   body pops above the title.
     */
@@ -619,7 +623,7 @@ export namespace VSUtil {
                                                 searchDisplayed: boolean): number {
       const body = expanded ? bodyHeight : 0;
       // selection's search bar height matches the title bar height
-      const searchBar = expanded && searchDisplayed ? titleHeight : 0;
+      const searchBar = searchDisplayed ? titleHeight : 0;
       return tabTop - titleHeight - body - searchBar;
    }
 }


### PR DESCRIPTION
The selection search bar uses [hidden] (not *ngIf), so it occupies layout space whenever searchDisplayed=true, even when the dropdown is collapsed. The viewer helper (computeBottomTabSelectionTop) and composer branch in VSSelection.topPosition only added searchBar height when expanded, so it overlapped the tab strip when collapsed inside a bottom-tabs VSTab.Now subtract searchBar height whenever searchDisplayed=true. 

Added unit tests for all (expanded × searchDisplayed) combinations and integration tests for the viewer and composer paths