### PR TITLE
Bug #75189, Fix ColumnNotFoundException when chart has discrete Y measures and aggregate X measure

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/VSDataSet.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/VSDataSet.java
@@ -726,6 +726,24 @@ public class VSDataSet extends AbstractDataSet implements AttributeDataSet {
          val = hmap3.getInt(col);
       }
 
+      // Fallback: when using Java post-aggregation (SummaryFilter), the column header in the
+      // TableLens is the pre-aggregation column name (e.g. "Product:Total") rather than the
+      // full aggregate name (e.g. "Sum(Product:Total)"). Try looking up the inner column name
+      // extracted from the aggregate formula.
+      if(val == HEADER_MAP_DEFAULT_VALUE && isAggregateColumn(col)) {
+         int open = col.indexOf('(');
+         int close = col.lastIndexOf(')');
+
+         if(open > 0 && close == col.length() - 1) {
+            String inner = col.substring(open + 1, close);
+            val = hmap.getInt(inner);
+
+            if(val == HEADER_MAP_DEFAULT_VALUE) {
+               val = hmap2.getInt(inner);
+            }
+         }
+      }
+
       idx0 = val == HEADER_MAP_DEFAULT_VALUE ? -1 : val;
       idx0 = idx0 >= ccount ? -1 : idx0;
       return idx0;

--- a/core/src/main/java/inetsoft/report/composition/graph/VSDataSet.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/VSDataSet.java
@@ -730,17 +730,15 @@ public class VSDataSet extends AbstractDataSet implements AttributeDataSet {
       // TableLens is the pre-aggregation column name (e.g. "Product:Total") rather than the
       // full aggregate name (e.g. "Sum(Product:Total)"). Try looking up the inner column name
       // extracted from the aggregate formula.
+      // hmap3 (CUBE ref names) is intentionally not checked here: CUBE data sources aggregate
+      // server-side and never go through SummaryFilter, so this path is unreachable for CUBE cols.
       if(val == HEADER_MAP_DEFAULT_VALUE && isAggregateColumn(col)) {
          int open = col.indexOf('(');
-         int close = col.lastIndexOf(')');
+         String inner = col.substring(open + 1, col.length() - 1);
+         val = hmap.getInt(inner);
 
-         if(open > 0 && close == col.length() - 1) {
-            String inner = col.substring(open + 1, close);
-            val = hmap.getInt(inner);
-
-            if(val == HEADER_MAP_DEFAULT_VALUE) {
-               val = hmap2.getInt(inner);
-            }
+         if(val == HEADER_MAP_DEFAULT_VALUE) {
+            val = hmap2.getInt(inner);
          }
       }
 


### PR DESCRIPTION
When Y bindings contain discrete measures, the query returns detail rows without SQL aggregation, leaving the X measure column header as the base name (e.g. "Product:Total") rather than the full aggregate name ("Sum(Product:Total)"). Add a fallback in VSDataSet.indexOfHeader0 to extract and look up the inner column name when the aggregate name lookup fails.