### PR TITLE
Bug #74624 - Stop reflowing selection list on quick-switch overlay hover

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
@@ -206,7 +206,6 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
    private _scrollbarMouseLeaveUnlisten: (() => void) | null = null;
    private _currentHoverElement: Element | null = null;
    private _currentSingleSelection: boolean = false;
-   private _columnShiftCleanup: (() => void) | null = null;
 
    get topPosition(): number {
       const bottomTab = VSUtil.getBottomTabContainer(this.model, this.vsInfo?.vsObjects);
@@ -708,7 +707,6 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
       this._overlayWheelUnlisten = null;
       this._scrollbarMouseLeaveUnlisten?.();
       this._scrollbarMouseLeaveUnlisten = null;
-      this._columnShiftCleanup?.();
 
       super.ngOnDestroy();
    }
@@ -755,13 +753,11 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
             .querySelector(".selection-list");
 
          if(!listEl) {
-            this._columnShiftCleanup?.();
             return;
          }
-         // Reset before measuring — re-entry from the overlay button leaves the list expanded
-         // and columns shifted, so without this reset the measurement would be wrong.
+         // Reset the locked width before measuring so getBoundingClientRect returns the
+         // natural width rather than the previously-locked value.
          this.renderer.removeStyle(listEl, "width");
-         this._columnShiftCleanup?.();
 
          const listRect = listEl.getBoundingClientRect();
          const cellRect = cellElement.getBoundingClientRect();
@@ -769,19 +765,35 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
          // getBoundingClientRect() returns viewport px; offsetWidth returns CSS layout px.
          // Divide by scale to convert viewport px → CSS px when setting inline styles.
          const scale = this.scale || 1;
+         const scrollbarAdjust = this.showScroll ? this.scrollbarWidth : 0;
+         const listWidthCss = listRect.width / scale;
 
-         // Determine which column index is being hovered so adjacent columns can be shifted.
-         const colEl = cellElement.closest(".selection-list-cell-column") as HTMLElement | null;
-         const rowEl = colEl?.parentElement as HTMLElement | null;
-         const colIndex = (rowEl && colEl) ? Array.from(rowEl.children).indexOf(colEl) : -1;
-         const numColumnsInRow = rowEl ? rowEl.children.length : 1;
-         const isLastColumn = colIndex < 0 || colIndex >= numColumnsInRow - 1;
+         // Float the button over the hovered cell using its semi-transparent background.
+         // Cells with a measure (text/bar): anchor at the start of the measure area
+         // (.selection-list-cell-label's right edge) so the label stays fully visible —
+         // .selection-list-cell-content collapses to 0px width because its children are
+         // absolutely positioned, so its own bounding rect cannot be used.  Label-only
+         // cells: anchor at the right edge of the hovered cell, clamped to the list's right
+         // edge (minus scrollbar) so the button stays in bounds for indented tree cells and
+         // last-column cells alike.
+         const measureContentEl = cellElement.querySelector(".selection-list-cell-content");
+         const labelEl = cellElement.querySelector(".selection-list-cell-label") as HTMLElement | null;
+         let leftCss: number;
 
-         if(!isLastColumn) {
-            this._positionOverlayNonLastColumn(btn, listEl, listRect, cellRect, btnWidth, colIndex, scale);
-         } else {
-            this._positionOverlayLastColumn(btn, listEl, listRect, cellRect, btnWidth, cellElement, scale);
+         if(measureContentEl && labelEl) {
+            leftCss = (labelEl.getBoundingClientRect().right - listRect.left) / scale;
          }
+         else {
+            const cellRightCss = (cellRect.right - listRect.left) / scale;
+            leftCss = Math.min(cellRightCss - btnWidth, listWidthCss - scrollbarAdjust - btnWidth);
+         }
+
+         this.renderer.setStyle(btn, "left", Math.max(0, leftCss) + "px");
+         this.renderer.setStyle(btn, "right", "auto");
+         // Lock the list width so the button's containing block stays stable between
+         // synchronous positioning and the next paint frame.  Without this the list can
+         // collapse to 0px and resolve the button's left offset against the wrong width.
+         this.renderer.setStyle(listEl, "width", listWidthCss + "px");
 
          this.renderer.setStyle(btn, "top", (cellRect.top - listRect.top) / scale + "px");
          this.renderer.setStyle(btn, "height", cellRect.height / scale + "px");
@@ -820,137 +832,11 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
          this.renderer.removeStyle(listEl, "width");
       }
 
-      this._columnShiftCleanup?.();
       this._quickSwitchClickCallback = null;
       this._currentHoverElement = null;
       this._currentSingleSelection = false;
       this._scrollbarMouseLeaveUnlisten?.();
       this._scrollbarMouseLeaveUnlisten = null;
-   }
-
-   // Body and row widths must be expanded so overflow-x:hidden does not clip the
-   // shifted column, and flex does not shrink items when margin-left is added.
-   private _positionOverlayNonLastColumn(
-      btn: HTMLElement,
-      listEl: Element,
-      listRect: DOMRect,
-      cellRect: DOMRect,
-      btnWidth: number,
-      colIndex: number,
-      scale: number
-   ): void {
-      const bodyEl = listEl.querySelector<HTMLElement>(".selection-list-body");
-      const bodyWidthCss = (bodyEl?.getBoundingClientRect().width ?? listRect.width) / scale;
-      const expandedBodyWidthCss = bodyWidthCss + btnWidth;
-
-      const cellRight = (cellRect.right - listRect.left) / scale;
-      this.renderer.setStyle(btn, "left", cellRight + "px");
-      this.renderer.setStyle(btn, "right", "auto");
-      // Use .vs-object (has an explicit width binding) rather than the host <vs-selection>
-      // element, which is display:inline and reports width=0 when its child is position:absolute.
-      const vsObjectEl = (this.elementRef.nativeElement as Element).querySelector(".vs-object");
-      const maxListWidthCss = vsObjectEl
-         ? vsObjectEl.getBoundingClientRect().width / scale
-         : listRect.width / scale;
-      this.renderer.setStyle(listEl, "width", Math.min(listRect.width / scale + btnWidth, maxListWidthCss) + "px");
-
-      if(bodyEl) {
-         this.renderer.setStyle(bodyEl, "width", expandedBodyWidthCss + "px");
-      }
-
-      const shiftedCols: HTMLElement[] = [];
-      const expandedRows: HTMLElement[] = [];
-      const allRows = listEl.querySelectorAll<HTMLElement>(
-         ".selection-list-cell-row:not(.others-container)"
-      );
-      allRows.forEach(row => {
-         this.renderer.setStyle(row, "width", expandedBodyWidthCss + "px");
-         expandedRows.push(row);
-         const nextCol = row.children[colIndex + 1] as HTMLElement | undefined;
-
-         if(nextCol) {
-            this.renderer.setStyle(nextCol, "margin-left", btnWidth + "px");
-            shiftedCols.push(nextCol);
-         }
-      });
-
-      this._columnShiftCleanup = () => {
-         // Restore rather than removeStyle: removeStyle erases Angular's binding before the
-         // next CD cycle, causing the next hover measurement to see a collapsed DOM.
-         if(bodyEl) {
-            this.renderer.setStyle(bodyEl, "width", bodyWidthCss + "px");
-         }
-
-         expandedRows.forEach(row => this.renderer.setStyle(row, "width", bodyWidthCss + "px"));
-         shiftedCols.forEach(col => this.renderer.removeStyle(col, "margin-left"));
-         this._columnShiftCleanup = null;
-      };
-   }
-
-   // Last (or only) column: anchor to the right edge of the cell.
-   // The button floats over the cell text rather than expanding the list width, which would
-   // overflow .vs-object and overlap adjacent selection lists (Bug #74107).
-   private _positionOverlayLastColumn(
-      btn: HTMLElement,
-      listEl: Element,
-      listRect: DOMRect,
-      cellRect: DOMRect,
-      btnWidth: number,
-      cellElement: Element,
-      scale: number
-   ): void {
-      this.renderer.removeStyle(btn, "left");
-      // In a VSSelectionContainer the scrollbar is at right:0 inside the list, so offset the
-      // button left so it doesn't cover the scrollbar.  In a standalone list the scrollbar sits
-      // outside the list at left:100%, so the same offset creates visual separation between the
-      // button and the scrollbar when the list is hovered.
-      const scrollbarAdjust = this.showScroll ? this.scrollbarWidth : 0;
-      // For container lists the list is position:static and expanding it reflows the parent,
-      // so clamp to the vs-object width.  For standalone the list is position:absolute and
-      // can expand freely without affecting surrounding layout.
-      // Use .vs-object (has an explicit width binding) rather than the host <vs-selection>
-      // element, which is display:inline and reports width=0 when its child is position:absolute.
-      const vsObjectEl = (this.elementRef.nativeElement as Element).querySelector(".vs-object");
-      const vsObjectWidthCss = vsObjectEl
-         ? vsObjectEl.getBoundingClientRect().width / scale
-         : listRect.width / scale;
-      const maxListWidthCss = this.inContainer ? vsObjectWidthCss : Number.MAX_SAFE_INTEGER;
-
-      // When the cell has measure content (bar/text), the measure area occupies the right side
-      // of the cell. Position the button to the right of the entire cell to avoid overlap.
-      const measureContentEl = cellElement.querySelector(".selection-list-cell-content") as HTMLElement | null;
-
-      // Always lock the list's explicit width to stabilize it as the button's containing block.
-      // Without this, the list can collapse between synchronous positioning and the next paint
-      // frame, causing right/left offsets to resolve against the wrong (0px) width.
-      const listWidthCss = listRect.width / scale;
-
-      if(measureContentEl) {
-         // .selection-list-cell-content collapses to 0px in the flex layout (all its children
-         // are absolutely positioned), so its getBoundingClientRect().left == cell.right — not
-         // the visual start of the measure area.  Use .selection-list-cell-label instead: it
-         // has an explicit [style.width.px]="labelWidth" so its right edge reliably marks the
-         // end of the label column.
-         const labelEl = cellElement.querySelector(".selection-list-cell-label") as HTMLElement | null;
-         const anchorCss = labelEl
-            ? (labelEl.getBoundingClientRect().right - listRect.left) / scale
-            : listWidthCss - scrollbarAdjust - btnWidth;
-         this.renderer.setStyle(btn, "left", Math.max(0, anchorCss) + "px");
-         this.renderer.setStyle(btn, "right", "auto");
-         this.renderer.setStyle(listEl, "width", listWidthCss + "px");
-         return;
-      }
-
-      // Always anchor the button to the list's right edge (+ scrollbar gap).
-      // Anchoring to the cell's right edge would push the button left of the list boundary for
-      // indented tree cells, causing overflow and making the button unreachable by mouse.
-      this.renderer.setStyle(btn, "right", scrollbarAdjust + "px");
-
-      // Don't expand the list — the button floats over the right side of the text using
-      // its semi-transparent background and z-index.  Expanding per-row causes the list
-      // width to shift as the user moves between items with different text lengths.
-      // For container lists, clamp to the vs-object width so the list doesn't reflow the parent.
-      this.renderer.setStyle(listEl, "width", Math.min(listWidthCss, maxListWidthCss) + "px");
    }
 
    public clearQuickSwitchHoverIfOwner(cellElement: Element | null): void {

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
@@ -705,8 +705,9 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
       this._overlayMouseLeaveUnlisten = null;
       this._overlayWheelUnlisten?.();
       this._overlayWheelUnlisten = null;
-      this._scrollbarMouseLeaveUnlisten?.();
-      this._scrollbarMouseLeaveUnlisten = null;
+      // Clears _scrollbarMouseLeaveUnlisten and the inline width on .selection-list
+      // in one place rather than duplicating that cleanup here.
+      this._hideOverlay();
 
       super.ngOnDestroy();
    }
@@ -776,6 +777,11 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
          // cells: anchor at the right edge of the hovered cell, clamped to the list's right
          // edge (minus scrollbar) so the button stays in bounds for indented tree cells and
          // last-column cells alike.
+         //
+         // labelEl is rendered unconditionally in selection-list-cell.component.html, so
+         // the (measureContentEl && !labelEl) case is unreachable; the else branch's
+         // cell-rect math is the safe fallback if a future template change ever changes
+         // that.
          const measureContentEl = cellElement.querySelector(".selection-list-cell-content");
          const labelEl = cellElement.querySelector(".selection-list-cell-label") as HTMLElement | null;
          let leftCss: number;

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.spec.ts
@@ -367,3 +367,150 @@ describe("VSSelection Test", () => {
       expect(fixture.componentInstance.topPosition).toBe(434);
    });
 });
+
+// Direct unit tests of setQuickSwitchHover's positioning math, without TestBed.
+// Mocks the renderer to capture setStyle calls and constructs minimal cell/list
+// elements with controlled getBoundingClientRect / offsetWidth values.
+describe("VSSelection - quick-switch overlay positioner", () => {
+   let vsSelection: VSSelection;
+   let setStyleCalls: Array<{ el: any; prop: string; value: string }>;
+   let listEl: any;
+   let btnEl: any;
+
+   const makeRect = (left: number, top: number, width: number, height: number): DOMRect => ({
+      left, top, width, height,
+      right: left + width,
+      bottom: top + height,
+      x: left, y: top,
+      toJSON: () => ({})
+   } as DOMRect);
+
+   const makeCell = (rect: DOMRect, hasMeasure: boolean, labelRect?: DOMRect): any => ({
+      getBoundingClientRect: () => rect,
+      querySelector: (sel: string) => {
+         if(sel === ".selection-list-cell-content") {
+            return hasMeasure ? {} : null;
+         }
+
+         if(sel === ".selection-list-cell-label") {
+            return labelRect ? { getBoundingClientRect: () => labelRect } : null;
+         }
+
+         return null;
+      }
+   });
+
+   const btnLeft = () => setStyleCalls.find(c => c.el === btnEl && c.prop === "left")?.value;
+   const btnRight = () => setStyleCalls.find(c => c.el === btnEl && c.prop === "right")?.value;
+   const listWidth = () => setStyleCalls.find(c => c.el === listEl && c.prop === "width")?.value;
+
+   beforeEach(() => {
+      setStyleCalls = [];
+      listEl = {
+         getBoundingClientRect: () => makeRect(0, 0, 200, 300),
+         querySelector: jest.fn(() => null),
+         querySelectorAll: jest.fn(() => [])
+      };
+      btnEl = { offsetWidth: 24 };
+
+      const renderer: any = {
+         setStyle: (el: any, prop: string, value: string) =>
+            setStyleCalls.push({ el, prop, value }),
+         removeStyle: jest.fn(),
+         setAttribute: jest.fn(),
+         addClass: jest.fn(),
+         removeClass: jest.fn(),
+         listen: jest.fn(() => () => {})
+      };
+
+      const elementRef: any = {
+         nativeElement: {
+            querySelector: (sel: string) => sel === ".selection-list" ? listEl : null
+         }
+      };
+
+      const zone: any = { run: (fn: any) => fn(), runOutsideAngular: (fn: any) => fn() };
+
+      const scaleService: any = {
+         getScale: () => observableOf(1),
+         setScale: jest.fn(),
+         getCurrentScale: jest.fn()
+      };
+
+      vsSelection = new VSSelection(
+         { sendEvent: jest.fn(), commands: observableOf([]) } as any,
+         {} as any,
+         renderer,
+         { showFilter: jest.fn(), adhocFilterShowing: false } as any,
+         elementRef,
+         { detectChanges: jest.fn() } as any,
+         zone,
+         scaleService,
+         {} as any,
+         { isDataTip: jest.fn() } as any,
+         { open: jest.fn() } as any,
+         {} as any,
+         { isCurrentPopComponent: jest.fn() } as any,
+         {} as HttpClient,
+         null
+      );
+
+      (vsSelection as any).quickSwitchOverlay = { nativeElement: btnEl };
+      (vsSelection as any).quickSwitchOverlayIcon = { nativeElement: {} };
+      (vsSelection as any).verticalScrollWrapper = { nativeElement: {} };
+      (vsSelection as any).scale = 1;
+      (vsSelection as any).scrollbarWidth = 16;
+      // Override the showScroll getter (depends on internal model state); each test
+      // can re-define it before calling setQuickSwitchHover.
+      Object.defineProperty(vsSelection, "showScroll", { get: () => false, configurable: true });
+   });
+
+   it("with measure content: anchors button at labelEl.right (column-agnostic)", () => {
+      const cell = makeCell(makeRect(0, 0, 100, 30), true, makeRect(0, 0, 70, 30));
+      vsSelection.setQuickSwitchHover(cell, false, () => {});
+
+      // labelRight(70) - listLeft(0) = 70
+      expect(btnLeft()).toBe("70px");
+      expect(btnRight()).toBe("auto");
+      expect(listWidth()).toBe("200px");
+   });
+
+   it("non-last column without measure: anchors button at right edge of hovered cell", () => {
+      const cell = makeCell(makeRect(0, 0, 100, 30), false);
+      vsSelection.setQuickSwitchHover(cell, false, () => {});
+
+      // cellRight(100) - btn(24) = 76; list(200) - 0 - 24 = 176; min = 76
+      expect(btnLeft()).toBe("76px");
+      expect(btnRight()).toBe("auto");
+   });
+
+   it("last/single column without measure, with scrollbar: clamps to listRight - scrollbar - btn", () => {
+      Object.defineProperty(vsSelection, "showScroll", { get: () => true, configurable: true });
+      const cell = makeCell(makeRect(0, 0, 200, 30), false);
+      vsSelection.setQuickSwitchHover(cell, false, () => {});
+
+      // cellRight(200) - btn(24) = 176; list(200) - scrollbar(16) - btn(24) = 160; min = 160
+      expect(btnLeft()).toBe("160px");
+   });
+
+   it("clamps button left to 0 when cell is narrower than the button", () => {
+      const cell = makeCell(makeRect(0, 0, 10, 30), false);
+      vsSelection.setQuickSwitchHover(cell, false, () => {});
+
+      // cellRight(10) - btn(24) = -14 → clamped to 0 by Math.max(0, ...)
+      expect(btnLeft()).toBe("0px");
+   });
+
+   it("does not expand body width or apply margin-left to adjacent columns", () => {
+      const cell = makeCell(makeRect(0, 0, 100, 30), false);
+      vsSelection.setQuickSwitchHover(cell, false, () => {});
+
+      // Required writes: button position + list width lock.
+      expect(setStyleCalls.find(c => c.el === btnEl && c.prop === "left")).toBeDefined();
+      expect(setStyleCalls.find(c => c.el === listEl && c.prop === "width")).toBeDefined();
+      // Forbidden writes from the removed column-shift path: any margin-left, or any
+      // width write on something other than the list element (body/row expansion).
+      expect(setStyleCalls.find(c => c.prop === "margin-left")).toBeUndefined();
+      expect(setStyleCalls.find(c => c.prop === "width" && c.el !== listEl)).toBeUndefined();
+   });
+});

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.spec.ts
@@ -385,6 +385,9 @@ describe("VSSelection - quick-switch overlay positioner", () => {
       toJSON: () => ({})
    } as DOMRect);
 
+   // Pass labelRect to model a cell whose label has been laid out; omit it to model
+   // the (template-impossible) case where .selection-list-cell-label is missing — used
+   // only by the regression test that pins the fallback contract.
    const makeCell = (rect: DOMRect, hasMeasure: boolean, labelRect?: DOMRect): any => ({
       getBoundingClientRect: () => rect,
       querySelector: (sel: string) => {
@@ -400,9 +403,14 @@ describe("VSSelection - quick-switch overlay positioner", () => {
       }
    });
 
-   const btnLeft = () => setStyleCalls.find(c => c.el === btnEl && c.prop === "left")?.value;
-   const btnRight = () => setStyleCalls.find(c => c.el === btnEl && c.prop === "right")?.value;
-   const listWidth = () => setStyleCalls.find(c => c.el === listEl && c.prop === "width")?.value;
+   // Reverse-find so the helpers return the LAST setStyle write for a given (el, prop) —
+   // that is what the rendered DOM reflects.  find() would silently mask a future
+   // reset-then-set sequence.
+   const lastStyle = (el: any, prop: string) =>
+      [...setStyleCalls].reverse().find(c => c.el === el && c.prop === prop)?.value;
+   const btnLeft = () => lastStyle(btnEl, "left");
+   const btnRight = () => lastStyle(btnEl, "right");
+   const listWidth = () => lastStyle(listEl, "width");
 
    beforeEach(() => {
       setStyleCalls = [];
@@ -512,5 +520,47 @@ describe("VSSelection - quick-switch overlay positioner", () => {
       // width write on something other than the list element (body/row expansion).
       expect(setStyleCalls.find(c => c.prop === "margin-left")).toBeUndefined();
       expect(setStyleCalls.find(c => c.prop === "width" && c.el !== listEl)).toBeUndefined();
+   });
+
+   it("converts viewport coordinates to CSS px when scale != 1", () => {
+      (vsSelection as any).scale = 2;
+      // List at viewport (100, 0), 400x600 viewport px → 200x300 CSS px.
+      listEl.getBoundingClientRect = () => makeRect(100, 0, 400, 600);
+      // Cell at viewport (100, 0), 200x60 viewport px → 100x30 CSS px (non-last column).
+      const cell = makeCell(makeRect(100, 0, 200, 60), false);
+      vsSelection.setQuickSwitchHover(cell, false, () => {});
+
+      // (cellRight 300 - listLeft 100) / scale 2 = 100 CSS px → 100 - btn(24) = 76;
+      // listWidth 200 - 0 - btn(24) = 176; min = 76.
+      expect(btnLeft()).toBe("76px");
+      expect(listWidth()).toBe("200px");
+   });
+
+   it("falls back to cell-rect math when measure content has no labelEl (defensive)", () => {
+      // Template-impossible state: .selection-list-cell-content present, but no
+      // .selection-list-cell-label.  Pins the fallback contract so a future template
+      // change cannot silently regress this case.
+      const cell = makeCell(makeRect(0, 0, 100, 30), true /* hasMeasure */ /* no labelRect */);
+      vsSelection.setQuickSwitchHover(cell, false, () => {});
+
+      // Falls into the else branch: cellRight(100) - btn(24) = 76; min vs 176 = 76.
+      expect(btnLeft()).toBe("76px");
+   });
+
+   it("returns early without writing position styles when the list element is missing", () => {
+      // Stub elementRef to return no .selection-list child.
+      (vsSelection as any).elementRef = {
+         nativeElement: { querySelector: () => null }
+      };
+      const cell = makeCell(makeRect(0, 0, 100, 30), false);
+      vsSelection.setQuickSwitchHover(cell, false, () => {});
+
+      // No left/width writes — the early return fires before measurement.
+      expect(btnLeft()).toBeUndefined();
+      expect(listWidth()).toBeUndefined();
+      // _currentHoverElement is still set by setQuickSwitchHover before the early return,
+      // documenting the contract that the hover state is recorded even when the list
+      // element cannot be located.
+      expect((vsSelection as any)._currentHoverElement).toBe(cell);
    });
 });


### PR DESCRIPTION
Collapse _positionOverlayNonLastColumn / _positionOverlayLastColumn into a single cell-anchored float in setQuickSwitchHover. The button now floats over the hovered cell using its existing semi-transparent background: at
labelEl.right when the cell has measure content, otherwise at cellRect.right - btnWidth (clamped to the list's right edge minus
scrollbar gap). Removes the _columnShiftCleanup state machine and the per-hover body/row width and margin-left writes it had to revert.

Trade-off: label-only cells in non-last columns now have the button overlap their rightmost ~24px of label text — the same compromise already accepted for last-column-no-measure cells.