### PR TITLE
75100 - Timeout exception generating MV is not reached

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
@@ -1626,6 +1626,9 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
          try {
             return igniteFuture.get();
          }
+         catch (IgniteInterruptedException e) {
+            throw new InterruptedException(e.getMessage());
+         }
          catch (Exception e) {
             throw new ExecutionException(e);
          }
@@ -1637,6 +1640,12 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
       {
          try {
             return igniteFuture.get(timeout, unit);
+         }
+         catch (IgniteFutureTimeoutException e) {
+            throw new java.util.concurrent.TimeoutException(e.getMessage());
+         }
+         catch (IgniteInterruptedException e) {
+            throw new InterruptedException(e.getMessage());
          }
          catch (Exception e) {
             throw new ExecutionException(e);

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
@@ -1627,7 +1627,10 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
             return igniteFuture.get();
          }
          catch (IgniteInterruptedException e) {
-            throw new InterruptedException(e.getMessage());
+            Thread.currentThread().interrupt();
+            InterruptedException ie = new InterruptedException(e.getMessage());
+            ie.initCause(e);
+            throw ie;
          }
          catch (Exception e) {
             throw new ExecutionException(e);
@@ -1642,10 +1645,15 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
             return igniteFuture.get(timeout, unit);
          }
          catch (IgniteFutureTimeoutException e) {
-            throw new java.util.concurrent.TimeoutException(e.getMessage());
+            java.util.concurrent.TimeoutException te = new java.util.concurrent.TimeoutException(e.getMessage());
+            te.initCause(e);
+            throw te;
          }
          catch (IgniteInterruptedException e) {
-            throw new InterruptedException(e.getMessage());
+            Thread.currentThread().interrupt();
+            InterruptedException ie = new InterruptedException(e.getMessage());
+            ie.initCause(e);
+            throw ie;
          }
          catch (Exception e) {
             throw new ExecutionException(e);

--- a/core/src/main/java/inetsoft/sree/schedule/MVAction.java
+++ b/core/src/main/java/inetsoft/sree/schedule/MVAction.java
@@ -289,6 +289,17 @@ public class MVAction implements AssetSupport, Cloneable, XMLSerializable, Cance
                throw new RuntimeException("MV creation timed out after " + (timeout / 1000) +
                                              "s: " + mv.getName(), ex);
             }
+            catch(ExecutionException ex) {
+               Throwable cause = ex.getCause();
+               mvFuture.cancel(true);
+
+               if(cause != null && cause.getClass().getName().contains("FutureTimeoutException")) {
+                  throw new RuntimeException("MV creation timed out after " + (timeout / 1000) +
+                                                "s: " + mv.getName(), ex);
+               }
+
+               throw ex;
+            }
             finally {
                mvFuture = null;
             }

--- a/core/src/main/java/inetsoft/sree/schedule/MVAction.java
+++ b/core/src/main/java/inetsoft/sree/schedule/MVAction.java
@@ -289,17 +289,6 @@ public class MVAction implements AssetSupport, Cloneable, XMLSerializable, Cance
                throw new RuntimeException("MV creation timed out after " + (timeout / 1000) +
                                              "s: " + mv.getName(), ex);
             }
-            catch(ExecutionException ex) {
-               Throwable cause = ex.getCause();
-               mvFuture.cancel(true);
-
-               if(cause != null && cause.getClass().getName().contains("FutureTimeoutException")) {
-                  throw new RuntimeException("MV creation timed out after " + (timeout / 1000) +
-                                                "s: " + mv.getName(), ex);
-               }
-
-               throw ex;
-            }
             finally {
                mvFuture = null;
             }


### PR DESCRIPTION
Root cause: IgniteFutureWrapper in IgniteCluster.java did not implement the java.util.concurrent.Future contract correctly — its get() and get(long, TimeUnit) overloads caught all exceptions
  and unconditionally wrapped them as ExecutionException. This meant IgniteFutureTimeoutException (timeout) and IgniteInterruptedException (interruption) were both swallowed into
  ExecutionException, making the existing catch(TimeoutException ex) in MVAction.createMV() dead code and causing MV task timeouts to propagate silently as generic execution failures.

  Fix: Proper exception translation added to both IgniteFutureWrapper overloads:

  - IgniteFutureTimeoutException → java.util.concurrent.TimeoutException (with initCause to preserve the stack trace)
  - IgniteInterruptedException → InterruptedException (with Thread.currentThread().interrupt() to restore the interrupt flag, and initCause to preserve the stack trace)
  - All other exceptions continue to be wrapped as ExecutionException