### PR TITLE
Fixes for Four Types of Visualization Generation Issues: Intent Misjudgment, Date Result Loss, Binding Validation Failure, and Null Pointer Exception

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/security/WizServiceAuthenticationFilter.java
+++ b/core/src/main/java/inetsoft/web/wiz/security/WizServiceAuthenticationFilter.java
@@ -163,7 +163,14 @@ public class WizServiceAuthenticationFilter extends AbstractSecurityFilter {
       throws WizAuthenticationException
    {
       if(ssoKeyPair == null) {
-         throw new WizAuthenticationException("SSO key pair not initialized");
+         // @PostConstruct may have run before SreeEnv was ready; retry loading lazily.
+         try {
+            ssoKeyPair = PasswordEncryption.newInstance().getSSOKeyPair();
+         }
+         catch(IOException e) {
+            LOG.error("Failed to lazily load SSO key pair for WIZ service authentication", e);
+            throw new WizAuthenticationException("SSO key pair not initialized");
+         }
       }
 
       SignedJWT jwt;

--- a/core/src/main/java/inetsoft/web/wiz/security/WizServiceAuthenticationFilter.java
+++ b/core/src/main/java/inetsoft/web/wiz/security/WizServiceAuthenticationFilter.java
@@ -166,6 +166,10 @@ public class WizServiceAuthenticationFilter extends AbstractSecurityFilter {
          // @PostConstruct may have run before SreeEnv was ready; retry loading lazily.
          try {
             ssoKeyPair = PasswordEncryption.newInstance().getSSOKeyPair();
+
+            if(ssoKeyPair == null) {
+               throw new WizAuthenticationException("SSO key pair not initialized");
+            }
          }
          catch(IOException e) {
             LOG.error("Failed to lazily load SSO key pair for WIZ service authentication", e);
@@ -385,7 +389,7 @@ public class WizServiceAuthenticationFilter extends AbstractSecurityFilter {
       response.getWriter().write("{\"error\":\"" + escaped + "\"}");
    }
 
-   private KeyPair ssoKeyPair;
+   private volatile KeyPair ssoKeyPair;
 
    private static final String AUTHORIZATION_HEADER = "Authorization";
    private static final String BEARER_PREFIX = "Bearer ";

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1372,12 +1372,18 @@ public class WizVsService {
 
    private GaugeVSAssembly createGaugeAssembly(Viewsheet vs, String name)
    {
-      return new GaugeVSAssembly(vs, name);
+      GaugeVSAssembly gauge = new GaugeVSAssembly(vs, name);
+      gauge.setScalarBindingInfo(new ScalarBindingInfo());
+
+      return gauge;
    }
 
    private TextVSAssembly createTextAssembly(Viewsheet vs, String name)
    {
-      return new TextVSAssembly(vs, name);
+      TextVSAssembly text = new TextVSAssembly(vs, name);
+      text.setScalarBindingInfo(new ScalarBindingInfo());
+
+      return text;
    }
 
    private ImageVSAssembly createImageAssembly(Viewsheet vs, String name,


### PR DESCRIPTION
1. **Intent Misjudgment**: A single time range query (e.g., "total orders in the last 30 days") was incorrectly identified as requiring a date comparison, leading to an incorrect workflow. Counterexamples have been added to the prompt to distinguish between the two scenarios.

2. **Date Comparison Result Dropped**: When the workflow entered the DateComparison path, subsequent processing logic failed to recognize the output from that path, returning nothing and resulting in no visualization being rendered. This has been fixed by correctly extracting the output and forwarding it to StyleBI.

3. **Text/Gauge Binding Validation Failure**: For Text and Gauge chart types, the LLM output failed Zod validation three times in a row due to mismatched binding type field values, ultimately resulting in an error: "Visualization binding not generated." The fix applies the correct validation rules.

4. **Null Pointer Leading to 401 in StyleBI**: When creating new Text/Gauge components, the internal binding object in StyleBI was not initialized. A null pointer exception occurred during invocation, which was incorrectly wrapped as a 401 error returned to wiz. The issue was fixed on the StyleBI side by completing initialization at component creation time. On the wiz side, pre-validation was added: if binding fields are missing, a user-friendly message is returned early, preventing invalid requests from being sent to StyleBI.