### PR TITLE
Bug #74596 - Fix input label clipping in HTML export with large fonts

### DIFF
--- a/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
@@ -3860,15 +3860,25 @@ public abstract class AbstractVSExporter implements VSExporter {
          return fmt.getFont();
       }
 
-      return GDefaults.DEFAULT_TEXT_FONT;
+      return VSAssemblyInfo.getDefaultFont(Font.PLAIN, 11);
    }
 
    /**
-    * Get the label format, returning a default if null.
+    * Get the label format, returning a default if null. The returned format always
+    * has an explicit font so the drawing path uses the same font as the measurement
+    * path (PDFPrinter.setFont ignores null, so an unset font would silently fall
+    * back to whatever font was previously on the printer).
     */
    protected static VSCompositeFormat getLabelFormat(LabelInfo labelInfo) {
       VSCompositeFormat fmt = labelInfo.getLabelFormat();
-      return fmt != null ? fmt : new VSCompositeFormat();
+
+      if(fmt != null && fmt.getFont() != null) {
+         return fmt;
+      }
+
+      VSCompositeFormat result = fmt != null ? fmt.clone() : new VSCompositeFormat();
+      result.getUserDefinedFormat().setFont(getLabelFont(labelInfo));
+      return result;
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
@@ -3851,7 +3851,8 @@ public abstract class AbstractVSExporter implements VSExporter {
    }
 
    /**
-    * Get the font to use for rendering an input label.
+    * Get the font to use for rendering an input label. The default size 11
+    * matches LabelInfo.getRenderedHeight() so drawing and measurement agree.
     */
    protected static Font getLabelFont(LabelInfo labelInfo) {
       VSCompositeFormat fmt = labelInfo.getLabelFormat();

--- a/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLVSExporter.java
@@ -24,6 +24,7 @@ import inetsoft.report.composition.VSTableLens;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.report.gui.viewsheet.VSGroupContainer;
 import inetsoft.report.gui.viewsheet.VSImage;
+import inetsoft.report.internal.Common;
 import inetsoft.report.internal.table.TableFormat;
 import inetsoft.report.io.viewsheet.AbstractVSExporter;
 import inetsoft.report.io.viewsheet.ExportUtil;
@@ -148,11 +149,45 @@ public class HTMLVSExporter extends AbstractVSExporter {
       // labelFormat lets CSS inherit when no font is set, keeping the label close to
       // the viewer's rendering (Roboto at the inherited size).
       VSCompositeFormat labelFormat = labelInfo.getLabelFormat();
-      helper.writeText(writer, bounds[0],
+      Rectangle2D labelBounds = adjustLabelBoundsForFont(
+         bounds[0], labelFormat, labelInfo.getLabelPosition());
+      helper.writeText(writer, labelBounds,
          labelFormat != null ? labelFormat : new VSCompositeFormat(),
          labelInfo.getLabelText(), null, false, null, false, info.getZIndex());
 
       return bounds[1];
+   }
+
+   /**
+    * Expand bounds vertically to fit the font (otherwise overflow:hidden clips it)
+    * and shift away from the widget to preserve the label-widget gap.
+    */
+   private static Rectangle2D adjustLabelBoundsForFont(Rectangle2D labelBounds,
+      VSCompositeFormat labelFormat, String position)
+   {
+      if(labelFormat == null || labelFormat.getFont() == null) {
+         return labelBounds;
+      }
+
+      double fontHeight = Common.getHeight(labelFormat.getFont());
+
+      if(fontHeight <= labelBounds.getHeight()) {
+         return labelBounds;
+      }
+
+      double extra = fontHeight - labelBounds.getHeight();
+      double newY = labelBounds.getY();
+
+      if(LabelInfo.LEFT.equals(position) || LabelInfo.RIGHT.equals(position)) {
+         newY -= extra / 2.0;  // recenter on widget
+      }
+      else if(LabelInfo.TOP.equals(position)) {
+         newY -= extra;  // grow upward; bottom anchored
+      }
+      // BOTTOM: grow downward; top anchored
+
+      return new Rectangle2D.Double(
+         labelBounds.getX(), newY, labelBounds.getWidth(), fontHeight);
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLVSExporter.java
@@ -142,7 +142,14 @@ public class HTMLVSExporter extends AbstractVSExporter {
       Rectangle2D fullBounds = expandBoundsForLabel(helper.getBounds(info), labelInfo);
       Rectangle2D[] bounds = splitInputBounds(fullBounds, labelInfo);
 
-      helper.writeText(writer, bounds[0], getLabelFormat(labelInfo),
+      // HTML uses overflow:hidden to clip rather than positioning on a shared canvas,
+      // so we don't need to materialize a default font (PDF/SVG do, since
+      // PDFPrinter.setFont(null) silently keeps a stale printer font). Passing the raw
+      // labelFormat lets CSS inherit when no font is set, keeping the label close to
+      // the viewer's rendering (Roboto at the inherited size).
+      VSCompositeFormat labelFormat = labelInfo.getLabelFormat();
+      helper.writeText(writer, bounds[0],
+         labelFormat != null ? labelFormat : new VSCompositeFormat(),
          labelInfo.getLabelText(), null, false, null, false, info.getZIndex());
 
       return bounds[1];


### PR DESCRIPTION
HTMLCoordinateHelper wraps input labels in a div with overflow:hidden at
a fixed AssetUtil.defh height (20px). Labels with larger fonts (e.g.
50px Roboto) were clipped, often leaving the text invisible.

Expand the label container to the font's measured height
(Common.getHeight) and shift y so the label grows away from the widget,
preserving the label-widget gap:
- LEFT/RIGHT: recenter on widget
- TOP: grow upward, bottom edge anchored
- BOTTOM: grow downward, top edge anchored