### PR TITLE
Bug #75004 - Promote measure in combined card tooltip; enlarge stack total

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
+++ b/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
@@ -165,7 +165,9 @@ public class ChartToolTip implements DataSerializable {
             for(int i = 0; i < section.length; i += 2) {
                String label = palette.get(section[i]);
                String value = (i + 1) < section.length ? palette.get(section[i + 1]) : "";
-               appendTier(buffer, 1, label + ChartToolTip.COLON + value);
+               buffer.append("<div class=\"tt-tier-1 tt-stack-total\">")
+                     .append(label).append(ChartToolTip.COLON).append(value)
+                     .append("</div>");
             }
 
             continue;
@@ -230,7 +232,9 @@ public class ChartToolTip implements DataSerializable {
             for(int i = 0; i < section.length; i += 2) {
                String label = palette.get(section[i]);
                String value = (i + 1) < section.length ? palette.get(section[i + 1]) : "";
-               appendTier(buffer, 1, label + ChartToolTip.COLON + value);
+               buffer.append("<div class=\"tt-tier-1 tt-stack-total\">")
+                     .append(label).append(ChartToolTip.COLON).append(value)
+                     .append("</div>");
             }
 
             continue;

--- a/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
+++ b/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
@@ -131,9 +131,80 @@ public class ChartToolTip implements DataSerializable {
       return tooltips.contains(-1);
    }
 
-   // Header (shared X-dim) + per-series .tt-section blocks for CSS spacing
-   // + emphasized stack-total row at the bottom.
+   // Header path: measure tier-1, X-dim subtitle tier-2, peers grouped.
+   // Positional fallback: first added pair as tier-1, rest tier-2.
    private String renderCombinedCard(IndexedSet<String> palette) {
+      return hasHeader()
+         ? renderCombinedCardWithHeader(palette)
+         : renderCombinedCardPositional(palette);
+   }
+
+   private String renderCombinedCardWithHeader(IndexedSet<String> palette) {
+      StringBuilder buffer = new StringBuilder();
+      List<int[]> sections = splitSections();
+
+      if(sections.isEmpty()) {
+         return "";
+      }
+
+      boolean hasStackTotal = stackTotalName != null && !stackTotalName.isEmpty()
+         && sections.size() > 1;
+      int lastIndex = sections.size() - 1;
+      boolean wroteSubtitle = false;
+
+      for(int s = 0; s < sections.size(); s++) {
+         int[] section = sections.get(s);
+
+         if(section.length == 0) {
+            continue;
+         }
+
+         boolean isStackTotal = hasStackTotal && s == lastIndex;
+
+         if(isStackTotal) {
+            for(int i = 0; i < section.length; i += 2) {
+               String label = palette.get(section[i]);
+               String value = (i + 1) < section.length ? palette.get(section[i + 1]) : "";
+               appendTier(buffer, 1, label + ChartToolTip.COLON + value);
+            }
+
+            continue;
+         }
+
+         boolean isFirst = !wroteSubtitle;
+         int start = 0;
+
+         if(isFirst && section.length >= 2) {
+            String label = palette.get(section[0]);
+            String value = palette.get(section[1]);
+            appendTier(buffer, 1, label + ChartToolTip.COLON + value);
+            appendSubtitle(buffer, palette.get(headerKey), palette.get(headerValue));
+            wroteSubtitle = true;
+            start = 2;
+         }
+
+         if(start < section.length) {
+            buffer.append(isFirst
+               ? "<div class=\"tt-section tt-section-first\">"
+               : "<div class=\"tt-section\">");
+
+            for(int i = start; i < section.length; i += 2) {
+               String label = palette.get(section[i]);
+               String value = (i + 1) < section.length ? palette.get(section[i + 1]) : "";
+               int tier = isFirst ? 3 : (i == start ? 2 : 3);
+               appendTier(buffer, tier, label + ChartToolTip.COLON + value);
+            }
+
+            buffer.append("</div>");
+         }
+      }
+
+      return buffer.toString();
+   }
+
+   // Legacy positional layout retained for callers that build combined
+   // tooltips without going through PlotArea (and for the matching test).
+   private String renderCombinedCardPositional(IndexedSet<String> palette) {
       StringBuilder buffer = new StringBuilder();
       List<int[]> sections = splitSections();
 
@@ -149,8 +220,6 @@ public class ChartToolTip implements DataSerializable {
       for(int s = 0; s < sections.size(); s++) {
          int[] section = sections.get(s);
 
-         // splitSections already filters empties; this guard keeps the
-         // positional header contract intact if that invariant ever drifts.
          if(section.length == 0) {
             continue;
          }
@@ -169,7 +238,6 @@ public class ChartToolTip implements DataSerializable {
 
          int start = 0;
 
-         // First pair → tier-1 header, outside any section wrapper.
          if(!wroteHeader && section.length >= 2) {
             String label = palette.get(section[0]);
             String value = palette.get(section[1]);
@@ -178,7 +246,6 @@ public class ChartToolTip implements DataSerializable {
             start = 2;
          }
 
-         // Remaining pairs of this section render as one visual group.
          if(start < section.length) {
             buffer.append("<div class=\"tt-section\">");
 
@@ -236,6 +303,14 @@ public class ChartToolTip implements DataSerializable {
       int t = Math.min(tier, 3);
       buffer.append("<div class=\"tt-tier-").append(t).append("\">")
             .append(content)
+            .append("</div>");
+   }
+
+   private void appendSubtitle(StringBuilder buffer, String label, String value) {
+      buffer.append("<div class=\"tt-tier-2 tt-subtitle\">")
+            .append(label == null ? "" : label)
+            .append(ChartToolTip.COLON)
+            .append(value == null ? "" : value)
             .append("</div>");
    }
 
@@ -359,6 +434,25 @@ public class ChartToolTip implements DataSerializable {
       this.style = style == null ? ChartInfo.TooltipStyle.DEFAULT : style;
    }
 
+   // Shared X-dim header for combined card tooltips. When set, renderCombinedCard
+   // promotes the hovered measure to tier-1 and emits this pair as a tier-2 subtitle.
+   public void setHeader(int key, int value) {
+      this.headerKey = key;
+      this.headerValue = value;
+   }
+
+   public boolean hasHeader() {
+      return headerKey >= 0;
+   }
+
+   public int getHeaderKey() {
+      return headerKey;
+   }
+
+   public int getHeaderValue() {
+      return headerValue;
+   }
+
    /**
     * Clear chart tooltip.
     */
@@ -400,11 +494,14 @@ public class ChartToolTip implements DataSerializable {
 
    @Override
    public String toString() {
-      return super.toString() + "[" + customToolTip + ": " + tooltips + "]";
+      return super.toString() + "[" + customToolTip + ": " + tooltips
+         + ", header=(" + headerKey + "," + headerValue + ")]";
    }
 
    private final List<Integer> tooltips;
    private String stackTotalName = null;
    private String customToolTip;
    private ChartInfo.TooltipStyle style = ChartInfo.TooltipStyle.DEFAULT;
+   private int headerKey = -1;
+   private int headerValue = -1;
 }

--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -1416,11 +1416,9 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
          }
       }
       else {
-         // Card solo: measures first (primary tier). Combined/Default: dims
-         // first so the shared X-dim becomes the combined-card header.
-         boolean cardSolo = chartInfo.getTooltipStyle() == ChartInfo.TooltipStyle.CARD
-            && !chartInfo.isCombinedToolTip();
-         String[][] cols = cardSolo
+         // Card style: measure leads at tier-1 for both solo and combined.
+         // Combined lifts the shared X-dim out later as a tier-2 subtitle.
+         String[][] cols = chartInfo.getTooltipStyle() == ChartInfo.TooltipStyle.CARD
             ? new String[][] {measures, dims, others}
             : new String[][] {dims, measures, others};
          HashSet<String> added = new HashSet<>();
@@ -1711,6 +1709,8 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
          dimIndexes[i] = palette.put(dims[i]);
       }
 
+      captureCombinedCardHeader(resultTooltip, dimIndexes);
+
       List<Integer> pidxs = rowIndexMap.get(rowValue);
 
       if(pidxs != null) {
@@ -1786,6 +1786,8 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
          dimIndexes[i] = palette.put(dims[i]);
       }
 
+      captureCombinedCardHeader(resultTooltip, dimIndexes);
+
       ChartToolTip tempTip;
       ElementVO tempVO;
 
@@ -1833,6 +1835,27 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
       }
 
       return resultTooltip;
+   }
+
+   // For card-style combined tooltips, move the shared X-dim out of the primary
+   // tooltip onto a separate header field so renderCombinedCard can use it as a
+   // tier-2 subtitle while the hovered measure stays at tier-1.
+   private void captureCombinedCardHeader(ChartToolTip primary, int[] dimIndexes) {
+      if(chartInfo.getTooltipStyle() != ChartInfo.TooltipStyle.CARD
+         || dimIndexes.length == 0)
+      {
+         return;
+      }
+
+      int xKey = dimIndexes[0];
+      int xVal = primary.getTooltipValue(xKey);
+
+      if(xVal < 0) {
+         return;
+      }
+
+      primary.setHeader(xKey, xVal);
+      primary.removeTooltip(xKey);
    }
 
    private Map<String, ArrayList<Integer>> getRowValuePointMap(List<VisualObject> vos) {

--- a/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
@@ -104,12 +104,13 @@ class ChartToolTipTest {
 
    @Test
    void combinedCardUsesListLayout() {
-      // Simulates a stacked-area combined tooltip: shared X-dim leads, each
-      // series adds rows, stack total appended at the end.
       IndexedSet<String> palette = new IndexedSet<>();
+      int xKey = palette.put("Cal QTR");
+      int xVal = palette.put("Q3-LY");
+
       ChartToolTip primary = new ChartToolTip();
       primary.setStyle(ChartInfo.TooltipStyle.CARD);
-      primary.addTooltip(palette.put("Cal QTR"), palette.put("Q3-LY"));
+      primary.setHeader(xKey, xVal);
       primary.addTooltip(palette.put("Sum"), palette.put("73.3K"));
       primary.addTooltip(palette.put("Category"), palette.put("Business"));
 
@@ -125,29 +126,30 @@ class ChartToolTipTest {
 
       String out = primary.getTooltip(palette);
 
-      // First pair is the header (tier-1).
-      assertTrue(out.startsWith("<div class=\"tt-tier-1\">Cal QTR"),
-                 "Combined card must lead with the X-dim header at tier-1");
-      // The shared X-dim header must not also appear at tier-2.
-      assertFalse(out.contains("<div class=\"tt-tier-2\">Cal QTR"));
-      // Other primary pairs and second-series pairs all render at tier-2.
-      assertTrue(out.contains("<div class=\"tt-tier-2\">Sum:&nbsp;73.3K"));
-      assertTrue(out.contains("<div class=\"tt-tier-2\">Category:&nbsp;Business"));
-      assertTrue(out.contains("<div class=\"tt-tier-2\">Sum:&nbsp;74.7K"));
-      assertTrue(out.contains("<div class=\"tt-tier-2\">Category:&nbsp;Personal"));
-      // The stack-total row is emphasized at tier-1.
-      assertTrue(out.contains("<div class=\"tt-tier-1\">Total:&nbsp;936.3K"));
-      // Combined layout never demotes to tier-3.
-      assertFalse(out.contains("tt-tier-3"));
+      assertTrue(out.startsWith("<div class=\"tt-tier-1\">Sum:&nbsp;73.3K"),
+                 "Combined card must promote the hovered measure to tier-1");
+      assertTrue(out.contains("<div class=\"tt-tier-2 tt-subtitle\">Cal QTR:&nbsp;Q3-LY"),
+                 "Shared X-dim must render as a tier-2 subtitle");
+      assertTrue(out.contains("<div class=\"tt-section tt-section-first\">"),
+                 "First section wrapper must carry tt-section-first for CSS targeting");
+      assertTrue(out.contains("<div class=\"tt-tier-3\">Category:&nbsp;Business"),
+                 "First section's remaining context drops to tier-3");
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Sum:&nbsp;74.7K"),
+                 "Peer section's measure stays prominent at tier-2");
+      assertTrue(out.contains("<div class=\"tt-tier-3\">Category:&nbsp;Personal"),
+                 "Peer section's context drops to tier-3");
+      assertTrue(out.contains("<div class=\"tt-tier-1\">Total:&nbsp;936.3K"),
+                 "Stack total stays emphasized at tier-1");
+
+      int firstClassCount = out.split("tt-section-first", -1).length - 1;
+      assertEquals(1, firstClassCount, "tt-section-first must appear exactly once");
    }
 
    @Test
-   void combinedCardHeaderFollowsFirstAddedPair() {
-      // Documents the contract that PlotArea's cardSolo cols-ordering gate
-      // depends on: the FIRST pair added to the primary section becomes the
-      // tier-1 header, regardless of whether it's the dim or the measure.
-      // If this test fails after a PlotArea refactor, the combined-card
-      // header will end up showing the wrong field.
+   void combinedCardWithoutExplicitHeaderFallsBackToFirstPair() {
+      // Fallback layout for callers that build a combined tooltip without
+      // going through PlotArea (which sets the header). Tier-1 = first added
+      // pair, remaining rows at tier-2. Preserves legacy behavior.
       IndexedSet<String> paletteA = new IndexedSet<>();
       ChartToolTip dimFirst = new ChartToolTip();
       dimFirst.setStyle(ChartInfo.TooltipStyle.CARD);
@@ -160,7 +162,7 @@ class ChartToolTipTest {
 
       assertTrue(dimFirst.getTooltip(paletteA)
             .startsWith("<div class=\"tt-tier-1\">Year:&nbsp;2024"),
-         "Dim added first → dim becomes the combined-card header");
+         "Fallback: first added pair becomes the tier-1 header");
 
       IndexedSet<String> paletteB = new IndexedSet<>();
       ChartToolTip measureFirst = new ChartToolTip();
@@ -174,15 +176,18 @@ class ChartToolTipTest {
 
       assertTrue(measureFirst.getTooltip(paletteB)
             .startsWith("<div class=\"tt-tier-1\">Sales:&nbsp;100"),
-         "Measure added first → measure becomes the header (it's positional)");
+         "Fallback is positional: measure added first → measure as header");
    }
 
    @Test
-   void combinedCardWithoutStackTotalKeepsAllRowsUniform() {
+   void combinedCardWithoutStackTotalUsesHeaderSubtitleLayout() {
       IndexedSet<String> palette = new IndexedSet<>();
+      int xKey = palette.put("Cal QTR");
+      int xVal = palette.put("Q3");
+
       ChartToolTip primary = new ChartToolTip();
       primary.setStyle(ChartInfo.TooltipStyle.CARD);
-      primary.addTooltip(palette.put("Cal QTR"), palette.put("Q3"));
+      primary.setHeader(xKey, xVal);
       primary.addTooltip(palette.put("Sum"), palette.put("100"));
 
       ChartToolTip second = new ChartToolTip();
@@ -191,12 +196,61 @@ class ChartToolTipTest {
 
       String out = primary.getTooltip(palette);
 
-      // Header tier-1 (X-dim) + uniform tier-2 rows; no tier-3, no extra tier-1.
       int tier1 = out.split("tt-tier-1", -1).length - 1;
       int tier2 = out.split("tt-tier-2", -1).length - 1;
       int tier3 = out.split("tt-tier-3", -1).length - 1;
-      assertEquals(1, tier1, "Without stack total, only the header is tier-1");
-      assertEquals(2, tier2, "Remaining pairs render uniformly at tier-2");
-      assertEquals(0, tier3);
+      assertEquals(1, tier1, "Without stack total, only the hovered measure is tier-1");
+      assertEquals(2, tier2, "Subtitle + peer measure both render at tier-2");
+      assertEquals(0, tier3, "No additional context → no tier-3 rows");
+      assertTrue(out.contains("tt-tier-2 tt-subtitle"),
+                 "Header must carry the tt-subtitle modifier");
+   }
+
+   @Test
+   void combinedCardPromotesMeasureWhenHeaderSet() {
+      IndexedSet<String> palette = new IndexedSet<>();
+      int xKey = palette.put("Year");
+      int xVal = palette.put("2024");
+
+      ChartToolTip primary = new ChartToolTip();
+      primary.setStyle(ChartInfo.TooltipStyle.CARD);
+      primary.setHeader(xKey, xVal);
+      primary.addTooltip(palette.put("Sales"), palette.put("500"));
+
+      ChartToolTip peer = new ChartToolTip();
+      peer.addTooltip(palette.put("Sales"), palette.put("750"));
+      primary.appendTooltips(peer);
+
+      String out = primary.getTooltip(palette);
+
+      assertTrue(out.startsWith("<div class=\"tt-tier-1\">Sales:&nbsp;500"),
+                 "Header set → hovered measure leads at tier-1");
+      assertTrue(out.contains("<div class=\"tt-tier-2 tt-subtitle\">Year:&nbsp;2024"),
+                 "Header set → shared X-dim renders as tier-2 subtitle");
+   }
+
+   @Test
+   void combinedCardEmitsHeaderOnce() {
+      IndexedSet<String> palette = new IndexedSet<>();
+      int xKey = palette.put("Region");
+      int xVal = palette.put("West");
+
+      ChartToolTip primary = new ChartToolTip();
+      primary.setStyle(ChartInfo.TooltipStyle.CARD);
+      primary.setHeader(xKey, xVal);
+      primary.addTooltip(palette.put("Sales"), palette.put("100"));
+
+      ChartToolTip peer1 = new ChartToolTip();
+      peer1.addTooltip(palette.put("Sales"), palette.put("200"));
+      primary.appendTooltips(peer1);
+
+      ChartToolTip peer2 = new ChartToolTip();
+      peer2.addTooltip(palette.put("Sales"), palette.put("300"));
+      primary.appendTooltips(peer2);
+
+      String out = primary.getTooltip(palette);
+
+      int regionCount = out.split("Region:&nbsp;West", -1).length - 1;
+      assertEquals(1, regionCount, "Header must be emitted exactly once across all sections");
    }
 }

--- a/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
@@ -138,8 +138,8 @@ class ChartToolTipTest {
                  "Peer section's measure stays prominent at tier-2");
       assertTrue(out.contains("<div class=\"tt-tier-3\">Category:&nbsp;Personal"),
                  "Peer section's context drops to tier-3");
-      assertTrue(out.contains("<div class=\"tt-tier-1\">Total:&nbsp;936.3K"),
-                 "Stack total stays emphasized at tier-1");
+      assertTrue(out.contains("<div class=\"tt-tier-1 tt-stack-total\">Total:&nbsp;936.3K"),
+                 "Stack total emits the dedicated tt-stack-total class");
 
       int firstClassCount = out.split("tt-section-first", -1).length - 1;
       assertEquals(1, firstClassCount, "tt-section-first must appear exactly once");

--- a/web/projects/portal/src/scss/internal/_directives.scss
+++ b/web/projects/portal/src/scss/internal/_directives.scss
@@ -234,6 +234,16 @@ table.scrollable-table {
   .tt-tier-2 { font-size: 13px; margin-top: 6px; opacity: 0.9; }
   .tt-tier-3 { font-size: 11px; margin-top: 4px; opacity: 0.7; }
 
+  // Shared X-dim header for combined card: reads as a caption beneath the
+  // hovered measure rather than as another value row.
+  .tt-tier-2.tt-subtitle {
+    font-size: 12px;
+    font-weight: 400;
+    margin-top: 2px;
+    opacity: 0.65;
+    letter-spacing: 0.02em;
+  }
+
   // Combined card: each .tt-section groups one series' rows so adjacent
   // series read as distinct blocks (mirrors the default tooltip's blank-line
   // separators between sub-tooltips).
@@ -242,10 +252,21 @@ table.scrollable-table {
 
     .tt-tier-2 { margin-top: 1px; }
     .tt-tier-2:first-child { margin-top: 0; }
+    .tt-tier-3 { margin-top: 1px; }
   }
 
-  .tt-section:first-of-type { margin-top: 8px; }
+  // The first section holds the hovered series' context (e.g. its color dim),
+  // which belongs to the header group above it — keep it close to the
+  // subtitle/measure rather than spaced like a peer series. (Can't use
+  // :first-of-type — every child is a <div>, so it matches the leading
+  // tier-1, not the first .tt-section.)
+  .tt-section.tt-section-first { margin-top: 2px; }
+
   .tt-tier-1:not(:first-child) { margin-top: 10px; }
+
+  // Stack total sits at the bottom as the summary headline; bump it slightly
+  // above the regular tier-1 size so it reads as the punch line.
+  .tt-tier-1:last-child { font-size: 20px; }
 }
 
 .hidden__annotation-tooltip {

--- a/web/projects/portal/src/scss/internal/_directives.scss
+++ b/web/projects/portal/src/scss/internal/_directives.scss
@@ -266,7 +266,7 @@ table.scrollable-table {
 
   // Stack total sits at the bottom as the summary headline; bump it slightly
   // above the regular tier-1 size so it reads as the punch line.
-  .tt-tier-1:last-child { font-size: 20px; }
+  .tt-stack-total { font-size: 20px; }
 }
 
 .hidden__annotation-tooltip {


### PR DESCRIPTION
## Summary

- Combined card tooltip now leads with the hovered measure at tier-1; the shared X-dim renders as a
tier-2 subtitle below it. Restores consistency with solo card style, which already promoted the
measure to the headline tier.
- Stack-total row at the bottom of a combined card is bumped from 16px to 20px so it reads as the
summary headline.
- First section's wrapper is now tagged `tt-section-first` so CSS can tighten its top spacing against
the subtitle. The previous `.tt-section:first-of-type` rule never matched (every child in
`.widget__card-tooltip` is a `<div>`, so `:first-of-type` selected the leading `.tt-tier-1`, not the
first `.tt-section`).

## What changed

- `ChartToolTip`: new `setHeader(int, int)` / `hasHeader()` / `getHeaderKey()` / `getHeaderValue()`
API for the shared X-dim. `renderCombinedCard` dispatches to a header-aware path (production) or a
positional fallback (callers that build a combined tooltip directly without going through `PlotArea`).
 The fallback keeps the legacy layout so direct callers aren't affected.
- `PlotArea`: card style now uses `{measures, dims, others}` ordering for both solo and combined.
`getMultiLineToolTip` and `getMultiLineTextToolTip` capture the X-dim onto the primary tooltip via a
new `captureCombinedCardHeader` helper, then remove it from the flat list so it isn't duplicated
inside section content.
- `_directives.scss`: adds `.tt-subtitle`, `.tt-section-first`, and `.tt-tier-1:last-child` rules.
Replaces the broken `.tt-section:first-of-type` selector.
- `ChartToolTipTest`: updates `combinedCardUsesListLayout` for the new layout, renames the fallback
test to make its scope explicit, and adds three tests covering the header-aware production path
(header subtitle rendering, `tt-section-first` class, header emitted exactly once).