### PR TITLE
fix Bug #73835: fix week is split by two years and find weekday is just on last year

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
@@ -1983,6 +1983,7 @@ public class DateComparisonUtil {
       Calendar calendar = new GregorianCalendar();
       calendar.setFirstDayOfWeek(Tool.getFirstDayOfWeek());
       calendar.setMinimalDaysInFirstWeek(7);
+
       return calendar;
    }
 }

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
@@ -1143,6 +1143,16 @@ public class DateComparisonUtil {
          }
       }
 
+      // When the partial week at the start of a year straddles the year boundary (e.g.,
+      // Dec 28-Jan 3 with firstDayOfWeek=Monday), the computed date may fall in the
+      // previous year. Advance by one week so the label stays within the reference year.
+      Calendar yearRefCal = new GregorianCalendar();
+      yearRefCal.setTime(date);
+
+      if(cal.get(Calendar.YEAR) < yearRefCal.get(Calendar.YEAR)) {
+         cal.add(Calendar.DATE, 7);
+      }
+
       Format dateFmt = fmt != null ? fmt : XUtil.getDefaultDateFormat(formatLevel);
 
       if(dateFmt instanceof ExtendedDecimalFormat) {
@@ -1977,7 +1987,6 @@ public class DateComparisonUtil {
       Calendar calendar = new GregorianCalendar();
       calendar.setFirstDayOfWeek(Tool.getFirstDayOfWeek());
       calendar.setMinimalDaysInFirstWeek(7);
-
       return calendar;
    }
 }

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
@@ -1071,6 +1071,7 @@ public class DateComparisonUtil {
       }
 
       cal.setTime(date);
+      int refYear = cal.get(Calendar.YEAR);
       List<XDimensionRef> mergedRefs = cell.getMergedRefs();
 
       for(int i = 0; i < mergedRefs.size(); i++) {
@@ -1143,13 +1144,8 @@ public class DateComparisonUtil {
          }
       }
 
-      // When the partial week at the start of a year straddles the year boundary (e.g.,
-      // Dec 28-Jan 3 with firstDayOfWeek=Monday), the computed date may fall in the
-      // previous year. Advance by one week so the label stays within the reference year.
-      Calendar yearRefCal = new GregorianCalendar();
-      yearRefCal.setTime(date);
-
-      if(cal.get(Calendar.YEAR) < yearRefCal.get(Calendar.YEAR)) {
+      // Partial week at year start (e.g. Dec 28-Jan 3) may land in the previous year; advance one week.
+      if(cal.get(Calendar.YEAR) < refYear) {
          cal.add(Calendar.DATE, 7);
       }
 

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
@@ -1148,6 +1148,9 @@ public class DateComparisonUtil {
       if(cal.get(Calendar.YEAR) < refYear) {
          cal.add(Calendar.DATE, 7);
       }
+      else if(cal.get(Calendar.YEAR) > refYear) {
+         cal.add(Calendar.DATE, -7);
+      }
 
       Format dateFmt = fmt != null ? fmt : XUtil.getDefaultDateFormat(formatLevel);
 


### PR DESCRIPTION
The bug is caused by find Tuesday for one range(2021-1 to 2021-10) so it will find first week from 2021-01-01, but that week is from 2020-12-28 to 2021-01-03. So it will find 2020-12-13.

In fact, when find day, should check if the day is in range 2021 year. If not, should find next week.