### PR TITLE
Bug #74857, fix IgniteSessionRepository.entryRemoved using getValue() instead of getOldValue()

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/user/UserService.java
+++ b/core/src/main/java/inetsoft/web/admin/user/UserService.java
@@ -392,7 +392,12 @@ public class UserService
       }
 
       for(String sessionId : sessionIds) {
-         logout(sessionId);
+         try {
+            logout(sessionId);
+         }
+         catch(Exception e) {
+            LOG.warn("Failed to logout session: {}", sessionId, e);
+         }
       }
    }
 

--- a/core/src/main/java/inetsoft/web/session/IgniteSessionRepository.java
+++ b/core/src/main/java/inetsoft/web/session/IgniteSessionRepository.java
@@ -275,7 +275,7 @@ public class IgniteSessionRepository
 
    @Override
    public void entryRemoved(EntryEvent<String, MapSession> event) {
-      MapSession session = event.getValue();
+      MapSession session = event.getOldValue();
 
       if(session != null) {
          if(session.isExpired()) {
@@ -285,7 +285,7 @@ public class IgniteSessionRepository
             LOG.debug("Session deleted with ID: {}", session.getId());
             sendApplicationEvent(new SessionDeletedEvent(this.getClass().getName(), session));
             logout(session, "");
-            destroySessionAttributeMap(event.getOldValue().getId());
+            destroySessionAttributeMap(session.getId());
          }
       }
    }


### PR DESCRIPTION
For removal events, getValue() returns null (the post-removal state). The old session is only available via getOldValue(), so the null check always failed, silently skipping logout and destroySessionAttributeMap on every session deletion — leaking a replicated Ignite map per session.

Skip failed sessions when logging out multiple sessions.