### PR TITLE
Add comprehensive unit tests for controllers to improve coverage

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/ExportAssetController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/ExportAssetController.java
@@ -305,9 +305,9 @@ public class ExportAssetController {
    private final DeployService deployService;
    private final IgniteSessionRepository igniteSessionRepository;
    private final Cluster cluster;
-   private static final String PERM_ATTR =
+   static final String PERM_ATTR =
       ExportAssetController.class.getName() + ".deployPermissions";
-   private static final String DEPS_ATTR =
+   static final String DEPS_ATTR =
       ExportAssetController.class.getName() + ".deployDependencies";
    private static final String PROPS_ATTR =
       ExportAssetController.class.getName() + ".deployJarProperties";

--- a/core/src/main/java/inetsoft/web/admin/content/repository/ResourcePermissionController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/ResourcePermissionController.java
@@ -35,10 +35,12 @@ import java.security.Principal;
 public class ResourcePermissionController {
    @Autowired
    public ResourcePermissionController(ResourcePermissionService service,
-                                       SecurityEngine securityEngine)
+                                       SecurityEngine securityEngine,
+                                       ScheduleManager scheduleManager)
    {
       this.resourcePermissionService = service;
       this.securityEngine = securityEngine;
+      this.scheduleManager = scheduleManager;
    }
 
    @Secured(
@@ -97,12 +99,12 @@ public class ResourcePermissionController {
       boolean allowed;
 
       if(resource.getType() == ResourceType.SCHEDULE_TASK) {
-         ScheduleTask task = ScheduleManager.getScheduleManager().getScheduleTask(path);
+         ScheduleTask task = scheduleManager.getScheduleTask(path);
          allowed = task != null &&
             ScheduleManager.hasTaskPermission(task.getOwner(), principal, scheduleTaskAction);
       }
       else {
-         allowed = SecurityEngine.getSecurity().checkPermission(
+         allowed = securityEngine.checkPermission(
             principal, resource.getType(), resource.getPath(), ResourceAction.ADMIN);
       }
 
@@ -114,4 +116,5 @@ public class ResourcePermissionController {
 
    private final ResourcePermissionService resourcePermissionService;
    private final SecurityEngine securityEngine;
+   private final ScheduleManager scheduleManager;
 }

--- a/core/src/main/java/inetsoft/web/admin/schedule/ImportTaskController.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ImportTaskController.java
@@ -17,7 +17,7 @@
  */
 package inetsoft.web.admin.schedule;
 
-import inetsoft.sree.RepletRepository;
+import inetsoft.sree.AnalyticRepository;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.schedule.*;
 import inetsoft.sree.security.ResourceAction;
@@ -42,9 +42,12 @@ import java.util.*;
 
 @RestController
 public class ImportTaskController {
-   public ImportTaskController(ScheduleManager scheduleManager, ScheduleTaskFolderService scheduleTaskFolderService) {
+   public ImportTaskController(ScheduleManager scheduleManager,
+                               ScheduleTaskFolderService scheduleTaskFolderService,
+                               AnalyticRepository analyticRepository) {
       this.scheduleManager = scheduleManager;
       this.scheduleTaskFolderService = scheduleTaskFolderService;
+      this.analyticRepository = analyticRepository;
    }
 
    @Secured(
@@ -122,7 +125,6 @@ public class ImportTaskController {
                                                 Principal principal) throws Exception
    {
       HttpSession session = request.getSession(true);
-      RepletRepository engine = SUtil.getRepletRepository();
       List<String> failedList = new ArrayList<>();
 
       List<ScheduleTask> tasklist = (ArrayList<ScheduleTask>)session.getAttribute(INFO_ATTR);
@@ -137,7 +139,7 @@ public class ImportTaskController {
          Boolean taskExists = oldTask != null;
 
          if(taskExists && overwriting && oldTask.isEditable() &&
-            !engine.checkPermission(principal, ResourceType.SCHEDULER, taskId, ResourceAction.ACCESS))
+            !analyticRepository.checkPermission(principal, ResourceType.SCHEDULER, taskId, ResourceAction.ACCESS))
          {
             failedList.add(taskId);
             continue;
@@ -208,5 +210,6 @@ public class ImportTaskController {
 
    private final ScheduleManager scheduleManager;
    private final ScheduleTaskFolderService scheduleTaskFolderService;
+   private final AnalyticRepository analyticRepository;
    private static final String INFO_ATTR = "__private_scheduleXmlInfo";
 }

--- a/core/src/main/java/inetsoft/web/admin/schedule/ImportTaskController.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ImportTaskController.java
@@ -150,9 +150,6 @@ public class ImportTaskController {
             scheduleManager.setScheduleTask(taskId, task, principal);
          }
 
-         AssetEntry parentEntry = new AssetEntry(
-            AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.SCHEDULE_TASK_FOLDER, path, null);
-
          if(path != null &&
             scheduleTaskFolderService.checkFolderExists(path))
          {
@@ -211,5 +208,5 @@ public class ImportTaskController {
    private final ScheduleManager scheduleManager;
    private final ScheduleTaskFolderService scheduleTaskFolderService;
    private final AnalyticRepository analyticRepository;
-   private static final String INFO_ATTR = "__private_scheduleXmlInfo";
+   static final String INFO_ATTR = "__private_scheduleXmlInfo";
 }

--- a/core/src/test/java/inetsoft/web/admin/content/dataspace/DataSpaceFileSettingsControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/dataspace/DataSpaceFileSettingsControllerTest.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.content.dataspace;
+
+/*
+ * Test strategy
+ *
+ * DataSpaceFileSettingsController has real in-controller logic in two areas:
+ *
+ *   getFileContent(String, boolean):
+ *     - path == null → getEditable() is skipped → content="" editable=false
+ *     - path ends with ".db" or ".dat" → probeContentType() returns false immediately
+ *       → editable=false, content=""
+ *     - editable=false → getContentFromPath() is never called
+ *
+ *   saveFileContent(DataSpaceFileContentModel):
+ *     - converts model.content() to InputStream and calls
+ *       dataSpace.withOutputStream(null, model.path(), lambda)
+ *     - errors are caught and logged; they do not propagate
+ *
+ * getModel() calls SreeEnv.getProperty() which requires Spring; covered by E2E tests.
+ * apply() calls Catalog / Audit / DataSpace with complex branching; covered by E2E tests.
+ * downloadFile() / deleteDataSpaceFile() are pure delegation; covered by E2E tests.
+ *
+ * Coverage scope:
+ *   [null path]           path=null → editable=false, content=""
+ *   [binary file path]    path ending ".db" → probeContentType returns false → editable=false
+ *   [saveFileContent]     withOutputStream called with correct path; errors caught internally
+ */
+
+import inetsoft.util.DataSpace;
+import inetsoft.web.admin.content.dataspace.model.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class DataSpaceFileSettingsControllerTest {
+
+   @Mock private DataSpaceContentSettingsService dataSpaceContentSettingsService;
+   @Mock private DataSpace dataSpace;
+
+   private DataSpaceFileSettingsController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new DataSpaceFileSettingsController(dataSpaceContentSettingsService, dataSpace);
+   }
+
+   // -------------------------------------------------------------------------
+   // getFileContent()
+   // -------------------------------------------------------------------------
+
+   // [null path] path=null → getEditable() skipped → editable=false, content=""
+   @Test
+   void getFileContent_nullPath_returnsEmptyNotEditable() {
+      DataSpaceFileContentModel result = controller.getFileContent(null, false);
+
+      assertFalse(result.editable());
+      assertEquals("", result.content());
+      assertNull(result.path());
+   }
+
+   // [binary file path] path ends with ".db" → probeContentType returns false → editable=false
+   @Test
+   void getFileContent_binaryFilePath_returnsEmptyNotEditable() {
+      DataSpaceFileContentModel result = controller.getFileContent("config/data.db", false);
+
+      assertFalse(result.editable());
+      assertEquals("", result.content());
+   }
+
+   // -------------------------------------------------------------------------
+   // saveFileContent()
+   // -------------------------------------------------------------------------
+
+   // [write path] content written via dataSpace.withOutputStream; errors caught internally
+   @Test
+   void saveFileContent_writesContentViaDataSpace() throws Exception {
+      DataSpaceFileContentModel model = DataSpaceFileContentModel.builder()
+         .content("hello world")
+         .path("data/file.txt")
+         .build();
+
+      controller.saveFileContent(model);
+
+      verify(dataSpace).withOutputStream(eq(null), eq("data/file.txt"), any());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/content/dataspace/DataSpaceTreeControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/dataspace/DataSpaceTreeControllerTest.java
@@ -1,0 +1,151 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.content.dataspace;
+
+/*
+ * Test strategy
+ *
+ * DataSpaceTreeController has real in-controller logic in deleteNodes():
+ *   - null guard: nodes == null → return immediately; no service call
+ *   - permission loop: calls private checkDeletePermission() for each node:
+ *       first check: securityEngine.checkPermission(EM, "*") → false → SecurityException
+ *       fall-through (non-shapes path): securityEngine.checkPermission(EM_COMPONENT, "data-space")
+ *   - delete loop: deleteDataSpaceNode(path, folder) per node; updateFolder(path) only for files
+ *
+ * checkDeletePermission() calls ImageShapes.getShapesDirectory() (which invokes SUtil.isMultiTenant()
+ * → SecurityEngine.getSecurity() → requires Spring). It is intercepted with MockedStatic when
+ * the EM permission passes (tests 3 and 4). ImageShapes.getGlobalShapesDirectory() is safe and
+ * called for real.
+ *
+ * getDataSpaceTree() / getDataSpaceTreeNode() / repairDataSpaceFiles() are pure delegation and
+ * are covered by E2E tests.
+ *
+ * Coverage scope:
+ *   [null nodes]              nodes == null → return; service never called
+ *   [no EM permission]        EM check fails → SecurityException; deleteDataSpaceNode never called
+ *   [file node permitted]     EM + data-space OK → deleteDataSpaceNode + updateFolder called
+ *   [folder node permitted]   folder=true → deleteDataSpaceNode called; updateFolder NOT called
+ */
+
+import inetsoft.sree.security.*;
+import inetsoft.uql.viewsheet.graph.aesthetic.ImageShapes;
+import inetsoft.web.admin.content.dataspace.model.*;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class DataSpaceTreeControllerTest {
+
+   @Mock private DataSpaceContentSettingsService dataSpaceContentSettingsService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private DeleteDataSpaceTreeNodesRequest deleteRequest;
+   @Mock private HttpServletRequest request;
+   @Mock private Principal principal;
+
+   private DataSpaceTreeController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new DataSpaceTreeController(dataSpaceContentSettingsService, securityEngine);
+   }
+
+   private static DataSpaceTreeNodeInfo fileNode(String path) {
+      return DataSpaceTreeNodeInfo.builder().label("file").path(path).folder(false).build();
+   }
+
+   private static DataSpaceTreeNodeInfo folderNode(String path) {
+      return DataSpaceTreeNodeInfo.builder().label("folder").path(path).folder(true).build();
+   }
+
+   // -------------------------------------------------------------------------
+   // deleteNodes()
+   // -------------------------------------------------------------------------
+
+   // [null nodes] nodes == null → return immediately; no permission check or service call
+   @Test
+   void deleteNodes_nullNodes_returnsImmediately() throws Exception {
+      when(deleteRequest.nodes()).thenReturn(null);
+
+      controller.deleteNodes(deleteRequest, principal, request);
+
+      verify(dataSpaceContentSettingsService, never()).deleteDataSpaceNode(any(), anyBoolean());
+   }
+
+   // [no EM permission] first checkPermission(EM, "*") returns false → SecurityException; no delete
+   @Test
+   void deleteNodes_noEmPermission_throwsSecurityException() throws Exception {
+      when(deleteRequest.nodes()).thenReturn(new DataSpaceTreeNodeInfo[]{ fileNode("reports/file.txt") });
+      when(securityEngine.checkPermission(principal, ResourceType.EM, (String) "*", ResourceAction.ACCESS))
+         .thenReturn(false);
+
+      assertThrows(inetsoft.sree.security.SecurityException.class,
+         () -> controller.deleteNodes(deleteRequest, principal, request));
+      verify(dataSpaceContentSettingsService, never()).deleteDataSpaceNode(any(), anyBoolean());
+   }
+
+   // [file node, permitted] EM + data-space permission granted → deleteDataSpaceNode + updateFolder
+   @Test
+   void deleteNodes_fileNode_dataSpacePermitted_deletesAndUpdatesFolder() throws Exception {
+      when(deleteRequest.nodes()).thenReturn(new DataSpaceTreeNodeInfo[]{ fileNode("reports/file.txt") });
+      when(securityEngine.checkPermission(principal, ResourceType.EM, (String) "*", ResourceAction.ACCESS))
+         .thenReturn(true);
+      when(securityEngine.checkPermission(
+         principal, ResourceType.EM_COMPONENT, "settings/content/data-space", ResourceAction.ACCESS))
+         .thenReturn(true);
+
+      try(MockedStatic<ImageShapes> imageShapesMock = mockStatic(ImageShapes.class, CALLS_REAL_METHODS)) {
+         imageShapesMock.when(ImageShapes::getShapesDirectory).thenReturn("portal/host-org/shapes");
+
+         controller.deleteNodes(deleteRequest, principal, request);
+
+         verify(dataSpaceContentSettingsService).deleteDataSpaceNode("reports/file.txt", false);
+         verify(dataSpaceContentSettingsService).updateFolder("reports/file.txt");
+      }
+   }
+
+   // [folder node, permitted] folder=true → deleteDataSpaceNode called; updateFolder NOT called
+   @Test
+   void deleteNodes_folderNode_dataSpacePermitted_deletesWithoutUpdatingFolder() throws Exception {
+      when(deleteRequest.nodes()).thenReturn(new DataSpaceTreeNodeInfo[]{ folderNode("reports") });
+      when(securityEngine.checkPermission(principal, ResourceType.EM, (String) "*", ResourceAction.ACCESS))
+         .thenReturn(true);
+      when(securityEngine.checkPermission(
+         principal, ResourceType.EM_COMPONENT, "settings/content/data-space", ResourceAction.ACCESS))
+         .thenReturn(true);
+
+      try(MockedStatic<ImageShapes> imageShapesMock = mockStatic(ImageShapes.class, CALLS_REAL_METHODS)) {
+         imageShapesMock.when(ImageShapes::getShapesDirectory).thenReturn("portal/host-org/shapes");
+
+         controller.deleteNodes(deleteRequest, principal, request);
+
+         verify(dataSpaceContentSettingsService).deleteDataSpaceNode("reports", true);
+         verify(dataSpaceContentSettingsService, never()).updateFolder(any());
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/content/plugins/PluginsControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/plugins/PluginsControllerTest.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.content.plugins;
+
+/*
+ * Test strategy
+ *
+ * PluginsController has real in-controller logic in three areas:
+ *
+ *   installPluginFiles(UploadDriverFileModel, Principal) — calls pluginsService.installPlugins()
+ *     with the request's file ID, then self-delegates to getPluginsModel() to return the
+ *     refreshed model.
+ *
+ *   deletePluginFiles(PluginsModel, Principal) — calls pluginsService.uninstallPlugins() with the
+ *     supplied model, then self-delegates to getPluginsModel() to return the refreshed model.
+ *
+ *   scanDrivers(String, Principal) — calls pluginsService.scanDrivers() and wraps the returned
+ *     List<String> in a DriverList.
+ *
+ * getPluginsModel() and createDriverPlugin() are pure delegation and are covered by E2E tests.
+ *
+ * Coverage scope:
+ *   [getPluginsModel delegation]          service.getModel() called; result returned unchanged
+ *   [installPluginFiles sequence]         installPlugins() then getModel(); refreshed model returned
+ *   [deletePluginFiles sequence]          uninstallPlugins() then getModel(); refreshed model returned
+ *   [scanDrivers wrapping]               scanDrivers() result wrapped in DriverList
+ */
+
+import inetsoft.web.admin.content.plugins.model.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class PluginsControllerTest {
+
+   @Mock private PluginsService pluginsService;
+   @Mock private PluginsModel pluginsModel;
+   @Mock private PluginsModel requestModel;
+   @Mock private UploadDriverFileModel uploadRequest;
+   @Mock private Principal principal;
+
+   private PluginsController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new PluginsController(pluginsService);
+   }
+
+   // -------------------------------------------------------------------------
+   // getPluginsModel()
+   // -------------------------------------------------------------------------
+
+   // [delegation] service.getModel() called; result returned unchanged
+   @Test
+   void getPluginsModel_delegatesToService() throws Exception {
+      when(pluginsService.getModel(principal)).thenReturn(pluginsModel);
+
+      assertSame(pluginsModel, controller.getPluginsModel(principal));
+      verify(pluginsService).getModel(principal);
+   }
+
+   // -------------------------------------------------------------------------
+   // installPluginFiles()
+   // -------------------------------------------------------------------------
+
+   // [sequence] installPlugins() called; then getModel() called; refreshed model returned
+   @Test
+   void installPluginFiles_installsThenFetchesRefreshedModel() throws Exception {
+      when(uploadRequest.files()).thenReturn("upload-id-123");
+      when(pluginsService.getModel(principal)).thenReturn(pluginsModel);
+
+      PluginsModel result = controller.installPluginFiles(uploadRequest, principal);
+
+      assertSame(pluginsModel, result);
+      verify(pluginsService).installPlugins("upload-id-123", principal);
+      verify(pluginsService).getModel(principal);
+   }
+
+   // -------------------------------------------------------------------------
+   // deletePluginFiles()
+   // -------------------------------------------------------------------------
+
+   // [sequence] uninstallPlugins() called with request model; then getModel(); refreshed model returned
+   @Test
+   void deletePluginFiles_uninstallsThenFetchesRefreshedModel() throws Exception {
+      when(pluginsService.getModel(principal)).thenReturn(pluginsModel);
+
+      PluginsModel result = controller.deletePluginFiles(requestModel, principal);
+
+      assertSame(pluginsModel, result);
+      verify(pluginsService).uninstallPlugins(requestModel, principal);
+      verify(pluginsService).getModel(principal);
+   }
+
+   // -------------------------------------------------------------------------
+   // scanDrivers()
+   // -------------------------------------------------------------------------
+
+   // [wrapping] service result wrapped in DriverList
+   @Test
+   void scanDrivers_wrapsServiceResultInDriverList() throws Exception {
+      List<String> drivers = List.of("com.mysql.Driver", "org.postgresql.Driver");
+      when(pluginsService.scanDrivers("upload-id-123", principal)).thenReturn(drivers);
+
+      DriverList result = controller.scanDrivers("upload-id-123", principal);
+
+      assertEquals(drivers, result.drivers());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/content/repository/AutoSaveControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/repository/AutoSaveControllerTest.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.content.repository;
+
+/*
+ * Test strategy
+ *
+ * AutoSaveController has real in-controller logic in restoreAutoSaveAssets():
+ *   - folder == "/" → assetName = fileName (no folder prefix)
+ *   - folder != "/" → assetName = folder + "/" + fileName
+ *   - ids.length == 1 → service called once with assetName (no numeric suffix)
+ *   - ids.length > 1 → service called N times with assetName + i (0-based suffix)
+ *   After each restore, AutoSaveUtils.deleteAutoSaveFile(id, user) is called.
+ *
+ * deleteAutoSaveAssets() calls Util.getObjectFullPath() which requires a Spring context;
+ * covered by E2E tests.
+ * getRepositoryTree() / getAssetFolder() logic is covered by E2E tests.
+ *
+ * AutoSaveUtils static methods are intercepted with MockedStatic (closed in try-with-resources).
+ * Tool.split() is a pure string utility called for real.
+ *
+ * Coverage scope:
+ *   [single id, root folder]   ids.length == 1, folder="/" → service called with fileName; deleteAutoSaveFile once
+ *   [multiple ids, sub-folder] ids.length > 1, folder="Reports" → numbered suffix; deleteAutoSaveFile per id
+ */
+
+import inetsoft.util.IndexedStorage;
+import inetsoft.web.AutoSaveServiceProxy;
+import inetsoft.web.AutoSaveUtils;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class AutoSaveControllerTest {
+
+   @Mock private AutoSaveServiceProxy autoSaveService;
+   @Mock private IndexedStorage indexedStorage;
+   @Mock private Principal principal;
+
+   private AutoSaveController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new AutoSaveController(autoSaveService, indexedStorage);
+   }
+
+   // -------------------------------------------------------------------------
+   // restoreAutoSaveAssets()
+   // -------------------------------------------------------------------------
+
+   // [single id, root folder] ids.length == 1, folder="/" → service called with fileName; deleteAutoSaveFile called once
+   @Test
+   void restoreAutoSaveAssets_singleId_rootFolder_callsServiceOnce() throws Exception {
+      Map<String, String> body = Map.of(
+         "ids", "id1", "name", "myFile", "folder", "/", "overwrite", "false");
+
+      try(MockedStatic<AutoSaveUtils> autoSaveMock = mockStatic(AutoSaveUtils.class, withSettings().lenient())) {
+         controller.restoreAutoSaveAssets(body, principal);
+
+         verify(autoSaveService).restoreAutoSaveAssets("id1", "myFile", false, principal);
+         autoSaveMock.verify(() -> AutoSaveUtils.deleteAutoSaveFile("id1", principal));
+      }
+   }
+
+   // [multiple ids, sub-folder] ids.length > 1, folder prepended, 0-based suffix appended per id
+   @Test
+   void restoreAutoSaveAssets_multipleIds_appendsNumberedSuffix() throws Exception {
+      Map<String, String> body = Map.of(
+         "ids", "id1,id2", "name", "myFile", "folder", "Reports", "overwrite", "false");
+
+      try(MockedStatic<AutoSaveUtils> autoSaveMock = mockStatic(AutoSaveUtils.class, withSettings().lenient())) {
+         controller.restoreAutoSaveAssets(body, principal);
+
+         verify(autoSaveService).restoreAutoSaveAssets("id1", "Reports/myFile0", false, principal);
+         verify(autoSaveService).restoreAutoSaveAssets("id2", "Reports/myFile1", false, principal);
+         autoSaveMock.verify(() -> AutoSaveUtils.deleteAutoSaveFile("id1", principal));
+         autoSaveMock.verify(() -> AutoSaveUtils.deleteAutoSaveFile("id2", principal));
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/content/repository/ContentRepositoryTreeControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/repository/ContentRepositoryTreeControllerTest.java
@@ -1,0 +1,231 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.content.repository;
+
+/*
+ * Test strategy
+ *
+ * ContentRepositoryTreeController has real in-controller logic in three methods:
+ *
+ *   POST /api/em/content/repository/tree (getRepositoryTree with body)
+ *     — validates current org via OrganizationManager + SecurityProvider; throws
+ *       InvalidOrgException when null; delegates to treeService.getRootNodes() on success.
+ *
+ *   POST /api/em/content/repository/private/tree (getRepositoryPrivateTree)
+ *     — iterates users array; branches on Tool.MY_DASHBOARD vs SUtil.MY_DASHBOARD;
+ *       calls treeService.getUserReports() or getUserDashboardNode() accordingly.
+ *
+ *   GET /api/em/content/repository/tree (getRepositoryTree with path+owner)
+ *     — parses owner key to IdentityID; fetches registry; branches on path value.
+ *
+ * Pure-delegation methods (no branch logic):
+ *   getLicensedComponents  → treeService.getLicensedComponents()
+ *   searchRepositoryTree   → treeService.searchNodes(principal, filter)
+ *
+ * Excluded: isSiteAdmin (calls OrganizationManager.isSiteAdmin which needs full security
+ * context); @Secured/@RequiredPermission annotations (Spring Security; E2E coverage).
+ *
+ * Static singletons (OrganizationManager, Catalog) are intercepted with
+ * mockStatic() using lenient() to suppress UnnecessaryStubbingException.
+ */
+
+import inetsoft.sree.RepletRegistry;
+import inetsoft.sree.RepletRegistryManager;
+import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.security.*;
+import inetsoft.util.Catalog;
+import inetsoft.util.InvalidOrgException;
+import inetsoft.util.Tool;
+import inetsoft.util.data.CommonKVModel;
+import inetsoft.web.admin.content.repository.model.LicensedComponents;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ContentRepositoryTreeControllerTest {
+
+   @Mock private ContentRepositoryTreeService treeService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private RepletRegistryManager repletRegistryManager;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private Organization organization;
+   @Mock private Catalog catalog;
+   @Mock private OrganizationManager orgManager;
+   @Mock private Principal principal;
+   @Mock private RepletRegistry registry;
+   @Mock private ContentRepositoryTreeNode treeNode;
+   @Mock private LicensedComponents licensedComponents;
+
+   private ContentRepositoryTreeController controller;
+
+   private MockedStatic<OrganizationManager> orgManagerStatic;
+   private MockedStatic<Catalog> catalogStatic;
+
+   @BeforeEach
+   void setUp() throws Exception {
+      controller = new ContentRepositoryTreeController(
+         treeService, securityEngine, repletRegistryManager);
+
+      orgManagerStatic = mockStatic(OrganizationManager.class, withSettings().lenient());
+      catalogStatic = mockStatic(Catalog.class, withSettings().lenient());
+
+      orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+      lenient().when(orgManager.getCurrentOrgID()).thenReturn("host-org");
+      lenient().when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      lenient().when(securityProvider.getOrganization("host-org")).thenReturn(organization);
+      catalogStatic.when(Catalog::getCatalog).thenReturn(catalog);
+      lenient().when(catalog.getString(anyString())).thenReturn("msg");
+
+      lenient().when(repletRegistryManager.getRegistry(any(IdentityID.class))).thenReturn(registry);
+      lenient().when(treeNode.children()).thenReturn(Collections.emptyList());
+   }
+
+   @AfterEach
+   void tearDown() {
+      orgManagerStatic.close();
+      catalogStatic.close();
+   }
+
+   // -------------------------------------------------------------------------
+   // POST /api/em/content/repository/tree — getRepositoryTree(List, Principal)
+   // -------------------------------------------------------------------------
+
+   // [invalid org] org lookup returns null → InvalidOrgException; treeService never called
+   @Test
+   void getRepositoryTree_invalidOrg_throwsInvalidOrgException() throws Exception {
+      when(securityProvider.getOrganization("host-org")).thenReturn(null);
+
+      assertThrows(InvalidOrgException.class,
+         () -> controller.getRepositoryTree(Collections.emptyList(), principal));
+
+      verify(treeService, never()).getRootNodes(any(), any());
+   }
+
+   // [valid org] valid org → treeService.getRootNodes() called and result wrapped in model
+   @Test
+   void getRepositoryTree_validOrg_delegatesToService() throws Exception {
+      List<String> usersToLoad = List.of("user1");
+      List<ContentRepositoryTreeNode> nodes = List.of(treeNode);
+      when(treeService.getRootNodes(principal, usersToLoad)).thenReturn(nodes);
+
+      ContentRepositoryTreeModel result = controller.getRepositoryTree(usersToLoad, principal);
+
+      assertSame(nodes, result.getNodes());
+      verify(treeService).getRootNodes(principal, usersToLoad);
+   }
+
+   // -------------------------------------------------------------------------
+   // POST /api/em/content/repository/private/tree — getRepositoryPrivateTree
+   // -------------------------------------------------------------------------
+
+   // [Tool.MY_DASHBOARD path] "My Dashboards" → treeService.getUserReports() called
+   @Test
+   void getRepositoryPrivateTree_myDashboardPath_callsGetUserReports() throws Exception {
+      String key = new IdentityID("alice", "org").convertToKey();
+      String path = Tool.MY_DASHBOARD;
+      CommonKVModel<String, String>[] users =
+         new CommonKVModel[]{ new CommonKVModel<>(key, path) };
+
+      when(treeService.getUserReports(any(IdentityID.class), eq(registry), eq(principal)))
+         .thenReturn(treeNode);
+
+      controller.getRepositoryPrivateTree(users, principal);
+
+      verify(treeService).getUserReports(any(IdentityID.class), eq(registry), eq(principal));
+      verify(treeService, never()).getUserDashboardNode(any(), any(), any());
+   }
+
+   // [SUtil.MY_DASHBOARD path] "My Portal Dashboards" → treeService.getUserDashboardNode() called
+   @Test
+   void getRepositoryPrivateTree_sutiMyDashboardPath_callsGetUserDashboardNode() throws Exception {
+      String key = new IdentityID("alice", "org").convertToKey();
+      String path = SUtil.MY_DASHBOARD;
+      CommonKVModel<String, String>[] users =
+         new CommonKVModel[]{ new CommonKVModel<>(key, path) };
+
+      when(treeService.getUserDashboardNode(any(IdentityID.class), eq(registry), eq(principal)))
+         .thenReturn(treeNode);
+
+      controller.getRepositoryPrivateTree(users, principal);
+
+      verify(treeService).getUserDashboardNode(any(IdentityID.class), eq(registry), eq(principal));
+      verify(treeService, never()).getUserReports(any(), any(), any());
+   }
+
+   // -------------------------------------------------------------------------
+   // GET /api/em/content/repository/tree — getRepositoryTree(path, owner, Principal)
+   // -------------------------------------------------------------------------
+
+   // [Tool.MY_DASHBOARD path] GET variant with "My Dashboards" → getUserReports() called
+   @Test
+   void getRepositoryTreeNode_myDashboardPath_callsGetUserReports() throws Exception {
+      String owner = new IdentityID("alice", "org").convertToKey();
+      String path = Tool.MY_DASHBOARD;
+
+      when(treeService.getUserReports(any(IdentityID.class), eq(registry), eq(principal)))
+         .thenReturn(treeNode);
+
+      controller.getRepositoryTree(path, owner, principal);
+
+      verify(treeService).getUserReports(any(IdentityID.class), eq(registry), eq(principal));
+      verify(treeService, never()).getUserDashboardNode(any(), any(), any());
+   }
+
+   // -------------------------------------------------------------------------
+   // GET /api/em/content/repository/tree/licensed — getLicensedComponents
+   // -------------------------------------------------------------------------
+
+   // [pure delegation] delegates entirely to treeService.getLicensedComponents()
+   @Test
+   void getLicensedComponents_delegatesToService() {
+      when(treeService.getLicensedComponents()).thenReturn(licensedComponents);
+
+      LicensedComponents result = controller.getLicensedComponents(principal);
+
+      assertSame(licensedComponents, result);
+      verify(treeService).getLicensedComponents();
+   }
+
+   // -------------------------------------------------------------------------
+   // GET /api/em/content/repository/tree/search — searchRepositoryTree
+   // -------------------------------------------------------------------------
+
+   // [pure delegation] delegates to treeService.searchNodes(principal, filter)
+   @Test
+   void searchRepositoryTree_delegatesToService() throws Exception {
+      String filter = "dash";
+      List<ContentRepositoryTreeNode> nodes = List.of(treeNode);
+      when(treeService.searchNodes(principal, filter)).thenReturn(nodes);
+
+      ContentRepositoryTreeModel result = controller.searchRepositoryTree(filter, principal);
+
+      assertSame(nodes, result.getNodes());
+      verify(treeService).searchNodes(principal, filter);
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/content/repository/ExportAssetControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/repository/ExportAssetControllerTest.java
@@ -63,6 +63,8 @@ import java.security.Principal;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import static inetsoft.web.admin.content.repository.ExportAssetController.DEPS_ATTR;
+import static inetsoft.web.admin.content.repository.ExportAssetController.PERM_ATTR;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -82,12 +84,6 @@ class ExportAssetControllerTest {
    @Mock private HttpServletResponse response;
    @Mock private HttpSession session;
    @Mock private Principal principal;
-
-   // Matches the private constant in ExportAssetController
-   private static final String PERM_ATTR =
-      ExportAssetController.class.getName() + ".deployPermissions";
-   private static final String DEPS_ATTR =
-      ExportAssetController.class.getName() + ".deployDependencies";
 
    private ExportAssetController controller;
 

--- a/core/src/test/java/inetsoft/web/admin/content/repository/ExportAssetControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/repository/ExportAssetControllerTest.java
@@ -1,0 +1,240 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.content.repository;
+
+/*
+ * Test strategy
+ *
+ * ExportAssetController has real in-controller logic in five areas:
+ *
+ *   getStatus() [private helper] — null future → 404; pending → ready=false; done → ready=true.
+ *     Exercised via getAssetPermissionStatus() (PERM_ATTR) and getDependentAssetsStatus() (DEPS_ATTR).
+ *
+ *   getData() [private helper] — happy path → casts and returns value; future fails with
+ *     MessageException → rethrows it; fails with other exception → wrapped ExecutionException.
+ *     Exercised via getAssetPermissionValue().
+ *
+ *   createExport() — generates a UUID job ID, passes it and the model's name() to the proxy,
+ *     and returns the UUID to the caller.
+ *
+ *   getCreateExportStatus() — delegates to proxy.checkExportStatus(), wraps boolean in
+ *     ResponseEntity<ExportStatusModel>.
+ *
+ *   downloadJar() — constructs filename, sets Content-Disposition, checks data null → 404.
+ *     SUtil.isIE / isMozilla / isHttpHeadersValid and Tool.isFilePathValid are pure string
+ *     utilities called for real. The success path (binaryTransferService.writeData()) is
+ *     covered by E2E tests.
+ *
+ * @PostConstruct (cluster cache init) is not invoked without a Spring context.
+ * checkAssetPermission / getDependentAssets use ThreadPool.addOnDemand() for async
+ * execution and are covered by E2E tests.
+ */
+
+import inetsoft.sree.internal.cluster.Cluster;
+import inetsoft.util.MessageException;
+import inetsoft.util.cachefs.BinaryTransfer;
+import inetsoft.web.admin.content.repository.model.*;
+import inetsoft.web.admin.deploy.DeployService;
+import inetsoft.web.service.BinaryTransferService;
+import inetsoft.web.session.IgniteSessionRepository;
+import jakarta.servlet.http.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.*;
+
+import java.security.Principal;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ExportAssetControllerTest {
+
+   @Mock private DeployService deployService;
+   @Mock private IgniteSessionRepository igniteSessionRepository;
+   @Mock private ExportAssetServiceProxy exportAssetServiceProxy;
+   @Mock private BinaryTransferService binaryTransferService;
+   @Mock private Cluster cluster;
+   @Mock private ExportedAssetsModel exportedAssetsModel;
+   @Mock private SelectedAssetModelList permissionResult;
+   @Mock private HttpServletRequest request;
+   @Mock private HttpServletResponse response;
+   @Mock private HttpSession session;
+   @Mock private Principal principal;
+
+   // Matches the private constant in ExportAssetController
+   private static final String PERM_ATTR =
+      ExportAssetController.class.getName() + ".deployPermissions";
+   private static final String DEPS_ATTR =
+      ExportAssetController.class.getName() + ".deployDependencies";
+
+   private ExportAssetController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new ExportAssetController(
+         deployService, igniteSessionRepository, exportAssetServiceProxy,
+         binaryTransferService, cluster);
+
+      lenient().when(request.getSession(true)).thenReturn(session);
+   }
+
+   // -------------------------------------------------------------------------
+   // getStatus() — exercised via getAssetPermissionStatus()
+   // -------------------------------------------------------------------------
+
+   // [no future in session] attribute absent → 404 Not Found
+   @Test
+   void getAssetPermissionStatus_noFuture_returnsNotFound() {
+      when(session.getAttribute(PERM_ATTR)).thenReturn(null);
+
+      ResponseEntity<ExportStatusModel> result = controller.getAssetPermissionStatus(request);
+
+      assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
+   }
+
+   // [future pending] future not yet done → ready=false
+   @Test
+   void getAssetPermissionStatus_futurePending_returnsReadyFalse() {
+      when(session.getAttribute(PERM_ATTR)).thenReturn(new CompletableFuture<>());
+
+      ResponseEntity<ExportStatusModel> result = controller.getAssetPermissionStatus(request);
+
+      assertEquals(HttpStatus.OK, result.getStatusCode());
+      assertFalse(result.getBody().ready());
+   }
+
+   // [future done] completed future → ready=true
+   @Test
+   void getAssetPermissionStatus_futureDone_returnsReadyTrue() {
+      when(session.getAttribute(PERM_ATTR))
+         .thenReturn(CompletableFuture.completedFuture("done"));
+
+      ResponseEntity<ExportStatusModel> result = controller.getAssetPermissionStatus(request);
+
+      assertEquals(HttpStatus.OK, result.getStatusCode());
+      assertTrue(result.getBody().ready());
+   }
+
+   // -------------------------------------------------------------------------
+   // getStatus() — exercised via getDependentAssetsStatus()
+   // -------------------------------------------------------------------------
+
+   // [no future in session] DEPS_ATTR absent → 404
+   @Test
+   void getDependentAssetsStatus_noFuture_returnsNotFound() {
+      when(session.getAttribute(DEPS_ATTR)).thenReturn(null);
+
+      ResponseEntity<ExportStatusModel> result = controller.getDependentAssetsStatus(request);
+
+      assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
+   }
+
+   // -------------------------------------------------------------------------
+   // getData() — exercised via getAssetPermissionValue()
+   // -------------------------------------------------------------------------
+
+   // [success] future completes normally → value returned and attribute removed
+   @Test
+   void getAssetPermissionValue_futureCompleted_returnsValue() throws Exception {
+      when(session.getAttribute(PERM_ATTR))
+         .thenReturn(CompletableFuture.completedFuture(permissionResult));
+
+      SelectedAssetModelList result = controller.getAssetPermissionValue(request);
+
+      assertSame(permissionResult, result);
+      verify(session).removeAttribute(PERM_ATTR);
+   }
+
+   // [MessageException] future fails with MessageException → rethrown directly
+   @Test
+   void getAssetPermissionValue_futureFailsWithMessageException_rethrows() {
+      CompletableFuture<SelectedAssetModelList> future = new CompletableFuture<>();
+      future.completeExceptionally(new MessageException("export failed"));
+      when(session.getAttribute(PERM_ATTR)).thenReturn(future);
+
+      assertThrows(MessageException.class,
+         () -> controller.getAssetPermissionValue(request));
+   }
+
+   // [other exception] future fails with non-MessageException → wrapped in ExecutionException
+   @Test
+   void getAssetPermissionValue_futureFailsWithOtherException_throwsExecutionException() {
+      CompletableFuture<SelectedAssetModelList> future = new CompletableFuture<>();
+      future.completeExceptionally(new RuntimeException("unexpected"));
+      when(session.getAttribute(PERM_ATTR)).thenReturn(future);
+
+      assertThrows(ExecutionException.class,
+         () -> controller.getAssetPermissionValue(request));
+   }
+
+   // -------------------------------------------------------------------------
+   // createExport()
+   // -------------------------------------------------------------------------
+
+   // [UUID generation] generates a job ID and passes it + filename to the proxy
+   @Test
+   void createExport_generatesJobIdAndDelegatesToProxy() {
+      when(exportedAssetsModel.name()).thenReturn("myExport");
+
+      String jobId = controller.createExport(request, exportedAssetsModel, principal);
+
+      assertNotNull(jobId);
+      assertFalse(jobId.isEmpty());
+      verify(exportAssetServiceProxy).createExport(
+         eq(jobId), eq("myExport"), eq(exportedAssetsModel), eq(principal));
+   }
+
+   // -------------------------------------------------------------------------
+   // getCreateExportStatus()
+   // -------------------------------------------------------------------------
+
+   // [delegation] proxy.checkExportStatus() → wrapped in ExportStatusModel
+   @Test
+   void getCreateExportStatus_delegatesToProxy() {
+      when(exportAssetServiceProxy.checkExportStatus("job123")).thenReturn(true);
+
+      ResponseEntity<ExportStatusModel> result = controller.getCreateExportStatus("job123");
+
+      assertEquals(HttpStatus.OK, result.getStatusCode());
+      assertTrue(result.getBody().ready());
+   }
+
+   // -------------------------------------------------------------------------
+   // downloadJar()
+   // -------------------------------------------------------------------------
+
+   // [null data] getJarFileBytes returns null → 404 status set; writeData never called
+   @Test
+   void downloadJar_nullData_setsNotFoundStatus() throws Exception {
+      when(exportAssetServiceProxy.getFileNameFromID("job123")).thenReturn("myFile");
+      when(request.getHeader("USER-AGENT")).thenReturn("NoAgent");
+      when(exportAssetServiceProxy.getJarFileBytes("job123")).thenReturn(null);
+
+      controller.downloadJar("job123", request, response);
+
+      verify(response).setStatus(HttpStatus.NOT_FOUND.value());
+      verify(binaryTransferService, never()).writeData(any(BinaryTransfer.class), any());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/content/repository/ImportAssetControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/repository/ImportAssetControllerTest.java
@@ -1,0 +1,137 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.content.repository;
+
+/*
+ * Test strategy
+ *
+ * ImportAssetController has real in-controller logic in one method:
+ *   setJarFile — generates a UUID import ID before delegating to the proxy
+ *
+ * All other endpoints (updateImportInfo, getJarFileInfo, importAsset, finishImport)
+ * are pure-delegation methods and are tested as such.
+ *
+ * @PostConstruct (cluster cache init) is not invoked without a Spring context.
+ *
+ * Coverage scope:
+ *   [setJarFile: UUID generation]     proxy called with a generated UUID, file, and principal
+ *   [updateImportInfo: delegation]    all parameters forwarded to proxy unchanged
+ *   [importAsset: delegation]         all parameters (including ignoreList, flags) forwarded
+ *   [finishImport: delegation]        proxy.finishImport(importId) called
+ */
+
+import inetsoft.sree.internal.cluster.Cluster;
+import inetsoft.web.admin.content.repository.model.*;
+import inetsoft.web.admin.model.FileData;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ImportAssetControllerTest {
+
+   @Mock private ImportAssetServiceProxy importService;
+   @Mock private Cluster cluster;
+   @Mock private FileData file;
+   @Mock private ExportedAssetsModel exportedAssetsModel;
+   @Mock private ImportAssetResponse importAssetResponse;
+   @Mock private Principal principal;
+
+   private ImportAssetController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new ImportAssetController(importService, cluster);
+   }
+
+   // -------------------------------------------------------------------------
+   // setJarFile()
+   // -------------------------------------------------------------------------
+
+   // [UUID generation] proxy called with a non-null UUID import ID; result returned unchanged
+   @Test
+   void setJarFile_generatesImportIdAndDelegatesToService() throws Exception {
+      when(importService.setJarFile(anyString(), eq(file), eq(principal)))
+         .thenReturn(exportedAssetsModel);
+
+      ExportedAssetsModel result = controller.setJarFile(file, principal);
+
+      assertSame(exportedAssetsModel, result);
+      verify(importService).setJarFile(
+         argThat(id -> id != null && !id.isEmpty()),
+         eq(file), eq(principal));
+   }
+
+   // -------------------------------------------------------------------------
+   // updateImportInfo()
+   // -------------------------------------------------------------------------
+
+   // [delegation] all parameters forwarded to proxy unchanged
+   @Test
+   void updateImportInfo_delegatesToService() throws Exception {
+      when(importService.updateImportInfo("id1", "/target", 2, "alice", principal))
+         .thenReturn(exportedAssetsModel);
+
+      ExportedAssetsModel result =
+         controller.updateImportInfo("id1", "/target", 2, "alice", principal);
+
+      assertSame(exportedAssetsModel, result);
+      verify(importService).updateImportInfo("id1", "/target", 2, "alice", principal);
+   }
+
+   // -------------------------------------------------------------------------
+   // importAsset()
+   // -------------------------------------------------------------------------
+
+   // [delegation] all parameters forwarded to proxy unchanged; response returned
+   @Test
+   void importAsset_delegatesToService() throws Exception {
+      List<String> ignoreList = List.of("ignoredAsset");
+      when(importService.importAsset(
+         "id1", "/target", 2, "alice", true, ignoreList, true, false, principal))
+         .thenReturn(importAssetResponse);
+
+      ImportAssetResponse result = controller.importAsset(
+         "id1", "/target", 2, "alice", true, ignoreList, true, false, principal);
+
+      assertSame(importAssetResponse, result);
+      verify(importService).importAsset(
+         "id1", "/target", 2, "alice", true, ignoreList, true, false, principal);
+   }
+
+   // -------------------------------------------------------------------------
+   // finishImport()
+   // -------------------------------------------------------------------------
+
+   // [delegation] proxy.finishImport(importId) called
+   @Test
+   void finishImport_delegatesToService() {
+      controller.finishImport("id1");
+
+      verify(importService).finishImport("id1");
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/content/repository/MVControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/repository/MVControllerTest.java
@@ -1,0 +1,219 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.content.repository;
+
+/*
+ * Test strategy
+ *
+ * MVController has real in-controller logic in several areas:
+ *
+ *   analyze(AnalyzeMVRequest, Principal) — delegates to mvService.analyze(), wraps the result's
+ *     ID in an AnalyzeMVResponse with completed=false.
+ *
+ *   getModel(boolean, boolean, String) — fetches the MVStatus list from support, calls
+ *     updateStatus() on each entry, delegates the model build to mvService, and wraps the result
+ *     in an AnalyzeMVResponse with completed=true.
+ *
+ *   getMVInfo(AnalyzeMVRequest, Principal) — guards against an invalid org:
+ *     securityEngine.getSecurityProvider().getOrganization(currOrgID) == null → InvalidOrgException.
+ *     When valid and nodes==null, calls mvService.getMVInfo(null, principal).
+ *
+ *   hasMVPermission(Principal) — calls securityProvider.checkPermission() and wraps the boolean
+ *     in MVHasPermissionModel.
+ *
+ *   deleteMVs(MVManagementModel) — extracts MV names from the model and passes them to
+ *     support.dispose().
+ *
+ *   mvAssetExists(String, Principal) — returns false immediately when
+ *     AssetEntry.createAssetEntry(path) returns null (null/invalid path).
+ *
+ * Tool.getDateFormatPattern() / OrganizationManager.getInstance().getCurrentOrgID() are safe to
+ * call for real (pure string utilities with graceful null/default fallbacks).
+ * Catalog.getCatalog() is intercepted with MockedStatic where the exception path is exercised,
+ * to avoid resource-bundle loading in a test environment.
+ *
+ * checkStatus(), showPlan(), create(), setCycle(analysisId, request), analyze(MVManagementModel),
+ * setShowAges(), setDataCycle(), updateMaterializedViews(), isWSMVEnabled() are pure delegation
+ * and are covered by E2E tests.
+ *
+ * Coverage scope:
+ *   [analyze wrapping]                     completed=false; analysisId from service result
+ *   [getModel iteration + wrapping]        updateStatus() called per entry; completed=true
+ *   [hasMVPermission granted]              checkPermission true → allow=true
+ *   [hasMVPermission denied]              checkPermission false → allow=false
+ *   [deleteMVs name extraction]            MV names mapped; support.dispose(names) called
+ *   [getMVInfo invalid org]               getOrganization returns null → InvalidOrgException
+ *   [getMVInfo valid org, null nodes]      org valid; nodes null → getMVInfo(null, principal)
+ *   [mvAssetExists null path]             createAssetEntry(null) → null → false
+ */
+
+import inetsoft.sree.security.*;
+import inetsoft.util.*;
+import inetsoft.web.admin.content.repository.model.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class MVControllerTest {
+
+   @Mock private MVService mvService;
+   @Mock private MVSupportService support;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SecurityProvider engineProvider;
+   @Mock private Organization mockOrganization;
+   @Mock private AnalyzeMVRequest analyzeMVRequest;
+   @Mock private MaterializedModel mv;
+   @Mock private Catalog catalog;
+   @Mock private Principal principal;
+
+   private MVController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new MVController(mvService, support, securityProvider, securityEngine);
+   }
+
+   // -------------------------------------------------------------------------
+   // analyze(AnalyzeMVRequest, Principal)
+   // -------------------------------------------------------------------------
+
+   // [analyze wrapping] completed=false; analysisId propagated from service result
+   @Test
+   void analyze_wrapsAnalysisIdWithCompletedFalse() throws Exception {
+      MVSupportService.AnalysisResult result = new MVSupportService.AnalysisResult("tid");
+      when(mvService.analyze(analyzeMVRequest, principal)).thenReturn(result);
+
+      AnalyzeMVResponse response = controller.analyze(analyzeMVRequest, principal);
+
+      assertFalse(response.completed());
+      assertEquals("tid", response.analysisId());
+   }
+
+   // -------------------------------------------------------------------------
+   // getModel(boolean, boolean, String)
+   // -------------------------------------------------------------------------
+
+   // [getModel wrapping] updateStatus called per status entry; completed=true returned
+   @Test
+   void getModel_callsUpdateStatusForEachEntry_returnsCompleted() {
+      when(support.getMVStatusList("aid")).thenReturn(List.of());
+      when(mvService.getMaterializedModel(List.of(), false, true)).thenReturn(List.of());
+
+      // Tool.getDateFormatPattern() calls SreeEnv which requires Spring — intercept it
+      try(MockedStatic<Tool> toolMock = mockStatic(Tool.class, withSettings().lenient())) {
+         toolMock.when(Tool::getDateFormatPattern).thenReturn("yyyy-MM-dd HH:mm:ss");
+
+         AnalyzeMVResponse response = controller.getModel(false, true, "aid");
+
+         assertTrue(response.completed());
+         assertEquals("aid", response.analysisId());
+         verify(mvService).getMaterializedModel(List.of(), false, true);
+      }
+   }
+
+   // -------------------------------------------------------------------------
+   // hasMVPermission(Principal)
+   // -------------------------------------------------------------------------
+
+   // [permission granted] checkPermission true → allow=true
+   @Test
+   void hasMVPermission_permissionGranted_returnsAllow() {
+      when(securityProvider.checkPermission(
+         principal, ResourceType.MATERIALIZATION, "*", ResourceAction.ACCESS))
+         .thenReturn(true);
+
+      assertTrue(controller.hasMVPermission(principal).allow());
+   }
+
+   // [permission denied] checkPermission false → allow=false
+   @Test
+   void hasMVPermission_permissionDenied_returnsNotAllow() {
+      when(securityProvider.checkPermission(
+         principal, ResourceType.MATERIALIZATION, "*", ResourceAction.ACCESS))
+         .thenReturn(false);
+
+      assertFalse(controller.hasMVPermission(principal).allow());
+   }
+
+   // -------------------------------------------------------------------------
+   // deleteMVs(MVManagementModel)
+   // -------------------------------------------------------------------------
+
+   // [name extraction] MV names extracted from model; support.dispose(names) called
+   @Test
+   void deleteMVs_extractsMvNamesAndCallsDispose() {
+      when(mv.name()).thenReturn("mv1");
+      MVManagementModel model = MVManagementModel.builder().addMvs(mv).build();
+
+      controller.deleteMVs(model);
+
+      verify(support).dispose(List.of("mv1"));
+   }
+
+   // -------------------------------------------------------------------------
+   // getMVInfo(AnalyzeMVRequest, Principal)
+   // -------------------------------------------------------------------------
+
+   // [invalid org] getOrganization returns null → InvalidOrgException thrown
+   @Test
+   void getMVInfo_invalidOrg_throwsInvalidOrgException() {
+      when(securityEngine.getSecurityProvider()).thenReturn(engineProvider);
+      // engineProvider.getOrganization() returns null by default → org guard triggers
+
+      try(MockedStatic<Catalog> catalogMock = mockStatic(Catalog.class, withSettings().lenient())) {
+         catalogMock.when(Catalog::getCatalog).thenReturn(catalog);
+         when(catalog.getString(any())).thenReturn("invalid org");
+
+         assertThrows(InvalidOrgException.class,
+            () -> controller.getMVInfo(null, principal));
+      }
+   }
+
+   // [valid org, null nodes] org valid; nodes=null → mvService.getMVInfo(null, principal) called
+   @Test
+   void getMVInfo_validOrg_nullNodes_delegatesToService() throws Exception {
+      when(securityEngine.getSecurityProvider()).thenReturn(engineProvider);
+      when(engineProvider.getOrganization(any())).thenReturn(mockOrganization);
+
+      controller.getMVInfo(null, principal);
+
+      verify(mvService).getMVInfo(null, principal);
+   }
+
+   // -------------------------------------------------------------------------
+   // mvAssetExists(String, Principal)
+   // -------------------------------------------------------------------------
+
+   // [null path] AssetEntry.createAssetEntry(null) returns null → false returned; no repository call
+   @Test
+   void mvAssetExists_nullPath_returnsFalse() {
+      assertFalse(controller.mvAssetExists(null, principal));
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/content/repository/RepositoryFolderControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/repository/RepositoryFolderControllerTest.java
@@ -1,0 +1,142 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.content.repository;
+
+/*
+ * Test strategy
+ *
+ * RepositoryFolderController has two endpoints:
+ *
+ *   GET /api/em/content/repository/folder/ (getRepositoryFolderSetting)
+ *     — validates current org via OrganizationManager + SecurityProvider; throws
+ *       InvalidOrgException when org is null; parses owner key to IdentityID; delegates
+ *       to repositoryFolderService.getSettings() on success.
+ *
+ *   POST /api/em/content/repository/edit/folder (setRepositoryFolderSettings)
+ *     — pure delegation: parses owner key to IdentityID and calls
+ *       repositoryFolderService.applySettings(ownerID, model, principal).
+ *
+ * Excluded: @Secured/@RequiredPermission annotations (Spring Security; E2E coverage).
+ *
+ * Static singletons (OrganizationManager, Catalog) are intercepted with
+ * mockStatic() using lenient() to suppress UnnecessaryStubbingException.
+ */
+
+import inetsoft.sree.security.*;
+import inetsoft.util.Catalog;
+import inetsoft.util.InvalidOrgException;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class RepositoryFolderControllerTest {
+
+   @Mock private RepositoryFolderService repositoryFolderService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private Organization organization;
+   @Mock private Catalog catalog;
+   @Mock private OrganizationManager orgManager;
+   @Mock private Principal principal;
+   @Mock private RepositoryFolderSettingsModel settingsModel;
+   @Mock private SetRepositoryFolderSettingsModel setSettingsModel;
+
+   private RepositoryFolderController controller;
+
+   private MockedStatic<OrganizationManager> orgManagerStatic;
+   private MockedStatic<Catalog> catalogStatic;
+
+   @BeforeEach
+   void setUp() {
+      controller = new RepositoryFolderController(repositoryFolderService, securityEngine);
+
+      orgManagerStatic = mockStatic(OrganizationManager.class, withSettings().lenient());
+      catalogStatic = mockStatic(Catalog.class, withSettings().lenient());
+
+      orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+      lenient().when(orgManager.getCurrentOrgID()).thenReturn("host-org");
+      lenient().when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      lenient().when(securityProvider.getOrganization("host-org")).thenReturn(organization);
+      catalogStatic.when(Catalog::getCatalog).thenReturn(catalog);
+      lenient().when(catalog.getString(anyString())).thenReturn("msg");
+   }
+
+   @AfterEach
+   void tearDown() {
+      orgManagerStatic.close();
+      catalogStatic.close();
+   }
+
+   // -------------------------------------------------------------------------
+   // GET /api/em/content/repository/folder/ — getRepositoryFolderSetting
+   // -------------------------------------------------------------------------
+
+   // [invalid org] org lookup returns null → InvalidOrgException; service never called
+   @Test
+   void getFolderSetting_invalidOrg_throwsInvalidOrgException() throws Exception {
+      when(securityProvider.getOrganization("host-org")).thenReturn(null);
+
+      assertThrows(InvalidOrgException.class,
+         () -> controller.getRepositoryFolderSetting("/reports", false, null, principal));
+
+      verify(repositoryFolderService, never()).getSettings(anyString(), anyBoolean(), any(), any());
+   }
+
+   // [valid org] valid org → service.getSettings() called with parsed ownerID; result returned
+   @Test
+   void getFolderSetting_validOrg_delegatesToService() throws Exception {
+      String owner = new IdentityID("alice", "org").convertToKey();
+      when(repositoryFolderService.getSettings(eq("/reports"), eq(false), any(IdentityID.class), eq(principal)))
+         .thenReturn(settingsModel);
+
+      RepositoryFolderSettingsModel result =
+         controller.getRepositoryFolderSetting("/reports", false, owner, principal);
+
+      assertSame(settingsModel, result);
+      verify(repositoryFolderService).getSettings(eq("/reports"), eq(false), any(IdentityID.class), eq(principal));
+   }
+
+   // -------------------------------------------------------------------------
+   // POST /api/em/content/repository/edit/folder — setRepositoryFolderSettings
+   // -------------------------------------------------------------------------
+
+   // [pure delegation] parses owner key to IdentityID; calls applySettings with correct args
+   @Test
+   void setFolderSettings_delegatesToService() throws Exception {
+      String owner = new IdentityID("alice", "org").convertToKey();
+      when(repositoryFolderService.applySettings(
+         argThat(id -> "alice".equals(id.name)), eq(setSettingsModel), eq(principal)))
+         .thenReturn(settingsModel);
+
+      RepositoryFolderSettingsModel result =
+         controller.setRepositoryFolderSettings(owner, setSettingsModel, principal);
+
+      assertSame(settingsModel, result);
+      verify(repositoryFolderService).applySettings(
+         argThat(id -> "alice".equals(id.name)), eq(setSettingsModel), eq(principal));
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/content/repository/RepositoryObjectControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/repository/RepositoryObjectControllerTest.java
@@ -1,0 +1,151 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.content.repository;
+
+/*
+ * Test strategy
+ *
+ * RepositoryObjectController has one method with real in-controller logic:
+ *
+ *   GET api/em/content/repository/tree/node/permission (getResourcePermission)
+ *     — parses the "type" string parameter to int via Integer.parseInt(), then makes
+ *       two sequential calls: permissionService.getRepositoryResourceType(int, path) to
+ *       resolve the Resource, and permissionService.getTableModel(path, type,
+ *       ADMIN_ACTIONS, principal) using the resolved resource's path and type.
+ *
+ * Pure-delegation methods (no branch logic):
+ *   addFolder             → repositoryObjectService.addFolder(parentInfo, isWorksheetFolder, principal)
+ *   deleteRepositoryEntry → repositoryObjectService.deleteNodes(nodes, principal, force, permanent)
+ *   moveFile              → repositoryObjectService.moveFiles(request, true, principal)
+ *
+ * Explicitly excluded:
+ *   setResourcePermission (POST) — calls Util.getObjectFullPath() and SecurityEngine.getSecurity(),
+ *   both of which require a full Spring context. These code paths are covered by E2E API tests.
+ *
+ * No static mocks are required for these tests; all behaviour is expressed through
+ * the injected service mocks.
+ */
+
+import inetsoft.sree.security.Resource;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.web.admin.content.repository.model.*;
+import inetsoft.web.admin.security.ConnectionStatus;
+import inetsoft.web.admin.security.ResourcePermissionModel;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class RepositoryObjectControllerTest {
+
+   @Mock private RepositoryObjectService repositoryObjectService;
+   @Mock private ResourcePermissionService permissionService;
+   @Mock private Principal principal;
+   @Mock private ResourcePermissionModel permissionModel;
+   @Mock private ContentRepositoryTreeNode treeNode;
+   @Mock private ConnectionStatus connectionStatus;
+   @Mock private NewRepositoryFolderRequest folderRequest;
+   @Mock private DeleteTreeNodesRequest deleteRequest;
+   @Mock private MoveCopyTreeNodesRequest moveRequest;
+
+   private RepositoryObjectController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new RepositoryObjectController(repositoryObjectService, permissionService);
+   }
+
+   // -------------------------------------------------------------------------
+   // GET api/em/content/repository/tree/node/permission — getResourcePermission
+   // -------------------------------------------------------------------------
+
+   // [parses type and sequences two service calls] type="128" → parseInt → getRepositoryResourceType
+   // → getTableModel with resolved resource path+type; result returned unchanged
+   @Test
+   void getResourcePermission_parsesTypeAndDelegatesToPermissionService() {
+      String path = "/reports/dash1";
+      Resource resource = new Resource(ResourceType.REPORT, path);
+
+      when(permissionService.getRepositoryResourceType(128, path)).thenReturn(resource);
+      when(permissionService.getTableModel(
+         path, ResourceType.REPORT, ResourcePermissionService.ADMIN_ACTIONS, principal))
+         .thenReturn(permissionModel);
+
+      ResourcePermissionModel result = controller.getResourcePermission(path, "128", principal);
+
+      assertSame(permissionModel, result);
+      verify(permissionService).getRepositoryResourceType(128, path);
+      verify(permissionService).getTableModel(
+         path, ResourceType.REPORT, ResourcePermissionService.ADMIN_ACTIONS, principal);
+   }
+
+   // -------------------------------------------------------------------------
+   // POST /api/em/settings/content/repository/folder/add/ — addFolder
+   // -------------------------------------------------------------------------
+
+   // [pure delegation] result from repositoryObjectService.addFolder() returned unchanged
+   @Test
+   void addFolder_delegatesToService() throws Exception {
+      when(repositoryObjectService.addFolder(folderRequest, false, principal))
+         .thenReturn(treeNode);
+
+      ContentRepositoryTreeNode result = controller.addFolder(folderRequest, false, principal);
+
+      assertSame(treeNode, result);
+      verify(repositoryObjectService).addFolder(folderRequest, false, principal);
+   }
+
+   // -------------------------------------------------------------------------
+   // POST api/em/content/repository/tree/delete — deleteRepositoryEntry
+   // -------------------------------------------------------------------------
+
+   // [pure delegation] deleteNodes() called with unpacked request fields; result returned unchanged
+   @Test
+   void deleteRepositoryEntry_delegatesToService() {
+      TreeNodeInfo[] nodes = new TreeNodeInfo[0];
+      when(deleteRequest.nodes()).thenReturn(nodes);
+      when(deleteRequest.force()).thenReturn(true);
+      when(deleteRequest.permanent()).thenReturn(false);
+      when(repositoryObjectService.deleteNodes(nodes, principal, true, false))
+         .thenReturn(connectionStatus);
+
+      ConnectionStatus result = controller.deleteRepositoryEntry(deleteRequest, principal);
+
+      assertSame(connectionStatus, result);
+      verify(repositoryObjectService).deleteNodes(nodes, principal, true, false);
+   }
+
+   // -------------------------------------------------------------------------
+   // POST api/em/content/repository/tree/move — moveFile
+   // -------------------------------------------------------------------------
+
+   // [pure delegation] repositoryObjectService.moveFiles(request, true, principal) called
+   @Test
+   void moveFile_delegatesToService() throws Exception {
+      controller.moveFile(moveRequest, principal);
+
+      verify(repositoryObjectService).moveFiles(moveRequest, true, principal);
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/content/repository/RepositoryRecycleBinControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/repository/RepositoryRecycleBinControllerTest.java
@@ -1,0 +1,233 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.content.repository;
+
+/*
+ * Test strategy
+ *
+ * RepositoryRecycleBinController has real in-controller logic in three areas:
+ *
+ *   clearRecycleBin() — permission guard via securityEngine.getSecurityProvider().checkPermission();
+ *     throws SecurityException when denied. When granted, drains indexedStorage (asset repository
+ *     entries) and recycleBin.getEntries(), then calls AutoSaveUtils.deleteRecycledAutoSaveFiles().
+ *
+ *   deleteRecycleBinFolder() — for each table item, calls SUtil.isMyDashboard(originalPath) to
+ *     decide whether to prepend Tool.MY_DASHBOARD to the path before looking up the recycle bin
+ *     entry; then delegates to repositoryObjectService.deleteNodes().
+ *
+ *   restoreNode() — looks up the entry; returns null when absent; dispatches to
+ *     RecycleUtils.restoreSheet() for sheets and RecycleUtils.restoreWSFolder() for WS folders.
+ *
+ * RecycleBin.Entry is a public static final class — created as a real instance via setters.
+ * SUtil.isMyDashboard() and Tool.MY_DASHBOARD are pure string utilities, called for real.
+ * AssetUtil.getAssetRepository() and AutoSaveUtils / RecycleUtils static methods are intercepted
+ * with MockedStatic (always closed in try-with-resources).
+ *
+ * getRecycleBinFolderSettings() and getRepositoryRecycleBinEntryModel() call
+ * AssetUtil.getAssetRepository() deeply and are covered by E2E tests.
+ *
+ * Coverage scope:
+ *   [permission denied]           checkPermission false → SecurityException; no storage touched
+ *   [permission granted]          empty storage/bin → removeEntry never called; deleteRecycledAutoSaveFiles called
+ *   [non-My-Dashboard path]       isMyDashboard false → getEntry(path) with original path
+ *   [My Portal Dashboards path]   isMyDashboard true → getEntry(Tool.MY_DASHBOARD + "/" + path)
+ *   [entry not found]             getEntry returns null → restoreNode returns null
+ *   [sheet entry]                 isSheet() true → RecycleUtils.restoreSheet() called
+ *   [WS folder entry]             isWSFolder() true → RecycleUtils.restoreWSFolder() called
+ */
+
+import inetsoft.sree.RepositoryEntry;
+import inetsoft.sree.security.*;
+import inetsoft.uql.asset.internal.AssetUtil;
+import inetsoft.util.*;
+import inetsoft.web.*;
+import inetsoft.web.admin.content.repository.model.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class RepositoryRecycleBinControllerTest {
+
+   @Mock private RepositoryObjectService repositoryObjectService;
+   @Mock private ContentRepositoryTreeService contentRepositoryTreeService;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private RepletRegistryService registryManager;
+   @Mock private IndexedStorage indexedStorage;
+   @Mock private RecycleBin recycleBin;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SecurityProvider engineProvider;
+   @Mock private Principal principal;
+
+   private RepositoryRecycleBinController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new RepositoryRecycleBinController(
+         repositoryObjectService, contentRepositoryTreeService, securityProvider,
+         registryManager, indexedStorage, recycleBin, securityEngine);
+   }
+
+   private static RecycleBin.Entry makeEntry(String path, String name, int type) {
+      RecycleBin.Entry e = new RecycleBin.Entry();
+      e.setPath(path);
+      e.setName(name);
+      e.setType(type);
+      e.setOriginalPath(path);
+      e.setTimestamp(new Date());
+      return e;
+   }
+
+   // -------------------------------------------------------------------------
+   // clearRecycleBin()
+   // -------------------------------------------------------------------------
+
+   // [permission denied] checkPermission returns false → SecurityException; indexedStorage never touched
+   @Test
+   void clearRecycleBin_permissionDenied_throwsSecurityException() {
+      when(securityEngine.getSecurityProvider()).thenReturn(engineProvider);
+      when(engineProvider.checkPermission(
+         principal, ResourceType.EM_COMPONENT, "settings/content/repository", ResourceAction.ACCESS))
+         .thenReturn(false);
+
+      assertThrows(inetsoft.sree.security.SecurityException.class,
+         () -> controller.clearRecycleBin(principal));
+      verify(indexedStorage, never()).getKeys(any());
+   }
+
+   // [permission granted] empty storage + empty recycle bin → no removals; deleteRecycledAutoSaveFiles called
+   @Test
+   void clearRecycleBin_withPermission_clearsRecycleBin() throws Exception {
+      when(securityEngine.getSecurityProvider()).thenReturn(engineProvider);
+      when(engineProvider.checkPermission(
+         principal, ResourceType.EM_COMPONENT, "settings/content/repository", ResourceAction.ACCESS))
+         .thenReturn(true);
+      when(indexedStorage.getKeys(any())).thenReturn(Set.of());
+      when(recycleBin.getEntries()).thenReturn(List.of());
+
+      try(MockedStatic<AssetUtil> assetUtilMock = mockStatic(AssetUtil.class, withSettings().lenient());
+          MockedStatic<AutoSaveUtils> autoSaveMock = mockStatic(AutoSaveUtils.class, withSettings().lenient()))
+      {
+         assetUtilMock.when(() -> AssetUtil.getAssetRepository(false)).thenReturn(null);
+
+         controller.clearRecycleBin(principal);
+
+         autoSaveMock.verify(() -> AutoSaveUtils.deleteRecycledAutoSaveFiles(principal));
+         verify(recycleBin, never()).removeEntry(any());
+      }
+   }
+
+   // -------------------------------------------------------------------------
+   // deleteRecycleBinFolder()
+   // -------------------------------------------------------------------------
+
+   // [non-My-Dashboard path] SUtil.isMyDashboard returns false → getEntry called with original path
+   @Test
+   void deleteRecycleBinFolder_nonMyDashboard_usesDirectPath() {
+      RecycleBin.Entry entry = makeEntry("binPath", "myEntry", RepositoryEntry.VIEWSHEET);
+      RepositoryFolderRecycleBinTableModel item =
+         RepositoryFolderRecycleBinTableModel.builder()
+            .path("binPath")
+            .originalPath("Reports")
+            .type("viewsheet")
+            .originalUser("alice")
+            .dateDeleted("")
+            .build();
+      RepositoryFolderRecycleBinSettingsModel model =
+         RepositoryFolderRecycleBinSettingsModel.builder().table(List.of(item)).build();
+      when(recycleBin.getEntry("binPath")).thenReturn(entry);
+
+      controller.deleteRecycleBinFolder(model, principal);
+
+      verify(recycleBin).getEntry("binPath");
+      verify(repositoryObjectService).deleteNodes(any(), eq(principal), eq(false), eq(false));
+   }
+
+   // [My Portal Dashboards path] SUtil.isMyDashboard returns true → path prepended with Tool.MY_DASHBOARD
+   @Test
+   void deleteRecycleBinFolder_myDashboardPath_prependsMyDashboard() {
+      String expectedKey = Tool.MY_DASHBOARD + "/binPath";
+      RecycleBin.Entry entry = makeEntry(expectedKey, "myEntry", RepositoryEntry.VIEWSHEET);
+      RepositoryFolderRecycleBinTableModel item =
+         RepositoryFolderRecycleBinTableModel.builder()
+            .path("binPath")
+            .originalPath("My Portal Dashboards")
+            .type("viewsheet")
+            .originalUser("alice")
+            .dateDeleted("")
+            .build();
+      RepositoryFolderRecycleBinSettingsModel model =
+         RepositoryFolderRecycleBinSettingsModel.builder().table(List.of(item)).build();
+      when(recycleBin.getEntry(expectedKey)).thenReturn(entry);
+
+      controller.deleteRecycleBinFolder(model, principal);
+
+      verify(recycleBin).getEntry(expectedKey);
+      verify(repositoryObjectService).deleteNodes(any(), eq(principal), eq(false), eq(false));
+   }
+
+   // -------------------------------------------------------------------------
+   // restoreNode()
+   // -------------------------------------------------------------------------
+
+   // [entry not found] getEntry returns null → null returned; no restore dispatched
+   @Test
+   void restoreNode_entryNotFound_returnsNull() throws Exception {
+      when(recycleBin.getEntry("missing")).thenReturn(null);
+
+      assertNull(controller.restoreNode("missing", false, principal));
+   }
+
+   // [sheet entry] isSheet() true → RecycleUtils.restoreSheet called
+   @Test
+   void restoreNode_sheetEntry_callsRestoreSheet() throws Exception {
+      RecycleBin.Entry entry = makeEntry("sheetPath", "mySheet", RepositoryEntry.VIEWSHEET);
+      when(recycleBin.getEntry("sheetPath")).thenReturn(entry);
+
+      try(MockedStatic<RecycleUtils> recycleMock = mockStatic(RecycleUtils.class, withSettings().lenient())) {
+         controller.restoreNode("sheetPath", false, principal);
+         recycleMock.verify(() -> RecycleUtils.restoreSheet(entry, false, principal, recycleBin));
+      }
+   }
+
+   // [WS folder entry] isFolder() + isWSFolder() true → RecycleUtils.restoreWSFolder called
+   @Test
+   void restoreNode_wsFolderEntry_callsRestoreWSFolder() throws Exception {
+      RecycleBin.Entry entry = makeEntry("wsPath", "myFolder", RepositoryEntry.WORKSHEET_FOLDER);
+      when(recycleBin.getEntry("wsPath")).thenReturn(entry);
+
+      try(MockedStatic<RecycleUtils> recycleMock = mockStatic(RecycleUtils.class, withSettings().lenient())) {
+         recycleMock.when(() -> RecycleUtils.restoreWSFolder(entry, false, principal, recycleBin))
+            .thenReturn(null);
+
+         controller.restoreNode("wsPath", false, principal);
+
+         recycleMock.verify(() -> RecycleUtils.restoreWSFolder(entry, false, principal, recycleBin));
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/content/repository/ResourcePermissionControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/repository/ResourcePermissionControllerTest.java
@@ -44,6 +44,7 @@ package inetsoft.web.admin.content.repository;
 
 import inetsoft.sree.RepositoryEntry;
 import inetsoft.sree.schedule.ScheduleManager;
+import inetsoft.sree.schedule.ScheduleTask;
 import inetsoft.sree.security.*;
 import inetsoft.util.Catalog;
 import inetsoft.util.InvalidOrgException;
@@ -177,5 +178,65 @@ class ResourcePermissionControllerTest {
 
       verify(resourcePermissionService, never()).setResourcePermissions(
          anyString(), any(), anyString(), any(), any(Principal.class), anyBoolean());
+   }
+
+   // -------------------------------------------------------------------------
+   // checkPermission() — SCHEDULE_TASK branch
+   // -------------------------------------------------------------------------
+
+   // [task not found] getScheduleTask returns null → allowed=false → MessageException
+   @Test
+   void getPermissions_scheduleTask_taskNotFound_throwsMessageException() throws Exception {
+      Resource resource = new Resource(ResourceType.SCHEDULE_TASK, "myTask");
+      when(resourcePermissionService.getRepositoryResourceType(RepositoryEntry.VIEWSHEET, "myTask"))
+         .thenReturn(resource);
+      when(scheduleManager.getScheduleTask("myTask")).thenReturn(null);
+
+      assertThrows(MessageException.class,
+         () -> controller.getRepositoryEntryPermissions(
+            "myTask", RepositoryEntry.VIEWSHEET, principal));
+   }
+
+   // [task found, no permission] hasTaskPermission returns false → MessageException
+   @Test
+   void getPermissions_scheduleTask_noPermission_throwsMessageException() throws Exception {
+      ScheduleTask task = mock(ScheduleTask.class);
+      Resource resource = new Resource(ResourceType.SCHEDULE_TASK, "myTask");
+      when(resourcePermissionService.getRepositoryResourceType(RepositoryEntry.VIEWSHEET, "myTask"))
+         .thenReturn(resource);
+      when(scheduleManager.getScheduleTask("myTask")).thenReturn(task);
+
+      try(MockedStatic<ScheduleManager> smStatic = mockStatic(ScheduleManager.class)) {
+         smStatic.when(() -> ScheduleManager.hasTaskPermission(any(), eq(principal), any()))
+            .thenReturn(false);
+
+         assertThrows(MessageException.class,
+            () -> controller.getRepositoryEntryPermissions(
+               "myTask", RepositoryEntry.VIEWSHEET, principal));
+      }
+   }
+
+   // [task found, permission granted] hasTaskPermission returns true → model returned
+   @Test
+   void getPermissions_scheduleTask_permissionGranted_returnsModel() throws Exception {
+      ScheduleTask task = mock(ScheduleTask.class);
+      Resource resource = new Resource(ResourceType.SCHEDULE_TASK, "myTask");
+      when(resourcePermissionService.getRepositoryResourceType(RepositoryEntry.VIEWSHEET, "myTask"))
+         .thenReturn(resource);
+      when(scheduleManager.getScheduleTask("myTask")).thenReturn(task);
+      when(resourcePermissionService.getTableModel(
+         "myTask", ResourceType.SCHEDULE_TASK,
+         ResourcePermissionService.ADMIN_ACTIONS, principal, false))
+         .thenReturn(permissionModel);
+
+      try(MockedStatic<ScheduleManager> smStatic = mockStatic(ScheduleManager.class)) {
+         smStatic.when(() -> ScheduleManager.hasTaskPermission(any(), eq(principal), any()))
+            .thenReturn(true);
+
+         ResourcePermissionModel result =
+            controller.getRepositoryEntryPermissions("myTask", RepositoryEntry.VIEWSHEET, principal);
+
+         assertSame(permissionModel, result);
+      }
    }
 }

--- a/core/src/test/java/inetsoft/web/admin/content/repository/ResourcePermissionControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/repository/ResourcePermissionControllerTest.java
@@ -1,0 +1,181 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.content.repository;
+
+/*
+ * Test strategy
+ *
+ * ResourcePermissionController orchestrates two endpoints:
+ *   getRepositoryEntryPermissions — validates org, checks resource permission, delegates to service
+ *   setRepositoryEntryPermissions — checks resource permission, delegates to service
+ *
+ * Coverage scope:
+ *   [getPermissions: invalid org]       getCurrentOrgID() → getOrganization() null → InvalidOrgException
+ *   [getPermissions: permission denied] SecurityEngine.checkPermission() false → MessageException
+ *   [getPermissions: valid]             valid org, permission granted → service model returned
+ *   [setPermissions: permission denied] checkPermission false → MessageException before Util is called
+ *
+ * The setPermissions success path (delegation + duplicate-identity tests) cannot be unit-tested here
+ * because ResourcePermissionController.setRepositoryEntryPermissions() calls
+ * Util.getObjectFullPath(), whose static initializer requires a Spring context. Those scenarios are
+ * covered by E2E API tests instead.
+ *
+ * Static singletons (OrganizationManager, Catalog) are intercepted with
+ * Mockito.mockStatic() using lenient() to suppress UnnecessaryStubbingException.
+ *
+ * Note: checkPermission() always calls securityEngine.checkPermission() with ResourceAction.ADMIN
+ * regardless of the action passed in (scheduleTaskAction only applies to SCHEDULE_TASK resources).
+ */
+
+import inetsoft.sree.RepositoryEntry;
+import inetsoft.sree.schedule.ScheduleManager;
+import inetsoft.sree.security.*;
+import inetsoft.util.Catalog;
+import inetsoft.util.InvalidOrgException;
+import inetsoft.util.MessageException;
+import inetsoft.web.admin.security.ResourcePermissionModel;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ResourcePermissionControllerTest {
+
+   @Mock private ResourcePermissionService resourcePermissionService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private ScheduleManager scheduleManager;
+   @Mock private Organization organization;
+   @Mock private ResourcePermissionModel permissionModel;
+   @Mock private Catalog catalog;
+   @Mock private Principal principal;
+   @Mock private OrganizationManager orgManager;
+
+   private ResourcePermissionController controller;
+
+   private MockedStatic<OrganizationManager> orgManagerStatic;
+   private MockedStatic<Catalog> catalogStatic;
+
+   @BeforeEach
+   void setUp() {
+      controller = new ResourcePermissionController(resourcePermissionService, securityEngine, scheduleManager);
+
+      orgManagerStatic = mockStatic(OrganizationManager.class, withSettings().lenient());
+      catalogStatic = mockStatic(Catalog.class, withSettings().lenient());
+
+      orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+      lenient().when(orgManager.getCurrentOrgID()).thenReturn("host-org");
+      lenient().when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      lenient().when(securityProvider.getOrganization("host-org")).thenReturn(organization);
+      catalogStatic.when(Catalog::getCatalog).thenReturn(catalog);
+      catalogStatic.when(() -> Catalog.getCatalog(any(Principal.class))).thenReturn(catalog);
+      lenient().when(catalog.getString(anyString())).thenReturn("msg");
+      lenient().when(catalog.getString(anyString(), any())).thenReturn("msg");
+   }
+
+   @AfterEach
+   void tearDown() {
+      orgManagerStatic.close();
+      catalogStatic.close();
+   }
+
+   // -------------------------------------------------------------------------
+   // getRepositoryEntryPermissions()
+   // -------------------------------------------------------------------------
+
+   // [invalid org] org lookup returns null → InvalidOrgException; service is never called
+   @Test
+   void getPermissions_invalidOrg_throwsInvalidOrgException() {
+      when(securityProvider.getOrganization("host-org")).thenReturn(null);
+
+      assertThrows(InvalidOrgException.class,
+         () -> controller.getRepositoryEntryPermissions(
+            "/reports/dash1", RepositoryEntry.VIEWSHEET, principal));
+
+      verify(resourcePermissionService, never()).getTableModel(
+         anyString(), any(), any(), any(Principal.class), anyBoolean());
+   }
+
+   // [permission denied] SecurityEngine.checkPermission() returns false → MessageException thrown
+   @Test
+   void getPermissions_permissionDenied_throwsMessageException() throws Exception {
+      Resource resource = new Resource(ResourceType.REPORT, "/reports/dash1");
+      when(resourcePermissionService.getRepositoryResourceType(RepositoryEntry.VIEWSHEET, "/reports/dash1"))
+         .thenReturn(resource);
+      when(securityEngine.checkPermission(
+         principal, ResourceType.REPORT, "/reports/dash1", ResourceAction.ADMIN))
+         .thenReturn(false);
+
+      assertThrows(MessageException.class,
+         () -> controller.getRepositoryEntryPermissions(
+            "/reports/dash1", RepositoryEntry.VIEWSHEET, principal));
+
+      verify(resourcePermissionService, never()).getTableModel(
+         anyString(), any(), any(), any(Principal.class), anyBoolean());
+   }
+
+   // [valid] valid org, permission granted → service model returned unchanged
+   @Test
+   void getPermissions_validResource_returnsPermissionModel() throws Exception {
+      Resource resource = new Resource(ResourceType.REPORT, "/reports/dash1");
+      when(resourcePermissionService.getRepositoryResourceType(RepositoryEntry.VIEWSHEET, "/reports/dash1"))
+         .thenReturn(resource);
+      when(securityEngine.checkPermission(
+         principal, ResourceType.REPORT, "/reports/dash1", ResourceAction.ADMIN))
+         .thenReturn(true);
+      when(resourcePermissionService.getTableModel(
+         "/reports/dash1", ResourceType.REPORT,
+         ResourcePermissionService.ADMIN_ACTIONS, principal, false))
+         .thenReturn(permissionModel);
+
+      ResourcePermissionModel result =
+         controller.getRepositoryEntryPermissions("/reports/dash1", RepositoryEntry.VIEWSHEET, principal);
+
+      assertSame(permissionModel, result);
+   }
+
+   // -------------------------------------------------------------------------
+   // setRepositoryEntryPermissions()
+   // -------------------------------------------------------------------------
+
+   // [permission denied] checkPermission returns false → MessageException thrown before Util is called
+   @Test
+   void setPermissions_permissionDenied_throwsMessageException() throws Exception {
+      Resource resource = new Resource(ResourceType.REPORT, "/reports/dash1");
+      when(resourcePermissionService.getRepositoryResourceType(RepositoryEntry.VIEWSHEET, "/reports/dash1"))
+         .thenReturn(resource);
+      when(securityEngine.checkPermission(
+         principal, ResourceType.REPORT, "/reports/dash1", ResourceAction.ADMIN))
+         .thenReturn(false);
+
+      assertThrows(MessageException.class,
+         () -> controller.setRepositoryEntryPermissions(
+            "/reports/dash1", RepositoryEntry.VIEWSHEET, permissionModel, principal));
+
+      verify(resourcePermissionService, never()).setResourcePermissions(
+         anyString(), any(), anyString(), any(), any(Principal.class), anyBoolean());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/content/repository/ResourcePermissionTreeControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/repository/ResourcePermissionTreeControllerTest.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.content.repository;
+
+/*
+ * Test strategy
+ *
+ * Class type: pure-delegation controller — ResourcePermissionTreeController contains no
+ * in-controller logic; the single method delegates entirely to SecurityTreeServer.
+ *
+ * Coverage scope:
+ *   [named provider]    delegates with isPermissions=true, providerChanged=false, correct flags
+ *   [null provider]     null provider is passed through unchanged
+ *   [org-admin flags]   hideOrgAdminRole=true and isTimeRange=true are forwarded correctly
+ */
+
+import inetsoft.web.admin.security.user.SecurityTreeRootModel;
+import inetsoft.web.admin.security.user.SecurityTreeServer;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ResourcePermissionTreeControllerTest {
+
+   @Mock private SecurityTreeServer securityTreeServer;
+   @Mock private SecurityTreeRootModel treeRootModel;
+   @Mock private Principal principal;
+
+   private ResourcePermissionTreeController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new ResourcePermissionTreeController(securityTreeServer);
+   }
+
+   // -------------------------------------------------------------------------
+   // getResourceTree()
+   // -------------------------------------------------------------------------
+
+   // [named provider] provider specified → delegates with isPermissions=true, providerChanged=false
+   @Test
+   void getResourceTree_namedProvider_delegatesToSecurityTreeServer() {
+      when(securityTreeServer.getSecurityTree("myProvider", principal, true, false, false, false))
+         .thenReturn(treeRootModel);
+
+      SecurityTreeRootModel result =
+         controller.getResourceTree("myProvider", false, false, principal);
+
+      assertSame(treeRootModel, result);
+      verify(securityTreeServer).getSecurityTree("myProvider", principal, true, false, false, false);
+   }
+
+   // [null provider] null provider is passed through to SecurityTreeServer unchanged
+   @Test
+   void getResourceTree_nullProvider_passesNullToServer() {
+      when(securityTreeServer.getSecurityTree(null, principal, true, false, false, false))
+         .thenReturn(treeRootModel);
+
+      SecurityTreeRootModel result =
+         controller.getResourceTree(null, false, false, principal);
+
+      assertSame(treeRootModel, result);
+      verify(securityTreeServer).getSecurityTree(null, principal, true, false, false, false);
+   }
+
+   // [org-admin flags] hideOrgAdminRole=true and isTimeRange=true are forwarded to the server
+   @Test
+   void getResourceTree_withOrgAdminFlags_forwardsToServer() {
+      when(securityTreeServer.getSecurityTree("myProvider", principal, true, false, true, true))
+         .thenReturn(treeRootModel);
+
+      SecurityTreeRootModel result =
+         controller.getResourceTree("myProvider", true, true, principal);
+
+      assertSame(treeRootModel, result);
+      verify(securityTreeServer).getSecurityTree("myProvider", principal, true, false, true, true);
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/schedule/EMScheduleBatchActionControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/EMScheduleBatchActionControllerTest.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.schedule;
+
+/*
+ * Test strategy
+ *
+ * EMScheduleBatchActionController has real in-controller logic in one method:
+ *   getParameters — null-task guard + static permission check before delegation
+ *
+ * The remaining methods (getScheduledTasks, getQueryTree, getQueryColumns) either delegate
+ * entirely to services or call AssetRepository which requires a live context; those are
+ * covered by E2E tests.
+ *
+ * Coverage scope:
+ *   [getParameters: task not found]    scheduleManager returns null → RuntimeException
+ *   [getParameters: permission denied] ScheduleManager.hasTaskPermission() false → SecurityException
+ *
+ * ScheduleManager.hasTaskPermission() is a static method intercepted with
+ * Mockito.mockStatic() using lenient() to suppress UnnecessaryStubbingException.
+ */
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.schedule.*;
+import inetsoft.sree.security.*;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.web.admin.content.repository.ContentRepositoryTreeService;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class EMScheduleBatchActionControllerTest {
+
+   @Mock private AssetRepository assetRepository;
+   @Mock private ScheduleService scheduleService;
+   @Mock private ScheduleManager scheduleManager;
+   @Mock private ContentRepositoryTreeService contentRepositoryTreeService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private ViewsheetService viewsheetService;
+   @Mock private ScheduleTaskActionServiceProxy actionServiceProxy;
+   @Mock private EMScheduleTaskActionServiceProxy emActionServiceProxy;
+   @Mock private ScheduleTask scheduleTask;
+   @Mock private Principal principal;
+
+   private EMScheduleBatchActionController controller;
+
+   private MockedStatic<ScheduleManager> scheduleManagerStatic;
+
+   @BeforeEach
+   void setUp() {
+      controller = new EMScheduleBatchActionController(
+         assetRepository, scheduleService, scheduleManager, contentRepositoryTreeService,
+         securityEngine, viewsheetService, actionServiceProxy, emActionServiceProxy);
+
+      scheduleManagerStatic = mockStatic(ScheduleManager.class, withSettings().lenient());
+   }
+
+   @AfterEach
+   void tearDown() {
+      scheduleManagerStatic.close();
+   }
+
+   // -------------------------------------------------------------------------
+   // getParameters()
+   // -------------------------------------------------------------------------
+
+   // [task not found] scheduleManager.getScheduleTask() returns null → RuntimeException
+   @Test
+   void getParameters_taskNotFound_throwsRuntimeException() {
+      when(scheduleManager.getScheduleTask("missingTask")).thenReturn(null);
+
+      assertThrows(RuntimeException.class,
+         () -> controller.getParameters("missingTask", principal));
+   }
+
+   // [permission denied] ScheduleManager.hasTaskPermission() false → SecurityException
+   @Test
+   void getParameters_permissionDenied_throwsSecurityException() {
+      IdentityID owner = new IdentityID("owner", "host-org");
+      when(scheduleManager.getScheduleTask("myTask")).thenReturn(scheduleTask);
+      when(scheduleTask.getOwner()).thenReturn(owner);
+      scheduleManagerStatic.when(
+         () -> ScheduleManager.hasTaskPermission(eq(owner), eq(principal), eq(ResourceAction.READ)))
+         .thenReturn(false);
+
+      assertThrows(inetsoft.sree.security.SecurityException.class,
+         () -> controller.getParameters("myTask", principal));
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/schedule/EMScheduleControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/EMScheduleControllerTest.java
@@ -1,0 +1,171 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.schedule;
+
+/*
+ * Test strategy
+ *
+ * EMScheduleController has real in-controller logic in three areas:
+ *   getScheduledTasksByFolder — builds an AssetEntry from parentInfo before delegating
+ *   runTasks                  — catches service exceptions and re-wraps as MessageException
+ *   stopTasks                 — same pattern as runTasks
+ *
+ * getScheduledTasks is a pure-delegation method; tests verify correct parameter forwarding.
+ *
+ * Coverage scope:
+ *   [getScheduledTasks: explicit params]       selectStr+filter forwarded unchanged
+ *   [getScheduledTasks: empty optionals]       absent optionals default to empty string
+ *   [getScheduledTasksByFolder: null owner]    null owner → GLOBAL_SCOPE AssetEntry
+ *   [getScheduledTasksByFolder: null parent]   null parentInfo → null entry passed to service
+ *   [runTasks: service throws]                 exception wrapped as MessageException
+ *   [stopTasks: delegation]                    calls stopScheduledTask for each task name
+ */
+
+import inetsoft.sree.portal.CustomThemesManager;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.util.MessageException;
+import inetsoft.web.admin.content.repository.ContentRepositoryTreeNode;
+import inetsoft.web.admin.schedule.model.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class EMScheduleControllerTest {
+
+   @Mock private ScheduleService scheduleService;
+   @Mock private ScheduleTaskService taskService;
+   @Mock private ScheduleUsersChangeService usersChangeService;
+   @Mock private CustomThemesManager customThemesManager;
+   @Mock private ScheduleTaskList taskList;
+   @Mock private Principal principal;
+
+   private EMScheduleController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new EMScheduleController(
+         scheduleService, taskService, usersChangeService, customThemesManager);
+   }
+
+   // -------------------------------------------------------------------------
+   // getScheduledTasks()
+   // -------------------------------------------------------------------------
+
+   // [explicit params] selectStr and filter forwarded to service unchanged
+   @Test
+   void getScheduledTasks_explicitParams_forwardsToService() throws Exception {
+      when(scheduleService.getScheduleTaskList("mySelect", "myFilter", principal))
+         .thenReturn(taskList);
+
+      ScheduleTaskList result =
+         controller.getScheduledTasks(Optional.of("mySelect"), Optional.of("myFilter"), principal);
+
+      assertSame(taskList, result);
+      verify(scheduleService).getScheduleTaskList("mySelect", "myFilter", principal);
+   }
+
+   // [empty optionals] absent params default to empty string
+   @Test
+   void getScheduledTasks_emptyOptionals_passesEmptyStrings() throws Exception {
+      when(scheduleService.getScheduleTaskList("", "", principal)).thenReturn(taskList);
+
+      controller.getScheduledTasks(Optional.empty(), Optional.empty(), principal);
+
+      verify(scheduleService).getScheduleTaskList("", "", principal);
+   }
+
+   // -------------------------------------------------------------------------
+   // getScheduledTasksByFolder()
+   // -------------------------------------------------------------------------
+
+   // [null owner] parentInfo with null owner → GLOBAL_SCOPE entry passed to service
+   @Test
+   void getScheduledTasksByFolder_nullOwner_usesGlobalScopeEntry() throws Exception {
+      ContentRepositoryTreeNode parentInfo = ContentRepositoryTreeNode.builder()
+         .label("Monthly")
+         .path("Monthly")
+         .type(0)
+         .build();
+      when(scheduleService.getScheduleTaskList(eq(""), eq(""), argThat(entry ->
+         entry != null &&
+         entry.getScope() == AssetRepository.GLOBAL_SCOPE &&
+         "Monthly".equals(entry.getPath())), eq(principal)))
+         .thenReturn(taskList);
+
+      ScheduleTaskList result = controller.getScheduledTasksByFolder(
+         Optional.empty(), Optional.empty(), parentInfo, principal);
+
+      assertSame(taskList, result);
+   }
+
+   // [null parentInfo] null parentInfo → null entry passed to service
+   @Test
+   void getScheduledTasksByFolder_nullParent_passesNullEntry() throws Exception {
+      when(scheduleService.getScheduleTaskList("", "", (inetsoft.uql.asset.AssetEntry) null, principal))
+         .thenReturn(taskList);
+
+      ScheduleTaskList result = controller.getScheduledTasksByFolder(
+         Optional.empty(), Optional.empty(), null, principal);
+
+      assertSame(taskList, result);
+      verify(scheduleService).getScheduleTaskList("", "", (inetsoft.uql.asset.AssetEntry) null, principal);
+   }
+
+   // -------------------------------------------------------------------------
+   // runTasks()
+   // -------------------------------------------------------------------------
+
+   // [service throws] exception from service wrapped as MessageException
+   @Test
+   void runTasks_serviceThrows_wrapsAsMessageException() throws Exception {
+      TaskListModel list = TaskListModel.builder().taskNames(List.of("myTask")).build();
+      doThrow(new RuntimeException("connection lost"))
+         .when(scheduleService).runScheduledTask("myTask", principal);
+
+      assertThrows(MessageException.class,
+         () -> controller.runTasks(list, principal));
+   }
+
+   // -------------------------------------------------------------------------
+   // stopTasks()
+   // -------------------------------------------------------------------------
+
+   // [delegation] calls stopScheduledTask for each task in the list
+   @Test
+   void stopTasks_delegatesToService() throws Exception {
+      TaskListModel list = TaskListModel.builder()
+         .taskNames(List.of("task1", "task2"))
+         .build();
+
+      controller.stopTasks(list, principal);
+
+      verify(scheduleService).stopScheduledTask("task1", principal);
+      verify(scheduleService).stopScheduledTask("task2", principal);
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/schedule/EMScheduleTaskActionControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/EMScheduleTaskActionControllerTest.java
@@ -1,0 +1,165 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.schedule;
+
+/*
+ * Test strategy
+ *
+ * EMScheduleTaskActionController has real in-controller logic in two methods:
+ *   getEmailTree      — streams users/groups from SecurityProvider, filters by ADMIN permission
+ *   getEmbeddedUsers  — same pattern, users only
+ *
+ * The remaining endpoints (getBookmarks, hasPrintLayout, getViewsheetHighlights,
+ * getViewsheetParameters) delegate to ViewsheetService.openViewsheet() which
+ * requires a live ApplicationContext and are covered by E2E tests instead.
+ * getViewsheetFolders and getViewsheets are pure-delegation methods tested
+ * as such here.
+ *
+ * Coverage scope:
+ *   [getEmailTree: user denied]    checkPermission(SECURITY_USER) false → user excluded
+ *   [getEmailTree: group permitted] checkPermission(SECURITY_GROUP) true → group included
+ *   [getViewsheets: delegation]    delegates to actionService.getViewsheets(principal)
+ *
+ * Static singleton Catalog is intercepted with Mockito.mockStatic() using lenient()
+ * to suppress UnnecessaryStubbingException.
+ */
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.security.*;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.util.Catalog;
+import inetsoft.web.admin.schedule.model.EmailTreeModel;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class EMScheduleTaskActionControllerTest {
+
+   @Mock private ScheduleTaskActionService actionService;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private AssetRepository assetRepository;
+   @Mock private EMScheduleTaskActionServiceProxy emActionService;
+   @Mock private ViewsheetService viewsheetService;
+   @Mock private ScheduleTaskActionServiceProxy actionServiceProxy;
+   @Mock private User aliceUser;
+   @Mock private Group grp1Group;
+   @Mock private Catalog catalog;
+   @Mock private Principal principal;
+
+   private EMScheduleTaskActionController controller;
+
+   private MockedStatic<Catalog> catalogStatic;
+
+   private final IdentityID aliceId = new IdentityID("alice", "host-org");
+   private final IdentityID bobId = new IdentityID("bob", "host-org");
+   private final IdentityID grp1Id = new IdentityID("grp1", "host-org");
+
+   @BeforeEach
+   void setUp() {
+      controller = new EMScheduleTaskActionController(
+         actionService, securityProvider, assetRepository,
+         emActionService, viewsheetService, actionServiceProxy);
+
+      catalogStatic = mockStatic(Catalog.class, withSettings().lenient());
+      catalogStatic.when(() -> Catalog.getCatalog(any(Principal.class))).thenReturn(catalog);
+      lenient().when(catalog.getString(anyString())).thenReturn("translated");
+
+      // getAuthenticationProvider() is a default method returning 'this'; Mockito returns null
+      // unless explicitly stubbed
+      lenient().when(securityProvider.getAuthenticationProvider()).thenReturn(securityProvider);
+   }
+
+   @AfterEach
+   void tearDown() {
+      catalogStatic.close();
+   }
+
+   // -------------------------------------------------------------------------
+   // getEmailTree()
+   // -------------------------------------------------------------------------
+
+   // [user denied] checkPermission(SECURITY_USER) false → user excluded from result
+   @Test
+   void getEmailTree_deniedUser_isExcluded() {
+      when(securityProvider.getUsers()).thenReturn(new IdentityID[]{ aliceId, bobId });
+      when(securityProvider.getGroups()).thenReturn(new IdentityID[0]);
+
+      // alice is permitted → set up User mock so UserEmailModel.from() can succeed
+      when(securityProvider.checkPermission(
+         principal, ResourceType.SECURITY_USER, aliceId.convertToKey(), ResourceAction.ADMIN))
+         .thenReturn(true);
+      when(securityProvider.getUser(aliceId)).thenReturn(aliceUser);
+      when(aliceUser.getEmails()).thenReturn(new String[0]);
+      when(aliceUser.getGroups()).thenReturn(new String[0]);
+
+      // bob is denied → should not appear in result
+      when(securityProvider.checkPermission(
+         principal, ResourceType.SECURITY_USER, bobId.convertToKey(), ResourceAction.ADMIN))
+         .thenReturn(false);
+
+      EmailTreeModel result = controller.getEmailTree(principal);
+
+      assertEquals(1, result.users().size(), "only alice should appear");
+      assertEquals(aliceId, result.users().get(0).userID());
+      assertEquals(0, result.groups().size());
+   }
+
+   // [group permitted] checkPermission(SECURITY_GROUP) true → group included in result
+   @Test
+   void getEmailTree_permittedGroup_isIncluded() {
+      when(securityProvider.getUsers()).thenReturn(new IdentityID[0]);
+      when(securityProvider.getGroups()).thenReturn(new IdentityID[]{ grp1Id });
+
+      when(securityProvider.checkPermission(
+         principal, ResourceType.SECURITY_GROUP, grp1Id.convertToKey(), ResourceAction.ADMIN))
+         .thenReturn(true);
+      when(securityProvider.getGroup(grp1Id)).thenReturn(grp1Group);
+      when(grp1Group.getGroups()).thenReturn(new String[0]);
+
+      EmailTreeModel result = controller.getEmailTree(principal);
+
+      assertEquals(1, result.groups().size());
+      assertEquals("grp1", result.groups().get(0).name());
+   }
+
+   // -------------------------------------------------------------------------
+   // getViewsheets()
+   // -------------------------------------------------------------------------
+
+   // [delegation] delegates to actionService.getViewsheets(principal) and returns result unchanged
+   @Test
+   void getViewsheets_delegatesToService() throws Exception {
+      Map<String, String> viewsheets = Map.of("id1", "My Viewsheet");
+      when(actionService.getViewsheets(principal)).thenReturn(viewsheets);
+
+      Map<String, String> result = controller.getViewsheets(principal);
+
+      assertSame(viewsheets, result);
+      verify(actionService).getViewsheets(principal);
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/schedule/EMScheduleTaskControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/EMScheduleTaskControllerTest.java
@@ -1,0 +1,218 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.schedule;
+
+/*
+ * Test strategy
+ *
+ * EMScheduleTaskController has real in-controller logic in three methods:
+ *   getNewTaskDialogModel — folder permission guard before delegation
+ *   getDialogModel        — multi-step permission check (WRITE+READ required; DELETE for external tasks)
+ *   toggleTaskEnabled     — per-task permission loop; early return on first denial
+ *
+ * saveTask is a pure-delegation method and is tested as such.
+ *
+ * Coverage scope:
+ *   [getNewTaskDialogModel: no folder permission]  checkFolderPermission returns false → SecurityException
+ *   [getNewTaskDialogModel: with permission]        permission granted → service model returned
+ *   [getDialogModel: no write permission]           checkTaskPermission(WRITE) false → SecurityException
+ *   [getDialogModel: external task, all perms]      WRITE+READ+DELETE granted → service model returned
+ *   [saveTask]                                      pure delegation to scheduleTaskService.saveTask()
+ *   [toggleTaskEnabled: no permission]              first task fails check → empty response, no toggle
+ *   [toggleTaskEnabled: with permission]            permission granted → toggles enabled state
+ *
+ * Static singletons (ScheduleManager.isInternalTask, Catalog) are intercepted with
+ * Mockito.mockStatic() using lenient() to suppress UnnecessaryStubbingException.
+ */
+
+import inetsoft.sree.schedule.ScheduleManager;
+import inetsoft.sree.schedule.ScheduleTask;
+import inetsoft.sree.security.*;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.util.Catalog;
+import inetsoft.web.admin.schedule.model.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class EMScheduleTaskControllerTest {
+
+   @Mock private ScheduleTaskService scheduleTaskService;
+   @Mock private ScheduleTaskFolderService scheduleTaskFolderService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private ScheduleManager scheduleManager;
+   @Mock private ScheduleTask scheduleTask;
+   @Mock private ScheduleTaskDialogModel dialogModel;
+   @Mock private ScheduleTaskEditorModel editorModel;
+   @Mock private Catalog catalog;
+   @Mock private Principal principal;
+
+   private EMScheduleTaskController controller;
+
+   private MockedStatic<ScheduleManager> scheduleManagerStatic;
+   private MockedStatic<Catalog> catalogStatic;
+
+   @BeforeEach
+   void setUp() {
+      controller = new EMScheduleTaskController(
+         scheduleTaskService, scheduleTaskFolderService, securityEngine, scheduleManager);
+
+      scheduleManagerStatic = mockStatic(ScheduleManager.class, withSettings().lenient());
+      catalogStatic = mockStatic(Catalog.class, withSettings().lenient());
+
+      catalogStatic.when(Catalog::getCatalog).thenReturn(catalog);
+      lenient().when(catalog.getString(anyString())).thenReturn("msg");
+      lenient().when(catalog.getString(anyString(), any())).thenReturn("msg");
+      // default: tasks are not internal
+      scheduleManagerStatic.when(() -> ScheduleManager.isInternalTask(anyString())).thenReturn(false);
+   }
+
+   @AfterEach
+   void tearDown() {
+      scheduleManagerStatic.close();
+      catalogStatic.close();
+   }
+
+   // -------------------------------------------------------------------------
+   // getNewTaskDialogModel()
+   // -------------------------------------------------------------------------
+
+   // [no folder permission] checkFolderPermission on "/" returns false → SecurityException
+   @Test
+   void getNewTaskDialogModel_noFolderPermission_throwsSecurityException() throws Exception {
+      when(scheduleTaskFolderService.checkFolderPermission("/", principal, ResourceAction.READ))
+         .thenReturn(false);
+
+      assertThrows(SecurityException.class,
+         () -> controller.getNewTaskDialogModel("UTC", null, null, principal));
+
+      verify(scheduleTaskService, never()).getNewTaskDialogModel(
+         any(), any(Principal.class), anyBoolean(), anyBoolean(), any(), anyString(), any());
+   }
+
+   // [with permission] permission granted on root "/" → delegates to scheduleTaskService
+   @Test
+   void getNewTaskDialogModel_withPermission_delegatesToService() throws Exception {
+      when(scheduleTaskFolderService.checkFolderPermission("/", principal, ResourceAction.READ))
+         .thenReturn(true);
+      when(scheduleTaskService.getNewTaskDialogModel(
+         isNull(), eq(principal), eq(true), eq(true), isNull(), eq("UTC"), isNull()))
+         .thenReturn(dialogModel);
+
+      ScheduleTaskDialogModel result =
+         controller.getNewTaskDialogModel("UTC", null, null, principal);
+
+      assertSame(dialogModel, result);
+   }
+
+   // -------------------------------------------------------------------------
+   // getDialogModel()
+   // -------------------------------------------------------------------------
+
+   // [no write permission] checkTaskPermission(WRITE) false → canEdit=false → SecurityException
+   @Test
+   void getDialogModel_noWritePermission_throwsSecurityException() throws Exception {
+      when(scheduleTaskService.checkTaskPermission("myTask", principal, ResourceAction.WRITE))
+         .thenReturn(false);
+
+      assertThrows(SecurityException.class,
+         () -> controller.getDialogModel("myTask", principal));
+
+      verify(scheduleTaskService, never()).getDialogModel(anyString(), any(Principal.class), anyBoolean());
+   }
+
+   // [external task, all perms] WRITE+READ+DELETE all granted → delegates to service
+   @Test
+   void getDialogModel_externalTaskAllPermissions_delegatesToService() throws Exception {
+      when(scheduleTaskService.checkTaskPermission("myTask", principal, ResourceAction.WRITE))
+         .thenReturn(true);
+      when(scheduleTaskService.checkTaskPermission("myTask", principal, ResourceAction.READ))
+         .thenReturn(true);
+      when(scheduleTaskService.checkTaskPermission("myTask", principal, ResourceAction.DELETE))
+         .thenReturn(true);
+      scheduleManagerStatic.when(() -> ScheduleManager.isInternalTask("myTask")).thenReturn(false);
+      when(scheduleTaskService.getDialogModel("myTask", principal, true)).thenReturn(dialogModel);
+
+      ScheduleTaskDialogModel result = controller.getDialogModel("myTask", principal);
+
+      assertSame(dialogModel, result);
+   }
+
+   // -------------------------------------------------------------------------
+   // saveTask()
+   // -------------------------------------------------------------------------
+
+   // [delegation] delegates to scheduleTaskService.saveTask() with em=true flag
+   @Test
+   void saveTask_delegatesToService() throws Exception {
+      when(scheduleTaskService.saveTask(editorModel, "http://host", principal, true))
+         .thenReturn(dialogModel);
+
+      ScheduleTaskDialogModel result =
+         controller.saveTask(editorModel, "http://host", principal);
+
+      assertSame(dialogModel, result);
+      verify(scheduleTaskService).saveTask(editorModel, "http://host", principal, true);
+   }
+
+   // -------------------------------------------------------------------------
+   // toggleTaskEnabled()
+   // -------------------------------------------------------------------------
+
+   // [no permission] first task fails both permission checks → returns empty response; no toggle
+   @Test
+   void toggleTaskEnabled_noPermission_returnsEmptyResponseWithoutToggling() throws Exception {
+      TaskListModel list = TaskListModel.builder().taskNames(List.of("myTask")).build();
+      when(scheduleManager.getScheduleTask("myTask")).thenReturn(scheduleTask);
+      when(securityEngine.checkPermission(
+         principal, ResourceType.SCHEDULE_TASK, "myTask", ResourceAction.WRITE))
+         .thenReturn(false);
+      when(scheduleTaskService.canDeleteTask(scheduleTask, principal)).thenReturn(false);
+
+      ToggleTaskResponse result = controller.toggleTaskEnabled(list, principal);
+
+      assertNotNull(result);
+      verify(scheduleTaskService, never()).setTaskEnabled(anyString(), anyBoolean(), any(Principal.class));
+   }
+
+   // [with permission] SCHEDULE_TASK WRITE granted → toggles enabled state
+   @Test
+   void toggleTaskEnabled_withPermission_togglesTask() throws Exception {
+      TaskListModel list = TaskListModel.builder().taskNames(List.of("myTask")).build();
+      when(scheduleManager.getScheduleTask("myTask")).thenReturn(scheduleTask);
+      when(securityEngine.checkPermission(
+         principal, ResourceType.SCHEDULE_TASK, "myTask", ResourceAction.WRITE))
+         .thenReturn(true);
+      when(scheduleTaskService.isTaskEnabled("myTask")).thenReturn(true);
+
+      controller.toggleTaskEnabled(list, principal);
+
+      // enabled was true → toggled to false
+      verify(scheduleTaskService).setTaskEnabled("myTask", false, principal);
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/schedule/EMScheduleTaskFolderControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/EMScheduleTaskFolderControllerTest.java
@@ -1,0 +1,215 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.schedule;
+
+/*
+ * Test strategy
+ *
+ * EMScheduleTaskFolderController has real in-controller logic in three methods:
+ *   addFolder     — path construction: prepends parent path unless parent is root or empty
+ *   getFolder     — org validity guard before recursive tree build
+ *   moveFolder    — per-task permission loop; silently returns without moving on first denial
+ *
+ * Coverage scope:
+ *   [addFolder: nested parent]          non-root path prepended → "Monthly/Q1"
+ *   [addFolder: root parent]            "/" or "" parent → folder name used verbatim → "Q1"
+ *   [getFolder: invalid org]            org null → InvalidOrgException; service never called
+ *   [moveFolder: task permission denied] first task fails → moveScheduleItems never called
+ *   [moveFolder: task permission granted] all tasks pass → moveScheduleItems called
+ *   [moveFolder: null task models]       no task models → permission loop skipped → moveScheduleItems called
+ *
+ * Static singletons (OrganizationManager, Catalog) are intercepted with
+ * Mockito.mockStatic() using lenient() to suppress UnnecessaryStubbingException.
+ */
+
+import inetsoft.sree.schedule.ScheduleManager;
+import inetsoft.sree.schedule.ScheduleTask;
+import inetsoft.sree.security.*;
+import inetsoft.util.Catalog;
+import inetsoft.util.InvalidOrgException;
+import inetsoft.web.admin.content.repository.ContentRepositoryTreeNode;
+import inetsoft.web.admin.schedule.model.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class EMScheduleTaskFolderControllerTest {
+
+   @Mock private ScheduleTaskFolderService scheduleTaskFolderService;
+   @Mock private ScheduleService scheduleService;
+   @Mock private ScheduleTaskService scheduleTaskService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private ScheduleManager scheduleManager;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private Organization organization;
+   @Mock private ScheduleTask scheduleTask;
+   @Mock private Catalog catalog;
+   @Mock private Principal principal;
+   @Mock private OrganizationManager orgManager;
+
+   private EMScheduleTaskFolderController controller;
+
+   private MockedStatic<OrganizationManager> orgManagerStatic;
+   private MockedStatic<Catalog> catalogStatic;
+
+   @BeforeEach
+   void setUp() {
+      controller = new EMScheduleTaskFolderController(
+         scheduleTaskFolderService, scheduleService, scheduleTaskService,
+         securityEngine, scheduleManager);
+
+      orgManagerStatic = mockStatic(OrganizationManager.class, withSettings().lenient());
+      catalogStatic = mockStatic(Catalog.class, withSettings().lenient());
+
+      orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+      lenient().when(orgManager.getCurrentOrgID(principal)).thenReturn("host-org");
+      lenient().when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      lenient().when(securityProvider.getOrganization("host-org")).thenReturn(organization);
+      catalogStatic.when(Catalog::getCatalog).thenReturn(catalog);
+      lenient().when(catalog.getString(anyString())).thenReturn("msg");
+   }
+
+   @AfterEach
+   void tearDown() {
+      orgManagerStatic.close();
+      catalogStatic.close();
+   }
+
+   // -------------------------------------------------------------------------
+   // addFolder()
+   // -------------------------------------------------------------------------
+
+   // [nested parent] parent path "Monthly" → folderName becomes "Monthly/Q1"
+   @Test
+   void addFolder_withNestedParentPath_constructsFullFolderName() throws Exception {
+      ContentRepositoryTreeNode parentNode = ContentRepositoryTreeNode.builder()
+         .label("Monthly").path("Monthly").type(0).build();
+      NewTaskFolderRequest req = mock(NewTaskFolderRequest.class);
+      when(req.getParent()).thenReturn(parentNode);
+      when(req.getFolderName()).thenReturn("Q1");
+
+      controller.addFolder(req, principal);
+
+      verify(scheduleTaskFolderService).addFolder(
+         any(), eq("Monthly/Q1"), eq("Monthly"), anyInt(), eq(principal));
+   }
+
+   // [root parent] parent path "/" → folderName is "Q1" with no prefix
+   @Test
+   void addFolder_withRootParentPath_usesFolderNameOnly() throws Exception {
+      ContentRepositoryTreeNode parentNode = ContentRepositoryTreeNode.builder()
+         .label("Root").path("/").type(0).build();
+      NewTaskFolderRequest req = mock(NewTaskFolderRequest.class);
+      when(req.getParent()).thenReturn(parentNode);
+      when(req.getFolderName()).thenReturn("Q1");
+
+      controller.addFolder(req, principal);
+
+      verify(scheduleTaskFolderService).addFolder(
+         any(), eq("Q1"), eq("/"), anyInt(), eq(principal));
+   }
+
+   // -------------------------------------------------------------------------
+   // getFolder()
+   // -------------------------------------------------------------------------
+
+   // [invalid org] org lookup returns null → InvalidOrgException; no tree building
+   @Test
+   void getFolder_invalidOrg_throwsInvalidOrgException() {
+      when(securityProvider.getOrganization("host-org")).thenReturn(null);
+
+      assertThrows(InvalidOrgException.class,
+         () -> controller.getFolder(principal));
+
+      verify(scheduleTaskFolderService, never()).getRootEntry();
+   }
+
+   // -------------------------------------------------------------------------
+   // moveFolder()
+   // -------------------------------------------------------------------------
+
+   // [task permission denied] first task fails both checks → moveScheduleItems never called
+   @Test
+   void moveFolder_taskPermissionDenied_skipsMove() throws Exception {
+      ScheduleTaskModel taskModel = mock(ScheduleTaskModel.class);
+      when(taskModel.name()).thenReturn("myTask");
+
+      MoveTaskFolderRequest request = mock(MoveTaskFolderRequest.class);
+      when(request.getTasks()).thenReturn(new ScheduleTaskModel[]{ taskModel });
+      // getTarget() not stubbed: controller returns early before reaching it
+
+      when(scheduleManager.getScheduleTask("myTask")).thenReturn(scheduleTask);
+      when(securityEngine.checkPermission(
+         principal, ResourceType.SCHEDULE_TASK, "myTask", ResourceAction.WRITE))
+         .thenReturn(false);
+      // canDeleteTask not stubbed: default false return satisfies the denial condition
+
+      controller.moveFolder(request, principal);
+
+      verify(scheduleTaskFolderService, never()).moveScheduleItems(any(), any(), any(), any());
+   }
+
+   // [task permission granted] SCHEDULE_TASK WRITE granted → moveScheduleItems called
+   @Test
+   void moveFolder_taskPermissionGranted_movesItems() throws Exception {
+      ScheduleTaskModel taskModel = mock(ScheduleTaskModel.class);
+      when(taskModel.name()).thenReturn("myTask");
+
+      ContentRepositoryTreeNode target = ContentRepositoryTreeNode.builder()
+         .label("Target").path("Target").type(0).build();
+      MoveTaskFolderRequest request = mock(MoveTaskFolderRequest.class);
+      when(request.getTasks()).thenReturn(new ScheduleTaskModel[]{ taskModel });
+      when(request.getFolders()).thenReturn(new String[]{"Monthly"});
+      when(request.getTarget()).thenReturn(target);
+
+      when(scheduleManager.getScheduleTask("myTask")).thenReturn(scheduleTask);
+      when(securityEngine.checkPermission(
+         principal, ResourceType.SCHEDULE_TASK, "myTask", ResourceAction.WRITE))
+         .thenReturn(true);
+
+      controller.moveFolder(request, principal);
+
+      verify(scheduleTaskFolderService).moveScheduleItems(
+         any(), eq(new String[]{"Monthly"}), argThat(e -> "Target".equals(e.getPath())), eq(principal));
+   }
+
+   // [null task models] no task models → permission loop skipped → moveScheduleItems called
+   @Test
+   void moveFolder_nullTaskModels_movesDirectly() throws Exception {
+      ContentRepositoryTreeNode target = ContentRepositoryTreeNode.builder()
+         .label("Target").path("Target").type(0).build();
+      MoveTaskFolderRequest request = mock(MoveTaskFolderRequest.class);
+      when(request.getTasks()).thenReturn(null);
+      when(request.getFolders()).thenReturn(new String[]{"Monthly"});
+      when(request.getTarget()).thenReturn(target);
+
+      controller.moveFolder(request, principal);
+
+      verify(scheduleTaskFolderService).moveScheduleItems(
+         isNull(), eq(new String[]{"Monthly"}), argThat(e -> "Target".equals(e.getPath())), eq(principal));
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/schedule/EMScheduleTaskFormulaControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/EMScheduleTaskFormulaControllerTest.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.schedule;
+
+/*
+ * Test strategy
+ *
+ * EMScheduleTaskFormulaController is a pure-delegation controller: all four methods
+ * pass through to ScheduleTaskFormulaService with no additional logic.
+ *
+ * Coverage scope:
+ *   [getScriptDefinition]              delegates to formulaService.getScriptDefinition()
+ *   [testScheduleParameterExpression]  delegates to formulaService.testScheduleParameterExpression()
+ *   [getFunctions]                     delegates to formulaService.getFunctions()
+ *   [getOperationTree]                 delegates to formulaService.getOperationTree()
+ */
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import inetsoft.web.admin.schedule.model.TestTaskParameterExpressionRequest;
+import inetsoft.web.composer.model.TreeNodeModel;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class EMScheduleTaskFormulaControllerTest {
+
+   @Mock private ScheduleTaskFormulaService formulaService;
+   @Mock private ObjectNode scriptDefinition;
+   @Mock private TreeNodeModel treeNode;
+
+   private EMScheduleTaskFormulaController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new EMScheduleTaskFormulaController(formulaService);
+   }
+
+   // [delegation] delegates to formulaService.getScriptDefinition() and returns result unchanged
+   @Test
+   void getScriptDefinition_delegatesToService() throws Exception {
+      when(formulaService.getScriptDefinition()).thenReturn(scriptDefinition);
+
+      ObjectNode result = controller.getScriptDefinition();
+
+      assertSame(scriptDefinition, result);
+   }
+
+   // [delegation] delegates to formulaService.testScheduleParameterExpression()
+   @Test
+   void testScheduleParameterExpression_delegatesToService() {
+      TestTaskParameterExpressionRequest req = mock(TestTaskParameterExpressionRequest.class);
+      when(req.expression()).thenReturn("1 + 1");
+      when(formulaService.testScheduleParameterExpression("1 + 1")).thenReturn("2");
+
+      String result = controller.testScheduleParameterExpression(req);
+
+      assertEquals("2", result);
+   }
+
+   // [delegation] delegates to formulaService.getFunctions() and returns result unchanged
+   @Test
+   void getFunctions_delegatesToService() {
+      when(formulaService.getFunctions()).thenReturn(treeNode);
+
+      TreeNodeModel result = controller.getFunctions();
+
+      assertSame(treeNode, result);
+   }
+
+   // [delegation] delegates to formulaService.getOperationTree() and returns result unchanged
+   @Test
+   void getOperationTree_delegatesToService() {
+      when(formulaService.getOperationTree()).thenReturn(treeNode);
+
+      TreeNodeModel result = controller.getOperationTree();
+
+      assertSame(treeNode, result);
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/schedule/ExportTaskControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/ExportTaskControllerTest.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.schedule;
+
+/*
+ * Test strategy
+ *
+ * ExportTaskController has real in-controller logic in getDependentTasks():
+ *   - Splits the comma-separated task list to build a "selected" set
+ *   - Recursively resolves dependencies not already in the selected set
+ *   - Returns one TaskDependencyModel per missing dependency, noting which task requires it
+ *
+ * exportScheduledTasks() delegates to scheduleService and writes to HttpServletResponse;
+ * that is covered by E2E tests.
+ *
+ * Coverage scope:
+ *   [task not found]                      scheduleManager returns null → dependency skipped → empty result
+ *   [direct dependency missing]           dep not in selected set → TaskDependencyModel returned
+ *   [dependency already selected]         dep in selected set → excluded from result
+ */
+
+import inetsoft.sree.schedule.*;
+import inetsoft.web.admin.schedule.model.TaskDependencyModel;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ExportTaskControllerTest {
+
+   @Mock private ScheduleService scheduleService;
+   @Mock private ScheduleManager scheduleManager;
+   @Mock private ScheduleTask taskA;
+   @Mock private Principal principal;
+
+   private ExportTaskController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new ExportTaskController(scheduleService, scheduleManager);
+   }
+
+   // -------------------------------------------------------------------------
+   // getDependentTasks()
+   // -------------------------------------------------------------------------
+
+   // [task not found] scheduleManager returns null → no dependencies resolved → empty list
+   @Test
+   void getDependentTasks_taskNotFound_returnsEmpty() {
+      when(scheduleManager.getScheduleTask("missingTask")).thenReturn(null);
+
+      List<TaskDependencyModel> result = controller.getDependentTasks("missingTask", principal);
+
+      assertTrue(result.isEmpty());
+   }
+
+   // [direct dependency missing] taskA depends on "depTask" which is not in selected set
+   @Test
+   void getDependentTasks_directDependency_includesMissingDependency() {
+      when(scheduleManager.getScheduleTask("taskA")).thenReturn(taskA);
+      when(taskA.getDependency()).thenReturn(Collections.enumeration(List.of("depTask")));
+      // depTask not found → recursion stops; depTask is not in selected → appears in result
+
+      List<TaskDependencyModel> result = controller.getDependentTasks("taskA", principal);
+
+      assertEquals(1, result.size());
+      assertEquals("depTask", result.get(0).task());
+      assertEquals("taskA", result.get(0).dependency());
+   }
+
+   // [dependency already selected] taskA depends on depTask, but depTask is also in the selected set
+   @Test
+   void getDependentTasks_dependencyAlreadySelected_isExcluded() {
+      when(scheduleManager.getScheduleTask("taskA")).thenReturn(taskA);
+      when(taskA.getDependency()).thenReturn(Collections.enumeration(List.of("depTask")));
+      // depTask is in the selected set → should be excluded from the result
+
+      List<TaskDependencyModel> result = controller.getDependentTasks("taskA,depTask", principal);
+
+      assertTrue(result.isEmpty(), "depTask is already selected, so no unresolved dependency");
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/schedule/ImportTaskControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/ImportTaskControllerTest.java
@@ -40,6 +40,7 @@ package inetsoft.web.admin.schedule;
 
 import inetsoft.sree.AnalyticRepository;
 import inetsoft.sree.schedule.*;
+import static inetsoft.web.admin.schedule.ImportTaskController.INFO_ATTR;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.web.admin.schedule.model.ImportTaskResponse;
@@ -71,8 +72,6 @@ class ImportTaskControllerTest {
    @Mock private HttpSession session;
    @Mock private Principal principal;
 
-   private static final String SESSION_ATTR = "__private_scheduleXmlInfo";
-
    private ImportTaskController controller;
 
    @BeforeEach
@@ -90,7 +89,7 @@ class ImportTaskControllerTest {
    // [permission denied] task exists + overwriting + editable + no permission → failedList; no import
    @Test
    void importScheduleTask_permissionDenied_addedToFailedList() throws Exception {
-      when(session.getAttribute(SESSION_ATTR)).thenReturn(new ArrayList<>(List.of(incomingTask)));
+      when(session.getAttribute(INFO_ATTR)).thenReturn(new ArrayList<>(List.of(incomingTask)));
       when(scheduleManager.getScheduleTask("myTask")).thenReturn(existingTask);
       when(existingTask.isEditable()).thenReturn(true);
       when(analyticRepository.checkPermission(
@@ -107,7 +106,7 @@ class ImportTaskControllerTest {
    // [new task imported] task does not exist + selected → setScheduleTask called
    @Test
    void importScheduleTask_newTask_isImported() throws Exception {
-      when(session.getAttribute(SESSION_ATTR)).thenReturn(new ArrayList<>(List.of(incomingTask)));
+      when(session.getAttribute(INFO_ATTR)).thenReturn(new ArrayList<>(List.of(incomingTask)));
       when(scheduleManager.getScheduleTask("myTask")).thenReturn(null); // task does not exist
       when(incomingTask.getActionStream()).thenReturn(Stream.empty()); // updateTaskInfo needs a stream
 
@@ -121,7 +120,7 @@ class ImportTaskControllerTest {
    // [not overwriting] task exists + overwriting=false → setScheduleTask never called
    @Test
    void importScheduleTask_existingTaskNotOverwriting_skipped() throws Exception {
-      when(session.getAttribute(SESSION_ATTR)).thenReturn(new ArrayList<>(List.of(incomingTask)));
+      when(session.getAttribute(INFO_ATTR)).thenReturn(new ArrayList<>(List.of(incomingTask)));
       when(scheduleManager.getScheduleTask("myTask")).thenReturn(existingTask);
 
       ImportTaskResponse result = controller.importScheduleTask(

--- a/core/src/test/java/inetsoft/web/admin/schedule/ImportTaskControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/ImportTaskControllerTest.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.schedule;
+
+/*
+ * Test strategy
+ *
+ * ImportTaskController.importScheduleTask() has real in-controller logic:
+ *   - For each task in the session-stored list, checks existence and overwrite permission
+ *   - If the task exists, overwriting=true, and it's editable but the principal lacks permission,
+ *     the taskId is added to failedList (not imported)
+ *   - If the task is new (or overwriting=true with permission), it is imported via
+ *     scheduleManager.setScheduleTask()
+ *   - If the task already exists and overwriting=false, it is silently skipped
+ *
+ * setTaskFile() parses XML from a Base64-encoded byte array; that is covered by E2E tests.
+ * moveTask() calls SUtil.getUserAlias() (static); to avoid triggering it, all tests set
+ * task.getPath() to null so the folder-move branch is never reached.
+ *
+ * Coverage scope:
+ *   [permission denied]     task exists + overwriting + editable + no permission → failedList; no import
+ *   [new task imported]     task does not exist + selected → setScheduleTask called
+ *   [not overwriting]       task exists + overwriting=false → setScheduleTask never called
+ */
+
+import inetsoft.sree.AnalyticRepository;
+import inetsoft.sree.schedule.*;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.web.admin.schedule.model.ImportTaskResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ImportTaskControllerTest {
+
+   @Mock private ScheduleManager scheduleManager;
+   @Mock private ScheduleTaskFolderService scheduleTaskFolderService;
+   @Mock private AnalyticRepository analyticRepository;
+   @Mock private ScheduleTask incomingTask;
+   @Mock private ScheduleTask existingTask;
+   @Mock private HttpServletRequest request;
+   @Mock private HttpSession session;
+   @Mock private Principal principal;
+
+   private static final String SESSION_ATTR = "__private_scheduleXmlInfo";
+
+   private ImportTaskController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new ImportTaskController(scheduleManager, scheduleTaskFolderService, analyticRepository);
+      when(request.getSession(true)).thenReturn(session);
+      lenient().when(incomingTask.getTaskId()).thenReturn("myTask");
+      lenient().when(incomingTask.getPath()).thenReturn(null); // skip moveTask()
+   }
+
+   // -------------------------------------------------------------------------
+   // importScheduleTask()
+   // -------------------------------------------------------------------------
+
+   // [permission denied] task exists + overwriting + editable + no permission → failedList; no import
+   @Test
+   void importScheduleTask_permissionDenied_addedToFailedList() throws Exception {
+      when(session.getAttribute(SESSION_ATTR)).thenReturn(new ArrayList<>(List.of(incomingTask)));
+      when(scheduleManager.getScheduleTask("myTask")).thenReturn(existingTask);
+      when(existingTask.isEditable()).thenReturn(true);
+      when(analyticRepository.checkPermission(
+         principal, ResourceType.SCHEDULER, "myTask", ResourceAction.ACCESS))
+         .thenReturn(false);
+
+      ImportTaskResponse result = controller.importScheduleTask(
+         List.of("myTask"), request, true, "http://host", principal);
+
+      assertTrue(result.failedTasks().contains("myTask"));
+      verify(scheduleManager, never()).setScheduleTask(anyString(), any(), any());
+   }
+
+   // [new task imported] task does not exist + selected → setScheduleTask called
+   @Test
+   void importScheduleTask_newTask_isImported() throws Exception {
+      when(session.getAttribute(SESSION_ATTR)).thenReturn(new ArrayList<>(List.of(incomingTask)));
+      when(scheduleManager.getScheduleTask("myTask")).thenReturn(null); // task does not exist
+      when(incomingTask.getActionStream()).thenReturn(Stream.empty()); // updateTaskInfo needs a stream
+
+      ImportTaskResponse result = controller.importScheduleTask(
+         List.of("myTask"), request, false, "http://host", principal);
+
+      assertTrue(result.failedTasks().isEmpty());
+      verify(scheduleManager).setScheduleTask("myTask", incomingTask, principal);
+   }
+
+   // [not overwriting] task exists + overwriting=false → setScheduleTask never called
+   @Test
+   void importScheduleTask_existingTaskNotOverwriting_skipped() throws Exception {
+      when(session.getAttribute(SESSION_ATTR)).thenReturn(new ArrayList<>(List.of(incomingTask)));
+      when(scheduleManager.getScheduleTask("myTask")).thenReturn(existingTask);
+
+      ImportTaskResponse result = controller.importScheduleTask(
+         List.of("myTask"), request, false, "http://host", principal);
+
+      assertTrue(result.failedTasks().isEmpty());
+      verify(scheduleManager, never()).setScheduleTask(anyString(), any(), any());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/schedule/ScheduleCycleControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/ScheduleCycleControllerTest.java
@@ -1,0 +1,102 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.schedule;
+
+/*
+ * Test strategy
+ *
+ * ScheduleCycleController has real in-controller logic in two areas:
+ *   subscribeToDataCycleNames — permission guard via securityEngine.getSecurityProvider().checkPermission()
+ *   editDataCycle             — two-step: editCycle() then re-fetches model via getDialogModel()
+ *
+ * Coverage scope:
+ *   [subscribeToDataCycleNames: no permission]  permission denied → SecurityException
+ *   [editDataCycle: two-step delegation]        editCycle called, then model re-fetched
+ */
+
+import inetsoft.sree.security.*;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.web.admin.monitoring.MonitoringDataService;
+import inetsoft.web.admin.schedule.model.ScheduleCycleDialogModel;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ScheduleCycleControllerTest {
+
+   @Mock private ScheduleCycleService scheduleCycleService;
+   @Mock private MonitoringDataService monitoringDataService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private ScheduleCycleDialogModel dialogModel;
+   @Mock private Principal principal;
+
+   private ScheduleCycleController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new ScheduleCycleController(
+         scheduleCycleService, monitoringDataService, securityEngine);
+
+      lenient().when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+   }
+
+   // -------------------------------------------------------------------------
+   // subscribeToDataCycleNames()
+   // -------------------------------------------------------------------------
+
+   // [no permission] checkPermission returns false → SecurityException thrown
+   @Test
+   void subscribeToDataCycleNames_noPermission_throwsSecurityException() {
+      when(securityProvider.checkPermission(
+         principal, ResourceType.EM_COMPONENT, "settings/schedule/cycles", ResourceAction.ACCESS))
+         .thenReturn(false);
+
+      assertThrows(SecurityException.class,
+         () -> controller.subscribeToDataCycleNames((StompHeaderAccessor) null, principal));
+
+      verify(monitoringDataService, never()).addSubscriber(any(), any());
+   }
+
+   // -------------------------------------------------------------------------
+   // editDataCycle()
+   // -------------------------------------------------------------------------
+
+   // [two-step delegation] editCycle called first, then model re-fetched via getDialogModel()
+   @Test
+   void editDataCycle_editsThenRefetchesModel() throws Exception {
+      ScheduleCycleDialogModel model = mock(ScheduleCycleDialogModel.class);
+      when(model.label()).thenReturn("MyCycle");
+      when(scheduleCycleService.getDialogModel("MyCycle", principal)).thenReturn(dialogModel);
+
+      ScheduleCycleDialogModel result = controller.editDataCycle(model, principal);
+
+      verify(scheduleCycleService).editCycle(model, principal);
+      verify(scheduleCycleService).getDialogModel("MyCycle", principal);
+      assertSame(dialogModel, result);
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/schedule/SchedulerConfigurationControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/SchedulerConfigurationControllerTest.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.schedule;
+
+/*
+ * Test strategy
+ *
+ * SchedulerConfigurationController has real in-controller logic in one method:
+ *   messageReceived — routes RestartSchedulerMessage to configService.setStatus("restart");
+ *                     ignores all other message types
+ *
+ * The REST endpoints (getConfiguration, setConfiguration, getStatus, setStatus, checkMail)
+ * are pure-delegation methods tested as such.
+ *
+ * @PostConstruct/@PreDestroy (cluster listener registration) are not invoked in pure
+ * unit tests (no Spring context), so they are not tested here.
+ *
+ * Coverage scope:
+ *   [messageReceived: restart message]   RestartSchedulerMessage → setStatus("restart") called
+ *   [messageReceived: other message]     unknown message type → setStatus never called
+ *   [getConfiguration: delegation]       delegates to configService.getConfiguration(principal)
+ *   [getStatus: delegation]              delegates to configService.getStatus()
+ */
+
+import inetsoft.sree.internal.cluster.*;
+import inetsoft.sree.schedule.RestartSchedulerMessage;
+import inetsoft.web.admin.schedule.model.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class SchedulerConfigurationControllerTest {
+
+   @Mock private SchedulerConfigurationService configService;
+   @Mock private Cluster cluster;
+   @Mock private ScheduleConfigurationModel configModel;
+   @Mock private ScheduleStatusModel statusModel;
+   @Mock private Principal principal;
+
+   private SchedulerConfigurationController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new SchedulerConfigurationController(configService, cluster);
+   }
+
+   // -------------------------------------------------------------------------
+   // messageReceived()
+   // -------------------------------------------------------------------------
+
+   // [restart message] RestartSchedulerMessage → configService.setStatus("restart") called
+   @Test
+   void messageReceived_restartMessage_callsSetStatus() throws Exception {
+      MessageEvent event = new MessageEvent("source", "sender", false, new RestartSchedulerMessage());
+
+      controller.messageReceived(event);
+
+      verify(configService).setStatus("restart");
+   }
+
+   // [other message] unknown message type → setStatus never called
+   @Test
+   void messageReceived_unknownMessage_doesNothing() throws Exception {
+      MessageEvent event = new MessageEvent("source", "sender", false, "some-other-message");
+
+      controller.messageReceived(event);
+
+      verify(configService, never()).setStatus(anyString());
+   }
+
+   // -------------------------------------------------------------------------
+   // getConfiguration() / getStatus()
+   // -------------------------------------------------------------------------
+
+   // [delegation] delegates to configService.getConfiguration(principal)
+   @Test
+   void getConfiguration_delegatesToService() throws Exception {
+      when(configService.getConfiguration(principal)).thenReturn(configModel);
+
+      ScheduleConfigurationModel result = controller.getConfiguration(principal);
+
+      assertSame(configModel, result);
+      verify(configService).getConfiguration(principal);
+   }
+
+   // [delegation] delegates to configService.getStatus()
+   @Test
+   void getStatus_delegatesToService() {
+      when(configService.getStatus()).thenReturn(statusModel);
+
+      ScheduleStatusModel result = controller.getStatus();
+
+      assertSame(statusModel, result);
+      verify(configService).getStatus();
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/security/action/ActionPermissionControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/security/action/ActionPermissionControllerTest.java
@@ -1,0 +1,222 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.security.action;
+
+/*
+ * Test strategy
+ *
+ * ActionPermissionController orchestrates four endpoints:
+ *   getActionTree       — pure delegation to ActionPermissionService
+ *   getPermissions      — validates org, refreshes actions cache, delegates to ResourcePermissionService
+ *   setPermissions      — validates org, saves via ResourcePermissionService, then re-fetches permissions
+ *   validateIdentities  — pure delegation to ResourcePermissionService
+ *
+ * Coverage scope:
+ *   [getActionTree]                      delegates to actionService.getActionTree(principal)
+ *   [getPermissions: invalid org]        org null → InvalidOrgException; service never called
+ *   [getPermissions: valid]              valid org → service model returned
+ *   [setPermissions: invalid org]        org null → InvalidOrgException; setResourcePermissions never called
+ *   [setPermissions: valid]              saves via setResourcePermissions, then returns re-fetched model
+ *   [validateIdentities]                 delegates to permissionService.findMissingIdentities()
+ *
+ * getPermissions() calls loadActions() internally, which calls actionService.getActionTree().
+ * The root node's children are traversed to populate the actions cache; using an empty children
+ * list keeps setup minimal while allowing the service delegation to proceed.
+ *
+ * Static singletons (OrganizationManager, ThreadContext, Catalog) are intercepted with
+ * Mockito.mockStatic() using lenient() to suppress UnnecessaryStubbingException.
+ * principal.getName() returns a valid IdentityID key so getIdentityIDFromKey() can run for real.
+ */
+
+import inetsoft.sree.security.*;
+import inetsoft.util.Catalog;
+import inetsoft.util.InvalidOrgException;
+import inetsoft.util.ThreadContext;
+import inetsoft.web.admin.content.repository.ResourcePermissionService;
+import inetsoft.web.admin.security.ResourcePermissionModel;
+import inetsoft.web.admin.security.ResourcePermissionTableModel;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ActionPermissionControllerTest {
+
+   @Mock private ActionPermissionService actionService;
+   @Mock private ResourcePermissionService permissionService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private Organization organization;
+   @Mock private ActionTreeNode rootNode;
+   @Mock private ResourcePermissionModel permissionModel;
+   @Mock private Catalog catalog;
+   @Mock private Principal principal;
+   @Mock private OrganizationManager orgManager;
+
+   private ActionPermissionController controller;
+
+   private MockedStatic<OrganizationManager> orgManagerStatic;
+   private MockedStatic<ThreadContext> threadContextStatic;
+   private MockedStatic<Catalog> catalogStatic;
+
+   @BeforeEach
+   void setUp() {
+      controller = new ActionPermissionController(actionService, permissionService, securityEngine);
+
+      orgManagerStatic = mockStatic(OrganizationManager.class, withSettings().lenient());
+      threadContextStatic = mockStatic(ThreadContext.class, withSettings().lenient());
+      catalogStatic = mockStatic(Catalog.class, withSettings().lenient());
+
+      orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+      lenient().when(orgManager.getCurrentOrgID()).thenReturn("host-org");
+      lenient().when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      lenient().when(securityProvider.getOrganization("host-org")).thenReturn(organization);
+      catalogStatic.when(Catalog::getCatalog).thenReturn(catalog);
+      lenient().when(catalog.getString(anyString())).thenReturn("translated-label");
+
+      // loadActions() calls actionService.getActionTree(ThreadContext.getContextPrincipal())
+      // and traverses root.children(); an empty children list keeps the actions cache empty
+      // without causing NPE. actions.get(resource) then returns null, which getTableModel accepts.
+      threadContextStatic.when(ThreadContext::getContextPrincipal).thenReturn(null);
+      lenient().when(actionService.getActionTree(any())).thenReturn(rootNode);
+      lenient().when(rootNode.children()).thenReturn(List.of());
+
+      // getPermissions() checks roles to determine org-admin status
+      lenient().when(securityProvider.getRoles(any(IdentityID.class))).thenReturn(new IdentityID[0]);
+      lenient().when(securityProvider.getAllRoles(any(IdentityID[].class))).thenReturn(new IdentityID[0]);
+
+      // principal.getName() must return a valid IdentityID key for getIdentityIDFromKey()
+      lenient().when(principal.getName())
+         .thenReturn(new IdentityID("alice", "host-org").convertToKey());
+   }
+
+   @AfterEach
+   void tearDown() {
+      orgManagerStatic.close();
+      threadContextStatic.close();
+      catalogStatic.close();
+   }
+
+   // -------------------------------------------------------------------------
+   // getActionTree()
+   // -------------------------------------------------------------------------
+
+   // [delegation] delegates to actionService.getActionTree(principal) and returns result unchanged
+   @Test
+   void getActionTree_delegatesToActionService() {
+      when(actionService.getActionTree(principal)).thenReturn(rootNode);
+
+      ActionTreeNode result = controller.getActionTree(principal);
+
+      assertSame(rootNode, result);
+      verify(actionService).getActionTree(principal);
+   }
+
+   // -------------------------------------------------------------------------
+   // getPermissions()
+   // -------------------------------------------------------------------------
+
+   // [invalid org] org lookup returns null → InvalidOrgException; service never called
+   @Test
+   void getPermissions_invalidOrg_throwsInvalidOrgException() {
+      when(securityProvider.getOrganization("host-org")).thenReturn(null);
+
+      assertThrows(InvalidOrgException.class,
+         () -> controller.getPermissions(
+            ResourceType.VIEWSHEET.name(), "*", true, principal));
+
+      verify(permissionService, never()).getTableModel(
+         anyString(), any(), any(), anyString(), any(Principal.class));
+   }
+
+   // [valid] valid org → cache refreshed, service model returned unchanged
+   @Test
+   void getPermissions_validResource_returnsPermissionModel() {
+      when(permissionService.getTableModel(
+         eq("*"), eq(ResourceType.VIEWSHEET), isNull(), anyString(), eq(principal)))
+         .thenReturn(permissionModel);
+
+      ResourcePermissionModel result =
+         controller.getPermissions(ResourceType.VIEWSHEET.name(), "*", true, principal);
+
+      assertSame(permissionModel, result);
+      verify(permissionService).getTableModel(
+         eq("*"), eq(ResourceType.VIEWSHEET), isNull(), anyString(), eq(principal));
+   }
+
+   // -------------------------------------------------------------------------
+   // setPermissions()
+   // -------------------------------------------------------------------------
+
+   // [invalid org] org lookup returns null → InvalidOrgException; setResourcePermissions never called
+   @Test
+   void setPermissions_invalidOrg_throwsInvalidOrgException() throws Exception {
+      when(securityProvider.getOrganization("host-org")).thenReturn(null);
+
+      assertThrows(InvalidOrgException.class,
+         () -> controller.setPermissions(
+            ResourceType.VIEWSHEET.name(), "*", true, permissionModel, principal));
+
+      verify(permissionService, never()).setResourcePermissions(
+         anyString(), any(), anyString(), any(), any(Principal.class));
+   }
+
+   // [valid] saves via setResourcePermissions, then re-fetches and returns updated permissions
+   @Test
+   void setPermissions_valid_savesAndReturnsUpdatedModel() throws Exception {
+      ResourcePermissionModel updatedModel = mock(ResourcePermissionModel.class);
+      when(permissionService.getTableModel(
+         eq("*"), eq(ResourceType.VIEWSHEET), isNull(), anyString(), eq(principal)))
+         .thenReturn(updatedModel);
+
+      ResourcePermissionModel result =
+         controller.setPermissions(
+            ResourceType.VIEWSHEET.name(), "*", true, permissionModel, principal);
+
+      verify(permissionService).setResourcePermissions(
+         eq("*"), eq(ResourceType.VIEWSHEET), eq("VIEWSHEET: *"),
+         eq(permissionModel), eq(principal));
+      assertSame(updatedModel, result);
+   }
+
+   // -------------------------------------------------------------------------
+   // validateIdentities()
+   // -------------------------------------------------------------------------
+
+   // [delegation] delegates to permissionService.findMissingIdentities() and returns result
+   @Test
+   void validateIdentities_delegatesToService() {
+      List<ResourcePermissionTableModel> identities = List.of(mock(ResourcePermissionTableModel.class));
+      List<ResourcePermissionTableModel> missing = List.of();
+      when(permissionService.findMissingIdentities(identities)).thenReturn(missing);
+
+      List<ResourcePermissionTableModel> result = controller.validateIdentities(identities);
+
+      assertSame(missing, result);
+      verify(permissionService).findMissingIdentities(identities);
+   }
+}


### PR DESCRIPTION
### Summary
This pull request introduces a suite of unit tests for various controllers in the core application. The goal is to increase the test coverage, ensure functionality, and identify any potential issues early.

### Included Changes and Updates
- Added tests for:
  - PluginsController
  - DataSpace controllers
  - MVController
  - AutoSaveController and RepositoryRecycleBinController
  - ExportAssetController and ImportAssetController
  - Repository-related controllers
  - Schedule-related controllers
  - ActionPermissionController
  - ResourcePermissionController and ResourcePermissionTreeController
  
### Checklist
- [ ] All existing and new unit tests pass locally.
- [ ] Improvements verified globally with no regressions.
- [ ] Documentation updated as necessary.

### Additional Notes
Continued focus on core areas ensures the stability of the platform over time.