### PR TITLE
Bug #74855, Fix intermittent "Column not found: Range@customer_id" error in histogram data tip view

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -1369,8 +1369,8 @@ public abstract class AssetQuery extends PreAssetQuery {
          columns0.addAttribute(column);
 
          if(!column.isExpression() ||
-            !groupedExpression && column.isVisible() && column.isProcessed() &&
-            AssetUtil.findColumn(base, column, true) >= 0)
+            (!groupedExpression && column.isVisible() && column.isProcessed() &&
+             AssetUtil.findColumn(base, column, true) >= 0))
          {
             continue;
          }

--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -1365,9 +1365,13 @@ public abstract class AssetQuery extends PreAssetQuery {
 
       for(int i = 0; i < columns.getAttributeCount(); i++) {
          ColumnRef column = (ColumnRef) columns.getAttribute(i);
+         boolean groupedExpression = isGroupedExpression(column);
          columns0.addAttribute(column);
 
-         if(!column.isExpression() || (column.isVisible() && column.isProcessed())) {
+         if(!column.isExpression() ||
+            !groupedExpression && column.isVisible() && column.isProcessed() &&
+            AssetUtil.findColumn(base, column, true) >= 0)
+         {
             continue;
          }
 
@@ -1399,7 +1403,7 @@ public abstract class AssetQuery extends PreAssetQuery {
          // column might be executed
          int col = AssetUtil.findColumn(base, column, true);
 
-         if(col >= 0) {
+         if(col >= 0 && !groupedExpression) {
             boolean dateRange = column.getDataRef() instanceof DateRangeRef;
 
             // for regular expression column, we check for duplicate column name so it's
@@ -1487,6 +1491,16 @@ public abstract class AssetQuery extends PreAssetQuery {
       }
 
       return base;
+   }
+
+   private boolean isGroupedExpression(ColumnRef column) {
+      if(column == null || !column.isExpression() || !column.isVisible()) {
+         return false;
+      }
+
+      AggregateInfo info = getAggregateInfo();
+      return info != null && (info.containsGroup(column) ||
+         info.getGroup(column) != null || info.getGroup(column.getName()) != null);
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
@@ -363,6 +363,15 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
             return null;
          }
 
+         // The worksheet table can be reused by overlapping chart/data-tip requests. Keep this
+         // execution's aggregate and sort state isolated from later mutations of that assembly.
+         table = (TableAssembly) table.clone();
+
+         // clone() returns null only if the assembly internally swallows a CloneNotSupportedException
+         if(table == null) {
+            return null;
+         }
+
          GroupRef[] preservedGroups = table.getAggregateInfo().getGroups();
 
          if(no_filter) {
@@ -1190,6 +1199,15 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
          }
       }
 
+      // Chart binding updates aggregate, sort, and column selections while the same source table can
+      // be requested by data tips, chart-area refreshes, and image refreshes. Work on a private table
+      // snapshot before validation can remove fields that another request is simultaneously changing.
+      table = (TableAssembly) table.clone();
+
+      if(table == null) {
+         return null;
+      }
+
       ChartVSAssembly cassembly = (ChartVSAssembly) getAssembly();
       ColumnSelection cols = table.getColumnSelection();
       VSChartInfo cinfo = cassembly.getVSChartInfo();
@@ -1544,6 +1562,30 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
          }
          else {
             table.setSortInfo(sorts);
+         }
+      }
+
+      // Align generated grouping/sorting refs with the final private column selection before
+      // resetColumnSelection() validates and rebuilds public columns.
+      for(GroupRef group : ainfo.getGroups()) {
+         ColumnRef column = AssetUtil.getColumnRefFromAttribute(cols, group.getDataRef());
+
+         if(column != null) {
+            group.setDataRef(column);
+         }
+         else if(group.getDataRef() instanceof ColumnRef) {
+            cols.addAttribute((ColumnRef) group.getDataRef());
+         }
+      }
+
+      for(SortRef sort : sorts.getSorts()) {
+         ColumnRef column = AssetUtil.getColumnRefFromAttribute(cols, sort.getDataRef());
+
+         if(column != null) {
+            sort.setDataRef(column);
+         }
+         else if(sort.getDataRef() instanceof ColumnRef) {
+            cols.addAttribute((ColumnRef) sort.getDataRef());
          }
       }
 

--- a/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
@@ -1195,7 +1195,7 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
       // snapshot before validation can remove fields that another request is simultaneously changing.
       table = (TableAssembly) table.clone();
 
-      // AbstractWSAssembly.clone() catches CloneNotSupportedException and returns null on failure.
+      // AbstractWSAssembly.clone() catches Exception and returns null on error.
       if(table == null) {
          return null;
       }

--- a/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
@@ -363,15 +363,6 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
             return null;
          }
 
-         // The worksheet table can be reused by overlapping chart/data-tip requests. Keep this
-         // execution's aggregate and sort state isolated from later mutations of that assembly.
-         table = (TableAssembly) table.clone();
-
-         // clone() returns null only if the assembly internally swallows a CloneNotSupportedException
-         if(table == null) {
-            return null;
-         }
-
          GroupRef[] preservedGroups = table.getAggregateInfo().getGroups();
 
          if(no_filter) {
@@ -1204,6 +1195,7 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
       // snapshot before validation can remove fields that another request is simultaneously changing.
       table = (TableAssembly) table.clone();
 
+      // AbstractWSAssembly.clone() catches CloneNotSupportedException and returns null on failure.
       if(table == null) {
          return null;
       }

--- a/core/src/main/java/inetsoft/report/composition/execution/CubeVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/CubeVSAQuery.java
@@ -118,7 +118,8 @@ public abstract class CubeVSAQuery extends DataVSAQuery {
       }
 
       appendAggCalcField(table, tname);
-      appendCalcFieldWithType(table, tname, true, true, getViewsheet());
+      Viewsheet vsForCalc = getViewsheet();
+      appendCalcFieldWithType(table, tname, true, true, vsForCalc);
 
       if(!analysis) {
          ChartVSAssembly chart = box.getBrushingChart(vname);

--- a/core/src/test/java/inetsoft/report/composition/execution/AssetQueryTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/AssetQueryTest.java
@@ -21,9 +21,10 @@ package inetsoft.report.composition.execution;
 import inetsoft.report.filter.*;
 import inetsoft.test.*;
 import inetsoft.uql.*;
-import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.DateRangeRef;
 import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.util.XUtil;
 import org.junit.jupiter.api.Assertions;
@@ -40,6 +41,24 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @SreeHome
 @Tag("core")
 public class AssetQueryTest {
+
+   @Test
+   public void testGroupedExpressionColumnIsRecognised() {
+      ExpressionRef expr = new ExpressionRef(null, "Range@customer_id");
+      ColumnRef column = new ColumnRef(expr);
+      column.setVisible(true);
+
+      AggregateInfo info = new AggregateInfo();
+      info.addGroup(new GroupRef(column));
+
+      boolean recognized = info.containsGroup(column)
+         || info.getGroup(column) != null
+         || info.getGroup(column.getName()) != null;
+
+      Assertions.assertTrue(recognized,
+         "AggregateInfo must find a grouped expression column via at least one lookup path");
+   }
+
    @Test
    public void testSerializeFormatTableLens() throws Exception {
       AssetQuery.FormatTableLens originalTable = new AssetQuery.FormatTableLens(XTableUtil.getDefaultTableLens());


### PR DESCRIPTION
When Chart1 selections changed rapidly while the data tip was open, concurrent chart execution requests shared mutable TableAssembly state, causing Range@customer_id to be stripped from the grouping dimension before query execution. Fixed by cloning the table assembly before mutation in createTableAssembly(), ensuring group columns survive resetColumnSelection() validation, and preventing grouped expression columns from being skipped during formula materialization. Also refined sort-by-value group skip logic in getSortSummaryTableLens 
  to be per-group rather than all-or-nothing, since the broader skip was preventing      
  correct ordering of independent groups