### PR TITLE
Fix composer loading failures after standalone component migration

### DIFF
--- a/web/projects/portal/src/app/composer/gui/composer-main.component.ts
+++ b/web/projects/portal/src/app/composer/gui/composer-main.component.ts
@@ -141,6 +141,7 @@ import { ScriptService } from "./script/script.service";
 import { StylePaneComponent } from "./tablestyle/editor/style-pane.component";
 import { ComposerToolbarComponent } from "./toolbar/composer-toolbar.component";
 import { ComposerObjectService } from "./vs/composer-object.service";
+import { EventQueueService } from "./vs/event-queue.service";
 import { CloseSheetEvent } from "./vs/event/close-sheet-event";
 import { LayoutUndoRedoEvent } from "./vs/event/layout-undo-redo-event";
 import { SaveSheetEvent } from "./ws/socket/save-sheet-event";
@@ -239,6 +240,7 @@ const CONFIRM_MESSAGE = {
             useClass: VSScaleService
         },
         ComposerObjectService,
+        EventQueueService,
         ResizeHandlerService,
         ClipboardService,
         ComposerRecentService,

--- a/web/projects/portal/src/app/composer/gui/composer-main.component.ts
+++ b/web/projects/portal/src/app/composer/gui/composer-main.component.ts
@@ -142,6 +142,7 @@ import { StylePaneComponent } from "./tablestyle/editor/style-pane.component";
 import { ComposerToolbarComponent } from "./toolbar/composer-toolbar.component";
 import { ComposerObjectService } from "./vs/composer-object.service";
 import { EventQueueService } from "./vs/event-queue.service";
+import { LineAnchorService } from "../services/line-anchor.service";
 import { CloseSheetEvent } from "./vs/event/close-sheet-event";
 import { LayoutUndoRedoEvent } from "./vs/event/layout-undo-redo-event";
 import { SaveSheetEvent } from "./ws/socket/save-sheet-event";
@@ -241,6 +242,7 @@ const CONFIRM_MESSAGE = {
         },
         ComposerObjectService,
         EventQueueService,
+        LineAnchorService,
         ResizeHandlerService,
         ClipboardService,
         ComposerRecentService,

--- a/web/projects/portal/src/app/composer/gui/composer-main.component.ts
+++ b/web/projects/portal/src/app/composer/gui/composer-main.component.ts
@@ -75,6 +75,15 @@ import { GuideBounds } from "../../vsobjects/model/layout/guide-bounds";
 import { VSObjectModel } from "../../vsobjects/model/vs-object-model";
 import { VSTabModel } from "../../vsobjects/model/vs-tab-model";
 import { ShowHyperlinkService } from "../../vsobjects/show-hyperlink.service";
+import { VSTabService } from "../../vsobjects/util/vs-tab.service";
+import { FormInputService } from "../../vsobjects/util/form-input.service";
+import { GlobalSubmitService } from "../../vsobjects/util/global-submit.service";
+import { CheckFormDataService } from "../../vsobjects/util/check-form-data.service";
+import { MiniToolbarService } from "../../vsobjects/objects/mini-toolbar/mini-toolbar.service";
+import { SelectionMobileService } from "../../vsobjects/objects/selection/services/selection-mobile.service";
+import { CKEditorRichTextService } from "../../vsobjects/dialog/rich-text-dialog/ckeditor-rich-text.service";
+import { RichTextService } from "../../vsobjects/dialog/rich-text-dialog/rich-text.service";
+import { FullScreenService } from "../../common/services/full-screen.service";
 import { VSUtil } from "../../vsobjects/util/vs-util";
 import { AssetTreeService } from "../../widget/asset-tree/asset-tree.service";
 import {
@@ -228,6 +237,24 @@ const CONFIRM_MESSAGE = {
         {
             provide: ScaleService,
             useClass: VSScaleService
+        },
+        ComposerObjectService,
+        ResizeHandlerService,
+        ClipboardService,
+        ComposerRecentService,
+        ScriptService,
+        ShowHyperlinkService,
+        MiniToolbarService,
+        VSTabService,
+        SelectionMobileService,
+        FormInputService,
+        GlobalSubmitService,
+        CheckFormDataService,
+        FullScreenService,
+        {
+            provide: RichTextService,
+            useClass: CKEditorRichTextService,
+            deps: [FontService, NgbModal, HttpClient]
         }
     ],
     standalone: true,

--- a/web/projects/portal/src/app/composer/gui/composer-main.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/composer-main.spec.ts
@@ -154,7 +154,7 @@ describe("ComposerMain Unit Tests", () => {
          
          schemas: [NO_ERRORS_SCHEMA]
       });
-      TestBed.overrideComponent(ComposerMainComponent, { set: { imports: [] } });
+      TestBed.overrideComponent(ComposerMainComponent, { set: { imports: [], providers: [] } });
       TestBed.compileComponents();
    });
 

--- a/web/projects/portal/src/app/composer/gui/composer-main.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/composer-main.spec.ts
@@ -41,6 +41,9 @@ import { ComposerRecentService } from "./composer-recent.service";
 import { ResizeHandlerService } from "./resize-handler.service";
 import { ScriptService } from "./script/script.service";
 import { ComposerObjectService } from "./vs/composer-object.service";
+import { ComposerClientService } from "./composer-client.service";
+import { ScaleService } from "../../widget/services/scale/scale-service";
+import { VSScaleService } from "../../widget/services/scale/vs-scale.service";
 
 describe("ComposerMain Unit Tests", () => {
    const oldBroadcastChannel = window.BroadcastChannel;
@@ -154,7 +157,15 @@ describe("ComposerMain Unit Tests", () => {
          
          schemas: [NO_ERRORS_SCHEMA]
       });
-      TestBed.overrideComponent(ComposerMainComponent, { set: { imports: [], providers: [] } });
+      TestBed.overrideComponent(ComposerMainComponent, {
+         set: {
+            imports: [],
+            providers: [
+               ComposerClientService,
+               { provide: ScaleService, useClass: VSScaleService }
+            ]
+         }
+      });
       TestBed.compileComponents();
    });
 

--- a/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.ts
@@ -196,7 +196,9 @@ const COLLECT_PARAMS_URI = "/events/vs/collectParameters";
         {
             provide: ChartService,
             useExisting: VSChartService
-        }
+        },
+        VSBindingTreeService,
+        ChatService
     ],
     standalone: true,
     imports: [OutOfZoneDirective, NgIf, MobileToolbarComponent, Rulers, SelectionBoxDirective, ActionsContextmenuAnchorDirective, InteractContainerDirective, NgStyle, NgFor, EditableObjectContainer, ComposerSelectionContainerChildren, LayoutPane, PlaceholderDragElement, StatusBar, FormsModule, VSLoadingDisplay, VSSavingDisplay, NotificationsComponent, VariableInputDialog, ConsoleDialogComponent]


### PR DESCRIPTION
## Summary

- **Missing providers in `ComposerMainComponent`**: When `ComposerAppModule` and `VSObjectModule` were deleted during the standalone migration, their `providers` arrays were not redistributed. `ComposerMainComponent` now declares the services its constructor requires directly (`ComposerObjectService`, `ResizeHandlerService`, `ClipboardService`, `ComposerRecentService`, `ScriptService`) plus all vsObject services needed by its `VSPane`/`EditableObjectContainer` subtree (`ShowHyperlinkService`, `MiniToolbarService`, `VSTabService`, `SelectionMobileService`, `FormInputService`, `GlobalSubmitService`, `CheckFormDataService`, `FullScreenService`). `RichTextService` is provided via `useClass: CKEditorRichTextService` so annotation dialogs use the real CKEditor implementation rather than the no-op base class.
- **Missing providers in `VSPane`**: Added `VSBindingTreeService` and `ChatService`, both injected by `VSPane`'s constructor and required by the `EditableObjectContainer` subtree it renders.

## Test Plan
- [ ] Composer loads without console errors
- [ ] Viewsheets open and render correctly in the composer editor
- [ ] Worksheets open and render correctly
- [ ] Chart property dialogs open correctly
- [ ] Annotation / rich text dialogs open correctly (CKEditor loads)
- [ ] Binding pane opens correctly when editing a chart or table
- [ ] Script editor opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)