### PR TITLE
Bug #75015 - Y-axis dim leads card tooltip for gantt charts

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -1416,9 +1416,19 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
          }
       }
       else {
-         // Card style: measure leads at tier-1 for both solo and combined.
-         // Combined lifts the shared X-dim out later as a tier-2 subtitle.
-         String[][] cols = chartInfo.getTooltipStyle() == ChartInfo.TooltipStyle.CARD
+         boolean isGantt = GraphTypes.isGantt(chartInfo.getChartType());
+
+         // Gantt: Y-axis is the "row" axis that distinguishes bars, so list
+         // Y dims ahead of X dims regardless of binding order in the element.
+         if(isGantt) {
+            dims = ganttDimsYFirst(dims, chartInfo);
+         }
+
+         // Card style: measure leads at tier-1; gantt is the exception — its
+         // Y-axis grouping dim identifies the bar, dates are timeline context.
+         boolean cardMeasureFirst =
+            chartInfo.getTooltipStyle() == ChartInfo.TooltipStyle.CARD && !isGantt;
+         String[][] cols = cardMeasureFirst
             ? new String[][] {measures, dims, others}
             : new String[][] {dims, measures, others};
          HashSet<String> added = new HashSet<>();
@@ -1856,6 +1866,26 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
 
       primary.setHeader(xKey, xVal);
       primary.removeTooltip(xKey);
+   }
+
+   // Partition the gantt's element dims into Y-axis dims first, then anything
+   // else (X dims, leftover refs). Order within each partition is preserved.
+   static String[] ganttDimsYFirst(String[] dims, ChartInfo chartInfo) {
+      Set<String> yNames = new HashSet<>();
+
+      for(ChartRef ref : chartInfo.getRTYFields()) {
+         yNames.add(GraphUtil.getName(ref));
+      }
+
+      List<String> head = new ArrayList<>(dims.length);
+      List<String> tail = new ArrayList<>();
+
+      for(String d : dims) {
+         (yNames.contains(d) ? head : tail).add(d);
+      }
+
+      head.addAll(tail);
+      return head.toArray(new String[0]);
    }
 
    private Map<String, ArrayList<Integer>> getRowValuePointMap(List<VisualObject> vos) {

--- a/core/src/test/java/inetsoft/report/composition/region/PlotAreaGanttDimsTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/PlotAreaGanttDimsTest.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.composition.region;
+
+import inetsoft.uql.viewsheet.graph.ChartInfo;
+import inetsoft.uql.viewsheet.graph.ChartRef;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PlotAreaGanttDimsTest {
+   @Test
+   void yDimsMoveToHeadXDimsToTail() {
+      // element.getDims() for a gantt with X bound puts X first, then Y.
+      // The reorder must hoist Y to the front so the row identifier leads
+      // the tooltip regardless of binding order.
+      ChartInfo info = chartInfoWithY("reseller", "datagroup(city)");
+      String[] result = PlotArea.ganttDimsYFirst(
+         new String[] { "month", "reseller", "datagroup(city)" }, info);
+
+      assertArrayEquals(
+         new String[] { "reseller", "datagroup(city)", "month" }, result);
+   }
+
+   @Test
+   void preservesRelativeOrderWithinHeadAndTail() {
+      ChartInfo info = chartInfoWithY("y1", "y2");
+      String[] result = PlotArea.ganttDimsYFirst(
+         new String[] { "x1", "y1", "x2", "y2", "x3" }, info);
+
+      assertArrayEquals(
+         new String[] { "y1", "y2", "x1", "x2", "x3" }, result);
+   }
+
+   @Test
+   void returnsUnchangedWhenNoDimMatchesY() {
+      ChartInfo info = chartInfoWithY("reseller");
+      String[] result = PlotArea.ganttDimsYFirst(
+         new String[] { "month", "product" }, info);
+
+      assertArrayEquals(new String[] { "month", "product" }, result);
+   }
+
+   @Test
+   void handlesEmptyDims() {
+      ChartInfo info = chartInfoWithY("reseller");
+      String[] result = PlotArea.ganttDimsYFirst(new String[0], info);
+
+      assertArrayEquals(new String[0], result);
+   }
+
+   private static ChartInfo chartInfoWithY(String... yFullNames) {
+      ChartRef[] refs = new ChartRef[yFullNames.length];
+
+      for(int i = 0; i < yFullNames.length; i++) {
+         ChartRef ref = mock(ChartRef.class);
+         when(ref.getFullName()).thenReturn(yFullNames[i]);
+         refs[i] = ref;
+      }
+
+      ChartInfo info = mock(ChartInfo.class);
+      when(info.getRTYFields()).thenReturn(refs);
+      return info;
+   }
+}


### PR DESCRIPTION
## Summary

- For gantt charts, the tooltip now leads with the Y-axis grouping field (e.g. `reseller`,
`DataGroup(city)`) instead of the gantt's start-date field. The Y-axis identifies which bar was
hovered; the start/end/milestone dates describe its timeline position, not its identity.
- Applies to both card and default tooltip styles, and regardless of whether an X-axis dim is bound.

## What changed

- `PlotArea.getToolTip0`: detect gantt up front (`boolean isGantt = GraphTypes.isGantt(...)`). For
gantt, reorder the element's dims so Y-axis dims come before X-axis dims. Also exempt gantt from the
`cardSolo` measure-first gate so the dim path wins regardless of style.
- New private-helper `ganttDimsYFirst(String[] dims, ChartInfo)`: partitions `dims` using
`chartInfo.getRTYFields()` membership — Y dims to head, everything else to tail, with relative order
preserved within each partition.
- With an X dim bound (e.g. user drags `month` to X), the reorder also pushes `month` behind Y dims, so
Y still leads.