### PR TITLE
Implement prestop distributed table cache replication

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetDataCache.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetDataCache.java
@@ -228,9 +228,22 @@ public class AssetDataCache extends DataCache<DataKey, TableLens> {
       // remove the entries
       entries.stream().forEach(key -> {
          dependenceMap.remove(key);
+         Principal keyPrincipal = principalMap.get(key);
+         Principal oldPrincipal = ThreadContext.getContextPrincipal();
 
-         if(store.exists(key)) {
-            store.remove(key);
+         if(keyPrincipal != null) {
+            ThreadContext.setContextPrincipal(keyPrincipal);
+         }
+
+         try {
+            if(store.exists(key)) {
+               store.remove(key);
+            }
+         }
+         finally {
+            if(keyPrincipal != null) {
+               ThreadContext.setContextPrincipal(oldPrincipal);
+            }
          }
 
          // recursively remove the parent dependency
@@ -247,12 +260,26 @@ public class AssetDataCache extends DataCache<DataKey, TableLens> {
 
    private Object removeCache(DataKey key) {
       DistributedTableCacheStore store = distributedTableCacheStoreProvider.getObject();
+      Principal keyPrincipal = principalMap.get(key);
+      Principal oldPrincipal = ThreadContext.getContextPrincipal();
 
-      if(store.exists(key)) {
-         store.remove(key);
+      if(keyPrincipal != null) {
+         ThreadContext.setContextPrincipal(keyPrincipal);
+      }
+
+      try {
+         if(store.exists(key)) {
+            store.remove(key);
+         }
+      }
+      finally {
+         if(keyPrincipal != null) {
+            ThreadContext.setContextPrincipal(oldPrincipal);
+         }
       }
 
       dependenceMap.remove(key);
+      principalMap.remove(key);
       return remove(key);
    }
 
@@ -453,6 +480,43 @@ public class AssetDataCache extends DataCache<DataKey, TableLens> {
       dataSourceRegistry.removeRefreshedListener(registryListener);
       dataSourceRegistry.removeModifiedListener(registryListener);
       clear();
+      principalMap.clear();
+   }
+
+   /**
+    * Returns all valid entries from the local in-memory cache. Used by
+    * {@link DistributedTableCacheStore#flushLocalCache()} to replicate data to the distributed
+    * store on node shutdown or in response to a {@link TableCacheReplicationRequest} from a new
+    * node. Cancelled, changed, or already-evicted entries are excluded.
+    */
+   public Map<DataKey, TableLens> getLocalEntries() {
+      Map<DataKey, TableLens> result = new LinkedHashMap<>();
+
+      for(DataKey key : keySet()) {
+         TableLens data = getCachedData(key, -1);
+
+         if(data != null) {
+            result.put(key, data);
+         }
+      }
+
+      return result;
+   }
+
+   /**
+    * Returns the principal that was active when the given key was cached, or {@code null} if not
+    * recorded. Used during distributed cache flush to write to the correct org-scoped storage.
+    */
+   public Principal getPrincipalForKey(DataKey key) {
+      return principalMap.get(key);
+   }
+
+   private void recordPrincipal(DataKey key) {
+      Principal principal = ThreadContext.getContextPrincipal();
+
+      if(principal != null) {
+         principalMap.put(key, principal);
+      }
    }
 
    private final java.beans.PropertyChangeListener registryListener = evt -> clearCache();
@@ -589,8 +653,6 @@ public class AssetDataCache extends DataCache<DataKey, TableLens> {
 
          if(executingKey != null) {
             synchronized(executingKey) {
-               DistributedTableCacheStore store = distributedTableCacheStoreProvider.getObject();
-               store.put(key, get(key));
                unmarkExecuting(executingKey);
                executingKey.notifyAll();
             }
@@ -1229,6 +1291,7 @@ public class AssetDataCache extends DataCache<DataKey, TableLens> {
    {
       CacheEntry<DataKey, TableLens> entry = super.put(key, data, timeout);
       lockEntries.get().monitor(entry);
+      recordPrincipal(key);
       return entry;
    }
 
@@ -1249,6 +1312,7 @@ public class AssetDataCache extends DataCache<DataKey, TableLens> {
    protected boolean demote(CacheEntry<DataKey, TableLens> entry) {
       // clean up when corresponding entry removed from cache
       dependenceMap.remove(entry.getKey());
+      principalMap.remove(entry.getKey());
       return super.demote(entry);
    }
 
@@ -1296,6 +1360,8 @@ public class AssetDataCache extends DataCache<DataKey, TableLens> {
    // key -> source (e.g. data source name)
    // if a key doesn't exist in dependenceMap (removed), then its cache is invalid.
    private final Map<DataKey, String> dependenceMap = new ConcurrentHashMap<>();
+   // key -> principal active when the entry was cached (for org-scoped distributed store writes)
+   private final Map<DataKey, Principal> principalMap = new ConcurrentHashMap<>();
    private final ThreadPool pool;
    private final AtomicInteger hits = new AtomicInteger();
    private final AtomicInteger noHits = new AtomicInteger();

--- a/core/src/main/java/inetsoft/report/composition/execution/AssetDataCache.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetDataCache.java
@@ -231,11 +231,11 @@ public class AssetDataCache extends DataCache<DataKey, TableLens> {
          Principal keyPrincipal = principalMap.get(key);
          Principal oldPrincipal = ThreadContext.getContextPrincipal();
 
-         if(keyPrincipal != null) {
-            ThreadContext.setContextPrincipal(keyPrincipal);
-         }
-
          try {
+            if(keyPrincipal != null) {
+               ThreadContext.setContextPrincipal(keyPrincipal);
+            }
+
             if(store.exists(key)) {
                store.remove(key);
             }
@@ -263,11 +263,11 @@ public class AssetDataCache extends DataCache<DataKey, TableLens> {
       Principal keyPrincipal = principalMap.get(key);
       Principal oldPrincipal = ThreadContext.getContextPrincipal();
 
-      if(keyPrincipal != null) {
-         ThreadContext.setContextPrincipal(keyPrincipal);
-      }
-
       try {
+         if(keyPrincipal != null) {
+            ThreadContext.setContextPrincipal(keyPrincipal);
+         }
+
          if(store.exists(key)) {
             store.remove(key);
          }

--- a/core/src/main/java/inetsoft/report/composition/execution/DistributedTableCacheStore.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/DistributedTableCacheStore.java
@@ -19,26 +19,41 @@
 package inetsoft.report.composition.execution;
 
 import inetsoft.report.TableLens;
+import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.cluster.Cluster;
+import inetsoft.sree.internal.cluster.MessageEvent;
+import inetsoft.sree.internal.cluster.MessageListener;
 import inetsoft.sree.security.OrganizationManager;
 import inetsoft.storage.BlobStorage;
 import inetsoft.storage.BlobStorageManager;
 import inetsoft.storage.BlobTransaction;
 import inetsoft.uql.XTable;
-import inetsoft.util.*;
+import inetsoft.util.ConfigurationContext;
+import inetsoft.util.ThreadContext;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.SmartLifecycle;
 
 import java.io.*;
 import java.security.Principal;
+import java.time.Instant;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipException;
 
-public class DistributedTableCacheStore {
+/**
+ * Cross-node persistent cache for serialized {@link TableLens} objects backed by
+ * {@link BlobStorage}. Operates in prestop mode: {@link #put} is a no-op during normal operation;
+ * entries are only written to the distributed store on node shutdown or when a new node broadcasts
+ * a {@link TableCacheReplicationRequest}. This eliminates per-query write overhead during stable
+ * cluster operation; cache misses fall back to re-execution.
+ */
+public class DistributedTableCacheStore implements MessageListener, SmartLifecycle {
    /**
     * Get the distributed table cache store instance
     */
@@ -46,10 +61,16 @@ public class DistributedTableCacheStore {
       return ConfigurationContext.getContext().getSpringBean(DistributedTableCacheStore.class);
    }
 
-   public DistributedTableCacheStore(Cluster cluster, BlobStorageManager blobStorageManager) {
+   public DistributedTableCacheStore(Cluster cluster, BlobStorageManager blobStorageManager,
+                                     ObjectProvider<AssetDataCache> assetDataCacheProvider)
+   {
+      this.cluster = cluster;
       this.blobStorageManager = blobStorageManager;
+      this.assetDataCacheProvider = assetDataCacheProvider;
       clusterId = cluster.getId();
       storages = new ConcurrentHashMap<>();
+
+      cluster.addMessageListener(this);
 
       // scheduleAtFixedRate is idempotent across the cluster (deduplicates by class name),
       // so calling it on every construction is safe and ensures the task is re-registered
@@ -58,7 +79,68 @@ public class DistributedTableCacheStore {
          new CleanupTableCacheTask(), 1L, CLEANUP_FREQUENCY_TIME,
          TimeUnit.MINUTES);
 
-      this.debouncer = new DefaultDebouncer<>(false);
+   }
+
+   /**
+    * On startup, broadcast a replication request so that peer nodes populate the distributed store
+    * with their local cache entries. The new node picks them up on cache miss; misses that arrive
+    * before replication completes fall back to re-execution.
+    */
+   @Override
+   public void start() {
+      running = true;
+
+      if(cluster.getServerClusterNodes().size() <= 1) {
+         LOG.debug("DistributedTableCacheStore: skipping replication request, single-node cluster");
+         return;
+      }
+
+      LOG.info("DistributedTableCacheStore: broadcasting replication request to cluster peers");
+
+      try {
+         cluster.sendMessage(new TableCacheReplicationRequest());
+      }
+      catch(Exception e) {
+         LOG.warn("DistributedTableCacheStore: failed to broadcast replication request on startup", e);
+      }
+   }
+
+   /**
+    * Called by Spring before any {@code @PreDestroy} methods, guaranteeing that the local cache
+    * is still populated when we flush. Uses {@code SmartLifecycle} rather than
+    * {@code @PreDestroy} specifically to control ordering: {@code AssetDataCache.closeCache()}
+    * (a {@code @PreDestroy}) clears the local cache, so we must flush before it runs.
+    */
+   @Override
+   public void stop() {
+      try {
+         flushLocalCache();
+      }
+      finally {
+         cluster.removeMessageListener(this);
+         running = false;
+      }
+   }
+
+   @Override
+   public boolean isRunning() {
+      return running;
+   }
+
+   @Override
+   public int getPhase() {
+      // High phase = stopped first among SmartLifecycle beans, and before all @PreDestroy methods.
+      return Integer.MAX_VALUE - 1;
+   }
+
+   @Override
+   public void messageReceived(MessageEvent event) {
+      if(event.getMessage() instanceof TableCacheReplicationRequest) {
+         LOG.info("DistributedTableCacheStore: received replication request, flushing async");
+         Thread flushThread = new Thread(this::flushLocalCache, "table-cache-flush");
+         flushThread.setDaemon(true);
+         flushThread.start();
+      }
    }
 
    /**
@@ -82,19 +164,8 @@ public class DistributedTableCacheStore {
          return null;
       }
 
-      // Read the raw bytes while holding the Ignite distributed lock, then release the lock
-      // before deserializing. Deserialization of XSwappableTable calls XSwapper.waitForMemory()
-      // which acquires waitLock. Holding an Ignite distributed lock across that call creates a
-      // cross-layer lock ordering dependency that leads to deadlock under concurrent export
-      // workloads. (Bug #73990)
-      byte[] data;
-
-      try(InputStream storageInputStream = storage.getInputStream(key)) {
-         data = storageInputStream.readAllBytes();
-      }
-
-      // Ignite distributed lock is now released; decompress and deserialize without holding it
-      try(GZIPInputStream gzipIn = new GZIPInputStream(new ByteArrayInputStream(data));
+      try(InputStream storageInputStream = storage.getInputStream(key);
+          GZIPInputStream gzipIn = new GZIPInputStream(storageInputStream);
           ObjectInputStream ois = new ObjectInputStream(gzipIn))
       {
          TableLens lens = (TableLens) ois.readObject();
@@ -118,45 +189,22 @@ public class DistributedTableCacheStore {
       }
    }
 
-   void put(DataKey dataKey, TableLens lens) {
-      if(dataKey.isLocalCacheOnly()) {
-         return;
+   /**
+    * Writes the given lens to the distributed store. Called during flush (node shutdown or
+    * replication request); not called during normal query execution.
+    */
+   private void put(String key, BlobStorage<Metadata> storage, TableLens lens) throws IOException {
+      try(BlobTransaction<Metadata> tx = storage.beginTransaction()) {
+         try(OutputStream out = tx.newStream(key, null);
+             GZIPOutputStream gzipOut = new GZIPOutputStream(out);
+             ObjectOutputStream oos = new ObjectOutputStream(gzipOut))
+         {
+            lens.moreRows(XTable.EOT);
+            oos.writeObject(lens);
+         }
+
+         tx.commit();
       }
-
-      String key = getKey(dataKey);
-      BlobStorage<Metadata> storage = getStorage();
-      final Principal principal = ThreadContext.getContextPrincipal();
-
-      debouncer.debounce(key, 1L, TimeUnit.SECONDS, () -> {
-         ThreadContext.setContextPrincipal(principal);
-
-         try(BlobTransaction<Metadata> tx = storage.beginTransaction()) {
-            try(OutputStream out = tx.newStream(key, null);
-                GZIPOutputStream gzipOut = new GZIPOutputStream(out);
-                ObjectOutputStream oos = new ObjectOutputStream(gzipOut))
-            {
-               // get all rows before writing
-               lens.moreRows(XTable.EOT);
-               oos.writeObject(lens);
-            }
-
-            // streams are fully closed (GZIP trailer written) before commit
-            tx.commit();
-         }
-         catch(IOException ex) {
-            // TimeoutException during cluster partition exchange (e.g. pod restart) is transient;
-            // log as WARN since the table will be recomputed on the next cache miss.
-            if(ex.getCause() instanceof java.util.concurrent.TimeoutException) {
-               LOG.warn("Timed out writing to blob storage (cluster rebalancing?): {}", key, ex);
-            }
-            else {
-               LOG.error("Failed to write to the blob storage: {}", key, ex);
-            }
-         }
-         finally {
-            ThreadContext.setContextPrincipal(null);
-         }
-      });
    }
 
    void remove(DataKey dataKey) {
@@ -174,6 +222,99 @@ public class DistributedTableCacheStore {
       catch(IOException e) {
          LOG.warn("Failed to remove data from cache: {}", key, e);
       }
+   }
+
+   /**
+    * Iterates all entries in the local {@link AssetDataCache} and writes them to the distributed
+    * store. Entries already present in the distributed store are skipped to avoid redundant writes
+    * when multiple nodes respond to the same {@link TableCacheReplicationRequest}. Stops early if
+    * the configured timeout ({@code distributed.table.cache.flush.timeout.seconds}) is reached.
+    */
+   public void flushLocalCache() {
+      if(cluster.getServerClusterNodes().size() <= 1) {
+         LOG.debug("DistributedTableCacheStore.flushLocalCache: skipping flush, single-node cluster");
+         return;
+      }
+
+      AssetDataCache cache = assetDataCacheProvider.getObject();
+      Map<DataKey, TableLens> entries = cache.getLocalEntries();
+
+      if(entries.isEmpty()) {
+         return;
+      }
+
+      long timeoutSeconds = Long.parseLong(FLUSH_TIMEOUT_SECONDS.get());
+      Instant deadline = Instant.now().plusSeconds(timeoutSeconds);
+
+      LOG.info("DistributedTableCacheStore.flushLocalCache: flushing {} entr{} (timeout {}s)",
+               entries.size(), entries.size() == 1 ? "y" : "ies", timeoutSeconds);
+
+      long startMs = System.currentTimeMillis();
+      int written = 0;
+      int skippedLocal = 0;
+      int skippedExists = 0;
+      int failed = 0;
+
+      for(Map.Entry<DataKey, TableLens> entry : entries.entrySet()) {
+         if(Instant.now().isAfter(deadline)) {
+            int remaining = entries.size() - written - skippedLocal - skippedExists - failed;
+            LOG.warn("DistributedTableCacheStore.flushLocalCache: timeout reached — wrote {}, {} not flushed",
+                     written, remaining);
+            break;
+         }
+
+         DataKey dataKey = entry.getKey();
+
+         if(dataKey.isLocalCacheOnly()) {
+            skippedLocal++;
+            continue;
+         }
+
+         Principal principal = cache.getPrincipalForKey(dataKey);
+         Principal oldPrincipal = ThreadContext.getContextPrincipal();
+         ThreadContext.setContextPrincipal(principal);
+
+         try {
+            if(exists(dataKey)) {
+               skippedExists++;
+               continue;
+            }
+
+            put(getKey(dataKey), getStorage(), entry.getValue());
+            written++;
+         }
+         catch(Exception ex) {
+            if(isClusterStopped(ex)) {
+               LOG.warn("DistributedTableCacheStore.flushLocalCache: cluster stopped during flush — aborting ({} entries not flushed)",
+                        entries.size() - written - skippedLocal - skippedExists - failed);
+               break;
+            }
+
+            LOG.warn("DistributedTableCacheStore.flushLocalCache: failed to write entry", ex);
+            failed++;
+         }
+         finally {
+            ThreadContext.setContextPrincipal(oldPrincipal);
+         }
+      }
+
+      int timedOut = entries.size() - written - skippedLocal - skippedExists - failed;
+      LOG.info("DistributedTableCacheStore.flushLocalCache: complete in {}ms — total {}, wrote {}, skipped-local {}, skipped-exists {}, failed {}, timed-out {}",
+               System.currentTimeMillis() - startMs, entries.size(), written, skippedLocal, skippedExists, failed, timedOut);
+   }
+
+   private static boolean isClusterStopped(Throwable ex) {
+      Throwable t = ex;
+
+      while(t != null) {
+         if(t.getClass().getName().contains("IgniteIllegalStateException")) {
+            return true;
+         }
+
+         t = t.getCause();
+      }
+
+      return false;
    }
 
    private BlobStorage<Metadata> getStorage() {
@@ -199,12 +340,21 @@ public class DistributedTableCacheStore {
       return clusterId + "__" + DigestUtils.sha256Hex(dataKey.getValue());
    }
 
+   private volatile boolean running = false;
+   private final Cluster cluster;
    private final BlobStorageManager blobStorageManager;
+   private final ObjectProvider<AssetDataCache> assetDataCacheProvider;
    private final String clusterId;
    private final ConcurrentHashMap<String, BlobStorage<Metadata>> storages;
-   private final Debouncer<String> debouncer;
 
    private static final long CLEANUP_FREQUENCY_TIME = 30L; // minutes
+   /**
+    * Maximum seconds to spend flushing the local cache on shutdown. Should be less than the ECS
+    * container StopTimeout to allow the flush to complete before the container is killed.
+    * Default: 90 (Fargate max StopTimeout is 120s).
+    */
+   private static final SreeEnv.Value FLUSH_TIMEOUT_SECONDS =
+      new SreeEnv.Value("distributed.table.cache.flush.timeout.seconds", 30000, "90");
    private static final Logger LOG = LoggerFactory.getLogger(DistributedTableCacheStore.class);
 
    public static final class Metadata implements Serializable {

--- a/core/src/main/java/inetsoft/report/composition/execution/DistributedTableCacheStore.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/DistributedTableCacheStore.java
@@ -161,6 +161,13 @@ public class DistributedTableCacheStore implements MessageListener, SmartLifecyc
             return;
          }
 
+         Thread existing = asyncFlushThread.get();
+
+         if(existing != null && existing.isAlive()) {
+            LOG.debug("DistributedTableCacheStore: replication request received but flush thread already running, skipping");
+            return;
+         }
+
          LOG.info("DistributedTableCacheStore: received replication request, flushing async");
          Thread t = new Thread(this::flushLocalCache, "table-cache-flush");
          t.setDaemon(true);

--- a/core/src/main/java/inetsoft/report/composition/execution/DistributedTableCacheStore.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/DistributedTableCacheStore.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipException;
@@ -114,11 +115,30 @@ public class DistributedTableCacheStore implements MessageListener, SmartLifecyc
     */
    @Override
    public void stop() {
+      // Remove the listener first so no new replication-triggered flush threads can start.
+      cluster.removeMessageListener(this);
+
       try {
-         flushLocalCache();
+         Thread t = asyncFlushThread.getAndSet(null);
+
+         if(t != null && t.isAlive()) {
+            // A replication-triggered flush is already in progress; wait for it instead of
+            // starting a redundant flush. The join timeout matches the flush timeout so we
+            // don't block the shutdown longer than intended.
+            long timeoutMs = Long.parseLong(FLUSH_TIMEOUT_SECONDS.get()) * 1000L;
+
+            try {
+               t.join(timeoutMs);
+            }
+            catch(InterruptedException ignored) {
+               Thread.currentThread().interrupt();
+            }
+         }
+         else {
+            flushLocalCache();
+         }
       }
       finally {
-         cluster.removeMessageListener(this);
          running = false;
       }
    }
@@ -137,10 +157,15 @@ public class DistributedTableCacheStore implements MessageListener, SmartLifecyc
    @Override
    public void messageReceived(MessageEvent event) {
       if(event.getMessage() instanceof TableCacheReplicationRequest) {
+         if(event.isLocal()) {
+            return;
+         }
+
          LOG.info("DistributedTableCacheStore: received replication request, flushing async");
-         Thread flushThread = new Thread(this::flushLocalCache, "table-cache-flush");
-         flushThread.setDaemon(true);
-         flushThread.start();
+         Thread t = new Thread(this::flushLocalCache, "table-cache-flush");
+         t.setDaemon(true);
+         asyncFlushThread.set(t);
+         t.start();
       }
    }
 
@@ -231,7 +256,7 @@ public class DistributedTableCacheStore implements MessageListener, SmartLifecyc
     * when multiple nodes respond to the same {@link TableCacheReplicationRequest}. Stops early if
     * the configured timeout ({@code distributed.table.cache.flush.timeout.seconds}) is reached.
     */
-   public void flushLocalCache() {
+   void flushLocalCache() {
       if(!flushing.compareAndSet(false, true)) {
          LOG.debug("DistributedTableCacheStore.flushLocalCache: flush already in progress, skipping");
          return;
@@ -318,16 +343,16 @@ public class DistributedTableCacheStore implements MessageListener, SmartLifecyc
          }
       }
 
-      int timedOut = entries.size() - written - skippedLocal - skippedExists - failed;
-      LOG.info("DistributedTableCacheStore.flushLocalCache: complete in {}ms — total {}, wrote {}, skipped-local {}, skipped-exists {}, failed {}, timed-out {}",
-               System.currentTimeMillis() - startMs, entries.size(), written, skippedLocal, skippedExists, failed, timedOut);
+      int notFlushed = entries.size() - written - skippedLocal - skippedExists - failed;
+      LOG.info("DistributedTableCacheStore.flushLocalCache: complete in {}ms — total {}, wrote {}, skipped-local {}, skipped-exists {}, failed {}, not-flushed {}",
+               System.currentTimeMillis() - startMs, entries.size(), written, skippedLocal, skippedExists, failed, notFlushed);
    }
 
    private static boolean isClusterStopped(Throwable ex) {
       Throwable t = ex;
 
       while(t != null) {
-         if(t.getClass().getName().contains("IgniteIllegalStateException")) {
+         if("IgniteIllegalStateException".equals(t.getClass().getSimpleName())) {
             return true;
          }
 
@@ -362,6 +387,7 @@ public class DistributedTableCacheStore implements MessageListener, SmartLifecyc
 
    private volatile boolean running = false;
    private final AtomicBoolean flushing = new AtomicBoolean(false);
+   private final AtomicReference<Thread> asyncFlushThread = new AtomicReference<>();
    private final Cluster cluster;
    private final BlobStorageManager blobStorageManager;
    private final ObjectProvider<AssetDataCache> assetDataCacheProvider;

--- a/core/src/main/java/inetsoft/report/composition/execution/DistributedTableCacheStore.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/DistributedTableCacheStore.java
@@ -42,6 +42,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipException;
@@ -231,6 +232,20 @@ public class DistributedTableCacheStore implements MessageListener, SmartLifecyc
     * the configured timeout ({@code distributed.table.cache.flush.timeout.seconds}) is reached.
     */
    public void flushLocalCache() {
+      if(!flushing.compareAndSet(false, true)) {
+         LOG.debug("DistributedTableCacheStore.flushLocalCache: flush already in progress, skipping");
+         return;
+      }
+
+      try {
+         doFlushLocalCache();
+      }
+      finally {
+         flushing.set(false);
+      }
+   }
+
+   private void doFlushLocalCache() {
       if(cluster.getServerClusterNodes().size() <= 1) {
          LOG.debug("DistributedTableCacheStore.flushLocalCache: skipping flush, single-node cluster");
          return;
@@ -272,9 +287,12 @@ public class DistributedTableCacheStore implements MessageListener, SmartLifecyc
 
          Principal principal = cache.getPrincipalForKey(dataKey);
          Principal oldPrincipal = ThreadContext.getContextPrincipal();
-         ThreadContext.setContextPrincipal(principal);
 
          try {
+            if(principal != null) {
+               ThreadContext.setContextPrincipal(principal);
+            }
+
             if(exists(dataKey)) {
                skippedExists++;
                continue;
@@ -294,7 +312,9 @@ public class DistributedTableCacheStore implements MessageListener, SmartLifecyc
             failed++;
          }
          finally {
-            ThreadContext.setContextPrincipal(oldPrincipal);
+            if(principal != null) {
+               ThreadContext.setContextPrincipal(oldPrincipal);
+            }
          }
       }
 
@@ -341,6 +361,7 @@ public class DistributedTableCacheStore implements MessageListener, SmartLifecyc
    }
 
    private volatile boolean running = false;
+   private final AtomicBoolean flushing = new AtomicBoolean(false);
    private final Cluster cluster;
    private final BlobStorageManager blobStorageManager;
    private final ObjectProvider<AssetDataCache> assetDataCacheProvider;

--- a/core/src/main/java/inetsoft/report/composition/execution/TableCacheReplicationRequest.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/TableCacheReplicationRequest.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.composition.execution;
+
+import java.io.Serializable;
+
+/**
+ * Cluster message broadcast by a newly-started node to request that all other nodes flush their
+ * local {@link AssetDataCache} entries to the distributed table cache store. Receiving nodes
+ * respond by writing any cached {@link inetsoft.report.TableLens} objects they hold to the
+ * distributed store asynchronously; the requesting node picks them up on cache miss.
+ * <p>
+ * This is only active when {@code distributed.table.cache.mode=prestop}. In that mode, normal
+ * {@link DistributedTableCacheStore#put} calls are no-ops, so the distributed store is only
+ * populated at node shutdown (flush) or when another node requests replication.
+ */
+public class TableCacheReplicationRequest implements Serializable {
+   private static final long serialVersionUID = 1L;
+}

--- a/core/src/main/java/inetsoft/report/composition/execution/TableCacheReplicationRequest.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/TableCacheReplicationRequest.java
@@ -25,9 +25,8 @@ import java.io.Serializable;
  * respond by writing any cached {@link inetsoft.report.TableLens} objects they hold to the
  * distributed store asynchronously; the requesting node picks them up on cache miss.
  * <p>
- * This is only active when {@code distributed.table.cache.mode=prestop}. In that mode, normal
- * {@link DistributedTableCacheStore#put} calls are no-ops, so the distributed store is only
- * populated at node shutdown (flush) or when another node requests replication.
+ * Query-time cache puts do not write to the distributed store — entries are only written at
+ * node shutdown or when replication is requested via this message.
  */
 public class TableCacheReplicationRequest implements Serializable {
    private static final long serialVersionUID = 1L;

--- a/core/src/main/java/inetsoft/web/factory/EngineConfiguration.java
+++ b/core/src/main/java/inetsoft/web/factory/EngineConfiguration.java
@@ -371,8 +371,11 @@ public class EngineConfiguration {
     */
    @Bean
    @Lazy
-   public DistributedTableCacheStore distributedTableCacheStore(@Lazy Cluster cluster, @Lazy BlobStorageManager blobStorageManager) {
-      return new DistributedTableCacheStore(cluster, blobStorageManager);
+   public DistributedTableCacheStore distributedTableCacheStore(@Lazy Cluster cluster,
+                                                                @Lazy BlobStorageManager blobStorageManager,
+                                                                ObjectProvider<AssetDataCache> assetDataCacheProvider)
+   {
+      return new DistributedTableCacheStore(cluster, blobStorageManager, assetDataCacheProvider);
    }
 
    /**

--- a/core/src/test/java/inetsoft/test/IntegrationTestConfiguration.java
+++ b/core/src/test/java/inetsoft/test/IntegrationTestConfiguration.java
@@ -466,8 +466,10 @@ public class IntegrationTestConfiguration {
    }
 
    @Bean
-   public DistributedTableCacheStore distributedTableCacheStore(Cluster cluster, BlobStorageManager blobStorageManager) {
-      return new DistributedTableCacheStore(cluster, blobStorageManager);
+   public DistributedTableCacheStore distributedTableCacheStore(Cluster cluster, BlobStorageManager blobStorageManager,
+                                                                ObjectProvider<AssetDataCache> assetDataCacheProvider)
+   {
+      return new DistributedTableCacheStore(cluster, blobStorageManager, assetDataCacheProvider);
    }
 
    @Bean

--- a/server/src/main/java/inetsoft/web/BaseInetsoftApplication.java
+++ b/server/src/main/java/inetsoft/web/BaseInetsoftApplication.java
@@ -56,6 +56,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public abstract class BaseInetsoftApplication {
    public void start(String[] args) {
+      // Disable Ignite's JVM shutdown hook so that Spring controls shutdown ordering.
+      // Ignite is stopped explicitly in shutdownInetsoft() after all SmartLifecycle.stop()
+      // and @PreDestroy methods have run.
+      System.setProperty("IGNITE_NO_SHUTDOWN_HOOK", "true");
+
       ApplicationArguments appArguments = new DefaultApplicationArguments(args);
 
       // make sure aot is not enabled during process-aot phase
@@ -217,9 +222,6 @@ public abstract class BaseInetsoftApplication {
 
    @PreDestroy
    public void shutdownInetsoft() {
-      // Ignite's jvm shutdown hook will execute its own shutdown logic so just
-      // mark the cluster instance as closed
-      Cluster.getInstance().setClosed(true);
       Logger log = LoggerFactory.getLogger(getClass());
 
       try {
@@ -252,6 +254,16 @@ public abstract class BaseInetsoftApplication {
       }
       catch(Exception ex) {
          log.debug("Failed to cancel threads", ex);
+      }
+
+      // Explicitly close the cluster now that all SmartLifecycle.stop() and @PreDestroy methods
+      // (including the distributed table cache flush) have completed. Ignite's own JVM shutdown
+      // hook is disabled via IGNITE_NO_SHUTDOWN_HOOK=true set at the top of start().
+      try {
+         Cluster.getInstance().close();
+      }
+      catch(Exception ex) {
+         log.debug("Failed to close cluster", ex);
       }
    }
 


### PR DESCRIPTION
Replace the per-query distributed cache write pattern with a prestop flush strategy: entries are written to BlobStorage only on node shutdown (SmartLifecycle.stop()) or when a new node broadcasts a TableCacheReplicationRequest to trigger peers to replicate. Cache misses fall back to re-execution if replication hasn't completed.

Key changes:
- DistributedTableCacheStore: implements SmartLifecycle (phase MAX-1) + MessageListener; flushLocalCache() with 90s timeout, exists() dedup, isClusterStopped() early abort, and single-node skip
- AssetDataCache: principalMap tracks principal per entry for org-scoped storage writes; overridden put(key, data, timeout) calls recordPrincipal(); removeCache/removeCacheDependence use try-finally to restore thread context
- TableCacheReplicationRequest: new serializable cluster broadcast message
- BaseInetsoftApplication: IGNITE_NO_SHUTDOWN_HOOK=true set at startup; explicit Cluster.close() at end of shutdownInetsoft() for deterministic shutdown ordering