### PR TITLE
Bug #74971 - Fix horizontal tree-chart canvas inflating X when faceted

### DIFF
--- a/core/src/main/java/inetsoft/graph/coord/RelationCoord.java
+++ b/core/src/main/java/inetsoft/graph/coord/RelationCoord.java
@@ -20,6 +20,7 @@ package inetsoft.graph.coord;
 import inetsoft.graph.*;
 import inetsoft.graph.data.DataSet;
 import inetsoft.graph.data.DataSetIndex;
+import inetsoft.graph.element.RelationElement;
 import inetsoft.graph.guide.axis.Axis;
 import inetsoft.graph.scale.Scale;
 
@@ -184,9 +185,17 @@ public class RelationCoord extends Coordinate {
    @Override
    public double getUnitMinWidth() {
       Rectangle2D box = getVisualObjectBounds();
-      // preferred size should be unscaled size
-      double scaleX = Math.abs(getVGraph().getScreenTransform().getScaleX());
-      return box != null ? (box.getMaxX() - box.getX()) / scaleX + GAP * 2 : 100;
+
+      if(box == null) {
+         return 100;
+      }
+
+      double width = box.getMaxX() - box.getX();
+      // Skip back-divide in horizontal mode: X is depth there, and fit()'s uniform scale is
+      // driven by Y, so dividing by scaleX inflates X spuriously and widens the chart canvas.
+      return isFirstElementHorizontal()
+         ? width + GAP * 2
+         : width / Math.abs(getVGraph().getScreenTransform().getScaleX()) + GAP * 2;
    }
 
    /**
@@ -220,6 +229,14 @@ public class RelationCoord extends Coordinate {
    @Override
    public Object clone(boolean srange) {
       return clone();
+   }
+
+   private boolean isFirstElementHorizontal() {
+      VGraph vg = getVGraph();
+      EGraph eg = vg != null ? vg.getEGraph() : null;
+      return eg != null && eg.getElementCount() > 0
+         && eg.getElement(0) instanceof RelationElement re
+         && re.isHorizontal();
    }
 
    private static final int GAP = 4;

--- a/core/src/test/java/inetsoft/graph/coord/RelationCoordMinSizeTest.java
+++ b/core/src/test/java/inetsoft/graph/coord/RelationCoordMinSizeTest.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.graph.coord;
+
+import inetsoft.graph.EGraph;
+import inetsoft.graph.Plotter;
+import inetsoft.graph.VGraph;
+import inetsoft.graph.aesthetic.StaticSizeFrame;
+import inetsoft.graph.data.DefaultDataSet;
+import inetsoft.graph.element.RelationElement;
+import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.Test;
+
+import java.awt.geom.AffineTransform;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Guards the asymmetric back-divide in {@link RelationCoord#getUnitMinWidth()}: vertical
+ * mode back-divides by scaleX (so post-fit calls recover natural width); horizontal mode
+ * skips the back-divide (X is depth, scaleX is Y-binding-driven, dividing would over-report
+ * X and force the chart canvas to widen unnecessarily).
+ */
+@SreeHome
+class RelationCoordMinSizeTest {
+   @Test
+   void horizontalModeSkipsBackDivideVerticalDoesNot() {
+      // Lay out one tree, then toggle the horizontal flag on the same coord and observe
+      // how getUnitMinWidth's formula reacts to a non-1 scaleX. Vertical mode back-divides
+      // and so reports ~2× horizontal's value when scaleX=0.5.
+      RelationCoord coord = treeCoord(false);
+      RelationElement elem = (RelationElement) coord.getVGraph().getEGraph().getElement(0);
+
+      coord.getVGraph().concat(AffineTransform.getScaleInstance(0.5, 0.5), true);
+
+      elem.setHorizontal(true);
+      double horizMin = coord.getUnitMinWidth();
+
+      elem.setHorizontal(false);
+      double vertMin = coord.getUnitMinWidth();
+
+      assertTrue(vertMin > horizMin * 1.5,
+         "vertical-mode back-divide should give a notably larger min than horizontal mode "
+            + "(horiz=" + horizMin + ", vert=" + vertMin + "); regression: horizontal also "
+            + "back-divides and X inflates spuriously");
+   }
+
+   @Test
+   void heightBackDivideAppliesInBothOrientations() {
+      // getUnitMinHeight intentionally does not gate on the horizontal flag — toggling
+      // the flag must not change Y's formula.
+      RelationCoord coord = treeCoord(false);
+      RelationElement elem = (RelationElement) coord.getVGraph().getEGraph().getElement(0);
+
+      coord.getVGraph().concat(AffineTransform.getScaleInstance(0.5, 0.5), true);
+
+      elem.setHorizontal(true);
+      double horizMinH = coord.getUnitMinHeight();
+
+      elem.setHorizontal(false);
+      double vertMinH = coord.getUnitMinHeight();
+
+      assertEquals(horizMinH, vertMinH, 0.5,
+         "getUnitMinHeight must back-divide in both orientations (horiz=" + horizMinH
+            + ", vert=" + vertMinH + ")");
+   }
+
+   private static RelationCoord treeCoord(boolean horizontal) {
+      DefaultDataSet data = new DefaultDataSet(new Object[][] {
+         { "From", "To"  },
+         { "R",    "A"   },
+         { "R",    "B"   },
+         { "R",    "C"   },
+         { "A",    "A1"  },
+         { "B",    "B1"  },
+         { "C",    "C1"  },
+      });
+
+      RelationElement element = new RelationElement("From", "To");
+      element.setAlgorithm(RelationElement.Algorithm.COMPACT_TREE);
+      element.setHorizontal(horizontal);
+      element.setSizeFrame(new StaticSizeFrame(5));
+      element.setNodeSizeFrame(new StaticSizeFrame(5));
+
+      EGraph egraph = new EGraph();
+      egraph.addElement(element);
+      RelationCoord coord = new RelationCoord();
+      egraph.setCoordinate(coord);
+
+      // plotAndLayout runs the full pipeline (createVGraph + layout) so coord.getVGraph()
+      // is wired up and visuals have bounds — what the production chart-engine sees.
+      VGraph vgraph = Plotter.getPlotter(egraph).plotAndLayout(data, 0, 0, 800, 600);
+      assertNotNull(vgraph, "Plotter.plotAndLayout must produce a vgraph for the test fixture");
+      return coord;
+   }
+}


### PR DESCRIPTION
 ## Summary
  - Fixes per-panel X-axis inflation in faceted relation charts when the layout direction option from PR #3616 is set to LEFT_RIGHT or RIGHT_LEFT
  - `RelationCoord.getUnitMinWidth()` no longer back-divides by `scaleX` in horizontal mode; scaleX there reflects a Y-binding shrink so back-dividing inflates X spuriously and forces the chart canvas to widen
  - Vertical-mode behavior is byte-for-byte unchanged (minPlotW/H, ewidth, eheight all match pre-fix exactly)

## Fix
In getUnitMinWidth, skip the back-divide when the underlying RelationElement is in horizontal layout. X is the depth axis in that
mode, so scaleX does not reflect an X-direction need. Vertical-mode behavior is unchanged.
  