### PR TITLE
Fix Bug #74854 theme jarPath not updated when JAR is renamed via DataSpace storage UI

### DIFF
--- a/core/src/main/java/inetsoft/sree/portal/CustomThemesManager.java
+++ b/core/src/main/java/inetsoft/sree/portal/CustomThemesManager.java
@@ -130,6 +130,7 @@ public class CustomThemesManager implements XMLSerializable, AutoCloseable {
 
       Set<CustomTheme> themes = new HashSet<>(allThemes);
       boolean changed = false;
+      String oldPathPrefix = oldPath + "/";
 
       for(CustomTheme theme : new ArrayList<>(themes)) {
          String jarPath = theme.getJarPath();
@@ -143,7 +144,7 @@ public class CustomThemesManager implements XMLSerializable, AutoCloseable {
          if(oldPath.equals(jarPath)) {
             updatedPath = newPath;
          }
-         else if(jarPath.startsWith(oldPath + "/")) {
+         else if(jarPath.startsWith(oldPathPrefix)) {
             updatedPath = newPath + jarPath.substring(oldPath.length());
          }
 
@@ -168,11 +169,12 @@ public class CustomThemesManager implements XMLSerializable, AutoCloseable {
       }
 
       Set<CustomTheme> newThemes = new HashSet<>();
+      String pathPrefix = path + "/";
 
       themes.forEach(theme -> {
          String jarPath = theme.getJarPath();
 
-         if(jarPath == null || (!jarPath.equals(path) && !jarPath.startsWith(path + "/"))) {
+         if(jarPath == null || (!jarPath.equals(path) && !jarPath.startsWith(pathPrefix))) {
             newThemes.add(theme);
          }
       });

--- a/core/src/main/java/inetsoft/sree/portal/CustomThemesManager.java
+++ b/core/src/main/java/inetsoft/sree/portal/CustomThemesManager.java
@@ -116,15 +116,35 @@ public class CustomThemesManager implements XMLSerializable, AutoCloseable {
       return impl.getSelectedTheme(user, this);
    }
 
-   // Updates the jarPath of the theme whose JAR was renamed in the DataSpace,
-   // keeping KV store metadata in sync with the physical file location.
+   /**
+    * Updates the jarPath of any theme whose JAR path matches oldPath exactly or starts
+    * with oldPath as a folder prefix, keeping KV store metadata in sync with the physical
+    * file location after a file or folder rename in the DataSpace.
+    */
    public void renameThemeJar(String oldPath, String newPath) {
       Set<CustomTheme> themes = new HashSet<>(getCustomThemes());
       boolean changed = false;
 
-      for(CustomTheme theme : themes) {
-         if(oldPath.equals(theme.getJarPath())) {
-            theme.setJarPath(newPath);
+      for(CustomTheme theme : new ArrayList<>(themes)) {
+         String jarPath = theme.getJarPath();
+
+         if(jarPath == null) {
+            continue;
+         }
+
+         String updatedPath = null;
+
+         if(oldPath.equals(jarPath)) {
+            updatedPath = newPath;
+         }
+         else if(jarPath.startsWith(oldPath + "/")) {
+            updatedPath = newPath + jarPath.substring(oldPath.length());
+         }
+
+         if(updatedPath != null) {
+            themes.remove(theme);
+            theme.setJarPath(updatedPath);
+            themes.add(theme);
             changed = true;
             break;
          }

--- a/core/src/main/java/inetsoft/sree/portal/CustomThemesManager.java
+++ b/core/src/main/java/inetsoft/sree/portal/CustomThemesManager.java
@@ -122,7 +122,13 @@ public class CustomThemesManager implements XMLSerializable, AutoCloseable {
     * file location after a file or folder rename in the DataSpace.
     */
    public void renameThemeJar(String oldPath, String newPath) {
-      Set<CustomTheme> themes = new HashSet<>(getCustomThemes());
+      Set<CustomTheme> allThemes = getCustomThemes();
+
+      if(allThemes == null || allThemes.isEmpty()) {
+         return;
+      }
+
+      Set<CustomTheme> themes = new HashSet<>(allThemes);
       boolean changed = false;
 
       for(CustomTheme theme : new ArrayList<>(themes)) {
@@ -146,7 +152,6 @@ public class CustomThemesManager implements XMLSerializable, AutoCloseable {
             theme.setJarPath(updatedPath);
             themes.add(theme);
             changed = true;
-            break;
          }
       }
 

--- a/core/src/main/java/inetsoft/sree/portal/CustomThemesManager.java
+++ b/core/src/main/java/inetsoft/sree/portal/CustomThemesManager.java
@@ -116,6 +116,25 @@ public class CustomThemesManager implements XMLSerializable, AutoCloseable {
       return impl.getSelectedTheme(user, this);
    }
 
+   // Updates the jarPath of the theme whose JAR was renamed in the DataSpace,
+   // keeping KV store metadata in sync with the physical file location.
+   public void renameThemeJar(String oldPath, String newPath) {
+      Set<CustomTheme> themes = new HashSet<>(getCustomThemes());
+      boolean changed = false;
+
+      for(CustomTheme theme : themes) {
+         if(oldPath.equals(theme.getJarPath())) {
+            theme.setJarPath(newPath);
+            changed = true;
+            break;
+         }
+      }
+
+      if(changed) {
+         setCustomThemes(themes);
+      }
+   }
+
    public void reloadThemes(String path) {
       Set<CustomTheme> themes = getCustomThemes();
 

--- a/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceContentSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceContentSettingsService.java
@@ -240,6 +240,12 @@ public class DataSpaceContentSettingsService {
       Audit.getInstance().auditAction(actionRecord, principal);
    }
 
+   // Notifies dependent managers when a DataSpace file is renamed, so that
+   // any metadata referencing the old path can be updated to the new path.
+   public void onFileRenamed(String oldPath, String newPath) {
+      customThemesManager.renameThemeJar(oldPath, newPath);
+   }
+
    // refresh last modified for the directory
    public void updateFolder(String path) {
       DataSpace.updateFolder(path);

--- a/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceContentSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceContentSettingsService.java
@@ -240,8 +240,10 @@ public class DataSpaceContentSettingsService {
       Audit.getInstance().auditAction(actionRecord, principal);
    }
 
-   // Notifies dependent managers when a DataSpace file is renamed, so that
-   // any metadata referencing the old path can be updated to the new path.
+   /**
+    * Notifies dependent managers when a DataSpace file or folder is renamed, so that
+    * any metadata referencing the old path can be updated to the new path.
+    */
    public void onFileRenamed(String oldPath, String newPath) {
       customThemesManager.renameThemeJar(oldPath, newPath);
    }

--- a/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceFileSettingsController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceFileSettingsController.java
@@ -171,8 +171,9 @@ public class DataSpaceFileSettingsController {
             }
             else {
                actionRecord.setActionName(ActionRecord.ACTION_NAME_EDIT);
+               // sync metadata (e.g. theme jarPath) that references the old file path
+               dataSpaceContentSettingsService.onFileRenamed(path, npath);
                path = npath;
-
             }
          }
       }

--- a/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceFileSettingsController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceFileSettingsController.java
@@ -171,7 +171,6 @@ public class DataSpaceFileSettingsController {
             }
             else {
                actionRecord.setActionName(ActionRecord.ACTION_NAME_EDIT);
-               // sync metadata (e.g. theme jarPath) that references the old file path
                dataSpaceContentSettingsService.onFileRenamed(path, npath);
                path = npath;
             }

--- a/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceFolderSettingsController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceFolderSettingsController.java
@@ -135,7 +135,6 @@ public class DataSpaceFolderSettingsController {
                }
             }
             else {
-               // sync metadata (e.g. theme jarPath) that references the old folder path
                dataSpaceContentSettingsService.onFileRenamed(model.path(), newPath);
             }
          }

--- a/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceFolderSettingsController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceFolderSettingsController.java
@@ -134,6 +134,10 @@ public class DataSpaceFolderSettingsController {
                      "adm.dataspace.rename", model.name(), model.newName()));
                }
             }
+            else {
+               // sync metadata (e.g. theme jarPath) that references the old folder path
+               dataSpaceContentSettingsService.onFileRenamed(model.path(), newPath);
+            }
          }
       }
 

--- a/core/src/test/java/inetsoft/sree/portal/CustomThemesManagerTest.java
+++ b/core/src/test/java/inetsoft/sree/portal/CustomThemesManagerTest.java
@@ -137,6 +137,117 @@ class CustomThemesManagerTest {
       verify(manager, never()).setCustomThemes(any());
    }
 
+   // =========================================================================
+   // renameThemeJar tests
+   // =========================================================================
+
+   // exact file rename — only the matched theme's jarPath is updated
+   @Test
+   void renameThemeJar_exactPath_updatesJarPath() {
+      CustomTheme target = theme("target", "portal/theme/target.jar");
+      CustomTheme other  = theme("other",  "portal/theme/other.jar");
+
+      CustomThemesManager manager = managerWithThemes(target, other);
+
+      manager.renameThemeJar("portal/theme/target.jar", "portal/theme/renamed.jar");
+
+      Set<CustomTheme> saved = captureSetCustomThemes(manager);
+      assertEquals(2, saved.size());
+      CustomTheme updatedTarget = saved.stream()
+         .filter(t -> "target".equals(t.getId()))
+         .findFirst().orElseThrow();
+      assertEquals("portal/theme/renamed.jar", updatedTarget.getJarPath());
+      CustomTheme untouchedOther = saved.stream()
+         .filter(t -> "other".equals(t.getId()))
+         .findFirst().orElseThrow();
+      assertEquals("portal/theme/other.jar", untouchedOther.getJarPath());
+   }
+
+   // folder rename — all themes under the renamed directory are updated; outside themes are not
+   @Test
+   void renameThemeJar_folderPath_updatesAllThemesUnderThatFolder() {
+      CustomTheme inDir1  = theme("t1", "portal/theme/t1.jar");
+      CustomTheme inDir2  = theme("t2", "portal/theme/t2.jar");
+      CustomTheme outside = theme("t3", "portal/other/t3.jar");
+
+      CustomThemesManager manager = managerWithThemes(inDir1, inDir2, outside);
+
+      manager.renameThemeJar("portal/theme", "portal/newtheme");
+
+      Set<CustomTheme> saved = captureSetCustomThemes(manager);
+      assertEquals(3, saved.size());
+      saved.stream()
+         .filter(t -> "t1".equals(t.getId()) || "t2".equals(t.getId()))
+         .forEach(t -> assertTrue(t.getJarPath().startsWith("portal/newtheme/")));
+      CustomTheme untouched = saved.stream()
+         .filter(t -> "t3".equals(t.getId()))
+         .findFirst().orElseThrow();
+      assertEquals("portal/other/t3.jar", untouched.getJarPath());
+   }
+
+   // no match — no theme has the old path, so setCustomThemes must not be called
+   @Test
+   void renameThemeJar_noMatchingPath_setCustomThemesNotCalled() {
+      CustomTheme t1 = theme("t1", "portal/theme/t1.jar");
+      CustomTheme t2 = theme("t2", "portal/theme/t2.jar");
+
+      CustomThemesManager manager = managerWithThemes(t1, t2);
+
+      manager.renameThemeJar("portal/theme/nonexistent.jar", "portal/theme/new.jar");
+
+      verify(manager, never()).setCustomThemes(any());
+   }
+
+   // null jarPath — themes without a JAR are passed through unchanged
+   @Test
+   void renameThemeJar_themeWithNullJarPath_isPreserved() {
+      CustomTheme withJar    = theme("with-jar", "portal/theme/target.jar");
+      CustomTheme withoutJar = theme("no-jar", null);
+
+      CustomThemesManager manager = managerWithThemes(withJar, withoutJar);
+
+      manager.renameThemeJar("portal/theme/target.jar", "portal/theme/renamed.jar");
+
+      Set<CustomTheme> saved = captureSetCustomThemes(manager);
+      assertEquals(2, saved.size());
+      CustomTheme nullJarTheme = saved.stream()
+         .filter(t -> "no-jar".equals(t.getId()))
+         .findFirst().orElseThrow();
+      assertNull(nullJarTheme.getJarPath());
+   }
+
+   // path-separator boundary — "portal/themes/" must not be renamed when the old path is "portal/theme"
+   @Test
+   void renameThemeJar_pathSharesPrefixButDifferentDirectory_notRenamed() {
+      CustomTheme inSimilarDir = theme("t1", "portal/themes/t1.jar");
+      CustomTheme inExactDir   = theme("t2", "portal/theme/t2.jar");
+
+      CustomThemesManager manager = managerWithThemes(inSimilarDir, inExactDir);
+
+      manager.renameThemeJar("portal/theme", "portal/newtheme");
+
+      Set<CustomTheme> saved = captureSetCustomThemes(manager);
+      assertEquals(2, saved.size());
+      CustomTheme untouched = saved.stream()
+         .filter(t -> "t1".equals(t.getId()))
+         .findFirst().orElseThrow();
+      assertEquals("portal/themes/t1.jar", untouched.getJarPath());
+      CustomTheme renamed = saved.stream()
+         .filter(t -> "t2".equals(t.getId()))
+         .findFirst().orElseThrow();
+      assertEquals("portal/newtheme/t2.jar", renamed.getJarPath());
+   }
+
+   // empty theme set — early exit; setCustomThemes is never invoked
+   @Test
+   void renameThemeJar_emptyThemeSet_doesNotCallSetCustomThemes() {
+      CustomThemesManager manager = managerWithThemes();
+
+      manager.renameThemeJar("portal/theme/any.jar", "portal/theme/new.jar");
+
+      verify(manager, never()).setCustomThemes(any());
+   }
+
    // -------------------------------------------------------------------------
    // helpers
    // -------------------------------------------------------------------------


### PR DESCRIPTION
  - Add CustomThemesManager.renameThemeJar() to update jarPath in KV store
  - Add DataSpaceContentSettingsService.onFileRenamed() to propagate rename events
  - Call onFileRenamed() after successful file rename in DataSpaceFileSettingsController

  Previously, renaming a theme JAR from the storage UI only moved the physical
  file but left the jarPath in the KV store pointing to the old path, causing
  the presentation/theme panel to fail loading the theme.