### PR TITLE
Bug #74792, fix NPE in AnonymousUserFilter when AuthenticationFailureException has no cause

### DIFF
--- a/core/src/main/java/inetsoft/web/security/AnonymousUserFilter.java
+++ b/core/src/main/java/inetsoft/web/security/AnonymousUserFilter.java
@@ -79,7 +79,7 @@ public class AnonymousUserFilter extends AbstractSecurityFilter {
                      ObjectMapper mapper = new ObjectMapper();
                      ObjectNode body = mapper.createObjectNode();
                      body.put("error", e.getReason().name());
-                     body.put("message", e.getCause().getMessage());
+                     body.put("message", e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
 
                      try(PrintWriter writer = httpResponse.getWriter()) {
                         mapper.writeValue(writer, body);


### PR DESCRIPTION
getCause() can return null, causing a NullPointerException when getMessage() is called on it. Fall back to the exception's own message in that case.