### PR TITLE
Filter Postgres partition children from wiz metadata APIs

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -544,6 +544,19 @@ public class MetadataApiService {
          throw new Exception("No meta data provider found for data source " + dsName);
       }
 
+      // Partition probe: identify Postgres partition/inheritance children up-front
+      // so we can drop them from the response (they're implementation detail,
+      // not user-facing tables). On any probe error we fall open — log a warning
+      // and proceed with an empty set, so a transient catalog issue doesn't block
+      // the whole metadata fetch.
+      Set<String> partitionChildren = Set.of();
+      try(java.sql.Connection probeConn = new inetsoft.uql.jdbc.JDBCHandler().getConnection(jdbcDataSource, principal)) {
+         partitionChildren = findPostgresPartitionChildren(jdbcDataSource, probeConn);
+      }
+      catch(Exception e) {
+         log.warn("Partition probe failed for '{}'; proceeding without partition filter", dsName, e);
+      }
+
       XNode rootMetaData = metaDataProvider.getRootMetaData(XUtil.OUTER_MOSE_LAYER_DATABASE);
 
       XNode typeQuery = new XNode();
@@ -586,6 +599,10 @@ public class MetadataApiService {
                String tableName = tableNode.getName();
                String catalog = (String) tableNode.getAttribute("catalog");
                String schema = (String) tableNode.getAttribute("schema");
+
+               if(isPartitionChild(schema, tableName, partitionChildren)) {
+                  continue;
+               }
 
                DatabaseTableInfo info = new DatabaseTableInfo();
                info.setType(tableType);

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -995,6 +995,53 @@ public class MetadataApiService {
       return "org.postgresql.Driver".equals(driver);
    }
 
+   /**
+    * Authoritative partition-children probe for Postgres. Queries pg_inherits
+    * (inheritance children, including pre-PG10 inheritance-based partitioning AND
+    * PG10+ declarative partitioning). Returns lowercased "schema.table" keys.
+    *
+    * Package-private static for direct unit testing — the only side effect besides
+    * returning is consuming the supplied Connection.
+    *
+    * On error: this method does NOT swallow exceptions. Callers must catch
+    * SQLException and decide whether to log and continue with an empty filter
+    * (current policy: leak partitions through rather than block the whole metadata
+    * request).
+    */
+   static Set<String> findPostgresPartitionChildren(
+      JDBCDataSource ds, java.sql.Connection conn) throws java.sql.SQLException
+   {
+      if(!isPostgresDriver(ds)) {
+         return Set.of();
+      }
+
+      // pg_inherits is the implementation mechanism for both pre-PG10 inheritance-
+      // based partitioning AND PG10+ declarative partitioning, so this single
+      // subquery covers both eras without referencing pg_class.relispartition
+      // (PG10+ only — would break catalog queries on older Postgres).
+      String sql =
+         "SELECT n.nspname || '.' || c.relname AS qualified " +
+         "FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid " +
+         "WHERE c.oid IN (SELECT inhrelid FROM pg_inherits)";
+
+      Set<String> out = new HashSet<>();
+
+      try(java.sql.PreparedStatement ps = conn.prepareStatement(sql);
+          java.sql.ResultSet rs = ps.executeQuery())
+      {
+         while(rs.next()) {
+            String qualified = rs.getString(1);
+            if(qualified != null) {
+               // Locale.ROOT avoids Turkish-locale "I" → dotless-ı conversion, which
+               // would produce keys that don't match the comparison side downstream.
+               out.add(qualified.toLowerCase(Locale.ROOT));
+            }
+         }
+      }
+
+      return Set.copyOf(out);
+   }
+
    private final XRepository xrepository;
    private final DataSourceService dataSourceService;
    private final AssetRepository assetRepository;

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -1042,6 +1042,40 @@ public class MetadataApiService {
       return Set.copyOf(out);
    }
 
+   /**
+    * True when (schema, tableName) refers to a row in the partition-children set.
+    * Used by getDatabaseTables, which already has schema and table broken out.
+    */
+   static boolean isPartitionChild(String schema, String tableName, Set<String> partitions) {
+      if(partitions == null || partitions.isEmpty() || tableName == null) {
+         return false;
+      }
+      // Locale.ROOT matches the lowercasing convention used in findPostgresPartitionChildren.
+      String qualified = ((schema == null ? "" : schema + ".") + tableName).toLowerCase(Locale.ROOT);
+      return partitions.contains(qualified);
+   }
+
+   /**
+    * True when a wiz asset path ("dsName/TABLE/schema/tableName") refers to a
+    * partition child. Used by filterWizTree, which only has the path string.
+    * Returns false for paths that aren't TABLE leaves (VIEW, folder paths, etc.)
+    * so the predicate is safe to call on any node.
+    */
+   static boolean isPartitionChild(String assetPath, Set<String> partitions) {
+      if(assetPath == null || assetPath.isEmpty() || partitions == null || partitions.isEmpty()) {
+         return false;
+      }
+      String[] parts = assetPath.split("/");
+      // Need at minimum: dsName/TABLE/schema/tableName
+      if(parts.length < 4) {
+         return false;
+      }
+      if(!"TABLE".equalsIgnoreCase(parts[1])) {
+         return false;
+      }
+      return isPartitionChild(parts[2], parts[3], partitions);
+   }
+
    private final XRepository xrepository;
    private final DataSourceService dataSourceService;
    private final AssetRepository assetRepository;

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -982,6 +982,19 @@ public class MetadataApiService {
       }
    }
 
+   /**
+    * Returns true when the datasource uses the Postgres JDBC driver. Package-private
+    * (not private) so the partition filter unit tests can call it without standing
+    * up the full service graph.
+    */
+   static boolean isPostgresDriver(JDBCDataSource ds) {
+      if(ds == null) {
+         return false;
+      }
+      String driver = ds.getDriver();
+      return "org.postgresql.Driver".equals(driver);
+   }
+
    private final XRepository xrepository;
    private final DataSourceService dataSourceService;
    private final AssetRepository assetRepository;

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -626,17 +626,21 @@ public class MetadataApiService {
    }
 
    private TreeNodeModel filterWizTree(TreeNodeModel node) {
-      return filterWizTree(node, new HashMap<>());
+      return filterWizTree(node, new HashMap<>(), new HashMap<>());
    }
 
-   private TreeNodeModel filterWizTree(TreeNodeModel node, Map<String, SystemFilter> filterCache) {
+   private TreeNodeModel filterWizTree(
+      TreeNodeModel node,
+      Map<String, SystemFilter> filterCache,
+      Map<String, Set<String>> partitionCache)
+   {
       if(node == null) {
          return null;
       }
 
       AssetEntry entry = node.data() instanceof AssetEntry assetEntry ? assetEntry : null;
 
-      if(shouldHideWizTreeNode(entry, filterCache)) {
+      if(shouldHideWizTreeNode(entry, filterCache, partitionCache)) {
          return null;
       }
 
@@ -644,7 +648,7 @@ public class MetadataApiService {
       builder.children(new ArrayList<>());
 
       for(TreeNodeModel child : node.children()) {
-         TreeNodeModel filteredChild = filterWizTree(child, filterCache);
+         TreeNodeModel filteredChild = filterWizTree(child, filterCache, partitionCache);
 
          if(filteredChild != null) {
             builder.addChildren(filteredChild);
@@ -654,7 +658,11 @@ public class MetadataApiService {
       return builder.build();
    }
 
-   private boolean shouldHideWizTreeNode(AssetEntry entry, Map<String, SystemFilter> filterCache) {
+   private boolean shouldHideWizTreeNode(
+      AssetEntry entry,
+      Map<String, SystemFilter> filterCache,
+      Map<String, Set<String>> partitionCache)
+   {
       if(entry == null || Tool.isEmptyString(entry.getPath())) {
          return false;
       }
@@ -671,7 +679,20 @@ public class MetadataApiService {
          return false;
       }
 
-      SystemFilter filter = getSystemFilter(parts[0], filterCache);
+      String dsName = parts[0];
+
+      // Partition-child check (Postgres only): TABLE leaves whose qualified name
+      // appears in the per-datasource partition set are dropped. Cached lazily
+      // because the asset tree can include many tables per datasource.
+      if("TABLE".equalsIgnoreCase(tableType)) {
+         Set<String> partitions = partitionCache.computeIfAbsent(
+            dsName, this::probePartitionsForTree);
+         if(isPartitionChild(entry.getPath(), partitions)) {
+            return true;
+         }
+      }
+
+      SystemFilter filter = getSystemFilter(dsName, filterCache);
 
       if(filter.isEmpty()) {
          return false;
@@ -686,6 +707,27 @@ public class MetadataApiService {
       }
 
       return parts.length > 3 && matchesSystemName(parts[3], filter.schemas);
+   }
+
+   /**
+    * Lazy partition probe for the asset-tree filter. Fail-open: returns empty
+    * set on any error so the tree still renders, mirroring getDatabaseTables.
+    */
+   private Set<String> probePartitionsForTree(String dsName) {
+      try {
+         JDBCDataSource ds = getJDBCDatasource(dsName);
+         if(ds == null || !isPostgresDriver(ds)) {
+            return Set.of();
+         }
+         try(java.sql.Connection conn = new inetsoft.uql.jdbc.JDBCHandler()
+               .getConnection(ds, inetsoft.util.ThreadContext.getContextPrincipal())) {
+            return findPostgresPartitionChildren(ds, conn);
+         }
+      }
+      catch(Exception e) {
+         log.warn("Partition probe failed for asset tree '{}'; tree will include partitions", dsName, e);
+         return Set.of();
+      }
    }
 
    private XNode filterSystemSchemaTree(XNode schemas, JDBCDataSource jdbcDataSource) {

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePartitionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePartitionTest.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.jdbc.JDBCDataSource;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Tag("core")
+class MetadataApiServicePartitionTest {
+
+   @Test
+   void isPostgresDriver_returnsTrueForPostgresDriver() {
+      JDBCDataSource ds = mock(JDBCDataSource.class);
+      when(ds.getDriver()).thenReturn("org.postgresql.Driver");
+      assertTrue(MetadataApiService.isPostgresDriver(ds));
+   }
+
+   @Test
+   void isPostgresDriver_returnsFalseForMysqlDriver() {
+      JDBCDataSource ds = mock(JDBCDataSource.class);
+      when(ds.getDriver()).thenReturn("com.mysql.cj.jdbc.Driver");
+      assertFalse(MetadataApiService.isPostgresDriver(ds));
+   }
+
+   @Test
+   void isPostgresDriver_returnsFalseForNullDriver() {
+      JDBCDataSource ds = mock(JDBCDataSource.class);
+      when(ds.getDriver()).thenReturn(null);
+      assertFalse(MetadataApiService.isPostgresDriver(ds));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePartitionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePartitionTest.java
@@ -143,4 +143,58 @@ class MetadataApiServicePartitionTest {
 
       verify(ps).close();
    }
+
+   @Test
+   void isPartitionChild_bySchemaAndTable_matchesLowercased() {
+      java.util.Set<String> partitions = java.util.Set.of(
+         "public.payment_p2007_01", "public.payment_p2007_02"
+      );
+      assertTrue(
+         MetadataApiService.isPartitionChild("public", "payment_p2007_01", partitions));
+      assertTrue(
+         MetadataApiService.isPartitionChild("PUBLIC", "Payment_P2007_01", partitions));
+      assertFalse(
+         MetadataApiService.isPartitionChild("public", "payment", partitions));
+   }
+
+   @Test
+   void isPartitionChild_bySchemaAndTable_nullSchemaBuildsBareKey() {
+      java.util.Set<String> partitions = java.util.Set.of("payment_p2007_01");
+      assertTrue(
+         MetadataApiService.isPartitionChild(null, "payment_p2007_01", partitions));
+   }
+
+   @Test
+   void isPartitionChild_bySchemaAndTable_emptyPartitionSetMatchesNothing() {
+      java.util.Set<String> partitions = java.util.Set.of();
+      assertFalse(
+         MetadataApiService.isPartitionChild("public", "anything", partitions));
+   }
+
+   @Test
+   void isPartitionChild_byAssetPath_parsesWizFormat() {
+      java.util.Set<String> partitions = java.util.Set.of("public.payment_p2007_01");
+      // Wiz asset paths look like "dsName/TABLE/schema/tableName"
+      assertTrue(
+         MetadataApiService.isPartitionChild("postgres/TABLE/public/payment_p2007_01", partitions));
+      assertFalse(
+         MetadataApiService.isPartitionChild("postgres/TABLE/public/payment", partitions));
+      assertFalse(
+         MetadataApiService.isPartitionChild("postgres/VIEW/public/payment_p2007_01", partitions));
+   }
+
+   @Test
+   void isPartitionChild_byAssetPath_handlesShortOrEmptyPaths() {
+      java.util.Set<String> partitions = java.util.Set.of("public.payment_p2007_01");
+      assertFalse(
+         MetadataApiService.isPartitionChild((String) null, partitions));
+      assertFalse(
+         MetadataApiService.isPartitionChild("", partitions));
+      assertFalse(
+         MetadataApiService.isPartitionChild("postgres", partitions));
+      assertFalse(
+         MetadataApiService.isPartitionChild("postgres/TABLE", partitions));
+      assertFalse(
+         MetadataApiService.isPartitionChild("postgres/TABLE/public", partitions));
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePartitionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePartitionTest.java
@@ -21,9 +21,14 @@ import inetsoft.uql.jdbc.JDBCDataSource;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @Tag("core")
@@ -48,5 +53,94 @@ class MetadataApiServicePartitionTest {
       JDBCDataSource ds = mock(JDBCDataSource.class);
       when(ds.getDriver()).thenReturn(null);
       assertFalse(MetadataApiService.isPostgresDriver(ds));
+   }
+
+   @Test
+   void findPostgresPartitionChildren_returnsLowercasedQualifiedNames() throws Exception {
+      JDBCDataSource ds = mock(JDBCDataSource.class);
+      when(ds.getDriver()).thenReturn("org.postgresql.Driver");
+
+      java.sql.Connection conn = mock(java.sql.Connection.class);
+      java.sql.PreparedStatement ps = mock(java.sql.PreparedStatement.class);
+      java.sql.ResultSet rs = mock(java.sql.ResultSet.class);
+      when(conn.prepareStatement(anyString())).thenReturn(ps);
+      when(ps.executeQuery()).thenReturn(rs);
+      when(rs.next()).thenReturn(true, true, true, false);
+      when(rs.getString(1))
+         .thenReturn("public.payment_p2007_01", "public.payment_p2007_02", "ANALYTICS.AUDIT_2026_05");
+
+      java.util.Set<String> result = MetadataApiService.findPostgresPartitionChildren(ds, conn);
+
+      assertEquals(
+         java.util.Set.of("public.payment_p2007_01", "public.payment_p2007_02", "analytics.audit_2026_05"),
+         result
+      );
+   }
+
+   @Test
+   void findPostgresPartitionChildren_returnsEmptySetForNonPostgres() throws Exception {
+      JDBCDataSource ds = mock(JDBCDataSource.class);
+      when(ds.getDriver()).thenReturn("com.mysql.cj.jdbc.Driver");
+      java.sql.Connection conn = mock(java.sql.Connection.class);
+
+      java.util.Set<String> result = MetadataApiService.findPostgresPartitionChildren(ds, conn);
+
+      assertTrue(result.isEmpty());
+      // The mock connection must never be touched on the non-Postgres path.
+      verifyNoInteractions(conn);
+   }
+
+   @Test
+   void findPostgresPartitionChildren_returnsEmptySetForEmptyResultSet() throws Exception {
+      JDBCDataSource ds = mock(JDBCDataSource.class);
+      when(ds.getDriver()).thenReturn("org.postgresql.Driver");
+
+      java.sql.Connection conn = mock(java.sql.Connection.class);
+      java.sql.PreparedStatement ps = mock(java.sql.PreparedStatement.class);
+      java.sql.ResultSet rs = mock(java.sql.ResultSet.class);
+      when(conn.prepareStatement(anyString())).thenReturn(ps);
+      when(ps.executeQuery()).thenReturn(rs);
+      when(rs.next()).thenReturn(false);
+
+      java.util.Set<String> result = MetadataApiService.findPostgresPartitionChildren(ds, conn);
+
+      assertTrue(result.isEmpty());
+   }
+
+   @Test
+   void findPostgresPartitionChildren_closesResources() throws Exception {
+      JDBCDataSource ds = mock(JDBCDataSource.class);
+      when(ds.getDriver()).thenReturn("org.postgresql.Driver");
+
+      java.sql.Connection conn = mock(java.sql.Connection.class);
+      java.sql.PreparedStatement ps = mock(java.sql.PreparedStatement.class);
+      java.sql.ResultSet rs = mock(java.sql.ResultSet.class);
+      when(conn.prepareStatement(anyString())).thenReturn(ps);
+      when(ps.executeQuery()).thenReturn(rs);
+      when(rs.next()).thenReturn(false);
+
+      MetadataApiService.findPostgresPartitionChildren(ds, conn);
+
+      // try-with-resources should close both
+      verify(ps).close();
+      verify(rs).close();
+   }
+
+   @Test
+   void findPostgresPartitionChildren_closesPreparedStatementWhenExecuteQueryThrows() throws Exception {
+      JDBCDataSource ds = mock(JDBCDataSource.class);
+      when(ds.getDriver()).thenReturn("org.postgresql.Driver");
+
+      java.sql.Connection conn = mock(java.sql.Connection.class);
+      java.sql.PreparedStatement ps = mock(java.sql.PreparedStatement.class);
+      when(conn.prepareStatement(anyString())).thenReturn(ps);
+      when(ps.executeQuery()).thenThrow(new java.sql.SQLException("simulated catalog read failure"));
+
+      // executeQuery throws, but try-with-resources must still close ps before
+      // the exception propagates.
+      assertThrows(java.sql.SQLException.class,
+         () -> MetadataApiService.findPostgresPartitionChildren(ds, conn));
+
+      verify(ps).close();
    }
 }


### PR DESCRIPTION
## Why this exists

The Postgres port of the Sakila sample database — and any user-supplied Postgres schema that uses table inheritance or declarative partitioning — exposes partition **child** tables as first-class tables to JDBC `DatabaseMetaData.getTables()`. StyleBI's wiz-facing metadata endpoints return them, and downstream consumers see them as if they were ordinary tables.

In Sakila specifically, the parent \`payment\` table holds all 16,049 rows. The six \`payment_p2007_01\`…\`payment_p2007_06\` partition children all have **0 rows** — the Sakila Postgres port creates the partition skeleton + CHECK constraints as a pedagogical demo, but the data loader inserts directly into the parent without a routing trigger. Net effect for users:

- The **annotation pipeline** burns LLM tokens generating descriptions for tables that are empty implementation detail.
- The **visualization LLM** can pick a partition child for a query and find no data, producing wrong or empty results.
- The **Data Annotation tree picker** clutters the asset list with technical noise — reviewers have to manually reject the partitions every time annotation is re-run.

The catalog-side signal is unambiguous: a table is a partition / inheritance child iff its OID appears in \`pg_inherits.inhrelid\`. (In Postgres 10+, declarative partition children also appear there — it's the implementation mechanism for partitioning, not an alternative to inheritance.) Since this signal exists, the right place to drop these tables is in the metadata layer, before any downstream consumer ever sees them.

## What this changes

Two wiz-facing entry points in \`MetadataApiService\` now filter Postgres partition children out of their responses:

1. **\`getDatabaseTables\`** — backs \`/datasource/tables\`, which the wiz annotation pipeline calls directly.
2. **\`filterWizTree\`** — post-processes the response of \`/datasets/asset_tree\`, which the Data Annotation picker UI uses.

Both call into a small family of new package-private static helpers on \`MetadataApiService\`:

| Helper | Purpose |
|---|---|
| \`isPostgresDriver(JDBCDataSource)\` | Guard for Postgres-specific code paths. |
| \`findPostgresPartitionChildren(JDBCDataSource, Connection)\` | One \`pg_catalog\` query; returns a lowercased \`schema.table\` \`Set<String>\`. |
| \`isPartitionChild(String schema, String tableName, Set<String>)\` | Used by \`getDatabaseTables\` (broken-out names). |
| \`isPartitionChild(String assetPath, Set<String>)\` | Used by \`filterWizTree\` (wiz \`dsName/TABLE/schema/tableName\` paths). |

The probe queries:

\`\`\`sql
SELECT n.nspname || '.' || c.relname AS qualified
FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid
WHERE c.oid IN (SELECT inhrelid FROM pg_inherits)
\`\`\`

That single \`pg_inherits\` subquery covers both legacy inheritance-based partitioning AND modern (Postgres 10+) declarative partitioning. We deliberately do NOT reference \`pg_class.relispartition\` — that column was introduced in PG10 and querying it on PG9.x produces \`column does not exist\`, breaking the catalog read on older Postgres. \`pg_inherits\` is the underlying implementation mechanism either way, so the simpler query is correct on every Postgres version still in the wild.

## Design decisions

- **Postgres only.** MySQL native partitioning isn't exposed as separate JDBC tables; Oracle / SQL Server have different models. Adding multi-dialect support is deferred until a second dialect needs it. \`isPostgresDriver\` short-circuits everywhere.
- **Drop, don't mark.** Partition children are removed entirely from the response — no \`isPartitionChild\` marker on the wire. Simplest mental model for callers, and keeps the LLM/UI from ever seeing them.
- **Fail open.** If the catalog probe throws (transient network, permission denied on \`pg_catalog\`, etc.), the code logs a WARN and proceeds with an empty filter — i.e., partition children resurface but the user can still see all their real tables. Failing closed (refusing to return any tables) would be a worse outcome.
- **No caching.** \`pg_inherits\` is a tiny system catalog; the probe is one indexed query. Caching across requests would introduce staleness if a reviewer creates or drops a partition between annotation runs. Within a single tree-walk, \`filterWizTree\` uses \`computeIfAbsent\` on a per-request \`HashMap\` so the probe runs at most once per datasource, then is reused for every node under that datasource.
- **Locale-safe lowercasing.** Both the probe and the predicate use \`toLowerCase(Locale.ROOT)\` so the qualified-name comparison doesn't get tripped by Turkish-locale JVMs where uppercase \`I\` lowercases to dotless-ı.

## How to test

Once this lands and the wiz docker image rebuilds:

1. Stand up the wiz stack with the bundled Sakila Postgres (\`postgresql\` service in \`stylebi-wiz/infra/docker-compose.yml\`).
2. Open the wiz portal → **Data Annotation** → expand the \`postgres\` datasource.
3. **Expected:** \`payment\` is present; \`payment_p2007_01\` through \`payment_p2007_06\` are absent.
4. Run annotation on the \`postgres\` datasource. The wiz-services log should show \`Generating DB annotation for postgres (~17 tables)\` rather than \`(28 tables)\`.
5. (Optional) Create a new partition table:
   \`\`\`sql
   CREATE TABLE payment_p2007_07 (LIKE payment INCLUDING ALL) INHERITS (payment);
   \`\`\`
   Refresh the picker — the new partition should NOT appear (no service restart required; no per-request caching).
6. (Optional, destructive) Revoke \`pg_catalog\` SELECT to simulate probe failure → tree should still render (with partitions resurfacing), wiz-services log shows the WARN.

## Tests

13 new unit tests in \`MetadataApiServicePartitionTest.java\` cover:

- \`isPostgresDriver\` (3): postgres driver, mysql driver, null driver.
- \`findPostgresPartitionChildren\` (5): lowercased qualified names, non-Postgres short-circuit (no \`Connection\` interaction), empty result set, resource closing on success, resource closing when \`executeQuery()\` throws.
- \`isPartitionChild\` overloads (5): schema+table lowercased matching, null schema bare key, empty partition set, asset-path parsing (\`dsName/TABLE/schema/tableName\` form), short/empty paths and non-TABLE leaves.

\`\`\`
Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
\`\`\`

## Scope

Two files touched:
- \`community/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java\` — added helpers + wired the filter into two existing methods.
- \`community/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePartitionTest.java\` — new test file (13 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)