### PR TITLE
Bug #74961 - Reset runtime chart descriptor on chart-type change

### DIFF
--- a/core/src/main/java/inetsoft/web/binding/controller/ChangeChartTypeController.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ChangeChartTypeController.java
@@ -206,6 +206,8 @@ public class ChangeChartTypeController {
       }
 
       applySmoothLinesTransition(oldType, newType, plotDesc);
+      // drop the runtime clone so the next render sees the design-time mutations above
+      ninfo.setRTChartDescriptor(null);
 
       if(!DateComparisonUtil.isDateComparisonChartTypeChanged(ninfo, oinfo)) {
          Catalog catalog = Catalog.getCatalog();

--- a/core/src/test/java/inetsoft/web/binding/controller/ChangeChartTypeControllerTest.java
+++ b/core/src/test/java/inetsoft/web/binding/controller/ChangeChartTypeControllerTest.java
@@ -55,6 +55,7 @@ import static org.mockito.Mockito.*;
  */
 @SreeHome
 @ExtendWith(MockitoExtension.class)
+// LENIENT: shared @BeforeEach stubs are not all exercised by every test path
 @MockitoSettings(strictness = Strictness.LENIENT)
 class ChangeChartTypeControllerTest {
 
@@ -122,6 +123,7 @@ class ChangeChartTypeControllerTest {
 
       ChartVSAssemblyInfo ainfo = (ChartVSAssemblyInfo) chart.getVSAssemblyInfo();
       ainfo.setRTChartDescriptor(new ChartDescriptor());
+      assertNotNull(ainfo.getRTChartDescriptor(), "precondition: RT descriptor is populated");
 
       ChangeChartTypeEvent event = new ChangeChartTypeEvent();
       event.setName("Chart1");

--- a/core/src/test/java/inetsoft/web/binding/controller/ChangeChartTypeControllerTest.java
+++ b/core/src/test/java/inetsoft/web/binding/controller/ChangeChartTypeControllerTest.java
@@ -1,0 +1,157 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.binding.controller;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.report.composition.graph.GraphTypeUtil;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.graph.*;
+import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.web.binding.event.ChangeChartTypeEvent;
+import inetsoft.web.binding.handler.VSAssemblyInfoHandler;
+import inetsoft.web.binding.handler.VSChartHandler;
+import inetsoft.web.binding.model.BindingModel;
+import inetsoft.web.binding.service.VSBindingService;
+import inetsoft.web.binding.service.graph.ChartRefModelFactoryService;
+import inetsoft.web.viewsheet.model.RuntimeViewsheetRef;
+import inetsoft.web.viewsheet.service.CommandDispatcher;
+import inetsoft.web.viewsheet.service.CoreLifecycleService;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Controller-level tests for {@link ChangeChartTypeController}. The static smoothLines
+ * transition matrix is covered by {@link ChangeChartTypeControllerSmoothLinesTransitionTest}.
+ */
+@SreeHome
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ChangeChartTypeControllerTest {
+
+   @BeforeEach
+   void setup() throws Exception {
+      controller = new ChangeChartTypeController(
+         bindingFactory, runtimeViewsheetRef, coreLifecycleService, chartRefService,
+         changeSeparateController, assemblyInfoHandler, chartHandler, bindingTreeController,
+         viewsheetService);
+
+      when(runtimeViewsheetRef.getRuntimeId()).thenReturn("vs1");
+      when(viewsheetService.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(rvs.getViewsheetSandbox()).thenReturn(viewsheetSandbox);
+      when(bindingFactory.createModel(any())).thenReturn(mock(BindingModel.class));
+
+      chart = new ChartVSAssembly(viewsheet, "Chart1");
+      when(viewsheet.getAssembly("Chart1")).thenReturn(chart);
+   }
+
+   /**
+    * After Network → Circular the runtime ChartDescriptor must be cleared so the next
+    * render reads the design-time smoothLines = true that applySmoothLinesTransition just
+    * set. Without this reset a cached RT clone (from any earlier script/foreground access)
+    * keeps the chart drawing straight chords despite the checkbox showing on.
+    */
+   @Test
+   void networkToCircular_clearsRuntimeChartDescriptor() throws Exception {
+      chart.setVSChartInfo(new RelationVSChartInfo());
+      chart.getVSChartInfo().setChartType(GraphTypes.CHART_NETWORK);
+      chart.setChartDescriptor(new ChartDescriptor());
+
+      ChartVSAssemblyInfo ainfo = (ChartVSAssemblyInfo) chart.getVSAssemblyInfo();
+      ainfo.setRTChartDescriptor(new ChartDescriptor());
+      assertNotNull(ainfo.getRTChartDescriptor(), "precondition: RT descriptor is populated");
+
+      ChangeChartTypeEvent event = new ChangeChartTypeEvent();
+      event.setName("Chart1");
+      event.setType(GraphTypes.CHART_CIRCULAR);
+
+      try(MockedStatic<GraphTypeUtil> mocked = Mockito.mockStatic(
+         GraphTypeUtil.class, Mockito.CALLS_REAL_METHODS))
+      {
+         mocked.when(() -> GraphTypeUtil.checkChartStylePermission(anyInt())).thenReturn(true);
+         controller.changeChartType(event, null, dispatcher, "/link");
+      }
+
+      assertNull(ainfo.getRTChartDescriptor(),
+         "Network → Circular must invalidate the runtime descriptor");
+      assertTrue(ainfo.getChartDescriptor().getPlotDescriptor().isSmoothLines(),
+         "smoothLines must be defaulted on for the new Circular type");
+   }
+
+   /**
+    * The RT reset is unconditional — it must fire even for type changes that
+    * applySmoothLinesTransition does not touch (Bar → Pie etc.), because the
+    * surrounding code mutates other PlotDescriptor fields (stackMeasures,
+    * valuesVisible, target lines) that would otherwise stay masked behind a stale RT clone.
+    */
+   @Test
+   void anyTypeChange_clearsRuntimeChartDescriptor() throws Exception {
+      chart.setVSChartInfo(new DefaultVSChartInfo());
+      chart.getVSChartInfo().setChartType(GraphTypes.CHART_BAR);
+      chart.setChartDescriptor(new ChartDescriptor());
+
+      ChartVSAssemblyInfo ainfo = (ChartVSAssemblyInfo) chart.getVSAssemblyInfo();
+      ainfo.setRTChartDescriptor(new ChartDescriptor());
+
+      ChangeChartTypeEvent event = new ChangeChartTypeEvent();
+      event.setName("Chart1");
+      event.setType(GraphTypes.CHART_PIE);
+
+      try(MockedStatic<GraphTypeUtil> mocked = Mockito.mockStatic(
+         GraphTypeUtil.class, Mockito.CALLS_REAL_METHODS))
+      {
+         mocked.when(() -> GraphTypeUtil.checkChartStylePermission(anyInt())).thenReturn(true);
+         controller.changeChartType(event, null, dispatcher, "/link");
+      }
+
+      assertNull(ainfo.getRTChartDescriptor(),
+         "RT descriptor must be cleared for every chart-type change, not just smoothLines transitions");
+   }
+
+   private ChangeChartTypeController controller;
+   private ChartVSAssembly chart;
+
+   @Mock VSBindingService bindingFactory;
+   @Mock RuntimeViewsheetRef runtimeViewsheetRef;
+   @Mock CoreLifecycleService coreLifecycleService;
+   @Mock ChartRefModelFactoryService chartRefService;
+   @Mock ChangeSeparateStatusController changeSeparateController;
+   @Mock VSAssemblyInfoHandler assemblyInfoHandler;
+   @Mock VSChartHandler chartHandler;
+   @Mock VSBindingTreeController bindingTreeController;
+   @Mock ViewsheetService viewsheetService;
+   @Mock RuntimeViewsheet rvs;
+   @Mock Viewsheet viewsheet;
+   @Mock ViewsheetSandbox viewsheetSandbox;
+   @Mock CommandDispatcher dispatcher;
+}


### PR DESCRIPTION
## Summary

- Fixes Circular Network drawing straight chords instead of smooth bezier
  curves when the user switches from Network to Circular Network from the
  chart-type dropdown on an unsaved viewsheet, despite the Smooth Lines
  checkbox showing as checked.
- Root cause: ChangeChartTypeController mutates the design-time
  PlotDescriptor (via applySmoothLinesTransition) but leaves the runtime
  ChartDescriptor clone in place. GraphGenerator reads RT when non-null
  (community/core/.../GraphGenerator.java:85-86 and :228-229), so the
  stale RT.smoothLines=false wins over the freshly set design-time
  smoothLines=true.
- Fix: add `ninfo.setRTChartDescriptor(null)` after the design-time
  mutations in `changeChartType`. This matches the convention already
  used by ChartPropertyDialogController.java:502,
  RegionPropertyDialogController.java:282/371,
  FormatPainterController.java:748,
  VSChartMoveLegendController.java:78, and
  VSChartMapController.java:174. ChangeChartTypeController was the
  missing sibling.

The reset is unconditional, so it also fixes the symmetric staleness
window for every other PlotDescriptor field this controller mutates
(stackMeasures, valuesVisible for Gantt/Treemap/Candle, target lines,
and the reverse Circular → Line smoothLines=false reset).