### PR TITLE
Bug #75068 - Hide Round Symbol Corner for measure-bound color legends

### DIFF
--- a/core/src/main/java/inetsoft/web/graph/model/dialog/LegendFormatDialogModel.java
+++ b/core/src/main/java/inetsoft/web/graph/model/dialog/LegendFormatDialogModel.java
@@ -52,9 +52,10 @@ public class LegendFormatDialogModel {
       generalPaneModel.setRoundCorners(legendsDesc.isRoundCorners());
       generalPaneModel.setSymbolRoundCorners(legendDesc.isSymbolRoundCorners());
       // only rect-based legends (Color/Size/Texture) actually render the rounded swatch;
-      // Shape and Line legends draw glyphs/lines so the toggle is hidden there
+      // Shape and Line legends draw glyphs/lines so the toggle is hidden there.
+      // Measure-bound color legends paint a gradient band, so the toggle is also hidden.
       generalPaneModel.setSymbolRoundCornersVisible(
-         "Color".equals(aestheticType) ||
+         ("Color".equals(aestheticType) && dimension) ||
          "Size".equals(aestheticType) ||
          "Texture".equals(aestheticType));
 


### PR DESCRIPTION
 ## Summary

A measure-bound color legend renders as a gradient band rather than per-value
swatches (Legend.isScalar / paintBand path), so the Round Symbol Corner toggle
in Legend Properties has no effect on what gets drawn. The checkbox was still
shown in the dialog, which is misleading.

This gates the Color branch of LegendFormatGeneralPaneModel.symbolRoundCornersVisible
on the existing `dimension` flag, mirroring the adjacent
`notShowNullVisible = dimension && field != null` pattern. Size and Texture
legends always draw discrete items even when bound to a measure, so they keep
the toggle visible.

No descriptor or wire format changes; `symbolRoundCorners` still round-trips
unchanged for existing viewsheets.