### PR TITLE
Bug #74623: Fix quick-switch overlay button extending beyond cell border on hover

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.scss
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.scss
@@ -276,6 +276,7 @@
   overflow: hidden;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
   pointer-events: auto;
+  box-sizing: border-box;
 
   i {
     flex: none;


### PR DESCRIPTION
## Root Cause Analysis

The quick-switch toggle button (`.quick-switch-overlay-btn`) is an absolutely-positioned `<button>` whose height is set dynamically in TypeScript to match the hovered cell:

```typescript
// vs-selection.component.ts
this.renderer.setStyle(btn, "height", cellRect.height / scale + "px");
```

`cellRect.height` is the cell's full bounding-rectangle height in viewport pixels (returned by `getBoundingClientRect()`), which includes the cell's own border pixels. Divided by `scale` this gives the correct CSS pixel outer height for the cell.

However, `.quick-switch-overlay-btn` had no explicit `box-sizing` declaration, so the browser used the default **`content-box`** model. Under `content-box`:

- The `height` property applies to the **content area only**
- The button's `border: 1px solid` adds **1 px top + 1 px bottom = 2 px extra** on top of the content height
- The button's rendered outer height = `cellRect.height / scale` **+ 2 px**

This means the toggle button always overflowed the cell by 2 px at the bottom, causing the icon border to visually extend beyond the cell's bottom border line.

## Fix

Add `box-sizing: border-box` to `.quick-switch-overlay-btn`. With `border-box`, the `height` property covers the entire border box (content + padding + border), so the button's total outer height equals `cellRect.height / scale` — exactly matching the cell — and the borders stay within the allocated space.

```scss
.quick-switch-overlay-btn {
  ...
  box-sizing: border-box;   // ← added
}
```

No TypeScript changes are needed; the height calculation was already correct for `border-box`.

## Test Plan

- [ ] Import `script1.vso`, open the viewsheet in the portal viewer
- [ ] Hover over any selection list value — confirm the toggle icon button appears flush with the cell border (no overflow above or below)
- [ ] Verify button renders correctly for cells with and without visible borders
- [ ] Verify behavior is unchanged for normal selection and quick-switch toggling between single/multi mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)