### PR TITLE
74973 - Polygon (Spider-Web) Grid for Radar Charts

### DIFF
--- a/core/src/main/java/inetsoft/graph/coord/PolarCoord.java
+++ b/core/src/main/java/inetsoft/graph/coord/PolarCoord.java
@@ -273,12 +273,18 @@ public class PolarCoord extends Coordinate {
 
          return new Line2D.Double(p1, p2);
       }
-      // horizontal line into arc
+      // horizontal line into arc (or polygon segment when webGrid is on)
       else if(p1.getY() == p2.getY()) {
          double r = getR(p1.getY());
+         double yratio = getRatioY();
+         int n = webGrid ? getSidesCount() : 0;
+
+         if(n >= 3) {
+            return createPolygonRing(r, yratio, p1.getX() / GWIDTH, p2.getX() / GWIDTH);
+         }
+
          double start = p1.getX() * 360 / GWIDTH;
          double end = p2.getX() * 360 / GWIDTH;
-         double yratio = getRatioY();
 
          return new Arc2D.Double(-r, -r * yratio, 2 * r, 2 * r * yratio,
                                  -start, -(end - start), Arc2D.OPEN);
@@ -467,6 +473,14 @@ public class PolarCoord extends Coordinate {
             axis2.setZIndex(axis.getZIndex());
             axis2.setWidth(r);
             axis2.setHeight(r);
+
+            if(webGrid) {
+               int n = getSidesCount();
+
+               if(n >= 3) {
+                  axis2.setPolygonSides(n);
+               }
+            }
 
             vgraph.setAxis(i, axis2);
             axises.add(axis2);
@@ -1084,6 +1098,52 @@ public class PolarCoord extends Coordinate {
       return type == coord.type && holeRatio == coord.holeRatio && pieRatio == coord.pieRatio;
    }
 
+   /**
+    * Enable polygon (spider-web) grid rings instead of circular arcs.
+    * When enabled, concentric grid rings and the polar axis boundary are drawn
+    * as N-sided polygons where N equals the number of theta-axis categories.
+    */
+   public void setWebGrid(boolean webGrid) {
+      this.webGrid = webGrid;
+   }
+
+   public boolean isWebGrid() {
+      return webGrid;
+   }
+
+   private int getSidesCount() {
+      if(coord instanceof RectCoord) {
+         Scale xscale = ((RectCoord) coord).getXScale();
+
+         if(xscale != null) {
+            double[] ticks = xscale.getTicks();
+
+            if(ticks != null) {
+               return ticks.length;
+            }
+         }
+      }
+      else if(coord != null) {
+         int n = coord.getDimCount();
+
+         if(n > 0) {
+            return n;
+         }
+      }
+
+      return 0;
+   }
+
+   private static Shape createPolygonRing(double r, double yratio,
+                                          double startFrac, double endFrac)
+   {
+      double startAngle = startFrac * 2 * Math.PI;
+      double endAngle = endFrac * 2 * Math.PI;
+      return new Line2D.Double(
+         r * Math.cos(startAngle), r * yratio * Math.sin(startAngle),
+         r * Math.cos(endAngle), r * yratio * Math.sin(endAngle));
+   }
+
    private static final double MIN_RADIUS = 20;
    private static final double PREFERRED_RADIUS = 48;
    private static final long serialVersionUID = 1L;
@@ -1094,6 +1154,7 @@ public class PolarCoord extends Coordinate {
    private Double pradius = null; // polar radius
    private double holeRatio = 0.3;
    private double pieRatio = 0;
+   private boolean webGrid = false;
    private boolean minApplied;
    private transient double rx0 = Double.NaN; // cached radio ratio x
    private transient double rc0 = Double.NaN; // cached radio ratio c

--- a/core/src/main/java/inetsoft/graph/coord/PolarCoord.java
+++ b/core/src/main/java/inetsoft/graph/coord/PolarCoord.java
@@ -474,12 +474,8 @@ public class PolarCoord extends Coordinate {
             axis2.setWidth(r);
             axis2.setHeight(r);
 
-            if(webGrid) {
-               int n = getSidesCount();
-
-               if(n >= 3) {
-                  axis2.setPolygonSides(n);
-               }
+            if(webGrid && getSidesCount() >= 3) {
+               axis2.setUsePolygon(true);
             }
 
             vgraph.setAxis(i, axis2);
@@ -1095,7 +1091,8 @@ public class PolarCoord extends Coordinate {
       }
 
       PolarCoord coord = (PolarCoord) obj;
-      return type == coord.type && holeRatio == coord.holeRatio && pieRatio == coord.pieRatio;
+      return type == coord.type && holeRatio == coord.holeRatio &&
+             pieRatio == coord.pieRatio && webGrid == coord.webGrid;
    }
 
    /**

--- a/core/src/main/java/inetsoft/graph/guide/axis/PolarAxis.java
+++ b/core/src/main/java/inetsoft/graph/guide/axis/PolarAxis.java
@@ -186,6 +186,7 @@ public class PolarAxis extends Axis {
 
       vlabels = new VLabel[0];
       line = new PolarAxisLine(this);
+      line.setPolygonSides(polygonSides);
       addVisual(line);
 
       if(isLabelVisible()) {
@@ -387,9 +388,19 @@ public class PolarAxis extends Axis {
       return new Rectangle2D.Double(x, y, w, h);
    }
 
+   public void setPolygonSides(int n) {
+      this.polygonSides = n;
+
+      if(line != null) {
+         line.setPolygonSides(n);
+      }
+   }
+
+
    private static final int TICK_SIZE = 3; // tick line length
    private double width; // width of the axis (oval) in pixels
    private double height; // width of the axis (oval) in pixels
+   private int polygonSides = 0;
    private PolarAxisLine line;
    private VLabel[] vlabels;
    private String[] measures = null;

--- a/core/src/main/java/inetsoft/graph/guide/axis/PolarAxis.java
+++ b/core/src/main/java/inetsoft/graph/guide/axis/PolarAxis.java
@@ -186,7 +186,7 @@ public class PolarAxis extends Axis {
 
       vlabels = new VLabel[0];
       line = new PolarAxisLine(this);
-      line.setPolygonSides(polygonSides);
+      line.setUsePolygon(usePolygon);
       addVisual(line);
 
       if(isLabelVisible()) {
@@ -388,19 +388,18 @@ public class PolarAxis extends Axis {
       return new Rectangle2D.Double(x, y, w, h);
    }
 
-   public void setPolygonSides(int n) {
-      this.polygonSides = n;
+   public void setUsePolygon(boolean usePolygon) {
+      this.usePolygon = usePolygon;
 
       if(line != null) {
-         line.setPolygonSides(n);
+         line.setUsePolygon(usePolygon);
       }
    }
-
 
    private static final int TICK_SIZE = 3; // tick line length
    private double width; // width of the axis (oval) in pixels
    private double height; // width of the axis (oval) in pixels
-   private int polygonSides = 0;
+   private boolean usePolygon = false;
    private PolarAxisLine line;
    private VLabel[] vlabels;
    private String[] measures = null;

--- a/core/src/main/java/inetsoft/graph/guide/axis/PolarAxisLine.java
+++ b/core/src/main/java/inetsoft/graph/guide/axis/PolarAxisLine.java
@@ -88,9 +88,10 @@ class PolarAxisLine extends AxisLine {
       if(getAxis().isLineVisible()) {
          Shape outline;
 
-         if(polygonSides >= 3) {
+         if(usePolygon) {
+            // clone to avoid mutating the scale's cached tick array a second time in paintTicks
             double[] angles = PolarUtil.getTickLocations(
-               getAxis().getScale(), getAxis().getScale().getTicks());
+               getAxis().getScale(), getAxis().getScale().getTicks().clone());
             outline = createPolygon(angles, width, height);
          }
          else {
@@ -174,15 +175,15 @@ class PolarAxisLine extends AxisLine {
       return new Rectangle2D.Double(pos1.getX(), pos1.getY(), width, height);
    }
 
-   public void setPolygonSides(int n) {
-      this.polygonSides = n;
+   public void setUsePolygon(boolean usePolygon) {
+      this.usePolygon = usePolygon;
    }
 
    private static Path2D createPolygon(double[] angles, double w, double h) {
-      double cx = w / 2;
-      double cy = h / 2;
-      double rx = w / 2;
-      double ry = h / 2;
+      double cx = w / 2; // center x
+      double cy = h / 2; // center y
+      double rx = w / 2; // radius x (half-width of bounding box)
+      double ry = h / 2; // radius y (half-height of bounding box)
       Path2D path = new Path2D.Double();
 
       for(int i = 0; i < angles.length; i++) {
@@ -203,5 +204,5 @@ class PolarAxisLine extends AxisLine {
 
    private double width;
    private double height;
-   private int polygonSides = 0;
+   private boolean usePolygon = false;
 }

--- a/core/src/main/java/inetsoft/graph/guide/axis/PolarAxisLine.java
+++ b/core/src/main/java/inetsoft/graph/guide/axis/PolarAxisLine.java
@@ -86,9 +86,18 @@ class PolarAxisLine extends AxisLine {
       g2.setColor(getAxis().getLineColor());
 
       if(getAxis().isLineVisible()) {
-         Ellipse2D oval = new Ellipse2D.Double(0, 0, width, height);
-         Shape path = getScreenTransform().createTransformedShape(oval);
+         Shape outline;
 
+         if(polygonSides >= 3) {
+            double[] angles = PolarUtil.getTickLocations(
+               getAxis().getScale(), getAxis().getScale().getTicks());
+            outline = createPolygon(angles, width, height);
+         }
+         else {
+            outline = new Ellipse2D.Double(0, 0, width, height);
+         }
+
+         Shape path = getScreenTransform().createTransformedShape(outline);
          g2.draw(path);
       }
 
@@ -165,6 +174,34 @@ class PolarAxisLine extends AxisLine {
       return new Rectangle2D.Double(pos1.getX(), pos1.getY(), width, height);
    }
 
+   public void setPolygonSides(int n) {
+      this.polygonSides = n;
+   }
+
+   private static Path2D createPolygon(double[] angles, double w, double h) {
+      double cx = w / 2;
+      double cy = h / 2;
+      double rx = w / 2;
+      double ry = h / 2;
+      Path2D path = new Path2D.Double();
+
+      for(int i = 0; i < angles.length; i++) {
+         double vx = cx + rx * Math.cos(angles[i]);
+         double vy = cy + ry * Math.sin(angles[i]);
+
+         if(i == 0) {
+            path.moveTo(vx, vy);
+         }
+         else {
+            path.lineTo(vx, vy);
+         }
+      }
+
+      path.closePath();
+      return path;
+   }
+
    private double width;
    private double height;
+   private int polygonSides = 0;
 }


### PR DESCRIPTION
  A new setWebGrid(true) option was added to PolarCoord that switches a radar chart's visual style from the default circular rings to a classic polygon/spider-web grid. When enabled, every
  concentric ring in the chart becomes an N-sided polygon rather than a circle — a hexagon for 6 dimensions, pentagon for 5, and so on. The outer axis boundary also becomes the matching polygon
  shape. The polygon corners land precisely where the spokes are, so the grid looks like the traditional radar chart you'd see in sports statistics or performance dashboards.

  Several bugs had to be worked through to get there:

  - The polygon side count wasn't reaching the axis line renderer because the visual was created before the count was assigned — fixed by forwarding the value to the already-live object, mirroring how width and height are handled.
  - For radar charts specifically, the inner coordinate is a ParallelCoord (not a RectCoord), so the dimension count had to be read differently.
  - The concentric rings in a radar chart are drawn as N separate short segments (one per spoke gap), not as a single full circle. This meant the ring-to-polygon conversion needed to draw a straight line between two spoke positions rather than trying to place intermediate vertices — which is exactly what a polygon edge is.
  - The outer boundary polygon's corners needed to use the actual spoke angles from the scale's tick positions rather than evenly-spaced angles starting from zero, since the spokes in a ParallelCoord are centered within their slots, not at the slot boundaries.