### PR TITLE
fix bug-74833: shoud clear cache when clone uniformsql

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/UniformSQL.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/UniformSQL.java
@@ -3336,6 +3336,7 @@ public class UniformSQL implements SQLDefinition, Cloneable, XMLSerializable {
          }
 
          obj.hints = new HashMap<>(hints);
+         obj.cachedSQLHelper = null;
          return obj;
       }
       catch(Exception ex) {


### PR DESCRIPTION
the bug is vpm can not apply, because vpm condtion add to UniformSQL,but when executesql, it use old cache helper's UniformSQL to getsqlstring, so its string will not have where condition and do not apply conditions