### PR TITLE
Performance: reduce redundant Ignite calls in hot paths

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
@@ -312,7 +312,7 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
    }
 
    protected SQLHelper getSQLHelper(UniformSQL sql) {
-      return SQLHelper.getSQLHelper(sql, box.getUser());
+      return sqlHelperCache.computeIfAbsent(sql, s -> SQLHelper.getSQLHelper(s, box.getUser()));
    }
 
    /**
@@ -4698,6 +4698,7 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
 
    private boolean mergeable; // query mergeable flag
    private boolean merged; // query merged flag
+   private final IdentityHashMap<UniformSQL, SQLHelper> sqlHelperCache = new IdentityHashMap<>(4);
    private Map<DataRef, ColumnRef> colmap = new HashMap<>(); // optimization
    private Map<Tuple, Object> exprAttrs = new Object2ObjectOpenHashMap<>();
    private Map<String, List<AttributeRef>> expr2Attrs = new Object2ObjectOpenHashMap<>();

--- a/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
@@ -312,6 +312,10 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
    }
 
    protected SQLHelper getSQLHelper(UniformSQL sql) {
+      if(sqlHelperCache == null) {
+         sqlHelperCache = new IdentityHashMap<>(4);
+      }
+
       return sqlHelperCache.computeIfAbsent(sql, s -> SQLHelper.getSQLHelper(s, box.getUser()));
    }
 
@@ -4698,7 +4702,7 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
 
    private boolean mergeable; // query mergeable flag
    private boolean merged; // query merged flag
-   private final IdentityHashMap<UniformSQL, SQLHelper> sqlHelperCache = new IdentityHashMap<>(4);
+   private transient IdentityHashMap<UniformSQL, SQLHelper> sqlHelperCache;
    private Map<DataRef, ColumnRef> colmap = new HashMap<>(); // optimization
    private Map<Tuple, Object> exprAttrs = new Object2ObjectOpenHashMap<>();
    private Map<String, List<AttributeRef>> expr2Attrs = new Object2ObjectOpenHashMap<>();

--- a/core/src/main/java/inetsoft/uql/jdbc/UniformSQL.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/UniformSQL.java
@@ -3719,7 +3719,7 @@ public class UniformSQL implements SQLDefinition, Cloneable, XMLSerializable {
    private Set<String> aliasflags = new HashSet<>();
    private Collection<XJoin> ojoins; // original joins before being transformed
    private transient Principal vpmUser; // vpm user apply for studio worksheet.
-   private transient SQLHelper cachedSQLHelper;
+   private transient volatile SQLHelper cachedSQLHelper;
    private Boolean lossy = null;
 
    private static final Logger LOG = LoggerFactory.getLogger(UniformSQL.class);

--- a/core/src/main/java/inetsoft/uql/jdbc/UniformSQL.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/UniformSQL.java
@@ -3129,6 +3129,7 @@ public class UniformSQL implements SQLDefinition, Cloneable, XMLSerializable {
    public synchronized void setDataSource(JDBCDataSource dataSource) {
       if(!Tool.equals(this.dataSource, dataSource)) {
          clearCachedString();
+         cachedSQLHelper = null;
       }
 
       this.dataSource = dataSource;
@@ -3609,15 +3610,17 @@ public class UniformSQL implements SQLDefinition, Cloneable, XMLSerializable {
    }
 
    public SQLHelper getSQLHelper() {
-      if(vpmUser != null) {
-         return SQLHelper.getSQLHelper(this, vpmUser);
+      if(cachedSQLHelper == null) {
+         cachedSQLHelper = vpmUser != null ?
+            SQLHelper.getSQLHelper(this, vpmUser) : SQLHelper.getSQLHelper(this);
       }
 
-      return SQLHelper.getSQLHelper(this);
+      return cachedSQLHelper;
    }
 
    public void setVpmUser(Principal user) {
       this.vpmUser = user;
+      cachedSQLHelper = null;
    }
 
    /**
@@ -3716,6 +3719,7 @@ public class UniformSQL implements SQLDefinition, Cloneable, XMLSerializable {
    private Set<String> aliasflags = new HashSet<>();
    private Collection<XJoin> ojoins; // original joins before being transformed
    private transient Principal vpmUser; // vpm user apply for studio worksheet.
+   private transient SQLHelper cachedSQLHelper;
    private Boolean lossy = null;
 
    private static final Logger LOG = LoggerFactory.getLogger(UniformSQL.class);

--- a/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
@@ -1519,7 +1519,7 @@ public class DataSourceRegistry implements MessageListener {
       // fast path: if the registry-level timestamp for this org hasn't advanced past
       // when we cached this object, no individual entry in that org can have changed —
       // skip the per-entry Ignite lastModified call entirely
-      if(obj != null) {
+      if(obj != null && orgId != null) {
          Long registryTS = ts.get(orgId);
 
          if(registryTS != null && registryTS <= obj.timeTS) {

--- a/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
@@ -1514,8 +1514,21 @@ public class DataSourceRegistry implements MessageListener {
     */
    private CachedObject getCachedObject(AssetEntry entry, boolean checkTS) {
       CachedObject obj = cachemap.get(entry); //NOSONAR can't use computeIfAbsent, b/c null would be present and not recomputed
+      String orgId = entry.getOrgID();
+
+      // fast path: if the registry-level timestamp for this org hasn't advanced past
+      // when we cached this object, no individual entry in that org can have changed —
+      // skip the per-entry Ignite lastModified call entirely
+      if(obj != null) {
+         Long registryTS = ts.get(orgId);
+
+         if(registryTS != null && registryTS <= obj.timeTS) {
+            return obj;
+         }
+      }
+
       String identifier = entry.toIdentifier();
-      long timeTS = indexedStorage.lastModified(identifier, entry.getOrgID());
+      long timeTS = indexedStorage.lastModified(identifier, orgId);
 
       // if changed, throw out the cached value
       // timeTS as 0 means we didn't find it

--- a/core/src/main/java/inetsoft/util/ConfigurationContext.java
+++ b/core/src/main/java/inetsoft/util/ConfigurationContext.java
@@ -17,6 +17,8 @@
  */
 package inetsoft.util;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -163,6 +165,7 @@ public class ConfigurationContext implements AutoCloseable {
    }
 
    public void setApplicationContext(ApplicationContext applicationContext) {
+      beanCache.invalidateAll();
       this.applicationContext = applicationContext;
 
       if(applicationContext != null) {
@@ -193,7 +196,7 @@ public class ConfigurationContext implements AutoCloseable {
          throw new ShutdownException();
       }
 
-      return applicationContext.getBean(type);
+      return type.cast(beanCache.get(type, t -> applicationContext.getBean(t)));
    }
 
    /**
@@ -206,12 +209,16 @@ public class ConfigurationContext implements AutoCloseable {
          return null;
       }
 
-      try {
-         return applicationContext.getBean(type);
-      }
-      catch(NoSuchBeanDefinitionException e) {
-         return null;
-      }
+      Object cached = beanCache.get(type, t -> {
+         try {
+            return applicationContext.getBean(t);
+         }
+         catch(NoSuchBeanDefinitionException e) {
+            return MISSING_BEAN;
+         }
+      });
+
+      return cached == MISSING_BEAN ? null : type.cast(cached);
    }
 
    public Object getSpringBean(String name) {
@@ -249,10 +256,14 @@ public class ConfigurationContext implements AutoCloseable {
    }
 
    private final Map<String, Object> data = new ConcurrentHashMap<>();
+   private final Cache<Class<?>, Object> beanCache = Caffeine.newBuilder()
+      .maximumSize(500L)
+      .build();
    private final PropertyChangeSupport support = new PropertyChangeSupport(this);
    private volatile String home = ".";
    private ApplicationContext applicationContext;
    private final CompletableFuture<Void> springContextReady = new CompletableFuture<>();
    private static volatile ConfigurationContext INSTANCE;
+   private static final Object MISSING_BEAN = new Object();
    private static final Logger LOG = LoggerFactory.getLogger(ConfigurationContext.class);
 }


### PR DESCRIPTION
- UniformSQL: cache SQLHelper per instance to avoid repeated creation during SQL generation
- PreAssetQuery: cache SQLHelper per UniformSQL instance using IdentityHashMap
- DataSourceRegistry.getCachedObject: skip per-entry Ignite lastModified call when the registry-level org timestamp hasn't advanced past the cached object's timestamp