### PR TITLE
Skip session invalidation for WIZ requests in InvalidateSessionFilter

### DIFF
--- a/core/src/main/java/inetsoft/web/security/AbstractSecurityFilter.java
+++ b/core/src/main/java/inetsoft/web/security/AbstractSecurityFilter.java
@@ -560,6 +560,31 @@ public abstract class AbstractSecurityFilter
       return isPageRequested(apiTableExportPath, request);
    }
 
+   /**
+    * Determines if an HTTP request originates from the WIZ service — either by path
+    * ({@code /api/wiz/**}) or by the presence of the {@code wiz_auth} cookie set during
+    * WIZ service login. Requests matched by cookie alone may not target a WIZ endpoint
+    * (e.g. {@code getAssemblyImage}), but they are still authenticated by
+    * {@link inetsoft.web.wiz.security.WizServiceAuthenticationFilter} via JWT and must
+    * not have their sessions invalidated by the standard active-user check.
+    *
+    * @param request the HTTP request object.
+    * @return {@code true} if the request is a WIZ service request.
+    */
+   protected boolean isWizRequest(HttpServletRequest request) {
+      Cookie[] cookies = request.getCookies();
+
+      if(cookies != null) {
+         for(Cookie cookie : cookies) {
+            if(WIZ_AUTH_COOKIE.equals(cookie.getName())) {
+               return true;
+            }
+         }
+      }
+
+      return isPageRequested(wizApiPath, request);
+   }
+
    @Override
    public void sessionAccessed(SessionAccessDispatcher.SessionAccessEvent event) {
       // NO-OP
@@ -731,6 +756,8 @@ public abstract class AbstractSecurityFilter
    private static final String apiTableExportPath = "/api/table-export/**"; // NOSONAR not applicable
    private static final String apiPath = "/api/**"; // NOSONAR not applicable
    private static final String publicApiPath = "/api/public/**"; // NOSONAR not applicable
+   private static final String wizApiPath = "/api/wiz/**"; // NOSONAR not applicable
+   protected static final String WIZ_AUTH_COOKIE = "wiz_auth";
    private static final String teamWebsocketEndpointPath = "/reports/**"; // NOSONAR not applicable
    private static final String[] publicResources = {
       "/", "/index.html", "/add-license.html",

--- a/core/src/main/java/inetsoft/web/security/InvalidateSessionFilter.java
+++ b/core/src/main/java/inetsoft/web/security/InvalidateSessionFilter.java
@@ -50,7 +50,7 @@ public class InvalidateSessionFilter extends AbstractSecurityFilter {
       HttpSession session = httpRequest.getSession(false);
 
       if(session != null && !isPublicResource(httpRequest) &&
-         !isPublicApi(httpRequest))
+         !isPublicApi(httpRequest) && !isWizRequest(httpRequest))
       {
          SRPrincipal principal = (SRPrincipal) SUtil.getPrincipal(httpRequest);
 

--- a/core/src/main/java/inetsoft/web/wiz/security/WizServiceAuthenticationFilter.java
+++ b/core/src/main/java/inetsoft/web/wiz/security/WizServiceAuthenticationFilter.java
@@ -38,7 +38,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import org.springframework.util.AntPathMatcher;
 
 import java.io.IOException;
 import java.security.KeyPair;
@@ -85,7 +84,7 @@ public class WizServiceAuthenticationFilter extends AbstractSecurityFilter {
       HttpServletResponse httpResponse = (HttpServletResponse) response;
 
       // Only process requests to WIZ endpoints
-      if(!isWizApiRequest(httpRequest)) {
+      if(!isWizRequest(httpRequest)) {
          chain.doFilter(request, response);
          return;
       }
@@ -143,29 +142,6 @@ public class WizServiceAuthenticationFilter extends AbstractSecurityFilter {
          LOG.error("Error during WIZ service authentication", e);
          sendUnauthorized(httpResponse, "Authentication error");
       }
-   }
-
-   /**
-    * Checks if the request has a wiz_auth cookie.
-    */
-   private boolean isWizApiRequest(HttpServletRequest request) {
-      Cookie[] cookies = request.getCookies();
-
-      if(cookies != null) {
-         for(Cookie cookie : cookies) {
-            if(WIZ_AUTH_COOKIE.equals(cookie.getName())) {
-               return true;
-            }
-         }
-      }
-
-      String path = request.getServletPath();
-
-      if(request.getPathInfo() != null) {
-         path += request.getPathInfo();
-      }
-
-      return pathMatcher.match(WIZ_API_PATTERN, path);
    }
 
    /**
@@ -404,13 +380,9 @@ public class WizServiceAuthenticationFilter extends AbstractSecurityFilter {
 
    private KeyPair ssoKeyPair;
 
-   private final AntPathMatcher pathMatcher = new AntPathMatcher();
-   private static final String WIZ_API_PATTERN = "/api/wiz/**";
-
    private static final String AUTHORIZATION_HEADER = "Authorization";
    private static final String BEARER_PREFIX = "Bearer ";
    private static final String WIZ_AUTH_ENABLED_PROPERTY = "wiz.auth.enabled";
-   private static final String WIZ_AUTH_COOKIE = "wiz_auth";
 
    // Valid audiences for WIZ service tokens
    private static final List<String> VALID_AUDIENCES = Arrays.asList(


### PR DESCRIPTION
  WIZ principals are authenticated per-request via JWT and are not
  registered in SecurityEngine.users, so isActiveUser() always returns
  false, causing the session to be invalidated on every request. This
  rotated the CSRF token on each response, triggering an infinite
  chart-image reload loop in embed-chart.

  Extract isWizRequest() into AbstractSecurityFilter so both
  WizServiceAuthenticationFilter and InvalidateSessionFilter share the
  same wiz_auth cookie / path detection logic, mirroring the existing
  isPublicApi() exemption pattern.