### PR TITLE
Fix deadlock on Ignite deserialization of SRPrincipal during startup

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/SRPrincipal.java
+++ b/core/src/main/java/inetsoft/sree/security/SRPrincipal.java
@@ -42,10 +42,17 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class SRPrincipal extends XPrincipal implements Serializable, Externalizable, LogPrincipal {
    /**
-    * Construct a <code>SRPrincipal</code> instance
+    * No-arg constructor required for Externalizable deserialization.
+    * Does not chain to the parameterized constructor to avoid calling
+    * XSessionService.getService(), which acquires Spring's singleton creation lock.
+    * If Ignite deserializes an SRPrincipal on a stripe worker while Spring is still
+    * initializing, that lock is held by the main thread waiting for Ignite's partition
+    * exchange — causing a circular deadlock. All fields are populated by readExternal().
     */
    public SRPrincipal() {
-      this(new ClientInfo(), new IdentityID[0], new String[0], null, 0);
+      prop = new ConcurrentHashMap<>();
+      age = new Date();
+      client = new ClientInfo();
    }
 
    /**

--- a/core/src/main/java/inetsoft/sree/security/SRPrincipal.java
+++ b/core/src/main/java/inetsoft/sree/security/SRPrincipal.java
@@ -50,7 +50,6 @@ public class SRPrincipal extends XPrincipal implements Serializable, Externaliza
     * exchange — causing a circular deadlock. All fields are populated by readExternal().
     */
    public SRPrincipal() {
-      prop = new ConcurrentHashMap<>();
       age = new Date();
       client = new ClientInfo();
    }

--- a/core/src/main/java/inetsoft/uql/XPrincipal.java
+++ b/core/src/main/java/inetsoft/uql/XPrincipal.java
@@ -66,6 +66,21 @@ public class XPrincipal implements Principal, Serializable, Cloneable {
    public static final String SYSTEM = "INETSOFT_SYSTEM";
 
    /**
+    * No-arg constructor for Externalizable deserialization only.
+    * Does not call XSessionService to prevent a deadlock when Ignite deserializes
+    * an SRPrincipal on a stripe worker while Spring is still initializing: the
+    * XSessionService lookup acquires Spring's singleton creation lock, which is held
+    * by the main thread waiting for Ignite's partition exchange to complete, causing
+    * a circular deadlock. All fields are populated by the subclass readExternal().
+    */
+   protected XPrincipal() {
+      this.roles = new IdentityID[0];
+      this.groups = new String[0];
+      this.prop = new ConcurrentHashMap<>();
+      this.params = new ConcurrentHashMap<>();
+   }
+
+   /**
     * Creates a new instance of XPrincipal.
     *
     * @param identityID the name of the user.


### PR DESCRIPTION
Add no-arg constructors to XPrincipal and SRPrincipal that initialize fields directly without calling XSessionService.getService(). When Ignite deserializes an SRPrincipal on a stripe worker during startup, the XSessionService lookup acquires Spring's singleton creation lock, which is held by the main thread waiting for Ignite's partition exchange to complete - causing a circular deadlock.