### PR TITLE
Fix hotspots in JDBC dashboards found during load testing

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/BoundQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/BoundQuery.java
@@ -453,7 +453,7 @@ public class BoundQuery extends AssetQuery {
       UniformSQL osql = (UniformSQL) oquery.getSQLDefinition();
       XSelection oselection = osql.getSelection();
       String name = getAttributeString(base);
-      SQLHelper helper = SQLHelper.getSQLHelper(osql);
+      SQLHelper helper = getSQLHelper(osql);
 
       // @by larryl, use indexOfColumn would not work if a column is used
       // twice with different aliases

--- a/core/src/main/java/inetsoft/report/composition/execution/ConcatenatedQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ConcatenatedQuery.java
@@ -254,6 +254,15 @@ public class ConcatenatedQuery extends AssetQuery {
     */
    @Override
    protected boolean isSourceMergeable() throws Exception {
+      if(sourceMergeable != null) {
+         return sourceMergeable;
+      }
+
+      sourceMergeable = computeIsSourceMergeable();
+      return sourceMergeable;
+   }
+
+   private boolean computeIsSourceMergeable() throws Exception {
       if(!super.isSourceMergeable()) {
          return false;
       }
@@ -788,6 +797,7 @@ public class ConcatenatedQuery extends AssetQuery {
    private TableAssembly[] tables; // base tables
    private AssetQuery[] queries; // base queries
    private JDBCQuery nquery; // new query
+   private transient Boolean sourceMergeable;
    protected Set<String> colset; // columns
 
    private static final Logger LOG =

--- a/core/src/main/java/inetsoft/report/composition/execution/JoinQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/JoinQuery.java
@@ -151,6 +151,15 @@ public class JoinQuery extends AssetQuery {
     */
    @Override
    protected boolean isSourceMergeable() throws Exception {
+      if(sourceMergeable != null) {
+         return sourceMergeable;
+      }
+
+      sourceMergeable = computeIsSourceMergeable();
+      return sourceMergeable;
+   }
+
+   private boolean computeIsSourceMergeable() throws Exception {
       if(!super.isSourceMergeable()) {
          return false;
       }
@@ -1058,6 +1067,7 @@ public class JoinQuery extends AssetQuery {
    private AssetQuery[] queries; // base queries
    private JDBCQuery nquery; // new query
    private final Set<String> colset; // columns
+   private transient Boolean sourceMergeable;
 
    private static final Logger LOG = LoggerFactory.getLogger(JoinQuery.class);
 }

--- a/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
@@ -2872,7 +2872,6 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
          return false;
       }
 
-      boolean isSQLite = isSQLite();
       SQLHelper sqlHelper = getSQLHelper(getUniformSQL());
 
       for(int i = 0; i < conds.getSize(); i += 2) {
@@ -4650,14 +4649,20 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
    }
 
    protected boolean isSQLite() {
+      if(sqlite != null) {
+         return sqlite;
+      }
+
       try {
          if(getQuery() instanceof JDBCQuery) {
-            return  Util.isSQLite(getQuery().getDataSource());
+            sqlite = Util.isSQLite(getQuery().getDataSource());
+            return sqlite;
          }
       }
       catch(Exception ignore) {
       }
 
+      sqlite = false;
       return false;
    }
 
@@ -4703,6 +4708,7 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
    private boolean mergeable; // query mergeable flag
    private boolean merged; // query merged flag
    private transient IdentityHashMap<UniformSQL, SQLHelper> sqlHelperCache;
+   private transient Boolean sqlite;
    private Map<DataRef, ColumnRef> colmap = new HashMap<>(); // optimization
    private Map<Tuple, Object> exprAttrs = new Object2ObjectOpenHashMap<>();
    private Map<String, List<AttributeRef>> expr2Attrs = new Object2ObjectOpenHashMap<>();

--- a/core/src/main/java/inetsoft/sree/security/SRPrincipal.java
+++ b/core/src/main/java/inetsoft/sree/security/SRPrincipal.java
@@ -439,13 +439,6 @@ public class SRPrincipal extends XPrincipal implements Serializable, Externaliza
          return false;
       }
 
-      boolean this_fake = "true".equals(getProperty("__FAKE__"));
-      boolean that_fake = "true".equals(that.getProperty("__FAKE__"));
-
-      if(this_fake || that_fake) {
-         return Tool.equals(getName(), that.getName());
-      }
-
       if(super.equals(that) &&
          this.client.equals(that.client) &&
          this.getSecureID() == that.getSecureID())
@@ -463,10 +456,6 @@ public class SRPrincipal extends XPrincipal implements Serializable, Externaliza
     */
    @Override
    public int hashCode() {
-      if("true".equals(getProperty("__FAKE__"))) {
-         return getName().hashCode();
-      }
-
       return super.hashCode() + client.hashCode();
    }
 

--- a/core/src/test/java/inetsoft/sree/security/SRPrincipalTest.java
+++ b/core/src/test/java/inetsoft/sree/security/SRPrincipalTest.java
@@ -24,7 +24,7 @@ package inetsoft.sree.security;
  * [CreateUser: internal]         principal marked as internal                                        -> createUser() returns null
  * [CreateUser: no-membership]    principal has no groups and no roles                                -> createUser() returns null
  * [Copy: constructor]            copy constructor receives a fully populated principal               -> all copied fields are reproduced in the new instance
- * [Equals: non-fake]             non-fake principals with same identity, client, and secureID        -> equal; differing secureID or null argument → not equal
+ * [Equals]                        principals with same identity, client, and secureID               -> equal; differing secureID or null argument → not equal
  * [Locale: property-sync]        setLocale writes LOCALE property when absent, skips when present   -> getProperty(LOCALE) reflects the first locale set; later calls do not overwrite it
  * [Session: valid-states]        sref null (no session set) or sref pointing to a live object       -> isValid() is true in both cases; getSession() returns the live object
  * [Identifier: internal]         principal marked as __internal__                                   -> toIdentifier() returns plain name with no SSO encoding
@@ -122,10 +122,10 @@ class SRPrincipalTest {
       }
    }
 
-   // [Equals: non-fake] same name + same client + same secureID → equal;
-   //                    differing secureID or null argument → not equal
+   // [Equals] same name + same client + same secureID → equal;
+   //          differing secureID or null argument → not equal
    @Test
-   void equals_nonFakePrincipals_equalByIdentityClientAndSecureID() {
+   void equals_principalsEqualByIdentityClientAndSecureID() {
       try(MockedStatic<XSessionService> sessionService = mockSessionService()) {
          ClientInfo client = new ClientInfo(new IdentityID("alice", ORG_A), "10.0.0.1", "s1");
          SRPrincipal a = new SRPrincipal(client, new IdentityID[0], new String[0], ORG_A, 42L);
@@ -295,24 +295,6 @@ class SRPrincipalTest {
             "<secureID>42</secureID><age>0</age><accessed>0</accessed>" +
             "<sessionID><![CDATA[]]></sessionID>" +
             "</principal>", "properties");
-      }
-   }
-
-   // [Suspect 1] fake principals that compare equal should also share the same hashCode
-   @Test
-   void fakePrincipalsEqualByName_haveSameHashCode() {
-      try(MockedStatic<XSessionService> sessionService = mockSessionService()) {
-         SRPrincipal first = new SRPrincipal(
-            new ClientInfo(new IdentityID("alice", ORG_A), "10.0.0.1", "session-1"),
-            new IdentityID[0], new String[0], ORG_A, 1L);
-         SRPrincipal second = new SRPrincipal(
-            new ClientInfo(new IdentityID("alice", ORG_A), "10.0.0.2", "session-2"),
-            new IdentityID[0], new String[0], ORG_A, 2L);
-         first.setProperty("__FAKE__", "true");
-         second.setProperty("__FAKE__", "true");
-
-         assertEquals(first, second);
-         assertEquals(first.hashCode(), second.hashCode());
       }
    }
 


### PR DESCRIPTION
- Cache isSourceMergeable() result in JoinQuery and ConcatenatedQuery to avoid recomputing the SQLHelper/ConnectionProcessor/Ignite chain on each call within a single merge pass
- Cache isSQLite() result in PreAssetQuery for the same reason
- Use the per-query sqlHelperCache in BoundQuery.getAlias instead of the static SQLHelper.getSQLHelper(), eliminating per-column Ignite round-trips during mergeSelect
- Remove __FAKE__ principal flag from SRPrincipal.equals/hashCode — the flag was never set anywhere in the codebase (leftover from Studio/Reports) and caused unnecessary Ignite lookups on every equality/hash check