### PR TITLE
Bug #74677: fix Ignite write-lock leak in MVSingleDispatcher causing service hang

### DIFF
--- a/core/src/main/java/inetsoft/mv/MVSingleDispatcher.java
+++ b/core/src/main/java/inetsoft/mv/MVSingleDispatcher.java
@@ -115,79 +115,83 @@ class MVSingleDispatcher extends MVDispatcher {
       // want to recreate mv
       Cluster.getInstance().lockWrite("mv.exec." + def.getName());
 
-      // there may be more than one scheduler updating fs (in memory),
-      // lock to make sure only one copy is modified and saved before
-      // the other is modified.
-      Cluster.getInstance().lockKey("mv.fs.update");
-
       try {
-         // should call with force=false, but that still causes
-         // data missing (Has Data = No). not sure why. we should
-         // consider refactoring the how local MV to avoid the
-         // problem with synchronizing in-memory copies across
-         // a cluster. Bug #9683
-         fsys.refresh(FSService.getDataNode().getBSystem(), true);
+         // there may be more than one scheduler updating fs (in memory),
+         // lock to make sure only one copy is modified and saved before
+         // the other is modified.
+         Cluster.getInstance().lockKey("mv.fs.update");
 
-         // update sub mv files in the distributed file system
          try {
-            boolean removed = fsys.remove(name);
+            // should call with force=false, but that still causes
+            // data missing (Has Data = No). not sure why. we should
+            // consider refactoring the how local MV to avoid the
+            // problem with synchronizing in-memory copies across
+            // a cluster. Bug #9683
+            fsys.refresh(FSService.getDataNode().getBSystem(), true);
 
-            if(!removed) {
-               throw new Exception("Failed to remove XFile: " + name);
+            // update sub mv files in the distributed file system
+            try {
+               boolean removed = fsys.remove(name);
+
+               if(!removed) {
+                  throw new Exception("Failed to remove XFile: " + name);
+               }
+
+               fsys.add(name, arr);
             }
-
-            fsys.add(name, arr);
-         }
-         finally {
-            // remove temp files if any
-            for(int i = 0; i < arr.length; i++) {
-               if(arr[i] != null) {
-                  try {
-                     arr[i].delete();
-                  }
-                  catch(Exception ex) {
-                     LOG.debug("Failed to delete temp file: " + arr[i] + " " + ex);
+            finally {
+               // remove temp files if any
+               for(int i = 0; i < arr.length; i++) {
+                  if(arr[i] != null) {
+                     try {
+                        arr[i].delete();
+                     }
+                     catch(Exception ex) {
+                        LOG.debug("Failed to delete temp file: " + arr[i] + " " + ex);
+                     }
                   }
                }
             }
+
+            // @by stephenwebster, For Bug #6637
+            // It seems we make an effort to create a _temp mv file, but we
+            // really never wrote to it.  If we get to the else statement, then
+            // there must be an original mv file that exists.
+            // So, first we will save to the _temp file, so that if it fails
+            // during save, we do not end up with a partial mv file and the
+            // current mv will continue to work, even though it may be stale.
+            mv.save(file);
+
+            // The file has to be removed first before sys.rename otherwise
+            // sys.rename will fail because the original file already exists.
+            MVBackupManager.remove(oname);
+            fsys.rename(name, oname);
+
+            // Get the original mv name and do an atomic move from the _temp
+            // file to the main mv file.
+            String mfile = MVStorage.getFile(oname);
+            storage.rename(file, mfile);
+
+            long saved = System.currentTimeMillis();
+            LOG.debug("Files saved and copied for materialized view " + def.getName() + " in " +
+                         (saved - built) + "ms");
          }
+         catch(Exception ex) {
+            try {
+               fsys.remove(name);
+            }
+            catch(Exception e1) {
+               // ignore it
+            }
 
-         // @by stephenwebster, For Bug #6637
-         // It seems we make an effort to create a _temp mv file, but we
-         // really never wrote to it.  If we get to the else statement, then
-         // there must be an original mv file that exists.
-         // So, first we will save to the _temp file, so that if it fails
-         // during save, we do not end up with a partial mv file and the
-         // current mv will continue to work, even though it may be stale.
-         mv.save(file);
-
-         // The file has to be removed first before sys.rename otherwise
-         // sys.rename will fail because the original file already exists.
-         MVBackupManager.remove(oname);
-         fsys.rename(name, oname);
-
-         // Get the original mv name and do an atomic move from the _temp
-         // file to the main mv file.
-         String mfile = MVStorage.getFile(oname);
-         storage.rename(file, mfile);
-
-         long saved = System.currentTimeMillis();
-         LOG.debug("Files saved and copied for materialized view " + def.getName() + " in " +
-                      (saved - built) + "ms");
-      }
-      catch(Exception ex) {
-         try {
-            fsys.remove(name);
+            throw ex;
          }
-         catch(Exception e1) {
-            // ignore it
+         finally {
+            Cluster.getInstance().unlockKey("mv.fs.update");
+            FSService.refreshCluster(true);
          }
-
-         throw ex;
       }
       finally {
-         Cluster.getInstance().unlockKey("mv.fs.update");
-         FSService.refreshCluster(true);
          Cluster.getInstance().unlockWrite("mv.exec." + def.getName());
 
          try {


### PR DESCRIPTION
## Root Cause

`MVSingleDispatcher.build()` acquires two distributed Ignite locks in sequence before a single `try/finally` block:

```java
// Line 116 — write lock acquired here
Cluster.getInstance().lockWrite("mv.exec." + def.getName());

// Line 121 — if THIS throws, line 116's lock is never released
Cluster.getInstance().lockKey("mv.fs.update");

try {          // Line 123
    ...
} finally {
    Cluster.getInstance().unlockKey("mv.fs.update");
    FSService.refreshCluster(true);
    Cluster.getInstance().unlockWrite("mv.exec." + def.getName());  // ← never reached
}
```

`lockKey()` calls `tryLock(10, TimeUnit.MINUTES)` on an Ignite distributed lock. If that call is interrupted or times out, it throws `RuntimeException`. Because the `try` block starts *after* that call, the `finally` is never entered, and the `"write.mv.exec.<name>"` distributed lock is permanently leaked.

### Cascading hang

Once the write lock leaks, every subsequent `addColumns` operation triggering MV creation calls `lockWrite("mv.exec.<name>")` through `DistributedLockProxy.lock()`. That method busy-waits in a `while(true)` loop calling `tryLock(3, SECONDS)` — when `tryLock` returns `false` (contended) the loop counter is *not* incremented, so the thread polls indefinitely.

Each blocked STOMP `clientInboundChannel` thread causes the executor to spawn a new thread for the next incoming WebSocket message, producing 164+ threads and 2+ GB of memory growth. The K6 load test shows 0 completed iterations and 1 interrupted because the graceful-stop window (30 s) expires with the WebSocket session still waiting for the leaked lock.

### Why idle HTTP / TimedQueue / pub threads show locked synchronizers

`unlockWrite()`/`unlockKey()` both delegate to `unlockLock()`, which calls `ignite.reentrantLock(name, ..., false)` to obtain a *fresh* `IgniteLock` Java object and calls `unlock()` on it. The `GridCacheLockImpl$Sync` object previously held by the acquiring thread's Java wrapper remains in "locked" state from the JVM's perspective even after the distributed lock is properly released. This explains the stale `@16aaf4a6` / `@3b0badef` / `@52b36c90` synchronizers visible in the thread dump on `http-nio-8080-exec-8`, `exec-9`, `TimedQueue`, and `pub-#116` — those threads completed their work normally; the synchronizer references are artefacts of `unlockLock()` using a different Java instance.

## Fix

Restructure the two lock acquisitions into nested `try/finally` blocks so that `unlockWrite` is guaranteed to run regardless of whether `lockKey` succeeds:

```java
Cluster.getInstance().lockWrite("mv.exec." + def.getName());

try {                                                      // outer — guards write lock
    Cluster.getInstance().lockKey("mv.fs.update");         // if this throws, outer finally still runs

    try {                                                  // inner — guards fs-update lock
        // ... all existing work unchanged ...
    }
    catch(Exception ex) {
        try { fsys.remove(name); } catch(Exception e1) {}
        throw ex;
    }
    finally {
        Cluster.getInstance().unlockKey("mv.fs.update");   // only if lockKey succeeded
        FSService.refreshCluster(true);
    }
}
finally {
    Cluster.getInstance().unlockWrite("mv.exec." + def.getName());  // always runs
    try { storage.remove(file); } catch(Exception ignore) {}
}
```

`MVCompositeDispatcher` uses `lockWrite` immediately adjacent to its `try` with no intervening code, so it is not affected.

## Test plan

- [ ] Run a K6 `add-columns` load test against a deployment with an MV-backed chart; verify all iterations complete and thread count remains stable
- [ ] Confirm no regression in MV creation/refresh: create an MV-backed viewsheet, open it, verify data is present
- [ ] Under normal MV dispatch (no interruption), verify the lock sequence (write + fs-update) is still acquired and released in the correct order by checking server logs for `Files saved and copied` debug lines
- [ ] Simulate `lockKey` timeout (configure a very short tryLock or inject a delay) and confirm the write lock is released and subsequent operations are not blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)