### PR TITLE
Bug #74747, fix NPE when defining ad hoc filter on crosstab with cancelled query

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/controller/FormatPainterService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/FormatPainterService.java
@@ -231,7 +231,14 @@ public class FormatPainterService {
             return null;
          }
 
-         VSTableLens lens = box.get().getVSTableLens(oname, detail);
+         VSTableLens lens;
+
+         try {
+            lens = box.get().getVSTableLens(oname, detail);
+         }
+         catch(CancelledException ignored) {
+            return null;
+         }
 
          if(lens == null || !lens.moreRows(event.getRow()) ||
             event.getColumn() >= lens.getColCount())

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerAdhocFilterService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerAdhocFilterService.java
@@ -112,7 +112,17 @@ public class ComposerAdhocFilterService {
          }
 
          VSTableLens lens = box.get().getVSTableLens(oname, detail);
+
+         if(lens == null) {
+            return null;
+         }
+
          TableDataPath tpath = lens.getTableDataPath(event.getRow(), event.getCol());
+
+         if(tpath == null) {
+            return null;
+         }
+
          String[] path = tpath.getPath();
 
          if(path != null) {
@@ -301,6 +311,11 @@ public class ComposerAdhocFilterService {
       }
 
       VSTableLens lens = box.get().getVSTableLens(oname, detail);
+
+      if(lens == null) {
+         return null;
+      }
+
       TableDataPath tpath = lens.getTableDataPath(row, col);
 
       return VSTableService.getCrosstabCellDataRef(table.getVSCrosstabInfo(), tpath, row,


### PR DESCRIPTION
## Summary
- Fix NPE in `ComposerAdhocFilterService.getCellDataRef()` when `getVSTableLens()` returns null (e.g. after a viewsheet import resets the sandbox cache)
- Fix same null-lens issue in the `CalcTableVSAssembly` branch of `addTableFilter()`
- Catch `CancelledException` in `FormatPainterService.getFormat()` when the crosstab query is independently cancelled, preventing an unhandled exception from surfacing to the user

## Test plan
- [ ] Import a viewsheet containing a crosstab, open it in the composer, click a measure cell, and select "Define Filter" — confirm no NPE popup appears
- [ ] Verify that defining an ad hoc filter on a normal (non-imported) crosstab still works correctly
- [ ] Verify that defining an ad hoc filter on a CalcTable still works correctly
- [ ] Confirm the format toolbar still populates when selecting crosstab cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)