### PR TITLE
Bug #74454, fix spinner hover border clipped by overflow: hidden on wrapper

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.html
@@ -26,6 +26,7 @@
                         [style.position]="viewer || embeddedVS ? 'absolute' : 'relative'"
                         [style.width.px]="model.objectFormat.width"
                         [objectHeight]="model.objectFormat.height"
+                        contentOverflow="visible"
                         [style.z-index]="viewer ? model.objectFormat.zIndex : null"
                         [style.background-color]="model.objectFormat.background"
                         [style.border-bottom]="model.objectFormat.border.bottom"


### PR DESCRIPTION
## Summary

- The `vs-input-label-wrapper` defaults to `overflow: hidden` (necessary for border-radius clipping in combo-box and slider), but for the spinner this clips the bottom of the native `<input>` hover border at the 20px fixed height boundary
- Root cause: `objectHeight` sets a fixed `height: 20px` on the wrapper host; the native browser hover border renders at that exact boundary and `overflow: hidden` clips the bottom pixel
- Fix: pass `contentOverflow="visible"` to the spinner's `vs-input-label-wrapper` to disable overflow clipping — the spinner does not rely on `overflow: hidden` for border-radius clipping

## Test plan

- [ ] Create a new spinner assembly in the composer
- [ ] Hover the mouse over the spinner — the highlight border should be fully visible on all four sides including the bottom
- [ ] Verify a spinner with a configured border (e.g. 2px solid blue) also shows the border correctly on hover
- [ ] Verify a spinner with rounded corners (`roundCorner > 0`) still clips content correctly within the border radius

🤖 Generated with [Claude Code](https://claude.com/claude-code)