### PR TITLE
Bug #75248, provide ExportAssetsService in BackupFileComponent to fix NG0201 after standalone migration

### DIFF
--- a/web/projects/em/src/app/settings/schedule/task-action-pane/backup-file/backup-file.component.ts
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/backup-file/backup-file.component.ts
@@ -67,7 +67,8 @@ export interface BackupPathsSave {
     templateUrl: "./backup-file.component.html",
     styleUrls: ["./backup-file.component.scss"],
     providers: [
-        RepositoryTreeDataSource
+        RepositoryTreeDataSource,
+        ExportAssetsService
     ],
     imports: [MatCard, MatCardHeader, MatCardTitle, MatCheckbox, FormsModule, MatCardContent, ReactiveFormsModule, MatFormField, MatInput, MatError, MatLabel, MatProgressBar, FlatTreeViewComponent, MatMiniFabButton, MatList, MatListItem, MatIcon, AsyncPipe]
 })


### PR DESCRIPTION
## Summary

- `ExportAssetsService` is declared with `@Injectable()` (no `providedIn`), so it must be explicitly registered in a `providers` array
- After the Angular standalone migration, the service was only provided in `REPOSITORY_ROUTES` — not reachable from the Schedule feature's DI scope
- `BackupFileComponent` (rendered when the "Backup" action is selected in the Scheduler) injects this service, causing `NG0201: No provider found for _ExportAssetsService` at runtime
- Fix: add `ExportAssetsService` to `BackupFileComponent`'s own `providers` array — it is stateless, so instantiating it per component is safe

## Test plan

- [ ] Open EM → Settings → Schedule → create or edit a task
- [ ] Click the Actions tab and select Backup action
- [ ] Verify the Backup action UI renders without console errors
- [ ] Verify the asset tree and path fields in the Backup action work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)