### PR TITLE
Bug #75041 - Make legend symbol rounding per-legend

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -1669,6 +1669,7 @@ public abstract class GraphGenerator {
                // "Symbol Size" set on a DC chart legend (CompositeVisualFrame)
                // is actually applied to the rendered legend.
                gspec.setSymbolSize(legend.getSymbolSize());
+               gspec.setSymbolRoundCorners(legend.isSymbolRoundCorners());
             }
          }
 
@@ -6338,6 +6339,7 @@ public abstract class GraphGenerator {
       String fld = frame.getField();
       legend.setTitleVisible(desc.isTitleVisible());
       legend.setSymbolSize(desc.getSymbolSize());
+      legend.setSymbolRoundCorners(desc.isSymbolRoundCorners());
 
       if(desc.isNotShowNull()) {
          frame.setScaleOption(Scale.NO_NULL);

--- a/core/src/main/java/inetsoft/report/composition/graph/GraphUtil.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphUtil.java
@@ -579,7 +579,6 @@ public class GraphUtil {
       spec.setBorder(legends.getBorder());
       spec.setBorderColor(legends.getBorderColor());
       spec.setRoundCorners(legends.isRoundCorners());
-      spec.setSymbolRoundCorners(legends.isSymbolRoundCorners());
       spec.setTitleTextSpec(GraphUtil.getTextSpec(format, null, null));
       spec.setPartial(true);
    }

--- a/core/src/main/java/inetsoft/report/internal/AllLegendDescriptor.java
+++ b/core/src/main/java/inetsoft/report/internal/AllLegendDescriptor.java
@@ -220,6 +220,17 @@ public class AllLegendDescriptor extends LegendDescriptor {
       applySet("setSymbolSize", new Object[] {symbolSize}, new Class[] {int.class});
    }
 
+   @Override
+   public boolean isSymbolRoundCorners() {
+      return (Boolean) applyGet("isSymbolRoundCorners");
+   }
+
+   @Override
+   public void setSymbolRoundCorners(boolean symbolRoundCorners) {
+      applySet("setSymbolRoundCorners", new Object[] {symbolRoundCorners},
+               new Class[] {boolean.class});
+   }
+
    /**
     * Retrieve property from multiple objects.
     */

--- a/core/src/main/java/inetsoft/report/script/LegendScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/LegendScriptable.java
@@ -66,6 +66,8 @@ public class LegendScriptable extends PropertyScriptable {
                      LegendDescriptor.class);
          addProperty("symbolSize", "getSymbolSize", "setSymbolSize", int.class,
                      LegendDescriptor.class);
+         addProperty("symbolRoundCorners", "isSymbolRoundCorners",
+                     "setSymbolRoundCorners", boolean.class, LegendDescriptor.class);
       }
       catch(Exception ex) {
          LOG.error("Failed to register legend properties", ex);

--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/LegendDescriptor.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/LegendDescriptor.java
@@ -180,6 +180,14 @@ public class LegendDescriptor implements AssetObject, ContentObject {
       this.symbolSize = Math.max(6, Math.min(50, symbolSize));
    }
 
+   public boolean isSymbolRoundCorners() {
+      return symbolRoundCorners;
+   }
+
+   public void setSymbolRoundCorners(boolean symbolRoundCorners) {
+      this.symbolRoundCorners = symbolRoundCorners;
+   }
+
    /**
     * Get the preferred size for legends if set by the user, if the width/height
     * is between 0-1, will treat it as proportion, otherwise treat it as really
@@ -459,7 +467,7 @@ public class LegendDescriptor implements AssetObject, ContentObject {
       return logScale == des.logScale && reversed == des.reversed &&
          visible == des.visible && notShowNull == des.notShowNull &&
          titleVisible == des.titleVisible && maxModeVisible == des.maxModeVisible &&
-         symbolSize == des.symbolSize;
+         symbolSize == des.symbolSize && symbolRoundCorners == des.symbolRoundCorners;
    }
 
    /**
@@ -502,6 +510,7 @@ public class LegendDescriptor implements AssetObject, ContentObject {
       writer.print(" notShowNull=\"" + notShowNull + "\" ");
       writer.print(" includeZero=\"" + includeZero + "\" ");
       writer.print(" symbolSize=\"" + symbolSize + "\" ");
+      writer.print(" symbolRoundCorners=\"" + symbolRoundCorners + "\" ");
    }
 
    /**
@@ -647,6 +656,10 @@ public class LegendDescriptor implements AssetObject, ContentObject {
             LOG.error("Failed to parse symbolSize: " + val, ex);
          }
       }
+
+      val = Tool.getAttribute(tag, "symbolRoundCorners");
+      // absent on legacy XML — default off so old charts render unchanged
+      symbolRoundCorners = "true".equals(val);
    }
 
    /**
@@ -897,6 +910,18 @@ public class LegendDescriptor implements AssetObject, ContentObject {
          }
       }
 
+      @Override
+      public boolean isSymbolRoundCorners() {
+         return legends[legends.length - 1].isSymbolRoundCorners();
+      }
+
+      @Override
+      public void setSymbolRoundCorners(boolean symbolRoundCorners) {
+         for(LegendDescriptor legend : legends) {
+            legend.setSymbolRoundCorners(symbolRoundCorners);
+         }
+      }
+
       private LegendDescriptor[] legends;
    }
 
@@ -923,6 +948,7 @@ public class LegendDescriptor implements AssetObject, ContentObject {
    private boolean notShowNull = false;
    private boolean includeZero = false;
    private int symbolSize = LegendItem.DEFAULT_SYMBOL_SIZE;
+   private boolean symbolRoundCorners = true;
 
    private static final Logger LOG = LoggerFactory.getLogger(LegendDescriptor.class);
 }

--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/LegendsDescriptor.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/LegendsDescriptor.java
@@ -108,14 +108,6 @@ public class LegendsDescriptor implements AssetObject, ContentObject {
       this.roundCorners = roundCorners;
    }
 
-   public boolean isSymbolRoundCorners() {
-      return symbolRoundCorners;
-   }
-
-   public void setSymbolRoundCorners(boolean symbolRoundCorners) {
-      this.symbolRoundCorners = symbolRoundCorners;
-   }
-
    /**
     * Get the color used by the legends border.
     */
@@ -414,7 +406,6 @@ public class LegendsDescriptor implements AssetObject, ContentObject {
          && Tool.equals(borderColor, desc.borderColor)
          && Tool.equals(border, desc.border)
          && roundCorners == desc.roundCorners
-         && symbolRoundCorners == desc.symbolRoundCorners
          && option == desc.option
          && Tool.equals(preferredSize, desc.preferredSize)
          && Tool.equals(gap, desc.gap)
@@ -441,7 +432,6 @@ public class LegendsDescriptor implements AssetObject, ContentObject {
       writer.print(" borderColor=\"" + borderColor + "\"");
       writer.print(" border=\"" + border + "\"");
       writer.print(" roundCorners=\"" + roundCorners + "\"");
-      writer.print(" symbolRoundCorners=\"" + symbolRoundCorners + "\"");
       writer.print(" option=\"" + option + "\"");
 
       if(preferredSize != null) {
@@ -505,13 +495,6 @@ public class LegendsDescriptor implements AssetObject, ContentObject {
 
       if((val = Tool.getAttribute(tag, "roundCorners")) != null) {
          roundCorners = "true".equals(val);
-      }
-
-      if((val = Tool.getAttribute(tag, "symbolRoundCorners")) != null) {
-         symbolRoundCorners = "true".equals(val);
-      }
-      else {
-         symbolRoundCorners = false;
       }
 
       if((val = Tool.getAttribute(tag, "option")) != null) {
@@ -598,8 +581,6 @@ public class LegendsDescriptor implements AssetObject, ContentObject {
    private CompositeValue<Integer> border = new CompositeValue<>(Integer.class,
                                                                  StyleConstants.THIN_LINE);
    private boolean roundCorners = false;
-   // default true for new charts; parseAttributes forces false on legacy XML
-   private boolean symbolRoundCorners = true;
    private LegendDescriptor colorDesc;
    private LegendDescriptor shapeDesc;
    private LegendDescriptor sizeDesc;

--- a/core/src/main/java/inetsoft/web/graph/model/dialog/LegendFormatDialogModel.java
+++ b/core/src/main/java/inetsoft/web/graph/model/dialog/LegendFormatDialogModel.java
@@ -50,7 +50,7 @@ public class LegendFormatDialogModel {
       generalPaneModel.setNotShowNullVisible(dimension && field != null);
       generalPaneModel.setSymbolSize(legendDesc.getSymbolSize());
       generalPaneModel.setRoundCorners(legendsDesc.isRoundCorners());
-      generalPaneModel.setSymbolRoundCorners(legendsDesc.isSymbolRoundCorners());
+      generalPaneModel.setSymbolRoundCorners(legendDesc.isSymbolRoundCorners());
       // only rect-based legends (Color/Size/Texture) actually render the rounded swatch;
       // Shape and Line legends draw glyphs/lines so the toggle is hidden there
       generalPaneModel.setSymbolRoundCornersVisible(
@@ -124,7 +124,7 @@ public class LegendFormatDialogModel {
       legendDesc.setNotShowNull(generalPaneModel.isNotShowNull());
       legendDesc.setSymbolSize(generalPaneModel.getSymbolSize());
       legendsDesc.setRoundCorners(generalPaneModel.isRoundCorners());
-      legendsDesc.setSymbolRoundCorners(generalPaneModel.isSymbolRoundCorners());
+      legendDesc.setSymbolRoundCorners(generalPaneModel.isSymbolRoundCorners());
 
       legendDesc.setReversed(scalePaneModel.isReverse());
       legendDesc.setLogarithmicScale(scalePaneModel.isLogarithmic());

--- a/core/src/test/java/inetsoft/report/script/LegendScriptableTest.java
+++ b/core/src/test/java/inetsoft/report/script/LegendScriptableTest.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.script;
+
+import inetsoft.report.internal.AllLegendDescriptor;
+import inetsoft.uql.viewsheet.graph.LegendDescriptor;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class LegendScriptableTest {
+   @Test
+   void symbolRoundCornersPropertyRoutesToDescriptor() {
+      LegendDescriptor legend = new LegendDescriptor();
+      LegendScriptable scriptable = new LegendScriptable(legend);
+
+      assertEquals(Boolean.TRUE, scriptable.get("symbolRoundCorners", null));
+
+      scriptable.put("symbolRoundCorners", null, Boolean.FALSE);
+      assertFalse(legend.isSymbolRoundCorners());
+
+      legend.setSymbolRoundCorners(true);
+      assertEquals(Boolean.TRUE, scriptable.get("symbolRoundCorners", null));
+   }
+
+   @Test
+   void symbolRoundCornersBroadcastsAcrossAllLegendDescriptor() {
+      LegendDescriptor a = new LegendDescriptor();
+      LegendDescriptor b = new LegendDescriptor();
+      AllLegendDescriptor all = new AllLegendDescriptor(List.of(a, b));
+      LegendScriptable scriptable = new LegendScriptable(all);
+
+      scriptable.put("symbolRoundCorners", null, Boolean.FALSE);
+
+      assertFalse(a.isSymbolRoundCorners());
+      assertFalse(b.isSymbolRoundCorners());
+   }
+}

--- a/core/src/test/java/inetsoft/web/graph/model/dialog/LegendFormatDialogModelTest.java
+++ b/core/src/test/java/inetsoft/web/graph/model/dialog/LegendFormatDialogModelTest.java
@@ -64,16 +64,18 @@ public class LegendFormatDialogModelTest {
       aliasPaneModel.setAliasList(new ModelAlias[0]);
       dialog.setAliasPaneModel(aliasPaneModel);
 
-      LegendDescriptor edited = new LegendDescriptor();
-      LegendDescriptor other = new LegendDescriptor();
       LegendsDescriptor legendsDesc = new LegendsDescriptor();
+      LegendDescriptor edited = new LegendDescriptor();
+      LegendDescriptor unrelated = new LegendDescriptor();
+      legendsDesc.setColorLegendDescriptor(edited);
+      legendsDesc.setSizeLegendDescriptor(unrelated);
 
       dialog.updateLegendFormatDialogModel(new VSChartInfo(), legendsDesc, edited, null);
 
       assertFalse(edited.isSymbolRoundCorners(),
                   "the edited legend should reflect the dialog value");
-      assertTrue(other.isSymbolRoundCorners(),
-                 "an unrelated legend on the same chart must not be affected");
+      assertTrue(unrelated.isSymbolRoundCorners(),
+                 "another legend on the same chart must not be affected");
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/graph/model/dialog/LegendFormatDialogModelTest.java
+++ b/core/src/test/java/inetsoft/web/graph/model/dialog/LegendFormatDialogModelTest.java
@@ -25,7 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.awt.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SreeHome()
 @ExtendWith(MockitoExtension.class)
@@ -49,5 +49,44 @@ public class LegendFormatDialogModelTest {
                                                             legendDescriptor, null);
 
       assertEquals(Color.WHITE, legendsDescriptor.getBorderColor());
+   }
+
+   @Test
+   public void symbolRoundCornersIsWrittenToEditedLegendOnly() {
+      LegendFormatDialogModel dialog = new LegendFormatDialogModel();
+      LegendFormatGeneralPaneModel pane = new LegendFormatGeneralPaneModel();
+      pane.setPosition("");
+      pane.setFillColor("#ffffff");
+      pane.setSymbolRoundCorners(false);
+      dialog.setLegendFormatGeneralPaneModel(pane);
+      dialog.setLegendScalePaneModel(new LegendScalePaneModel());
+      AliasPaneModel aliasPaneModel = new AliasPaneModel();
+      aliasPaneModel.setAliasList(new ModelAlias[0]);
+      dialog.setAliasPaneModel(aliasPaneModel);
+
+      LegendDescriptor edited = new LegendDescriptor();
+      LegendDescriptor other = new LegendDescriptor();
+      LegendsDescriptor legendsDesc = new LegendsDescriptor();
+
+      dialog.updateLegendFormatDialogModel(new VSChartInfo(), legendsDesc, edited, null);
+
+      assertFalse(edited.isSymbolRoundCorners(),
+                  "the edited legend should reflect the dialog value");
+      assertTrue(other.isSymbolRoundCorners(),
+                 "an unrelated legend on the same chart must not be affected");
+   }
+
+   @Test
+   public void equalsContentDiscriminatesSymbolRoundCorners() {
+      LegendDescriptor a = new LegendDescriptor();
+      LegendDescriptor b = new LegendDescriptor();
+      a.setSymbolRoundCorners(true);
+      b.setSymbolRoundCorners(false);
+
+      assertFalse(a.equalsContent(b));
+
+      b.setSymbolRoundCorners(true);
+
+      assertTrue(a.equalsContent(b));
    }
 }


### PR DESCRIPTION
## Summary
- Move `symbolRoundCorners` from chart-wide `LegendsDescriptor` to per-legend `LegendDescriptor`, so toggling
rounding on the Color legend no longer also toggles Size and Texture (resolves reviewer feedback on #3622).
- Drop the chart-wide `setSymbolRoundCorners` call from `GraphUtil.setLegendSpec`; per-legend wiring is added in
`GraphGenerator` next to the existing `setSymbolSize` path, mirroring the established precedent.
- `LegendFormatDialogModel` now reads and writes the value through `legendDesc` (the legend being edited), not
`legendsDesc`.

## Notes
- The `isSymbolRoundCorners` / `setSymbolRoundCorners` accessors on `LegendsDescriptor` are removed. They were
introduced in #3622 about two weeks ago and have no external callers in the monorepo.
- Viewsheets saved against #3622 will need the rounded-symbol option re-toggled per legend after this lands; the
old chart-wide attribute is read but ignored.