### PR TITLE
Bug #74648, fix unhandled promise rejection when canceling new script function save dialog

### DIFF
--- a/web/projects/portal/src/app/composer/gui/composer-main.component.ts
+++ b/web/projects/portal/src/app/composer/gui/composer-main.component.ts
@@ -2004,7 +2004,7 @@ export class ComposerMainComponent implements OnInit, OnDestroy, AfterViewInit {
             if(close) {
                this.closeLibTab(script);
             }
-         });
+         }).catch(() => {});
 
    }
 


### PR DESCRIPTION
## Summary

- In the Visual Composer, clicking Cancel on the "Save Script Function" dialog was causing an unhandled Promise rejection: `Uncaught (in promise): [object Undefined]`
- The `saveScriptAs()` method opened a modal and called `.then()` on the result Promise without a rejection handler; when the user cancels, `ngbModal` rejects the Promise with `undefined`
- Added `.catch(() => {})` to silently handle the dismissal, consistent with the pattern used elsewhere in the same file

## Test plan

- [ ] Open the Visual Composer
- [ ] Create a new script function (Library > New Script)
- [ ] Click Cancel on the Save dialog
- [ ] Verify no error appears in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)