### PR TITLE
Feature #74786 - Smooth/curved edges for circular network charts

### DIFF
--- a/core/src/main/java/inetsoft/graph/element/RelationElement.java
+++ b/core/src/main/java/inetsoft/graph/element/RelationElement.java
@@ -373,18 +373,24 @@ public class RelationElement extends GraphElement {
       edges.stream()
          .forEach(v -> v.getEdge().getGeometry().translate(-minX, -minY));
 
-      // Cache centroid of node centres for smooth-edge rendering. Computed in the same
-      // post-flip / post-translate space the edge geometry produces.
-      double sumCx = 0, sumCy = 0;
+      // Cache centroid of node centres for smooth-edge rendering. Only CIRCLE consumes it;
+      // skip the O(n) pass for other algorithms. Computed in the same post-flip /
+      // post-translate space the edge geometry produces.
+      if(algorithm == Algorithm.CIRCLE) {
+         double sumCx = 0, sumCy = 0;
 
-      for(RelationGeometry n : nodes.values()) {
-         mxGeometry g = n.getMxCell().getGeometry();
-         sumCx += g.getX() + g.getWidth() / 2.0;
-         sumCy += g.getY() + g.getHeight() / 2.0;
+         for(RelationGeometry n : nodes.values()) {
+            mxGeometry g = n.getMxCell().getGeometry();
+            sumCx += g.getX() + g.getWidth() / 2.0;
+            sumCy += g.getY() + g.getHeight() / 2.0;
+         }
+
+         int n = nodes.size();
+         layoutCenter = n > 0 ? new Point2D.Double(sumCx / n, sumCy / n) : null;
       }
-
-      int n = nodes.size();
-      layoutCenter = n > 0 ? new Point2D.Double(sumCx / n, sumCy / n) : null;
+      else {
+         layoutCenter = null;
+      }
    }
 
    // flip the Y so root is on top.

--- a/core/src/main/java/inetsoft/graph/element/RelationElement.java
+++ b/core/src/main/java/inetsoft/graph/element/RelationElement.java
@@ -26,6 +26,7 @@ import inetsoft.graph.internal.GTool;
 import inetsoft.graph.mxgraph.layout.hierarchical.mxHierarchicalLayout;
 import inetsoft.graph.mxgraph.layout.*;
 import inetsoft.graph.mxgraph.model.mxCell;
+import inetsoft.graph.mxgraph.model.mxGeometry;
 import inetsoft.graph.mxgraph.view.mxGraph;
 import inetsoft.graph.visual.ElementVO;
 import inetsoft.graph.visual.VOText;
@@ -34,6 +35,7 @@ import inetsoft.util.CoreTool;
 
 import java.awt.*;
 import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.text.Format;
 import java.util.List;
@@ -370,6 +372,19 @@ public class RelationElement extends GraphElement {
          .forEach(v -> v.getMxCell().getGeometry().translate(-minX, -minY));
       edges.stream()
          .forEach(v -> v.getEdge().getGeometry().translate(-minX, -minY));
+
+      // Cache centroid of node centres for smooth-edge rendering. Computed in the same
+      // post-flip / post-translate space the edge geometry produces.
+      double sumCx = 0, sumCy = 0;
+
+      for(RelationGeometry n : nodes.values()) {
+         mxGeometry g = n.getMxCell().getGeometry();
+         sumCx += g.getX() + g.getWidth() / 2.0;
+         sumCy += g.getY() + g.getHeight() / 2.0;
+      }
+
+      int n = nodes.size();
+      layoutCenter = n > 0 ? new Point2D.Double(sumCx / n, sumCy / n) : null;
    }
 
    // flip the Y so root is on top.
@@ -560,6 +575,26 @@ public class RelationElement extends GraphElement {
    }
 
    /**
+    * Whether edges should be drawn as smooth curves (currently only honored for Algorithm.CIRCLE).
+    */
+   public boolean isSmoothEdges() {
+      return smoothEdges;
+   }
+
+   public void setSmoothEdges(boolean smoothEdges) {
+      this.smoothEdges = smoothEdges;
+   }
+
+   /**
+    * Centroid of all node positions after layout, in graph coordinates. Populated by mxLayout()
+    * and consumed by RelationEdgeGeometry to bend curves toward the ring centre. Null until
+    * layout runs.
+    */
+   public Point2D getLayoutCenter() {
+      return layoutCenter;
+   }
+
+   /**
     * Set the color frame for getting the color aesthetic for nodes.
     */
    public void setNodeColorFrame(ColorFrame colors) {
@@ -731,6 +766,7 @@ public class RelationElement extends GraphElement {
             this.algorithm == elem.algorithm && widthRatio == elem.widthRatio &&
             heightRatio == elem.heightRatio &&
             applyAestheticsToSource == elem.applyAestheticsToSource &&
+            smoothEdges == elem.smoothEdges &&
             Objects.equals(nodeColors, elem.nodeColors) &&
             Objects.equals(nodeSizes, elem.nodeSizes) &&
             Objects.equals(layoutSize, elem.layoutSize) &&
@@ -761,6 +797,9 @@ public class RelationElement extends GraphElement {
    private Dimension layoutSize = new Dimension(200, 200);
    private Color fillColor;
    private boolean applyAestheticsToSource = false;
+   private boolean smoothEdges = false;
+   // derived; populated by mxLayout, not part of element identity
+   private transient Point2D layoutCenter;
 
    private static final long serialVersionUID = 1L;
 }

--- a/core/src/main/java/inetsoft/graph/element/RelationElement.java
+++ b/core/src/main/java/inetsoft/graph/element/RelationElement.java
@@ -385,8 +385,9 @@ public class RelationElement extends GraphElement {
             sumCy += g.getY() + g.getHeight() / 2.0;
          }
 
-         int n = nodes.size();
-         layoutCenter = n > 0 ? new Point2D.Double(sumCx / n, sumCy / n) : null;
+         int nodeCount = nodes.size();
+         layoutCenter = nodeCount > 0
+            ? new Point2D.Double(sumCx / nodeCount, sumCy / nodeCount) : null;
       }
       else {
          layoutCenter = null;

--- a/core/src/main/java/inetsoft/graph/geometry/RelationEdgeGeometry.java
+++ b/core/src/main/java/inetsoft/graph/geometry/RelationEdgeGeometry.java
@@ -22,6 +22,7 @@ import inetsoft.graph.aesthetic.VisualModel;
 import inetsoft.graph.coord.Coordinate;
 import inetsoft.graph.data.DataSet;
 import inetsoft.graph.element.GraphElement;
+import inetsoft.graph.element.RelationElement;
 import inetsoft.graph.internal.GTool;
 import inetsoft.graph.mxgraph.model.mxCell;
 import inetsoft.graph.mxgraph.util.mxPoint;
@@ -88,14 +89,33 @@ public class RelationEdgeGeometry extends ElementGeometry {
       List<Shape> edges = new ArrayList<>();
       mxCell e = getEdge();
       List<mxPoint> pts = e.getGeometry().getPoints();
+      RelationElement elem = (RelationElement) getElement();
+      boolean smooth = elem.isSmoothEdges()
+         && elem.getAlgorithm() == RelationElement.Algorithm.CIRCLE
+         && elem.getLayoutCenter() != null;
 
       // in case lines are not created by layout, draw a straight line from the target to source.
       if(pts == null || pts.isEmpty()) {
          Line2D line = e.getSource().getGeometry().getConnector(e.getTarget().getGeometry());
 
          if(line != null) {
-            edges.add(line);
+            edges.add(smooth
+               ? GTool.computeCenterPullCurve(line.getP1(), line.getP2(),
+                                              elem.getLayoutCenter(),
+                                              GTool.CIRCULAR_EDGE_SMOOTHING)
+               : line);
          }
+      }
+      else if(smooth && pts.size() == 2) {
+         // mxCircleLayout typically leaves pts empty (handled above via getConnector); this
+         // branch covers any layout that emits an explicit 2-point edge so it still gets curved.
+         Point2D p1 = pts.get(0).getPoint();
+         Point2D p2 = pts.get(1).getPoint();
+         // preserve existing y-swap (java vs graph coord) so curve sits in same visual space
+         Point2D s = new Point2D.Double(p1.getX(), p2.getY());
+         Point2D t = new Point2D.Double(p2.getX(), p1.getY());
+         edges.add(GTool.computeCenterPullCurve(s, t, elem.getLayoutCenter(),
+                                                GTool.CIRCULAR_EDGE_SMOOTHING));
       }
       else {
          for(int i = 1; i < pts.size(); i++) {

--- a/core/src/main/java/inetsoft/graph/geometry/RelationEdgeGeometry.java
+++ b/core/src/main/java/inetsoft/graph/geometry/RelationEdgeGeometry.java
@@ -106,17 +106,6 @@ public class RelationEdgeGeometry extends ElementGeometry {
                : line);
          }
       }
-      else if(smooth && pts.size() == 2) {
-         // mxCircleLayout typically leaves pts empty (handled above via getConnector); this
-         // branch covers any layout that emits an explicit 2-point edge so it still gets curved.
-         Point2D p1 = pts.get(0).getPoint();
-         Point2D p2 = pts.get(1).getPoint();
-         // preserve existing y-swap (java vs graph coord) so curve sits in same visual space
-         Point2D s = new Point2D.Double(p1.getX(), p2.getY());
-         Point2D t = new Point2D.Double(p2.getX(), p1.getY());
-         edges.add(GTool.computeCenterPullCurve(s, t, elem.getLayoutCenter(),
-                                                GTool.CIRCULAR_EDGE_SMOOTHING));
-      }
       else {
          for(int i = 1; i < pts.size(); i++) {
             Point2D p1 = pts.get(i - 1).getPoint();

--- a/core/src/main/java/inetsoft/graph/internal/GTool.java
+++ b/core/src/main/java/inetsoft/graph/internal/GTool.java
@@ -1400,6 +1400,25 @@ public final class GTool {
    // Catmull-Rom (curve passes through every point). 0.0 = straight lines. >1.0 = looser/bouncier.
    private static final double CATMULL_ROM_SMOOTHING = 1.0;
 
+   /**
+    * Build a quadratic Bezier from src to dst whose control point is the midpoint pulled
+    * toward center by the given smoothing factor (0 = straight line; 1 = curve through center).
+    * Used by circular relation charts to bend chord lines toward the ring's centroid.
+    */
+   public static QuadCurve2D computeCenterPullCurve(Point2D src, Point2D dst,
+                                                    Point2D center, double smoothing)
+   {
+      double mx = (src.getX() + dst.getX()) / 2.0;
+      double my = (src.getY() + dst.getY()) / 2.0;
+      double cx = mx + (center.getX() - mx) * smoothing;
+      double cy = my + (center.getY() - my) * smoothing;
+      return new QuadCurve2D.Double(src.getX(), src.getY(), cx, cy, dst.getX(), dst.getY());
+   }
+
+   // Pull strength of the control point toward the ring centre for circular network edges.
+   // 0.0 = straight chord. 1.0 = curve passes through the centre. 0.5 matches goal mockup.
+   public static final double CIRCULAR_EDGE_SMOOTHING = 0.5;
+
    private static GImpl impl;
    private static boolean jdk16 = false;
    // @by stephenwebster, For bug1416439678841

--- a/core/src/main/java/inetsoft/graph/internal/GTool.java
+++ b/core/src/main/java/inetsoft/graph/internal/GTool.java
@@ -1400,6 +1400,10 @@ public final class GTool {
    // Catmull-Rom (curve passes through every point). 0.0 = straight lines. >1.0 = looser/bouncier.
    private static final double CATMULL_ROM_SMOOTHING = 1.0;
 
+   // Pull strength of the control point toward the ring centre for circular network edges.
+   // 0.0 = straight chord. 1.0 = curve passes through the centre.
+   public static final double CIRCULAR_EDGE_SMOOTHING = 0.5;
+
    /**
     * Build a quadratic Bezier from src to dst whose control point is the midpoint pulled
     * toward center by the given smoothing factor (0 = straight line; 1 = curve through center).
@@ -1414,10 +1418,6 @@ public final class GTool {
       double cy = my + (center.getY() - my) * smoothing;
       return new QuadCurve2D.Double(src.getX(), src.getY(), cx, cy, dst.getX(), dst.getY());
    }
-
-   // Pull strength of the control point toward the ring centre for circular network edges.
-   // 0.0 = straight chord. 1.0 = curve passes through the centre. 0.5 matches goal mockup.
-   public static final double CIRCULAR_EDGE_SMOOTHING = 0.5;
 
    private static GImpl impl;
    private static boolean jdk16 = false;

--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -3704,6 +3704,11 @@ public abstract class GraphGenerator {
            break;
          case CHART_CIRCULAR:
             elem.setAlgorithm(RelationElement.Algorithm.CIRCLE);
+
+            if(desc.getPlotDescriptor().isSmoothLines()) {
+               elem.setSmoothEdges(true);
+            }
+
             break;
          }
 

--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -3705,6 +3705,8 @@ public abstract class GraphGenerator {
          case CHART_CIRCULAR:
             elem.setAlgorithm(RelationElement.Algorithm.CIRCLE);
 
+            // PlotDescriptor.smoothLines is reused here as the chord-curve toggle for
+            // CIRCULAR; the element-side flag is smoothEdges (bends edges, not lines).
             if(desc.getPlotDescriptor().isSmoothLines()) {
                elem.setSmoothEdges(true);
             }

--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -3704,13 +3704,9 @@ public abstract class GraphGenerator {
            break;
          case CHART_CIRCULAR:
             elem.setAlgorithm(RelationElement.Algorithm.CIRCLE);
-
             // PlotDescriptor.smoothLines is reused here as the chord-curve toggle for
             // CIRCULAR; the element-side flag is smoothEdges (bends edges, not lines).
-            if(desc.getPlotDescriptor().isSmoothLines()) {
-               elem.setSmoothEdges(true);
-            }
-
+            elem.setSmoothEdges(desc.getPlotDescriptor().isSmoothLines());
             break;
          }
 

--- a/core/src/main/java/inetsoft/web/binding/controller/ChangeChartTypeController.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ChangeChartTypeController.java
@@ -205,22 +205,7 @@ public class ChangeChartTypeController {
          plotDesc.setValuesVisible(false);
       }
 
-      // Default smoothLines on first transition into a (non-step) Area type so newly-created
-      // area charts use smooth curves; user can still explicitly turn it off via Plot Options.
-      // On the reverse transition (Area → non-step Line) we clear the flag so a Line chart
-      // created from a previously-smooth Area chart does not silently inherit curves.
-      boolean newIsArea = newType == GraphTypes.CHART_AREA || newType == GraphTypes.CHART_AREA_STACK;
-      boolean oldIsArea = oldType == GraphTypes.CHART_AREA || oldType == GraphTypes.CHART_AREA_STACK;
-      boolean newIsLine = newType == GraphTypes.CHART_LINE || newType == GraphTypes.CHART_LINE_STACK;
-      boolean newIsCircular = newType == GraphTypes.CHART_CIRCULAR;
-      boolean oldIsCircular = oldType == GraphTypes.CHART_CIRCULAR;
-
-      if(newIsArea && !oldIsArea || newIsCircular && !oldIsCircular) {
-         plotDesc.setSmoothLines(true);
-      }
-      else if(newIsLine && oldIsArea) {
-         plotDesc.setSmoothLines(false);
-      }
+      applySmoothLinesTransition(oldType, newType, plotDesc);
 
       if(!DateComparisonUtil.isDateComparisonChartTypeChanged(ninfo, oinfo)) {
          Catalog catalog = Catalog.getCatalog();
@@ -321,6 +306,30 @@ public class ChangeChartTypeController {
       }
 
       return gflds.length > 0;
+   }
+
+   /**
+    * Default smoothLines on first transition into a (non-step) Area or Circular type so newly-
+    * created charts use smooth curves; user can still turn it off via Plot Options. On the
+    * reverse transition (Area/Circular → Line) clear the flag so the Line chart does not
+    * silently inherit curves from the previously-smooth source type.
+    *
+    * <p>Package-private and pure (no Spring/runtime state) so the transition matrix is unit-
+    * testable without standing up the WebSocket controller.
+    */
+   static void applySmoothLinesTransition(int oldType, int newType, PlotDescriptor plotDesc) {
+      boolean newIsArea = newType == GraphTypes.CHART_AREA || newType == GraphTypes.CHART_AREA_STACK;
+      boolean oldIsArea = oldType == GraphTypes.CHART_AREA || oldType == GraphTypes.CHART_AREA_STACK;
+      boolean newIsLine = newType == GraphTypes.CHART_LINE || newType == GraphTypes.CHART_LINE_STACK;
+      boolean newIsCircular = newType == GraphTypes.CHART_CIRCULAR;
+      boolean oldIsCircular = oldType == GraphTypes.CHART_CIRCULAR;
+
+      if(newIsArea && !oldIsArea || newIsCircular && !oldIsCircular) {
+         plotDesc.setSmoothLines(true);
+      }
+      else if(newIsLine && (oldIsArea || oldIsCircular)) {
+         plotDesc.setSmoothLines(false);
+      }
    }
 
    private final VSBindingService bindingFactory;

--- a/core/src/main/java/inetsoft/web/binding/controller/ChangeChartTypeController.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ChangeChartTypeController.java
@@ -324,7 +324,7 @@ public class ChangeChartTypeController {
       boolean newIsCircular = newType == GraphTypes.CHART_CIRCULAR;
       boolean oldIsCircular = oldType == GraphTypes.CHART_CIRCULAR;
 
-      if(newIsArea && !oldIsArea || newIsCircular && !oldIsCircular) {
+      if((newIsArea && !oldIsArea) || (newIsCircular && !oldIsCircular)) {
          plotDesc.setSmoothLines(true);
       }
       else if(newIsLine && (oldIsArea || oldIsCircular)) {

--- a/core/src/main/java/inetsoft/web/binding/controller/ChangeChartTypeController.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ChangeChartTypeController.java
@@ -212,8 +212,10 @@ public class ChangeChartTypeController {
       boolean newIsArea = newType == GraphTypes.CHART_AREA || newType == GraphTypes.CHART_AREA_STACK;
       boolean oldIsArea = oldType == GraphTypes.CHART_AREA || oldType == GraphTypes.CHART_AREA_STACK;
       boolean newIsLine = newType == GraphTypes.CHART_LINE || newType == GraphTypes.CHART_LINE_STACK;
+      boolean newIsCircular = newType == GraphTypes.CHART_CIRCULAR;
+      boolean oldIsCircular = oldType == GraphTypes.CHART_CIRCULAR;
 
-      if(newIsArea && !oldIsArea) {
+      if(newIsArea && !oldIsArea || newIsCircular && !oldIsCircular) {
          plotDesc.setSmoothLines(true);
       }
       else if(newIsLine && oldIsArea) {

--- a/core/src/main/java/inetsoft/web/graph/model/dialog/ChartPlotOptionsPaneModel.java
+++ b/core/src/main/java/inetsoft/web/graph/model/dialog/ChartPlotOptionsPaneModel.java
@@ -147,10 +147,11 @@ public class ChartPlotOptionsPaneModel {
 
    public static boolean isSmoothLinesVisible(ChartInfo info) {
       return GraphTypeUtil.isChartType(info, true, ctype ->
-         (GraphTypes.isLine(ctype) || GraphTypes.isArea(ctype)) &&
-         ctype != GraphTypes.CHART_STEP && ctype != GraphTypes.CHART_STEP_STACK &&
-         ctype != GraphTypes.CHART_JUMP &&
-         ctype != GraphTypes.CHART_STEP_AREA && ctype != GraphTypes.CHART_STEP_AREA_STACK);
+         ((GraphTypes.isLine(ctype) || GraphTypes.isArea(ctype)) &&
+            ctype != GraphTypes.CHART_STEP && ctype != GraphTypes.CHART_STEP_STACK &&
+            ctype != GraphTypes.CHART_JUMP &&
+            ctype != GraphTypes.CHART_STEP_AREA && ctype != GraphTypes.CHART_STEP_AREA_STACK)
+         || ctype == GraphTypes.CHART_CIRCULAR);
    }
 
    public static boolean isBorderColorVisible(ChartInfo info) {

--- a/core/src/main/java/inetsoft/web/vswizard/handler/VSWizardBindingHandler.java
+++ b/core/src/main/java/inetsoft/web/vswizard/handler/VSWizardBindingHandler.java
@@ -858,12 +858,14 @@ public class VSWizardBindingHandler {
          VSUtil.setDefaultGeoColumns(chartInfo, rvs, source.getSource());
       }
 
-      // Default smoothLines on for wizard-recommended (non-step) Area charts, matching the
-      // default applied when a user picks Area via the chart-type chooser.
+      // Default smoothLines on for wizard-recommended (non-step) Area and Circular charts,
+      // matching the default applied when a user picks the type via the chart-type chooser.
       if(chartInfo != null) {
          int ctype = chartInfo.getChartType();
 
-         if(ctype == GraphTypes.CHART_AREA || ctype == GraphTypes.CHART_AREA_STACK) {
+         if(ctype == GraphTypes.CHART_AREA || ctype == GraphTypes.CHART_AREA_STACK
+            || ctype == GraphTypes.CHART_CIRCULAR)
+         {
             chartDescriptor.getPlotDescriptor().setSmoothLines(true);
          }
       }

--- a/core/src/test/java/inetsoft/graph/element/RelationElementLayoutCenterTest.java
+++ b/core/src/test/java/inetsoft/graph/element/RelationElementLayoutCenterTest.java
@@ -1,0 +1,142 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.graph.element;
+
+import inetsoft.graph.EGraph;
+import inetsoft.graph.GGraph;
+import inetsoft.graph.aesthetic.StaticSizeFrame;
+import inetsoft.graph.coord.RelationCoord;
+import inetsoft.graph.data.DefaultDataSet;
+import inetsoft.graph.geometry.RelationGeometry;
+import inetsoft.graph.mxgraph.model.mxGeometry;
+import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.Test;
+
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests that RelationElement.mxLayout() populates getLayoutCenter() with the centroid of
+ * laid-out node positions (post flipY + translate-to-origin), in the same coordinate space
+ * the edge geometry will subsequently report. Required by RelationEdgeGeometry.getEdges()
+ * to bend smooth edges toward a meaningful pull point.
+ */
+@SreeHome
+class RelationElementLayoutCenterTest {
+   @Test
+   void mxLayoutPopulatesLayoutCenterAsNodeCentroid_circular() {
+      DefaultDataSet data = new DefaultDataSet(new Object[][]{
+         { "From", "To" },
+         { "A",    "B"  },
+         { "B",    "C"  },
+         { "C",    "D"  },
+         { "D",    "A"  },
+      });
+
+      RelationElement element = new RelationElement("From", "To");
+      element.setAlgorithm(RelationElement.Algorithm.CIRCLE);
+      // createGeometry / RelationGeometry.getSize dereference the edge and node size frames;
+      // static frames keep those paths NPE-free without affecting layout positions.
+      element.setSizeFrame(new StaticSizeFrame(5));
+      element.setNodeSizeFrame(new StaticSizeFrame(5));
+
+      EGraph egraph = new EGraph();
+      egraph.addElement(element);
+
+      RelationCoord coord = new RelationCoord();
+      egraph.setCoordinate(coord);
+
+      GGraph ggraph = egraph.createGGraph(coord, data);
+
+      // GGraph builds geometries lazily on first access; force the layout pass so the
+      // element's layoutCenter gets populated.
+      List<RelationGeometry> nodes = new ArrayList<>();
+
+      for(int i = 0; i < ggraph.getGeometryCount(); i++) {
+         if(ggraph.getGeometry(i) instanceof RelationGeometry) {
+            nodes.add((RelationGeometry) ggraph.getGeometry(i));
+         }
+      }
+
+      Point2D layoutCenter = element.getLayoutCenter();
+      assertNotNull(layoutCenter,
+         "mxLayout must populate layoutCenter after a circular layout pass");
+
+      assertEquals(4, nodes.size(), "expected one geometry per unique node (A,B,C,D)");
+
+      double sumCx = 0, sumCy = 0;
+
+      for(RelationGeometry n : nodes) {
+         mxGeometry g = n.getMxCell().getGeometry();
+         sumCx += g.getX() + g.getWidth() / 2.0;
+         sumCy += g.getY() + g.getHeight() / 2.0;
+      }
+
+      double expectedCx = sumCx / nodes.size();
+      double expectedCy = sumCy / nodes.size();
+
+      assertEquals(expectedCx, layoutCenter.getX(), 1e-6,
+         "layoutCenter x must equal the mean of node-centre x positions");
+      assertEquals(expectedCy, layoutCenter.getY(), 1e-6,
+         "layoutCenter y must equal the mean of node-centre y positions");
+   }
+
+   @Test
+   void layoutCenterStartsNullBeforeLayoutRuns() {
+      RelationElement element = new RelationElement("From", "To");
+      assertNull(element.getLayoutCenter(),
+         "layoutCenter must be null until mxLayout runs so consumers gate on it");
+   }
+
+   @Test
+   void mxLayoutSkipsCentroidForNonCircularAlgorithm() {
+      // Smooth-edge curving only consumes layoutCenter for Algorithm.CIRCLE; other algorithms
+      // (HIERARCHY/RADIAL/COMPACT_TREE/ORGANIC) skip the O(n) centroid pass and leave it null.
+      DefaultDataSet data = new DefaultDataSet(new Object[][]{
+         { "From", "To" },
+         { "A",    "B"  },
+         { "B",    "C"  },
+         { "C",    "D"  },
+      });
+
+      RelationElement element = new RelationElement("From", "To");
+      element.setAlgorithm(RelationElement.Algorithm.ORGANIC);
+      element.setSizeFrame(new StaticSizeFrame(5));
+      element.setNodeSizeFrame(new StaticSizeFrame(5));
+
+      EGraph egraph = new EGraph();
+      egraph.addElement(element);
+
+      RelationCoord coord = new RelationCoord();
+      egraph.setCoordinate(coord);
+
+      GGraph ggraph = egraph.createGGraph(coord, data);
+
+      // force the layout pass.
+      for(int i = 0; i < ggraph.getGeometryCount(); i++) {
+         ggraph.getGeometry(i);
+      }
+
+      assertNull(element.getLayoutCenter(),
+         "non-CIRCLE algorithms must leave layoutCenter null so non-circular smooth-edge "
+         + "guards short-circuit");
+   }
+}

--- a/core/src/test/java/inetsoft/graph/internal/GToolCenterPullCurveTest.java
+++ b/core/src/test/java/inetsoft/graph/internal/GToolCenterPullCurveTest.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.graph.internal;
+
+import org.junit.jupiter.api.Test;
+
+import java.awt.geom.Point2D;
+import java.awt.geom.QuadCurve2D;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for GTool.computeCenterPullCurve, the helper that builds chord-bending bezier
+ * curves used by circular network charts.
+ */
+class GToolCenterPullCurveTest {
+   @Test
+   void zeroSmoothing_keepsControlPointAtMidpoint() {
+      Point2D src = new Point2D.Double(0, 0);
+      Point2D dst = new Point2D.Double(100, 0);
+      Point2D center = new Point2D.Double(50, 50);
+
+      QuadCurve2D q = GTool.computeCenterPullCurve(src, dst, center, 0.0);
+
+      assertEquals(50.0, q.getCtrlX(), 1e-9, "k=0 keeps control x at chord midpoint");
+      assertEquals(0.0, q.getCtrlY(), 1e-9, "k=0 keeps control y at chord midpoint");
+   }
+
+   @Test
+   void fullSmoothing_pullsControlPointAllTheWayToCenter() {
+      Point2D src = new Point2D.Double(0, 0);
+      Point2D dst = new Point2D.Double(100, 0);
+      Point2D center = new Point2D.Double(50, 50);
+
+      QuadCurve2D q = GTool.computeCenterPullCurve(src, dst, center, 1.0);
+
+      assertEquals(50.0, q.getCtrlX(), 1e-9, "k=1 puts control x at the centre");
+      assertEquals(50.0, q.getCtrlY(), 1e-9, "k=1 puts control y at the centre");
+   }
+
+   @Test
+   void halfSmoothing_pullsControlPointHalfwayToCenter() {
+      Point2D src = new Point2D.Double(0, 0);
+      Point2D dst = new Point2D.Double(100, 0);
+      Point2D center = new Point2D.Double(50, 50);
+
+      QuadCurve2D q = GTool.computeCenterPullCurve(src, dst, center,
+                                                   GTool.CIRCULAR_EDGE_SMOOTHING);
+
+      assertEquals(50.0, q.getCtrlX(), 1e-9);
+      // midpoint y is 0; centre y is 50; halfway pull yields 25.
+      assertEquals(25.0, q.getCtrlY(), 1e-9, "k=0.5 puts control y halfway to centre");
+   }
+
+   @Test
+   void endpointsAlwaysMatchSourceAndDestination() {
+      Point2D src = new Point2D.Double(7, -3);
+      Point2D dst = new Point2D.Double(11, 42);
+      Point2D center = new Point2D.Double(0, 0);
+
+      QuadCurve2D q = GTool.computeCenterPullCurve(src, dst, center, 0.7);
+
+      assertEquals(src.getX(), q.getX1(), 1e-9);
+      assertEquals(src.getY(), q.getY1(), 1e-9);
+      assertEquals(dst.getX(), q.getX2(), 1e-9);
+      assertEquals(dst.getY(), q.getY2(), 1e-9);
+   }
+
+   @Test
+   void coincidentEndpoints_produceDegenerateCurveWithoutCrash() {
+      Point2D pt = new Point2D.Double(5, 5);
+      Point2D center = new Point2D.Double(50, 50);
+
+      QuadCurve2D q = GTool.computeCenterPullCurve(pt, pt, center,
+                                                   GTool.CIRCULAR_EDGE_SMOOTHING);
+
+      assertEquals(5.0, q.getX1(), 1e-9);
+      assertEquals(5.0, q.getX2(), 1e-9);
+      // self-edge: control point still pulls toward centre, harmless because painter just
+      // draws an inward stub.
+      assertEquals(27.5, q.getCtrlX(), 1e-9);
+      assertEquals(27.5, q.getCtrlY(), 1e-9);
+   }
+}

--- a/core/src/test/java/inetsoft/graph/internal/GToolCenterPullCurveTest.java
+++ b/core/src/test/java/inetsoft/graph/internal/GToolCenterPullCurveTest.java
@@ -82,6 +82,24 @@ class GToolCenterPullCurveTest {
    }
 
    @Test
+   void negativeSmoothing_extrapolatesAwayFromCenter() {
+      // Documented contract: the formula extrapolates linearly through the chord midpoint
+      // when smoothing < 0 (control point pushed away from center). Not used in production
+      // (callers pass 0 ≤ k ≤ 1) but pinning the math prevents a future change from
+      // silently flipping the sign.
+      Point2D src = new Point2D.Double(0, 0);
+      Point2D dst = new Point2D.Double(100, 0);
+      Point2D center = new Point2D.Double(50, 50);
+
+      QuadCurve2D q = GTool.computeCenterPullCurve(src, dst, center, -0.5);
+
+      // midpoint y is 0; centre y is 50; pulling by -0.5 moves the control point 25 units
+      // to the opposite side of the midpoint from the centre.
+      assertEquals(50.0, q.getCtrlX(), 1e-9, "x stays on the chord midpoint when src/dst x are symmetric about it");
+      assertEquals(-25.0, q.getCtrlY(), 1e-9, "k=-0.5 pushes control y away from centre");
+   }
+
+   @Test
    void coincidentEndpoints_produceDegenerateCurveWithoutCrash() {
       Point2D pt = new Point2D.Double(5, 5);
       Point2D center = new Point2D.Double(50, 50);

--- a/core/src/test/java/inetsoft/web/binding/controller/ChangeChartTypeControllerSmoothLinesTransitionTest.java
+++ b/core/src/test/java/inetsoft/web/binding/controller/ChangeChartTypeControllerSmoothLinesTransitionTest.java
@@ -1,0 +1,181 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.binding.controller;
+
+import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.uql.viewsheet.graph.PlotDescriptor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the smoothLines defaulting/reset matrix applied when a chart's type changes.
+ * Covers the Area↔Line, Circular↔Line, and Area↔Circular transitions.
+ */
+class ChangeChartTypeControllerSmoothLinesTransitionTest {
+   private static PlotDescriptor descWith(boolean smoothLines) {
+      PlotDescriptor pd = new PlotDescriptor();
+      pd.setSmoothLines(smoothLines);
+      return pd;
+   }
+
+   // --- Default-on transitions ---
+
+   @Test
+   void barToArea_setsSmoothLinesTrue() {
+      PlotDescriptor pd = descWith(false);
+      ChangeChartTypeController.applySmoothLinesTransition(
+         GraphTypes.CHART_BAR, GraphTypes.CHART_AREA, pd);
+      assertTrue(pd.isSmoothLines(),
+         "first transition into Area should default smoothLines on");
+   }
+
+   @Test
+   void lineToStackedArea_setsSmoothLinesTrue() {
+      PlotDescriptor pd = descWith(false);
+      ChangeChartTypeController.applySmoothLinesTransition(
+         GraphTypes.CHART_LINE, GraphTypes.CHART_AREA_STACK, pd);
+      assertTrue(pd.isSmoothLines(),
+         "first transition into stacked Area should default smoothLines on");
+   }
+
+   @Test
+   void barToCircular_setsSmoothLinesTrue() {
+      PlotDescriptor pd = descWith(false);
+      ChangeChartTypeController.applySmoothLinesTransition(
+         GraphTypes.CHART_BAR, GraphTypes.CHART_CIRCULAR, pd);
+      assertTrue(pd.isSmoothLines(),
+         "first transition into Circular should default smoothLines on");
+   }
+
+   @Test
+   void networkToCircular_setsSmoothLinesTrue() {
+      PlotDescriptor pd = descWith(false);
+      ChangeChartTypeController.applySmoothLinesTransition(
+         GraphTypes.CHART_NETWORK, GraphTypes.CHART_CIRCULAR, pd);
+      assertTrue(pd.isSmoothLines(),
+         "Network → Circular is a first-into-circular transition; defaults on");
+   }
+
+   // --- Reset transitions ---
+
+   @Test
+   void areaToLine_resetsSmoothLinesFalse() {
+      PlotDescriptor pd = descWith(true);
+      ChangeChartTypeController.applySmoothLinesTransition(
+         GraphTypes.CHART_AREA, GraphTypes.CHART_LINE, pd);
+      assertFalse(pd.isSmoothLines(),
+         "Area → Line must clear smoothLines so the line chart isn't silently smooth");
+   }
+
+   @Test
+   void stackedAreaToStackedLine_resetsSmoothLinesFalse() {
+      PlotDescriptor pd = descWith(true);
+      ChangeChartTypeController.applySmoothLinesTransition(
+         GraphTypes.CHART_AREA_STACK, GraphTypes.CHART_LINE_STACK, pd);
+      assertFalse(pd.isSmoothLines());
+   }
+
+   @Test
+   void circularToLine_resetsSmoothLinesFalse() {
+      PlotDescriptor pd = descWith(true);
+      ChangeChartTypeController.applySmoothLinesTransition(
+         GraphTypes.CHART_CIRCULAR, GraphTypes.CHART_LINE, pd);
+      assertFalse(pd.isSmoothLines(),
+         "Circular → Line must clear smoothLines so the line chart isn't silently smooth");
+   }
+
+   @Test
+   void circularToStackedLine_resetsSmoothLinesFalse() {
+      PlotDescriptor pd = descWith(true);
+      ChangeChartTypeController.applySmoothLinesTransition(
+         GraphTypes.CHART_CIRCULAR, GraphTypes.CHART_LINE_STACK, pd);
+      assertFalse(pd.isSmoothLines());
+   }
+
+   // --- No-op transitions ---
+
+   @Test
+   void areaToArea_preservesUserSetting() {
+      PlotDescriptor offToOff = descWith(false);
+      ChangeChartTypeController.applySmoothLinesTransition(
+         GraphTypes.CHART_AREA, GraphTypes.CHART_AREA_STACK, offToOff);
+      assertFalse(offToOff.isSmoothLines(),
+         "Area → Area is not a first-into transition; user's off setting must persist");
+
+      PlotDescriptor onToOn = descWith(true);
+      ChangeChartTypeController.applySmoothLinesTransition(
+         GraphTypes.CHART_AREA, GraphTypes.CHART_AREA_STACK, onToOn);
+      assertTrue(onToOn.isSmoothLines(),
+         "Area → Area is not a first-into transition; user's on setting must persist");
+   }
+
+   @Test
+   void circularToCircular_preservesUserSetting() {
+      PlotDescriptor pd = descWith(false);
+      ChangeChartTypeController.applySmoothLinesTransition(
+         GraphTypes.CHART_CIRCULAR, GraphTypes.CHART_CIRCULAR, pd);
+      assertFalse(pd.isSmoothLines(),
+         "same-type transition must not toggle smoothLines");
+   }
+
+   @Test
+   void areaToCircular_setsSmoothLinesTrue() {
+      // Both branches happen to overlap here: area→circular is first-into-circular.
+      PlotDescriptor pd = descWith(false);
+      ChangeChartTypeController.applySmoothLinesTransition(
+         GraphTypes.CHART_AREA, GraphTypes.CHART_CIRCULAR, pd);
+      assertTrue(pd.isSmoothLines());
+   }
+
+   @Test
+   void circularToArea_setsSmoothLinesTrue() {
+      PlotDescriptor pd = descWith(false);
+      ChangeChartTypeController.applySmoothLinesTransition(
+         GraphTypes.CHART_CIRCULAR, GraphTypes.CHART_AREA, pd);
+      assertTrue(pd.isSmoothLines(),
+         "Circular → Area is a first-into-area transition; defaults on");
+   }
+
+   @Test
+   void barToLine_doesNotTouchSmoothLines() {
+      PlotDescriptor on = descWith(true);
+      ChangeChartTypeController.applySmoothLinesTransition(
+         GraphTypes.CHART_BAR, GraphTypes.CHART_LINE, on);
+      assertTrue(on.isSmoothLines(),
+         "Bar → Line is neither a default-on nor a reset transition");
+
+      PlotDescriptor off = descWith(false);
+      ChangeChartTypeController.applySmoothLinesTransition(
+         GraphTypes.CHART_BAR, GraphTypes.CHART_LINE, off);
+      assertFalse(off.isSmoothLines());
+   }
+
+   @Test
+   void circularToNetwork_leavesSmoothLinesUnchanged() {
+      // Network/Tree don't render with smoothLines, so the value is irrelevant for rendering.
+      // The transition is intentionally a no-op (no rendering effect, no UI surface that
+      // exposes the field for these types).
+      PlotDescriptor pd = descWith(true);
+      ChangeChartTypeController.applySmoothLinesTransition(
+         GraphTypes.CHART_CIRCULAR, GraphTypes.CHART_NETWORK, pd);
+      assertTrue(pd.isSmoothLines(),
+         "no reset is wired for Circular → Network because the flag has no rendering "
+         + "effect on Network and the checkbox is hidden");
+   }
+}

--- a/core/src/test/java/inetsoft/web/graph/model/dialog/ChartPlotOptionsPaneModelTest.java
+++ b/core/src/test/java/inetsoft/web/graph/model/dialog/ChartPlotOptionsPaneModelTest.java
@@ -294,4 +294,37 @@ class ChartPlotOptionsPaneModelTest {
    void smoothLinesVisible_pieChartHidden() {
       assertFalse(modelFor(GraphTypes.CHART_PIE).isSmoothLinesVisible());
    }
+
+   @Test
+   void smoothLinesVisible_circularNetworkChart() {
+      // Circular network reuses the smoothLines flag to bend chord edges toward the ring centre.
+      assertTrue(modelFor(GraphTypes.CHART_CIRCULAR).isSmoothLinesVisible());
+   }
+
+   @Test
+   void smoothLinesVisible_networkChartHidden() {
+      // Organic Network has no fixed centroid the curves can pull toward, so the toggle stays
+      // hidden until/unless a separate edge-curving algorithm is added for it.
+      assertFalse(modelFor(GraphTypes.CHART_NETWORK).isSmoothLinesVisible());
+   }
+
+   @Test
+   void smoothLinesVisible_treeChartHidden() {
+      assertFalse(modelFor(GraphTypes.CHART_TREE).isSmoothLinesVisible());
+   }
+
+   @Test
+   void updateModel_smoothLinesRoundTripsForCircularChart() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_CIRCULAR);
+      PlotDescriptor plotDesc = new PlotDescriptor();
+      plotDesc.setSmoothLines(false);
+
+      ChartPlotOptionsPaneModel model = new ChartPlotOptionsPaneModel(info, plotDesc);
+      model.setSmoothLines(true);
+      model.updateChartPlotOptionsPaneModel(info, plotDesc);
+
+      assertTrue(plotDesc.isSmoothLines(),
+         "smoothLines should round-trip through the model for circular charts");
+   }
 }


### PR DESCRIPTION
## Summary

  - Bends chord lines on Circular Network charts using a quadratic Bezier whose
    control point is pulled from the chord midpoint toward the ring centroid.
  - Reuses `PlotDescriptor.smoothLines` (and its Plot Options checkbox) from
    #3609. Visibility extended to `CHART_CIRCULAR`; Network/Tree stay hidden.
  - New Circular charts (chart-type chooser + wizard) default smooth=on. Saved
    viewsheets keep straight edges (`smoothLines` defaults `false` on parse).
  - Gated to `Algorithm.CIRCLE` and 2-point edges; multi-segment edges and other
    relation layouts unchanged. No frontend changes.