### PR TITLE
Bug #75030 - Fix the information hierarchy of card-style chart toolti…

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -1484,6 +1484,7 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
             }
 
             int sizeBefore = tooltip.getTooltipList().size();
+            int stackTotalPairs = 0;
 
             for(int i = 0; i < cols[k].length; i++) {
                String name = cols[k][i];
@@ -1568,12 +1569,15 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
                   name = getStackTotalName(showFullTotalName ? name : null);
                   tooltip.setStackTotalName(name);
 
+                  int beforeStackTotal = tooltip.getTooltipList().size();
                   addTooltip(label, name, value, null, null, list, vtext, tooltip, false);
+                  // Stack-total footer is not a rankable measure; keep it out of the count.
+                  stackTotalPairs += (tooltip.getTooltipList().size() - beforeStackTotal) / 2;
                }
             }
 
             if(cols[k] == measures) {
-               measurePairs = (tooltip.getTooltipList().size() - sizeBefore) / 2;
+               measurePairs = (tooltip.getTooltipList().size() - sizeBefore) / 2 - stackTotalPairs;
             }
          }
 

--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -1472,6 +1472,8 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
             }
          }
 
+         int measurePairs = 0;
+
          for(int k = 0; k < cols.length; k++) {
             if(cols[k] == null) {
                continue;
@@ -1480,6 +1482,8 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
             if(isText && isStackValue(evo, vtext) && cols[k] == others) {
                continue;
             }
+
+            int sizeBefore = tooltip.getTooltipList().size();
 
             for(int i = 0; i < cols[k].length; i++) {
                String name = cols[k][i];
@@ -1549,7 +1553,10 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
                   }
                }
 
-               addTooltip(label, name, value, nameNoCalc, ovalue, list, vtext, tooltip);
+               boolean originalFirst = cardMeasureFirst && cols[k] == measures &&
+                  !(isText && isStackValue(evo, vtext));
+               addTooltip(label, name, value, nameNoCalc, ovalue, list, vtext, tooltip,
+                          originalFirst);
 
                if(cols[k] == measures && isStackChart(name) &&
                   (!isText || !isStackValue(evo, vtext)))
@@ -1561,8 +1568,12 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
                   name = getStackTotalName(showFullTotalName ? name : null);
                   tooltip.setStackTotalName(name);
 
-                  addTooltip(label, name, value, null, null, list, vtext, tooltip);
+                  addTooltip(label, name, value, null, null, list, vtext, tooltip, false);
                }
+            }
+
+            if(cols[k] == measures) {
+               measurePairs = (tooltip.getTooltipList().size() - sizeBefore) / 2;
             }
          }
 
@@ -1616,11 +1627,16 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
          if(candleCardLayout && dims.length > 0) {
             applyCandleCardHeader(tooltip, dims[0], tipMeasures);
          }
-         // Solo measure-first card: lift the X-dim to the tier-1 subtitle header so a
-         // single-series hover matches the combined-tooltip layout. Only dims[0] lifts.
          else if(cardMeasureFirst && dims.length > 0) {
-            captureCombinedCardHeader(
-               tooltip, new int[]{ palette.put(dims[0]) }, chartInfo.getTooltipStyle());
+            if(groupMeasuresAtTier2(measures, full2NoCalcNames.keySet(), measurePairs)) {
+               tooltip.setGroupedTiers(true);
+               tooltip.setTier2GroupSize(measurePairs - 1);
+            }
+            // Single measure: lift the X-dim to the tier-1 subtitle (matches combined card).
+            else {
+               captureCombinedCardHeader(
+                  tooltip, new int[]{ palette.put(dims[0]) }, chartInfo.getTooltipStyle());
+            }
          }
       }
 
@@ -1693,7 +1709,8 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
    }
 
    private void addTooltip(String label, String name, String value, String oname, String ovalue,
-                           List<VSDataRef> list, VOText vtext, ChartToolTip tooltip)
+                           List<VSDataRef> list, VOText vtext, ChartToolTip tooltip,
+                           boolean originalFirst)
    {
       final List<Legend> legends = getLegends(name);
       AxisDescriptor desc = getAxisDescriptor(name);
@@ -1734,13 +1751,47 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
       name = tips.get(name) == null ? name : tips.get(name);
       int key = palette.put(name);
       int val = palette.put(label);
-      tooltip.addTooltip(key, val);
+      Integer okey = null;
+      Integer oval = null;
 
       if(ovalue != null) {
-         key = palette.put(Tool.localize(oname));
-         val = palette.put(ovalue);
+         okey = palette.put(Tool.localize(oname));
+         oval = palette.put(ovalue);
+      }
+
+      appendMeasurePair(tooltip, key, val, okey, oval, originalFirst);
+   }
+
+   // Card headlines the core value: emit the original measure pair before its
+   // calc-derived (Change/Change%/…) pair so the original takes tier-1.
+   static void appendMeasurePair(ChartToolTip tooltip, int key, int val,
+                                 Integer okey, Integer oval, boolean originalFirst)
+   {
+      if(originalFirst && okey != null) {
+         tooltip.addTooltip(okey, oval);
          tooltip.addTooltip(key, val);
       }
+      else {
+         tooltip.addTooltip(key, val);
+
+         if(okey != null) {
+            tooltip.addTooltip(okey, oval);
+         }
+      }
+   }
+
+   // A derived (calc) measure outranks the X-dim: group non-headline measures at
+   // tier-2 and drop dimensions to tier-3 instead of lifting the X-dim subtitle.
+   // Needs >1 measure pair so there is a non-headline measure to rank.
+   static boolean groupMeasuresAtTier2(String[] measures, Set<String> derivedMeasureNames,
+                                       int measurePairs)
+   {
+      if(measurePairs <= 1) {
+         return false;
+      }
+
+      return Arrays.stream(measures)
+         .anyMatch(m -> m != null && derivedMeasureNames.contains(m));
    }
 
    private String getStackTotalName(String measureName) {

--- a/core/src/test/java/inetsoft/report/composition/region/PlotAreaCardMeasureFirstTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/PlotAreaCardMeasureFirstTest.java
@@ -281,6 +281,10 @@ class PlotAreaCardMeasureFirstTest {
       // No derived measure (plain multi-measure card) → keep the X-dim subtitle lift.
       assertFalse(PlotArea.groupMeasuresAtTier2(
          new String[]{ "Sum(A)", "Avg(B)" }, new HashSet<>(), 2));
+
+      // Single plain measure: guard fires on measurePairs <= 1 → no grouping.
+      assertFalse(PlotArea.groupMeasuresAtTier2(
+         new String[]{ "Sum(A)" }, new HashSet<>(), 1));
    }
 
    private static ChartInfo chartInfo(ChartInfo.TooltipStyle style, int chartType) {

--- a/core/src/test/java/inetsoft/report/composition/region/PlotAreaCardMeasureFirstTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/PlotAreaCardMeasureFirstTest.java
@@ -174,6 +174,115 @@ class PlotAreaCardMeasureFirstTest {
       assertTrue(tip.containsTooltip(xKey));
    }
 
+   @Test
+   void cardEmitsOriginalMeasureBeforeCalcDerived() {
+      // Original measure leads at tier-1, derived Change follows at tier-2.
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+
+      int calcKey = palette.put("Change from previous year of Year(Date): Sum(Quantity Purchased)");
+      int calcVal = palette.put("24");
+      int origKey = palette.put("Sum(Quantity Purchased)");
+      int origVal = palette.put("2,865.00");
+
+      PlotArea.appendMeasurePair(tip, calcKey, calcVal, origKey, origVal, true);
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-1\">Sum(Quantity Purchased)" +
+         ChartToolTip.COLON + "2,865.00"), "original measure leads at tier-1");
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Change from previous year"),
+         "derived Change value follows at tier-2");
+   }
+
+   @Test
+   void defaultOrderKeepsCalcFirst() {
+      // originalFirst=false keeps the legacy calc-then-original order.
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+
+      int calcKey = palette.put("Change");
+      int calcVal = palette.put("24");
+      int origKey = palette.put("Sum");
+      int origVal = palette.put("2865");
+
+      PlotArea.appendMeasurePair(tip, calcKey, calcVal, origKey, origVal, false);
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-1\">Change"),
+         "calc value stays first when originalFirst is false");
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Sum"));
+   }
+
+   @Test
+   void appendMeasurePairWithoutOriginalIsNoop() {
+      // No calc (no ovalue) emits only the single pair, regardless of the flag.
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+
+      int key = palette.put("Sum");
+      int val = palette.put("100");
+
+      PlotArea.appendMeasurePair(tip, key, val, null, null, true);
+
+      assertEquals(2, tip.getTooltipList().size(), "exactly one pair added");
+      assertTrue(tip.getTooltip(palette).contains("<div class=\"tt-tier-1\">Sum"));
+   }
+
+   @Test
+   void derivedMeasureGroupsAtTierTwoAboveDimensions() {
+      // Derived measure present: original tier-1, Change tier-2, dims tier-3.
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+
+      // measure pairs: original (headline) then derived
+      tip.addTooltip(palette.put("Sum(Quantity Purchased)"), palette.put("2,934.00"));
+      tip.addTooltip(palette.put("Change from previous year of Year(Date): Sum(Quantity Purchased)"),
+         palette.put("268"));
+      // dimension pairs
+      tip.addTooltip(palette.put("QuarterOfYear(Date)"), palette.put("2nd"));
+      tip.addTooltip(palette.put("Year(Date)"), palette.put("2019"));
+
+      // 2 measure pairs → group the 1 non-headline measure at tier-2.
+      tip.setGroupedTiers(true);
+      tip.setTier2GroupSize(1);
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-1\">Sum(Quantity Purchased)" +
+         ChartToolTip.COLON + "2,934.00"), "original measure leads at tier-1");
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Change from previous year"),
+         "derived Change value at tier-2");
+      assertTrue(out.contains("<div class=\"tt-tier-3\">QuarterOfYear(Date)" +
+         ChartToolTip.COLON + "2nd"), "dimension drops to tier-3");
+      assertTrue(out.contains("<div class=\"tt-tier-3\">Year(Date)" +
+         ChartToolTip.COLON + "2019"), "dimension drops to tier-3");
+      assertFalse(out.contains("tt-subtitle"), "no X-dim subtitle lift when a derived measure leads");
+   }
+
+   @Test
+   void groupMeasuresAtTier2OnlyWhenDerivedMeasureAndMultiplePairs() {
+      String[] measures = { "Sum(Quantity Purchased)",
+         "Change from previous year of Year(Date): Sum(Quantity Purchased)" };
+      Set<String> derived = new HashSet<>(Collections.singletonList(
+         "Change from previous year of Year(Date): Sum(Quantity Purchased)"));
+
+      // Derived measure present + 2 pairs → group the derived measure at tier-2.
+      assertTrue(PlotArea.groupMeasuresAtTier2(measures, derived, 2));
+
+      // A single measure pair has no non-headline measure to rank → no grouping.
+      assertFalse(PlotArea.groupMeasuresAtTier2(measures, derived, 1));
+
+      // No derived measure (plain multi-measure card) → keep the X-dim subtitle lift.
+      assertFalse(PlotArea.groupMeasuresAtTier2(
+         new String[]{ "Sum(A)", "Avg(B)" }, new HashSet<>(), 2));
+   }
+
    private static ChartInfo chartInfo(ChartInfo.TooltipStyle style, int chartType) {
       ChartInfo info = mock(ChartInfo.class);
       when(info.getTooltipStyle()).thenReturn(style);


### PR DESCRIPTION
…ps when a measure has a calculator applied (Date Comparison, Trend & Comparison, or a user-added calc)

## Summary

Fixes the information hierarchy of card-style chart tooltips when a measure has a calculator applied (Date Comparison, Trend & Comparison, or a user-added calc).

Previously, the derived comparison value (e.g. "Change from previous year of Year(Date): Sum(Quantity Purchased)") took the large tier-1 headline with its long label, while the original measure ("Sum(Quantity Purchased): 2,934.00") and the dimensions were ranked inconsistently — a dimension could even outrank the derived value via the X-dim subtitle lift.

A card is meant to highlight the core value. Now:

- tier-1: the original measure value (the core number)
- tier-2: the derived comparison value(s)
- tier-3: the dimensions that identify the point

## Before / After

Before:

Change from previous year of Year(Date): Sum(Quantity Purchased): 24   (tier-1)
Sum(Quantity Purchased): 2,865.00                                       (lower)

After:

Sum(Quantity Purchased): 2,934.00                                       (tier-1)
Change from previous year of Year(Date): Sum(Quantity Purchased): 268   (tier-2)
QuarterOfYear(Date): 2nd                                                (tier-3)
Year(Date): 2019                                                        (tier-3)

## Changes

`PlotArea.java`:

- `addTooltip` gained an `originalFirst` flag; the new `appendMeasurePair` helper emits the original (no-calc) measure pair before the calc-derived pair when the card promotes measures, so the original value lands on tier-1.
- New `groupMeasuresAtTier2` helper: when a derived calc measure is present and there is more than one measure pair, non-headline measures group at tier-2 (via `setGroupedTiers` / `setTier2GroupSize`) and dimensions drop to tier-3,
rather than lifting the X-dim to the subtitle. Single-measure cards are unchanged.

## Scope and compatibility

- Applies to all calc-derived measures (Date Comparison, Trend & Comparison, and user calcs like % of total), since they share the same calc/original tooltip path.
- Candle/stock, Gantt, scatter, and word-cloud cards are untouched (they have their own layout helpers and do not promote a single headline measure).
- Non-card (default) tooltips keep the legacy calc-then-original ordering.
- No public API, serialized format, or model change. `addTooltip` is private with two callers, both updated; the new helpers are package-private statics.