### PR TITLE
Bug #75066 - Refine card-style chart tooltip tiering for scatter, Gantt, and solo cards

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
+++ b/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
@@ -571,8 +571,13 @@ public class ChartToolTip implements DataSerializable {
 
    // Use the grouped solo-card layout (tier-1 headline + tier-2 group + tier-3)
    // even without a header. Gantt sets this so Start/End sit together at tier-2.
+   // Mutually exclusive with uniformTier; enabling one clears the other.
    public void setGroupedTiers(boolean groupedTiers) {
       this.groupedTiers = groupedTiers;
+
+      if(groupedTiers) {
+         this.uniformTier = false;
+      }
    }
 
    public boolean isGroupedTiers() {
@@ -581,8 +586,13 @@ public class ChartToolTip implements DataSerializable {
 
    // Render every row at the same tier with no headline. Scatter sets this when
    // no identity dim leads, so equal-weight coordinates aren't ranked.
+   // Mutually exclusive with groupedTiers; enabling one clears the other.
    public void setUniformTier(boolean uniformTier) {
       this.uniformTier = uniformTier;
+
+      if(uniformTier) {
+         this.groupedTiers = false;
+      }
    }
 
    public boolean isUniformTier() {

--- a/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
+++ b/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
@@ -91,8 +91,12 @@ public class ChartToolTip implements DataSerializable {
          return renderCombinedCard(palette);
       }
 
-      if(hasHeader() && (customToolTip == null || customToolTip.isEmpty())) {
-         return renderSoloCardWithHeader(palette);
+      if((hasHeader() || groupedTiers) && (customToolTip == null || customToolTip.isEmpty())) {
+         return renderGroupedSoloCard(palette);
+      }
+
+      if(uniformTier && (customToolTip == null || customToolTip.isEmpty())) {
+         return renderUniformCard(palette);
       }
 
       StringBuilder buffer = new StringBuilder();
@@ -146,7 +150,30 @@ public class ChartToolTip implements DataSerializable {
       return buffer.toString();
    }
 
-   private String renderSoloCardWithHeader(IndexedSet<String> palette) {
+   // Every row at the same tier, no headline. Used by scatter (coordinates of
+   // equal weight) when no identity dim leads — mirrors the flat default tooltip.
+   private String renderUniformCard(IndexedSet<String> palette) {
+      StringBuilder buffer = new StringBuilder();
+
+      for(int i = 0; i < tooltips.size(); i += 2) {
+         int keyIdx = tooltips.get(i);
+
+         if(keyIdx == -1) {
+            continue;
+         }
+
+         String label = palette.get(keyIdx);
+         String value = (i + 1) < tooltips.size() ? palette.get(tooltips.get(i + 1)) : "";
+         appendTier(buffer, 2, label + ChartToolTip.COLON + value);
+      }
+
+      return buffer.toString();
+   }
+
+   // Tier-1 headline, then tier2GroupSize pairs grouped at tier-2, rest at tier-3.
+   // The header (if any) renders as a tier-1 subtitle under the headline; Gantt
+   // uses this without a header so Start/End group at tier-2 like candle OHL.
+   private String renderGroupedSoloCard(IndexedSet<String> palette) {
       StringBuilder buffer = new StringBuilder();
       int pairsRendered = 0;
 
@@ -173,7 +200,7 @@ public class ChartToolTip implements DataSerializable {
 
          appendTier(buffer, tier, label + ChartToolTip.COLON + value);
 
-         if(pairsRendered == 0) {
+         if(pairsRendered == 0 && hasHeader()) {
             appendSubtitle(buffer, 1, palette.get(headerKey), palette.get(headerValue));
          }
 
@@ -542,6 +569,26 @@ public class ChartToolTip implements DataSerializable {
       return tier2GroupSize;
    }
 
+   // Use the grouped solo-card layout (tier-1 headline + tier-2 group + tier-3)
+   // even without a header. Gantt sets this so Start/End sit together at tier-2.
+   public void setGroupedTiers(boolean groupedTiers) {
+      this.groupedTiers = groupedTiers;
+   }
+
+   public boolean isGroupedTiers() {
+      return groupedTiers;
+   }
+
+   // Render every row at the same tier with no headline. Scatter sets this when
+   // no identity dim leads, so equal-weight coordinates aren't ranked.
+   public void setUniformTier(boolean uniformTier) {
+      this.uniformTier = uniformTier;
+   }
+
+   public boolean isUniformTier() {
+      return uniformTier;
+   }
+
    /**
     * Clear chart tooltip.
     */
@@ -595,4 +642,6 @@ public class ChartToolTip implements DataSerializable {
    private int headerKey = -1;
    private int headerValue = -1;
    private int tier2GroupSize = 1;
+   private boolean groupedTiers = false;
+   private boolean uniformTier = false;
 }

--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -1418,11 +1418,29 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
       else {
          boolean isGantt = GraphTypes.isGantt(chartInfo.getChartType());
          boolean isCandleOrStock = chartInfo instanceof CandleChartInfo;
+         boolean isScatter = isScatterPlot(chartInfo);
 
          // Gantt: Y-axis is the "row" axis that distinguishes bars, so list
          // Y dims ahead of X dims regardless of binding order in the element.
          if(isGantt) {
             dims = ganttDimsYFirst(dims, chartInfo);
+         }
+         // Scatter: the categorical color/shape aesthetic identifies each point,
+         // but it lives in an aesthetic frame rather than element.getDims(). Lift
+         // it ahead of the measures so it leads as the tier-1 identity headline
+         // (the measures are co-equal coordinates that group at tier-2 below).
+         else if(isScatter) {
+            List<String> idDims = getScatterIdentityDims(element, dataset, aesthetics);
+
+            if(!idDims.isEmpty()) {
+               for(String d : dims) {
+                  if(!idDims.contains(d)) {
+                     idDims.add(d);
+                  }
+               }
+
+               dims = idDims.toArray(new String[0]);
+            }
          }
 
          boolean cardMeasureFirst = cardPutsMeasureFirst(chartInfo, element);
@@ -1546,6 +1564,28 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
             }
          }
 
+         // Gantt and scatter present values of equal importance, not a headline
+         // measure. When a real identity dim leads (Gantt task / scatter color
+         // dim) it becomes the tier-1 headline and the values group at tier-2;
+         // a scatter with no identity dim renders every row at a uniform tier
+         // (like the flat default tooltip). Sized here, before appendInfo adds
+         // aesthetics, so only structural rows join the tier-2 group.
+         if(chartInfo.getTooltipStyle() == ChartInfo.TooltipStyle.CARD &&
+            (isGantt || isScatter))
+         {
+            boolean hasIdentityDim = Arrays.stream(dims)
+               .anyMatch(d -> d != null && allfields.contains(d));
+
+            if(hasIdentityDim) {
+               int structuralPairs = tooltip.getTooltipList().size() / 2;
+               tooltip.setGroupedTiers(true);
+               tooltip.setTier2GroupSize(Math.max(0, structuralPairs - 1));
+            }
+            else if(isScatter) {
+               tooltip.setUniformTier(true);
+            }
+         }
+
          // add count as tooltip per MF requirement. may want t omake it more generic
          // when the graph type is available on gui.
          if(evo instanceof ParaboxPointVO) {
@@ -1573,6 +1613,17 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
          // Lift only dims[0]; nested X-dims stay as regular rows (matches captureCombinedCardHeader).
          if(candleCardLayout && dims.length > 0) {
             applyCandleCardHeader(tooltip, dims[0], tipMeasures);
+         }
+         // Solo measure-first card: lift the X-dim to the tier-1 subtitle header so a
+         // single-series hover matches the combined-tooltip layout.
+         else if(cardMeasureFirst && dims.length > 0) {
+            int[] dimIndexes = new int[dims.length];
+
+            for(int i = 0; i < dims.length; i++) {
+               dimIndexes[i] = palette.put(dims[i]);
+            }
+
+            captureCombinedCardHeader(tooltip, dimIndexes);
          }
       }
 
@@ -1950,7 +2001,8 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
 
    // Card style puts the hovered measure at tier-1 — except where the dim
    // itself identifies the hovered shape (Gantt Y-dim labels the bar; word
-   // cloud dim is rendered as the word). In those cases the dim leads.
+   // cloud dim is rendered as the word), or where the axes are co-equal
+   // coordinates (scatter). In those cases no single measure leads.
    static boolean cardPutsMeasureFirst(ChartInfo chartInfo, GraphElement element) {
       if(chartInfo == null
          || chartInfo.getTooltipStyle() != ChartInfo.TooltipStyle.CARD)
@@ -1966,7 +2018,83 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
          return false;
       }
 
+      if(isScatterPlot(chartInfo)) {
+         return false;
+      }
+
       return true;
+   }
+
+   // Scatter (including the scatter matrix): a point chart with measures on both
+   // the X and Y axes. The two measures are coordinates of equal weight, so no
+   // single measure should be promoted as a card headline.
+   static boolean isScatterPlot(ChartInfo chartInfo) {
+      if(chartInfo == null || !GraphTypes.isPoint(chartInfo.getChartType())) {
+         return false;
+      }
+
+      return chartInfo.getXFieldCount() > 0 && chartInfo.getYFieldCount() > 0 &&
+         !GraphUtil.hasDimensionOnX(chartInfo) && !GraphUtil.hasDimensionOnY(chartInfo);
+   }
+
+   // Categorical (non-measure) aesthetic dims that identify a scatter point,
+   // ordered color → shape → texture → line → size so the tier-1 headline is
+   // predictable when several aesthetics are bound. Membership comes from the
+   // resolved aesthetics set, which already unwraps composite/multi-field frames.
+   static List<String> getScatterIdentityDims(GraphElement element, DataSet dataset,
+                                              Set<String> aesthetics)
+   {
+      VisualFrame[] ordered = { element.getColorFrame(), element.getShapeFrame(),
+         element.getTextureFrame(), element.getLineFrame(), element.getSizeFrame() };
+      List<String> idDims = new ArrayList<>();
+
+      for(VisualFrame frame : ordered) {
+         for(String field : frameFields(frame)) {
+            if(field != null && aesthetics.contains(field) && !dataset.isMeasure(field) &&
+               !idDims.contains(field))
+            {
+               idDims.add(field);
+            }
+         }
+      }
+
+      // Any remaining resolved aesthetic dim (e.g. a text-frame field) still
+      // leads the measures, after the frame-ranked ones.
+      for(String aes : aesthetics) {
+         if(aes != null && !dataset.isMeasure(aes) && !idDims.contains(aes)) {
+            idDims.add(aes);
+         }
+      }
+
+      return idDims;
+   }
+
+   // Resolve a frame's bound field(s), unwrapping composite/multi-field frames.
+   static String[] frameFields(VisualFrame frame) {
+      if(frame == null) {
+         return new String[0];
+      }
+
+      if(frame instanceof CompositeColorFrame) {
+         CompositeColorFrame composite = (CompositeColorFrame) frame;
+         List<String> fields = new ArrayList<>();
+
+         for(int i = 0; i < composite.getFrameCount(); i++) {
+            String field = composite.getFrame(i).getField();
+
+            if(field != null) {
+               fields.add(field);
+            }
+         }
+
+         return fields.toArray(new String[0]);
+      }
+
+      if(frame instanceof MultiFieldFrame) {
+         return ((MultiFieldFrame) frame).getFields();
+      }
+
+      return frame.getField() == null ? new String[0] : new String[]{ frame.getField() };
    }
 
    // Partition the gantt's element dims into Y-axis dims first, then anything

--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -1066,7 +1066,9 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
       // get all bound fields so we can ignore fake ("value") column
       Set<String> allfields = new HashSet<>();
       Set<String> excludeFields = new HashSet<>();
-      Set<String> aesthetics = new HashSet<>();
+      // LinkedHashSet so getScatterIdentityDims' fallback iterates in stable
+      // insertion (frame) order rather than JVM hash order.
+      Set<String> aesthetics = new LinkedHashSet<>();
 
       // if no binding (created from script), add all dims/vars
       if(list.isEmpty()) {
@@ -1615,15 +1617,10 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
             applyCandleCardHeader(tooltip, dims[0], tipMeasures);
          }
          // Solo measure-first card: lift the X-dim to the tier-1 subtitle header so a
-         // single-series hover matches the combined-tooltip layout.
+         // single-series hover matches the combined-tooltip layout. Only dims[0] lifts.
          else if(cardMeasureFirst && dims.length > 0) {
-            int[] dimIndexes = new int[dims.length];
-
-            for(int i = 0; i < dims.length; i++) {
-               dimIndexes[i] = palette.put(dims[i]);
-            }
-
-            captureCombinedCardHeader(tooltip, dimIndexes);
+            captureCombinedCardHeader(
+               tooltip, new int[]{ palette.put(dims[0]) }, chartInfo.getTooltipStyle());
          }
       }
 
@@ -1850,7 +1847,7 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
          dimIndexes[i] = palette.put(dims[i]);
       }
 
-      captureCombinedCardHeader(resultTooltip, dimIndexes);
+      captureCombinedCardHeader(resultTooltip, dimIndexes, chartInfo.getTooltipStyle());
 
       List<Integer> pidxs = rowIndexMap.get(rowValue);
 
@@ -1927,7 +1924,7 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
          dimIndexes[i] = palette.put(dims[i]);
       }
 
-      captureCombinedCardHeader(resultTooltip, dimIndexes);
+      captureCombinedCardHeader(resultTooltip, dimIndexes, chartInfo.getTooltipStyle());
 
       ChartToolTip tempTip;
       ElementVO tempVO;
@@ -1980,11 +1977,12 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
 
    // For card-style combined tooltips, move the shared X-dim out of the primary
    // tooltip onto a separate header field so renderCombinedCard can use it as a
-   // tier-2 subtitle while the hovered measure stays at tier-1.
-   private void captureCombinedCardHeader(ChartToolTip primary, int[] dimIndexes) {
-      if(chartInfo.getTooltipStyle() != ChartInfo.TooltipStyle.CARD
-         || dimIndexes.length == 0)
-      {
+   // tier-2 subtitle while the hovered measure stays at tier-1. Only dimIndexes[0]
+   // is lifted; nested dims stay as regular rows.
+   static void captureCombinedCardHeader(ChartToolTip primary, int[] dimIndexes,
+                                         ChartInfo.TooltipStyle style)
+   {
+      if(style != ChartInfo.TooltipStyle.CARD || dimIndexes.length == 0) {
          return;
       }
 

--- a/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
@@ -395,6 +395,57 @@ class ChartToolTipTest {
    }
 
    @Test
+   void groupedSoloCardWithoutHeaderGroupsValuesAtTier2() {
+      // Gantt: the Y-dim (task) is the tier-1 headline with no subtitle; Start
+      // and End are equally-important values grouped at tier-2; aesthetic dims
+      // drop to tier-3. Mirrors candle OHL grouping but without a header.
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.addTooltip(palette.put("Task"), palette.put("Design Phase"));
+      tip.addTooltip(palette.put("Start"), palette.put("2025-01-01"));
+      tip.addTooltip(palette.put("End"), palette.put("2025-03-15"));
+      tip.addTooltip(palette.put("Owner"), palette.put("Alice"));
+      tip.setGroupedTiers(true);
+      tip.setTier2GroupSize(2);
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-1\">Task:&nbsp;Design Phase"),
+                 "Task (Y-dim) is the tier-1 headline");
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Start:&nbsp;2025-01-01"),
+                 "Start joins the tier-2 group");
+      assertTrue(out.contains("<div class=\"tt-tier-2\">End:&nbsp;2025-03-15"),
+                 "End joins the tier-2 group with equal importance to Start");
+      assertTrue(out.contains("<div class=\"tt-tier-3\">Owner:&nbsp;Alice"),
+                 "Aesthetic past the tier-2 group drops to tier-3");
+      assertFalse(out.contains("tt-subtitle"),
+                  "No header set → no subtitle row");
+   }
+
+   @Test
+   void uniformTierCardRendersAllRowsAtSameTier() {
+      // Scatter with no identity dim: the measures are coordinates of equal
+      // weight, so every row renders at the same tier with no headline.
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.addTooltip(palette.put("Quantity Purchased"), palette.put("5"));
+      tip.addTooltip(palette.put("Paid"), palette.put("20"));
+      tip.addTooltip(palette.put("Discount"), palette.put("0.1"));
+      tip.setUniformTier(true);
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Quantity Purchased:&nbsp;5"));
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Paid:&nbsp;20"));
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Discount:&nbsp;0.1"));
+      assertFalse(out.contains("tt-tier-1"), "Uniform card must not promote any row to tier-1");
+      assertFalse(out.contains("tt-tier-3"), "Uniform card keeps every row at the same tier");
+      assertFalse(out.contains("tt-subtitle"));
+   }
+
+   @Test
    void combinedCardEmitsHeaderOnce() {
       IndexedSet<String> palette = new IndexedSet<>();
       int xKey = palette.put("Region");

--- a/core/src/test/java/inetsoft/report/composition/region/PlotAreaCardMeasureFirstTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/PlotAreaCardMeasureFirstTest.java
@@ -17,17 +17,25 @@
  */
 package inetsoft.report.composition.region;
 
+import inetsoft.graph.aesthetic.*;
+import inetsoft.graph.data.DataSet;
 import inetsoft.graph.element.GraphElement;
 import inetsoft.graph.element.PointElement;
-import inetsoft.uql.viewsheet.graph.ChartInfo;
-import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.uql.viewsheet.graph.*;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@Tag("core")
 class PlotAreaCardMeasureFirstTest {
    @Test
    void cardOnNormalChartPromotesMeasure() {
@@ -74,20 +82,81 @@ class PlotAreaCardMeasureFirstTest {
 
    @Test
    void cardOnPointElementNotWordCloudPromotesMeasure() {
-      // Regression guard: only word-cloud PointElements get the dim-first
-      // treatment, regular point charts (scatter, etc.) keep measure-first.
+      // Regression guard: a dot plot (a dimension on X, measure on Y) keeps
+      // measure-first. Only word cloud and scatter (measures on both axes) get
+      // the dim-first / no-headline treatment.
+      ChartInfo info = chartInfo(ChartInfo.TooltipStyle.CARD, GraphTypes.CHART_POINT);
+      when(info.getXFieldCount()).thenReturn(1);
+      when(info.getYFieldCount()).thenReturn(1);
+      when(info.getXField(0)).thenReturn(mock(ChartDimensionRef.class));
+      when(info.getYField(0)).thenReturn(mock(ChartAggregateRef.class));
+
       PointElement point = mock(PointElement.class);
       when(point.isWordCloud()).thenReturn(false);
 
-      assertTrue(PlotArea.cardPutsMeasureFirst(
-         chartInfo(ChartInfo.TooltipStyle.CARD, GraphTypes.CHART_POINT),
-         point));
+      assertTrue(PlotArea.cardPutsMeasureFirst(info, point));
+   }
+
+   @Test
+   void cardOnScatterPromotesDim() {
+      // Scatter (measures on both X and Y) → coordinates of equal weight, so no
+      // single measure leads as the headline.
+      assertFalse(PlotArea.cardPutsMeasureFirst(scatterInfo(), mock(GraphElement.class)));
+   }
+
+   @Test
+   void scatterPlotDetectedWhenMeasuresOnBothAxes() {
+      assertTrue(PlotArea.isScatterPlot(scatterInfo()));
+   }
+
+   @Test
+   void scatterPlotNotDetectedWithDimensionOnAxis() {
+      // A dimension on X makes it a dot plot, not a scatter.
+      ChartInfo info = scatterInfo();
+      when(info.getXField(0)).thenReturn(mock(ChartDimensionRef.class));
+      assertFalse(PlotArea.isScatterPlot(info));
+   }
+
+   @Test
+   void scatterPlotNotDetectedForNonPointChart() {
+      assertFalse(PlotArea.isScatterPlot(
+         chartInfo(ChartInfo.TooltipStyle.CARD, GraphTypes.CHART_BAR)));
+   }
+
+   @Test
+   void scatterIdentityDimsLeadWithColorThenShape() {
+      // Color identifies a scatter point most directly, so it leads as the
+      // tier-1 headline; remaining aesthetic dims follow by frame priority.
+      GraphElement element = mock(GraphElement.class);
+      ColorFrame color = mock(ColorFrame.class);
+      ShapeFrame shape = mock(ShapeFrame.class);
+      when(color.getField()).thenReturn("State");
+      when(shape.getField()).thenReturn("Region");
+      when(element.getColorFrame()).thenReturn(color);
+      when(element.getShapeFrame()).thenReturn(shape);
+
+      DataSet dataset = mock(DataSet.class);
+      when(dataset.isMeasure(anyString())).thenReturn(false);
+
+      List<String> idDims = PlotArea.getScatterIdentityDims(
+         element, dataset, new HashSet<>(Arrays.asList("State", "Region")));
+
+      assertEquals(Arrays.asList("State", "Region"), idDims);
    }
 
    private static ChartInfo chartInfo(ChartInfo.TooltipStyle style, int chartType) {
       ChartInfo info = mock(ChartInfo.class);
       when(info.getTooltipStyle()).thenReturn(style);
       when(info.getChartType()).thenReturn(chartType);
+      return info;
+   }
+
+   private static ChartInfo scatterInfo() {
+      ChartInfo info = chartInfo(ChartInfo.TooltipStyle.CARD, GraphTypes.CHART_POINT);
+      when(info.getXFieldCount()).thenReturn(2);
+      when(info.getYFieldCount()).thenReturn(2);
+      when(info.getXField(anyInt())).thenReturn(mock(ChartAggregateRef.class));
+      when(info.getYField(anyInt())).thenReturn(mock(ChartAggregateRef.class));
       return info;
    }
 

--- a/core/src/test/java/inetsoft/report/composition/region/PlotAreaCardMeasureFirstTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/PlotAreaCardMeasureFirstTest.java
@@ -144,6 +144,36 @@ class PlotAreaCardMeasureFirstTest {
       assertEquals(Arrays.asList("State", "Region"), idDims);
    }
 
+   @Test
+   void soloCardLiftsXDimToHeader() {
+      // Solo measure-first card: the X-dim is lifted out of the value rows onto
+      // the header so it renders as the tier-1 subtitle under the measure.
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.addTooltip(palette.put("Sales"), palette.put("100"));
+      int xKey = palette.put("Year");
+      tip.addTooltip(xKey, palette.put("2024"));
+
+      PlotArea.captureCombinedCardHeader(tip, new int[]{ xKey }, ChartInfo.TooltipStyle.CARD);
+
+      assertEquals(xKey, tip.getHeaderKey(), "X-dim lifts to the subtitle header");
+      assertFalse(tip.containsTooltip(xKey), "lifted X-dim is removed from the value rows");
+   }
+
+   @Test
+   void soloCardHeaderLiftSkippedForDefaultStyle() {
+      // Default style is the flat tooltip, so no header lift.
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      int xKey = palette.put("Year");
+      tip.addTooltip(xKey, palette.put("2024"));
+
+      PlotArea.captureCombinedCardHeader(tip, new int[]{ xKey }, ChartInfo.TooltipStyle.DEFAULT);
+
+      assertFalse(tip.hasHeader(), "non-card style must not lift a header");
+      assertTrue(tip.containsTooltip(xKey));
+   }
+
    private static ChartInfo chartInfo(ChartInfo.TooltipStyle style, int chartType) {
       ChartInfo info = mock(ChartInfo.class);
       when(info.getTooltipStyle()).thenReturn(style);


### PR DESCRIPTION
## Summary

Card-style chart tooltips assigned tiers by a single rule — promote the first bound measure to the tier-1 headline — which produced misleading layouts for chart types where that assumption doesn't hold. This PR makes the tier assignment fit each chart family and keeps single-series hovers consistent regardless of the Combined-tooltip toggle. Three related issues are addressed.

### 1. Scatter plot tooltips

For a scatter or scatter matrix the X and Y measures are coordinates of equal weight, so promoting one to the headline is wrong. `cardPutsMeasureFirst` now excludes scatter (a point chart with measures on both axes and no dimension on either). Instead:

- When a categorical color/shape aesthetic identifies the point, it is lifted ahead of the measures as the tier-1 headline (ordered color, shape, texture, line, size) and the measures group at tier-2.
- When no identity dim is bound, every row renders at a uniform tier with no headline, mirroring the flat default tooltip.

The identity dim is resolved from the already-computed aesthetics set, so composite and multi-field color frames (brushing, highlights) are unwrapped correctly.

### 2. Gantt tooltips

Gantt previously placed Start at tier-2 and End at tier-3, so the two dates read as unequal. Gantt now treats them like candle/stock OHL: the task (Y-dim) is the tier-1 headline and Start/End (plus any other structural rows) group together at tier-2 as equally-important values.

### 3. Subtitle below tier-1 for solo cards

A single-series hover on a measure-first card now lifts the X-dim to a tier-1 subtitle directly under the measure headline, so the layout is identical whether Combined tooltip is enabled or disabled (previously the X-dim rendered as a plain tier-2 row when Combined was off).

## Implementation notes

- `ChartToolTip` gains two render modes: `groupedTiers` (tier-1 headline plus a tier-2 group, optional subtitle) and `uniformTier` (all rows at one tier). Both are transient render-time state and are not serialized, matching the existing header/tier2GroupSize fields.
- Tier sizing for grouped cards happens before aesthetics are appended, so only structural rows join the tier-2 group and aesthetics fall to tier-3.
- No public API, serialized format, or event-contract changes. Only CARD-style tooltips are affected; default tooltips and all other chart types are unchanged.