### PR TITLE
Bug #74711: fix host org theme leaking into cloned org

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
@@ -144,7 +144,7 @@ public abstract class AbstractEditableAuthenticationProvider
       String fromOrgId = fromOrganization.getId();
       copyScopedProperties(fromOrgId, newOrgID, replace);
       copyDataSpace(fromOrganization, newOrg, replace);
-      copyThemes(fromOrgId, newOrgID, replace);
+      String newOrgThemeId = copyThemes(fromOrgId, newOrgID, replace);
 
       if(replace) {
          clearScopedProperties(fromOrgId);
@@ -248,7 +248,7 @@ public abstract class AbstractEditableAuthenticationProvider
       else {
          newOrg.setMembers(addedMembers.stream().map(id -> id.name).toArray(String[]::new));
          newOrg.setLocale(fromOrganization.getLocale());
-         newOrg.setTheme(fromOrganization.getTheme());
+         newOrg.setTheme(newOrgThemeId);
       }
 
       addOrganization(newOrg);
@@ -301,9 +301,9 @@ public abstract class AbstractEditableAuthenticationProvider
       }
    }
 
-   private void copyThemes(String fromOrgId, String toOrgId, boolean replace) {
+   private String copyThemes(String fromOrgId, String toOrgId, boolean replace) {
       if(Tool.isEmptyString(fromOrgId)) {
-         return;
+         return null;
       }
 
       DataSpace dataSpace = DataSpace.getDataSpace();
@@ -332,6 +332,8 @@ public abstract class AbstractEditableAuthenticationProvider
             }
          }
       }
+
+      String newOrgThemeId = null;
 
       for(CustomTheme theme : sourceThemes) {
          try {
@@ -368,6 +370,7 @@ public abstract class AbstractEditableAuthenticationProvider
                   clone.setOrganizations(newOrgs);
 
                   manager.setOrgSelectedTheme(clone.getId(), toOrgId);
+                  newOrgThemeId = clone.getId();
                }
 
                //if copying a global theme, need to actually copy the dataspace jar
@@ -376,7 +379,7 @@ public abstract class AbstractEditableAuthenticationProvider
                   String oldJarPath = clone.getJarPath();
                   String newJarPath = clone.getJarPath().replace("portal/theme", "portal/" + toOrgId + "/theme");
 
-                  if(Tool.isEmptyString(theme.getOrgID()) || Tool.equals(fromOrgId, Organization.getDefaultOrganizationID())) {
+                  if(Tool.isEmptyString(theme.getOrgID())) {
                      if(dataSpace.exists(null, clone.getJarPath())) {
                         try(InputStream in = dataSpace.getInputStream(null, oldJarPath)) {
                            int index = newJarPath.lastIndexOf('/');
@@ -407,6 +410,7 @@ public abstract class AbstractEditableAuthenticationProvider
       }
 
       manager.setCustomThemes(themes);
+      return newOrgThemeId;
    }
 
    protected void clearScopedProperties(String oldOrgId) {

--- a/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
@@ -376,10 +376,10 @@ public abstract class AbstractEditableAuthenticationProvider
                //if copying a global theme, need to actually copy the dataspace jar
                //since this is usually wrapped into copying the dataspace
                if(!Tool.isEmptyString(clone.getJarPath())) {
-                  String oldJarPath = clone.getJarPath();
-                  String newJarPath = clone.getJarPath().replace("portal/theme", "portal/" + toOrgId + "/theme");
-
                   if(Tool.isEmptyString(theme.getOrgID())) {
+                     String oldJarPath = clone.getJarPath();
+                     String newJarPath = clone.getJarPath().replace("portal/theme", "portal/" + toOrgId + "/theme");
+
                      if(dataSpace.exists(null, clone.getJarPath())) {
                         try(InputStream in = dataSpace.getInputStream(null, oldJarPath)) {
                            int index = newJarPath.lastIndexOf('/');

--- a/core/src/test/java/inetsoft/sree/security/AbstractEditableAuthenticationProviderStaticDepTest.java
+++ b/core/src/test/java/inetsoft/sree/security/AbstractEditableAuthenticationProviderStaticDepTest.java
@@ -407,6 +407,31 @@ class AbstractEditableAuthenticationProviderStaticDepTest {
       }
    }
 
+   // [Path F] theme is the org's selected default → return value is the clone's ID (not the original's)
+   @Test
+   void copyThemes_orgSelectedTheme_returnsCloneId() {
+      CustomTheme theme = new CustomTheme();
+      theme.setId("theme-1");
+      theme.setOrgID("fromOrg");
+      theme.setOrganizations(new ArrayList<>(List.of("fromOrg")));
+
+      try(MockedStatic<DataSpace> ds = mockStatic(DataSpace.class);
+          MockedStatic<CustomThemesManager> ctm = mockStatic(CustomThemesManager.class)) {
+
+         DataSpace mockDs = mock(DataSpace.class);
+         ds.when(DataSpace::getDataSpace).thenReturn(mockDs);
+
+         CustomThemesManager mockManager = mock(CustomThemesManager.class);
+         ctm.when(CustomThemesManager::getManager).thenReturn(mockManager);
+         when(mockManager.getCustomThemes()).thenReturn(new HashSet<>(Set.of(theme)));
+
+         String returnedId = provider.callCopyThemes("fromOrg", "toOrg", false);
+
+         assertNotNull(returnedId, "clone ID must be returned when theme is the org's selected default");
+         assertNotEquals("theme-1", returnedId, "returned ID must be the clone's new ID, not the original's");
+      }
+   }
+
    // -------------------------------------------------------------------------
    // copyDataSpace — private; tested via reflection
    // -------------------------------------------------------------------------
@@ -567,12 +592,12 @@ class AbstractEditableAuthenticationProviderStaticDepTest {
          }
       }
 
-      void callCopyThemes(String fromOrgId, String toOrgId, boolean replace) {
+      String callCopyThemes(String fromOrgId, String toOrgId, boolean replace) {
          try {
             var m = AbstractEditableAuthenticationProvider.class.getDeclaredMethod(
                "copyThemes", String.class, String.class, boolean.class);
             m.setAccessible(true);
-            m.invoke(this, fromOrgId, toOrgId, replace);
+            return (String) m.invoke(this, fromOrgId, toOrgId, replace);
          }
          catch(ReflectiveOperationException e) {
             throw new AssertionError("reflection failed: copyThemes", e);


### PR DESCRIPTION
## Root Cause

When an org is cloned, `copyOrganizationInternal` in `AbstractEditableAuthenticationProvider` sets the new org's theme field by copying the **source org's theme ID** directly:

```java
newOrg.setTheme(fromOrganization.getTheme());  // e.g. the host org's theme ID "X"
```

`copyThemes` correctly creates a clone of each theme with a new UUID (`Y`) and stores the association in a SreeEnv property (`portal.org.selectedThemeId.{newOrgId} = Y`). However, it never updates the org object's `theme` field.

`GlobalStyleController.getResource()` checks `provider.getOrganization(currOrgID).getTheme()` **first** (before consulting `portal.org.selectedThemeId`). Since the org's `theme` field points at the original host-org theme ID `X`, the portal loads that theme's JAR — serving the original unedited CSS (red color).

When the org-user subsequently opens EM, selects the theme, edits the CSS, and saves, `updateTheme` calls `updateThemeOrganization` only when:

```java
if(!theme.getId().equals(customThemesManager.getOrgSelectedTheme())) {
    updateThemeOrganization(orgID, theme.getId());
    ...
}
```

Because `portal.org.selectedThemeId.{newOrgId}` was already correctly set to `Y` by `copyThemes`, this condition is `false` and `updateThemeOrganization` is **never called**. The org's `theme` field remains `X` forever, and the portal always loads the host-org theme's CSS.

## Fixes

### Fix 1 — `copyThemes` returns the cloned org's theme ID (`AbstractEditableAuthenticationProvider.java`)

Changed `copyThemes` from `void` to `String`, tracking the clone ID whenever a theme is promoted to org default:

```java
// inside copyThemes, where setOrgSelectedTheme is called:
manager.setOrgSelectedTheme(clone.getId(), toOrgId);
newOrgThemeId = clone.getId();   // ← new: track it

// at the end:
return newOrgThemeId;
```

`copyOrganizationInternal` now uses the returned ID for the new org:

```java
String newOrgThemeId = copyThemes(fromOrgId, newOrgID, replace);
// ...
newOrg.setTheme(newOrgThemeId);   // was: fromOrganization.getTheme()
```

This ensures `org.theme` in the cloned org points at the correct clone ID `Y`, so `GlobalStyleController` loads the right JAR immediately — without requiring the org-user to re-select the theme.

### Fix 2 — JAR path replacement for host-org-scoped themes (`copyThemes`)

The JAR copy branch was guarded by:

```java
if(Tool.isEmptyString(theme.getOrgID()) || Tool.equals(fromOrgId, Organization.getDefaultOrganizationID()))
```

When the source theme is **org-scoped to host-org** (`orgID = "host-org"`), this condition is `true` (because `fromOrgId == "host-org"`), but the path replacement it applies:

```java
clone.getJarPath().replace("portal/theme", "portal/" + toOrgId + "/theme")
```

is a **no-op** on paths like `portal/host-org/theme/X.jar` because `"portal/theme"` is not a substring of that path. The clone ends up with the wrong `jarPath`, pointing back at the source org's JAR file.

Changed the condition to `Tool.isEmptyString(theme.getOrgID())` so only truly global JARs (`portal/theme/X.jar`) use the `replace("portal/theme", ...)` strategy. Host-org-scoped themes fall into the `else` branch and correctly use `replace(fromOrgId, toOrgId)`.

## Test Plan

- [ ] Enable security and multi-tenancy
- [ ] Log in as site-admin, create a theme "host", check **Default for This Organization**
- [ ] Clone host org; create a user in the new org with org-admin permission
- [ ] Log in as org-user in EM, open the theme, edit a CSS color (e.g. primary color), click Apply
- [ ] Log in as org-user in Portal — verify the edited color is applied (not the host org's original color)
- [ ] Verify the host org's portal still shows its original theme unchanged
- [ ] Repeat with the source theme created as org-scoped (uncheck Global Theme) to exercise Fix 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)