### PR TITLE
Delete source worksheet when deleting a wiz viewsheet.

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1785,7 +1785,37 @@ public class WizVsService {
             "Viewsheet is not in the managed visualizations folder and cannot be deleted: " + path);
       }
 
+      AssetEntry wsEntry = null;
+
+      try {
+         AbstractSheet sheet = engine.getSheet(entry, user, true, AssetContent.NO_DATA);
+
+         if(sheet instanceof Viewsheet vs) {
+            AssetEntry baseEntry = vs.getBaseEntry();
+
+            if(baseEntry != null && baseEntry.getPath() != null &&
+               baseEntry.getPath().startsWith(GenerateWsService.WORKSHEET_ROOT_FOLDER_PATH + "/"))
+            {
+               wsEntry = baseEntry;
+            }
+         }
+      }
+      catch(Exception e) {
+         LOG.warn("Failed to retrieve source worksheet entry for viewsheet [{}]: {}",
+                  identifier, e.getMessage());
+      }
+
       engine.removeSheet(entry, user, true);
+
+      if(wsEntry != null) {
+         try {
+            engine.removeSheet(wsEntry, user, true);
+         }
+         catch(Exception e) {
+            LOG.warn("Failed to delete source worksheet [{}] for viewsheet [{}]: {}",
+                     wsEntry.toIdentifier(), identifier, e.getMessage());
+         }
+      }
    }
 
    private final ViewsheetService viewsheetService;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1809,13 +1809,11 @@ public class WizVsService {
 
       engine.removeSheet(entry, user, true);
 
+      // Wiz enforces a strict 1-viewsheet-to-1-worksheet contract: each wiz viewsheet
+      // owns its worksheet exclusively, so no dependency check is needed before deletion.
       if(wsEntry != null) {
          try {
-            AssetEntry[] dependents = engine.getSheetDependencies(wsEntry, user);
-
-            if(dependents == null || dependents.length == 0) {
-               engine.removeSheet(wsEntry, user, true);
-            }
+            engine.removeSheet(wsEntry, user, true);
          }
          catch(Exception e) {
             LOG.warn("Failed to delete source worksheet [{}] for viewsheet [{}]: {}",

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1788,6 +1788,8 @@ public class WizVsService {
       AssetEntry wsEntry = null;
 
       try {
+         // AssetContent.NO_DATA strips assembly/embeddedData nodes but preserves
+         // <worksheetEntry>, so getBaseEntry() is always populated at this level.
          AbstractSheet sheet = engine.getSheet(entry, user, true, AssetContent.NO_DATA);
 
          if(sheet instanceof Viewsheet vs) {
@@ -1809,7 +1811,11 @@ public class WizVsService {
 
       if(wsEntry != null) {
          try {
-            engine.removeSheet(wsEntry, user, true);
+            AssetEntry[] dependents = engine.getSheetDependencies(wsEntry, user);
+
+            if(dependents == null || dependents.length == 0) {
+               engine.removeSheet(wsEntry, user, true);
+            }
          }
          catch(Exception e) {
             LOG.warn("Failed to delete source worksheet [{}] for viewsheet [{}]: {}",

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1803,8 +1803,8 @@ public class WizVsService {
          }
       }
       catch(Exception e) {
-         LOG.warn("Failed to retrieve source worksheet entry for viewsheet [{}]: {}",
-                  identifier, e.getMessage());
+         LOG.warn("Failed to retrieve source worksheet entry for viewsheet [{}]",
+                  identifier, e);
       }
 
       engine.removeSheet(entry, user, true);
@@ -1816,8 +1816,8 @@ public class WizVsService {
             engine.removeSheet(wsEntry, user, true);
          }
          catch(Exception e) {
-            LOG.warn("Failed to delete source worksheet [{}] for viewsheet [{}]: {}",
-                     wsEntry.toIdentifier(), identifier, e.getMessage());
+            LOG.warn("Failed to delete source worksheet [{}] for viewsheet [{}]",
+                     wsEntry.toIdentifier(), identifier, e);
          }
       }
    }


### PR DESCRIPTION
When deleteViewsheet is called, also remove the associated worksheet if it resides in the wiz-managed worksheet folder, to avoid orphaned assets.