### PR TITLE
Bug #74851, fix memory leak in distributed lock management

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/CleanupTableCacheTask.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/CleanupTableCacheTask.java
@@ -70,6 +70,7 @@ public class CleanupTableCacheTask implements Runnable, Serializable {
                LOG.info("CleanupTableCacheTask: deleting {} expired entr{} from store '{}'",
                         keysToRemove.size(), keysToRemove.size() == 1 ? "y" : "ies", storeId);
                storage.deleteAll(keysToRemove);
+               keysToRemove.forEach(storage::destroyPathLock);
             }
          }
       }

--- a/core/src/main/java/inetsoft/report/composition/execution/DistributedTableCacheStore.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/DistributedTableCacheStore.java
@@ -168,6 +168,7 @@ public class DistributedTableCacheStore {
 
       try {
          storage.delete(key);
+         storage.destroyPathLock(key);
       }
       catch(IOException e) {
          LOG.warn("Failed to remove data from cache: {}", key, e);

--- a/core/src/main/java/inetsoft/report/composition/execution/DistributedTableCacheStore.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/DistributedTableCacheStore.java
@@ -108,6 +108,7 @@ public class DistributedTableCacheStore {
 
          try {
             storage.delete(key);
+            storage.destroyPathLock(key);
          }
          catch(IOException deleteEx) {
             LOG.debug("Failed to delete stale uncompressed entry {}", key, deleteEx);

--- a/core/src/main/java/inetsoft/sree/internal/cluster/MockCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/MockCluster.java
@@ -131,11 +131,7 @@ public class MockCluster implements Cluster {
 
    @Override
    public void destroyLock(String name) {
-      Lock lock = locks.get(name);
-
-      if(lock != null) {
-         lock.unlock();
-      }
+      locks.remove(name);
    }
 
    @SuppressWarnings("ResultOfMethodCallIgnored")

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/DistributedLockProxy.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/DistributedLockProxy.java
@@ -26,12 +26,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.*;
 
 public class DistributedLockProxy implements Lock {
-   public DistributedLockProxy(String lockName) {
+   public DistributedLockProxy(String lockName, Lock realLock) {
       this.lockName = lockName;
-   }
-
-   public void setRealLock(Lock lock) {
-      this.realLock = lock;
+      this.realLock = realLock;
    }
 
    @Override
@@ -96,7 +93,7 @@ public class DistributedLockProxy implements Lock {
       return realLock.newCondition();
    }
 
-   private Lock realLock;
+   private final Lock realLock;
    private String lockName;
    private static final int MAX_TRY_COUNT = 10;
    private static final int LOCK_TIMEOUT_SECONDS = 3;

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/DistributedLockProxy.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/DistributedLockProxy.java
@@ -94,7 +94,7 @@ public class DistributedLockProxy implements Lock {
    }
 
    private final Lock realLock;
-   private String lockName;
+   private final String lockName;
    private static final int MAX_TRY_COUNT = 10;
    private static final int LOCK_TIMEOUT_SECONDS = 3;
    private static final int RETRY_DELAY_MS = 3_000;

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
@@ -711,14 +711,9 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
 
    @Override
    public Lock getLock(String name) {
-      return DISTRIBUTED_LOCK_MAP.compute(name, (k, existingProxy) -> {
-         DistributedLockProxy wrapper = (existingProxy != null) ? existingProxy :
-            new DistributedLockProxy(name);
-
-         Lock lock = ignite.reentrantLock(name, true, false, true);
-         wrapper.setRealLock(lock);
-         return wrapper;
-      });
+      DistributedLockProxy wrapper = new DistributedLockProxy(name);
+      wrapper.setRealLock(ignite.reentrantLock(name, true, false, true));
+      return wrapper;
    }
 
    @Override
@@ -1896,8 +1891,6 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
    private static final String IGNITE_EXECUTE_POOL = "IGNITE_EXECUTE_POOL";
    private static final int IGNITE_EXECUTE_POOL_COUNT = 2;
    private static final long SERVICE_TASK_TIMEOUT_MINUTES = 5;
-   private static final Map<String, DistributedLockProxy> DISTRIBUTED_LOCK_MAP = new ConcurrentHashMap<>();
-
    private static final Logger LOG = LoggerFactory.getLogger(IgniteCluster.class);
 
    private static final Set<String> SPRING_PROXY_PARTITIONED_CACHES = Collections.synchronizedSet(new HashSet<>());

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
@@ -711,17 +711,15 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
 
    @Override
    public Lock getLock(String name) {
-      DistributedLockProxy wrapper = new DistributedLockProxy(name);
-      wrapper.setRealLock(ignite.reentrantLock(name, true, false, true));
-      return wrapper;
+      return new DistributedLockProxy(name, ignite.reentrantLock(name, true, false, true));
    }
 
    @Override
    public void destroyLock(String name) {
-      try(IgniteLock lock = ignite.reentrantLock(name, true, false, false)) {
-         if(lock != null) {
-            lock.unlock();
-         }
+      IgniteLock lock = ignite.reentrantLock(name, true, false, false);
+
+      if(lock != null) {
+         lock.close();
       }
    }
 

--- a/core/src/main/java/inetsoft/storage/BlobStorage.java
+++ b/core/src/main/java/inetsoft/storage/BlobStorage.java
@@ -590,7 +590,12 @@ public abstract class BlobStorage<T extends Serializable> implements AutoCloseab
    }
 
    public final void destroyPathLock(String path) {
-      cluster.destroyLock("write." + lockHost + ":" + id + ":" + path);
+      try {
+         cluster.destroyLock("write." + lockHost + ":" + id + ":" + path);
+      }
+      catch(Exception e) {
+         LOG.warn("Failed to destroy lock for path: {}", path, e);
+      }
    }
 
    protected final Cluster getCluster() {

--- a/core/src/main/java/inetsoft/storage/BlobStorage.java
+++ b/core/src/main/java/inetsoft/storage/BlobStorage.java
@@ -589,6 +589,10 @@ public abstract class BlobStorage<T extends Serializable> implements AutoCloseab
       return new BlobLock(cluster, lockName, readOnly);
    }
 
+   public final void destroyPathLock(String path) {
+      cluster.destroyLock("write." + lockHost + ":" + id + ":" + path);
+   }
+
    protected final Cluster getCluster() {
       return cluster;
    }


### PR DESCRIPTION
Remove static DISTRIBUTED_LOCK_MAP cache from IgniteCluster, which accumulated one DistributedLockProxy entry per unique lock name and never evicted them. DistributedTableCacheStore generates a unique lock per blob key under load, causing thousands of entries to accumulate. getLock() now creates a fresh wrapper per call, letting instances be GC'd after use.