### PR TITLE
Bug #74739, fix SQL string lost when switching from Advanced Query to Simple Query without parsing

### DIFF
--- a/web/projects/portal/src/app/widget/dialog/sql-query-dialog/sql-query-dialog.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/sql-query-dialog/sql-query-dialog.component.ts
@@ -411,10 +411,19 @@ export class SQLQueryDialog implements OnInit {
          .set("runtimeWsId", runtimeId)
          .set("runtimeQueryId", this.model.runtimeId)
          .set("advancedEdit", advancedEdit);
+      const advancedSqlString = this.model.advancedModel?.freeFormSQLPaneModel?.sqlString;
 
       this.http.post<SqlQueryDialogModel>(CHANGE_EDIT_MODE_URI, this.model, {params: params})
          .subscribe(data => {
             this.model = data;
+
+            if(!advancedEdit && this.model.simpleModel?.sqlEdited &&
+               !this.model.simpleModel.sqlString && advancedSqlString)
+            {
+               this.model.simpleModel.sqlString = advancedSqlString;
+               this.model.simpleModel.sqlParseResult = null;
+            }
+
             this.loadDataSourceTree(true);
          });
    }


### PR DESCRIPTION
## Summary
- When a user enters SQL in the Advanced Query free-form SQL pane and switches back to Simple Query without clicking "Parse Now", the SQL string was lost and a false "SQL parsing failed" status was shown.
- The SQL typed in the free-form pane was only sent to the backend when "Parse Now" was clicked; switching modes without parsing left the backend runtime query empty, so `convertToSimpleQueryModel` returned a null `sqlString` with `PARSE_FAILED`.
- Fix: capture the free-form SQL string from the advanced model before the mode-change request, and copy it into the returned simple model when the backend response is missing it.

## Test plan
- [ ] New worksheet → Add → select data source → enable Advanced Query → go to SQL String tab → type a valid SQL query → switch Advanced Query off → confirm SQL appears in the text area with no error status
- [ ] Same flow but click "Parse Now" before switching off → confirm existing behavior unchanged
- [ ] Switch to Advanced Query from Simple Query → confirm no regression
- [ ] Switch to Advanced Query with structured tables/fields (no SQL string tab) → switch back to Simple → confirm structured SQL is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)