### PR TITLE
Bug #75249, fix TernServer not a constructor error in script panes after esbuild migration

### DIFF
--- a/web/projects/shared/util/codemirror/default-codemirror.service.ts
+++ b/web/projects/shared/util/codemirror/default-codemirror.service.ts
@@ -41,7 +41,11 @@ import { CodemirrorService, TokenType } from "./codemirror.service";
 })
 export class DefaultCodemirrorService extends CodemirrorService {
    createTernServer(options: object): object {
-      return new CodeMirror.TernServer(options);
+      // esbuild's __toESM() snapshots the CJS exports at import time, so TernServer
+      // (added by the tern side-effect import after the snapshot) is absent from the
+      // namespace wrapper. Access via .default, which is the live CJS exports reference.
+      const CM: any = (CodeMirror as any).default || CodeMirror;
+      return new CM.TernServer(options);
    }
 
    getEcmaScriptDefs(): object[] {


### PR DESCRIPTION
## Summary

- `DefaultCodemirrorService.createTernServer` throws `TypeError: CodeMirror2.TernServer is not a constructor` when opening script panes (VPM trigger, Composer script editor, portal formula editor)
- Root cause: esbuild's `__toESM()` snapshots the CJS exports when `import * as CodeMirror from "codemirror"` is evaluated; the tern addon side-effect import runs after this snapshot so `TernServer` is never added to the namespace wrapper's getter map
- Fix: access `TernServer` through `(CodeMirror as any).default`, which `__toESM` sets as a live reference to the actual CJS module exports

## Test plan

- [ ] Open a VPM in portal, add a condition with a physical view, select a table, click the Trigger tab — script pane should open without errors
- [ ] Open the Composer, open a viewsheet script editor — should open without errors
- [ ] Open the portal formula editor — should open without errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)