### PR TITLE
Bug #75154, fix waterfall IndexOutOfBoundsException from stale cachedColCount in AbstractDataSetFilter

### DIFF
--- a/core/src/main/java/inetsoft/graph/data/AbstractDataSet.java
+++ b/core/src/main/java/inetsoft/graph/data/AbstractDataSet.java
@@ -354,7 +354,7 @@ public abstract class AbstractDataSet implements DataSet {
     */
    @Override
    @TernMethod
-   public final int getColCount() {
+   public int getColCount() {
       int cached = cachedColCount;
 
       if(cached >= 0) {

--- a/core/src/main/java/inetsoft/graph/data/AbstractDataSetFilter.java
+++ b/core/src/main/java/inetsoft/graph/data/AbstractDataSetFilter.java
@@ -385,6 +385,34 @@ public abstract class AbstractDataSetFilter extends AbstractDataSet
    }
 
    /**
+    * Return the column count, re-validating the cache whenever the base dataset's
+    * column count has changed.
+    *
+    * AbstractDataSet.getColCount() caches getColCount0() + calcCols.  For a filter
+    * getColCount0() == data.getColCount(), which can shrink independently (e.g. when
+    * an outer caller removes calc-values from the base dataset directly without
+    * going through this filter's removeCalcValues()).  If that happens the cached
+    * count stays too large; sortData() then iterates beyond the valid range and
+    * getHeader() computes a wrong calc-column offset → IndexOutOfBoundsException.
+    * Checking the base count on every call is cheap because it is itself cached.
+    * (75154)
+    */
+   @Override
+   public int getColCount() {
+      int baseCount = data.getColCount();
+
+      if(baseCount != cachedBaseColCount) {
+         // Base dataset's column count changed (e.g. its calcvals were removed directly,
+         // without going through this filter's removeCalcValues()).  Invalidate our own
+         // cached count so super.getColCount() recomputes it with the new base count. (75154)
+         invalidateCachedColCount();
+         cachedBaseColCount = baseCount;
+      }
+
+      return super.getColCount();
+   }
+
+   /**
     * Return the number of columns in the data set without the calculated
     * column.
     */
@@ -495,4 +523,6 @@ public abstract class AbstractDataSetFilter extends AbstractDataSet
    private DataSet data;
    private AttributeDataSet attr;
    private SparseMatrix links;
+   // last known data.getColCount() used to detect stale cachedColCount (75154)
+   private transient int cachedBaseColCount = -1;
 }


### PR DESCRIPTION
When a base dataset's calcvals are cleared directly (not via the filter's own removeCalcValues()), its getColCount() shrinks but the wrapping filter's cachedColCount stays at the old larger value. sortData() then iterates beyond the valid range and getHeader() computes an out-of-bounds calc-column offset.

Override getColCount() in AbstractDataSetFilter to invalidate cachedColCount whenever data.getColCount() differs from the last known base count.