### PR TITLE
Bug #75061, return MessageException as error message from query/update endpoint

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/model/ws/UpdateQueryResult.java
+++ b/core/src/main/java/inetsoft/web/composer/model/ws/UpdateQueryResult.java
@@ -1,0 +1,21 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.model.ws;
+
+public record UpdateQueryResult(String errorMsg) {
+}

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/SQLQueryDialogController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/SQLQueryDialogController.java
@@ -221,7 +221,7 @@ public class SQLQueryDialogController extends WorksheetController {
 
    @PostMapping("/api/composer/ws/sql-query-dialog/query/update")
    @ResponseBody
-   public UpdateQueryResult updateQueryBySample(@RequestBody() BasicSQLQueryModel model,
+   public UpdateQueryResult updateQueryBySample(@RequestBody BasicSQLQueryModel model,
                                                 @RequestParam("runtimeId") String runtimeId,
                                                 @RequestParam("datasource") String datasource,
                                                 Principal principal)

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/SQLQueryDialogController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/SQLQueryDialogController.java
@@ -30,6 +30,7 @@ import inetsoft.web.binding.service.DataRefModelFactoryService;
 import inetsoft.web.composer.model.BrowseDataModel;
 import inetsoft.web.composer.model.ws.BasicSQLQueryModel;
 import inetsoft.web.composer.model.ws.SQLQueryDialogModel;
+import inetsoft.web.composer.model.ws.UpdateQueryResult;
 import inetsoft.web.composer.ws.WorksheetController;
 import inetsoft.web.portal.controller.database.QueryManagerService;
 import inetsoft.web.viewsheet.LoadingMask;
@@ -220,13 +221,19 @@ public class SQLQueryDialogController extends WorksheetController {
 
    @PostMapping("/api/composer/ws/sql-query-dialog/query/update")
    @ResponseBody
-   public void updateQueryBySample(@RequestBody() BasicSQLQueryModel model,
-                                   @RequestParam("runtimeId") String runtimeId,
-                                   @RequestParam("datasource") String datasource,
-                                   Principal principal)
+   public UpdateQueryResult updateQueryBySample(@RequestBody() BasicSQLQueryModel model,
+                                                @RequestParam("runtimeId") String runtimeId,
+                                                @RequestParam("datasource") String datasource,
+                                                Principal principal)
       throws Exception
    {
-      queryManagerService.updateQuery(runtimeId, model, datasource, principal);
+      try {
+         queryManagerService.updateQuery(runtimeId, model, datasource, principal);
+         return new UpdateQueryResult(null);
+      }
+      catch(MessageException e) {
+         return new UpdateQueryResult(e.getMessage());
+      }
    }
 
    @Undoable

--- a/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
@@ -81,7 +81,7 @@ public class QueryManagerService {
 
       if(runtimeQuery == null) {
          throw new MessageException(
-            "The query session has expired. Please close and reopen the query editor.");
+            Catalog.getCatalog().getString("common.sqlquery.sessionExpired"));
       }
 
       JDBCQuery query = createQueryByBaseModel(queryModel, datasource, principal);
@@ -952,7 +952,7 @@ public class QueryManagerService {
 
       if(runtimeQuery == null) {
          throw new MessageException(
-            "The query session has expired. Please close and reopen the query editor.");
+            Catalog.getCatalog().getString("common.sqlquery.sessionExpired"));
       }
 
       JDBCQuery query = createNewQuery(name, database);
@@ -1199,7 +1199,7 @@ public class QueryManagerService {
 
       if(runtimeQuery == null) {
          throw new MessageException(
-            "The query session has expired. Please close and reopen the query editor.");
+            Catalog.getCatalog().getString("common.sqlquery.sessionExpired"));
       }
 
       JDBCQuery query = runtimeQuery.getQuery();
@@ -1581,7 +1581,7 @@ public class QueryManagerService {
 
       if(runtimeQuery == null) {
          throw new MessageException(
-            "The query session has expired. Please close and reopen the query editor.");
+            Catalog.getCatalog().getString("common.sqlquery.sessionExpired"));
       }
 
       String sqlString = event.getSqlString();
@@ -1672,7 +1672,7 @@ public class QueryManagerService {
 
       if(runtimeQuery == null) {
          throw new MessageException(
-            "The query session has expired. Please close and reopen the query editor.");
+            Catalog.getCatalog().getString("common.sqlquery.sessionExpired"));
       }
 
       JDBCQuery query = runtimeQuery.getQuery();
@@ -1839,7 +1839,7 @@ public class QueryManagerService {
 
       if(runtimeQuery == null) {
          throw new MessageException(
-            "The query session has expired. Please close and reopen the query editor.");
+            Catalog.getCatalog().getString("common.sqlquery.sessionExpired"));
       }
 
       JDBCQuery query = runtimeQuery.getQuery();

--- a/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
@@ -80,7 +80,8 @@ public class QueryManagerService {
          runtimeQueryService.getRuntimeQuery(runtimeId);
 
       if(runtimeQuery == null) {
-         throw new RuntimeException("runtime query do not exist");
+         throw new MessageException(
+            "The query session has expired. Please close and reopen the query editor.");
       }
 
       JDBCQuery query = createQueryByBaseModel(queryModel, datasource, principal);

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -3433,6 +3433,7 @@ common.sourceNull=Source is null\!
 common.sourcePrefixNull=Prefix is null\!
 common.sqlquery.cartesianJoin=Multiple tables are selected without any join conditions. Please define join conditions between the tables to avoid a Cartesian product query.
 common.sqlquery.datasourceNotFound=The datasource for the given query has not been found\!
+common.sqlquery.sessionExpired=The query session has expired. Please close and reopen the query editor.
 common.sqlquery.editsql=Editing SQL will make the structured editing interface unavailable. All future changes will be made by editing SQL.
 common.sqlquery.joinDuplicate=This join is already contained in the list
 common.sqlquery.joinTableRepeat=Join can only be performed in columns of different tables.

--- a/web/projects/portal/src/app/widget/dialog/sql-query-dialog/simple-query-pane.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/sql-query-dialog/simple-query-pane.component.ts
@@ -639,12 +639,18 @@ export class SimpleQueryPaneComponent {
             .set("datasource", this.datasource);
 
          this.http.post<{errorMsg: string}>(UPDATE_QUERY_URI, this.model, {params: params})
-            .subscribe(res => {
-               if(res?.errorMsg) {
-                  ComponentTool.showMessageDialog(this.modal, "_#(js:Error)", res.errorMsg);
-               }
-               else {
-                  this._defaultTab = next;
+            .subscribe({
+               next: res => {
+                  if(res?.errorMsg) {
+                     ComponentTool.showMessageDialog(this.modal, "_#(js:Error)", res.errorMsg);
+                  }
+                  else {
+                     this._defaultTab = next;
+                  }
+               },
+               error: () => {
+                  ComponentTool.showMessageDialog(
+                     this.modal, "_#(js:Error)", "_#(js:common.network.error)");
                }
             });
       }

--- a/web/projects/portal/src/app/widget/dialog/sql-query-dialog/simple-query-pane.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/sql-query-dialog/simple-query-pane.component.ts
@@ -638,9 +638,15 @@ export class SimpleQueryPaneComponent {
             .set("runtimeId", this.runtimeId)
             .set("datasource", this.datasource);
 
-         this.http.post(UPDATE_QUERY_URI, this.model, {params: params}).subscribe(data => {
-            this._defaultTab = next;
-         });
+         this.http.post<{errorMsg: string}>(UPDATE_QUERY_URI, this.model, {params: params})
+            .subscribe(res => {
+               if(res?.errorMsg) {
+                  ComponentTool.showMessageDialog(this.modal, "_#(js:Error)", res.errorMsg);
+               }
+               else {
+                  this._defaultTab = next;
+               }
+            });
       }
       else {
          this._defaultTab = next;


### PR DESCRIPTION
## Summary

- When the runtime query session expires (~3 minutes of inactivity), clicking the **Preview** tab in the worksheet SQL query dialog sent a `POST` to `/api/composer/ws/sql-query-dialog/query/update`, which called `QueryManagerService.updateQuery()`. That method threw `RuntimeException("runtime query do not exist")` when the session was not found, propagating as an HTTP 500.
- The frontend `updateQueryTab()` subscribe had no error callback, so the 500 surfaced as a browser error popup instead of a user-friendly warning.
- Fix: changed `RuntimeException` to `MessageException` with a user-friendly message in `QueryManagerService.updateQuery()`. The controller now catches `MessageException` and returns it as the `errorMsg` field of a new `UpdateQueryResult` response (HTTP 200). The frontend checks `errorMsg` and displays a warning dialog, leaving the tab unchanged.

This is the same root cause as Bug #74920 (fixed in PR #3672), which affected the `/api/data/datasource/query/save/freeSQLModel` endpoint. This fix applies the same pattern to the `/api/composer/ws/sql-query-dialog/query/update` endpoint.

## Test plan

- [ ] Create a worksheet, add a query, and open the SQL query editor
- [ ] Wait 4+ minutes without interacting (past the ~3-minute session cache TTL)
- [ ] Click the **Preview** tab — confirm a warning dialog appears ("The query session has expired. Please close and reopen the query editor.") instead of a browser 500 popup
- [ ] Verify the tab does not switch when the error dialog is shown
- [ ] Verify normal tab switching still works when the session has not expired

🤖 Generated with [Claude Code](https://claude.com/claude-code)