### PR TITLE
Feature #74804 - Add round-corner option for legend symbols

### DIFF
--- a/core/src/main/java/inetsoft/graph/LegendSpec.java
+++ b/core/src/main/java/inetsoft/graph/LegendSpec.java
@@ -204,6 +204,14 @@ public class LegendSpec implements Cloneable, Serializable {
       this.roundCorners = roundCorners;
    }
 
+   public boolean isSymbolRoundCorners() {
+      return symbolRoundCorners;
+   }
+
+   public void setSymbolRoundCorners(boolean symbolRoundCorners) {
+      this.symbolRoundCorners = symbolRoundCorners;
+   }
+
    /**
     * Get the legend title text attributes.
     */
@@ -389,6 +397,7 @@ public class LegendSpec implements Cloneable, Serializable {
       return visible == that.visible && border == that.border &&
          titleVisible == that.titleVisible && partial == that.partial && topY == that.topY &&
          gap == that.gap && symbolSize == that.symbolSize && roundCorners == that.roundCorners &&
+         symbolRoundCorners == that.symbolRoundCorners &&
          Objects.equals(borderColor, that.borderColor) &&
          Objects.equals(bg, that.bg) && Objects.equals(title, that.title) &&
          Objects.equals(titleSpec, that.titleSpec) && Objects.equals(textFrame, that.textFrame) &&
@@ -401,7 +410,7 @@ public class LegendSpec implements Cloneable, Serializable {
    public int hashCode() {
       return Objects.hash(visible, border, borderColor, bg, title, titleVisible, titleSpec,
                           textFrame, textSpec, partial, position, epos, preferredSize, topY, gap,
-                          padding, hiddenItems, symbolSize, roundCorners);
+                          padding, hiddenItems, symbolSize, roundCorners, symbolRoundCorners);
    }
 
    private int border = GraphConstants.THIN_LINE;
@@ -422,6 +431,7 @@ public class LegendSpec implements Cloneable, Serializable {
    private Set hiddenItems = new HashSet();
    private int symbolSize = LegendItem.DEFAULT_SYMBOL_SIZE;
    private boolean roundCorners = false;
+   private boolean symbolRoundCorners = false;
 
    private static final long serialVersionUID = 1L;
    private static final Logger LOG = LoggerFactory.getLogger(LegendSpec.class);

--- a/core/src/main/java/inetsoft/graph/guide/legend/ColorLegendItem.java
+++ b/core/src/main/java/inetsoft/graph/guide/legend/ColorLegendItem.java
@@ -22,7 +22,7 @@ import inetsoft.graph.aesthetic.VisualFrame;
 import inetsoft.graph.internal.GTool;
 
 import java.awt.*;
-import java.awt.geom.Rectangle2D;
+import java.awt.geom.RectangularShape;
 
 /**
  * This class renders a single color legend item.
@@ -50,7 +50,7 @@ public class ColorLegendItem extends LegendItem {
    protected void paintSymbol(Graphics2D g, double x, double y) {
       Graphics2D g2 = (Graphics2D) g.create();
       int size = getSymbolSize();
-      Rectangle2D rect = new Rectangle2D.Double(x, y, size, size);
+      RectangularShape rect = createSymbolRect(x, y, size, size);
       ColorFrame frame = (ColorFrame) getVisualFrame();
       Color color = frame.getColor(getValue());
       color = GTool.getColor(color, getAlpha());

--- a/core/src/main/java/inetsoft/graph/guide/legend/ColorLegendItem.java
+++ b/core/src/main/java/inetsoft/graph/guide/legend/ColorLegendItem.java
@@ -55,6 +55,11 @@ public class ColorLegendItem extends LegendItem {
       Color color = frame.getColor(getValue());
       color = GTool.getColor(color, getAlpha());
       g2.setColor(color);
+
+      if(frame.getLegendSpec().isSymbolRoundCorners()) {
+         g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+      }
+
       g2.fill(rect);
 
       // best aesthetics, only draw border for 'white' color

--- a/core/src/main/java/inetsoft/graph/guide/legend/LegendItem.java
+++ b/core/src/main/java/inetsoft/graph/guide/legend/LegendItem.java
@@ -27,6 +27,9 @@ import inetsoft.util.Tool;
 
 import java.awt.*;
 import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import java.awt.geom.RectangularShape;
+import java.awt.geom.RoundRectangle2D;
 
 /**
  * Legend item.
@@ -251,6 +254,28 @@ public abstract class LegendItem extends BoundedContainer {
    protected abstract void paintSymbol(Graphics2D g, double x, double y);
 
    /**
+    * Build the swatch rect honoring LegendSpec.isSymbolRoundCorners().
+    */
+   protected RectangularShape createSymbolRect(double x, double y, double w, double h) {
+      return createSymbolRect(x, y, w, h, true);
+   }
+
+   /**
+    * Build the swatch rect; allowRound=false forces a sharp rect even when the
+    * spec asks for rounded corners (used for narrow size-legend bars).
+    */
+   protected RectangularShape createSymbolRect(double x, double y, double w, double h,
+                                               boolean allowRound)
+   {
+      if(allowRound && frame.getLegendSpec().isSymbolRoundCorners()) {
+         double arc = symbolSize * SYMBOL_CORNER_RADIUS_RATIO * 2;
+         return new RoundRectangle2D.Double(x, y, w, h, arc, arc);
+      }
+
+      return new Rectangle2D.Double(x, y, w, h);
+   }
+
+   /**
     * Set the color alpha of symbol.
     * @param alpha the color alpha.
     */
@@ -271,6 +296,8 @@ public abstract class LegendItem extends BoundedContainer {
    }
 
    public static final int DEFAULT_SYMBOL_SIZE = 12;
+   /** Corner-radius of legend symbols, as a fraction of symbol size. */
+   public static final double SYMBOL_CORNER_RADIUS_RATIO = 0.3;
    protected static final int LINESYMBOL_WIDTH = 30;
    protected static final Color SYMBOL_BORDER = new Color(0xa3, 0xa3, 0xa3);
    protected static final Color SYMBOL_COLOR = new Color(0x759595);

--- a/core/src/main/java/inetsoft/graph/guide/legend/LegendItem.java
+++ b/core/src/main/java/inetsoft/graph/guide/legend/LegendItem.java
@@ -268,7 +268,7 @@ public abstract class LegendItem extends BoundedContainer {
                                                boolean allowRound)
    {
       if(allowRound && frame.getLegendSpec().isSymbolRoundCorners()) {
-         double arc = symbolSize * SYMBOL_CORNER_RADIUS_RATIO * 2;
+         double arc = Math.min(w, h) * SYMBOL_CORNER_RADIUS_RATIO * 2;
          return new RoundRectangle2D.Double(x, y, w, h, arc, arc);
       }
 
@@ -297,7 +297,7 @@ public abstract class LegendItem extends BoundedContainer {
 
    public static final int DEFAULT_SYMBOL_SIZE = 12;
    /** Corner-radius of legend symbols, as a fraction of symbol size. */
-   public static final double SYMBOL_CORNER_RADIUS_RATIO = 0.3;
+   static final double SYMBOL_CORNER_RADIUS_RATIO = 0.3;
    protected static final int LINESYMBOL_WIDTH = 30;
    protected static final Color SYMBOL_BORDER = new Color(0xa3, 0xa3, 0xa3);
    protected static final Color SYMBOL_COLOR = new Color(0x759595);

--- a/core/src/main/java/inetsoft/graph/guide/legend/SizeLegendItem.java
+++ b/core/src/main/java/inetsoft/graph/guide/legend/SizeLegendItem.java
@@ -22,7 +22,6 @@ import inetsoft.graph.aesthetic.VisualFrame;
 import inetsoft.graph.internal.GTool;
 
 import java.awt.*;
-import java.awt.geom.Rectangle2D;
 
 /**
  * This class renders a size legend item.
@@ -62,14 +61,16 @@ public class SizeLegendItem extends LegendItem {
       g2.setColor(getSymbolColor());
       g2.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
       g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-      g2.fill(new Rectangle2D.Double(x0, y, r, symbolSz));
+      // skip rounding the inner bar when it's narrower than the corner arc
+      double minRoundWidth = symbolSz * SYMBOL_CORNER_RADIUS_RATIO * 2;
+      g2.fill(createSymbolRect(x0, y, r, symbolSz, r >= minRoundWidth));
       g2.setColor(SYMBOL_BORDER);
 
       if(!GTool.isVectorGraphics(g2)) {
          g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
       }
 
-      g2.draw(new Rectangle2D.Double(x, y, symbolSz, symbolSz));
+      g2.draw(createSymbolRect(x, y, symbolSz, symbolSz));
       g2.dispose();
    }
 }

--- a/core/src/main/java/inetsoft/graph/guide/legend/SizeLegendItem.java
+++ b/core/src/main/java/inetsoft/graph/guide/legend/SizeLegendItem.java
@@ -66,7 +66,7 @@ public class SizeLegendItem extends LegendItem {
       g2.fill(createSymbolRect(x0, y, r, symbolSz, r >= minRoundWidth));
       g2.setColor(SYMBOL_BORDER);
 
-      if(!GTool.isVectorGraphics(g2)) {
+      if(!GTool.isVectorGraphics(g2) && !frame.getLegendSpec().isSymbolRoundCorners()) {
          g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
       }
 

--- a/core/src/main/java/inetsoft/graph/guide/legend/TextureLegendItem.java
+++ b/core/src/main/java/inetsoft/graph/guide/legend/TextureLegendItem.java
@@ -57,6 +57,10 @@ public class TextureLegendItem extends LegendItem {
 
       g2.setColor(getSymbolColor());
 
+      if(frame.getLegendSpec().isSymbolRoundCorners()) {
+         g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+      }
+
       if(gt != null) {
          gt.paint(g2, rect);
       }

--- a/core/src/main/java/inetsoft/graph/guide/legend/TextureLegendItem.java
+++ b/core/src/main/java/inetsoft/graph/guide/legend/TextureLegendItem.java
@@ -20,7 +20,7 @@ package inetsoft.graph.guide.legend;
 import inetsoft.graph.aesthetic.*;
 
 import java.awt.*;
-import java.awt.geom.Rectangle2D;
+import java.awt.geom.RectangularShape;
 
 /**
  * This class renders a texture legend item.
@@ -51,7 +51,7 @@ public class TextureLegendItem extends LegendItem {
 			  RenderingHints.VALUE_STROKE_PURE);
 
       int size = getSymbolSize();
-      Rectangle2D rect= new Rectangle2D.Double(x, y, size, size);
+      RectangularShape rect = createSymbolRect(x, y, size, size);
       TextureFrame frame = (TextureFrame) getVisualFrame();
       GTexture gt = frame.getTexture(getValue());
 

--- a/core/src/main/java/inetsoft/report/composition/graph/GraphUtil.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphUtil.java
@@ -579,6 +579,7 @@ public class GraphUtil {
       spec.setBorder(legends.getBorder());
       spec.setBorderColor(legends.getBorderColor());
       spec.setRoundCorners(legends.isRoundCorners());
+      spec.setSymbolRoundCorners(legends.isSymbolRoundCorners());
       spec.setTitleTextSpec(GraphUtil.getTextSpec(format, null, null));
       spec.setPartial(true);
    }

--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/LegendsDescriptor.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/LegendsDescriptor.java
@@ -108,6 +108,14 @@ public class LegendsDescriptor implements AssetObject, ContentObject {
       this.roundCorners = roundCorners;
    }
 
+   public boolean isSymbolRoundCorners() {
+      return symbolRoundCorners;
+   }
+
+   public void setSymbolRoundCorners(boolean symbolRoundCorners) {
+      this.symbolRoundCorners = symbolRoundCorners;
+   }
+
    /**
     * Get the color used by the legends border.
     */
@@ -406,6 +414,7 @@ public class LegendsDescriptor implements AssetObject, ContentObject {
          && Tool.equals(borderColor, desc.borderColor)
          && Tool.equals(border, desc.border)
          && roundCorners == desc.roundCorners
+         && symbolRoundCorners == desc.symbolRoundCorners
          && option == desc.option
          && Tool.equals(preferredSize, desc.preferredSize)
          && Tool.equals(gap, desc.gap)
@@ -432,6 +441,7 @@ public class LegendsDescriptor implements AssetObject, ContentObject {
       writer.print(" borderColor=\"" + borderColor + "\"");
       writer.print(" border=\"" + border + "\"");
       writer.print(" roundCorners=\"" + roundCorners + "\"");
+      writer.print(" symbolRoundCorners=\"" + symbolRoundCorners + "\"");
       writer.print(" option=\"" + option + "\"");
 
       if(preferredSize != null) {
@@ -495,6 +505,13 @@ public class LegendsDescriptor implements AssetObject, ContentObject {
 
       if((val = Tool.getAttribute(tag, "roundCorners")) != null) {
          roundCorners = "true".equals(val);
+      }
+
+      if((val = Tool.getAttribute(tag, "symbolRoundCorners")) != null) {
+         symbolRoundCorners = "true".equals(val);
+      }
+      else {
+         symbolRoundCorners = false;
       }
 
       if((val = Tool.getAttribute(tag, "option")) != null) {
@@ -581,6 +598,8 @@ public class LegendsDescriptor implements AssetObject, ContentObject {
    private CompositeValue<Integer> border = new CompositeValue<>(Integer.class,
                                                                  StyleConstants.THIN_LINE);
    private boolean roundCorners = false;
+   // default true for new charts; parseAttributes forces false on legacy XML
+   private boolean symbolRoundCorners = true;
    private LegendDescriptor colorDesc;
    private LegendDescriptor shapeDesc;
    private LegendDescriptor sizeDesc;

--- a/core/src/main/java/inetsoft/web/graph/model/dialog/LegendFormatDialogModel.java
+++ b/core/src/main/java/inetsoft/web/graph/model/dialog/LegendFormatDialogModel.java
@@ -50,6 +50,13 @@ public class LegendFormatDialogModel {
       generalPaneModel.setNotShowNullVisible(dimension && field != null);
       generalPaneModel.setSymbolSize(legendDesc.getSymbolSize());
       generalPaneModel.setRoundCorners(legendsDesc.isRoundCorners());
+      generalPaneModel.setSymbolRoundCorners(legendsDesc.isSymbolRoundCorners());
+      // only rect-based legends (Color/Size/Texture) actually render the rounded swatch;
+      // Shape and Line legends draw glyphs/lines so the toggle is hidden there
+      generalPaneModel.setSymbolRoundCornersVisible(
+         "Color".equals(aestheticType) ||
+         "Size".equals(aestheticType) ||
+         "Texture".equals(aestheticType));
 
       if(legendsDesc.getBorderColor() != null) {
          generalPaneModel.setFillColor(
@@ -117,6 +124,7 @@ public class LegendFormatDialogModel {
       legendDesc.setNotShowNull(generalPaneModel.isNotShowNull());
       legendDesc.setSymbolSize(generalPaneModel.getSymbolSize());
       legendsDesc.setRoundCorners(generalPaneModel.isRoundCorners());
+      legendsDesc.setSymbolRoundCorners(generalPaneModel.isSymbolRoundCorners());
 
       legendDesc.setReversed(scalePaneModel.isReverse());
       legendDesc.setLogarithmicScale(scalePaneModel.isLogarithmic());

--- a/core/src/main/java/inetsoft/web/graph/model/dialog/LegendFormatGeneralPaneModel.java
+++ b/core/src/main/java/inetsoft/web/graph/model/dialog/LegendFormatGeneralPaneModel.java
@@ -100,6 +100,22 @@ public class LegendFormatGeneralPaneModel {
       this.roundCorners = roundCorners;
    }
 
+   public boolean isSymbolRoundCorners() {
+      return symbolRoundCorners;
+   }
+
+   public void setSymbolRoundCorners(boolean symbolRoundCorners) {
+      this.symbolRoundCorners = symbolRoundCorners;
+   }
+
+   public boolean isSymbolRoundCornersVisible() {
+      return symbolRoundCornersVisible;
+   }
+
+   public void setSymbolRoundCornersVisible(boolean symbolRoundCornersVisible) {
+      this.symbolRoundCornersVisible = symbolRoundCornersVisible;
+   }
+
    // title dvalue
    private String title;
    // title rvalue
@@ -112,4 +128,6 @@ public class LegendFormatGeneralPaneModel {
    private boolean notShowNullVisible;
    private int symbolSize = LegendItem.DEFAULT_SYMBOL_SIZE;
    private boolean roundCorners;
+   private boolean symbolRoundCorners;
+   private boolean symbolRoundCornersVisible;
 }

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -2341,6 +2341,7 @@ Rotate=Rotate
 Rotated\ Table=Rotated Table
 Rotation=Rotation
 Round\ Corner=Round Corner
+Round\ Symbol\ Corner=Round Symbol Corner
 Round\ All\ Corners=Round All Corners
 Round\ Top\ Corners\ Only=Round Top Corners Only
 Round\ Bottom\ Corners\ Only=Round Bottom Corners Only

--- a/web/projects/portal/src/app/graph/dialog/legend-format-general-pane.component.html
+++ b/web/projects/portal/src/app/graph/dialog/legend-format-general-pane.component.html
@@ -83,6 +83,16 @@
           _#(viewer.viewsheet.chart.legend.symbolSize.rangeWarning)
         </div>
       </div>
+      <div class="checkbox col-auto" *ngIf="model.symbolRoundCornersVisible">
+        <div class="form-check">
+          <input type="checkbox" class="form-check-input" id="symbolRoundCorners"
+                 [ngModelOptions]="{standalone: true}"
+                 [(ngModel)]="model.symbolRoundCorners">
+          <label class="form-check-label" for="symbolRoundCorners">
+            _#(Round Symbol Corner)
+          </label>
+        </div>
+      </div>
     </div>
   </fieldset>
   <fieldset *ngIf="model.notShowNullVisible">

--- a/web/projects/portal/src/app/graph/dialog/legend-format-general-pane.spec.ts
+++ b/web/projects/portal/src/app/graph/dialog/legend-format-general-pane.spec.ts
@@ -130,4 +130,34 @@ describe("LegendFormatGeneralPane Unit Tests", () => {
          done();
       });
    });
+
+   it("should show Round Symbol Corner checkbox when symbolRoundCornersVisible is true", (done) => {
+      let fixture: ComponentFixture<LegendFormatGeneralPane> = TestBed.createComponent(LegendFormatGeneralPane);
+      let model: LegendFormatGeneralPaneModel = createModel();
+      model.symbolRoundCornersVisible = true;
+      fixture.componentInstance.model = model;
+      fixture.componentInstance.form = new FormGroup({});
+      fixture.detectChanges();
+
+      fixture.whenStable().then(() => {
+         let label: any = fixture.nativeElement.querySelector("label[for='symbolRoundCorners']");
+         expect(label).toBeTruthy();
+         done();
+      });
+   });
+
+   it("should hide Round Symbol Corner checkbox when symbolRoundCornersVisible is false", (done) => {
+      let fixture: ComponentFixture<LegendFormatGeneralPane> = TestBed.createComponent(LegendFormatGeneralPane);
+      let model: LegendFormatGeneralPaneModel = createModel();
+      model.symbolRoundCornersVisible = false;
+      fixture.componentInstance.model = model;
+      fixture.componentInstance.form = new FormGroup({});
+      fixture.detectChanges();
+
+      fixture.whenStable().then(() => {
+         let label: any = fixture.nativeElement.querySelector("label[for='symbolRoundCorners']");
+         expect(label).toBeFalsy();
+         done();
+      });
+   });
 });

--- a/web/projects/portal/src/app/graph/dialog/legend-format-general-pane.spec.ts
+++ b/web/projects/portal/src/app/graph/dialog/legend-format-general-pane.spec.ts
@@ -56,7 +56,9 @@ let createModel: () => LegendFormatGeneralPaneModel = () => {
       notShowNull: false,
       notShowNullVisible: false,
       symbolSize: 0,
-      roundCorners: false
+      roundCorners: false,
+      symbolRoundCorners: false,
+      symbolRoundCornersVisible: true
    };
 };
 

--- a/web/projects/portal/src/app/graph/model/dialog/legend-format-general-pane-model.ts
+++ b/web/projects/portal/src/app/graph/model/dialog/legend-format-general-pane-model.ts
@@ -26,4 +26,6 @@ export interface LegendFormatGeneralPaneModel {
    notShowNullVisible: boolean;
    symbolSize: number;
    roundCorners: boolean;
+   symbolRoundCorners: boolean;
+   symbolRoundCornersVisible: boolean;
 }


### PR DESCRIPTION
## Summary
  - Adds a "Round Symbol Corner" toggle in the legend format dialog (Symbol fieldset),
  separate from the existing legend-box round-corner option.
  - Applies to Color/Size/Texture legends (rect-based swatches); hidden for Shape/Line
  legends since their glyphs/lines aren't rectangles. Size legend skips rounding when the
  inner bar is narrower than the corner arc, to avoid degenerate shapes.
  - Defaults on for new charts; legacy saved viewsheets parse to off, preserving existing
  appearance.