### PR TITLE
Fix NPE in XTableStyle.getRowHeight when CSSParameter.type is null

### DIFF
--- a/core/src/main/java/inetsoft/report/style/XTableStyle.java
+++ b/core/src/main/java/inetsoft/report/style/XTableStyle.java
@@ -1076,7 +1076,7 @@ public class XTableStyle extends TableStyle {
 
       if(this instanceof CSSTableStyle) {
          CSSParameter sheetParam = ((CSSTableStyle) this).getSheetParam();
-         vsLens = sheetParam != null && sheetParam.getCSSType().equals(CSSConstants.VIEWSHEET);
+         vsLens = sheetParam != null && CSSConstants.VIEWSHEET.equals(sheetParam.getCSSType());
       }
 
       // only get the css height if there is no base height specified

--- a/core/src/test/java/inetsoft/util/css/CSSTableStyleTest.java
+++ b/core/src/test/java/inetsoft/util/css/CSSTableStyleTest.java
@@ -43,4 +43,17 @@ public class CSSTableStyleTest {
       XTable deserializedTable = TestSerializeUtils.serializeAndDeserialize(originalTable);
       Assertions.assertEquals(CSSTableStyle.class, deserializedTable.getClass());
    }
+
+   // Bug #XTableStyle-NPE: getRowHeight() NPE'd when sheetParam was non-null but its
+   // CSS type was null (CSSParameter's no-arg constructor leaves type null).
+   @Test
+   public void getRowHeightDoesNotThrowWhenSheetParamCSSTypeIsNull() {
+      CSSParameter sheetParam = new CSSParameter();
+      Assertions.assertNull(sheetParam.getCSSType());
+
+      CSSTableStyle style = new CSSTableStyle(null, CSSConstants.TABLE, null,
+                                              XTableUtil.getDefaultTableLens(), null, sheetParam);
+
+      Assertions.assertDoesNotThrow(() -> style.getRowHeight(0));
+   }
 }


### PR DESCRIPTION
## Symptom

Viewsheet refresh fails with an NPE when any table assembly's `CSSParameter.type` happens to be null:

\`\`\`
java.lang.NullPointerException: Cannot invoke \"String.equals(Object)\"
  because the return value of \"inetsoft.util.css.CSSParameter.getCSSType()\"
  is null
  at inetsoft.report.style.XTableStyle.getRowHeight(XTableStyle.java:1079)
  at inetsoft.report.internal.table.FormatTableLens.nextRow(FormatTableLens.java:1089)
  at inetsoft.report.internal.table.FormatTableLens.getRowBorder(FormatTableLens.java:237)
  at inetsoft.report.lens.AttributeTableLens.getRowBorder(AttributeTableLens.java:754)
  at inetsoft.report.filter.DefaultTableFilter.getRowBorder(DefaultTableFilter.java:373)
  at inetsoft.report.composition.VSTableLens.getFormat(VSTableLens.java:132)
  at inetsoft.web.viewsheet.model.table.BaseTableCellModel.createTableCell(BaseTableCellModel.java:132)
  at inetsoft.web.viewsheet.controller.table.BaseTableService.getTableCells(BaseTableService.java:887)
  at inetsoft.web.viewsheet.controller.table.BaseTableService.loadTableData0(BaseTableService.java:303)
  at inetsoft.web.viewsheet.controller.VSRefreshService.refreshAssemblyAndDependencies(VSRefreshService.java:510)
  at inetsoft.web.viewsheet.controller.VSRefreshService.refreshVsAssembly(VSRefreshService.java:131)
  at inetsoft.web.viewsheet.controller.VSRefreshController.refreshVsAssembly(VSRefreshController.java:65)
\`\`\`

The crash surfaces from viewsheet refresh requests for AI-generated visualizations in the stylebi-wiz integration, and blocks the table from rendering at all (chart area is empty in the chat UI).

## Root cause

\`XTableStyle.java:1077-1080\`:

\`\`\`java
if(this instanceof CSSTableStyle) {
   CSSParameter sheetParam = ((CSSTableStyle) this).getSheetParam();
   vsLens = sheetParam != null && sheetParam.getCSSType().equals(CSSConstants.VIEWSHEET);
}
\`\`\`

\`sheetParam\` is null-guarded, but \`sheetParam.getCSSType()\` is not. The \`CSSParameter\` class has a no-arg constructor (\`CSSParameter.java:32-33\`) that leaves the \`type\` field as null, and \`getCSSType()\` is a plain field accessor with no null fallback — so the field can legitimately be null. Other call sites already treat null as a valid state, e.g. \`VSCSSFormat.java:622\` does an explicit \`!= null\` check before serialising.

## Fix

One-line change: flip to Yoda comparison so the constant (which is known non-null) is the receiver.

\`\`\`diff
-         vsLens = sheetParam != null && sheetParam.getCSSType().equals(CSSConstants.VIEWSHEET);
+         vsLens = sheetParam != null && CSSConstants.VIEWSHEET.equals(sheetParam.getCSSType());
\`\`\`

Semantically equivalent for all non-null inputs; correctly returns \`false\` instead of throwing when \`getCSSType()\` returns null.

## Test plan

- [ ] Existing unit tests pass
- [ ] Render a viewsheet whose table assembly was produced via the stylebi-wiz AI flow (this previously NPE'd) — table renders without exception
- [ ] Verify CSS row-height styling still applies for viewsheets where \`getCSSType()\` *is* \`CSSConstants.VIEWSHEET\` (no behavioural regression in the happy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)