### PR TITLE
for wiz, use vs wizard auto binding.

### DIFF
--- a/core/src/main/java/inetsoft/web/vswizard/recommender/WizardRecommenderUtil.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/WizardRecommenderUtil.java
@@ -959,6 +959,22 @@ public final class WizardRecommenderUtil {
       }
    }
 
+   /**
+    * Returns the field name used as a lookup key for a chart ref.
+    * Handles dimension (groupColumnValue), aggregate (columnValue), and generic (attribute) refs.
+    */
+   public static String getChartRefFieldName(DataRef ref) {
+      if(ref instanceof VSChartDimensionRef dim) {
+         return dim.getGroupColumnValue();
+      }
+
+      if(ref instanceof VSChartAggregateRef agg) {
+         return agg.getColumnValue();
+      }
+
+      return ref != null ? ref.getAttribute() : null;
+   }
+
    private static final String CHILDREN_FLAG = "__children__";
    private static final String CHILDREN_SPLITER = "__:::::__";
    private static final String DEPENDENCY_CHECKED = "__dependency_checked__";

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartCombinationUtil.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartCombinationUtil.java
@@ -54,8 +54,6 @@ public class ChartCombinationUtil {
       ChartRef[] aggs = temp.getYFields();
       int n = groups.length + aggs.length;
 
-      // sanity check. the thread should never reach here (see ChartRecommenderUtil.isTableOnly).
-      // if the n is large, it could cause OOM. (42284)
       if(n > 10) {
          LOG.error("Number of columns exceeds chart limit: " + n + " x: " +
                       Arrays.toString(groups) + " y: " + Arrays.toString(aggs));
@@ -64,9 +62,67 @@ public class ChartCombinationUtil {
 
       List<List<ChartRef>> hgroup = getHierarchy(entries, temp);
       List<ChartTypeFilter> filters = createFilters(entries, temp, hgroup, geoCols, autoOrder);
-      List<ChartInfo> infos = getChartInfos(n, filters);
+      return getChartInfos(n, filters);
+   }
 
-      return infos;
+   /**
+    * Preference-aware variant: each filter selects its best candidate using slot-field bonuses
+    * from {@code pref} before the global score sort.
+    * Returns a {@link ChartInfosResult} that carries both the sorted infos list and the score
+    * map, so the caller can make score-based primary selection without relying solely on list order.
+    */
+   public static ChartInfosResult getChartInfosWithScores(AssetEntry[] entries, VSChartInfo temp,
+                                                          ColumnSelection geoCols, boolean autoOrder,
+                                                          ChartPreference pref)
+   {
+      ChartRef[] groups = temp.getXFields();
+      ChartRef[] aggs = temp.getYFields();
+      int n = groups.length + aggs.length;
+
+      if(n > 10) {
+         LOG.error("Number of columns exceeds chart limit: " + n + " x: " +
+                      Arrays.toString(groups) + " y: " + Arrays.toString(aggs));
+         return new ChartInfosResult(Collections.emptyList(), null);
+      }
+
+      List<List<ChartRef>> hgroup = getHierarchy(entries, temp);
+      List<ChartTypeFilter> filters = createFilters(entries, temp, hgroup, geoCols, autoOrder);
+      return getChartInfosWithScores(n, filters, pref);
+   }
+
+   /**
+    * Carries a ChartInfo together with its preference-adjusted score.
+    */
+   public static class ScoredInfo {
+      public ScoredInfo(ChartInfo info, int score) {
+         this.info = info;
+         this.score = score;
+      }
+
+      public ChartInfo getInfo() { return info; }
+      public int getScore() { return score; }
+
+      private final ChartInfo info;
+      private final int score;
+   }
+
+   /**
+    * Carries the recommendation result:
+    * {@code infos} — sorted by base data-score (for the recommendations list);
+    * {@code prefInfos} — sorted by preference-adjusted score (for primary selection), or
+    * {@code null} when no preference was supplied.
+    */
+   public static class ChartInfosResult {
+      public ChartInfosResult(List<ChartInfo> infos, List<ScoredInfo> prefInfos) {
+         this.infos = infos;
+         this.prefInfos = prefInfos;
+      }
+
+      public List<ChartInfo> getInfos() { return infos; }
+      public List<ScoredInfo> getPrefInfos() { return prefInfos; }
+
+      private final List<ChartInfo> infos;
+      private final List<ScoredInfo> prefInfos;
    }
 
    public static List<List<ChartRef>> getHierarchy(AssetEntry[] entries, VSChartInfo temp) {
@@ -135,24 +191,47 @@ public class ChartCombinationUtil {
     * it will return strings such as: 003, 012, 021....
     */
    private static List<ChartInfo> getChartInfos(int n, List<ChartTypeFilter> filters) {
+      return getChartInfosWithScores(n, filters, null).getInfos();
+   }
+
+   private static ChartInfosResult getChartInfosWithScores(int n, List<ChartTypeFilter> filters,
+                                                            ChartPreference pref)
+   {
       getChartCombination(n, filters);
 
-      List<ChartInfo> allInfos = new ArrayList<>();
-      Map<Integer, Integer> scores = new HashMap<>();
+      List<ChartInfo> allDefaultInfos = new ArrayList<>();
+      List<ScoredInfo> allPrefInfos = pref != null ? new ArrayList<>() : null;
+      Map<Integer, Integer> baseScores = new HashMap<>();
 
-      // Filter infos in every styles at first, then score for the filtered infos.
       filters.forEach(f -> {
-         List<ChartInfo> charts = f.filter();
-         scores.putAll(f.getScores());
-         charts = charts.stream()
-            .filter(chartInfo -> GraphTypeUtil.checkChartStylePermission(chartInfo.getChartType()))
-            .collect(Collectors.toList());
-         allInfos.addAll(charts);
+         if(pref != null) {
+            ChartTypeFilter.FilterResult result = f.filterWithPreference(pref);
+            baseScores.putAll(f.getScores());
+
+            result.defaultRanked.stream()
+               .filter(ci -> GraphTypeUtil.checkChartStylePermission(ci.getChartType()))
+               .forEach(ci -> allDefaultInfos.add(ci));
+
+            result.prefRanked.stream()
+               .filter(si -> GraphTypeUtil.checkChartStylePermission(si.getInfo().getChartType()))
+               .forEach(si -> allPrefInfos.add(si));
+         }
+         else {
+            List<ChartInfo> charts = f.filter();
+            baseScores.putAll(f.getScores());
+            charts.stream()
+               .filter(ci -> GraphTypeUtil.checkChartStylePermission(ci.getChartType()))
+               .forEach(ci -> allDefaultInfos.add(ci));
+         }
       });
 
-      Collections.sort(allInfos, new VSChartScoreComparator(scores));
+      allDefaultInfos.sort(new VSChartScoreComparator(baseScores));
 
-      return allInfos;
+      if(allPrefInfos != null) {
+         allPrefInfos.sort(Comparator.comparingInt(ScoredInfo::getScore).reversed());
+      }
+
+      return new ChartInfosResult(allDefaultInfos, allPrefInfos);
    }
 
    private static void getChartCombination(int n, List<ChartTypeFilter> filters) {

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartPreference.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartPreference.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.vswizard.recommender.chart;
+
+import java.util.*;
+
+/**
+ * Carries the user's slot-field preferences for chart recommendation.
+ * Keys are slot names ("x", "y", "group", "color", "shape", "size", "text");
+ * values are the set of field names the user wants in that slot.
+ */
+public class ChartPreference {
+   public ChartPreference(Map<String, Set<String>> slotFields) {
+      this.slotFields = slotFields != null ? slotFields : Collections.emptyMap();
+   }
+
+   public Map<String, Set<String>> getSlotFields() {
+      return slotFields;
+   }
+
+   public boolean isEmpty() {
+      return slotFields.isEmpty();
+   }
+
+   private final Map<String, Set<String>> slotFields;
+}

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartTypeFilter.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartTypeFilter.java
@@ -21,11 +21,13 @@ import inetsoft.util.data.CommonKVModel;
 import inetsoft.report.composition.graph.GraphUtil;
 import inetsoft.uql.asset.AggregateFormula;
 import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.viewsheet.VSDimensionRef;
 import inetsoft.uql.viewsheet.graph.*;
 import inetsoft.uql.viewsheet.graph.aesthetic.StaticSizeFrameWrapper;
 import inetsoft.web.vswizard.recommender.ChartRecommenderUtil;
+import inetsoft.web.vswizard.recommender.WizardRecommenderUtil;
 import inetsoft.web.vswizard.recommender.object.VSChartScoreComparator;
 import it.unimi.dsi.fastutil.ints.IntList;
 
@@ -89,6 +91,97 @@ public class ChartTypeFilter {
       Collections.sort(infos, scoreComp);
 
       return infos.stream().limit(getStyleCount()).collect(Collectors.toList());
+   }
+
+   /**
+    * Produces both the default-ranked list (base data-score) and a preference-ranked list
+    * (base score + slot-match bonuses) in a single pass.
+    * The {@link FilterResult#defaultRanked} list mirrors what {@link #filter()} returns and
+    * is used to build the recommendations list. The {@link FilterResult#prefRanked} list is
+    * used only for primary visualization selection.
+    */
+   FilterResult filterWithPreference(ChartPreference pref) {
+      List<ChartInfo> defaultList = filter();
+
+      if(pref == null || pref.isEmpty() || infos.isEmpty()) {
+         return new FilterResult(defaultList, Collections.emptyList());
+      }
+
+      Map<String, Set<String>> slotFields = pref.getSlotFields();
+      Map<Integer, Integer> adjustedScores = new HashMap<>(scores);
+
+      for(ChartInfo info : infos) {
+         int bonus = computePreferenceBonus((VSChartInfo) info, slotFields);
+
+         if(bonus > 0) {
+            adjustedScores.merge(info.hashCode(), bonus * PREFERENCE_SLOT_BONUS, Integer::sum);
+         }
+      }
+
+      List<ChartInfo> prefSorted = new ArrayList<>(infos);
+      prefSorted.sort(new VSChartScoreComparator(adjustedScores));
+
+      List<ChartCombinationUtil.ScoredInfo> prefRanked = prefSorted.stream()
+         .limit(getStyleCount())
+         .map(ci -> new ChartCombinationUtil.ScoredInfo(
+            ci, adjustedScores.getOrDefault(ci.hashCode(), 0)))
+         .collect(Collectors.toList());
+
+      return new FilterResult(defaultList, prefRanked);
+   }
+
+   static class FilterResult {
+      FilterResult(List<ChartInfo> defaultRanked, List<ChartCombinationUtil.ScoredInfo> prefRanked) {
+         this.defaultRanked = defaultRanked;
+         this.prefRanked = prefRanked;
+      }
+
+      final List<ChartInfo> defaultRanked;
+      final List<ChartCombinationUtil.ScoredInfo> prefRanked;
+   }
+
+   // score bonus per matched slot when selecting the primary recommendation
+   protected static final int PREFERENCE_SLOT_BONUS = 5;
+
+   private int computePreferenceBonus(VSChartInfo info, Map<String, Set<String>> slotFields) {
+      int bonus = 0;
+      bonus += countSlotMatches(info.getXFields(), slotFields.get("x"));
+      bonus += countSlotMatches(info.getYFields(), slotFields.get("y"));
+      bonus += countSlotMatches(info.getGroupFields(), slotFields.get("group"));
+      bonus += countAestheticMatch(info.getColorField(), slotFields.get("color"));
+      bonus += countAestheticMatch(info.getShapeField(), slotFields.get("shape"));
+      bonus += countAestheticMatch(info.getSizeField(), slotFields.get("size"));
+      bonus += countAestheticMatch(info.getTextField(), slotFields.get("text"));
+      return bonus;
+   }
+
+   private int countSlotMatches(ChartRef[] refs, Set<String> preferred) {
+      if(refs == null || preferred == null || preferred.isEmpty()) {
+         return 0;
+      }
+
+      int count = 0;
+
+      for(ChartRef ref : refs) {
+         if(preferred.contains(getRefFieldName(ref))) {
+            count++;
+         }
+      }
+
+      return count;
+   }
+
+   private int countAestheticMatch(AestheticRef aesthetic, Set<String> preferred) {
+      if(aesthetic == null || preferred == null || preferred.isEmpty()) {
+         return 0;
+      }
+
+      DataRef dataRef = aesthetic.getDataRef();
+      return dataRef != null && preferred.contains(getRefFieldName(dataRef)) ? 1 : 0;
+   }
+
+   private String getRefFieldName(DataRef ref) {
+      return WizardRecommenderUtil.getChartRefFieldName(ref);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartTypeFilter.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartTypeFilter.java
@@ -100,7 +100,7 @@ public class ChartTypeFilter {
     * is used to build the recommendations list. The {@link FilterResult#prefRanked} list is
     * used only for primary visualization selection.
     */
-   FilterResult filterWithPreference(ChartPreference pref) {
+   protected FilterResult filterWithPreference(ChartPreference pref) {
       List<ChartInfo> defaultList = filter();
 
       if(pref == null || pref.isEmpty() || infos.isEmpty()) {

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/object/VSObjectRecommendationFactory.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/object/VSObjectRecommendationFactory.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.vswizard.recommender.object;
 
+import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.web.vswizard.model.VSWizardData;
 import inetsoft.web.vswizard.model.recommender.VSObjectRecommendation;
 
@@ -27,4 +28,13 @@ public interface VSObjectRecommendationFactory<M extends VSObjectRecommendation>
     * Return the VSRecommendObject list for target selections.
     */
    M recommend(VSWizardData wizardData, Principal principal);
+
+   /**
+    * Variant that accepts a pre-fetched {@link RuntimeViewsheet}.
+    * Implementations may use it to avoid a second lookup; the default delegates to
+    * {@link #recommend(VSWizardData, Principal)} with a null principal.
+    */
+   default M recommend(VSWizardData wizardData, RuntimeViewsheet rvs, Principal principal) {
+      return recommend(wizardData, principal);
+   }
 }

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/object/VSTableRecommendationFactory.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/object/VSTableRecommendationFactory.java
@@ -46,17 +46,24 @@ public class VSTableRecommendationFactory implements VSObjectRecommendationFacto
 
    @Override
    public VSTableRecommendation recommend(VSWizardData wizardData, Principal principal) {
-      VSTableRecommendation tableRecommendation = new VSTableRecommendation();
-      tableRecommendation.setColumns(createColumnSelection(wizardData.getSelectedEntries(),
-         principal));
+      return buildRecommendation(wizardData, getRuntimeViewsheet(principal));
+   }
 
+   @Override
+   public VSTableRecommendation recommend(VSWizardData wizardData, RuntimeViewsheet rvs,
+                                          Principal principal)
+   {
+      return buildRecommendation(wizardData, rvs);
+   }
+
+   private VSTableRecommendation buildRecommendation(VSWizardData wizardData, RuntimeViewsheet rvs) {
+      VSTableRecommendation tableRecommendation = new VSTableRecommendation();
+      tableRecommendation.setColumns(createColumnSelection(wizardData.getSelectedEntries(), rvs));
       return tableRecommendation;
    }
 
-   private ColumnSelection createColumnSelection(AssetEntry[] entries, Principal principal) {
-      RuntimeViewsheet rvs = getRuntimeViewsheet(principal);
-
-      if(entries == null || entries.length < 1 || rvs == null) {
+   private ColumnSelection createColumnSelection(AssetEntry[] entries, RuntimeViewsheet rvs) {
+      if(entries == null || entries.length < 1) {
          return null;
       }
 
@@ -66,7 +73,7 @@ public class VSTableRecommendationFactory implements VSObjectRecommendationFacto
          ColumnRef columnRef = WizardRecommenderUtil.createColumnRef(entry);
 
          if(WizardRecommenderUtil.isDimension(entry) ||
-            !WizardRecommenderUtil.isCalcAggregateField(rvs, columnRef))
+            rvs == null || !WizardRecommenderUtil.isCalcAggregateField(rvs, columnRef))
          {
             columns.addAttribute(columnRef);
          }
@@ -78,7 +85,8 @@ public class VSTableRecommendationFactory implements VSObjectRecommendationFacto
    private RuntimeViewsheet getRuntimeViewsheet(Principal principal) {
       try {
          return viewsheetService.getViewsheet(runtimeViewsheetRef.getRuntimeId(), principal);
-      } catch (Exception ex) {
+      }
+      catch(Exception ex) {
          LOG.error("Failed to get viewsheet", ex);
          return null;
       }

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
@@ -18,8 +18,8 @@
 
 package inetsoft.web.wiz.controller;
 
-import inetsoft.web.wiz.model.CreateVisualizationModel;
-import inetsoft.web.wiz.model.CreateViewsheetResult;
+import inetsoft.web.wiz.model.*;
+import inetsoft.web.wiz.service.WizAutoBindingService;
 import inetsoft.web.wiz.service.WizVsService;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -29,8 +29,11 @@ import java.security.Principal;
 @RestController
 @RequestMapping("/api/wiz")
 public class WizViewsheetController {
-   public WizViewsheetController(WizVsService wizVsService) {
+   public WizViewsheetController(WizVsService wizVsService,
+                                  WizAutoBindingService wizAutoBindingService)
+   {
       this.wizVsService = wizVsService;
+      this.wizAutoBindingService = wizAutoBindingService;
    }
 
    @PostMapping(value = "/viewsheet/create", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -47,6 +50,13 @@ public class WizViewsheetController {
       wizVsService.validateBinding(model, user);
    }
 
+   @PostMapping(value = "/viewsheet/autoBinding", produces = MediaType.APPLICATION_JSON_VALUE)
+   public AutoBindingResponse autoBinding(@RequestBody AutoBindingRequest request,
+                                          Principal user) throws Exception
+   {
+      return wizAutoBindingService.autoBinding(request, user);
+   }
+
    @DeleteMapping("/viewsheet")
    public void deleteViewsheet(@RequestParam("identifier") String identifier,
                                Principal user) throws Exception
@@ -55,4 +65,5 @@ public class WizViewsheetController {
    }
 
    private final WizVsService wizVsService;
+   private final WizAutoBindingService wizAutoBindingService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/AutoBindingRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/AutoBindingRequest.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * Request body for {@code POST /api/wiz/viewsheet/autoBinding}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AutoBindingRequest {
+   public String getWorksheetId() {
+      return worksheetId;
+   }
+
+   public void setWorksheetId(String worksheetId) {
+      this.worksheetId = worksheetId;
+   }
+
+   public String getVisualizationType() {
+      return visualizationType;
+   }
+
+   public void setVisualizationType(String visualizationType) {
+      this.visualizationType = visualizationType;
+   }
+
+   public List<SimpleFieldInfo> getFieldConfigs() {
+      return fieldConfigs;
+   }
+
+   public void setFieldConfigs(List<SimpleFieldInfo> fieldConfigs) {
+      this.fieldConfigs = fieldConfigs;
+   }
+
+   public List<ExplicitBinding> getExplicitBindings() {
+      return explicitBindings;
+   }
+
+   public void setExplicitBindings(List<ExplicitBinding> explicitBindings) {
+      this.explicitBindings = explicitBindings;
+   }
+
+   public String getIntentCategory() {
+      return intentCategory;
+   }
+
+   public void setIntentCategory(String intentCategory) {
+      this.intentCategory = intentCategory;
+   }
+
+   /** Worksheet global path, same as VisualizationConfig.data.source. */
+   private String worksheetId;
+   /** Expected visualization type string, e.g. "bar", "table", "crosstab", "gauge". */
+   private String visualizationType;
+   /**
+    * Per-field configurations from the LLM.
+    * Uses the existing {@link SimpleFieldInfo} polymorphic hierarchy:
+    * {@code fieldType:"dimension"} → {@link DimensionFieldInfo},
+    * {@code fieldType:"measure"} → {@link MeasureFieldInfo}.
+    */
+   private List<SimpleFieldInfo> fieldConfigs;
+   /** Optional explicit slot assignments; may be null or empty. */
+   private List<ExplicitBinding> explicitBindings;
+   /**
+    * Visualization intent category inferred by the LLM.
+    * One of: "comparison", "trend", "distribution", "proportion",
+    * "relationship", "ranking", "geospatial", "other".
+    */
+   private String intentCategory;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/AutoBindingResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/AutoBindingResponse.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import java.util.List;
+
+/**
+ * Response body for {@code POST /api/wiz/viewsheet/autoBinding}.
+ */
+public class AutoBindingResponse {
+   public List<RecommendedVisualization> getRecommendations() {
+      return recommendations;
+   }
+
+   public void setRecommendations(List<RecommendedVisualization> recommendations) {
+      this.recommendations = recommendations;
+   }
+
+   public RecommendedVisualization getPrimary() {
+      return primary;
+   }
+
+   public void setPrimary(RecommendedVisualization primary) {
+      this.primary = primary;
+   }
+
+   /** All candidate visualizations, charts ordered by vsWizard score followed by crosstab/table/output. */
+   private List<RecommendedVisualization> recommendations;
+   /** Best-fit visualization built from user preferences; null when no preference can be determined. */
+   private RecommendedVisualization primary;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/AutoBindingResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/AutoBindingResponse.java
@@ -39,7 +39,9 @@ public class AutoBindingResponse {
       this.primary = primary;
    }
 
-   /** All candidate visualizations, charts ordered by vsWizard score followed by crosstab/table/output. */
+   /** All candidate visualizations: charts ordered by vsWizard score, then table (always),
+    *  crosstab (only when both dimensions and measures are present),
+    *  and gauge (only when there is exactly one measure and no dimensions). */
    private List<RecommendedVisualization> recommendations;
    /** Best-fit visualization built from user preferences; null when no preference can be determined. */
    private RecommendedVisualization primary;

--- a/core/src/main/java/inetsoft/web/wiz/model/ExplicitBinding.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ExplicitBinding.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * An explicit field-to-slot assignment from the LLM, used to steer recommendation
+ * selection toward a ChartInfo whose slot assignment matches the user intent.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ExplicitBinding {
+   public String getRole() {
+      return role;
+   }
+
+   public void setRole(String role) {
+      this.role = role;
+   }
+
+   public String getField() {
+      return field;
+   }
+
+   public void setField(String field) {
+      this.field = field;
+   }
+
+   /** Chart slot name: "x", "y", "color", "shape", "size", "text", "group", "rows", "cols", "aggregates", "details" */
+   private String role;
+   /** Field name exactly as it appears in the data source. */
+   private String field;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/RecommendedVisualization.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/RecommendedVisualization.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+/**
+ * A single candidate visualization returned by {@code POST /api/wiz/viewsheet/autoBinding}.
+ */
+public class RecommendedVisualization {
+   public String getVisualizationType() {
+      return visualizationType;
+   }
+
+   public void setVisualizationType(String visualizationType) {
+      this.visualizationType = visualizationType;
+   }
+
+   public VisualizationConfig getConfig() {
+      return config;
+   }
+
+   public void setConfig(VisualizationConfig config) {
+      this.config = config;
+   }
+
+   /** Visualization type string, e.g. "bar", "line", "crosstab", "table". */
+   private String visualizationType;
+   /** Complete binding config; can be passed directly to createViewsheet. */
+   private VisualizationConfig config;
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -115,6 +115,7 @@ public class WizAutoBindingService {
          }
 
          Map<String, SimpleFieldInfo> configMap = fieldConfigs.stream()
+            .filter(f -> f != null && f.getField() != null)
             .collect(Collectors.toMap(SimpleFieldInfo::getField, f -> f, (a, b) -> a));
 
          // Convert all columns to AssetEntry[]; fieldConfigs only adds config overrides
@@ -388,13 +389,23 @@ public class WizAutoBindingService {
       }
 
       if(dimCount > 0 && measCount > 0) {
-         recs.add(buildCrosstabRecommendation(entries, worksheetId, tempInfo, user));
+         RecommendedVisualization crosstabRec =
+            buildCrosstabRecommendation(entries, worksheetId, tempInfo, user);
+
+         if(crosstabRec != null) {
+            recs.add(crosstabRec);
+         }
       }
 
       recs.add(buildTableRecommendation(entries, worksheetId, rvs, user));
 
       if(measCount == 1 && dimCount == 0) {
-         recs.add(buildOutputRecommendation(entries, worksheetId, tempInfo, user));
+         RecommendedVisualization outputRec =
+            buildOutputRecommendation(entries, worksheetId, tempInfo, user);
+
+         if(outputRec != null) {
+            recs.add(outputRec);
+         }
       }
 
       return recs;
@@ -747,15 +758,20 @@ public class WizAutoBindingService {
       Set<Integer> categoryTypes = intentCategory != null
          ? INTENT_CATEGORY_CHART_TYPES.get(intentCategory) : null;
 
+      ChartInfo highestScored = prefInfos.stream()
+         .max(Comparator.comparingInt(ChartCombinationUtil.ScoredInfo::getScore))
+         .map(ChartCombinationUtil.ScoredInfo::getInfo)
+         .orElse(null);
+
       if(categoryTypes != null && !categoryTypes.isEmpty()) {
          bestInfo = prefInfos.stream()
             .filter(si -> categoryTypes.contains(si.getInfo().getChartType()))
+            .max(Comparator.comparingInt(ChartCombinationUtil.ScoredInfo::getScore))
             .map(ChartCombinationUtil.ScoredInfo::getInfo)
-            .findFirst()
-            .orElse(prefInfos.get(0).getInfo());
+            .orElse(highestScored);
       }
       else {
-         bestInfo = prefInfos.get(0).getInfo();
+         bestInfo = highestScored;
       }
 
       return toRecommendedVisualization(bestInfo, worksheetId);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -195,6 +195,7 @@ public class WizAutoBindingService {
       AssetEntry entry = new AssetEntry(
          AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.COLUMN, path, null);
       entry.setProperty("assembly", tableName != null ? tableName : "");
+      entry.setProperty("attribute", colName);
 
       String dtype = col.getDataType() != null ? col.getDataType() : XSchema.STRING;
       entry.setProperty("dtype", dtype);
@@ -230,6 +231,7 @@ public class WizAutoBindingService {
       AssetEntry entry = new AssetEntry(
          AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.COLUMN, path, null);
       entry.setProperty("assembly", tableName != null ? tableName : "");
+      entry.setProperty("attribute", fieldName);
 
       String dtype = field.getType() != null ? field.getType() : XSchema.STRING;
       entry.setProperty("dtype", dtype);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -1,0 +1,918 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.*;
+import inetsoft.uql.asset.*;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.graph.*;
+import inetsoft.util.Tool;
+import inetsoft.web.vswizard.handler.VSWizardBindingHandler;
+import inetsoft.web.vswizard.model.VSWizardData;
+import inetsoft.web.vswizard.model.recommender.*;
+import inetsoft.web.vswizard.recommender.WizardRecommenderUtil;
+import inetsoft.web.vswizard.recommender.chart.ChartCombinationUtil;
+import inetsoft.web.vswizard.recommender.chart.ChartPreference;
+import inetsoft.web.vswizard.recommender.object.VSCrosstabDefaultRecommendationFactory;
+import inetsoft.web.vswizard.recommender.object.VSGaugeRecommendationFactory;
+import inetsoft.web.vswizard.recommender.object.VSTableRecommendationFactory;
+import inetsoft.web.vswizard.service.VSWizardTemporaryInfoService;
+import inetsoft.web.wiz.model.*;
+import inetsoft.web.wiz.model.BindingInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.awt.*;
+import java.security.Principal;
+import java.util.*;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class WizAutoBindingService {
+   public WizAutoBindingService(ViewsheetService viewsheetService,
+                                 AssetRepository engine,
+                                 VSWizardTemporaryInfoService temporaryInfoService,
+                                 VSWizardBindingHandler bindingHandler,
+                                 VSCrosstabDefaultRecommendationFactory crosstabFactory,
+                                 VSGaugeRecommendationFactory gaugeFactory,
+                                 VSTableRecommendationFactory tableFactory)
+   {
+      this.viewsheetService = viewsheetService;
+      this.engine = engine;
+      this.temporaryInfoService = temporaryInfoService;
+      this.bindingHandler = bindingHandler;
+      this.crosstabFactory = crosstabFactory;
+      this.gaugeFactory = gaugeFactory;
+      this.tableFactory = tableFactory;
+   }
+
+   public AutoBindingResponse autoBinding(AutoBindingRequest request, Principal user)
+      throws Exception
+   {
+      List<SimpleFieldInfo> fieldConfigs = request.getFieldConfigs() != null
+         ? request.getFieldConfigs() : Collections.emptyList();
+      String worksheetId = request.getWorksheetId();
+
+      Viewsheet.WizInfo wizInfo = new Viewsheet.WizInfo(true, null, null);
+      String runtimeId = viewsheetService.openTemporaryViewsheet(null, null, user, wizInfo);
+
+      try {
+         temporaryInfoService.initTemporary(runtimeId, user, new Point(0, 0));
+         RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, user);
+         VSTemporaryInfo tempInfo = rvs.getVSTemporaryInfo();
+
+         String tableName = null;
+         List<ColumnRef> worksheetColumns = new ArrayList<>();
+
+         if(!Tool.isEmptyString(worksheetId)) {
+            AssetEntry wsEntry = new AssetEntry(
+               AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, worksheetId, null);
+
+            try {
+               AbstractSheet sheet = engine.getSheet(wsEntry, user, true, AssetContent.ALL);
+
+               if(sheet instanceof Worksheet ws) {
+                  WSAssembly primary = ws.getPrimaryAssembly();
+
+                  if(primary instanceof TableAssembly ta) {
+                     tableName = primary.getName();
+                     ColumnSelection cs = ta.getColumnSelection();
+
+                     for(int i = 0; i < cs.getAttributeCount(); i++) {
+                        DataRef ref = cs.getAttribute(i);
+
+                        if(ref instanceof ColumnRef colRef) {
+                           worksheetColumns.add(colRef);
+                        }
+                     }
+                  }
+               }
+            }
+            catch(Exception e) {
+               LOG.warn("Failed to load worksheet '{}': {}", worksheetId, e.getMessage());
+            }
+         }
+
+         Map<String, SimpleFieldInfo> configMap = fieldConfigs.stream()
+            .collect(Collectors.toMap(SimpleFieldInfo::getField, f -> f, (a, b) -> a));
+
+         // Convert all columns to AssetEntry[]; fieldConfigs only adds config overrides
+         final String tableNameFinal = tableName;
+         AssetEntry[] entries;
+
+         if(!worksheetColumns.isEmpty()) {
+            // Primary path: use all worksheet columns (fieldConfigs as overlay only)
+            entries = worksheetColumns.stream()
+               .map(col -> buildEntryFromColumn(
+                  col, worksheetId, tableNameFinal, configMap.get(col.getAttribute())))
+               .toArray(AssetEntry[]::new);
+         }
+         else {
+            // Fallback: worksheet not available, use fieldConfigs directly
+            entries = fieldConfigs.stream()
+               .map(field -> buildEntryFromFieldInfo(field, worksheetId, tableNameFinal))
+               .toArray(AssetEntry[]::new);
+         }
+
+         bindingHandler.updateTemporaryFields(rvs, entries, tempInfo);
+
+         VSChartInfo tempChartInfo = tempInfo.getTempChart().getVSChartInfo();
+         applyFieldConfigs(tempChartInfo, configMap);
+
+         String vizType = request.getVisualizationType();
+         List<ExplicitBinding> explicitBindings = request.getExplicitBindings();
+         ChartPreference pref = buildChartPreference(explicitBindings);
+
+         // Single call: produces both the recommendations list (default-scored) and the
+         // preference-ranked infos for primary selection.
+         ChartCombinationUtil.ChartInfosResult chartResult =
+            buildChartInfos(entries, tempChartInfo, pref);
+
+         List<RecommendedVisualization> recommendations =
+            buildRecommendations(entries, worksheetId, chartResult, rvs, tempInfo, user);
+
+         List<ChartCombinationUtil.ScoredInfo> prefInfos =
+            chartResult != null ? chartResult.getPrefInfos() : null;
+
+         String intentCategory = request.getIntentCategory();
+         RecommendedVisualization primary = buildPrimaryVisualization(
+            recommendations, worksheetId, vizType,
+            explicitBindings, prefInfos, intentCategory);
+
+         AutoBindingResponse resp = new AutoBindingResponse();
+         resp.setRecommendations(recommendations);
+         resp.setPrimary(primary);
+         return resp;
+      }
+      finally {
+         try {
+            temporaryInfoService.destroyTemporary(runtimeId, user);
+         }
+         catch(Exception e) {
+            LOG.warn("Failed to destroy temp viewsheet info [{}]: {}", runtimeId, e.getMessage());
+         }
+
+         try {
+            viewsheetService.closeViewsheet(runtimeId, user);
+         }
+         catch(Exception e) {
+            LOG.warn("Failed to close temp viewsheet [{}]: {}", runtimeId, e.getMessage());
+         }
+      }
+   }
+
+   // ── AssetEntry building ──────────────────────────────────────────────────────
+
+   private AssetEntry buildEntryFromColumn(ColumnRef col, String wsPath, String tableName,
+                                            SimpleFieldInfo fc)
+   {
+      String colName = col.getAttribute();
+      String path = (wsPath != null && tableName != null)
+         ? wsPath + "/" + tableName + "/" + colName : colName;
+
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.COLUMN, path, null);
+      entry.setProperty("assembly", tableName != null ? tableName : "");
+
+      String dtype = col.getDataType() != null ? col.getDataType() : XSchema.STRING;
+      entry.setProperty("dtype", dtype);
+
+      String alias = col.getAlias();
+      entry.setProperty("caption", alias != null ? alias : colName);
+
+      // fieldConfig fieldType takes precedence over dtype inference (design doc §4.3)
+      boolean isMeasure;
+
+      if(fc instanceof MeasureFieldInfo) {
+         isMeasure = true;
+      }
+      else if(fc instanceof DimensionFieldInfo) {
+         isMeasure = false;
+      }
+      else {
+         isMeasure = XSchema.isNumericType(dtype) && !XSchema.isDateType(dtype);
+      }
+
+      setRefType(entry, isMeasure);
+      applyFieldConfigToEntry(entry, fc, isMeasure);
+      return entry;
+   }
+
+   private AssetEntry buildEntryFromFieldInfo(SimpleFieldInfo field, String wsPath,
+                                               String tableName)
+   {
+      String fieldName = field.getField();
+      String path = (wsPath != null && tableName != null)
+         ? wsPath + "/" + tableName + "/" + fieldName : fieldName;
+
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.COLUMN, path, null);
+      entry.setProperty("assembly", tableName != null ? tableName : "");
+
+      String dtype = field.getType() != null ? field.getType() : XSchema.STRING;
+      entry.setProperty("dtype", dtype);
+      entry.setProperty("caption", field.getTitle() != null ? field.getTitle() : fieldName);
+
+      boolean isMeasure = field instanceof MeasureFieldInfo;
+      setRefType(entry, isMeasure);
+      applyFieldConfigToEntry(entry, field, isMeasure);
+      return entry;
+   }
+
+   private void setRefType(AssetEntry entry, boolean isMeasure) {
+      if(isMeasure) {
+         // NONE(0) is correct: isDimension() checks for DIMENSION bit, so 0 → treated as measure
+         entry.setProperty("refType", "0");
+         entry.setProperty(AssetEntry.CUBE_COL_TYPE, String.valueOf(AssetEntry.MEASURES));
+      }
+      else {
+         entry.setProperty("refType", String.valueOf(DataRef.DIMENSION));
+         entry.setProperty(AssetEntry.CUBE_COL_TYPE, String.valueOf(AssetEntry.DIMENSIONS));
+      }
+   }
+
+   private void applyFieldConfigToEntry(AssetEntry entry, SimpleFieldInfo fc, boolean isMeasure) {
+      if(fc == null) {
+         return;
+      }
+
+      // propagate date level as "interval" property consumed by setDefaultDateLevel
+      if(!isMeasure && fc instanceof DimensionFieldInfo dim && dim.getDateGroupLevel() != null) {
+         int level = WizVsService.getDateGroupLevel(dim.getDateGroupLevel());
+         entry.setProperty("interval", String.valueOf(level));
+      }
+
+      if(isMeasure && fc instanceof MeasureFieldInfo mea && mea.getAggregateFormula() != null) {
+         entry.setProperty("formula", mea.getAggregateFormula());
+      }
+   }
+
+   // ── Apply fieldConfigs to generated ChartRefs ────────────────────────────────
+
+   private void applyFieldConfigs(VSChartInfo chartInfo, Map<String, SimpleFieldInfo> configMap) {
+      for(ChartRef ref : chartInfo.getXFields()) {
+         applyFieldConfig(ref, configMap);
+      }
+
+      for(ChartRef ref : chartInfo.getYFields()) {
+         applyFieldConfig(ref, configMap);
+      }
+
+      for(ChartRef ref : chartInfo.getGroupFields()) {
+         applyFieldConfig(ref, configMap);
+      }
+
+      applyAestheticFieldConfig(chartInfo.getColorField(), configMap);
+      applyAestheticFieldConfig(chartInfo.getSizeField(), configMap);
+      applyAestheticFieldConfig(chartInfo.getShapeField(), configMap);
+      applyAestheticFieldConfig(chartInfo.getTextField(), configMap);
+   }
+
+   private void applyAestheticFieldConfig(AestheticRef aestheticRef,
+                                           Map<String, SimpleFieldInfo> configMap)
+   {
+      if(aestheticRef != null && aestheticRef.getDataRef() instanceof ChartRef ref) {
+         applyFieldConfig(ref, configMap);
+      }
+   }
+
+   private void applyFieldConfig(ChartRef ref, Map<String, SimpleFieldInfo> configMap) {
+      String fieldName = WizardRecommenderUtil.getChartRefFieldName(ref);
+      SimpleFieldInfo fc = configMap.get(fieldName);
+
+      if(fc == null) {
+         return;
+      }
+
+      if(ref instanceof VSChartDimensionRef dim) {
+         if(fc instanceof DimensionFieldInfo dimFc && dimFc.getRanking() != null) {
+            Ranking r = dimFc.getRanking();
+            dim.setRankingOptionValue(String.valueOf(r.getOptionValue()));
+            dim.setRankingNValue(String.valueOf(r.getRankingN()));
+            dim.setRankingColValue(r.getRankingCol());
+         }
+
+         if(fc.getOrder() != null) {
+            dim.setOrder(fc.getOrder());
+         }
+      }
+      else if(ref instanceof VSChartAggregateRef agg) {
+         if(fc instanceof MeasureFieldInfo meaFc && meaFc.getAggregateFormula() != null) {
+            agg.setFormulaValue(meaFc.getAggregateFormula());
+         }
+      }
+   }
+
+   // ── Chart preference helpers ──────────────────────────────────────────────────
+
+   private static ChartPreference buildChartPreference(List<ExplicitBinding> bindings) {
+      if(bindings == null || bindings.isEmpty()) {
+         return null;
+      }
+
+      Map<String, Set<String>> slotFields = new HashMap<>();
+
+      for(ExplicitBinding eb : bindings) {
+         if(eb.getRole() != null && eb.getField() != null) {
+            slotFields.computeIfAbsent(eb.getRole(), k -> new LinkedHashSet<>())
+                      .add(eb.getField());
+         }
+      }
+
+      return slotFields.isEmpty() ? null : new ChartPreference(slotFields);
+   }
+
+   // ── Build full recommendations list ───────────────────────────────────────────
+
+   private ChartCombinationUtil.ChartInfosResult buildChartInfos(
+      AssetEntry[] entries, VSChartInfo tempChartInfo, ChartPreference pref)
+   {
+      long dimCount = Arrays.stream(entries).filter(e -> !isMeasureEntry(e)).count();
+      long measCount = entries.length - dimCount;
+
+      if(dimCount == 0 || measCount == 0) {
+         return null;
+      }
+
+      try {
+         return ChartCombinationUtil.getChartInfosWithScores(
+            entries, tempChartInfo, new ColumnSelection(), true, pref);
+      }
+      catch(Exception e) {
+         LOG.warn("ChartCombinationUtil.getChartInfosWithScores failed: {}", e.getMessage());
+         return null;
+      }
+   }
+
+   private List<RecommendedVisualization> buildRecommendations(
+      AssetEntry[] entries, String worksheetId,
+      ChartCombinationUtil.ChartInfosResult chartResult,
+      RuntimeViewsheet rvs, VSTemporaryInfo tempInfo, Principal user)
+   {
+      List<RecommendedVisualization> recs = new ArrayList<>();
+      long dimCount = Arrays.stream(entries).filter(e -> !isMeasureEntry(e)).count();
+      long measCount = entries.length - dimCount;
+
+      if(chartResult != null) {
+         for(ChartInfo ci : chartResult.getInfos()) {
+            String vizType = getChartTypeString(ci.getChartType());
+
+            if(vizType != null) {
+               RecommendedVisualization rec = new RecommendedVisualization();
+               rec.setVisualizationType(vizType);
+               rec.setConfig(convertToChartConfig(ci, worksheetId));
+               recs.add(rec);
+            }
+         }
+      }
+
+      if(dimCount > 0 && measCount > 0) {
+         recs.add(buildCrosstabRecommendation(entries, worksheetId, tempInfo, user));
+      }
+
+      recs.add(buildTableRecommendation(entries, worksheetId, rvs, user));
+
+      if(measCount == 1 && dimCount == 0) {
+         recs.add(buildOutputRecommendation(entries, worksheetId, tempInfo, user));
+      }
+
+      return recs;
+   }
+
+   private boolean isMeasureEntry(AssetEntry entry) {
+      return String.valueOf(AssetEntry.MEASURES).equals(entry.getProperty(AssetEntry.CUBE_COL_TYPE));
+   }
+
+   private RecommendedVisualization buildTableRecommendation(AssetEntry[] entries,
+                                                               String worksheetId,
+                                                               RuntimeViewsheet rvs,
+                                                               Principal user)
+   {
+      VSWizardData wizardData = new VSWizardData(entries, null);
+      ColumnSelection columns = tableFactory.recommend(wizardData, rvs, user).getColumns();
+
+      TableBinding binding = new TableBinding();
+
+      if(columns != null) {
+         Map<String, AssetEntry> entryByName = Arrays.stream(entries)
+            .collect(Collectors.toMap(WizardRecommenderUtil::getFieldName, e -> e, (a, b) -> a));
+         List<SimpleFieldInfo> details = new ArrayList<>();
+
+         for(int i = 0; i < columns.getAttributeCount(); i++) {
+            AssetEntry entry = entryByName.get(columns.getAttribute(i).getAttribute());
+
+            if(entry != null) {
+               details.add(entryToSimpleFieldInfo(entry));
+            }
+         }
+
+         binding.setDetails(details);
+      }
+
+      RecommendedVisualization rec = new RecommendedVisualization();
+      rec.setVisualizationType("table");
+      rec.setConfig(wrapInConfig(binding, worksheetId));
+      return rec;
+   }
+
+   private RecommendedVisualization buildCrosstabRecommendation(AssetEntry[] entries,
+                                                                  String worksheetId,
+                                                                  VSTemporaryInfo tempInfo,
+                                                                  Principal user)
+   {
+      VSWizardData wizardData = new VSWizardData(entries, tempInfo);
+      VSCrosstabRecommendation crosstabRec = crosstabFactory.recommend(wizardData, user);
+
+      if(crosstabRec == null) {
+         return null;
+      }
+
+      CrosstabBinding binding = crosstabInfoToBinding(crosstabRec.getCrosstabInfo());
+      RecommendedVisualization rec = new RecommendedVisualization();
+      rec.setVisualizationType("crosstab");
+      rec.setConfig(wrapInConfig(binding, worksheetId));
+      return rec;
+   }
+
+   private RecommendedVisualization buildOutputRecommendation(AssetEntry[] entries,
+                                                               String worksheetId,
+                                                               VSTemporaryInfo tempInfo,
+                                                               Principal user)
+   {
+      VSWizardData wizardData = new VSWizardData(entries, tempInfo);
+      VSGaugeRecommendation gaugeRec = gaugeFactory.recommend(wizardData, user);
+
+      if(gaugeRec == null || gaugeRec.getDataRef() == null) {
+         return null;
+      }
+
+      OutputBinding binding = new OutputBinding();
+      binding.setField(dataRefToMeasureFieldInfo(gaugeRec.getDataRef()));
+      RecommendedVisualization rec = new RecommendedVisualization();
+      rec.setVisualizationType("gauge");
+      rec.setConfig(wrapInConfig(binding, worksheetId));
+      return rec;
+   }
+
+   // ── Factory output → BindingInfo conversion ──────────────────────────────────
+
+   private CrosstabBinding crosstabInfoToBinding(VSCrosstabInfo info) {
+      CrosstabBinding binding = new CrosstabBinding();
+
+      List<DimensionFieldInfo> rows = dataRefsToFields(info.getDesignRowHeaders());
+      if(!rows.isEmpty()) binding.setRows(rows);
+
+      List<DimensionFieldInfo> cols = dataRefsToFields(info.getDesignColHeaders());
+      if(!cols.isEmpty()) binding.setCols(cols);
+
+      List<MeasureFieldInfo> aggs = Arrays.stream(info.getDesignAggregates())
+         .filter(r -> r instanceof VSAggregateRef)
+         .map(r -> vsAggRefToFieldInfo((VSAggregateRef) r))
+         .collect(Collectors.toList());
+      if(!aggs.isEmpty()) binding.setAggregates(aggs);
+
+      return binding;
+   }
+
+   private List<DimensionFieldInfo> dataRefsToFields(DataRef[] refs) {
+      if(refs == null) return Collections.emptyList();
+      return Arrays.stream(refs)
+         .filter(r -> r instanceof VSDimensionRef)
+         .map(r -> vsDimRefToFieldInfo((VSDimensionRef) r))
+         .collect(Collectors.toList());
+   }
+
+   private DimensionFieldInfo vsDimRefToFieldInfo(VSDimensionRef dim) {
+      DimensionFieldInfo info = new DimensionFieldInfo();
+      info.setField(dim.getGroupColumnValue());
+      info.setType(dim.getDataType());
+      int level = dim.getDateLevel();
+
+      if(level != XConstants.NONE_DATE_GROUP) {
+         info.setDateGroupLevel(WizVsService.getDateGroupLevelName(level));
+      }
+
+      return info;
+   }
+
+   private MeasureFieldInfo vsAggRefToFieldInfo(VSAggregateRef agg) {
+      MeasureFieldInfo info = new MeasureFieldInfo();
+      info.setField(agg.getColumnValue());
+      info.setAggregateFormula(agg.getFormula() != null ? agg.getFormula().getFormulaName() : null);
+      return info;
+   }
+
+   private MeasureFieldInfo dataRefToMeasureFieldInfo(DataRef ref) {
+      MeasureFieldInfo info = new MeasureFieldInfo();
+      info.setField(ref.getAttribute());
+      info.setType(ref.getDataType());
+      return info;
+   }
+
+   // ── ChartInfo → VisualizationConfig (design doc §4.4) ───────────────────────
+
+   private VisualizationConfig convertToChartConfig(ChartInfo info, String worksheetId) {
+      ChartBinding binding = new ChartBinding();
+
+      List<SimpleFieldInfo> x = chartRefsToFieldInfos(info.getXFields());
+      if(!x.isEmpty()) binding.setX(x);
+
+      List<SimpleFieldInfo> y = chartRefsToFieldInfos(info.getYFields());
+      if(!y.isEmpty()) binding.setY(y);
+
+      List<SimpleFieldInfo> group = chartRefsToFieldInfos(info.getGroupFields());
+      if(!group.isEmpty()) binding.setGroup(group);
+
+      if(info.getColorField() != null) {
+         binding.setColor(chartRefToFieldInfo(info.getColorField().getDataRef()));
+      }
+
+      if(info.getShapeField() != null) {
+         binding.setShape(chartRefToFieldInfo(info.getShapeField().getDataRef()));
+      }
+
+      if(info.getSizeField() != null) {
+         binding.setSize(chartRefToFieldInfo(info.getSizeField().getDataRef()));
+      }
+
+      if(info.getTextField() != null) {
+         binding.setText(chartRefToFieldInfo(info.getTextField().getDataRef()));
+      }
+
+      return wrapInConfig(binding, worksheetId);
+   }
+
+   private List<SimpleFieldInfo> chartRefsToFieldInfos(ChartRef[] refs) {
+      if(refs == null || refs.length == 0) {
+         return Collections.emptyList();
+      }
+
+      return Arrays.stream(refs)
+         .map(this::chartRefToFieldInfo)
+         .filter(Objects::nonNull)
+         .collect(Collectors.toList());
+   }
+
+   private SimpleFieldInfo chartRefToFieldInfo(DataRef ref) {
+      if(ref == null) {
+         return null;
+      }
+
+      if(ref instanceof VSAggregateRef agg) {
+         MeasureFieldInfo info = new MeasureFieldInfo();
+         info.setField(agg.getColumnValue());
+         info.setAggregateFormula(agg.getFormulaValue());
+         info.setFullName(agg.getFullName());
+         return info;
+      }
+
+      if(ref instanceof VSDimensionRef dim) {
+         DimensionFieldInfo info = new DimensionFieldInfo();
+         info.setField(dim.getGroupColumnValue());
+         info.setFullName(dim.getFullName());
+         int level = dim.getDateLevel();
+
+         if(level != XConstants.NONE_DATE_GROUP) {
+            info.setDateGroupLevel(WizVsService.getDateGroupLevelName(level));
+         }
+
+         return info;
+      }
+
+      SimpleFieldInfo info = new SimpleFieldInfo();
+      info.setField(ref.getAttribute());
+      return info;
+   }
+
+   // ── Entry → FieldInfo conversion ─────────────────────────────────────────────
+
+   private SimpleFieldInfo entryToSimpleFieldInfo(AssetEntry entry) {
+      return isMeasureEntry(entry)
+         ? entryToMeasureFieldInfo(entry)
+         : entryToDimensionFieldInfo(entry);
+   }
+
+   private MeasureFieldInfo entryToMeasureFieldInfo(AssetEntry entry) {
+      MeasureFieldInfo info = new MeasureFieldInfo();
+      info.setField(WizardRecommenderUtil.getFieldName(entry));
+      info.setType(entry.getProperty("dtype"));
+      return info;
+   }
+
+   private DimensionFieldInfo entryToDimensionFieldInfo(AssetEntry entry) {
+      DimensionFieldInfo info = new DimensionFieldInfo();
+      info.setField(WizardRecommenderUtil.getFieldName(entry));
+      info.setType(entry.getProperty("dtype"));
+      return info;
+   }
+
+   // ── Primary visualization selection ───────────────────────────────────────────
+
+   /**
+    * Selects the primary visualization.
+    * <ul>
+    *   <li>{@code vizType} non-null (chart) → pick best binding of that type from {@code prefInfos}.</li>
+    *   <li>{@code vizType} non-null (non-chart) → find it in {@code recommendations}.</li>
+    *   <li>No vizType, explicit bindings → infer viz type from binding role names
+    *       (non-chart type wins only when its role-match count strictly exceeds chart roles),
+    *       then find it in {@code recommendations}.</li>
+    *   <li>No vizType fallback → if top recommendation is a chart, apply {@code intentCategory}
+    *       filter on {@code prefInfos}; otherwise return the top recommendation.</li>
+    * </ul>
+    */
+   private RecommendedVisualization buildPrimaryVisualization(
+      List<RecommendedVisualization> recommendations,
+      String worksheetId,
+      String vizType,
+      List<ExplicitBinding> explicitBindings,
+      List<ChartCombinationUtil.ScoredInfo> prefInfos,
+      String intentCategory)
+   {
+      if(vizType != null) {
+         if(isChartVizType(vizType)) {
+            RecommendedVisualization byType = buildBestChartVizByType(prefInfos, vizType, worksheetId);
+            if(byType != null) return byType;
+         }
+
+         RecommendedVisualization found = findInRecommendations(vizType, recommendations);
+         return found != null ? found : (!recommendations.isEmpty() ? recommendations.get(0) : null);
+      }
+
+      // Infer viz type from explicit binding roles when present.
+      if(explicitBindings != null && !explicitBindings.isEmpty()) {
+         String inferredType = inferNonChartVizType(explicitBindings);
+
+         if(inferredType != null) {
+            RecommendedVisualization found = findInRecommendations(inferredType, recommendations);
+            if(found != null) return found;
+         }
+      }
+
+      // Fallback: delegate viz-type decision to the recommendation engine.
+      if(!recommendations.isEmpty()) {
+         RecommendedVisualization topRec = recommendations.get(0);
+
+         if(isChartVizType(topRec.getVisualizationType())) {
+            RecommendedVisualization chartPrimary =
+               buildBestChartViz(prefInfos, intentCategory, worksheetId);
+            return chartPrimary != null ? chartPrimary : topRec;
+         }
+
+         return topRec;
+      }
+
+      return null;
+   }
+
+   private RecommendedVisualization findInRecommendations(String vizType,
+                                                            List<RecommendedVisualization> recommendations)
+   {
+      return recommendations.stream()
+         .filter(r -> vizType.equals(r.getVisualizationType()))
+         .findFirst()
+         .orElse(null);
+   }
+
+   private String inferNonChartVizType(List<ExplicitBinding> bindings) {
+      int chartScore = countRoleMatches(bindings, CHART_ROLES);
+
+      if(countRoleMatches(bindings, CROSSTAB_ROLES) > chartScore) return "crosstab";
+      if(countRoleMatches(bindings, TABLE_ROLES) > chartScore) return "table";
+
+      return null;
+   }
+
+   private int countRoleMatches(List<ExplicitBinding> bindings, Set<String> roles) {
+      int count = 0;
+
+      for(ExplicitBinding eb : bindings) {
+         if(roles.contains(eb.getRole())) {
+            count++;
+         }
+      }
+
+      return count;
+   }
+
+   private static final Set<String> CHART_ROLES = Set.of("x", "y", "group", "color", "shape", "size", "text");
+   private static final Set<String> CROSSTAB_ROLES = Set.of("rows", "cols", "aggregates");
+   private static final Set<String> TABLE_ROLES = Set.of("details");
+
+   private RecommendedVisualization buildBestChartVizByType(
+      List<ChartCombinationUtil.ScoredInfo> prefInfos,
+      String explicitChartType, String worksheetId)
+   {
+      if(prefInfos == null || prefInfos.isEmpty()) {
+         return null;
+      }
+
+      return prefInfos.stream()
+         .map(ChartCombinationUtil.ScoredInfo::getInfo)
+         .filter(ci -> explicitChartType.equals(getChartTypeString(ci.getChartType())))
+         .findFirst()
+         .map(ci -> toRecommendedVisualization(ci, worksheetId))
+         .orElse(null);
+   }
+
+   private RecommendedVisualization buildBestChartViz(
+      List<ChartCombinationUtil.ScoredInfo> prefInfos,
+      String intentCategory, String worksheetId)
+   {
+      if(prefInfos == null || prefInfos.isEmpty()) {
+         return null;
+      }
+
+      ChartInfo bestInfo;
+      Set<Integer> categoryTypes = intentCategory != null
+         ? INTENT_CATEGORY_CHART_TYPES.get(intentCategory) : null;
+
+      if(categoryTypes != null && !categoryTypes.isEmpty()) {
+         bestInfo = prefInfos.stream()
+            .filter(si -> categoryTypes.contains(si.getInfo().getChartType()))
+            .map(ChartCombinationUtil.ScoredInfo::getInfo)
+            .findFirst()
+            .orElse(prefInfos.get(0).getInfo());
+      }
+      else {
+         bestInfo = prefInfos.get(0).getInfo();
+      }
+
+      return toRecommendedVisualization(bestInfo, worksheetId);
+   }
+
+   private RecommendedVisualization toRecommendedVisualization(ChartInfo info, String worksheetId) {
+      String vizType = getChartTypeString(info.getChartType());
+
+      if(vizType == null) {
+         return null;
+      }
+
+      RecommendedVisualization rec = new RecommendedVisualization();
+      rec.setVisualizationType(vizType);
+      rec.setConfig(convertToChartConfig(info, worksheetId));
+      return rec;
+   }
+
+
+   private static final Set<String> NON_CHART_VIZ_TYPES = Set.of("table", "crosstab", "gauge");
+
+   /**
+    * Maps each intent category to the set of {@link GraphTypes} chart-type constants that best
+    * express that intent.  Categories are not mutually exclusive — a chart type may appear in
+    * multiple categories.  "other" is absent intentionally: it acts as the no-filter fallback.
+    */
+   private static final Map<String, Set<Integer>> INTENT_CATEGORY_CHART_TYPES;
+
+   static {
+      Map<String, Set<Integer>> m = new HashMap<>();
+
+      // comparison — values side-by-side across categories
+      m.put("comparison", Set.of(
+         GraphTypes.CHART_BAR, GraphTypes.CHART_BAR_STACK,
+         GraphTypes.CHART_3D_BAR, GraphTypes.CHART_3D_BAR_STACK,
+         GraphTypes.CHART_RADAR, GraphTypes.CHART_FILL_RADAR,
+         GraphTypes.CHART_MEKKO,
+         GraphTypes.CHART_AREA, GraphTypes.CHART_AREA_STACK
+      ));
+
+      // trend — change over time
+      m.put("trend", Set.of(
+         GraphTypes.CHART_LINE, GraphTypes.CHART_LINE_STACK,
+         GraphTypes.CHART_AREA, GraphTypes.CHART_AREA_STACK,
+         GraphTypes.CHART_STEP, GraphTypes.CHART_STEP_STACK,
+         GraphTypes.CHART_STEP_AREA, GraphTypes.CHART_STEP_AREA_STACK,
+         GraphTypes.CHART_JUMP,
+         GraphTypes.CHART_WATERFALL
+      ));
+
+      // distribution — spread / frequency of values
+      m.put("distribution", Set.of(
+         GraphTypes.CHART_BOXPLOT,
+         GraphTypes.CHART_POINT, GraphTypes.CHART_POINT_STACK,
+         GraphTypes.CHART_SCATTER_CONTOUR,
+         GraphTypes.CHART_BAR
+      ));
+
+      // proportion — part-to-whole relationships
+      m.put("proportion", Set.of(
+         GraphTypes.CHART_PIE, GraphTypes.CHART_3D_PIE, GraphTypes.CHART_DONUT,
+         GraphTypes.CHART_TREEMAP, GraphTypes.CHART_SUNBURST,
+         GraphTypes.CHART_CIRCLE_PACKING, GraphTypes.CHART_ICICLE,
+         GraphTypes.CHART_MEKKO,
+         GraphTypes.CHART_BAR_STACK, GraphTypes.CHART_AREA_STACK
+      ));
+
+      // relationship — correlations, connections, dependencies
+      m.put("relationship", Set.of(
+         GraphTypes.CHART_POINT, GraphTypes.CHART_POINT_STACK,
+         GraphTypes.CHART_SCATTER_CONTOUR,
+         GraphTypes.CHART_NETWORK, GraphTypes.CHART_CIRCULAR,
+         GraphTypes.CHART_TREE
+      ));
+
+      // ranking — ordered comparison, top-N
+      m.put("ranking", Set.of(
+         GraphTypes.CHART_BAR, GraphTypes.CHART_BAR_STACK,
+         GraphTypes.CHART_PARETO,
+         GraphTypes.CHART_WATERFALL
+      ));
+
+      // geospatial — location-based data
+      m.put("geospatial", Set.of(
+         GraphTypes.CHART_MAP,
+         GraphTypes.CHART_MAP_CONTOUR
+      ));
+
+      INTENT_CATEGORY_CHART_TYPES = Collections.unmodifiableMap(m);
+   }
+
+   private boolean isChartVizType(String vizType) {
+      return vizType != null && !NON_CHART_VIZ_TYPES.contains(vizType);
+   }
+
+   // ── Chart type string mapping (inverse of WizVsService.getChartType) ─────────
+
+   private static String getChartTypeString(int chartType) {
+      return switch(chartType) {
+         case GraphTypes.CHART_BAR, GraphTypes.CHART_BAR_STACK -> "bar";
+         case GraphTypes.CHART_3D_BAR, GraphTypes.CHART_3D_BAR_STACK -> "3d_bar";
+         case GraphTypes.CHART_AREA, GraphTypes.CHART_AREA_STACK -> "area";
+         case GraphTypes.CHART_POINT, GraphTypes.CHART_POINT_STACK -> "point";
+         case GraphTypes.CHART_STEP_AREA, GraphTypes.CHART_STEP_AREA_STACK -> "step_area";
+         case GraphTypes.CHART_INTERVAL -> "interval";
+         case GraphTypes.CHART_LINE, GraphTypes.CHART_LINE_STACK -> "line";
+         case GraphTypes.CHART_STEP, GraphTypes.CHART_STEP_STACK -> "step_line";
+         case GraphTypes.CHART_JUMP -> "jump_line";
+         case GraphTypes.CHART_PIE -> "pie";
+         case GraphTypes.CHART_3D_PIE -> "3d_pie";
+         case GraphTypes.CHART_DONUT -> "donut";
+         case GraphTypes.CHART_RADAR -> "radar";
+         case GraphTypes.CHART_FILL_RADAR -> "filled_radar";
+         case GraphTypes.CHART_SCATTER_CONTOUR -> "scatter_contour";
+         case GraphTypes.CHART_STOCK -> "stock";
+         case GraphTypes.CHART_CANDLE -> "candle";
+         case GraphTypes.CHART_BOXPLOT -> "boxplot";
+         case GraphTypes.CHART_WATERFALL -> "waterfall";
+         case GraphTypes.CHART_PARETO -> "pareto";
+         case GraphTypes.CHART_TREEMAP -> "treemap";
+         case GraphTypes.CHART_SUNBURST -> "sunburst";
+         case GraphTypes.CHART_CIRCLE_PACKING -> "circle_packing";
+         case GraphTypes.CHART_ICICLE -> "icircle";
+         case GraphTypes.CHART_MEKKO -> "marimekko";
+         case GraphTypes.CHART_GANTT -> "gantt";
+         case GraphTypes.CHART_FUNNEL -> "funnel";
+         case GraphTypes.CHART_TREE -> "tree";
+         case GraphTypes.CHART_NETWORK -> "network";
+         case GraphTypes.CHART_CIRCULAR -> "circular_network";
+         case GraphTypes.CHART_MAP_CONTOUR -> "contour_map";
+         case GraphTypes.CHART_MAP -> "map";
+         default -> null;
+      };
+   }
+
+   // ── VisualizationConfig wrapper ───────────────────────────────────────────────
+
+   private VisualizationConfig wrapInConfig(BindingInfo binding, String worksheetId) {
+      VisualizationConfig config = new VisualizationConfig();
+      config.setBindingInfo(binding);
+
+      if(!Tool.isEmptyString(worksheetId)) {
+         VisualizationConfig.DataSource ds = new VisualizationConfig.DataSource();
+         ds.setSource(worksheetId);
+         config.setData(ds);
+      }
+
+      return config;
+   }
+
+   private static final Logger LOG = LoggerFactory.getLogger(WizAutoBindingService.class);
+
+   private final ViewsheetService viewsheetService;
+   private final AssetRepository engine;
+   private final VSWizardTemporaryInfoService temporaryInfoService;
+   private final VSWizardBindingHandler bindingHandler;
+   private final VSCrosstabDefaultRecommendationFactory crosstabFactory;
+   private final VSGaugeRecommendationFactory gaugeFactory;
+   private final VSTableRecommendationFactory tableFactory;
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1755,7 +1755,7 @@ public class WizVsService {
     * @param level the integer date level constant
     * @return the human-readable name, or null if level is NONE_DATE_GROUP or unrecognized
     */
-   private static String getDateGroupLevelName(int level) {
+   public static String getDateGroupLevelName(int level) {
       return switch(level) {
          // Interval levels
          case XConstants.YEAR_DATE_GROUP -> "year";


### PR DESCRIPTION
Introduces POST /api/wiz/viewsheet/autoBinding: given a worksheet ID, field configs, optional explicit bindings, and an intent category, the endpoint returns a ranked list of recommended visualizations plus a primary selection.

Key design decisions:
- Chart recommendations go through ChartCombinationUtil with a ChartPreference built from explicit bindings; a single engine pass produces both the default-ranked list and a preference-adjusted list for primary selection.
- ChartTypeFilter.filterWithPreference() returns a FilterResult carrying two orderings (default + pref-adjusted) so the engine runs only once.
- intentCategory ("comparison"/"trend"/"distribution"/"proportion"/ "relationship"/"ranking"/"geospatial"/"other") narrows primary chart selection when no explicit viz type is provided.
- Non-chart recommendations (crosstab/table/gauge) delegate to the existing VSWizard factory pipeline: VSCrosstabDefaultRecommendationFactory — hierarchy-aware row/col layout VSTableRecommendationFactory — calc-aggregate field filtering via new recommend(VSWizardData, RuntimeViewsheet, Principal) overload VSGaugeRecommendationFactory — single-measure output
- visualizationTypeIsExplicit removed; non-null vizType implies explicit.
- getDateGroupLevelName made public in WizVsService; getChartRefFieldName extracted to WizardRecommenderUtil to eliminate duplication.