### PR TITLE
merge ws: fix table names

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
@@ -156,9 +156,12 @@ public class WsMergeService {
 
    /**
     * If {@code existingTable} does not yet have a wiz mirror pointing to it, promotes it
-    * to a "base" table: strips its conditions/aggregation (moving them to a new mirror
-    * that takes its original role), and records the rename in {@code vsRenameMap} so the
-    * caller can redirect any VS-level bindings.
+    * to a "base" table: renames the base to "{name}_base", then creates a mirror under
+    * the original name that carries the first viz's conditions/aggregation.
+    *
+    * <p>By keeping the original name on the mirror (not the bare base), any VS assemblies
+    * already bound to that name continue to reference the correct filtered view without
+    * needing to be updated.</p>
     */
    private void ensureBaseHasPrevMirror(Worksheet dashWS,
                                         BoundTableAssembly existingTable,
@@ -185,23 +188,25 @@ public class WsMergeService {
       AggregateInfo aggr = (AggregateInfo) existingTable.getAggregateInfo().clone();
       ColumnSelection origCols = existingTable.getColumnSelection(true).clone();
 
-      // Strip conditions/aggregation from the base so it becomes a "full data" query
+      // Rename the base to "{name}_base", freeing the original name for the mirror.
+      // renameAssembly updates the registry and calls renameDepended on all assemblies.
+      String newBaseName = baseName + "_base";
+      dashWS.renameAssembly(baseName, newBaseName, true);
+
+      // Strip conditions/aggregation from the (now-renamed) base so it becomes "full data"
       existingTable.setPreConditionList(new ConditionList());
       existingTable.setPostConditionList(new ConditionList());
       existingTable.setAggregateInfo(new AggregateInfo());
 
-      // Create a mirror that restores the original viz's view
-      String prevMirrorName = ensureUniqueName(baseName, dashWS);
-      MirrorTableAssembly prevMirror = new MirrorTableAssembly(dashWS, prevMirrorName, existingTable);
+      // Create a mirror under the original name that restores the first viz's view.
+      // VS assemblies already bound to baseName now point to this mirror — no VS update needed.
+      MirrorTableAssembly prevMirror = new MirrorTableAssembly(dashWS, baseName, existingTable);
       prevMirror.setColumnSelection(origCols, true);
       prevMirror.setPreConditionList(preconds);
       prevMirror.setPostConditionList(postconds);
       prevMirror.setAggregateInfo(aggr);
       prevMirror.setProperty(PROP_WIZ_MERGED, "true");
       dashWS.addAssembly(prevMirror);
-
-      // Collect the redirect so the caller can apply it to VS bindings if needed
-      vsRenameMap.put(baseName, prevMirrorName);
    }
 
    /**
@@ -232,7 +237,13 @@ public class WsMergeService {
    private String createVizMirror(Worksheet dashWS, BoundTableAssembly base,
                                    BoundTableAssembly srcTable)
    {
-      String mirrorName = ensureUniqueName(base.getName(), dashWS);
+      // Derive naming prefix from base: strip "_base" suffix to recover the original name,
+      // then ensureUniqueName to get "Query_1", "Query_2", etc.
+      String baseName = base.getName();
+      String namePrefix = baseName.endsWith("_base")
+         ? baseName.substring(0, baseName.length() - 5)
+         : baseName;
+      String mirrorName = ensureUniqueName(namePrefix, dashWS);
       ColumnSelection vizCols = srcTable.getColumnSelection(true).clone();
 
       MirrorTableAssembly mirror = new MirrorTableAssembly(dashWS, mirrorName, base);


### PR DESCRIPTION
in old case, if query have same parent with new query2, we need to change vs to use query1.  In order to avoid rename vs, we just use this ws structure.

query_base-> query, query_1, query_2...