### PR TITLE
Bug #74852 - Enable bar corner rounding for gantt charts

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -3724,6 +3724,9 @@ public abstract class GraphGenerator {
       else if(GraphTypes.isGantt(chartType)) {
          IntervalElement elem = new IntervalElement();
          elem.setLabelPlacement(GraphConstants.CENTER);
+         elem.setCornerRadius(desc.getPlotDescriptor().getBarCornerRadius());
+         // Gantt bars span between two value endpoints (start/end), so always round all corners.
+         elem.setRoundAllCorners(true);
          elements.add(elem);
 
          if(((GanttChartInfo) info).getRTMilestoneField() instanceof ChartAggregateRef) {

--- a/core/src/main/java/inetsoft/web/graph/model/dialog/ChartPlotOptionsPaneModel.java
+++ b/core/src/main/java/inetsoft/web/graph/model/dialog/ChartPlotOptionsPaneModel.java
@@ -118,7 +118,8 @@ public class ChartPlotOptionsPaneModel {
          ? plotDesc.getBarCornerRadius() : null;
       this.barCornerRadiusVisible = GraphTypeUtil.checkType(info, ctype ->
          (GraphTypes.isBar(ctype) || GraphTypes.isInterval(ctype) ||
-          GraphTypes.isPareto(ctype) || GraphTypes.isWaterfall(ctype)) &&
+          GraphTypes.isPareto(ctype) || GraphTypes.isWaterfall(ctype) ||
+          GraphTypes.isGantt(ctype)) &&
          !GraphTypes.is3DBar(ctype) && !GraphTypes.isFunnel(ctype));
       // "Round All Corners" hidden for interval and waterfall — both always round all corners
       this.barRoundAllCornersVisible = GraphTypeUtil.checkType(info, ctype ->
@@ -220,9 +221,11 @@ public class ChartPlotOptionsPaneModel {
          plotDesc.setBarRoundAllCorners(barRoundAllCorners);
       }
       else if(GraphTypeUtil.checkType(info,
-                  c -> GraphTypes.isInterval(c) || GraphTypes.isWaterfall(c)))
+                  c -> GraphTypes.isInterval(c) || GraphTypes.isWaterfall(c) ||
+                       GraphTypes.isGantt(c)))
       {
-         // Interval and waterfall always round all corners in GraphGenerator; persist the invariant.
+         // Interval, waterfall, and gantt always round all corners in GraphGenerator;
+         // persist the invariant.
          plotDesc.setBarRoundAllCorners(true);
       }
       else {

--- a/core/src/main/java/inetsoft/web/graph/model/dialog/ChartPlotOptionsPaneModel.java
+++ b/core/src/main/java/inetsoft/web/graph/model/dialog/ChartPlotOptionsPaneModel.java
@@ -121,7 +121,7 @@ public class ChartPlotOptionsPaneModel {
           GraphTypes.isPareto(ctype) || GraphTypes.isWaterfall(ctype) ||
           GraphTypes.isGantt(ctype)) &&
          !GraphTypes.is3DBar(ctype) && !GraphTypes.isFunnel(ctype));
-      // "Round All Corners" hidden for interval and waterfall — both always round all corners
+      // "Round All Corners" hidden for interval, waterfall, and gantt — all always round all corners
       this.barRoundAllCornersVisible = GraphTypeUtil.checkType(info, ctype ->
          (GraphTypes.isBar(ctype) || GraphTypes.isPareto(ctype)) &&
          !GraphTypes.is3DBar(ctype) && !GraphTypes.isFunnel(ctype));

--- a/core/src/test/java/inetsoft/web/graph/model/dialog/ChartPlotOptionsPaneModelTest.java
+++ b/core/src/test/java/inetsoft/web/graph/model/dialog/ChartPlotOptionsPaneModelTest.java
@@ -65,6 +65,11 @@ class ChartPlotOptionsPaneModelTest {
       assertTrue(modelFor(GraphTypes.CHART_WATERFALL).isBarCornerRadiusVisible());
    }
 
+   @Test
+   void barCornerRadiusVisible_ganttChart() {
+      assertTrue(modelFor(GraphTypes.CHART_GANTT).isBarCornerRadiusVisible());
+   }
+
    // --- barRoundAllCornersVisible ---
 
    @Test
@@ -94,6 +99,13 @@ class ChartPlotOptionsPaneModelTest {
       // Waterfall always rounds all corners (each segment floats with no zero baseline);
       // the checkbox is hidden, same pattern as interval.
       assertFalse(modelFor(GraphTypes.CHART_WATERFALL).isBarRoundAllCornersVisible());
+   }
+
+   @Test
+   void barRoundAllCornersVisible_ganttChart() {
+      // Gantt bars span between start/end with no zero baseline; rounding is always all-corners
+      // and the checkbox is hidden, same pattern as interval and waterfall.
+      assertFalse(modelFor(GraphTypes.CHART_GANTT).isBarRoundAllCornersVisible());
    }
 
    // --- updateChartPlotOptionsPaneModel: barRoundAllCorners save guard ---
@@ -190,6 +202,22 @@ class ChartPlotOptionsPaneModelTest {
 
       assertTrue(plotDesc.isBarRoundAllCorners(),
          "barRoundAllCorners should be forced true for waterfall charts to match GraphGenerator");
+   }
+
+   @Test
+   void updateModel_setsBarRoundAllCornersTrueForGanttChart() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_GANTT);
+      PlotDescriptor plotDesc = new PlotDescriptor();
+      plotDesc.setBarRoundAllCorners(false);
+
+      ChartPlotOptionsPaneModel model = new ChartPlotOptionsPaneModel(info, plotDesc);
+      // Frontend sends barRoundAllCorners=false because the checkbox is hidden
+      model.setBarRoundAllCorners(false);
+      model.updateChartPlotOptionsPaneModel(info, plotDesc);
+
+      assertTrue(plotDesc.isBarRoundAllCorners(),
+         "barRoundAllCorners should be forced true for gantt charts to match GraphGenerator");
    }
 
    @Test


### PR DESCRIPTION
Gantt charts were excluded from the bar corner rounding feature even though the underlying rendering
pipeline (BarVO → GraphBuilder → frontend canvas) already handled any IntervalElement with cornerRadius > 0. This PR wires Gantt through the existing barCornerRadius channel:

- New gantt charts default to radius 0.3 with all four corners rounded; the "Bar Corner Radius" input
is exposed in the Plot Options dialog.
- Gantt always rounds all corners (each task bar spans between two value endpoints — start and end —
with no fixed zero baseline, same justification used for interval and waterfall). The "Round All
Corners" checkbox stays hidden and barRoundAllCorners is forced true at render time and on dialog save,
keeping the persisted state consistent with GraphGenerator.
- Gantt charts saved before the original bar-rounding feature (commit 2cc0215a6, 2026-03-11) keep
barCornerRadius=0.0 via PlotDescriptor.parseXML's legacy fallback and stay sharp-cornered.