### PR TITLE
Bug #74718, fix ClassCastException when opening VS wizard

### DIFF
--- a/core/src/main/java/inetsoft/web/factory/EngineConfiguration.java
+++ b/core/src/main/java/inetsoft/web/factory/EngineConfiguration.java
@@ -444,7 +444,7 @@ public class EngineConfiguration {
     */
    @Bean
    @Lazy
-   public DesignSession designSession(@Lazy XDataService dataService, @Lazy XSessionService sessionService, @Lazy DataSourceRegistry dataSourceRegistry) throws RemoteException {
+   public DesignSession designSession(@Lazy XRepository dataService, @Lazy XSessionService sessionService, @Lazy DataSourceRegistry dataSourceRegistry) throws RemoteException {
       return new DesignSession(dataService, sessionService, dataSourceRegistry);
    }
 


### PR DESCRIPTION
## Summary

- `AnalyticEngine.getLogicalModel()` casts `designSession.getDataService()` to `XRepository`, but the Spring `@Lazy XDataService` injection point caused a JDK dynamic proxy to be created that only implemented `XDataService` — not `XRepository` — resulting in a `ClassCastException` when opening the VS wizard on a viewsheet with a logical model binding.
- Fixed by changing the `designSession` bean parameter type from `@Lazy XDataService` to `@Lazy XRepository`, so the lazy proxy correctly implements `XRepository` and the cast succeeds.

## Test plan

- [ ] Open the `chartwizard` viewsheet in the portal
- [ ] Click the **Edit** button to open the VS wizard
- [ ] Verify no `ClassCastException` appears in the server log
- [ ] Verify the wizard opens and chart recommendations load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)