### PR TITLE
Fix portal chart container fill issue by passing assetId and adding size sync mechanism

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshService.java
@@ -97,6 +97,14 @@ public class VSRefreshService {
          coreLifecycleService.setViewsheetInfo(rvs, linkUri, dispatcher);
       }
 
+      if(event.getEmbedAssemblySize() != null) {
+         EmbedAssemblyInfo embedAssemblyInfo = rvs.getEmbedAssemblyInfo();
+
+         if(embedAssemblyInfo != null) {
+            embedAssemblyInfo.setAssemblySize(event.getEmbedAssemblySize());
+         }
+      }
+
       // reset the assembly and dependencies.
       if(assembly != null) {
          refreshAssemblyAndDependencies(rvs, assembly, linkUri, dispatcher);

--- a/core/src/main/java/inetsoft/web/viewsheet/event/RefreshVSAssemblyEvent.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/event/RefreshVSAssemblyEvent.java
@@ -19,9 +19,11 @@ package inetsoft.web.viewsheet.event;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import inetsoft.web.admin.cache.CacheMetrics;
 import org.immutables.serial.Serial;
 import org.immutables.value.Value;
+
+import javax.annotation.Nullable;
+import java.awt.Dimension;
 
 @Value.Immutable
 @Serial.Structural
@@ -43,8 +45,10 @@ public abstract class RefreshVSAssemblyEvent {
       return false;
    }
 
-   public static CacheMetrics.Builder builder() {
-      return new CacheMetrics.Builder();
+   public abstract @Nullable Dimension getEmbedAssemblySize();
+
+   public static Builder builder() {
+      return new Builder();
    }
 
    public static final class Builder extends ImmutableRefreshVSAssemblyEvent.Builder {

--- a/web/projects/portal/src/app/embed/chart/embed-chart.component.ts
+++ b/web/projects/portal/src/app/embed/chart/embed-chart.component.ts
@@ -99,7 +99,6 @@ declare const window: any;
 export class EmbedChartComponent extends CommandProcessor implements OnInit, OnDestroy, AfterViewInit {
    @Input() url: string;
    appSize: Dimension;
-   assemblySize: Dimension;
    vsInfo: ViewsheetInfo;
    vsObject: VSChartModel;
    vsObjectActions: AbstractVSActions<any>;
@@ -477,10 +476,6 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
    setAppSize(): void {
       this.appSize = new Dimension(this.viewerRoot.nativeElement.offsetWidth,
          this.viewerRoot.nativeElement.offsetHeight);
-
-      const sbSize = GuiTool.measureScrollbars();
-      this.assemblySize = new Dimension(Math.max(0, this.appSize.width - sbSize),
-         Math.max(0, this.appSize.height - sbSize));
    }
 
    private fitChartToContainer(vsObject: VSChartModel): void {
@@ -574,7 +569,6 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
 
       const oldAppSize = new Dimension(this.appSize.width, this.appSize.height);
       this.setAppSize();
-      this.fitChartToContainer(this.vsObject);
 
       // no change or set to 0 then ignore
       if(this.appSize.width == 0 || this.appSize.height == 0 ||
@@ -582,6 +576,8 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
       {
          return;
       }
+
+      this.fitChartToContainer(this.vsObject);
 
       this.debounceService.debounce("embed-chart-vs-resize" + this.runtimeId, () => {
          if(this.inputRuntimeId) {

--- a/web/projects/portal/src/app/embed/chart/embed-chart.component.ts
+++ b/web/projects/portal/src/app/embed/chart/embed-chart.component.ts
@@ -288,6 +288,7 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
       }
 
       this.vsObject.active = true;
+      this.fitChartToContainer(this.vsObject);
       this.updateVSInfo();
 
       this.vsObjectActions = new EmbedChartActions(this.vsObject, null,
@@ -308,6 +309,7 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
       }
 
       this.vsObject.active = true;
+      this.fitChartToContainer(this.vsObject);
       this.vsObjectActions = new EmbedChartActions(this.vsObject, null,
          this.contextProvider, false, null, null, this.miniToolbarService);
    }
@@ -415,7 +417,8 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
       const refreshEvent: RefreshVsAssemblyEvent = {
          vsRuntimeId: this.runtimeId,
          assemblyName: this.assemblyName,
-         embed: true
+         embed: true,
+         embedAssemblySize: this.appSize
       };
       this.viewsheetClient.sendEvent("/events/vs/refresh/assembly", refreshEvent);
    }
@@ -429,7 +432,7 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
          this.assetId, this.appSize.width, this.appSize.height, this.mobileDevice,
          window.navigator.userAgent);
       event.embedAssemblyName = this.assemblyName;
-      event.embedAssemblySize = this.assemblySize;
+      event.embedAssemblySize = this.appSize;
       event.disableParameterSheet = true;
 
       for(let param in this.queryParams) {
@@ -478,6 +481,15 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
       const sbSize = GuiTool.measureScrollbars();
       this.assemblySize = new Dimension(Math.max(0, this.appSize.width - sbSize),
          Math.max(0, this.appSize.height - sbSize));
+   }
+
+   private fitChartToContainer(vsObject: VSChartModel): void {
+      if(vsObject?.objectFormat && this.appSize?.width > 0 && this.appSize?.height > 0) {
+         vsObject.objectFormat.left = 0;
+         vsObject.objectFormat.top = 0;
+         vsObject.objectFormat.width = this.appSize.width;
+         vsObject.objectFormat.height = this.appSize.height;
+      }
    }
 
    onOpenContextMenu(event: MouseEvent) {
@@ -562,6 +574,7 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
 
       const oldAppSize = new Dimension(this.appSize.width, this.appSize.height);
       this.setAppSize();
+      this.fitChartToContainer(this.vsObject);
 
       // no change or set to 0 then ignore
       if(this.appSize.width == 0 || this.appSize.height == 0 ||
@@ -574,7 +587,8 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
          if(this.inputRuntimeId) {
             const refreshEvent: RefreshVsAssemblyEvent = {
                vsRuntimeId: this.runtimeId,
-               assemblyName: this.assemblyName
+               assemblyName: this.assemblyName,
+               embedAssemblySize: this.appSize
             };
             this.viewsheetClient.sendEvent("/events/vs/refresh/assembly", refreshEvent);
          }
@@ -582,7 +596,7 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
             const refreshEvent = new VSRefreshEvent();
             refreshEvent.setWidth(this.appSize.width);
             refreshEvent.setHeight(this.appSize.height);
-            refreshEvent.setEmbedAssemblySize(this.assemblySize);
+            refreshEvent.setEmbedAssemblySize(this.appSize);
             this.viewsheetClient.sendEvent("/events/vs/refresh", refreshEvent);
          }
       }, 100, []);

--- a/web/projects/portal/src/app/vsobjects/event/refresh-vs-assembly-event.ts
+++ b/web/projects/portal/src/app/vsobjects/event/refresh-vs-assembly-event.ts
@@ -19,4 +19,5 @@ export interface RefreshVsAssemblyEvent {
    vsRuntimeId: string;
    assemblyName: string;
    embed?: boolean;
+   embedAssemblySize?: { width: number; height: number };
 }


### PR DESCRIPTION
This fix resolves the issue where charts generated in the portal's conversation view failed to fill their container area. The root cause was twofold: first, the `runtimeId` generated by the wiz backend is a server-side session, which the browser cannot directly reuse to re-establish a WebSocket connection. Therefore, we added support for passing `assetId` (a persistent viewsheet identifier) in the backend (`chatRoutes.ts`/`chatRoutes2.ts`). On the frontend (`ChatPage.tsx`, `message.ts`, `VizCard.tsx`), `buildEmbedUrl` is modified to prioritize using `assetId` to invoke the `openViewsheet0()` flow, allowing the browser to create an accessible viewsheet instance within its own session.

Second, the styleBI `embed-chart.component.ts` lacked a proper size synchronization mechanism. To address this, we introduced the `fitChartToContainer` method, which, upon receiving chart data (in `processAddVSObjectCommand`/`processRefreshVSObjectCommand`) or when the container is resized, forcibly overrides the `objectFormat` to match the container dimensions. Additionally, during `refreshEmbedAssembly` and `onResize` refresh events, we added `embedAssemblySize: this.appSize` to ensure the backend generates chart content at the correct size. The `assemblySize` (previously adjusted to subtract scrollbar width) is now uniformly changed to `appSize` (full container dimensions), ultimately achieving a centered and fully filled container.