### PR TITLE
Bug #75240, provide FormulaEditorService in root injector to fix NG0201 after standalone migration

### DIFF
--- a/web/projects/em/src/app/widget/formula-editor.service.ts
+++ b/web/projects/em/src/app/widget/formula-editor.service.ts
@@ -21,7 +21,9 @@ import { Observable, throwError } from "rxjs";
 import { TreeNodeModel } from "../../../../portal/src/app/widget/tree/tree-node-model";
 import { catchError } from "rxjs/operators";
 
-@Injectable()
+@Injectable({
+   providedIn: "root"
+})
 export class FormulaEditorService {
    constructor(private http: HttpClient) {
    }


### PR DESCRIPTION
## Summary

- `FormulaEditorService` in the EM app was decorated with `@Injectable()` (no `providedIn`) and was previously provided via `WidgetModule.providers`
- The NgModule pruning step of the standalone migration deleted `WidgetModule`, leaving `FormulaEditorService` orphaned with no provider
- When `DynamicComboBoxComponent` opens `FormulaEditorDialogComponent` as a standalone dialog via `MatDialog`, Angular cannot find the service in any injector → `NG0201: No provider found for FormulaEditorService`
- Fix: add `providedIn: 'root'` to match the portal's equivalent `FormulaEditorService` and the existing `CodemirrorService` pattern

## Test plan

- [ ] In EM, create a new schedule task
- [ ] Open the Actions tab, click Add on Creation Parameters
- [ ] Click the Value Type icon and select Expression
- [ ] Verify the Formula Editor dialog opens without a console error

🤖 Generated with [Claude Code](https://claude.com/claude-code)