### PR TITLE
Bug #74731, fix dashboard creation error when security is disabled

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/DashboardController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/DashboardController.java
@@ -254,8 +254,9 @@ public class DashboardController {
       String type;
       boolean composedDashboard = false;
 
-      Identity identity = getIdentity((XPrincipal) principal);
-      IdentityID user = identity.getIdentityID();
+      IdentityID user = principal != null
+         ? getIdentity((XPrincipal) principal).getIdentityID()
+         : new IdentityID(XPrincipal.ANONYMOUS, Organization.getDefaultOrganizationID());
       DashboardRegistry registry = dashboardRegistryManager.getRegistry(user);
       // log create dashboard action
       String actionName = ActionRecord.ACTION_NAME_CREATE;
@@ -276,7 +277,7 @@ public class DashboardController {
          AssetEntry entry;
 
          if(identifier == null) {
-            owner = identity.getIdentityID();
+            owner = user;
             AssetRepository engine = AssetUtil.getAssetRepository(false);
             entry = new AssetEntry(AssetRepository.USER_SCOPE,
                AssetEntry.Type.VIEWSHEET, dashboardModel.name(), owner);
@@ -405,7 +406,7 @@ public class DashboardController {
          AssetEntry entry;
 
          if(identifier == null) {
-            owner = principal == null ? null : IdentityID.getIdentityIDFromKey(principal.getName());
+            owner = user;
             AssetRepository engine = viewsheetService.getAssetRepository();
             entry = new AssetEntry(AssetRepository.USER_SCOPE,
                AssetEntry.Type.VIEWSHEET, dashboardModel.name(), owner);

--- a/core/src/main/java/inetsoft/web/portal/controller/DashboardController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/DashboardController.java
@@ -140,8 +140,9 @@ public class DashboardController {
    {
       try {
          Catalog catalog = Catalog.getCatalog(principal, Catalog.REPORT);
-         IdentityID user = principal != null ? IdentityID.getIdentityIDFromKey(principal.getName()) :
-            new IdentityID(XPrincipal.ANONYMOUS, Organization.getDefaultOrganizationID());
+         IdentityID user = principal != null
+            ? getIdentity((XPrincipal) principal).getIdentityID()
+            : new IdentityID(XPrincipal.ANONYMOUS, Organization.getDefaultOrganizationID());
          DashboardRegistry uregistry = dashboardRegistryManager.getRegistry(user);
          DashboardRegistry registry = dashboardRegistryManager.getRegistry();
          Dashboard dashboard;
@@ -253,8 +254,8 @@ public class DashboardController {
       String type;
       boolean composedDashboard = false;
 
-      IdentityID user = principal != null ? IdentityID.getIdentityIDFromKey(principal.getName()) :
-         new IdentityID(XPrincipal.ANONYMOUS, Organization.getDefaultOrganizationID());
+      Identity identity = getIdentity((XPrincipal) principal);
+      IdentityID user = identity.getIdentityID();
       DashboardRegistry registry = dashboardRegistryManager.getRegistry(user);
       // log create dashboard action
       String actionName = ActionRecord.ACTION_NAME_CREATE;
@@ -264,7 +265,6 @@ public class DashboardController {
       ActionRecord actionRecord = new ActionRecord(SUtil.getUserName(principal),
                                                    actionName, objectName, objectType, actionTimestamp,
                                                    ActionRecord.ACTION_STATUS_FAILURE, null);
-      Identity identity = getIdentity((XPrincipal) principal);
 
       try {
          actionRecord.setObjectName(dashboardModel.name());
@@ -366,8 +366,9 @@ public class DashboardController {
       boolean composedDashboard = false;
 
       ActionRecord actionRecord = null;
-      IdentityID user = principal != null ? IdentityID.getIdentityIDFromKey(principal.getName()) :
-         new IdentityID(XPrincipal.ANONYMOUS, Organization.getDefaultOrganizationID());
+      IdentityID user = principal != null
+         ? getIdentity((XPrincipal) principal).getIdentityID()
+         : new IdentityID(XPrincipal.ANONYMOUS, Organization.getDefaultOrganizationID());
       DashboardRegistry registry = dashboardRegistryManager.getRegistry(user);
       Catalog catalog = Catalog.getCatalog();
 
@@ -561,8 +562,9 @@ public class DashboardController {
             Catalog.getCatalog().getString("dashboard.globalCopyLabel"));
          actionRecord.setObjectName(historyName);
 
-         IdentityID user = principal != null ? IdentityID.getIdentityIDFromKey(principal.getName()) :
-            new IdentityID(XPrincipal.ANONYMOUS, Organization.getDefaultOrganizationID());
+         IdentityID user = principal != null
+            ? getIdentity((XPrincipal) principal).getIdentityID()
+            : new IdentityID(XPrincipal.ANONYMOUS, Organization.getDefaultOrganizationID());
          DashboardRegistry registry;
 
          if(dashboardName.endsWith("__GLOBAL")) {


### PR DESCRIPTION
## Summary

- When security is disabled, `getIdentity()` returns the `ANONYMOUS` identity, but four methods in `DashboardController` (`getDashboardModel`, `newDashboard`, `editDashboard`, `deleteDashboard`) were still deriving the registry user from `principal.getName()` (the real user, e.g. `admin`)
- This caused a mismatch with `DashboardManager`, which validates selected dashboards against the ANONYMOUS registry and discards any not found there, resulting in a "Dashboard not found" error immediately after creation
- Fixed by using `getIdentity((XPrincipal) principal).getIdentityID()` consistently in all four methods, matching what `getDashboards` and `isDashboardNameDuplicate` already did

## Test plan

- [ ] With security disabled, create a new dashboard — verify it appears and opens without error
- [ ] With security enabled, create/edit/delete dashboards — verify no regression in behavior
- [ ] Verify global dashboards (ending in `__GLOBAL`) still resolve via the global registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)