### PR TITLE
Fix the issue in WorksheetWrapper where the original table is not replaced with the cloned table, causing missing aggregation fields in the mirror table and resulting in an error.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
@@ -1200,6 +1200,17 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
          return null;
       }
 
+      // Replace the original in the worksheet wrapper with the clone. createBaseTableAssembly0()
+      // adds the original bound table to the WorksheetWrapper. MirrorTableAssembly's constructor
+      // calls MirrorAssemblyImpl.setWorksheet() -> update0() -> ws.getAssembly(name), which would
+      // return the unprocessed original instead of this clone (with aggregate info applied).
+      // Adding the clone replaces the original so the mirror picks up the correct processed table.
+      Worksheet cloneWs = table.getWorksheet();
+
+      if(cloneWs != null) {
+         cloneWs.addAssembly(table);
+      }
+
       ChartVSAssembly cassembly = (ChartVSAssembly) getAssembly();
       ColumnSelection cols = table.getColumnSelection();
       VSChartInfo cinfo = cassembly.getVSChartInfo();

--- a/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
@@ -1200,17 +1200,6 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
          return null;
       }
 
-      // Replace the original in the worksheet wrapper with the clone. createBaseTableAssembly0()
-      // adds the original bound table to the WorksheetWrapper. MirrorTableAssembly's constructor
-      // calls MirrorAssemblyImpl.setWorksheet() -> update0() -> ws.getAssembly(name), which would
-      // return the unprocessed original instead of this clone (with aggregate info applied).
-      // Adding the clone replaces the original so the mirror picks up the correct processed table.
-      Worksheet ws = table.getWorksheet();
-
-      if(ws != null) {
-         ws.addAssembly(table);
-      }
-
       ChartVSAssembly cassembly = (ChartVSAssembly) getAssembly();
       ColumnSelection cols = table.getColumnSelection();
       VSChartInfo cinfo = cassembly.getVSChartInfo();
@@ -1772,6 +1761,7 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
    private MirrorTableAssembly createMirrorTableAssembly(TableAssembly table, String vname) {
       String mname = Assembly.TABLE_VS + vname + "_mirror";
       Worksheet ws = table.getWorksheet();
+      ws.addAssembly(table);
       MirrorTableAssembly mtable = new MirrorTableAssembly(ws, mname, null, false, table);
 
       normalizeTable(mtable);

--- a/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
@@ -1205,10 +1205,10 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
       // calls MirrorAssemblyImpl.setWorksheet() -> update0() -> ws.getAssembly(name), which would
       // return the unprocessed original instead of this clone (with aggregate info applied).
       // Adding the clone replaces the original so the mirror picks up the correct processed table.
-      Worksheet cloneWs = table.getWorksheet();
+      Worksheet ws = table.getWorksheet();
 
-      if(cloneWs != null) {
-         cloneWs.addAssembly(table);
+      if(ws != null) {
+         ws.addAssembly(table);
       }
 
       ChartVSAssembly cassembly = (ChartVSAssembly) getAssembly();


### PR DESCRIPTION
The newly cloned table has replaced the original table in all subsequent processing, but the wrapper still stores the old original table. In update0(), when looking up the base table by name in the wrapper, if the CLONE table is not added in advance, the wrapper will still contain the old ORIGINAL table (which lacks aggregation information).