### PR TITLE
Bug #74546, fix duplicate API calls when switching security provider on Users page

### DIFF
--- a/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.ts
+++ b/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.ts
@@ -84,6 +84,7 @@ export class UsersSettingsPageComponent implements OnInit, OnDestroy {
    public identityEditable = new Subject<boolean>;
    currOrg: string;
    loading: boolean = false;
+   private selfRefreshing = false;
    newUserIdentity: IdentityId | null = null;
 
    get hasIncompleteNewUser(): boolean {
@@ -102,6 +103,10 @@ export class UsersSettingsPageComponent implements OnInit, OnDestroy {
                private orgBusy: SecurityBusyService)
    {
       orgDropdownService.onRefresh.subscribe(res => {
+         if(this.selfRefreshing) {
+            return;
+         }
+
          this.selectedProvider = res.provider;
          this.refreshProvider(this.selectedProvider, res.providerChanged)
       });
@@ -538,7 +543,9 @@ export class UsersSettingsPageComponent implements OnInit, OnDestroy {
 
    private refreshTree(id?: IdentityId, type?: number, providerChanged?: boolean, selectProvider: boolean = false) {
       if(!!selectProvider) {
+         this.selfRefreshing = true;
          this.orgDropdownService.refresh(this.selectedProvider, providerChanged);
+         this.selfRefreshing = false;
       }
 
       let provider = Tool.byteEncodeURLComponent(this.selectedProvider);


### PR DESCRIPTION
## Summary

- When the user switches the provider dropdown on **Settings → Security → Users**, `refreshTree` called `orgDropdownService.refresh()` which synchronously fired `onRefresh`, causing the constructor subscription to re-enter `refreshTree` a second time.
- Both calls had `providerChanged=true`, so `loadScheduleUsers()` was invoked twice. The `ScheduleUsersService` guard set `reload=true` on the second call, queuing a redundant `users-model` HTTP request after the first completed — visible in cloud environments as two requests within ~640ms.
- Fix adds a `selfRefreshing` flag that blocks the component's own `onRefresh` re-entry while leaving all other subscribers (page header, clipboard services) unaffected.

## Test plan

- [ ] Navigate to Settings → Security → Users in a cloud/latency environment
- [ ] Switch the Provider dropdown and verify only one `users-model` request appears in browser DevTools Network tab (previously two)
- [ ] Verify the security tree reloads correctly after switching providers
- [ ] Verify provider changes triggered externally (e.g. another admin modifying providers) still refresh the Users page tree
- [ ] Verify create/edit/delete operations on users, groups, and roles still work correctly and refresh the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)