### PR TITLE
Bug #74616 (re-opened): fix bottomTabs not restored when selection is in tab container

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/TabVSAssembly.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/TabVSAssembly.java
@@ -177,11 +177,9 @@ public class TabVSAssembly extends AbstractContainerVSAssembly {
          writer.println("</state_selected>");
       }
 
-      // Persist bottomTabs only when true (non-default). On restore, absence of the
-      // element leaves bottomTabs at its design-time default (false) without setting rValue.
-      if(getTabInfo().isBottomTabs()) {
-         writer.println("<state_bottomTabs>true</state_bottomTabs>");
-      }
+      // Always write bottomTabs so parseStateContent can distinguish an explicit script-set
+      // false from an absent element (old bookmarks without the element → backward-compat).
+      writer.println("<state_bottomTabs>" + getTabInfo().isBottomTabs() + "</state_bottomTabs>");
    }
 
    /**
@@ -197,10 +195,13 @@ public class TabVSAssembly extends AbstractContainerVSAssembly {
       String selected = Tool.getChildValueByTagName(elem, "state_selected");
       setSelectedValue(selected);
 
-      // Restore bottomTabs when the element is present (only written when true).
-      // Positions are already restored by the super call, so no repositioning is needed.
-      if(Tool.getChildValueByTagName(elem, "state_bottomTabs") != null) {
-         getTabInfo().setBottomTabs(true);
+      // Restore bottomTabs rValue when the element is present (written for both true/false).
+      // Absent element means an old bookmark created before this fix — leave rValue untouched
+      // so the value set by onInit (if any) is preserved (backward-compat).
+      String bottomTabsVal = Tool.getChildValueByTagName(elem, "state_bottomTabs");
+
+      if(bottomTabsVal != null) {
+         getTabInfo().setBottomTabs("true".equals(bottomTabsVal));
       }
    }
 

--- a/core/src/main/java/inetsoft/uql/viewsheet/TabVSAssembly.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/TabVSAssembly.java
@@ -177,8 +177,12 @@ public class TabVSAssembly extends AbstractContainerVSAssembly {
          writer.println("</state_selected>");
       }
 
-      // Always write bottomTabs so parseStateContent can distinguish an explicit script-set
-      // false from an absent element (old bookmarks without the element → backward-compat).
+      // Always write so parseStateContent can distinguish an explicit script-set false
+      // from an absent element (old bookmark — leave rValue alone for backward-compat).
+      // Note: writing the value here can set rValue on tabs that previously had rValue=null,
+      // but DynamicValue.getRValue() already auto-promotes dvalue → rvalue on first access,
+      // so this is the de-facto state by the time any layout/render runs; persisting it
+      // explicitly only mirrors that, with no behavioral consequence beyond the bookmark.
       writer.println("<state_bottomTabs>" + getTabInfo().isBottomTabs() + "</state_bottomTabs>");
    }
 

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
@@ -537,7 +537,10 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
 
       labelsValue.setRValue(null);
       selectedValue.setRValue(null);
-      bottomTabs.setRValue(null);
+      // bottomTabs rValue is intentionally NOT cleared here. It is set by onInit scripts
+      // and must survive refreshViewsheet() calls. The processOnInit "run-once" guard
+      // means it won't be re-applied on subsequent refreshes, so clearing it here would
+      // leave bottomTabs=false after bookmark navigation.
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
@@ -537,10 +537,8 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
 
       labelsValue.setRValue(null);
       selectedValue.setRValue(null);
-      // bottomTabs rValue is intentionally NOT cleared here. It is set by onInit scripts
-      // and must survive refreshViewsheet() calls. The processOnInit "run-once" guard
-      // means it won't be re-applied on subsequent refreshes, so clearing it here would
-      // leave bottomTabs=false after bookmark navigation.
+      // Not cleared: onInit sets bottomTabs once; the run-once guard prevents re-application
+      // on refresh. rValue is reset by bookmark load (parseStateContent) or session restart.
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
@@ -749,6 +749,9 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
       // to init vs to apply the shared filter when switch to home bookmark,
       // because the home bookmark created before initViewsheet in the runtime viewsheet.
       if(VSBookmark.HOME_BOOKMARK.equals(name)) {
+         // Allow processOnInit to re-run so script-set rValues (e.g. bottomTabs) are
+         // restored after the HOME bookmark resets assembly state to design-time defaults.
+         rvs.getViewsheetSandbox().ifPresent(box -> box.clearInit());
          rvs.initViewsheet(rvs.getViewsheet(), false);
       }
 

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
@@ -746,11 +746,13 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
          }
       }
 
-      // to init vs to apply the shared filter when switch to home bookmark,
-      // because the home bookmark created before initViewsheet in the runtime viewsheet.
+      // Navigating to HOME resets assemblies to design-time state (the HOME bookmark was
+      // created before initViewsheet in the runtime viewsheet) and applies the shared
+      // filter. Clear the onInit guard first so processOnInit is allowed to re-run on the
+      // following refreshViewsheet(), restoring any rValues set by onInit (e.g. bottomTabs).
+      // Note: clearInit affects the whole sandbox — every onInit script in the viewsheet
+      // re-runs, which matches the semantics of "HOME = same as a fresh open".
       if(VSBookmark.HOME_BOOKMARK.equals(name)) {
-         // Allow processOnInit to re-run so script-set rValues (e.g. bottomTabs) are
-         // restored after the HOME bookmark resets assembly state to design-time defaults.
          rvs.getViewsheetSandbox().ifPresent(box -> box.clearInit());
          rvs.initViewsheet(rvs.getViewsheet(), false);
       }

--- a/core/src/test/java/inetsoft/uql/viewsheet/TabVSAssemblyTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/TabVSAssemblyTest.java
@@ -17,7 +17,13 @@
  */
 package inetsoft.uql.viewsheet;
 
+import inetsoft.test.*;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.w3c.dom.*;
 
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -25,6 +31,11 @@ import java.io.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
 class TabVSAssemblyTest {
 
    @Test
@@ -34,7 +45,8 @@ class TabVSAssemblyTest {
 
       String xml = writeState(assembly);
 
-      assertTrue(xml.contains("<state_bottomTabs>"), "state_bottomTabs element should be present when bottomTabs=true");
+      assertTrue(xml.contains("<state_bottomTabs>true</state_bottomTabs>"),
+         "state_bottomTabs=true element should be written");
 
       TabVSAssembly restored = new TabVSAssembly();
       restored.parseState(parseXml(xml));
@@ -43,25 +55,54 @@ class TabVSAssemblyTest {
    }
 
    @Test
-   void writeStateOmitsElementWhenBottomTabsFalse() throws Exception {
+   void writeAndParseStateRoundTripBottomTabsExplicitFalse() throws Exception {
+      // Script explicitly sets bottomTabs to false. The element must be written and
+      // restored, so an explicit script-set false survives bookmark navigation (the
+      // pre-fix code only wrote when true and could not distinguish explicit false
+      // from an absent/old bookmark element).
+      TabVSAssembly assembly = new TabVSAssembly();
+      assembly.getTabInfo().setBottomTabs(false);
+
+      String xml = writeState(assembly);
+
+      assertTrue(xml.contains("<state_bottomTabs>false</state_bottomTabs>"),
+         "state_bottomTabs=false element should be written for explicit false");
+
+      TabVSAssembly restored = new TabVSAssembly();
+      restored.parseState(parseXml(xml));
+
+      assertFalse(restored.getTabInfo().isBottomTabs(), "isBottomTabs should be false after round-trip");
+   }
+
+   @Test
+   void writeStateAlwaysIncludesBottomTabsForDefault() throws Exception {
+      // Default constructor leaves bottomTabs at design-time false. writeStateContent
+      // always emits the element so parseStateContent can distinguish "explicit false"
+      // from "absent element" (old bookmark). Per DynamicValue.getRValue auto-promotion,
+      // there is no meaningful "no rValue" state by the time the state is written.
       TabVSAssembly assembly = new TabVSAssembly();
 
       String xml = writeState(assembly);
 
-      assertFalse(xml.contains("<state_bottomTabs>"), "state_bottomTabs element should be absent for default bottomTabs=false");
+      assertTrue(xml.contains("<state_bottomTabs>false</state_bottomTabs>"),
+         "state_bottomTabs=false element should be present in default state");
    }
 
    @Test
    void parseStateBackwardCompatibilityWithoutBottomTabsElement() throws Exception {
-      // Simulate old bookmark XML that has no <state_bottomTabs> element
+      // Simulate old bookmark XML created before this fix — no <state_bottomTabs> element.
+      // parseStateContent must leave the current rValue alone so any onInit-set value is
+      // preserved across loads of legacy bookmarks.
       String legacyXml = "<assembly class=\"inetsoft.uql.viewsheet.TabVSAssembly\">" +
          "<name><![CDATA[Tab1]]></name>" +
          "</assembly>";
 
       TabVSAssembly assembly = new TabVSAssembly();
+      assembly.getTabInfo().setBottomTabs(true); // simulate onInit script having run first
       assembly.parseState(parseXml(legacyXml));
 
-      assertFalse(assembly.getTabInfo().isBottomTabs(), "isBottomTabs should remain false when element is absent");
+      assertTrue(assembly.getTabInfo().isBottomTabs(),
+         "isBottomTabs should remain true (onInit-set) when element is absent in legacy bookmark");
    }
 
    private static String writeState(TabVSAssembly assembly) {

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
@@ -211,7 +211,7 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
       const bottomTab = VSUtil.getBottomTabContainer(this.model, this.vsInfo?.vsObjects);
       const inBottomTab = !!bottomTab;
 
-      if((this.viewer || this.embeddedVS) && !this.model.maxMode && !this.inContainer) {
+      if((this.viewer || this.embeddedVS) && !this.model.maxMode && (!this.inContainer || inBottomTab)) {
          if(this.atBottom && this.model.dropdown &&
             !SelectionBaseController.isHidden(this.model) && !inBottomTab)
          {
@@ -224,13 +224,14 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
          else if(this.model.dropdown && inBottomTab) {
             // applies whether the dropdown is collapsed or expanded; the collapsed
             // case is critical because it's where objectFormat.top would be stale
-            // when bottomTabs is toggled via script.
+            // when bottomTabs is toggled via script. Also reached when inContainer=true
+            // (selection inside a tab container with bottomTabs enabled).
             const expanded = !SelectionBaseController.isHidden(this.model);
             return VSUtil.computeBottomTabSelectionTop(
                bottomTab.objectFormat.top, this.model.titleFormat.height,
                expanded, this.getBodyHeight(), this.model.searchDisplayed);
          }
-         else {
+         else if(!this.inContainer) {
             return this.model.objectFormat.top;
          }
       }


### PR DESCRIPTION
## Root Cause

This bug was re-opened after the initial fix (PR #3562) because the prior fix was incomplete and missed two additional failure paths.

### Why the initial fix wasn't enough

PR #3562 added `writeStateContent`/`parseStateContent` support for `<state_bottomTabs>` to persist and restore the `bottomTabs` rValue through bookmark XML. But it broke down for two reasons:

**Root cause 1 — `resetRuntimeValues()` clears bottomTabs rValue, and `processOnInit()` has a run-once guard**

`TabVSAssemblyInfo.resetRuntimeValues()` was unconditionally calling `bottomTabs.setRValue(null)`. This is called by `VSUtil.resetRuntimeValues()` in `CoreLifecycleService.refreshViewsheet()` on every refresh, *before* `processOnInit()` runs. On the very first refresh after viewsheet open, `processOnInit()` runs (because `lastOnInit == ""`), restores `bottomTabs.rValue = true`, and the tab renders correctly. On every subsequent refresh — including bookmark navigation — the run-once guard (`lastOnInit == onInit`) causes `processOnInit()` to be skipped, leaving `bottomTabs.rValue = null` after `resetRuntimeValues()` clears it. The backend then sends `bottomTabs = false` to the frontend.

**Root cause 2 — `writeStateContent` only saved `true`; `parseStateContent` only restored `true`**

Even if `parseStateContent` was called to restore the bookmark state, it could not distinguish an explicitly-saved `false` from an absent element (old bookmark). More importantly, `resetRuntimeValues()` runs *after* `parseStateContent` during the subsequent refresh, clearing whatever was just restored.

**Root cause 3 — HOME bookmark path: `initViewsheet()` resets to design-time state but `processOnInit()` can't re-run**

When navigating to the HOME bookmark, `VSBookmarkService.processBookmark()` calls `rvs.initViewsheet(...)` which resets assemblies to their design-time state (`bottomTabs.rValue = null`). The fix in root cause 1 stops `resetRuntimeValues()` from clearing rValue on every refresh, but the HOME path explicitly resets to design-time state via `initViewsheet`. After this, `processOnInit()` should re-run to restore `bottomTabs.rValue = true`, but the run-once guard prevents it.

**Root cause 4 — Frontend `topPosition` blocked by `!this.inContainer` guard**

This is the case the user identified: when the selection list is *inside* a tab container, `this.inContainer = true`. The outer `if` in `topPosition` required `!this.inContainer`, which blocked the entire block including the `computeBottomTabSelectionTop` branch. The dropdown would fall through to return `null`, placing it at the bottom instead of above the tab bar.

## Fix

### `TabVSAssemblyInfo.java` — don't clear bottomTabs rValue in `resetRuntimeValues()`

Removed `bottomTabs.setRValue(null)`. Since `processOnInit()` won't re-apply the script value on subsequent refreshes, clearing it here permanently broke any tab with `bottomTabs` set by script.

### `TabVSAssembly.java` — always write and correctly restore `<state_bottomTabs>`

- `writeStateContent()`: always writes `<state_bottomTabs>true/false</state_bottomTabs>` (previously only wrote when true), so `parseStateContent` can distinguish explicit `false` from an absent element (old bookmark = backward-compat).
- `parseStateContent()`: handles all three cases — element=`true` → `setBottomTabs(true)`, element=`false` → `setBottomTabs(false)`, element absent → leave rValue untouched (backward-compat with bookmarks created before this fix).

### `VSBookmarkService.java` — `clearInit()` before HOME bookmark's `initViewsheet()`

Added `rvs.getViewsheetSandbox().ifPresent(box -> box.clearInit())` before `initViewsheet()` in the HOME bookmark path. This resets the `lastOnInit` guard so `processOnInit()` is allowed to re-run on the next `refreshViewsheet()`, restoring `bottomTabs.rValue = true`.

### `vs-selection.component.ts` — fix `topPosition` guard for in-container selections

Changed the outer `if` condition from `!this.inContainer` to `(!this.inContainer || inBottomTab)` so the bottom-tab dropdown positioning branch (`computeBottomTabSelectionTop`) is reachable even when the selection list is inside a tab container. Added `else if(!this.inContainer)` on the plain-position fallback to avoid incorrectly positioning in-container selections that are not in a bottom-tab.

## Test scenario

1. Open `tabposition_dropdown_script.vso` — viewsheet with `Tab1.bottomTabs=true` set in `onInit` script, with a selection list inside the tab container.
2. Verify the selection dropdown opens *above* the tab bar on initial load.
3. Navigate to bookmark `bk1` — dropdown must still open above the tab bar (was broken before this fix).
4. Navigate to HOME and back to `bk1` — dropdown must still open above the tab bar (was also broken: the HOME→bk1 path required both root cause 3 and root cause 4 to be fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)