### PR TITLE
Bug #74703 - Fix NPE in export-assets when invalid pattern passed as excludeDependencies

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/deploy/DeployService.java
+++ b/core/src/main/java/inetsoft/web/admin/deploy/DeployService.java
@@ -652,7 +652,15 @@ public class DeployService {
             continue;
          }
 
-         List<String> subassets = findAssets(pattern);
+         List<String> subassets;
+
+         try {
+            subassets = findAssets(pattern);
+         }
+         catch(IllegalArgumentException e) {
+            errPatterns.add(pattern);
+            continue;
+         }
 
          if(subassets == null || subassets.isEmpty()) {
             errPatterns.add(pattern);
@@ -1413,6 +1421,9 @@ public class DeployService {
          else {
             throw new IllegalArgumentException("Invalid pattern string: " + patternStr);
          }
+      }
+      else {
+         throw new IllegalArgumentException("Invalid pattern string: " + patternStr);
       }
 
       if(path != null) {

--- a/core/src/main/java/inetsoft/web/admin/deploy/DeployService.java
+++ b/core/src/main/java/inetsoft/web/admin/deploy/DeployService.java
@@ -658,6 +658,7 @@ public class DeployService {
             subassets = findAssets(pattern);
          }
          catch(IllegalArgumentException e) {
+            LOG.warn("Skipping invalid pattern in findAssets: {}", pattern);
             errPatterns.add(pattern);
             continue;
          }


### PR DESCRIPTION
## Root Cause

`DeployService.getSearchOptions(String patternStr)` parses Ant-style asset path patterns that must begin with either `/global/` or `/user/`. Before this fix the method had no `else` branch — if `patternStr` matched neither prefix the method fell through silently with `path = null` and `type = null`.

This null `path` was then passed to `searchIndexedStorage`, which called `convertToReg(opts.path)`. `convertToReg` immediately dereferences its argument via `pattern.length()` with no null guard, producing:

```
java.lang.NullPointerException: Cannot invoke "String.replace(CharSequence, CharSequence)" because "path" is null
    at inetsoft.web.admin.deploy.DeployService.getSearchOptions(DeployService.java:1456)
```

### Trigger scenarios

1. `:file export-assets exported1.zip included excluded false` — the literal token `false` (intended as the 4th positional `excludeDependencies` boolean flag but mis-parsed as a pattern list) was passed as a pattern string.
2. `:file export-assets exported1.zip included ''` — an empty-string variable resolved to a list containing `""`, which is already skipped, but any non-empty non-path value would hit the same code path.

Both result in HTTP 500 from `DeployService.exportAssets` → `findAssets` → `getSearchOptions`.

## Fix

### 1. `getSearchOptions` — add missing `else` branch (`DeployService.java:1425`)

Added an explicit `else` that throws `IllegalArgumentException` for any `patternStr` that does not start with `/global/` or `/user/`. This makes the contract clear and prevents a null `path`/`type` from propagating downstream.

```java
else {
    throw new IllegalArgumentException("Invalid pattern string: " + patternStr);
}
```

### 2. `findAssets(List<String>)` — catch `IllegalArgumentException` per-pattern (`DeployService.java:657`)

Wrapped the per-pattern `findAssets(pattern)` call in a try/catch. An invalid pattern is recorded in `errPatterns` (surfaced in the error prefix of the returned list) and the loop continues, so a single bad entry in the exclude list does not abort the entire export.

```java
try {
    subassets = findAssets(pattern);
}
catch(IllegalArgumentException e) {
    errPatterns.add(pattern);
    continue;
}
```

## Test plan

- [ ] `:file export-assets exported1.zip included excluded false` — no longer throws 500; export completes with valid includes
- [ ] `:file export-assets exported1.zip included ''` — no longer throws 500
- [ ] `:file export-assets exported1.zip '/global/viewsheet/Examples/*' '/global/worksheet/Examples/Hurricane'` — excluded asset is absent from ZIP
- [ ] `:file export-assets exported1.zip '/global/worksheet/**' ''` — empty excludes still works (existing behaviour)
- [ ] Confirm invalid pattern token is reported in the error prefix string rather than silently dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)