### PR TITLE
Bug #75094 - Preserve combined tooltip when switching chart type to bar

### DIFF
--- a/core/src/main/java/inetsoft/report/internal/graph/ChangeChartTypeProcessor.java
+++ b/core/src/main/java/inetsoft/report/internal/graph/ChangeChartTypeProcessor.java
@@ -285,7 +285,7 @@ public class ChangeChartTypeProcessor extends ChangeChartProcessor {
             info.setChartType(newType);
 
             if(info instanceof  VSChartInfo) {
-               // preserve combined tooltip for types that support it (line/area/bar)
+               // clear combined tooltip for types that don't support it; mirrors supportsCombinedTooltip()
                if(!GraphTypes.isLine(newType) && !GraphTypes.isArea(newType) &&
                   !GraphTypes.isBar(newType))
                {

--- a/core/src/main/java/inetsoft/report/internal/graph/ChangeChartTypeProcessor.java
+++ b/core/src/main/java/inetsoft/report/internal/graph/ChangeChartTypeProcessor.java
@@ -285,15 +285,9 @@ public class ChangeChartTypeProcessor extends ChangeChartProcessor {
             info.setChartType(newType);
 
             if(info instanceof  VSChartInfo) {
-               if(newType != GraphTypes.CHART_LINE &&
-                  newType != GraphTypes.CHART_LINE_STACK &&
-                  newType != GraphTypes.CHART_STEP &&
-                  newType != GraphTypes.CHART_STEP_STACK &&
-                  newType != GraphTypes.CHART_JUMP &&
-                  newType != GraphTypes.CHART_STEP_AREA &&
-                  newType != GraphTypes.CHART_STEP_AREA_STACK &&
-                  newType != GraphTypes.CHART_AREA &&
-                  newType != GraphTypes.CHART_AREA_STACK)
+               // preserve combined tooltip for types that support it (line/area/bar)
+               if(!GraphTypes.isLine(newType) && !GraphTypes.isArea(newType) &&
+                  !GraphTypes.isBar(newType))
                {
                   ((VSChartInfo) info).setCombinedToolTipValue(false);
                }

--- a/core/src/test/java/inetsoft/report/internal/graph/ChangeChartTypeCombinedTooltipTest.java
+++ b/core/src/test/java/inetsoft/report/internal/graph/ChangeChartTypeCombinedTooltipTest.java
@@ -42,7 +42,10 @@ class ChangeChartTypeCombinedTooltipTest {
    void switchBetweenSupportingTypesKeepsCombinedTooltip() {
       assertPreserved(GraphTypes.CHART_LINE_STACK, GraphTypes.CHART_BAR_STACK);
       assertPreserved(GraphTypes.CHART_LINE, GraphTypes.CHART_BAR);
+      assertPreserved(GraphTypes.CHART_LINE_STACK, GraphTypes.CHART_3D_BAR);
+      assertPreserved(GraphTypes.CHART_LINE_STACK, GraphTypes.CHART_3D_BAR_STACK);
       assertPreserved(GraphTypes.CHART_LINE_STACK, GraphTypes.CHART_AREA_STACK);
+      assertPreserved(GraphTypes.CHART_AREA_STACK, GraphTypes.CHART_BAR_STACK);
    }
 
    @Test

--- a/core/src/test/java/inetsoft/report/internal/graph/ChangeChartTypeCombinedTooltipTest.java
+++ b/core/src/test/java/inetsoft/report/internal/graph/ChangeChartTypeCombinedTooltipTest.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.internal.graph;
+
+import inetsoft.test.*;
+import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A chart-type change must keep the combined-tooltip design value for any type
+ * that still supports it (line/area/bar) and drop it for types that do not.
+ */
+@SreeHome
+@Tag("core")
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+class ChangeChartTypeCombinedTooltipTest {
+   @Test
+   void switchBetweenSupportingTypesKeepsCombinedTooltip() {
+      assertPreserved(GraphTypes.CHART_LINE_STACK, GraphTypes.CHART_BAR_STACK);
+      assertPreserved(GraphTypes.CHART_LINE, GraphTypes.CHART_BAR);
+      assertPreserved(GraphTypes.CHART_LINE_STACK, GraphTypes.CHART_AREA_STACK);
+   }
+
+   @Test
+   void switchToUnsupportingTypeClearsCombinedTooltip() {
+      assertCleared(GraphTypes.CHART_LINE_STACK, GraphTypes.CHART_PIE);
+   }
+
+   private static void assertPreserved(int oldType, int newType) {
+      assertTrue(changeType(oldType, newType),
+                 "combined tooltip must survive " + oldType + " -> " + newType);
+   }
+
+   private static void assertCleared(int oldType, int newType) {
+      assertFalse(changeType(oldType, newType),
+                  "combined tooltip must be cleared for " + oldType + " -> " + newType);
+   }
+
+   private static boolean changeType(int oldType, int newType) {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(oldType);
+      info.setCombinedToolTipValue(true);
+
+      new ChangeChartTypeProcessor(oldType, newType, null, info).process();
+
+      return info.getCombinedToolTipValue();
+   }
+}


### PR DESCRIPTION
## Summary

A stacked line chart with "Combine tooltips" enabled lost that setting
when its type was switched to stacked bar. The combined tooltip should
remain enabled because bar charts support it.

## Root cause

When a chart type changes, ChangeChartTypeProcessor reset the
combined-tooltip design value to false for any new type not present in a
hardcoded list of line/area types. Bar types (CHART_BAR, CHART_BAR_STACK,
CHART_3D_BAR, CHART_3D_BAR_STACK) were never in that list, so a switch to
a bar chart cleared the setting — even though ChartInfo.supportsCombinedTooltip()
reports line, area, and bar as supported. The reset logic was inconsistent
with the support check.

## Change

Replace the nine-clause hardcoded condition with GraphTypes.isLine /
isArea / isBar, which is the exact negation of supportsCombinedTooltip()'s
type check. The setting is now cleared only for types that do not support
a combined tooltip.

- Behavior is identical for line/area transitions (the helpers cover
exactly the original type list).
- Switching to an unsupported type (e.g. pie) still clears the value, as
before.
- Only bar types gain the corrected, preserving behavior.

No frontend change is needed: the Tip Customize dialog reads the stored
value from the model, so fixing the backend reset is sufficient.