### PR TITLE
Bug #74412: clear stale bookmark layout state when no layout is active

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
@@ -840,6 +840,14 @@ public class RuntimeViewsheet extends RuntimeSheet {
          if(rvsLayout != null) {
             processedViewsheet = rvsLayout.apply(processedViewsheet);
          }
+         else {
+            // Clear any stale layout state (layoutPosition/layoutSize/layoutVisible) that
+            // CalcTableVSAssembly.parseStateContent() may have restored from the bookmark.
+            // rvsLayout.apply() normally does this via clearLayoutState() before applying new
+            // positions, but when no layout is active that call is skipped entirely, leaving
+            // stale (0,0) layout coordinates from a prior layout application in the bookmark.
+            processedViewsheet.clearLayoutState();
+         }
 
          setOpenedBookmark(bookmark == null ? null : bookmark.getBookmarkInfo(name));
 


### PR DESCRIPTION
## Summary

- `CalcTableVSAssembly.parseStateContent()` restores the full `VSAssemblyInfo` from the bookmark, including `layoutX/layoutY/layoutVisible` set by a prior `rvsLayout.apply()` call. When the layout is later made mobile-only and accessed from a desktop browser, `rvsLayout` is `null` and `apply()` is never called, so `clearLayoutState()` is never invoked. The stale `(0,0)` layout position from the bookmark causes the freehand table to render at the wrong location while other assemblies (chart, crosstab) are unaffected because their `parseStateContent()` does not restore position data.
- Fix: call `clearLayoutState()` on the bookmark-restored viewsheet when `rvsLayout == null`, mirroring the clearing that `rvsLayout.apply()` performs internally before positioning assemblies.

## Test plan

- [ ] Import the `annotation` viewsheet from the attached test asset in Redmine issue #74412
- [ ] Open the viewsheet in the portal and select the bookmark `annotation` — verify the mobile layout is applied correctly
- [ ] Open the viewsheet in Composer → Dashboard Options → Layout tab → edit `layout1` → check **Mobile Only** → save
- [ ] Open the viewsheet in the portal again and select the bookmark `annotation`
- [ ] Verify `FreehandTable1` is at its default position (not at the top-left corner)
- [ ] Verify `Chart1` and `Crosstab1` are also at their default positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)