### PR TITLE
Bug #74884, fix Show Plan failing on unsaved worksheets by eliminating duplicate WorksheetEngine

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
+++ b/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
@@ -51,7 +51,7 @@ import java.util.concurrent.*;
  * @version 8.0
  * @author InetSoft Technology Corp
  */
-public class WorksheetEngine extends SheetLibraryEngine implements WorksheetService {
+public abstract class WorksheetEngine extends SheetLibraryEngine implements WorksheetService {
    /**
     * Constructor.
     * throws RemoteException

--- a/core/src/main/java/inetsoft/web/composer/ws/WorksheetController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/WorksheetController.java
@@ -41,11 +41,6 @@ import java.util.Arrays;
 
 @Controller
 public class WorksheetController {
-//   protected RuntimeWorksheet getRuntimeWorksheet(Principal principal) throws Exception {
-//      WorksheetService engine = getWorksheetEngine();
-//      return engine.getWorksheet(getRuntimeId(), principal);
-//   }
-
    protected WorksheetService getWorksheetEngine() {
       return wsEngine;
    }

--- a/core/src/main/java/inetsoft/web/factory/EngineConfiguration.java
+++ b/core/src/main/java/inetsoft/web/factory/EngineConfiguration.java
@@ -25,7 +25,6 @@ import inetsoft.mv.data.MVStorage;
 import inetsoft.mv.fs.internal.BlockFileStorage;
 import inetsoft.report.LibManagerProvider;
 import inetsoft.report.XSessionManager;
-import inetsoft.report.composition.WorksheetEngine;
 import inetsoft.report.composition.WorksheetService;
 import inetsoft.report.composition.execution.AssetDataCache;
 import inetsoft.report.composition.execution.DistributedTableCacheStore;
@@ -141,18 +140,13 @@ public class EngineConfiguration {
    }
 
    /**
-    * Worksheet composition engine. Depends on AnalyticRepository for its asset store.
+    * Worksheet composition engine. Returns the same ViewsheetEngine instance so that all
+    * runtime worksheet/viewsheet sessions share one local cache and one distributed map entry.
     */
    @Bean("worksheetService")
-   @Lazy
    @Primary
-   public WorksheetService worksheetService(@Lazy AnalyticRepository analyticRepository, @Lazy Cluster cluster) {
-      try {
-         return new WorksheetEngine(analyticRepository.unwrap(AssetRepository.class), cluster);
-      }
-      catch(RemoteException e) {
-         throw new BeanCreationException("worksheetService", "Failed to create WorksheetEngine", e);
-      }
+   public WorksheetService worksheetService(ViewsheetService viewsheetService) {
+      return viewsheetService;
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/factory/EngineConfiguration.java
+++ b/core/src/main/java/inetsoft/web/factory/EngineConfiguration.java
@@ -144,6 +144,7 @@ public class EngineConfiguration {
     * runtime worksheet/viewsheet sessions share one local cache and one distributed map entry.
     */
    @Bean("worksheetService")
+   @Lazy
    @Primary
    public WorksheetService worksheetService(ViewsheetService viewsheetService) {
       return viewsheetService;

--- a/core/src/test/java/inetsoft/test/IntegrationTestConfiguration.java
+++ b/core/src/test/java/inetsoft/test/IntegrationTestConfiguration.java
@@ -22,7 +22,6 @@ import inetsoft.analytic.composition.ViewsheetEngine;
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.mv.MVManager;
 import inetsoft.report.LibManagerProvider;
-import inetsoft.report.composition.WorksheetEngine;
 import inetsoft.report.composition.WorksheetService;
 import inetsoft.report.composition.execution.AssetDataCache;
 import inetsoft.report.composition.execution.DistributedTableCacheStore;
@@ -94,8 +93,8 @@ public class IntegrationTestConfiguration {
 
    @Bean("worksheetService")
    @Primary
-   public WorksheetService worksheetService(AnalyticRepository engine, Cluster cluster) throws Exception {
-      return new WorksheetEngine(engine.unwrap(AssetRepository.class), cluster);
+   public WorksheetService worksheetService(ViewsheetService viewsheetService) {
+      return viewsheetService;
    }
 
    @Bean


### PR DESCRIPTION
WorksheetEngine was instantiated as a separate @Primary WorksheetService bean alongside the ViewsheetEngine bean. Each had its own RuntimeSheetCache local map, both backed by the same Ignite distributed cache. Worksheet composer sessions are opened through ViewsheetEngine, so any service injecting WorksheetService (e.g. ShowPlanService) would miss the live session in ViewsheetEngine's local cache.

Make WorksheetEngine abstract and change the worksheetService bean to alias the ViewsheetEngine instance. All session state now lives in a single local cache, fixing Show Plan on fresh unsaved worksheets.

Remove dead code in WorksheetController