### PR TITLE
Bug #74584 - Fix input label overlap in PDF/SVG export with default font

### DIFF
--- a/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
@@ -3860,15 +3860,25 @@ public abstract class AbstractVSExporter implements VSExporter {
          return fmt.getFont();
       }
 
-      return GDefaults.DEFAULT_TEXT_FONT;
+      return VSAssemblyInfo.getDefaultFont(Font.PLAIN, 11);
    }
 
    /**
-    * Get the label format, returning a default if null.
+    * Get the label format, returning a default if null. The returned format always
+    * has an explicit font so the drawing path uses the same font as the measurement
+    * path (PDFPrinter.setFont ignores null, so an unset font would silently fall
+    * back to whatever font was previously on the printer).
     */
    protected static VSCompositeFormat getLabelFormat(LabelInfo labelInfo) {
       VSCompositeFormat fmt = labelInfo.getLabelFormat();
-      return fmt != null ? fmt : new VSCompositeFormat();
+
+      if(fmt != null && fmt.getFont() != null) {
+         return fmt;
+      }
+
+      VSCompositeFormat result = fmt != null ? fmt.clone() : new VSCompositeFormat();
+      result.getUserDefinedFormat().setFont(getLabelFont(labelInfo));
+      return result;
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLVSExporter.java
@@ -142,7 +142,14 @@ public class HTMLVSExporter extends AbstractVSExporter {
       Rectangle2D fullBounds = expandBoundsForLabel(helper.getBounds(info), labelInfo);
       Rectangle2D[] bounds = splitInputBounds(fullBounds, labelInfo);
 
-      helper.writeText(writer, bounds[0], getLabelFormat(labelInfo),
+      // HTML uses overflow:hidden to clip rather than positioning on a shared canvas,
+      // so we don't need to materialize a default font (PDF/SVG do, since
+      // PDFPrinter.setFont(null) silently keeps a stale printer font). Passing the raw
+      // labelFormat lets CSS inherit when no font is set, keeping the label close to
+      // the viewer's rendering (Roboto at the inherited size).
+      VSCompositeFormat labelFormat = labelInfo.getLabelFormat();
+      helper.writeText(writer, bounds[0],
+         labelFormat != null ? labelFormat : new VSCompositeFormat(),
          labelInfo.getLabelText(), null, false, null, false, info.getZIndex());
 
       return bounds[1];


### PR DESCRIPTION
getLabelFormat() returned a font-less VSCompositeFormat when labelFormat
was null, causing PDFPrinter.setFont(null) to silently keep the prior
printer font while getLabelFont() measured at 10pt — drawn labels
overflowed the calculated bounds and overlapped the form widget.

Now getLabelFormat() materializes the default font (StyleFont Default
PLAIN 11, matching LabelInfo.getRenderedHeight) onto a clone so drawing
and measurement agree. HTMLVSExporter bypasses this — HTML clips with
overflow:hidden and CSS inheritance keeps the label closer to the
viewer's rendering.