### PR TITLE
Filter Postgres partition children from wiz metadata APIs

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -544,6 +544,19 @@ public class MetadataApiService {
          throw new Exception("No meta data provider found for data source " + dsName);
       }
 
+      // Partition probe: identify Postgres partition/inheritance children up-front
+      // so we can drop them from the response (they're implementation detail,
+      // not user-facing tables). On any probe error we fall open — log a warning
+      // and proceed with an empty set, so a transient catalog issue doesn't block
+      // the whole metadata fetch.
+      Set<String> partitionChildren = Set.of();
+      try(java.sql.Connection probeConn = new inetsoft.uql.jdbc.JDBCHandler().getConnection(jdbcDataSource, principal)) {
+         partitionChildren = findPostgresPartitionChildren(jdbcDataSource, probeConn);
+      }
+      catch(Exception e) {
+         log.warn("Partition probe failed for '{}'; proceeding without partition filter", dsName, e);
+      }
+
       XNode rootMetaData = metaDataProvider.getRootMetaData(XUtil.OUTER_MOSE_LAYER_DATABASE);
 
       XNode typeQuery = new XNode();
@@ -586,6 +599,10 @@ public class MetadataApiService {
                String tableName = tableNode.getName();
                String catalog = (String) tableNode.getAttribute("catalog");
                String schema = (String) tableNode.getAttribute("schema");
+
+               if(isPartitionChild(schema, tableName, partitionChildren)) {
+                  continue;
+               }
 
                DatabaseTableInfo info = new DatabaseTableInfo();
                info.setType(tableType);

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -995,6 +995,53 @@ public class MetadataApiService {
       return "org.postgresql.Driver".equals(driver);
    }
 
+   /**
+    * Authoritative partition-children probe for Postgres. Queries pg_inherits
+    * (inheritance children, including pre-PG10 inheritance-based partitioning AND
+    * PG10+ declarative partitioning). Returns lowercased "schema.table" keys.
+    *
+    * Package-private static for direct unit testing — the only side effect besides
+    * returning is consuming the supplied Connection.
+    *
+    * On error: this method does NOT swallow exceptions. Callers must catch
+    * SQLException and decide whether to log and continue with an empty filter
+    * (current policy: leak partitions through rather than block the whole metadata
+    * request).
+    */
+   static Set<String> findPostgresPartitionChildren(
+      JDBCDataSource ds, java.sql.Connection conn) throws java.sql.SQLException
+   {
+      if(!isPostgresDriver(ds)) {
+         return Set.of();
+      }
+
+      // pg_inherits is the implementation mechanism for both pre-PG10 inheritance-
+      // based partitioning AND PG10+ declarative partitioning, so this single
+      // subquery covers both eras without referencing pg_class.relispartition
+      // (PG10+ only — would break catalog queries on older Postgres).
+      String sql =
+         "SELECT n.nspname || '.' || c.relname AS qualified " +
+         "FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid " +
+         "WHERE c.oid IN (SELECT inhrelid FROM pg_inherits)";
+
+      Set<String> out = new HashSet<>();
+
+      try(java.sql.PreparedStatement ps = conn.prepareStatement(sql);
+          java.sql.ResultSet rs = ps.executeQuery())
+      {
+         while(rs.next()) {
+            String qualified = rs.getString(1);
+            if(qualified != null) {
+               // Locale.ROOT avoids Turkish-locale "I" → dotless-ı conversion, which
+               // would produce keys that don't match the comparison side downstream.
+               out.add(qualified.toLowerCase(Locale.ROOT));
+            }
+         }
+      }
+
+      return Set.copyOf(out);
+   }
+
    private final XRepository xrepository;
    private final DataSourceService dataSourceService;
    private final AssetRepository assetRepository;

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -1042,6 +1042,40 @@ public class MetadataApiService {
       return Set.copyOf(out);
    }
 
+   /**
+    * True when (schema, tableName) refers to a row in the partition-children set.
+    * Used by getDatabaseTables, which already has schema and table broken out.
+    */
+   static boolean isPartitionChild(String schema, String tableName, Set<String> partitions) {
+      if(partitions == null || partitions.isEmpty() || tableName == null) {
+         return false;
+      }
+      // Locale.ROOT matches the lowercasing convention used in findPostgresPartitionChildren.
+      String qualified = ((schema == null ? "" : schema + ".") + tableName).toLowerCase(Locale.ROOT);
+      return partitions.contains(qualified);
+   }
+
+   /**
+    * True when a wiz asset path ("dsName/TABLE/schema/tableName") refers to a
+    * partition child. Used by filterWizTree, which only has the path string.
+    * Returns false for paths that aren't TABLE leaves (VIEW, folder paths, etc.)
+    * so the predicate is safe to call on any node.
+    */
+   static boolean isPartitionChild(String assetPath, Set<String> partitions) {
+      if(assetPath == null || assetPath.isEmpty() || partitions == null || partitions.isEmpty()) {
+         return false;
+      }
+      String[] parts = assetPath.split("/");
+      // Need at minimum: dsName/TABLE/schema/tableName
+      if(parts.length < 4) {
+         return false;
+      }
+      if(!"TABLE".equalsIgnoreCase(parts[1])) {
+         return false;
+      }
+      return isPartitionChild(parts[2], parts[3], partitions);
+   }
+
    private final XRepository xrepository;
    private final DataSourceService dataSourceService;
    private final AssetRepository assetRepository;

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -27,6 +27,7 @@ import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.erm.*;
 import inetsoft.uql.jdbc.JDBCDataSource;
+import inetsoft.uql.jdbc.JDBCHandler;
 import inetsoft.uql.jdbc.util.JDBCUtil;
 import inetsoft.uql.jdbc.util.SQLTypes;
 import inetsoft.uql.schema.XSchema;
@@ -34,6 +35,7 @@ import inetsoft.uql.schema.XTypeNode;
 import inetsoft.uql.util.DefaultMetaDataProvider;
 import inetsoft.uql.util.XSourceInfo;
 import inetsoft.uql.util.XUtil;
+import inetsoft.util.ThreadContext;
 import inetsoft.util.Tool;
 import inetsoft.web.composer.AssetTreeService;
 import inetsoft.web.composer.model.LoadAssetTreeNodesEvent;
@@ -45,6 +47,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.security.Principal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.*;
 
 @Service
@@ -550,11 +556,13 @@ public class MetadataApiService {
       // and proceed with an empty set, so a transient catalog issue doesn't block
       // the whole metadata fetch.
       Set<String> partitionChildren = Set.of();
-      try(java.sql.Connection probeConn = new inetsoft.uql.jdbc.JDBCHandler().getConnection(jdbcDataSource, principal)) {
-         partitionChildren = findPostgresPartitionChildren(jdbcDataSource, probeConn);
-      }
-      catch(Exception e) {
-         log.warn("Partition probe failed for '{}'; proceeding without partition filter", dsName, e);
+      if(isPostgresDriver(jdbcDataSource)) {
+         try(Connection probeConn = new JDBCHandler().getConnection(jdbcDataSource, principal)) {
+            partitionChildren = findPostgresPartitionChildren(jdbcDataSource, probeConn);
+         }
+         catch(Exception e) {
+            log.warn("Partition probe failed for '{}'; proceeding without partition filter", dsName, e);
+         }
       }
 
       XNode rootMetaData = metaDataProvider.getRootMetaData(XUtil.OUTER_MOSE_LAYER_DATABASE);
@@ -719,8 +727,8 @@ public class MetadataApiService {
          if(ds == null || !isPostgresDriver(ds)) {
             return Set.of();
          }
-         try(java.sql.Connection conn = new inetsoft.uql.jdbc.JDBCHandler()
-               .getConnection(ds, inetsoft.util.ThreadContext.getContextPrincipal())) {
+         try(Connection conn = new JDBCHandler()
+               .getConnection(ds, ThreadContext.getContextPrincipal())) {
             return findPostgresPartitionChildren(ds, conn);
          }
       }
@@ -1068,7 +1076,7 @@ public class MetadataApiService {
     * request).
     */
    static Set<String> findPostgresPartitionChildren(
-      JDBCDataSource ds, java.sql.Connection conn) throws java.sql.SQLException
+      JDBCDataSource ds, Connection conn) throws SQLException
    {
       if(!isPostgresDriver(ds)) {
          return Set.of();
@@ -1085,8 +1093,8 @@ public class MetadataApiService {
 
       Set<String> out = new HashSet<>();
 
-      try(java.sql.PreparedStatement ps = conn.prepareStatement(sql);
-          java.sql.ResultSet rs = ps.executeQuery())
+      try(PreparedStatement ps = conn.prepareStatement(sql);
+          ResultSet rs = ps.executeQuery())
       {
          while(rs.next()) {
             String qualified = rs.getString(1);

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -724,9 +724,12 @@ public class MetadataApiService {
    private Set<String> probePartitionsForTree(String dsName) {
       try {
          JDBCDataSource ds = getJDBCDatasource(dsName);
-         if(ds == null || !isPostgresDriver(ds)) {
+         if(!isPostgresDriver(ds)) {
             return Set.of();
          }
+         // Unlike getDatabaseTables, there's no Principal parameter here: this runs
+         // inside a computeIfAbsent lambda during the tree walk, so we resolve the
+         // caller from the request-scoped ThreadContext instead.
          try(Connection conn = new JDBCHandler()
                .getConnection(ds, ThreadContext.getContextPrincipal())) {
             return findPostgresPartitionChildren(ds, conn);
@@ -1086,10 +1089,14 @@ public class MetadataApiService {
       // based partitioning AND PG10+ declarative partitioning, so this single
       // subquery covers both eras without referencing pg_class.relispartition
       // (PG10+ only — would break catalog queries on older Postgres).
+      // relkind IN ('r','p') restricts to ordinary and partitioned tables.
+      // pg_inherits also records partitioned-index inheritance (PG11+), so without
+      // this filter index oids would leak in as "schema.indexname" keys.
       String sql =
          "SELECT n.nspname || '.' || c.relname AS qualified " +
          "FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid " +
-         "WHERE c.oid IN (SELECT inhrelid FROM pg_inherits)";
+         "WHERE c.relkind IN ('r', 'p') " +
+         "AND c.oid IN (SELECT inhrelid FROM pg_inherits)";
 
       Set<String> out = new HashSet<>();
 

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -982,6 +982,19 @@ public class MetadataApiService {
       }
    }
 
+   /**
+    * Returns true when the datasource uses the Postgres JDBC driver. Package-private
+    * (not private) so the partition filter unit tests can call it without standing
+    * up the full service graph.
+    */
+   static boolean isPostgresDriver(JDBCDataSource ds) {
+      if(ds == null) {
+         return false;
+      }
+      String driver = ds.getDriver();
+      return "org.postgresql.Driver".equals(driver);
+   }
+
    private final XRepository xrepository;
    private final DataSourceService dataSourceService;
    private final AssetRepository assetRepository;

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -626,17 +626,21 @@ public class MetadataApiService {
    }
 
    private TreeNodeModel filterWizTree(TreeNodeModel node) {
-      return filterWizTree(node, new HashMap<>());
+      return filterWizTree(node, new HashMap<>(), new HashMap<>());
    }
 
-   private TreeNodeModel filterWizTree(TreeNodeModel node, Map<String, SystemFilter> filterCache) {
+   private TreeNodeModel filterWizTree(
+      TreeNodeModel node,
+      Map<String, SystemFilter> filterCache,
+      Map<String, Set<String>> partitionCache)
+   {
       if(node == null) {
          return null;
       }
 
       AssetEntry entry = node.data() instanceof AssetEntry assetEntry ? assetEntry : null;
 
-      if(shouldHideWizTreeNode(entry, filterCache)) {
+      if(shouldHideWizTreeNode(entry, filterCache, partitionCache)) {
          return null;
       }
 
@@ -644,7 +648,7 @@ public class MetadataApiService {
       builder.children(new ArrayList<>());
 
       for(TreeNodeModel child : node.children()) {
-         TreeNodeModel filteredChild = filterWizTree(child, filterCache);
+         TreeNodeModel filteredChild = filterWizTree(child, filterCache, partitionCache);
 
          if(filteredChild != null) {
             builder.addChildren(filteredChild);
@@ -654,7 +658,11 @@ public class MetadataApiService {
       return builder.build();
    }
 
-   private boolean shouldHideWizTreeNode(AssetEntry entry, Map<String, SystemFilter> filterCache) {
+   private boolean shouldHideWizTreeNode(
+      AssetEntry entry,
+      Map<String, SystemFilter> filterCache,
+      Map<String, Set<String>> partitionCache)
+   {
       if(entry == null || Tool.isEmptyString(entry.getPath())) {
          return false;
       }
@@ -671,7 +679,20 @@ public class MetadataApiService {
          return false;
       }
 
-      SystemFilter filter = getSystemFilter(parts[0], filterCache);
+      String dsName = parts[0];
+
+      // Partition-child check (Postgres only): TABLE leaves whose qualified name
+      // appears in the per-datasource partition set are dropped. Cached lazily
+      // because the asset tree can include many tables per datasource.
+      if("TABLE".equalsIgnoreCase(tableType)) {
+         Set<String> partitions = partitionCache.computeIfAbsent(
+            dsName, this::probePartitionsForTree);
+         if(isPartitionChild(entry.getPath(), partitions)) {
+            return true;
+         }
+      }
+
+      SystemFilter filter = getSystemFilter(dsName, filterCache);
 
       if(filter.isEmpty()) {
          return false;
@@ -686,6 +707,27 @@ public class MetadataApiService {
       }
 
       return parts.length > 3 && matchesSystemName(parts[3], filter.schemas);
+   }
+
+   /**
+    * Lazy partition probe for the asset-tree filter. Fail-open: returns empty
+    * set on any error so the tree still renders, mirroring getDatabaseTables.
+    */
+   private Set<String> probePartitionsForTree(String dsName) {
+      try {
+         JDBCDataSource ds = getJDBCDatasource(dsName);
+         if(ds == null || !isPostgresDriver(ds)) {
+            return Set.of();
+         }
+         try(java.sql.Connection conn = new inetsoft.uql.jdbc.JDBCHandler()
+               .getConnection(ds, inetsoft.util.ThreadContext.getContextPrincipal())) {
+            return findPostgresPartitionChildren(ds, conn);
+         }
+      }
+      catch(Exception e) {
+         log.warn("Partition probe failed for asset tree '{}'; tree will include partitions", dsName, e);
+         return Set.of();
+      }
    }
 
    private XNode filterSystemSchemaTree(XNode schemas, JDBCDataSource jdbcDataSource) {

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePartitionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePartitionTest.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.jdbc.JDBCDataSource;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Tag("core")
+class MetadataApiServicePartitionTest {
+
+   @Test
+   void isPostgresDriver_returnsTrueForPostgresDriver() {
+      JDBCDataSource ds = mock(JDBCDataSource.class);
+      when(ds.getDriver()).thenReturn("org.postgresql.Driver");
+      assertTrue(MetadataApiService.isPostgresDriver(ds));
+   }
+
+   @Test
+   void isPostgresDriver_returnsFalseForMysqlDriver() {
+      JDBCDataSource ds = mock(JDBCDataSource.class);
+      when(ds.getDriver()).thenReturn("com.mysql.cj.jdbc.Driver");
+      assertFalse(MetadataApiService.isPostgresDriver(ds));
+   }
+
+   @Test
+   void isPostgresDriver_returnsFalseForNullDriver() {
+      JDBCDataSource ds = mock(JDBCDataSource.class);
+      when(ds.getDriver()).thenReturn(null);
+      assertFalse(MetadataApiService.isPostgresDriver(ds));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePartitionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePartitionTest.java
@@ -143,4 +143,58 @@ class MetadataApiServicePartitionTest {
 
       verify(ps).close();
    }
+
+   @Test
+   void isPartitionChild_bySchemaAndTable_matchesLowercased() {
+      java.util.Set<String> partitions = java.util.Set.of(
+         "public.payment_p2007_01", "public.payment_p2007_02"
+      );
+      assertTrue(
+         MetadataApiService.isPartitionChild("public", "payment_p2007_01", partitions));
+      assertTrue(
+         MetadataApiService.isPartitionChild("PUBLIC", "Payment_P2007_01", partitions));
+      assertFalse(
+         MetadataApiService.isPartitionChild("public", "payment", partitions));
+   }
+
+   @Test
+   void isPartitionChild_bySchemaAndTable_nullSchemaBuildsBareKey() {
+      java.util.Set<String> partitions = java.util.Set.of("payment_p2007_01");
+      assertTrue(
+         MetadataApiService.isPartitionChild(null, "payment_p2007_01", partitions));
+   }
+
+   @Test
+   void isPartitionChild_bySchemaAndTable_emptyPartitionSetMatchesNothing() {
+      java.util.Set<String> partitions = java.util.Set.of();
+      assertFalse(
+         MetadataApiService.isPartitionChild("public", "anything", partitions));
+   }
+
+   @Test
+   void isPartitionChild_byAssetPath_parsesWizFormat() {
+      java.util.Set<String> partitions = java.util.Set.of("public.payment_p2007_01");
+      // Wiz asset paths look like "dsName/TABLE/schema/tableName"
+      assertTrue(
+         MetadataApiService.isPartitionChild("postgres/TABLE/public/payment_p2007_01", partitions));
+      assertFalse(
+         MetadataApiService.isPartitionChild("postgres/TABLE/public/payment", partitions));
+      assertFalse(
+         MetadataApiService.isPartitionChild("postgres/VIEW/public/payment_p2007_01", partitions));
+   }
+
+   @Test
+   void isPartitionChild_byAssetPath_handlesShortOrEmptyPaths() {
+      java.util.Set<String> partitions = java.util.Set.of("public.payment_p2007_01");
+      assertFalse(
+         MetadataApiService.isPartitionChild((String) null, partitions));
+      assertFalse(
+         MetadataApiService.isPartitionChild("", partitions));
+      assertFalse(
+         MetadataApiService.isPartitionChild("postgres", partitions));
+      assertFalse(
+         MetadataApiService.isPartitionChild("postgres/TABLE", partitions));
+      assertFalse(
+         MetadataApiService.isPartitionChild("postgres/TABLE/public", partitions));
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePartitionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePartitionTest.java
@@ -62,6 +62,11 @@ class MetadataApiServicePartitionTest {
    }
 
    @Test
+   void isPostgresDriver_returnsFalseForNullDatasource() {
+      assertFalse(MetadataApiService.isPostgresDriver(null));
+   }
+
+   @Test
    void findPostgresPartitionChildren_returnsLowercasedQualifiedNames() throws Exception {
       JDBCDataSource ds = mock(JDBCDataSource.class);
       when(ds.getDriver()).thenReturn("org.postgresql.Driver");
@@ -164,9 +169,13 @@ class MetadataApiServicePartitionTest {
    }
 
    @Test
-   void isPartitionChild_bySchemaAndTable_nullSchemaBuildsBareKey() {
-      Set<String> partitions = Set.of("payment_p2007_01");
-      assertTrue(
+   void isPartitionChild_bySchemaAndTable_nullSchemaDoesNotMatchQualifiedKeys() {
+      // findPostgresPartitionChildren always emits "schema.table" keys, so a null
+      // schema (bare "table" key) cannot match a real partition entry. In practice
+      // Postgres metadata always supplies a schema (public by default), so this
+      // path doesn't occur for the only datasources that produce a non-empty set.
+      Set<String> partitions = Set.of("public.payment_p2007_01");
+      assertFalse(
          MetadataApiService.isPartitionChild(null, "payment_p2007_01", partitions));
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePartitionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePartitionTest.java
@@ -21,9 +21,14 @@ import inetsoft.uql.jdbc.JDBCDataSource;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @Tag("core")
@@ -48,5 +53,94 @@ class MetadataApiServicePartitionTest {
       JDBCDataSource ds = mock(JDBCDataSource.class);
       when(ds.getDriver()).thenReturn(null);
       assertFalse(MetadataApiService.isPostgresDriver(ds));
+   }
+
+   @Test
+   void findPostgresPartitionChildren_returnsLowercasedQualifiedNames() throws Exception {
+      JDBCDataSource ds = mock(JDBCDataSource.class);
+      when(ds.getDriver()).thenReturn("org.postgresql.Driver");
+
+      java.sql.Connection conn = mock(java.sql.Connection.class);
+      java.sql.PreparedStatement ps = mock(java.sql.PreparedStatement.class);
+      java.sql.ResultSet rs = mock(java.sql.ResultSet.class);
+      when(conn.prepareStatement(anyString())).thenReturn(ps);
+      when(ps.executeQuery()).thenReturn(rs);
+      when(rs.next()).thenReturn(true, true, true, false);
+      when(rs.getString(1))
+         .thenReturn("public.payment_p2007_01", "public.payment_p2007_02", "ANALYTICS.AUDIT_2026_05");
+
+      java.util.Set<String> result = MetadataApiService.findPostgresPartitionChildren(ds, conn);
+
+      assertEquals(
+         java.util.Set.of("public.payment_p2007_01", "public.payment_p2007_02", "analytics.audit_2026_05"),
+         result
+      );
+   }
+
+   @Test
+   void findPostgresPartitionChildren_returnsEmptySetForNonPostgres() throws Exception {
+      JDBCDataSource ds = mock(JDBCDataSource.class);
+      when(ds.getDriver()).thenReturn("com.mysql.cj.jdbc.Driver");
+      java.sql.Connection conn = mock(java.sql.Connection.class);
+
+      java.util.Set<String> result = MetadataApiService.findPostgresPartitionChildren(ds, conn);
+
+      assertTrue(result.isEmpty());
+      // The mock connection must never be touched on the non-Postgres path.
+      verifyNoInteractions(conn);
+   }
+
+   @Test
+   void findPostgresPartitionChildren_returnsEmptySetForEmptyResultSet() throws Exception {
+      JDBCDataSource ds = mock(JDBCDataSource.class);
+      when(ds.getDriver()).thenReturn("org.postgresql.Driver");
+
+      java.sql.Connection conn = mock(java.sql.Connection.class);
+      java.sql.PreparedStatement ps = mock(java.sql.PreparedStatement.class);
+      java.sql.ResultSet rs = mock(java.sql.ResultSet.class);
+      when(conn.prepareStatement(anyString())).thenReturn(ps);
+      when(ps.executeQuery()).thenReturn(rs);
+      when(rs.next()).thenReturn(false);
+
+      java.util.Set<String> result = MetadataApiService.findPostgresPartitionChildren(ds, conn);
+
+      assertTrue(result.isEmpty());
+   }
+
+   @Test
+   void findPostgresPartitionChildren_closesResources() throws Exception {
+      JDBCDataSource ds = mock(JDBCDataSource.class);
+      when(ds.getDriver()).thenReturn("org.postgresql.Driver");
+
+      java.sql.Connection conn = mock(java.sql.Connection.class);
+      java.sql.PreparedStatement ps = mock(java.sql.PreparedStatement.class);
+      java.sql.ResultSet rs = mock(java.sql.ResultSet.class);
+      when(conn.prepareStatement(anyString())).thenReturn(ps);
+      when(ps.executeQuery()).thenReturn(rs);
+      when(rs.next()).thenReturn(false);
+
+      MetadataApiService.findPostgresPartitionChildren(ds, conn);
+
+      // try-with-resources should close both
+      verify(ps).close();
+      verify(rs).close();
+   }
+
+   @Test
+   void findPostgresPartitionChildren_closesPreparedStatementWhenExecuteQueryThrows() throws Exception {
+      JDBCDataSource ds = mock(JDBCDataSource.class);
+      when(ds.getDriver()).thenReturn("org.postgresql.Driver");
+
+      java.sql.Connection conn = mock(java.sql.Connection.class);
+      java.sql.PreparedStatement ps = mock(java.sql.PreparedStatement.class);
+      when(conn.prepareStatement(anyString())).thenReturn(ps);
+      when(ps.executeQuery()).thenThrow(new java.sql.SQLException("simulated catalog read failure"));
+
+      // executeQuery throws, but try-with-resources must still close ps before
+      // the exception propagates.
+      assertThrows(java.sql.SQLException.class,
+         () -> MetadataApiService.findPostgresPartitionChildren(ds, conn));
+
+      verify(ps).close();
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePartitionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePartitionTest.java
@@ -21,6 +21,12 @@ import inetsoft.uql.jdbc.JDBCDataSource;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -60,19 +66,19 @@ class MetadataApiServicePartitionTest {
       JDBCDataSource ds = mock(JDBCDataSource.class);
       when(ds.getDriver()).thenReturn("org.postgresql.Driver");
 
-      java.sql.Connection conn = mock(java.sql.Connection.class);
-      java.sql.PreparedStatement ps = mock(java.sql.PreparedStatement.class);
-      java.sql.ResultSet rs = mock(java.sql.ResultSet.class);
+      Connection conn = mock(Connection.class);
+      PreparedStatement ps = mock(PreparedStatement.class);
+      ResultSet rs = mock(ResultSet.class);
       when(conn.prepareStatement(anyString())).thenReturn(ps);
       when(ps.executeQuery()).thenReturn(rs);
       when(rs.next()).thenReturn(true, true, true, false);
       when(rs.getString(1))
          .thenReturn("public.payment_p2007_01", "public.payment_p2007_02", "ANALYTICS.AUDIT_2026_05");
 
-      java.util.Set<String> result = MetadataApiService.findPostgresPartitionChildren(ds, conn);
+      Set<String> result = MetadataApiService.findPostgresPartitionChildren(ds, conn);
 
       assertEquals(
-         java.util.Set.of("public.payment_p2007_01", "public.payment_p2007_02", "analytics.audit_2026_05"),
+         Set.of("public.payment_p2007_01", "public.payment_p2007_02", "analytics.audit_2026_05"),
          result
       );
    }
@@ -81,9 +87,9 @@ class MetadataApiServicePartitionTest {
    void findPostgresPartitionChildren_returnsEmptySetForNonPostgres() throws Exception {
       JDBCDataSource ds = mock(JDBCDataSource.class);
       when(ds.getDriver()).thenReturn("com.mysql.cj.jdbc.Driver");
-      java.sql.Connection conn = mock(java.sql.Connection.class);
+      Connection conn = mock(Connection.class);
 
-      java.util.Set<String> result = MetadataApiService.findPostgresPartitionChildren(ds, conn);
+      Set<String> result = MetadataApiService.findPostgresPartitionChildren(ds, conn);
 
       assertTrue(result.isEmpty());
       // The mock connection must never be touched on the non-Postgres path.
@@ -95,14 +101,14 @@ class MetadataApiServicePartitionTest {
       JDBCDataSource ds = mock(JDBCDataSource.class);
       when(ds.getDriver()).thenReturn("org.postgresql.Driver");
 
-      java.sql.Connection conn = mock(java.sql.Connection.class);
-      java.sql.PreparedStatement ps = mock(java.sql.PreparedStatement.class);
-      java.sql.ResultSet rs = mock(java.sql.ResultSet.class);
+      Connection conn = mock(Connection.class);
+      PreparedStatement ps = mock(PreparedStatement.class);
+      ResultSet rs = mock(ResultSet.class);
       when(conn.prepareStatement(anyString())).thenReturn(ps);
       when(ps.executeQuery()).thenReturn(rs);
       when(rs.next()).thenReturn(false);
 
-      java.util.Set<String> result = MetadataApiService.findPostgresPartitionChildren(ds, conn);
+      Set<String> result = MetadataApiService.findPostgresPartitionChildren(ds, conn);
 
       assertTrue(result.isEmpty());
    }
@@ -112,9 +118,9 @@ class MetadataApiServicePartitionTest {
       JDBCDataSource ds = mock(JDBCDataSource.class);
       when(ds.getDriver()).thenReturn("org.postgresql.Driver");
 
-      java.sql.Connection conn = mock(java.sql.Connection.class);
-      java.sql.PreparedStatement ps = mock(java.sql.PreparedStatement.class);
-      java.sql.ResultSet rs = mock(java.sql.ResultSet.class);
+      Connection conn = mock(Connection.class);
+      PreparedStatement ps = mock(PreparedStatement.class);
+      ResultSet rs = mock(ResultSet.class);
       when(conn.prepareStatement(anyString())).thenReturn(ps);
       when(ps.executeQuery()).thenReturn(rs);
       when(rs.next()).thenReturn(false);
@@ -131,14 +137,14 @@ class MetadataApiServicePartitionTest {
       JDBCDataSource ds = mock(JDBCDataSource.class);
       when(ds.getDriver()).thenReturn("org.postgresql.Driver");
 
-      java.sql.Connection conn = mock(java.sql.Connection.class);
-      java.sql.PreparedStatement ps = mock(java.sql.PreparedStatement.class);
+      Connection conn = mock(Connection.class);
+      PreparedStatement ps = mock(PreparedStatement.class);
       when(conn.prepareStatement(anyString())).thenReturn(ps);
-      when(ps.executeQuery()).thenThrow(new java.sql.SQLException("simulated catalog read failure"));
+      when(ps.executeQuery()).thenThrow(new SQLException("simulated catalog read failure"));
 
       // executeQuery throws, but try-with-resources must still close ps before
       // the exception propagates.
-      assertThrows(java.sql.SQLException.class,
+      assertThrows(SQLException.class,
          () -> MetadataApiService.findPostgresPartitionChildren(ds, conn));
 
       verify(ps).close();
@@ -146,7 +152,7 @@ class MetadataApiServicePartitionTest {
 
    @Test
    void isPartitionChild_bySchemaAndTable_matchesLowercased() {
-      java.util.Set<String> partitions = java.util.Set.of(
+      Set<String> partitions = Set.of(
          "public.payment_p2007_01", "public.payment_p2007_02"
       );
       assertTrue(
@@ -159,21 +165,21 @@ class MetadataApiServicePartitionTest {
 
    @Test
    void isPartitionChild_bySchemaAndTable_nullSchemaBuildsBareKey() {
-      java.util.Set<String> partitions = java.util.Set.of("payment_p2007_01");
+      Set<String> partitions = Set.of("payment_p2007_01");
       assertTrue(
          MetadataApiService.isPartitionChild(null, "payment_p2007_01", partitions));
    }
 
    @Test
    void isPartitionChild_bySchemaAndTable_emptyPartitionSetMatchesNothing() {
-      java.util.Set<String> partitions = java.util.Set.of();
+      Set<String> partitions = Set.of();
       assertFalse(
          MetadataApiService.isPartitionChild("public", "anything", partitions));
    }
 
    @Test
    void isPartitionChild_byAssetPath_parsesWizFormat() {
-      java.util.Set<String> partitions = java.util.Set.of("public.payment_p2007_01");
+      Set<String> partitions = Set.of("public.payment_p2007_01");
       // Wiz asset paths look like "dsName/TABLE/schema/tableName"
       assertTrue(
          MetadataApiService.isPartitionChild("postgres/TABLE/public/payment_p2007_01", partitions));
@@ -185,7 +191,7 @@ class MetadataApiServicePartitionTest {
 
    @Test
    void isPartitionChild_byAssetPath_handlesShortOrEmptyPaths() {
-      java.util.Set<String> partitions = java.util.Set.of("public.payment_p2007_01");
+      Set<String> partitions = Set.of("public.payment_p2007_01");
       assertFalse(
          MetadataApiService.isPartitionChild((String) null, partitions));
       assertFalse(


### PR DESCRIPTION
Retarget of #3794 onto `stylebi-wiz-main-rebase` per @nelsoncao-Inetsoft's request that Wiz code be submitted to that branch.

## What this does

Postgres partition/inheritance children are an implementation detail, not user-facing tables. This filters them out of the wiz metadata APIs (both `/datasource/tables` and the asset tree) using a `pg_inherits`-based catalog probe.

## Changes since #3794 (addressing the review)

- **Bug fix:** `getDatabaseTables` now guards the partition probe with `isPostgresDriver()` before opening a JDBC connection, matching `probePartitionsForTree`. Previously a connection was opened/closed unconditionally for every datasource (MySQL, Oracle, SQL Server, etc.) even though the probe immediately returns `Set.of()` for non-Postgres drivers.
- **Style:** Replaced fully-qualified `java.sql.*`, `JDBCHandler`, and `ThreadContext` references with top-level imports in both the service and the test.

## Notes

- `pg_inherits` covers both pre-PG10 inheritance partitioning and PG10+ declarative partitioning, without relying on `pg_class.relispartition` (which breaks on PG 9.x).
- Probe is **fail-open**: a transient catalog error logs a warning and proceeds with no filtering rather than blocking the metadata fetch.
- `findPostgresPartitionChildren` results are cached per-datasource (`computeIfAbsent`) during a tree walk to avoid redundant probes.

## Test plan

- [x] `MetadataApiServicePartitionTest` — 13 tests pass (helpers, resource-closing, exception propagation, non-Postgres short-circuit)
- [ ] Manual: Postgres datasource with partitioned tables — children hidden in wiz tables list and asset tree
- [ ] Manual: non-Postgres datasource — no extra connection opened, all tables shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)