### PR TITLE
Bug #74967 - Widen tree chart Layout Direction dropdown so floating label fits

### DIFF
--- a/web/projects/portal/src/app/graph/dialog/chart-plot-options-pane.component.html
+++ b/web/projects/portal/src/app/graph/dialog/chart-plot-options-pane.component.html
@@ -223,7 +223,7 @@
             </div>
          </div>
          <div class="col-auto form-floating" *ngIf="model.treeLayoutVisible">
-            <select class="form-control" id="treeLayout"
+            <select class="form-control tree-layout" id="treeLayout"
                     [(ngModel)]="model.treeLayout"
                     [ngModelOptions]="{standalone: true}">
                <option value="TOP_BOTTOM">_#(Top to Bottom)</option>

--- a/web/projects/portal/src/app/graph/dialog/chart-plot-options-pane.component.scss
+++ b/web/projects/portal/src/app/graph/dialog/chart-plot-options-pane.component.scss
@@ -34,3 +34,7 @@ fieldset > legend {
 .corner-radius {
   min-width: 160px;
 }
+
+.tree-layout {
+  min-width: 140px;
+}


### PR DESCRIPTION
The "Layout Direction" floating label is wider than the select's
content, causing it to overhang the dropdown in Chart Properties >
Advanced > Plot Options. Add a tree-layout class with min-width: 140px,
matching the existing pattern used by .pie-ratio, .font-multiplier, and
.corner-radius in the same pane.