### PR TITLE
Bug #74775: allow existing self-org users to log in when self-signup is disabled

### DIFF
--- a/core/src/main/java/inetsoft/web/security/BasicAuthenticationFilter.java
+++ b/core/src/main/java/inetsoft/web/security/BasicAuthenticationFilter.java
@@ -238,12 +238,10 @@ public class BasicAuthenticationFilter extends AbstractSecurityFilter {
                      // Site admin is replacing an existing session: authenticate without
                      // creating a session, then create the session with the replacement.
                      //check if user belongs to self org if not provided an organization via redirect
-                     if(SecurityEngine.getSecurity().isSelfSignupEnabled() &&
+                     if(SUtil.isMultiTenant() &&
                         recordedOrgID.equalsIgnoreCase(Organization.getDefaultOrganizationID()))
                      {
-                        IdentityID selfUser = SUtil.isMultiTenant() ?
-                           new IdentityID(userKey, Organization.getSelfOrganizationID()) :
-                           new IdentityID(userKey, Organization.getDefaultOrganizationID());
+                        IdentityID selfUser = new IdentityID(userKey, Organization.getSelfOrganizationID());
                         loginUser = selfUser;
                         principal = authenticate(request, selfUser, password, null, locale, false);
                      }
@@ -276,12 +274,10 @@ public class BasicAuthenticationFilter extends AbstractSecurityFilter {
                   }
                   else {
                      //check if user belongs to self org if not provided an organization via redirect
-                     if(SecurityEngine.getSecurity().isSelfSignupEnabled() &&
+                     if(SUtil.isMultiTenant() &&
                         recordedOrgID.equalsIgnoreCase(Organization.getDefaultOrganizationID()))
                      {
-                        IdentityID selfUser = SUtil.isMultiTenant() ?
-                           new IdentityID(userKey, Organization.getSelfOrganizationID()) :
-                           new IdentityID(userKey, Organization.getDefaultOrganizationID());
+                        IdentityID selfUser = new IdentityID(userKey, Organization.getSelfOrganizationID());
                         loginUser = selfUser;
 
                         principal =
@@ -295,11 +291,8 @@ public class BasicAuthenticationFilter extends AbstractSecurityFilter {
                      }
 
                      IdentityID loginAsUser = IdentityID.getIdentityIDFromKey(loginAsUserKey);
-                     boolean isSelfUser = loginAsUser != null &&
-                        Tool.equals(loginAsUser.orgID, Organization.getSelfOrganizationID());
-                     boolean selfLogin = isSelfUser && SecurityEngine.getSecurity().isSelfSignupEnabled();
 
-                     if(principal != null && (!isSelfUser || selfLogin)) {
+                     if(principal != null) {
                         authorized = true;
                         principal.setProperty("curr_provider_name", providerName);
 


### PR DESCRIPTION
## Summary

- The self-org authentication fallback in `BasicAuthenticationFilter` was gated by `isSelfSignupEnabled()`, which prevented existing self-org users from logging in whenever "Enable Self Signup" was turned off
- Self-signup controls new registrations only; existing users must always be able to authenticate regardless of that setting
- The same incorrect gate also blocked admin "login-as" impersonation of self-org users when self-signup was disabled

## Changes

**`core/src/main/java/inetsoft/web/security/BasicAuthenticationFilter.java`**

- Replaced `isSelfSignupEnabled()` with `SUtil.isMultiTenant()` as the guard on the self-org authentication fallback in both the normal login path and the session-replace path. `SUtil.isMultiTenant()` already implies `isSecurityEnabled()` (plus enterprise license and multi-tenant config), making it the correct condition — the self-org concept only exists in multi-tenant mode
- Simplified the `IdentityID` construction in the self-org block (the ternary's single-tenant branch was dead code since `isMultiTenant()` is now in the condition)
- Removed the `isSelfUser`/`selfLogin` variables and their `isSelfSignupEnabled()` gate on the login-as flow; the existing user-existence check at the point of impersonation is the correct guard

## Test plan

- [ ] Enable multi-tenancy, enable self-signup, create a self-org user with a password
- [ ] Disable self-signup
- [ ] Confirm the self-org user can still log in to the portal
- [ ] Confirm a site admin can use "login as" to impersonate the self-org user
- [ ] Confirm non-self-org users are unaffected
- [ ] Confirm new self-org signups are correctly blocked while self-signup is disabled

Fixes #74775

🤖 Generated with [Claude Code](https://claude.com/claude-code)