### PR TITLE
Bug #74766, show incomplete user warning when creating a new organization

### DIFF
--- a/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.ts
+++ b/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.ts
@@ -270,6 +270,10 @@ export class UsersSettingsPageComponent implements OnInit, OnDestroy {
    }
 
    public newOrganization(event: {parentGroup: string, defaultPassword?: string}) {
+      this.withIncompleteUserGuard(() => this.createNewOrganization(event));
+   }
+
+   private createNewOrganization(event: {parentGroup: string, defaultPassword?: string}) {
       this.loading = true;
       const uri = "../api/em/security/users/create-organization/" + Tool.byteEncodeURLComponent(this.selectedProvider);
       this.http.post<EditOrganizationPaneModel>(uri, {parentGroup: event.parentGroup, defaultPassword: event.defaultPassword})


### PR DESCRIPTION
## Summary

- `newOrganization()` was the only "create new" action in `UsersSettingsPageComponent` that did not go through `withIncompleteUserGuard()`, so no warning appeared when a user with no password was pending and "New Organization" was clicked.
- Refactored `newOrganization()` to delegate through the guard (matching `newUser()`, `newGroup()`, and `newRole()`), and moved the API call into a private `createNewOrganization()` method.

## Test plan

- [ ] Enable security; create a new user in the host organization without setting a password.
- [ ] Click "New Organization" — confirm the "Incomplete User" warning dialog appears before the organization is created.
- [ ] Confirm the organization, dismiss the warning, and verify the organization is/isn't created accordingly.
- [ ] Verify that clicking "New User", "New Group", and "New Role" while an incomplete user exists still shows the warning (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)