### PR TITLE
Bug #74595: Fix NodeStoppingException in data cycle task on cloud-runner nodes

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/DataCycleManager.java
+++ b/core/src/main/java/inetsoft/sree/internal/DataCycleManager.java
@@ -268,6 +268,13 @@ public class DataCycleManager
             return;
          }
 
+         // cloud-runner nodes are short-lived task executors; they don't maintain
+         // pregenerated tasks and their Ignite client may be shutting down when this
+         // is triggered by an MVChangedMessage after task completion
+         if(System.getProperty("ScheduleTaskRunner") != null) {
+            return;
+         }
+
       IndexedStorage storage = getIndexedStorage();
       List<ScheduleTask> tasks = new ArrayList<>();
 


### PR DESCRIPTION
## Root Cause Analysis

When a cloud-runner node finishes executing a data cycle Stage 2 task, the task updates MV data which broadcasts an `MVChangedMessage` to the Ignite cluster. Because the cloud-runner is an active cluster member, its `MVManager.messageReceived` receives the message and fires a `PropertyChangeEvent` to all listeners — including `DataCycleManager`.

`DataCycleManager.propertyChange` calls `generateTasks`, which iterates over **all** organizations and calls `MVManager.list(orgId)` for each one. For `organization0` (an org cloned from `org-sara`), this tries to initialize `LocalKeyValueStorage` via `BlobStorage`, which in turn calls `IgniteCluster.getReplicatedMap` → `Ignite.getOrCreateCache`. However, `CloudRunnerContext.runScheduleTask` calls `cluster.close()` after the task completes, and the Ignite node is shutting down concurrently with this message handler. The result is a cascade of `NodeStoppingException` errors logged as:

```
ERROR i.m.MVManager: Failed to read MV definition: upload_ASSOCIATION_contacts_..._organization0 organization0
Caused by: javax.cache.CacheException: Failed to execute dynamic cache change request, node is stopping.
```

The errors occur even though the MV data itself is correct and the task completes successfully — `cluster.close()` races with Ignite processing the queued `MVChangedMessage`.

## Why Cloud-Runner Nodes Should Not Run `generateTasks`

Cloud-runner nodes are ephemeral task executors that:
- Connect to the cluster, execute a single task, and exit
- Never serve schedule dispatch requests
- Do not use `pregeneratedTasksMap` (the in-memory structure `generateTasks` populates)

Running `generateTasks` on a cloud-runner is both wasteful and fragile — it opens storage for every organization at a point when the Ignite client is already starting to shut down.

## Fix

Added an early-return guard in `DataCycleManager.generateTasks` that skips processing when `System.getProperty("ScheduleTaskRunner") != null`. `CloudRunnerApplication` unconditionally sets this property at startup (before Spring context initialization), so it reliably identifies cloud-runner processes.

```java
// cloud-runner nodes are short-lived task executors; they don't maintain
// pregenerated tasks and their Ignite client may be shutting down when this
// is triggered by an MVChangedMessage after task completion
if(System.getProperty("ScheduleTaskRunner") != null) {
    return;
}
```

This mirrors the existing guard for secondary schedulers (`ScheduleServer` property) and is the minimal, targeted change needed to eliminate the race condition.

## Test Plan

- [ ] Reproduce the original scenario: security + multi-tenancy enabled, `org-sara` created, VS imported, MV created with data cycle, `organization0` cloned from `org-sara`
- [ ] Wait for data cycle tasks to run for both orgs
- [ ] Confirm no `NodeStoppingException` / `Failed to read MV definition` errors in the Stage 2 task log
- [ ] Confirm MV data is still correctly generated for both orgs

🤖 Generated with [Claude Code](https://claude.com/claude-code)