### PR TITLE
Bug #75172 - Fix race condition causing NPE when cancelling MV creation

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/MVAction.java
+++ b/core/src/main/java/inetsoft/sree/schedule/MVAction.java
@@ -432,7 +432,9 @@ public class MVAction implements AssetSupport, Cloneable, XMLSerializable, Cance
 
    @Override
    public void cancel() {
-      if(mvFuture != null) {
+      Future<String> future = mvFuture;
+
+      if(future != null) {
          MVCancelledMessage mvCancelledMessage = new MVCancelledMessage(mvname);
 
          try {
@@ -442,7 +444,7 @@ public class MVAction implements AssetSupport, Cloneable, XMLSerializable, Cance
             LOG.debug("Failed to send MV cancelled message", e);
          }
 
-         mvFuture.cancel(true);
+         future.cancel(true);
       }
 
       if(runningCreators.get(mvname) != null) {
@@ -550,7 +552,7 @@ public class MVAction implements AssetSupport, Cloneable, XMLSerializable, Cance
    private MVDef mv;
    private volatile boolean reloadMv = false;
    private String email;
-   private Future<String> mvFuture;
+   private volatile Future<String> mvFuture;
    private static final Map<String, MVCreator> runningCreators = new ConcurrentHashMap<>();
    private static final Logger LOG = LoggerFactory.getLogger(MVAction.class);
 }

--- a/core/src/main/java/inetsoft/sree/schedule/MVAction.java
+++ b/core/src/main/java/inetsoft/sree/schedule/MVAction.java
@@ -447,8 +447,10 @@ public class MVAction implements AssetSupport, Cloneable, XMLSerializable, Cance
          future.cancel(true);
       }
 
-      if(runningCreators.get(mvname) != null) {
-         runningCreators.get(mvname).cancel();
+      MVCreator creator = runningCreators.get(mvname);
+
+      if(creator != null) {
+         creator.cancel();
       }
    }
 


### PR DESCRIPTION
## Summary

- `mvFuture` in `MVAction` was a non-volatile field, and `cancel()` performed a non-atomic check-then-act on it
- A concurrent thread could clear `mvFuture` to `null` (in the `finally` block of `createMV()`) between the null-check at line 435 and the `cancel()` call at line 445, producing `NullPointerException: Cannot invoke "Future.cancel(boolean)" because "this.mvFuture" is null`
- The race is triggered when the schedule task timeout fires: `ScheduleTask.doRun()` cancels thread-pool futures (interrupting the task runner thread) and then immediately calls `MVAction.cancel()`, creating the window for the race

## Changes

- Declared `mvFuture` as `volatile` to ensure cross-thread visibility of writes
- Captured `mvFuture` into a local variable in `cancel()` so the null-check and the `cancel()` call are a single atomic read

## Test plan

- [ ] Reproduce with `schedule.task.timeout=10000`, scheduler running, trigger MV creation for a folder with multiple views — confirm NPE no longer occurs
- [ ] Verify MV creation still completes successfully when no timeout is hit
- [ ] Verify MV creation is properly cancelled when timeout fires

Fixes: https://issues.inetsoft.com/issues/75172

🤖 Generated with [Claude Code](https://claude.com/claude-code)