### PR TITLE
Bug #75054 - Emphasize stack total in solo card tooltip

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
+++ b/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
@@ -112,6 +112,10 @@ public class ChartToolTip implements DataSerializable {
          }
       }
 
+      // Emit the stack total separately at tier-1 so it reads as a footer total,
+      // matching the combined-card path.
+      int stackTotalIdx = findStackTotalIndex(palette);
+
       for(int i = 0; i < tooltips.size(); i += 2) {
          int keyIdx = tooltips.get(i);
 
@@ -120,10 +124,23 @@ public class ChartToolTip implements DataSerializable {
             continue;
          }
 
+         if(i == stackTotalIdx) {
+            continue;
+         }
+
          String label = palette.get(keyIdx);
          String value = (i + 1) < tooltips.size() ? palette.get(tooltips.get(i + 1)) : "";
          appendTier(buffer, tier, label + ChartToolTip.COLON + value);
          tier++;
+      }
+
+      if(stackTotalIdx >= 0) {
+         String label = palette.get(tooltips.get(stackTotalIdx));
+         String value = (stackTotalIdx + 1) < tooltips.size()
+            ? palette.get(tooltips.get(stackTotalIdx + 1)) : "";
+         buffer.append("<div class=\"tt-tier-1 tt-stack-total\">")
+               .append(label).append(ChartToolTip.COLON).append(value)
+               .append("</div>");
       }
 
       return buffer.toString();
@@ -164,6 +181,23 @@ public class ChartToolTip implements DataSerializable {
       }
 
       return buffer.toString();
+   }
+
+   // Match by name rather than position so callers that skip moveTotalToBottom still work.
+   private int findStackTotalIndex(IndexedSet<String> palette) {
+      if(stackTotalName == null || stackTotalName.isEmpty()) {
+         return -1;
+      }
+
+      for(int i = 0; i < tooltips.size(); i += 2) {
+         int keyIdx = tooltips.get(i);
+
+         if(keyIdx >= 0 && stackTotalName.equals(palette.get(keyIdx))) {
+            return i;
+         }
+      }
+
+      return -1;
    }
 
    private boolean isMultiSection() {

--- a/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
@@ -18,10 +18,12 @@
 package inetsoft.report.composition.region;
 
 import inetsoft.uql.viewsheet.graph.ChartInfo;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@Tag("core")
 class ChartToolTipTest {
    @Test
    void defaultStyleRendersLegacyFormat() {
@@ -111,6 +113,30 @@ class ChartToolTipTest {
                  "Real content must claim tier-1, not be demoted by a blank leading line");
       assertTrue(out.contains("<div class=\"tt-tier-2\">Line2"));
       assertFalse(out.contains("tt-tier-3"));
+   }
+
+   @Test
+   void cardStyleSoloEmphasizesStackTotal() {
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.addTooltip(palette.put("Sum(Gross Amount)"), palette.put("994.7K"));
+      tip.addTooltip(palette.put("Cal Month"), palette.put("JUL-TY"));
+      tip.addTooltip(palette.put("Category"), palette.put("Personal"));
+      tip.addTooltip(palette.put("Total"), palette.put("13.6M"));
+      tip.setStackTotalName("Total");
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-1\">Sum(Gross Amount):&nbsp;994.7K"),
+                 "Hovered measure stays at tier-1");
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Cal Month:&nbsp;JUL-TY"));
+      assertTrue(out.contains("<div class=\"tt-tier-3\">Category:&nbsp;Personal"));
+      assertTrue(out.endsWith("<div class=\"tt-tier-1 tt-stack-total\">Total:&nbsp;13.6M</div>"),
+                 "Solo card must emphasize the stack total with tt-stack-total at the end");
+      // The stack total must not also appear as a plain tier row.
+      int totalCount = out.split("Total:&nbsp;13\\.6M", -1).length - 1;
+      assertEquals(1, totalCount, "Stack total must appear exactly once");
    }
 
    @Test


### PR DESCRIPTION
Mirror the combined-card layout: in solo card mode, render the stack
total at tier-1 with the .tt-stack-total class (20px) instead of as a
small trailing tier-3 row.

Also add @Tag("core") to ChartToolTipTest — the class was previously
excluded by surefire's <groups>core</groups> filter, so its 11 existing
tests were silently dormant. They now run alongside the new
cardStyleSoloEmphasizesStackTotal test (12 total).