### PR TITLE
Bug #75154, fix IndexOutOfBoundsException in waterfall chart tooltip …

### DIFF
--- a/core/src/main/java/inetsoft/graph/data/AbstractDataSet.java
+++ b/core/src/main/java/inetsoft/graph/data/AbstractDataSet.java
@@ -542,8 +542,29 @@ public abstract class AbstractDataSet implements DataSet {
    @Override
    @TernMethod
    public final String getHeader(int col) {
-      return (calcs == null || col < getColCount0()) ? getHeader0(col) :
-         getCalcColumns(true).get(col - getColCount0()).getHeader();
+      // Snapshot getColCount0() once to avoid a TOCTOU race: for dynamic datasets
+      // (e.g. IntervalDataSet, SumDataSet) getColCount0() is recomputed each time it
+      // is called and may return a smaller value if the underlying dataset's calc-column
+      // state changes between the condition check and the index calculation.  Calling it
+      // twice with different results makes (col - getColCount0()) larger than expected and
+      // causes an IndexOutOfBoundsException in getCalcColumns(true).get(). (75154)
+      int colCount0 = getColCount0();
+
+      if(calcs == null || col < colCount0) {
+         return getHeader0(col);
+      }
+
+      List<CalcColumn> calcList = getCalcColumns(true);
+      int calcIdx = col - colCount0;
+
+      if(calcIdx >= calcList.size()) {
+         // colCount0 shrank after getColCount() was cached (e.g. inner dataset lost
+         // calc columns between the snapshot and this call).  Return null so callers
+         // that iterate with a stale colCnt can safely skip the column.
+         return null;
+      }
+
+      return calcList.get(calcIdx).getHeader();
    }
 
    /**

--- a/core/src/main/java/inetsoft/graph/element/StackableElement.java
+++ b/core/src/main/java/inetsoft/graph/element/StackableElement.java
@@ -206,6 +206,13 @@ public abstract class StackableElement extends GraphElement {
       for(int i = 0; i < colCnt; i++) {
          String vfld = data.getHeader(i);
 
+         // getHeader() may return null when the dataset's colCount0 shrank (due to
+         // concurrent modification or stale state) between the colCnt snapshot above
+         // and this getHeader() call; skip such columns safely. (75154)
+         if(vfld == null) {
+            continue;
+         }
+
          if(!sorted.contains(vfld) && data.getComparator(vfld) != null) {
             if(sdata == null) {
                sdata = createSortedDataSet(data, vfld);


### PR DESCRIPTION
…caused by getHeader calling getColCount0() twice

The two calls could return different values if the inner dataset's calc columns changed between them, making the calc index out of bounds.

Fix: snapshot getColCount0() once in getHeader(); add bounds check returning null for stale indices; null-guard the getHeader() call in StackableElement.sortData.