### PR TITLE
Bug #75075: raise composer overlay z-index to support 100 embedded viewsheets

### DIFF
--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/VSUtilZIndexTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/VSUtilZIndexTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // Bug #75075
 public class VSUtilZIndexTest {
-   // Must match the z-index of .top-level-composer-overlay in vs-viewsheet.component.scss.
+   // Must match the z-index of .composer-overlay in vs-viewsheet.component.scss.
    private static final int COMPOSER_OVERLAY_ZINDEX = 99997;
 
    @Test
@@ -41,7 +41,7 @@ public class VSUtilZIndexTest {
    }
 
    // Regression test: inner objects of the 11th embedded viewsheet were assigned z-indexes
-   // starting at 10002, exceeding the top-level-composer-overlay CSS z-index of 9998 and
+   // starting at 10002, exceeding the composer-overlay CSS z-index of 9998 and
    // blocking right-click access to Properties. The overlay was raised to 99997.
    @Test
    void innerObjectZIndexesRemainBelowComposerOverlayFor100EmbeddedViewsheets() {

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/VSUtilZIndexTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/VSUtilZIndexTest.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.uql.viewsheet.internal;
+
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.viewsheet.TextVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+// Bug #75075
+public class VSUtilZIndexTest {
+   // Must match the z-index of .top-level-composer-overlay in vs-viewsheet.component.scss.
+   private static final int COMPOSER_OVERLAY_ZINDEX = 99997;
+
+   @Test
+   void embeddedViewsheetZIndexIncreasesByViewsheetZIndexGap() {
+      Viewsheet[] embedded = createEmbeddedViewsheets(11);
+      VSUtil.calcChildZIndex(embedded, 0);
+
+      assertEquals(1, embedded[0].getZIndex());
+      assertEquals(1 + 10 * Viewsheet.VIEWSHEET_ZINDEX_GAP, embedded[10].getZIndex());
+   }
+
+   // Regression test: inner objects of the 11th embedded viewsheet were assigned z-indexes
+   // starting at 10002, exceeding the top-level-composer-overlay CSS z-index of 9998 and
+   // blocking right-click access to Properties. The overlay was raised to 99997.
+   @Test
+   void innerObjectZIndexesRemainBelowComposerOverlayFor100EmbeddedViewsheets() {
+      final int maxEmbedded = 100;
+      Viewsheet[] embedded = createEmbeddedViewsheets(maxEmbedded);
+      VSUtil.calcChildZIndex(embedded, 0);
+
+      for(int i = 0; i < maxEmbedded; i++) {
+         int embeddedZIndex = embedded[i].getZIndex();
+         TextVSAssembly innerObject = new TextVSAssembly();
+         innerObject.getVSAssemblyInfo().setName("Text" + i);
+         VSUtil.calcChildZIndex(new Assembly[]{ innerObject }, embeddedZIndex);
+
+         assertTrue(innerObject.getZIndex() < COMPOSER_OVERLAY_ZINDEX,
+                    "Inner object z-index " + innerObject.getZIndex() + " of embedded viewsheet #" +
+                    (i + 1) + " (outer z-index=" + embeddedZIndex + ") must be below " +
+                    "composer overlay z-index " + COMPOSER_OVERLAY_ZINDEX);
+      }
+   }
+
+   private Viewsheet[] createEmbeddedViewsheets(int count) {
+      Viewsheet[] viewsheets = new Viewsheet[count];
+
+      for(int i = 0; i < count; i++) {
+         viewsheets[i] = new Viewsheet();
+         viewsheets[i].getVSAssemblyInfo().setName("Embedded" + i);
+      }
+
+      return viewsheets;
+   }
+}

--- a/web/projects/portal/src/app/composer/gui/vs/editor/editable-object-container.component.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/editor/editable-object-container.component.spec.ts
@@ -283,6 +283,45 @@ describe("EditableObjectContainer", () => {
       expect(element.classList).toContain("fade-assembly");
    });
 
+   // Bug #75075: inner objects of the 11th+ embedded viewsheet were assigned z-indexes that
+   // exceeded the top-level-composer-overlay CSS z-index (was 9998, now 99997), blocking
+   // right-click access to Properties. The VIEWSHEET_ZINDEX_GAP of 1000 means the Nth
+   // embedded viewsheet gets outer z-index 1 + (N-1)*1000, and its inner objects start
+   // at that value + 1. For N=11 the inner objects start at 10002, which now sits well
+   // below the raised overlay threshold.
+   describe("calculateZIndex", () => {
+      // Must match .top-level-composer-overlay z-index in vs-viewsheet.component.scss.
+      const COMPOSER_OVERLAY_ZINDEX = 99997;
+      const VIEWSHEET_ZINDEX_GAP = 1000;
+
+      it("should return the object z-index when the object has no container", () => {
+         const obj = TestUtils.createMockVSObjectModel("VSText", "Text1");
+         obj.objectFormat.zIndex = 42;
+         expect(EditableObjectContainer.calculateZIndex(obj, viewsheet)).toBe(42);
+      });
+
+      it("should return inner object z-index below composer overlay for 11th embedded viewsheet", () => {
+         // 11th embedded viewsheet gets outer z-index 10001; its inner objects start at 10002.
+         const embeddedZIndex = 1 + 10 * VIEWSHEET_ZINDEX_GAP; // 10001
+         const obj = TestUtils.createMockVSObjectModel("VSText", "Text1");
+         obj.objectFormat.zIndex = embeddedZIndex + 1; // 10002
+         const zIndex = EditableObjectContainer.calculateZIndex(obj, viewsheet);
+         expect(zIndex).toBe(embeddedZIndex + 1);
+         expect(zIndex).toBeLessThan(COMPOSER_OVERLAY_ZINDEX);
+      });
+
+      it("should keep inner object z-indexes below composer overlay for up to 100 embedded viewsheets", () => {
+         for(let n = 1; n <= 100; n++) {
+            const embeddedZIndex = 1 + (n - 1) * VIEWSHEET_ZINDEX_GAP;
+            const obj = TestUtils.createMockVSObjectModel("VSText", "Text" + n);
+            obj.objectFormat.zIndex = embeddedZIndex + 1;
+
+            const zIndex = EditableObjectContainer.calculateZIndex(obj, viewsheet);
+            expect(zIndex).toBeLessThan(COMPOSER_OVERLAY_ZINDEX);
+         }
+      });
+   });
+
    //Bug #21294, Bug #23392 should not hide selected assembly in tab when tab is invisible in design
    it("should not hide selected assembly in tab when tab is invisible in design", () => {
       const fixture: ComponentFixture<EditableObjectContainer> =

--- a/web/projects/portal/src/app/composer/gui/vs/editor/editable-object-container.component.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/editor/editable-object-container.component.spec.ts
@@ -284,13 +284,13 @@ describe("EditableObjectContainer", () => {
    });
 
    // Bug #75075: inner objects of the 11th+ embedded viewsheet were assigned z-indexes that
-   // exceeded the top-level-composer-overlay CSS z-index (was 9998, now 99997), blocking
+   // exceeded the composer-overlay CSS z-index (was 9998, now 99997), blocking
    // right-click access to Properties. The VIEWSHEET_ZINDEX_GAP of 1000 means the Nth
    // embedded viewsheet gets outer z-index 1 + (N-1)*1000, and its inner objects start
    // at that value + 1. For N=11 the inner objects start at 10002, which now sits well
    // below the raised overlay threshold.
    describe("calculateZIndex", () => {
-      // Must match .top-level-composer-overlay z-index in vs-viewsheet.component.scss.
+      // Must match .composer-overlay z-index in vs-viewsheet.component.scss.
       const COMPOSER_OVERLAY_ZINDEX = 99997;
       const VIEWSHEET_ZINDEX_GAP = 1000;
 

--- a/web/projects/portal/src/app/composer/gui/vs/editor/editable-object-container.component.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/editor/editable-object-container.component.ts
@@ -271,7 +271,7 @@ export class EditableObjectContainer extends AbstractActionComponent
       if((<any> vsObject).dropdown && !SelectionBaseController.isHidden(<any> vsObject) ||
          (<any> vsObject).dropdownCalendar && (<any> vsObject).calendarsShown)
       {
-         zIndex += 9999;
+         zIndex += 100000;
       }
 
       return zIndex;

--- a/web/projects/portal/src/app/vsobjects/objects/viewsheet/vs-viewsheet.component.scss
+++ b/web/projects/portal/src/app/vsobjects/objects/viewsheet/vs-viewsheet.component.scss
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 .viewsheet-link {
-   z-index: 10000;
+   z-index: 100000;
    position: absolute;
    top: 0;
    left: 0;
@@ -32,13 +32,13 @@
   position: absolute;
   top: 0;
   display: none;
-  z-index: 9999;
+  z-index: 99999;
   width: 20px;
   background-color: var(--inet-toolbar-bg-color);
 }
 
 .composer-overlay {
-  z-index: 9997;
+  z-index: 99997;
   position: absolute;
   top: 0;
   left: 0;
@@ -47,7 +47,7 @@
 }
 
 .top-level-composer-overlay {
-  z-index: 9998;
+  z-index: 99998;
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
The .top-level-composer-overlay CSS class had a hardcoded z-index of 9998. The backend assigns embedded viewsheet assemblies a z-index gap of 1000, so the 11th embedded viewsheet gets z-index 10001 and its inner objects start at 10002. Since 10002 > 9998, those inner editable-object-container elements rendered above the overlay, swallowing right-click events and making Properties inaccessible.

Raise the four z-index values in vs-viewsheet.component.scss by 10x (9997–10000 → 99997–100000), providing headroom for up to 100 embedded viewsheets. Add regression tests in both Java and TypeScript that pin the relationship between embedded viewsheet z-indexes and the overlay threshold.