### PR TITLE
Bug #74717, remove theme from manager when its JAR is deleted via storage browser

### DIFF
--- a/core/src/main/java/inetsoft/sree/portal/CustomThemesManager.java
+++ b/core/src/main/java/inetsoft/sree/portal/CustomThemesManager.java
@@ -117,19 +117,25 @@ public class CustomThemesManager implements XMLSerializable, AutoCloseable {
    }
 
    public void reloadThemes(String path) {
-      if(getCustomThemes() == null || getCustomThemes().isEmpty()) {
+      Set<CustomTheme> themes = getCustomThemes();
+
+      if(themes == null || themes.isEmpty()) {
          return;
       }
 
       Set<CustomTheme> newThemes = new HashSet<>();
 
-      getCustomThemes().forEach(theme -> {
+      themes.forEach(theme -> {
          String jarPath = theme.getJarPath();
 
-         if(jarPath == null || !jarPath.startsWith(path)) {
+         if(jarPath == null || (!jarPath.equals(path) && !jarPath.startsWith(path + "/"))) {
             newThemes.add(theme);
          }
       });
+
+      themes.stream()
+         .filter(t -> !newThemes.contains(t))
+         .forEach(t -> removeSelectedTheme(t.getId()));
 
       setCustomThemes(newThemes);
    }

--- a/core/src/main/java/inetsoft/sree/portal/CustomThemesManager.java
+++ b/core/src/main/java/inetsoft/sree/portal/CustomThemesManager.java
@@ -126,14 +126,7 @@ public class CustomThemesManager implements XMLSerializable, AutoCloseable {
       getCustomThemes().forEach(theme -> {
          String jarPath = theme.getJarPath();
 
-         if(jarPath != null && jarPath.startsWith(path)) {
-            CustomTheme newTheme = (CustomTheme) theme.clone();
-            newTheme.setEMDark(false);
-            newTheme.setPortalScript(null);
-            newTheme.setEmScript(null);
-            newThemes.add(newTheme);
-         }
-         else {
+         if(jarPath == null || !jarPath.startsWith(path)) {
             newThemes.add(theme);
          }
       });

--- a/core/src/test/java/inetsoft/sree/portal/CustomThemesManagerTest.java
+++ b/core/src/test/java/inetsoft/sree/portal/CustomThemesManagerTest.java
@@ -1,0 +1,146 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.sree.portal;
+
+/*
+ * reloadThemes(path) — invoked by the storage browser after it deletes a file or directory.
+ * The method must remove every theme whose jarPath begins with the deleted path and preserve
+ * all others.
+ *
+ *  [A] exact file path match     → matching theme removed, others kept
+ *  [B] directory prefix match    → all themes under that directory removed
+ *  [C] no match                  → set unchanged (setCustomThemes still called)
+ *  [D] theme with null jarPath   → always preserved (null-safe guard)
+ *  [E] empty theme set           → setCustomThemes never called (early-exit guard)
+ */
+
+import inetsoft.storage.KeyValueStorageManager;
+import inetsoft.util.DataSpace;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CustomThemesManagerTest {
+   @Mock private KeyValueStorageManager keyValueStorageManager;
+   @Mock private DataSpace dataSpace;
+
+   // [A] exact file path — only the theme whose jarPath matches the deleted file is removed
+   @Test
+   void reloadThemes_exactFilePath_removesMatchingThemeOnly() {
+      CustomTheme target = theme("target", "portal/theme/target.jar");
+      CustomTheme other  = theme("other",  "portal/theme/other.jar");
+
+      CustomThemesManager manager = managerWithThemes(target, other);
+
+      manager.reloadThemes("portal/theme/target.jar");
+
+      Set<CustomTheme> saved = captureSetCustomThemes(manager);
+      assertEquals(1, saved.size());
+      assertEquals("other", saved.iterator().next().getId());
+   }
+
+   // [B] directory prefix — all themes stored under the deleted directory are removed
+   @Test
+   void reloadThemes_directoryPath_removesAllThemesUnderThatDirectory() {
+      CustomTheme inDir1  = theme("t1", "portal/theme/t1.jar");
+      CustomTheme inDir2  = theme("t2", "portal/theme/t2.jar");
+      CustomTheme outside = theme("t3", "portal/other/t3.jar");
+
+      CustomThemesManager manager = managerWithThemes(inDir1, inDir2, outside);
+
+      manager.reloadThemes("portal/theme");
+
+      Set<CustomTheme> saved = captureSetCustomThemes(manager);
+      assertEquals(1, saved.size());
+      assertEquals("t3", saved.iterator().next().getId());
+   }
+
+   // [C] no match — all themes are preserved; setCustomThemes is still called
+   @Test
+   void reloadThemes_noMatchingPath_allThemesPreserved() {
+      CustomTheme t1 = theme("t1", "portal/theme/t1.jar");
+      CustomTheme t2 = theme("t2", "portal/theme/t2.jar");
+
+      CustomThemesManager manager = managerWithThemes(t1, t2);
+
+      manager.reloadThemes("portal/theme/gone.jar");
+
+      Set<CustomTheme> saved = captureSetCustomThemes(manager);
+      assertEquals(2, saved.size());
+   }
+
+   // [D] null jarPath — themes with no JAR are never affected by reloadThemes
+   @Test
+   void reloadThemes_themeWithNullJarPath_alwaysPreserved() {
+      CustomTheme withJar    = theme("with-jar", "portal/theme/target.jar");
+      CustomTheme withoutJar = theme("no-jar", null);
+
+      CustomThemesManager manager = managerWithThemes(withJar, withoutJar);
+
+      manager.reloadThemes("portal/theme/target.jar");
+
+      Set<CustomTheme> saved = captureSetCustomThemes(manager);
+      assertEquals(1, saved.size());
+      assertEquals("no-jar", saved.iterator().next().getId());
+   }
+
+   // [E] empty theme set — early exit; setCustomThemes is never invoked
+   @Test
+   void reloadThemes_emptyThemeSet_doesNotCallSetCustomThemes() {
+      CustomThemesManager manager = managerWithThemes();
+
+      manager.reloadThemes("portal/theme/any.jar");
+
+      verify(manager, never()).setCustomThemes(any());
+   }
+
+   // -------------------------------------------------------------------------
+   // helpers
+   // -------------------------------------------------------------------------
+
+   private static CustomTheme theme(String id, String jarPath) {
+      CustomTheme t = new CustomTheme();
+      t.setId(id);
+      t.setName(id);
+      t.setJarPath(jarPath);
+      return t;
+   }
+
+   private CustomThemesManager managerWithThemes(CustomTheme... themes) {
+      CustomThemesManager manager = spy(new CustomThemesManager(keyValueStorageManager, dataSpace));
+      Set<CustomTheme> themeSet = new HashSet<>(Arrays.asList(themes));
+      doReturn(themeSet).when(manager).getCustomThemes();
+      doNothing().when(manager).setCustomThemes(any());
+      return manager;
+   }
+
+   @SuppressWarnings("unchecked")
+   private static Set<CustomTheme> captureSetCustomThemes(CustomThemesManager manager) {
+      ArgumentCaptor<Set> captor = ArgumentCaptor.forClass(Set.class);
+      verify(manager).setCustomThemes(captor.capture());
+      return captor.getValue();
+   }
+}

--- a/core/src/test/java/inetsoft/sree/portal/CustomThemesManagerTest.java
+++ b/core/src/test/java/inetsoft/sree/portal/CustomThemesManagerTest.java
@@ -17,20 +17,9 @@
  */
 package inetsoft.sree.portal;
 
-/*
- * reloadThemes(path) — invoked by the storage browser after it deletes a file or directory.
- * The method must remove every theme whose jarPath begins with the deleted path and preserve
- * all others.
- *
- *  [A] exact file path match     → matching theme removed, others kept
- *  [B] directory prefix match    → all themes under that directory removed
- *  [C] no match                  → set unchanged (setCustomThemes still called)
- *  [D] theme with null jarPath   → always preserved (null-safe guard)
- *  [E] empty theme set           → setCustomThemes never called (early-exit guard)
- */
-
 import inetsoft.storage.KeyValueStorageManager;
 import inetsoft.util.DataSpace;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -42,6 +31,7 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@Tag("core")
 @ExtendWith(MockitoExtension.class)
 class CustomThemesManagerTest {
    @Mock private KeyValueStorageManager keyValueStorageManager;
@@ -107,6 +97,36 @@ class CustomThemesManagerTest {
       assertEquals("no-jar", saved.iterator().next().getId());
    }
 
+   // [F] path-separator boundary — a theme under "portal/themes/" must not be removed when
+   //     the deleted path is "portal/theme" (shares a string prefix but a different directory)
+   @Test
+   void reloadThemes_pathSharesPrefixButDifferentDirectory_doesNotRemoveUnrelatedTheme() {
+      CustomTheme inSimilarDir = theme("t1", "portal/themes/t1.jar");
+      CustomTheme inExactDir   = theme("t2", "portal/theme/t2.jar");
+
+      CustomThemesManager manager = managerWithThemes(inSimilarDir, inExactDir);
+
+      manager.reloadThemes("portal/theme");
+
+      Set<CustomTheme> saved = captureSetCustomThemes(manager);
+      assertEquals(1, saved.size());
+      assertEquals("t1", saved.iterator().next().getId());
+   }
+
+   // removeSelectedTheme is called for each deleted theme but not for preserved ones
+   @Test
+   void reloadThemes_deletedThemes_removeSelectedThemeCalledForDeletedOnly() {
+      CustomTheme deleted = theme("deleted", "portal/theme/deleted.jar");
+      CustomTheme kept    = theme("kept",    "portal/theme/kept.jar");
+
+      CustomThemesManager manager = managerWithThemes(deleted, kept);
+
+      manager.reloadThemes("portal/theme/deleted.jar");
+
+      verify(manager).removeSelectedTheme("deleted");
+      verify(manager, never()).removeSelectedTheme("kept");
+   }
+
    // [E] empty theme set — early exit; setCustomThemes is never invoked
    @Test
    void reloadThemes_emptyThemeSet_doesNotCallSetCustomThemes() {
@@ -133,13 +153,14 @@ class CustomThemesManagerTest {
       CustomThemesManager manager = spy(new CustomThemesManager(keyValueStorageManager, dataSpace));
       Set<CustomTheme> themeSet = new HashSet<>(Arrays.asList(themes));
       doReturn(themeSet).when(manager).getCustomThemes();
-      doNothing().when(manager).setCustomThemes(any());
+      lenient().doNothing().when(manager).setCustomThemes(any());
+      lenient().doNothing().when(manager).removeSelectedTheme(any());
       return manager;
    }
 
-   @SuppressWarnings("unchecked")
    private static Set<CustomTheme> captureSetCustomThemes(CustomThemesManager manager) {
-      ArgumentCaptor<Set> captor = ArgumentCaptor.forClass(Set.class);
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Set<CustomTheme>> captor = ArgumentCaptor.forClass((Class) Set.class);
       verify(manager).setCustomThemes(captor.capture());
       return captor.getValue();
    }


### PR DESCRIPTION
## Summary

- When a theme JAR is deleted directly from the storage browser (Content → Storage), `DataSpaceContentSettingsService.deleteDataSpaceNode()` called `CustomThemesManager.reloadThemes(path)` after removing the file. That method only reset derived CSS properties (`emDark`, `portalScript`, `emScript`) on matching themes but left the theme entry itself in the KV store, so the theme continued to appear in Presentation → Theme.
- Fixed by changing `reloadThemes()` to remove themes whose `jarPath` starts with the deleted path instead of keeping them with reset properties.
- Added unit tests for all cases: exact file match, directory prefix, no match, null jar path, and empty theme set.

Fixes #74717

## Test plan

- [ ] Add a theme via Presentation → Theme, confirm the JAR appears in Content → Storage under `portal/theme/`.
- [ ] Delete the JAR from Content → Storage.
- [ ] Return to Presentation → Theme and confirm the theme is no longer listed.
- [ ] Run `CustomThemesManagerTest` unit tests.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)