### PR TITLE
Bug #74710, disable JAR upload for global themes when viewed by org-admin

### DIFF
--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-properties-view/theme-properties-view.component.html
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-properties-view/theme-properties-view.component.html
@@ -31,7 +31,7 @@
         </mat-form-field>
         <mat-form-field appearance="outline" color="accent">
           <mat-label>_#(Theme JAR File)</mat-label>
-          <em-file-chooser [hidden]="form.disabled" formControlName="jar" placeholder="_#(Theme JAR File)" accept=".jar"></em-file-chooser>
+          <em-file-chooser [hidden]="jarHidden" formControlName="jar" placeholder="_#(Theme JAR File)" accept=".jar"></em-file-chooser>
           <mat-icon matSuffix fontSet="ineticons" fontIcon="folder-open-icon"></mat-icon>
           <mat-error *ngIf="form.controls.jar?.errors?.required">_#(em.laf.theme.jarRequired)</mat-error>
         </mat-form-field>

--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-properties-view/theme-properties-view.component.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-properties-view/theme-properties-view.component.ts
@@ -131,6 +131,10 @@ export class ThemePropertiesViewComponent implements OnInit, OnDestroy {
       return this.orgId == "host-org";
    }
 
+   get jarHidden(): boolean {
+      return this._isMultiTenant && !this._isSiteAdmin && !!this._theme?.global;
+   }
+
    private updateFormState(): void {
       if(!this.form || !this.theme) {
          return;


### PR DESCRIPTION
## Summary
- Org-admin users viewing a global theme in EM could trigger the JAR file picker, even though the form appeared disabled
- Root cause: re-enabling `defaultThemeOrg` after `form.disable()` caused Angular to recalculate `form.disabled` to `false` (a FormGroup is only `disabled` when *all* its controls are disabled), inadvertently unhiding the file chooser
- Fix: replace `[hidden]="form.disabled"` with `[hidden]="jarHidden"` where `jarHidden` is an explicit getter that directly checks `isMultiTenant && !isSiteAdmin && theme.global`

## Test plan
- [ ] Enable security and multi-tenancy
- [ ] Log in as site-admin, create a global theme (Visible to All Organizations checked)
- [ ] Create an org and an org-admin user
- [ ] Log in as the org-admin, navigate to EM → Presentation → Themes, select the global theme
- [ ] Verify the Theme JAR File field does not open a file picker when clicked
- [ ] Verify org-admin can still set/unset Default for This Organization on the global theme
- [ ] Verify site-admin can still upload a JAR for the global theme
- [ ] Verify org-admin can still upload a JAR for an org-scoped theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)