### PR TITLE
Bug #75086 - Hide DC bar rounding UI on chart types DC can't convert

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/model/vs/ChartAdvancedPaneModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/ChartAdvancedPaneModel.java
@@ -163,12 +163,12 @@ public class ChartAdvancedPaneModel {
       // runtime bar conversion, so it incorrectly resets barRoundAllCorners=false.
       // Re-apply the user's value only when DC will actually create bars (mirrors the
       // visibility guard in the constructor).
-      DateComparisonInfo updateDcInfo = chartAssemblyInfo.getDateComparisonInfo();
+      DateComparisonInfo dcInfo = chartAssemblyInfo.getDateComparisonInfo();
 
       if(chartAssemblyInfo.isDateComparisonEnabled() &&
          DateComparisonUtil.isDateComparisonDefined(chartAssemblyInfo) &&
          DateComparisonUtil.supportDateComparison(info, true) &&
-         updateDcInfo != null && !updateDcInfo.isValueOnly() &&
+         dcInfo != null && !dcInfo.isValueOnly() &&
          !GraphTypeUtil.checkType(info, ctype ->
             GraphTypes.isBar(ctype) || GraphTypes.isInterval(ctype)))
       {

--- a/core/src/main/java/inetsoft/web/composer/model/vs/ChartAdvancedPaneModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/ChartAdvancedPaneModel.java
@@ -64,12 +64,14 @@ public class ChartAdvancedPaneModel {
 
       // design-time info has no DC runtime state, so barCornerRadiusVisible is false
       // for non-bar charts even when DC will convert them to bars at runtime.
-      // Exclude value-only DC since it doesn't add comparison bars.
+      // Exclude value-only DC (no comparison bars) and chart types DC can't run on
+      // (icicle/treemap/etc. — DC silently no-ops, no bars are ever created).
       DateComparisonInfo dcInfo = chartAssemblyInfo.getDateComparisonInfo();
 
       if(!chartPlotOptionsPaneModel.isBarCornerRadiusVisible() &&
          chartAssemblyInfo.isDateComparisonEnabled() &&
          DateComparisonUtil.isDateComparisonDefined(chartAssemblyInfo) &&
+         this.dateComparisonSupport &&
          dcInfo != null && !dcInfo.isValueOnly())
       {
          chartPlotOptionsPaneModel.setBarCornerRadiusVisible(true);
@@ -159,9 +161,14 @@ public class ChartAdvancedPaneModel {
 
       // updateChartPlotOptionsPaneModel uses design-time checkType which doesn't see DC's
       // runtime bar conversion, so it incorrectly resets barRoundAllCorners=false.
-      // Re-apply the user's value when DC is defined and chart type isn't natively bar/interval.
+      // Re-apply the user's value only when DC will actually create bars (mirrors the
+      // visibility guard in the constructor).
+      DateComparisonInfo updateDcInfo = chartAssemblyInfo.getDateComparisonInfo();
+
       if(chartAssemblyInfo.isDateComparisonEnabled() &&
          DateComparisonUtil.isDateComparisonDefined(chartAssemblyInfo) &&
+         DateComparisonUtil.supportDateComparison(info, true) &&
+         updateDcInfo != null && !updateDcInfo.isValueOnly() &&
          !GraphTypeUtil.checkType(info, ctype ->
             GraphTypes.isBar(ctype) || GraphTypes.isInterval(ctype)))
       {

--- a/core/src/test/java/inetsoft/report/composition/graph/GraphTypeUtilCheckTypeTest.java
+++ b/core/src/test/java/inetsoft/report/composition/graph/GraphTypeUtilCheckTypeTest.java
@@ -181,7 +181,8 @@ class GraphTypeUtilCheckTypeTest {
          "DC-created bars on a LINE chart should pass isBar check");
       assertTrue(GraphTypeUtil.checkType(info, ctype ->
                (GraphTypes.isBar(ctype) || GraphTypes.isInterval(ctype) ||
-                GraphTypes.isPareto(ctype) || GraphTypes.isWaterfall(ctype)) &&
+                GraphTypes.isPareto(ctype) || GraphTypes.isWaterfall(ctype) ||
+                GraphTypes.isGantt(ctype)) &&
                !GraphTypes.is3DBar(ctype) && !GraphTypes.isFunnel(ctype)),
          "barCornerRadiusVisible predicate should be true for DC bar on LINE chart");
    }


### PR DESCRIPTION
## Summary

Gate the date-comparison bar-rounding UI override on supportDateComparison
so charts where DC silently no-ops (icicle, treemap, pie, etc.) no longer
show the Bar Corner Radius / Round All Corners controls. Apply the same
guard plus the value-only exclusion to the update path so it stays
symmetric with the constructor.