### PR TITLE
Bug #75152, Clean up incorrect DC chart axis labels. 

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -1110,10 +1110,11 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
       if(dateComparisonInfo == null) {
          boolean dcEnabled = !(info instanceof DataVSAssemblyInfo) ||
             ((DataVSAssemblyInfo) info).isDateComparisonEnabled();
+         VSAssembly shareAssembly = (vs != null && !Tool.isEmptyString(info.getComparisonShareFrom()))
+            ? vs.getAssembly(info.getComparisonShareFrom()) : null;
          boolean validShare = Tool.isEmptyString(info.getComparisonShareFrom()) ||
-            (vs != null && vs.getAssembly(info.getComparisonShareFrom()) != null &&
-               vs.getAssembly(info.getComparisonShareFrom()).getVSAssemblyInfo()
-                  instanceof DateCompareAbleAssemblyInfo);
+            (shareAssembly != null &&
+               shareAssembly.getVSAssemblyInfo() instanceof DateCompareAbleAssemblyInfo);
 
          if(dcEnabled && validShare) {
             dateComparisonInfo = info.getDateComparisonInfo();
@@ -1133,19 +1134,8 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
          VSChartInfo cinfo = ((ChartVSAssemblyInfo) vsAssemblyInfo).getVSChartInfo();
 
          if(cinfo != null) {
-            DataRef found = null;
-            ChartRef[] xFields = cinfo.getXFields();
-            ChartRef[] yFields = cinfo.getYFields();
-
-            // Mirror ChartDcProcessor.getComparisonDateRef(): X date only if Y has an
-            // aggregate; Y date only if X has an aggregate.
-            if(DateComparisonUtil.containsAggregate(yFields)) {
-               found = DateComparisonUtil.findDateDimension(xFields);
-            }
-
-            if(found == null && DateComparisonUtil.containsAggregate(xFields)) {
-               found = DateComparisonUtil.findDateDimension(yFields);
-            }
+            // Use the shared utility to match ChartDcProcessor.getComparisonDateRef() logic.
+            DataRef found = DateComparisonUtil.findDcDateRef(cinfo.getXFields(), cinfo.getYFields());
 
             if(found instanceof VSDataRef) {
                dcRef = (VSDataRef) found;

--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -1103,11 +1103,57 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
       DateCompareAbleAssemblyInfo info = (DateCompareAbleAssemblyInfo) vsAssemblyInfo;
       DateComparisonInfo dateComparisonInfo = DateComparisonUtil.getDateComparison(info, vs);
 
+      // getDateComparison() may return null if DC hasn't been applied to the runtime chart
+      // state yet (the initial worksheet-table setup call happens before ChartDcProcessor
+      // runs). Fall back to the assembly's raw DC info only when DC is genuinely enabled
+      // and the share-from assembly reference is valid — preserving all other null semantics.
+      if(dateComparisonInfo == null) {
+         boolean dcEnabled = !(info instanceof DataVSAssemblyInfo) ||
+            ((DataVSAssemblyInfo) info).isDateComparisonEnabled();
+         boolean validShare = Tool.isEmptyString(info.getComparisonShareFrom()) ||
+            (vs != null && vs.getAssembly(info.getComparisonShareFrom()) != null &&
+               vs.getAssembly(info.getComparisonShareFrom()).getVSAssemblyInfo()
+                  instanceof DateCompareAbleAssemblyInfo);
+
+         if(dcEnabled && validShare) {
+            dateComparisonInfo = info.getDateComparisonInfo();
+         }
+      }
+
       if(dateComparisonInfo == null) {
          return null;
       }
 
-      return dateComparisonInfo.getDateComparisonConditions(info.getDateComparisonRef());
+      VSDataRef dcRef = info.getDateComparisonRef();
+
+      // dateComparisonRef is only set by ChartDcProcessor.process() during chart execution.
+      // For the early worksheet-table setup call, derive the date ref from the chart's
+      // design fields, using the same axis-aggregate logic as ChartDcProcessor.
+      if(dcRef == null && vsAssemblyInfo instanceof ChartVSAssemblyInfo) {
+         VSChartInfo cinfo = ((ChartVSAssemblyInfo) vsAssemblyInfo).getVSChartInfo();
+
+         if(cinfo != null) {
+            DataRef found = null;
+            ChartRef[] xFields = cinfo.getXFields();
+            ChartRef[] yFields = cinfo.getYFields();
+
+            // Mirror ChartDcProcessor.getComparisonDateRef(): X date only if Y has an
+            // aggregate; Y date only if X has an aggregate.
+            if(DateComparisonUtil.containsAggregate(yFields)) {
+               found = DateComparisonUtil.findDateDimension(xFields);
+            }
+
+            if(found == null && DateComparisonUtil.containsAggregate(xFields)) {
+               found = DateComparisonUtil.findDateDimension(yFields);
+            }
+
+            if(found instanceof VSDataRef) {
+               dcRef = (VSDataRef) found;
+            }
+         }
+      }
+
+      return dateComparisonInfo.getDateComparisonConditions(dcRef);
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonFormat.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonFormat.java
@@ -150,6 +150,46 @@ public class DateComparisonFormat extends Format {
             }
          }
 
+         // Remove orphaned cells: cells that have no data from the most recent (current)
+         // year. These arise when comparison-year data exists at a position that has no
+         // corresponding current-year entry. Without this filter, the format would compute
+         // wrong label dates from the comparison-year value.
+         // This only applies when dateCol stores period-bucket dates where the same year date
+         // is shared by many cells. If each cell has a unique date, maxYearDate would appear
+         // in only one cell and removing all others would blank the entire axis
+         Set<Object> orphanedCells = new HashSet<>();
+
+         if(!partDates.isEmpty()) {
+            Date maxYearDate = partDates.values().stream()
+               .flatMap(Set::stream)
+               .max(Date::compareTo)
+               .orElse(null);
+
+            if(maxYearDate != null) {
+               final Date maxDate = maxYearDate;
+               long cellsWithMaxDate = partDates.values().stream()
+                  .filter(s -> s.stream().anyMatch(d -> d.compareTo(maxDate) == 0))
+                  .count();
+
+               // Only remove orphans if the max date is shared across multiple cells
+               // (period-bucket case). A unique max date means per-part real dates —
+               // skip the filter to avoid blanking valid labels.
+               if(cellsWithMaxDate > 1) {
+                  Iterator<Map.Entry<Object, Set<Date>>> it = partDates.entrySet().iterator();
+
+                  while(it.hasNext()) {
+                     Map.Entry<Object, Set<Date>> entry = it.next();
+
+                     if(entry.getValue().stream().noneMatch(d -> d.compareTo(maxDate) == 0)) {
+                        orphanedCells.add(entry.getKey());
+                        it.remove();
+                     }
+                  }
+               }
+            }
+         }
+
+         this.orphanedCells = orphanedCells;
          this.partDates = partDates;
          this.partDates2 = partDates2;
          fixDisplayShortDate();
@@ -198,6 +238,7 @@ public class DateComparisonFormat extends Format {
    public void setGraphDataSelector(GraphtDataSelector selector) {
       this.selector = selector;
       partDates = null;
+      orphanedCells = new HashSet<>();
    }
 
    /**
@@ -262,6 +303,12 @@ public class DateComparisonFormat extends Format {
                                boolean onlyShowMostRecentDate)
    {
       initPartDate();
+
+      // Orphaned cells have no current-year data — suppress their labels entirely.
+      if(orphanedCells != null && orphanedCells.contains(obj)) {
+         return toAppendTo;
+      }
+
       Set<Date> dates = partDates.get(obj);
       dates = dates == null ? partDates2.get(obj) : dates;
       Format dateFmt = format != null ?
@@ -419,6 +466,7 @@ public class DateComparisonFormat extends Format {
 
    private Map<Object, Set<Date>> partDates;
    private Map<Object, Set<Date>> partDates2;
+   private Set<Object> orphanedCells = new HashSet<>();
    private Map<Object, Format> preferFormat;
    private int datePart;
    private DataSet data;

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonFormat.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonFormat.java
@@ -150,41 +150,22 @@ public class DateComparisonFormat extends Format {
             }
          }
 
-         // Remove orphaned cells: cells that have no data from the most recent (current)
-         // year. These arise when comparison-year data exists at a position that has no
-         // corresponding current-year entry. Without this filter, the format would compute
-         // wrong label dates from the comparison-year value.
-         // This only applies when dateCol stores period-bucket dates where the same year date
-         // is shared by many cells. If each cell has a unique date, maxYearDate would appear
-         // in only one cell and removing all others would blank the entire axis
+         // Remove orphaned cells (no current-year data) using the same heuristic as
+         // DateComparisonUtil.computeValidParts(). An empty validParts set means either
+         // no data, MergePartCell period without a date value, or per-part real-date
+         // layout — in all those cases no filtering is applied.
          Set<Object> orphanedCells = new HashSet<>();
+         Set<Object> validParts = DateComparisonUtil.computeValidParts(data, dateCol, partCol, null);
 
-         if(!partDates.isEmpty()) {
-            Date maxYearDate = partDates.values().stream()
-               .flatMap(Set::stream)
-               .max(Date::compareTo)
-               .orElse(null);
+         if(!validParts.isEmpty()) {
+            Iterator<Map.Entry<Object, Set<Date>>> it = partDates.entrySet().iterator();
 
-            if(maxYearDate != null) {
-               final Date maxDate = maxYearDate;
-               long cellsWithMaxDate = partDates.values().stream()
-                  .filter(s -> s.stream().anyMatch(d -> d.compareTo(maxDate) == 0))
-                  .count();
+            while(it.hasNext()) {
+               Map.Entry<Object, Set<Date>> entry = it.next();
 
-               // Only remove orphans if the max date is shared across multiple cells
-               // (period-bucket case). A unique max date means per-part real dates —
-               // skip the filter to avoid blanking valid labels.
-               if(cellsWithMaxDate > 1) {
-                  Iterator<Map.Entry<Object, Set<Date>>> it = partDates.entrySet().iterator();
-
-                  while(it.hasNext()) {
-                     Map.Entry<Object, Set<Date>> entry = it.next();
-
-                     if(entry.getValue().stream().noneMatch(d -> d.compareTo(maxDate) == 0)) {
-                        orphanedCells.add(entry.getKey());
-                        it.remove();
-                     }
-                  }
+               if(!validParts.contains(entry.getKey())) {
+                  orphanedCells.add(entry.getKey());
+                  it.remove();
                }
             }
          }

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonInfo.java
@@ -1526,6 +1526,7 @@ public class DateComparisonInfo implements Cloneable, XMLSerializable {
    {
       int contextCalendarLevel = getCalendarLevel(contextLevel);
       boolean contextLevelIsQuarter = contextLevel ==  XConstants.QUARTER_DATE_GROUP;
+      Calendar rangeStartYearCal = getCalendar();
 
       while(rangeStartCal.before(rangeEndCal) || rangeStartCal.equals(rangeEndCal)) {
          int contextYear = rangeEndCal.get(Calendar.YEAR);
@@ -1539,13 +1540,11 @@ public class DateComparisonInfo implements Cloneable, XMLSerializable {
             continue;
          }
 
-         Calendar rangeStartYear = getCalendar();
-         rangeStartYear.setTime(range[0]);
+         rangeStartYearCal.setTime(range[0]);
 
-         if(rangeStartYear.get(Calendar.YEAR) > contextYear) {
+         if(rangeStartYearCal.get(Calendar.YEAR) > contextYear) {
             continue;
          }
-
 
          ConditionItem item = (range[1] == null || !alignWeek() && range[0].after(range[1]))
             ? null : createDateRangeCondition(ref, range[0], range[1]);

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonInfo.java
@@ -1528,9 +1528,27 @@ public class DateComparisonInfo implements Cloneable, XMLSerializable {
       boolean contextLevelIsQuarter = contextLevel ==  XConstants.QUARTER_DATE_GROUP;
 
       while(rangeStartCal.before(rangeEndCal) || rangeStartCal.equals(rangeEndCal)) {
-         ConditionItem item = getConditionItemFromDateRangeAndInterval(ref, contextLevel,
-            dcInterval.getLevel(), dcInterval.getGranularity(), rangeEndCal.getTime(), toDate);
+         int contextYear = rangeEndCal.get(Calendar.YEAR);
+         Date[] range = getIntervalDateRange(contextLevel, dcInterval.getLevel(),
+            dcInterval.getGranularity(), rangeEndCal.getTime(), toDate);
          setToNextIntervalStart(rangeEndCal, contextCalendarLevel, contextLevelIsQuarter, false, alignWeek());
+
+         // Skip conditions whose range start overflows into a later year than the context month.
+         // e.g. "week 5 of December 2020" starts Jan 2021 — that overflow causes spurious labels.
+         if(range == null || range[0] == null) {
+            continue;
+         }
+
+         Calendar rangeStartYear = getCalendar();
+         rangeStartYear.setTime(range[0]);
+
+         if(rangeStartYear.get(Calendar.YEAR) > contextYear) {
+            continue;
+         }
+
+
+         ConditionItem item = (range[1] == null || !alignWeek() && range[0].after(range[1]))
+            ? null : createDateRangeCondition(ref, range[0], range[1]);
 
          if(item == null) {
             continue;
@@ -1673,7 +1691,6 @@ public class DateComparisonInfo implements Cloneable, XMLSerializable {
          calendar.add(calendarPeriodLevel, -(quarterCalendar ? 3 : 1));
       }
 
-      setDateToEndOfPeriod(calendar, periodLevel);
       setDateToLevelStart(calendar, dcInterval.getContextLevel());
       appendRangeToDateConditions(endDateCalendar, calendar, dcInterval.getContextLevel(),
                                   toDate, conditionList, ref);

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
@@ -387,6 +387,29 @@ public class DateComparisonUtil {
       return Arrays.stream(fields).anyMatch(VSAggregateRef.class::isInstance);
    }
 
+   /**
+    * Derive the date dimension ref used for DC from a chart's X/Y fields using the same
+    * axis-aggregate logic as ChartDcProcessor.getComparisonDateRef(): X date only when Y
+    * has an aggregate, Y date only when X has an aggregate.
+    *
+    * @param xFields X-axis fields (design or runtime).
+    * @param yFields Y-axis fields (design or runtime).
+    * @return the date DataRef, or null if none found.
+    */
+   public static DataRef findDcDateRef(DataRef[] xFields, DataRef[] yFields) {
+      DataRef found = null;
+
+      if(containsAggregate(yFields)) {
+         found = findDateDimension(xFields);
+      }
+
+      if(found == null && containsAggregate(xFields)) {
+         found = findDateDimension(yFields);
+      }
+
+      return found;
+   }
+
    public static void checkGraphValidity(ChartVSAssemblyInfo info, VGraph vgraph) {
       DataSet data = vgraph.getCoordinate().getDataSet();
       List<VisualObject> vos = GTool.getVOs(vgraph);
@@ -629,8 +652,7 @@ public class DateComparisonUtil {
                Format fmt = scale.getAxisSpec().getTextSpec().getFormat();
                DateSelector basePartSel = new DateSelector(periodCol, startDate, fmt);
                GraphtDataSelector partSelector = validParts.isEmpty() ? basePartSel
-                  : (dataset, row, f) -> validParts.contains(dataset.getData(partCol, row))
-                     && basePartSel.accept(dataset, row, f);
+                  : new ValidPartsSelector(validParts, partCol, basePartSel);
                applyGraphDataSelector(data, scale, partSelector);
             }
             else if(scale instanceof LinearScale ||
@@ -655,8 +677,7 @@ public class DateComparisonUtil {
             if(spec.getTextSpec().getFormat() instanceof DateComparisonFormat) {
                DateComparisonFormat fmt = (DateComparisonFormat) spec.getTextSpec().getFormat();
                GraphtDataSelector fmtSelector = validParts.isEmpty() ? selector
-                  : (dataset, row, f) -> validParts.contains(dataset.getData(partCol, row))
-                     && selector.accept(dataset, row, f);
+                  : new ValidPartsSelector(validParts, partCol, selector);
                fmt.setGraphDataSelector(fmtSelector);
             }
          }
@@ -675,15 +696,26 @@ public class DateComparisonUtil {
    /**
     * Find which part cells (x-axis positions) have data from the most recent year.
     * Cells without current-year data are orphaned and should be excluded from the axis.
+    * Returns the set of valid part cells (those with current-year data), or an empty set
+    * when the data is not in year-bucket layout (per-part real dates, or no repeated period
+    * value). An empty return means "no orphan filtering should be applied."
+    *
+    * This method is also used by DateComparisonFormat.initPartDate() to drive the same
+    * heuristic at the pre-aggregated partDates level — both callers rely on this single
+    * implementation so the logic stays in sync.
     */
-   private static Set<Object> computeValidParts(DataSet data, String periodCol,
-                                                 String partCol, Date startDate)
+   static Set<Object> computeValidParts(DataSet data, String periodCol,
+                                        String partCol, Date startDate)
    {
       if(periodCol == null || partCol == null) {
          return Collections.emptySet();
       }
 
+      // Single pass: find max year date AND detect year-bucket layout (any date repeating
+      // across more than one row indicates period-bucket data rather than per-part real dates).
       Date maxYearDate = null;
+      Set<Date> seenDates = new HashSet<>();
+      boolean isYearBucketCase = false;
 
       for(int i = 0; i < data.getRowCount(); i++) {
          Date date = toPeriodDate(data.getData(periodCol, i));
@@ -692,10 +724,16 @@ public class DateComparisonUtil {
             if(maxYearDate == null || date.after(maxYearDate)) {
                maxYearDate = date;
             }
+
+            if(!seenDates.add(date)) {
+               isYearBucketCase = true;
+            }
          }
       }
 
-      if(maxYearDate == null) {
+      // Return empty when there is no data or when all period dates are unique per row
+      // (per-part real-date charts) — orphan filtering must not apply in that case.
+      if(maxYearDate == null || !isYearBucketCase) {
          return Collections.emptySet();
       }
 
@@ -2058,5 +2096,23 @@ public class DateComparisonUtil {
       calendar.setMinimalDaysInFirstWeek(7);
 
       return calendar;
+   }
+
+   /** Selector that filters out orphaned part cells not present in the current-year set. */
+   private static final class ValidPartsSelector implements GraphtDataSelector {
+      private final Set<Object> validParts;
+      private final String partCol;
+      private final GraphtDataSelector base;
+
+      ValidPartsSelector(Set<Object> validParts, String partCol, GraphtDataSelector base) {
+         this.validParts = validParts;
+         this.partCol = partCol;
+         this.base = base;
+      }
+
+      @Override
+      public boolean accept(DataSet dataset, int row, String[] fields) {
+         return validParts.contains(dataset.getData(partCol, row)) && base.accept(dataset, row, fields);
+      }
    }
 }

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
@@ -383,7 +383,7 @@ public class DateComparisonUtil {
     *
     * @return <tt>true</tt> if contains, <tt>false</tt> otherwise.
     */
-   private static boolean containsAggregate(DataRef[] fields) {
+   public static boolean containsAggregate(DataRef[] fields) {
       return Arrays.stream(fields).anyMatch(VSAggregateRef.class::isInstance);
    }
 
@@ -617,12 +617,21 @@ public class DateComparisonUtil {
          Date startDate = dcInfo.getStartDate();
          DateSelector selector = new DateSelector(periodCol, startDate, null);
 
+         // Compute which part cells have data from the most recent (current) year.
+         // Orphaned cells — those with only comparison-year data — should be excluded
+         // from the x-axis scale so they don't produce spurious labels.
+         final Set<Object> validParts = computeValidParts(data, periodCol, partCol, startDate);
+
          for(Scale scale : egraph.getCoordinate().getScales()) {
             String[] fields = scale.getFields();
 
             if(fields.length > 0 && Tool.equals(partCol, fields[0])) {
                Format fmt = scale.getAxisSpec().getTextSpec().getFormat();
-               applyGraphDataSelector(data, scale, new DateSelector(periodCol, startDate, fmt));
+               DateSelector basePartSel = new DateSelector(periodCol, startDate, fmt);
+               GraphtDataSelector partSelector = validParts.isEmpty() ? basePartSel
+                  : (dataset, row, f) -> validParts.contains(dataset.getData(partCol, row))
+                     && basePartSel.accept(dataset, row, f);
+               applyGraphDataSelector(data, scale, partSelector);
             }
             else if(scale instanceof LinearScale ||
                fields.length > 0 && Tool.equals(getBaseName(periodCol), (getBaseName(fields[0]))))
@@ -645,7 +654,10 @@ public class DateComparisonUtil {
 
             if(spec.getTextSpec().getFormat() instanceof DateComparisonFormat) {
                DateComparisonFormat fmt = (DateComparisonFormat) spec.getTextSpec().getFormat();
-               fmt.setGraphDataSelector(selector);
+               GraphtDataSelector fmtSelector = validParts.isEmpty() ? selector
+                  : (dataset, row, f) -> validParts.contains(dataset.getData(partCol, row))
+                     && selector.accept(dataset, row, f);
+               fmt.setGraphDataSelector(fmtSelector);
             }
          }
 
@@ -658,6 +670,64 @@ public class DateComparisonUtil {
             }
          }
       }
+   }
+
+   /**
+    * Find which part cells (x-axis positions) have data from the most recent year.
+    * Cells without current-year data are orphaned and should be excluded from the axis.
+    */
+   private static Set<Object> computeValidParts(DataSet data, String periodCol,
+                                                 String partCol, Date startDate)
+   {
+      if(periodCol == null || partCol == null) {
+         return Collections.emptySet();
+      }
+
+      Date maxYearDate = null;
+
+      for(int i = 0; i < data.getRowCount(); i++) {
+         Date date = toPeriodDate(data.getData(periodCol, i));
+
+         if(date != null && (startDate == null || !date.before(startDate))) {
+            if(maxYearDate == null || date.after(maxYearDate)) {
+               maxYearDate = date;
+            }
+         }
+      }
+
+      if(maxYearDate == null) {
+         return Collections.emptySet();
+      }
+
+      Set<Object> validParts = new HashSet<>();
+      final Date max = maxYearDate;
+
+      for(int i = 0; i < data.getRowCount(); i++) {
+         Date date = toPeriodDate(data.getData(periodCol, i));
+
+         if(max.equals(date)) {
+            validParts.add(data.getData(partCol, i));
+         }
+      }
+
+      return validParts;
+   }
+
+   /** Extract a comparable Date from a period column value (raw Date or MergePartCell). */
+   private static Date toPeriodDate(Object val) {
+      if(val instanceof Date) {
+         return (Date) val;
+      }
+
+      if(val instanceof MergePartCell) {
+         // Use getDateGroupValue() to match DateSelector's MergePartCell handling.
+         // getOriginalRawDate() is only set for isIgnoreDcTemp refs; it is null in
+         // most DC configurations and would cause computeValidParts to return empty.
+         Object dateGroupValue = ((MergePartCell) val).getDateGroupValue();
+         return dateGroupValue instanceof Date ? (Date) dateGroupValue : null;
+      }
+
+      return null;
    }
 
    private static void applyGraphDataSelector(DataSet data, Scale scale,


### PR DESCRIPTION
Fix 1 — Interval condition year-overflow
When generating interval conditions for each calendar month, the December context computed "week 5 of December" as a date in January of the following year. Those January rows were then mislabeled as belonging to the prior year by the DC year-assignment logic, producing orphaned axis cells with no current-year counterpart and wrong labels (Dec 27, Dec 29). Fix: skip any generated interval condition whose range-start year exceeds the context month's calendar year.

Fix 2 — Interval iteration upper bound
getStandardPeriodsIntervalCondition expanded the iteration's upper bound to the full year-end (December 31) via setDateToEndOfPeriod, causing a December 2021 context to be processed. Its condition overflowed to January 2022 and was caught by Fix 1, but the underlying cause was the over-wide bound. Fix: remove setDateToEndOfPeriod so the upper bound is the actual period-end month.

Fix 3 — DC conditions bypassed on initial worksheet query
ViewsheetSandbox.getBoundTable calls appendDateComparisonConditions before chart execution starts. At that point VSChartInfo.dateComparisonRef is null — it is only populated by ChartDcProcessor during execution — so the DC condition was silently dropped for the initial worksheet table query. Fix: derive the date ref from the chart's design fields using the same axis-aggregate logic as ChartDcProcessor (X date only when Y has aggregates, Y date only when X has aggregates), and only fall back when DC is genuinely enabled and the share-from reference is structurally valid.

Fix 4 — Orphaned axis cells produce wrong labels
Comparison-year data (e.g. November 2020) can map to a different month context than the current-year data (e.g. October 2021) due to the MONTH_OF_FULL_WEEK_PART week-boundary assignment. This leaves axis cells that have comparison-year data but no current-year counterpart. When formatPartMergeCell computes the label from only a year value plus the forced week position, it overflows to the wrong date. Fix: DateComparisonUtil.applyDateRange computes the set of axis cells that have current-year data and wraps the existing DateSelector to exclude orphaned cells from the scale entirely. DateComparisonFormat.initPartDate additionally removes orphaned cells from partDates (guarded by a shared-max-date check to avoid affecting per-part real-date cases), and format() returns an empty string for any orphaned cell that still reaches the formatter.
