### PR TITLE
Fix installPlugin() void return causing incorrect plugin installation status and CGLIB proxy error

### DIFF
--- a/core/src/main/java/inetsoft/setup/StorageInitializer.java
+++ b/core/src/main/java/inetsoft/setup/StorageInitializer.java
@@ -204,11 +204,11 @@ public class StorageInitializer implements Callable<Integer> {
       if(files != null && files.length > 0) {
          try(StorageService service = new StorageService(configDirectory.getAbsolutePath())) {
             for(File file : files) {
-               service.installPlugin(file);
+               if(service.installPlugin(file)) {
+                  context.attributes().put("pluginsInstalled", true);
+               }
             }
          }
-
-         context.attributes().put("pluginsInstalled", true);
       }
    }
 
@@ -412,7 +412,7 @@ public class StorageInitializer implements Callable<Integer> {
       }
    }
 
-   @Configuration
+   @Configuration(proxyBeanMethods = false)
    private static class ClusterConfig {
       @Bean
       public InetsoftConfig inetsoftConfig() {

--- a/core/src/main/java/inetsoft/setup/StorageService.java
+++ b/core/src/main/java/inetsoft/setup/StorageService.java
@@ -203,7 +203,7 @@ public class StorageService extends AbstractStorageService {
     *
     * @throws IOException if an I/O error occurs.
     */
-   public void installPlugin(File file) throws IOException {
+   public boolean installPlugin(File file) throws IOException {
       Plugin.Descriptor descriptor = new Plugin.Descriptor(file);
       String message = "Installed plugin ";
 
@@ -215,7 +215,7 @@ public class StorageService extends AbstractStorageService {
          if(newVersion.isLowerThanOrEquivalentTo(oldVersion)) {
             System.out.println(
                "Plugin is up to date " + descriptor.getId() + ":" + descriptor.getVersion());
-            return;
+            return false;
          }
 
          try {
@@ -235,6 +235,8 @@ public class StorageService extends AbstractStorageService {
       keyValueEngine.put("plugins", descriptor.getId(), blob);
 
       System.out.println(message + descriptor.getId() + ":" + descriptor.getVersion());
+
+      return true;
    }
 
    /**

--- a/core/src/main/java/inetsoft/setup/StorageService.java
+++ b/core/src/main/java/inetsoft/setup/StorageService.java
@@ -201,6 +201,8 @@ public class StorageService extends AbstractStorageService {
     *
     * @param file the plugin ZIP file to install.
     *
+    * @return {@code true} if the plugin was installed or upgraded;
+    *         {@code false} if the existing installed version is already up to date.
     * @throws IOException if an I/O error occurs.
     */
    public boolean installPlugin(File file) throws IOException {


### PR DESCRIPTION
installPlugin() has a return type of void, which prevents the caller from determining whether the plugin was actually installed. As long as a zip file exists in the directory, pluginsInstalled is set to true. On the second startup, the INSTALL_ASSETS phase is skipped, and this flag is not reset, which triggers reloadClusterPlugins. Then, because ClusterConfig is a private static class, CGLIB proxy fails and an error is reported.

Fix: Change installPlugin() to return boolean (returns true if actually installed, false if skipped). The caller sets pluginsInstalled = true only when the return value is true. Additionally, add proxyBeanMethods = false to the @Configuration annotation on ClusterConfig as a defensive fix.