### PR TITLE
Bug #74946, fix AxisSpec.setAllTicks() having no visible effect

### DIFF
--- a/core/src/main/java/inetsoft/graph/guide/axis/DefaultAxis.java
+++ b/core/src/main/java/inetsoft/graph/guide/axis/DefaultAxis.java
@@ -1865,10 +1865,18 @@ public class DefaultAxis extends Axis {
          .filter(label -> label.getZIndex() >= 0)
          .collect(Collectors.toList());
 
+      // Map each label to its index in vlabels (== its index in scale.getTicks()),
+      // so that dupTicks bits correspond to the original tick array positions.
+      Map<VDimensionLabel, Integer> tickIndex = new IdentityHashMap<>();
+
+      for(int k = 0; k < vlabels.length; k++) {
+         tickIndex.put(vlabels[k], k);
+      }
+
       for(int i = 1; i < labels.size(); i++) {
          if(labels.get(i).getText().equals(labels.get(i - 1).getText())) {
             if(!spec.isAllTicks()) {
-               dupTicks.set(i);
+               dupTicks.set(tickIndex.get(labels.get(i)));
             }
 
             labels.get(i).setZIndex(-1);


### PR DESCRIPTION
## Summary

- `AxisSpec.setAllTicks(false)` was supposed to suppress tick marks at positions where duplicate `TimeScale` labels were hidden, but had no visible effect — both `true` and `false` produced identical output.
- Root cause: `removeDuplicateLabels()` was calling `dupTicks.set(i)` using the index `i` from a local, shrinking copy of the labels list. As duplicates were removed, `i` kept resetting to a small value, so only bits `{1, 2, 3}` were ever set regardless of how many duplicates existed. `getTicks()` then filtered the original 90-element tick array by those wrong indices, excluding only the 2nd, 3rd, and 4th ticks instead of the actual duplicate positions.
- Fix: build an `IdentityHashMap` from each `VDimensionLabel` to its original index in `vlabels` (which is parallel to `scale.getTicks()`) before the loop, and use that original index when setting bits in `dupTicks`.

## Test plan

- [ ] Create a chart component script with a `TimeScale` set to `DAY` interval and a `SimpleDateFormat('MMM')` format, spanning ~90 days across 3 months
- [ ] With `setAllTicks(true)`: verify ~90 densely packed tick marks are visible (one per day), with only 3 month labels
- [ ] With `setAllTicks(false)`: verify only 3 tick marks are visible (one per visible label)
- [ ] Confirm no regression on charts without a duplicate-suppressing format

🤖 Generated with [Claude Code](https://claude.com/claude-code)