### PR TITLE
Bug #74784 - Enable bar corner rounding for pareto and waterfall charts

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -3578,6 +3578,8 @@ public abstract class GraphGenerator {
          line.setStackGroup(false);
          bar.setCollisionModifier(GraphElement.STACK_SYMMETRIC);
          bar.setStackGroup(true);
+         bar.setCornerRadius(desc.getPlotDescriptor().getBarCornerRadius());
+         bar.setRoundAllCorners(desc.getPlotDescriptor().isBarRoundAllCorners());
 
          elements.add(bar);
          elements.add(line);
@@ -3608,6 +3610,14 @@ public abstract class GraphGenerator {
          bar.setVisualStacked(stacked);
          sumBar.setHint("editable", "false");
          sumBar.setHint("_waterfall_", "true");
+
+         // Each segment floats on the prior segment's end (no zero baseline) — round all corners.
+         double r = desc.getPlotDescriptor().getBarCornerRadius();
+         bar.setCornerRadius(r);
+         bar.setRoundAllCorners(true);
+         sumBar.setCornerRadius(r);
+         sumBar.setRoundAllCorners(true);
+
          elements.add(bar);
          elements.add(sumBar);
       }

--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -3611,7 +3611,8 @@ public abstract class GraphGenerator {
          sumBar.setHint("editable", "false");
          sumBar.setHint("_waterfall_", "true");
 
-         // Each segment floats on the prior segment's end (no zero baseline) — round all corners.
+         // Intermediate bars float on prior totals (no zero anchor) — always round all corners.
+         // sumBar mirrors the same treatment for visual consistency.
          double r = desc.getPlotDescriptor().getBarCornerRadius();
          bar.setCornerRadius(r);
          bar.setRoundAllCorners(true);

--- a/core/src/main/java/inetsoft/web/graph/model/dialog/ChartPlotOptionsPaneModel.java
+++ b/core/src/main/java/inetsoft/web/graph/model/dialog/ChartPlotOptionsPaneModel.java
@@ -116,14 +116,13 @@ public class ChartPlotOptionsPaneModel {
       this.barCornerRadius = plotDesc.getBarCornerRadius() > 0
          ? plotDesc.getBarCornerRadius() : null;
       this.barCornerRadiusVisible = GraphTypeUtil.checkType(info, ctype ->
-         (GraphTypes.isBar(ctype) || GraphTypes.isInterval(ctype)) && !GraphTypes.is3DBar(ctype) &&
-         !GraphTypes.isPareto(ctype) && !GraphTypes.isWaterfall(ctype) &&
-         !GraphTypes.isFunnel(ctype));
-      // "Round All Corners" is hidden for interval charts — both ends are always rounded
+         (GraphTypes.isBar(ctype) || GraphTypes.isInterval(ctype) ||
+          GraphTypes.isPareto(ctype) || GraphTypes.isWaterfall(ctype)) &&
+         !GraphTypes.is3DBar(ctype) && !GraphTypes.isFunnel(ctype));
+      // "Round All Corners" hidden for interval and waterfall — both always round all corners
       this.barRoundAllCornersVisible = GraphTypeUtil.checkType(info, ctype ->
-         GraphTypes.isBar(ctype) && !GraphTypes.is3DBar(ctype) &&
-         !GraphTypes.isPareto(ctype) && !GraphTypes.isWaterfall(ctype) &&
-         !GraphTypes.isFunnel(ctype) && !GraphTypes.isInterval(ctype));
+         (GraphTypes.isBar(ctype) || GraphTypes.isPareto(ctype)) &&
+         !GraphTypes.is3DBar(ctype) && !GraphTypes.isFunnel(ctype));
       this.barRoundAllCorners = plotDesc.isBarRoundAllCorners();
 
       try {
@@ -200,14 +199,15 @@ public class ChartPlotOptionsPaneModel {
       plotDesc.setBarCornerRadius(barCornerRadius != null ? barCornerRadius : 0);
       // Re-derive from info rather than trusting the client-supplied barRoundAllCornersVisible field.
       boolean roundAllCornersVisible = GraphTypeUtil.checkType(info, ctype ->
-         GraphTypes.isBar(ctype) && !GraphTypes.is3DBar(ctype) &&
-         !GraphTypes.isPareto(ctype) && !GraphTypes.isWaterfall(ctype) &&
-         !GraphTypes.isFunnel(ctype) && !GraphTypes.isInterval(ctype));
+         (GraphTypes.isBar(ctype) || GraphTypes.isPareto(ctype)) &&
+         !GraphTypes.is3DBar(ctype) && !GraphTypes.isFunnel(ctype));
       if(roundAllCornersVisible) {
          plotDesc.setBarRoundAllCorners(barRoundAllCorners);
       }
-      else if(GraphTypeUtil.checkType(info, GraphTypes::isInterval)) {
-         // Interval charts always round all corners in GraphGenerator; persist the invariant.
+      else if(GraphTypeUtil.checkType(info,
+                  c -> GraphTypes.isInterval(c) || GraphTypes.isWaterfall(c)))
+      {
+         // Interval and waterfall always round all corners in GraphGenerator; persist the invariant.
          plotDesc.setBarRoundAllCorners(true);
       }
       else {

--- a/core/src/test/java/inetsoft/report/composition/graph/GraphTypeUtilCheckTypeTest.java
+++ b/core/src/test/java/inetsoft/report/composition/graph/GraphTypeUtilCheckTypeTest.java
@@ -180,9 +180,9 @@ class GraphTypeUtilCheckTypeTest {
       assertTrue(GraphTypeUtil.checkType(info, GraphTypes::isBar),
          "DC-created bars on a LINE chart should pass isBar check");
       assertTrue(GraphTypeUtil.checkType(info, ctype ->
-               (GraphTypes.isBar(ctype) || GraphTypes.isInterval(ctype)) &&
-               !GraphTypes.is3DBar(ctype) && !GraphTypes.isPareto(ctype) &&
-               !GraphTypes.isWaterfall(ctype) && !GraphTypes.isFunnel(ctype)),
+               (GraphTypes.isBar(ctype) || GraphTypes.isInterval(ctype) ||
+                GraphTypes.isPareto(ctype) || GraphTypes.isWaterfall(ctype)) &&
+               !GraphTypes.is3DBar(ctype) && !GraphTypes.isFunnel(ctype)),
          "barCornerRadiusVisible predicate should be true for DC bar on LINE chart");
    }
 

--- a/core/src/test/java/inetsoft/web/graph/model/dialog/ChartPlotOptionsPaneModelTest.java
+++ b/core/src/test/java/inetsoft/web/graph/model/dialog/ChartPlotOptionsPaneModelTest.java
@@ -221,4 +221,19 @@ class ChartPlotOptionsPaneModelTest {
       assertFalse(plotDesc.isBarRoundAllCorners(),
          "barRoundAllCorners=false should be persisted for pareto charts");
    }
+
+   @Test
+   void updateModel_resetsBarRoundAllCornersFalseForLineChart() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_LINE);
+      PlotDescriptor plotDesc = new PlotDescriptor();
+      // Stale descriptor value left from when the chart was a different type
+      plotDesc.setBarRoundAllCorners(true);
+
+      ChartPlotOptionsPaneModel model = new ChartPlotOptionsPaneModel(info, plotDesc);
+      model.updateChartPlotOptionsPaneModel(info, plotDesc);
+
+      assertFalse(plotDesc.isBarRoundAllCorners(),
+         "barRoundAllCorners should be reset to false for chart types where rounding doesn't apply");
+   }
 }

--- a/core/src/test/java/inetsoft/web/graph/model/dialog/ChartPlotOptionsPaneModelTest.java
+++ b/core/src/test/java/inetsoft/web/graph/model/dialog/ChartPlotOptionsPaneModelTest.java
@@ -55,6 +55,16 @@ class ChartPlotOptionsPaneModelTest {
       assertFalse(modelFor(GraphTypes.CHART_LINE).isBarCornerRadiusVisible());
    }
 
+   @Test
+   void barCornerRadiusVisible_paretoChart() {
+      assertTrue(modelFor(GraphTypes.CHART_PARETO).isBarCornerRadiusVisible());
+   }
+
+   @Test
+   void barCornerRadiusVisible_waterfallChart() {
+      assertTrue(modelFor(GraphTypes.CHART_WATERFALL).isBarCornerRadiusVisible());
+   }
+
    // --- barRoundAllCornersVisible ---
 
    @Test
@@ -72,6 +82,18 @@ class ChartPlotOptionsPaneModelTest {
    @Test
    void barRoundAllCornersVisible_stackedBarChart() {
       assertTrue(modelFor(GraphTypes.CHART_BAR_STACK).isBarRoundAllCornersVisible());
+   }
+
+   @Test
+   void barRoundAllCornersVisible_paretoChart() {
+      assertTrue(modelFor(GraphTypes.CHART_PARETO).isBarRoundAllCornersVisible());
+   }
+
+   @Test
+   void barRoundAllCornersVisible_waterfallChart() {
+      // Waterfall always rounds all corners (each segment floats with no zero baseline);
+      // the checkbox is hidden, same pattern as interval.
+      assertFalse(modelFor(GraphTypes.CHART_WATERFALL).isBarRoundAllCornersVisible());
    }
 
    // --- updateChartPlotOptionsPaneModel: barRoundAllCorners save guard ---
@@ -154,17 +176,49 @@ class ChartPlotOptionsPaneModelTest {
    }
 
    @Test
-   void updateModel_resetsBarRoundAllCornersForWaterfallChart() {
+   void updateModel_setsBarRoundAllCornersTrueForWaterfallChart() {
       VSChartInfo info = new VSChartInfo();
       info.setChartType(GraphTypes.CHART_WATERFALL);
       PlotDescriptor plotDesc = new PlotDescriptor();
-      // Simulate a stale descriptor value that could exist before the barRoundAllCornersVisible guard was introduced
+      // Stale descriptor value of false (e.g. created before waterfall rounding was added)
+      plotDesc.setBarRoundAllCorners(false);
+
+      ChartPlotOptionsPaneModel model = new ChartPlotOptionsPaneModel(info, plotDesc);
+      // Frontend sends barRoundAllCorners=false because the checkbox is hidden
+      model.setBarRoundAllCorners(false);
+      model.updateChartPlotOptionsPaneModel(info, plotDesc);
+
+      assertTrue(plotDesc.isBarRoundAllCorners(),
+         "barRoundAllCorners should be forced true for waterfall charts to match GraphGenerator");
+   }
+
+   @Test
+   void updateModel_savesBarRoundAllCornersForParetoChart() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_PARETO);
+      PlotDescriptor plotDesc = new PlotDescriptor();
+      plotDesc.setBarRoundAllCorners(false);
+
+      ChartPlotOptionsPaneModel model = new ChartPlotOptionsPaneModel(info, plotDesc);
+      model.setBarRoundAllCorners(true);
+      model.updateChartPlotOptionsPaneModel(info, plotDesc);
+
+      assertTrue(plotDesc.isBarRoundAllCorners(),
+         "barRoundAllCorners should be persisted for pareto charts");
+   }
+
+   @Test
+   void updateModel_savesBarRoundAllCornersFalseForParetoChart() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_PARETO);
+      PlotDescriptor plotDesc = new PlotDescriptor();
       plotDesc.setBarRoundAllCorners(true);
 
       ChartPlotOptionsPaneModel model = new ChartPlotOptionsPaneModel(info, plotDesc);
+      model.setBarRoundAllCorners(false);
       model.updateChartPlotOptionsPaneModel(info, plotDesc);
 
       assertFalse(plotDesc.isBarRoundAllCorners(),
-         "barRoundAllCorners should be reset to false for chart types where it is not applicable");
+         "barRoundAllCorners=false should be persisted for pareto charts");
    }
 }


### PR DESCRIPTION
Pareto and waterfall charts were previously excluded from the bar corner rounding feature even though the underlying rendering
pipeline (BarVO → GraphBuilder → frontend canvas) could already handle any IntervalElement with cornerRadius > 0. This PR wires both chart types through:

- Pareto behaves like a standard (stacked) bar chart — both UI controls (radius input + "Round All Corners" checkbox) are exposed and applied per the user's settings.
- Waterfall always rounds all corners. Each segment floats on the previous segment's value (no fixed zero baseline), so
geometrically both ends are "value ends" — same justification used for interval charts. Only the radius input is exposed; the
"Round All Corners" checkbox is hidden and the flag is forced true at render time.