### PR TITLE
Bug #74920, return MessageException as error message from freeSQLModel endpoint

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/database/QueryController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/QueryController.java
@@ -23,6 +23,7 @@ import inetsoft.uql.XFormatInfo;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.jdbc.*;
 import inetsoft.util.Catalog;
+import inetsoft.util.MessageException;
 import inetsoft.web.adhoc.model.FormatInfoModel;
 import inetsoft.web.composer.BrowseDataController;
 import inetsoft.web.composer.model.TreeNodeModel;
@@ -233,13 +234,20 @@ public class QueryController extends WorksheetController {
                                                       @RequestBody UpdateFreeFormSQLPaneEvent event,
                                                       Principal principal)
    {
-      String errorMsg = queryManager.setFreeFormSQLPaneModel(event, principal);
-      RuntimeQueryService.RuntimeXQuery runtimeQuery =
-         runtimeQueryService.getRuntimeQuery(event.getRuntimeId());
-      UpdateFreeFormSQLPaneResult result = new UpdateFreeFormSQLPaneResult();
-      result.setErrorMsg(errorMsg);
-      result.setModel(queryManager.getAdvancedQueryModel(runtimeQuery, principal));
-      return result;
+      try {
+         String errorMsg = queryManager.setFreeFormSQLPaneModel(event, principal);
+         RuntimeQueryService.RuntimeXQuery runtimeQuery =
+            runtimeQueryService.getRuntimeQuery(event.getRuntimeId());
+         UpdateFreeFormSQLPaneResult result = new UpdateFreeFormSQLPaneResult();
+         result.setErrorMsg(errorMsg);
+         result.setModel(queryManager.getAdvancedQueryModel(runtimeQuery, principal));
+         return result;
+      }
+      catch(MessageException e) {
+         UpdateFreeFormSQLPaneResult result = new UpdateFreeFormSQLPaneResult();
+         result.setErrorMsg(e.getMessage());
+         return result;
+      }
    }
 
    @GetMapping("/api/data/datasource/query/load/data")


### PR DESCRIPTION
## Summary

- When the runtime query session expires (after the 3-minute cache TTL), clicking the Preview tab causes a POST to `/api/data/datasource/query/save/freeSQLModel` which was returning HTTP 500 instead of a user-friendly warning.
- Root cause: `QueryManagerService.parseSqlString()` throws a `MessageException` when the runtime query is not found. The controller had no handler for this, so `ControllerErrorHandler` returned a 500, and the Angular `HttpClient` subscription had no error callback — resulting in a browser 500 popup.
- Fix: wrap the controller method body in a try-catch for `MessageException` and return the exception message as the `errorMsg` field of the response. The frontend already has logic to display a warning dialog when `errorMsg` is set, and the catch also covers any other `MessageException` that could be thrown deeper in the call stack.

## Test plan

- [ ] Create a worksheet, add a query, switch to Advanced Query mode, enter SQL in the SQL String tab
- [ ] Wait 4+ minutes (past the 3-minute session cache TTL) without interacting with the query editor
- [ ] Click the Preview tab — confirm a warning dialog appears rather than a browser 500 popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)