### PR TITLE
Bug #75242, fix schedule Options tab content not showing after Angular 21 upgrade

### DIFF
--- a/web/projects/em/src/app/settings/schedule/schedule.routes.ts
+++ b/web/projects/em/src/app/settings/schedule/schedule.routes.ts
@@ -16,11 +16,12 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { Routes } from "@angular/router";
-import { DateAdapter, ErrorStateMatcher } from "@angular/material/core";
+import { DateAdapter, ErrorStateMatcher, MAT_DATE_FORMATS, MAT_NATIVE_DATE_FORMATS } from "@angular/material/core";
 import { MatPaginatorIntl } from "@angular/material/paginator";
 import { LocalizedMatPaginator } from "../../../../../shared/util/localized-mat-paginator";
 import { authorizationGuard } from "../../authorization/authorization-guard.service";
 import { CustomNativeDateAdapter } from "../../common/util/datepicker/custom-native-date-adapter.service";
+import { FirstDayOfWeekService } from "../../../../../portal/src/app/common/services/first-day-of-week.service";
 import { EmErrorStateMatcher } from "../../common/util/error/em-error-state-matcher";
 import { MonitoringDataService } from "../../monitoring/monitoring-data.service";
 import { scheduleConfigSaveGuard } from "./schedule-configuration-page/schedule-config-save.guard";
@@ -39,7 +40,9 @@ export const SCHEDULE_ROUTES: Routes = [
       component: ScheduleSettingsPageComponent,
       providers: [
          MonitoringDataService,
+         FirstDayOfWeekService,
          { provide: DateAdapter, useClass: CustomNativeDateAdapter },
+         { provide: MAT_DATE_FORMATS, useValue: MAT_NATIVE_DATE_FORMATS },
          { provide: MatPaginatorIntl, useClass: LocalizedMatPaginator },
          { provide: ErrorStateMatcher, useClass: EmErrorStateMatcher }
       ],

--- a/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.html
+++ b/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.html
@@ -22,7 +22,7 @@
       _#(Enabled)
     </mat-slide-toggle>
   </div>
-  @if (model?.enabled) {
+  @if (showOptions) {
     @if (!internal) {
       <div class="flex-row margin-bottom">
         <mat-checkbox formControlName="deleteIfNotScheduledToRun"

--- a/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.ts
+++ b/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.ts
@@ -145,7 +145,7 @@ export class TaskOptionsPane {
    {
       this.optionsForm = fb.group(
          {
-            taskEnabled: [true],
+            taskEnabled: [false],
             deleteIfNotScheduledToRun: [false],
             startDate: [new Date()],
             endDate: [new Date()],
@@ -201,6 +201,10 @@ export class TaskOptionsPane {
                }
             })
          );
+   }
+
+   get showOptions(): boolean {
+      return !!this.optionsForm.get('taskEnabled').value;
    }
 
    fireModelChanged(): void {

--- a/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.ts
+++ b/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.ts
@@ -204,7 +204,7 @@ export class TaskOptionsPane {
    }
 
    get showOptions(): boolean {
-      return !!this.optionsForm.get('taskEnabled').value;
+      return !!this.optionsForm.get("taskEnabled").value;
    }
 
    fireModelChanged(): void {


### PR DESCRIPTION
## Summary

- **Angular Material 21 requires `MAT_DATE_FORMATS`**: `MatDatepickerInput/Toggle/Picker` now inject `MAT_DATE_FORMATS` as a required token (previously optional). The schedule route only provided `DateAdapter` via `CustomNativeDateAdapter`, causing `NG0201` to destroy the datepicker view on every change-detection cycle. Added `MAT_NATIVE_DATE_FORMATS` and `FirstDayOfWeekService` (a dependency of `CustomNativeDateAdapter`) to the schedule route providers.
- **`@if` condition used `model?.enabled` instead of form control**: The `@if (model?.enabled)` guard read from `this._model` which is `null` until the model setter fires. Angular Material 21 renders tab content lazily via portals, so the component is created before the model input is propagated, leaving `_model` null while the toggle appeared ON from the form's initial value. Changed to `@if (showOptions)` backed by the form control value, which is always in sync with the toggle.

## Test plan

- [ ] Open the EM Schedule page and edit an existing enabled task
- [ ] Click the Options tab — verify Delete/Start From/Stop On/Description/Locale/Owner/Execute As fields are all visible
- [ ] Toggle "Enabled" off — verify the fields below hide
- [ ] Toggle "Enabled" back on — verify the fields reappear
- [ ] Create a new task and verify the Options tab behaves the same way
- [ ] Verify no `NG0201` errors appear in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)