### PR TITLE
Bug #74598 - Fix bottomTabs script toggle in mobile/screen layout preview

### DIFF
--- a/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
+++ b/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
@@ -1279,44 +1279,18 @@ public final class VSEventUtil {
       Dimension tabLayoutSize = tabInfo.getLayoutSize(false);
 
       if(tabLayoutPos != null && tabLayoutSize != null) {
-         int maxChildBottom = Integer.MIN_VALUE;
-         int minChildTop = Integer.MAX_VALUE;
-         boolean hasValidChild = false;
+         TabVSAssemblyInfo.ChildExtent extent = TabVSAssemblyInfo.scanChildExtent(
+            assemblies, viewsheet,
+            c -> c.getVSAssemblyInfo().getLayoutPosition(false),
+            c -> c.getVSAssemblyInfo().getLayoutSize(false));
 
-         for(String name : assemblies) {
-            VSAssembly child = viewsheet.getAssembly(name);
-
-            if(child == null) {
-               continue;
-            }
-
-            VSAssemblyInfo cInfo = child.getVSAssemblyInfo();
-            Point cp = cInfo.getLayoutPosition(false);
-            Dimension cs = cInfo.getLayoutSize(false);
-
-            if(cp != null && cs != null) {
-               int ch = TabVSAssemblyInfo.getBottomTabChildHeight(cInfo, cs);
-
-               if(ch == 0) {
-                  continue;
-               }
-
-               maxChildBottom = Math.max(maxChildBottom, cp.y + ch);
-               minChildTop = Math.min(minChildTop, cp.y);
-               hasValidChild = true;
-            }
-         }
-
-         if(hasValidChild) {
+         if(extent != null) {
             int newTabLayoutY = bottomTabs
-               ? maxChildBottom
-               : Math.max(0, minChildTop - tabLayoutSize.height);
+               ? extent.maxBottom()
+               : Math.max(0, extent.minTop() - tabLayoutSize.height);
+            int newTabScaledX = (int) Math.floor(tabLayoutPos.x * scaleRatio.x);
             int newTabScaledY = (int) Math.floor(newTabLayoutY * scaleRatio.y);
-            Point curScaled = tabInfo.getLayoutPosition(true);
-            int x = curScaled != null
-               ? curScaled.x
-               : (int) Math.floor(tabLayoutPos.x * scaleRatio.x);
-            tabInfo.setScaledPosition(new Point(x, newTabScaledY));
+            tabInfo.setScaledPosition(new Point(newTabScaledX, newTabScaledY));
          }
       }
 

--- a/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
+++ b/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
@@ -1270,12 +1270,60 @@ public final class VSEventUtil {
    {
       VSAssemblyInfo tabInfo = (VSAssemblyInfo) assembly.getInfo();
       boolean bottomTabs = ((TabVSAssemblyInfo) tabInfo).isBottomTabs();
+      String[] assemblies = assembly.getAssemblies();
+
+      // Re-anchor the tab for the current bottomTabs value. AbstractLayout.applyTab
+      // baked in the design-time value, so runtime toggles need this on every
+      // refresh/resize. Master-pixel-space semantics: tab moves, children stay.
+      Point tabLayoutPos = tabInfo.getLayoutPosition(false);
+      Dimension tabLayoutSize = tabInfo.getLayoutSize(false);
+
+      if(tabLayoutPos != null && tabLayoutSize != null) {
+         int maxChildBottom = Integer.MIN_VALUE;
+         int minChildTop = Integer.MAX_VALUE;
+         boolean hasValidChild = false;
+
+         for(String name : assemblies) {
+            VSAssembly child = viewsheet.getAssembly(name);
+
+            if(child == null) {
+               continue;
+            }
+
+            VSAssemblyInfo cInfo = child.getVSAssemblyInfo();
+            Point cp = cInfo.getLayoutPosition(false);
+            Dimension cs = cInfo.getLayoutSize(false);
+
+            if(cp != null && cs != null) {
+               int ch = TabVSAssemblyInfo.getBottomTabChildHeight(cInfo, cs);
+
+               if(ch == 0) {
+                  continue;
+               }
+
+               maxChildBottom = Math.max(maxChildBottom, cp.y + ch);
+               minChildTop = Math.min(minChildTop, cp.y);
+               hasValidChild = true;
+            }
+         }
+
+         if(hasValidChild) {
+            int newTabLayoutY = bottomTabs
+               ? maxChildBottom
+               : Math.max(0, minChildTop - tabLayoutSize.height);
+            int newTabScaledY = (int) Math.floor(newTabLayoutY * scaleRatio.y);
+            Point curScaled = tabInfo.getLayoutPosition(true);
+            int x = curScaled != null
+               ? curScaled.x
+               : (int) Math.floor(tabLayoutPos.x * scaleRatio.x);
+            tabInfo.setScaledPosition(new Point(x, newTabScaledY));
+         }
+      }
 
       // for bottom tabs, getLayoutPosition() returns the tab bar position
       // (set by AbstractLayout.applyTab as npos.y + contentHeight)
       Point tabPos = tabInfo.getLayoutPosition();
       Dimension tabSize = tabInfo.getLayoutSize();
-      String[] assemblies = assembly.getAssemblies();
       // when apply tab scale, the tab height is not scale, so it's children
       // scale size is (pixelsize * scaleRadio + repairH).
       double repairH = tabSize.height * scaleRatio.y - tabSize.height;

--- a/core/src/main/java/inetsoft/report/script/viewsheet/TabVSAScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/viewsheet/TabVSAScriptable.java
@@ -152,7 +152,10 @@ public class TabVSAScriptable extends VSAScriptable {
       info.setBottomTabs(bottomTabs);
 
       if(box.isRuntime() && bottomTabs != isCurrentlyAtBottom) {
-         TabVSAssemblyInfo.repositionForBottomTabs(info, box.getViewsheet(), bottomTabs);
+         Viewsheet vs = box.getViewsheet();
+         TabVSAssemblyInfo.repositionForBottomTabs(info, vs, bottomTabs);
+         // scaled space: makes the toggle visible immediately in layout previews
+         TabVSAssemblyInfo.repositionForBottomTabsInScaledSpace(info, vs, bottomTabs);
       }
    }
 

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
@@ -413,12 +413,7 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
          ? maxChildBottom
          : Math.max(0, minChildTop - tabHeight);
 
-      int actualTabDy = newTabY - tabPos.y;
       tabInfo.setPixelOffset(new Point(tabPos.x, newTabY));
-
-      if(tabInfo.getLayoutPosition() != null) {
-         tabInfo.getLayoutPosition().translate(0, actualTabDy);
-      }
 
       // reposition children whose edges aren't flush with the tab bar
       for(String childName : children) {
@@ -441,13 +436,83 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
             : newTabY + tabHeight;    // top edge flush with tab bar bottom
 
          if(newChildY != childPos.y) {
-            int childDy = newChildY - childPos.y;
             childInfo.setPixelOffset(new Point(childPos.x, newChildY));
-
-            if(childInfo.getLayoutPosition() != null) {
-               childInfo.getLayoutPosition().translate(0, childDy);
-            }
          }
+      }
+   }
+
+   /**
+    * Scaled-space counterpart of {@link #repositionForBottomTabs}. Lets a
+    * runtime script toggle take effect immediately in layout previews. Tab
+    * moves; children stay. No-op in master view (no scaledPosition).
+    */
+   public static void repositionForBottomTabsInScaledSpace(TabVSAssemblyInfo tabInfo,
+                                                           Viewsheet vs,
+                                                           boolean toBottomTabs)
+   {
+      String[] children = tabInfo.getAssemblies();
+
+      if(children == null || children.length == 0 || vs == null) {
+         return;
+      }
+
+      Point tabScaledPos = tabInfo.getLayoutPosition(true);
+
+      if(tabScaledPos == null || tabScaledPos == tabInfo.getLayoutPosition(false)) {
+         return;
+      }
+
+      Dimension tabSize = tabInfo.getLayoutSize(true);
+
+      if(tabSize == null) {
+         tabSize = tabInfo.getLayoutSize(false);
+      }
+
+      if(tabSize == null || tabSize.height == 0) {
+         return;
+      }
+
+      int tabHeight = tabSize.height;
+      int maxChildBottom = Integer.MIN_VALUE;
+      int minChildTop = Integer.MAX_VALUE;
+      boolean hasValidChild = false;
+
+      for(String childName : children) {
+         VSAssembly child = (VSAssembly) vs.getAssembly(childName);
+
+         if(child == null) {
+            continue;
+         }
+
+         VSAssemblyInfo childInfo = child.getVSAssemblyInfo();
+         Point childPos = childInfo.getLayoutPosition(true);
+         Dimension childSize = childInfo.getLayoutSize(true);
+
+         if(childPos == null || childSize == null) {
+            continue;
+         }
+
+         int childHeight = getBottomTabChildHeight(childInfo, childSize);
+
+         if(childHeight == 0) {
+            continue;
+         }
+
+         maxChildBottom = Math.max(maxChildBottom, childPos.y + childHeight);
+         minChildTop = Math.min(minChildTop, childPos.y);
+         hasValidChild = true;
+      }
+
+      if(!hasValidChild) {
+         return;
+      }
+
+      int newTabY = toBottomTabs
+         ? maxChildBottom
+         : Math.max(0, minChildTop - tabHeight);
+
+      if(newTabY != tabScaledPos.y) {
+         tabInfo.setScaledPosition(new Point(tabScaledPos.x, newTabY));
       }
    }
 

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
@@ -32,6 +32,7 @@ import org.w3c.dom.NodeList;
 import java.awt.*;
 import java.awt.geom.Point2D;
 import java.io.PrintWriter;
+import java.util.function.Function;
 
 /**
  * TabVSAssemblyInfo stores basic tab assembly information.
@@ -379,39 +380,18 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
       }
 
       int tabHeight = tabDim.height;
+      // VSAssembly::getPixelSize applies the assembly's minimum-size floor
+      // (e.g. TableVSAssembly's 20x60); info.getPixelSize() would not.
+      ChildExtent extent = scanChildExtent(children, vs,
+         VSAssembly::getPixelOffset, VSAssembly::getPixelSize);
 
-      // find the child extent needed to position the tab bar
-      int maxChildBottom = Integer.MIN_VALUE;
-      int minChildTop = Integer.MAX_VALUE;
-      boolean hasValidChild = false;
-
-      for(String childName : children) {
-         VSAssembly child = (VSAssembly) vs.getAssembly(childName);
-
-         if(child == null) {
-            continue;
-         }
-
-         Point childPos = child.getPixelOffset();
-         int childHeight = getBottomTabChildHeight(child.getVSAssemblyInfo(), child.getPixelSize());
-
-         if(childPos == null || childHeight == 0) {
-            continue;
-         }
-
-         maxChildBottom = Math.max(maxChildBottom, childPos.y + childHeight);
-         minChildTop = Math.min(minChildTop, childPos.y);
-         hasValidChild = true;
-      }
-
-      if(!hasValidChild) {
+      if(extent == null) {
          return;
       }
 
-      // move the tab bar
       int newTabY = toBottomTabs
-         ? maxChildBottom
-         : Math.max(0, minChildTop - tabHeight);
+         ? extent.maxBottom()
+         : Math.max(0, extent.minTop() - tabHeight);
 
       tabInfo.setPixelOffset(new Point(tabPos.x, newTabY));
 
@@ -458,6 +438,8 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
 
       Point tabScaledPos = tabInfo.getLayoutPosition(true);
 
+      // scaledPosition unset → both overloads return the same layoutPosition object;
+      // reference compare detects that case without exposing scaledPosition publicly.
       if(tabScaledPos == null || tabScaledPos == tabInfo.getLayoutPosition(false)) {
          return;
       }
@@ -473,9 +455,42 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
       }
 
       int tabHeight = tabSize.height;
-      int maxChildBottom = Integer.MIN_VALUE;
-      int minChildTop = Integer.MAX_VALUE;
-      boolean hasValidChild = false;
+      ChildExtent extent = scanChildExtent(children, vs,
+         c -> c.getVSAssemblyInfo().getLayoutPosition(true),
+         c -> c.getVSAssemblyInfo().getLayoutSize(true));
+
+      if(extent == null) {
+         return;
+      }
+
+      int newTabY = toBottomTabs
+         ? extent.maxBottom()
+         : Math.max(0, extent.minTop() - tabHeight);
+
+      if(newTabY != tabScaledPos.y) {
+         tabInfo.setScaledPosition(new Point(tabScaledPos.x, newTabY));
+      }
+   }
+
+   /**
+    * Tab children's vertical extent in some coordinate space.
+    */
+   public record ChildExtent(int minTop, int maxBottom) {}
+
+   /**
+    * Scan tab children for the bounding-box top/bottom in the coordinate space
+    * defined by the accessors. Returns null when no child contributes a valid
+    * extent. Shared by master-pixel, layout, and scaled-space anchor logic.
+    * Accessors take VSAssembly (not VSAssemblyInfo) so callers can pick
+    * floored sizes (e.g. {@link VSAssembly#getPixelSize}) when needed.
+    */
+   public static ChildExtent scanChildExtent(String[] children, Viewsheet vs,
+                                             Function<VSAssembly, Point> posGetter,
+                                             Function<VSAssembly, Dimension> sizeGetter)
+   {
+      int maxBottom = Integer.MIN_VALUE;
+      int minTop = Integer.MAX_VALUE;
+      boolean hasValid = false;
 
       for(String childName : children) {
          VSAssembly child = (VSAssembly) vs.getAssembly(childName);
@@ -484,36 +499,25 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
             continue;
          }
 
-         VSAssemblyInfo childInfo = child.getVSAssemblyInfo();
-         Point childPos = childInfo.getLayoutPosition(true);
-         Dimension childSize = childInfo.getLayoutSize(true);
+         Point pos = posGetter.apply(child);
+         Dimension size = sizeGetter.apply(child);
 
-         if(childPos == null || childSize == null) {
+         if(pos == null || size == null) {
             continue;
          }
 
-         int childHeight = getBottomTabChildHeight(childInfo, childSize);
+         int height = getBottomTabChildHeight(child.getVSAssemblyInfo(), size);
 
-         if(childHeight == 0) {
+         if(height == 0) {
             continue;
          }
 
-         maxChildBottom = Math.max(maxChildBottom, childPos.y + childHeight);
-         minChildTop = Math.min(minChildTop, childPos.y);
-         hasValidChild = true;
+         maxBottom = Math.max(maxBottom, pos.y + height);
+         minTop = Math.min(minTop, pos.y);
+         hasValid = true;
       }
 
-      if(!hasValidChild) {
-         return;
-      }
-
-      int newTabY = toBottomTabs
-         ? maxChildBottom
-         : Math.max(0, minChildTop - tabHeight);
-
-      if(newTabY != tabScaledPos.y) {
-         tabInfo.setScaledPosition(new Point(tabScaledPos.x, newTabY));
-      }
+      return hasValid ? new ChildExtent(minTop, maxBottom) : null;
    }
 
    /**

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
@@ -115,10 +115,37 @@ class TabVSAssemblyInfoTest {
       tabInfo.setPixelOffset(new Point(50, 0));
       tabInfo.setPixelSize(new Dimension(200, 24));
 
+      Point pixelBefore = new Point(tabInfo.getPixelOffset());
       TabVSAssemblyInfo.repositionForBottomTabsInScaledSpace(tabInfo, vs, true);
 
-      // no scaledPosition was set; helper must not introduce one
+      // helper must not introduce a scaled position when none was present
       assertNull(tabInfo.getLayoutPosition(true));
+      // master pixelOffset must be unchanged
+      assertEquals(pixelBefore, tabInfo.getPixelOffset());
+   }
+
+   @Test
+   void repositionForBottomTabsInScaledSpaceUsesLayoutSizeWhenScaledSizeAbsent() {
+      Viewsheet vs = Mockito.mock(Viewsheet.class);
+
+      SelectionListVSAssemblyInfo childInfo = new SelectionListVSAssemblyInfo();
+      childInfo.setShowTypeValue(SelectionVSAssemblyInfo.LIST_SHOW_TYPE);
+      childInfo.setScaledPosition(new Point(50, 24));
+      // no setScaledSize call — helper must fall back to layoutSize(false)
+      childInfo.setLayoutSize(new Dimension(200, 200));
+      VSAssembly child = Mockito.mock(VSAssembly.class);
+      when(child.getVSAssemblyInfo()).thenReturn(childInfo);
+      when(vs.getAssembly("Child1")).thenReturn(child);
+
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setAssemblies(new String[]{"Child1"});
+      tabInfo.setScaledPosition(new Point(50, 0));
+      tabInfo.setLayoutSize(new Dimension(200, 24));
+
+      TabVSAssemblyInfo.repositionForBottomTabsInScaledSpace(tabInfo, vs, true);
+
+      // maxChildBottom using layoutSize fallback = 24 + 200 = 224
+      assertEquals(224, tabInfo.getLayoutPosition(true).y);
    }
 
    @Test

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
@@ -99,6 +99,106 @@ class TabVSAssemblyInfoTest {
    }
 
    @Test
+   void repositionForBottomTabsInScaledSpaceNoopWhenNoScaledPosition() {
+      Viewsheet vs = Mockito.mock(Viewsheet.class);
+
+      SelectionListVSAssemblyInfo childInfo = new SelectionListVSAssemblyInfo();
+      childInfo.setShowTypeValue(SelectionVSAssemblyInfo.LIST_SHOW_TYPE);
+      childInfo.setPixelOffset(new Point(50, 24));
+      childInfo.setPixelSize(new Dimension(200, 200));
+      VSAssembly child = Mockito.mock(VSAssembly.class);
+      when(child.getVSAssemblyInfo()).thenReturn(childInfo);
+      when(vs.getAssembly("Child1")).thenReturn(child);
+
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setAssemblies(new String[]{"Child1"});
+      tabInfo.setPixelOffset(new Point(50, 0));
+      tabInfo.setPixelSize(new Dimension(200, 24));
+
+      TabVSAssemblyInfo.repositionForBottomTabsInScaledSpace(tabInfo, vs, true);
+
+      // no scaledPosition was set; helper must not introduce one
+      assertNull(tabInfo.getLayoutPosition(true));
+   }
+
+   @Test
+   void repositionForBottomTabsInScaledSpaceBottomTabsMovesTabToMaxChildBottom() {
+      Viewsheet vs = Mockito.mock(Viewsheet.class);
+
+      SelectionListVSAssemblyInfo childInfo = new SelectionListVSAssemblyInfo();
+      childInfo.setShowTypeValue(SelectionVSAssemblyInfo.LIST_SHOW_TYPE);
+      childInfo.setScaledPosition(new Point(50, 24));
+      childInfo.setScaledSize(new Dimension(200, 200));
+      VSAssembly child = Mockito.mock(VSAssembly.class);
+      when(child.getVSAssemblyInfo()).thenReturn(childInfo);
+      when(vs.getAssembly("Child1")).thenReturn(child);
+
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setAssemblies(new String[]{"Child1"});
+      tabInfo.setScaledPosition(new Point(50, 0));
+      tabInfo.setScaledSize(new Dimension(200, 24));
+
+      TabVSAssemblyInfo.repositionForBottomTabsInScaledSpace(tabInfo, vs, true);
+
+      // maxChildBottom = 24 + 200 = 224
+      assertEquals(224, tabInfo.getLayoutPosition(true).y);
+      // child unchanged (master semantics: only the tab moves)
+      assertEquals(24, childInfo.getLayoutPosition(true).y);
+   }
+
+   @Test
+   void repositionForBottomTabsInScaledSpaceTopTabsMovesTabAboveMinChildTop() {
+      Viewsheet vs = Mockito.mock(Viewsheet.class);
+
+      SelectionListVSAssemblyInfo childInfo = new SelectionListVSAssemblyInfo();
+      childInfo.setShowTypeValue(SelectionVSAssemblyInfo.LIST_SHOW_TYPE);
+      childInfo.setScaledPosition(new Point(50, 24));
+      childInfo.setScaledSize(new Dimension(200, 200));
+      VSAssembly child = Mockito.mock(VSAssembly.class);
+      when(child.getVSAssemblyInfo()).thenReturn(childInfo);
+      when(vs.getAssembly("Child1")).thenReturn(child);
+
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setAssemblies(new String[]{"Child1"});
+      tabInfo.setScaledPosition(new Point(50, 224));
+      tabInfo.setScaledSize(new Dimension(200, 24));
+
+      TabVSAssemblyInfo.repositionForBottomTabsInScaledSpace(tabInfo, vs, false);
+
+      // minChildTop - tabHeight = 24 - 24 = 0
+      assertEquals(0, tabInfo.getLayoutPosition(true).y);
+      assertEquals(24, childInfo.getLayoutPosition(true).y);
+   }
+
+   @Test
+   void repositionForBottomTabsInScaledSpaceDoesNotTouchPixelOffset() {
+      Viewsheet vs = Mockito.mock(Viewsheet.class);
+
+      SelectionListVSAssemblyInfo childInfo = new SelectionListVSAssemblyInfo();
+      childInfo.setShowTypeValue(SelectionVSAssemblyInfo.LIST_SHOW_TYPE);
+      childInfo.setPixelOffset(new Point(50, 124));
+      childInfo.setScaledPosition(new Point(50, 24));
+      childInfo.setScaledSize(new Dimension(200, 200));
+      VSAssembly child = Mockito.mock(VSAssembly.class);
+      when(child.getVSAssemblyInfo()).thenReturn(childInfo);
+      when(vs.getAssembly("Child1")).thenReturn(child);
+
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setAssemblies(new String[]{"Child1"});
+      tabInfo.setPixelOffset(new Point(50, 100));
+      tabInfo.setScaledPosition(new Point(50, 0));
+      tabInfo.setScaledSize(new Dimension(200, 24));
+
+      TabVSAssemblyInfo.repositionForBottomTabsInScaledSpace(tabInfo, vs, true);
+
+      // master pixelOffset must be untouched
+      assertEquals(100, tabInfo.getPixelOffset().y);
+      assertEquals(124, childInfo.getPixelOffset().y);
+      // scaled tab moved to maxChildBottom = 24 + 200 = 224
+      assertEquals(224, tabInfo.getLayoutPosition(true).y);
+   }
+
+   @Test
    void getBottomTabChildHeightReturnsPixelHeightForNonDropdown() {
       SelectionListVSAssemblyInfo info = new SelectionListVSAssemblyInfo();
       info.setShowTypeValue(SelectionVSAssemblyInfo.LIST_SHOW_TYPE);


### PR DESCRIPTION
Toggling TabVSAssembly.bottomTabs via a viewsheet script in a layout preview hid the tab off-screen on click and clipped the chart child above the viewport after refresh. Master preview was unaffected.

Two root causes:

1. repositionForBottomTabs computed actualTabDy in master pixel space and applied it to tabInfo.getLayoutPosition().translate(...). In layout previews that getter returns scaledPosition, so a master-space delta corrupted the scaled position.

2. AbstractLayout.applyTab bakes in the design-time bottomTabs value. On every refresh, applyTabScale restored the tab to its initial edge and positioned children past the container bound.

Changes:
- Drop the cross-coordinate-space getLayoutPosition().translate calls in repositionForBottomTabs. pixelOffset updates are unchanged.
- Add repositionForBottomTabsInScaledSpace, the scaled-space twin invoked from TabVSAScriptable.setBottomTabs so a script toggle takes effect immediately in layout previews. Master-pixel-space semantics: only the tab moves; children stay anchored.
- Re-anchor the tab from child bounds at the top of applyTabScale on every refresh/resize. Gated on layoutPosition(false) so master preview behavior is unchanged.

Adds four unit tests for the new helper. Existing pixel-space tests in TabVSAssemblyInfoTest are preserved unchanged.