### PR TITLE
Bug #74872. Fix SQL Server table query missing schema/catalog prefix and filter system schemas.

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/RawDataService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/RawDataService.java
@@ -35,9 +35,6 @@ import inetsoft.uql.util.XSourceInfo;
 import inetsoft.util.Tool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
 import org.springframework.stereotype.Service;
 
 import java.io.*;
@@ -132,7 +129,7 @@ public class RawDataService {
       String name = table.getProperty("source_with_no_quote");
       String catalog = table.getProperty(XSourceInfo.CATALOG);
       String schema = table.getProperty(XSourceInfo.SCHEMA);
-      name = buildQualifiedTableName(name, catalog, schema, dataSource, principal);
+      name = buildQualifiedTableName(name, catalog, schema, table);
       SelectTable selectTable = sql.addTable(name);
       selectTable.setCatalog(catalog);
       selectTable.setSchema(schema);
@@ -141,28 +138,33 @@ public class RawDataService {
    }
 
    private String buildQualifiedTableName(String name, String catalog, String schema,
-                                          JDBCDataSource dataSource, XPrincipal principal)
+                                          AssetEntry tableEntry)
    {
-      try(Connection conn = new JDBCHandler().getConnection(dataSource, principal)) {
-         DatabaseMetaData meta = conn.getMetaData();
-         StringBuilder qualified = new StringBuilder();
+      // Capability flags are set on the entry by MetadataApiService.buildTableAssetEntry().
+      // For databases with neither catalog nor schema (SQLite, MS Access, etc.) the
+      // catalog/schema strings on the entry are empty, so the Tool.isEmptyString() guards
+      // below are sufficient without consulting the database.
+      boolean supportsCatalog = "true".equals(tableEntry.getProperty("supportCatalog"));
+      boolean supportsSchema = "true".equals(tableEntry.getProperty("hasSchema"));
 
-         if(meta.supportsCatalogsInDataManipulation() && !Tool.isEmptyString(catalog)) {
-            qualified.append(catalog).append(".");
-         }
+      // Strip the catalog prefix already present in name before checking the schema prefix,
+      // so that "mydb.dbo.mytable" does not get a redundant "dbo." prepended.
+      String nameWithoutCatalog = !Tool.isEmptyString(catalog) && name.startsWith(catalog + ".")
+         ? name.substring(catalog.length() + 1)
+         : name;
 
-         if(meta.supportsSchemasInDataManipulation() && !Tool.isEmptyString(schema)) {
-            qualified.append(schema).append(".");
-         }
+      StringBuilder qualified = new StringBuilder();
 
-         qualified.append(name);
-
-         return qualified.toString();
+      if(supportsCatalog && !Tool.isEmptyString(catalog) && !name.startsWith(catalog + ".")) {
+         qualified.append(catalog).append(".");
       }
-      catch(Exception e) {
-         LOG.warn("Failed to build qualified table name for {}, using unqualified name", name, e);
-         return name;
+
+      if(supportsSchema && !Tool.isEmptyString(schema) && !nameWithoutCatalog.startsWith(schema + ".")) {
+         qualified.append(schema).append(".");
       }
+
+      qualified.append(name);
+      return qualified.toString();
    }
 
    private void setupColumns(JDBCQuery query, AssetEntry[] entries) {

--- a/core/src/main/java/inetsoft/web/wiz/service/RawDataService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/RawDataService.java
@@ -33,6 +33,11 @@ import inetsoft.uql.jdbc.*;
 import inetsoft.uql.jdbc.util.JDBCUtil;
 import inetsoft.uql.util.XSourceInfo;
 import inetsoft.util.Tool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import org.springframework.stereotype.Service;
 
 import java.io.*;
@@ -125,11 +130,39 @@ public class RawDataService {
       JDBCDataSource dataSource = (JDBCDataSource) query.getDataSource();
       UniformSQL sql = (UniformSQL) query.getSQLDefinition();
       String name = table.getProperty("source_with_no_quote");
+      String catalog = table.getProperty(XSourceInfo.CATALOG);
+      String schema = table.getProperty(XSourceInfo.SCHEMA);
+      name = buildQualifiedTableName(name, catalog, schema, dataSource, principal);
       SelectTable selectTable = sql.addTable(name);
-      selectTable.setCatalog(table.getProperty(XSourceInfo.CATALOG));
-      selectTable.setSchema(table.getProperty(XSourceInfo.SCHEMA));
+      selectTable.setCatalog(catalog);
+      selectTable.setSchema(schema);
       sql.removeAllFields();
       JDBCUtil.fixUniformSQLInfo(sql, xrepository, principal.getName(), dataSource, principal);
+   }
+
+   private String buildQualifiedTableName(String name, String catalog, String schema,
+                                          JDBCDataSource dataSource, XPrincipal principal)
+   {
+      try(Connection conn = new JDBCHandler().getConnection(dataSource, principal)) {
+         DatabaseMetaData meta = conn.getMetaData();
+         StringBuilder qualified = new StringBuilder();
+
+         if(meta.supportsCatalogsInDataManipulation() && !Tool.isEmptyString(catalog)) {
+            qualified.append(catalog).append(".");
+         }
+
+         if(meta.supportsSchemasInDataManipulation() && !Tool.isEmptyString(schema)) {
+            qualified.append(schema).append(".");
+         }
+
+         qualified.append(name);
+
+         return qualified.toString();
+      }
+      catch(Exception e) {
+         LOG.warn("Failed to build qualified table name for {}, using unqualified name", name, e);
+         return name;
+      }
    }
 
    private void setupColumns(JDBCQuery query, AssetEntry[] entries) {
@@ -201,5 +234,6 @@ public class RawDataService {
 
    private final XRepository xrepository;
    private final AssetRepository assetRepository;
-   private final static int RAW_DATA_MAX_ROW = 10000;
+   private static final int RAW_DATA_MAX_ROW = 10000;
+   private static final Logger LOG = LoggerFactory.getLogger(RawDataService.class);
 }

--- a/core/src/main/resources/inetsoft/uql/jdbc/tablefilter.xml
+++ b/core/src/main/resources/inetsoft/uql/jdbc/tablefilter.xml
@@ -74,6 +74,8 @@
     <database type="7">
         <catalog>master</catalog>
         <catalog>msdb</catalog>
+        <schema>sys</schema>
+        <schema>INFORMATION_SCHEMA</schema>
     </database>
 </tablefilter>
 


### PR DESCRIPTION
- In RawDataService, qualify table name with schema/catalog when the database supports them in DML (fixes queries against views like sys.dm_hadr_*).
- Add sys and INFORMATION_SCHEMA to SQL Server system schema filter in tablefilter.xml so they are excluded from table listings.