### PR TITLE
Fix ObjectUnsubscribedError in theme editor components

### DIFF
--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-css-view/theme-css-view.component.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-css-view/theme-css-view.component.ts
@@ -349,7 +349,7 @@ export class ThemeCssViewComponent implements OnInit, OnDestroy, OnChanges {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    ngOnChanges(changes: SimpleChanges): void {

--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-properties-view/theme-properties-view.component.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-properties-view/theme-properties-view.component.ts
@@ -128,7 +128,7 @@ export class ThemePropertiesViewComponent implements OnInit, OnDestroy {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    get defaultThemeGlobalLable(): string {


### PR DESCRIPTION
## Summary

- Replaces `destroy$.unsubscribe()` with `destroy$.complete()` in `ngOnDestroy` of `ThemeCssViewComponent` and `ThemePropertiesViewComponent`

## Root cause

Both components set up their form subscriptions via `setTimeout(..., 200)` in `ngOnInit`, but called `destroy$.unsubscribe()` in `ngOnDestroy`. In RxJS 7, `Subject.unsubscribe()` sets `closed = true`, which causes any subsequent `subscribe()` call (including from `takeUntil`) to throw `ObjectUnsubscribedError`.

In fast test environments like Vitest, the full test lifecycle (create → assert → destroy) can complete in under 200 ms. This means `ngOnDestroy` closes the subject before the `setTimeout` fires, so when `takeUntil(this.destroy$)` later tries to subscribe to `destroy$`, it throws.

`Subject.complete()` sets `isStopped = true` but leaves `closed = false`, so new subscriptions are still permitted — they just immediately receive a completion notification, which is the correct behavior.

## Test plan

- [ ] Run `npm run test:em` and confirm no `ObjectUnsubscribedError` appears in the output
- [ ] Confirm the theme editor still works as expected (properties and CSS changes emit correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)