### PR TITLE
Bug #75243, schedule folder tree not shown after toggling task list view

### DIFF
--- a/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.html
+++ b/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.html
@@ -43,9 +43,9 @@
   </mat-card-header>
   <mat-card-content class="list-card-content">
     <mat-drawer-container class="users-container" autosize>
-      @if (!showTasksAsList) {
-        <mat-drawer class="users-mat-drawer" mode="side" disableClose [opened]="true"
-          [class.repository-tree]="true">
+      <mat-drawer class="users-mat-drawer" mode="side" disableClose [opened]="!showTasksAsList"
+        [class.repository-tree]="true">
+        @if (!showTasksAsList) {
           <div class="mat-drawer-inner-container">
             <em-schedule-folder-tree #folderTree
               [treeSource]="fTreeSource"
@@ -56,8 +56,8 @@
               (errorResponse)="handleError($event)" (tasksMoved)="loadTasks()">
             </em-schedule-folder-tree>
           </div>
-        </mat-drawer>
-      }
+        }
+      </mat-drawer>
       <mat-drawer-content [class.repository-editor]="!showTasksAsList">
         <table mat-table multiTemplateDataRows matSort class="task-list-table" [dataSource]="dataSource">
 


### PR DESCRIPTION
## Summary

- After the Angular 20→21 upgrade, clicking "Toggle Task List View" on the EM schedule tasks page (`em/settings/schedule/tasks`) caused the folder tree to not appear
- Root cause: `<mat-drawer>` was wrapped in `@if (!showTasksAsList)`, so `MatDrawerContainer` initialized with an empty drawer list when the page loaded in list-view mode. When the toggle later added the drawer dynamically, the `opened` state raced with `_transitionsEnabled`, leaving `mat-drawer-opened` never applied — which hid the `.mat-drawer-inner-container` via the CSS rule `.mat-drawer:not(.mat-drawer-opened) .mat-drawer-inner-container { display: none }`
- Fix: keep `<mat-drawer>` always in the DOM (consistent with every other EM drawer component) using `[opened]="!showTasksAsList"`, and move the `@if` inside the drawer to only conditionally render the folder-tree content

## Test plan

- [ ] Open `em/settings/schedule/tasks`
- [ ] Verify the page loads in folder-tree view with the tree visible on the left
- [ ] Click the "Toggle Task List View" (hamburger) icon — verify the tree panel disappears and a flat task list is shown
- [ ] Click the icon again — verify the folder tree reappears and selecting a folder loads tasks for that folder
- [ ] Verify the same flows work when the server-side preference is saved as list-view (i.e., refresh the page while in list mode, then toggle back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)