### PR TITLE
Fix the issue of container size passing for embedded StyleBI charts

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshService.java
@@ -99,6 +99,33 @@ public class VSRefreshService {
          coreLifecycleService.setViewsheetInfo(rvs, linkUri, dispatcher);
       }
 
+      if(event.getAssemblySize() != null) {
+         final Optional<ViewsheetSandbox> box = rvs.getViewsheetSandbox();
+
+         if(box.isPresent()) {
+            box.get().lockWrite();
+
+            try {
+               EmbedAssemblyInfo embedAssemblyInfo = rvs.getEmbedAssemblyInfo();
+
+               // Only create embed assembly metadata during the explicit embed refresh path.
+               // Resize events may omit embed=true and should only update existing state.
+               if(embedAssemblyInfo == null && event.getEmbed()) {
+                  embedAssemblyInfo = new EmbedAssemblyInfo();
+                  embedAssemblyInfo.setAssemblyName(event.getAssemblyName());
+                  rvs.setEmbedAssemblyInfo(embedAssemblyInfo);
+               }
+
+               if(embedAssemblyInfo != null) {
+                  embedAssemblyInfo.setAssemblySize(event.getAssemblySize());
+               }
+            }
+            finally {
+               box.get().unlockWrite();
+            }
+         }
+      }
+
       // reset the assembly and dependencies.
       if(assembly != null) {
          refreshAssemblyAndDependencies(rvs, assembly, linkUri, dispatcher);

--- a/core/src/main/java/inetsoft/web/viewsheet/event/RefreshVSAssemblyEvent.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/event/RefreshVSAssemblyEvent.java
@@ -19,9 +19,11 @@ package inetsoft.web.viewsheet.event;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import inetsoft.web.admin.cache.CacheMetrics;
 import org.immutables.serial.Serial;
 import org.immutables.value.Value;
+
+import javax.annotation.Nullable;
+import java.awt.*;
 
 @Value.Immutable
 @Serial.Structural
@@ -43,8 +45,10 @@ public abstract class RefreshVSAssemblyEvent {
       return false;
    }
 
-   public static CacheMetrics.Builder builder() {
-      return new CacheMetrics.Builder();
+   public abstract @Nullable Dimension getAssemblySize();
+
+   public static Builder builder() {
+      return new Builder();
    }
 
    public static final class Builder extends ImmutableRefreshVSAssemblyEvent.Builder {

--- a/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
@@ -1227,6 +1227,8 @@ public class CoreLifecycleService {
             }
          }
 
+         applyEmbedChartSize(rvs, assembly);
+
          box.get().lockWrite();
 
          try {
@@ -1376,22 +1378,13 @@ public class CoreLifecycleService {
 
       ViewsheetSandbox box = boxOpt.get();
 
-      if(rvs.getEmbedAssemblyInfo() != null && name != null) {
-         EmbedAssemblyInfo embedAssemblyInfo = rvs.getEmbedAssemblyInfo();
-
-         if(!Tool.equals(name, embedAssemblyInfo.getAssemblyName())) {
-            return;
-         }
-
-         AssemblyInfo info = assembly.getInfo();
-
-         if(info instanceof ChartVSAssemblyInfo) {
-            // open with max mode
-            ((ChartVSAssemblyInfo) info).setMaxSize(
-               embedAssemblyInfo.getAssemblySize());
-            info.setPixelSize(embedAssemblyInfo.getAssemblySize());
-         }
+      if(rvs.getEmbedAssemblyInfo() != null && name != null &&
+         !Tool.equals(name, rvs.getEmbedAssemblyInfo().getAssemblyName()))
+      {
+         return;
       }
+
+      applyEmbedChartSize(rvs, assembly);
 
       // @by yanie: bug1422049637079
       // The runtime dynamic values might be reset, so herein execute them to
@@ -1588,6 +1581,30 @@ public class CoreLifecycleService {
          else {
             dispatcher.sendCommand(command);
          }
+      }
+   }
+
+   // This only applies to embedded charts; other assembly types intentionally remain unchanged.
+   private void applyEmbedChartSize(RuntimeViewsheet rvs, VSAssembly assembly) {
+      String name = assembly == null ? null : assembly.getAbsoluteName();
+
+      if(rvs.getEmbedAssemblyInfo() == null || name == null) {
+         return;
+      }
+
+      EmbedAssemblyInfo embedAssemblyInfo = rvs.getEmbedAssemblyInfo();
+      Dimension assemblySize = embedAssemblyInfo.getAssemblySize();
+
+      if(!Tool.equals(name, embedAssemblyInfo.getAssemblyName())) {
+         return;
+      }
+
+      AssemblyInfo info = assembly.getInfo();
+
+      if(info instanceof ChartVSAssemblyInfo && assemblySize != null) {
+         // Apply the embed container size before building the runtime chart model.
+         ((ChartVSAssemblyInfo) info).setMaxSize(assemblySize);
+         info.setPixelSize(assemblySize);
       }
    }
 

--- a/web/projects/portal/src/app/embed/chart/embed-chart.component.ts
+++ b/web/projects/portal/src/app/embed/chart/embed-chart.component.ts
@@ -249,6 +249,15 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
       this.viewsheetClient.runtimeId = command.runtimeId;
       this.runtimeId = command.runtimeId;
 
+      // A newly opened embedded assembly may need an explicit refresh to apply the
+      // requested assembly size after the runtime is established.
+      if(this.assemblyName && !this.inputRuntimeId) {
+         // The fresh-open path only needs the targeted refresh; a full onResize() here
+         // would be redundant because it would see the same current dimensions.
+         this.refreshEmbedAssembly();
+         return;
+      }
+
       // call onResize in case the element was resized while the server was processing
       // open viewsheet event
       this.onResize();
@@ -409,13 +418,19 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
 
    private refreshEmbedAssembly(): void {
       this.setAppSize();
+
+      if(this.assemblySize == null || this.assemblySize.width == 0 || this.assemblySize.height == 0) {
+         return;
+      }
+
       // queryParams are intentionally not forwarded: the caller-owned viewsheet was
       // already opened with its parameters applied; re-sending them on refresh would
       // override any runtime state the caller has set since opening.
       const refreshEvent: RefreshVsAssemblyEvent = {
          vsRuntimeId: this.runtimeId,
          assemblyName: this.assemblyName,
-         embed: true
+         embed: true,
+         assemblySize: this.assemblySize
       };
       this.viewsheetClient.sendEvent("/events/vs/refresh/assembly", refreshEvent);
    }
@@ -428,6 +443,7 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
       let event: OpenViewsheetEvent = new OpenViewsheetEvent(
          this.assetId, this.appSize.width, this.appSize.height, this.mobileDevice,
          window.navigator.userAgent);
+      event.embed = true;
       event.embedAssemblyName = this.assemblyName;
       event.embedAssemblySize = this.assemblySize;
       event.disableParameterSheet = true;
@@ -574,7 +590,10 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
          if(this.inputRuntimeId) {
             const refreshEvent: RefreshVsAssemblyEvent = {
                vsRuntimeId: this.runtimeId,
-               assemblyName: this.assemblyName
+               assemblyName: this.assemblyName,
+               // Intentionally omit embed=true here: resize should update an existing
+               // embedded assembly session, not create embed metadata on the server.
+               assemblySize: this.assemblySize
             };
             this.viewsheetClient.sendEvent("/events/vs/refresh/assembly", refreshEvent);
          }

--- a/web/projects/portal/src/app/vsobjects/event/refresh-vs-assembly-event.ts
+++ b/web/projects/portal/src/app/vsobjects/event/refresh-vs-assembly-event.ts
@@ -15,8 +15,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+import { Dimension } from "../../common/data/dimension";
+
 export interface RefreshVsAssemblyEvent {
    vsRuntimeId: string;
    assemblyName: string;
    embed?: boolean;
+   assemblySize?: Dimension;
 }


### PR DESCRIPTION
The purpose of this modification is to ensure that when a StyleBI chart embedded in a Wiz chat card is opened and subsequently refreshed, the container size — specifically the assemblySize — is correctly passed to and applied on the embed chart's runtime model, so that the chart fills the display area according to the container size.