### PR TITLE
Fix DataSpace appearing empty after clone + two org renames (#75162)

### DIFF
--- a/core/src/main/java/inetsoft/storage/BlobStorage.java
+++ b/core/src/main/java/inetsoft/storage/BlobStorage.java
@@ -609,13 +609,21 @@ public abstract class BlobStorage<T extends Serializable> implements AutoCloseab
    @Override
    public void close() throws Exception {
       eventExecutor.shutdown();
-      storage.removeListener(listener);
-      storage.close();
+
+      // Guard against double-close: when KeyValueStorageManager LRU-evicts the inner
+      // LocalKeyValueStorage, its close() is already called by the eviction listener.
+      // Calling removeListener/close a second time is unsafe (removes a listener that is
+      // already gone). Skip both if the inner storage is already closed.
+      if(!storage.isClosed()) {
+         storage.removeListener(listener);
+         storage.close();
+      }
+
       isClosed = true;
    }
 
    public boolean isClosed() {
-      return isClosed;
+      return isClosed || storage.isClosed();
    }
 
    public static <T extends Serializable> BlobStorage<T> createBlobStorage(String id,
@@ -655,7 +663,7 @@ public abstract class BlobStorage<T extends Serializable> implements AutoCloseab
    private final Set<Listener<T>> listeners =
       new ConcurrentSkipListSet<>(Comparator.comparing(Listener::hashCode));
    private final String lockHost;
-   private boolean isClosed = false;
+   private volatile boolean isClosed = false;
    private final ExecutorService eventExecutor =
       Executors.newSingleThreadExecutor(r -> new GroupedThread(r, "BlobStorageEvent"));
    private static final Logger LOG = LoggerFactory.getLogger(BlobStorage.class);

--- a/core/src/main/java/inetsoft/util/BlobIndexedStorage.java
+++ b/core/src/main/java/inetsoft/util/BlobIndexedStorage.java
@@ -597,6 +597,7 @@ public class BlobIndexedStorage extends AbstractIndexedStorage {
          OrganizationManager.getInstance().getCurrentOrgID();
       String nId = norg instanceof Organization ? ((Organization) norg).getId() :
          OrganizationManager.getInstance().getCurrentOrgID();
+      Set<String> allKeys = getKeys(null, oId);
       int numThreads = Runtime.getRuntime().availableProcessors();
       ExecutorService executor = Executors.newFixedThreadPool(numThreads, r -> {
          Thread t = new Thread(r, "BlobStorageMigrateOrg");
@@ -604,7 +605,7 @@ public class BlobIndexedStorage extends AbstractIndexedStorage {
          return t;
       });
 
-      for(String key : getKeys(null, oId)) {
+      for(String key : allKeys) {
          final AssetEntry entry = AssetEntry.createAssetEntry(key);
 
          if(entry.isViewsheet()) {

--- a/core/src/main/java/inetsoft/util/DataSpace.java
+++ b/core/src/main/java/inetsoft/util/DataSpace.java
@@ -47,20 +47,56 @@ public class DataSpace implements AutoCloseable {
     */
    @Autowired
    public DataSpace(BlobStorageManager blobStorageManager) {
-      this(blobStorageManager.<Metadata>getStorage("dataSpace", true));
-   }
-
-   private DataSpace(BlobStorage<Metadata> blobStorage) {
-      this.blobStorage = blobStorage;
+      this.blobStorageManager = blobStorageManager;
       listeners = new ListenerTree();
 
-      if(blobStorage != null) {
-         blobStorage.addListener(listeners);
+      BlobStorage<Metadata> storage = blobStorageManager.<Metadata>getStorage("dataSpace", true);
+      this.blobStorage = storage;
+
+      if(storage != null) {
+         storage.addListener(listeners);
       }
 
       String home = ConfigurationContext.getContext().getHome()
          .trim().replace('\\', '/').replace("//", "/");
       homePath = home.endsWith("/") ? home.substring(0, home.length() - 1) : home;
+   }
+
+   /**
+    * Gets the current live blob storage for the data space, refreshing it if the inner
+    * key-value storage has been evicted from the {@link inetsoft.storage.KeyValueStorageManager}
+    * cache.
+    */
+   private BlobStorage<Metadata> storage() {
+      if(blobStorage != null && blobStorage.isClosed()) {
+         synchronized(this) {
+            BlobStorage<Metadata> old = blobStorage;
+
+            if(old != null && old.isClosed()) {
+               BlobStorage<Metadata> fresh = blobStorageManager.<Metadata>getStorage("dataSpace", false);
+
+               if(fresh == null) {
+                  LOG.error("Failed to obtain a fresh DataSpace blob storage after eviction");
+                  return blobStorage;
+               }
+
+               fresh.addListener(listeners);
+               blobStorage = fresh;
+
+               // Explicitly close the old BlobStorage to shut down its eventExecutor thread.
+               // Its inner KeyValueStorage was already closed (by LRU eviction), so
+               // BlobStorageManager's removal listener skipped close(); we must do it here.
+               try {
+                  old.close();
+               }
+               catch(Exception e) {
+                  LOG.warn("Failed to close stale DataSpace blob storage", e);
+               }
+            }
+         }
+      }
+
+      return blobStorage;
    }
 
    @Override
@@ -145,7 +181,7 @@ public class DataSpace implements AutoCloseable {
       String path = getPath(dir, file);
 
       try {
-         return blobStorage.getLength(path);
+         return storage().getLength(path);
       }
       catch(FileNotFoundException ignore) {
          return 0L;
@@ -164,7 +200,7 @@ public class DataSpace implements AutoCloseable {
       String path = getPath(dir, file);
 
       try {
-         return blobStorage.getInputStream(path);
+         return storage().getInputStream(path);
       }
       catch(FileNotFoundException | NoSuchFileException ignore) {
          return null;
@@ -223,7 +259,7 @@ public class DataSpace implements AutoCloseable {
    public String[] list(String dir) {
       String path = sanitizePathComponent(dir);
       String prefix = path == null || path.isEmpty() ? "" : path + "/";
-      return blobStorage.stream()
+      return storage().stream()
          .map(Blob::getPath)
          .filter(p -> isChildPath(prefix, p))
          .map(p -> p.substring(prefix.length()))
@@ -242,7 +278,7 @@ public class DataSpace implements AutoCloseable {
          return true;
       }
 
-      return blobStorage.isDirectory(sanitizePathComponent(path));
+      return storage().isDirectory(sanitizePathComponent(path));
    }
 
    /**
@@ -280,7 +316,7 @@ public class DataSpace implements AutoCloseable {
     * @return true if path exists
     */
    public boolean exists(String dir, String file) {
-      return blobStorage.exists(getPath(dir, file));
+      return storage().exists(getPath(dir, file));
    }
 
    /**
@@ -305,8 +341,8 @@ public class DataSpace implements AutoCloseable {
       }
 
       try {
-         if(blobStorage.exists(path)) {
-            blobStorage.delete(path);
+         if(storage().exists(path)) {
+            storage().delete(path);
          }
 
          return true;
@@ -331,8 +367,12 @@ public class DataSpace implements AutoCloseable {
    }
 
    private boolean renameRecursively(String oldPath, String newPath) {
-      if(isDirectory(oldPath)) {
-         for(String child : list(oldPath)) {
+      boolean isDir = isDirectory(oldPath);
+
+      if(isDir) {
+         String[] children = list(oldPath);
+
+         for(String child : children) {
             String ochild = oldPath.isEmpty() ? child : oldPath + "/" + child;
             String nchild = newPath.isEmpty() ? child : newPath + "/" + child;
 
@@ -343,7 +383,7 @@ public class DataSpace implements AutoCloseable {
       }
 
       try {
-         blobStorage.rename(oldPath, newPath);
+         storage().rename(oldPath, newPath);
          return true;
       }
       catch(FileNotFoundException ignore) {
@@ -362,7 +402,7 @@ public class DataSpace implements AutoCloseable {
     * @return String[] containing org scoped paths
     */
    public String[] getOrgScopedPaths(Organization oorg) {
-      return blobStorage.paths().filter(p -> p.equals("portal/" + oorg.getId()) ||
+      return storage().paths().filter(p -> p.equals("portal/" + oorg.getId()) ||
          p.startsWith("portal/" + oorg.getId() + "/") || p.startsWith(oorg.getId() + "__") ||
          p.equals(oorg.getId()) || p.startsWith(oorg.getId() + "/") ||
          p.startsWith("sreeUserData/") &&
@@ -395,7 +435,7 @@ public class DataSpace implements AutoCloseable {
       }
 
       try {
-         blobStorage.copy(oldPath, newPath);
+         storage().copy(oldPath, newPath);
          return true;
       }
       catch(FileNotFoundException ignore) {
@@ -409,7 +449,7 @@ public class DataSpace implements AutoCloseable {
    }
 
    public String listBlobs() throws IOException {
-      return blobStorage.listBlobs();
+      return storage().listBlobs();
    }
 
    /**
@@ -424,7 +464,7 @@ public class DataSpace implements AutoCloseable {
       String path = getPath(dir, file);
 
       try {
-         return blobStorage.getLastModified(path).toEpochMilli();
+         return storage().getLastModified(path).toEpochMilli();
       }
       catch(FileNotFoundException ignore) {
          return 0L;
@@ -442,7 +482,7 @@ public class DataSpace implements AutoCloseable {
       String sanitized = sanitizePathComponent(path);
 
       try {
-         blobStorage.createDirectory(sanitized, new Metadata());
+         storage().createDirectory(sanitized, new Metadata());
          return true;
       }
       catch(IOException e) {
@@ -485,11 +525,15 @@ public class DataSpace implements AutoCloseable {
     * Dispose the data space.
     */
    public void dispose() {
-      try {
-         blobStorage.close();
-      }
-      catch(Exception e) {
-         LOG.warn("Failed to close blob storage", e);
+      BlobStorage<Metadata> s = blobStorage;
+
+      if(s != null) {
+         try {
+            s.close();
+         }
+         catch(Exception e) {
+            LOG.warn("Failed to close blob storage", e);
+         }
       }
    }
 
@@ -537,7 +581,8 @@ public class DataSpace implements AutoCloseable {
       return path.startsWith(prefix) && path.indexOf('/', prefix.length()) < 0;
    }
 
-   private final BlobStorage<Metadata> blobStorage;
+   private volatile BlobStorage<Metadata> blobStorage;
+   private final BlobStorageManager blobStorageManager;
    private final String homePath;
    private final ListenerTree listeners;
 
@@ -600,7 +645,7 @@ public class DataSpace implements AutoCloseable {
 
    public final class TransactionImpl implements Transaction {
       TransactionImpl() {
-         tx = blobStorage.beginTransaction();
+         tx = storage().beginTransaction();
       }
 
       public OutputStream newStream(String dir, String file) throws IOException {

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -2028,7 +2028,9 @@ public class IdentityService {
       newOrg.setLocale(localeString);
       updateCustomThemeOrganization(fromOrg.getTheme(), model.theme(), fromOrgID, newOrg.getId());
       newOrg.setTheme(model.theme());
-      syncIdentity(eprovider, newOrg, new IdentityID(model.oldName(), eprovider.getOrgIdFromName(model.oldName())));
+      String syncOldName = model.oldName();
+      String syncOldOrgID = eprovider.getOrgIdFromName(syncOldName);
+      syncIdentity(eprovider, newOrg, new IdentityID(syncOldName, syncOldOrgID));
 
       return newOrg;
    }


### PR DESCRIPTION
## Summary

Fixes Redmine bug #75162: In EM → Content → Storage tab, the tree shows only the root "Data Space" folder with no children after cloning the host org and renaming the clone twice. The first rename succeeds; the second rename breaks it.

## Root Cause

`KeyValueStorageManager` has a Caffeine LRU cache (`MAX_SIZE=50`). Each per-org blob storage opens a `LocalKeyValueStorage` entry in this cache (~11 per org). After a clone + 2 renames, ~52 entries accumulate (4 orgs × 11 per-org + 8 global), exceeding the limit.

Caffeine evicts the **LRU entry** — `"dataSpace"` — which was loaded at startup and never re-accessed via `KeyValueStorageManager` (all DataSpace operations went through the cached `BlobStorage → LocalKeyValueStorage` reference chain). Eviction called `LocalKeyValueStorage.close()` → `isClosed = true`. Since `BlobStorage.isClosed()` only checked its own flag (not the inner storage's), the staleness was invisible. Every `DataSpace.stream()` call returned `Stream.empty()` → all `list()` calls returned `[]`.

## Fix

**`BlobStorage.isClosed()`** — propagate inner storage's closed state:
```java
public boolean isClosed() {
    return isClosed || storage.isClosed();
}
```
This makes `BlobStorageManager.getStorage()`'s while-loop detect when the inner KV storage has been LRU-evicted, so it replaces the stale `BlobStorage` with a fresh one.

**`DataSpace`** — store `BlobStorageManager` and add a `storage()` accessor that transparently refreshes the `BlobStorage` reference using double-checked locking on a `volatile` field:
```java
private BlobStorage<Metadata> storage() {
    if (blobStorage != null && blobStorage.isClosed()) {
        synchronized (this) {
            BlobStorage<Metadata> old = blobStorage;
            if (old != null && old.isClosed()) {
                BlobStorage<Metadata> fresh = blobStorageManager.getStorage("dataSpace", false);
                fresh.addListener(listeners);
                blobStorage = fresh;
                old.close(); // shut down orphaned eventExecutor thread
            }
        }
    }
    return blobStorage;
}
```
All DataSpace operations call `storage()` instead of the field directly.

## Testing

Manually verified: clone host org → rename clone → rename clone again → EM Content/Storage tab shows full tree correctly.

All 2,483 unit tests pass (0 failures, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)