### PR TITLE
Bug #74916, pre-scan the sort refs for any sort-by-value group dimension, and if one is found, skip all group dimension sorts entirely

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -2533,6 +2533,21 @@ public abstract class AssetQuery extends PreAssetQuery {
       ColumnIndexMap columnIndexMap = new ColumnIndexMap(base);
       boolean saggregated = false;
 
+      boolean hasSortByValGroup = false;
+
+      for(SortRef s : sorts) {
+         GroupRef g = ginfo.getGroup(s);
+
+         if(g != null) {
+            OrderInfo o = g.getOrderInfo();
+
+            if(o != null && o.isSortByVal()) {
+               hasSortByValGroup = true;
+               break;
+            }
+         }
+      }
+
       for(SortRef sort : sorts) {
          DataRef attr = sort.getDataRef();
          int col = AssetUtil.findColumn(base, attr, columnIndexMap);
@@ -2546,11 +2561,9 @@ public abstract class AssetQuery extends PreAssetQuery {
          AggregateRef aggregate = ginfo.getAggregate(sort);
 
          if(group != null) {
-            // if the group uses sort-by-value, the ordering is already applied
-            // by SummaryFilter via setSortByValInfo — do not re-sort here
-            OrderInfo oinfo = group.getOrderInfo();
-
-            if(oinfo != null && oinfo.isSortByVal()) {
+            // if any sort-by-value group is present, SummaryFilter owns all group
+            // ordering — applying any group sort here would interleave groups
+            if(hasSortByValGroup) {
                continue;
             }
 

--- a/core/src/main/java/inetsoft/report/composition/graph/calc/RunningTotalColumn.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/calc/RunningTotalColumn.java
@@ -162,7 +162,7 @@ public class RunningTotalColumn extends AbstractColumn {
 
          for(int i = row; i >= 0; i--) {
             Object breakByVal = baseData.getData(breakBy, i);
-            long intervali = getInterval(data, i);
+            long intervali = getInterval(baseData, i);
 
             if(interval != intervali) {
                continue;

--- a/core/src/main/java/inetsoft/report/composition/graph/calc/RunningTotalColumn.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/calc/RunningTotalColumn.java
@@ -154,10 +154,11 @@ public class RunningTotalColumn extends AbstractColumn {
       if(breakBy != null && !breakBy.isEmpty()) {
          DataSet baseData = data instanceof DataSetFilter ?
             ((DataSetFilter) data).getRootDataSet() : data;
+         int sortedRow = row;
          row = data instanceof DataSetFilter ? ((DataSetFilter) data).getRootRow(row) : row;
 
          Object firstBreakByVal = baseData.getData(breakBy, row);
-         long interval = getInterval(data, row);
+         long interval = getInterval(data, sortedRow);
 
          for(int i = row; i >= 0; i--) {
             Object breakByVal = baseData.getData(breakBy, i);


### PR DESCRIPTION
falling back on SummaryFilter already producing correct group ordering. Also correct related bug in RunningTotalColumn where the interval lookup for a DataSetFilter-backed dataset was using the remapped root-row index to query the filter layer instead of the original display-layer row index