### PR TITLE
74945 - Add ring to circular network graph

### DIFF
--- a/core/src/main/java/inetsoft/graph/element/RelationElement.java
+++ b/core/src/main/java/inetsoft/graph/element/RelationElement.java
@@ -17,11 +17,12 @@
  */
 package inetsoft.graph.element;
 
-import inetsoft.graph.GGraph;
-import inetsoft.graph.GraphConstants;
+import inetsoft.graph.*;
 import inetsoft.graph.aesthetic.*;
+import inetsoft.graph.coord.Coordinate;
 import inetsoft.graph.data.*;
 import inetsoft.graph.geometry.*;
+import inetsoft.graph.guide.form.GraphForm;
 import inetsoft.graph.internal.GTool;
 import inetsoft.graph.mxgraph.layout.hierarchical.mxHierarchicalLayout;
 import inetsoft.graph.mxgraph.layout.*;
@@ -30,6 +31,7 @@ import inetsoft.graph.mxgraph.model.mxGeometry;
 import inetsoft.graph.mxgraph.util.mxPoint;
 import inetsoft.graph.mxgraph.view.mxGraph;
 import inetsoft.graph.visual.ElementVO;
+import inetsoft.graph.visual.FormVO;
 import inetsoft.graph.visual.VOText;
 import inetsoft.sree.SreeEnv;
 import inetsoft.util.CoreTool;
@@ -253,6 +255,10 @@ public class RelationElement extends GraphElement {
          }
 
          mxLayout(nodes, edges, mxgraph, mxroot, graph);
+
+         if(shapeBorderShape != null && layoutCenter != null && layoutRadius > 0) {
+            graph.getEGraph().addForm(new BorderForm(this));
+         }
       }
    }
 
@@ -389,9 +395,20 @@ public class RelationElement extends GraphElement {
          int nodeCount = nodes.size();
          layoutCenter = nodeCount > 0
             ? new Point2D.Double(sumCx / nodeCount, sumCy / nodeCount) : null;
+
+         // radius = distance from centroid to any node centre (all equidistant on CIRCLE layout)
+         if(layoutCenter != null && nodeCount > 0) {
+            mxGeometry g = nodes.values().iterator().next().getMxCell().getGeometry();
+            layoutRadius = layoutCenter.distance(g.getX() + g.getWidth() / 2.0,
+                                                 g.getY() + g.getHeight() / 2.0);
+         }
+         else {
+            layoutRadius = 0;
+         }
       }
       else {
          layoutCenter = null;
+         layoutRadius = 0;
       }
 
       if(flipped && algorithm == Algorithm.COMPACT_TREE) {
@@ -663,6 +680,25 @@ public class RelationElement extends GraphElement {
    }
 
    /**
+    * Radius of the node ring after circular layout, in graph coordinates. Populated by mxLayout()
+    * for Algorithm.CIRCLE only; 0 for all other algorithms.
+    */
+   public double getLayoutRadius() {
+      return layoutRadius;
+   }
+
+   /**
+    * Configure a shape to be drawn as a border ring around the layout. The shape is drawn in
+    * graph coordinates using {@code gshape.getShape(cx-r, cy-r, 2r, 2r)} and scales correctly
+    * with the chart. Pass {@code null} for any argument to remove a previously-set border.
+    */
+   public void addShapeBorder(GShape gshape, Color color, GLine line) {
+      this.shapeBorderShape = gshape;
+      this.shapeBorderColor = color;
+      this.shapeBorderLine = line;
+   }
+
+   /**
     * Set the color frame for getting the color aesthetic for nodes.
     */
    public void setNodeColorFrame(ColorFrame colors) {
@@ -914,10 +950,48 @@ public class RelationElement extends GraphElement {
    private boolean applyAestheticsToSource = false;
    private double nodeCornerRadius = 0;
    private boolean smoothEdges = false;
+   private GShape shapeBorderShape;
+   private Color shapeBorderColor;
+   private GLine shapeBorderLine;
    // derived; populated by mxLayout, not part of element identity
    private transient Point2D layoutCenter;
+   private transient double layoutRadius;
    private boolean horizontal = false;
    private boolean flipped = false;
 
    private static final long serialVersionUID = 1L;
+
+   /**
+    * Renders the configured shape border around the circular layout. The shape is created in
+    * mxGraph layout space so that RelationCoord's screen transform scales it correctly.
+    */
+   private static final class BorderForm extends GraphForm {
+      BorderForm(RelationElement elem) {
+         this.elem = elem;
+         setColor(elem.shapeBorderColor);
+         setLine(elem.shapeBorderLine != null
+            ? elem.shapeBorderLine.getStyle() : GraphConstants.THIN_LINE);
+      }
+
+      @Override
+      public Visualizable createVisual(Coordinate coord) {
+         Point2D center = elem.getLayoutCenter();
+         double radius = elem.getLayoutRadius();
+
+         if(center == null || radius <= 0) {
+            return null;
+         }
+
+         double cx = center.getX();
+         double cy = center.getY();
+         java.awt.Shape s = elem.shapeBorderShape.getShape(
+            cx - radius, cy - radius, 2 * radius, 2 * radius);
+         FormVO vo = new FormVO(this);
+         vo.setShape(s);
+         return vo;
+      }
+
+      private final RelationElement elem;
+      private static final long serialVersionUID = 1L;
+   }
 }

--- a/core/src/main/java/inetsoft/graph/element/RelationElement.java
+++ b/core/src/main/java/inetsoft/graph/element/RelationElement.java
@@ -690,7 +690,9 @@ public class RelationElement extends GraphElement {
    /**
     * Configure a shape to be drawn as a border ring around the layout. The shape is drawn in
     * graph coordinates using {@code gshape.getShape(cx-r, cy-r, 2r, 2r)} and scales correctly
-    * with the chart. Pass {@code null} for any argument to remove a previously-set border.
+    * with the chart. Pass {@code null} for {@code gshape} to remove a previously-set border;
+    * {@code null} color falls back to the default line color, {@code null} line falls back to
+    * {@link inetsoft.graph.GraphConstants#THIN_LINE}.
     */
    public void addShapeBorder(GShape gshape, Color color, GLine line) {
       this.shapeBorderShape = gshape;
@@ -974,7 +976,7 @@ public class RelationElement extends GraphElement {
       }
 
       @Override
-      public Visualizable createVisual(Coordinate coord) {
+      public Visualizable createVisual(Coordinate coord) { // coord unused; FormVO.transform applies it later
          Point2D center = elem.getLayoutCenter();
          double radius = elem.getLayoutRadius();
 

--- a/core/src/main/java/inetsoft/graph/element/RelationElement.java
+++ b/core/src/main/java/inetsoft/graph/element/RelationElement.java
@@ -396,7 +396,9 @@ public class RelationElement extends GraphElement {
          layoutCenter = nodeCount > 0
             ? new Point2D.Double(sumCx / nodeCount, sumCy / nodeCount) : null;
 
-         // radius = distance from centroid to any node centre (all equidistant on CIRCLE layout)
+         // radius = distance from centroid to any node centre (all equidistant on CIRCLE layout).
+         // The ring intentionally passes through node centers rather than their outer edges,
+         // so it visually connects node centers without adding extra padding around each node.
          if(layoutCenter != null && nodeCount > 0) {
             mxGeometry g = nodes.values().iterator().next().getMxCell().getGeometry();
             layoutRadius = layoutCenter.distance(g.getX() + g.getWidth() / 2.0,
@@ -693,6 +695,10 @@ public class RelationElement extends GraphElement {
     * with the chart. Pass {@code null} for {@code gshape} to remove a previously-set border;
     * {@code null} color falls back to the default line color, {@code null} line falls back to
     * {@link inetsoft.graph.GraphConstants#THIN_LINE}.
+    * <p>
+    * Only symmetric shapes (e.g. {@link GShape#CIRCLE}) are visually meaningful here; a
+    * non-symmetric shape is centered on the layout centroid but will not follow the node
+    * positions.
     */
    public void addShapeBorder(GShape gshape, Color color, GLine line) {
       this.shapeBorderShape = gshape;
@@ -923,7 +929,10 @@ public class RelationElement extends GraphElement {
             Objects.equals(nodeColors, elem.nodeColors) &&
             Objects.equals(nodeSizes, elem.nodeSizes) &&
             Objects.equals(layoutSize, elem.layoutSize) &&
-            Objects.equals(fillColor, elem.fillColor);
+            Objects.equals(fillColor, elem.fillColor) &&
+            Objects.equals(shapeBorderShape, elem.shapeBorderShape) &&
+            Objects.equals(shapeBorderColor, elem.shapeBorderColor) &&
+            Objects.equals(shapeBorderLine, elem.shapeBorderLine);
       }
 
       return false;
@@ -961,7 +970,8 @@ public class RelationElement extends GraphElement {
    private boolean horizontal = false;
    private boolean flipped = false;
 
-   private static final long serialVersionUID = 1L;
+   // Bumped to 2L when shapeBorderShape/Color/Line were added; null on deserialization = no border (safe).
+   private static final long serialVersionUID = 2L;
 
    /**
     * Renders the configured shape border around the circular layout. The shape is created in
@@ -976,7 +986,7 @@ public class RelationElement extends GraphElement {
       }
 
       @Override
-      public Visualizable createVisual(Coordinate coord) { // coord unused; FormVO.transform applies it later
+      public Visualizable createVisual(Coordinate coord) { // coord not used here; the renderer calls FormVO.transform() to apply the coordinate transform
          Point2D center = elem.getLayoutCenter();
          double radius = elem.getLayoutRadius();
 

--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -3719,9 +3719,7 @@ public abstract class GraphGenerator {
             // PlotDescriptor.smoothLines is reused here as the chord-curve toggle for
             // CIRCULAR; the element-side flag is smoothEdges (bends edges, not lines).
             elem.setSmoothEdges(desc.getPlotDescriptor().isSmoothLines());
-            elem.addShapeBorder(GShape.CIRCLE,
-                                GDefaults.DEFAULT_LINE_COLOR,
-                                new GLine(GraphConstants.MEDIUM_DASH));
+            elem.addShapeBorder(GShape.CIRCLE, GDefaults.DEFAULT_LINE_COLOR, GLine.MEDIUM_DASH);
             break;
          }
 

--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -3719,6 +3719,9 @@ public abstract class GraphGenerator {
             // PlotDescriptor.smoothLines is reused here as the chord-curve toggle for
             // CIRCULAR; the element-side flag is smoothEdges (bends edges, not lines).
             elem.setSmoothEdges(desc.getPlotDescriptor().isSmoothLines());
+            elem.addShapeBorder(GShape.CIRCLE,
+                                GDefaults.DEFAULT_LINE_COLOR,
+                                new GLine(GraphConstants.MEDIUM_DASH));
             break;
          }
 

--- a/core/src/test/java/inetsoft/graph/element/RelationElementLayoutCenterTest.java
+++ b/core/src/test/java/inetsoft/graph/element/RelationElementLayoutCenterTest.java
@@ -19,6 +19,8 @@ package inetsoft.graph.element;
 
 import inetsoft.graph.EGraph;
 import inetsoft.graph.GGraph;
+import inetsoft.graph.aesthetic.GLine;
+import inetsoft.graph.aesthetic.GShape;
 import inetsoft.graph.aesthetic.StaticSizeFrame;
 import inetsoft.graph.coord.RelationCoord;
 import inetsoft.graph.data.DefaultDataSet;
@@ -27,6 +29,7 @@ import inetsoft.graph.mxgraph.model.mxGeometry;
 import inetsoft.test.SreeHome;
 import org.junit.jupiter.api.Test;
 
+import java.awt.Color;
 import java.awt.geom.Point2D;
 import java.util.ArrayList;
 import java.util.List;
@@ -104,6 +107,90 @@ class RelationElementLayoutCenterTest {
       RelationElement element = new RelationElement("From", "To");
       assertNull(element.getLayoutCenter(),
          "layoutCenter must be null until mxLayout runs so consumers gate on it");
+   }
+
+   @Test
+   void mxLayoutPopulatesLayoutRadiusAsDistanceToNodeCenter_circular() {
+      DefaultDataSet data = new DefaultDataSet(new Object[][]{
+         { "From", "To" },
+         { "A",    "B"  },
+         { "B",    "C"  },
+         { "C",    "A"  },
+      });
+
+      RelationElement element = new RelationElement("From", "To");
+      element.setAlgorithm(RelationElement.Algorithm.CIRCLE);
+      element.setSizeFrame(new StaticSizeFrame(5));
+      element.setNodeSizeFrame(new StaticSizeFrame(5));
+
+      EGraph egraph = new EGraph();
+      egraph.addElement(element);
+      RelationCoord coord = new RelationCoord();
+      egraph.setCoordinate(coord);
+      GGraph ggraph = egraph.createGGraph(coord, data);
+
+      for(int i = 0; i < ggraph.getGeometryCount(); i++) {
+         ggraph.getGeometry(i);
+      }
+
+      assertTrue(element.getLayoutRadius() > 0,
+         "layoutRadius must be positive after a circular layout with multiple nodes");
+   }
+
+   @Test
+   void singleNodeCircularLayoutProducesZeroRadius() {
+      // A single node means layoutCenter == node center, so distance is 0 and no ring is drawn.
+      DefaultDataSet data = new DefaultDataSet(new Object[][]{
+         { "From", "To" },
+         { "A",    "A"  },
+      });
+
+      RelationElement element = new RelationElement("From", "To");
+      element.setAlgorithm(RelationElement.Algorithm.CIRCLE);
+      element.setSizeFrame(new StaticSizeFrame(5));
+      element.setNodeSizeFrame(new StaticSizeFrame(5));
+
+      EGraph egraph = new EGraph();
+      egraph.addElement(element);
+      RelationCoord coord = new RelationCoord();
+      egraph.setCoordinate(coord);
+      GGraph ggraph = egraph.createGGraph(coord, data);
+
+      for(int i = 0; i < ggraph.getGeometryCount(); i++) {
+         ggraph.getGeometry(i);
+      }
+
+      assertEquals(0.0, element.getLayoutRadius(), 1e-6,
+         "single-node circular layout must produce layoutRadius == 0 so no ring is added");
+   }
+
+   @Test
+   void addShapeBorderRegistersFormInEGraphAfterLayout() {
+      DefaultDataSet data = new DefaultDataSet(new Object[][]{
+         { "From", "To" },
+         { "A",    "B"  },
+         { "B",    "C"  },
+         { "C",    "A"  },
+      });
+
+      RelationElement element = new RelationElement("From", "To");
+      element.setAlgorithm(RelationElement.Algorithm.CIRCLE);
+      element.setSizeFrame(new StaticSizeFrame(5));
+      element.setNodeSizeFrame(new StaticSizeFrame(5));
+      element.addShapeBorder(GShape.CIRCLE, Color.GRAY, GLine.MEDIUM_DASH);
+
+      EGraph egraph = new EGraph();
+      egraph.addElement(element);
+      RelationCoord coord = new RelationCoord();
+      egraph.setCoordinate(coord);
+      GGraph ggraph = egraph.createGGraph(coord, data);
+
+      for(int i = 0; i < ggraph.getGeometryCount(); i++) {
+         ggraph.getGeometry(i);
+      }
+
+      assertEquals(1, ggraph.getEGraph().getFormCount(),
+         "addShapeBorder must register exactly one BorderForm in the EGraph after layout");
    }
 
    @Test


### PR DESCRIPTION
 ---
  What was implemented

  When a chart is set to type CHART_CIRCULAR (circular network), the chart now renders a circumscribed ring that passes through all node centers.

  How it works end-to-end:

  1. GraphGenerator.java — in the CHART_CIRCULAR switch case, after setting the algorithm to CIRCLE and the smooth-edges flag, calls elem.addShapeBorder(GShape.CIRCLE, GDefaults.DEFAULT_LINE_COLOR, new GLine(GraphConstants.MEDIUM_DASH)). The color and style are hard-coded here — no UI setting, no persistence.
  2. RelationElement.java — addShapeBorder() stores the shape, color, and line. After mxLayout() runs and places all nodes equidistant on the circle, it records layoutRadius as the distance from the computed centroid (layoutCenter) to any one node center. Then createGeometry() adds a BorderForm to the EGraph if a border was registered and the layout geometry is valid.
  3. BorderForm (private inner class in RelationElement) — at render time its createVisual() reads layoutCenter and layoutRadius, calls GShape.CIRCLE.getShape(cx-r, cy-r, 2r, 2r) to produce an Ellipse2D in mxGraph layout space, and wraps it in a FormVO. RelationCoord propagates the mxGraph→screen AffineTransform to all VOs including this one, so the ring scales and positions correctly with any chart size.