### PR TITLE
Bug #74830, update session principal roles and groups after user save

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -51,6 +51,7 @@ import inetsoft.util.audit.*;
 import inetsoft.util.css.CSSDictionary;
 import inetsoft.util.log.LogManager;
 import inetsoft.web.AutoSaveUtils;
+import inetsoft.web.session.IgniteSessionRepository;
 import inetsoft.web.RecycleBin;
 import inetsoft.web.admin.favorites.FavoriteList;
 import inetsoft.web.admin.security.user.*;
@@ -97,7 +98,8 @@ public class IdentityService {
                           DependencyStorageService dependencyStorageService,
                           ExternalStorageService externalStorageService,
                           XRepository xRepository,
-                          RepletRegistryManager repletRegistryManager)
+                          RepletRegistryManager repletRegistryManager,
+                          IgniteSessionRepository sessionRepository)
    {
       this.securityEngine = securityEngine;
       this.securityProvider = securityProvider;
@@ -127,6 +129,7 @@ public class IdentityService {
       this.externalStorageService = externalStorageService;
       this.xRepository = xRepository;
       this.repletRegistryManager = repletRegistryManager;
+      this.sessionRepository = sessionRepository;
    }
 
    private AuthenticationProvider getProvider(String providerName) {
@@ -1712,6 +1715,7 @@ public class IdentityService {
       }
 
       syncIdentity(eprovider, user, oIdentity);
+      sessionRepository.updatePrincipalRolesAndGroups(oIdentity, user.getRoles(), user.getGroups(), eprovider);
 
       return user;
    }
@@ -2658,4 +2662,5 @@ public class IdentityService {
    private final ExternalStorageService externalStorageService;
    private final XRepository xRepository;
    private final RepletRegistryManager repletRegistryManager;
+   private final IgniteSessionRepository sessionRepository;
 }

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -1715,7 +1715,13 @@ public class IdentityService {
       }
 
       syncIdentity(eprovider, user, oIdentity);
-      sessionRepository.updatePrincipalRolesAndGroups(oIdentity, user.getRoles(), user.getGroups(), eprovider);
+
+      try {
+         sessionRepository.updatePrincipalRolesAndGroups(oIdentity, user.getRoles(), user.getGroups(), eprovider);
+      }
+      catch(Exception e) {
+         LOG.warn("Failed to update live session principals for user {}", oIdentity, e);
+      }
 
       return user;
    }

--- a/core/src/main/java/inetsoft/web/session/IgniteSessionRepository.java
+++ b/core/src/main/java/inetsoft/web/session/IgniteSessionRepository.java
@@ -376,6 +376,45 @@ public class IgniteSessionRepository
       return result;
    }
 
+   public void updatePrincipalRolesAndGroups(IdentityID userID, IdentityID[] newRoles,
+                                             String[] newGroups, AuthenticationProvider provider)
+   {
+      Iterator<Cache.Entry<String, MapSession>> iter = sessions.iterator();
+
+      try {
+         while(iter.hasNext()) {
+            Cache.Entry<String, MapSession> entry = iter.next();
+            IgniteSession igniteSession = findById(entry.getValue().getId());
+
+            if(igniteSession != null) {
+               updatePrincipalInSession(
+                  igniteSession, RepletRepository.PRINCIPAL_COOKIE, userID, newRoles, newGroups,
+                  provider);
+               updatePrincipalInSession(
+                  igniteSession, RepletRepository.EM_PRINCIPAL_COOKIE, userID, newRoles, newGroups,
+                  provider);
+            }
+         }
+      }
+      finally {
+         Tool.closeIterator(iter);
+      }
+   }
+
+   private void updatePrincipalInSession(IgniteSession session, String cookieKey,
+                                         IdentityID userID, IdentityID[] newRoles,
+                                         String[] newGroups, AuthenticationProvider provider)
+   {
+      SRPrincipal principal = session.getAttribute(cookieKey);
+
+      if(principal != null && Tool.equals(principal.getIdentityID(), userID)) {
+         principal.setRoles(newRoles);
+         principal.setGroups(newGroups);
+         principal.updateRoles(provider);
+         session.setAttribute(cookieKey, principal);
+      }
+   }
+
    public void invalidateSession(String id) {
       final IgniteSession session = this.findById(id);
 


### PR DESCRIPTION
When a user's roles or groups are changed via the EM security pane, update the cached roles and groups on any live SRPrincipal in the session store so that permission checks reflect the change immediately without requiring a re-login.