### PR TITLE
Radar axis and labels not painting

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/VGraphPair.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/VGraphPair.java
@@ -1661,8 +1661,10 @@ public class VGraphPair {
    public BufferedImage getPlotImage(int row, int col) {
       final VGraph vgraph = getExpandedVGraph();
       final GraphBounds gbounds = new GraphBounds(vgraph, getRealSizeVGraph(), cinfo);
+      // Radar charts render PolarAxis (spokes/rings) inside the plot tile, so paintAxes must
+      // be true for them. All other types suppress axes to prevent label bleed into plot tiles.
       return getFlipYSubimage(vgraph, gbounds.getPlotBounds(), row, col, true,
-         getEVGraphContext(false, true));
+         getEVGraphContext(hasRadarCoord(vgraph), true));
    }
 
    /**
@@ -2018,7 +2020,9 @@ public class VGraphPair {
    public Graphics2D getPlotGraphic(int row, int col) {
       final VGraph vgraph = getExpandedVGraph();
       final GraphBounds gbounds = new GraphBounds(vgraph, getRealSizeVGraph(), cinfo);
-      return getFlipYSubGraphic(vgraph, gbounds.getPlotBounds(), row, col, true, getEVGraphContext(false, true), true);
+      // Radar charts render PolarAxis (spokes/rings) inside the plot tile, so paintAxes must
+      // be true for them. All other types suppress axes to prevent label bleed into plot tiles.
+      return getFlipYSubGraphic(vgraph, gbounds.getPlotBounds(), row, col, true, getEVGraphContext(hasRadarCoord(vgraph), true), true);
    }
 
    /**


### PR DESCRIPTION
Root cause: PR #3624 changed plot tile contexts from paintAxes=true to paintAxes=false to prevent axis labels from bleeding into plot tiles. This was correct for standard charts where axes are

   rendered in separate tiles, but radar charts render their PolarAxis objects (spokes and grid rings) inside the plot area — gating them on paintAxes caused them to disappear entirely.

  Fix: In getPlotImage and getPlotGraphic, replace the hardcoded false with hasRadarCoord(vgraph), so radar charts get paintAxes=true (axes stay visible in the plot tile) while all other chart
  types keep paintAxes=false (no label bleed).