### PR TITLE
Bug #74991 - Prevent text overflow on rounded relation/network chart nodes

### DIFF
--- a/core/src/main/java/inetsoft/graph/visual/RelationVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/RelationVO.java
@@ -200,9 +200,11 @@ public class RelationVO extends ElementVO {
       RelationElement elem = (RelationElement) gobj.getElement();
 
       Rectangle2D box = getScreenTransform().createTransformedShape(shape).getBounds2D();
+      // inside labels: confine wrapping to inscribed rect so text stays within curved edges
+      Rectangle2D textBox = elem.isLabelInside() ? getInsideTextBox(box, elem) : box;
       double prefw = getVOTextWidth(vtext, vgraph, (ElementGeometry) getGeometry());
       double prefh = elem.isLabelInside()
-         ? vtext.getPreferredHeight(box.getWidth(), box.getHeight()) : vtext.getPreferredHeight();
+         ? vtext.getPreferredHeight(textBox.getWidth(), textBox.getHeight()) : vtext.getPreferredHeight();
 
       Rectangle2D vbounds = vgraph.getPlotBounds();
       int placement = gobj.getLabelPlacement();
@@ -243,10 +245,10 @@ public class RelationVO extends ElementVO {
       case GraphConstants.CENTER:
       default: // auto
          midx = box.getX() + box.getWidth() / 2;
-         tx = midx - Math.min(box.getWidth(), prefw) / 2;
+         tx = midx - Math.min(textBox.getWidth(), prefw) / 2;
 
          midy = box.getY() + box.getHeight() / 2;
-         ty = midy - Math.min(box.getHeight(), prefh) / 2;
+         ty = midy - Math.min(textBox.getHeight(), prefh) / 2;
 
          vtext.setAlignmentX(GraphConstants.LEFT_ALIGNMENT);
          vtext.setPlacement(placement);
@@ -256,8 +258,8 @@ public class RelationVO extends ElementVO {
       vtext.setPosition(new Point2D.Double(Math.max(tx, vbounds.getX()), ty));
 
       // if wider than area, reduce the width and use ...
-      if(prefw > box.getWidth() && elem.isLabelInside()) {
-         prefw = Math.max(10, box.getWidth());
+      if(prefw > textBox.getWidth() && elem.isLabelInside()) {
+         prefw = Math.max(10, textBox.getWidth());
       }
 
       vtext.setSize(new DimensionD(prefw, prefh));
@@ -265,6 +267,32 @@ public class RelationVO extends ElementVO {
       Point2D pt = new Point2D.Double(midx, midy);
       Point2D offset = vtext.getRotationOffset(pt, placement);
       vtext.setOffset(offset);
+   }
+
+   // 45deg inscribed rect for the rounded/ellipse node shape; inset = r*(1-1/sqrt2).
+   static Rectangle2D getInsideTextBox(Rectangle2D box, RelationElement elem) {
+      double insetX = 0, insetY = 0;
+      double w = box.getWidth(), h = box.getHeight();
+      GShape nodeShape = elem.getNodeShape();
+
+      if(nodeShape != null) {
+         insetX = w * (1 - 1 / Math.sqrt(2)) / 2;
+         insetY = h * (1 - 1 / Math.sqrt(2)) / 2;
+      }
+      else {
+         double r = elem.getNodeCornerRadius();
+
+         if(r > 0) {
+            double aRadius = r * Math.min(w, h);
+            insetX = insetY = aRadius * (1 - 1 / Math.sqrt(2));
+         }
+      }
+
+      double tw = Math.max(1, w - 2 * insetX);
+      double th = Math.max(1, h - 2 * insetY);
+      return new Rectangle2D.Double(box.getX() + (w - tw) / 2,
+                                    box.getY() + (h - th) / 2,
+                                    tw, th);
    }
 
    @Override

--- a/core/src/main/java/inetsoft/graph/visual/RelationVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/RelationVO.java
@@ -285,6 +285,7 @@ public class RelationVO extends ElementVO {
             insetY = h * (1 - 1 / Math.sqrt(2)) / 2;
          }
          else if(s != null && !(s instanceof Rectangle2D)) {
+            // exact for diamond/triangle; over-shrinks open paths (CROSS, STAR) but stays safe
             insetX = w / 4;
             insetY = h / 4;
          }

--- a/core/src/main/java/inetsoft/graph/visual/RelationVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/RelationVO.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.awt.*;
+import java.awt.geom.Ellipse2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.geom.RoundRectangle2D;
@@ -269,15 +270,25 @@ public class RelationVO extends ElementVO {
       vtext.setOffset(offset);
    }
 
-   // 45deg inscribed rect for the rounded/ellipse node shape; inset = r*(1-1/sqrt2).
+   // Inscribed rect for the painted node shape so wrapping stays inside curved/polygon edges.
+   // ellipse: w/sqrt2 x h/sqrt2; polygons: conservative w/2 x h/2 (exact for diamond/triangle).
    static Rectangle2D getInsideTextBox(Rectangle2D box, RelationElement elem) {
       double insetX = 0, insetY = 0;
       double w = box.getWidth(), h = box.getHeight();
       GShape nodeShape = elem.getNodeShape();
 
       if(nodeShape != null) {
-         insetX = w * (1 - 1 / Math.sqrt(2)) / 2;
-         insetY = h * (1 - 1 / Math.sqrt(2)) / 2;
+         Shape s = nodeShape.getShape(box.getX(), box.getY(), w, h);
+
+         if(s instanceof Ellipse2D) {
+            insetX = w * (1 - 1 / Math.sqrt(2)) / 2;
+            insetY = h * (1 - 1 / Math.sqrt(2)) / 2;
+         }
+         else if(s != null && !(s instanceof Rectangle2D)) {
+            insetX = w / 4;
+            insetY = h / 4;
+         }
+         // null (NIL) or full-bbox Rectangle2D (SQUARE): no shrinking needed
       }
       else {
          double r = elem.getNodeCornerRadius();

--- a/core/src/test/java/inetsoft/graph/visual/RelationVOInsideTextBoxTest.java
+++ b/core/src/test/java/inetsoft/graph/visual/RelationVOInsideTextBoxTest.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.graph.visual;
+
+import inetsoft.graph.aesthetic.GShape;
+import inetsoft.graph.element.RelationElement;
+import org.junit.jupiter.api.Test;
+
+import java.awt.geom.Rectangle2D;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression guard for the inside-label inscribed-rect inset on rounded relation nodes
+ * (ex.png overflow case): the text-layout box must shrink to fit the curved boundary,
+ * not the outer rectangle.
+ */
+class RelationVOInsideTextBoxTest {
+   private static final double SQRT2_INSET = 1 - 1 / Math.sqrt(2);   // ~0.2929
+   private static final double EPS = 1e-9;
+
+   @Test
+   void noRoundingReturnsBoxUnchanged() {
+      Rectangle2D box = new Rectangle2D.Double(10, 20, 100, 40);
+      RelationElement elem = new RelationElement("From", "To");
+      // nodeCornerRadius defaults to 0 and nodeShape defaults to null
+
+      Rectangle2D out = RelationVO.getInsideTextBox(box, elem);
+      assertEquals(box.getX(), out.getX(), EPS);
+      assertEquals(box.getY(), out.getY(), EPS);
+      assertEquals(box.getWidth(), out.getWidth(), EPS);
+      assertEquals(box.getHeight(), out.getHeight(), EPS);
+   }
+
+   @Test
+   void cornerRadiusShrinksInscribedRectBy45DegInset() {
+      Rectangle2D box = new Rectangle2D.Double(0, 0, 100, 40);
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeCornerRadius(0.3);
+
+      Rectangle2D out = RelationVO.getInsideTextBox(box, elem);
+      // aRadius = 0.3 * min(100,40) = 12; per-side inset = 12 * (1 - 1/sqrt2) ~ 3.515
+      double expectedInset = 0.3 * 40 * SQRT2_INSET;
+      assertEquals(100 - 2 * expectedInset, out.getWidth(), EPS);
+      assertEquals(40 - 2 * expectedInset, out.getHeight(), EPS);
+      // centred on the input box
+      assertEquals(box.getCenterX(), out.getCenterX(), EPS);
+      assertEquals(box.getCenterY(), out.getCenterY(), EPS);
+   }
+
+   @Test
+   void inscribedRectStrictlySmallerThanBoxForAnyPositiveRadius() {
+      Rectangle2D box = new Rectangle2D.Double(0, 0, 100, 40);
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeCornerRadius(0.05);   // small but non-zero
+
+      Rectangle2D out = RelationVO.getInsideTextBox(box, elem);
+      assertTrue(out.getWidth() < box.getWidth(),
+                 "any positive corner radius must shrink the available text width");
+      assertTrue(out.getHeight() < box.getHeight(),
+                 "any positive corner radius must shrink the available text height");
+   }
+
+   @Test
+   void halfRadiusStadiumShrinksToShortDimDriven() {
+      // r=0.5 on a wide-short rect produces a stadium; inset is driven by min(w,h)
+      Rectangle2D box = new Rectangle2D.Double(0, 0, 80, 30);
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeCornerRadius(0.5);
+
+      Rectangle2D out = RelationVO.getInsideTextBox(box, elem);
+      double expectedInset = 0.5 * 30 * SQRT2_INSET;   // aRadius = 15
+      assertEquals(80 - 2 * expectedInset, out.getWidth(), EPS);
+      assertEquals(30 - 2 * expectedInset, out.getHeight(), EPS);
+   }
+
+   @Test
+   void customNodeShapeUsesEllipseInset() {
+      Rectangle2D box = new Rectangle2D.Double(0, 0, 100, 60);
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeShape(GShape.CIRCLE);   // any GShape triggers the ellipse-inscribed branch
+
+      Rectangle2D out = RelationVO.getInsideTextBox(box, elem);
+      // inscribed rect for an ellipse with full dims (w,h): w/sqrt2 x h/sqrt2
+      assertEquals(100 / Math.sqrt(2), out.getWidth(), EPS);
+      assertEquals(60 / Math.sqrt(2), out.getHeight(), EPS);
+   }
+
+   @Test
+   void customNodeShapeOverridesCornerRadius() {
+      // matches paint() precedence: nodeShape wins over nodeCornerRadius
+      Rectangle2D box = new Rectangle2D.Double(0, 0, 100, 60);
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeCornerRadius(0.1);
+      elem.setNodeShape(GShape.CIRCLE);
+
+      Rectangle2D out = RelationVO.getInsideTextBox(box, elem);
+      assertEquals(100 / Math.sqrt(2), out.getWidth(), EPS,
+                   "nodeShape inset must win over the smaller corner-radius inset");
+   }
+
+   @Test
+   void tinyNodeFloorsAtOnePixel() {
+      // pathological tiny node should not produce zero/negative dims
+      Rectangle2D box = new Rectangle2D.Double(0, 0, 2, 2);
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeShape(GShape.CIRCLE);   // ellipse inset on tiny box would shrink below 1px
+
+      Rectangle2D out = RelationVO.getInsideTextBox(box, elem);
+      assertTrue(out.getWidth() >= 1.0, "width must be floored at 1px");
+      assertTrue(out.getHeight() >= 1.0, "height must be floored at 1px");
+   }
+}

--- a/core/src/test/java/inetsoft/graph/visual/RelationVOInsideTextBoxTest.java
+++ b/core/src/test/java/inetsoft/graph/visual/RelationVOInsideTextBoxTest.java
@@ -115,6 +115,70 @@ class RelationVOInsideTextBoxTest {
    }
 
    @Test
+   void nilNodeShapeReturnsBoxUnchanged() {
+      // GShape.NIL renders as a plain rectangle, so no inset.
+      Rectangle2D box = new Rectangle2D.Double(10, 20, 100, 40);
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeShape(GShape.NIL);
+
+      Rectangle2D out = RelationVO.getInsideTextBox(box, elem);
+      assertEquals(box.getX(), out.getX(), EPS);
+      assertEquals(box.getY(), out.getY(), EPS);
+      assertEquals(box.getWidth(), out.getWidth(), EPS);
+      assertEquals(box.getHeight(), out.getHeight(), EPS);
+   }
+
+   @Test
+   void squareNodeShapeReturnsBoxUnchanged() {
+      // GShape.SQUARE returns a full-bounds Rectangle2D, so the painted node is just the bbox.
+      Rectangle2D box = new Rectangle2D.Double(0, 0, 100, 40);
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeShape(GShape.SQUARE);
+
+      Rectangle2D out = RelationVO.getInsideTextBox(box, elem);
+      assertEquals(box.getWidth(), out.getWidth(), EPS);
+      assertEquals(box.getHeight(), out.getHeight(), EPS);
+   }
+
+   @Test
+   void diamondNodeShapeUsesConservativeInset() {
+      // For a diamond, the largest inscribed axis-aligned rect is w/2 x h/2.
+      Rectangle2D box = new Rectangle2D.Double(0, 0, 100, 40);
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeShape(GShape.DIAMOND);
+
+      Rectangle2D out = RelationVO.getInsideTextBox(box, elem);
+      assertEquals(50.0, out.getWidth(), EPS);
+      assertEquals(20.0, out.getHeight(), EPS);
+   }
+
+   @Test
+   void triangleNodeShapeUsesConservativeInset() {
+      // Triangle's max inscribed axis-aligned rect is also w/2 x h/2.
+      Rectangle2D box = new Rectangle2D.Double(0, 0, 100, 40);
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeShape(GShape.TRIANGLE);
+
+      Rectangle2D out = RelationVO.getInsideTextBox(box, elem);
+      assertEquals(50.0, out.getWidth(), EPS);
+      assertEquals(20.0, out.getHeight(), EPS);
+   }
+
+   @Test
+   void strokedNodeShapeUsesConservativeInset() {
+      // Stroked paths (CROSS = two perpendicular lines) aren't closed regions; the
+      // conservative branch still applies a w/2 x h/2 inset so text doesn't run past
+      // the bbox of the strokes.
+      Rectangle2D box = new Rectangle2D.Double(0, 0, 100, 40);
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeShape(GShape.CROSS);
+
+      Rectangle2D out = RelationVO.getInsideTextBox(box, elem);
+      assertEquals(50.0, out.getWidth(), EPS);
+      assertEquals(20.0, out.getHeight(), EPS);
+   }
+
+   @Test
    void tinyNodeFloorsAtOnePixel() {
       // pathological tiny node should not produce zero/negative dims
       Rectangle2D box = new Rectangle2D.Double(0, 0, 2, 2);

--- a/core/src/test/java/inetsoft/graph/visual/RelationVOInsideTextBoxTest.java
+++ b/core/src/test/java/inetsoft/graph/visual/RelationVOInsideTextBoxTest.java
@@ -93,7 +93,7 @@ class RelationVOInsideTextBoxTest {
    void customNodeShapeUsesEllipseInset() {
       Rectangle2D box = new Rectangle2D.Double(0, 0, 100, 60);
       RelationElement elem = new RelationElement("From", "To");
-      elem.setNodeShape(GShape.CIRCLE);   // any GShape triggers the ellipse-inscribed branch
+      elem.setNodeShape(GShape.CIRCLE);   // CIRCLE returns Ellipse2D -> ellipse branch
 
       Rectangle2D out = RelationVO.getInsideTextBox(box, elem);
       // inscribed rect for an ellipse with full dims (w,h): w/sqrt2 x h/sqrt2


### PR DESCRIPTION
 ## Summary
  - Fixes Bug #75006: relation/network chart node labels overflowed past the
  curved boundary when `nodeCornerRadius > 0` or a `nodeShape` was set
  (rounded-corner feature from #3615 / additional node shapes from #3663).
  - `RelationVO.layoutText()` now shrinks the inside-label box to the 45deg
  inscribed rectangle of the painted shape so wrapping and `..` truncation
  stay inside the curve.
  - Default rectangular nodes are byte-identical to before; outside-label
  placements (TOP/BOTTOM/LEFT/RIGHT) still anchor to the outer rectangle.

  ## Geometry
  - Corner radius `r ∈ [0, 0.5]` (matches `RelationVO.paint`): arc radius `r *
   min(w,h)`, per-side inset `aRadius * (1 - 1/sqrt(2))` ≈ `0.293 * aRadius`.
  - Custom `GShape` (most commonly `CIRCLE` / ellipse): inscribed rectangle of
   the bounding ellipse, `w/sqrt(2) x h/sqrt(2)`.
  - Width and height floored at 1 px so labels still render on pathologically
  tiny nodes.
  - `nodeShape` takes precedence over `nodeCornerRadius`, matching the
  precedence in `paint()`.