### PR TITLE
Add EM controller unit tests (Phases 1, 2, 6)

### DIFF
--- a/core/src/test/java/inetsoft/web/admin/cache/CacheManagerControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/cache/CacheManagerControllerTest.java
@@ -1,0 +1,164 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.cache;
+
+/*
+ * Test strategy
+ *
+ * CacheManagerController is a pure REST controller that exposes cache properties as
+ * individual GET/POST endpoints. Each setter uses Tool.defaultIfNull() to substitute
+ * a sensible default when the incoming property has a null value field.
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] getDataCacheSize — returns a CacheProperty named "dataCacheSize" wrapping the
+ *      service value.
+ * [G2] setDataCacheSize — null longValue → 0L forwarded to service.
+ * [G3] setDataCacheSize — non-null longValue → that value forwarded to service.
+ * [G4] setDataCacheTimeout — null longValue → 0L forwarded to service.
+ * [G5] getWorksetSize — returns a CacheProperty named "worksetSize" wrapping the
+ *      service value.
+ * [G6] setWorksetSize — null intValue → 0 forwarded to service.
+ * [G7] isDataSetCachingEnabled — returns a CacheProperty named "dataSetCachingEnabled"
+ *      wrapping the boolean from the service.
+ * [G8] setDataSetCachingEnabled — null booleanValue → true forwarded to service.
+ * [G9] isSecurityCachingEnabled — wraps service boolean in CacheProperty named
+ *      "securityCachingEnabled".
+ */
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class CacheManagerControllerTest {
+
+   @Mock private CacheService cacheService;
+   @Mock private Principal principal;
+
+   private CacheManagerController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new CacheManagerController(cacheService);
+   }
+
+   // [G1] get wraps service value in a named CacheProperty
+   @Test
+   void getDataCacheSize_returnsNamedPropertyWithServiceValue() {
+      when(cacheService.getDataCacheSize()).thenReturn(512L);
+
+      CacheProperty result = controller.getDataCacheSize(principal);
+
+      assertEquals("dataCacheSize", result.name());
+      assertEquals(512L, result.longValue());
+   }
+
+   // [G2] null longValue → service receives 0L
+   @Test
+   void setDataCacheSize_nullValue_usesZeroDefault() throws Exception {
+      CacheProperty property = CacheProperty.builder().name("dataCacheSize").build();
+
+      controller.setDataCacheSize(property, principal);
+
+      verify(cacheService).setDataCacheSize(0L);
+   }
+
+   // [G3] non-null longValue → service receives exact value
+   @Test
+   void setDataCacheSize_nonNullValue_forwardsToService() throws Exception {
+      CacheProperty property = CacheProperty.builder()
+         .name("dataCacheSize").longValue(256L).build();
+
+      controller.setDataCacheSize(property, principal);
+
+      verify(cacheService).setDataCacheSize(256L);
+   }
+
+   // [G4] null timeout → service receives 0L
+   @Test
+   void setDataCacheTimeout_nullValue_usesZeroDefault() throws Exception {
+      CacheProperty property = CacheProperty.builder().name("dataCacheTimeout").build();
+
+      controller.setDataCacheTimeout(property, principal);
+
+      verify(cacheService).setDataCacheTimeout(0L);
+   }
+
+   // [G5] get wraps worksetSize integer in a named CacheProperty
+   @Test
+   void getWorksetSize_returnsNamedPropertyWithServiceValue() {
+      when(cacheService.getWorksetSize()).thenReturn(64);
+
+      CacheProperty result = controller.getWorksetSize(principal);
+
+      assertEquals("worksetSize", result.name());
+      assertEquals(64, result.intValue());
+   }
+
+   // [G6] null intValue → service receives 0
+   @Test
+   void setWorksetSize_nullValue_usesZeroDefault() throws Exception {
+      CacheProperty property = CacheProperty.builder().name("worksetSize").build();
+
+      controller.setWorksetSize(property, principal);
+
+      verify(cacheService).setWorksetSize(0);
+   }
+
+   // [G7] get wraps boolean in a named CacheProperty
+   @Test
+   void isDataSetCachingEnabled_returnsNamedPropertyWithServiceValue() {
+      when(cacheService.isDataSetCachingEnabled()).thenReturn(true);
+
+      CacheProperty result = controller.isDataSetCachingEnabled(principal);
+
+      assertEquals("dataSetCachingEnabled", result.name());
+      assertTrue(result.booleanValue());
+   }
+
+   // [G8] null booleanValue → service receives true (safe default)
+   @Test
+   void setDataSetCachingEnabled_nullValue_usesTrueDefault() throws Exception {
+      CacheProperty property = CacheProperty.builder().name("dataSetCachingEnabled").build();
+
+      controller.setDataSetCachingEnabled(property, principal);
+
+      verify(cacheService).setDataSetCachingEnabled(true);
+   }
+
+   // [G9] get wraps security caching boolean in a named CacheProperty
+   @Test
+   void isSecurityCachingEnabled_returnsNamedPropertyWithServiceValue() {
+      when(cacheService.isSecurityCachingEnabled()).thenReturn(false);
+
+      CacheProperty result = controller.isSecurityCachingEnabled(principal);
+
+      assertEquals("securityCachingEnabled", result.name());
+      assertFalse(result.booleanValue());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/cache/CacheMonitoringControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/cache/CacheMonitoringControllerTest.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.cache;
+
+/*
+ * Test strategy
+ *
+ * CacheMonitoringController has a single STOMP subscribe handler — subscribeDataGrid — that
+ * enforces an inline permission check before delegating to MonitoringDataService.
+ * No REST endpoints exist in this controller.
+ *
+ * The permission check is:
+ *   securityEngine.getSecurityProvider().checkPermission(
+ *       principal, EM_COMPONENT, "monitoring/cache", ACCESS)
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] When checkPermission returns false → SecurityException is thrown, addSubscriber
+ *      is never called.
+ * [G2] When checkPermission returns true → monitoringDataService.addSubscriber is called
+ *      with the provided StompHeaderAccessor.
+ */
+
+import inetsoft.sree.security.*;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.web.admin.monitoring.MonitoringDataService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+import java.security.Principal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class CacheMonitoringControllerTest {
+
+   @Mock private CacheService cacheService;
+   @Mock private MonitoringDataService monitoringDataService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private StompHeaderAccessor stompHeaderAccessor;
+   @Mock private Principal principal;
+
+   private CacheMonitoringController controller() {
+      return new CacheMonitoringController(cacheService, monitoringDataService, securityEngine);
+   }
+
+   private void stubPermission(boolean granted) {
+      when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      when(securityProvider.checkPermission(
+            eq(principal), eq(ResourceType.EM_COMPONENT),
+            eq("monitoring/cache"), eq(ResourceAction.ACCESS)))
+         .thenReturn(granted);
+   }
+
+   // [G1] permission denied → SecurityException; addSubscriber never reached
+   @Test
+   void subscribeDataGrid_permissionDenied_throwsSecurityException() {
+      stubPermission(false);
+
+      assertThrows(SecurityException.class,
+         () -> controller().subscribeDataGrid(stompHeaderAccessor, Optional.empty(), principal));
+
+      verifyNoInteractions(monitoringDataService);
+   }
+
+   // [G2] permission granted → addSubscriber is invoked with the header accessor
+   @Test
+   void subscribeDataGrid_permissionGranted_delegatesToMonitoringDataService() throws Exception {
+      stubPermission(true);
+      when(monitoringDataService.addSubscriber(same(stompHeaderAccessor), any())).thenReturn(null);
+
+      controller().subscribeDataGrid(stompHeaderAccessor, Optional.empty(), principal);
+
+      verify(monitoringDataService).addSubscriber(same(stompHeaderAccessor), any());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/cluster/ClusterControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/cluster/ClusterControllerTest.java
@@ -1,0 +1,154 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.cluster;
+
+/*
+ * Test strategy
+ *
+ * ClusterController has two shapes of behavior:
+ *
+ *   REST endpoints (tested here):
+ *     getClusterNodes  — checks SreeEnv.getProperty("server.type"); returns null when
+ *                        not "server_cluster", otherwise builds ClusterNodesModel.
+ *     getClusterStatus — pure delegation to ClusterService.
+ *     getClusterEnabled — pure delegation to ClusterService.
+ *     pauseServer / resumeServer — pure delegation to ClusterService.
+ *
+ *   STOMP subscriber (subscribeClusterStatus) — permission guard tested separately;
+ *     omitted here because the subscriber delegates through MonitoringDataService.
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] getClusterNodes when server.type != "server_cluster" → returns null (not cluster mode).
+ * [G2] getClusterStatus delegates to clusterService and returns the result.
+ * [G3] getClusterEnabled delegates to clusterService and returns the result.
+ * [G4] pauseServer delegates servers array to clusterService.pauseServers().
+ * [G5] resumeServer delegates servers array to clusterService.resumeServers().
+ * [G6] subscribeClusterStatus STOMP handler throws SecurityException when permission denied.
+ */
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.sree.security.*;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.web.admin.monitoring.MonitoringDataService;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ClusterControllerTest {
+
+   @Mock private ClusterService clusterService;
+   @Mock private MonitoringDataService monitoringDataService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private StompHeaderAccessor stompHeaderAccessor;
+   @Mock private Principal principal;
+
+   private ClusterController controller;
+   private MockedStatic<SreeEnv> sreeEnvStatic;
+
+   @BeforeEach
+   void setUp() {
+      controller = new ClusterController(clusterService, monitoringDataService, securityEngine);
+      sreeEnvStatic = mockStatic(SreeEnv.class, withSettings().lenient());
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("server.type")).thenReturn("standalone");
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnvStatic.close();
+   }
+
+   // [G1] non-cluster server type → getClusterNodes returns null
+   @Test
+   void getClusterNodes_notServerCluster_returnsNull() {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("server.type")).thenReturn("standalone");
+
+      ClusterNodesModel result = controller.getClusterNodes();
+
+      assertNull(result);
+   }
+
+   // [G2] getClusterStatus delegates to clusterService
+   @Test
+   void getClusterStatus_delegatesToService() {
+      List<ReportClusterNodeModel> expected = List.of();
+      when(clusterService.getClusterStatus()).thenReturn(expected);
+
+      List<ReportClusterNodeModel> result = controller.getClusterStatus();
+
+      assertSame(expected, result);
+      verify(clusterService).getClusterStatus();
+   }
+
+   // [G3] getClusterEnabled delegates to clusterService
+   @Test
+   void getClusterEnabled_delegatesToService() {
+      ClusterEnabledModel expected = mock(ClusterEnabledModel.class);
+      when(clusterService.getClusterEnabled()).thenReturn(expected);
+
+      ClusterEnabledModel result = controller.getClusterEnabled();
+
+      assertSame(expected, result);
+   }
+
+   // [G4] pauseServer delegates server array to clusterService.pauseServers
+   @Test
+   void pauseServer_delegatesToService() {
+      String[] servers = { "node1", "node2" };
+
+      controller.pauseServer(servers);
+
+      verify(clusterService).pauseServers(servers);
+   }
+
+   // [G5] resumeServer delegates server array to clusterService.resumeServers
+   @Test
+   void resumeServer_delegatesToService() {
+      String[] servers = { "node1" };
+
+      controller.resumeServer(servers);
+
+      verify(clusterService).resumeServers(servers);
+   }
+
+   // [G6] STOMP subscribe with denied permission throws SecurityException
+   @Test
+   void subscribeClusterStatus_permissionDenied_throwsSecurityException() {
+      when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      when(securityProvider.checkPermission(
+            eq(principal), eq(ResourceType.EM_COMPONENT),
+            eq("monitoring/cluster/reportCluster"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      assertThrows(SecurityException.class,
+         () -> controller.subscribeClusterStatus(stompHeaderAccessor, principal));
+
+      verifyNoInteractions(monitoringDataService);
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/general/GeneralSettingsPageControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/general/GeneralSettingsPageControllerTest.java
@@ -1,0 +1,302 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.general;
+
+/*
+ * Test strategy
+ *
+ * GeneralSettingsPageController has two endpoints with in-controller conditional logic:
+ *
+ * --- getPageModel ---
+ *   A multi-tenancy + admin gate decides which sub-models to include:
+ *     [multi-tenant non-site-admin]  security on AND isMultiTenant AND !isSiteAdmin
+ *                                    → only mvSettingsModel populated; all other fields null
+ *     [site admin / not multi-tenant] all conditions not met → full model; all service
+ *                                    getters called; securityEnabled = !provider.isVirtual()
+ *
+ * --- setPageModel ---
+ *   Same gate controls which service setters are called:
+ *     [multi-tenant non-site-admin]  only mvSettingsService.setModel() called
+ *     [site admin]                   all non-null sub-model setters called
+ *     [null sub-model]               corresponding service.setModel() is skipped
+ *   Always ends by delegating to getPageModel and returning its result.
+ */
+
+import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.security.*;
+import inetsoft.web.admin.general.model.*;
+import inetsoft.web.admin.general.model.model.OAuthParams;
+import inetsoft.web.admin.general.model.model.OAuthParamsRequest;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class GeneralSettingsPageControllerTest {
+
+   @Mock private LicenseKeySettingsService licenseKeySettingsService;
+   @Mock private LocalizationSettingsService localizationSettingsService;
+   @Mock private MVSettingsService mvSettingsService;
+   @Mock private CacheSettingsService cacheSettingsService;
+   @Mock private DataSpaceSettingsService dataSpaceSettingsService;
+   @Mock private EmailSettingsService emailSettingsService;
+   @Mock private PerformanceSettingsService performanceSettingsService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private OrganizationManager orgManager;
+   @Mock private Principal principal;
+
+   @Mock private MVSettingsModel mvSettingsModel;
+   @Mock private LicenseKeySettingsModel licenseKeySettingsModel;
+   @Mock private LocalizationSettingsModel localizationSettingsModel;
+   @Mock private CacheSettingsModel cacheSettingsModel;
+   @Mock private DataSpaceSettingsModel dataSpaceSettingsModel;
+   @Mock private EmailSettingsModel emailSettingsModel;
+   @Mock private PerformanceSettingsModel performanceSettingsModel;
+
+   private GeneralSettingsPageController controller;
+   private MockedStatic<SUtil> sUtilStatic;
+   private MockedStatic<OrganizationManager> orgManagerStatic;
+
+   @BeforeEach
+   void setUp() {
+      controller = new GeneralSettingsPageController(
+         licenseKeySettingsService, localizationSettingsService, mvSettingsService,
+         cacheSettingsService, dataSpaceSettingsService, emailSettingsService,
+         performanceSettingsService, securityEngine);
+
+      sUtilStatic = mockStatic(SUtil.class, withSettings().lenient());
+      orgManagerStatic = mockStatic(OrganizationManager.class, withSettings().lenient());
+      orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+
+      lenient().when(principal.getName()).thenReturn("user");
+      lenient().when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      lenient().when(securityProvider.isVirtual()).thenReturn(false);
+   }
+
+   @AfterEach
+   void tearDown() {
+      sUtilStatic.close();
+      orgManagerStatic.close();
+   }
+
+   // -------------------------------------------------------------------------
+   // getPageModel
+   // -------------------------------------------------------------------------
+
+   // [multi-tenant non-site-admin] only mvSettingsModel populated; all others null
+   @Test
+   void getPageModel_multiTenantNonSiteAdmin_returnsMvModelOnly() throws Exception {
+      when(securityEngine.isSecurityEnabled()).thenReturn(true);
+      sUtilStatic.when(SUtil::isMultiTenant).thenReturn(true);
+      when(orgManager.isSiteAdmin(principal)).thenReturn(false);
+      when(mvSettingsService.getModel(principal)).thenReturn(mvSettingsModel);
+
+      GeneralSettingsPageModel model = controller.getPageModel(principal);
+
+      assertSame(mvSettingsModel, model.mvSettingsModel());
+      assertNull(model.licenseKeySettingsModel());
+      assertNull(model.localizationSettingsModel());
+      assertNull(model.cacheSettingsModel());
+      assertNull(model.dataSpaceSettingsModel());
+      assertNull(model.emailSettingsModel());
+      assertNull(model.performanceSettingsModel());
+   }
+
+   // [site admin] all service getters called; full model returned
+   @Test
+   void getPageModel_siteAdmin_returnsFullModel() throws Exception {
+      when(securityEngine.isSecurityEnabled()).thenReturn(true);
+      sUtilStatic.when(SUtil::isMultiTenant).thenReturn(true);
+      when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+      when(licenseKeySettingsService.getModel()).thenReturn(licenseKeySettingsModel);
+      when(localizationSettingsService.getModel()).thenReturn(localizationSettingsModel);
+      when(mvSettingsService.getModel(principal)).thenReturn(mvSettingsModel);
+      when(cacheSettingsService.getModel()).thenReturn(cacheSettingsModel);
+      when(dataSpaceSettingsService.getModel(principal)).thenReturn(dataSpaceSettingsModel);
+      when(emailSettingsService.getModel()).thenReturn(emailSettingsModel);
+      when(performanceSettingsService.getModel()).thenReturn(performanceSettingsModel);
+
+      GeneralSettingsPageModel model = controller.getPageModel(principal);
+
+      assertSame(licenseKeySettingsModel, model.licenseKeySettingsModel());
+      assertSame(localizationSettingsModel, model.localizationSettingsModel());
+      assertSame(mvSettingsModel, model.mvSettingsModel());
+      assertSame(cacheSettingsModel, model.cacheSettingsModel());
+      assertSame(dataSpaceSettingsModel, model.dataSpaceSettingsModel());
+      assertSame(emailSettingsModel, model.emailSettingsModel());
+      assertSame(performanceSettingsModel, model.performanceSettingsModel());
+      assertTrue(model.securityEnabled()); // !isVirtual()=false → securityEnabled=true
+   }
+
+   // [not multi-tenant] security enabled but not multi-tenant → full model path taken
+   @Test
+   void getPageModel_securityEnabledNotMultiTenant_returnsFullModel() throws Exception {
+      when(securityEngine.isSecurityEnabled()).thenReturn(true);
+      sUtilStatic.when(SUtil::isMultiTenant).thenReturn(false);
+      when(licenseKeySettingsService.getModel()).thenReturn(licenseKeySettingsModel);
+      when(localizationSettingsService.getModel()).thenReturn(localizationSettingsModel);
+      when(mvSettingsService.getModel(principal)).thenReturn(mvSettingsModel);
+      when(cacheSettingsService.getModel()).thenReturn(cacheSettingsModel);
+      when(dataSpaceSettingsService.getModel(principal)).thenReturn(dataSpaceSettingsModel);
+      when(emailSettingsService.getModel()).thenReturn(emailSettingsModel);
+      when(performanceSettingsService.getModel()).thenReturn(performanceSettingsModel);
+
+      GeneralSettingsPageModel model = controller.getPageModel(principal);
+
+      assertNotNull(model.licenseKeySettingsModel());
+      assertNotNull(model.mvSettingsModel());
+   }
+
+   // securityEnabled field = !provider.isVirtual()
+   @Test
+   void getPageModel_virtualProvider_securityEnabledIsFalse() throws Exception {
+      when(securityEngine.isSecurityEnabled()).thenReturn(false);
+      when(securityProvider.isVirtual()).thenReturn(true);
+      lenient().when(mvSettingsService.getModel(principal)).thenReturn(mvSettingsModel);
+
+      GeneralSettingsPageModel model = controller.getPageModel(principal);
+
+      assertFalse(model.securityEnabled());
+   }
+
+   // -------------------------------------------------------------------------
+   // setPageModel
+   // -------------------------------------------------------------------------
+
+   // [multi-tenant non-site-admin] only mvSettingsService.setModel called
+   @Test
+   void setPageModel_multiTenantNonSiteAdmin_onlyCallsMvService() throws Exception {
+      when(securityEngine.isSecurityEnabled()).thenReturn(true);
+      sUtilStatic.when(SUtil::isMultiTenant).thenReturn(true);
+      when(orgManager.isSiteAdmin(principal)).thenReturn(false);
+      when(mvSettingsService.getModel(principal)).thenReturn(mvSettingsModel);
+
+      GeneralSettingsPageModel input = GeneralSettingsPageModel.builder()
+         .mvSettingsModel(mvSettingsModel)
+         .licenseKeySettingsModel(licenseKeySettingsModel)
+         .build();
+
+      controller.setPageModel(input, principal, null);
+
+      verify(mvSettingsService).setModel(mvSettingsModel, principal);
+      verify(licenseKeySettingsService, never()).setModel(any(), any());
+      verify(localizationSettingsService, never()).setModel(any(), any());
+      verify(cacheSettingsService, never()).setModel(any(), any());
+      verify(emailSettingsService, never()).setModel(any(), any());
+      verify(performanceSettingsService, never()).setModel(any(), any());
+   }
+
+   // [site admin] all non-null sub-model setters called
+   @Test
+   void setPageModel_siteAdmin_callsAllNonNullSubModelSetters() throws Exception {
+      when(securityEngine.isSecurityEnabled()).thenReturn(true);
+      sUtilStatic.when(SUtil::isMultiTenant).thenReturn(true);
+      when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+      stubAllGetters();
+
+      GeneralSettingsPageModel input = GeneralSettingsPageModel.builder()
+         .licenseKeySettingsModel(licenseKeySettingsModel)
+         .localizationSettingsModel(localizationSettingsModel)
+         .mvSettingsModel(mvSettingsModel)
+         .cacheSettingsModel(cacheSettingsModel)
+         .emailSettingsModel(emailSettingsModel)
+         .performanceSettingsModel(performanceSettingsModel)
+         .build();
+
+      controller.setPageModel(input, principal, null);
+
+      verify(licenseKeySettingsService).setModel(licenseKeySettingsModel, principal);
+      verify(localizationSettingsService).setModel(localizationSettingsModel, principal);
+      verify(mvSettingsService).setModel(mvSettingsModel, principal);
+      verify(cacheSettingsService).setModel(cacheSettingsModel, principal);
+      verify(emailSettingsService).setModel(emailSettingsModel, principal);
+      verify(performanceSettingsService).setModel(performanceSettingsModel, principal);
+   }
+
+   // [null sub-model] null mvSettingsModel → mvSettingsService.setModel not called
+   @Test
+   void setPageModel_nullMvModel_skipsMvService() throws Exception {
+      when(securityEngine.isSecurityEnabled()).thenReturn(true);
+      sUtilStatic.when(SUtil::isMultiTenant).thenReturn(true);
+      when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+      stubAllGetters();
+
+      GeneralSettingsPageModel input = GeneralSettingsPageModel.builder()
+         .licenseKeySettingsModel(licenseKeySettingsModel)
+         .build();
+
+      controller.setPageModel(input, principal, null);
+
+      verify(mvSettingsService, never()).setModel(any(), any());
+      verify(licenseKeySettingsService).setModel(licenseKeySettingsModel, principal);
+   }
+
+   // -------------------------------------------------------------------------
+   // Simple delegation endpoints
+   // -------------------------------------------------------------------------
+
+   // backup delegates to dataSpaceSettingsService.doBackup
+   @Test
+   void backup_delegatesToDataSpaceService() {
+      BackupDataModel model = mock(BackupDataModel.class);
+      when(dataSpaceSettingsService.doBackup(model)).thenReturn("backup-ok");
+
+      assertEquals("backup-ok", controller.backup(model, principal).getStatus());
+   }
+
+   // cleanUpCache delegates to cacheSettingsService
+   @Test
+   void cleanUpCache_delegatesToCacheService() {
+      controller.cleanUpCache();
+
+      verify(cacheSettingsService).cleanUpCache();
+   }
+
+   // getOAuthParams delegates to emailSettingsService
+   @Test
+   void getOAuthParams_delegatesToEmailService() throws Exception {
+      OAuthParamsRequest request = mock(OAuthParamsRequest.class);
+      OAuthParams params = mock(OAuthParams.class);
+      when(emailSettingsService.getOAuthParams(request)).thenReturn(params);
+
+      assertSame(params, controller.getOAuthParams(request));
+   }
+
+   // -------------------------------------------------------------------------
+   // helpers
+   // -------------------------------------------------------------------------
+
+   private void stubAllGetters() throws Exception {
+      lenient().when(licenseKeySettingsService.getModel()).thenReturn(licenseKeySettingsModel);
+      lenient().when(localizationSettingsService.getModel()).thenReturn(localizationSettingsModel);
+      lenient().when(mvSettingsService.getModel(principal)).thenReturn(mvSettingsModel);
+      lenient().when(cacheSettingsService.getModel()).thenReturn(cacheSettingsModel);
+      lenient().when(dataSpaceSettingsService.getModel(principal)).thenReturn(dataSpaceSettingsModel);
+      lenient().when(emailSettingsService.getModel()).thenReturn(emailSettingsModel);
+      lenient().when(performanceSettingsService.getModel()).thenReturn(performanceSettingsModel);
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/help/HelpControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/help/HelpControllerTest.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.help;
+
+/*
+ * Test strategy
+ *
+ * HelpController has two endpoints and one @PostConstruct initializer:
+ *
+ *   loadLinks() — reads help-links.json from the classpath (relative to the class package),
+ *     prepends Tool.getHelpBaseURL() + "#cshid=" to every link, and appends a default
+ *     empty-route link pointing at "#cshid=EM".
+ *
+ *   getHelpLinks() — returns the HelpLinks object built by loadLinks().
+ *   getHelpUrL()   — returns Encode.forUri(Tool.getHelpBaseURL()).
+ *
+ * Tool.getHelpBaseURL() reads "help.url" from SreeEnv, so the base URL is
+ * controlled in tests via SreeEnv mock.
+ *
+ * A minimal help-links.json is placed in the test resources tree at the same
+ * classpath location so that loadLinks() can find it without the web module.
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] Every link returned by getHelpLinks() starts with the configured base URL + "#cshid=".
+ * [G2] A default link with route="" and suffix "#cshid=EM" is always added.
+ * [G3] Routes from the JSON file are present in the returned list with their cshid suffix.
+ * [G4] getHelpUrL() returns the URI-encoded base URL.
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.sree.SreeEnv;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class HelpControllerTest {
+
+   private static final String BASE_URL = "https://example.com/docs";
+   private static final String EXPECTED_PREFIX = BASE_URL + "#cshid=";
+
+   private HelpController controller;
+   private MockedStatic<SreeEnv> sreeEnvStatic;
+
+   @BeforeEach
+   void setUp() throws Exception {
+      sreeEnvStatic = mockStatic(SreeEnv.class, withSettings().lenient());
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("help.url")).thenReturn(BASE_URL);
+
+      controller = new HelpController(new ObjectMapper());
+      controller.loadLinks();
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnvStatic.close();
+   }
+
+   // [G1] every link starts with the configured base URL + "#cshid="
+   @Test
+   void getHelpLinks_allLinksHaveBaseUrlPrefix() {
+      List<HelpLink> links = controller.getHelpLinks(null).links();
+
+      assertFalse(links.isEmpty());
+      for(HelpLink link : links) {
+         assertTrue(link.link().startsWith(EXPECTED_PREFIX),
+            "Expected link to start with prefix, but was: " + link.link());
+      }
+   }
+
+   // [G2] default link for route "" with "#cshid=EM" is always appended
+   @Test
+   void getHelpLinks_defaultEmLinkAlwaysPresent() {
+      List<HelpLink> links = controller.getHelpLinks(null).links();
+
+      assertTrue(links.stream().anyMatch(l -> l.route().isEmpty() && l.link().equals(EXPECTED_PREFIX + "EM")),
+         "Default EM link not found in: " + links);
+   }
+
+   // [G3] routes from the JSON are present, each with their cshid value appended
+   @Test
+   void getHelpLinks_routesFromJsonHaveCorrectCshidSuffix() {
+      List<HelpLink> links = controller.getHelpLinks(null).links();
+
+      assertTrue(links.stream().anyMatch(
+         l -> l.route().equals("/monitoring/log") && l.link().equals(EXPECTED_PREFIX + "EMMonitoringLog")));
+      assertTrue(links.stream().anyMatch(
+         l -> l.route().equals("/settings/general") && l.link().equals(EXPECTED_PREFIX + "EMSettingsGeneral")));
+   }
+
+   // [G4] getHelpUrL() returns the URI-encoded base URL
+   @Test
+   void getHelpUrL_returnsEncodedBaseUrl() {
+      String result = controller.getHelpUrL(null);
+
+      assertEquals(BASE_URL, result);
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/logviewer/LogMonitoringControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/logviewer/LogMonitoringControllerTest.java
@@ -1,0 +1,193 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.logviewer;
+
+/*
+ * Test strategy
+ *
+ * LogMonitoringController has the following testable behaviors:
+ *
+ *   REST endpoints (pure delegation, @Secured handled by framework):
+ *     getLogs           — delegates to logMonitoringService.getLogs()
+ *     refreshLogViewer  — delegates to logMonitoringService.getLog(node, file, offset, len)
+ *     rotateLogFile     — delegates to logMonitoringService.rotateLogFile(node, file)
+ *     downloadLogs      — delegates to logMonitoringService.downloadLogs(); wraps any
+ *                         checked exception as RuntimeException
+ *     getLogLinks       — delegates to logMonitoringService.getLinks(principal)
+ *     getAuditLinks     — delegates to logMonitoringService.getLinks(principal)
+ *
+ *   STOMP subscriber (subscribeToLogRefresh) — permission guard:
+ *     permission denied → SecurityException; addSubscriber not called
+ *     permission granted → addSubscriber invoked
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] getLogs delegates and returns the LogMonitoringModel.
+ * [G2] refreshLogViewer forwards all four path variables to the service.
+ * [G3] rotateLogFile delegates clusterNode and logFileName to the service.
+ * [G4] downloadLogs delegates response and clusterNode; service exception → RuntimeException.
+ * [G5] getLogLinks delegates to service with principal.
+ * [G6] getAuditLinks delegates to service with principal.
+ * [G7] STOMP subscribe: permission denied → SecurityException; addSubscriber not reached.
+ * [G8] STOMP subscribe: permission granted → addSubscriber called.
+ */
+
+import inetsoft.sree.security.*;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.web.admin.monitoring.MonitoringDataService;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class LogMonitoringControllerTest {
+
+   @Mock private LogMonitoringService logMonitoringService;
+   @Mock private MonitoringDataService monitoringDataService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private HttpServletResponse response;
+   @Mock private StompHeaderAccessor stompHeaderAccessor;
+   @Mock private Principal principal;
+
+   private LogMonitoringController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new LogMonitoringController(
+         logMonitoringService, monitoringDataService, securityEngine);
+   }
+
+   // [G1] getLogs returns the LogMonitoringModel from the service
+   @Test
+   void getLogs_delegatesToService() {
+      LogMonitoringModel model = new LogMonitoringModel(null, List.of(), false, false, 100);
+      when(logMonitoringService.getLogs()).thenReturn(model);
+
+      LogMonitoringModel result = controller.getLogs();
+
+      assertSame(model, result);
+   }
+
+   // [G2] refreshLogViewer forwards all four path variables
+   @Test
+   void refreshLogViewer_forwardsAllParams() {
+      List<String> lines = List.of("line1", "line2");
+      when(logMonitoringService.getLog("node1", "server.log", 0, 100)).thenReturn(lines);
+
+      List<String> result = controller.refreshLogViewer("node1", "server.log", 0, 100);
+
+      assertSame(lines, result);
+   }
+
+   // [G3] rotateLogFile delegates clusterNode and logFileName
+   @Test
+   void rotateLogFile_delegatesParams() throws Exception {
+      LogMonitoringModel model = new LogMonitoringModel(null, List.of(), false, true, 100);
+      when(logMonitoringService.rotateLogFile("node1", "server.log")).thenReturn(model);
+
+      LogMonitoringModel result = controller.rotateLogFile("node1", "server.log");
+
+      assertSame(model, result);
+   }
+
+   // [G4a] downloadLogs delegates response and clusterNode to the service
+   @Test
+   void downloadLogs_delegatesToService() throws Exception {
+      controller.downloadLogs(response, "node1");
+
+      verify(logMonitoringService).downloadLogs(response, "node1");
+   }
+
+   // [G4b] downloadLogs wraps any exception from service as RuntimeException
+   @Test
+   void downloadLogs_serviceThrows_wrappedAsRuntimeException() {
+      doThrow(new RuntimeException("disk full")).when(logMonitoringService).downloadLogs(any(), any());
+
+      assertThrows(RuntimeException.class,
+         () -> controller.downloadLogs(response, null));
+   }
+
+   // [G5] getLogLinks delegates to service with principal
+   @Test
+   void getLogLinks_delegatesWithPrincipal() {
+      LogViewLinks links = mock(LogViewLinks.class);
+      when(logMonitoringService.getLinks(principal)).thenReturn(links);
+
+      LogViewLinks result = controller.getLogLinks(principal);
+
+      assertSame(links, result);
+   }
+
+   // [G6] getAuditLinks delegates to service with principal
+   @Test
+   void getAuditLinks_delegatesWithPrincipal() {
+      LogViewLinks links = mock(LogViewLinks.class);
+      when(logMonitoringService.getLinks(principal)).thenReturn(links);
+
+      LogViewLinks result = controller.getAuditLinks(principal);
+
+      assertSame(links, result);
+   }
+
+   // [G7] STOMP permission denied → SecurityException; addSubscriber never called
+   @Test
+   void subscribeToLogRefresh_permissionDenied_throwsSecurityException() {
+      when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      when(securityProvider.checkPermission(
+            eq(principal), eq(ResourceType.EM_COMPONENT),
+            eq("monitoring/log"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      assertThrows(SecurityException.class,
+         () -> controller.subscribeToLogRefresh(
+            stompHeaderAccessor, "node1", "server.log", 0, 100, principal));
+
+      verifyNoInteractions(monitoringDataService);
+   }
+
+   // [G8] STOMP permission granted → addSubscriber invoked
+   @Test
+   void subscribeToLogRefresh_permissionGranted_delegatesToMonitoringDataService()
+      throws Exception
+   {
+      when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      when(securityProvider.checkPermission(
+            eq(principal), eq(ResourceType.EM_COMPONENT),
+            eq("monitoring/log"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(monitoringDataService.addSubscriber(same(stompHeaderAccessor), any())).thenReturn(null);
+
+      controller.subscribeToLogRefresh(stompHeaderAccessor, "node1", "server.log", 0, 100, principal);
+
+      verify(monitoringDataService).addSubscriber(same(stompHeaderAccessor), any());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/logviewer/LogSettingControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/logviewer/LogSettingControllerTest.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.logviewer;
+
+/*
+ * Test strategy
+ *
+ * LogSettingController is a thin delegation layer over LogSettingService.
+ * All permission enforcement is handled by the @Secured framework annotation
+ * and is not exercised at the unit level.
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] getLogSettings() returns the LogSettingsModel from the service.
+ * [G2] setLogSettings(model, principal) forwards both arguments to the service.
+ */
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class LogSettingControllerTest {
+
+   @Mock private LogSettingService logSettingService;
+   @Mock private Principal principal;
+
+   private LogSettingController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new LogSettingController(logSettingService);
+   }
+
+   // [G1] getLogSettings returns the model from the service
+   @Test
+   void getLogSettings_delegatesToService() {
+      LogSettingsModel model = mock(LogSettingsModel.class);
+      when(logSettingService.getConfiguration()).thenReturn(model);
+
+      assertSame(model, controller.getLogSettings());
+   }
+
+   // [G2] setLogSettings forwards model and principal to the service
+   @Test
+   void setLogSettings_delegatesModelAndPrincipalToService() {
+      LogSettingsModel model = mock(LogSettingsModel.class);
+
+      controller.setLogSettings(model, principal);
+
+      verify(logSettingService).setConfiguration(model, principal);
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/monitoring/MonitorLevelControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/monitoring/MonitorLevelControllerTest.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.monitoring;
+
+/*
+ * Test strategy
+ *
+ * MonitorLevelController exposes two entry points:
+ *
+ *   REST GET /api/em/monitoring/level — calls the static MonitorLevelService.getMonitorLevel()
+ *     and returns the integer result. Any exception from that call is caught and re-thrown as
+ *     RuntimeException.
+ *
+ *   STOMP @SubscribeMapping /monitoring/monitor-level — first checks the caller's EM permission;
+ *     denied → SecurityException; granted → delegates to MonitoringDataService.addSubscriber.
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] REST getMonitoringLevel returns the value from MonitorLevelService.getMonitorLevel().
+ * [G2] REST getMonitoringLevel wraps any exception from MonitorLevelService as RuntimeException.
+ * [G3] STOMP getMonitoringLevel: permission denied → SecurityException; addSubscriber not called.
+ * [G4] STOMP getMonitoringLevel: permission granted → addSubscriber invoked.
+ */
+
+import inetsoft.sree.security.*;
+import inetsoft.sree.security.SecurityException;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class MonitorLevelControllerTest {
+
+   @Mock private MonitoringDataService monitoringDataService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private StompHeaderAccessor stompHeaderAccessor;
+   @Mock private Principal principal;
+
+   private MonitorLevelController controller;
+   private MockedStatic<MonitorLevelService> monitorLevelServiceStatic;
+
+   @BeforeEach
+   void setUp() {
+      controller = new MonitorLevelController(monitoringDataService, securityEngine);
+      monitorLevelServiceStatic = mockStatic(MonitorLevelService.class, withSettings().lenient());
+      monitorLevelServiceStatic.when(MonitorLevelService::getMonitorLevel).thenReturn(1);
+   }
+
+   @AfterEach
+   void tearDown() {
+      monitorLevelServiceStatic.close();
+   }
+
+   // [G1] REST endpoint returns value from MonitorLevelService.getMonitorLevel()
+   @Test
+   void getMonitoringLevel_rest_returnsServiceLevel() {
+      monitorLevelServiceStatic.when(MonitorLevelService::getMonitorLevel).thenReturn(2);
+
+      int result = controller.getMonitoringLevel();
+
+      assertEquals(2, result);
+   }
+
+   // [G2] any exception from MonitorLevelService is re-thrown as RuntimeException
+   @Test
+   void getMonitoringLevel_rest_serviceThrows_wrappedAsRuntimeException() {
+      monitorLevelServiceStatic.when(MonitorLevelService::getMonitorLevel)
+         .thenThrow(new RuntimeException("config error"));
+
+      assertThrows(RuntimeException.class, () -> controller.getMonitoringLevel());
+   }
+
+   // [G3] STOMP subscribe: permission denied → SecurityException; addSubscriber not reached
+   @Test
+   void getMonitoringLevel_stomp_permissionDenied_throwsSecurityException() {
+      when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      when(securityProvider.checkPermission(
+            eq(principal), eq(ResourceType.EM), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      assertThrows(SecurityException.class,
+         () -> controller.getMonitoringLevel(stompHeaderAccessor, principal));
+
+      verifyNoInteractions(monitoringDataService);
+   }
+
+   // [G4] STOMP subscribe: permission granted → addSubscriber invoked
+   @Test
+   void getMonitoringLevel_stomp_permissionGranted_delegatesToMonitoringDataService()
+      throws Exception
+   {
+      when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      when(securityProvider.checkPermission(
+            eq(principal), eq(ResourceType.EM), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(monitoringDataService.addSubscriber(same(stompHeaderAccessor), any())).thenReturn(0);
+
+      controller.getMonitoringLevel(stompHeaderAccessor, principal);
+
+      verify(monitoringDataService).addSubscriber(same(stompHeaderAccessor), any());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/navbar/EmNavBarControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/navbar/EmNavBarControllerTest.java
@@ -1,0 +1,366 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.navbar;
+
+/*
+ * Test strategy
+ *
+ * EmNavBarController builds an EmNavBarModel from several independent concerns.
+ * Each field has its own in-controller logic worth verifying:
+ *
+ * --- logoutUrl ---
+ *   The controller reads sso.protocol.type and sso.logout.url from SreeEnv and applies
+ *   three rules:
+ *     [SSO, no '?'] protocol != NONE and configured URL has no '?' → appends "?fromEm=true"
+ *     [SSO, has '?'] protocol != NONE and URL already contains '?' → appends "&fromEm=true"
+ *     [no SSO / blank URL] protocol == NONE OR URL blank → uses DEFAULT_LOGOUT_URI
+ *
+ * --- ssoUser ---
+ *   [non-XPrincipal]        plain Principal → false
+ *   [XPrincipal internal]   __internal__ == "true" → false (managed/internal account)
+ *   [XPrincipal external]   __internal__ != "true" → true (federated/SSO user)
+ *
+ * --- elasticLicenseExhausted ---
+ *   [elastic, 0 hours]      elastic license and remaining hours == 0 → true
+ *   [elastic, hours left]   elastic license and remaining hours > 0 → false
+ *   [hosted, 0 hours]       hosted license and SRPrincipal with 0 remaining hours → true
+ *   [hosted, hours left]    hosted license and SRPrincipal with hours > 0 → false
+ *
+ * --- aiAssistantVisible ---
+ *   [service off]           aiSettingsService.isAiAssistantVisible() == false → false
+ *   [service on, permitted] service on AND permission granted → true
+ *   [service on, denied]    service on AND permission denied → false
+ *
+ * --- simple delegation endpoints ---
+ *   getCurrOrg      — returns OrganizationManager.getCurrentOrgID()
+ *   isMultiTenant   — returns SUtil.isMultiTenant()
+ *   isOrgAdminOnly  — isOrgAdmin && !isSiteAdmin
+ *   isSiteAdmin     — delegates to OrganizationManager.isSiteAdmin()
+ *   getUserInfo     — returns (orgId, isSiteAdmin) pair
+ */
+
+import inetsoft.report.internal.license.LicenseManager;
+import inetsoft.sree.SreeEnv;
+import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.portal.PortalThemesManager;
+import inetsoft.sree.security.*;
+import inetsoft.uql.XPrincipal;
+import inetsoft.web.admin.presentation.AISettingsService;
+import inetsoft.web.admin.security.SSOType;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class EmNavBarControllerTest {
+
+   @Mock private AISettingsService aiSettingsService;
+   @Mock private LicenseManager licenseManager;
+   @Mock private PortalThemesManager portalThemesManager;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private OrganizationManager orgManager;
+
+   private EmNavBarController controller;
+   private MockedStatic<SreeEnv> sreeEnvStatic;
+   private MockedStatic<LicenseManager> licenseManagerStatic;
+   private MockedStatic<OrganizationManager> orgManagerStatic;
+   private MockedStatic<SUtil> sUtilStatic;
+
+   @BeforeEach
+   void setUp() {
+      controller = new EmNavBarController(
+         aiSettingsService, licenseManager, portalThemesManager, securityEngine);
+
+      sreeEnvStatic = mockStatic(SreeEnv.class, withSettings().lenient());
+      licenseManagerStatic = mockStatic(LicenseManager.class, withSettings().lenient());
+      orgManagerStatic = mockStatic(OrganizationManager.class, withSettings().lenient());
+      sUtilStatic = mockStatic(SUtil.class, withSettings().lenient());
+
+      // safe defaults so unrelated tests don't need to stub everything
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("sso.protocol.type"))
+         .thenReturn(SSOType.NONE.getName());
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("sso.logout.url")).thenReturn("");
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("em.home.link", "..")).thenReturn("..");
+      licenseManagerStatic.when(LicenseManager::isEnterprise).thenReturn(false);
+      orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+      lenient().when(orgManager.getCurrentOrgID()).thenReturn("testOrg");
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnvStatic.close();
+      licenseManagerStatic.close();
+      orgManagerStatic.close();
+      sUtilStatic.close();
+   }
+
+   // -------------------------------------------------------------------------
+   // logoutUrl
+   // -------------------------------------------------------------------------
+
+   // [no SSO] protocol == NONE → DEFAULT_LOGOUT_URI used regardless of configured URL
+   @Test
+   void getNavBarModel_noSso_usesDefaultLogoutUri() throws Exception {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("sso.protocol.type"))
+         .thenReturn(SSOType.NONE.getName());
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("sso.logout.url"))
+         .thenReturn("https://idp.example.com/logout");
+
+      EmNavBarModel model = controller.getNavBarModel(mock(Principal.class));
+
+      assertEquals("../logout?fromEm=true", model.logoutUrl());
+   }
+
+   // [SSO, no '?'] configured URL without '?' → "?fromEm=true" appended
+   @Test
+   void getNavBarModel_ssoWithoutQueryString_appendsQuestionMarkParam() throws Exception {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("sso.protocol.type")).thenReturn("SAML2");
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("sso.logout.url"))
+         .thenReturn("https://idp.example.com/logout");
+
+      EmNavBarModel model = controller.getNavBarModel(mock(Principal.class));
+
+      assertEquals("https://idp.example.com/logout?fromEm=true", model.logoutUrl());
+   }
+
+   // [SSO, has '?'] configured URL already contains '?' → "&fromEm=true" appended
+   @Test
+   void getNavBarModel_ssoWithExistingQueryString_appendsAmpersandParam() throws Exception {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("sso.protocol.type")).thenReturn("SAML2");
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("sso.logout.url"))
+         .thenReturn("https://idp.example.com/logout?session=abc");
+
+      EmNavBarModel model = controller.getNavBarModel(mock(Principal.class));
+
+      assertEquals("https://idp.example.com/logout?session=abc&fromEm=true", model.logoutUrl());
+   }
+
+   // [blank URL] protocol is not NONE but URL is blank → DEFAULT_LOGOUT_URI
+   @Test
+   void getNavBarModel_ssoBlankLogoutUrl_usesDefaultLogoutUri() throws Exception {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("sso.protocol.type")).thenReturn("SAML2");
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("sso.logout.url")).thenReturn("");
+
+      EmNavBarModel model = controller.getNavBarModel(mock(Principal.class));
+
+      assertEquals("../logout?fromEm=true", model.logoutUrl());
+   }
+
+   // -------------------------------------------------------------------------
+   // ssoUser
+   // -------------------------------------------------------------------------
+
+   // [non-XPrincipal] plain Principal → ssoUser is false
+   @Test
+   void getNavBarModel_plainPrincipal_ssoUserIsFalse() throws Exception {
+      EmNavBarModel model = controller.getNavBarModel(mock(Principal.class));
+
+      assertFalse(model.ssoUser());
+   }
+
+   // [XPrincipal internal] __internal__ == "true" → ssoUser is false
+   @Test
+   void getNavBarModel_internalXPrincipal_ssoUserIsFalse() throws Exception {
+      XPrincipal principal = mock(XPrincipal.class);
+      when(principal.getProperty("__internal__")).thenReturn("true");
+
+      EmNavBarModel model = controller.getNavBarModel(principal);
+
+      assertFalse(model.ssoUser());
+   }
+
+   // [XPrincipal external] __internal__ != "true" → ssoUser is true
+   @Test
+   void getNavBarModel_externalXPrincipal_ssoUserIsTrue() throws Exception {
+      XPrincipal principal = mock(XPrincipal.class);
+      when(principal.getProperty("__internal__")).thenReturn(null);
+
+      EmNavBarModel model = controller.getNavBarModel(principal);
+
+      assertTrue(model.ssoUser());
+   }
+
+   // -------------------------------------------------------------------------
+   // elasticLicenseExhausted
+   // -------------------------------------------------------------------------
+
+   // [elastic, 0 hours] → exhausted
+   @Test
+   void getNavBarModel_elasticLicenseNoHoursRemaining_exhaustedIsTrue() throws Exception {
+      when(licenseManager.isElasticLicense()).thenReturn(true);
+      when(licenseManager.getElasticRemainingHours()).thenReturn(0);
+
+      EmNavBarModel model = controller.getNavBarModel(mock(Principal.class));
+
+      assertTrue(model.elasticLicenseExhausted());
+   }
+
+   // [elastic, hours left] → not exhausted
+   @Test
+   void getNavBarModel_elasticLicenseHoursRemaining_exhaustedIsFalse() throws Exception {
+      when(licenseManager.isElasticLicense()).thenReturn(true);
+      when(licenseManager.getElasticRemainingHours()).thenReturn(5);
+
+      EmNavBarModel model = controller.getNavBarModel(mock(Principal.class));
+
+      assertFalse(model.elasticLicenseExhausted());
+   }
+
+   // [hosted, 0 hours] SRPrincipal with zero remaining hours → exhausted
+   @Test
+   void getNavBarModel_hostedLicenseNoHoursRemaining_exhaustedIsTrue() throws Exception {
+      when(licenseManager.isElasticLicense()).thenReturn(false);
+      when(licenseManager.isHostedLicense()).thenReturn(true);
+      SRPrincipal principal = mock(SRPrincipal.class);
+      when(principal.getOrgId()).thenReturn("org1");
+      when(principal.getName()).thenReturn("user1");
+      when(licenseManager.getHostedRemainingHours("org1", "user1")).thenReturn(0);
+
+      EmNavBarModel model = controller.getNavBarModel(principal);
+
+      assertTrue(model.elasticLicenseExhausted());
+   }
+
+   // [hosted, hours left] SRPrincipal with remaining hours → not exhausted
+   @Test
+   void getNavBarModel_hostedLicenseHoursRemaining_exhaustedIsFalse() throws Exception {
+      when(licenseManager.isElasticLicense()).thenReturn(false);
+      when(licenseManager.isHostedLicense()).thenReturn(true);
+      SRPrincipal principal = mock(SRPrincipal.class);
+      when(principal.getOrgId()).thenReturn("org1");
+      when(principal.getName()).thenReturn("user1");
+      when(licenseManager.getHostedRemainingHours("org1", "user1")).thenReturn(3);
+
+      EmNavBarModel model = controller.getNavBarModel(principal);
+
+      assertFalse(model.elasticLicenseExhausted());
+   }
+
+   // -------------------------------------------------------------------------
+   // aiAssistantVisible
+   // -------------------------------------------------------------------------
+
+   // [service off] isAiAssistantVisible() == false → field is false; permission not checked
+   @Test
+   void getNavBarModel_aiServiceOff_aiAssistantNotVisible() throws Exception {
+      when(aiSettingsService.isAiAssistantVisible()).thenReturn(false);
+
+      EmNavBarModel model = controller.getNavBarModel(mock(Principal.class));
+
+      assertFalse(model.aiAssistantVisible());
+      verify(securityEngine, never()).checkPermission(any(), any(), anyString(), any());
+   }
+
+   // [service on, permitted] service on AND permission granted → true
+   @Test
+   void getNavBarModel_aiServiceOnAndPermitted_aiAssistantVisible() throws Exception {
+      when(aiSettingsService.isAiAssistantVisible()).thenReturn(true);
+      when(securityEngine.checkPermission(
+            any(), eq(ResourceType.AI_ASSISTANT), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      EmNavBarModel model = controller.getNavBarModel(mock(Principal.class));
+
+      assertTrue(model.aiAssistantVisible());
+   }
+
+   // [service on, denied] service on AND permission denied → false
+   @Test
+   void getNavBarModel_aiServiceOnButDenied_aiAssistantNotVisible() throws Exception {
+      when(aiSettingsService.isAiAssistantVisible()).thenReturn(true);
+      when(securityEngine.checkPermission(
+            any(), eq(ResourceType.AI_ASSISTANT), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      EmNavBarModel model = controller.getNavBarModel(mock(Principal.class));
+
+      assertFalse(model.aiAssistantVisible());
+   }
+
+   // -------------------------------------------------------------------------
+   // Simple delegation endpoints
+   // -------------------------------------------------------------------------
+
+   // getCurrOrg returns the current org ID from OrganizationManager
+   @Test
+   void getCurrOrg_returnsCurrentOrgId() {
+      when(orgManager.getCurrentOrgID()).thenReturn("acmeOrg");
+
+      String result = controller.getCurrOrg(mock(Principal.class));
+
+      assertEquals("acmeOrg", result);
+   }
+
+   // isMultiTenant delegates to SUtil.isMultiTenant()
+   @Test
+   void isMultiTenant_delegatesToSUtil() {
+      sUtilStatic.when(SUtil::isMultiTenant).thenReturn(true);
+
+      assertTrue(controller.isMultiTenant(mock(Principal.class)));
+   }
+
+   // isOrgAdminOnly: org admin AND not site admin → true
+   @Test
+   void isOrgAdminOnly_orgAdminNotSiteAdmin_returnsTrue() {
+      Principal principal = mock(Principal.class);
+      when(orgManager.isOrgAdmin(principal)).thenReturn(true);
+      when(orgManager.isSiteAdmin(principal)).thenReturn(false);
+
+      assertTrue(controller.isOrgAdminOnly(principal));
+   }
+
+   // isOrgAdminOnly: site admin → false even if also org admin
+   @Test
+   void isOrgAdminOnly_siteAdmin_returnsFalse() {
+      Principal principal = mock(Principal.class);
+      when(orgManager.isOrgAdmin(principal)).thenReturn(true);
+      when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+
+      assertFalse(controller.isOrgAdminOnly(principal));
+   }
+
+   // isSiteAdmin delegates to OrganizationManager.isSiteAdmin
+   @Test
+   void isSiteAdmin_delegatesToOrgManager() {
+      Principal principal = mock(Principal.class);
+      when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+
+      assertTrue(controller.isSiteAdmin(principal));
+   }
+
+   // getUserInfo returns orgId and isSiteAdmin from OrganizationManager
+   @Test
+   void getUserInfo_returnsOrgIdAndSiteAdminFlag() {
+      Principal principal = mock(Principal.class);
+      when(orgManager.getCurrentOrgID()).thenReturn("myOrg");
+      when(orgManager.isSiteAdmin(principal)).thenReturn(false);
+
+      var result = controller.getUserInfo(principal);
+
+      assertEquals("myOrg", result.getKey());
+      assertEquals(false, result.getValue());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/pageheader/EmPageHeaderControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/pageheader/EmPageHeaderControllerTest.java
@@ -17,72 +17,163 @@
  */
 package inetsoft.web.admin.pageheader;
 
+/*
+ * Test strategy
+ *
+ * EmPageHeaderController has two endpoints with testable in-controller logic:
+ *
+ * --- getPageHeaderModel ---
+ *   The method conditionally builds an org list for site administrators.
+ *   XUtil.getSecurityProvider() — called on the site-admin path — cannot be mocked
+ *   statically in this environment, so only the non-site-admin gate is unit-tested here:
+ *
+ *     [security disabled]  isSecurityEnabled() == false → orgs/orgIDs/currOrgID all null
+ *     [non-site admin]     security on, isSiteAdmin() == false → same nulls; XUtil not reached
+ *
+ * --- setCurrOrg ---
+ *     [non-site admin]            security on, isSiteAdmin() == false → returns early;
+ *                                 cluster message not sent
+ *     [site admin]                principal properties updated; cluster.sendMessage() called
+ *     [storage not initialized]   dataSourceRegistry.init() and mvManager.initMVDefMap() called;
+ *                                 indexedStorage.setInitialized() called
+ */
+
+import inetsoft.mv.MVManager;
 import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.internal.cluster.Cluster;
 import inetsoft.sree.security.*;
-import inetsoft.test.*;
-import inetsoft.util.Tool;
+import inetsoft.uql.XPrincipal;
+import inetsoft.uql.service.DataSourceRegistry;
+import inetsoft.uql.util.ConnectionProcessor;
+import inetsoft.util.IndexedStorage;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@SreeHome()
-@Disabled
 @Tag("core")
+@ExtendWith(MockitoExtension.class)
 class EmPageHeaderControllerTest {
-   @Autowired SecurityEngine engine;
-   FileAuthenticationProvider provider;
+
+   @Mock private SecurityEngine securityEngine;
+   @Mock private Cluster cluster;
+   @Mock private DataSourceRegistry dataSourceRegistry;
+   @Mock private MVManager mvManager;
+   @Mock private IndexedStorage indexedStorage;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private OrganizationManager orgManager;
+   @Mock private XPrincipal xPrincipal;
+
+   private EmPageHeaderController controller;
+   private MockedStatic<SUtil> sUtilStatic;
+   private MockedStatic<OrganizationManager> orgManagerStatic;
+   private MockedStatic<ConnectionProcessor> connectionProcessorStatic;
 
    @BeforeEach
-   void before() throws Exception {
-      engine.enableSecurity();
-      SUtil.setMultiTenant(true);
+   void setUp() {
+      controller = new EmPageHeaderController(
+         securityEngine, cluster, dataSourceRegistry, mvManager, indexedStorage);
 
-      AuthenticationChain chain =
-         (AuthenticationChain) engine.getSecurityProvider().getAuthenticationProvider();
-      provider = (FileAuthenticationProvider) chain.getProviders().getFirst();
+      sUtilStatic = mockStatic(SUtil.class, withSettings().lenient());
+      orgManagerStatic = mockStatic(OrganizationManager.class, withSettings().lenient());
+      connectionProcessorStatic = mockStatic(ConnectionProcessor.class, withSettings().lenient());
 
-      FSUser org_admin = new FSUser(new IdentityID("org_admin", "org0"));
-      org_admin.setRoles(new IdentityID[] {new IdentityID("Organization Administrator", null)});
-      provider.addUser(org_admin);
-
-      FSOrganization org0 = new FSOrganization("org0", "org0", null, null);
-      org0.setMembers(new String[] {"org_admin"});
-      provider.addOrganization(org0);
-
-      FSUser sys_admin = new FSUser(new IdentityID("sys_admin", "host-org"));
-      sys_admin.setRoles(new IdentityID[] {new IdentityID("Administrator", null)});
-      provider.addUser(sys_admin);
-      provider.getOrganization("host-org").setMembers(new String[]{"sys_admin"});
+      sUtilStatic.when(SUtil::isMultiTenant).thenReturn(false);
+      orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
    }
 
+   @AfterEach
+   void tearDown() {
+      sUtilStatic.close();
+      orgManagerStatic.close();
+      connectionProcessorStatic.close();
+   }
+
+   // -------------------------------------------------------------------------
+   // getPageHeaderModel
+   // -------------------------------------------------------------------------
+
+   // [security disabled] isSecurityEnabled() == false → all org fields are null
    @Test
-   void checkDiffUserForPageHeader() throws Exception {
-      EmPageHeaderController emPageHeaderController = new EmPageHeaderController(engine, null, null, null, null);
+   void getPageHeaderModel_securityDisabled_returnsNullOrgs() throws Exception {
+      when(securityEngine.isSecurityEnabled()).thenReturn(false);
 
-      SRPrincipal org_admin = new SRPrincipal(new IdentityID("org_admin", "org0"), new IdentityID[] {new IdentityID("Organization Administrator", null)},
-                                              new String[0], "org0",
-                                              Tool.getSecureRandom().nextLong());
-      EmPageHeaderModel orgEmPageModel =
-         emPageHeaderController.getPageHeaderModel("Primary", false, org_admin);
-      assertNull(orgEmPageModel.currOrgID());
+      EmPageHeaderModel model = controller.getPageHeaderModel("Primary", false, mock(Principal.class));
 
-      IdentityID[] administrator = {new IdentityID("Administrator", null)};
-      SRPrincipal sys_admin = new SRPrincipal(new IdentityID("sys_admin", Organization.getDefaultOrganizationID()), administrator, new String[0],
-                                              Organization.getDefaultOrganizationID(),
-                                              Tool.getSecureRandom().nextLong());
-      EmPageHeaderModel emPageHeaderModel =
-         emPageHeaderController.getPageHeaderModel("Primary", false, sys_admin);
-      String[] expOrgs = {"host-org", "template-org", "SELF", "org0"};
+      assertNull(model.orgs());
+      assertNull(model.orgIDs());
+      assertNull(model.currOrgID());
+   }
 
-      assertArrayEquals(expOrgs, emPageHeaderModel.orgIDs().toArray(new String[0]));
-      assertEquals("host-org", emPageHeaderModel.currOrgID());
+   // [non-site admin] security enabled, isSiteAdmin == false → all org fields are null
+   @Test
+   void getPageHeaderModel_nonSiteAdmin_returnsNullOrgs() throws Exception {
+      when(securityEngine.isSecurityEnabled()).thenReturn(true);
+      when(orgManager.isSiteAdmin(xPrincipal)).thenReturn(false);
+
+      EmPageHeaderModel model = controller.getPageHeaderModel("Primary", false, xPrincipal);
+
+      assertNull(model.orgs());
+      assertNull(model.orgIDs());
+      assertNull(model.currOrgID());
+   }
+
+   // -------------------------------------------------------------------------
+   // setCurrOrg
+   // -------------------------------------------------------------------------
+
+   // [non-site admin] returns early without sending cluster message
+   @Test
+   void setCurrOrg_nonSiteAdmin_doesNotSendClusterMessage() throws Exception {
+      when(securityEngine.isSecurityEnabled()).thenReturn(true);
+      when(orgManager.isSiteAdmin(xPrincipal)).thenReturn(false);
+
+      controller.setCurrOrg(new EmPageHeaderModel(null, null, "org1", "Primary", false), xPrincipal);
+
+      verify(cluster, never()).sendMessage(any());
+   }
+
+   // [site admin] principal properties updated; cluster message sent
+   @Test
+   void setCurrOrg_siteAdmin_updatesPropertiesAndSendsMessage() throws Exception {
+      when(securityEngine.isSecurityEnabled()).thenReturn(true);
+      when(orgManager.isSiteAdmin(xPrincipal)).thenReturn(true);
+      when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      when(securityProvider.getOrgNameFromID("org1")).thenReturn("Org One");
+      when(xPrincipal.getSessionID()).thenReturn("session-123");
+      when(indexedStorage.isInitialized("org1")).thenReturn(true);
+      ConnectionProcessor connProcessor = mock(ConnectionProcessor.class);
+      connectionProcessorStatic.when(ConnectionProcessor::getInstance).thenReturn(connProcessor);
+
+      controller.setCurrOrg(new EmPageHeaderModel(null, null, "org1", "Primary", false), xPrincipal);
+
+      verify(xPrincipal).setProperty("curr_org_id", "org1");
+      verify(xPrincipal).setProperty("curr_provider_name", "Primary");
+      verify(cluster).sendMessage(any());
+   }
+
+   // [storage not initialized] dataSourceRegistry and mvManager init delegated; storage marked initialized
+   @Test
+   void setCurrOrg_storageNotInitialized_initializesStorage() throws Exception {
+      when(securityEngine.isSecurityEnabled()).thenReturn(true);
+      when(orgManager.isSiteAdmin(xPrincipal)).thenReturn(true);
+      when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      when(securityProvider.getOrgNameFromID("org1")).thenReturn("Org One");
+      when(xPrincipal.getSessionID()).thenReturn("session-123");
+      when(indexedStorage.isInitialized("org1")).thenReturn(false);
+      ConnectionProcessor connProcessor = mock(ConnectionProcessor.class);
+      connectionProcessorStatic.when(ConnectionProcessor::getInstance).thenReturn(connProcessor);
+
+      controller.setCurrOrg(new EmPageHeaderModel(null, null, "org1", "Primary", false), xPrincipal);
+
+      verify(dataSourceRegistry).init();
+      verify(mvManager).initMVDefMap();
+      verify(indexedStorage).setInitialized("org1");
    }
 }

--- a/core/src/test/java/inetsoft/web/admin/presentation/LookAndFeelSettingsControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/presentation/LookAndFeelSettingsControllerTest.java
@@ -1,0 +1,139 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.presentation;
+
+/*
+ * Test strategy
+ *
+ * LookAndFeelSettingsController.getIdentities() queries SecurityProvider for all
+ * users, groups, and roles, then filters each list to those for which the
+ * calling principal has ResourceAction.ADMIN permission.  The resource type
+ * used for the permission check differs per collection:
+ *
+ *   users  → ResourceType.SECURITY_USER   + ADMIN
+ *   groups → ResourceType.SECURITY_GROUP  + ADMIN
+ *   roles  → ResourceType.SECURITY_USER   + ADMIN  (same type as users, not SECURITY_ROLE)
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] Users for which checkPermission returns true are included; others are excluded.
+ * [G2] Groups for which checkPermission returns true are included; others are excluded.
+ * [G3] Roles are filtered against ResourceType.SECURITY_USER (not SECURITY_ROLE).
+ */
+
+import inetsoft.sree.security.*;
+import inetsoft.web.admin.presentation.model.GetAllIdentitiesResponse;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class LookAndFeelSettingsControllerTest {
+
+   @Mock private SecurityProvider securityProvider;
+   @Mock private Principal principal;
+
+   private LookAndFeelSettingsController<?, ?> controller;
+
+   private final IdentityID permittedUser  = new IdentityID("alice", "org1");
+   private final IdentityID deniedUser     = new IdentityID("bob",   "org1");
+   private final IdentityID permittedGroup = new IdentityID("admins", "org1");
+   private final IdentityID deniedGroup    = new IdentityID("guests", "org1");
+   private final IdentityID permittedRole  = new IdentityID("Manager", "org1");
+   private final IdentityID deniedRole     = new IdentityID("Viewer",  "org1");
+
+   @BeforeEach
+   void setUp() {
+      controller = new LookAndFeelSettingsController<>(securityProvider);
+
+      // users
+      lenient().when(securityProvider.getUsers())
+         .thenReturn(new IdentityID[]{ permittedUser, deniedUser });
+      lenient().when(securityProvider.checkPermission(
+            principal, ResourceType.SECURITY_USER,
+            permittedUser.convertToKey(), ResourceAction.ADMIN))
+         .thenReturn(true);
+      lenient().when(securityProvider.checkPermission(
+            principal, ResourceType.SECURITY_USER,
+            deniedUser.convertToKey(), ResourceAction.ADMIN))
+         .thenReturn(false);
+
+      // groups
+      lenient().when(securityProvider.getGroups())
+         .thenReturn(new IdentityID[]{ permittedGroup, deniedGroup });
+      lenient().when(securityProvider.checkPermission(
+            principal, ResourceType.SECURITY_GROUP,
+            permittedGroup.convertToKey(), ResourceAction.ADMIN))
+         .thenReturn(true);
+      lenient().when(securityProvider.checkPermission(
+            principal, ResourceType.SECURITY_GROUP,
+            deniedGroup.convertToKey(), ResourceAction.ADMIN))
+         .thenReturn(false);
+
+      // roles — filtered via SECURITY_USER type, same as users
+      lenient().when(securityProvider.getRoles())
+         .thenReturn(new IdentityID[]{ permittedRole, deniedRole });
+      lenient().when(securityProvider.checkPermission(
+            principal, ResourceType.SECURITY_USER,
+            permittedRole.convertToKey(), ResourceAction.ADMIN))
+         .thenReturn(true);
+      lenient().when(securityProvider.checkPermission(
+            principal, ResourceType.SECURITY_USER,
+            deniedRole.convertToKey(), ResourceAction.ADMIN))
+         .thenReturn(false);
+   }
+
+   // [G1] only users with ADMIN permission on SECURITY_USER are included
+   @Test
+   void getIdentities_usersFilteredByAdminPermission() {
+      GetAllIdentitiesResponse response = controller.getIdentities(principal);
+
+      assertTrue(response.users().contains(permittedUser));
+      assertFalse(response.users().contains(deniedUser));
+   }
+
+   // [G2] only groups with ADMIN permission on SECURITY_GROUP are included
+   @Test
+   void getIdentities_groupsFilteredByAdminPermissionOnSecurityGroup() {
+      GetAllIdentitiesResponse response = controller.getIdentities(principal);
+
+      assertTrue(response.groups().contains(permittedGroup));
+      assertFalse(response.groups().contains(deniedGroup));
+   }
+
+   // [G3] roles are filtered using ResourceType.SECURITY_USER, not SECURITY_ROLE
+   @Test
+   void getIdentities_rolesPermissionCheckedWithSecurityUserType() {
+      GetAllIdentitiesResponse response = controller.getIdentities(principal);
+
+      assertTrue(response.roles().contains(permittedRole));
+      assertFalse(response.roles().contains(deniedRole));
+
+      // confirm SECURITY_USER type was used (not SECURITY_ROLE)
+      verify(securityProvider, atLeastOnce()).checkPermission(
+         eq(principal), eq(ResourceType.SECURITY_USER),
+         eq(permittedRole.convertToKey()), eq(ResourceAction.ADMIN));
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/presentation/PresentationSettingsControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/presentation/PresentationSettingsControllerTest.java
@@ -1,0 +1,310 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.presentation;
+
+/*
+ * Test strategy
+ *
+ * PresentationSettingsController has three endpoints sharing a "globalProperty /
+ * globalSettings" flag that controls whether global-only or org-scoped sub-models
+ * are read and written.
+ *
+ * --- getSettings ---
+ *   globalProperty = (isSiteAdmin && !orgSettings) || !securityEnabled
+ *                    || (securityEnabled && !isMultiTenant)
+ *     [site admin, orgSettings=false]           globalProperty=true
+ *     [site admin, orgSettings=true + MT + sec] globalProperty=false → orgSettings=true in result
+ *     [invalid org]                             InvalidOrgException thrown
+ *
+ * --- applySettings ---
+ *   globalSettings controls whether fontMapping and AI setters are called:
+ *     [global]     fontMappingSettingsService.setModel and aiSettingsService.setModel called
+ *     [non-global] those two services skipped even when non-null sub-models present
+ *   Distributed lock acquired and released around service calls.
+ *
+ * --- resetSettings ---
+ *   Same globalSettings gate for fontMapping and AI:
+ *     [global]     fontMappingSettingsService.resetSettings and aiSettingsService.resetSettings called
+ *     [non-global] those two services skipped
+ */
+
+import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.internal.cluster.Cluster;
+import inetsoft.sree.security.*;
+import inetsoft.util.InvalidOrgException;
+import inetsoft.web.admin.content.dataspace.DataSpaceContentSettingsService;
+import inetsoft.web.admin.general.WebMapSettingsService;
+import inetsoft.web.admin.general.model.WebMapSettingsModel;
+import inetsoft.web.admin.presentation.model.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.concurrent.locks.Lock;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class PresentationSettingsControllerTest {
+
+   @Mock private PresentationFormatsSettingsService formatsSettingsService;
+   @Mock private LookAndFeelService lookAndFeelService;
+   @Mock private WelcomePageService welcomePageService;
+   @Mock private PresentationLoginBannerSettingsService loginBannerSettingsService;
+   @Mock private PresentationToolbarSettingsService toolbarSettingsService;
+   @Mock private PortalIntegrationViewSettingsService portalIntegrationViewSettingsService;
+   @Mock private PresentationDashboardSettingsService dashboardSettingsService;
+   @Mock private PresentationPdfGenerationSettingsService pdfGenerationSettingsService;
+   @Mock private ExportMenuSettingsService exportMenuSettingsService;
+   @Mock private PresentationFontMappingSettingsService fontMappingSettingsService;
+   @Mock private ShareSettingsService shareSettingsService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private PresentationComposerMessageSettingsService composerMessageSettingsService;
+   @Mock private PresentationTimeSettingsService timeSettingsService;
+   @Mock private PresentationDataSourceVisibilitySettingsService dataSourceVisibilitySettingsService;
+   @Mock private WebMapSettingsService webMapSettingsService;
+   @Mock private DataSpaceContentSettingsService dataSpaceContentSettingsService;
+   @Mock private AISettingsService aiSettingsService;
+   @Mock private Cluster cluster;
+   @Mock private Lock settingsLock;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private OrganizationManager orgManager;
+   @Mock private Organization organization;
+   @Mock private Principal principal;
+
+   private PresentationSettingsController controller;
+   private MockedStatic<SUtil> sUtilStatic;
+   private MockedStatic<OrganizationManager> orgManagerStatic;
+
+   @BeforeEach
+   void setUp() {
+      controller = new PresentationSettingsController(
+         formatsSettingsService, lookAndFeelService, welcomePageService,
+         loginBannerSettingsService, toolbarSettingsService,
+         portalIntegrationViewSettingsService, dashboardSettingsService,
+         pdfGenerationSettingsService, exportMenuSettingsService,
+         fontMappingSettingsService, shareSettingsService, securityEngine,
+         composerMessageSettingsService, timeSettingsService,
+         dataSourceVisibilitySettingsService, webMapSettingsService,
+         dataSpaceContentSettingsService, aiSettingsService, cluster);
+
+      sUtilStatic = mockStatic(SUtil.class, withSettings().lenient());
+      orgManagerStatic = mockStatic(OrganizationManager.class, withSettings().lenient());
+      orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+
+      // safe defaults
+      lenient().when(principal.getName()).thenReturn("user");
+      lenient().when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      lenient().when(securityProvider.isVirtual()).thenReturn(false);    // security enabled
+      lenient().when(securityProvider.getOrganization(any())).thenReturn(organization);
+      lenient().when(orgManager.getCurrentOrgID()).thenReturn("org1");
+      sUtilStatic.when(SUtil::isMultiTenant).thenReturn(true);
+      lenient().when(cluster.getLock(any())).thenReturn(settingsLock);
+   }
+
+   @AfterEach
+   void tearDown() {
+      sUtilStatic.close();
+      orgManagerStatic.close();
+   }
+
+   // -------------------------------------------------------------------------
+   // getSettings — globalProperty flag
+   // -------------------------------------------------------------------------
+
+   // [site admin, orgSettings=false] globalProperty=true → orgSettings field false in result
+   @Test
+   void getSettings_siteAdminOrgSettingsFalse_globalPropertyTrue() {
+      when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+      stubAllGetters(true);
+
+      PresentationSettingsModel result = controller.getSettings(principal, false);
+
+      assertFalse(result.orgSettings());
+      verify(lookAndFeelService).getModel(principal, true);
+      verify(aiSettingsService).getModel();    // aiSettingsModel only included when global
+   }
+
+   // [site admin, orgSettings=true, security enabled, multi-tenant] globalProperty=false
+   @Test
+   void getSettings_siteAdminOrgSettingsTrue_multiTenant_globalPropertyFalse() {
+      when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+      stubAllGetters(false);
+
+      PresentationSettingsModel result = controller.getSettings(principal, true);
+
+      assertTrue(result.orgSettings());
+      verify(lookAndFeelService).getModel(principal, false);
+      verify(aiSettingsService, never()).getModel(); // AI skipped when non-global
+   }
+
+   // [invalid org] getOrganization returns null → InvalidOrgException
+   @Test
+   void getSettings_invalidOrg_throwsInvalidOrgException() {
+      when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+      when(securityProvider.getOrganization(any())).thenReturn(null);
+
+      assertThrows(InvalidOrgException.class,
+         () -> controller.getSettings(principal, false));
+   }
+
+   // -------------------------------------------------------------------------
+   // applySettings — lock + globalSettings gate
+   // -------------------------------------------------------------------------
+
+   // [global] fontMapping and AI setters called when globalSettings=true
+   @Test
+   void applySettings_globalSettings_callsFontMappingAndAi() throws Exception {
+      when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+      stubAllGetters(true);
+
+      PresentationFontMappingSettingsModel fontModel = mock(PresentationFontMappingSettingsModel.class);
+      PresentationAISettingsModel aiModel = mock(PresentationAISettingsModel.class);
+
+      PresentationSettingsModel input = PresentationSettingsModel.builder()
+         .orgSettings(false)
+         .fontMappingSettingsModel(fontModel)
+         .aiSettingsModel(aiModel)
+         .build();
+
+      controller.applySettings(input, principal);
+
+      verify(fontMappingSettingsService).setModel(fontModel);
+      verify(aiSettingsService).setModel(aiModel);
+   }
+
+   // [non-global] fontMapping and AI setters skipped when globalSettings=false
+   @Test
+   void applySettings_nonGlobalSettings_skipsFontMappingAndAi() throws Exception {
+      when(orgManager.isSiteAdmin(principal)).thenReturn(false);
+      sUtilStatic.when(SUtil::isMultiTenant).thenReturn(true);
+      when(securityProvider.isVirtual()).thenReturn(false);
+      stubAllGetters(false);
+
+      PresentationFontMappingSettingsModel fontModel = mock(PresentationFontMappingSettingsModel.class);
+      PresentationAISettingsModel aiModel = mock(PresentationAISettingsModel.class);
+
+      PresentationSettingsModel input = PresentationSettingsModel.builder()
+         .orgSettings(true)
+         .fontMappingSettingsModel(fontModel)
+         .aiSettingsModel(aiModel)
+         .build();
+
+      controller.applySettings(input, principal);
+
+      verify(fontMappingSettingsService, never()).setModel(any());
+      verify(aiSettingsService, never()).setModel(any());
+   }
+
+   // lock is acquired and released around service calls
+   @Test
+   void applySettings_acquiresAndReleasesLock() throws Exception {
+      when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+      stubAllGetters(true);
+
+      controller.applySettings(
+         PresentationSettingsModel.builder().orgSettings(false).build(), principal);
+
+      InOrder order = inOrder(settingsLock);
+      order.verify(settingsLock).lock();
+      order.verify(settingsLock).unlock();
+   }
+
+   // -------------------------------------------------------------------------
+   // resetSettings — globalSettings gate for fontMapping and AI
+   // -------------------------------------------------------------------------
+
+   // [global] fontMapping and AI reset methods called
+   @Test
+   void resetSettings_globalSettings_resetsFontMappingAndAi() throws Exception {
+      when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+      stubAllGetters(true);
+
+      controller.resetSettings(
+         PresentationSettingsModel.builder().orgSettings(false).build(), principal);
+
+      verify(fontMappingSettingsService).resetSettings();
+      verify(aiSettingsService).resetSettings();
+   }
+
+   // [non-global] fontMapping and AI reset skipped
+   @Test
+   void resetSettings_nonGlobalSettings_skipsFontMappingAndAiReset() throws Exception {
+      when(orgManager.isSiteAdmin(principal)).thenReturn(false);
+      when(securityProvider.isVirtual()).thenReturn(false);
+      sUtilStatic.when(SUtil::isMultiTenant).thenReturn(true);
+      stubAllGetters(false);
+
+      // checkPermission returns false so the "non-MT override" doesn't flip globalSettings
+      lenient().when(securityProvider.checkPermission(
+            any(), eq(ResourceType.EM), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      controller.resetSettings(
+         PresentationSettingsModel.builder().orgSettings(true).build(), principal);
+
+      verify(fontMappingSettingsService, never()).resetSettings();
+      verify(aiSettingsService, never()).resetSettings();
+   }
+
+   // -------------------------------------------------------------------------
+   // helpers
+   // -------------------------------------------------------------------------
+
+   private void stubAllGetters(boolean global) {
+      lenient().when(lookAndFeelService.getModel(any(), eq(global)))
+         .thenReturn(mock(LookAndFeelSettingsModel.class));
+      lenient().when(welcomePageService.getModel(global))
+         .thenReturn(mock(WelcomePageSettingsModel.class));
+      lenient().when(formatsSettingsService.getModel(global))
+         .thenReturn(mock(PresentationFormatsSettingsModel.class));
+      lenient().when(loginBannerSettingsService.getModel(global))
+         .thenReturn(mock(PresentationLoginBannerSettingsModel.class));
+      lenient().when(toolbarSettingsService.getViewsheetOptions(global))
+         .thenReturn(mock(PresentationViewsheetToolbarOptionsModel.class));
+      lenient().when(portalIntegrationViewSettingsService.getModel(any(), eq(global)))
+         .thenReturn(mock(PortalIntegrationSettingsModel.class));
+      lenient().when(dashboardSettingsService.getModel(global))
+         .thenReturn(mock(PresentationDashboardSettingsModel.class));
+      lenient().when(pdfGenerationSettingsService.getModel(global))
+         .thenReturn(mock(PresentationPdfGenerationSettingsModel.class));
+      lenient().when(exportMenuSettingsService.getExportMenuSettings(global))
+         .thenReturn(mock(PresentationExportMenuSettingsModel.class));
+      lenient().when(fontMappingSettingsService.getModel())
+         .thenReturn(mock(PresentationFontMappingSettingsModel.class));
+      lenient().when(shareSettingsService.getModel(global))
+         .thenReturn(mock(PresentationShareSettingsModel.class));
+      lenient().when(composerMessageSettingsService.getModel(global))
+         .thenReturn(mock(PresentationComposerMessageSettingsModel.class));
+      lenient().when(timeSettingsService.getModel(global))
+         .thenReturn(mock(PresentationTimeSettingsModel.class));
+      lenient().when(dataSourceVisibilitySettingsService.getModel(global))
+         .thenReturn(mock(PresentationDataSourceVisibilitySettingsModel.class));
+      lenient().when(webMapSettingsService.getModel(global))
+         .thenReturn(mock(WebMapSettingsModel.class));
+      if(global) {
+         lenient().when(aiSettingsService.getModel())
+            .thenReturn(mock(PresentationAISettingsModel.class));
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/properties/PropertiesControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/properties/PropertiesControllerTest.java
@@ -1,0 +1,225 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.properties;
+
+/*
+ * Test strategy
+ *
+ * PropertiesController has three main behaviors with in-controller logic:
+ *
+ * --- getProperties / getDefaultProperties ---
+ *   Both methods filter the returned Properties when not enterprise:
+ *     [enterprise]     LicenseManager.isEnterprise() == true → properties returned as-is
+ *     [non-enterprise] LicenseManager.isEnterprise() == false → fluentd and other
+ *                      enterprise-specific keys removed before returning
+ *
+ * --- deleteProperty ---
+ *     [normal property]             SreeEnv.remove() and SreeEnv.save() called
+ *     [security.exposedefaultorgtoall] additionally fires assetRepository event
+ *
+ * --- editProperty ---
+ *     [non-empty value]             SreeEnv.setProperty(name, trimmedValue) and save() called
+ *     [empty value]                 reads existing value from SreeEnv; stores it back
+ *                                   (keeps current value rather than overwriting with empty string)
+ *     [security.exposedefaultorgtoall] additionally fires assetRepository event
+ */
+
+import inetsoft.report.internal.license.LicenseManager;
+import inetsoft.sree.SreeEnv;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.util.log.LogManager;
+import inetsoft.web.admin.security.PropertyModel;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class PropertiesControllerTest {
+
+   @Mock private AssetRepository assetRepository;
+   @Mock private LogManager logManager;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private Principal principal;
+
+   private PropertiesController controller;
+   private MockedStatic<SreeEnv> sreeEnvStatic;
+   private MockedStatic<LicenseManager> licenseManagerStatic;
+
+   @BeforeEach
+   void setUp() {
+      controller = new PropertiesController(assetRepository, logManager, securityEngine);
+
+      sreeEnvStatic = mockStatic(SreeEnv.class, withSettings().lenient());
+      licenseManagerStatic = mockStatic(LicenseManager.class, withSettings().lenient());
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnvStatic.close();
+      licenseManagerStatic.close();
+   }
+
+   // -------------------------------------------------------------------------
+   // getProperties
+   // -------------------------------------------------------------------------
+
+   // [enterprise] properties returned with no keys removed
+   @Test
+   void getProperties_enterprise_returnsUnfilteredProperties() {
+      licenseManagerStatic.when(LicenseManager::isEnterprise).thenReturn(true);
+      Properties props = new Properties();
+      props.setProperty("log.fluentd.host", "logs.example.com");
+      props.setProperty("app.name", "StyleBI");
+      sreeEnvStatic.when(SreeEnv::getProperties).thenReturn(props);
+
+      Properties result = controller.getProperties();
+
+      assertTrue(result.containsKey("log.fluentd.host"));
+      assertTrue(result.containsKey("app.name"));
+   }
+
+   // [non-enterprise] fluentd and other enterprise keys removed
+   @Test
+   void getProperties_nonEnterprise_removesEnterpriseOnlyKeys() {
+      licenseManagerStatic.when(LicenseManager::isEnterprise).thenReturn(false);
+      Properties props = new Properties();
+      props.setProperty("log.fluentd.host", "logs.example.com");
+      props.setProperty("log.fluentd.port", "24224");
+      props.setProperty("log.level.inetsoft_audit", "INFO");
+      props.setProperty("app.name", "StyleBI");
+      sreeEnvStatic.when(SreeEnv::getProperties).thenReturn(props);
+
+      Properties result = controller.getProperties();
+
+      assertFalse(result.containsKey("log.fluentd.host"));
+      assertFalse(result.containsKey("log.fluentd.port"));
+      assertFalse(result.containsKey("log.level.inetsoft_audit"));
+      assertTrue(result.containsKey("app.name"));
+   }
+
+   // [non-enterprise] getDefaultProperties applies same filter
+   @Test
+   void getDefaultProperties_nonEnterprise_removesEnterpriseOnlyKeys() {
+      licenseManagerStatic.when(LicenseManager::isEnterprise).thenReturn(false);
+      Properties props = new Properties();
+      props.setProperty("log.fluentd.host", "logs.example.com");
+      props.setProperty("cache.size", "512");
+      sreeEnvStatic.when(SreeEnv::getDefaultProperties).thenReturn(props);
+
+      Properties result = controller.getDefaultProperties();
+
+      assertFalse(result.containsKey("log.fluentd.host"));
+      assertTrue(result.containsKey("cache.size"));
+   }
+
+   // -------------------------------------------------------------------------
+   // deleteProperty
+   // -------------------------------------------------------------------------
+
+   // [normal property] delegates remove and save to SreeEnv
+   @Test
+   void deleteProperty_normalProperty_removesAndSaves() throws Exception {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("some.property")).thenReturn(null);
+
+      controller.deleteProperty(principal, "some.property");
+
+      sreeEnvStatic.verify(() -> SreeEnv.remove("some.property"));
+      sreeEnvStatic.verify(SreeEnv::save);
+   }
+
+   // [security.exposedefaultorgtoall] fires repository event after removal
+   @Test
+   void deleteProperty_exposeDefaultOrgProperty_firesRepositoryEvent() throws Exception {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("security.exposedefaultorgtoall"))
+         .thenReturn(null);
+
+      controller.deleteProperty(principal, "security.exposedefaultorgtoall");
+
+      verify(assetRepository).fireExposeDefaultOrgPropertyChange();
+   }
+
+   // -------------------------------------------------------------------------
+   // editProperty
+   // -------------------------------------------------------------------------
+
+   // [non-empty value] stores trimmed value and saves
+   @Test
+   void editProperty_nonEmptyValue_setsPropertyAndSaves() throws Exception {
+      PropertyModel property = PropertyModel.builder()
+         .name("my.setting")
+         .value("  hello world  ")
+         .build();
+
+      controller.editProperty(principal, property);
+
+      sreeEnvStatic.verify(() -> SreeEnv.setProperty("my.setting", "hello world"));
+      sreeEnvStatic.verify(SreeEnv::save);
+   }
+
+   // [empty value] reads existing value from SreeEnv; stores it back unchanged
+   @Test
+   void editProperty_emptyValue_preservesExistingValue() throws Exception {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("my.setting")).thenReturn("existing-value");
+
+      PropertyModel property = PropertyModel.builder()
+         .name("my.setting")
+         .value("")
+         .build();
+
+      controller.editProperty(principal, property);
+
+      sreeEnvStatic.verify(() -> SreeEnv.setProperty("my.setting", "existing-value"));
+   }
+
+   // [empty value, no existing] no existing value → stores empty string
+   @Test
+   void editProperty_emptyValue_noExisting_storesEmptyString() throws Exception {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("new.setting")).thenReturn(null);
+
+      PropertyModel property = PropertyModel.builder()
+         .name("new.setting")
+         .value("")
+         .build();
+
+      controller.editProperty(principal, property);
+
+      sreeEnvStatic.verify(() -> SreeEnv.setProperty("new.setting", ""));
+   }
+
+   // [security.exposedefaultorgtoall] fires repository event after set
+   @Test
+   void editProperty_exposeDefaultOrgProperty_firesRepositoryEvent() throws Exception {
+      PropertyModel property = PropertyModel.builder()
+         .name("security.exposedefaultorgtoall")
+         .value("true")
+         .build();
+
+      controller.editProperty(principal, property);
+
+      verify(assetRepository).fireExposeDefaultOrgPropertyChange();
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/query/QueryMonitoringControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/query/QueryMonitoringControllerTest.java
@@ -1,0 +1,132 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.query;
+
+/*
+ * Test strategy
+ *
+ * QueryMonitoringController has two entry points:
+ *
+ *   STOMP @SubscribeMapping — inline permission check before delegating to
+ *     MonitoringDataService.addSubscriber.
+ *
+ *   REST POST /api/em/monitoring/queries/remove/** — delegates to
+ *     queryService.destroyClusterQueries(address, ids). Any exception is caught,
+ *     logged, and NOT rethrown (silent failure).
+ *
+ * The REST endpoint inherits getServerClusterNode() from AbstractMonitoringController.
+ * For a blank/null server path, getServerClusterNode returns null, which is passed as the
+ * address. For non-trivial cluster-node resolution (SUtil.computeServerClusterNode), the
+ * behavior is outside this controller's scope and is not tested here.
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] STOMP subscribe: permission denied → SecurityException; addSubscriber not called.
+ * [G2] STOMP subscribe: permission granted → addSubscriber invoked.
+ * [G3] REST remove: delegates ids and resolved address to queryService.destroyClusterQueries.
+ * [G4] REST remove: exception from queryService is swallowed (no rethrow).
+ */
+
+import inetsoft.sree.security.*;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.web.admin.monitoring.MonitoringDataService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+import java.security.Principal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class QueryMonitoringControllerTest {
+
+   @Mock private QueryService queryService;
+   @Mock private MonitoringDataService monitoringDataService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private StompHeaderAccessor stompHeaderAccessor;
+   @Mock private Principal principal;
+
+   private QueryMonitoringController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new QueryMonitoringController(
+         queryService, monitoringDataService, securityEngine);
+   }
+
+   // [G1] STOMP permission denied → SecurityException; addSubscriber not called
+   @Test
+   void subscribe_permissionDenied_throwsSecurityException() {
+      when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      when(securityProvider.checkPermission(
+            eq(principal), eq(ResourceType.EM_COMPONENT),
+            eq("monitoring/queries/executing"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      assertThrows(SecurityException.class,
+         () -> controller.subscribe(stompHeaderAccessor, Optional.empty(), principal));
+
+      verifyNoInteractions(monitoringDataService);
+   }
+
+   // [G2] STOMP permission granted → addSubscriber invoked
+   @Test
+   void subscribe_permissionGranted_delegatesToMonitoringDataService() throws Exception {
+      when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      when(securityProvider.checkPermission(
+            eq(principal), eq(ResourceType.EM_COMPONENT),
+            eq("monitoring/queries/executing"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(monitoringDataService.addSubscriber(same(stompHeaderAccessor), any())).thenReturn(null);
+
+      controller.subscribe(stompHeaderAccessor, Optional.empty(), principal);
+
+      verify(monitoringDataService).addSubscriber(same(stompHeaderAccessor), any());
+   }
+
+   // [G3] REST remove with blank server → null address forwarded to destroyClusterQueries
+   @Test
+   void remove_blankServer_passesNullAddressToService() throws Exception {
+      String[] ids = { "q1", "q2" };
+
+      // blank server path → getServerClusterNode returns null
+      controller.remove(ids, "/");
+
+      verify(queryService).destroyClusterQueries(isNull(), eq(ids));
+   }
+
+   // [G4] exception from queryService is swallowed; no exception propagates to caller
+   @Test
+   void remove_serviceThrows_exceptionSwallowed() throws Exception {
+      String[] ids = { "q1" };
+      doThrow(new RuntimeException("connection lost"))
+         .when(queryService).destroyClusterQueries(any(), any());
+
+      assertDoesNotThrow(() -> controller.remove(ids, "/"));
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/server/ServerMonitoringControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/server/ServerMonitoringControllerTest.java
@@ -1,0 +1,141 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.server;
+
+/*
+ * Test strategy
+ *
+ * ServerMonitoringController has many REST and STOMP endpoints. The REST endpoints
+ * (getServerSummaryModel, getMonitoringChartLegends, etc.) call several static utility
+ * methods (Tool.getReportVersion, SUtil.isCluster, SreeEnv.getProperty) and build
+ * compound models, making pure unit testing impractical without extensive static mocking.
+ *
+ * The most isolated and highest-value behavior is the STOMP permission guard in
+ * subscribeServerCharts, which has the same inline-check pattern as the other monitoring
+ * controllers. The REST endpoint permission is enforced by @Secured (framework level).
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] STOMP subscribeServerCharts: permission denied → SecurityException thrown;
+ *      MonitoringDataService is never reached.
+ * [G2] STOMP subscribeServerCharts: permission granted → MonitoringDataService.addSubscriber
+ *      is invoked with the provided StompHeaderAccessor.
+ */
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.sree.internal.cluster.Cluster;
+import inetsoft.sree.portal.CustomThemesManager;
+import inetsoft.sree.schedule.ScheduleClient;
+import inetsoft.sree.security.*;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.storage.ExternalStorageService;
+import inetsoft.util.FileSystemService;
+import inetsoft.web.admin.cache.CacheService;
+import inetsoft.web.admin.monitoring.MonitoringDataService;
+import inetsoft.web.admin.query.QueryService;
+import inetsoft.web.admin.schedule.SchedulerMonitoringService;
+import inetsoft.web.admin.viewsheet.ViewsheetService;
+import inetsoft.web.cluster.ServerClusterClient;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ServerMonitoringControllerTest {
+
+   @Mock private ServerService serverService;
+   @Mock private MonitoringDataService monitoringDataService;
+   @Mock private CacheService cacheService;
+   @Mock private ViewsheetService viewsheetService;
+   @Mock private QueryService queryService;
+   @Mock private SchedulerMonitoringService schedulerMonitoringService;
+   @Mock private ServerClusterClient serverClusterClient;
+   @Mock private UsageHistoryService usageHistoryService;
+   @Mock private ClusterCacheUsageService clusterCacheUsageService;
+   @Mock private Cluster cluster;
+   @Mock private CustomThemesManager customThemesManager;
+   @Mock private ScheduleClient scheduleClient;
+   @Mock private ExternalStorageService externalStorageService;
+   @Mock private FileSystemService fileSystemService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private StompHeaderAccessor stompHeaderAccessor;
+   @Mock private Principal principal;
+
+   private ServerMonitoringController controller;
+   private MockedStatic<SreeEnv> sreeEnvStatic;
+
+   @BeforeEach
+   void setUp() {
+      sreeEnvStatic = mockStatic(SreeEnv.class, withSettings().lenient());
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("server.type")).thenReturn("standalone");
+      lenient().when(scheduleClient.isCluster()).thenReturn(false);
+
+      controller = new ServerMonitoringController(
+         serverService, monitoringDataService, cacheService, viewsheetService, queryService,
+         schedulerMonitoringService, serverClusterClient, usageHistoryService,
+         clusterCacheUsageService, cluster, customThemesManager, scheduleClient,
+         externalStorageService, fileSystemService, securityEngine);
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnvStatic.close();
+   }
+
+   // [G1] STOMP permission denied → SecurityException; addSubscriber never called
+   @Test
+   void subscribeServerCharts_permissionDenied_throwsSecurityException() {
+      when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      when(securityProvider.checkPermission(
+            eq(principal), eq(ResourceType.EM_COMPONENT),
+            eq("monitoring/summary"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      assertThrows(SecurityException.class,
+         () -> controller.subscribeServerCharts(stompHeaderAccessor, principal));
+
+      verifyNoInteractions(monitoringDataService);
+   }
+
+   // [G2] STOMP permission granted → MonitoringDataService.addSubscriber invoked
+   @Test
+   void subscribeServerCharts_permissionGranted_delegatesToMonitoringDataService()
+      throws Exception
+   {
+      when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      when(securityProvider.checkPermission(
+            eq(principal), eq(ResourceType.EM_COMPONENT),
+            eq("monitoring/summary"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(monitoringDataService.addSubscriber(same(stompHeaderAccessor), any())).thenReturn(null);
+
+      controller.subscribeServerCharts(stompHeaderAccessor, principal);
+
+      verify(monitoringDataService).addSubscriber(same(stompHeaderAccessor), any());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/user/UserStatusControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/user/UserStatusControllerTest.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.user;
+
+/*
+ * Test strategy
+ *
+ * UserStatusController has three STOMP subscribers and one REST endpoint.
+ *
+ *   Three STOMP subscribers (subscribeSessionModel, subscribeFailedLoginGrid,
+ *   subscribeTop5UsersGrid) each perform an inline permission check before delegating to
+ *   MonitoringDataService.addSubscriber. Different resources are guarded:
+ *     subscribeSessionModel / subscribeFailedLoginGrid → "monitoring/users"
+ *     subscribeTop5UsersGrid                           → "monitoring/summary"
+ *
+ *   REST POST /api/em/monitor/user/logout (logout) — delegates session IDs and resolved
+ *   cluster address to userService.logoutSession().
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] subscribeSessionModel: permission denied → SecurityException; addSubscriber not called.
+ * [G2] subscribeFailedLoginGrid: permission denied → SecurityException.
+ * [G3] subscribeTop5UsersGrid: permission denied (monitoring/summary) → SecurityException.
+ * [G4] logout delegates session IDs and null address (blank server) to userService.
+ */
+
+import inetsoft.sree.security.*;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.web.admin.monitoring.MonitoringDataService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+import java.security.Principal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class UserStatusControllerTest {
+
+   @Mock private UserService userService;
+   @Mock private MonitoringDataService monitoringDataService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private StompHeaderAccessor stompHeaderAccessor;
+   @Mock private Principal principal;
+
+   private UserStatusController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new UserStatusController(userService, monitoringDataService, securityEngine);
+      lenient().when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+   }
+
+   private void stubPermission(String resource, boolean granted) {
+      lenient().when(securityProvider.checkPermission(
+            eq(principal), eq(ResourceType.EM_COMPONENT),
+            eq(resource), eq(ResourceAction.ACCESS)))
+         .thenReturn(granted);
+   }
+
+   // [G1] session model subscribe: permission denied → SecurityException
+   @Test
+   void subscribeSessionModel_permissionDenied_throwsSecurityException() {
+      stubPermission("monitoring/users", false);
+
+      assertThrows(SecurityException.class,
+         () -> controller.subscribeSessionModel(stompHeaderAccessor, Optional.empty(), principal));
+
+      verifyNoInteractions(monitoringDataService);
+   }
+
+   // [G2] failed login subscribe: permission denied → SecurityException
+   @Test
+   void subscribeFailedLoginGrid_permissionDenied_throwsSecurityException() {
+      stubPermission("monitoring/users", false);
+
+      assertThrows(SecurityException.class,
+         () -> controller.subscribeFailedLoginGrid(stompHeaderAccessor, Optional.empty(), principal));
+
+      verifyNoInteractions(monitoringDataService);
+   }
+
+   // [G3] top-5-users subscribe: denied on "monitoring/summary" → SecurityException
+   @Test
+   void subscribeTop5UsersGrid_permissionDenied_throwsSecurityException() {
+      stubPermission("monitoring/summary", false);
+
+      assertThrows(SecurityException.class,
+         () -> controller.subscribeTop5UsersGrid(stompHeaderAccessor, Optional.empty(), principal));
+
+      verifyNoInteractions(monitoringDataService);
+   }
+
+   // [G4] logout delegates sessionIds and null address (blank server path) to userService
+   @Test
+   void logout_blankServer_passesNullAddressToService() {
+      String[] sessionIds = { "s1", "s2" };
+
+      controller.logout(sessionIds, "/");
+
+      verify(userService).logoutSession(isNull(), eq(sessionIds));
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/viewsheet/ViewsheetMonitorControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/viewsheet/ViewsheetMonitorControllerTest.java
@@ -1,0 +1,137 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.viewsheet;
+
+/*
+ * Test strategy
+ *
+ * ViewsheetMonitorController has:
+ *
+ *   Two STOMP subscribers (subscribeToExecuting, subscribeToOpen) — each with an inline
+ *     permission check. Permission denied → SecurityException; granted → addSubscriber called.
+ *
+ *   REST POST /api/em/monitoring/viewsheets/remove/** (closeViewsheets) — delegates to
+ *     viewsheetService.destroyClusterNodeViewsheets(address, ids). The controller explicitly
+ *     swallows IllegalArgumentException and ExpiredSheetException (viewsheet already gone);
+ *     other exceptions propagate.
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] STOMP subscribeToExecuting: permission denied → SecurityException.
+ * [G2] STOMP subscribeToOpen: permission denied → SecurityException.
+ * [G3] closeViewsheets delegates ids and resolved address to destroyClusterNodeViewsheets.
+ * [G4] closeViewsheets swallows IllegalArgumentException (viewsheet already removed).
+ * [G5] closeViewsheets swallows ExpiredSheetException (viewsheet already expired).
+ */
+
+import inetsoft.report.composition.ExpiredSheetException;
+import inetsoft.sree.security.*;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.web.admin.monitoring.MonitoringDataService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+import java.security.Principal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ViewsheetMonitorControllerTest {
+
+   @Mock private ViewsheetService viewsheetService;
+   @Mock private MonitoringDataService monitoringDataService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private StompHeaderAccessor stompHeaderAccessor;
+   @Mock private Principal principal;
+
+   private ViewsheetMonitorController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new ViewsheetMonitorController(
+         viewsheetService, monitoringDataService, securityEngine);
+   }
+
+   private void stubPermission(String resource, boolean granted) {
+      lenient().when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      lenient().when(securityProvider.checkPermission(
+            eq(principal), eq(ResourceType.EM_COMPONENT),
+            eq(resource), eq(ResourceAction.ACCESS)))
+         .thenReturn(granted);
+   }
+
+   // [G1] executing-viewsheets subscribe: permission denied → SecurityException
+   @Test
+   void subscribeToExecuting_permissionDenied_throwsSecurityException() {
+      stubPermission("monitoring/viewsheets/executing", false);
+
+      assertThrows(SecurityException.class,
+         () -> controller.subscribeToExecuting(stompHeaderAccessor, Optional.empty(), principal));
+
+      verifyNoInteractions(monitoringDataService);
+   }
+
+   // [G2] open-viewsheets subscribe: permission denied → SecurityException
+   @Test
+   void subscribeToOpen_permissionDenied_throwsSecurityException() {
+      stubPermission("monitoring/viewsheets/open", false);
+
+      assertThrows(SecurityException.class,
+         () -> controller.subscribeToOpen(stompHeaderAccessor, Optional.empty(), principal));
+
+      verifyNoInteractions(monitoringDataService);
+   }
+
+   // [G3] closeViewsheets with blank server → null address; delegates to service
+   @Test
+   void closeViewsheets_blankServer_passesNullAddressToService() throws Exception {
+      String[] ids = { "vs1", "vs2" };
+
+      controller.closeViewsheets("/", ids);
+
+      verify(viewsheetService).destroyClusterNodeViewsheets(isNull(), eq(ids));
+   }
+
+   // [G4] IllegalArgumentException (viewsheet already gone) is silently swallowed
+   @Test
+   void closeViewsheets_illegalArgument_swallowed() throws Exception {
+      doThrow(new IllegalArgumentException("not found"))
+         .when(viewsheetService).destroyClusterNodeViewsheets(any(), any());
+
+      assertDoesNotThrow(() -> controller.closeViewsheets("/", new String[]{ "vs1" }));
+   }
+
+   // [G5] ExpiredSheetException (viewsheet already expired) is silently swallowed
+   @Test
+   void closeViewsheets_expiredSheetException_swallowed() throws Exception {
+      doThrow(new ExpiredSheetException("vs1", null))
+         .when(viewsheetService).destroyClusterNodeViewsheets(any(), any());
+
+      assertDoesNotThrow(() -> controller.closeViewsheets("/", new String[]{ "vs1" }));
+   }
+}

--- a/core/src/test/resources/inetsoft/web/admin/help/help-links.json
+++ b/core/src/test/resources/inetsoft/web/admin/help/help-links.json
@@ -1,0 +1,1 @@
+{"links":[{"route":"/monitoring/log","link":"EMMonitoringLog"},{"route":"/settings/general","link":"EMSettingsGeneral"},{"route":"/settings/security/users","link":"EMSettingsSecurityUsers"}]}


### PR DESCRIPTION
## Summary

- Add Phase 1 unit tests for EM navbar, page header, and help components
- Add Phase 2 unit tests for EM monitoring controllers
- Add Phase 6 unit tests for general settings, log settings, and presentation controllers
- Add comprehensive unit test coverage for EM security controllers

## Test plan

- [ ] Verify all new unit tests pass: `./mvnw test -pl community`
- [ ] Confirm no existing tests regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)