### PR TITLE
Bug #74927. Fix NLU aggregate modifier recognition and worksheet aggregation guard.

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
@@ -263,10 +263,8 @@ public class GenerateWsService {
 
       // Apply GROUP BY and aggregate info
       // Apply HAVING conditions (stored in postconds)
-      if(model.getAggregates() != null && model.getHaving() != null) {
-         applyAggregateInfo(table, model.getGroupBy(), model.getAggregates(), model.getHaving());
-         applyHavingCondition(table, model.getHaving());
-      }
+      applyAggregateInfo(table, model.getGroupBy(), model.getAggregates(), model.getHaving());
+      applyHavingCondition(table, model.getHaving());
 
       return new WorksheetBuildResult(worksheet, table);
    }


### PR DESCRIPTION
Remove incorrect `aggregates != null && having != null` guard around applyAggregateInfo/applyHavingCondition — both methods already handle null inputs internally, and the conjunction caused GROUP BY + aggregates to be silently skipped whenever HAVING was absent.