### PR TITLE
Bug #75239, provide DateAdapter and MAT_DATE_FORMATS in DateTimePickerComponent

### DIFF
--- a/web/projects/em/src/app/common/util/datepicker/date-time-picker.component.ts
+++ b/web/projects/em/src/app/common/util/datepicker/date-time-picker.component.ts
@@ -23,12 +23,20 @@ import { FormsModule } from "@angular/forms";
 import { MatInput } from "@angular/material/input";
 import { MatFormField, MatLabel } from "@angular/material/form-field";
 import { MatCalendar } from "@angular/material/datepicker";
+import { DateAdapter, MAT_DATE_FORMATS, MAT_NATIVE_DATE_FORMATS } from "@angular/material/core";
+import { CustomNativeDateAdapter } from "./custom-native-date-adapter.service";
+import { FirstDayOfWeekService } from "../../../../../../portal/src/app/common/services/first-day-of-week.service";
 
 
 @Component({
     selector: "em-date-time-picker",
     templateUrl: "date-time-picker.component.html",
     styleUrls: ["date-time-picker.component.scss"],
+    providers: [
+        { provide: DateAdapter, useClass: CustomNativeDateAdapter },
+        { provide: MAT_DATE_FORMATS, useValue: MAT_NATIVE_DATE_FORMATS },
+        FirstDayOfWeekService,
+    ],
     imports: [MatCalendar, MatFormField, MatLabel, MatInput, FormsModule]
 })
 export class DateTimePickerComponent implements OnInit {


### PR DESCRIPTION
## Summary

- `DateTimePickerComponent` uses `MatCalendar`, which requires both `DateAdapter` and `MAT_DATE_FORMATS` to be in its injector chain
- These were previously supplied transitively by `DatepickerModule` → `MatDatepickerModule` → `MatNativeDateModule`, but that module was deleted in the standalone migration
- The route-level `DateAdapter` in `schedule.routes.ts` does not reach the component because `MatDialog` uses the application root injector (not the route injector) when no `injector` option is passed to `dialog.open()`
- Fix: add `providers` directly to `DateTimePickerComponent` with `CustomNativeDateAdapter`, `MAT_NATIVE_DATE_FORMATS`, and `FirstDayOfWeekService`, making it self-contained regardless of rendering context

## Test plan

- [ ] In EM, create a new schedule task
- [ ] Go to the Actions tab and click Add on Creation Parameters
- [ ] Select Date type and click the "Select a Date" calendar icon
- [ ] Verify the date picker opens with no console errors
- [ ] Verify the calendar respects the configured first day of week

🤖 Generated with [Claude Code](https://claude.com/claude-code)