### PR TITLE
Bug #75095 - Fix horizontal non-faceted tree chart vertical slack

### DIFF
--- a/core/src/main/java/inetsoft/graph/coord/RelationCoord.java
+++ b/core/src/main/java/inetsoft/graph/coord/RelationCoord.java
@@ -193,11 +193,14 @@ public class RelationCoord extends Coordinate {
       }
 
       double width = box.getMaxX() - box.getX();
-      // Skip back-divide in horizontal mode: X is depth there, and fit()'s uniform scale is
-      // driven by Y, so dividing by scaleX inflates X spuriously and widens the chart canvas.
-      return isFirstElementHorizontal()
-         ? width + GAP * 2
-         : width / Math.abs(getVGraph().getScreenTransform().getScaleX()) + GAP * 2;
+      // Back-divide recovers the natural width incl. labels (so V-scrollable expand gives the
+      // tree a wide enough plot). Skip for horizontal-faceted: per-row scaleX would inflate the
+      // depth direction.
+      if(isFirstElementHorizontal() && getParentCoordinate() != null) {
+         return width + GAP * 2;
+      }
+
+      return width / Math.abs(getVGraph().getScreenTransform().getScaleX()) + GAP * 2;
    }
 
    /**

--- a/core/src/test/java/inetsoft/graph/coord/RelationCoordMinSizeTest.java
+++ b/core/src/test/java/inetsoft/graph/coord/RelationCoordMinSizeTest.java
@@ -39,10 +39,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Guards the horizontal-mode special-casing in {@link RelationCoord#getUnitMinWidth()} and
- * {@link RelationCoord#getUnitMinHeight()}: vertical mode goes through the back-divide path
- * (so post-fit calls recover natural size); horizontal mode skips the back-divide for width
- * (X is depth, scaleX is Y-binding-driven) and reads natural mxcell bounds directly for
- * height (avoiding label-amplified 1/scaleY inflation in faceted layouts).
+ * {@link RelationCoord#getUnitMinHeight()}. Horizontal width skips back-divide only when
+ * faceted (so each facet cell's depth-direction X isn't inflated by 1/scaleX); non-faceted
+ * horizontal back-divides so the natural width is reported and the V-scrollable expand step
+ * gives the tree a wide enough plot to render at full scale. Height uses natural mxcell bounds
+ * in horizontal mode to avoid label-amplified 1/scaleY inflation in faceted layouts.
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
@@ -51,12 +52,13 @@ import static org.junit.jupiter.api.Assertions.*;
 @Tag("core")
 class RelationCoordMinSizeTest {
    @Test
-   void horizontalModeSkipsBackDivideVerticalDoesNot() {
-      // Lay out one tree, then toggle the horizontal flag on the same coord and observe
-      // how getUnitMinWidth's formula reacts to a non-1 scaleX. Vertical mode back-divides
-      // and so reports ~2× horizontal's value when scaleX=0.5.
+   void facetedHorizontalSkipsBackDivideVerticalDoesNot() {
+      // In a facet cell, scaleX is shrunk per row; back-dividing the depth-direction width
+      // would inflate X. The horizontal-faceted branch skips back-divide so the cell's min
+      // width stays sane. Simulate the facet by wiring a parent coordinate.
       RelationCoord coord = treeCoord(false);
       RelationElement elem = (RelationElement) coord.getVGraph().getEGraph().getElement(0);
+      coord.setParentCoordinate(new FacetCoord());
 
       coord.getVGraph().concat(AffineTransform.getScaleInstance(0.5, 0.5), true);
 
@@ -67,9 +69,33 @@ class RelationCoordMinSizeTest {
       double vertMin = coord.getUnitMinWidth();
 
       assertTrue(vertMin > horizMin * 1.5,
-         "vertical-mode back-divide should give a notably larger min than horizontal mode "
-            + "(horiz=" + horizMin + ", vert=" + vertMin + "); regression: horizontal also "
+         "faceted-horizontal must skip back-divide while vertical back-divides "
+            + "(horiz=" + horizMin + ", vert=" + vertMin + "); regression: faceted horizontal "
             + "back-divides and X inflates spuriously");
+   }
+
+   @Test
+   void nonFacetedHorizontalBackDividesWidth() {
+      // Non-faceted: back-divide so the reported width is the natural unscaled width including
+      // labels. This is what the V-scrollable expand step needs to give the tree a wide enough
+      // plot to render at full scale - otherwise uniform fit shrinks it and leaves vertical
+      // slack inside the expanded scroll region.
+      RelationCoord coord = treeCoord(false);
+      RelationElement elem = (RelationElement) coord.getVGraph().getEGraph().getElement(0);
+      assertNull(coord.getParentCoordinate(), "test fixture must be non-faceted for this guard");
+
+      coord.getVGraph().concat(AffineTransform.getScaleInstance(0.5, 0.5), true);
+
+      elem.setHorizontal(true);
+      double horizMin = coord.getUnitMinWidth();
+
+      elem.setHorizontal(false);
+      double vertMin = coord.getUnitMinWidth();
+
+      assertEquals(vertMin, horizMin, 0.5,
+         "non-faceted horizontal must back-divide like vertical (horiz=" + horizMin
+            + ", vert=" + vertMin + "); regression: horizontal skips back-divide and reports "
+            + "the scaled visual width instead of the natural width");
    }
 
    @Test


### PR DESCRIPTION
A horizontal tree chart whose natural height exceeded the viewport was
uniformly shrunk and centered vertically inside the expanded scroll
region, producing large empty bands above and below the tree — the chart
scrolled into empty space.

Root cause: `RelationCoord.getUnitMinWidth()` skipped the back-divide
in horizontal mode (introduced for the faceted X-inflation bug in
PR #3687) and returned the post-fit scaled visual width instead of the
natural width including labels. That under-reported `minPlotWidth`, so
the V-scrollable expand step in `VGraphPair` sized `ewidth` to the
viewport instead of the natural label-inclusive width. `fit()`'s uniform
`min(w2/width, h2/height)` then picked the width ratio as binding,
shrinking the tree and leaving the height under-filled.

Fix: gate the "skip back-divide" branch on
`getParentCoordinate() != null` so it applies only to the faceted case
PR #3687 targeted. Non-faceted horizontal now back-divides like
vertical, reporting the natural unscaled width; the expand step sizes
`ewidth` to fit it; the tree renders at full scale and fills the
expanded height. Trees whose natural label width exceeds the viewport
will gain an H-scrollbar, matching the design intent in
`ChartPainter.getPreferredSize()` that tree/network charts use their
real size.

Completes the symmetric series with PR #3687 (Bug #74971, faceted X)
and PR #3772 (Bug #75050, faceted Y).