### PR TITLE
Add changeType endpoint for fast visualization type switching

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
@@ -57,6 +57,13 @@ public class WizViewsheetController {
       return wizAutoBindingService.autoBinding(request, user);
    }
 
+   @PostMapping(value = "/viewsheet/changeType", produces = MediaType.APPLICATION_JSON_VALUE)
+   public CreateViewsheetResult changeType(@RequestBody ChangeTypeRequest request,
+                                           Principal user) throws Exception
+   {
+      return wizAutoBindingService.changeType(request, user);
+   }
+
    @DeleteMapping("/viewsheet")
    public void deleteViewsheet(@RequestParam("identifier") String identifier,
                                Principal user) throws Exception

--- a/core/src/main/java/inetsoft/web/wiz/model/ChangeTypeRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChangeTypeRequest.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Request body for {@code POST /api/wiz/viewsheet/changeType}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChangeTypeRequest {
+   public String getWorksheetId() {
+      return worksheetId;
+   }
+
+   public void setWorksheetId(String worksheetId) {
+      this.worksheetId = worksheetId;
+   }
+
+   public String getVisualizationType() {
+      return visualizationType;
+   }
+
+   public void setVisualizationType(String visualizationType) {
+      this.visualizationType = visualizationType;
+   }
+
+   public String getAutoBindingRuntimeId() {
+      return autoBindingRuntimeId;
+   }
+
+   public void setAutoBindingRuntimeId(String autoBindingRuntimeId) {
+      this.autoBindingRuntimeId = autoBindingRuntimeId;
+   }
+
+   public String getWizRuntimeId() {
+      return wizRuntimeId;
+   }
+
+   public void setWizRuntimeId(String wizRuntimeId) {
+      this.wizRuntimeId = wizRuntimeId;
+   }
+
+   public String getViewsheetIdentifier() {
+      return viewsheetIdentifier;
+   }
+
+   public void setViewsheetIdentifier(String viewsheetIdentifier) {
+      this.viewsheetIdentifier = viewsheetIdentifier;
+   }
+
+   private String worksheetId;
+   private String visualizationType;
+   /**
+    * Recommendation-computation RVS ID returned by a prior {@code autoBinding} call.
+    * The recommendation model stored on this RVS is reused to select the new primary.
+    * When absent or stale, the service falls back to re-running auto binding.
+    */
+   private String autoBindingRuntimeId;
+   /**
+    * Output-viewsheet RVS ID. The primary assembly in this RVS is replaced with the
+    * assembly corresponding to {@code visualizationType}.
+    */
+   private String wizRuntimeId;
+   /**
+    * Persisted viewsheet identifier returned from the previous call.
+    * Passed back so the viewsheet entry is overwritten in place rather than duplicated.
+    */
+   private String viewsheetIdentifier;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/CreateViewsheetResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/CreateViewsheetResult.java
@@ -109,6 +109,14 @@ public class CreateViewsheetResult {
       this.hasData = hasData;
    }
 
+   public String getAutoBindingRuntimeId() {
+      return autoBindingRuntimeId;
+   }
+
+   public void setAutoBindingRuntimeId(String autoBindingRuntimeId) {
+      this.autoBindingRuntimeId = autoBindingRuntimeId;
+   }
+
    private List<String> headers;
    private List<Map<String, Object>> rows;
    private FlatBinding binding;
@@ -117,6 +125,8 @@ public class CreateViewsheetResult {
    private String assemblyName;
    private String viewsheetIdentifier;
    private Boolean hasData;
+   /** Echoed back so the client can reuse the recommendation RVS on the next changeType call. */
+   private String autoBindingRuntimeId;
 
    // -------------------------------------------------------------------------
    // Nested model

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -76,7 +76,10 @@ public class WizAutoBindingService {
 
       if(Tool.isEmptyString(autoBindingRuntimeId)) {
          Viewsheet.WizInfo wizInfo = new Viewsheet.WizInfo(true, null, null);
-         autoBindingRuntimeId = viewsheetService.openTemporaryViewsheet(null, null, user, wizInfo);
+         AssetEntry wsEntry = !Tool.isEmptyString(worksheetId)
+            ? new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, worksheetId, null)
+            : null;
+         autoBindingRuntimeId = viewsheetService.openTemporaryViewsheet(null, wsEntry, user, wizInfo);
          createdAutoBindingRvs = true;
       }
 
@@ -152,6 +155,7 @@ public class WizAutoBindingService {
          ChartPreference pref = buildChartPreference(explicitBindings);
          VSWizardData wizardData = new VSWizardData(entries, tempInfo, pref);
          VSRecommendationModel model = defaultRecommendationFactory.recommend(wizardData, rvs, user);
+         tempInfo.setRecommendationModel(model);
 
          // Phase 2: compute recommendations and primary binding.
          List<VSObjectRecommendation> recommendations = Collections.emptyList();
@@ -661,8 +665,8 @@ public class WizAutoBindingService {
       return null;
    }
 
-   private PrimaryBinding findPrimaryBindingByType(String vizType, VSRecommendationModel model,
-                                                   AssetEntry[] entries)
+   PrimaryBinding findPrimaryBindingByType(String vizType, VSRecommendationModel model,
+                                           AssetEntry[] entries)
    {
       for(VSObjectRecommendation rec : model.getRecommendationList()) {
          if(isChartVizType(vizType) && rec instanceof VSChartRecommendation cr) {
@@ -981,6 +985,98 @@ public class WizAutoBindingService {
       }
 
       return config;
+   }
+
+   /**
+    * Changes the visualization type of an existing wizard viewsheet without re-running queries.
+    *
+    * <p>The recommendation model previously computed by {@link #autoBinding} is read from the
+    * {@code autoBindingRuntimeId} RVS.  If it is absent the service falls back to a full
+    * {@link #autoBinding} call (which also handles placing the primary and returning the result).
+    * Otherwise the matching {@link PrimaryBinding} is selected and placed in the
+    * {@code wizRuntimeId} RVS without executing the sandbox, so the response is fast and does
+    * not carry row data.
+    */
+   public CreateViewsheetResult changeType(ChangeTypeRequest request, Principal user)
+      throws Exception
+   {
+      String autoBindingRuntimeId = request.getAutoBindingRuntimeId();
+      String visualizationType = request.getVisualizationType();
+      String wizRuntimeId = request.getWizRuntimeId();
+      String worksheetId = request.getWorksheetId();
+      String viewsheetIdentifier = request.getViewsheetIdentifier();
+
+      // 1. Try to get the recommendation model stored by a prior autoBinding call.
+      VSRecommendationModel model = null;
+
+      if(!Tool.isEmptyString(autoBindingRuntimeId)) {
+         try {
+            RuntimeViewsheet autoBindingRvs = viewsheetService.getViewsheet(autoBindingRuntimeId, user);
+
+            if(autoBindingRvs != null) {
+               VSTemporaryInfo tempInfo = autoBindingRvs.getVSTemporaryInfo();
+
+               if(tempInfo != null) {
+                  model = tempInfo.getRecommendationModel();
+               }
+            }
+         }
+         catch(Exception e) {
+            LOG.warn("Could not read recommendation model from autoBindingRuntimeId {}: {}",
+                     autoBindingRuntimeId, e.getMessage());
+         }
+      }
+
+      // 3. Model missing — fall back to full autoBinding (handles placement too).
+      if(model == null) {
+         AutoBindingRequest fallback = new AutoBindingRequest();
+         fallback.setWorksheetId(worksheetId);
+         fallback.setVisualizationType(visualizationType);
+         // Do not forward autoBindingRuntimeId: if it was non-empty but invalid (expired RVS),
+         // autoBinding() would skip creating a new RVS and fail on the same dead id again.
+         fallback.setWizRuntimeId(wizRuntimeId);
+         fallback.setViewsheetIdentifier(viewsheetIdentifier);
+         AutoBindingResponse resp = autoBinding(fallback, user);
+         CreateViewsheetResult result = resp.getVisualizationResult();
+         return result != null ? result : new CreateViewsheetResult();
+      }
+
+      // 4. Select the primary binding for the requested type.
+      PrimaryBinding primaryBinding = findPrimaryBindingByType(visualizationType, model, null);
+
+      if(primaryBinding == null) {
+         List<VSObjectRecommendation> recs = model.getRecommendationList().stream()
+            .filter(r -> !(r instanceof VSFilterRecommendation))
+            .collect(Collectors.toList());
+
+         if(!recs.isEmpty()) {
+            primaryBinding = toPrimaryBinding(recs.get(0), null);
+         }
+      }
+
+      if(primaryBinding == null || Tool.isEmptyString(worksheetId) || Tool.isEmptyString(wizRuntimeId)) {
+         return new CreateViewsheetResult();
+      }
+
+      // 5. Place the new primary in wizRuntimeId without executing the sandbox.
+      VisualizationConfig sourceConfig = new VisualizationConfig();
+      VisualizationConfig.DataSource ds = new VisualizationConfig.DataSource();
+      ds.setSource(worksheetId);
+      sourceConfig.setData(ds);
+
+      CreateVisualizationModel vsModel = new CreateVisualizationModel();
+      vsModel.setConfig(sourceConfig);
+      vsModel.setPrimaryBinding(primaryBinding);
+      vsModel.setRuntimeId(wizRuntimeId);
+      vsModel.setViewsheetIdentifier(viewsheetIdentifier);
+
+      CreateViewsheetResult result = wizVsService.createViewsheetSkipExecution(vsModel, user);
+
+      if(Tool.isEmptyString(result.getRuntimeId())) {
+         result.setRuntimeId(wizRuntimeId);
+      }
+
+      return result;
    }
 
    private static final Logger LOG = LoggerFactory.getLogger(WizAutoBindingService.class);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -665,6 +665,7 @@ public class WizAutoBindingService {
       return null;
    }
 
+   /** Package-private so {@code changeType()} can select a binding from a cached model. */
    PrimaryBinding findPrimaryBindingByType(String vizType, VSRecommendationModel model,
                                            AssetEntry[] entries)
    {
@@ -1027,7 +1028,7 @@ public class WizAutoBindingService {
          }
       }
 
-      // 3. Model missing — fall back to full autoBinding (handles placement too).
+      // 2. Model missing — fall back to full autoBinding (handles placement too).
       if(model == null) {
          AutoBindingRequest fallback = new AutoBindingRequest();
          fallback.setWorksheetId(worksheetId);
@@ -1038,10 +1039,18 @@ public class WizAutoBindingService {
          fallback.setViewsheetIdentifier(viewsheetIdentifier);
          AutoBindingResponse resp = autoBinding(fallback, user);
          CreateViewsheetResult result = resp.getVisualizationResult();
-         return result != null ? result : new CreateViewsheetResult();
+
+         if(result == null) {
+            result = new CreateViewsheetResult();
+         }
+
+         // Forward the newly created autoBindingRuntimeId so the client can use the fast
+         // path on subsequent changeType calls instead of triggering another full autoBinding.
+         result.setAutoBindingRuntimeId(resp.getAutoBindingRuntimeId());
+         return result;
       }
 
-      // 4. Select the primary binding for the requested type.
+      // 3. Select the primary binding for the requested type.
       PrimaryBinding primaryBinding = findPrimaryBindingByType(visualizationType, model, null);
 
       if(primaryBinding == null) {
@@ -1055,10 +1064,12 @@ public class WizAutoBindingService {
       }
 
       if(primaryBinding == null || Tool.isEmptyString(worksheetId) || Tool.isEmptyString(wizRuntimeId)) {
+         LOG.warn("changeType skipped: primaryBinding={}, worksheetId='{}', wizRuntimeId='{}'",
+                  primaryBinding, worksheetId, wizRuntimeId);
          return new CreateViewsheetResult();
       }
 
-      // 5. Place the new primary in wizRuntimeId without executing the sandbox.
+      // 4. Place the new primary in wizRuntimeId without executing the sandbox.
       VisualizationConfig sourceConfig = new VisualizationConfig();
       VisualizationConfig.DataSource ds = new VisualizationConfig.DataSource();
       ds.setSource(worksheetId);
@@ -1076,6 +1087,8 @@ public class WizAutoBindingService {
          result.setRuntimeId(wizRuntimeId);
       }
 
+      // Echo the autoBindingRuntimeId back so the client can reuse it on the next call.
+      result.setAutoBindingRuntimeId(autoBindingRuntimeId);
       return result;
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -56,6 +56,23 @@ public class WizVsService {
    }
 
    public CreateViewsheetResult createViewsheet(CreateVisualizationModel model, Principal user) throws Exception {
+      return createViewsheetInternal(model, user, false);
+   }
+
+   /**
+    * Places the primary assembly without executing the sandbox.
+    * Returns a {@link CreateViewsheetResult} with binding and assembly metadata but no row data.
+    */
+   CreateViewsheetResult createViewsheetSkipExecution(CreateVisualizationModel model, Principal user)
+      throws Exception
+   {
+      return createViewsheetInternal(model, user, true);
+   }
+
+   private CreateViewsheetResult createViewsheetInternal(CreateVisualizationModel model,
+                                                         Principal user,
+                                                         boolean skipExecution) throws Exception
+   {
       String runtimeId = model.getRuntimeId();
       boolean createdRuntimeId = false;
 
@@ -165,6 +182,7 @@ public class WizVsService {
          AssetEntry wsEntry = null;
          Worksheet originWs = null;
          boolean wsModified = false;
+         boolean removedPreviousPrimary = false;
 
          try {
             // All mutations happen inside this try so the catch can roll back everything
@@ -211,14 +229,29 @@ public class WizVsService {
                targetVs.reloadBaseWorksheet(engine, user);
             }
 
-            CreateViewsheetResult result = executeAndExtract(rvs, assembly);
+            CreateViewsheetResult result;
+
+            if(skipExecution) {
+               result = new CreateViewsheetResult();
+            }
+            else {
+               result = executeAndExtract(rvs, assembly);
+               boolean metadataMode = rvs.getViewsheet().getViewsheetInfo().isMetadata();
+               result.setHasData(!metadataMode && result.getRows() != null && !result.getRows().isEmpty());
+            }
+
             result.setBinding(binding);
             result.setAssemblyName(assembly.getName());
-            boolean metadataMode = rvs.getViewsheet().getViewsheetInfo().isMetadata();
-            result.setHasData(!metadataMode && result.getRows() != null && !result.getRows().isEmpty());
 
             if(createdRuntimeId) {
                result.setRuntimeId(runtimeId);
+            }
+
+            // For skipExecution (changeType): remove the displaced primary before persisting
+            // so the stored viewsheet contains only the new assembly.
+            if(skipExecution && previousPrimaryAssembly != null && !createdRuntimeId) {
+               targetVs.removeAssembly(previousPrimaryAssembly.getName());
+               removedPreviousPrimary = true;
             }
 
             String identifierToUse = model.getViewsheetIdentifier();
@@ -248,6 +281,11 @@ public class WizVsService {
 
                if(previousPrimaryAssembly != null) {
                   previousPrimaryAssembly.setPrimary(true);
+
+                  // Re-add the old primary if it was removed by the skipExecution path.
+                  if(removedPreviousPrimary) {
+                     previousVs.addAssembly(previousPrimaryAssembly);
+                  }
                }
 
                if(!modificationOnly) {
@@ -1105,24 +1143,30 @@ public class WizVsService {
       TableVSAssembly table = new TableVSAssembly(vs, name);
       table.initDefaultFormat();
 
-      if(columns != null && entries != null) {
-         Map<String, AssetEntry> entryByName = Arrays.stream(entries)
-            .collect(Collectors.toMap(WizardRecommenderUtil::getFieldName, e -> e, (a, b) -> a));
-         ColumnSelection typedColumns = new ColumnSelection();
+      if(columns != null) {
+         if(entries != null) {
+            Map<String, AssetEntry> entryByName = Arrays.stream(entries)
+               .collect(Collectors.toMap(WizardRecommenderUtil::getFieldName, e -> e, (a, b) -> a));
+            ColumnSelection typedColumns = new ColumnSelection();
 
-         for(int i = 0; i < columns.getAttributeCount(); i++) {
-            DataRef attr = columns.getAttribute(i);
-            AttributeRef attributeRef = new AttributeRef(null, attr.getAttribute());
-            AssetEntry entry = entryByName.get(attr.getAttribute());
+            for(int i = 0; i < columns.getAttributeCount(); i++) {
+               DataRef attr = columns.getAttribute(i);
+               AttributeRef attributeRef = new AttributeRef(null, attr.getAttribute());
+               AssetEntry entry = entryByName.get(attr.getAttribute());
 
-            if(entry != null) {
-               attributeRef.setDataType(entry.getProperty("dtype"));
+               if(entry != null) {
+                  attributeRef.setDataType(entry.getProperty("dtype"));
+               }
+
+               typedColumns.addAttribute(new ColumnRef(attributeRef));
             }
 
-            typedColumns.addAttribute(new ColumnRef(attributeRef));
+            table.setColumnSelection(typedColumns);
          }
-
-         table.setColumnSelection(typedColumns);
+         else {
+            // No entries available; use ColumnRefs as-is (dtypes already set during recommendation).
+            table.setColumnSelection(columns);
+         }
       }
 
       return table;


### PR DESCRIPTION
Add POST /viewsheet/changeType that reuses the recommendation model cached by a prior autoBinding call to switch the primary assembly type without re-executing the sandbox. Falls back to a full autoBinding when the model is unavailable.

- Fix fallback path not clearing the (potentially expired) autoBindingRuntimeId, which caused autoBinding to skip RVS creation and fail on the same dead id.
- Replace fragile getAssembly()==null rollback guard with an explicit boolean flag (removedPreviousPrimary) to track whether the old primary was removed.