### PR TITLE
Bug #75033 - Fix gradient legend selection highlight clipping at canvas edge

### DIFF
--- a/core/src/main/java/inetsoft/graph/guide/legend/Legend.java
+++ b/core/src/main/java/inetsoft/graph/guide/legend/Legend.java
@@ -1215,7 +1215,7 @@ public abstract class Legend extends BoundedContainer {
    private static final int TITLE_RIGHT_PADDING = 4;
    private static final int ITEM_LEFT_PADDING = TITLE_LEFT_PADDING;
    private static final int ITEM_RIGHT_PADDING = 4;
-   private static final int TITLE_LINE_GAP = 1;
+   public static final int TITLE_LINE_GAP = 1;
    private static final int MIN_CHAR_COUNT = 4;
    private static final int PREFERRED_CHAR_COUNT = 30;
 

--- a/core/src/main/java/inetsoft/report/composition/region/LegendTitleArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/LegendTitleArea.java
@@ -114,7 +114,7 @@ public class LegendTitleArea extends DefaultArea implements MenuArea, RollOverAr
    @Override
    public Region[] getRegions() {
       return new Region[] {
-         new RectangleRegion(getTransformedTitleBounds(TITLE_LINE_GAP + getBorderWidth()))};
+         new RectangleRegion(getTransformedTitleBounds(Legend.TITLE_LINE_GAP + getBorderWidth()))};
    }
 
    private Rectangle2D.Double getTransformedTitleBounds(double heightInset) {
@@ -124,12 +124,12 @@ public class LegendTitleArea extends DefaultArea implements MenuArea, RollOverAr
       Point2D p = getRelPos();
       rect2d.x = rect2d.x - p.getX();
       rect2d.y = rect2d.y - p.getY();
-      rect2d.width -= 2 * getBorderWidth();
-      rect2d.height -= heightInset;
+      rect2d.width = Math.max(0, rect2d.width - 2 * getBorderWidth());
+      rect2d.height = Math.max(0, rect2d.height - heightInset);
       return rect2d;
    }
 
-   // 0 when the frame is absent; the constructor treats a null frame as valid.
+   // null-safe: 0 when the legend has no visual frame
    private double getBorderWidth() {
       VisualFrame frame = ((Legend) vobj).getVisualFrame();
       return frame == null ? 0 : GTool.getLineWidth(frame.getLegendSpec().getBorder());
@@ -215,7 +215,4 @@ public class LegendTitleArea extends DefaultArea implements MenuArea, RollOverAr
    private boolean sharedColor;
    private String titleLabel;
    private boolean nodeAesthetic;
-
-   // mirrors Legend.TITLE_LINE_GAP (the gap baked into the title bounds height)
-   private static final int TITLE_LINE_GAP = 1;
 }

--- a/core/src/main/java/inetsoft/report/composition/region/LegendTitleArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/LegendTitleArea.java
@@ -97,9 +97,11 @@ public class LegendTitleArea extends DefaultArea implements MenuArea, RollOverAr
 
    /**
     * Layout bounds: width inset by 2 * borderWidth so the element fits inside
-    * the wrapper's inner content (layoutTitle uses the full legend width).
-    * Height stays full so the SVG tile matches the container, otherwise the
-    * hover:overflow-y:auto rule would spawn a scrollbar.
+    * the wrapper's inner content (layoutTitle uses the full legend width). The
+    * inset applies to every legend type, since the border sits outside the
+    * title box for both categorical and scalar legends. Height stays full so
+    * the SVG tile matches the container, otherwise the hover:overflow-y:auto
+    * rule would spawn a scrollbar.
     */
    @Override
    public Region getRegion() {
@@ -129,7 +131,7 @@ public class LegendTitleArea extends DefaultArea implements MenuArea, RollOverAr
       return rect2d;
    }
 
-   // null-safe: 0 when the legend has no visual frame
+   // 0 if the frame is absent; the rest of this class requires a non-null frame
    private double getBorderWidth() {
       VisualFrame frame = ((Legend) vobj).getVisualFrame();
       return frame == null ? 0 : GTool.getLineWidth(frame.getLegendSpec().getBorder());

--- a/core/src/main/java/inetsoft/report/composition/region/LegendTitleArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/LegendTitleArea.java
@@ -96,18 +96,43 @@ public class LegendTitleArea extends DefaultArea implements MenuArea, RollOverAr
    }
 
    /**
-    * Get regions.
+    * Layout bounds: width inset by 2 * borderWidth so the element fits inside
+    * the wrapper's inner content (layoutTitle uses the full legend width).
+    * Height stays full so the SVG tile matches the container, otherwise the
+    * hover:overflow-y:auto rule would spawn a scrollbar.
+    */
+   @Override
+   public Region getRegion() {
+      return new RectangleRegion(getTransformedTitleBounds(0));
+   }
+
+   /**
+    * Selection region: same width inset as getRegion(), plus height shrunk by
+    * (TITLE_LINE_GAP + borderWidth) so the bottom stroke clears legend_content,
+    * which GraphBuilder shifts up to overlap and which stacks above in DOM.
     */
    @Override
    public Region[] getRegions() {
+      return new Region[] {
+         new RectangleRegion(getTransformedTitleBounds(TITLE_LINE_GAP + getBorderWidth()))};
+   }
+
+   private Rectangle2D.Double getTransformedTitleBounds(double heightInset) {
       Rectangle2D bounds = ((Legend) vobj).getTitleBounds();
       Rectangle2D.Double rect2d =
          (Rectangle2D.Double) GTool.transform(bounds, trans);
       Point2D p = getRelPos();
       rect2d.x = rect2d.x - p.getX();
       rect2d.y = rect2d.y - p.getY();
+      rect2d.width -= 2 * getBorderWidth();
+      rect2d.height -= heightInset;
+      return rect2d;
+   }
 
-      return new Region[] {new RectangleRegion(rect2d)};
+   // 0 when the frame is absent; the constructor treats a null frame as valid.
+   private double getBorderWidth() {
+      VisualFrame frame = ((Legend) vobj).getVisualFrame();
+      return frame == null ? 0 : GTool.getLineWidth(frame.getLegendSpec().getBorder());
    }
 
    /**
@@ -190,4 +215,7 @@ public class LegendTitleArea extends DefaultArea implements MenuArea, RollOverAr
    private boolean sharedColor;
    private String titleLabel;
    private boolean nodeAesthetic;
+
+   // mirrors Legend.TITLE_LINE_GAP (the gap baked into the title bounds height)
+   private static final int TITLE_LINE_GAP = 1;
 }

--- a/core/src/main/java/inetsoft/web/graph/GraphBuilder.java
+++ b/core/src/main/java/inetsoft/web/graph/GraphBuilder.java
@@ -682,6 +682,7 @@ public class GraphBuilder {
             .containsCustomDcRangeRef(containsCustomDcRangeRef(new String[] { field }))
             .containsCustomDcMergeRef(containsCustomDcMergeRef(new String[] { field }))
             .nodeAesthetic(nodeFrame)
+            .scalar(area instanceof ScalarLegendContentArea)
             .build();
       }
       else {

--- a/core/src/main/java/inetsoft/web/graph/model/Legend.java
+++ b/core/src/main/java/inetsoft/web/graph/model/Legend.java
@@ -66,6 +66,15 @@ public abstract class Legend extends ChartObject {
     */
    public abstract Optional<Boolean> nodeAesthetic();
 
+   /**
+    * True for the content area of a scalar (gradient) legend; false for
+    * categorical (where regions are per-item).
+    */
+   @Value.Default
+   public boolean scalar() {
+      return false;
+   }
+
    public static Builder builder() {
       return new Builder();
    }

--- a/core/src/test/java/inetsoft/report/composition/region/LegendTitleAreaTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/LegendTitleAreaTest.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.composition.region;
+
+import inetsoft.graph.GraphConstants;
+import inetsoft.graph.LegendSpec;
+import inetsoft.graph.TextSpec;
+import inetsoft.graph.aesthetic.VisualFrame;
+import inetsoft.graph.guide.legend.Legend;
+import inetsoft.report.internal.RectangleRegion;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies the asymmetric insets in LegendTitleArea: getRegion() insets only
+ * width (for layout/SVG sizing); getRegions()[0] also insets height bottom
+ * (for the selection rect).
+ */
+@Tag("core")
+class LegendTitleAreaTest {
+   private static final double TITLE_WIDTH = 116;
+   private static final double TITLE_HEIGHT_RAW = 19;  // titleh + TITLE_LINE_GAP
+
+   @Test
+   void thinBorderInsetsBy1() {
+      assertInsets(GraphConstants.THIN_LINE, 1);
+   }
+
+   @Test
+   void mediumBorderInsetsBy2() {
+      assertInsets(GraphConstants.MEDIUM_LINE, 2);
+   }
+
+   @Test
+   void thickBorderInsetsBy3() {
+      assertInsets(GraphConstants.THICK_LINE, 3);
+   }
+
+   @Test
+   void zeroBorderInsetsByZero() {
+      assertInsets(GraphConstants.NONE, 0);
+   }
+
+   private void assertInsets(int borderStyle, double expectedLw) {
+      LegendTitleArea area = newTitleArea(borderStyle);
+
+      Rectangle2D layoutBounds = ((RectangleRegion) area.getRegion()).getBounds();
+      assertEquals(TITLE_WIDTH - 2 * expectedLw, layoutBounds.getWidth(), "layout width");
+      assertEquals(TITLE_HEIGHT_RAW, layoutBounds.getHeight(), "layout height");
+
+      Rectangle2D selectionBounds = ((RectangleRegion) area.getRegions()[0]).getBounds();
+      assertEquals(TITLE_WIDTH - 2 * expectedLw, selectionBounds.getWidth(), "selection width");
+      assertEquals(TITLE_HEIGHT_RAW - (1 + expectedLw), selectionBounds.getHeight(),
+                   "selection height");
+   }
+
+   private LegendTitleArea newTitleArea(int borderStyle) {
+      // Identity transform → only (w, h) matter for inset checks.
+      Rectangle2D titleBounds = new Rectangle2D.Double(0, 0, TITLE_WIDTH, TITLE_HEIGHT_RAW);
+
+      TextSpec titleTextSpec = mock(TextSpec.class);
+      when(titleTextSpec.getBackground()).thenReturn(null);
+
+      LegendSpec spec = mock(LegendSpec.class);
+      when(spec.getBorder()).thenReturn(borderStyle);
+      when(spec.getTitleTextSpec()).thenReturn(titleTextSpec);
+
+      VisualFrame frame = mock(VisualFrame.class);
+      when(frame.getLegendSpec()).thenReturn(spec);
+      when(frame.getTitle()).thenReturn("Title");
+      when(frame.getField()).thenReturn("field");
+
+      Legend legend = mock(Legend.class);
+      when(legend.getTitleBounds()).thenReturn(titleBounds);
+      when(legend.getVisualFrame()).thenReturn(frame);
+      when(legend.getBounds()).thenReturn(titleBounds);
+      when(legend.getGraphElement()).thenReturn(null);
+
+      return new LegendTitleArea(
+         legend, java.util.Collections.emptyList(), false,
+         new AffineTransform(), new IndexedSet<>());
+   }
+}

--- a/core/src/test/java/inetsoft/report/composition/region/LegendTitleAreaTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/LegendTitleAreaTest.java
@@ -72,8 +72,8 @@ class LegendTitleAreaTest {
 
       Rectangle2D selectionBounds = ((RectangleRegion) area.getRegions()[0]).getBounds();
       assertEquals(TITLE_WIDTH - 2 * expectedLw, selectionBounds.getWidth(), "selection width");
-      assertEquals(TITLE_HEIGHT_RAW - (1 + expectedLw), selectionBounds.getHeight(),
-                   "selection height");
+      assertEquals(TITLE_HEIGHT_RAW - (Legend.TITLE_LINE_GAP + expectedLw),
+                   selectionBounds.getHeight(), "selection height");
    }
 
    private LegendTitleArea newTitleArea(int borderStyle) {

--- a/web/projects/portal/src/app/graph/model/legend.ts
+++ b/web/projects/portal/src/app/graph/model/legend.ts
@@ -28,4 +28,5 @@ export interface Legend extends ChartObject {
    drillLevels?: DrillLevel[];
    drillFilter?: boolean;
    nodeAesthetic?: boolean;
+   scalar?: boolean;
 }

--- a/web/projects/portal/src/app/graph/objects/chart-area.component.html
+++ b/web/projects/portal/src/app/graph/objects/chart-area.component.html
@@ -241,6 +241,7 @@
                            [objectIndex]="legend.legendIndex"
                            [urlPrefix]="urlPrefix"
                            [maxHeight]="getLegendContentHeight(legend, legendObject)"
+                           [borderWidth]="getBorderWidth(legend.border)"
                            [wTooltip]="tooltipString"
                            [tooltipCSS]="tooltipCSS"
                            [followCursor]="true"

--- a/web/projects/portal/src/app/graph/objects/chart-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-area.component.ts
@@ -1394,7 +1394,7 @@ export class ChartArea implements OnInit, OnChanges, OnDestroy {
       return paddingLeft;
    }
 
-   private getBorderWidth(border: string): number {
+   getBorderWidth(border: string): number {
       if(!border) {
          return 0;
       }

--- a/web/projects/portal/src/app/graph/objects/chart-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-area.component.ts
@@ -1394,7 +1394,7 @@ export class ChartArea implements OnInit, OnChanges, OnDestroy {
       return paddingLeft;
    }
 
-   getBorderWidth(border: string): number {
+   protected getBorderWidth(border: string): number {
       if(!border) {
          return 0;
       }

--- a/web/projects/portal/src/app/graph/objects/chart-legend-area.component.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-legend-area.component.spec.ts
@@ -1,0 +1,82 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { BehaviorSubject } from "rxjs";
+import { Rectangle } from "../../common/data/rectangle";
+import { Legend } from "../model/legend";
+import { ChartService } from "../services/chart.service";
+import { ScaleService } from "../../widget/services/scale/scale-service";
+import { ChartLegendArea } from "./chart-legend-area.component";
+
+describe("ChartLegendArea canvas offsets", () => {
+   let area: ChartLegendArea;
+
+   beforeEach(() => {
+      const chartService = new ChartService();
+      const scaleService = { getScale: () => new BehaviorSubject(1) } as ScaleService;
+      area = new ChartLegendArea(chartService, scaleService);
+   });
+
+   function makeChartObject(areaName: string, scalar: boolean): Legend {
+      return <Legend> <unknown> {
+         areaName,
+         scalar,
+         bounds: new Rectangle(0, 0, 110, 38),
+         layoutBounds: new Rectangle(0, 16, 110, 38),
+         tiles: [],
+         regions: [],
+         titleLabel: "",
+         titleVisible: true,
+         aestheticType: "Color",
+         targetFields: [],
+      };
+   }
+
+   it("returns borderWidth for scalar legend_content", () => {
+      area.chartObject = makeChartObject("legend_content", true);
+      area.borderWidth = 3;
+      expect((<any> area).canvasX).toBe(3);
+      expect((<any> area).canvasY).toBe(3);
+   });
+
+   it("returns 0 for categorical legend_content", () => {
+      area.chartObject = makeChartObject("legend_content", false);
+      area.borderWidth = 3;
+      expect((<any> area).canvasX).toBe(0);
+      expect((<any> area).canvasY).toBe(0);
+   });
+
+   it("returns 0 for legend_title regardless of border width", () => {
+      area.chartObject = makeChartObject("legend_title", false);
+      area.borderWidth = 3;
+      expect((<any> area).canvasX).toBe(0);
+      expect((<any> area).canvasY).toBe(0);
+   });
+
+   it("returns 0 when borderWidth is 0 even for scalar", () => {
+      area.chartObject = makeChartObject("legend_content", true);
+      area.borderWidth = 0;
+      expect((<any> area).canvasX).toBe(0);
+      expect((<any> area).canvasY).toBe(0);
+   });
+
+   it("returns 0 when chartObject is null", () => {
+      area.borderWidth = 3;
+      expect((<any> area).canvasX).toBe(0);
+      expect((<any> area).canvasY).toBe(0);
+   });
+});

--- a/web/projects/portal/src/app/graph/objects/chart-legend-area.component.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-legend-area.component.spec.ts
@@ -27,7 +27,7 @@ describe("ChartLegendArea canvas offsets", () => {
 
    beforeEach(() => {
       const chartService = new ChartService();
-      const scaleService = { getScale: () => new BehaviorSubject(1) } as ScaleService;
+      const scaleService = <ScaleService> <unknown> { getScale: () => new BehaviorSubject(1) };
       area = new ChartLegendArea(chartService, scaleService);
    });
 

--- a/web/projects/portal/src/app/graph/objects/chart-legend-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-legend-area.component.ts
@@ -38,6 +38,7 @@ import { TooltipInfo } from "../model/tooltip-info";
 export class ChartLegendArea extends ChartObjectAreaBase<Legend> {
    @Input() maxHeight: number;
    @Input() container: Element;
+   @Input() borderWidth: number = 0;
    @Output() selectRegion = new EventEmitter();
    @Output() brushChart = new EventEmitter();
    @Output() showTooltip = new EventEmitter<TooltipInfo>();
@@ -54,6 +55,18 @@ export class ChartLegendArea extends ChartObjectAreaBase<Legend> {
                scaleService: ScaleService)
    {
       super(chartService, scaleService);
+   }
+
+   // Compensate for GraphBuilder's -borderWidth shift on scalar legend_content;
+   // without this, the band's selection rect clips at the canvas bottom/right.
+   // Skipped for categorical (first item sits at the content top, shifting
+   // would clip it) and legend_title (region starts at (0, 0)).
+   protected get canvasX(): number {
+      return this.chartObject?.scalar ? this.borderWidth : 0;
+   }
+
+   protected get canvasY(): number {
+      return this.chartObject?.scalar ? this.borderWidth : 0;
    }
 
    onDown(event: MouseEvent): void {

--- a/web/projects/portal/src/app/graph/objects/chart-legend-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-legend-area.component.ts
@@ -66,7 +66,7 @@ export class ChartLegendArea extends ChartObjectAreaBase<Legend> {
    }
 
    protected get canvasY(): number {
-      return this.chartObject?.scalar ? this.borderWidth : 0;
+      return this.canvasX;
    }
 
    onDown(event: MouseEvent): void {

--- a/web/projects/portal/src/app/graph/services/chart.service.spec.ts
+++ b/web/projects/portal/src/app/graph/services/chart.service.spec.ts
@@ -109,4 +109,21 @@ describe("Chart service test", () => {
       chartModel.regionMetaDictionary = [{dimIdx: -1, axisFldIdx: 0}];
       expect(ChartTool.getSelectedAxisColumnName(chartModel)).toBe("AxisColumnName");
    }));
+
+   // drawRegions leaves a scale+translate on the context; clearCanvas must reset
+   // it before clearRect, otherwise a strip along the right/bottom edges is missed.
+   it("resets the transform before clearing the canvas", () => {
+      const calls: string[] = [];
+      const context: any = {
+         canvas: { width: 200, height: 100 },
+         save: () => calls.push("save"),
+         setTransform: () => calls.push("setTransform"),
+         clearRect: () => calls.push("clearRect"),
+         restore: () => calls.push("restore"),
+      };
+
+      chartService.clearCanvas(context);
+
+      expect(calls).toEqual(["save", "setTransform", "clearRect", "restore"]);
+   });
 });

--- a/web/projects/portal/src/app/graph/services/chart.service.spec.ts
+++ b/web/projects/portal/src/app/graph/services/chart.service.spec.ts
@@ -114,10 +114,14 @@ describe("Chart service test", () => {
    // it before clearRect, otherwise a strip along the right/bottom edges is missed.
    it("resets the transform before clearing the canvas", () => {
       const calls: string[] = [];
+      const setTransformArgs: number[][] = [];
       const context: any = {
          canvas: { width: 200, height: 100 },
          save: () => calls.push("save"),
-         setTransform: () => calls.push("setTransform"),
+         setTransform: (...args: number[]) => {
+            calls.push("setTransform");
+            setTransformArgs.push(args);
+         },
          clearRect: () => calls.push("clearRect"),
          restore: () => calls.push("restore"),
       };
@@ -125,5 +129,6 @@ describe("Chart service test", () => {
       chartService.clearCanvas(context);
 
       expect(calls).toEqual(["save", "setTransform", "clearRect", "restore"]);
+      expect(setTransformArgs[0]).toEqual([1, 0, 0, 1, 0, 0]);
    });
 });

--- a/web/projects/portal/src/app/graph/services/chart.service.ts
+++ b/web/projects/portal/src/app/graph/services/chart.service.ts
@@ -21,7 +21,12 @@ import { Rectangle } from "../../common/data/rectangle";
 @Injectable()
 export class ChartService {
    clearCanvas(context: CanvasRenderingContext2D): void {
+      // Reset transform — drawRegions leaves a scale+translate on the context,
+      // otherwise clearRect would miss a strip along the right/bottom edges.
+      context.save();
+      context.setTransform(1, 0, 0, 1, 0, 0);
       context.clearRect(0, 0, context.canvas.width, context.canvas.height);
+      context.restore();
    }
 
    /**


### PR DESCRIPTION
## Problem

For a scalar (gradient) legend with a border, the orange selection
highlight rectangle was clipped along the right and bottom edges of the
legend canvas. The legend title region could also overflow far enough to
spawn a scrollbar when hovered.

## Root cause

GraphBuilder offsets the legend content area by the border width, but the
client drew selection regions from a fixed (0, 0) origin, so the highlight
landed outside the canvas by exactly that border width. Separately,
clearCanvas ran clearRect while drawRegions had left a scale+translate on
the canvas context, so a strip along the right/bottom edges was never
cleared. The legend title region used the full legend bounds, so its
bottom stroke overlapped the content area that stacks directly below it.

## Fix

Backend - LegendTitleArea now distinguishes layout bounds from the
selection rectangle: getRegion() insets only the width (by 2 * borderWidth)
so the SVG tile still matches the container, while getRegions() also shrinks
the height by TITLE_LINE_GAP + borderWidth so the selection stroke clears
the content area below. Border width is read through a null-safe helper,
consistent with the constructor's existing tolerance for a null visual
frame. GraphBuilder and the Legend model expose a new scalar flag so the
client can distinguish gradient legends from categorical ones.

Frontend - ChartLegendArea offsets the region draw origin by the border
width for scalar legends only (categorical and title areas are unchanged,
since shifting them would clip the first item or a region anchored at the
origin). ChartService.clearCanvas resets the canvas transform to identity
before clearRect.