### PR TITLE
Bug #74716, fix server startup failure due to JDK proxy on beans with @Audited methods

### DIFF
--- a/core/src/main/java/inetsoft/web/WebConfig.java
+++ b/core/src/main/java/inetsoft/web/WebConfig.java
@@ -63,7 +63,7 @@ import java.util.*;
  * @since 12.3
  */
 @EnableWebMvc
-@EnableAspectJAutoProxy
+@EnableAspectJAutoProxy(proxyTargetClass = true)
 @EnableMBeanExport
 @EnableScheduling
 @Configuration

--- a/core/src/main/java/inetsoft/web/admin/general/LicenseKeySettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/general/LicenseKeySettingsService.java
@@ -38,7 +38,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 @Service
-public class LicenseKeySettingsService implements MessageListener {
+public class LicenseKeySettingsService {
    @Autowired
    public LicenseKeySettingsService(LicenseManager licenseManager, Cluster cluster,
                                     AuthenticationService authenticationService)
@@ -50,12 +50,13 @@ public class LicenseKeySettingsService implements MessageListener {
 
    @PostConstruct
    public void registerListeners() {
-      cluster.addMessageListener(this);
+      messageListener = this::messageReceived;
+      cluster.addMessageListener(messageListener);
    }
 
    @PreDestroy
    public void unregisterListeners() {
-      cluster.removeMessageListener(this);
+      cluster.removeMessageListener(messageListener);
    }
 
    public LicenseKeySettingsModel getModel() {
@@ -78,7 +79,6 @@ public class LicenseKeySettingsService implements MessageListener {
       authenticationService.reset();
    }
 
-   @Override
    public void messageReceived(MessageEvent event) {
       if(event.getMessage() instanceof ResetLicenseKeyMessage) {
          authenticationService.reset();
@@ -144,4 +144,5 @@ public class LicenseKeySettingsService implements MessageListener {
    private final LicenseManager licenseManager;
    private final Cluster cluster;
    private final AuthenticationService authenticationService;
+   private MessageListener messageListener;
 }

--- a/core/src/main/java/inetsoft/web/admin/general/LicenseKeySettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/general/LicenseKeySettingsService.java
@@ -56,7 +56,9 @@ public class LicenseKeySettingsService {
 
    @PreDestroy
    public void unregisterListeners() {
-      cluster.removeMessageListener(messageListener);
+      if(messageListener != null) {
+         cluster.removeMessageListener(messageListener);
+      }
    }
 
    public LicenseKeySettingsModel getModel() {

--- a/core/src/main/java/inetsoft/web/admin/schedule/SchedulerConfigurationController.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/SchedulerConfigurationController.java
@@ -30,13 +30,11 @@ import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 
 @RestController
-@EnableAspectJAutoProxy(proxyTargetClass = true)
 public class SchedulerConfigurationController implements MessageListener {
    @Autowired
    public SchedulerConfigurationController(SchedulerConfigurationService configService,

--- a/core/src/main/java/inetsoft/web/admin/security/AuthenticationProviderService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/AuthenticationProviderService.java
@@ -25,6 +25,7 @@ import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.internal.cluster.*;
 import inetsoft.sree.security.*;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import inetsoft.sree.security.db.DatabaseAuthenticationProvider;
 import inetsoft.sree.security.ldap.*;
 import inetsoft.uql.XPrincipal;
@@ -37,7 +38,6 @@ import inetsoft.web.viewsheet.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.handler.DestinationPatternsMessageCondition;
@@ -54,8 +54,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
-@EnableAspectJAutoProxy(proxyTargetClass = true)
-public class AuthenticationProviderService extends BaseSubscribeChangeHandler implements MessageListener {
+public class AuthenticationProviderService extends BaseSubscribeChangeHandler {
    @Autowired
    public AuthenticationProviderService(SecurityEngine securityEngine, ObjectMapper objectMapper,
                                         SimpMessagingTemplate messageTemplate,
@@ -71,7 +70,13 @@ public class AuthenticationProviderService extends BaseSubscribeChangeHandler im
 
    @PostConstruct
    public void init() {
-      cluster.addMessageListener(this);
+      messageListener = this::messageReceived;
+      cluster.addMessageListener(messageListener);
+   }
+
+   @PreDestroy
+   public void destroy() {
+      cluster.removeMessageListener(messageListener);
    }
 
    @EventListener(SessionDisconnectEvent.class)
@@ -867,7 +872,6 @@ public class AuthenticationProviderService extends BaseSubscribeChangeHandler im
       }
    }
 
-   @Override
    public void messageReceived(MessageEvent event) {
       if(event.getMessage() instanceof AuthenticationProvidersChanged) {
          getSubscribers().stream()
@@ -906,5 +910,6 @@ public class AuthenticationProviderService extends BaseSubscribeChangeHandler im
    private final Cluster cluster;
    private final LicenseManager licenseManager;
    private final DefaultDebouncer<String> debouncer = new DefaultDebouncer<>();
-   private final Logger LOG = LoggerFactory.getLogger(AuthenticationProviderService.class);
+   private MessageListener messageListener;
+   private static final Logger LOG = LoggerFactory.getLogger(AuthenticationProviderService.class);
 }

--- a/core/src/main/java/inetsoft/web/admin/security/AuthenticationProviderService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/AuthenticationProviderService.java
@@ -76,7 +76,9 @@ public class AuthenticationProviderService extends BaseSubscribeChangeHandler {
 
    @PreDestroy
    public void destroy() {
-      cluster.removeMessageListener(messageListener);
+      if(messageListener != null) {
+         cluster.removeMessageListener(messageListener);
+      }
    }
 
    @EventListener(SessionDisconnectEvent.class)


### PR DESCRIPTION
## Summary

- Beans in `inetsoft.web.*` that both implement `MessageListener` and have `@Audited` methods were being wrapped in JDK dynamic proxies by the lazy-init AOP infrastructure, causing injection failures when dependent beans expected the concrete type (e.g. `AuthenticationProviderService` injected into `UserSignupService`).
- Fixed `WebConfig` to use `@EnableAspectJAutoProxy(proxyTargetClass = true)` so all lazy proxies use CGLIB instead of JDK proxies.
- Removed `implements MessageListener` from `AuthenticationProviderService` and `LicenseKeySettingsService`, replacing `addMessageListener(this)` with a stored method reference so the interface is decoupled from the bean class. Added `@PreDestroy` cleanup to both.
- Removed misplaced `@EnableAspectJAutoProxy(proxyTargetClass = true)` from `AuthenticationProviderService` and `SchedulerConfigurationController` (this annotation belongs only on `@Configuration` classes).

## Test plan

- [ ] Build Docker image and start server with `docker compose up` — server should start successfully
- [ ] Verify authentication provider settings page loads in EM
- [ ] Verify license key settings page loads in EM
- [ ] Verify scheduler configuration page loads in EM

🤖 Generated with [Claude Code](https://claude.ai/claude-code)