### PR TITLE
Bug #75026 - Close leads card tooltip for candle/stock charts

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
+++ b/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
@@ -508,9 +508,10 @@ public class ChartToolTip implements DataSerializable {
 
    // Number of pairs after the tier-1 headline that should render at tier-2 in
    // the solo-card-with-header path (candle/stock OHL group). Pairs past this
-   // group drop to tier-3.
+   // group drop to tier-3. 0 is valid: no tier-2 group, so everything after the
+   // headline lands at tier-3 (e.g. partial OHL binding with only Close).
    public void setTier2GroupSize(int size) {
-      this.tier2GroupSize = Math.max(1, size);
+      this.tier2GroupSize = Math.max(0, size);
    }
 
    public int getTier2GroupSize() {
@@ -563,6 +564,9 @@ public class ChartToolTip implements DataSerializable {
    }
 
    private final List<Integer> tooltips;
+   // Render-time only: stackTotalName, style, headerKey, headerValue, and
+   // tier2GroupSize are reconstructed by PlotArea each render and are not part
+   // of the writeData wire format. parseData is a no-op; keep them off the wire.
    private String stackTotalName = null;
    private String customToolTip;
    private ChartInfo.TooltipStyle style = ChartInfo.TooltipStyle.DEFAULT;

--- a/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
+++ b/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
@@ -91,10 +91,6 @@ public class ChartToolTip implements DataSerializable {
          return renderCombinedCard(palette);
       }
 
-      // Solo card with an explicit header (e.g. candle/stock X-dim): pair[0] is
-      // the headline, header renders as a tier-1 subtitle directly below it,
-      // the next tier2GroupSize pairs form an auxiliary tier-2 group, the
-      // remainder tail at tier-3.
       if(hasHeader() && (customToolTip == null || customToolTip.isEmpty())) {
          return renderSoloCardWithHeader(palette);
       }
@@ -355,8 +351,7 @@ public class ChartToolTip implements DataSerializable {
             .append("</div>");
    }
 
-   // Solo card uses tier=1 (headline-bound subtitle, e.g. candle/stock date);
-   // combined card uses tier=2 (shared X-dim that scopes all peer sections).
+   // Solo card uses tier=1 (headline-bound); combined card uses tier=2 (scopes peer sections).
    private void appendSubtitle(StringBuilder buffer, int tier, String label, String value) {
       int t = Math.min(Math.max(tier, 1), 3);
       buffer.append("<div class=\"tt-tier-").append(t).append(" tt-subtitle\">")
@@ -486,9 +481,7 @@ public class ChartToolTip implements DataSerializable {
       this.style = style == null ? ChartInfo.TooltipStyle.DEFAULT : style;
    }
 
-   // Shared X-dim header. Solo card renders it as a tier-1 subtitle directly
-   // under the headline; combined card renders it as a tier-2 subtitle scoping
-   // multiple peer sections.
+   // Shared X-dim header. Solo card → tier-1 subtitle; combined card → tier-2 subtitle.
    public void setHeader(int key, int value) {
       this.headerKey = key;
       this.headerValue = value;
@@ -506,10 +499,7 @@ public class ChartToolTip implements DataSerializable {
       return headerValue;
    }
 
-   // Number of pairs after the tier-1 headline that should render at tier-2 in
-   // the solo-card-with-header path (candle/stock OHL group). Pairs past this
-   // group drop to tier-3. 0 is valid: no tier-2 group, so everything after the
-   // headline lands at tier-3 (e.g. partial OHL binding with only Close).
+   // Pairs after the headline that render at tier-2; rest drop to tier-3. 0 = none (e.g. only Close bound).
    public void setTier2GroupSize(int size) {
       this.tier2GroupSize = Math.max(0, size);
    }
@@ -564,9 +554,7 @@ public class ChartToolTip implements DataSerializable {
    }
 
    private final List<Integer> tooltips;
-   // Render-time only: stackTotalName, style, headerKey, headerValue, and
-   // tier2GroupSize are reconstructed by PlotArea each render and are not part
-   // of the writeData wire format. parseData is a no-op; keep them off the wire.
+   // Render-time state below; reconstructed each render, not written by writeData.
    private String stackTotalName = null;
    private String customToolTip;
    private ChartInfo.TooltipStyle style = ChartInfo.TooltipStyle.DEFAULT;

--- a/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
+++ b/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
@@ -91,6 +91,14 @@ public class ChartToolTip implements DataSerializable {
          return renderCombinedCard(palette);
       }
 
+      // Solo card with an explicit header (e.g. candle/stock X-dim): pair[0] is
+      // the headline, header renders as a tier-1 subtitle directly below it,
+      // the next tier2GroupSize pairs form an auxiliary tier-2 group, the
+      // remainder tail at tier-3.
+      if(hasHeader() && (customToolTip == null || customToolTip.isEmpty())) {
+         return renderSoloCardWithHeader(palette);
+      }
+
       StringBuilder buffer = new StringBuilder();
       int tier = 1;
 
@@ -120,6 +128,43 @@ public class ChartToolTip implements DataSerializable {
          String value = (i + 1) < tooltips.size() ? palette.get(tooltips.get(i + 1)) : "";
          appendTier(buffer, tier, label + ChartToolTip.COLON + value);
          tier++;
+      }
+
+      return buffer.toString();
+   }
+
+   private String renderSoloCardWithHeader(IndexedSet<String> palette) {
+      StringBuilder buffer = new StringBuilder();
+      int pairsRendered = 0;
+
+      for(int i = 0; i < tooltips.size(); i += 2) {
+         int keyIdx = tooltips.get(i);
+
+         if(keyIdx == -1) {
+            continue;
+         }
+
+         String label = palette.get(keyIdx);
+         String value = (i + 1) < tooltips.size() ? palette.get(tooltips.get(i + 1)) : "";
+         int tier;
+
+         if(pairsRendered == 0) {
+            tier = 1;
+         }
+         else if(pairsRendered < 1 + tier2GroupSize) {
+            tier = 2;
+         }
+         else {
+            tier = 3;
+         }
+
+         appendTier(buffer, tier, label + ChartToolTip.COLON + value);
+
+         if(pairsRendered == 0) {
+            appendSubtitle(buffer, 1, palette.get(headerKey), palette.get(headerValue));
+         }
+
+         pairsRendered++;
       }
 
       return buffer.toString();
@@ -180,7 +225,7 @@ public class ChartToolTip implements DataSerializable {
             String label = palette.get(section[0]);
             String value = palette.get(section[1]);
             appendTier(buffer, 1, label + ChartToolTip.COLON + value);
-            appendSubtitle(buffer, palette.get(headerKey), palette.get(headerValue));
+            appendSubtitle(buffer, 2, palette.get(headerKey), palette.get(headerValue));
             wroteSubtitle = true;
             start = 2;
          }
@@ -310,8 +355,11 @@ public class ChartToolTip implements DataSerializable {
             .append("</div>");
    }
 
-   private void appendSubtitle(StringBuilder buffer, String label, String value) {
-      buffer.append("<div class=\"tt-tier-2 tt-subtitle\">")
+   // Solo card uses tier=1 (headline-bound subtitle, e.g. candle/stock date);
+   // combined card uses tier=2 (shared X-dim that scopes all peer sections).
+   private void appendSubtitle(StringBuilder buffer, int tier, String label, String value) {
+      int t = Math.min(Math.max(tier, 1), 3);
+      buffer.append("<div class=\"tt-tier-").append(t).append(" tt-subtitle\">")
             .append(label == null ? "" : label)
             .append(ChartToolTip.COLON)
             .append(value == null ? "" : value)
@@ -438,8 +486,9 @@ public class ChartToolTip implements DataSerializable {
       this.style = style == null ? ChartInfo.TooltipStyle.DEFAULT : style;
    }
 
-   // Shared X-dim header for combined card tooltips. When set, renderCombinedCard
-   // promotes the hovered measure to tier-1 and emits this pair as a tier-2 subtitle.
+   // Shared X-dim header. Solo card renders it as a tier-1 subtitle directly
+   // under the headline; combined card renders it as a tier-2 subtitle scoping
+   // multiple peer sections.
    public void setHeader(int key, int value) {
       this.headerKey = key;
       this.headerValue = value;
@@ -455,6 +504,17 @@ public class ChartToolTip implements DataSerializable {
 
    public int getHeaderValue() {
       return headerValue;
+   }
+
+   // Number of pairs after the tier-1 headline that should render at tier-2 in
+   // the solo-card-with-header path (candle/stock OHL group). Pairs past this
+   // group drop to tier-3.
+   public void setTier2GroupSize(int size) {
+      this.tier2GroupSize = Math.max(1, size);
+   }
+
+   public int getTier2GroupSize() {
+      return tier2GroupSize;
    }
 
    /**
@@ -508,4 +568,5 @@ public class ChartToolTip implements DataSerializable {
    private ChartInfo.TooltipStyle style = ChartInfo.TooltipStyle.DEFAULT;
    private int headerKey = -1;
    private int headerValue = -1;
+   private int tier2GroupSize = 1;
 }

--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -1570,10 +1570,7 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
             }
          }
 
-         // Candle/Stock card: lift the X-dim (date) to a tier-1 subtitle below
-         // the Close headline, and keep OHL together at tier-2 above aesthetics.
-         // Only dims[0] is lifted — nested X-dims (e.g. Year + Month) remain as
-         // regular tooltip rows. Same single-dim policy as captureCombinedCardHeader.
+         // Lift only dims[0]; nested X-dims stay as regular rows (matches captureCombinedCardHeader).
          if(candleCardLayout && dims.length > 0) {
             applyCandleCardHeader(tooltip, dims[0], tipMeasures);
          }
@@ -1702,11 +1699,8 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
       return measureName == null ? STACK_TOTAL : STACK_TOTAL + " " + measureName;
    }
 
-   // Build the candle/stock tip measure order: Close, Open, High, Low, then any
-   // extras in their original position. Only OHLC names actually present in
-   // measures are included — phantom names (e.g. an info field whose column
-   // wasn't bound) would inflate the result length and over-count the tier-2
-   // group size in applyCandleCardHeader.
+   // Only OHLC names present in measures are kept; unbound getRT*Field() values would
+   // inflate the result length and over-count tier-2 group size in applyCandleCardHeader.
    private String[] reorderCandleMeasuresCloseFirst(String[] measures,
                                                     CandleChartInfo info)
    {
@@ -1739,8 +1733,7 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
       return ref == null ? null : GraphUtil.getName(ref);
    }
 
-   // Set the X-dim as the tooltip header (rendered as tier-1 subtitle by
-   // ChartToolTip's solo-card-with-header path) and group OHL pairs at tier-2.
+   // Set X-dim as header (solo-card-with-header renders it as tier-1 subtitle); group OHL at tier-2.
    private void applyCandleCardHeader(ChartToolTip tooltip, String xDim,
                                       String[] tipMeasures)
    {
@@ -1758,8 +1751,7 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
          tooltip.removeTooltip(xKey);
       }
 
-      // Pairs 1..N (Open/High/Low) stay at tier-2; anything past them
-      // (aesthetics like color dims) drops to tier-3.
+      // OHL stay at tier-2; aesthetics past them drop to tier-3.
       int auxCount = Math.max(0, tipMeasures.length - 1);
       tooltip.setTier2GroupSize(auxCount);
    }

--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -1751,8 +1751,18 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
          tooltip.removeTooltip(xKey);
       }
 
-      // OHL stay at tier-2; aesthetics past them drop to tier-3.
-      int auxCount = Math.max(0, tipMeasures.length - 1);
+      // Count only entries that actually landed in the tooltip — skips OHLC names
+      // dropped by the allfields filter so aesthetics don't get promoted to tier-2.
+      int auxCount = 0;
+
+      for(int i = 1; i < tipMeasures.length; i++) {
+         String label = tips.get(tipMeasures[i]);
+
+         if(label != null && tooltip.containsTooltip(palette.put(label))) {
+            auxCount++;
+         }
+      }
+
       tooltip.setTier2GroupSize(auxCount);
    }
 

--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -1572,6 +1572,8 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
 
          // Candle/Stock card: lift the X-dim (date) to a tier-1 subtitle below
          // the Close headline, and keep OHL together at tier-2 above aesthetics.
+         // Only dims[0] is lifted — nested X-dims (e.g. Year + Month) remain as
+         // regular tooltip rows. Same single-dim policy as captureCombinedCardHeader.
          if(candleCardLayout && dims.length > 0) {
             applyCandleCardHeader(tooltip, dims[0], tipMeasures);
          }
@@ -1700,40 +1702,36 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
       return measureName == null ? STACK_TOTAL : STACK_TOTAL + " " + measureName;
    }
 
-   // Build the candle/stock tip measure order: Close, Open, High, Low,
-   // then any extras in their original position. Null fields are dropped.
+   // Build the candle/stock tip measure order: Close, Open, High, Low, then any
+   // extras in their original position. Only OHLC names actually present in
+   // measures are included — phantom names (e.g. an info field whose column
+   // wasn't bound) would inflate the result length and over-count the tier-2
+   // group size in applyCandleCardHeader.
    private String[] reorderCandleMeasuresCloseFirst(String[] measures,
                                                     CandleChartInfo info)
    {
-      String closeName = nameOf(info.getRTCloseField());
-      String openName = nameOf(info.getRTOpenField());
-      String highName = nameOf(info.getRTHighField());
-      String lowName = nameOf(info.getRTLowField());
-
-      List<String> reordered = new ArrayList<>();
-
-      if(closeName != null) {
-         reordered.add(closeName);
-      }
-
-      if(openName != null) {
-         reordered.add(openName);
-      }
-
-      if(highName != null) {
-         reordered.add(highName);
-      }
-
-      if(lowName != null) {
-         reordered.add(lowName);
-      }
+      Set<String> remaining = new LinkedHashSet<>();
 
       for(String m : measures) {
-         if(m != null && !reordered.contains(m)) {
-            reordered.add(m);
+         if(m != null) {
+            remaining.add(m);
          }
       }
 
+      List<String> reordered = new ArrayList<>();
+
+      for(String candidate : new String[] {
+         nameOf(info.getRTCloseField()),
+         nameOf(info.getRTOpenField()),
+         nameOf(info.getRTHighField()),
+         nameOf(info.getRTLowField()) })
+      {
+         if(candidate != null && remaining.remove(candidate)) {
+            reordered.add(candidate);
+         }
+      }
+
+      reordered.addAll(remaining);
       return reordered.toArray(new String[0]);
    }
 

--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -1417,6 +1417,7 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
       }
       else {
          boolean isGantt = GraphTypes.isGantt(chartInfo.getChartType());
+         boolean isCandleOrStock = chartInfo instanceof CandleChartInfo;
 
          // Gantt: Y-axis is the "row" axis that distinguishes bars, so list
          // Y dims ahead of X dims regardless of binding order in the element.
@@ -1425,8 +1426,18 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
          }
 
          boolean cardMeasureFirst = cardPutsMeasureFirst(chartInfo, element);
+         String[] tipMeasures = measures;
+         boolean candleCardLayout = isCandleOrStock && cardMeasureFirst;
+
+         // Candle/Stock card: Close is the canonical headline price; promote it
+         // ahead of OHL so it becomes the tier-1 row.
+         if(candleCardLayout) {
+            tipMeasures = reorderCandleMeasuresCloseFirst(
+               measures, (CandleChartInfo) chartInfo);
+         }
+
          String[][] cols = cardMeasureFirst
-            ? new String[][] {measures, dims, others}
+            ? new String[][] {tipMeasures, dims, others}
             : new String[][] {dims, measures, others};
          HashSet<String> added = new HashSet<>();
          Object[] arr = new Object[list.size()];
@@ -1558,6 +1569,12 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
                appendInfo(vmodel, tooltip, index, dataset, added, aesthetics, evo, excludeDims);
             }
          }
+
+         // Candle/Stock card: lift the X-dim (date) to a tier-1 subtitle below
+         // the Close headline, and keep OHL together at tier-2 above aesthetics.
+         if(candleCardLayout && dims.length > 0) {
+            applyCandleCardHeader(tooltip, dims[0], tipMeasures);
+         }
       }
 
       HRef ref = getHyperlink(evo, col, vgraph, false, null);
@@ -1681,6 +1698,72 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
 
    private String getStackTotalName(String measureName) {
       return measureName == null ? STACK_TOTAL : STACK_TOTAL + " " + measureName;
+   }
+
+   // Build the candle/stock tip measure order: Close, Open, High, Low,
+   // then any extras in their original position. Null fields are dropped.
+   private String[] reorderCandleMeasuresCloseFirst(String[] measures,
+                                                    CandleChartInfo info)
+   {
+      String closeName = nameOf(info.getRTCloseField());
+      String openName = nameOf(info.getRTOpenField());
+      String highName = nameOf(info.getRTHighField());
+      String lowName = nameOf(info.getRTLowField());
+
+      List<String> reordered = new ArrayList<>();
+
+      if(closeName != null) {
+         reordered.add(closeName);
+      }
+
+      if(openName != null) {
+         reordered.add(openName);
+      }
+
+      if(highName != null) {
+         reordered.add(highName);
+      }
+
+      if(lowName != null) {
+         reordered.add(lowName);
+      }
+
+      for(String m : measures) {
+         if(m != null && !reordered.contains(m)) {
+            reordered.add(m);
+         }
+      }
+
+      return reordered.toArray(new String[0]);
+   }
+
+   private String nameOf(ChartRef ref) {
+      return ref == null ? null : GraphUtil.getName(ref);
+   }
+
+   // Set the X-dim as the tooltip header (rendered as tier-1 subtitle by
+   // ChartToolTip's solo-card-with-header path) and group OHL pairs at tier-2.
+   private void applyCandleCardHeader(ChartToolTip tooltip, String xDim,
+                                      String[] tipMeasures)
+   {
+      String dimName = tips.get(xDim);
+
+      if(dimName == null) {
+         dimName = xDim;
+      }
+
+      int xKey = palette.put(dimName);
+      int xVal = tooltip.getTooltipValue(xKey);
+
+      if(xVal >= 0) {
+         tooltip.setHeader(xKey, xVal);
+         tooltip.removeTooltip(xKey);
+      }
+
+      // Pairs 1..N (Open/High/Low) stay at tier-2; anything past them
+      // (aesthetics like color dims) drops to tier-3.
+      int auxCount = Math.max(0, tipMeasures.length - 1);
+      tooltip.setTier2GroupSize(auxCount);
    }
 
    // check if point corresponding to null value should show tooltip.

--- a/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
@@ -248,6 +248,82 @@ class ChartToolTipTest {
    }
 
    @Test
+   void soloCardWithHeaderRendersCandleStockLayout() {
+      // Candle/Stock: Close at tier-1, Date as tier-1 subtitle, OHL grouped at
+      // tier-2, aesthetic dims (e.g. bullOrbear) at tier-3.
+      IndexedSet<String> palette = new IndexedSet<>();
+      int xKey = palette.put("Week(date)");
+      int xVal = palette.put("2025-01-19");
+
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.setHeader(xKey, xVal);
+      tip.addTooltip(palette.put("Last(close, date)"), palette.put("165.8"));
+      tip.addTooltip(palette.put("First(open, date)"), palette.put("158.3"));
+      tip.addTooltip(palette.put("Max(high)"), palette.put("166.5"));
+      tip.addTooltip(palette.put("Min(low)"), palette.put("157.5"));
+      tip.addTooltip(palette.put("bullOrbear"), palette.put("Bullish"));
+      tip.setTier2GroupSize(3);
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-1\">Last(close, date):&nbsp;165.8"),
+                 "Close is the canonical headline price at tier-1");
+      assertTrue(out.contains("<div class=\"tt-tier-1 tt-subtitle\">Week(date):&nbsp;2025-01-19"),
+                 "X-dim renders as a tier-1 subtitle under the headline");
+      assertTrue(out.contains("<div class=\"tt-tier-2\">First(open, date):&nbsp;158.3"),
+                 "Open stays in the tier-2 OHL group");
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Max(high):&nbsp;166.5"),
+                 "High stays in the tier-2 OHL group");
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Min(low):&nbsp;157.5"),
+                 "Low stays in the tier-2 OHL group");
+      assertTrue(out.contains("<div class=\"tt-tier-3\">bullOrbear:&nbsp;Bullish"),
+                 "Aesthetic dims past the OHL group drop to tier-3");
+      assertFalse(out.contains("tt-tier-4"), "Tiers must cap at 3");
+   }
+
+   @Test
+   void soloCardWithHeaderRespectsTier2GroupSizeBoundary() {
+      // tier2GroupSize=1 (default) keeps only one pair at tier-2 below the
+      // headline; the rest fall to tier-3.
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.setHeader(palette.put("Year"), palette.put("2024"));
+      tip.addTooltip(palette.put("Close"), palette.put("100"));
+      tip.addTooltip(palette.put("Open"), palette.put("90"));
+      tip.addTooltip(palette.put("High"), palette.put("110"));
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-1\">Close:&nbsp;100"));
+      assertTrue(out.contains("<div class=\"tt-tier-1 tt-subtitle\">Year:&nbsp;2024"));
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Open:&nbsp;90"));
+      assertTrue(out.contains("<div class=\"tt-tier-3\">High:&nbsp;110"));
+   }
+
+   @Test
+   void soloCardWithoutHeaderKeepsLegacyTierCap() {
+      // No header → legacy path: 1, 2, 3, 3, 3...
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.setTier2GroupSize(3); // Without a header this has no effect.
+      tip.addTooltip(palette.put("A"), palette.put("1"));
+      tip.addTooltip(palette.put("B"), palette.put("2"));
+      tip.addTooltip(palette.put("C"), palette.put("3"));
+      tip.addTooltip(palette.put("D"), palette.put("4"));
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-1\">A"));
+      assertTrue(out.contains("<div class=\"tt-tier-2\">B"));
+      assertTrue(out.contains("<div class=\"tt-tier-3\">C"));
+      assertTrue(out.contains("<div class=\"tt-tier-3\">D"));
+      assertFalse(out.contains("tt-subtitle"));
+   }
+
+   @Test
    void combinedCardEmitsHeaderOnce() {
       IndexedSet<String> palette = new IndexedSet<>();
       int xKey = palette.put("Region");

--- a/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
@@ -324,6 +324,51 @@ class ChartToolTipTest {
    }
 
    @Test
+   void soloCardWithHeaderTier2GroupSizeZeroSkipsTier2() {
+      // Partial OHL binding (only Close): no auxiliary tier-2 group, so the
+      // first aesthetic after the headline drops straight to tier-3.
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.setHeader(palette.put("Year"), palette.put("2024"));
+      tip.addTooltip(palette.put("Close"), palette.put("100"));
+      tip.addTooltip(palette.put("Bullish"), palette.put("true"));
+      tip.setTier2GroupSize(0);
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-1\">Close:&nbsp;100"));
+      assertTrue(out.contains("<div class=\"tt-tier-1 tt-subtitle\">Year:&nbsp;2024"));
+      assertTrue(out.contains("<div class=\"tt-tier-3\">Bullish:&nbsp;true"),
+                 "tier2GroupSize=0 puts the next pair directly at tier-3");
+      assertFalse(out.contains("<div class=\"tt-tier-2\">"),
+                  "tier2GroupSize=0 must produce no tier-2 rows");
+   }
+
+   @Test
+   void soloCardWithHeaderRendersPartialOhlBinding() {
+      // Stock chart bound with Close + High + Low but no Open: tier-2 group
+      // shrinks accordingly and aesthetic dims still drop to tier-3.
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.setHeader(palette.put("Week"), palette.put("2025-01-19"));
+      tip.addTooltip(palette.put("Close"), palette.put("165.8"));
+      tip.addTooltip(palette.put("High"), palette.put("166.5"));
+      tip.addTooltip(palette.put("Low"), palette.put("157.5"));
+      tip.addTooltip(palette.put("color"), palette.put("Bullish"));
+      tip.setTier2GroupSize(2);
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-1\">Close:&nbsp;165.8"));
+      assertTrue(out.contains("<div class=\"tt-tier-1 tt-subtitle\">Week:&nbsp;2025-01-19"));
+      assertTrue(out.contains("<div class=\"tt-tier-2\">High:&nbsp;166.5"));
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Low:&nbsp;157.5"));
+      assertTrue(out.contains("<div class=\"tt-tier-3\">color:&nbsp;Bullish"));
+   }
+
+   @Test
    void combinedCardEmitsHeaderOnce() {
       IndexedSet<String> palette = new IndexedSet<>();
       int xKey = palette.put("Region");

--- a/web/projects/portal/src/scss/internal/_directives.scss
+++ b/web/projects/portal/src/scss/internal/_directives.scss
@@ -244,17 +244,6 @@ table.scrollable-table {
     letter-spacing: 0.02em;
   }
 
-  // Headline-bound subtitle (e.g. candle/stock date below the Close row): sits
-  // visually closer to the tier-1 row than tier-2 subtitle does — it identifies
-  // the period the headline value belongs to rather than scoping peer sections.
-  // Inherits tier-1's full opacity; size + weight do the subordination.
-  .tt-tier-1.tt-subtitle {
-    font-size: 14px;
-    font-weight: 400;
-    margin-top: 2px;
-    letter-spacing: 0.02em;
-  }
-
   // Combined card: each .tt-section groups one series' rows so adjacent
   // series read as distinct blocks (mirrors the default tooltip's blank-line
   // separators between sub-tooltips).
@@ -274,6 +263,20 @@ table.scrollable-table {
   .tt-section.tt-section-first { margin-top: 2px; }
 
   .tt-tier-1:not(:first-child) { margin-top: 10px; }
+
+  // Headline-bound subtitle (e.g. candle/stock date below the Close row): sits
+  // visually closer to the tier-1 row than tier-2 subtitle does — it identifies
+  // the period the headline value belongs to rather than scoping peer sections.
+  // Inherits tier-1's full opacity; size + weight do the subordination.
+  // Must come after .tt-tier-1:not(:first-child) — both have equal specificity
+  // so the later rule wins; without this ordering the 10px margin would clobber
+  // the intended 2px.
+  .tt-tier-1.tt-subtitle {
+    font-size: 14px;
+    font-weight: 400;
+    margin-top: 2px;
+    letter-spacing: 0.02em;
+  }
 
   // Stack total sits at the bottom as the summary headline; bump it slightly
   // above the regular tier-1 size so it reads as the punch line.

--- a/web/projects/portal/src/scss/internal/_directives.scss
+++ b/web/projects/portal/src/scss/internal/_directives.scss
@@ -244,6 +244,17 @@ table.scrollable-table {
     letter-spacing: 0.02em;
   }
 
+  // Headline-bound subtitle (e.g. candle/stock date below the Close row): sits
+  // visually closer to the tier-1 row than tier-2 subtitle does — it identifies
+  // the period the headline value belongs to rather than scoping peer sections.
+  // Inherits tier-1's full opacity; size + weight do the subordination.
+  .tt-tier-1.tt-subtitle {
+    font-size: 14px;
+    font-weight: 400;
+    margin-top: 2px;
+    letter-spacing: 0.02em;
+  }
+
   // Combined card: each .tt-section groups one series' rows so adjacent
   // series read as distinct blocks (mirrors the default tooltip's blank-line
   // separators between sub-tooltips).

--- a/web/projects/portal/src/scss/internal/_directives.scss
+++ b/web/projects/portal/src/scss/internal/_directives.scss
@@ -264,13 +264,7 @@ table.scrollable-table {
 
   .tt-tier-1:not(:first-child) { margin-top: 10px; }
 
-  // Headline-bound subtitle (e.g. candle/stock date below the Close row): sits
-  // visually closer to the tier-1 row than tier-2 subtitle does — it identifies
-  // the period the headline value belongs to rather than scoping peer sections.
-  // Inherits tier-1's full opacity; size + weight do the subordination.
-  // Must come after .tt-tier-1:not(:first-child) — both have equal specificity
-  // so the later rule wins; without this ordering the 10px margin would clobber
-  // the intended 2px.
+  // Must follow .tt-tier-1:not(:first-child) — equal specificity, later rule wins (10px → 2px margin).
   .tt-tier-1.tt-subtitle {
     font-size: 14px;
     font-weight: 400;


### PR DESCRIPTION
## Summary

- For candle/stock charts, the card tooltip now leads with **Close** (the canonical headline price for the period) instead of High. Date renders directly below as a tier-1 subtitle. Open / High / Low group together at tier-2 as auxiliary candlestick context. Aesthetics (color frames, etc.) drop to tier-3.
- Matches how financial UIs (Yahoo Finance, TradingView, Bloomberg terminals) treat the close/date pair: Close is the value, Date is the period label.
- Preserves the card-style single-headline invariant (one tier-1 row per card) used by every other chart type. The reviewer's "Date + Close both at tier-1" reading would have made candle the only chart where the headline is two equal rows; instead Date gets a tier-1-sized subtitle that's visually paired with Close.

## What changed

`PlotArea.getToolTip0`:

- Detect `chartInfo instanceof CandleChartInfo` and only act when card style is enabled.
- New `reorderCandleMeasuresCloseFirst(measures, info)` helper: produces `[Close, Open, High, Low, ...extras]` so Close is the first measure pair added to the tooltip. Original measure order (driven by `SchemaElement.getVars()`) puts High first, which is the source of the bug.
- New `applyCandleCardHeader(tooltip, dims[0], tipMeasures)` helper: after the cols loop and `appendInfo` (aesthetics) have run, lift the X-dim onto `tooltip.setHeader(...)` and remove it from the flat tooltip list. Also sets `tier2GroupSize = tipMeasures.length - 1` so the OHL auxiliary measures stay grouped at tier-2 instead of falling to tier-3.

`ChartToolTip`:

- New `tier2GroupSize` field (default 1). Controls how many pairs after the tier-1 headline render at tier-2 before the renderer caps the rest at tier-3. Without this knob the existing counter would push High / Low down alongside `bullOrbear` and other aesthetic dims.
- New `renderSoloCardWithHeader` path: triggered from `renderCard` when `hasHeader()` is true, the tooltip isn't multi-section, and no custom template is set. Emits pair[0] at tier-1, then the header as a tier-1 subtitle, then the next `tier2GroupSize` pairs at tier-2, then the remainder at tier-3.
- `appendSubtitle` now takes an explicit tier: solo card uses tier=1 (headline-bound subtitle, directly below Close), combined card continues to use tier=2 (subtitle scoping multiple peer sections). The two scopes are different and the CSS now treats them differently.

CSS:

- New `.tt-tier-1.tt-subtitle` rule (14px, lighter weight, full opacity, light letter-spacing). Visually pairs with the tier-1 headline rather than reading as muted context. Existing `.tt-tier-2.tt-subtitle` (combined card) is unchanged.

Resulting tooltip on the stock binding from the bug report (`Week(date)` X-axis, OHLC measures, `bullOrbear` color):

```
Last(close, date): 165.8        tier-1 (headline)
Week(date): 2025-01-19          tier-1 subtitle
First(open, date): 158.3        tier-2
Max(high): 166.5                tier-2
Min(low): 157.5                 tier-2
bullOrbear: Bullish             tier-3
```

## Custom-template behavior

Users with a custom tooltip template (`chartInfo.getToolTip()` non-empty) bypass the new path entirely — `PlotArea.getToolTip0` returns before reaching the candle/stock reorder, and `ChartToolTip.renderCard` falls back to the legacy 1/2/3 tier cap for the user's lines. Custom templates remain authoritative.

## Stacked on

This branch is temporarily based on `bug-75015` (#3711) since the candle/stock changes build on the combined-card `setHeader` / `appendSubtitle` infrastructure introduced by Bug #75004 (in #3711's ancestor chain). Once #3711 merges to main, this branch rebases onto main and the gantt-related commits drop out of the diff.
