### PR TITLE
Bug #74724, handle null orgID in LibManagerProvider.getManager()

### DIFF
--- a/core/src/main/java/inetsoft/report/LibManagerProvider.java
+++ b/core/src/main/java/inetsoft/report/LibManagerProvider.java
@@ -59,6 +59,10 @@ public class LibManagerProvider {
    }
 
    public LibManager getManager(String orgID) {
+      if(orgID == null) {
+         return getManager();
+      }
+
       lock.lock();
       try {
          LibManager manager = managers.get(orgID);


### PR DESCRIPTION
## Summary

- The Spring beans migration (`Feature #36295`) replaced `LibManager.getManager(orgID)` (which fell back to the current org when `orgID` was null via `SingletonManager.Reference.get()`) with `LibManagerProvider.getManager(orgID)`, which lacked that null guard.
- Callers such as `VSUtil.getTableStyle(name)` pass `null` explicitly as the org ID, which flows through `StyleTreeModel.get(name, null)` → `LibManagerProvider.getManager(null)` → `new LibManager(null, ...)` → `null.toLowerCase()` → NPE.
- Fix: add a null check in `LibManagerProvider.getManager(String orgID)` that delegates to `getManager()` (the no-arg form, which resolves the org via `OrganizationManager.getCurrentOrgID()`), restoring the pre-regression behavior.

## Test plan

- [ ] Start server on the sessions branch with security enabled
- [ ] Import the attached viewsheet (`FormTable.zip`) and open `Embedded Form`
- [ ] Click the import icon on the toolbar and import the attached Excel file — should succeed without NPE

🤖 Generated with [Claude Code](https://claude.com/claude-code)