### PR TITLE
Bug #74769, fix schedule status page 500 error when user only has status permission

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/SchedulerConfigurationController.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/SchedulerConfigurationController.java
@@ -73,7 +73,7 @@ public class SchedulerConfigurationController implements MessageListener {
    @Secured(
       @RequiredPermission(
          resourceType = ResourceType.EM_COMPONENT,
-         resource = "settings/schedule/settings",
+         resource = "settings/schedule/status",
          actions = ResourceAction.ACCESS
       )
    )
@@ -85,7 +85,7 @@ public class SchedulerConfigurationController implements MessageListener {
    @Secured(
       @RequiredPermission(
          resourceType = ResourceType.EM_COMPONENT,
-         resource = "settings/schedule/settings",
+         resource = "settings/schedule/status",
          actions = ResourceAction.ACCESS
       )
    )


### PR DESCRIPTION
## Summary
- The `getStatus()` and `setStatus()` endpoints in `SchedulerConfigurationController` were secured with the wrong EM component resource (`settings/schedule/settings` instead of `settings/schedule/status`).
- A user with only the `settings/schedule/status` permission could see the Status tab in the navigation (correctly guarded on the frontend) but received a 500 `SecurityException` when the page loaded because the backend checked for `settings/schedule/settings` permission.
- Fixed by correcting the `@Secured` resource on both methods to `"settings/schedule/status"`.

## Test plan
- [ ] Enable security and create a non-admin user (e.g. `user0`)
- [ ] Grant `user0` access to Enterprise Manager
- [ ] Grant only `admin` access to `Enterprise Manager > Settings > Schedule > Settings`
- [ ] Log in as `user0` and navigate to `em/settings/schedule/status`
- [ ] Verify the Status page loads without a 500 error
- [ ] Verify that a user with `settings/schedule/settings` permission can still access the Settings tab normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)