### PR TITLE
Fix XSwapper class initialization failure during test teardown

### DIFF
--- a/core/src/main/java/inetsoft/util/swap/XSwapper.java
+++ b/core/src/main/java/inetsoft/util/swap/XSwapper.java
@@ -791,7 +791,15 @@ public final class XSwapper {
    // In case the OOM still occurs, this property can be used to raise
    // the free ratio (e.g. 0.2) to avoid OOM.
    static {
-      String str = SreeEnv.getProperty("swapper.free.ratio");
+      String str = null;
+
+      try {
+         str = SreeEnv.getProperty("swapper.free.ratio");
+      }
+      catch(Exception ignored) {
+         // singleton manager unavailable (e.g. during test teardown); use default ratio
+      }
+
       double ratio = 0.20;
 
       if(str != null) {


### PR DESCRIPTION
## Summary
- `XSwapper`'s static initializer called `SreeEnv.getProperty()`, which goes through `SingletonManager.getInstance()`
- During test teardown, `SreeHomeExtension.afterAll()` resets the `SingletonManager` while background `TimedQueue` threads may simultaneously load `XSwapper` for the first time
- The `ResurrectException` thrown mid-reset caused an `ExceptionInInitializerError`, permanently poisoning the class — all subsequent tests using `XSwappableTable` failed with `NoClassDefFoundError`
- Fix wraps the property read in a try-catch so the initializer uses the default ratio (0.20) when the singleton manager is unavailable

## Test plan
- [ ] Verify the CI build passes without the cascade of `NoClassDefFoundError` failures in `JoinTableLensTest`, `MergeJoinTableTest`, `XBooleanColumnTest`, `RangeSliderVSAScriptableTest`, and related tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)