### PR TITLE
fix bug 75161:WizAutoBindingService does not filter invisible columns, causing the join key to be mistakenly treated as a measure.

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -45,6 +45,7 @@ import java.security.Principal;
 import java.util.*;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 public class WizAutoBindingService {
@@ -111,7 +112,7 @@ public class WizAutoBindingService {
                      for(int i = 0; i < cs.getAttributeCount(); i++) {
                         DataRef ref = cs.getAttribute(i);
 
-                        if(ref instanceof ColumnRef colRef) {
+                        if(ref instanceof ColumnRef colRef && colRef.isVisible()) {
                            worksheetColumns.add(colRef);
                         }
                      }
@@ -132,8 +133,15 @@ public class WizAutoBindingService {
          AssetEntry[] entries;
 
          if(!worksheetColumns.isEmpty()) {
-            // Primary path: use all worksheet columns (fieldConfigs as overlay only)
-            entries = worksheetColumns.stream()
+            // When fieldConfigs are provided, restrict to only those columns to exclude
+            // join key columns (marked visible=false) from the recommendation engine.
+            Stream<ColumnRef> colStream = worksheetColumns.stream();
+
+            if(!configMap.isEmpty()) {
+               colStream = colStream.filter(col -> configMap.containsKey(col.getAttribute()));
+            }
+
+            entries = colStream
                .map(col -> buildEntryFromColumn(
                   col, worksheetId, tableNameFinal, configMap.get(col.getAttribute())))
                .toArray(AssetEntry[]::new);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -45,7 +45,6 @@ import java.security.Principal;
 import java.util.*;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Service
 public class WizAutoBindingService {
@@ -112,7 +111,7 @@ public class WizAutoBindingService {
                      for(int i = 0; i < cs.getAttributeCount(); i++) {
                         DataRef ref = cs.getAttribute(i);
 
-                        if(ref instanceof ColumnRef colRef && colRef.isVisible()) {
+                        if(ref instanceof ColumnRef colRef) {
                            worksheetColumns.add(colRef);
                         }
                      }
@@ -133,15 +132,8 @@ public class WizAutoBindingService {
          AssetEntry[] entries;
 
          if(!worksheetColumns.isEmpty()) {
-            // When fieldConfigs are provided, restrict to only those columns to exclude
-            // join key columns (marked visible=false) from the recommendation engine.
-            Stream<ColumnRef> colStream = worksheetColumns.stream();
-
-            if(!configMap.isEmpty()) {
-               colStream = colStream.filter(col -> configMap.containsKey(col.getAttribute()));
-            }
-
-            entries = colStream
+            // Primary path: use all worksheet columns (fieldConfigs as overlay only)
+            entries = worksheetColumns.stream()
                .map(col -> buildEntryFromColumn(
                   col, worksheetId, tableNameFinal, configMap.get(col.getAttribute())))
                .toArray(AssetEntry[]::new);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -106,12 +106,14 @@ public class WizAutoBindingService {
 
                   if(primary instanceof TableAssembly ta) {
                      tableName = primary.getName();
-                     ColumnSelection cs = ta.getColumnSelection();
+                     // Use private selection so visibility flags set by applyFieldVisibility
+                     // (which writes to the private selection) are correctly reflected.
+                     ColumnSelection cs = ta.getColumnSelection(false);
 
                      for(int i = 0; i < cs.getAttributeCount(); i++) {
                         DataRef ref = cs.getAttribute(i);
 
-                        if(ref instanceof ColumnRef colRef) {
+                        if(ref instanceof ColumnRef colRef && colRef.isVisible()) {
                            worksheetColumns.add(colRef);
                         }
                      }


### PR DESCRIPTION
When wiz-services builds a Worksheet, it marks the join key (CUSTOMER_ID) as visible=false, but StyleBI's WizAutoBindingService does not filter out invisible columns when reading the Worksheet columns, causing CUSTOMER_ID to enter the recommendation engine. Because it is an integer type, it is treated as a measure, resulting in an unnecessary Sum(CUSTOMER_ID) binding.