### PR TITLE
Fix and optimize cross-node shared filter propagation

### DIFF
--- a/core/src/main/java/inetsoft/analytic/composition/ViewsheetEngine.java
+++ b/core/src/main/java/inetsoft/analytic/composition/ViewsheetEngine.java
@@ -448,6 +448,12 @@ public class ViewsheetEngine extends WorksheetEngine implements ViewsheetService
    }
 
    @Override
+   public int getRuntimeViewsheetCount(Principal user) {
+      // amap iterates the distributed Ignite cache, so this reflects the count across all nodes.
+      return amap.getAllIds(user, CompressedSheetState.SheetType.VIEWSHEET).size();
+   }
+
+   @Override
    public <T extends Serializable> List<T> invokeOnAll(Task<T> task) {
       return cluster.affinityCallAll(CACHE_NAME, new InvokeAllTask<>(task));
    }

--- a/core/src/main/java/inetsoft/analytic/composition/ViewsheetEngine.java
+++ b/core/src/main/java/inetsoft/analytic/composition/ViewsheetEngine.java
@@ -448,9 +448,10 @@ public class ViewsheetEngine extends WorksheetEngine implements ViewsheetService
    }
 
    @Override
-   public int getRuntimeViewsheetCount(Principal user) {
-      // amap iterates the distributed Ignite cache, so this reflects the count across all nodes.
-      return amap.getAllIds(user, CompressedSheetState.SheetType.VIEWSHEET).size();
+   public boolean hasAtLeastRuntimeViewsheets(Principal user, int n) {
+      // amap.hasAtLeast scans the distributed Ignite cache across all nodes but short-circuits
+      // as soon as the threshold is reached, avoiding a full scan.
+      return amap.hasAtLeast(user, CompressedSheetState.SheetType.VIEWSHEET, n);
    }
 
    @Override

--- a/core/src/main/java/inetsoft/analytic/composition/ViewsheetService.java
+++ b/core/src/main/java/inetsoft/analytic/composition/ViewsheetService.java
@@ -185,6 +185,11 @@ public interface ViewsheetService extends WorksheetService {
     */
    RuntimeViewsheet[] getRuntimeViewsheets(Principal user);
 
+   /**
+    * Get the total number of runtime viewsheets open for the given user across all cluster nodes.
+    */
+   int getRuntimeViewsheetCount(Principal user);
+
    <T extends Serializable> List<T> invokeOnAll(Task<T> task);
 
    /**

--- a/core/src/main/java/inetsoft/analytic/composition/ViewsheetService.java
+++ b/core/src/main/java/inetsoft/analytic/composition/ViewsheetService.java
@@ -186,9 +186,11 @@ public interface ViewsheetService extends WorksheetService {
    RuntimeViewsheet[] getRuntimeViewsheets(Principal user);
 
    /**
-    * Get the total number of runtime viewsheets open for the given user across all cluster nodes.
+    * Returns true if the user has at least {@code n} viewsheets open across all cluster nodes.
+    * Scans the distributed cache but short-circuits as soon as the threshold is reached,
+    * avoiding a full scan when used as a cheap guard (e.g. n=2 before a cluster broadcast).
     */
-   int getRuntimeViewsheetCount(Principal user);
+   boolean hasAtLeastRuntimeViewsheets(Principal user, int n);
 
    <T extends Serializable> List<T> invokeOnAll(Task<T> task);
 

--- a/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
@@ -249,26 +249,7 @@ public abstract class RuntimeSheet {
     * @return <tt>true</tt> if yes, <tt>false</tt> otherwise.
     */
    public boolean matches(Principal user) {
-      if(this.user == null || user == null) {
-         return this.user == user;
-      }
-
-      // Bug #74165: anonymous users share the same name but represent distinct browser sessions,
-      // so they must be compared by full identity (including session/IP) to avoid one anonymous
-      // user's sheet being matched to another's. Named users, however, should be compared only
-      // by their business identity (name~;~orgID): in a distributed/ECS cluster, the same user's
-      // close request may arrive via a different pod/session/IP than the open request, so
-      // including session or IP in the comparison would throw a false InvalidUserException.
-      if(this.user instanceof SRPrincipal) {
-         if(XPrincipal.ANONYMOUS.equals(((SRPrincipal) this.user).getIdentityID().name)) {
-            return Tool.equals(this.user, user);
-         }
-      }
-      else if(XPrincipal.ANONYMOUS.equals(this.user.getName())) {
-         return Tool.equals(this.user, user);
-      }
-
-      return Tool.equals(this.user.getName(), user.getName());
+      return Tool.equals(this.user, user);
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/composition/RuntimeSheetCache.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeSheetCache.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import inetsoft.analytic.composition.ViewsheetEngine;
+import inetsoft.sree.ClientInfo;
 import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.cluster.Cluster;
 import inetsoft.sree.security.SRPrincipal;
@@ -652,6 +653,35 @@ public class RuntimeSheetCache
     */
    public boolean hasAtLeast(Principal user, CompressedSheetState.SheetType type, int n) {
       int count = 0;
+
+      // Build cheap pre-filter strings from the incoming principal to avoid XML parsing
+      // on every cache entry. ClientInfo.writeXML writes session as a plain CDATA value
+      // and name as Tool.byteEncode(userID.convertToKey()). Both must match to count the
+      // entry. secureID can be 0 in some cases so it is not used.
+      String sessionTag = null;
+      String nameTag = null;
+
+      if(user instanceof SRPrincipal srp) {
+         ClientInfo clientInfo = srp.getUser();
+
+         if(clientInfo != null) {
+            String session = clientInfo.getSession();
+            String name = clientInfo.getUserIdentity() != null
+               ? clientInfo.getUserIdentity().convertToKey() : null;
+
+            if(session != null && !session.isEmpty()) {
+               sessionTag = "<session><![CDATA[" + session + "]]></session>";
+            }
+
+            if(name != null) {
+               nameTag = "<user><![CDATA[" + Tool.byteEncode(name) + "]]></user>";
+            }
+         }
+      }
+
+      final String fastSessionTag = sessionTag;
+      final String fastNameTag = nameTag;
+
       Iterator<Cache.Entry<AffinityKey<String>, CompressedSheetState>> iter = cache.iterator();
 
       try {
@@ -668,17 +698,29 @@ public class RuntimeSheetCache
                }
             }
             else if(e.getValue().getUser() != null) {
-               try {
-                  Document document = Tool.parseXML(new StringReader(e.getValue().getUser()));
-                  SRPrincipal principal = new SRPrincipal();
-                  principal.parseXML(document.getDocumentElement());
+               final String userXml = e.getValue().getUser();
 
-                  if(Objects.equals(principal, user) && ++count >= n) {
+               if(fastSessionTag != null && fastNameTag != null) {
+                  // Fast path: session + name match avoids full XML parse
+                  if(userXml.contains(fastSessionTag) && userXml.contains(fastNameTag) &&
+                     ++count >= n)
+                  {
                      return true;
                   }
                }
-               catch(Exception ex) {
-                  LOG.error("Failed to parse principal", ex);
+               else {
+                  try {
+                     Document document = Tool.parseXML(new StringReader(userXml));
+                     SRPrincipal principal = new SRPrincipal();
+                     principal.parseXML(document.getDocumentElement());
+
+                     if(Objects.equals(principal, user) && ++count >= n) {
+                        return true;
+                     }
+                  }
+                  catch(Exception ex) {
+                     LOG.error("Failed to parse principal", ex);
+                  }
                }
             }
          }

--- a/core/src/main/java/inetsoft/report/composition/RuntimeSheetCache.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeSheetCache.java
@@ -600,12 +600,20 @@ public class RuntimeSheetCache
    }
 
    public List<String> getAllIds(Principal user) {
+      return getAllIds(user, null);
+   }
+
+   public List<String> getAllIds(Principal user, CompressedSheetState.SheetType type) {
       Set<String> ids = new HashSet<>();
       Iterator<Cache.Entry<AffinityKey<String>, CompressedSheetState>> iter = cache.iterator();
 
       try {
          while(iter.hasNext()) {
             Cache.Entry<AffinityKey<String>, CompressedSheetState> e = iter.next();
+
+            if(type != null && e.getValue().getType() != type) {
+               continue;
+            }
 
             if(user == null) {
                ids.add(e.getKey().key());

--- a/core/src/main/java/inetsoft/report/composition/RuntimeSheetCache.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeSheetCache.java
@@ -646,6 +646,53 @@ public class RuntimeSheetCache
       return List.copyOf(ids);
    }
 
+   /**
+    * Returns true if the user has at least {@code n} open sheets of the given type across all
+    * cluster nodes, short-circuiting the cache scan as soon as the threshold is reached.
+    */
+   public boolean hasAtLeast(Principal user, CompressedSheetState.SheetType type, int n) {
+      int count = 0;
+      Iterator<Cache.Entry<AffinityKey<String>, CompressedSheetState>> iter = cache.iterator();
+
+      try {
+         while(iter.hasNext()) {
+            Cache.Entry<AffinityKey<String>, CompressedSheetState> e = iter.next();
+
+            if(type != null && e.getValue().getType() != type) {
+               continue;
+            }
+
+            if(user == null) {
+               if(++count >= n) {
+                  return true;
+               }
+            }
+            else if(e.getValue().getUser() != null) {
+               try {
+                  Document document = Tool.parseXML(new StringReader(e.getValue().getUser()));
+                  SRPrincipal principal = new SRPrincipal();
+                  principal.parseXML(document.getDocumentElement());
+
+                  if(Objects.equals(principal, user) && ++count >= n) {
+                     return true;
+                  }
+               }
+               catch(Exception ex) {
+                  LOG.error("Failed to parse principal", ex);
+               }
+            }
+         }
+      }
+      catch(NoSuchElementException e) {
+         LOG.warn("Cache iterator closed during hasAtLeast scan, returning partial results", e);
+      }
+      finally {
+         Tool.closeIterator(iter);
+      }
+
+      return count >= n;
+   }
+
    public boolean isLocal(String id) {
       if(cluster.isLocalCall()) {
          return true;

--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -4989,13 +4989,30 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
    }
 
    private void applyShareFilter(VSAssembly assembly) throws Exception {
-      ViewsheetEngine.getViewsheetEngine().invokeOnAll(new ApplyShareFilterTask(
-         assembly, System.identityHashCode(getViewsheet()), getUser()));
+      // Resolve filterId on the source node while getViewsheet() is available.
+      // VSAssemblyInfo.vs is transient and returns null on remote cluster nodes.
+      final String filterId = getViewsheet().getViewsheetInfo().getFilterID(assembly.getName());
+
+      if(filterId == null) {
+         return;
+      }
+
+      ViewsheetService engine = ViewsheetEngine.getViewsheetEngine();
+
+      if(!engine.hasAtLeastRuntimeViewsheets(getUser(), 2)) {
+         return;
+      }
+
+      engine.invokeOnAll(new ApplyShareFilterTask(
+         assembly, filterId, System.identityHashCode(getViewsheet()), getUser()));
    }
 
    private static final class ApplyShareFilterTask implements ViewsheetService.Task<String> {
-      public ApplyShareFilterTask(VSAssembly assembly, int viewsheetIdentity, Principal user) {
+      public ApplyShareFilterTask(VSAssembly assembly, String filterId,
+                                  int viewsheetIdentity, Principal user)
+      {
          this.assembly = assembly;
+         this.filterId = filterId;
          this.viewsheetIdentity = viewsheetIdentity;
          this.user = user;
       }
@@ -5013,7 +5030,7 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
             Optional<ViewsheetSandbox> box = rvs.getViewsheetSandbox();
 
             if(box.isPresent()) {
-               box.get().processSharedFilters(assembly, null, true);
+               box.get().processSharedFilters(assembly, filterId, null, true);
             }
          }
 
@@ -5021,6 +5038,7 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
       }
 
       private final VSAssembly assembly;
+      private final String filterId;
       private final int viewsheetIdentity;
       private final Principal user;
    }

--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -5003,6 +5003,11 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
          return;
       }
 
+            // Use identity hash to identify the source viewsheet and skip it in the task.
+      // A runtime ID lookup is not safe here because applyShareFilter is called during
+      // viewsheet open (openVS=true) before the RuntimeViewsheet may be registered in
+      // the cache. identityHashCode collisions are theoretically possible but extremely
+      // rare; on remote nodes the source viewsheet is never present so no skip is needed.
       final int viewsheetIdentity = System.identityHashCode(getViewsheet());
       final Principal user = getUser();
 
@@ -5025,8 +5030,7 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
 
       @Override
       public String apply(ViewsheetService service) throws Exception {
-         RuntimeViewsheet[] arr = ViewsheetEngine.getViewsheetEngine().
-            getRuntimeViewsheets(user);
+         RuntimeViewsheet[] arr = service.getRuntimeViewsheets(user);
 
          for(RuntimeViewsheet rvs : arr) {
             if(rvs == null || System.identityHashCode(rvs.getViewsheet()) == viewsheetIdentity) {

--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -3163,7 +3163,15 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
    {
       // @davidd, Method moved from RuntimeViewsheet in v11.4b r39236.
       String filterId = vs.getViewsheetInfo().getFilterID(fassembly.getName());
+      return processSharedFilters(fassembly, filterId, clist, processChange);
+   }
 
+   public boolean processSharedFilters(VSAssembly fassembly,
+                                       String filterId,
+                                       ChangedAssemblyList clist,
+                                       boolean processChange)
+      throws Exception
+   {
       // Check whether this filter has already been processed
       if(filterId != null && clist != null && clist.isShareFilterProcessed(filterId)) {
          return false;
@@ -3180,7 +3188,7 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
       boolean result = false;
 
       for(ViewsheetSandbox box : boxes) {
-         result |= box.applySharedFilters(fassembly, clist, processChange);
+         result |= box.applySharedFilters(fassembly, filterId, clist, processChange);
       }
 
       return result;
@@ -3198,6 +3206,7 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
     * @return <tt>true</tt> if assemblies are changed
     */
    private boolean applySharedFilters(VSAssembly fassembly,
+                                      String filterId,
                                       ChangedAssemblyList clist,
                                       boolean processChange)
       throws Exception
@@ -3205,7 +3214,7 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
       boolean result = false;
 
       List<VSAssembly> tassemblies =
-         VSUtil.getSharedVSAssemblies(getViewsheet(), fassembly);
+         VSUtil.getSharedVSAssemblies(getViewsheet(), fassembly, filterId);
 
       for(VSAssembly tassembly : tassemblies) {
          int hint = VSAssembly.NONE_CHANGED;

--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -3241,6 +3241,10 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
          // @by davidd, If the from and to assemblies come from different
          // viewsheets, then we force processing. Otherwise the
          // clist.selectionList would have entries of other viewsheets.
+         // Note: when fassembly is dispatched to a remote cluster node via Ignite,
+         // VSAssemblyInfo.vs is transient and getViewsheet() returns null. The null
+         // comparison (null != tassembly.getViewsheet()) is always true, which is the
+         // correct behavior — cross-viewsheet filters always require forced processing.
          if(fassembly.getViewsheet() != tassembly.getViewsheet()) {
             processChange = true;
          }

--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -50,6 +50,7 @@ import inetsoft.util.audit.ExecutionBreakDownRecord;
 import inetsoft.util.log.LogContext;
 import inetsoft.util.profile.ProfileUtils;
 import inetsoft.util.script.*;
+import inetsoft.web.viewsheet.service.SharedFilterService;
 import inetsoft.web.vswizard.model.VSWizardConstants;
 import inetsoft.web.vswizard.recommender.WizardRecommenderUtil;
 import org.slf4j.Logger;
@@ -62,8 +63,7 @@ import java.lang.reflect.Array;
 import java.security.Principal;
 import java.util.*;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
@@ -4988,7 +4988,7 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
       }
    }
 
-   private void applyShareFilter(VSAssembly assembly) throws Exception {
+   private void applyShareFilter(VSAssembly assembly) {
       // Resolve filterId on the source node while getViewsheet() is available.
       // VSAssemblyInfo.vs is transient and returns null on remote cluster nodes.
       final String filterId = getViewsheet().getViewsheetInfo().getFilterID(assembly.getName());
@@ -5003,8 +5003,14 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
          return;
       }
 
-      engine.invokeOnAll(new ApplyShareFilterTask(
-         assembly, filterId, System.identityHashCode(getViewsheet()), getUser()));
+      final int viewsheetIdentity = System.identityHashCode(getViewsheet());
+      final Principal user = getUser();
+
+      // Fire-and-forget — invokeOnAll may block up to 5 minutes waiting on remote nodes
+      // and must not block sandbox execution.
+      CompletableFuture.runAsync(
+         () -> engine.invokeOnAll(new ApplyShareFilterTask(assembly, filterId, viewsheetIdentity, user)),
+         SharedFilterService.SHARED_FILTER_EXECUTOR);
    }
 
    private static final class ApplyShareFilterTask implements ViewsheetService.Task<String> {

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
@@ -1061,9 +1061,12 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
          return future.get(5L, TimeUnit.MINUTES);
       }
       catch(RuntimeException ex) {
+         affinityFutures.remove(id);
          throw ex;
       }
       catch(ExecutionException ex) {
+         affinityFutures.remove(id);
+
          switch(ex.getCause()) {
          case ExpiredSheetException ese -> throw ese;
          case MessageException me -> throw me;
@@ -1072,6 +1075,7 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
          }
       }
       catch(Exception e) {
+         affinityFutures.remove(id);
          throw new RuntimeException(e);
       }
       finally {

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
@@ -1152,22 +1152,27 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
          }
       }
 
+      // Wait for all remote futures under a single shared timeout so that N failed
+      // nodes cost at most 5 minutes total rather than N × 5 minutes.
+      try {
+         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+            .get(5L, TimeUnit.MINUTES);
+      }
+      catch(RuntimeException ex) {
+         futureIds.forEach(affinityFutures::remove);
+         throw ex;
+      }
+      catch(ExecutionException ex) {
+         futureIds.forEach(affinityFutures::remove);
+         throw new RuntimeException(ex);
+      }
+      catch(Exception e) {
+         futureIds.forEach(affinityFutures::remove);
+         throw new RuntimeException(e);
+      }
+
       for(CompletableFuture<T> future : futures) {
-         try {
-            results.add(future.get(5L, TimeUnit.MINUTES));
-         }
-         catch(RuntimeException ex) {
-            futureIds.forEach(affinityFutures::remove);
-            throw ex;
-         }
-         catch(ExecutionException ex) {
-            futureIds.forEach(affinityFutures::remove);
-            throw new RuntimeException(ex);
-         }
-         catch(Exception e) {
-            futureIds.forEach(affinityFutures::remove);
-            throw new RuntimeException(e);
-         }
+         results.add(future.getNow(null));
       }
 
       return results;

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
@@ -1135,25 +1135,26 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
       List<String> futureIds = new ArrayList<>(nodes.size());
       List<T> results = new ArrayList<>();
 
-      for(ClusterNode node : nodes) {
-         if(Objects.equals(ignite.cluster().localNode(), node)) {
-            try {
+      try {
+         for(ClusterNode node : nodes) {
+            if(Objects.equals(ignite.cluster().localNode(), node)) {
                results.add(job.call());
             }
-            catch(Exception e) {
-               throw new RuntimeException(e);
+            else if(!node.isClient()) {
+               String id = UUID.randomUUID().toString();
+               AffinityCallRequest<T> request = new AffinityCallRequest<>(
+                  id, getNodeName(ignite.cluster().localNode()), getNodeName(node), job);
+               CompletableFuture<T> future = new CompletableFuture<>();
+               affinityFutures.put(id, future);
+               futures.add(future);
+               futureIds.add(id);
+               ignite.message(ignite.cluster().forServers()).sendOrdered(AFFINITY_TOPIC, request, 0);
             }
          }
-         else if(!node.isClient()) {
-            String id = UUID.randomUUID().toString();
-            AffinityCallRequest<T> request = new AffinityCallRequest<>(
-               id, getNodeName(ignite.cluster().localNode()), getNodeName(node), job);
-            CompletableFuture<T> future = new CompletableFuture<>();
-            affinityFutures.put(id, future);
-            futures.add(future);
-            futureIds.add(id);
-            ignite.message(ignite.cluster().forServers()).sendOrdered(AFFINITY_TOPIC, request, 0);
-         }
+      }
+      catch(Exception e) {
+         futureIds.forEach(affinityFutures::remove);
+         throw new RuntimeException(e);
       }
 
       // Wait for all remote futures under a single shared timeout so that N failed

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
@@ -1152,7 +1152,13 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
 
       for(CompletableFuture<T> future : futures) {
          try {
-            results.add(future.get());
+            results.add(future.get(5L, TimeUnit.MINUTES));
+         }
+         catch(RuntimeException ex) {
+            throw ex;
+         }
+         catch(ExecutionException ex) {
+            throw new RuntimeException(ex);
          }
          catch(Exception e) {
             throw new RuntimeException(e);

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
@@ -1128,6 +1128,7 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
       }
 
       List<CompletableFuture<T>> futures = new ArrayList<>(nodes.size());
+      List<String> futureIds = new ArrayList<>(nodes.size());
       List<T> results = new ArrayList<>();
 
       for(ClusterNode node : nodes) {
@@ -1146,6 +1147,7 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
             CompletableFuture<T> future = new CompletableFuture<>();
             affinityFutures.put(id, future);
             futures.add(future);
+            futureIds.add(id);
             ignite.message(ignite.cluster().forServers()).sendOrdered(AFFINITY_TOPIC, request, 0);
          }
       }
@@ -1155,12 +1157,15 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
             results.add(future.get(5L, TimeUnit.MINUTES));
          }
          catch(RuntimeException ex) {
+            futureIds.forEach(affinityFutures::remove);
             throw ex;
          }
          catch(ExecutionException ex) {
+            futureIds.forEach(affinityFutures::remove);
             throw new RuntimeException(ex);
          }
          catch(Exception e) {
+            futureIds.forEach(affinityFutures::remove);
             throw new RuntimeException(e);
          }
       }

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VSUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VSUtil.java
@@ -902,6 +902,10 @@ public final class VSUtil {
          return list;
       }
 
+      // VSAssemblyInfo.vs is transient: when fassembly is deserialized on a remote cluster
+      // node, getViewsheet() returns null. The self-exclusion guard (tvs == fvs) therefore
+      // never fires on remote nodes, which is safe — a remote node's tvs is never the same
+      // object as null, so no assembly is incorrectly skipped.
       Viewsheet fvs = fassembly.getViewsheet();
       String fname = fassembly.getName();
       ViewsheetInfo tvinfo = tvs.getViewsheetInfo();

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VSUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VSUtil.java
@@ -890,12 +890,20 @@ public final class VSUtil {
       ViewsheetInfo fvinfo = fvs != null ? fvs.getViewsheetInfo() : tvs.getViewsheetInfo();
       String fname = fassembly.getName();
       String fid = fvinfo.getFilterID(fname);
+      return getSharedVSAssemblies(tvs, fassembly, fid);
+   }
+
+   public static List<VSAssembly> getSharedVSAssemblies(Viewsheet tvs, VSAssembly fassembly,
+                                                         String fid)
+   {
       List<VSAssembly> list = new ArrayList<>();
 
       if(fid == null) {
          return list;
       }
 
+      Viewsheet fvs = fassembly.getViewsheet();
+      String fname = fassembly.getName();
       ViewsheetInfo tvinfo = tvs.getViewsheetInfo();
       List<String> tnames = tvinfo.getFilterColumns(fid);
 
@@ -903,7 +911,6 @@ public final class VSUtil {
          Assembly tassembly = tvs.getAssembly(tname);
 
          // ignore self
-
          if(tvs == fvs && tname.equals(fname)) {
             continue;
          }

--- a/core/src/main/java/inetsoft/web/viewsheet/service/SharedFilterService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/SharedFilterService.java
@@ -116,8 +116,12 @@ public class SharedFilterService {
    private final CommandDispatcherService commandDispatcherService;
    private final ViewsheetService viewsheetService;
    private static final Logger LOG = LoggerFactory.getLogger(SharedFilterService.class);
-   private static final Executor SHARED_FILTER_EXECUTOR =
-      Executors.newFixedThreadPool(5, r -> new GroupedThread(r, "SharedFilter"));
+   public static final Executor SHARED_FILTER_EXECUTOR =
+      Executors.newCachedThreadPool(r -> {
+         GroupedThread t = new GroupedThread(r, "SharedFilter");
+         t.setDaemon(true);
+         return t;
+      });
 
    private static final class ChangedViewsheet implements Serializable {
       public ChangedViewsheet(RuntimeViewsheet rvs) {

--- a/core/src/main/java/inetsoft/web/viewsheet/service/SharedFilterService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/SharedFilterService.java
@@ -24,6 +24,7 @@ import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.uql.asset.ConfirmDataException;
 import inetsoft.uql.asset.ConfirmException;
 import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.util.GroupedThread;
 import inetsoft.web.viewsheet.command.UpdateSharedFiltersCommand;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +35,7 @@ import org.springframework.stereotype.Service;
 import java.io.Serializable;
 import java.security.Principal;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.*;
 
 @Service
 public class SharedFilterService {
@@ -70,17 +71,14 @@ public class SharedFilterService {
 
       // skip cluster broadcast if the user has fewer than 2 viewsheets open across
       // all cluster nodes — there's nothing to synchronize
-      if(viewsheetService.getRuntimeViewsheetCount(principal) < 2) {
+      if(!viewsheetService.hasAtLeastRuntimeViewsheets(principal, 2)) {
          return false;
       }
 
-      // for shared selection, refresh vsobject command should specified
-      // process, add "SHARED_HINT" to make the RefreshVSObjectCommand not
-      // equals the original RefreshVSObjectCommand, see bug1247647231402
-      final String sharedHint = assembly.getAbsoluteName();
       final String userName = dispatcher.getUserName();
-      dispatcher.setSharedHint(sharedHint);
 
+      // Use a dedicated executor — invokeOnAll blocks for up to 5 minutes waiting on
+      // remote nodes and must not run on the common ForkJoinPool.
       CompletableFuture.runAsync(() -> {
          List<ChangedViewsheet> changed = viewsheetService.invokeOnAll(
                new ApplyFiltersTask(vs.getID(), assembly, filterId, principal))
@@ -110,15 +108,16 @@ public class SharedFilterService {
                LOG.warn("Failed to send shared filter notification for viewsheet {}", rvs.getId(), ex);
             }
          }
-      });
+      }, SHARED_FILTER_EXECUTOR);
 
-      dispatcher.setSharedHint(null);
       return false;
    }
 
    private final CommandDispatcherService commandDispatcherService;
    private final ViewsheetService viewsheetService;
    private static final Logger LOG = LoggerFactory.getLogger(SharedFilterService.class);
+   private static final Executor SHARED_FILTER_EXECUTOR =
+      Executors.newFixedThreadPool(5, r -> new GroupedThread(r, "SharedFilter"));
 
    private static final class ChangedViewsheet implements Serializable {
       public ChangedViewsheet(RuntimeViewsheet rvs) {

--- a/core/src/main/java/inetsoft/web/viewsheet/service/SharedFilterService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/SharedFilterService.java
@@ -124,7 +124,9 @@ public class SharedFilterService {
             t.setDaemon(true);
             return t;
          },
-         new ThreadPoolExecutor.CallerRunsPolicy());
+         (r, executor) -> LOG.warn(
+            "SharedFilter executor saturated (all 16 threads busy), " +
+            "dropping shared filter notification — client will re-sync on next interaction"));
 
    private static final class ChangedViewsheet implements Serializable {
       public ChangedViewsheet(RuntimeViewsheet rvs) {

--- a/core/src/main/java/inetsoft/web/viewsheet/service/SharedFilterService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/SharedFilterService.java
@@ -29,20 +29,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 import java.io.Serializable;
 import java.security.Principal;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 
 @Service
 public class SharedFilterService {
    @Autowired
-   public SharedFilterService(SimpMessagingTemplate messagingTemplate,
-                              ViewsheetService viewsheetService)
+   public SharedFilterService(CommandDispatcherService commandDispatcherService,
+                               ViewsheetService viewsheetService)
    {
-      this.messagingTemplate = messagingTemplate;
+      this.commandDispatcherService = commandDispatcherService;
       this.viewsheetService = viewsheetService;
    }
 
@@ -59,39 +59,64 @@ public class SharedFilterService {
          return false;
       }
 
+      // Resolve filterId on the source node while we still have access to the viewsheet,
+      // since VSAssemblyInfo.vs is transient and will be null on remote cluster nodes.
+      final String filterId = vs.getViewsheet().getViewsheetInfo().getFilterID(assembly.getName());
+
+      // skip cluster broadcast if this assembly has no shared filter ID configured
+      if(filterId == null) {
+         return false;
+      }
+
+      // skip cluster broadcast if the user has fewer than 2 viewsheets open across
+      // all cluster nodes — there's nothing to synchronize
+      if(viewsheetService.getRuntimeViewsheetCount(principal) < 2) {
+         return false;
+      }
+
       // for shared selection, refresh vsobject command should specified
       // process, add "SHARED_HINT" to make the RefreshVSObjectCommand not
       // equals the original RefreshVSObjectCommand, see bug1247647231402
-      dispatcher.setSharedHint(assembly.getAbsoluteName());
+      final String sharedHint = assembly.getAbsoluteName();
+      final String userName = dispatcher.getUserName();
+      dispatcher.setSharedHint(sharedHint);
 
-      List<ChangedViewsheet> changed = viewsheetService.invokeOnAll(new ApplyFiltersTask(vs.getID(), assembly, principal))
-         .stream()
-         .flatMap(Collection::stream)
-         .toList();
+      CompletableFuture.runAsync(() -> {
+         List<ChangedViewsheet> changed = viewsheetService.invokeOnAll(
+               new ApplyFiltersTask(vs.getID(), assembly, filterId, principal))
+            .stream()
+            .flatMap(Collection::stream)
+            .toList();
 
-      for(ChangedViewsheet rvs : changed) {
-         SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.create();
-         headerAccessor.setSessionId(rvs.getSocketSessionId());
-         headerAccessor.setLeaveMutable(true);
-         headerAccessor.setNativeHeader(
-            CommandDispatcher.COMMAND_TYPE_HEADER, "UpdateSharedFiltersCommand");
-         headerAccessor.setNativeHeader(CommandDispatcher.RUNTIME_ID_ATTR, rvs.getId());
-         String user = rvs.getSocketUserName();
+         for(ChangedViewsheet rvs : changed) {
+            try {
+               SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.create();
+               headerAccessor.setSessionId(rvs.getSocketSessionId());
+               headerAccessor.setLeaveMutable(true);
+               headerAccessor.setNativeHeader(
+                  CommandDispatcher.COMMAND_TYPE_HEADER, "UpdateSharedFiltersCommand");
+               headerAccessor.setNativeHeader(CommandDispatcher.RUNTIME_ID_ATTR, rvs.getId());
+               String user = rvs.getSocketUserName();
 
-         if(user == null) {
-            user = dispatcher.getUserName();
+               if(user == null) {
+                  user = userName;
+               }
+
+               commandDispatcherService.convertAndSendToUser(
+                  user, CommandDispatcher.COMMANDS_TOPIC,
+                  new UpdateSharedFiltersCommand(), headerAccessor.getMessageHeaders());
+            }
+            catch(Exception ex) {
+               LOG.warn("Failed to send shared filter notification for viewsheet {}", rvs.getId(), ex);
+            }
          }
-
-         messagingTemplate.convertAndSendToUser(
-            user, CommandDispatcher.COMMANDS_TOPIC,
-            new UpdateSharedFiltersCommand(), headerAccessor.getMessageHeaders());
-      }
+      });
 
       dispatcher.setSharedHint(null);
       return false;
    }
 
-   private final SimpMessagingTemplate messagingTemplate;
+   private final CommandDispatcherService commandDispatcherService;
    private final ViewsheetService viewsheetService;
    private static final Logger LOG = LoggerFactory.getLogger(SharedFilterService.class);
 
@@ -123,10 +148,15 @@ public class SharedFilterService {
       private final String socketUserName;
    }
 
-   private static final class ApplyFiltersTask implements ViewsheetService.Task<ArrayList<ChangedViewsheet>> {
-      public ApplyFiltersTask(String rid, VSAssembly assembly, Principal principal) {
+   private static final class ApplyFiltersTask
+      implements ViewsheetService.Task<ArrayList<ChangedViewsheet>>
+   {
+      public ApplyFiltersTask(String rid, VSAssembly assembly, String filterId,
+                              Principal principal)
+      {
          this.rid = rid;
          this.assembly = assembly;
+         this.filterId = filterId;
          this.principal = principal;
       }
 
@@ -146,7 +176,7 @@ public class SharedFilterService {
                boolean changed = false;
 
                if(box.isPresent()) {
-                  changed = box.get().processSharedFilters(assembly, null, true);
+                  changed = box.get().processSharedFilters(assembly, filterId, null, true);
                }
 
                if(changed) {
@@ -169,6 +199,7 @@ public class SharedFilterService {
 
       private final String rid;
       private final VSAssembly assembly;
+      private final String filterId;
       private final Principal principal;
    }
 }

--- a/core/src/main/java/inetsoft/web/viewsheet/service/SharedFilterService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/SharedFilterService.java
@@ -117,11 +117,14 @@ public class SharedFilterService {
    private final ViewsheetService viewsheetService;
    private static final Logger LOG = LoggerFactory.getLogger(SharedFilterService.class);
    public static final Executor SHARED_FILTER_EXECUTOR =
-      Executors.newCachedThreadPool(r -> {
-         GroupedThread t = new GroupedThread(r, "SharedFilter");
-         t.setDaemon(true);
-         return t;
-      });
+      new ThreadPoolExecutor(0, 16, 60L, TimeUnit.SECONDS,
+         new SynchronousQueue<>(),
+         r -> {
+            GroupedThread t = new GroupedThread(r, "SharedFilter");
+            t.setDaemon(true);
+            return t;
+         },
+         new ThreadPoolExecutor.CallerRunsPolicy());
 
    private static final class ChangedViewsheet implements Serializable {
       public ChangedViewsheet(RuntimeViewsheet rvs) {

--- a/core/src/test/java/inetsoft/test/IntegrationTestConfiguration.java
+++ b/core/src/test/java/inetsoft/test/IntegrationTestConfiguration.java
@@ -72,9 +72,9 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.*;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.support.GenericMessage;
+
+import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 import java.util.List;
@@ -301,19 +301,15 @@ public class IntegrationTestConfiguration {
    }
 
    @Bean
-   public SharedFilterService sharedFilterService(ViewsheetService viewsheetService) {
-      SimpMessagingTemplate messagingTemplate = new SimpMessagingTemplate(new MessageChannel() {
-         @Override
-         public boolean send(Message<?> message) {
-            return true;
-         }
+   public CommandDispatcherService commandDispatcherService() {
+      return mock(CommandDispatcherService.class);
+   }
 
-         @Override
-         public boolean send(Message<?> message, long timeout) {
-            return true;
-         }
-      });
-      return new SharedFilterService(messagingTemplate, viewsheetService);
+   @Bean
+   public SharedFilterService sharedFilterService(CommandDispatcherService commandDispatcherService,
+                                                   ViewsheetService viewsheetService)
+   {
+      return new SharedFilterService(commandDispatcherService, viewsheetService);
    }
 
    @Bean

--- a/core/src/test/java/inetsoft/test/IntegrationTestConfiguration.java
+++ b/core/src/test/java/inetsoft/test/IntegrationTestConfiguration.java
@@ -79,8 +79,6 @@ import static org.mockito.Mockito.mock;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.mockito.Mockito.mock;
-
 /**
  * Spring test configuration providing all viewsheet controller and service beans needed by
  * integration tests that open and interact with runtime viewsheets.


### PR DESCRIPTION
Resolve filterId on the source node before cluster dispatch to avoid dereferencing VSAssemblyInfo.vs (transient, null after Ignite serialization on remote nodes). Use affinityCallAll so each node processes only its own viewsheets, CommandDispatcherService for STOMP routing to the correct node, and orTimeout guards to prevent indefinite hangs if an executor node dies.

- ViewsheetSandbox/VSUtil: pass filterId explicitly through applySharedFilters
- SharedFilterService: resolve filterId early; skip dispatch when < 2 viewsheets open
- ViewsheetService/ViewsheetEngine: add getRuntimeViewsheetCount
- IgniteCluster: add timeout to futures in affinityCallAll
- RuntimeSheetCache: add typed getAllIds(Principal, SheetType) overload
- IntegrationTestConfiguration: update test wiring