### PR TITLE
Bug #74737, fix NPE when SQL query session expires before user submits

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
@@ -949,6 +949,11 @@ public class QueryManagerService {
       RuntimeQueryService.RuntimeXQuery runtimeQuery =
          runtimeQueryService.getRuntimeQuery(model.getRuntimeId());
 
+      if(runtimeQuery == null) {
+         throw new MessageException(
+            "The query session has expired. Please close and reopen the query editor.");
+      }
+
       JDBCQuery query = createNewQuery(name, database);
       runtimeQuery.setQuery(query);
       TableAssembly assembly = (TableAssembly) rws.getWorksheet().getAssembly(model.getName());
@@ -1190,6 +1195,12 @@ public class QueryManagerService {
    private BasicSQLQueryModel processConvertToSimpleQuery(String runtimeQueryId) {
       RuntimeQueryService.RuntimeXQuery runtimeQuery =
          runtimeQueryService.getRuntimeQuery(runtimeQueryId);
+
+      if(runtimeQuery == null) {
+         throw new MessageException(
+            "The query session has expired. Please close and reopen the query editor.");
+      }
+
       JDBCQuery query = runtimeQuery.getQuery();
       BasicSQLQueryModel model = new BasicSQLQueryModel();
 
@@ -1502,6 +1513,11 @@ public class QueryManagerService {
    {
       RuntimeQueryService.RuntimeXQuery runtimeQuery =
          runtimeQueryService.getRuntimeQuery(runtimeId);
+
+      if(runtimeQuery == null) {
+         return null;
+      }
+
       JDBCQuery query = runtimeQuery.getQuery();
 
       if(!StringUtils.isEmpty(nSqlString)) {
@@ -1545,6 +1561,11 @@ public class QueryManagerService {
       throws Exception
    {
       RuntimeQueryService.RuntimeXQuery runtimeQuery = runtimeQueryService.getRuntimeQuery(runtimeId);
+
+      if(runtimeQuery == null) {
+         return;
+      }
+
       VariableTable vtable = runtimeQuery.getVariables();
       vtable.addAll(VariableAssemblyModelInfo.getVariableTable(variables));
       runtimeQueryService.saveRuntimeQuery(runtimeQuery);
@@ -1556,6 +1577,12 @@ public class QueryManagerService {
    {
       RuntimeQueryService.RuntimeXQuery runtimeQuery =
          runtimeQueryService.getRuntimeQuery(event.getRuntimeId());
+
+      if(runtimeQuery == null) {
+         throw new MessageException(
+            "The query session has expired. Please close and reopen the query editor.");
+      }
+
       String sqlString = event.getSqlString();
       JDBCQuery query = runtimeQuery.getQuery();
       JDBCQuery nquery = query.clone();
@@ -1614,6 +1641,11 @@ public class QueryManagerService {
    public void clearColumnInfo(String runtimeId) {
       RuntimeQueryService.RuntimeXQuery runtimeQuery =
          runtimeQueryService.getRuntimeQuery(runtimeId);
+
+      if(runtimeQuery == null) {
+         return;
+      }
+
       JDBCQuery query = runtimeQuery.getQuery();
       SQLDefinition sqlDefinition = query.getSQLDefinition();
       UniformSQL sql = (UniformSQL) sqlDefinition;
@@ -1636,6 +1668,12 @@ public class QueryManagerService {
    {
       RuntimeQueryService.RuntimeXQuery runtimeQuery =
          runtimeQueryService.getRuntimeQuery(runtimeId);
+
+      if(runtimeQuery == null) {
+         throw new MessageException(
+            "The query session has expired. Please close and reopen the query editor.");
+      }
+
       JDBCQuery query = runtimeQuery.getQuery();
       SQLDefinition sqlDefinition = query.getSQLDefinition();
       UniformSQL sql = (UniformSQL) sqlDefinition;
@@ -1797,6 +1835,12 @@ public class QueryManagerService {
    {
       RuntimeQueryService.RuntimeXQuery runtimeQuery =
          runtimeQueryService.getRuntimeQuery(runtimeId);
+
+      if(runtimeQuery == null) {
+         throw new MessageException(
+            "The query session has expired. Please close and reopen the query editor.");
+      }
+
       JDBCQuery query = runtimeQuery.getQuery();
 
       if(sqlString != null) {


### PR DESCRIPTION
## Summary

- Fixes NullPointerException thrown when a SQL query editor session expires (3-minute TTL) and the user then interacts with the dialog (switches edit mode, edits SQL, previews data, etc.)
- Added null guards to 8 methods in `QueryManagerService` that called `getRuntimeQuery()` without checking for a `null` result
- User-facing actions now throw a `MessageException` with a clear message; side-effect-only helpers return early

## Test plan

- [ ] Open the SQL query editor on a worksheet
- [ ] Wait more than 3 minutes without interacting
- [ ] Click OK / switch between Simple and Advanced mode — verify a user-friendly error message appears instead of a console NPE
- [ ] Verify normal query editing flow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)