### PR TITLE
Bug #74757, fix NotSerializableException when saving backup task with library assets

### DIFF
--- a/core/src/main/java/inetsoft/util/dep/ScriptAsset.java
+++ b/core/src/main/java/inetsoft/util/dep/ScriptAsset.java
@@ -53,7 +53,6 @@ public class ScriptAsset extends AbstractXAsset {
     */
    public ScriptAsset() {
       super();
-      libManagerProvider = LibManagerProvider.getInstance();
    }
 
    /**
@@ -61,7 +60,6 @@ public class ScriptAsset extends AbstractXAsset {
     * @param script the specified script function name.
     */
    public ScriptAsset(String script) {
-      this();
       this.script = script;
    }
 
@@ -72,7 +70,7 @@ public class ScriptAsset extends AbstractXAsset {
    @Override
    public XAssetDependency[] getDependencies(List<XAssetDependency> list) {
       List<XAssetDependency> deps = new ArrayList<>();
-      final LibManager manager = libManagerProvider.getManager();
+      final LibManager manager = LibManagerProvider.getInstance().getManager();
 
       if(manager.findScriptName(script) != null) {
          String check = manager.getScript(script);
@@ -260,7 +258,7 @@ public class ScriptAsset extends AbstractXAsset {
          return;
       }
 
-      LibManager manager = libManagerProvider.getManager();
+      LibManager manager = LibManagerProvider.getInstance().getManager();
       boolean overwriting = config != null && config.isOverwriting();
 
       if(manager.findScriptName(script) != null && !overwriting) {
@@ -302,7 +300,7 @@ public class ScriptAsset extends AbstractXAsset {
     */
    @Override
    public synchronized boolean writeContent(OutputStream output) throws Exception {
-      LibManager manager = libManagerProvider.getManager();
+      LibManager manager = LibManagerProvider.getInstance().getManager();
       String body = manager.getScript(script);
 
       if(body == null) {
@@ -351,12 +349,12 @@ public class ScriptAsset extends AbstractXAsset {
    }
 
    public LogicalLibraryEntry getLogicalLibraryEntry() {
-      return libManagerProvider.getManager().getLogicalLibraryEntry(script);
+      return LibManagerProvider.getInstance().getManager().getLogicalLibraryEntry(script);
    }
 
    @Override
    public boolean exists() {
-      return libManagerProvider.getManager().findScriptName(script) != null;
+      return LibManagerProvider.getInstance().getManager().findScriptName(script) != null;
    }
 
    @Override
@@ -375,7 +373,6 @@ public class ScriptAsset extends AbstractXAsset {
    }
 
    private String script;
-   private final LibManagerProvider libManagerProvider;
    private static final String COMMENT = "__COMMENT__";
    private static final String FILE_INFO="__FILEINFO__";
 }

--- a/core/src/main/java/inetsoft/util/dep/TableStyleAsset.java
+++ b/core/src/main/java/inetsoft/util/dep/TableStyleAsset.java
@@ -47,7 +47,6 @@ public class TableStyleAsset extends AbstractXAsset {
     */
    public TableStyleAsset() {
       super();
-      libManagerProvider = LibManagerProvider.getInstance();
    }
 
    /**
@@ -55,7 +54,6 @@ public class TableStyleAsset extends AbstractXAsset {
     * @param style the specified table style name.
     */
    public TableStyleAsset(String style) {
-      this();
       this.style = style;
    }
 
@@ -129,7 +127,7 @@ public class TableStyleAsset extends AbstractXAsset {
     * Get table style id by path
     */
    public String getStyleID() {
-      LibManager manager = libManagerProvider.getManager();
+      LibManager manager = LibManagerProvider.getInstance().getManager();
       XTableStyle tableStyle = manager.getTableStyle(style);
 
       if(tableStyle == null) {
@@ -140,7 +138,7 @@ public class TableStyleAsset extends AbstractXAsset {
    }
 
    public String getLabel() {
-      LibManager manager = libManagerProvider.getManager();
+      LibManager manager = LibManagerProvider.getInstance().getManager();
       XTableStyle tableStyle = manager.getTableStyle(style);
       return tableStyle.getName();
    }
@@ -172,7 +170,7 @@ public class TableStyleAsset extends AbstractXAsset {
          return;
       }
 
-      LibManager manager = libManagerProvider.getManager();
+      LibManager manager = LibManagerProvider.getInstance().getManager();
       String id = xstyle.getID();
       String name = xstyle.getName();
 
@@ -222,7 +220,7 @@ public class TableStyleAsset extends AbstractXAsset {
    public synchronized boolean writeContent(OutputStream output) throws Exception {
       String style0 = Tool.replaceAll(style, "/", "~");
       style0 = StyleTreeModel.getTableStyleID(style0);
-      LibManager manager = libManagerProvider.getManager();
+      LibManager manager = LibManagerProvider.getInstance().getManager();
       XTableStyle xstyle = manager.getTableStyle(style0);
 
       if(xstyle == null) {
@@ -242,7 +240,7 @@ public class TableStyleAsset extends AbstractXAsset {
    public XTableStyle getXTableStyle() {
       String id = Tool.replaceAll(style, "/", "~");
       id = StyleTreeModel.getTableStyleID(id);
-      return libManagerProvider.getManager().getTableStyle(id);
+      return LibManagerProvider.getInstance().getManager().getTableStyle(id);
    }
 
    @Override
@@ -267,5 +265,4 @@ public class TableStyleAsset extends AbstractXAsset {
 
    private String style;
    private String label;
-   private final LibManagerProvider libManagerProvider;
 }


### PR DESCRIPTION
## Summary

- `TableStyleAsset` and `ScriptAsset` both implement `XAsset` (which extends `Serializable`) but stored a `LibManagerProvider` instance field — a non-serializable Spring bean
- When saving a backup task that includes library assets (table styles or scripts), the `ScheduleTask` is marshalled over RMI to the scheduler process, causing `NotSerializableException: inetsoft.report.LibManagerProvider`
- Fix removes the instance field from both classes and replaces all usages with direct calls to `LibManagerProvider.getInstance()`

## Test plan

- [ ] In EM, create a new schedule task with a backup action
- [ ] Add a library asset (table style or script) to the backup action
- [ ] Save the task — should succeed without exception
- [ ] Verify the task appears in the scheduler and can be run

🤖 Generated with [Claude Code](https://claude.com/claude-code)