### PR TITLE
Bug #75006 - Round corners on waterfall negative-delta bars

### DIFF
--- a/core/src/main/java/inetsoft/graph/visual/BarVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/BarVO.java
@@ -1457,9 +1457,10 @@ public class BarVO extends ElementVO {
                                            IntervalElement ielem, double r,
                                            int openDir, boolean stdOrientation)
    {
-      double totalStackInterval = geom.getTotalStackInterval();
+      // negGrp=false stacks (e.g. waterfall) carry signed values; use magnitude.
+      double totalStackInterval = Math.abs(geom.getTotalStackInterval());
 
-      if(totalStackInterval <= 0 || geom.getInterval() == 0) {
+      if(totalStackInterval == 0 || geom.getInterval() == 0) {
          return path0;
       }
 
@@ -1482,7 +1483,7 @@ public class BarVO extends ElementVO {
 
       Rectangle2D fullBounds = computeFullBarBounds(
          segBounds, stdOrientation, openDir,
-         geom.getInterval(), geom.getCumulativeStackInterval(),
+         geom.getInterval(), Math.abs(geom.getCumulativeStackInterval()),
          totalStackInterval);
 
       Area result = new Area(segBounds);
@@ -1636,10 +1637,11 @@ public class BarVO extends ElementVO {
                                       double barWidth, double segDim,
                                       boolean roundAllCorners)
    {
-      double totalStackInterval = geom.getTotalStackInterval();
+      // negGrp=false stacks (e.g. waterfall) carry signed values; use magnitude.
+      double totalStackInterval = Math.abs(geom.getTotalStackInterval());
       double scale = segDim / Math.abs(geom.getInterval());
       double stackDim = totalStackInterval * scale;
-      double cumulative = geom.getCumulativeStackInterval();
+      double cumulative = Math.abs(geom.getCumulativeStackInterval());
 
       double arc = Math.min(r * barWidth, Math.min(barWidth / 2, stackDim));
       double distFromOuter = (totalStackInterval - cumulative) * scale;

--- a/core/src/main/java/inetsoft/web/graph/GraphBuilder.java
+++ b/core/src/main/java/inetsoft/web/graph/GraphBuilder.java
@@ -1380,7 +1380,8 @@ public class GraphBuilder {
                   }
                }
                else {
-                  double totalStackInterval = geom.getTotalStackInterval();
+                  // negGrp=false stacks (e.g. waterfall) carry signed values; use magnitude.
+                  double totalStackInterval = Math.abs(geom.getTotalStackInterval());
 
                   if(totalStackInterval > 0 && geom.getInterval() != 0) {
                      Rectangle2D barBounds = barVO.getPreRoundingBounds();

--- a/core/src/test/java/inetsoft/graph/visual/BarVOStackRoundingTest.java
+++ b/core/src/test/java/inetsoft/graph/visual/BarVOStackRoundingTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for BarVO.computeFullBarBounds geometry.
+ * Unit tests for BarVO stack rounding geometry helpers.
  */
 class BarVOStackRoundingTest {
 
@@ -144,6 +144,7 @@ class BarVOStackRoundingTest {
       when(neg.getTotalStackInterval()).thenReturn(-72.0);
       when(neg.getCumulativeStackInterval()).thenReturn(-72.0);
 
+      // roundAllCorners=true so inInnerArcZone is also exercised by the comparison.
       BarVO.ArcZoneInfo posZones = BarVO.computeArcZones(pos, 0.5, 40, 100, true);
       BarVO.ArcZoneInfo negZones = BarVO.computeArcZones(neg, 0.5, 40, 100, true);
 

--- a/core/src/test/java/inetsoft/graph/visual/BarVOStackRoundingTest.java
+++ b/core/src/test/java/inetsoft/graph/visual/BarVOStackRoundingTest.java
@@ -17,11 +17,14 @@
  */
 package inetsoft.graph.visual;
 
+import inetsoft.graph.geometry.IntervalGeometry;
 import org.junit.jupiter.api.Test;
 
 import java.awt.geom.Rectangle2D;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for BarVO.computeFullBarBounds geometry.
@@ -106,5 +109,47 @@ class BarVOStackRoundingTest {
       assertEquals(seg.getY(), full.getY(), 1e-9);
       assertEquals(seg.getWidth(), full.getWidth(), 1e-9);
       assertEquals(seg.getHeight(), full.getHeight(), 1e-9);
+   }
+
+   // -----------------------------------------------------------------------
+   // computeArcZones: waterfall negative-delta single-segment stack.
+   // IntervalElement carries signed totalStackInterval/cumulative when
+   // negGrp=false; computeArcZones must normalize via Math.abs.
+   // -----------------------------------------------------------------------
+
+   @Test
+   void computeArcZones_negativeSingleSegment_detectsOuterArcZone() {
+      IntervalGeometry geom = mock(IntervalGeometry.class);
+      when(geom.getInterval()).thenReturn(-72.0);
+      when(geom.getTotalStackInterval()).thenReturn(-72.0);
+      when(geom.getCumulativeStackInterval()).thenReturn(-72.0);
+
+      BarVO.ArcZoneInfo zones = BarVO.computeArcZones(geom, 0.5, 40, 100, false);
+
+      assertTrue(zones.stackDim() > 0, "stackDim should be positive magnitude");
+      assertTrue(zones.arc() > 0, "arc radius should be positive");
+      assertTrue(zones.inOuterArcZone(),
+                 "single-segment bar must register as inside the outer arc zone");
+   }
+
+   @Test
+   void computeArcZones_positiveSingleSegment_matchesNegative() {
+      IntervalGeometry pos = mock(IntervalGeometry.class);
+      when(pos.getInterval()).thenReturn(72.0);
+      when(pos.getTotalStackInterval()).thenReturn(72.0);
+      when(pos.getCumulativeStackInterval()).thenReturn(72.0);
+
+      IntervalGeometry neg = mock(IntervalGeometry.class);
+      when(neg.getInterval()).thenReturn(-72.0);
+      when(neg.getTotalStackInterval()).thenReturn(-72.0);
+      when(neg.getCumulativeStackInterval()).thenReturn(-72.0);
+
+      BarVO.ArcZoneInfo posZones = BarVO.computeArcZones(pos, 0.5, 40, 100, true);
+      BarVO.ArcZoneInfo negZones = BarVO.computeArcZones(neg, 0.5, 40, 100, true);
+
+      assertEquals(posZones.stackDim(), negZones.stackDim(), 1e-9);
+      assertEquals(posZones.arc(), negZones.arc(), 1e-9);
+      assertEquals(posZones.inOuterArcZone(), negZones.inOuterArcZone());
+      assertEquals(posZones.inInnerArcZone(), negZones.inInnerArcZone());
    }
 }


### PR DESCRIPTION
## Summary

Negative-delta bars in a waterfall chart were rendering with square corners
while positive-delta bars were correctly rounded.

## Root cause

Waterfall bars are configured with `STACK_SYMMETRIC` +
`setStackNegative(false)`, so each bar is a single-segment "stack."
`IntervalElement` accumulates the *signed* `interval2` into
`posIntervalSum`, which means the geometry's `totalStackInterval` and
`cumulativeStackInterval` come out negative when the bar's delta is
negative.

Two rendering paths consumed those values as positive magnitudes:

- `BarVO.applyStackRounding` early-returned on `totalStackInterval <= 0`,
never reaching the single-segment all-corners-round branch.
- `BarVO.computeArcZones` multiplied through to produce a negative
`arc`/`stackDim`, falsely setting `inOuterArcZone=false`.
- `GraphBuilder` (SVG annotation) used the same `> 0` guard.

Introduced by #3603, which enabled rounding for waterfall/pareto without
accounting for the signed accumulation in the `stackNegative=false` case.

## Fix

Normalize with `Math.abs` at the rendering layer:

- `BarVO.applyStackRounding` — abs on `totalStackInterval` and the
cumulative passed to `computeFullBarBounds`; guard changed to `== 0`.
- `BarVO.computeArcZones` — abs on `totalStackInterval` and `cumulative`.
- `GraphBuilder.java` — abs on `totalStackInterval`.

Localized to rendering; `IntervalElement` accumulation semantics unchanged
(the exotic mixed-sign-with-`stackNegative=false` case is untouched).