### PR TITLE
Bug #74751, data tip components with OnPush CD lag behind scroll position

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/data-tip/vs-data-tip.directive.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/data-tip/vs-data-tip.directive.ts
@@ -166,8 +166,17 @@ export class VSDataTipDirective implements DoCheck {
                left += popInfo.left - containerInfo.left;
             }
 
-            this.renderer.setStyle(nativeElement, "left", left + "px");
-            this.renderer.setStyle(nativeElement, "top", top + "px");
+            // Only reposition focus-assembly elements. Component outer divs own their
+            // top/left via template bindings, so overriding them here breaks OnPush
+            // components (e.g. vs-crosstab) that don't re-evaluate bindings on scroll.
+            const isFocusAssembly = nativeElement.classList.contains("focus-assembly");
+
+            if(isFocusAssembly) {
+               this.renderer.setStyle(nativeElement, "left", left + "px");
+               this.renderer.setStyle(nativeElement, "top", top + "px");
+               this.renderer.setStyle(nativeElement, "position", "absolute");
+            }
+
             this.renderer.addClass(nativeElement, this.dataTipClass);
 
             if(!this.miniToolbar) {
@@ -181,8 +190,6 @@ export class VSDataTipDirective implements DoCheck {
                this.renderer.setStyle(this.elementRef.nativeElement, "display", "block");
                this.renderer.setStyle(nativeElement, "width", mainComponent.clientWidth + "px");
             }
-
-            this.renderer.setStyle(nativeElement, "position", "absolute");
             // background set on the server so alpha can be applied to all backgrounds
             //this.renderer.setStyle(nativeElement, "background", "rgba(245,245,245,1.0)");
             let showingComponent = this.popService.hasPopUpComponentShowing();


### PR DESCRIPTION
## Summary

- The `VSDataTip` directive was setting `top`/`left`/`position` imperatively on every element matching the current data tip, including component outer divs that have their own `[style.top.px]` Angular template bindings.
- For `OnPush` components (`VSCrosstab`, `VSTable`, `VSCalcTable`, `VSSelection`), those template bindings do not re-evaluate during scroll events, so the directive's stale viewport-compensated value persisted, making the component appear fixed in the viewport instead of scrolling with the viewsheet content.
- Fixed by restricting imperative `top`/`left`/`position` updates to `focus-assembly` elements only. All other elements have their position owned by their own template bindings and are unaffected by this change.

## Test plan

- [ ] Open a viewsheet that has a data tip view containing a table/crosstab. Trigger the data tip (hover or click). Scroll the viewsheet and verify the table in the data tip view scrolls correctly with the content.
- [ ] Verify data tip views containing only charts still function correctly.
- [ ] Verify data tip positioning (appears near the triggered data point) is unchanged.
- [ ] Verify frozen data tips (click-to-freeze) still work correctly including hide-on-outside-click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)