### PR TITLE
Fix recursive ConcurrentHashMap update in ConfigurationContext bean cache

### DIFF
--- a/core/src/main/java/inetsoft/util/ConfigurationContext.java
+++ b/core/src/main/java/inetsoft/util/ConfigurationContext.java
@@ -198,7 +198,12 @@ public class ConfigurationContext implements AutoCloseable {
 
       if(IN_CACHE_LOAD.get()) {
          Object cached = beanCache.getIfPresent(type);
-         return cached != null ? type.cast(cached) : applicationContext.getBean(type);
+
+         if(cached != null && cached != MISSING_BEAN) {
+            return type.cast(cached);
+         }
+
+         return applicationContext.getBean(type);
       }
 
       return type.cast(beanCache.get(type, t -> {

--- a/core/src/main/java/inetsoft/util/ConfigurationContext.java
+++ b/core/src/main/java/inetsoft/util/ConfigurationContext.java
@@ -235,12 +235,10 @@ public class ConfigurationContext implements AutoCloseable {
          IN_CACHE_LOAD.set(true);
 
          try {
-            try {
-               return applicationContext.getBean(t);
-            }
-            catch(NoSuchBeanDefinitionException e) {
-               return MISSING_BEAN;
-            }
+            return applicationContext.getBean(t);
+         }
+         catch(NoSuchBeanDefinitionException e) {
+            return MISSING_BEAN;
          }
          finally {
             IN_CACHE_LOAD.remove();

--- a/core/src/main/java/inetsoft/util/ConfigurationContext.java
+++ b/core/src/main/java/inetsoft/util/ConfigurationContext.java
@@ -196,7 +196,20 @@ public class ConfigurationContext implements AutoCloseable {
          throw new ShutdownException();
       }
 
-      return type.cast(beanCache.get(type, t -> applicationContext.getBean(t)));
+      if(IN_CACHE_LOAD.get()) {
+         return applicationContext.getBean(type);
+      }
+
+      return type.cast(beanCache.get(type, t -> {
+         IN_CACHE_LOAD.set(true);
+
+         try {
+            return applicationContext.getBean(t);
+         }
+         finally {
+            IN_CACHE_LOAD.remove();
+         }
+      }));
    }
 
    /**
@@ -209,12 +222,28 @@ public class ConfigurationContext implements AutoCloseable {
          return null;
       }
 
-      Object cached = beanCache.get(type, t -> {
+      if(IN_CACHE_LOAD.get()) {
          try {
-            return applicationContext.getBean(t);
+            return applicationContext.getBean(type);
          }
          catch(NoSuchBeanDefinitionException e) {
-            return MISSING_BEAN;
+            return null;
+         }
+      }
+
+      Object cached = beanCache.get(type, t -> {
+         IN_CACHE_LOAD.set(true);
+
+         try {
+            try {
+               return applicationContext.getBean(t);
+            }
+            catch(NoSuchBeanDefinitionException e) {
+               return MISSING_BEAN;
+            }
+         }
+         finally {
+            IN_CACHE_LOAD.remove();
          }
       });
 
@@ -265,5 +294,6 @@ public class ConfigurationContext implements AutoCloseable {
    private final CompletableFuture<Void> springContextReady = new CompletableFuture<>();
    private static volatile ConfigurationContext INSTANCE;
    private static final Object MISSING_BEAN = new Object();
+   private static final ThreadLocal<Boolean> IN_CACHE_LOAD = ThreadLocal.withInitial(() -> false);
    private static final Logger LOG = LoggerFactory.getLogger(ConfigurationContext.class);
 }

--- a/core/src/main/java/inetsoft/util/ConfigurationContext.java
+++ b/core/src/main/java/inetsoft/util/ConfigurationContext.java
@@ -197,7 +197,8 @@ public class ConfigurationContext implements AutoCloseable {
       }
 
       if(IN_CACHE_LOAD.get()) {
-         return applicationContext.getBean(type);
+         Object cached = beanCache.getIfPresent(type);
+         return cached != null ? type.cast(cached) : applicationContext.getBean(type);
       }
 
       return type.cast(beanCache.get(type, t -> {
@@ -223,6 +224,12 @@ public class ConfigurationContext implements AutoCloseable {
       }
 
       if(IN_CACHE_LOAD.get()) {
+         Object cached = beanCache.getIfPresent(type);
+
+         if(cached != null) {
+            return cached == MISSING_BEAN ? null : type.cast(cached);
+         }
+
          try {
             return applicationContext.getBean(type);
          }
@@ -292,6 +299,8 @@ public class ConfigurationContext implements AutoCloseable {
    private final CompletableFuture<Void> springContextReady = new CompletableFuture<>();
    private static volatile ConfigurationContext INSTANCE;
    private static final Object MISSING_BEAN = new Object();
+   // Prevents ConcurrentHashMap recursive update when Spring bean initialization
+   // triggers a nested getSpringBean/getOptionalSpringBean call on the same thread.
    private static final ThreadLocal<Boolean> IN_CACHE_LOAD = ThreadLocal.withInitial(() -> false);
    private static final Logger LOG = LoggerFactory.getLogger(ConfigurationContext.class);
 }


### PR DESCRIPTION
Use a ThreadLocal flag to detect reentrant getSpringBean/getOptionalSpringBean calls on the same thread and bypass the Caffeine cache for the inner lookup, preventing ConcurrentHashMap from throwing IllegalStateException: Recursive update during Spring startup.