### PR TITLE
Bug #74743, fix Kubernetes pod restart data loss due to incomplete Ignite migration.

### DIFF
--- a/core/src/main/java/inetsoft/storage/KeyValueEngine.java
+++ b/core/src/main/java/inetsoft/storage/KeyValueEngine.java
@@ -82,6 +82,15 @@ public interface KeyValueEngine extends AutoCloseable {
    <T> T remove(String id, String key);
 
    /**
+    * Gets the number of entries in a key-value store.
+    *
+    * @param id the unique identifier of the key-value store.
+    *
+    * @return the size.
+    */
+   long size(String id);
+
+   /**
     * Deletes the store with the specified storeID and all associated data
     *
     * @param id  the unique identifier of the key-value store.

--- a/core/src/main/java/inetsoft/storage/LoadKeyValueTask.java
+++ b/core/src/main/java/inetsoft/storage/LoadKeyValueTask.java
@@ -34,7 +34,7 @@ public class LoadKeyValueTask<T extends Serializable>
    extends KeyValueTask<T> implements SingletonRunnableTask
 {
    /**
-    * Creates a new instance of {@code DeleteKeyValueTask}.
+    * Creates a new instance of {@code LoadKeyValueTask}.
     *
     * @param id the unique identifier of the key-value store.
     */
@@ -43,7 +43,7 @@ public class LoadKeyValueTask<T extends Serializable>
    }
 
    /**
-    * Creates a new instance of {@code DeleteKeyValueTask}.
+    * Creates a new instance of {@code LoadKeyValueTask}.
     *
     * @param id       the unique identifier of the key-value store.
     * @param external a flag indicating if this load was triggered by an external change.
@@ -58,7 +58,7 @@ public class LoadKeyValueTask<T extends Serializable>
       try {
          Map<String, T> map = getMap();
 
-         if(map.isEmpty() || external) {
+         if(map.isEmpty() || external || map.size() != getEngine().size(getId())) {
             TreeMap<String, T> temp = new TreeMap<>();
             getEngine().<T>stream(getId())
                .forEach(p -> temp.put(p.getKey(), p.getValue()));

--- a/core/src/test/java/inetsoft/test/TestKeyValueEngine.java
+++ b/core/src/test/java/inetsoft/test/TestKeyValueEngine.java
@@ -63,6 +63,11 @@ public class TestKeyValueEngine implements KeyValueEngine {
    }
 
    @Override
+   public long size(String id) {
+      return storage.getOrDefault(id, new ConcurrentHashMap<>()).size();
+   }
+
+   @Override
    public Stream<String> idStream() {
       return storage.keySet().stream();
    }

--- a/server/src/main/java/inetsoft/web/health/ClusterReadinessHealthIndicator.java
+++ b/server/src/main/java/inetsoft/web/health/ClusterReadinessHealthIndicator.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.health;
+
+import inetsoft.sree.internal.cluster.Cluster;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.actuate.availability.ReadinessStateHealthIndicator;
+import org.springframework.boot.availability.*;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Component
+public class ClusterReadinessHealthIndicator extends ReadinessStateHealthIndicator {
+   public ClusterReadinessHealthIndicator(ApplicationAvailability availability) {
+      super(availability);
+   }
+
+   @PostConstruct
+   public void initClusterReadiness() {
+      ForkJoinPool pool = ForkJoinPool.commonPool();
+      ForkJoinTask<Cluster> task = pool.submit(Cluster::getInstance);
+      pool.submit(() -> {
+         try {
+            task.get(2L, TimeUnit.MINUTES);
+            clusterReady.set(true);
+            LOG.info("Cluster is ready");
+         }
+         catch(InterruptedException | ExecutionException | TimeoutException e) {
+            LOG.error("Failed to get cluster readiness, pod will not accept traffic", e);
+         }
+      });
+   }
+
+   @Override
+   protected AvailabilityState getState(ApplicationAvailability applicationAvailability) {
+      AvailabilityState state = super.getState(applicationAvailability);
+
+      if(state == ReadinessState.ACCEPTING_TRAFFIC) {
+         return clusterReady.get() ? state : ReadinessState.REFUSING_TRAFFIC;
+      }
+
+      return state;
+   }
+
+   private final AtomicBoolean clusterReady = new AtomicBoolean(false);
+   private static final Logger LOG = LoggerFactory.getLogger(ClusterReadinessHealthIndicator.class);
+}

--- a/server/src/main/java/inetsoft/web/health/ClusterReadinessHealthIndicator.java
+++ b/server/src/main/java/inetsoft/web/health/ClusterReadinessHealthIndicator.java
@@ -46,6 +46,10 @@ public class ClusterReadinessHealthIndicator extends ReadinessStateHealthIndicat
             clusterReady.set(true);
             LOG.info("Cluster is ready");
          }
+         catch(InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.error("Interrupted while waiting for cluster readiness, pod will not accept traffic", e);
+         }
          catch(Exception e) {
             LOG.error("Failed to initialize cluster, pod will not accept traffic", e);
          }
@@ -82,6 +86,6 @@ public class ClusterReadinessHealthIndicator extends ReadinessStateHealthIndicat
    }
 
    private final AtomicBoolean clusterReady = new AtomicBoolean(false);
-   private ExecutorService executor;
+   private volatile ExecutorService executor;
    private static final Logger LOG = LoggerFactory.getLogger(ClusterReadinessHealthIndicator.class);
 }

--- a/server/src/main/java/inetsoft/web/health/ClusterReadinessHealthIndicator.java
+++ b/server/src/main/java/inetsoft/web/health/ClusterReadinessHealthIndicator.java
@@ -46,10 +46,6 @@ public class ClusterReadinessHealthIndicator extends ReadinessStateHealthIndicat
             clusterReady.set(true);
             LOG.info("Cluster is ready");
          }
-         catch(InterruptedException e) {
-            Thread.currentThread().interrupt();
-            LOG.error("Interrupted while waiting for cluster readiness, pod will not accept traffic", e);
-         }
          catch(Exception e) {
             LOG.error("Failed to initialize cluster, pod will not accept traffic", e);
          }

--- a/server/src/main/java/inetsoft/web/health/ClusterReadinessHealthIndicator.java
+++ b/server/src/main/java/inetsoft/web/health/ClusterReadinessHealthIndicator.java
@@ -20,13 +20,15 @@ package inetsoft.web.health;
 
 import inetsoft.sree.internal.cluster.Cluster;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.availability.ReadinessStateHealthIndicator;
 import org.springframework.boot.availability.*;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Component
@@ -37,18 +39,35 @@ public class ClusterReadinessHealthIndicator extends ReadinessStateHealthIndicat
 
    @PostConstruct
    public void initClusterReadiness() {
-      ForkJoinPool pool = ForkJoinPool.commonPool();
-      ForkJoinTask<Cluster> task = pool.submit(Cluster::getInstance);
-      pool.submit(() -> {
+      this.executor = Executors.newSingleThreadExecutor();
+      this.executor.submit(() -> {
          try {
-            task.get(2L, TimeUnit.MINUTES);
+            Cluster.getInstance();
             clusterReady.set(true);
             LOG.info("Cluster is ready");
          }
-         catch(InterruptedException | ExecutionException | TimeoutException e) {
-            LOG.error("Failed to get cluster readiness, pod will not accept traffic", e);
+         catch(Exception e) {
+            LOG.error("Failed to initialize cluster, pod will not accept traffic", e);
+         }
+         finally {
+            ExecutorService exec = this.executor;
+
+            if(exec != null) {
+               exec.shutdown();
+               this.executor = null;
+            }
          }
       });
+   }
+
+   @PreDestroy
+   public void stopExecutor() {
+      ExecutorService exec = this.executor;
+
+      if(exec != null) {
+         exec.shutdown();
+         this.executor = null;
+      }
    }
 
    @Override
@@ -63,5 +82,6 @@ public class ClusterReadinessHealthIndicator extends ReadinessStateHealthIndicat
    }
 
    private final AtomicBoolean clusterReady = new AtomicBoolean(false);
+   private ExecutorService executor;
    private static final Logger LOG = LoggerFactory.getLogger(ClusterReadinessHealthIndicator.class);
 }

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -82,8 +82,8 @@ management:
             - fileSystem
         readiness:
           include:
-            - readinessState
-            - clusterReadiness
+            - readinessState # nosemgrep: java.spring.security.audit.spring-actuator-non-health-enabled-yaml.spring-actuator-dangerous-endpoints-enabled-yaml
+            - clusterReadiness # nosemgrep: java.spring.security.audit.spring-actuator-non-health-enabled-yaml.spring-actuator-dangerous-endpoints-enabled-yaml
       show-details: always
       show-components: always
   health:

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -80,6 +80,10 @@ management:
             - scheduler
             - securityProvider
             - fileSystem
+        readiness:
+          include:
+            - readinessState
+            - clusterReadiness
       show-details: always
       show-components: always
   health:

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -80,6 +80,7 @@ management:
             - scheduler
             - securityProvider
             - fileSystem
+            - clusterReadiness # nosemgrep: java.spring.security.audit.spring-actuator-non-health-enabled-yaml.spring-actuator-dangerous-endpoints-enabled-yaml
         readiness:
           include:
             - readinessState # nosemgrep: java.spring.security.audit.spring-actuator-non-health-enabled-yaml.spring-actuator-dangerous-endpoints-enabled-yaml
@@ -106,6 +107,8 @@ management:
     securityProvider:
       enabled: true
     fileSystem:
+      enabled: true
+    clusterReadiness:
       enabled: true
   server:
     port: 8081

--- a/utils/inetsoft-storage-mapdb/src/main/java/inetsoft/storage/mapdb/MapDBKeyValueEngine.java
+++ b/utils/inetsoft-storage-mapdb/src/main/java/inetsoft/storage/mapdb/MapDBKeyValueEngine.java
@@ -135,6 +135,11 @@ public class MapDBKeyValueEngine implements KeyValueEngine {
    }
 
    @Override
+   public long size(String id) {
+      return read(id, map -> (long) map.size());
+   }
+
+   @Override
    public <T> Stream<KeyValuePair<T>> stream(String id) {
       return read(id, (ConcurrentMap<String, T> map) -> map.entrySet()
          .stream()

--- a/utils/inetsoft-storage-mapdb/src/test/java/inetsoft/storage/mapdb/MapDBKeyValueEngineTests.java
+++ b/utils/inetsoft-storage-mapdb/src/test/java/inetsoft/storage/mapdb/MapDBKeyValueEngineTests.java
@@ -130,6 +130,13 @@ public class MapDBKeyValueEngineTests {
    }
 
    @Test
+   void sizeShouldReturnCount() {
+      long expected = expectedUsers.size();
+      long actual = engine.size("users");
+      assertEquals(expected, actual);
+   }
+
+   @Test
    void streamShouldReturnValues() {
       Map<String, TestData> actualUsers = new HashMap<>();
       engine.<TestData>stream("users").forEach(p -> actualUsers.put(p.getKey(), p.getValue()));


### PR DESCRIPTION
In a clustered Kubernetes deployment with no quorum, a simultaneous restart of all pods could cause all assets and properties to disappear. The root cause is that Ignite may not finish replicating distributed map data to the new pods before the old pods terminate. When LoadKeyValueTask runs on startup it only reloads from the backend store if the map is empty, so a partially-migrated map is kept as-is with missing entries.

Prevention: add ClusterReadinessHealthIndicator, a custom Spring Boot readiness probe that keeps the pod in REFUSING_TRAFFIC state until the Ignite cluster instance is available. Combined with correct maxUnavailable/maxSurge settings this prevents Kubernetes from terminating old pods before new ones have joined the cluster.

Recovery: extend LoadKeyValueTask to also reload when the distributed map size differs from the backend store size. A mismatch on startup is a reliable indicator that migration did not complete. Add KeyValueEngine.size() and implement it across all backends (filesystem, database, DynamoDB, CosmosDB, Firestore, MongoDB, MapDB) to support this check.