### PR TITLE
Fix portal loading failures after standalone component migration

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/datasources-database.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/datasources-database.component.ts
@@ -61,7 +61,7 @@ import { DeleteDatasourceInfo } from "../../commands/delete-datasource-info";
 import { DataNotificationsComponent } from "../../data-notifications.component";
 import { DatabaseDefinitionModel } from "../../../../../../../shared/util/model/database-definition-model";
 import { InputNameDescDialog } from "../../input-name-desc-dialog/input-name-desc-dialog.component";
-import { AdditionalDatasourceDialog } from "./additional-datasource-dialog";
+import type { AdditionalDatasourceDialog } from "./additional-datasource-dialog";
 import { NetworkLocationModel } from "../../../../../../../shared/util/model/network-location-model";
 import { DriverWizardComponent } from "./driver-wizard/driver-wizard.component";
 import { EditPropertyDialogComponent } from "./edit-property-dialog.component";
@@ -385,7 +385,8 @@ export class DatasourcesDatabaseComponent extends DataSourceSettingsPage impleme
    }
 
    newAdditional() {
-      this.httpClient.get("../api/data/database/default").subscribe((model: DataSourceSettingsModel) => {
+      this.httpClient.get("../api/data/database/default").subscribe(async (model: DataSourceSettingsModel) => {
+         const { AdditionalDatasourceDialog } = await import("./additional-datasource-dialog");
          let dialog = ComponentTool.showDialog(this.modalService, AdditionalDatasourceDialog,
             (additional: DatabaseDefinitionModel) => {
 
@@ -473,10 +474,11 @@ export class DatasourcesDatabaseComponent extends DataSourceSettingsPage impleme
       this.updateAdditionalList();
    }
 
-   editAdditional() {
+   async editAdditional() {
       const dss = this.getSelectedAdditional();
 
       if(!!dss && dss.length == 1) {
+         const { AdditionalDatasourceDialog } = await import("./additional-datasource-dialog");
          let ds = dss[0];
          let dialog = ComponentTool.showDialog(this.modalService, AdditionalDatasourceDialog,
             (model: DatabaseDefinitionModel) => {

--- a/web/projects/portal/src/app/portal/dialog/vpm-condition-dialog/vpm-condition-pane/vpm-condition-item-pane/vpm-condition-editor/vpm-subquery-editor/vpm-subquery-editor.component.ts
+++ b/web/projects/portal/src/app/portal/dialog/vpm-condition-dialog/vpm-condition-pane/vpm-condition-item-pane/vpm-condition-editor/vpm-subquery-editor/vpm-subquery-editor.component.ts
@@ -24,7 +24,7 @@ import {
 import {
    SqlQueryDialogController
 } from "../../../../../../../widget/dialog/sql-query-dialog/sql-query-dialog-controller";
-import {
+import type {
    SQLQueryDialog
 } from "../../../../../../../widget/dialog/sql-query-dialog/sql-query-dialog.component";
 import { ModelService } from "../../../../../../../widget/services/model.service";
@@ -83,7 +83,7 @@ export class VpmSubqueryEditorComponent implements OnInit {
       this.setupModel();
    }
 
-   editSubQuery() {
+   async editSubQuery() {
       this.setupModel();
 
       const modalOptions: SlideOutOptions = {
@@ -92,10 +92,11 @@ export class VpmSubqueryEditorComponent implements OnInit {
          keyboard: false
       };
 
+      const { SQLQueryDialog } = await import("../../../../../../../widget/dialog/sql-query-dialog/sql-query-dialog.component");
       const dialog = ComponentTool.showDialog(this.modalService, SQLQueryDialog, (result: any) => {
          this._model.query = Tool.clone(<SqlQueryDialogModel> result.model);
          this.valueChange.emit(this._model.query);
-      }, modalOptions);
+      }, modalOptions) as SQLQueryDialog;
 
       dialog.controller = this.subSqlQueryController;
       dialog.applyVisible = false;

--- a/web/projects/portal/src/app/vsobjects/objects/viewsheet/vs-viewsheet.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/viewsheet/vs-viewsheet.component.ts
@@ -20,6 +20,7 @@ import {
    ChangeDetectorRef,
    Component,
    EventEmitter,
+   forwardRef,
    Input,
    NgZone,
    OnChanges,
@@ -71,7 +72,7 @@ declare const window: any;
     styleUrls: ["vs-viewsheet.component.scss"],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [NgIf, VSObjectContainer]
+    imports: [NgIf, forwardRef(() => VSObjectContainer)]
 })
 export class VSViewsheet extends NavigationComponent<VSViewsheetModel> implements OnChanges, OnDestroy {
    @Input() deployed: boolean;

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -146,6 +146,7 @@ import { ViewsheetInfo } from "./data/viewsheet-info";
 import { AnnotationFormatDialogModel } from "./dialog/annotation/annotation-format-dialog-model";
 import { AnnotationFormatDialog } from "./dialog/annotation/annotation-format-dialog.component";
 import { ProfilingDialog } from "./dialog/profiling-dialog.component";
+import { CKEditorRichTextService } from "./dialog/rich-text-dialog/ckeditor-rich-text.service";
 import { RichTextService } from "./dialog/rich-text-dialog/rich-text.service";
 import { AddAnnotationEvent } from "./event/annotation/add-annotation-event";
 import { RemoveAnnotationEvent } from "./event/annotation/remove-annotation-event";
@@ -193,6 +194,8 @@ import { CalcTableActionHandler } from "./objects/table/calc-table-action-handle
 import { CrosstabActionHandler } from "./objects/table/crosstab-action-handler";
 import { TableActionHandler } from "./objects/table/table-action-handler";
 import { ShowHyperlinkService } from "./show-hyperlink.service";
+import { VSTabService } from "./util/vs-tab.service";
+import { FontService } from "../widget/services/font.service";
 import { ToolbarActionsHandler } from "./toolbar-actions-handler";
 import { CheckFormDataService } from "./util/check-form-data.service";
 import { FormInputService } from "./util/form-input.service";
@@ -315,7 +318,18 @@ export interface ScrollViewportRect {
             useExisting: VSChartService
         },
         ComposerRecentService,
-        SelectionMobileService
+        SelectionMobileService,
+        MiniToolbarService,
+        ShowHyperlinkService,
+        {
+            provide: RichTextService,
+            useClass: CKEditorRichTextService,
+            deps: [FontService, NgbModal, HttpClient]
+        },
+        VSTabService,
+        ViewDataService,
+        FirstDayOfWeekService,
+        PageTabService
     ],
     standalone: true,
     imports: [NgIf, PagingControlComponent, OutOfZoneDirective, VsToolbarButtonDirective, FixedDropdownDirective, DefaultFocusDirective, EnterClickDirective, NgFor, BlockMouseDirective, ViewerMobileToolbarComponent, VsBookmarkPaneComponent, InteractContainerDirective, ViewerFormatPane, VSObjectContainer, StatusBar, VSLoadingDisplay, ExportDialog, EmailDialog, ScheduleDialog, BookmarkPropertyDialog, VariableInputDialog, ShareEmailDialogComponent, ShareGoogleChatDialog, ShareSlackDialog, ShareLinkDialog, RemoveBookmarksDialog, NotificationsComponent]

--- a/web/projects/portal/src/app/widget/responsive-tabs/responsive-tabs.component.ts
+++ b/web/projects/portal/src/app/widget/responsive-tabs/responsive-tabs.component.ts
@@ -77,6 +77,10 @@ export class ResponsiveTabsComponent implements OnInit {
    }
 
    private updateView(): void {
+      if(!this.tabSet) {
+         return;
+      }
+
       // need to unhide the tabs to figure out if they can fit in cases where
       // the window size gets larger
       if(this.firstTabDropdownIndex !== -1) {


### PR DESCRIPTION
## Summary

- **Circular import TDZ errors**: Three import cycles introduced by the standalone migration caused `ReferenceError: can't access lexical declaration '...' before initialization` at bootstrap, preventing the portal from loading past the loading screen. Fixed by converting to dynamic `import()` where the dependency is programmatic-only (`VpmSubqueryEditorComponent → SQLQueryDialog`, `DatasourcesDatabaseComponent → AdditionalDatasourceDialog`) and by using `forwardRef()` where both sides genuinely need each other in their templates (`VSViewsheet ↔ VSObjectContainer`).
- **Missing providers in ViewerAppComponent**: `VSObjectModule` previously supplied several services (`MiniToolbarService`, `ShowHyperlinkService`, `VSTabService`, `ViewDataService`, `FirstDayOfWeekService`, `PageTabService`) via its `providers` array; these were dropped when the module was removed. Also corrected `RichTextService` to be provided as `CKEditorRichTextService` (the no-op base class was being used instead of the real implementation).
- **Null guard in ResponsiveTabsComponent**: `updateView()` was being called via a microtask before `ngAfterViewInit`, leaving `@ViewChild("tabSet")` uninitialised; added an early-return guard.

## Test Plan
- [ ] Portal loads past the loading screen without console errors
- [ ] Viewsheets render correctly in the viewer
- [ ] Annotations / rich text dialogs open correctly
- [ ] VPM condition pane (subquery editor) opens correctly
- [ ] Additional datasource dialog opens correctly from database datasource editor
- [ ] Embedded viewsheet objects (`VSViewsheet` inside `VSObjectContainer`) render without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)