### PR TITLE
Performance: remove dead Style Studio code and fix hot-path overhead

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/internal/AssetUtil.java
+++ b/core/src/main/java/inetsoft/uql/asset/internal/AssetUtil.java
@@ -2129,7 +2129,7 @@ public class AssetUtil {
       boolean view, boolean out)
    {
       List<Assembly> assemblies = new ArrayList<>();
-      getDependedAssemblies0(sheet, assembly, assemblies, included, view, out);
+      getDependedAssemblies0(sheet, assembly, assemblies, new HashSet<>(), included, view, out);
       Assembly[] arr = new Assembly[assemblies.size()];
       assemblies.toArray(arr);
 
@@ -2142,14 +2142,15 @@ public class AssetUtil {
     * @param sheet      the specified sheet container.
     * @param assembly   the specified assembly.
     * @param assemblies the assembly container.
+    * @param visited    tracks visited assemblies for O(1) cycle detection.
     * @param included   <tt>true</tt> to include itself, <tt>false</tt> otherwise.
     * @return all the assemblies depended on.
     */
    private static void getDependedAssemblies0(
       AbstractSheet sheet, Assembly assembly, List<Assembly> assemblies,
-      boolean included, boolean view, boolean out)
+      Set<Assembly> visited, boolean included, boolean view, boolean out)
    {
-      if(assemblies.contains(assembly)) {
+      if(!visited.add(assembly)) {
          return;
       }
 
@@ -2176,7 +2177,7 @@ public class AssetUtil {
             continue;
          }
 
-         getDependedAssemblies0(sheet, assembly2, assemblies, true, view, out);
+         getDependedAssemblies0(sheet, assembly2, assemblies, visited, true, view, out);
       }
    }
 

--- a/core/src/main/java/inetsoft/uql/service/XEngine.java
+++ b/core/src/main/java/inetsoft/uql/service/XEngine.java
@@ -1002,34 +1002,6 @@ public class XEngine implements XRepository, XQueryRepository {
       return dx.getParameters();
    }
 
-   private void closeInvalidConnection(Object session, XQuery xquery) throws RemoteException {
-      if(xquery == null) {
-         throw new RemoteException("Query not found!");
-      }
-
-      XDataSource dx = xquery.getDataSource();
-
-      dx = ConnectionProcessor.getInstance().getAdditionalConnection(dx);
-
-      Pair pair = new Pair(session, dx);
-      XHandler handler = sessionrun.get(pair);
-
-      if(handler instanceof JDBCHandler) {
-         JDBCDataSource connectionDx = ((JDBCHandler) handler).getDataSource();
-
-         if(connectionDx != null && connectionDx.isRequireLogin() && connectionDx.getUser() == null) {
-            try {
-               handler.close();
-            }
-            catch(Exception ex) {
-               LOG.error("Failed to close handler for {}", pair, ex);
-            }
-
-            this.sessionrun.remove(pair);
-         }
-      }
-   }
-
    /**
     * Get the parameters for a query. The parameters should be filled in
     * and passed to execute().
@@ -1058,7 +1030,6 @@ public class XEngine implements XRepository, XQueryRepository {
    private void populateVariables(Object session, XQuery xquery, List<UserVariable> vars,
                                   boolean promptOnly) throws RemoteException
    {
-      closeInvalidConnection(session, xquery);
       appendArrayToVector(vars, getConnectionParameters(session, xquery));
       appendArrayToVector(vars, VpmProcessor.getInstance().getVPMParameters(xquery, ThreadContext.getContextPrincipal(), promptOnly));
 
@@ -1740,12 +1711,6 @@ public class XEngine implements XRepository, XQueryRepository {
          if(getConnectionParameters(session, dx) != null) {
             vars = new VariableTable();
             Principal principal = ThreadContext.getContextPrincipal();
-            boolean resetParameters = dx instanceof JDBCDataSource &&
-               ((JDBCDataSource) dx).isRequireLogin() && !((JDBCDataSource) dx).isRequireSave();
-
-            if(resetParameters) {
-               ((JDBCDataSource) dx).setUser(null);
-            }
 
             if(principal instanceof XPrincipal) {
                Object username = ((XPrincipal) principal).getParameter(


### PR DESCRIPTION
AssetUtil.getDependedAssemblies0 cycle detection changed from List.contains() O(n²) to a separate HashSet for O(n) traversal.

XEngine.closeInvalidConnection called getAdditionalConnection on every query parameter lookup, triggering an Ignite roundtrip per assembly. Removed along with resetParameters/setUser(null) in getMetaDataInternal — both dead since Style Studio was removed and isRequireSave() always returns true.