### PR TITLE
fix: Remove problematic reloadClusterPlugins() method to fix IgniteCl…

### DIFF
--- a/core/src/main/java/inetsoft/setup/StorageInitializer.java
+++ b/core/src/main/java/inetsoft/setup/StorageInitializer.java
@@ -23,18 +23,13 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.ConsoleAppender;
 import inetsoft.sree.internal.SUtil;
-import inetsoft.sree.internal.cluster.Cluster;
-import inetsoft.sree.internal.cluster.ignite.IgniteCluster;
 import inetsoft.sree.security.*;
-import inetsoft.storage.LoadKeyValueTask;
 import inetsoft.util.*;
 import inetsoft.util.config.InetsoftConfig;
 import inetsoft.util.config.SecretsConfig;
 import inetsoft.util.log.LogUtil;
 import inetsoft.util.log.logback.AuditLogFilter;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.*;
-import org.springframework.context.support.AbstractApplicationContext;
 import picocli.CommandLine;
 
 import java.io.*;
@@ -122,7 +117,6 @@ public class StorageInitializer implements Callable<Integer> {
          context = configureSecurity(context, extensions);
          context = importFiles(context, extensions);
          context = importAssets(context, extensions);
-         reloadClusterPlugins(context);
       }
       finally {
          for(Object value : context.attributes().values()) {
@@ -388,41 +382,8 @@ public class StorageInitializer implements Callable<Integer> {
       return appender;
    }
 
-   private void reloadClusterPlugins(SetupExtension.Context context) {
-      if(Boolean.TRUE.equals(context.attributes().get("pluginsInstalled"))) {
-         // send a message to reload the plugins from the kv store
-         String home = context.configDirectory().getAbsolutePath();
-         System.setProperty("sree.home", home);
-         ConfigurationContext configContext = ConfigurationContext.getContext();
-         configContext.setHome(home);
-
-         try {
-            InetsoftConfig.bootstrap();
-
-            try(AbstractApplicationContext applicationContext = new AnnotationConfigApplicationContext(ClusterConfig.class)) {
-               configContext.setApplicationContext(applicationContext);
-               Cluster.getInstance().submit("plugins", new LoadKeyValueTask<>("plugins", true));
-               context.attributes().put("pluginsInstalled", false);
-            }
-         }
-         finally {
-            configContext.setApplicationContext(null);
-            InetsoftConfig.BOOTSTRAP_INSTANCE = null;
-         }
-      }
-   }
-
-   @Configuration
-   private static class ClusterConfig {
-      @Bean
-      public InetsoftConfig inetsoftConfig() {
-         return InetsoftConfig.BOOTSTRAP_INSTANCE;
-      }
-
-      @Bean
-      public Cluster cluster(InetsoftConfig config) {
-         // todo use client mode
-         return new IgniteCluster();
-      }
-   }
+   // Plugin reload is handled by:
+   // 1. Enterprise ImportAssetsExtension during INSTALL_ASSETS phase (uses ClientFactory with full Spring context)
+   // 2. Server startup automatically loads plugins from KV store
+   // No need to send cluster messages during init - no other servers are running at that point.
 }


### PR DESCRIPTION
…uster initialization

The root cause was that IgniteCluster constructor requires Spring beans from ConfigurationContext, but the Spring context was not fully initialized when reloadClusterPlugins() was called during storage initialization.

Call chain that failed:
  IgniteCluster.<init>()
    → getDefaultConfig()
      → createSslContextFactory()
        → PasswordEncryption.newInstance()
          → ConfigurationContext.getSpringBean() ← fails

The reloadClusterPlugins() method attempted to create an AnnotationConfigApplicationContext during init phase, but configContext.setApplicationContext() happens after bean creation, causing initialization failures.

Moreover, sending cluster messages during init is unnecessary because:
1. No other servers are running when init container executes
2. Server container automatically loads plugins from KV store on startup

Changes made:
- Remove entire reloadClusterPlugins() method (including ClusterConfig inner class)
- Remove the method call from the initialization flow
- Clean up unused imports (Cluster, IgniteCluster, LoadKeyValueTask, Spring context annotations, etc.)

Plugin loading is now handled by:
- Enterprise ImportAssetsExtension during INSTALL_ASSETS phase
- Server startup auto-loading from KV store

This simplifies the code and eliminates a failure point during storage initialization.