### PR TITLE
Add thumbnail generation and fallback logic after saveViewsheet()

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationSaveEvent.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationSaveEvent.java
@@ -66,9 +66,18 @@ public class WizVisualizationSaveEvent {
       this.displayName = displayName;
    }
 
+   public String getSourceViewsheetRuntimeId() {
+      return sourceViewsheetRuntimeId;
+   }
+
+   public void setSourceViewsheetRuntimeId(String sourceViewsheetRuntimeId) {
+      this.sourceViewsheetRuntimeId = sourceViewsheetRuntimeId;
+   }
+
    private String sourceViewsheetIdentifier;
    private String assemblyName;
    private String conversationId;
    private String targetFolderPath;
    private String displayName;
+   private String sourceViewsheetRuntimeId;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationSaveResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationSaveResult.java
@@ -39,6 +39,7 @@ public class WizVisualizationSaveResult {
    }
 
    private String savedViewsheetIdentifier;
-   /** SVG or PNG data URI depending on assembly type. */
+   /** Base64-encoded PNG data URI ({@code data:image/png;base64,...}) for chart assemblies,
+    *  or raw SVG markup for vector-rendered assemblies. */
    private String thumbnail;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationSaveResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationSaveResult.java
@@ -30,5 +30,14 @@ public class WizVisualizationSaveResult {
       this.savedViewsheetIdentifier = savedViewsheetIdentifier;
    }
 
+   public String getSvg() {
+      return svg;
+   }
+
+   public void setSvg(String svg) {
+      this.svg = svg;
+   }
+
    private String savedViewsheetIdentifier;
+   private String svg;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationSaveResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationSaveResult.java
@@ -50,7 +50,13 @@ public class WizVisualizationSaveResult {
    }
 
    private String savedViewsheetIdentifier;
-   /** Raw SVG markup or {@code data:image/png;base64,...} depending on assembly type. */
+   /**
+    * Raw SVG markup ({@code thumbnailFormat="svg"}) or a {@code data:image/png;base64,...} URI
+    * ({@code thumbnailFormat="png"}) depending on assembly type, or {@code null} if unavailable.
+    *
+    * <p><b>Security:</b> when {@code thumbnailFormat} is {@code "svg"} the value is raw SVG markup.
+    * Callers must sanitize it before embedding in the DOM to prevent XSS.
+    */
    private String thumbnail;
    /** Discriminator for {@link #thumbnail}: {@code "svg"} or {@code "png"}, {@code null} if absent. */
    private String thumbnailFormat;

--- a/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationSaveResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationSaveResult.java
@@ -18,9 +18,12 @@
 
 package inetsoft.web.wiz.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * Response body for POST /api/wiz/visualization/save.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class WizVisualizationSaveResult {
    public String getSavedViewsheetIdentifier() {
       return savedViewsheetIdentifier;

--- a/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationSaveResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationSaveResult.java
@@ -38,8 +38,17 @@ public class WizVisualizationSaveResult {
       this.thumbnail = thumbnail;
    }
 
+   public String getThumbnailFormat() {
+      return thumbnailFormat;
+   }
+
+   public void setThumbnailFormat(String thumbnailFormat) {
+      this.thumbnailFormat = thumbnailFormat;
+   }
+
    private String savedViewsheetIdentifier;
-   /** Base64-encoded PNG data URI ({@code data:image/png;base64,...}) for chart assemblies,
-    *  or raw SVG markup for vector-rendered assemblies. */
+   /** Raw SVG markup or {@code data:image/png;base64,...} depending on assembly type. */
    private String thumbnail;
+   /** Discriminator for {@link #thumbnail}: {@code "svg"} or {@code "png"}, {@code null} if absent. */
+   private String thumbnailFormat;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationSaveResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationSaveResult.java
@@ -30,14 +30,15 @@ public class WizVisualizationSaveResult {
       this.savedViewsheetIdentifier = savedViewsheetIdentifier;
    }
 
-   public String getSvg() {
-      return svg;
+   public String getThumbnail() {
+      return thumbnail;
    }
 
-   public void setSvg(String svg) {
-      this.svg = svg;
+   public void setThumbnail(String thumbnail) {
+      this.thumbnail = thumbnail;
    }
 
    private String savedViewsheetIdentifier;
-   private String svg;
+   /** SVG or PNG data URI depending on assembly type. */
+   private String thumbnail;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -49,9 +49,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 
 @Service
 public class WizVisualizationService {
@@ -234,19 +232,22 @@ public class WizVisualizationService {
       String runtimeId = event.getSourceViewsheetRuntimeId();
 
       if(!Tool.isEmptyString(runtimeId)) {
-         try {
-            CompletableFuture.runAsync(() -> {
-
+         // Run thumbnail generation on a dedicated executor (not ForkJoinPool.commonPool())
+         // so that blocking I/O does not starve CPU-bound tasks across the JVM.
+         // The callable returns [thumbnailData, format]; result is set only in this thread
+         // after get() succeeds, eliminating any cross-thread mutation race.
+         Future<String[]> thumbnailFuture = THUMBNAIL_EXECUTOR.submit(() -> {
             try {
-            // Fetch once: validates ownership (prevents cross-session access) and
-            // is reused for the fallback path, avoiding redundant lookups.
-            RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
+               // Fetch once: validates ownership (prevents cross-session access) and
+               // is reused for the fallback path, avoiding redundant lookups.
+               RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
 
-            if(rvs == null) {
-               LOG.warn("runtimeId '{}' not accessible for principal '{}', skipping thumbnail",
-                        runtimeId, principal.getName());
-            }
-            else {
+               if(rvs == null) {
+                  LOG.warn("runtimeId '{}' not accessible for principal '{}', skipping thumbnail",
+                           runtimeId, principal.getName());
+                  return null;
+               }
+
                Viewsheet preCheckVs = rvs.getViewsheet();
 
                // Always attempt the lightweight primary path regardless of viewsheet size.
@@ -259,8 +260,10 @@ public class WizVisualizationService {
                if(imgResult != null && imgResult.getRetryAfter() > 0) {
                   LOG.debug("downloadAssemblyImage not yet ready for '{}' (retryAfter={}), skipping thumbnail",
                             event.getAssemblyName(), imgResult.getRetryAfter());
+                  return null;
                }
-               else if(imgResult != null && imgResult.getImageData() != null) {
+
+               if(imgResult != null && imgResult.getImageData() != null) {
                   byte[] imageBytes = binaryTransferService.getData(imgResult.getImageData());
 
                   if(imageBytes != null && imageBytes.length > 0) {
@@ -298,10 +301,7 @@ public class WizVisualizationService {
                            }
                         }
 
-                        if(thumbnailValue != null) {
-                           result.setThumbnail(thumbnailValue);
-                           result.setThumbnailFormat("png");
-                        }
+                        return thumbnailValue != null ? new String[]{thumbnailValue, "png"} : null;
                      }
                      else {
                         if(imageBytes.length > MAX_SVG_THUMBNAIL_BYTES) {
@@ -310,22 +310,34 @@ public class WizVisualizationService {
                                      MAX_SVG_THUMBNAIL_BYTES);
                         }
                         else {
-                           result.setThumbnail(normalizeSvgNamespace(
-                              new String(imageBytes, StandardCharsets.UTF_8)));
-                           result.setThumbnailFormat("svg");
+                           return new String[]{
+                              normalizeSvgNamespace(new String(imageBytes, StandardCharsets.UTF_8)),
+                              "svg"
+                           };
                         }
                      }
                   }
                }
+
+               return null;
             }
-         }
             catch(Exception e) {
                LOG.warn("Failed to generate thumbnail for assembly '{}' (non-fatal): {}",
                         event.getAssemblyName(), e.getMessage());
+               return null;
             }
-            }).get(THUMBNAIL_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+         });
+
+         try {
+            String[] thumbResult = thumbnailFuture.get(THUMBNAIL_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            if(thumbResult != null) {
+               result.setThumbnail(thumbResult[0]);
+               result.setThumbnailFormat(thumbResult[1]);
+            }
          }
          catch(TimeoutException te) {
+            thumbnailFuture.cancel(true);
             LOG.debug("Thumbnail generation timed out after {}s for assembly '{}'",
                       THUMBNAIL_TIMEOUT_SECONDS, event.getAssemblyName());
          }
@@ -665,6 +677,11 @@ public class WizVisualizationService {
     * prefix (e.g. {@code a0:fill="..."}) are not stripped. Batik does not apply the SVG namespace
     * prefix to attribute names, so this is not an issue in practice.
     *
+    * <p><b>Security:</b> the returned string is raw SVG markup. Callers that embed it in the DOM
+    * via {@code innerHTML} or Angular {@code [innerHTML]} must sanitize it first (strip
+    * {@code on*} event-handler attributes and {@code <script>} elements) to prevent XSS. Batik
+    * output is generally safe, but this method provides no sanitization guarantee.
+    *
     * <p>Coupling: this method assumes Batik generates a non-colliding prefix such as {@code a0:}.
     * If a renderer emits a short common prefix (e.g. {@code x:} or {@code s:}), the
     * {@code "<" + prefixColon} replacement could corrupt unrelated tags such as
@@ -717,10 +734,12 @@ public class WizVisualizationService {
             continue;
          }
 
+         // Use the detected quote character so only one replacement can ever match.
          String prefixColon = prefix + ":";
+         String nsDeclaration = "xmlns:" + prefix + "=" + quote + SVG_NS + quote;
+         String nsDefault     = "xmlns="                 + quote + SVG_NS + quote;
          return svg
-            .replace("xmlns:" + prefix + "=\"" + SVG_NS + "\"", "xmlns=\"" + SVG_NS + "\"")
-            .replace("xmlns:" + prefix + "='" + SVG_NS + "'", "xmlns='" + SVG_NS + "'")
+            .replace(nsDeclaration, nsDefault)
             .replace("<" + prefixColon, "<")
             .replace("</" + prefixColon, "</");
       }
@@ -742,5 +761,8 @@ public class WizVisualizationService {
    /** Skip the full-viewsheet fallback export for viewsheets with many assemblies. */
    private static final int MAX_ASSEMBLIES_FOR_FALLBACK_THUMBNAIL = 50;
    /** Maximum wall-clock seconds to spend on thumbnail generation before returning the save result. */
-   private static final long THUMBNAIL_TIMEOUT_SECONDS = 2;
+   private static final long THUMBNAIL_TIMEOUT_SECONDS = 5;
+   /** Dedicated executor for thumbnail I/O — keeps blocking work off ForkJoinPool.commonPool(). */
+   private static final ExecutorService THUMBNAIL_EXECUTOR =
+      Executors.newVirtualThreadPerTaskExecutor();
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -316,12 +316,11 @@ public class WizVisualizationService {
          return null;
       }
 
-      // Only DataVSAssembly references a worksheet table; others need no worksheet.
-      String rootTable = assembly instanceof DataVSAssembly
-         ? ((DataVSAssembly) assembly).getTableName()
-         : null;
+      String rootTable = assembly.getTableName();
 
       if(Tool.isEmptyString(rootTable)) {
+         LOG.debug("saveWorksheet: no source table for assembly '{}' ({}), skipping worksheet save",
+                   assembly.getName(), assembly.getClass().getSimpleName());
          return null;
       }
 
@@ -395,26 +394,11 @@ public class WizVisualizationService {
          required.add(name);
          Assembly a = ws.getAssembly(name);
 
-         if(a instanceof AbstractJoinTableAssembly joinTable) {
-            Enumeration<?> opTables = joinTable.getOperatorTables();
-
-            while(opTables.hasMoreElements()) {
-               String[] pair = (String[]) opTables.nextElement();
-
-               if(pair[0] != null) {
-                  stack.push(pair[0]);
+         if(a instanceof ComposedTableAssembly composed) {
+            for(String tname : composed.getTableNames()) {
+               if(!Tool.isEmptyString(tname)) {
+                  stack.push(tname);
                }
-
-               if(pair[1] != null) {
-                  stack.push(pair[1]);
-               }
-            }
-         }
-         else if(a instanceof MirrorAssembly mirror) {
-            String mirrored = mirror.getAssemblyName();
-
-            if(!Tool.isEmptyString(mirrored)) {
-               stack.push(mirrored);
             }
          }
       }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -19,6 +19,7 @@
 package inetsoft.web.wiz.service;
 
 import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.uql.asset.*;
@@ -27,23 +28,40 @@ import inetsoft.uql.viewsheet.internal.WizUtil;
 import inetsoft.util.Tool;
 import inetsoft.web.composer.model.TreeNodeModel;
 import inetsoft.web.composer.wiz.service.VisualizationService;
+import inetsoft.web.service.BinaryTransferService;
+import inetsoft.web.viewsheet.controller.AssemblyImageService;
+import inetsoft.web.viewsheet.service.ExportResponse;
+import inetsoft.web.viewsheet.service.VSExportService;
 import inetsoft.web.wiz.model.WizVisualizationSaveEvent;
 import inetsoft.web.wiz.model.WizVisualizationSaveResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import javax.imageio.ImageIO;
+import java.awt.Dimension;
 import java.awt.Point;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.*;
+import java.util.Base64;
 
 @Service
 public class WizVisualizationService {
    public WizVisualizationService(ViewsheetService viewsheetService,
-                                   AssetRepository assetRepository)
+                                   AssetRepository assetRepository,
+                                   AssemblyImageService assemblyImageService,
+                                   BinaryTransferService binaryTransferService,
+                                   VSExportService vsExportService)
    {
       this.viewsheetService = viewsheetService;
       this.assetRepository = assetRepository;
+      this.assemblyImageService = assemblyImageService;
+      this.binaryTransferService = binaryTransferService;
+      this.vsExportService = vsExportService;
    }
 
    /**
@@ -207,6 +225,55 @@ public class WizVisualizationService {
 
       WizVisualizationSaveResult result = new WizVisualizationSaveResult();
       result.setSavedViewsheetIdentifier(newVsEntry.toIdentifier());
+
+      // Try to generate SVG thumbnail from the source runtime viewsheet (non-fatal)
+      String runtimeId = event.getSourceViewsheetRuntimeId();
+
+      if(!Tool.isEmptyString(runtimeId)) {
+         try {
+            AssemblyImageService.ImageRenderResult imgResult =
+               assemblyImageService.downloadAssemblyImage(
+                  runtimeId, Tool.byteEncode(event.getAssemblyName()),
+                  400, 300, 400, 300, true, principal);
+
+            if(imgResult != null && imgResult.getImageData() != null) {
+               byte[] imageBytes = binaryTransferService.getData(imgResult.getImageData());
+
+               if(imageBytes != null && imageBytes.length > 0) {
+                  if(imgResult.isPng()) {
+                     // 1×1 is a StyleBI placeholder returned for assembly types that
+                     // downloadAssemblyImage does not support (e.g. Crosstab, Table).
+                     // In that case fall back to a full-viewsheet PNG export + crop.
+                     boolean use1x1Fallback = true;
+                     try {
+                        BufferedImage decoded = ImageIO.read(
+                           new ByteArrayInputStream(imageBytes));
+                        if(decoded != null && decoded.getWidth() > 1 && decoded.getHeight() > 1) {
+                           result.setSvg("data:image/png;base64," +
+                              Base64.getEncoder().encodeToString(imageBytes));
+                           use1x1Fallback = false;
+                        }
+                     }
+                     catch(Exception ignored) { /* fall through to fallback */ }
+
+                     if(use1x1Fallback) {
+                        result.setSvg(renderTableThumbnail(
+                           runtimeId, event.getAssemblyName(), principal));
+                     }
+                  }
+                  else {
+                     result.setSvg(normalizeSvgNamespace(
+                        new String(imageBytes, StandardCharsets.UTF_8)));
+                  }
+               }
+            }
+         }
+         catch(Exception e) {
+            LOG.warn("Failed to generate SVG thumbnail for assembly '{}' (non-fatal): {}",
+                     event.getAssemblyName(), e.getMessage());
+         }
+      }
+
       return result;
    }
 
@@ -405,7 +472,150 @@ public class WizVisualizationService {
       }
    }
 
+   /**
+    * Exports the source runtime viewsheet as a full PNG and crops to the target assembly bounds.
+    * Used as a fallback for assembly types (Crosstab, Table) that downloadAssemblyImage
+    * does not support — those return a 1×1 placeholder PNG instead of real content.
+    */
+   private String renderTableThumbnail(String runtimeId, String assemblyName, Principal principal) {
+      try {
+         RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
+
+         if(rvs == null) {
+            LOG.warn("renderTableThumbnail: RuntimeViewsheet not found for id='{}'", runtimeId);
+            return null;
+         }
+
+         Viewsheet vs = rvs.getViewsheet();
+
+         if(vs == null) {
+            LOG.warn("renderTableThumbnail: Viewsheet is null for id='{}'", runtimeId);
+            return null;
+         }
+
+         Assembly assembly = vs.getAssembly(assemblyName);
+
+         if(!(assembly instanceof VSAssembly)) {
+            LOG.warn("renderTableThumbnail: assembly '{}' not found or not VSAssembly (type={})",
+                     assemblyName, assembly == null ? "null" : assembly.getClass().getSimpleName());
+            return null;
+         }
+
+         Point offset = assembly.getPixelOffset();
+         Dimension size = assembly.getPixelSize();
+         LOG.info("renderTableThumbnail: assembly='{}' offset={} size={}", assemblyName, offset, size);
+
+         if(size == null || size.width <= 0 || size.height <= 0) {
+            LOG.warn("renderTableThumbnail: invalid size {} for assembly '{}'", size, assemblyName);
+            return null;
+         }
+
+         // Export full viewsheet to an in-memory PNG.
+         // current=true is required: with current=false and no bookmarks, the exporter's
+         // export() method is never called and write() produces 0 bytes.
+         ByteArrayOutputStream baos = new ByteArrayOutputStream();
+         vsExportService.exportViewsheet(rvs, FileFormatInfo.EXPORT_TYPE_PNG,
+            true, false, true, false, false, null, false,
+            new ExportResponse(baos), principal);
+
+         byte[] pngBytes = baos.toByteArray();
+         LOG.info("renderTableThumbnail: export produced {} bytes for assembly '{}'",
+                  pngBytes.length, assemblyName);
+
+         if(pngBytes.length == 0) {
+            LOG.warn("renderTableThumbnail: exportViewsheet produced 0 bytes for assembly '{}'", assemblyName);
+            return null;
+         }
+
+         BufferedImage full = ImageIO.read(new ByteArrayInputStream(pngBytes));
+
+         if(full == null) {
+            LOG.warn("renderTableThumbnail: ImageIO.read returned null for assembly '{}'", assemblyName);
+            return null;
+         }
+
+         LOG.info("renderTableThumbnail: full image {}x{}, crop at ({},{}) size {}x{}",
+                  full.getWidth(), full.getHeight(),
+                  offset != null ? offset.x : 0, offset != null ? offset.y : 0,
+                  size.width, size.height);
+
+         // Crop to assembly bounds (PNGCoordinateHelper renders at 1:1 pixel scale)
+         int cropX = Math.max(0, offset != null ? offset.x : 0);
+         int cropY = Math.max(0, offset != null ? offset.y : 0);
+         int cropW = Math.min(size.width, full.getWidth() - cropX);
+         int cropH = Math.min(size.height, full.getHeight() - cropY);
+
+         if(cropW <= 1 || cropH <= 1) {
+            LOG.warn("renderTableThumbnail: crop dimensions too small ({}x{}) for assembly '{}'",
+                     cropW, cropH, assemblyName);
+            return null;
+         }
+
+         BufferedImage cropped = full.getSubimage(cropX, cropY, cropW, cropH);
+         ByteArrayOutputStream out = new ByteArrayOutputStream();
+         ImageIO.write(cropped, "PNG", out);
+         byte[] croppedBytes = out.toByteArray();
+
+         if(croppedBytes.length == 0) {
+            LOG.warn("renderTableThumbnail: re-encoded PNG is empty for assembly '{}'", assemblyName);
+            return null;
+         }
+
+         LOG.info("renderTableThumbnail: success, cropped PNG {} bytes for assembly '{}'",
+                  croppedBytes.length, assemblyName);
+         return "data:image/png;base64," + Base64.getEncoder().encodeToString(croppedBytes);
+      }
+      catch(Exception e) {
+         LOG.warn("renderTableThumbnail: exception for assembly '{}': {}",
+                  assemblyName, e.getMessage(), e);
+         return null;
+      }
+   }
+
+   /**
+    * Removes custom XML namespace prefixes (e.g. "a0:") added by the Batik SVG generator
+    * so the resulting SVG can be rendered directly by browsers.
+    *
+    * Batik generates: {@code <a0:svg xmlns:a0="http://www.w3.org/2000/svg">}
+    * Browser requires: {@code <svg xmlns="http://www.w3.org/2000/svg">}
+    */
+   private static String normalizeSvgNamespace(String svg) {
+      if(svg == null || !svg.contains("xmlns:")) {
+         return svg;
+      }
+
+      // Locate "xmlns:PREFIX=" — the prefix sits between "xmlns:" and the "=" sign
+      int nsIdx = svg.indexOf("xmlns:");
+
+      if(nsIdx < 0) {
+         return svg;
+      }
+
+      int eqIdx = svg.indexOf('=', nsIdx + 6); // skip past "xmlns:" itself
+
+      if(eqIdx < 0) {
+         return svg;
+      }
+
+      String prefix = svg.substring(nsIdx + 6, eqIdx).trim(); // e.g. "a0"
+
+      if(prefix.isEmpty()) {
+         return svg;
+      }
+
+      String prefixColon = prefix + ":"; // "a0:"
+
+      return svg
+         .replace("xmlns:" + prefix + "=\"http://www.w3.org/2000/svg\"",
+                  "xmlns=\"http://www.w3.org/2000/svg\"")
+         .replace("<" + prefixColon, "<")
+         .replace("</" + prefixColon, "</");
+   }
+
    private final ViewsheetService viewsheetService;
    private final AssetRepository assetRepository;
+   private final AssemblyImageService assemblyImageService;
+   private final BinaryTransferService binaryTransferService;
+   private final VSExportService vsExportService;
    private static final Logger LOG = LoggerFactory.getLogger(WizVisualizationService.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -556,6 +556,18 @@ public class WizVisualizationService {
          }
 
          BufferedImage cropped = full.getSubimage(cropX, cropY, cropW, cropH);
+
+         if(cropW > THUMBNAIL_WIDTH || cropH > THUMBNAIL_HEIGHT) {
+            double scale = Math.min((double) THUMBNAIL_WIDTH / cropW, (double) THUMBNAIL_HEIGHT / cropH);
+            int scaledW = Math.max(1, (int)(cropW * scale));
+            int scaledH = Math.max(1, (int)(cropH * scale));
+            BufferedImage scaled = new BufferedImage(scaledW, scaledH, BufferedImage.TYPE_INT_ARGB);
+            scaled.createGraphics().drawImage(cropped, 0, 0, scaledW, scaledH, null);
+            cropped = scaled;
+
+            LOG.debug("renderTableThumbnail: scaled crop from {}x{} to {}x{}", cropW, cropH, scaledW, scaledH);
+         }
+
          ByteArrayOutputStream out = new ByteArrayOutputStream();
          ImageIO.write(cropped, "PNG", out);
          byte[] croppedBytes = out.toByteArray();
@@ -600,6 +612,7 @@ public class WizVisualizationService {
       int eqIdx = svg.indexOf('=', nsIdx + 6); // skip past "xmlns:" itself
 
       if(eqIdx < 0) {
+         LOG.debug("normalizeSvgNamespace: malformed xmlns declaration, skipping normalization");
          return svg;
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -241,72 +241,72 @@ public class WizVisualizationService {
                         runtimeId, principal.getName());
             }
             else {
-               // Short-circuit fallback path for large viewsheets to avoid heap pressure.
                Viewsheet preCheckVs = rvs.getViewsheet();
 
-               if(preCheckVs != null &&
-                  preCheckVs.getAssemblies().length > MAX_ASSEMBLIES_FOR_FALLBACK_THUMBNAIL)
-               {
-                  LOG.debug("Skipping fallback thumbnail for '{}': viewsheet has {} assemblies (limit {})",
-                            event.getAssemblyName(), preCheckVs.getAssemblies().length,
-                            MAX_ASSEMBLIES_FOR_FALLBACK_THUMBNAIL);
+               // Always attempt the lightweight primary path regardless of viewsheet size.
+               AssemblyImageService.ImageRenderResult imgResult =
+                  assemblyImageService.downloadAssemblyImage(
+                     runtimeId, Tool.byteEncode(event.getAssemblyName()),
+                     THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT,
+                     true, principal);
+
+               if(imgResult != null && imgResult.getRetryAfter() > 0) {
+                  LOG.debug("downloadAssemblyImage not yet ready for '{}' (retryAfter={}), skipping thumbnail",
+                            event.getAssemblyName(), imgResult.getRetryAfter());
                }
-               else {
-                  AssemblyImageService.ImageRenderResult imgResult =
-                     assemblyImageService.downloadAssemblyImage(
-                        runtimeId, Tool.byteEncode(event.getAssemblyName()),
-                        THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT,
-                        true, principal);
+               else if(imgResult != null && imgResult.getImageData() != null) {
+                  byte[] imageBytes = binaryTransferService.getData(imgResult.getImageData());
 
-                  if(imgResult != null && imgResult.getRetryAfter() > 0) {
-                     LOG.debug("downloadAssemblyImage not yet ready for '{}' (retryAfter={}), skipping thumbnail",
-                               event.getAssemblyName(), imgResult.getRetryAfter());
-                  }
-                  else if(imgResult != null && imgResult.getImageData() != null) {
-                     byte[] imageBytes = binaryTransferService.getData(imgResult.getImageData());
+                  if(imageBytes != null && imageBytes.length > 0) {
+                     if(imgResult.isPng()) {
+                        // 1×1 is a StyleBI placeholder returned for assembly types that
+                        // downloadAssemblyImage does not support (e.g. Crosstab, Table).
+                        // In that case fall back to a full-viewsheet PNG export + crop.
+                        String thumbnailValue = null;
+                        try {
+                           BufferedImage decoded = ImageIO.read(new ByteArrayInputStream(imageBytes));
 
-                     if(imageBytes != null && imageBytes.length > 0) {
-                        if(imgResult.isPng()) {
-                           // 1×1 is a StyleBI placeholder returned for assembly types that
-                           // downloadAssemblyImage does not support (e.g. Crosstab, Table).
-                           // In that case fall back to a full-viewsheet PNG export + crop.
-                           String thumbnailValue = null;
-                           try {
-                              BufferedImage decoded = ImageIO.read(new ByteArrayInputStream(imageBytes));
-
-                              if(decoded != null && decoded.getWidth() > 1 && decoded.getHeight() > 1) {
-                                 thumbnailValue = "data:image/png;base64," +
-                                    Base64.getEncoder().encodeToString(imageBytes);
-                              }
+                           if(decoded != null && decoded.getWidth() > 1 && decoded.getHeight() > 1) {
+                              thumbnailValue = "data:image/png;base64," +
+                                 Base64.getEncoder().encodeToString(imageBytes);
                            }
-                           catch(Exception e) {
-                              LOG.debug("Failed to decode PNG for '{}': {}. Attempting full-viewsheet fallback.",
-                                        event.getAssemblyName(), e.getMessage());
-                           }
+                        }
+                        catch(Exception e) {
+                           LOG.debug("Failed to decode PNG for '{}': {}. Attempting full-viewsheet fallback.",
+                                     event.getAssemblyName(), e.getMessage());
+                        }
 
-                           if(thumbnailValue == null) {
+                        // Only use the expensive fallback if within the assembly-count limit.
+                        if(thumbnailValue == null) {
+                           if(preCheckVs != null &&
+                              preCheckVs.getAssemblies().length > MAX_ASSEMBLIES_FOR_FALLBACK_THUMBNAIL)
+                           {
+                              LOG.debug("Skipping fallback thumbnail for '{}': viewsheet has {} assemblies (limit {})",
+                                        event.getAssemblyName(), preCheckVs.getAssemblies().length,
+                                        MAX_ASSEMBLIES_FOR_FALLBACK_THUMBNAIL);
+                           }
+                           else {
                               LOG.debug("PNG was 1×1 or undecodable for '{}', using full-viewsheet fallback",
                                         event.getAssemblyName());
                               thumbnailValue = renderFallbackThumbnail(rvs, event.getAssemblyName(), principal);
                            }
+                        }
 
-                           if(thumbnailValue != null) {
-                              result.setThumbnail(thumbnailValue);
-                              result.setThumbnailFormat("png");
-                           }
+                        if(thumbnailValue != null) {
+                           result.setThumbnail(thumbnailValue);
+                           result.setThumbnailFormat("png");
+                        }
+                     }
+                     else {
+                        if(imageBytes.length > MAX_SVG_THUMBNAIL_BYTES) {
+                           LOG.debug("SVG thumbnail for '{}' is {} bytes (limit {}), skipping",
+                                     event.getAssemblyName(), imageBytes.length,
+                                     MAX_SVG_THUMBNAIL_BYTES);
                         }
                         else {
-                           // Issue 6: guard against oversized SVG payloads
-                           if(imageBytes.length > MAX_SVG_THUMBNAIL_BYTES) {
-                              LOG.debug("SVG thumbnail for '{}' is {} bytes (limit {}), skipping",
-                                        event.getAssemblyName(), imageBytes.length,
-                                        MAX_SVG_THUMBNAIL_BYTES);
-                           }
-                           else {
-                              result.setThumbnail(normalizeSvgNamespace(
-                                 new String(imageBytes, StandardCharsets.UTF_8)));
-                              result.setThumbnailFormat("svg");
-                           }
+                           result.setThumbnail(normalizeSvgNamespace(
+                              new String(imageBytes, StandardCharsets.UTF_8)));
+                           result.setThumbnailFormat("svg");
                         }
                      }
                   }
@@ -605,6 +605,12 @@ public class WizVisualizationService {
             return null;
          }
 
+         if(croppedBytes.length > MAX_PNG_THUMBNAIL_BYTES) {
+            LOG.debug("renderFallbackThumbnail: PNG thumbnail for '{}' is {} bytes (limit {}), skipping",
+                      assemblyName, croppedBytes.length, MAX_PNG_THUMBNAIL_BYTES);
+            return null;
+         }
+
          LOG.debug("renderFallbackThumbnail: success, cropped PNG {} bytes for assembly '{}'",
                    croppedBytes.length, assemblyName);
          return "data:image/png;base64," + Base64.getEncoder().encodeToString(croppedBytes);
@@ -687,6 +693,7 @@ public class WizVisualizationService {
          String prefixColon = prefix + ":";
          return svg
             .replace("xmlns:" + prefix + "=\"" + SVG_NS + "\"", "xmlns=\"" + SVG_NS + "\"")
+            .replace("xmlns:" + prefix + "='" + SVG_NS + "'", "xmlns='" + SVG_NS + "'")
             .replace("<" + prefixColon, "<")
             .replace("</" + prefixColon, "</");
       }
@@ -703,6 +710,8 @@ public class WizVisualizationService {
    private static final String SVG_NS = "http://www.w3.org/2000/svg";
    /** Drop SVG thumbnails larger than 512 KB to prevent oversized response payloads. */
    private static final int MAX_SVG_THUMBNAIL_BYTES = 512 * 1024;
+   /** Drop PNG thumbnails larger than 256 KB to prevent oversized response payloads. */
+   private static final int MAX_PNG_THUMBNAIL_BYTES = 256 * 1024;
    /** Skip the full-viewsheet fallback export for viewsheets with many assemblies. */
    private static final int MAX_ASSEMBLIES_FOR_FALLBACK_THUMBNAIL = 50;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -232,57 +232,82 @@ public class WizVisualizationService {
 
       if(!Tool.isEmptyString(runtimeId)) {
          try {
-            // Validate ownership: getViewsheet enforces that the runtime viewsheet
-            // belongs to this principal, preventing cross-session thumbnail access.
-            if(viewsheetService.getViewsheet(runtimeId, principal) == null) {
+            // Fetch once: validates ownership (prevents cross-session access) and
+            // is reused for the fallback path, avoiding redundant lookups.
+            RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
+
+            if(rvs == null) {
                LOG.warn("runtimeId '{}' not accessible for principal '{}', skipping thumbnail",
                         runtimeId, principal.getName());
             }
             else {
-               AssemblyImageService.ImageRenderResult imgResult =
-                  assemblyImageService.downloadAssemblyImage(
-                     runtimeId, Tool.byteEncode(event.getAssemblyName()),
-                     THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT,
-                     true, principal);
+               // Short-circuit fallback path for large viewsheets to avoid heap pressure.
+               Viewsheet preCheckVs = rvs.getViewsheet();
 
-               if(imgResult != null && imgResult.getRetryAfter() > 0) {
-                  LOG.debug("downloadAssemblyImage not yet ready for '{}' (retryAfter={}), skipping thumbnail",
-                            event.getAssemblyName(), imgResult.getRetryAfter());
+               if(preCheckVs != null &&
+                  preCheckVs.getAssemblies().length > MAX_ASSEMBLIES_FOR_FALLBACK_THUMBNAIL)
+               {
+                  LOG.debug("Skipping fallback thumbnail for '{}': viewsheet has {} assemblies (limit {})",
+                            event.getAssemblyName(), preCheckVs.getAssemblies().length,
+                            MAX_ASSEMBLIES_FOR_FALLBACK_THUMBNAIL);
                }
-               else if(imgResult != null && imgResult.getImageData() != null) {
-                  byte[] imageBytes = binaryTransferService.getData(imgResult.getImageData());
+               else {
+                  AssemblyImageService.ImageRenderResult imgResult =
+                     assemblyImageService.downloadAssemblyImage(
+                        runtimeId, Tool.byteEncode(event.getAssemblyName()),
+                        THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT,
+                        true, principal);
 
-                  if(imageBytes != null && imageBytes.length > 0) {
-                     if(imgResult.isPng()) {
-                        // 1×1 is a StyleBI placeholder returned for assembly types that
-                        // downloadAssemblyImage does not support (e.g. Crosstab, Table).
-                        // In that case fall back to a full-viewsheet PNG export + crop.
-                        String thumbnailValue = null;
-                        try {
-                           BufferedImage decoded = ImageIO.read(new ByteArrayInputStream(imageBytes));
+                  if(imgResult != null && imgResult.getRetryAfter() > 0) {
+                     LOG.debug("downloadAssemblyImage not yet ready for '{}' (retryAfter={}), skipping thumbnail",
+                               event.getAssemblyName(), imgResult.getRetryAfter());
+                  }
+                  else if(imgResult != null && imgResult.getImageData() != null) {
+                     byte[] imageBytes = binaryTransferService.getData(imgResult.getImageData());
 
-                           if(decoded != null && decoded.getWidth() > 1 && decoded.getHeight() > 1) {
-                              thumbnailValue = "data:image/png;base64," +
-                                 Base64.getEncoder().encodeToString(imageBytes);
+                     if(imageBytes != null && imageBytes.length > 0) {
+                        if(imgResult.isPng()) {
+                           // 1×1 is a StyleBI placeholder returned for assembly types that
+                           // downloadAssemblyImage does not support (e.g. Crosstab, Table).
+                           // In that case fall back to a full-viewsheet PNG export + crop.
+                           String thumbnailValue = null;
+                           try {
+                              BufferedImage decoded = ImageIO.read(new ByteArrayInputStream(imageBytes));
+
+                              if(decoded != null && decoded.getWidth() > 1 && decoded.getHeight() > 1) {
+                                 thumbnailValue = "data:image/png;base64," +
+                                    Base64.getEncoder().encodeToString(imageBytes);
+                              }
+                           }
+                           catch(Exception e) {
+                              LOG.debug("Failed to decode PNG for '{}': {}. Attempting full-viewsheet fallback.",
+                                        event.getAssemblyName(), e.getMessage());
+                           }
+
+                           if(thumbnailValue == null) {
+                              LOG.debug("PNG was 1×1 or undecodable for '{}', using full-viewsheet fallback",
+                                        event.getAssemblyName());
+                              thumbnailValue = renderFallbackThumbnail(rvs, event.getAssemblyName(), principal);
+                           }
+
+                           if(thumbnailValue != null) {
+                              result.setThumbnail(thumbnailValue);
+                              result.setThumbnailFormat("png");
                            }
                         }
-                        catch(Exception e) {
-                           LOG.debug("Failed to decode PNG for '{}': {}. Attempting full-viewsheet fallback.",
-                                     event.getAssemblyName(), e.getMessage());
+                        else {
+                           // Issue 6: guard against oversized SVG payloads
+                           if(imageBytes.length > MAX_SVG_THUMBNAIL_BYTES) {
+                              LOG.debug("SVG thumbnail for '{}' is {} bytes (limit {}), skipping",
+                                        event.getAssemblyName(), imageBytes.length,
+                                        MAX_SVG_THUMBNAIL_BYTES);
+                           }
+                           else {
+                              result.setThumbnail(normalizeSvgNamespace(
+                                 new String(imageBytes, StandardCharsets.UTF_8)));
+                              result.setThumbnailFormat("svg");
+                           }
                         }
-
-                        if(thumbnailValue == null) {
-                           LOG.debug("PNG was 1×1 or undecodable for '{}', using full-viewsheet fallback",
-                                     event.getAssemblyName());
-                           thumbnailValue = renderFallbackThumbnail(
-                              runtimeId, event.getAssemblyName(), principal);
-                        }
-
-                        result.setThumbnail(thumbnailValue);
-                     }
-                     else {
-                        result.setThumbnail(normalizeSvgNamespace(
-                           new String(imageBytes, StandardCharsets.UTF_8)));
                      }
                   }
                }
@@ -481,19 +506,14 @@ public class WizVisualizationService {
     * Used as a fallback for assembly types (Crosstab, Table) that downloadAssemblyImage
     * does not support — those return a 1×1 placeholder PNG instead of real content.
     */
-   private String renderFallbackThumbnail(String runtimeId, String assemblyName, Principal principal) {
+   private String renderFallbackThumbnail(RuntimeViewsheet rvs, String assemblyName,
+                                           Principal principal)
+   {
       try {
-         RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
-
-         if(rvs == null) {
-            LOG.warn("renderFallbackThumbnail: RuntimeViewsheet not found for id='{}'", runtimeId);
-            return null;
-         }
-
          Viewsheet vs = rvs.getViewsheet();
 
          if(vs == null) {
-            LOG.warn("renderFallbackThumbnail: Viewsheet is null for id='{}'", runtimeId);
+            LOG.warn("renderFallbackThumbnail: Viewsheet is null for assembly '{}'", assemblyName);
             return null;
          }
 
@@ -549,8 +569,8 @@ public class WizVisualizationService {
          int cropW = Math.min(size.width, full.getWidth() - cropX);
          int cropH = Math.min(size.height, full.getHeight() - cropY);
 
-         if(cropW <= 1 || cropH <= 1) {
-            LOG.warn("renderFallbackThumbnail: crop dimensions too small ({}x{}) for assembly '{}'",
+         if(cropW <= 0 || cropH <= 0) {
+            LOG.warn("renderFallbackThumbnail: crop dimensions invalid ({}x{}) for assembly '{}'",
                      cropW, cropH, assemblyName);
             return null;
          }
@@ -622,6 +642,12 @@ public class WizVisualizationService {
     * <p>Note: only element start/end tags are de-prefixed. Attributes carrying the same namespace
     * prefix (e.g. {@code a0:fill="..."}) are not stripped. Batik does not apply the SVG namespace
     * prefix to attribute names, so this is not an issue in practice.
+    *
+    * <p>Coupling: this method assumes Batik generates a non-colliding prefix such as {@code a0:}.
+    * If a renderer emits a short common prefix (e.g. {@code x:} or {@code s:}), the
+    * {@code "<" + prefixColon} replacement could corrupt unrelated tags such as
+    * {@code &lt;xlink:href&gt;}. The SVG-namespace URI guard in the loop reduces this risk but
+    * does not eliminate it. A proper fix requires an XML-aware namespace stripper.
     */
    private static String normalizeSvgNamespace(String svg) {
       if(svg == null) {
@@ -675,4 +701,8 @@ public class WizVisualizationService {
    private static final int THUMBNAIL_WIDTH  = 400;
    private static final int THUMBNAIL_HEIGHT = 300;
    private static final String SVG_NS = "http://www.w3.org/2000/svg";
+   /** Drop SVG thumbnails larger than 512 KB to prevent oversized response payloads. */
+   private static final int MAX_SVG_THUMBNAIL_BYTES = 512 * 1024;
+   /** Skip the full-viewsheet fallback export for viewsheets with many assemblies. */
+   private static final int MAX_ASSEMBLIES_FOR_FALLBACK_THUMBNAIL = 50;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -40,7 +40,9 @@ import org.springframework.stereotype.Service;
 
 import javax.imageio.ImageIO;
 import java.awt.Dimension;
+import java.awt.Graphics2D;
 import java.awt.Point;
+import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -254,11 +256,13 @@ public class WizVisualizationService {
                         }
                      }
                      catch(Exception e) {
-                        LOG.debug("Failed to decode PNG for '{}', trying fallback: {}",
+                        LOG.debug("Failed to decode PNG for '{}': {}. Attempting full-viewsheet fallback.",
                                   event.getAssemblyName(), e.getMessage());
                      }
 
                      if(thumbnailValue == null) {
+                        LOG.debug("PNG was 1×1 or undecodable for '{}', using full-viewsheet fallback",
+                                  event.getAssemblyName());
                         thumbnailValue = renderTableThumbnail(
                            runtimeId, event.getAssemblyName(), principal);
                      }
@@ -562,7 +566,15 @@ public class WizVisualizationService {
             int scaledW = Math.max(1, (int)(cropW * scale));
             int scaledH = Math.max(1, (int)(cropH * scale));
             BufferedImage scaled = new BufferedImage(scaledW, scaledH, BufferedImage.TYPE_INT_ARGB);
-            scaled.createGraphics().drawImage(cropped, 0, 0, scaledW, scaledH, null);
+            Graphics2D g = scaled.createGraphics();
+            try {
+               g.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                                  RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+               g.drawImage(cropped, 0, 0, scaledW, scaledH, null);
+            }
+            finally {
+               g.dispose();
+            }
             cropped = scaled;
 
             LOG.debug("renderTableThumbnail: scaled crop from {}x{} to {}x{}", cropW, cropH, scaledW, scaledH);
@@ -580,6 +592,11 @@ public class WizVisualizationService {
          LOG.debug("renderTableThumbnail: success, cropped PNG {} bytes for assembly '{}'",
                    croppedBytes.length, assemblyName);
          return "data:image/png;base64," + Base64.getEncoder().encodeToString(croppedBytes);
+      }
+      catch(OutOfMemoryError oom) {
+         LOG.warn("renderTableThumbnail: out of memory for assembly '{}', skipping thumbnail",
+                  assemblyName);
+         return null;
       }
       catch(Exception e) {
          LOG.warn("renderTableThumbnail: exception for assembly '{}': {}",

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -232,50 +232,58 @@ public class WizVisualizationService {
 
       if(!Tool.isEmptyString(runtimeId)) {
          try {
-            AssemblyImageService.ImageRenderResult imgResult =
-               assemblyImageService.downloadAssemblyImage(
-                  runtimeId, Tool.byteEncode(event.getAssemblyName()),
-                  THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT,
-                  true, principal);
-
-            if(imgResult != null && imgResult.getRetryAfter() > 0) {
-               LOG.debug("downloadAssemblyImage not yet ready for '{}' (retryAfter={}), skipping thumbnail",
-                         event.getAssemblyName(), imgResult.getRetryAfter());
+            // Validate ownership: getViewsheet enforces that the runtime viewsheet
+            // belongs to this principal, preventing cross-session thumbnail access.
+            if(viewsheetService.getViewsheet(runtimeId, principal) == null) {
+               LOG.warn("runtimeId '{}' not accessible for principal '{}', skipping thumbnail",
+                        runtimeId, principal.getName());
             }
-            else if(imgResult != null && imgResult.getImageData() != null) {
-               byte[] imageBytes = binaryTransferService.getData(imgResult.getImageData());
+            else {
+               AssemblyImageService.ImageRenderResult imgResult =
+                  assemblyImageService.downloadAssemblyImage(
+                     runtimeId, Tool.byteEncode(event.getAssemblyName()),
+                     THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT,
+                     true, principal);
 
-               if(imageBytes != null && imageBytes.length > 0) {
-                  if(imgResult.isPng()) {
-                     // 1×1 is a StyleBI placeholder returned for assembly types that
-                     // downloadAssemblyImage does not support (e.g. Crosstab, Table).
-                     // In that case fall back to a full-viewsheet PNG export + crop.
-                     String thumbnailValue = null;
-                     try {
-                        BufferedImage decoded = ImageIO.read(new ByteArrayInputStream(imageBytes));
+               if(imgResult != null && imgResult.getRetryAfter() > 0) {
+                  LOG.debug("downloadAssemblyImage not yet ready for '{}' (retryAfter={}), skipping thumbnail",
+                            event.getAssemblyName(), imgResult.getRetryAfter());
+               }
+               else if(imgResult != null && imgResult.getImageData() != null) {
+                  byte[] imageBytes = binaryTransferService.getData(imgResult.getImageData());
 
-                        if(decoded != null && decoded.getWidth() > 1 && decoded.getHeight() > 1) {
-                           thumbnailValue = "data:image/png;base64," +
-                              Base64.getEncoder().encodeToString(imageBytes);
+                  if(imageBytes != null && imageBytes.length > 0) {
+                     if(imgResult.isPng()) {
+                        // 1×1 is a StyleBI placeholder returned for assembly types that
+                        // downloadAssemblyImage does not support (e.g. Crosstab, Table).
+                        // In that case fall back to a full-viewsheet PNG export + crop.
+                        String thumbnailValue = null;
+                        try {
+                           BufferedImage decoded = ImageIO.read(new ByteArrayInputStream(imageBytes));
+
+                           if(decoded != null && decoded.getWidth() > 1 && decoded.getHeight() > 1) {
+                              thumbnailValue = "data:image/png;base64," +
+                                 Base64.getEncoder().encodeToString(imageBytes);
+                           }
                         }
-                     }
-                     catch(Exception e) {
-                        LOG.debug("Failed to decode PNG for '{}': {}. Attempting full-viewsheet fallback.",
-                                  event.getAssemblyName(), e.getMessage());
-                     }
+                        catch(Exception e) {
+                           LOG.debug("Failed to decode PNG for '{}': {}. Attempting full-viewsheet fallback.",
+                                     event.getAssemblyName(), e.getMessage());
+                        }
 
-                     if(thumbnailValue == null) {
-                        LOG.debug("PNG was 1×1 or undecodable for '{}', using full-viewsheet fallback",
-                                  event.getAssemblyName());
-                        thumbnailValue = renderFallbackThumbnail(
-                           runtimeId, event.getAssemblyName(), principal);
-                     }
+                        if(thumbnailValue == null) {
+                           LOG.debug("PNG was 1×1 or undecodable for '{}', using full-viewsheet fallback",
+                                     event.getAssemblyName());
+                           thumbnailValue = renderFallbackThumbnail(
+                              runtimeId, event.getAssemblyName(), principal);
+                        }
 
-                     result.setThumbnail(thumbnailValue);
-                  }
-                  else {
-                     result.setThumbnail(normalizeSvgNamespace(
-                        new String(imageBytes, StandardCharsets.UTF_8)));
+                        result.setThumbnail(thumbnailValue);
+                     }
+                     else {
+                        result.setThumbnail(normalizeSvgNamespace(
+                           new String(imageBytes, StandardCharsets.UTF_8)));
+                     }
                   }
                }
             }
@@ -598,8 +606,11 @@ public class WizVisualizationService {
          return "data:image/png;base64," + Base64.getEncoder().encodeToString(croppedBytes);
       }
       catch(OutOfMemoryError oom) {
-         LOG.warn("renderFallbackThumbnail: out of memory for assembly '{}', skipping thumbnail",
-                  assemblyName);
+         // Log at ERROR so repeated OOM occurrences are visible as systemic memory pressure,
+         // not buried as routine warnings.
+         LOG.error("renderFallbackThumbnail: out of memory exporting viewsheet PNG for assembly '{}' " +
+                   "— if this recurs, investigate heap usage during concurrent thumbnail generation",
+                   assemblyName);
          return null;
       }
       catch(Exception e) {
@@ -610,14 +621,15 @@ public class WizVisualizationService {
    }
 
    /**
-    * Removes the first custom XML namespace prefix (e.g. "a0:") added by the Batik SVG generator
-    * so the resulting SVG can be rendered directly by browsers.
+    * Removes the custom XML namespace prefix (e.g. "a0:") that Batik adds to the SVG namespace
+    * so the resulting markup can be rendered directly by browsers.
     *
-    * Batik generates: {@code <a0:svg xmlns:a0="http://www.w3.org/2000/svg">}
+    * Batik generates: {@code <a0:svg xmlns:xlink="..." xmlns:a0="http://www.w3.org/2000/svg">}
     * Browser requires: {@code <svg xmlns="http://www.w3.org/2000/svg">}
     *
-    * <p>Note: only the first xmlns: prefix is stripped. Additional Batik prefixes (e.g. xlink:)
-    * are not removed. This is sufficient for the chart SVG output validated against Batik 1.17.
+    * <p>The method scans all {@code xmlns:PREFIX} declarations until it finds one whose value is
+    * exactly {@value #SVG_NS}. This avoids incorrectly treating an earlier {@code xmlns:xlink}
+    * declaration as the SVG-namespace prefix (a real Batik output ordering).
     *
     * <p>Note: String.replace is a literal full-text replacement, not XML-aware. An attribute value
     * or text node containing the literal prefix string (e.g. "&lt;a0:") would be incorrectly
@@ -628,32 +640,46 @@ public class WizVisualizationService {
     * prefix to attribute names, so this is not an issue in practice.
     */
    private static String normalizeSvgNamespace(String svg) {
-      if(svg == null || !svg.contains("xmlns:")) {
-         return svg;
+      if(svg == null) {
+         return null;
       }
 
-      // nsIdx >= 0 is guaranteed by the contains("xmlns:") guard above
-      int nsIdx = svg.indexOf("xmlns:");
-      int eqIdx = svg.indexOf('=', nsIdx + 6); // skip past "xmlns:" itself
+      int searchFrom = 0;
 
-      if(eqIdx < 0) {
-         LOG.debug("normalizeSvgNamespace: malformed xmlns declaration, skipping normalization");
-         return svg;
+      while(true) {
+         int nsIdx = svg.indexOf("xmlns:", searchFrom);
+
+         if(nsIdx < 0) {
+            return svg; // no xmlns: declaration maps to the SVG namespace
+         }
+
+         int eqIdx = svg.indexOf('=', nsIdx + 6);
+
+         if(eqIdx < 0) {
+            return svg;
+         }
+
+         String prefix = svg.substring(nsIdx + 6, eqIdx).trim();
+
+         if(prefix.isEmpty()) {
+            searchFrom = nsIdx + 1;
+            continue;
+         }
+
+         // Only normalize when this declaration's value is the SVG namespace URI
+         String afterEq = svg.substring(eqIdx + 1).stripLeading();
+
+         if(!afterEq.startsWith("\"" + SVG_NS + "\"") && !afterEq.startsWith("'" + SVG_NS + "'")) {
+            searchFrom = nsIdx + 1;
+            continue;
+         }
+
+         String prefixColon = prefix + ":";
+         return svg
+            .replace("xmlns:" + prefix + "=\"" + SVG_NS + "\"", "xmlns=\"" + SVG_NS + "\"")
+            .replace("<" + prefixColon, "<")
+            .replace("</" + prefixColon, "</");
       }
-
-      String prefix = svg.substring(nsIdx + 6, eqIdx).trim(); // e.g. "a0"
-
-      if(prefix.isEmpty()) {
-         return svg;
-      }
-
-      String prefixColon = prefix + ":"; // "a0:"
-
-      return svg
-         .replace("xmlns:" + prefix + "=\"http://www.w3.org/2000/svg\"",
-                  "xmlns=\"http://www.w3.org/2000/svg\"")
-         .replace("<" + prefixColon, "<")
-         .replace("</" + prefixColon, "</");
    }
 
    private final ViewsheetService viewsheetService;
@@ -664,4 +690,5 @@ public class WizVisualizationService {
    private static final Logger LOG = LoggerFactory.getLogger(WizVisualizationService.class);
    private static final int THUMBNAIL_WIDTH  = 400;
    private static final int THUMBNAIL_HEIGHT = 300;
+   private static final String SVG_NS = "http://www.w3.org/2000/svg";
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -47,7 +47,6 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.*;
-import java.util.Base64;
 
 @Service
 public class WizVisualizationService {
@@ -226,7 +225,7 @@ public class WizVisualizationService {
       WizVisualizationSaveResult result = new WizVisualizationSaveResult();
       result.setSavedViewsheetIdentifier(newVsEntry.toIdentifier());
 
-      // Try to generate SVG thumbnail from the source runtime viewsheet (non-fatal)
+      // Try to generate thumbnail from the source runtime viewsheet (non-fatal)
       String runtimeId = event.getSourceViewsheetRuntimeId();
 
       if(!Tool.isEmptyString(runtimeId)) {
@@ -234,7 +233,8 @@ public class WizVisualizationService {
             AssemblyImageService.ImageRenderResult imgResult =
                assemblyImageService.downloadAssemblyImage(
                   runtimeId, Tool.byteEncode(event.getAssemblyName()),
-                  400, 300, 400, 300, true, principal);
+                  THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT,
+                  true, principal);
 
             if(imgResult != null && imgResult.getImageData() != null) {
                byte[] imageBytes = binaryTransferService.getData(imgResult.getImageData());
@@ -244,32 +244,36 @@ public class WizVisualizationService {
                      // 1×1 is a StyleBI placeholder returned for assembly types that
                      // downloadAssemblyImage does not support (e.g. Crosstab, Table).
                      // In that case fall back to a full-viewsheet PNG export + crop.
-                     boolean use1x1Fallback = true;
+                     String thumbnailValue = null;
                      try {
-                        BufferedImage decoded = ImageIO.read(
-                           new ByteArrayInputStream(imageBytes));
+                        BufferedImage decoded = ImageIO.read(new ByteArrayInputStream(imageBytes));
+
                         if(decoded != null && decoded.getWidth() > 1 && decoded.getHeight() > 1) {
-                           result.setSvg("data:image/png;base64," +
-                              Base64.getEncoder().encodeToString(imageBytes));
-                           use1x1Fallback = false;
+                           thumbnailValue = "data:image/png;base64," +
+                              Base64.getEncoder().encodeToString(imageBytes);
                         }
                      }
-                     catch(Exception ignored) { /* fall through to fallback */ }
-
-                     if(use1x1Fallback) {
-                        result.setSvg(renderTableThumbnail(
-                           runtimeId, event.getAssemblyName(), principal));
+                     catch(Exception e) {
+                        LOG.debug("Failed to decode PNG for '{}', trying fallback: {}",
+                                  event.getAssemblyName(), e.getMessage());
                      }
+
+                     if(thumbnailValue == null) {
+                        thumbnailValue = renderTableThumbnail(
+                           runtimeId, event.getAssemblyName(), principal);
+                     }
+
+                     result.setThumbnail(thumbnailValue);
                   }
                   else {
-                     result.setSvg(normalizeSvgNamespace(
+                     result.setThumbnail(normalizeSvgNamespace(
                         new String(imageBytes, StandardCharsets.UTF_8)));
                   }
                }
             }
          }
          catch(Exception e) {
-            LOG.warn("Failed to generate SVG thumbnail for assembly '{}' (non-fatal): {}",
+            LOG.warn("Failed to generate thumbnail for assembly '{}' (non-fatal): {}",
                      event.getAssemblyName(), e.getMessage());
          }
       }
@@ -503,7 +507,7 @@ public class WizVisualizationService {
 
          Point offset = assembly.getPixelOffset();
          Dimension size = assembly.getPixelSize();
-         LOG.info("renderTableThumbnail: assembly='{}' offset={} size={}", assemblyName, offset, size);
+         LOG.debug("renderTableThumbnail: assembly='{}' offset={} size={}", assemblyName, offset, size);
 
          if(size == null || size.width <= 0 || size.height <= 0) {
             LOG.warn("renderTableThumbnail: invalid size {} for assembly '{}'", size, assemblyName);
@@ -519,8 +523,8 @@ public class WizVisualizationService {
             new ExportResponse(baos), principal);
 
          byte[] pngBytes = baos.toByteArray();
-         LOG.info("renderTableThumbnail: export produced {} bytes for assembly '{}'",
-                  pngBytes.length, assemblyName);
+         LOG.debug("renderTableThumbnail: export produced {} bytes for assembly '{}'",
+                   pngBytes.length, assemblyName);
 
          if(pngBytes.length == 0) {
             LOG.warn("renderTableThumbnail: exportViewsheet produced 0 bytes for assembly '{}'", assemblyName);
@@ -534,10 +538,10 @@ public class WizVisualizationService {
             return null;
          }
 
-         LOG.info("renderTableThumbnail: full image {}x{}, crop at ({},{}) size {}x{}",
-                  full.getWidth(), full.getHeight(),
-                  offset != null ? offset.x : 0, offset != null ? offset.y : 0,
-                  size.width, size.height);
+         LOG.debug("renderTableThumbnail: full image {}x{}, crop at ({},{}) size {}x{}",
+                   full.getWidth(), full.getHeight(),
+                   offset != null ? offset.x : 0, offset != null ? offset.y : 0,
+                   size.width, size.height);
 
          // Crop to assembly bounds (PNGCoordinateHelper renders at 1:1 pixel scale)
          int cropX = Math.max(0, offset != null ? offset.x : 0);
@@ -561,8 +565,8 @@ public class WizVisualizationService {
             return null;
          }
 
-         LOG.info("renderTableThumbnail: success, cropped PNG {} bytes for assembly '{}'",
-                  croppedBytes.length, assemblyName);
+         LOG.debug("renderTableThumbnail: success, cropped PNG {} bytes for assembly '{}'",
+                   croppedBytes.length, assemblyName);
          return "data:image/png;base64," + Base64.getEncoder().encodeToString(croppedBytes);
       }
       catch(Exception e) {
@@ -573,24 +577,26 @@ public class WizVisualizationService {
    }
 
    /**
-    * Removes custom XML namespace prefixes (e.g. "a0:") added by the Batik SVG generator
+    * Removes the first custom XML namespace prefix (e.g. "a0:") added by the Batik SVG generator
     * so the resulting SVG can be rendered directly by browsers.
     *
     * Batik generates: {@code <a0:svg xmlns:a0="http://www.w3.org/2000/svg">}
     * Browser requires: {@code <svg xmlns="http://www.w3.org/2000/svg">}
+    *
+    * <p>Note: only the first xmlns: prefix is stripped. Additional Batik prefixes (e.g. xlink:)
+    * are not removed. This is sufficient for the chart SVG output validated against Batik 1.17.
+    *
+    * <p>Note: String.replace is a literal full-text replacement, not XML-aware. An attribute value
+    * or text node containing the literal prefix string (e.g. "&lt;a0:") would be incorrectly
+    * mutated. This is not expected in normal Batik chart output.
     */
    private static String normalizeSvgNamespace(String svg) {
       if(svg == null || !svg.contains("xmlns:")) {
          return svg;
       }
 
-      // Locate "xmlns:PREFIX=" — the prefix sits between "xmlns:" and the "=" sign
+      // nsIdx >= 0 is guaranteed by the contains("xmlns:") guard above
       int nsIdx = svg.indexOf("xmlns:");
-
-      if(nsIdx < 0) {
-         return svg;
-      }
-
       int eqIdx = svg.indexOf('=', nsIdx + 6); // skip past "xmlns:" itself
 
       if(eqIdx < 0) {
@@ -618,4 +624,6 @@ public class WizVisualizationService {
    private final BinaryTransferService binaryTransferService;
    private final VSExportService vsExportService;
    private static final Logger LOG = LoggerFactory.getLogger(WizVisualizationService.class);
+   private static final int THUMBNAIL_WIDTH  = 400;
+   private static final int THUMBNAIL_HEIGHT = 300;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -238,7 +238,11 @@ public class WizVisualizationService {
                   THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT,
                   true, principal);
 
-            if(imgResult != null && imgResult.getImageData() != null) {
+            if(imgResult != null && imgResult.getRetryAfter() > 0) {
+               LOG.debug("downloadAssemblyImage not yet ready for '{}' (retryAfter={}), skipping thumbnail",
+                         event.getAssemblyName(), imgResult.getRetryAfter());
+            }
+            else if(imgResult != null && imgResult.getImageData() != null) {
                byte[] imageBytes = binaryTransferService.getData(imgResult.getImageData());
 
                if(imageBytes != null && imageBytes.length > 0) {
@@ -263,7 +267,7 @@ public class WizVisualizationService {
                      if(thumbnailValue == null) {
                         LOG.debug("PNG was 1×1 or undecodable for '{}', using full-viewsheet fallback",
                                   event.getAssemblyName());
-                        thumbnailValue = renderTableThumbnail(
+                        thumbnailValue = renderFallbackThumbnail(
                            runtimeId, event.getAssemblyName(), principal);
                      }
 
@@ -485,36 +489,36 @@ public class WizVisualizationService {
     * Used as a fallback for assembly types (Crosstab, Table) that downloadAssemblyImage
     * does not support — those return a 1×1 placeholder PNG instead of real content.
     */
-   private String renderTableThumbnail(String runtimeId, String assemblyName, Principal principal) {
+   private String renderFallbackThumbnail(String runtimeId, String assemblyName, Principal principal) {
       try {
          RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
 
          if(rvs == null) {
-            LOG.warn("renderTableThumbnail: RuntimeViewsheet not found for id='{}'", runtimeId);
+            LOG.warn("renderFallbackThumbnail: RuntimeViewsheet not found for id='{}'", runtimeId);
             return null;
          }
 
          Viewsheet vs = rvs.getViewsheet();
 
          if(vs == null) {
-            LOG.warn("renderTableThumbnail: Viewsheet is null for id='{}'", runtimeId);
+            LOG.warn("renderFallbackThumbnail: Viewsheet is null for id='{}'", runtimeId);
             return null;
          }
 
          Assembly assembly = vs.getAssembly(assemblyName);
 
          if(!(assembly instanceof VSAssembly)) {
-            LOG.warn("renderTableThumbnail: assembly '{}' not found or not VSAssembly (type={})",
+            LOG.warn("renderFallbackThumbnail: assembly '{}' not found or not VSAssembly (type={})",
                      assemblyName, assembly == null ? "null" : assembly.getClass().getSimpleName());
             return null;
          }
 
          Point offset = assembly.getPixelOffset();
          Dimension size = assembly.getPixelSize();
-         LOG.debug("renderTableThumbnail: assembly='{}' offset={} size={}", assemblyName, offset, size);
+         LOG.debug("renderFallbackThumbnail: assembly='{}' offset={} size={}", assemblyName, offset, size);
 
          if(size == null || size.width <= 0 || size.height <= 0) {
-            LOG.warn("renderTableThumbnail: invalid size {} for assembly '{}'", size, assemblyName);
+            LOG.warn("renderFallbackThumbnail: invalid size {} for assembly '{}'", size, assemblyName);
             return null;
          }
 
@@ -527,22 +531,22 @@ public class WizVisualizationService {
             new ExportResponse(baos), principal);
 
          byte[] pngBytes = baos.toByteArray();
-         LOG.debug("renderTableThumbnail: export produced {} bytes for assembly '{}'",
+         LOG.debug("renderFallbackThumbnail: export produced {} bytes for assembly '{}'",
                    pngBytes.length, assemblyName);
 
          if(pngBytes.length == 0) {
-            LOG.warn("renderTableThumbnail: exportViewsheet produced 0 bytes for assembly '{}'", assemblyName);
+            LOG.warn("renderFallbackThumbnail: exportViewsheet produced 0 bytes for assembly '{}'", assemblyName);
             return null;
          }
 
          BufferedImage full = ImageIO.read(new ByteArrayInputStream(pngBytes));
 
          if(full == null) {
-            LOG.warn("renderTableThumbnail: ImageIO.read returned null for assembly '{}'", assemblyName);
+            LOG.warn("renderFallbackThumbnail: ImageIO.read returned null for assembly '{}'", assemblyName);
             return null;
          }
 
-         LOG.debug("renderTableThumbnail: full image {}x{}, crop at ({},{}) size {}x{}",
+         LOG.debug("renderFallbackThumbnail: full image {}x{}, crop at ({},{}) size {}x{}",
                    full.getWidth(), full.getHeight(),
                    offset != null ? offset.x : 0, offset != null ? offset.y : 0,
                    size.width, size.height);
@@ -554,7 +558,7 @@ public class WizVisualizationService {
          int cropH = Math.min(size.height, full.getHeight() - cropY);
 
          if(cropW <= 1 || cropH <= 1) {
-            LOG.warn("renderTableThumbnail: crop dimensions too small ({}x{}) for assembly '{}'",
+            LOG.warn("renderFallbackThumbnail: crop dimensions too small ({}x{}) for assembly '{}'",
                      cropW, cropH, assemblyName);
             return null;
          }
@@ -577,7 +581,7 @@ public class WizVisualizationService {
             }
             cropped = scaled;
 
-            LOG.debug("renderTableThumbnail: scaled crop from {}x{} to {}x{}", cropW, cropH, scaledW, scaledH);
+            LOG.debug("renderFallbackThumbnail: scaled crop from {}x{} to {}x{}", cropW, cropH, scaledW, scaledH);
          }
 
          ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -585,21 +589,21 @@ public class WizVisualizationService {
          byte[] croppedBytes = out.toByteArray();
 
          if(croppedBytes.length == 0) {
-            LOG.warn("renderTableThumbnail: re-encoded PNG is empty for assembly '{}'", assemblyName);
+            LOG.warn("renderFallbackThumbnail: re-encoded PNG is empty for assembly '{}'", assemblyName);
             return null;
          }
 
-         LOG.debug("renderTableThumbnail: success, cropped PNG {} bytes for assembly '{}'",
+         LOG.debug("renderFallbackThumbnail: success, cropped PNG {} bytes for assembly '{}'",
                    croppedBytes.length, assemblyName);
          return "data:image/png;base64," + Base64.getEncoder().encodeToString(croppedBytes);
       }
       catch(OutOfMemoryError oom) {
-         LOG.warn("renderTableThumbnail: out of memory for assembly '{}', skipping thumbnail",
+         LOG.warn("renderFallbackThumbnail: out of memory for assembly '{}', skipping thumbnail",
                   assemblyName);
          return null;
       }
       catch(Exception e) {
-         LOG.warn("renderTableThumbnail: exception for assembly '{}': {}",
+         LOG.warn("renderFallbackThumbnail: exception for assembly '{}': {}",
                   assemblyName, e.getMessage(), e);
          return null;
       }
@@ -618,6 +622,10 @@ public class WizVisualizationService {
     * <p>Note: String.replace is a literal full-text replacement, not XML-aware. An attribute value
     * or text node containing the literal prefix string (e.g. "&lt;a0:") would be incorrectly
     * mutated. This is not expected in normal Batik chart output.
+    *
+    * <p>Note: only element start/end tags are de-prefixed. Attributes carrying the same namespace
+    * prefix (e.g. {@code a0:fill="..."}) are not stripped. Batik does not apply the SVG namespace
+    * prefix to attribute names, so this is not an issue in practice.
     */
    private static String normalizeSvgNamespace(String svg) {
       if(svg == null || !svg.contains("xmlns:")) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -49,6 +49,9 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 @Service
 public class WizVisualizationService {
@@ -232,6 +235,9 @@ public class WizVisualizationService {
 
       if(!Tool.isEmptyString(runtimeId)) {
          try {
+            CompletableFuture.runAsync(() -> {
+
+            try {
             // Fetch once: validates ownership (prevents cross-session access) and
             // is reused for the fallback path, avoiding redundant lookups.
             RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
@@ -313,8 +319,18 @@ public class WizVisualizationService {
                }
             }
          }
+            catch(Exception e) {
+               LOG.warn("Failed to generate thumbnail for assembly '{}' (non-fatal): {}",
+                        event.getAssemblyName(), e.getMessage());
+            }
+            }).get(THUMBNAIL_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+         }
+         catch(TimeoutException te) {
+            LOG.debug("Thumbnail generation timed out after {}s for assembly '{}'",
+                      THUMBNAIL_TIMEOUT_SECONDS, event.getAssemblyName());
+         }
          catch(Exception e) {
-            LOG.warn("Failed to generate thumbnail for assembly '{}' (non-fatal): {}",
+            LOG.warn("Thumbnail future failed for assembly '{}' (non-fatal): {}",
                      event.getAssemblyName(), e.getMessage());
          }
       }
@@ -682,10 +698,21 @@ public class WizVisualizationService {
             continue;
          }
 
-         // Only normalize when this declaration's value is the SVG namespace URI
-         String afterEq = svg.substring(eqIdx + 1).stripLeading();
+         // Only normalize when this declaration's value is the SVG namespace URI.
+         // Avoid substring allocation by scanning the position directly.
+         int valStart = eqIdx + 1;
 
-         if(!afterEq.startsWith("\"" + SVG_NS + "\"") && !afterEq.startsWith("'" + SVG_NS + "'")) {
+         while(valStart < svg.length() && Character.isWhitespace(svg.charAt(valStart))) {
+            valStart++;
+         }
+
+         char quote = valStart < svg.length() ? svg.charAt(valStart) : 0;
+         boolean matchesSvgNs = (quote == '"' || quote == '\'') &&
+            svg.startsWith(SVG_NS, valStart + 1) &&
+            valStart + 1 + SVG_NS.length() < svg.length() &&
+            svg.charAt(valStart + 1 + SVG_NS.length()) == quote;
+
+         if(!matchesSvgNs) {
             searchFrom = nsIdx + 1;
             continue;
          }
@@ -714,4 +741,6 @@ public class WizVisualizationService {
    private static final int MAX_PNG_THUMBNAIL_BYTES = 256 * 1024;
    /** Skip the full-viewsheet fallback export for viewsheets with many assemblies. */
    private static final int MAX_ASSEMBLIES_FOR_FALLBACK_THUMBNAIL = 50;
+   /** Maximum wall-clock seconds to spend on thumbnail generation before returning the save result. */
+   private static final long THUMBNAIL_TIMEOUT_SECONDS = 2;
 }


### PR DESCRIPTION
Add thumbnail generation logic after `saveViewsheet()` completes — prioritize calling `AssemblyImageService.downloadAssemblyImage()` to obtain SVG or PNG; if a 1×1 placeholder image is returned (indicating unsupported types such as Table or Crosstab), fall back to using `VSExportService.exportViewsheet()` to export the entire Viewsheet as PNG, then crop the corresponding area based on the Assembly's pixel coordinates; SVG results must also be processed through `normalizeSvgNamespace()` to remove Batik-generated custom namespace prefixes, ensuring the browser can render them directly. The entire thumbnail generation process should be wrapped in a try-catch block, with failures not affecting the main save workflow.