### PR TITLE
Fix SQLHelper.vJoin accumulating duplicate join conditions across executions

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/SQLHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/SQLHelper.java
@@ -750,6 +750,8 @@ public class SQLHelper implements KeywordProvider {
     * @return SQL statement.
     */
    public final String generateSentence() {
+      vJoin = null;
+
       // make sure the table aliases don't exceed database limit
       fixTableAliases();
 


### PR DESCRIPTION
## Summary

- `SQLHelper.vJoin` was never reset between calls to `generateSentence()`, causing join conditions to accumulate on every re-execution of the query
- `SQLBoundQuery.nquery` holds a direct reference to the original `JDBCQuery` from `SQLBoundTableAssemblyInfo` (not a clone), so the same `SQLHelper` instance (cached in `UniformSQL.cachedSQLHelper`) was reused across all executions
- After N executions (e.g., each viewsheet component deletion triggering a re-query), each original join condition appeared N times in the generated SQL, producing 400+ line ON clauses and ultimately causing `Unknown column` database errors in MySQL

Fix: reset `vJoin = null` at the top of `generateSentence()` so the list is always rebuilt cleanly from the current WHERE clause on each invocation.

Fixes #74816

## Test plan

- [ ] Import `binding7.zip` against the MySQL Docker image described in the issue, open the `binding7` viewsheet, verify the SQL executes cleanly
- [ ] Delete a viewsheet component and re-execute — confirm the generated SQL does not grow with repeated re-executions
- [ ] Verify existing ANSI-join queries (inner join, left/right outer join, multi-table) still produce correct SQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)