### PR TITLE
Bug #74750: handle permission error in InputNameDialog duplicate check

### DIFF
--- a/web/projects/portal/src/app/portal/data/input-name-desc-dialog/input-name-desc-dialog.component.ts
+++ b/web/projects/portal/src/app/portal/data/input-name-desc-dialog/input-name-desc-dialog.component.ts
@@ -26,6 +26,7 @@ import {
    OnChanges, ChangeDetectorRef, NgZone
 } from "@angular/core";
 import { UntypedFormControl, ValidatorFn } from "@angular/forms";
+import { HttpErrorResponse } from "@angular/common/http";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { Observable } from "rxjs";
 import { FormValidators } from "../../../../../../shared/util/form-validators";
@@ -107,6 +108,18 @@ export class InputNameDescDialog implements OnChanges, OnInit {
                   });
                }
             },
+            (error: HttpErrorResponse) => {
+               this.zone.run(() => {
+                  const message = error?.status === 403
+                     ? "_#(js:composer.authorization.permissionDenied)"
+                     : "_#(js:internal.error)";
+                  this.changeDetectorRef.detach();
+                  ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)", message).then(() => {
+                     this.changeDetectorRef.reattach();
+                     this.onCancel.emit("cancel");
+                  });
+               });
+            }
          );
       }
       else {

--- a/web/projects/portal/src/app/portal/data/input-name-desc-dialog/input-name-desc-dialog.component.ts
+++ b/web/projects/portal/src/app/portal/data/input-name-desc-dialog/input-name-desc-dialog.component.ts
@@ -111,7 +111,7 @@ export class InputNameDescDialog implements OnChanges, OnInit {
             (error: HttpErrorResponse) => {
                this.zone.run(() => {
                   const message = error?.status === 403
-                     ? "_#(js:composer.authorization.permissionDenied)"
+                     ? "_#(js:data.datasets.unauthorized)"
                      : "_#(js:internal.error)";
                   this.changeDetectorRef.detach();
                   ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)", message).then(() => {

--- a/web/projects/portal/src/app/widget/dialog/input-name-dialog/input-name-dialog.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/input-name-dialog/input-name-dialog.component.ts
@@ -116,7 +116,7 @@ export class InputNameDialog implements OnChanges, OnInit, AfterViewInit {
             (error: HttpErrorResponse) => {
                this.zone.run(() => {
                   const message = error?.status === 403
-                     ? "_#(js:composer.authorization.permissionDenied)"
+                     ? "_#(js:data.datasets.unauthorized)"
                      : "_#(js:internal.error)";
                   this.changeDetectorRef.detach();
                   ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)", message).then(() => {

--- a/web/projects/portal/src/app/widget/dialog/input-name-dialog/input-name-dialog.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/input-name-dialog/input-name-dialog.component.ts
@@ -33,6 +33,7 @@ import {
 import { UntypedFormControl, ValidatorFn } from "@angular/forms";
 import { FormValidators } from "../../../../../../shared/util/form-validators";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
+import { HttpErrorResponse } from "@angular/common/http";
 import { Observable } from "rxjs";
 import { ComponentTool } from "../../../common/util/component-tool";
 
@@ -112,12 +113,13 @@ export class InputNameDialog implements OnChanges, OnInit, AfterViewInit {
                   this.onCommit.emit(newName);
                }
             },
-            () => {
+            (error: HttpErrorResponse) => {
                this.zone.run(() => {
+                  const message = error?.status === 403
+                     ? "_#(js:composer.authorization.permissionDenied)"
+                     : "_#(js:internal.error)";
                   this.changeDetectorRef.detach();
-                  ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)",
-                     "_#(js:composer.authorization.permissionDenied)").then(() =>
-                  {
+                  ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)", message).then(() => {
                      this.changeDetectorRef.reattach();
                      this.onCancel.emit("cancel");
                   });

--- a/web/projects/portal/src/app/widget/dialog/input-name-dialog/input-name-dialog.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/input-name-dialog/input-name-dialog.component.ts
@@ -112,6 +112,17 @@ export class InputNameDialog implements OnChanges, OnInit, AfterViewInit {
                   this.onCommit.emit(newName);
                }
             },
+            () => {
+               this.zone.run(() => {
+                  this.changeDetectorRef.detach();
+                  ComponentTool.showMessageDialog(this.modalService, "_#(js:Error)",
+                     "_#(js:composer.authorization.permissionDenied)").then(() =>
+                  {
+                     this.changeDetectorRef.reattach();
+                     this.onCancel.emit("cancel");
+                  });
+               });
+            }
          );
       }
       else {


### PR DESCRIPTION
## Summary
- When the `isDuplicate` endpoint returns a 403 (e.g. the Data tab permission is revoked mid-session), the `InputNameDialog` now shows a permission-denied error dialog and closes, instead of freezing with an unhandled Observable error in the console.

## Root Cause
`InputNameDialog.ok()` subscribed to `hasDuplicateCheck` with no error handler. A 403 from the server caused the Observable to error, leaving the dialog frozen.

## Test plan
- [ ] Enable Multi-Tenancy; create an org and user
- [ ] Grant the user access to the Data portal tab and Data Worksheets
- [ ] Log in as the user and open the Data tab
- [ ] In EM, revoke the Data tab permission for the user (Deny access to all users)
- [ ] Click "New Folder" in the Data tab and submit a name — verify a permission-denied error dialog appears and the dialog closes
- [ ] Also verify the normal flow (user has permission): new folder creation still works correctly

Fixes #74750

🤖 Generated with [Claude Code](https://claude.com/claude-code)