### PR TITLE
Bug #75091 - Clear stale snap-tooltip overlay after chart-type change

### DIFF
--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.spec.ts
@@ -31,6 +31,7 @@ import { ModelService } from "../../widget/services/model.service";
 import { ScaleService } from "../../widget/services/scale/scale-service";
 import { ChartObject } from "../model/chart-object";
 import { Plot } from "../model/plot";
+import { ChartTool } from "../model/chart-tool";
 import { ChartService } from "../services/chart.service";
 import { ChartPlotArea } from "./chart-plot-area.component";
 
@@ -385,6 +386,55 @@ describe("ChartPlotArea Integration Tests", () => {
       }
 
       done();
+   });
+
+   it("clears stale snap state when the Plot reference is replaced", () => {
+      const fixture = TestBed.createComponent(TestApp);
+      const debugEl = fixture.debugElement.query(By.css("chart-plot-area"));
+      const component: ChartPlotArea = debugEl.componentInstance;
+      jest.spyOn(component, "getSrc").mockImplementation(() => "");
+      fixture.detectChanges();
+
+      const oldPlot = component.chartObject;
+      // Pretend a prior hover seeded the snap cache and a prior click left
+      // a selection that still references the now-stale Plot.
+      (component as any).snapXTicksFor = oldPlot;
+      component.chartSelection = {
+         chartObject: oldPlot,
+         regions: [oldPlot.regions[0]]
+      } as any;
+
+      const clearSnapSpy = jest.spyOn(component as any, "clearSnapGuideline");
+      const drawRegionsSpy = jest.spyOn(ChartTool, "drawRegions");
+
+      // Swap in a new Plot reference (chart-type rebuild / data refresh).
+      const newPlot: Plot = { ...oldPlot } as Plot;
+      component.chartObject = newPlot;
+
+      expect(clearSnapSpy).toHaveBeenCalled();
+      expect((component as any).snapXTicksFor).toBeNull();
+      // Stale-selection branch must not paint synchronously; the base-class
+      // drawSelectedRegions defers via setTimeout so it won't pollute this.
+      expect(drawRegionsSpy).not.toHaveBeenCalled();
+
+      drawRegionsSpy.mockRestore();
+   });
+
+   it("leaves snap state untouched when updateChartObject is called with no oldObj", () => {
+      const fixture = TestBed.createComponent(TestApp);
+      const debugEl = fixture.debugElement.query(By.css("chart-plot-area"));
+      const component: ChartPlotArea = debugEl.componentInstance;
+      jest.spyOn(component, "getSrc").mockImplementation(() => "");
+      fixture.detectChanges();
+
+      (component as any).snapXTicksFor = component.chartObject;
+      const clearSnapSpy = jest.spyOn(component as any, "clearSnapGuideline");
+
+      // Scroll-debounce path: updateChartObject() is called with no argument.
+      component.updateChartObject();
+
+      expect(clearSnapSpy).not.toHaveBeenCalled();
+      expect((component as any).snapXTicksFor).toBe(component.chartObject);
    });
 
    xit("should be able to select regions", () => {

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
@@ -701,6 +701,13 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
          this.fireOnLoad();
       }
 
+      // Plot replaced: referenceLineCanvas isn't auto-cleared, and the snap
+      // index is keyed on Plot identity so it must be invalidated explicitly.
+      if(oldObj && oldObj !== this.chartObject) {
+         this.clearSnapGuideline();
+         this.snapXTicksFor = null;
+      }
+
       const context = this.getContext();
 
       if(context) {
@@ -708,7 +715,8 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
 
          if(this.chartSelection && this.chartSelection.regions &&
             this.chartSelection.chartObject &&
-            this.chartSelection.chartObject.areaName === "plot_area")
+            this.chartSelection.chartObject.areaName === "plot_area" &&
+            this.chartSelection.chartObject === this.chartObject)
          {
             ChartTool.drawRegions(this.getContext(), this.chartSelection.regions,
                                   this.canvasX, this.canvasY, this.viewsheetScale);


### PR DESCRIPTION
## Summary

In the visual composer, switching a snap-supporting chart type (line/area/bar
with a dimension on X and "Snap to nearest" enabled) to a snap-unsupported type
(e.g., point) could leave a dashed snap guideline and a stray region highlight
painted on the rebuilt chart if the user hovered the chart before the rebuild
finished.

The server side is already correct — `GraphBuilder` gates `model.snapTooltip`
with `cinfo.supportsSnapTooltip()`, which returns false for Point, so the new
model has `snapTooltip = false` and the active snap path on `onMove` is
correctly skipped. The artifact is leftover paint from the previous chart's
hover, not a fresh snap render.

## Root cause

In `chart-plot-area.component.ts`, when the parent's `model.plot` reference is
replaced, the `chartObject` setter (in `ChartObjectAreaBase`) invokes
`updateChartObject(oldObj)`. That method:

- Cleared the main `objectCanvas` but never cleared `referenceLineCanvas`, so
  the dashed guideline drawn earlier by `drawSnapGuideline` survived the
  rebuild.
- Unconditionally redrew `chartSelection.regions` on the new canvas after only
  checking the area name, so a stale selection whose `chartObject` still
  pointed at the previous Plot got painted onto the new chart.

## Changes

In `updateChartObject(oldObj?: Plot)`:

- When `oldObj` is defined and differs from the current `chartObject` (a real
  Plot swap, not the scroll-debounce path), call the existing
  `clearSnapGuideline()` and reset `snapXTicksFor = null` so the snap-tick
  cache rebuilds against the new regions on the next hover.
- Tighten the chartSelection redraw guard to also require
  `chartSelection.chartObject === this.chartObject`. Legitimate selections set
  by `selectRegion` already point at the current Plot, so this only skips the
  stale-Plot case.

Two Jest cases added in `chart-plot-area.component.spec.ts` cover the
Plot-swap reset path and the scroll-debounce no-op path