### PR TITLE
Bug #74642, fix plugins view layout in Firefox

### DIFF
--- a/web/projects/em/src/app/settings/content/drivers-and-plugins/plugins-view/plugins-view.component.scss
+++ b/web/projects/em/src/app/settings/content/drivers-and-plugins/plugins-view/plugins-view.component.scss
@@ -24,9 +24,8 @@
   overflow: hidden;
 
   .em-staged-file-chooser {
-    flex-grow: 1;
+    flex-grow: 0;
     flex-shrink: 1;
-    max-height: fit-content;
   }
 
   .file-loading-indicator {


### PR DESCRIPTION
## Summary

- In the Drivers and Plugins EM pane, the `em-staged-file-chooser` component adds the CSS class `em-staged-file-chooser` to its host element via a `host` binding. In `plugins-view.component.scss` this class was styled with `flex-grow: 1` and `max-height: fit-content` — intended to let the file chooser grow while capping it at its content height, leaving the remaining space for the plugins table.
- `max-height: fit-content` is not correctly respected by Firefox on flex items, so the file chooser grew proportionally (taking roughly half the vertical space) and pushed the plugins table into the lower half of the page.
- Fixed by changing `flex-grow` to `0` on `.em-staged-file-chooser` so the file chooser uses only its intrinsic content height in all browsers and the plugins table card fills the remaining space.

## Test plan

- [ ] Open EM in Firefox, navigate to Content → Drivers and Plugins
- [ ] Verify the plugins table fills the available space below the file chooser buttons
- [ ] Install one or more plugins, select all, click Uninstall, confirm — verify the layout remains correct after the list becomes empty
- [ ] Verify the same steps work correctly in Chrome (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)