### PR TITLE
Bug #74933 - Keep shrunk table flush with bottom-tabs strip in exports

### DIFF
--- a/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
@@ -284,6 +284,7 @@ public abstract class AbstractVSExporter implements VSExporter {
          }
       }
 
+      applyShrunkBottomTabsShift(assemblies, box);
       addTableMaxRowMessage(assemblies, box);
       TextVSAssembly warningText = viewsheet.getWarningTextAssembly(false);
 
@@ -301,6 +302,40 @@ public abstract class AbstractVSExporter implements VSExporter {
       }
 
       prepareAnnotation(box);
+   }
+
+   /**
+    * Keep shrunk tables in a bottom-tabs container flush with the tab strip,
+    * matching viewer {@code BaseTable.getObjectTop()}.
+    */
+   private void applyShrunkBottomTabsShift(Assembly[] assemblies, ViewsheetSandbox box) {
+      if(assemblies == null || box == null) {
+         return;
+      }
+
+      for(Assembly assembly : assemblies) {
+         if(!(assembly instanceof TableDataVSAssembly tableAssembly) ||
+            !needExport(tableAssembly))
+         {
+            continue;
+         }
+
+         try {
+            VSTableLens lens = box.getVSTableLens(
+               tableAssembly.getAbsoluteName(), false, 1);
+
+            if(lens == null) {
+               continue;
+            }
+
+            lens.initTableGrid((TableDataVSAssemblyInfo) tableAssembly.getVSAssemblyInfo());
+            VSTableDataHelper.applyShrunkBottomTabsShift(tableAssembly, lens);
+         }
+         catch(Exception ex) {
+            LOG.debug("Failed to apply bottom-tabs shrink shift for {}",
+               tableAssembly.getAbsoluteName(), ex);
+         }
+      }
    }
 
    private void addTableMaxRowMessage(Assembly[] assemblies, ViewsheetSandbox box)

--- a/core/src/main/java/inetsoft/report/io/viewsheet/VSTableDataHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/VSTableDataHelper.java
@@ -831,6 +831,103 @@ public abstract class VSTableDataHelper extends ExporterHelper {
       return null;
    }
 
+   /**
+    * Shift a shrunk table so its rendered bottom stays flush with the
+    * bottom-tabs tab bar. Mirrors viewer {@code BaseTable.getObjectTop()}.
+    * Computes rendered height from padded row heights (PDF/PNG/HTML/Excel);
+    * print layout renders unpadded and must use the three-arg overload.
+    */
+   public static void applyShrunkBottomTabsShift(TableDataVSAssembly assembly,
+                                                 VSTableLens lens)
+   {
+      if(assembly == null || lens == null) {
+         return;
+      }
+
+      TableDataVSAssemblyInfo info = (TableDataVSAssemblyInfo) assembly.getVSAssemblyInfo();
+
+      if(info == null) {
+         return;
+      }
+
+      applyShrunkBottomTabsShift(
+         assembly, info.getPixelSize().height, computeShrunkRenderedHeight(info, lens));
+   }
+
+   /**
+    * Variant for pipelines that allocate the table from something other than
+    * {@code pixelSize.height} (e.g. print layout uses {@code layoutSize}).
+    */
+   public static void applyShrunkBottomTabsShift(TableDataVSAssembly assembly,
+                                                 int designHeight,
+                                                 int actualRenderedHeight)
+   {
+      if(assembly == null) {
+         return;
+      }
+
+      TableDataVSAssemblyInfo info = (TableDataVSAssemblyInfo) assembly.getVSAssemblyInfo();
+
+      if(info == null || !info.isShrink() || info.getMaxSize() != null) {
+         return;
+      }
+
+      if(!TabVSAssemblyInfo.isInBottomTabs(assembly)) {
+         return;
+      }
+
+      int shift = designHeight - actualRenderedHeight;
+
+      if(shift <= 0) {
+         return;
+      }
+
+      Point offset = info.getPixelOffset();
+
+      if(offset != null) {
+         info.setPixelOffset(new Point(offset.x, offset.y + shift));
+      }
+
+      Point layout = info.getLayoutPosition();
+
+      if(layout != null) {
+         info.setLayoutPosition(new Point(layout.x, layout.y + shift));
+      }
+   }
+
+   private static int computeShrunkRenderedHeight(TableDataVSAssemblyInfo info,
+                                                  VSTableLens lens)
+   {
+      int height = info.isTitleVisible() ? info.getTitleHeight() : 0;
+      int rowCount = lens.getRowCount();
+
+      if(rowCount < 0) {
+         lens.moreRows(Integer.MAX_VALUE);
+         rowCount = lens.getRowCount();
+      }
+
+      int[] rowHeights = lens.getRowHeights();
+
+      for(int i = 0; i < rowCount; i++) {
+         double rowH = AssetUtil.defh;
+
+         if(rowHeights != null && i < rowHeights.length) {
+            double wrappedH = lens.getWrappedHeight(i, true);
+
+            if(!Double.isNaN(wrappedH)) {
+               rowH = wrappedH;
+            }
+            else if(rowHeights[i] > 0) {
+               rowH = rowHeights[i];
+            }
+         }
+
+         height += (int) lens.getRowHeightWithPadding(rowH, i);
+      }
+
+      return Math.min(height, info.getPixelSize().height);
+   }
+
    private static final Logger LOG =
       LoggerFactory.getLogger(VSTableDataHelper.class);
    public static final int DEFAULT_COLWIDTH = ExcelVSUtil.DEFAULT_COLWIDTH;

--- a/core/src/main/java/inetsoft/report/io/viewsheet/VSTableDataHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/VSTableDataHelper.java
@@ -898,14 +898,16 @@ public abstract class VSTableDataHelper extends ExporterHelper {
    private static int computeShrunkRenderedHeight(TableDataVSAssemblyInfo info,
                                                   VSTableLens lens)
    {
-      int height = info.isTitleVisible() ? info.getTitleHeight() : 0;
       int rowCount = lens.getRowCount();
 
+      // rowCount < 0 means the lens hasn't fully loaded; that only happens
+      // with > initTableGrid's 10k row budget. Such a table can't be shrunk
+      // within the design box anyway — return the design height so shift = 0.
       if(rowCount < 0) {
-         lens.moreRows(Integer.MAX_VALUE);
-         rowCount = lens.getRowCount();
+         return info.getPixelSize().height;
       }
 
+      int height = info.isTitleVisible() ? info.getTitleHeight() : 0;
       int[] rowHeights = lens.getRowHeights();
 
       for(int i = 0; i < rowCount; i++) {

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
@@ -529,6 +529,22 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
    }
 
    /**
+    * True if {@code child}'s container is a tab in bottom-tabs mode. Used by
+    * exports to gate the flush-to-tab-bar shift for shrunk children.
+    */
+   public static boolean isInBottomTabs(VSAssembly child) {
+      if(child == null) {
+         return false;
+      }
+
+      VSAssembly container = child.getContainer();
+
+      return container instanceof TabVSAssembly tab &&
+         tab.getVSAssemblyInfo() instanceof TabVSAssemblyInfo tabInfo &&
+         tabInfo.isBottomTabs();
+   }
+
+   /**
     * Reset runtime values.
     */
    @Override

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
@@ -974,9 +974,17 @@ public class VsToReportConverter {
             continue;
          }
 
+         String name = tableAssembly.getAbsoluteName();
+         Viewsheet vs = tableAssembly.getViewsheet();
+
+         // skip assemblies the print layout won't render (matches the
+         // tip/pop check in convertVSAssembly).
+         if(VSUtil.isTipView(name, vs) || VSUtil.isPopComponent(name, vs)) {
+            continue;
+         }
+
          try {
-            VSTableLens lens = box.getVSTableLens(
-               tableAssembly.getAbsoluteName(), false, scalefont);
+            VSTableLens lens = box.getVSTableLens(name, false, scalefont);
 
             if(lens == null) {
                continue;
@@ -996,7 +1004,10 @@ public class VsToReportConverter {
 
             // Tighten layoutSize so addTable's bounds end at the tab top;
             // otherwise the renderer top-aligns inside the full design box.
-            if(info.isShrink() && actualHeight < designHeight &&
+            // Gated on the same conditions the helper uses so layoutSize and
+            // pixelOffset stay consistent.
+            if(info.isShrink() && info.getMaxSize() == null &&
+               actualHeight < designHeight &&
                info.getLayoutSize() != null &&
                TabVSAssemblyInfo.isInBottomTabs(tableAssembly))
             {
@@ -1005,8 +1016,7 @@ public class VsToReportConverter {
             }
          }
          catch(Exception ex) {
-            LOG.debug("Failed to apply bottom-tabs shrink shift for {}",
-               tableAssembly.getAbsoluteName(), ex);
+            LOG.debug("Failed to apply bottom-tabs shrink shift for {}", name, ex);
          }
       }
    }

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
@@ -38,6 +38,7 @@ import inetsoft.report.internal.binding.BindingAttr;
 import inetsoft.report.internal.binding.ChartOption;
 import inetsoft.report.internal.table.PresenterRef;
 import inetsoft.report.internal.table.TableHighlightAttr.HighlightTableLens;
+import inetsoft.report.io.viewsheet.VSTableDataHelper;
 import inetsoft.report.lens.AttributeTableLens;
 import inetsoft.report.lens.DefaultTextLens;
 import inetsoft.report.painter.ImagePainter;
@@ -165,6 +166,7 @@ public class VsToReportConverter {
          }
       }
 
+      applyShrunkBottomTabsShift(allAssemblies);
       VSAssembly[] sorted = sortByPosition(allAssemblies.toArray(new Assembly[0]));
       createReportSections(sorted, sectionMap);
 
@@ -958,6 +960,89 @@ public class VsToReportConverter {
    }
 
    /**
+    * Keep shrunk tables in a bottom-tabs container flush with the tab strip.
+    * Uses an unpadded height calc because the print-layout cell renderer
+    * doesn't add the padding {@code lens.getRowHeightWithPadding} adds.
+    */
+   private void applyShrunkBottomTabsShift(List<Assembly> assemblies) {
+      if(assemblies == null) {
+         return;
+      }
+
+      for(Assembly assembly : assemblies) {
+         if(!(assembly instanceof TableDataVSAssembly tableAssembly)) {
+            continue;
+         }
+
+         try {
+            VSTableLens lens = box.getVSTableLens(
+               tableAssembly.getAbsoluteName(), false, scalefont);
+
+            if(lens == null) {
+               continue;
+            }
+
+            TableDataVSAssemblyInfo info =
+               (TableDataVSAssemblyInfo) tableAssembly.getVSAssemblyInfo();
+            lens.initTableGrid(info);
+
+            int actualHeight = computePrintLayoutTableHeight(info, lens);
+            // print layout sizes the table from layoutSize, not pixelSize.
+            int designHeight = info.getLayoutSize() != null ?
+               info.getLayoutSize().height : info.getPixelSize().height;
+
+            VSTableDataHelper.applyShrunkBottomTabsShift(
+               tableAssembly, designHeight, actualHeight);
+
+            // Tighten layoutSize so addTable's bounds end at the tab top;
+            // otherwise the renderer top-aligns inside the full design box.
+            if(info.isShrink() && actualHeight < designHeight &&
+               info.getLayoutSize() != null &&
+               TabVSAssemblyInfo.isInBottomTabs(tableAssembly))
+            {
+               Dimension oldSize = info.getLayoutSize();
+               info.setLayoutSize(new Dimension(oldSize.width, actualHeight));
+            }
+         }
+         catch(Exception ex) {
+            LOG.debug("Failed to apply bottom-tabs shrink shift for {}",
+               tableAssembly.getAbsoluteName(), ex);
+         }
+      }
+   }
+
+   /**
+    * Title + sum of cell heights the print layout will render, matching
+    * {@link #calculateRowHeights}. Wrap-marker {@code -1} rows fall back to
+    * the default row height so we don't undercount.
+    */
+   private int computePrintLayoutTableHeight(TableDataVSAssemblyInfo info, VSTableLens lens) {
+      int height = info.isTitleVisible() ? Math.round(info.getTitleHeight() * scalefont) : 0;
+      int[] rowHeights = calculateRowHeights(info, lens);
+
+      for(int h : rowHeights) {
+         height += h > 0 ? h : Math.round(AssetUtil.defh * scalefont);
+      }
+
+      return height;
+   }
+
+   /**
+    * Replace wrap-marker {@code -1} entries with the same default used in
+    * {@link #computePrintLayoutTableHeight} so the rendered height equals the
+    * predicted height after layoutSize is tightened.
+    */
+   private void forceFixedHeightsForShrunkTable(int[] rowHs) {
+      int defaultRowH = Math.round(AssetUtil.defh * scalefont);
+
+      for(int i = 0; i < rowHs.length; i++) {
+         if(rowHs[i] < 0) {
+            rowHs[i] = defaultRowH;
+         }
+      }
+   }
+
+   /**
     * Add reportelement to fixed position of the report section.
     */
    private void addElement(VSAssembly assembly, BaseElement elem, String sectionName) {
@@ -1047,7 +1132,14 @@ public class VsToReportConverter {
       // setted the fixed widths to report table, the column widths may not
       // be exactly same as the vs column width, and i think it's reasonable.
       tableelem.setFixedWidths(columnPixelW);
-      tableelem.setFixedHeights(calculateRowHeights(info, lens));
+
+      int[] rowHs = calculateRowHeights(info, lens);
+
+      if(info.isShrink() && TabVSAssemblyInfo.isInBottomTabs(assembly)) {
+         forceFixedHeightsForShrunkTable(rowHs);
+      }
+
+      tableelem.setFixedHeights(rowHs);
 
       tableelem.setZIndex(assembly.getZIndex());
       FormatInfo finfo = info.getFormatInfo();

--- a/core/src/test/java/inetsoft/report/io/viewsheet/VSTableDataHelperTest.java
+++ b/core/src/test/java/inetsoft/report/io/viewsheet/VSTableDataHelperTest.java
@@ -1,0 +1,138 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.io.viewsheet;
+
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.*;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.awt.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+class VSTableDataHelperTest {
+
+   @Test
+   void applyShrunkBottomTabsShiftShiftsBothOffsetAndLayoutPosition() {
+      TableDataVSAssembly assembly = bottomTabsTable(/*shrink*/ true, /*maxSize*/ null);
+      TableDataVSAssemblyInfo info = (TableDataVSAssemblyInfo) assembly.getVSAssemblyInfo();
+      info.setPixelOffset(new Point(40, 100));
+      info.setLayoutPosition(new Point(40, 80));
+
+      VSTableDataHelper.applyShrunkBottomTabsShift(assembly, 220, 100);
+
+      // shift = designH - actualH = 220 - 100 = 120
+      assertEquals(220, info.getPixelOffset().y);   // 100 + 120
+      assertEquals(200, info.getLayoutPosition().y); // 80 + 120
+   }
+
+   @Test
+   void applyShrunkBottomTabsShiftNoopWhenNotShrink() {
+      TableDataVSAssembly assembly = bottomTabsTable(/*shrink*/ false, null);
+      TableDataVSAssemblyInfo info = (TableDataVSAssemblyInfo) assembly.getVSAssemblyInfo();
+      info.setPixelOffset(new Point(40, 100));
+
+      VSTableDataHelper.applyShrunkBottomTabsShift(assembly, 220, 100);
+
+      assertEquals(100, info.getPixelOffset().y);
+   }
+
+   @Test
+   void applyShrunkBottomTabsShiftNoopWhenMaxMode() {
+      TableDataVSAssembly assembly = bottomTabsTable(true, new Dimension(800, 600));
+      TableDataVSAssemblyInfo info = (TableDataVSAssemblyInfo) assembly.getVSAssemblyInfo();
+      info.setPixelOffset(new Point(40, 100));
+
+      VSTableDataHelper.applyShrunkBottomTabsShift(assembly, 220, 100);
+
+      assertEquals(100, info.getPixelOffset().y);
+   }
+
+   @Test
+   void applyShrunkBottomTabsShiftNoopWhenNotInBottomTabs() {
+      TableDataVSAssembly assembly = topTabsTable(true);
+      TableDataVSAssemblyInfo info = (TableDataVSAssemblyInfo) assembly.getVSAssemblyInfo();
+      info.setPixelOffset(new Point(40, 100));
+
+      VSTableDataHelper.applyShrunkBottomTabsShift(assembly, 220, 100);
+
+      assertEquals(100, info.getPixelOffset().y);
+   }
+
+   @Test
+   void applyShrunkBottomTabsShiftNoopWhenShiftNonPositive() {
+      TableDataVSAssembly assembly = bottomTabsTable(true, null);
+      TableDataVSAssemblyInfo info = (TableDataVSAssemblyInfo) assembly.getVSAssemblyInfo();
+      info.setPixelOffset(new Point(40, 100));
+
+      // actual >= design → shift <= 0 → no-op
+      VSTableDataHelper.applyShrunkBottomTabsShift(assembly, 220, 220);
+      assertEquals(100, info.getPixelOffset().y);
+
+      VSTableDataHelper.applyShrunkBottomTabsShift(assembly, 220, 300);
+      assertEquals(100, info.getPixelOffset().y);
+   }
+
+   @Test
+   void applyShrunkBottomTabsShiftHandlesNullAssembly() {
+      // does not throw
+      VSTableDataHelper.applyShrunkBottomTabsShift((TableDataVSAssembly) null, 220, 100);
+   }
+
+   @Test
+   void applyShrunkBottomTabsShiftHandlesNullLayoutPosition() {
+      TableDataVSAssembly assembly = bottomTabsTable(true, null);
+      TableDataVSAssemblyInfo info = (TableDataVSAssemblyInfo) assembly.getVSAssemblyInfo();
+      info.setPixelOffset(new Point(40, 100));
+      info.setLayoutPosition(null);
+
+      VSTableDataHelper.applyShrunkBottomTabsShift(assembly, 220, 100);
+
+      assertEquals(220, info.getPixelOffset().y);
+      assertNull(info.getLayoutPosition());
+   }
+
+   private TableDataVSAssembly bottomTabsTable(boolean shrink, Dimension maxSize) {
+      return tabChild(shrink, maxSize, /*bottomTabs*/ true);
+   }
+
+   private TableDataVSAssembly topTabsTable(boolean shrink) {
+      return tabChild(shrink, null, /*bottomTabs*/ false);
+   }
+
+   private TableDataVSAssembly tabChild(boolean shrink, Dimension maxSize, boolean bottomTabs) {
+      TableVSAssemblyInfo info = new TableVSAssemblyInfo();
+      info.setShrink(shrink);
+      info.setMaxSize(maxSize);
+      info.setPixelSize(new Dimension(400, 220));
+
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setBottomTabsValue(bottomTabs);
+      TabVSAssembly tab = Mockito.mock(TabVSAssembly.class);
+      when(tab.getVSAssemblyInfo()).thenReturn(tabInfo);
+
+      TableDataVSAssembly assembly = Mockito.mock(TableDataVSAssembly.class);
+      when(assembly.getVSAssemblyInfo()).thenReturn(info);
+      when(assembly.getContainer()).thenReturn(tab);
+      when(assembly.getAbsoluteName()).thenReturn("TableView1");
+
+      return assembly;
+   }
+}

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
@@ -24,7 +24,9 @@ import org.mockito.Mockito;
 import java.awt.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 class TabVSAssemblyInfoTest {
@@ -301,7 +303,7 @@ class TabVSAssemblyInfoTest {
       VSAssembly child = Mockito.mock(VSAssembly.class);
       when(child.getContainer()).thenReturn(tab);
 
-      assertEquals(true, TabVSAssemblyInfo.isInBottomTabs(child));
+      assertTrue(TabVSAssemblyInfo.isInBottomTabs(child));
    }
 
    @Test
@@ -314,7 +316,7 @@ class TabVSAssemblyInfoTest {
       VSAssembly child = Mockito.mock(VSAssembly.class);
       when(child.getContainer()).thenReturn(tab);
 
-      assertEquals(false, TabVSAssemblyInfo.isInBottomTabs(child));
+      assertFalse(TabVSAssemblyInfo.isInBottomTabs(child));
    }
 
    @Test
@@ -322,12 +324,12 @@ class TabVSAssemblyInfoTest {
       VSAssembly child = Mockito.mock(VSAssembly.class);
       when(child.getContainer()).thenReturn(null);
 
-      assertEquals(false, TabVSAssemblyInfo.isInBottomTabs(child));
+      assertFalse(TabVSAssemblyInfo.isInBottomTabs(child));
    }
 
    @Test
    void isInBottomTabsFalseForNullAssembly() {
-      assertEquals(false, TabVSAssemblyInfo.isInBottomTabs(null));
+      assertFalse(TabVSAssemblyInfo.isInBottomTabs(null));
    }
 
    private VSAssembly mockChild(String name, SelectionBaseVSAssemblyInfo info,

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
@@ -291,6 +291,45 @@ class TabVSAssemblyInfoTest {
       assertEquals(170, childInfo.getPixelOffset().y);
    }
 
+   @Test
+   void isInBottomTabsTrueForBottomTabsContainer() {
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setBottomTabsValue(true);
+      TabVSAssembly tab = Mockito.mock(TabVSAssembly.class);
+      when(tab.getVSAssemblyInfo()).thenReturn(tabInfo);
+
+      VSAssembly child = Mockito.mock(VSAssembly.class);
+      when(child.getContainer()).thenReturn(tab);
+
+      assertEquals(true, TabVSAssemblyInfo.isInBottomTabs(child));
+   }
+
+   @Test
+   void isInBottomTabsFalseForTopTabsContainer() {
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setBottomTabsValue(false);
+      TabVSAssembly tab = Mockito.mock(TabVSAssembly.class);
+      when(tab.getVSAssemblyInfo()).thenReturn(tabInfo);
+
+      VSAssembly child = Mockito.mock(VSAssembly.class);
+      when(child.getContainer()).thenReturn(tab);
+
+      assertEquals(false, TabVSAssemblyInfo.isInBottomTabs(child));
+   }
+
+   @Test
+   void isInBottomTabsFalseWhenNotInTab() {
+      VSAssembly child = Mockito.mock(VSAssembly.class);
+      when(child.getContainer()).thenReturn(null);
+
+      assertEquals(false, TabVSAssemblyInfo.isInBottomTabs(child));
+   }
+
+   @Test
+   void isInBottomTabsFalseForNullAssembly() {
+      assertEquals(false, TabVSAssemblyInfo.isInBottomTabs(null));
+   }
+
    private VSAssembly mockChild(String name, SelectionBaseVSAssemblyInfo info,
                                 Point offset, Dimension size, int showType)
    {


### PR DESCRIPTION
## Summary

  - Mirrors the viewer behavior `base-table.ts BaseTable.getObjectTop()` on
    the Java export pipeline. When a shrunk table sits inside a bottom-tabs
    tab container, exports now shift the table down so its rendered bottom is
    flush with the tab strip, matching the viewer.
  - `AbstractVSExporter.prepareSheet` covers PDF, PNG, HTML, Excel and CSV
    via a single hook that mutates `info.pixelOffset` and
    `info.layoutPosition` after `expandAll`. Height is computed from padded
    row heights matching the cell-painting pipeline.
  - `VsToReportConverter.generateReport` applies the shift before
    `createReportSections` so section bounds reflect the new positions. It
    uses an unpadded height calc that matches its own `calculateRowHeights`,
    tightens `layoutSize.height`, and substitutes the default row height for
    `-1` wrap-marker rows so the rendered bottom lands at the tab strip.
  - `TabVSAssemblyInfo.isInBottomTabs(VSAssembly)` is a new static helper
    that gates the shift across both export paths.