### PR TITLE
Bug #74635: single/multi-selection quick-switch icon not shown on mobile

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/selection/selection-list-cell.component.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/selection-list-cell.component.spec.ts
@@ -297,13 +297,13 @@ describe("Selection List Cell Test", () => {
          expect(selectionListCell.quickSwitchAllowed).toBe(false);
       });
 
-      it("should set quickSwitchAllowed to false on mobile even in viewer context", () => {
+      it("should set quickSwitchAllowed to true on mobile in viewer context", () => {
          vsSelectionComponent.model.quickSwitchAllowed = true;
          selectionListCell.contextProvider = viewerContext();
          selectionListCell.mobile = true;
          selectionListCell.ngOnInit();
 
-         expect(selectionListCell.quickSwitchAllowed).toBe(false);
+         expect(selectionListCell.quickSwitchAllowed).toBe(true);
       });
 
       // Long-press timer cancellation

--- a/web/projects/portal/src/app/vsobjects/objects/selection/selection-list-cell.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/selection-list-cell.component.ts
@@ -169,7 +169,7 @@ export class SelectionListCell implements OnInit, OnChanges, OnDestroy {
       this.isParentIDTree = model.objectType === "VSSelectionTree" && (<VSSelectionTreeModel> model).mode == MODE.ID;
       this.quickSwitchAllowed = model.quickSwitchAllowed &&
          (model.objectType === "VSSelectionList" || model.objectType === "VSSelectionTree")
-         && (this.contextProvider.viewer || this.contextProvider.preview) && !this.mobile;
+         && (this.contextProvider.viewer || this.contextProvider.preview);
 
       switch(this.measureTextFormat.vAlign) {
       case "top":


### PR DESCRIPTION
## Root Cause

`quickSwitchAllowed` was unconditionally forced to `false` on mobile devices via `&& !this.mobile` in `SelectionListCell.updateModelInfo()`. Because `onMouseEnter()` checks `quickSwitchAllowed` before calling `setQuickSwitchHover()`, the single/multi-selection overlay icon was never displayed when hovering on:

- Hybrid devices (touchscreen + mouse, e.g. Surface Pro, iPad + trackpad)
- Android/iOS browsers where mouse-enter events fire after touch interaction
- Desktop browsers in mobile device emulation mode

## Fix

Removed `&& !this.mobile` from the `quickSwitchAllowed` computation in `selection-list-cell.component.ts`.

The long-press mechanism in `onTouchStart` (500 ms hold → toggle single/multi mode) is entirely independent of `quickSwitchAllowed` and is unaffected. `updateSelectionState()` already uses the container-aware `isMaxMode()` guard, so clicking the overlay on mobile remains correctly gated by that existing check.

## Test Plan

- [ ] Open a viewsheet with a Selection List or Selection Tree in mobile mode (DevTools emulation or a real device with mouse)
- [ ] Mouse over a selection cell — the single/multi-switch overlay icon should appear
- [ ] Click the icon — selection mode should toggle between single and multi
- [ ] Verify long-press (500 ms) on touch still toggles the mode (no regression)
- [ ] Verify desktop hover behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)