### PR TITLE
Fix scheduler subprocess startup when running from source

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/SUtil.java
+++ b/core/src/main/java/inetsoft/sree/internal/SUtil.java
@@ -471,7 +471,13 @@ public class SUtil {
       }
 
       if(cp.isEmpty() || ".".equals(cp)) {
-         return System.getProperty("java.class.path", ".");
+         cp = System.getProperty("java.class.path", ".");
+      }
+
+      String extraCp = System.getProperty("scheduler.extra.classpath");
+
+      if(extraCp != null && !extraCp.isEmpty()) {
+         cp = cp + File.pathSeparator + extraCp;
       }
 
       return cp;

--- a/schedule-server/src/main/java/inetsoft/sree/schedule/ScheduleServerContext.java
+++ b/schedule-server/src/main/java/inetsoft/sree/schedule/ScheduleServerContext.java
@@ -29,12 +29,15 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.annotation.*;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 /**
  * Spring configuration for the standalone schedule server process. Handles RMI
  * registry binding and scheduler lifecycle after the application context starts.
  */
+// @Lazy(false) overrides the global lazy-initialization=true so that
+// setApplicationContext() fires before SmartLifecycle beans start.
 @Configuration
 @Lazy(false)
 public class ScheduleServerContext implements ApplicationRunner, ApplicationContextAware {

--- a/schedule-server/src/main/java/inetsoft/sree/schedule/ScheduleServerContext.java
+++ b/schedule-server/src/main/java/inetsoft/sree/schedule/ScheduleServerContext.java
@@ -29,13 +29,14 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.*;
 
 /**
  * Spring configuration for the standalone schedule server process. Handles RMI
  * registry binding and scheduler lifecycle after the application context starts.
  */
 @Configuration
+@Lazy(false)
 public class ScheduleServerContext implements ApplicationRunner, ApplicationContextAware {
    @Override
    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -401,6 +401,7 @@
             <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
             <inetsoftClusterDir>${project.build.directory}/server/cluster</inetsoftClusterDir>
             <spring.aot.enabled>true</spring.aot.enabled>
+            <scheduler.extra.classpath>${basedir}/../schedule-server/target/inetsoft-schedule-server-${project.version}.jar</scheduler.extra.classpath>
           </systemPropertyVariables>
           <jvmArguments>
             -server -Xmx2g -Xmx2g -XX:InitialCodeCacheSize=100M -XX:ReservedCodeCacheSize=200m
@@ -440,7 +441,6 @@
             <element>${basedir}/../web/target/generated-resources/gulp</element>
             <element>${basedir}/../web/target/generated-resources/ng</element>
             <element>${basedir}/src/test/config/orders.jar</element>
-            <element>${basedir}/../schedule-server/target/inetsoft-schedule-server-${project.version}.jar}</element>
           </additionalClasspathElements>
         </configuration>
       </plugin>


### PR DESCRIPTION
Add scheduler.extra.classpath system property support to SUtil.getApplicationClasspath() so the schedule-server JAR is included only in the scheduler subprocess classpath, not the server JVM. Set this property in both server pom.xml files via spring-boot-maven-plugin systemPropertyVariables. Add @Lazy(false) to ScheduleServerContext to ensure ConfigurationContext.setApplicationContext() is called before SmartLifecycle beans start.