### PR TITLE
Bug #74752: handle HTTP errors in dashboard add/edit/delete

### DIFF
--- a/web/projects/portal/src/app/portal/dashboard/dashboard-tab.component.ts
+++ b/web/projects/portal/src/app/portal/dashboard/dashboard-tab.component.ts
@@ -218,25 +218,31 @@ export class DashboardTabComponent implements OnInit, OnDestroy {
          (result: string) => {
             if(result === "ok") {
                this.http.delete(DELETE_DASHBOARD_URI + this.selectedDashboard.name)
-                  .subscribe((success) => {
-                     if(success) {
-                        this.updateModel().subscribe((model) => {
-                           if(model.dashboards && model.dashboards.length > 0) {
-                              this.selectedDashboardIndex = 0;
-                              this.selectDashboard(model.dashboards[0]);
-                           }
-                           else {
-                              this.selectedDashboardIndex = -1;
-                              this.selectedDashboard = null;
-                              this.router.navigate(["/portal/tab/dashboard"]);
-                           }
-                        });
-                     }
-                     else {
+                  .subscribe(
+                     (success) => {
+                        if(success) {
+                           this.updateModel().subscribe((model) => {
+                              if(model.dashboards && model.dashboards.length > 0) {
+                                 this.selectedDashboardIndex = 0;
+                                 this.selectDashboard(model.dashboards[0]);
+                              }
+                              else {
+                                 this.selectedDashboardIndex = -1;
+                                 this.selectedDashboard = null;
+                                 this.router.navigate(["/portal/tab/dashboard"]);
+                              }
+                           });
+                        }
+                        else {
+                           ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)",
+                              "_#(js:viewer.dashboardDeleteError)");
+                        }
+                     },
+                     (err) => {
                         ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)",
-                           "_#(js:viewer.dashboardDeleteError)");
+                           "_#(js:common.noPermission)");
                      }
-                  });
+                  );
             }
          });
    }

--- a/web/projects/portal/src/app/portal/dialog/edit-dashboard-dialog.component.ts
+++ b/web/projects/portal/src/app/portal/dialog/edit-dashboard-dialog.component.ts
@@ -123,31 +123,41 @@ export class EditDashboardDialog implements OnInit {
          }
 
          this.http.get<boolean>(DASHBOARD_DUPLICATE_URI + encodeURIComponent(newDashboard.name))
-            .subscribe((duplicate) => {
-               if(duplicate) {
-                  ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)",
-                     "_#(js:viewer.dashboard.nameValid)");
-               }
-               else {
-                  this.http.post<DashboardModel>(NEW_DASHBOARD_URI, newDashboard)
-                     .subscribe(
-                        (dashboard: DashboardModel) => {
-                           if(this.compose) {
-                              const composerUrl = "composer";
-                              GuiTool.openBrowserTab(composerUrl,
-                                 new HttpParams()
-                                    .set("vsId", dashboard.identifier)
-                                    .set("deployed", "true")
-                              );
-                           }
+            .subscribe(
+               (duplicate) => {
+                  if(duplicate) {
+                     ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)",
+                        "_#(js:viewer.dashboard.nameValid)");
+                  }
+                  else {
+                     this.http.post<DashboardModel>(NEW_DASHBOARD_URI, newDashboard)
+                        .subscribe(
+                           (dashboard: DashboardModel) => {
+                              if(this.compose) {
+                                 const composerUrl = "composer";
+                                 GuiTool.openBrowserTab(composerUrl,
+                                    new HttpParams()
+                                       .set("vsId", dashboard.identifier)
+                                       .set("deployed", "true")
+                                 );
+                              }
 
-                           this.onCommit.emit(dashboard);
-                        },
-                        (err: any) => {
-                        }
-                     );
+                              this.onCommit.emit(dashboard);
+                           },
+                           (err: any) => {
+                              ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)",
+                                 "_#(js:common.noPermission)")
+                                 .then(() => this.onCancel.emit("cancel"));
+                           }
+                        );
+                  }
+               },
+               (err) => {
+                  ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)",
+                     "_#(js:common.noPermission)")
+                     .then(() => this.onCancel.emit("cancel"));
                }
-            });
+            );
       }
       // edit existing dashboard
       else {
@@ -157,15 +167,22 @@ export class EditDashboardDialog implements OnInit {
 
          if(this.oldName !== newDashboard.name) {
             this.http.get<boolean>(DASHBOARD_DUPLICATE_URI + encodeURIComponent(newDashboard.name))
-               .subscribe((duplicate) => {
-                  if(duplicate) {
+               .subscribe(
+                  (duplicate) => {
+                     if(duplicate) {
+                        ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)",
+                           "_#(js:viewer.nameValid)");
+                     }
+                     else {
+                        this.editDashboard(newDashboard);
+                     }
+                  },
+                  (err) => {
                      ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)",
-                        "_#(js:viewer.nameValid)");
+                        "_#(js:common.noPermission)")
+                        .then(() => this.onCancel.emit("cancel"));
                   }
-                  else {
-                     this.editDashboard(newDashboard);
-                  }
-               });
+               );
          }
          else {
             this.editDashboard(newDashboard);
@@ -189,7 +206,9 @@ export class EditDashboardDialog implements OnInit {
                this.onCommit.emit(dashboard);
             },
             (err: any) => {
-               console.error("Dashboard edit was unsuccessful.");
+               ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)",
+                  "_#(js:common.noPermission)")
+                  .then(() => this.onCancel.emit("cancel"));
             }
          );
    }


### PR DESCRIPTION
## Summary

- Add error handlers to the duplicate-name check `subscribe()` calls in `EditDashboardDialog.okClicked()` (new and edit flows) — previously unhandled 403 responses caused the dialog to freeze with no feedback
- Add error handler to the `editDashboard()` POST call, which previously only logged to the console and left the dialog open
- Add error handler to the `deleteDashboard()` HTTP delete call in `DashboardTabComponent`

When Dashboard tab permissions are revoked mid-session, all three operations (add, edit, delete) now show a "You don't have permission." message and close the dialog/surface the error to the user instead of silently failing.

## Test plan

- [ ] Enable multi-tenancy, create org, grant Dashboard tab + repository permissions to admin
- [ ] Log in as org admin and open the Dashboard tab
- [ ] Revoke Dashboard tab permission via EM while the portal is still open
- [ ] Attempt to add a dashboard — verify error dialog appears and the "New Pin" dialog closes
- [ ] Attempt to edit a dashboard — verify error dialog appears and dialog closes
- [ ] Attempt to delete a dashboard — verify error dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)