### PR TITLE
Add condition group node to support nested condition trees.

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/VisualizationConditionModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/VisualizationConditionModel.java
@@ -18,31 +18,49 @@
 
 package inetsoft.web.wiz.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.*;
 
 import java.util.List;
 
 /**
  * Transport model representing a condition/filter specification sent from the Wiz AI service.
  * Mirrors the TypeScript {@code ConditionModel} structure.
+ * Each entry in {@code conditions} is either a leaf ({@link ConditionLeaf}) or a
+ * parenthesized group ({@link ConditionGroup}), distinguished by the {@code type} field.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class VisualizationConditionModel {
-   public List<Entry> getConditions() {
+   public List<ConditionNode> getConditions() {
       return conditions;
    }
 
-   public void setConditions(List<Entry> conditions) {
+   public void setConditions(List<ConditionNode> conditions) {
       this.conditions = conditions;
    }
 
-   private List<Entry> conditions;
+   private List<ConditionNode> conditions;
 
+   /**
+    * Polymorphic base for condition tree nodes.
+    * Deserialized based on the {@code type} JSON property.
+    */
+   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = ConditionLeaf.class)
+   @JsonSubTypes({
+      @JsonSubTypes.Type(value = ConditionLeaf.class,  name = "condition"),
+      @JsonSubTypes.Type(value = ConditionGroup.class, name = "group")
+   })
    @JsonIgnoreProperties(ignoreUnknown = true)
-   public static class Entry {
-      /**
-       * "and" | "or" — ignored for the first entry.
-       */
+   public interface ConditionNode {
+      /** "and" | "or" — the logical relationship with the previous sibling; null for the first. */
+      String getJunction();
+   }
+
+   /**
+    * Leaf node: a single filter condition.
+    */
+   @JsonIgnoreProperties(ignoreUnknown = true)
+   public static class ConditionLeaf implements ConditionNode {
+      @Override
       public String getJunction() {
          return junction;
       }
@@ -62,6 +80,34 @@ public class VisualizationConditionModel {
       private String junction;
       private ConditionSpec condition;
    }
+
+   /**
+    * Group node: parenthesizes its children (equivalent to brackets in logical expressions).
+    * Children may be leaves or nested groups.
+    */
+   @JsonIgnoreProperties(ignoreUnknown = true)
+   public static class ConditionGroup implements ConditionNode {
+      @Override
+      public String getJunction() {
+         return junction;
+      }
+
+      public void setJunction(String junction) {
+         this.junction = junction;
+      }
+
+      public List<ConditionNode> getItems() {
+         return items;
+      }
+
+      public void setItems(List<ConditionNode> items) {
+         this.items = items;
+      }
+
+      private String junction;
+      private List<ConditionNode> items;
+   }
+
 
    @JsonIgnoreProperties(ignoreUnknown = true)
    public static class ConditionSpec {
@@ -122,7 +168,7 @@ public class VisualizationConditionModel {
    @JsonIgnoreProperties(ignoreUnknown = true)
    public static class ValueSpec {
       /**
-       * VALUE | VARIABLE | EXPRESSION | FIELD | SESSION_DATA
+       * VALUE | EXPRESSION | FIELD | SESSION_DATA
        */
       public String getType() {
          return type;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1576,46 +1576,110 @@ public class WizVsService {
 
    /**
     * Converts a {@link VisualizationConditionModel} into a {@link ConditionList}.
-    * Junction operators are inserted between consecutive condition entries.
+    * Recursively traverses the node tree, assigning junction levels based on nesting depth.
+    * Items within a group at depth {@code d} receive level {@code d}, so the Java
+    * ConditionList evaluator groups them at higher precedence than items at outer depths.
     */
    private ConditionList buildConditionList(VisualizationConditionModel wizModel) {
       ConditionList conditionList = new ConditionList();
-      List<VisualizationConditionModel.Entry> entries = wizModel.getConditions();
 
-      for(VisualizationConditionModel.Entry entry : entries) {
-         VisualizationConditionModel.ConditionSpec spec = entry.getCondition();
-
-         if(spec == null || Tool.isEmptyString(spec.getField())) {
-            continue;
-         }
-
-         if(!conditionList.isEmpty()) {
-            int junctionType = "or".equalsIgnoreCase(entry.getJunction())
-               ? JunctionOperator.OR
-               : JunctionOperator.AND;
-            conditionList.append(new JunctionOperator(junctionType, 0));
-         }
-
-         AttributeRef attr = new AttributeRef(null, spec.getField());
-         Condition condition = new Condition();
-         condition.setOperation(mapConditionOperation(spec.getOperation()));
-         condition.setNegated(spec.isNegated());
-
-         if(spec.getEqual() != null) {
-            condition.setEqual(spec.getEqual());
-         }
-
-         if(spec.getValues() != null) {
-            for(VisualizationConditionModel.ValueSpec val : spec.getValues()) {
-               condition.addValue(convertConditionValue(val));
-            }
-         }
-
-         ConditionItem item = new ConditionItem(attr, condition, 0);
-         conditionList.append(item);
+      if(wizModel != null && wizModel.getConditions() != null) {
+         appendConditionNodes(wizModel.getConditions(), 0, conditionList, new boolean[]{true});
       }
 
       return conditionList;
+   }
+
+   /**
+    * Recursively appends condition nodes to {@code result}.
+    *
+    * @param nodes     the sibling nodes at the current level
+    * @param depth     current nesting depth (0 = top-level); controls junction/item level values
+    * @param result    the ConditionList being built
+    * @param isFirst   single-element boolean array used to track whether any item has been
+    *                  appended yet at the current level (avoids a leading junction)
+    */
+   private void appendConditionNodes(List<VisualizationConditionModel.ConditionNode> nodes,
+                                     int depth,
+                                     ConditionList result,
+                                     boolean[] isFirst)
+   {
+      for(VisualizationConditionModel.ConditionNode node : nodes) {
+         if(node == null) {
+            continue;
+         }
+
+         if(node instanceof VisualizationConditionModel.ConditionLeaf leaf) {
+            VisualizationConditionModel.ConditionSpec spec = leaf.getCondition();
+
+            if(spec == null || Tool.isEmptyString(spec.getField())) {
+               continue;
+            }
+
+            if(!isFirst[0]) {
+               result.append(new JunctionOperator(parseJunction(leaf.getJunction()), depth));
+            }
+
+            result.append(buildConditionItem(spec, depth));
+            isFirst[0] = false;
+         }
+         else if(node instanceof VisualizationConditionModel.ConditionGroup group) {
+            List<VisualizationConditionModel.ConditionNode> items = group.getItems();
+
+            if(items == null || items.isEmpty()) {
+               continue;
+            }
+
+            // Build the group's contents into a temporary list first so we can check
+            // whether it produced any valid items before committing a junction.
+            ConditionList groupContents = new ConditionList();
+            appendConditionNodes(items, depth + 1, groupContents, new boolean[]{true});
+
+            if(groupContents.isEmpty()) {
+               continue;
+            }
+
+            if(!isFirst[0]) {
+               result.append(new JunctionOperator(parseJunction(group.getJunction()), depth));
+            }
+
+            for(int i = 0; i < groupContents.getSize(); i++) {
+               if(i % 2 == 0) {
+                  result.append(groupContents.getConditionItem(i));
+               }
+               else {
+                  result.append(groupContents.getJunctionOperator(i));
+               }
+            }
+
+            isFirst[0] = false;
+         }
+      }
+   }
+
+   private ConditionItem buildConditionItem(VisualizationConditionModel.ConditionSpec spec,
+                                            int level)
+   {
+      AttributeRef attr = new AttributeRef(null, spec.getField());
+      Condition condition = new Condition();
+      condition.setOperation(mapConditionOperation(spec.getOperation()));
+      condition.setNegated(spec.isNegated());
+
+      if(spec.getEqual() != null) {
+         condition.setEqual(spec.getEqual());
+      }
+
+      if(spec.getValues() != null) {
+         for(VisualizationConditionModel.ValueSpec val : spec.getValues()) {
+            condition.addValue(convertConditionValue(val));
+         }
+      }
+
+      return new ConditionItem(attr, condition, level);
+   }
+
+   private int parseJunction(String junction) {
+      return "or".equalsIgnoreCase(junction) ? JunctionOperator.OR : JunctionOperator.AND;
    }
 
    private Object convertConditionValue(VisualizationConditionModel.ValueSpec val) {


### PR DESCRIPTION
Introduce a group node type to the condition tree, enabling parenthesized logical grouping (e.g. (A AND B) OR (C AND D)). Previously conditions could only be expressed as a flat list with no way to mix AND/OR precedence; group nodes allow any subset of conditions to be bracketed together so they evaluate as a unit before combining with adjacent nodes, supporting arbitrary nesting depth.