### PR TITLE
Bug #74966 - Expose treeLayout as a chart script property

### DIFF
--- a/core/src/main/java/inetsoft/report/script/ChartProcessor.java
+++ b/core/src/main/java/inetsoft/report/script/ChartProcessor.java
@@ -244,6 +244,8 @@ public class ChartProcessor extends ScriptableObject {
                              "setFillGapWithDash", boolean.class, PlotDescriptor.class, plot);
       scriptable.addProperty("smoothLines", "isSmoothLines",
                              "setSmoothLines", boolean.class, PlotDescriptor.class, plot);
+      scriptable.addProperty("treeLayout", "getTreeLayout",
+                             "setTreeLayout", String.class, PlotDescriptor.class, plot);
       scriptable.addProperty("pieRatio", "getPieRatio",
                              "setPieRatio", double.class, PlotDescriptor.class, plot);
       scriptable.addProperty("barCornerRadius", "getBarCornerRadius",

--- a/core/src/main/java/inetsoft/report/script/ChartProcessor.java
+++ b/core/src/main/java/inetsoft/report/script/ChartProcessor.java
@@ -242,6 +242,8 @@ public class ChartProcessor extends ScriptableObject {
 
       scriptable.addProperty("fillGapWithDash", "isFillGapWithDash",
                              "setFillGapWithDash", boolean.class, PlotDescriptor.class, plot);
+      scriptable.addProperty("smoothLines", "isSmoothLines",
+                             "setSmoothLines", boolean.class, PlotDescriptor.class, plot);
       scriptable.addProperty("pieRatio", "getPieRatio",
                              "setPieRatio", double.class, PlotDescriptor.class, plot);
       scriptable.addProperty("barCornerRadius", "getBarCornerRadius",

--- a/core/src/main/resources/inetsoft/web/binding/property-type.properties
+++ b/core/src/main/resources/inetsoft/web/binding/property-type.properties
@@ -302,6 +302,7 @@ Chart.sortOthersLast=?
 Chart.trendLine=?
 Chart.textField=string
 Chart.toolTip=string
+Chart.treeLayout=string
 Chart.trendLineColor=?
 Chart.trendLineStyle=number
 Chart.trendPerColor=?

--- a/core/src/main/resources/inetsoft/web/binding/property-type.properties
+++ b/core/src/main/resources/inetsoft/web/binding/property-type.properties
@@ -295,6 +295,7 @@ Chart.sizeLegends.font=?
 Chart.sizeLegends.format=?
 Chart.sizeLegends.noNull=bool
 Chart.sizeLegends.title=string
+Chart.smoothLines=bool
 Chart.stackValue=bool
 Chart.stackMeasures=bool
 Chart.sortOthersLast=?

--- a/core/src/test/java/inetsoft/report/script/viewsheet/ChartVSAScriptableTest.java
+++ b/core/src/test/java/inetsoft/report/script/viewsheet/ChartVSAScriptableTest.java
@@ -216,7 +216,7 @@ public class ChartVSAScriptableTest {
       chartVSAScriptable.setTipView("this is a tip view");
       assertEquals("this is a tip view", chartVSAScriptable.getTipView());
 
-      assertEquals(145, chartVSAScriptable.getIds().length);
+      assertEquals(146, chartVSAScriptable.getIds().length);
    }
 
    /**

--- a/core/src/test/java/inetsoft/report/script/viewsheet/ChartVSAScriptableTest.java
+++ b/core/src/test/java/inetsoft/report/script/viewsheet/ChartVSAScriptableTest.java
@@ -132,6 +132,28 @@ public class ChartVSAScriptableTest {
    }
 
    @Test
+   void testTreeLayoutScriptProperty() {
+      chartVSAScriptable.addProperties();
+      PlotDescriptor plot = chartVSAScriptable.getRTChartDescriptor().getPlotDescriptor();
+
+      // round-trip each valid value
+      for(String layout : new String[] {
+         PlotDescriptor.TREE_LAYOUT_TOP_BOTTOM,
+         PlotDescriptor.TREE_LAYOUT_BOTTOM_TOP,
+         PlotDescriptor.TREE_LAYOUT_LEFT_RIGHT,
+         PlotDescriptor.TREE_LAYOUT_RIGHT_LEFT })
+      {
+         chartVSAScriptable.put("treeLayout", null, layout);
+         assertEquals(layout, plot.getTreeLayout());
+         assertEquals(layout, chartVSAScriptable.get("treeLayout", null));
+      }
+
+      // unknown values fall back to TOP_BOTTOM
+      chartVSAScriptable.put("treeLayout", null, "BOGUS");
+      assertEquals(PlotDescriptor.TREE_LAYOUT_TOP_BOTTOM, plot.getTreeLayout());
+   }
+
+   @Test
    void testPutProperties() {
       EGraph graph = new EGraph();
       LineElement elem = new LineElement("State", "Quantity");

--- a/core/src/test/java/inetsoft/report/script/viewsheet/ChartVSAScriptableTest.java
+++ b/core/src/test/java/inetsoft/report/script/viewsheet/ChartVSAScriptableTest.java
@@ -216,7 +216,7 @@ public class ChartVSAScriptableTest {
       chartVSAScriptable.setTipView("this is a tip view");
       assertEquals("this is a tip view", chartVSAScriptable.getTipView());
 
-      assertEquals(146, chartVSAScriptable.getIds().length);
+      assertEquals(147, chartVSAScriptable.getIds().length);
    }
 
    /**


### PR DESCRIPTION
 ## Summary
  - Adds `Chart.treeLayout` script binding on `ChartVSAScriptable` so chart scripts can set the
  tree-chart layout direction (the existing Plot Options dialog already wrote this field, but JavaScript
  had no access).
  - Adds `Chart.treeLayout=string` to `property-type.properties` for script-editor autocomplete and type
  hints.
  - Updates `ChartVSAScriptableTest.testCommonFunctions` property count 146 → 147.

  ## Why
  `treeLayout` already had field, accessors, XML persistence, dialog model, and UI wiring. The only
  missing surface was scripting. Sibling `PlotDescriptor` properties (`smoothLines`, `fillGapWithDash`,
  `oneLine`, etc.) are all script-accessible; this closes the same gap for tree charts.

  Valid values are the four `PlotDescriptor.TREE_LAYOUT_*` constants: `"TOP_BOTTOM"`, `"BOTTOM_TOP"`,
  `"LEFT_RIGHT"`, `"RIGHT_LEFT"`. `setTreeLayout` already silently normalizes unknown strings to
  `TOP_BOTTOM`, so a script passing a typo gets a safe fallback instead of an exception. Script writes
  target the runtime `ChartDescriptor` clone, so values set from script affect rendering but don't
  persist into the saved viewsheet.

  The property is registered unconditionally (not gated on `CHART_TREE`) for consistency with
  `smoothLines` and other layout-style properties — non-tree chart rendering paths simply ignore the
  field.