### PR TITLE
Fix bug 75171: Race Condition in Static Singleton Causing Crosstab Aggregation Formula to Be Incorrectly Changed to Sum

### DIFF
--- a/core/src/main/java/inetsoft/web/vswizard/recommender/CrosstabRecommenderUtil.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/CrosstabRecommenderUtil.java
@@ -115,7 +115,18 @@ public class CrosstabRecommenderUtil {
       VSAggregateRef agg = new VSAggregateRef();
       agg.setColumnValue(oagg.getColumnValue());
       agg.setRefType(oagg.getRefType());
-      agg.setFormula(oagg.getFormula());
+      // Use setFormulaValue to copy the design-time formula string directly, bypassing the
+      // AggregateFormula static singleton whose getFormulaName() can transiently return "Sum"
+      // instead of "Count" when the composite flag is set by another thread (MV processing).
+      String formulaValue = oagg.getFormulaValue();
+
+      if(formulaValue != null) {
+         agg.setFormulaValue(formulaValue);
+      }
+      else {
+         agg.setFormula(oagg.getFormula());
+      }
+
       agg.setNValue(oagg.getNValue());
       agg.setCaption(oagg.getCaption());
       agg.setSecondaryColumnValue(oagg.getSecondaryColumnValue());

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/CrosstabRecommenderUtil.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/CrosstabRecommenderUtil.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.vswizard.recommender;
 
+import inetsoft.uql.XConstants;
 import inetsoft.uql.asset.AggregateFormula;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.erm.AbstractDataRef;
@@ -121,7 +122,7 @@ public class CrosstabRecommenderUtil {
       // getDValue() is always non-null in practice (constructor default is "none"), so the
       // fallback to "none" is a safety net only.
       String formulaValue = oagg.getFormulaValue();
-      agg.setFormulaValue(formulaValue != null ? formulaValue : "none");
+      agg.setFormulaValue(formulaValue != null ? formulaValue : XConstants.NONE_FORMULA);
 
       agg.setNValue(oagg.getNValue());
       agg.setCaption(oagg.getCaption());

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/CrosstabRecommenderUtil.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/CrosstabRecommenderUtil.java
@@ -118,14 +118,10 @@ public class CrosstabRecommenderUtil {
       // Use setFormulaValue to copy the design-time formula string directly, bypassing the
       // AggregateFormula static singleton whose getFormulaName() can transiently return "Sum"
       // instead of "Count" when the composite flag is set by another thread (MV processing).
+      // getDValue() is always non-null in practice (constructor default is "none"), so the
+      // fallback to "none" is a safety net only.
       String formulaValue = oagg.getFormulaValue();
-
-      if(formulaValue != null) {
-         agg.setFormulaValue(formulaValue);
-      }
-      else {
-         agg.setFormula(oagg.getFormula());
-      }
+      agg.setFormulaValue(formulaValue != null ? formulaValue : "none");
 
       agg.setNValue(oagg.getNValue());
       agg.setCaption(oagg.getCaption());


### PR DESCRIPTION
In the original code, when converting chart aggregation fields to Crosstab aggregation fields, the formula name is obtained via the static singleton `AggregateFormula.COUNT_ALL`'s `getFormulaName()` method. The return value of this method depends on the `composite` flag (`isComposite() ? "Sum" : "Count"`). When an MV processing thread temporarily sets this flag to `true`, it triggers a race condition, causing the formula name to be incorrectly returned as `"Sum"`, which in turn changes the Crosstab aggregation formula to `Sum`. The fix is to use `getFormulaValue()` instead to directly read the formula string stored at design time, bypassing the static singleton and eliminating the race condition risk.