### PR TITLE
Bug #75050 - Fix horizontal faceted tree chart inflating Y when faceted

### DIFF
--- a/core/src/main/java/inetsoft/graph/coord/RelationCoord.java
+++ b/core/src/main/java/inetsoft/graph/coord/RelationCoord.java
@@ -21,8 +21,10 @@ import inetsoft.graph.*;
 import inetsoft.graph.data.DataSet;
 import inetsoft.graph.data.DataSetIndex;
 import inetsoft.graph.element.RelationElement;
+import inetsoft.graph.geometry.RelationGeometry;
 import inetsoft.graph.guide.axis.Axis;
 import inetsoft.graph.scale.Scale;
+import inetsoft.graph.visual.RelationVO;
 
 import java.awt.geom.*;
 import java.util.Map;
@@ -203,10 +205,47 @@ public class RelationCoord extends Coordinate {
     */
    @Override
    public double getUnitMinHeight() {
+      // Horizontal mode: read natural mxcell bounds directly. Visual bounds union scaled node
+      // positions with fixed-pixel text labels; back-dividing then amplifies the label
+      // contribution by 1/scaleY, padding each cell well beyond the rotated tree's actual
+      // extent when facet rows shrink scaleY.
+      if(isFirstElementHorizontal()) {
+         Rectangle2D natural = getNaturalLayoutBounds();
+
+         if(natural != null) {
+            return natural.getHeight() + GAP * 2;
+         }
+      }
+
       Rectangle2D box = getVisualObjectBounds();
-      // preferred size should be unscaled size
+
+      if(box == null) {
+         return 100;
+      }
+
       double scaleY = Math.abs(getVGraph().getScreenTransform().getScaleY());
-      return box != null ? (box.getMaxY() - box.getY()) / scaleY + GAP * 2 : 100;
+      return (box.getMaxY() - box.getY()) / scaleY + GAP * 2;
+   }
+
+   private Rectangle2D getNaturalLayoutBounds() {
+      VGraph vgraph = getVGraph();
+
+      if(vgraph == null) {
+         return null;
+      }
+
+      Rectangle2D bounds = null;
+
+      for(int i = 0; i < vgraph.getVisualCount(); i++) {
+         if(vgraph.getVisual(i) instanceof RelationVO vo
+            && vo.getGeometry() instanceof RelationGeometry geo)
+         {
+            Rectangle2D rect = geo.getMxCell().getGeometry().getRectangle();
+            bounds = bounds == null ? rect : bounds.createUnion(rect);
+         }
+      }
+
+      return bounds;
    }
 
    /**

--- a/core/src/main/java/inetsoft/graph/coord/RelationCoord.java
+++ b/core/src/main/java/inetsoft/graph/coord/RelationCoord.java
@@ -238,7 +238,8 @@ public class RelationCoord extends Coordinate {
 
       for(int i = 0; i < vgraph.getVisualCount(); i++) {
          if(vgraph.getVisual(i) instanceof RelationVO vo
-            && vo.getGeometry() instanceof RelationGeometry geo)
+            && vo.getGeometry() instanceof RelationGeometry geo
+            && geo.getMxCell().getGeometry() != null)
          {
             Rectangle2D rect = geo.getMxCell().getGeometry().getRectangle();
             bounds = bounds == null ? rect : bounds.createUnion(rect);

--- a/core/src/test/java/inetsoft/graph/coord/RelationCoordMinSizeTest.java
+++ b/core/src/test/java/inetsoft/graph/coord/RelationCoordMinSizeTest.java
@@ -23,8 +23,15 @@ import inetsoft.graph.VGraph;
 import inetsoft.graph.aesthetic.StaticSizeFrame;
 import inetsoft.graph.data.DefaultDataSet;
 import inetsoft.graph.element.RelationElement;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.awt.geom.AffineTransform;
 
@@ -36,7 +43,11 @@ import static org.junit.jupiter.api.Assertions.*;
  * skips the back-divide (X is depth, scaleX is Y-binding-driven, dividing would over-report
  * X and force the chart canvas to widen unnecessarily).
  */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @SreeHome
+@Tag("core")
 class RelationCoordMinSizeTest {
    @Test
    void horizontalModeSkipsBackDivideVerticalDoesNot() {
@@ -61,23 +72,21 @@ class RelationCoordMinSizeTest {
    }
 
    @Test
-   void heightBackDivideAppliesInBothOrientations() {
-      // getUnitMinHeight intentionally does not gate on the horizontal flag — toggling
-      // the flag must not change Y's formula.
+   void heightInHorizontalModeIsInvariantToScreenScale() {
+      // Horizontal mode reads the natural mxgraph layout bounds directly, so artificial
+      // changes to the screen transform must not affect the reported height. Vertical mode
+      // still goes through visual bounds + back-divide and so is scale-sensitive.
       RelationCoord coord = treeCoord(false);
       RelationElement elem = (RelationElement) coord.getVGraph().getEGraph().getElement(0);
 
-      coord.getVGraph().concat(AffineTransform.getScaleInstance(0.5, 0.5), true);
-
       elem.setHorizontal(true);
-      double horizMinH = coord.getUnitMinHeight();
+      double horizBefore = coord.getUnitMinHeight();
+      coord.getVGraph().concat(AffineTransform.getScaleInstance(0.5, 0.05), true);
+      double horizAfter = coord.getUnitMinHeight();
 
-      elem.setHorizontal(false);
-      double vertMinH = coord.getUnitMinHeight();
-
-      assertEquals(horizMinH, vertMinH, 0.5,
-         "getUnitMinHeight must back-divide in both orientations (horiz=" + horizMinH
-            + ", vert=" + vertMinH + ")");
+      assertEquals(horizBefore, horizAfter, 0.5,
+         "horizontal-mode unitMinHeight must be invariant to screen-transform scaling "
+            + "(before=" + horizBefore + ", after=" + horizAfter + ")");
    }
 
    private static RelationCoord treeCoord(boolean horizontal) {

--- a/core/src/test/java/inetsoft/graph/coord/RelationCoordMinSizeTest.java
+++ b/core/src/test/java/inetsoft/graph/coord/RelationCoordMinSizeTest.java
@@ -38,10 +38,11 @@ import java.awt.geom.AffineTransform;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Guards the asymmetric back-divide in {@link RelationCoord#getUnitMinWidth()}: vertical
- * mode back-divides by scaleX (so post-fit calls recover natural width); horizontal mode
- * skips the back-divide (X is depth, scaleX is Y-binding-driven, dividing would over-report
- * X and force the chart canvas to widen unnecessarily).
+ * Guards the horizontal-mode special-casing in {@link RelationCoord#getUnitMinWidth()} and
+ * {@link RelationCoord#getUnitMinHeight()}: vertical mode goes through the back-divide path
+ * (so post-fit calls recover natural size); horizontal mode skips the back-divide for width
+ * (X is depth, scaleX is Y-binding-driven) and reads natural mxcell bounds directly for
+ * height (avoiding label-amplified 1/scaleY inflation in faceted layouts).
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)


### PR DESCRIPTION
 ## Summary

- In horizontal-orientation faceted tree charts, `RelationCoord.getUnitMinHeight`
over-reported the per-cell minimum height, allocating far more vertical space than the
 rotated tree needed and producing a chart canvas several times taller than the
viewport with large empty padding around each tree.
- Root cause: the existing back-divide formula `boxHeight / scaleY` unions fixed-pixel
 text labels with scaled node positions in `boxHeight`, then amplifies the label
contribution by `1/scaleY`. With many facet rows squeezing each cell's scaleY small,
that amplification dominates and stacks multiplicatively with the row count.
- Fix: in horizontal mode, read natural bounds directly from each node's
`mxCell.getGeometry().getRectangle()` rather than back-dividing screen-transformed
visual bounds. Layout-coord bounds are invariant to screen-transform state and exclude
 labels, so they reflect the tree's true natural extent.
- This is the symmetric counterpart to commit 8268aebd (Bug #74971), which addressed
the X-axis inflation with an analogous gate.
- Vertical mode is untouched (still back-divides visual bounds).