### PR TITLE
Bug #74651: fix StringIndexOutOfBoundsException when renaming user with chained system task condition

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleManager.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleManager.java
@@ -1159,7 +1159,13 @@ public class ScheduleManager {
             if(condition instanceof CompletionCondition) {
                CompletionCondition completeCondition = (CompletionCondition) condition;
                String taskName = completeCondition.getTaskName();
-               String userName = taskName.substring(0,taskName.indexOf(":"));
+               int colonIdx = taskName == null ? -1 : taskName.indexOf(":");
+
+               if(colonIdx < 0) {
+                  continue;
+               }
+
+               String userName = taskName.substring(0, colonIdx);
 
                if(Tool.equals(userName, oname.getName()) ||
                   Tool.equals(IdentityID.getIdentityIDFromKey(userName).name, oname.getName()))
@@ -1174,7 +1180,13 @@ public class ScheduleManager {
 
          while(taskDependencies.hasMoreElements()) {
             String taskDep = taskDependencies.nextElement();
-            String userName = taskDep.substring(0, taskDep.indexOf(":"));
+            int colonIdx = taskDep == null ? -1 : taskDep.indexOf(":");
+
+            if(colonIdx < 0) {
+               continue;
+            }
+
+            String userName = taskDep.substring(0, colonIdx);
 
             if(Tool.equals(userName, oname.getName()) ||
                Tool.equals(IdentityID.getIdentityIDFromKey(userName).name, oname.getName()))

--- a/core/src/test/java/inetsoft/sree/schedule/ScheduleManagerTest.java
+++ b/core/src/test/java/inetsoft/sree/schedule/ScheduleManagerTest.java
@@ -344,6 +344,32 @@ public class ScheduleManagerTest {
       assertEquals("tuser0_1~;~host-org:user_tk2",  completionCondition.getTaskName());
    }
 
+   /**
+    * Regression test for Bug #74651: identityRenamed() must not throw
+    * StringIndexOutOfBoundsException when a CompletionCondition or dependency
+    * references a system/internal task name that has no owner prefix (no colon).
+    */
+   @Test
+   void checkIdentityRenamedWithSystemTaskCondition() throws Exception {
+      CompletionCondition systemCondition = spy(CompletionCondition.class);
+      systemCondition.setTaskName("__balance tasks__");
+
+      ScheduleTask userTask = new ScheduleTask("user_tk_sys");
+      userTask.setOwner(new IdentityID("tuser0", "host-org"));
+      userTask.addCondition(systemCondition);
+      userTask.setCondition(0, systemCondition);
+      userTask.setIdentity(new User(identityID_tuser0));
+
+      scheduleManager.setScheduleTask("tuser0~;~host-org:user_tk_sys", userTask, admin);
+
+      User tuser0_1 = new User(new IdentityID("tuser0_1", "host-org"));
+      assertDoesNotThrow(() -> scheduleManager.identityRenamed(identityID_tuser0, tuser0_1));
+
+      CompletionCondition cond = (CompletionCondition)
+         scheduleManager.getScheduleTask("tuser0_1~;~host-org:user_tk_sys").getCondition(0);
+      assertEquals("__balance tasks__", cond.getTaskName());
+   }
+
    private ScheduleTask createScheduleTask(String taskName) {
       ViewsheetAction spyVSAction = spy(ViewsheetAction.class);
       spyVSAction.setViewsheet("1^128^__NULL__^f1/vs1^host-org");


### PR DESCRIPTION
## Root Cause

`ScheduleManager.identityRenamed()` iterates every task in the org and inspects each `CompletionCondition` and task dependency to update references when a user is renamed. The code assumed all task-name strings follow the `owner:taskName` format and called `substring(0, indexOf(":"))` unconditionally:

```java
// CompletionCondition block (line 1162)
String userName = taskName.substring(0, taskName.indexOf(":"));

// Dependency loop (line 1177)
String userName = taskDep.substring(0, taskDep.indexOf(":"));
```

**Internal/system tasks** (e.g. `__balance tasks__`, `__asset file backup__`) use `ScheduleTask.Type.INTERNAL_TASK`, and their task ID is set to the bare task name with **no owner prefix and no colon** (`id = name` in `ScheduleTask`). When a user task's `CompletionCondition` references such a system task, `getTaskName()` returns `__balance tasks__` (17 characters, no `:`). `indexOf(":")` returns `-1`, so `substring(0, -1)` throws:

```
java.lang.StringIndexOutOfBoundsException: Range [0, -1) out of bounds for length 17
    at inetsoft.sree.schedule.ScheduleManager.identityRenamed(ScheduleManager.java:1162)
    at inetsoft.web.admin.security.IdentityService.syncIdentity(IdentityService.java:453)
```

The trigger requires multi-tenancy enabled, because the per-org task scan (`getOrgTaskMap(orgID)`) is what surfaces a user task (in org0) whose completion condition references the system task.

## Fix

Guard both call sites against `indexOf` returning `-1`. If no colon is present the name belongs to a system/internal task that has no owner — it cannot reference any user and should be skipped during a user rename.

```java
// CompletionCondition block
int colonIdx = taskName == null ? -1 : taskName.indexOf(":");
if(colonIdx < 0) {
    continue;
}
String userName = taskName.substring(0, colonIdx);

// Dependency loop
int colonIdx = taskDep == null ? -1 : taskDep.indexOf(":");
if(colonIdx < 0) {
    continue;
}
String userName = taskDep.substring(0, colonIdx);
```

Skipping is semantically correct: system task names are owner-less and will never match a user's `IdentityID`, so they require no update during a rename regardless.

## Test Plan

- [ ] Enable Multi-Tenancy
- [ ] Create a portal schedule task with a **Chained** completion condition pointing to `INETSOFT_SYSTEM:__balance tasks__`
- [ ] In EM → Security → Users, create a new organization (e.g. `organization0`) by cloning Host Organization
- [ ] Rename user `admin` to `admin1` inside `organization0`
- [ ] Verify rename succeeds without `StringIndexOutOfBoundsException` in the console
- [ ] Verify the renamed user's own tasks are still correctly updated (task owner renamed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)