### PR TITLE
Bug #75211, fix table row highlight foreground color lost on export

### DIFF
--- a/core/src/main/java/inetsoft/report/internal/table/TableHighlightAttr.java
+++ b/core/src/main/java/inetsoft/report/internal/table/TableHighlightAttr.java
@@ -1031,7 +1031,20 @@ public class TableHighlightAttr extends TableAttr {
        * Setter of asset query sandbox.
        */
       public void setQuerySandbox(Object box) {
-         this.querySandbox = box;
+         if(this.querySandbox != box) {
+            this.querySandbox = box;
+
+            // Clear highlight caches since condition evaluation (e.g. parameter expressions)
+            // may produce different results with the new sandbox. Without clearing, stale
+            // null values cached before the sandbox was available would suppress re-evaluation.
+            if(rowcache != null) {
+               rowcache.clear();
+            }
+
+            if(cellcache != null) {
+               cellcache.clear();
+            }
+         }
       }
 
       @Override


### PR DESCRIPTION
When exporting a viewsheet to PDF/PNG, row highlight foreground colors were not applied to table cells. The HighlightTableLens rowcache was populated with null values before the querySandbox was set (during table lens initialization), causing parameter-dependent conditions to evaluate as unmatched. The subsequent setQuerySandbox call in getRegionTableLens arrived too late - the cached nulls suppressed re-evaluation on every later getForeground call.

Fix: clear the rowcache and cellcache in setQuerySandbox whenever the sandbox value changes, ensuring stale pre-sandbox evaluations are discarded and conditions are correctly re-evaluated with the sandbox.