### PR TITLE
Bug #75042: Fix incorrect highlight conditions for small numeric values from REST connector

### DIFF
--- a/connectors/inetsoft-tabular-util/src/main/java/inetsoft/uql/util/JsonTable.java
+++ b/connectors/inetsoft-tabular-util/src/main/java/inetsoft/uql/util/JsonTable.java
@@ -330,6 +330,28 @@ public class JsonTable extends BaseJsonTable {
             // fall-through
          }
       }
+      else if(val instanceof com.fasterxml.jackson.databind.JsonNode node) {
+         // Jackson nodes arrive here when JacksonJsonProvider is used by JSONPath.
+         // Numeric nodes (e.g. DoubleNode) do not implement java.lang.Number, so
+         // without this branch they fall through to toString(), which produces
+         // scientific notation strings like "2.777172E-4" for small values.
+
+         if(node.isNumber()) {
+            return node.numberValue();
+         }
+
+         if(node.isTextual()) {
+            return node.textValue();
+         }
+
+         if(node.isBoolean()) {
+            return node.booleanValue();
+         }
+
+         if(node.isNull()) {
+            return null;
+         }
+      }
       else if(val instanceof Number || val instanceof Date || val instanceof Boolean) {
          return val;
       }

--- a/core/src/main/java/inetsoft/util/CoreTool.java
+++ b/core/src/main/java/inetsoft/util/CoreTool.java
@@ -2315,7 +2315,7 @@ public class CoreTool {
                if(!num1) {
                   String str = v1.toString();
 
-                  if(NumberUtils.isParsable(str)) {
+                  if(NumberUtils.isCreatable(str)) {
                      try {
                         v1 = Double.parseDouble(str);
                      }
@@ -2328,7 +2328,7 @@ public class CoreTool {
                if(!num2) {
                   String str = v2.toString();
 
-                  if(NumberUtils.isParsable(str)) {
+                  if(NumberUtils.isCreatable(str)) {
                      try {
                         v2 = Double.parseDouble(str);
                      }


### PR DESCRIPTION
Jackson JsonNode values (produced by JacksonJsonProvider in the JSONPath library) do not implement java.lang.Number, so numeric nodes fell through to toString() in getJavaValue(), producing scientific notation strings (e.g. '2.777172E-4') for values smaller than 1e-3. This caused columns to be typed as String at runtime, making any string compare as greater than any number and triggering highlight conditions incorrectly.

Fix: add an explicit JsonNode branch in JsonTable.getJavaValue() that calls numberValue(), textValue(), booleanValue(), or returns null as appropriate.