### PR TITLE
Bug 74897 All context-sensitive help links now resolve through

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -870,7 +870,7 @@
           <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
           <proc>full</proc>
           <compilerArgs>
-            <arg>-Atern.baseUrl=https://www.inetsoft.com/docs/stylebi/InetSoftUserDocumentation/${project.version}/index.html</arg>
+            <arg>-Atern.baseUrl=https://www.inetsoft.com/docs/stylebi/index.html</arg>
             <arg>-Atern.outputFile=inetsoft/web/binding/js-functions.generated.json</arg>
             <arg>-parameters</arg>
           </compilerArgs>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -870,7 +870,7 @@
           <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
           <proc>full</proc>
           <compilerArgs>
-            <arg>-Atern.baseUrl=https://www.inetsoft.com/docs/stylebi/index.html</arg>
+            <arg>-Atern.baseUrl=https://www.inetsoft.com/docs/stylebi/InetSoftUserDocumentation/${project.version}/index.html</arg>
             <arg>-Atern.outputFile=inetsoft/web/binding/js-functions.generated.json</arg>
             <arg>-parameters</arg>
           </compilerArgs>

--- a/core/src/main/java/inetsoft/uql/tabular/LayoutCreator.java
+++ b/core/src/main/java/inetsoft/uql/tabular/LayoutCreator.java
@@ -20,6 +20,7 @@ package inetsoft.uql.tabular;
 import inetsoft.uql.XDataSource;
 import inetsoft.uql.XQuery;
 import inetsoft.uql.util.Config;
+import inetsoft.util.InetsoftUserDocumentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -305,6 +306,7 @@ public class LayoutCreator {
 
          if(bundle != null) {
             displayLabel = bundle.getString(displayLabel);
+            displayLabel = InetsoftUserDocumentation.normalizeStyleBiDocHtmlContent(displayLabel);
          }
       }
       catch(MissingResourceException ex) {

--- a/core/src/main/java/inetsoft/util/InetsoftUserDocumentation.java
+++ b/core/src/main/java/inetsoft/util/InetsoftUserDocumentation.java
@@ -1,0 +1,154 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026 InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.Iterator;
+
+/**
+ * User documentation index URL for context-sensitive script help.
+ */
+public final class InetsoftUserDocumentation {
+   private InetsoftUserDocumentation() {
+   }
+
+   private static final String STYLEBI_DOC_SITE = "https://www.inetsoft.com/docs/stylebi/";
+   private static final String DOC_INDEX_PREFIX =
+      STYLEBI_DOC_SITE + "InetSoftUserDocumentation/";
+   private static final String DOC_INDEX_SUFFIX = "/index.html";
+
+   private static volatile String indexBaseUrl;
+
+   /**
+    * Base URL of the user documentation index (no fragment), e.g.
+    * {@code https://www.inetsoft.com/docs/stylebi/InetSoftUserDocumentation/1.1.0/index.html}.
+    */
+   public static String getUserDocumentationIndexBaseUrl() {
+      String local = indexBaseUrl;
+
+      if(local != null) {
+         return local;
+      }
+
+      synchronized(InetsoftUserDocumentation.class) {
+         local = indexBaseUrl;
+
+         if(local == null) {
+            indexBaseUrl = local = loadIndexBaseUrl();
+         }
+
+         return local;
+      }
+   }
+
+   /**
+    * Full context-sensitive help URL for the given CSH id (anchor only, no encoding).
+    */
+   public static String contextSensitiveHelpUrl(String cshid) {
+      return getUserDocumentationIndexBaseUrl() + "#cshid=" + cshid;
+   }
+
+   /**
+    * Normalizes {@code !url} entries for StyleBI script API docs to the versioned index base.
+    * Rewrites legacy {@code .../stylebi/index.html#cshid=} URLs and aligns Tern output when the
+    * build used a {@code -SNAPSHOT} {@code project.version}.
+    */
+   public static void rewriteScriptApiDocUrls(JsonNode node) {
+      if(node == null || node.isNull()) {
+         return;
+      }
+
+      if(node.isObject()) {
+         ObjectNode o = (ObjectNode) node;
+         JsonNode urlNode = o.get("!url");
+
+         if(urlNode != null && urlNode.isTextual()) {
+            String t = urlNode.asText();
+            String n = normalizeStyleBiScriptDocUrl(t);
+
+            if(!n.equals(t)) {
+               o.put("!url", n);
+            }
+         }
+
+         for(Iterator<String> it = o.fieldNames(); it.hasNext(); ) {
+            rewriteScriptApiDocUrls(o.get(it.next()));
+         }
+      }
+      else if(node.isArray()) {
+         for(JsonNode c : node) {
+            rewriteScriptApiDocUrls(c);
+         }
+      }
+   }
+
+   /**
+    * Rewrites any legacy unversioned StyleBI doc URL embedded inside an HTML string
+    * (e.g. a Bundle.properties label value that contains an {@code <a href='...'>} tag).
+    */
+   public static String normalizeStyleBiDocHtmlContent(String html) {
+      if(html == null || !html.contains(STYLEBI_DOC_SITE)) {
+         return html;
+      }
+
+      return html.replace(STYLEBI_DOC_SITE + "index.html",
+                          getUserDocumentationIndexBaseUrl());
+   }
+
+   static String normalizeStyleBiScriptDocUrl(String url) {
+      if(url == null) {
+         return null;
+      }
+
+      int csh = url.indexOf("#cshid=");
+
+      if(csh < 0 || !url.startsWith(STYLEBI_DOC_SITE)) {
+         return url;
+      }
+
+      return getUserDocumentationIndexBaseUrl() + url.substring(csh);
+   }
+
+   private static String loadIndexBaseUrl() {
+      Package pkg = InetsoftUserDocumentation.class.getPackage();
+
+      if(pkg != null) {
+         String ver = pkg.getSpecificationVersion();
+
+         if(ver != null && !ver.isBlank()) {
+            return indexBaseForDocVersion(stripSnapshotSuffix(ver.trim()));
+         }
+      }
+
+      return indexBaseForDocVersion("1.1.0");
+   }
+
+   private static String indexBaseForDocVersion(String docVersion) {
+      return DOC_INDEX_PREFIX + docVersion + DOC_INDEX_SUFFIX;
+   }
+
+   private static String stripSnapshotSuffix(String version) {
+      if(version.endsWith("-SNAPSHOT")) {
+         return version.substring(0, version.length() - "-SNAPSHOT".length());
+      }
+
+      return version;
+   }
+}

--- a/core/src/main/java/inetsoft/util/InetsoftUserDocumentation.java
+++ b/core/src/main/java/inetsoft/util/InetsoftUserDocumentation.java
@@ -19,6 +19,8 @@ package inetsoft.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
 
@@ -26,6 +28,8 @@ import java.util.Iterator;
  * User documentation index URL for context-sensitive script help.
  */
 public final class InetsoftUserDocumentation {
+   private static final Logger LOG = LoggerFactory.getLogger(InetsoftUserDocumentation.class);
+
    private InetsoftUserDocumentation() {
    }
 
@@ -133,10 +137,12 @@ public final class InetsoftUserDocumentation {
          String ver = pkg.getSpecificationVersion();
 
          if(ver != null && !ver.isBlank()) {
-            return indexBaseForDocVersion(stripSnapshotSuffix(ver.trim()));
+            return indexBaseForDocVersion(stripPreReleaseSuffix(ver.trim()));
          }
       }
 
+      LOG.warn("Could not determine Specification-Version from package manifest; " +
+               "falling back to hardcoded doc version 1.1.0");
       return indexBaseForDocVersion("1.1.0");
    }
 
@@ -144,11 +150,12 @@ public final class InetsoftUserDocumentation {
       return DOC_INDEX_PREFIX + docVersion + DOC_INDEX_SUFFIX;
    }
 
-   private static String stripSnapshotSuffix(String version) {
-      if(version.endsWith("-SNAPSHOT")) {
-         return version.substring(0, version.length() - "-SNAPSHOT".length());
+   private static String stripPreReleaseSuffix(String version) {
+      if(version.startsWith("v") || version.startsWith("V")) {
+         version = version.substring(1);
       }
 
-      return version;
+      int dash = version.indexOf('-');
+      return dash < 0 ? version : version.substring(0, dash);
    }
 }

--- a/core/src/main/java/inetsoft/util/InetsoftUserDocumentation.java
+++ b/core/src/main/java/inetsoft/util/InetsoftUserDocumentation.java
@@ -23,6 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * User documentation index URL for context-sensitive script help.
@@ -37,6 +39,9 @@ public final class InetsoftUserDocumentation {
    private static final String DOC_INDEX_PREFIX =
       STYLEBI_DOC_SITE + "InetSoftUserDocumentation/";
    private static final String DOC_INDEX_SUFFIX = "/index.html";
+
+   private static final Pattern VERSIONED_DOC_URL_PATTERN = Pattern.compile(
+      Pattern.quote(DOC_INDEX_PREFIX) + "[^/]+" + Pattern.quote(DOC_INDEX_SUFFIX));
 
    private static volatile String indexBaseUrl;
 
@@ -104,16 +109,19 @@ public final class InetsoftUserDocumentation {
    }
 
    /**
-    * Rewrites any legacy unversioned StyleBI doc URL embedded inside an HTML string
-    * (e.g. a Bundle.properties label value that contains an {@code <a href='...'>} tag).
+    * Rewrites StyleBI user-documentation index URLs embedded in an HTML string (for example a
+    * {@code Bundle.properties} label containing an {@code <a href='...'>} tag) to the current
+    * versioned index base. Handles the legacy unversioned {@code .../stylebi/index.html} path and
+    * any stale {@code .../InetSoftUserDocumentation/&lt;version&gt;/index.html} URL.
     */
    public static String normalizeStyleBiDocHtmlContent(String html) {
       if(html == null || !html.contains(STYLEBI_DOC_SITE)) {
          return html;
       }
 
-      return html.replace(STYLEBI_DOC_SITE + "index.html",
-                          getUserDocumentationIndexBaseUrl());
+      String base = getUserDocumentationIndexBaseUrl();
+      String out = html.replace(STYLEBI_DOC_SITE + "index.html", base);
+      return VERSIONED_DOC_URL_PATTERN.matcher(out).replaceAll(Matcher.quoteReplacement(base));
    }
 
    static String normalizeStyleBiScriptDocUrl(String url) {

--- a/core/src/main/java/inetsoft/util/InetsoftUserDocumentation.java
+++ b/core/src/main/java/inetsoft/util/InetsoftUserDocumentation.java
@@ -43,6 +43,9 @@ public final class InetsoftUserDocumentation {
    private static final Pattern VERSIONED_DOC_URL_PATTERN = Pattern.compile(
       Pattern.quote(DOC_INDEX_PREFIX) + "[^/]+" + Pattern.quote(DOC_INDEX_SUFFIX));
 
+   // Cached once per JVM lifetime via double-checked locking. There is intentionally no reset
+   // mechanism; tests that need to exercise loadIndexBaseUrl() directly must clear this field
+   // via reflection in a @BeforeEach, as done in InetsoftUserDocumentationTest.
    private static volatile String indexBaseUrl;
 
    /**
@@ -69,6 +72,8 @@ public final class InetsoftUserDocumentation {
 
    /**
     * Full context-sensitive help URL for the given CSH id (anchor only, no encoding).
+    *
+    * @param cshid the context-sensitive help identifier; must not be null
     */
    public static String contextSensitiveHelpUrl(String cshid) {
       return getUserDocumentationIndexBaseUrl() + "#cshid=" + cshid;
@@ -93,6 +98,8 @@ public final class InetsoftUserDocumentation {
             String n = normalizeStyleBiScriptDocUrl(t);
 
             if(!n.equals(t)) {
+               // put() replaces an existing key in-place; no structural change to the map,
+               // so the fieldNames() iterator below remains valid.
                o.put("!url", n);
             }
          }
@@ -120,8 +127,8 @@ public final class InetsoftUserDocumentation {
       }
 
       String base = getUserDocumentationIndexBaseUrl();
-      String out = html.replace(STYLEBI_DOC_SITE + "index.html", base);
-      return VERSIONED_DOC_URL_PATTERN.matcher(out).replaceAll(Matcher.quoteReplacement(base));
+      String out = VERSIONED_DOC_URL_PATTERN.matcher(html).replaceAll(Matcher.quoteReplacement(base));
+      return out.replace(STYLEBI_DOC_SITE + "index.html", base);
    }
 
    static String normalizeStyleBiScriptDocUrl(String url) {
@@ -158,7 +165,7 @@ public final class InetsoftUserDocumentation {
       return DOC_INDEX_PREFIX + docVersion + DOC_INDEX_SUFFIX;
    }
 
-   private static String stripPreReleaseSuffix(String version) {
+   static String stripPreReleaseSuffix(String version) {
       if(version.startsWith("v") || version.startsWith("V")) {
          version = version.substring(1);
       }

--- a/core/src/main/java/inetsoft/util/Tool.java
+++ b/core/src/main/java/inetsoft/util/Tool.java
@@ -4260,7 +4260,7 @@ public final class Tool extends CoreTool {
       String uri = SreeEnv.getProperty("help.url");
 
       if(uri == null || uri.equals("")) {
-         uri = "https://www.inetsoft.com/docs/stylebi/index.html";
+         uri = InetsoftUserDocumentation.getUserDocumentationIndexBaseUrl();
       }
 
       return uri;

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskFormulaService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskFormulaService.java
@@ -99,6 +99,7 @@ public class ScheduleTaskFormulaService {
       ObjectNode functions = (ObjectNode) mapper.readTree(
          getClass().getResource("/inetsoft/web/binding/js-functions.json"));
       library.setAll(functions);
+      InetsoftUserDocumentation.rewriteScriptApiDocUrls(library);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskFormulaService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskFormulaService.java
@@ -72,7 +72,7 @@ public class ScheduleTaskFormulaService {
 
             ObjectNode node = mapper.createObjectNode();
             node.put("prototype", "{}");
-            node.put("!url", Tool.getHelpBaseURL() + "#cshid=EMAddParameter");
+            node.put("!url", InetsoftUserDocumentation.contextSensitiveHelpUrl("EMAddParameter"));
             root.put(id.toString(), node);
          }
       }

--- a/core/src/main/java/inetsoft/web/binding/VSScriptableController.java
+++ b/core/src/main/java/inetsoft/web/binding/VSScriptableController.java
@@ -712,6 +712,7 @@ public class VSScriptableController {
       }
 
       library.setAll(functions);
+      InetsoftUserDocumentation.rewriteScriptApiDocUrls(library);
 
       ObjectNode chartConstants = (ObjectNode) library.get("Chart");
 
@@ -2405,8 +2406,7 @@ public class VSScriptableController {
          return null;
       }
 
-      return "https://www.inetsoft.com/docs/stylebi/index.html#cshid=" +
-         FUNCTION_CSHIDS.get(funcName);
+      return InetsoftUserDocumentation.contextSensitiveHelpUrl(FUNCTION_CSHIDS.get(funcName));
    }
 
    private static final Set sreeOnly = new HashSet();

--- a/core/src/main/java/inetsoft/web/composer/script/service/ScriptService.java
+++ b/core/src/main/java/inetsoft/web/composer/script/service/ScriptService.java
@@ -25,6 +25,7 @@ import inetsoft.analytic.web.adhoc.AdHocQueryHandler;
 import inetsoft.report.internal.graph.MapData;
 import inetsoft.uql.asset.*;
 import inetsoft.util.Catalog;
+import inetsoft.util.InetsoftUserDocumentation;
 import inetsoft.util.ItemMap;
 import inetsoft.web.admin.content.repository.ResourcePermissionService;
 import inetsoft.web.binding.model.ScriptTreeNodeData;
@@ -191,6 +192,7 @@ public class ScriptService {
       }
 
       library.setAll(functions);
+      InetsoftUserDocumentation.rewriteScriptApiDocUrls(library);
 
       ObjectNode chartConstants = (ObjectNode) library.get("Chart");
 
@@ -234,8 +236,7 @@ public class ScriptService {
          return null;
       }
 
-      return "https://www.inetsoft.com/docs/stylebi/index.html#cshid=" +
-         FUNCTION_CSHIDS.get(funcName);
+      return InetsoftUserDocumentation.contextSensitiveHelpUrl(FUNCTION_CSHIDS.get(funcName));
    }
 
    public static final Set sreeOnly = new HashSet();

--- a/core/src/test/java/inetsoft/util/InetsoftUserDocumentationTest.java
+++ b/core/src/test/java/inetsoft/util/InetsoftUserDocumentationTest.java
@@ -1,0 +1,232 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026 InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InetsoftUserDocumentationTest {
+
+   private static final String FALLBACK_BASE =
+      "https://www.inetsoft.com/docs/stylebi/InetSoftUserDocumentation/1.1.0/index.html";
+
+   @BeforeEach
+   void resetCache() throws Exception {
+      Field f = InetsoftUserDocumentation.class.getDeclaredField("indexBaseUrl");
+      f.setAccessible(true);
+      f.set(null, null);
+   }
+
+   // -------------------------------------------------------------------------
+   // stripPreReleaseSuffix
+   // -------------------------------------------------------------------------
+
+   @ParameterizedTest(name = "''{0}'' -> ''{1}''")
+   @CsvSource({
+      "1.1.0,           1.1.0",
+      "1.1,             1.1",
+      "1.1.0-SNAPSHOT,  1.1.0",
+      "1.1.0-alpha,     1.1.0",
+      "1.1.0-RC1,       1.1.0",
+      "v1.1.0,          1.1.0",
+      "V1.1.0,          1.1.0",
+      "v1.1.0-beta-1,   1.1.0",
+      "v1.0.0-beta-2,   1.0.0",
+      "v1.1.0-RC1,      1.1.0",
+   })
+   void stripPreReleaseSuffix(String input, String expected) {
+      assertEquals(expected, InetsoftUserDocumentation.stripPreReleaseSuffix(input.trim()));
+   }
+
+   // -------------------------------------------------------------------------
+   // getUserDocumentationIndexBaseUrl
+   // -------------------------------------------------------------------------
+
+   @Test
+   void indexBaseUrlFallsBackToHardcodedVersion() {
+      // Test JVM has no Specification-Version in its manifest, so the hardcoded "1.1.0" is used.
+      assertEquals(FALLBACK_BASE, InetsoftUserDocumentation.getUserDocumentationIndexBaseUrl());
+   }
+
+   @Test
+   void indexBaseUrlIsCached() {
+      String first = InetsoftUserDocumentation.getUserDocumentationIndexBaseUrl();
+      String second = InetsoftUserDocumentation.getUserDocumentationIndexBaseUrl();
+      assertSame(first, second);
+   }
+
+   // -------------------------------------------------------------------------
+   // contextSensitiveHelpUrl
+   // -------------------------------------------------------------------------
+
+   @Test
+   void contextSensitiveHelpUrlAppendsCshid() {
+      assertEquals(
+         FALLBACK_BASE + "#cshid=CreatingaChart",
+         InetsoftUserDocumentation.contextSensitiveHelpUrl("CreatingaChart"));
+   }
+
+   // -------------------------------------------------------------------------
+   // normalizeStyleBiScriptDocUrl
+   // -------------------------------------------------------------------------
+
+   @Test
+   void normalizeScriptDocUrlNull() {
+      assertNull(InetsoftUserDocumentation.normalizeStyleBiScriptDocUrl(null));
+   }
+
+   @Test
+   void normalizeScriptDocUrlNoCshidFragment() {
+      String url = "https://www.inetsoft.com/docs/stylebi/index.html";
+      assertEquals(url, InetsoftUserDocumentation.normalizeStyleBiScriptDocUrl(url));
+   }
+
+   @Test
+   void normalizeScriptDocUrlExternalSiteIgnored() {
+      String url = "https://example.com/docs#cshid=foo";
+      assertEquals(url, InetsoftUserDocumentation.normalizeStyleBiScriptDocUrl(url));
+   }
+
+   @Test
+   void normalizeScriptDocUrlLegacyUnversioned() {
+      String url = "https://www.inetsoft.com/docs/stylebi/index.html#cshid=CreatingaChart";
+      assertEquals(
+         FALLBACK_BASE + "#cshid=CreatingaChart",
+         InetsoftUserDocumentation.normalizeStyleBiScriptDocUrl(url));
+   }
+
+   @Test
+   void normalizeScriptDocUrlStaleVersionedUrl() {
+      String url = "https://www.inetsoft.com/docs/stylebi/InetSoftUserDocumentation/1.1.0-SNAPSHOT/index.html#cshid=dateAdd";
+      assertEquals(
+         FALLBACK_BASE + "#cshid=dateAdd",
+         InetsoftUserDocumentation.normalizeStyleBiScriptDocUrl(url));
+   }
+
+   @Test
+   void normalizeScriptDocUrlAlreadyCorrect() {
+      String url = FALLBACK_BASE + "#cshid=dateAdd";
+      assertEquals(url, InetsoftUserDocumentation.normalizeStyleBiScriptDocUrl(url));
+   }
+
+   // -------------------------------------------------------------------------
+   // normalizeStyleBiDocHtmlContent
+   // -------------------------------------------------------------------------
+
+   @Test
+   void normalizeHtmlNull() {
+      assertNull(InetsoftUserDocumentation.normalizeStyleBiDocHtmlContent(null));
+   }
+
+   @Test
+   void normalizeHtmlNoDocUrl() {
+      String html = "<p>Hello world</p>";
+      assertEquals(html, InetsoftUserDocumentation.normalizeStyleBiDocHtmlContent(html));
+   }
+
+   @Test
+   void normalizeHtmlLegacyUnversionedUrl() {
+      String html = "<a href='https://www.inetsoft.com/docs/stylebi/index.html#cshid=CreatingaChart'>docs</a>";
+      String expected = "<a href='" + FALLBACK_BASE + "#cshid=CreatingaChart'>docs</a>";
+      assertEquals(expected, InetsoftUserDocumentation.normalizeStyleBiDocHtmlContent(html));
+   }
+
+   @Test
+   void normalizeHtmlStaleVersionedUrl() {
+      String html = "<a href='https://www.inetsoft.com/docs/stylebi/InetSoftUserDocumentation/1.0.0/index.html'>docs</a>";
+      String expected = "<a href='" + FALLBACK_BASE + "'>docs</a>";
+      assertEquals(expected, InetsoftUserDocumentation.normalizeStyleBiDocHtmlContent(html));
+   }
+
+   @Test
+   void normalizeHtmlMultipleUrlsInOneLine() {
+      String old = "https://www.inetsoft.com/docs/stylebi/InetSoftUserDocumentation/1.0.0/index.html";
+      String html = "<a href='" + old + "'>a</a> and <a href='" + old + "'>b</a>";
+      String expected = "<a href='" + FALLBACK_BASE + "'>a</a> and <a href='" + FALLBACK_BASE + "'>b</a>";
+      assertEquals(expected, InetsoftUserDocumentation.normalizeStyleBiDocHtmlContent(html));
+   }
+
+   // -------------------------------------------------------------------------
+   // rewriteScriptApiDocUrls
+   // -------------------------------------------------------------------------
+
+   @Test
+   void rewriteNullIsNoOp() {
+      assertDoesNotThrow(() -> InetsoftUserDocumentation.rewriteScriptApiDocUrls(null));
+   }
+
+   @Test
+   void rewriteReplacesUrlFieldInObject() {
+      ObjectMapper mapper = new ObjectMapper();
+      ObjectNode node = mapper.createObjectNode();
+      node.put("!url", "https://www.inetsoft.com/docs/stylebi/index.html#cshid=dateAdd");
+      node.put("!doc", "returns the date");
+
+      InetsoftUserDocumentation.rewriteScriptApiDocUrls(node);
+
+      assertEquals(FALLBACK_BASE + "#cshid=dateAdd", node.get("!url").asText());
+      assertEquals("returns the date", node.get("!doc").asText());
+   }
+
+   @Test
+   void rewriteRecursesIntoNestedObject() {
+      ObjectMapper mapper = new ObjectMapper();
+      ObjectNode root = mapper.createObjectNode();
+      ObjectNode child = mapper.createObjectNode();
+      child.put("!url", "https://www.inetsoft.com/docs/stylebi/index.html#cshid=CreatingaChart");
+      root.set("dateAdd", child);
+
+      InetsoftUserDocumentation.rewriteScriptApiDocUrls(root);
+
+      assertEquals(
+         FALLBACK_BASE + "#cshid=CreatingaChart",
+         root.get("dateAdd").get("!url").asText());
+   }
+
+   @Test
+   void rewriteRecursesIntoArray() {
+      ObjectMapper mapper = new ObjectMapper();
+      ArrayNode array = mapper.createArrayNode();
+      ObjectNode item = mapper.createObjectNode();
+      item.put("!url", "https://www.inetsoft.com/docs/stylebi/index.html#cshid=Highlights");
+      array.add(item);
+
+      InetsoftUserDocumentation.rewriteScriptApiDocUrls(array);
+
+      assertEquals(FALLBACK_BASE + "#cshid=Highlights", array.get(0).get("!url").asText());
+   }
+
+   @Test
+   void rewriteLeavesNonDocUrlUntouched() {
+      ObjectMapper mapper = new ObjectMapper();
+      ObjectNode node = mapper.createObjectNode();
+      node.put("!url", "https://developer.mozilla.org/en-US/docs/Web/JavaScript");
+
+      InetsoftUserDocumentation.rewriteScriptApiDocUrls(node);
+
+      assertEquals("https://developer.mozilla.org/en-US/docs/Web/JavaScript", node.get("!url").asText());
+   }
+}


### PR DESCRIPTION
InetsoftUserDocumentation so they automatically target the correct versioned doc tree (e.g. .../InetSoftUserDocumentation/1.1.0/index.html).

- Tool.getHelpBaseURL() delegates to getUserDocumentationIndexBaseUrl()
  instead of falling back to the hardcoded unversioned URL, fixing all
  seven callers (EM help links, Composer, Portal, ScriptPropertyTool,
  ScheduleTaskFormulaService).
- Add normalizeStyleBiDocHtmlContent() to InetsoftUserDocumentation for
  rewriting legacy URLs embedded in HTML strings; apply it in
  LayoutCreator after the ResourceBundle lookup so all 23 connector
  Bundle.properties files are normalized at runtime without editing them.
- Replace deprecated Package.getPackage("inetsoft.util") with
  InetsoftUserDocumentation.class.getPackage() for reliable
  Specification-Version lookup in Spring Boot fat-JAR deployments.