### PR TITLE
Bug #75214, Add fallback aggregate expression lookup and reimport missing services to restore functionality after merge

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
@@ -356,7 +356,7 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
          // Extract the column name from inside the parentheses and retry.
          if(ref == null) {
             int idx1 = alias.indexOf('(');
-            int idx2 = alias.lastIndexOf(')');
+            int idx2 = alias.indexOf(')');
 
             if(idx1 > 0 && idx2 > idx1) {
                String baseAttr = alias.substring(idx1 + 1, idx2);

--- a/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
@@ -351,6 +351,19 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
          String alias = ref.getAttribute();
          ref = columns.getAttribute(ref.getAttribute());
 
+         // If the attribute is an aggregate expression like "Count(Order:Num)",
+         // the mirror's column selection only contains the base column "Order:Num".
+         // Extract the column name from inside the parentheses and retry.
+         if(ref == null) {
+            int idx1 = alias.indexOf('(');
+            int idx2 = alias.lastIndexOf(')');
+
+            if(idx1 > 0 && idx2 > idx1) {
+               String baseAttr = alias.substring(idx1 + 1, idx2);
+               ref = columns.getAttribute(baseAttr);
+            }
+         }
+
          if(ref == null) {
             throw new RuntimeException("column \"" + alias +
                "\" not found in assembly \"" + assembly +

--- a/web/projects/portal/src/app/viewer/viewer-edit/viewer-edit.routes.ts
+++ b/web/projects/portal/src/app/viewer/viewer-edit/viewer-edit.routes.ts
@@ -15,8 +15,27 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+import { Injector, Optional } from "@angular/core";
 import { Routes } from "@angular/router";
+import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { SERVICE_PROVIDERS } from "../../composer/services.provider";
+import { UIContextService } from "../../common/services/ui-context.service";
+import { FullScreenService } from "../../common/services/full-screen.service";
+import { ChartService } from "../../graph/services/chart.service";
+import { ComposerToken, ContextProvider, ViewerContextProviderFactory } from "../../vsobjects/context-provider.service";
+import { RichTextService } from "../../vsobjects/dialog/rich-text-dialog/rich-text.service";
+import { VSChartService } from "../../vsobjects/objects/chart/services/vs-chart.service";
+import { AdhocFilterService } from "../../vsobjects/objects/data-tip/adhoc-filter.service";
+import { DataTipService } from "../../vsobjects/objects/data-tip/data-tip.service";
+import { PopComponentService } from "../../vsobjects/objects/data-tip/pop-component.service";
+import { MiniToolbarService } from "../../vsobjects/objects/mini-toolbar/mini-toolbar.service";
+import { ShowHyperlinkService } from "../../vsobjects/show-hyperlink.service";
+import { CheckFormDataService } from "../../vsobjects/util/check-form-data.service";
+import { VSTabService } from "../../vsobjects/util/vs-tab.service";
+import { ScaleService } from "../../widget/services/scale/scale-service";
+import { VSScaleService } from "../../widget/services/scale/vs-scale.service";
+import { DialogService, ViewerDialogServiceFactory } from "../../widget/slide-out/dialog-service.service";
+import { SlideOutService } from "../../widget/slide-out/slide-out.service";
 import { ViewerEditComponent } from "./viewer-edit.component";
 
 export const viewerEditRoutes: Routes = [
@@ -24,7 +43,37 @@ export const viewerEditRoutes: Routes = [
       path: "",
       component: ViewerEditComponent,
       providers: [
-         ...SERVICE_PROVIDERS
+         ...SERVICE_PROVIDERS,
+         DataTipService,
+         PopComponentService,
+         AdhocFilterService,
+         MiniToolbarService,
+         VSChartService,
+         SlideOutService,
+         UIContextService,
+         CheckFormDataService,
+         ShowHyperlinkService,
+         VSTabService,
+         RichTextService,
+         FullScreenService,
+         {
+            provide: ScaleService,
+            useClass: VSScaleService
+         },
+         {
+            provide: ContextProvider,
+            useFactory: ViewerContextProviderFactory,
+            deps: [[new Optional(), ComposerToken]]
+         },
+         {
+            provide: DialogService,
+            useFactory: ViewerDialogServiceFactory,
+            deps: [NgbModal, SlideOutService, Injector, UIContextService]
+         },
+         {
+            provide: ChartService,
+            useExisting: VSChartService
+         }
       ]
    }
 ];


### PR DESCRIPTION
When a RangeSlider is bound to a chart assembly (VS_ASSEMBLY source type) and its DataRef is an aggregate expression such as Count(Order:Num), createAssemblyTable() was looking up the column by that full aggregate name. The chart's mirror table only exposes base worksheet columns (Order:Num, Order:Date, etc.), so the lookup returned null and threw a RuntimeException. Added a fallback: if the initial lookup fails and the attribute contains parentheses, the base column name is extracted from inside them and the lookup is retried. The mirror's underlying chart table retains its own AggregateInfo (group-by dimensions → COUNT), so the outer MIN/MAX query the slider applies on top correctly operates over the per-group count values rather than the raw column values.

The Angular standalone component migration converted ViewerEditComponent to standalone and replaced BindingModule.forRoot() with SERVICE_PROVIDERS in the route definition. However, the deleted ViewerModule had previously provided viewer-layer services transitively through VSObjectsModule.Those services are @Injectable() without providedIn: 'root' and were no longer provided anywhere in the route's injector chain. Added them to viewerEditRoutes providers.
