### PR TITLE
Bug #74748, fix JobExecutionException when running scheduled tasks

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
@@ -67,6 +67,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Service;
 
@@ -94,7 +95,7 @@ public class CoreLifecycleService {
       VSLayoutService vsLayoutService, ParameterService parameterService,
       VSCompositionService vsCompositionService,
       DataRefModelFactoryService dataRefModelFactoryService,
-      RuntimeViewsheetRef runtimeViewsheetRef, ApplicationEventPublisher eventPublisher,
+      @Nullable RuntimeViewsheetRef runtimeViewsheetRef, ApplicationEventPublisher eventPublisher,
       LicenseManager licenseManager, SecurityEngine securityEngine, Cluster cluster,
       DataSourceRegistry dataSourceRegistry)
    {
@@ -3274,6 +3275,7 @@ public class CoreLifecycleService {
 
    private final VSCompositionService vsCompositionService;
    private final DataRefModelFactoryService dataRefModelFactoryService;
+   @Nullable
    private final RuntimeViewsheetRef runtimeViewsheetRef;
    private final ApplicationEventPublisher eventPublisher;
    private final LicenseManager licenseManager;

--- a/schedule-server/src/main/java/inetsoft/sree/schedule/ScheduleServerApplication.java
+++ b/schedule-server/src/main/java/inetsoft/sree/schedule/ScheduleServerApplication.java
@@ -21,11 +21,12 @@ import inetsoft.sree.UserEnv;
 import inetsoft.util.*;
 import inetsoft.util.config.InetsoftConfig;
 import inetsoft.util.log.LogManager;
+import inetsoft.web.viewsheet.model.RuntimeViewsheetRef;
 import org.apache.commons.lang3.SystemUtils;
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.boot.*;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.*;
 import org.springframework.core.io.ClassPathResource;
 
 import java.io.File;
@@ -47,8 +48,17 @@ import java.util.*;
    "inetsoft.util",
    "inetsoft.sree",
    "inetsoft.storage",
-   "inetsoft.web.factory"
-})
+   "inetsoft.web.factory",
+   "inetsoft.web.viewsheet.service",
+   "inetsoft.web.viewsheet.model",
+   "inetsoft.web.composer.vs.controller",
+   "inetsoft.web.binding.service",
+   "inetsoft.web.binding.drm",
+   "inetsoft.web.binding.model"
+}, excludeFilters = @ComponentScan.Filter(
+   type = FilterType.ASSIGNABLE_TYPE,
+   classes = RuntimeViewsheetRef.class
+))
 @Import(ScheduleServerContext.class)
 public class ScheduleServerApplication {
    public static void main(String[] args) {

--- a/schedule-server/src/main/java/inetsoft/sree/schedule/ScheduleServerApplication.java
+++ b/schedule-server/src/main/java/inetsoft/sree/schedule/ScheduleServerApplication.java
@@ -21,6 +21,7 @@ import inetsoft.sree.UserEnv;
 import inetsoft.util.*;
 import inetsoft.util.config.InetsoftConfig;
 import inetsoft.util.log.LogManager;
+import inetsoft.web.composer.vs.controller.VSLayoutService;
 import inetsoft.web.viewsheet.model.RuntimeViewsheetRef;
 import org.apache.commons.lang3.SystemUtils;
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
@@ -55,7 +56,6 @@ import java.util.*;
       "inetsoft.web.factory",
       "inetsoft.web.viewsheet.service",
       "inetsoft.web.viewsheet.model",
-      "inetsoft.web.composer.vs.controller",
       "inetsoft.web.binding.service",
       "inetsoft.web.binding.drm",
       "inetsoft.web.binding.model"
@@ -66,7 +66,7 @@ import java.util.*;
       @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = RuntimeViewsheetRef.class)
    }
 )
-@Import(ScheduleServerContext.class)
+@Import({ ScheduleServerContext.class, VSLayoutService.class })
 public class ScheduleServerApplication {
    public static void main(String[] args) {
       ApplicationArguments appArguments = new DefaultApplicationArguments(args);

--- a/schedule-server/src/main/java/inetsoft/sree/schedule/ScheduleServerApplication.java
+++ b/schedule-server/src/main/java/inetsoft/sree/schedule/ScheduleServerApplication.java
@@ -25,7 +25,9 @@ import inetsoft.web.viewsheet.model.RuntimeViewsheetRef;
 import org.apache.commons.lang3.SystemUtils;
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.boot.*;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.context.annotation.*;
 import org.springframework.core.io.ClassPathResource;
 
@@ -43,22 +45,27 @@ import java.util.*;
  * here before the application context is started. RMI binding and scheduler startup
  * are handled by {@link ScheduleServerContext}.
  */
-@SpringBootApplication(scanBasePackages = {
-   "inetsoft.sree.schedule",
-   "inetsoft.util",
-   "inetsoft.sree",
-   "inetsoft.storage",
-   "inetsoft.web.factory",
-   "inetsoft.web.viewsheet.service",
-   "inetsoft.web.viewsheet.model",
-   "inetsoft.web.composer.vs.controller",
-   "inetsoft.web.binding.service",
-   "inetsoft.web.binding.drm",
-   "inetsoft.web.binding.model"
-}, excludeFilters = @ComponentScan.Filter(
-   type = FilterType.ASSIGNABLE_TYPE,
-   classes = RuntimeViewsheetRef.class
-))
+@SpringBootApplication
+@ComponentScan(
+   basePackages = {
+      "inetsoft.sree.schedule",
+      "inetsoft.util",
+      "inetsoft.sree",
+      "inetsoft.storage",
+      "inetsoft.web.factory",
+      "inetsoft.web.viewsheet.service",
+      "inetsoft.web.viewsheet.model",
+      "inetsoft.web.composer.vs.controller",
+      "inetsoft.web.binding.service",
+      "inetsoft.web.binding.drm",
+      "inetsoft.web.binding.model"
+   },
+   excludeFilters = {
+      @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+      @ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class),
+      @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = RuntimeViewsheetRef.class)
+   }
+)
 @Import(ScheduleServerContext.class)
 public class ScheduleServerApplication {
    public static void main(String[] args) {


### PR DESCRIPTION
## Summary

- Expands the schedule-server component scan to include the packages required by `CoreLifecycleService` and its transitive dependencies (`inetsoft.web.viewsheet.service`, `.model`, `inetsoft.web.composer.vs.controller`, `inetsoft.web.binding.service`, `.drm`, `.model`)
- Excludes `RuntimeViewsheetRef` from the scheduler scan — it is `@Scope("message")` (STOMP WebSocket session scope) and cannot be instantiated outside a web context
- Marks the `RuntimeViewsheetRef` constructor parameter and field in `CoreLifecycleService` as `@Nullable` so Spring injects `null` in the scheduler (where the bean is absent) while the web server continues to inject the normal scoped proxy

## Root cause

Commit 4b90649 (Feature #36295) converted `ScheduleViewsheetService` from a `@SingletonManager.Singleton` to a `@Service` Spring bean and converted `CoreLifecycleService` from a manually constructed object to a Spring-injected dependency. However, the schedule-server's `ScheduleServerApplication` had a narrower component scan that did not include `inetsoft.web.viewsheet.service` (where `CoreLifecycleService` lives) or any of its required dependencies. When `ViewsheetAction.run()` called `ScheduleViewsheetService.getInstance()`, Spring attempted to lazily instantiate the bean and failed with `UnsatisfiedDependencyException` because `CoreLifecycleService` could not be created.

## Test plan

- [ ] Start the schedule server and create a new task that runs a viewsheet action — confirm it completes without `JobExecutionException`
- [ ] Confirm the main web server starts and opens viewsheets normally (no regression in `CoreLifecycleService` injection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)