### PR TITLE
Bug #75019 - Skip whitespace-only lines in card-style tooltip

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
+++ b/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
@@ -99,7 +99,7 @@ public class ChartToolTip implements DataSerializable {
          String[] lines = customToolTip.split(ChartToolTip.ENTER + "|\\r|\\n");
 
          for(String line : lines) {
-            if(line.isEmpty()) {
+            if(line.isBlank()) {
                continue;
             }
 

--- a/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
@@ -96,6 +96,24 @@ class ChartToolTipTest {
    }
 
    @Test
+   void cardStyleSkipsWhitespaceOnlyCustomTooltipLines() {
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.setCustomToolTip("   " + ChartToolTip.ENTER + "Line1" + ChartToolTip.ENTER + "Line2");
+
+      String out = tip.getTooltip(palette);
+
+      int tierCount = out.split("<div class=\"tt-tier-", -1).length - 1;
+      assertEquals(2, tierCount,
+                   "Whitespace-only line must be skipped, leaving only the two real lines");
+      assertTrue(out.contains("<div class=\"tt-tier-1\">Line1"),
+                 "Real content must claim tier-1, not be demoted by a blank leading line");
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Line2"));
+      assertFalse(out.contains("tt-tier-3"));
+   }
+
+   @Test
    void setStyleNullDefaultsToLegacyStyle() {
       ChartToolTip tip = new ChartToolTip();
       tip.setStyle(null);


### PR DESCRIPTION
A whitespace-only line in a custom tooltip format was rendered as a
visible empty tier-1 styled div, demoting real content to tier-2/3
(and capping the tier-3 slot prematurely). Switch the skip-condition
in ChartToolTip.renderCard() from isEmpty() to isBlank() so whitespace-
only lines are skipped alongside truly empty ones. Default-style
tooltip is unaffected (it appends customToolTip verbatim inside a
white-space: pre-wrap container, so blank lines render unobtrusively
and carry no structural role).