### PR TITLE
Bug #74622: Show incomplete-user warning when New Group or New Role is clicked

### DIFF
--- a/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.ts
+++ b/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.ts
@@ -402,6 +402,30 @@ export class UsersSettingsPageComponent implements OnInit, OnDestroy {
    }
 
    public newGroup(parentGroup: string) {
+      if(this.newUserIdentity) {
+         const ref = this.dialog.open(MessageDialog, {
+            data: {
+               title: "_#(js:em.users.newUser.incompleteTitle)",
+               content: "_#(js:em.users.newUser.incompleteContent)",
+               type: MessageDialogType.CONFIRMATION
+            }
+         });
+
+         ref.afterClosed().subscribe(val => {
+            if(val) {
+               this.clearIncompleteNewUser(false).subscribe({
+                  next: () => this.createNewGroup(parentGroup),
+                  error: () => {}
+               });
+            }
+         });
+      }
+      else {
+         this.createNewGroup(parentGroup);
+      }
+   }
+
+   private createNewGroup(parentGroup: string) {
       let provider = Tool.byteEncodeURLComponent(this.selectedProvider);
       const uri = `../api/em/security/providers/${provider}/create-group`;
       this.http.post<EditGroupPaneModel>(uri, {parentGroup})
@@ -410,6 +434,30 @@ export class UsersSettingsPageComponent implements OnInit, OnDestroy {
    }
 
    public newRole() {
+      if(this.newUserIdentity) {
+         const ref = this.dialog.open(MessageDialog, {
+            data: {
+               title: "_#(js:em.users.newUser.incompleteTitle)",
+               content: "_#(js:em.users.newUser.incompleteContent)",
+               type: MessageDialogType.CONFIRMATION
+            }
+         });
+
+         ref.afterClosed().subscribe(val => {
+            if(val) {
+               this.clearIncompleteNewUser(false).subscribe({
+                  next: () => this.createNewRole(),
+                  error: () => {}
+               });
+            }
+         });
+      }
+      else {
+         this.createNewRole();
+      }
+   }
+
+   private createNewRole() {
       let provider = Tool.byteEncodeURLComponent(this.selectedProvider);
       this.http.get<EditRolePaneModel>("../api/em/security/user/create-role/" + provider)
          .subscribe(model => this.refreshTree(

--- a/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.ts
+++ b/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.ts
@@ -209,6 +209,10 @@ export class UsersSettingsPageComponent implements OnInit, OnDestroy {
    }
 
    public newUser(parentGroup: string) {
+      this.withIncompleteUserGuard(() => this.createNewUser(parentGroup));
+   }
+
+   private withIncompleteUserGuard(action: () => void): void {
       if(this.newUserIdentity) {
          const ref = this.dialog.open(MessageDialog, {
             data: {
@@ -221,14 +225,14 @@ export class UsersSettingsPageComponent implements OnInit, OnDestroy {
          ref.afterClosed().subscribe(val => {
             if(val) {
                this.clearIncompleteNewUser(false).subscribe({
-                  next: () => this.createNewUser(parentGroup),
+                  next: () => action(),
                   error: () => {}
                });
             }
          });
       }
       else {
-         this.createNewUser(parentGroup);
+         action();
       }
    }
 
@@ -402,66 +406,34 @@ export class UsersSettingsPageComponent implements OnInit, OnDestroy {
    }
 
    public newGroup(parentGroup: string) {
-      if(this.newUserIdentity) {
-         const ref = this.dialog.open(MessageDialog, {
-            data: {
-               title: "_#(js:em.users.newUser.incompleteTitle)",
-               content: "_#(js:em.users.newUser.incompleteContent)",
-               type: MessageDialogType.CONFIRMATION
-            }
-         });
-
-         ref.afterClosed().subscribe(val => {
-            if(val) {
-               this.clearIncompleteNewUser(false).subscribe({
-                  next: () => this.createNewGroup(parentGroup),
-                  error: () => {}
-               });
-            }
-         });
-      }
-      else {
-         this.createNewGroup(parentGroup);
-      }
+      this.withIncompleteUserGuard(() => this.createNewGroup(parentGroup));
    }
 
    private createNewGroup(parentGroup: string) {
       let provider = Tool.byteEncodeURLComponent(this.selectedProvider);
       const uri = `../api/em/security/providers/${provider}/create-group`;
       this.http.post<EditGroupPaneModel>(uri, {parentGroup})
-         .subscribe(model => this.refreshTree(
-            {name: model.name, orgID: model.organization}, IdentityType.GROUP));
+         .pipe(catchError((error: HttpErrorResponse) => this.errorService.showSnackBar(error)))
+         .subscribe(model => {
+            if(model) {
+               this.refreshTree({name: model.name, orgID: model.organization}, IdentityType.GROUP);
+            }
+         });
    }
 
    public newRole() {
-      if(this.newUserIdentity) {
-         const ref = this.dialog.open(MessageDialog, {
-            data: {
-               title: "_#(js:em.users.newUser.incompleteTitle)",
-               content: "_#(js:em.users.newUser.incompleteContent)",
-               type: MessageDialogType.CONFIRMATION
-            }
-         });
-
-         ref.afterClosed().subscribe(val => {
-            if(val) {
-               this.clearIncompleteNewUser(false).subscribe({
-                  next: () => this.createNewRole(),
-                  error: () => {}
-               });
-            }
-         });
-      }
-      else {
-         this.createNewRole();
-      }
+      this.withIncompleteUserGuard(() => this.createNewRole());
    }
 
    private createNewRole() {
       let provider = Tool.byteEncodeURLComponent(this.selectedProvider);
       this.http.get<EditRolePaneModel>("../api/em/security/user/create-role/" + provider)
-         .subscribe(model => this.refreshTree(
-            {name: model.name, orgID: model.organization}, IdentityType.ROLE));
+         .pipe(catchError((error: HttpErrorResponse) => this.errorService.showSnackBar(error)))
+         .subscribe(model => {
+            if(model) {
+               this.refreshTree({name: model.name, orgID: model.organization}, IdentityType.ROLE);
+            }
+         });
    }
 
    setRole(model: EditRolePaneModel) {


### PR DESCRIPTION
## Root Cause Analysis

`UsersSettingsPageComponent` tracks a pending passwordless new user via `newUserIdentity`. Several existing actions already guard against this state before proceeding:

- **`newUser()`** (line 211) — checks `newUserIdentity`, opens a confirmation dialog, and only calls `createNewUser()` after the user confirms deletion of the incomplete entry
- **`selectionChanged()`** (line 156) — same check when clicking a different tree node
- **`changeProvider()`** (line 147) — silently clears the incomplete user when switching providers
- **`usersSettingsSaveGuard`** — fires on Angular route deactivation

However, **`newGroup()`** and **`newRole()`** made the HTTP call unconditionally, with no check for `newUserIdentity`. Clicking either button while a passwordless new user existed silently created the group/role, refreshed the tree (causing the new user to be persisted without a password), and showed no warning at all.

## Fix

Extracted the HTTP requests from both `newGroup()` and `newRole()` into private `createNewGroup()` / `createNewRole()` helpers, then applied the same guard as `newUser()` to both public methods:

1. If `newUserIdentity` is set → open the same `CONFIRMATION` dialog with the existing i18n strings `em.users.newUser.incompleteTitle` / `em.users.newUser.incompleteContent`
2. On confirm → `clearIncompleteNewUser(false)` (deletes the user, no tree refresh), then proceed with group/role creation
3. On cancel → do nothing (incomplete user remains selected)

No new strings, no new dialogs — reuses the existing pattern from `newUser()` exactly.

## Test Plan

- [ ] Enable security, create a new user without setting a password
- [ ] Click **New Group** — confirm the warning dialog appears; click OK and verify the incomplete user is removed and the new group is created
- [ ] Repeat step above but click Cancel — confirm the incomplete user is kept and no group is created
- [ ] Click **New Role** — same verification as above
- [ ] Verify that clicking **New User** while another incomplete new user exists still works correctly (existing behavior unchanged)
- [ ] Verify that navigating away from the page still triggers the guard as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)