### PR TITLE
Bug #75096 - Snap to the bar nearest the cursor in multi-measure bar charts

### DIFF
--- a/web/projects/portal/src/app/composer/dialog/vs/data-input-pane.spec.ts
+++ b/web/projects/portal/src/app/composer/dialog/vs/data-input-pane.spec.ts
@@ -166,7 +166,7 @@ describe("Data Input Pane Test", () => {
    });
 
    //Bug #19833
-   it("should input page number on popup table page", () => new Promise<void>((done) => {
+   it("should input page number on popup table page", async () => {
       dataInputPane = <DataInputPane>fixture.componentInstance;
       dataInputPane.model = createModel();
       dataInputPane.model.rowValue = "1";
@@ -191,24 +191,24 @@ describe("Data Input Pane Test", () => {
       fixture.debugElement.query(By.css("span.edit-icon")).nativeElement.click();
       fixture.detectChanges();
 
-      fixture.whenStable().then(() => {
-         let fixedDropdown = document.getElementsByTagName("fixed-dropdown")[0];
-         let pageInput = fixedDropdown.getElementsByTagName("input")[0];
-         let beforeBtns = fixedDropdown.getElementsByTagName("button");
-         expect(beforeBtns[0].disabled).toBeTruthy();
-         expect(beforeBtns[1].disabled).toBeTruthy();
+      await fixture.whenStable();
+      fixture.detectChanges();
 
-         pageInput.value = "2";
-         fixture.componentInstance.updatePopupTablePage(new KeyboardEvent("keydown", {key: "enter"}), 2);
-         fixture.detectChanges();
-         expect(pageInput.getAttribute("ng-reflect-model")).toBe("2");
-         expect(beforeBtns[0].disabled).toBeFalsy();
-         expect(beforeBtns[1].disabled).toBeFalsy();
-         let id = fixedDropdown.getElementsByTagName("td")[4].textContent;
-         expect(id.trim()).toBe("11");
-         done();
-      });
-   }));
+      let fixedDropdown = document.getElementsByTagName("fixed-dropdown")[0];
+      let pageInput = fixedDropdown.getElementsByTagName("input")[0];
+      let beforeBtns = fixedDropdown.getElementsByTagName("button");
+      expect(beforeBtns[0].disabled).toBeTruthy();
+      expect(beforeBtns[1].disabled).toBeTruthy();
+
+      pageInput.value = "2";
+      fixture.componentInstance.updatePopupTablePage(new KeyboardEvent("keydown", {key: "enter"}), 2);
+      fixture.detectChanges();
+      expect(pageInput.getAttribute("ng-reflect-model")).toBe("2");
+      expect(beforeBtns[0].disabled).toBeFalsy();
+      expect(beforeBtns[1].disabled).toBeFalsy();
+      let id = fixedDropdown.getElementsByTagName("td")[4].textContent;
+      expect(id.trim()).toBe("11");
+   });
 
    it("row should update when change to expression", () => {
       let model = createModel();

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.spec.ts
@@ -435,6 +435,43 @@ describe("ChartPlotArea Integration Tests", () => {
       expect((component as any).snapXTicksFor).toBe(component.chartObject);
    });
 
+   it("snaps to the region nearest the cursor within an x-bucket", () => {
+      const fixture = TestBed.createComponent(TestApp);
+      const debugEl = fixture.debugElement.query(By.css("chart-plot-area"));
+      const component: ChartPlotArea = debugEl.componentInstance;
+      jest.spyOn(component, "getSrc").mockImplementation(() => "");
+      fixture.detectChanges();
+
+      // region 9 centerX ~53.5 (x 44-63), region 0 centerX ~348.5 (x 339-358).
+      const left = (component as any).findPrimarySnapRegion([0, 9], 55, 200);
+      expect(left.region.index).toBe(9);
+
+      const right = (component as any).findPrimarySnapRegion([0, 9], 345, 200);
+      expect(right.region.index).toBe(0);
+   });
+
+   it("skips wide area polygons when snapping to the nearest point", () => {
+      const fixture = TestBed.createComponent(TestApp);
+      const debugEl = fixture.debugElement.query(By.css("chart-plot-area"));
+      const component: ChartPlotArea = debugEl.componentInstance;
+      jest.spyOn(component, "getSrc").mockImplementation(() => "");
+      fixture.detectChanges();
+
+      const regions: any[] = component.chartObject.regions;
+      const narrowIdx = regions.length;
+      regions.push({ segTypes: [[8]], pts: [[[[100, 0], [10, 50]]]], centroid: null,
+         index: narrowIdx, tipIdx: 20, rowIdx: 50, valIdx: -1, hyperlinks: [],
+         noselect: false, grouped: false, boundaryIdx: -1 });
+      const wideIdx = regions.length;
+      regions.push({ segTypes: [[0, 1]], pts: [[[[0, 0], [400, 0]]]], centroid: null,
+         index: wideIdx, tipIdx: 21, rowIdx: 50, valIdx: -1, hyperlinks: [],
+         noselect: false, grouped: false, boundaryIdx: -1 });
+
+      // Cursor at 200 is the wide polygon's center but should snap to the point.
+      const primary = (component as any).findPrimarySnapRegion([narrowIdx, wideIdx], 200, 25);
+      expect(primary.region.index).toBe(narrowIdx);
+   });
+
    it.skip("should be able to select regions", () => {
       let fixture = TestBed.createComponent(TestApp);
       let testComponent = fixture.componentInstance;

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.spec.ts
@@ -439,9 +439,10 @@ describe("ChartPlotArea Integration Tests", () => {
       const fixture = TestBed.createComponent(TestApp);
       const debugEl = fixture.debugElement.query(By.css("chart-plot-area"));
       const component: ChartPlotArea = debugEl.componentInstance;
-      jest.spyOn(component, "getSrc").mockImplementation(() => "");
+      vi.spyOn(component, "getSrc").mockImplementation(() => "");
       fixture.detectChanges();
 
+      // Pass both indices directly to exercise X-distance selection in isolation.
       // region 9 centerX ~53.5 (x 44-63), region 0 centerX ~348.5 (x 339-358).
       const left = (component as any).findPrimarySnapRegion([0, 9], 55, 200);
       expect(left.region.index).toBe(9);
@@ -454,7 +455,7 @@ describe("ChartPlotArea Integration Tests", () => {
       const fixture = TestBed.createComponent(TestApp);
       const debugEl = fixture.debugElement.query(By.css("chart-plot-area"));
       const component: ChartPlotArea = debugEl.componentInstance;
-      jest.spyOn(component, "getSrc").mockImplementation(() => "");
+      vi.spyOn(component, "getSrc").mockImplementation(() => "");
       fixture.detectChanges();
 
       const regions: any[] = component.chartObject.regions;

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
@@ -195,6 +195,8 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
    }
 
    private emitTooltip(regions: ChartRegion[], primary?: ChartRegion): void {
+      // A snap-selected primary (nearest the cursor) wins over the default
+      // lowest-index ordering used for plain hover.
       if(primary && primary.tipIdx >= 0) {
          this.showTooltip.emit({ tipIndex: primary.tipIdx, region: primary });
          return;
@@ -355,9 +357,13 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
          }
 
          const bounds = this.regionBoundsX(region);
-         const width = bounds ? bounds.width : 0;
-         candidates.push({ region, centerX: bounds ? bounds.centerX : eventX, width });
-         minWidth = Math.min(minWidth, width);
+
+         if(!bounds) {
+            continue;
+         }
+
+         candidates.push({ region, centerX: bounds.centerX, width: bounds.width });
+         minWidth = Math.min(minWidth, bounds.width);
       }
 
       let best: { region: ChartRegion, centerX: number } = null;

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
@@ -194,7 +194,12 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
       this.sendFlyover.emit(flyoverPayload);
    }
 
-   private emitTooltip(regions: ChartRegion[]): void {
+   private emitTooltip(regions: ChartRegion[], primary?: ChartRegion): void {
+      if(primary && primary.tipIdx >= 0) {
+         this.showTooltip.emit({ tipIndex: primary.tipIdx, region: primary });
+         return;
+      }
+
       const tipInfo = regions
          .filter(region => !!region)
          .sort((a, b) => a.index - b.index)
@@ -334,6 +339,52 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
       return nearest;
    }
 
+   // Within a snapped x-bucket, pick the region nearest the cursor so the header,
+   // guideline and highlight track the hovered bar/series rather than the first.
+   private findPrimarySnapRegion(regionIndices: number[], eventX: number,
+                                 eventY: number): { region: ChartRegion, centerX: number }
+   {
+      const candidates: { region: ChartRegion, centerX: number, width: number }[] = [];
+      let minWidth = Infinity;
+
+      for(const i of regionIndices) {
+         const region = this.chartObject.regions[i];
+
+         if(!region || region.tipIdx < 0) {
+            continue;
+         }
+
+         const bounds = this.regionBoundsX(region);
+         const width = bounds ? bounds.width : 0;
+         candidates.push({ region, centerX: bounds ? bounds.centerX : eventX, width });
+         minWidth = Math.min(minWidth, width);
+      }
+
+      let best: { region: ChartRegion, centerX: number } = null;
+      let bestDx = Infinity;
+      let bestDy = Infinity;
+
+      for(const c of candidates) {
+         // Skip wide area polygons whose center is the series midpoint, not a
+         // data point; only the narrowest tier (bars/markers) locates the cursor.
+         if(c.width > minWidth + 1) {
+            continue;
+         }
+
+         const dx = Math.abs(c.centerX - eventX);
+         // Tie-break near-equal X (overlapping line/area points) by vertical distance.
+         const dy = c.region.centroid ? Math.abs(c.region.centroid.y - eventY) : 0;
+
+         if(dx < bestDx - 1 || (Math.abs(dx - bestDx) <= 1 && dy < bestDy)) {
+            best = { region: c.region, centerX: c.centerX };
+            bestDx = dx;
+            bestDy = dy;
+         }
+      }
+
+      return best;
+   }
+
    private drawSnapGuideline(pixelX: number): void {
       if(!this.referenceLineCanvas) {
          return;
@@ -408,9 +459,11 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
          let eventX = mevent.offsetX + this.scrollLeft;
          let eventY = mevent.offsetY + this.scrollTop;
          let regions: ChartRegion[] = this.getTreeRegions(eventX, eventY);
+         let snapPrimary: ChartRegion = null;
 
-         // Snap: replace hit-tested regions with the nearest X tick's set
-         // and draw a dashed vertical line there.
+         // Snap: replace hit-tested regions with the nearest X tick's set, then
+         // pick the region nearest the cursor as the header and draw a dashed
+         // vertical line at it.
          if(this.model && this.model.snapTooltip) {
             if(this.snapXTicksFor !== this.chartObject) {
                this.rebuildSnapIndex();
@@ -420,7 +473,9 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
 
             if(snap) {
                regions = snap.regionIndices.map(i => this.chartObject.regions[i]);
-               this.drawSnapGuideline(snap.pixelX);
+               const primary = this.findPrimarySnapRegion(snap.regionIndices, eventX, eventY);
+               snapPrimary = primary ? primary.region : null;
+               this.drawSnapGuideline(primary ? Math.round(primary.centerX) : snap.pixelX);
             }
             else {
                this.clearSnapGuideline();
@@ -442,7 +497,7 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
             }, 100, []);
          }
          else {
-            this.emitTooltip(regions);
+            this.emitTooltip(regions, snapPrimary);
          }
 
          if(this.viewerMode || this.previewMode) {
@@ -491,8 +546,12 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
 
          if(this.inlineSvg) {
             // Find the hovered VO region (bar, point, etc.) by row/col presence.
-            const voRegion = regions?.find(r => r && r.rowIdx >= 0 &&
-               ChartTool.colIdx(this.model, r) >= 0);
+            // Snap supplies the nearest bar/series so the highlight tracks it.
+            const voRegion = (snapPrimary && snapPrimary.rowIdx >= 0 &&
+               ChartTool.colIdx(this.model, snapPrimary) >= 0)
+               ? snapPrimary
+               : regions?.find(r => r && r.rowIdx >= 0 &&
+                  ChartTool.colIdx(this.model, r) >= 0);
             const rowIdx = voRegion != null ? voRegion.rowIdx : null;
             const colIdx = voRegion != null ? ChartTool.colIdx(this.model, voRegion) : null;
             this.inlineSvgTiles?.forEach(d => d.highlightElement(rowIdx, colIdx));


### PR DESCRIPTION
Problem

On a non-stacked bar chart with multiple Y measures (e.g. Sum(customer_id), Sum(orderno), Sum(product_id) grouped by state), enabling the Snap tooltip always snapped to the third/last bar at every x-axis point, and the combined tooltip always showed the last measure as the header — no matter which bar the cursor was over.

Root cause

Snap auto-enables combined tooltips. The server builds a separate combined card for every bar, each headed by its own measure. Visual objects are iterated in reverse order, so the last measure's region receives the smallest region index. The frontend snap path replaced hit-tested regions with the entire rowIdx bucket (all bars at that x) and then emitted the smallest-index region as the
header — always the last measure. Nothing considered where the cursor was within the group, so it could not target an individual bar.

Fix

Frontend only, in chart-plot-area.component.ts. The nearest x-group selection and the server-built per-bar combined cards are unchanged. Within the snapped bucket, a new helper picks the region nearest the cursor and routes it to the tooltip header, the dashed guideline anchor, and the inline-SVG highlight. Selection is limited to the narrowest-width tier in the bucket so wide area
polygons (whose bounding-box center is the series midpoint) are excluded; for bars every bar qualifies and X-distance selects the right one. Near-equal X ties break by vertical distance so overlapping line/area series points pick the nearest one.

Snap remains available for these charts. The flyover and data-tip paths still receive the full bucket; only the plain tooltip header, guideline, and highlight become bar-specific