### PR TITLE
Address code review findings

### DIFF
--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSCloseObjectWizardService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSCloseObjectWizardService.java
@@ -23,7 +23,6 @@ import inetsoft.cluster.*;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.WorksheetEngine;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
-import inetsoft.uql.asset.AggregateRef;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.*;
 import inetsoft.web.viewsheet.command.UpdateUndoStateCommand;
@@ -45,7 +44,6 @@ import org.springframework.util.StringUtils;
 
 import java.awt.*;
 import java.security.Principal;
-import java.util.Arrays;
 import java.util.Optional;
 
 @Service
@@ -132,7 +130,7 @@ public class VSCloseObjectWizardService {
             RuntimeViewsheet orvs = objectHandler.getOriginalRViewsheet(rvs, principal);
 
             if(save) {
-               updateAllCalcField(vs, orvs.getViewsheet());
+               WizardRecommenderUtil.syncCalcFields(vs, orvs.getViewsheet());
             }
 
             viewsheetService.flushRuntimeSheet(vsId);
@@ -163,7 +161,7 @@ public class VSCloseObjectWizardService {
 
          boolean wizardDashboard = VSWizardEditModes.WIZARD_DASHBOARD.equals(event.getEditMode());
          RuntimeViewsheet orvs = objectHandler.getOriginalRViewsheet(rvs, principal);
-         updateAllCalcField(vs, orvs.getViewsheet());
+         WizardRecommenderUtil.syncCalcFields(vs, orvs.getViewsheet());
          tempAssembly = objectHandler.updateAssemblyByTemporary(
             orvs, rvs, tempAssembly, originalAssembly, dispatcher, linkUri);
          boolean maxMode = vs.isMaxMode();
@@ -221,47 +219,6 @@ public class VSCloseObjectWizardService {
          // In any case, the user should be able to close the dialog.
          CloseObjectWizardCommand command = new CloseObjectWizardCommand(model, save);
          dispatcher.sendCommand(command);
-      }
-
-      return null;
-   }
-
-   private Void updateAllCalcField(Viewsheet currentVS, Viewsheet originalVS) {
-      if(currentVS.getCalcFieldSources() == null || currentVS.getCalcFieldSources().size() == 0) {
-         for(String source : originalVS.getCalcFieldSources()) {
-            originalVS.removeCalcField(source);
-         }
-      }
-      else {
-         for(String source : currentVS.getCalcFieldSources()) {
-            updateCalcField(currentVS, originalVS, source);
-         }
-      }
-
-      return null;
-   }
-
-   private Void updateCalcField(Viewsheet currentVS, Viewsheet originalVS, String source) {
-      if(currentVS == originalVS || source == null) {
-         return null;
-      }
-
-      originalVS.removeCalcField(source);
-      originalVS.removeAggrField(source);
-      CalculateRef[] calcs = currentVS.getCalcFields(source);
-
-      if(calcs != null) {
-         Arrays.stream(calcs).forEach((CalculateRef calc) -> {
-            originalVS.addCalcField(source, calc);
-         });
-      }
-
-      AggregateRef[] aggrs = currentVS.getAggrFields(source);
-
-      if(aggrs != null) {
-         Arrays.stream(aggrs).forEach((AggregateRef ref) -> {
-            originalVS.addAggrField(source, ref);
-         });
       }
 
       return null;

--- a/core/src/main/java/inetsoft/web/vswizard/handler/VSWizardBindingHandler.java
+++ b/core/src/main/java/inetsoft/web/vswizard/handler/VSWizardBindingHandler.java
@@ -69,6 +69,7 @@ import inetsoft.web.vswizard.model.*;
 import inetsoft.web.vswizard.model.recommender.*;
 import inetsoft.web.vswizard.recommender.ChartRecommenderUtil;
 import inetsoft.web.vswizard.recommender.WizardRecommenderUtil;
+import inetsoft.web.vswizard.recommender.chart.ChartCombinationUtil;
 import inetsoft.web.vswizard.service.VSWizardTemporaryInfoService;
 import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
@@ -844,8 +845,22 @@ public class VSWizardBindingHandler {
       ChartVSAssemblyInfo info = (ChartVSAssemblyInfo) assembly.getInfo();
 
       VSTemporaryInfo temporaryInfo = temporaryInfoService.getVSTemporaryInfo(rvs);
+      int listSize = list != null ? list.size() : 0;
+      VSChartInfo selectedChartInfo;
+
+      if(list != null && idx < listSize) {
+         selectedChartInfo = (VSChartInfo) list.get(idx);
+      }
+      else {
+         int prefIdx = idx - listSize;
+         List<ChartCombinationUtil.ScoredInfo> prefInfos = model.getPrefInfos();
+         ChartInfo ci = prefInfos != null && prefIdx >= 0 && prefIdx < prefInfos.size()
+            ? prefInfos.get(prefIdx).getInfo() : null;
+         selectedChartInfo = ci instanceof VSChartInfo vci ? vci : null;
+      }
+
       info.setTitleVisibleValue(true);
-      info.setVSChartInfo(list.size() > 0 && idx < list.size() ? (VSChartInfo) list.get(idx) : null);
+      info.setVSChartInfo(selectedChartInfo);
       info.setSourceInfo(source);
       WizardRecommenderUtil.prepareCalculateRefs(rvs, info, temporaryInfo);
       GraphFormatUtil.fixDefaultNumberFormat(assembly.getChartDescriptor(),

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/WizardRecommenderUtil.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/WizardRecommenderUtil.java
@@ -49,8 +49,8 @@ import static inetsoft.web.vswizard.model.VSWizardConstants.*;
 /**
  * Utility methods for wizard recommender.
  *
- * @version 13.2
  * @author InetSoft Technology Corp
+ * @version 13.2
  */
 public final class WizardRecommenderUtil {
    /**
@@ -169,7 +169,7 @@ public final class WizardRecommenderUtil {
       // cube entry set, the name should use entity + attribute
       if(attribute != null) {
          String entity = entry.getProperty("entity");
-         cvalue = (entity != null ?  entity + "." : "") + attribute;
+         cvalue = (entity != null ? entity + "." : "") + attribute;
       }
 
       return cvalue;
@@ -178,8 +178,9 @@ public final class WizardRecommenderUtil {
    /**
     * Check if the target field is a normal dimension which need to
     * consider the cardinality and hierarchy when doing recommendation.
-    * @param entry      the target field.
-    * @param ignoreGeo  true if geo is treated as normal dimension, else not.
+    *
+    * @param entry     the target field.
+    * @param ignoreGeo true if geo is treated as normal dimension, else not.
     */
    public static boolean isNormalDimension(AssetEntry entry, boolean ignoreGeo) {
       if(entry == null || !isDimension(entry) || isDateType(entry)) {
@@ -198,7 +199,8 @@ public final class WizardRecommenderUtil {
 
    /**
     * Sorted the hierarchy lists by the numbers of the hierarchy level.
-    * @param ignoreGeo  true if geo is treated as normal dimension, else not.
+    *
+    * @param ignoreGeo true if geo is treated as normal dimension, else not.
     */
    public static List<List<AssetEntry>> getSortedHierarchyLists(AssetEntry[] entries,
                                                                 boolean ignoreGeo)
@@ -238,14 +240,14 @@ public final class WizardRecommenderUtil {
    /**
     * Return all hierarchy field lists.
     * for example, the following list maybe returned.
+    * <p>
+    * {
+    * {a, a1},
+    * {a, a2},
+    * {b, b1, b11}
+    * }
     *
-    *  {
-    *     {a, a1},
-    *     {a, a2},
-    *     {b, b1, b11}
-    *  }
-    *
-    * @param  entries the selected dimension fields.
+    * @param entries the selected dimension fields.
     */
    public static List<List<AssetEntry>> getHierarchyLists(AssetEntry[] entries) {
       AssetEntry[] entries0 = entries.clone();
@@ -265,15 +267,15 @@ public final class WizardRecommenderUtil {
    /**
     * Return the hierarchy field lists for the target parent field.
     * for example, find hierarchy lists for field a, the following list maybe returned.
+    * <p>
+    * {
+    * {a, a1, a11},
+    * {a, a1, a12},
+    * {a, a2}
+    * }
     *
-    *  {
-    *     {a, a1, a11},
-    *     {a, a1, a12},
-    *     {a, a2}
-    *  }
-    *
-    * @param  parent  the target parent field.
-    * @param  entries the selected dimension fields.
+    * @param parent  the target parent field.
+    * @param entries the selected dimension fields.
     */
    private static List<List<AssetEntry>> getHierarchyFields(AssetEntry parent, AssetEntry[] entries)
    {
@@ -300,7 +302,7 @@ public final class WizardRecommenderUtil {
          List<List<AssetEntry>> clist = getHierarchyFields(child, entries);
 
          if(clist.size() != 0) {
-             clist.stream().forEach(l -> {
+            clist.stream().forEach(l -> {
                l.add(0, parent);
                list.add(l);
             });
@@ -348,8 +350,11 @@ public final class WizardRecommenderUtil {
 
    /**
     * Get the default interval for date type dimension.
+    *
     * @param entries
+    *
     * @return
+    *
     * @throws Exception
     */
    public static void refreshDateInterval(ViewsheetSandbox box, AssetEntry[] entries,
@@ -436,6 +441,7 @@ public final class WizardRecommenderUtil {
    /**
     * Check hierarchy relationship for the entries,
     * and add children columns for the entries by setting property.
+    *
     * @param box     the viewsheetsandbox.
     * @param entries the asset entries which sorted ascending by cardinality percentage
     */
@@ -471,8 +477,9 @@ public final class WizardRecommenderUtil {
    /**
     * Update cardinality information to the entries by setting property,
     * and return sorted entries with ascending order of cardinalityPercentage.
-    * @param box     the viewsheet sandbox.
-    * @param tname   the table name.
+    *
+    * @param box        the viewsheet sandbox.
+    * @param tname      the table name.
     * @param dimEntries the selected dimension fields.
     */
    private static List<AssetEntry> updateCardinalityInfo(ViewsheetSandbox box,
@@ -512,8 +519,9 @@ public final class WizardRecommenderUtil {
    /**
     * Check hierarchy relationship for the entries,
     * and add children columns for the entries by setting property.
-    * @param box     the viewsheetsandbox.
-    * @param tname   the table name.
+    *
+    * @param box        the viewsheetsandbox.
+    * @param tname      the table name.
     * @param dimEntries the asset entries which sorted ascending by cardinality percentage
     */
    private static void updateHierarchyInfo(VSTemporaryInfo temporaryInfo, ViewsheetSandbox box, String tname,
@@ -582,8 +590,8 @@ public final class WizardRecommenderUtil {
     */
    public static List<ChartRef> getNoDateDimensions(List<ChartRef> dims) {
       return dims.stream()
-              .filter(dim -> !XSchema.isDateType((dim).getDataType()))
-              .collect(Collectors.toList());
+         .filter(dim -> !XSchema.isDateType((dim).getDataType()))
+         .collect(Collectors.toList());
    }
 
    public static boolean containsCalc(List<ChartRef> refs, RuntimeViewsheet rvs) {
@@ -607,7 +615,7 @@ public final class WizardRecommenderUtil {
          return null;
       }
 
-      ChartVSAssemblyInfo info = (ChartVSAssemblyInfo)assembly.getVSAssemblyInfo();
+      ChartVSAssemblyInfo info = (ChartVSAssemblyInfo) assembly.getVSAssemblyInfo();
       SourceInfo src = info.getSourceInfo();
 
       if(src == null) {
@@ -627,7 +635,7 @@ public final class WizardRecommenderUtil {
       }
 
       return Arrays.asList(calcs).stream().anyMatch(calc ->
-         Tool.equals(calc.getName(), ref.getName()));
+                                                       Tool.equals(calc.getName(), ref.getName()));
    }
 
    public static boolean isCalcAggregateField(RuntimeViewsheet rvs, DataRef ref)
@@ -642,7 +650,7 @@ public final class WizardRecommenderUtil {
       }
 
       return Arrays.asList(calcs).stream().anyMatch(calc ->
-         !calc.isBaseOnDetail() && Tool.equals(calc.getName(), ref.getName()));
+                                                       !calc.isBaseOnDetail() && Tool.equals(calc.getName(), ref.getName()));
    }
 
    public static VSObjectRecommendation getSelectedRecommendation(VSRecommendType type,
@@ -658,7 +666,7 @@ public final class WizardRecommenderUtil {
       if(recommendationModel != null) {
          List<VSObjectRecommendation> list = recommendationModel.getRecommendationList();
 
-         for (VSObjectRecommendation item: list) {
+         for(VSObjectRecommendation item : list) {
             if(item.getType() == type) {
                return item;
             }
@@ -765,7 +773,7 @@ public final class WizardRecommenderUtil {
 
    private static void createRangeDimension(VSDimensionRef dim, RuntimeViewsheet rvs,
                                             String tname, VSTemporaryInfo tempInfo)
-         throws Exception
+      throws Exception
    {
       Optional<ViewsheetSandbox> box = rvs.getViewsheetSandbox();
 
@@ -973,6 +981,44 @@ public final class WizardRecommenderUtil {
       }
 
       return ref != null ? ref.getAttribute() : null;
+   }
+
+   /**
+    * Syncs all calc fields and aggregate fields from {@code sourceVs} to {@code targetVs}.
+    * Follows the same pattern as VSCloseObjectWizardService when finishing the wizard.
+    */
+   public static void syncCalcFields(Viewsheet sourceVs, Viewsheet targetVs) {
+      if(sourceVs == targetVs) {
+         return;
+      }
+
+      if(sourceVs.getCalcFieldSources() == null || sourceVs.getCalcFieldSources().isEmpty()) {
+         for(String source : new ArrayList<>(targetVs.getCalcFieldSources())) {
+            targetVs.removeCalcField(source);
+         }
+
+         return;
+      }
+
+      for(String source : sourceVs.getCalcFieldSources()) {
+         if(source == null) {
+            continue;
+         }
+
+         targetVs.removeCalcField(source);
+         targetVs.removeAggrField(source);
+         CalculateRef[] calcs = sourceVs.getCalcFields(source);
+
+         if(calcs != null) {
+            Arrays.stream(calcs).forEach(calc -> targetVs.addCalcField(source, calc));
+         }
+
+         AggregateRef[] aggrs = sourceVs.getAggrFields(source);
+
+         if(aggrs != null) {
+            Arrays.stream(aggrs).forEach(aggr -> targetVs.addAggrField(source, aggr));
+         }
+      }
    }
 
    private static final String CHILDREN_FLAG = "__children__";

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -25,6 +25,7 @@ import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.graph.*;
+import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
 import inetsoft.util.Tool;
 import inetsoft.web.vswizard.handler.VSWizardBindingHandler;
 import inetsoft.web.vswizard.model.VSWizardData;
@@ -33,6 +34,7 @@ import inetsoft.web.vswizard.recommender.VSDefaultRecommendationFactory;
 import inetsoft.web.vswizard.recommender.WizardRecommenderUtil;
 import inetsoft.web.vswizard.recommender.chart.ChartCombinationUtil;
 import inetsoft.web.vswizard.recommender.chart.ChartPreference;
+import inetsoft.web.viewsheet.service.CommandDispatcher;
 import inetsoft.web.vswizard.service.VSWizardTemporaryInfoService;
 import inetsoft.web.wiz.model.*;
 import inetsoft.web.wiz.model.BindingInfo;
@@ -148,6 +150,7 @@ public class WizAutoBindingService {
          }
 
          bindingHandler.updateTemporaryFields(rvs, entries, tempInfo);
+         tempInfo.getTempChart().setSourceInfo(bindingHandler.getCurrentSource(entries, tableName));
 
          VSChartInfo tempChartInfo = tempInfo.getTempChart().getVSChartInfo();
          applyFieldConfigs(tempChartInfo, configMap);
@@ -177,6 +180,14 @@ public class WizAutoBindingService {
             String intentCategory = request.getIntentCategory();
             primaryBinding = buildPrimaryVisualization(model, entries, vizType, explicitBindings,
                                                        prefInfos, intentCategory);
+
+            // Mirror the wizard path: call updatePrimaryAssembly on autoBindingRvs so it gets
+            // the same full setup (calc field registration, format, legend, temp assembly cleanup).
+            if(primaryBinding instanceof PrimaryBinding.ChartPrimaryBinding chartBinding &&
+               chartRec instanceof VSChartRecommendation vcr)
+            {
+               primaryBinding = refreshChartBinding(chartBinding, vcr, rvs, user);
+            }
          }
 
          // Phase 3: place primary into the output viewsheet.
@@ -194,7 +205,11 @@ public class WizAutoBindingService {
             vsModel.setRuntimeId(request.getWizRuntimeId());
             vsModel.setViewsheetIdentifier(request.getViewsheetIdentifier());
 
-            visualizationResult = wizVsService.createViewsheet(vsModel, user);
+            visualizationResult = wizVsService.createViewsheet(vsModel, user, (wizRvs, asm) -> {
+               if(asm instanceof ChartVSAssembly) {
+                  WizardRecommenderUtil.syncCalcFields(rvs.getViewsheet(), wizRvs.getViewsheet());
+               }
+            });
 
             // createViewsheet only sets runtimeId when it creates a new RVS.
             // Back-fill it so the client always receives the effective wizRuntimeId.
@@ -667,7 +682,9 @@ public class WizAutoBindingService {
       return null;
    }
 
-   /** Package-private so {@code changeType()} can select a binding from a cached model. */
+   /**
+    * Package-private so {@code changeType()} can select a binding from a cached model.
+    */
    PrimaryBinding findPrimaryBindingByType(String vizType, VSRecommendationModel model,
                                            AssetEntry[] entries)
    {
@@ -677,7 +694,7 @@ public class WizAutoBindingService {
 
             if(infos != null) {
                for(ChartInfo ci : infos) {
-                  if(vizType.equals(getChartTypeString(ci.getChartType()))) {
+                  if(chartTypeMatches(vizType, ci)) {
                      return new PrimaryBinding.ChartPrimaryBinding(ci);
                   }
                }
@@ -801,7 +818,7 @@ public class WizAutoBindingService {
 
       return prefInfos.stream()
          .map(ChartCombinationUtil.ScoredInfo::getInfo)
-         .filter(ci -> explicitChartType.equals(getChartTypeString(ci.getChartType())))
+         .filter(ci -> chartTypeMatches(explicitChartType, ci))
          .findFirst()
          .map(PrimaryBinding.ChartPrimaryBinding::new)
          .orElse(null);
@@ -975,6 +992,38 @@ public class WizAutoBindingService {
       };
    }
 
+   /**
+    * Returns true when {@code vizType} (the frontend string such as "donut" or "area") matches
+    * the given ChartInfo from the recommendation model.
+    *
+    * Two special cases require this method instead of a plain string compare:
+    * <ul>
+    *   <li><b>donut</b>: DonutChartFilter stores chartType=CHART_PIE with isDonut=true,
+    *       so getChartTypeString(CHART_PIE) returns "pie", not "donut".</li>
+    *   <li><b>area</b>: AreaChartFilter only ever generates CHART_AREA_STACK; the
+    *       recommendation model therefore never contains a plain CHART_AREA entry.</li>
+    * </ul>
+    */
+   private static boolean chartTypeMatches(String vizType, ChartInfo ci) {
+      if("donut".equals(vizType)) {
+         return GraphTypes.isDonut(ci);
+      }
+
+      // DonutChartFilter stores chartType=CHART_PIE with isDonut=true; exclude it from "pie"
+      if("pie".equals(vizType) && GraphTypes.isDonut(ci)) {
+         return false;
+      }
+
+      String ciType = getChartTypeString(ci.getChartType());
+
+      if(vizType.equals(ciType)) {
+         return true;
+      }
+
+      // "area" request can be satisfied by an area_stack recommendation
+      return "area".equals(vizType) && "area_stack".equals(ciType);
+   }
+
    // ── VisualizationConfig wrapper ───────────────────────────────────────────────
 
    private VisualizationConfig wrapInConfig(BindingInfo binding, String worksheetId) {
@@ -1011,16 +1060,19 @@ public class WizAutoBindingService {
 
       // 1. Try to get the recommendation model stored by a prior autoBinding call.
       VSRecommendationModel model = null;
+      VSTemporaryInfo autoBindingTempInfo = null;
+      RuntimeViewsheet capturedAutoBindingRvs = null;
 
       if(!Tool.isEmptyString(autoBindingRuntimeId)) {
          try {
             RuntimeViewsheet autoBindingRvs = viewsheetService.getViewsheet(autoBindingRuntimeId, user);
 
             if(autoBindingRvs != null) {
-               VSTemporaryInfo tempInfo = autoBindingRvs.getVSTemporaryInfo();
+               capturedAutoBindingRvs = autoBindingRvs;
+               autoBindingTempInfo = autoBindingRvs.getVSTemporaryInfo();
 
-               if(tempInfo != null) {
-                  model = tempInfo.getRecommendationModel();
+               if(autoBindingTempInfo != null) {
+                  model = autoBindingTempInfo.getRecommendationModel();
                }
             }
          }
@@ -1071,6 +1123,18 @@ public class WizAutoBindingService {
          return new CreateViewsheetResult();
       }
 
+      // Mirror the wizard path: update autoBindingRvs so its state stays consistent
+      // (calc fields, format, legend, cleanup of previous temp assembly).
+      if(primaryBinding instanceof PrimaryBinding.ChartPrimaryBinding chartBinding &&
+         capturedAutoBindingRvs != null)
+      {
+         VSObjectRecommendation chartRec = model.findRecommendation(VSRecommendType.CHART, false);
+
+         if(chartRec instanceof VSChartRecommendation vcr) {
+            primaryBinding = refreshChartBinding(chartBinding, vcr, capturedAutoBindingRvs, user);
+         }
+      }
+
       // 4. Place the new primary in wizRuntimeId without executing the sandbox.
       VisualizationConfig sourceConfig = new VisualizationConfig();
       VisualizationConfig.DataSource ds = new VisualizationConfig.DataSource();
@@ -1083,7 +1147,13 @@ public class WizAutoBindingService {
       vsModel.setRuntimeId(wizRuntimeId);
       vsModel.setViewsheetIdentifier(viewsheetIdentifier);
 
-      CreateViewsheetResult result = wizVsService.createViewsheetSkipExecution(vsModel, user);
+      final RuntimeViewsheet autoRvsForHook = capturedAutoBindingRvs;
+      CreateViewsheetResult result = wizVsService.createViewsheetSkipExecution(vsModel, user,
+         (wizRvs, asm) -> {
+            if(asm instanceof ChartVSAssembly && autoRvsForHook != null) {
+               WizardRecommenderUtil.syncCalcFields(autoRvsForHook.getViewsheet(), wizRvs.getViewsheet());
+            }
+         });
 
       if(Tool.isEmptyString(result.getRuntimeId())) {
          result.setRuntimeId(wizRuntimeId);
@@ -1092,6 +1162,64 @@ public class WizAutoBindingService {
       // Echo the autoBindingRuntimeId back so the client can reuse it on the next call.
       result.setAutoBindingRuntimeId(autoBindingRuntimeId);
       return result;
+   }
+
+   /**
+    * Calls updatePrimaryAssembly on {@code rvs} to mirror the full wizard setup path
+    * (calc field registration, format, legend, temp assembly cleanup), then extracts the
+    * updated ChartInfo from the resulting temp assembly. Returns the refreshed binding, or
+    * the original binding if the temp assembly is not a chart.
+    */
+   private PrimaryBinding refreshChartBinding(PrimaryBinding.ChartPrimaryBinding chartBinding,
+                                               VSChartRecommendation vcr,
+                                               RuntimeViewsheet rvs,
+                                               Principal user) throws Exception
+   {
+      syncChartSelectedIndex(vcr, chartBinding.info());
+
+      CommandDispatcher.withDummyDispatcher(user, dispatcher -> {
+         bindingHandler.updatePrimaryAssembly(vcr, rvs, false, "", dispatcher, false);
+         return null;
+      });
+
+      VSAssembly autoTempAsm = WizardRecommenderUtil.getTempAssembly(rvs.getViewsheet());
+
+      if(autoTempAsm instanceof ChartVSAssembly autoChart) {
+         return new PrimaryBinding.ChartPrimaryBinding(
+            ((ChartVSAssemblyInfo) autoChart.getInfo()).getVSChartInfo());
+      }
+
+      return chartBinding;
+   }
+
+   /**
+    * Sets selectedIndex on {@code vcr} so that {@code addChartVSAssembly} fetches
+    * {@code selectedInfo}. Checks chartInfos first (plain index), then prefInfos
+    * (chartInfos.size() + prefIdx) to cover both selection paths.
+    */
+   private static void syncChartSelectedIndex(VSChartRecommendation vcr, ChartInfo selectedInfo) {
+      List<ChartInfo> chartInfos = vcr.getChartInfos();
+      int chartInfosSize = chartInfos != null ? chartInfos.size() : 0;
+
+      if(chartInfos != null) {
+         for(int i = 0; i < chartInfosSize; i++) {
+            if(chartInfos.get(i) == selectedInfo) {
+               vcr.setSelectedIndex(i);
+               return;
+            }
+         }
+      }
+
+      List<ChartCombinationUtil.ScoredInfo> prefInfos = vcr.getPrefInfos();
+
+      if(prefInfos != null) {
+         for(int i = 0; i < prefInfos.size(); i++) {
+            if(prefInfos.get(i).getInfo() == selectedInfo) {
+               vcr.setSelectedIndex(chartInfosSize + i);
+               return;
+            }
+         }
+      }
    }
 
    private static final Logger LOG = LoggerFactory.getLogger(WizAutoBindingService.class);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -55,8 +55,19 @@ public class WizVsService {
       this.engine = engine;
    }
 
+   @FunctionalInterface
+   public interface PostAssemblyHook {
+      void apply(RuntimeViewsheet rvs, VSAssembly assembly) throws Exception;
+   }
+
    public CreateViewsheetResult createViewsheet(CreateVisualizationModel model, Principal user) throws Exception {
-      return createViewsheetInternal(model, user, false);
+      return createViewsheetInternal(model, user, false, null);
+   }
+
+   public CreateViewsheetResult createViewsheet(CreateVisualizationModel model, Principal user,
+                                                PostAssemblyHook hook) throws Exception
+   {
+      return createViewsheetInternal(model, user, false, hook);
    }
 
    /**
@@ -66,12 +77,19 @@ public class WizVsService {
    CreateViewsheetResult createViewsheetSkipExecution(CreateVisualizationModel model, Principal user)
       throws Exception
    {
-      return createViewsheetInternal(model, user, true);
+      return createViewsheetInternal(model, user, true, null);
+   }
+
+   CreateViewsheetResult createViewsheetSkipExecution(CreateVisualizationModel model, Principal user,
+                                                      PostAssemblyHook hook) throws Exception
+   {
+      return createViewsheetInternal(model, user, true, hook);
    }
 
    private CreateViewsheetResult createViewsheetInternal(CreateVisualizationModel model,
                                                          Principal user,
-                                                         boolean skipExecution) throws Exception
+                                                         boolean skipExecution,
+                                                         PostAssemblyHook hook) throws Exception
    {
       String runtimeId = model.getRuntimeId();
       boolean createdRuntimeId = false;
@@ -214,7 +232,7 @@ public class WizVsService {
                else {
                   // Fallback to original path if worksheet table not found
                   LOG.warn("Aggregate conditions specified but worksheet table '{}' not found; " +
-                           "aggregate conditions will be ignored", wsTableName);
+                              "aggregate conditions will be ignored", wsTableName);
                   applyConditionModel(assembly, conditionModel);
                }
             }
@@ -227,6 +245,10 @@ public class WizVsService {
             // inside try so any failure triggers the same rollback as an execution failure.
             if(wsModified || !createdRuntimeId && !modificationOnly) {
                targetVs.reloadBaseWorksheet(engine, user);
+            }
+
+            if(hook != null) {
+               hook.apply(rvs, assembly);
             }
 
             CreateViewsheetResult result;
@@ -1084,7 +1106,7 @@ public class WizVsService {
    }
 
    private VSAssembly createAssemblyFromPrimaryBinding(Viewsheet vs, String name,
-                                                      PrimaryBinding binding, String tname)
+                                                       PrimaryBinding binding, String tname)
    {
       VSAssembly assembly = switch(binding) {
          case PrimaryBinding.ChartPrimaryBinding cb ->
@@ -1353,7 +1375,7 @@ public class WizVsService {
                }
                catch(Exception e) {
                   throw new RuntimeException("Invalid layer '" + layerConfig.getLayer() +
-                                             "': " + e.getMessage(), e);
+                                                "': " + e.getMessage(), e);
                }
             }
 
@@ -1853,10 +1875,11 @@ public class WizVsService {
     * Builds a VSAggregateRef from individual parameters and returns its fullName.
     * This ensures consistent fullName generation across the codebase.
     *
-    * @param columnValue      the primary column/field name
-    * @param formulaValue     the aggregate formula (e.g., "Sum", "Average")
-    * @param secondaryField   the secondary field name for two-column formulas (may be null)
-    * @param nOrP             the N or P parameter for Nth/Percentile formulas (may be null)
+    * @param columnValue    the primary column/field name
+    * @param formulaValue   the aggregate formula (e.g., "Sum", "Average")
+    * @param secondaryField the secondary field name for two-column formulas (may be null)
+    * @param nOrP           the N or P parameter for Nth/Percentile formulas (may be null)
+    *
     * @return the computed fullName from VSAggregateRef
     */
    private String buildVSAggregateRefFullName(String columnValue, String formulaValue,
@@ -1931,6 +1954,7 @@ public class WizVsService {
     * This is the reverse of {@link #getDateGroupLevel(String)}.
     *
     * @param level the integer date level constant
+    *
     * @return the human-readable name, or null if level is NONE_DATE_GROUP or unrecognized
     */
    public static String getDateGroupLevelName(int level) {
@@ -2005,7 +2029,7 @@ public class WizVsService {
       ConditionList conditionList = new ConditionList();
 
       if(wizModel != null && wizModel.getBaseConditions() != null) {
-         appendConditionNodes(wizModel.getBaseConditions(), 0, conditionList, new boolean[]{true}, null);
+         appendConditionNodes(wizModel.getBaseConditions(), 0, conditionList, new boolean[]{ true }, null);
       }
 
       return conditionList;
@@ -2057,7 +2081,7 @@ public class WizVsService {
             // Build the group's contents into a temporary list first so we can check
             // whether it produced any valid items before committing a junction.
             ConditionList groupContents = new ConditionList();
-            appendConditionNodes(items, depth + 1, groupContents, new boolean[]{true}, dimColumnMapping);
+            appendConditionNodes(items, depth + 1, groupContents, new boolean[]{ true }, dimColumnMapping);
 
             if(groupContents.isEmpty()) {
                continue;
@@ -2234,7 +2258,7 @@ public class WizVsService {
 
             if(colRef == null) {
                LOG.warn("Dimension field '{}' not found in worksheet column selection; " +
-                        "skipping from aggregation", dim.getField());
+                           "skipping from aggregation", dim.getField());
                continue;
             }
 
@@ -2285,7 +2309,7 @@ public class WizVsService {
 
             if(colRef == null) {
                LOG.warn("Measure field '{}' not found in worksheet column selection; " +
-                        "skipping from aggregation", measure.getField());
+                           "skipping from aggregation", measure.getField());
                continue;
             }
 
@@ -2293,7 +2317,7 @@ public class WizVsService {
 
             if(formula == null) {
                LOG.warn("Aggregate formula '{}' for measure '{}' is null or unrecognized; " +
-                        "defaulting to SUM", measure.getAggregateFormula(), measure.getField());
+                           "defaulting to SUM", measure.getAggregateFormula(), measure.getField());
                formula = AggregateFormula.SUM;
             }
 
@@ -2348,7 +2372,7 @@ public class WizVsService {
       // Apply base conditions as pre-conditions (WHERE equivalent)
       if(conditionModel.getBaseConditions() != null && !conditionModel.getBaseConditions().isEmpty()) {
          ConditionList preCondList = new ConditionList();
-         appendConditionNodes(conditionModel.getBaseConditions(), 0, preCondList, new boolean[]{true}, null);
+         appendConditionNodes(conditionModel.getBaseConditions(), 0, preCondList, new boolean[]{ true }, null);
 
          if(!preCondList.isEmpty()) {
             table.setPreConditionList(preCondList);
@@ -2360,7 +2384,7 @@ public class WizVsService {
       // Use dimColumnMapping to translate dimension field+dateGroupLevel to DateRangeRef column names
       if(conditionModel.getAggregateConditions() != null && !conditionModel.getAggregateConditions().isEmpty()) {
          ConditionList postCondList = new ConditionList();
-         appendConditionNodes(conditionModel.getAggregateConditions(), 0, postCondList, new boolean[]{true}, dimColumnMapping);
+         appendConditionNodes(conditionModel.getAggregateConditions(), 0, postCondList, new boolean[]{ true }, dimColumnMapping);
 
          if(!postCondList.isEmpty()) {
             table.setPostConditionList(postCondList);
@@ -2612,13 +2636,16 @@ public class WizVsService {
 
    /**
     * Holds the mapping information from pushAggregationToWorksheet.
-    * @param dimColumnMapping set of DateRangeRef column names (for date grouping) that were pushed to worksheet
+    *
+    * @param dimColumnMapping       set of DateRangeRef column names (for date grouping) that were pushed to worksheet
     * @param pushedMeasureFullNames set of measure fullNames (e.g., "Sum(Amount)") that were pushed to worksheet
     */
    private record PreAggregationMapping(
       Set<String> dimColumnMapping,
       Set<String> pushedMeasureFullNames
-   ) {}
+   )
+   {
+   }
 
    private final ViewsheetService viewsheetService;
    private final AssetRepository engine;


### PR DESCRIPTION
- Fix ConcurrentModificationException risk in WizardRecommenderUtil.syncCalcFields: iterate over a copy of targetVs.getCalcFieldSources() before removing entries
- Fix unsafe ChartInfo cast in VSWizardBindingHandler.addChartVSAssembly: use instanceof pattern match instead of direct cast when selecting from prefInfos
- Extract duplicate syncChartSelectedIndex+updatePrimaryAssembly+getTempAssembly pattern into WizAutoBindingService.refreshChartBinding helper method
- Fix overly-indented lambda in WizAutoBindingService.changeType