### PR TITLE
Bug #74630, fix LDAP cache not refreshing when Search User Subtree setting changes

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
@@ -807,7 +807,7 @@ public abstract class LdapAuthenticationProvider
          LdapAuthenticationCache cache = isIgnoreCache() ? this.cache : getCache();
 
          if(cache != null) {
-            cache.load();
+            cache.refresh();
          }
       }
       finally {


### PR DESCRIPTION
## Summary

- When an LDAP provider's "Search User Subtree" setting is changed and saved, the user list was not updated until a server restart.
- Root cause: `clearCache()` called `cache.load()`, which calls `loadInternal(force=false)`. Since `lastLoad` is a distributed cluster value that was recently set by the old provider, `isReloadRequired()` returns false and the reload is skipped entirely — leaving stale data in the distributed cache maps.
- Fix: changed to `cache.refresh()`, which calls `loadInternal(force=true)`, bypassing the freshness check and unconditionally clearing and reloading the distributed cache with the updated provider configuration.

## Test plan

- [ ] Configure LDAP with "Search User Subtree" unchecked, verify user count
- [ ] Edit the provider and check "Search User Subtree", apply without restarting
- [ ] Verify the user list immediately reflects the correct count (no restart required)
- [ ] Verify that explicitly clearing the provider cache (EM admin action) also forces a fresh reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)