### PR TITLE
Revert Bug #74606 - fix admin login failing when a custom security provider chain is active (#3480)

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
+++ b/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
@@ -107,7 +107,6 @@ public class SecurityEngine implements SessionListener, MessageListener, AutoClo
 
          if(!authcChain.getProviders().isEmpty() && !authzChain.getProviders().isEmpty()) {
             provider = CompositeSecurityProvider.create(authcChain, authzChain);
-            migrateSiteAdminToChain(authcChain);
          }
          else {
             authcChain.tearDown();
@@ -202,39 +201,6 @@ public class SecurityEngine implements SessionListener, MessageListener, AutoClo
       return result;
    }
 
-   /**
-    * Ensures the virtual site admin ({@code admin^<defaultOrg>}) exists in the primary
-    * authentication provider of the given chain so that admin login works when a custom
-    * security provider chain is active.
-    */
-   private void migrateSiteAdminToChain(AuthenticationChain authcChain) {
-      if(vprovider == null || authcChain.getProviders().isEmpty()) {
-         return;
-      }
-
-      AuthenticationProvider primary = authcChain.getProviders().get(0);
-
-      if(!(primary instanceof EditableAuthenticationProvider editablePrimary)) {
-         return;
-      }
-
-      IdentityID siteAdminId = new IdentityID("admin", Organization.getDefaultOrganizationID());
-      boolean alreadyPresent = primary.getUser(siteAdminId) != null;
-      String envVar = System.getenv("INETSOFT_ADMIN_PASSWORD");
-      boolean envVarSet = envVar != null && !envVar.isBlank();
-
-      // When the env var is set it acts as a recovery mechanism: always update the File
-      // provider so a corrupted or unknown password can be reset without wiping data.
-      // When not set, only add the admin if it is missing (first-time migration).
-      if(!alreadyPresent || envVarSet) {
-         User virtualAdmin = vprovider.getAuthenticationProvider().getUser(siteAdminId);
-
-         if(virtualAdmin != null) {
-            editablePrimary.addUser(virtualAdmin);
-         }
-      }
-   }
-
    public void newChain() {
       AuthenticationChain authcChain = new AuthenticationChain();
       List<AuthenticationProvider> authcProviders = authcChain.getProviderList();
@@ -242,7 +208,6 @@ public class SecurityEngine implements SessionListener, MessageListener, AutoClo
       authcProvider.setProviderName("Primary");
       authcProviders.add(authcProvider);
       authcChain.setProviders(authcProviders);
-      migrateSiteAdminToChain(authcChain);
 
       AuthorizationChain authzChain = new AuthorizationChain();
       List<AuthorizationProvider> authzProviders = authzChain.getProviderList();
@@ -268,7 +233,6 @@ public class SecurityEngine implements SessionListener, MessageListener, AutoClo
 
       if(!authcChain.getProviders().isEmpty() && !authzChain.getProviders().isEmpty()) {
          provider = CompositeSecurityProvider.create(authcChain, authzChain);
-         migrateSiteAdminToChain(authcChain);
          authcChain.addAuthenticationChangeListener(authzChain);
          authcChain.addAuthenticationChangeListener(this::fireAuthenticationChange);
       }

--- a/core/src/main/java/inetsoft/sree/security/VirtualAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/VirtualAuthenticationProvider.java
@@ -91,8 +91,6 @@ public class VirtualAuthenticationProvider
       String algorithm =
          admin.getPasswordAlgorithm() == null ? "MD5" : admin.getPasswordAlgorithm();
       return Objects.equals(userIdentity.name, admin.getName()) &&
-         (userIdentity.orgID == null ||
-          Organization.getDefaultOrganizationID().equals(userIdentity.orgID)) &&
          Objects.equals(userid.name, admin.getName()) &&
          Tool.checkHashedPassword(
             admin.getPassword(), passwd, algorithm, admin.getPasswordSalt(),
@@ -139,10 +137,7 @@ public class VirtualAuthenticationProvider
     */
    @Override
    public User getUser(IdentityID userIdentity) {
-      if("admin".equals(userIdentity.name) &&
-         (userIdentity.orgID == null ||
-          Organization.getDefaultOrganizationID().equals(userIdentity.orgID)))
-      {
+      if("admin".equals(userIdentity.name)) {
          return admin;
       }
 
@@ -259,23 +254,6 @@ public class VirtualAuthenticationProvider
       catch(Exception ex) {
          LOG.error("Failed to load virtual security file: " + fileName, ex);
       }
-
-      // If INETSOFT_ADMIN_PASSWORD is set, sync the stored password to match the env var.
-      // This allows the env var to serve as a recovery mechanism when the stored password
-      // has become corrupted or is otherwise unknown.
-      String envPassword = System.getenv("INETSOFT_ADMIN_PASSWORD");
-
-      if(envPassword != null && !envPassword.isBlank()) {
-         try {
-            SUtil.setPassword(admin, AdminCredentialUtil.getRequiredAdminPassword());
-            save();
-            LOG.debug("INETSOFT_ADMIN_PASSWORD is set; admin password synced from environment variable.");
-         }
-         catch(Exception e) {
-            LOG.warn("INETSOFT_ADMIN_PASSWORD is set but could not be applied: {}. " +
-                     "Ensure the password meets strength requirements.", e.getMessage());
-         }
-      }
    }
 
    /**
@@ -285,10 +263,7 @@ public class VirtualAuthenticationProvider
     */
    @Override
    public void addUser(User user) {
-      if(user.getName().equals("admin") &&
-         Organization.getDefaultOrganizationID().equals(user.getIdentityID().orgID) &&
-         user instanceof FSUser)
-      {
+      if(user.getName().equals("admin")) {
          admin = (FSUser) user;
          save();
       }

--- a/core/src/main/resources/inetsoft/web/resources/js/login.js
+++ b/core/src/main/resources/inetsoft/web/resources/js/login.js
@@ -16,25 +16,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 function initLoginView(requestedUrl, sessionExpired, defaultErrorMessage, gatewayErrorMessage, currentUser, onloadError) {
-   // Normalize requestedUrl to the current page's origin.  This handles the case where the
-   // server (behind a proxy that strips the subdomain) embeds a requestedUrl pointing to the
-   // host-org origin (e.g. localhost:8080) while the login page itself is served from
-   // org0.localhost:8080.  If left uncorrected the AJAX auth call and post-login redirect
-   // would both target the wrong origin, causing CORS failures and session loss.
-   try {
-      var _target = new URL(requestedUrl, window.location.href);
-
-      if(_target.origin !== window.location.origin) {
-         _target.protocol = window.location.protocol;
-         _target.hostname = window.location.hostname;
-         _target.port = window.location.port;
-         requestedUrl = _target.toString();
-      }
-   }
-   catch(e) {
-      // ignore — use requestedUrl as-is if URL parsing fails
-   }
-
    var $userNameField = $("#loginUserName");
    var $userNameError = $("#userNameError");
 


### PR DESCRIPTION
## Summary

Reverts #3480 (commit 676c5518e).

The fix introduced in #3480 is incorrect for the reported bug and is causing multiple regressions. This revert restores the prior behavior while the correct fix is investigated.

## Changes Reverted

- `SecurityEngine.java` — removes `migrateSiteAdminToChain()` and its call sites
- `VirtualAuthenticationProvider.java` — removes org-guard and `INETSOFT_ADMIN_PASSWORD` sync-on-load logic
- `login.js` — removes origin normalization in `initLoginView()`