### PR TITLE
Bug #74760, return HTTP 403 instead of 500 when user lacks worksheet expression column permission

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/ComposerControllerErrorHandler.java
+++ b/core/src/main/java/inetsoft/web/composer/ComposerControllerErrorHandler.java
@@ -68,6 +68,13 @@ public class ComposerControllerErrorHandler {
 
    @ExceptionHandler({SecurityException.class, java.lang.SecurityException.class})
    public ResponseEntity<Map<String, String>> handleSecurityException(Exception e) {
+      if(logManager.isDebugEnabled(LOG.getName())) {
+         logManager.logException(LOG, LogLevel.WARN, "Unauthorized access", e);
+      }
+      else {
+         logManager.logException(LOG, LogLevel.WARN, "Unauthorized access: " + e.getMessage(), null);
+      }
+
       Map<String, String> payload = new HashMap<>();
       payload.put("error", "Forbidden");
       payload.put("message", Catalog.getCatalog().getString("http.error.unauthorized"));

--- a/core/src/main/java/inetsoft/web/composer/ComposerControllerErrorHandler.java
+++ b/core/src/main/java/inetsoft/web/composer/ComposerControllerErrorHandler.java
@@ -23,6 +23,7 @@ import inetsoft.report.composition.execution.BoundTableNotFoundException;
 import inetsoft.uql.asset.ConfirmException;
 import inetsoft.uql.asset.InvalidDependencyException;
 import inetsoft.uql.viewsheet.ColumnNotFoundException;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.util.*;
 import inetsoft.util.log.LogLevel;
 import inetsoft.util.log.LogManager;
@@ -63,6 +64,14 @@ public class ComposerControllerErrorHandler {
    @MessageExceptionHandler(ScriptException.class)
    public void handleScriptException(ScriptException e, CommandDispatcher commandDispatcher) {
       sendMessageCommand(e, commandDispatcher, MessageCommand.Type.ERROR);
+   }
+
+   @ExceptionHandler({SecurityException.class, java.lang.SecurityException.class})
+   public ResponseEntity<Map<String, String>> handleSecurityException(Exception e) {
+      Map<String, String> payload = new HashMap<>();
+      payload.put("error", "Forbidden");
+      payload.put("message", Catalog.getCatalog().getString("http.error.unauthorized"));
+      return new ResponseEntity<>(payload, null, HttpStatus.FORBIDDEN);
    }
 
    @ExceptionHandler(MessageException.class)


### PR DESCRIPTION
## Summary

- `ComposerControllerErrorHandler` (the `@ControllerAdvice` for the `inetsoft.web.composer` and related packages) had no `@ExceptionHandler` for `SecurityException`, so permission-denied errors from composer REST controllers propagated as HTTP 500 instead of 403.
- Added `handleSecurityException` to catch both `inetsoft.sree.security.SecurityException` and `java.lang.SecurityException`, returning HTTP 403 with a localized message — matching the pattern already in `ControllerErrorHandler` for the portal package.

## Test plan

- [ ] Enable Multi-Tenancy, create an org, clone host
- [ ] Grant admin user permission to "Data Worksheet" in EM security actions and content repository
- [ ] Login to portal as org admin, open worksheet "All Sales"
- [ ] In EM, assign "Edit Worksheet Expression Columns" permission to a role that does NOT include admin
- [ ] Click "Create Expression" icon on the worksheet table
- [ ] Verify: a permission-denied warning dialog appears instead of an HTTP 500 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)