### PR TITLE
Add vitest/globals to root tsconfig for IntelliJ IDE support

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -29,7 +29,8 @@
     },
     "types": [
       "geojson",
-      "node"
+      "node",
+      "vitest/globals"
     ]
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
## Summary

- Adds `vitest/globals` to the `types` array in the root `web/tsconfig.json`
- Fixes IntelliJ IDEA being unable to resolve `describe`, `it`, `vi`, `expect`, and other Vitest test globals in spec files after the Jest → Vitest migration

## Root cause

IntelliJ's TypeScript language service resolves types from the root `tsconfig.json`, which has no `include` restriction and thus implicitly covers all `.ts` files in the tree. The individual `tsconfig.spec.json` files already had `vitest/globals` in their `types` arrays, but IntelliJ matched spec files to the root config first.

## Production build safety

The production build is not affected. Both `projects/portal/tsconfig.app.json` and `projects/em/tsconfig.app.json` explicitly override the `types` array without `vitest/globals`. TypeScript does not merge `types` arrays across `extends` — the child value fully replaces the parent's — so Vitest globals are never in scope during `ng build`.

## Test plan

- [ ] Open a `*.spec.ts` file in IntelliJ; verify `describe`, `it`, `vi`, and `expect` are resolved without errors
- [ ] Run `ng build` (or `./mvnw clean install -DskipTests -pl community/web`) and confirm no new type errors
- [ ] Run `npm run test` and `npm run test:em` and confirm all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)