### PR TITLE
Bug #75235, provide ExportAssetsService in ExportAssetDialogComponent to fix NG0201 after standalone migration

### DIFF
--- a/web/projects/em/src/app/settings/content/repository/import-export/export-asset-dialog/export-asset-dialog.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/import-export/export-asset-dialog/export-asset-dialog.component.ts
@@ -50,6 +50,7 @@ export interface ExportAssetDialogData {
     templateUrl: "./export-asset-dialog.component.html",
     styleUrls: ["./export-asset-dialog.component.scss"],
     encapsulation: ViewEncapsulation.None,
+    providers: [ExportAssetsService],
     imports: [ModalHeaderComponent, MatDialogContent, FormsModule, ReactiveFormsModule, MatFormField, MatLabel, MatInput, MatError, MatCheckbox, SelectedAssetListComponent, MatButton, RequiredAssetListComponent, MatProgressBar]
 })
 export class ExportAssetDialogComponent implements OnInit {


### PR DESCRIPTION
## Summary
- `ExportAssetDialogComponent` is a standalone dialog opened via `MatDialog.open()`, which instantiates it outside the route's injector hierarchy
- `ExportAssetsService` was only provided at the route level (in `REPOSITORY_ROUTES`), so the dialog's injector could not find it after the standalone migration, causing `NG0201`
- Added `providers: [ExportAssetsService]` to the `ExportAssetDialogComponent` decorator, giving the dialog its own instance of the service — the same pattern used to fix the identical issue in `BackupFileComponent` (#75248)

## Test plan
- [ ] Open EM → Settings → Content → Repository
- [ ] Select a viewsheet (e.g. Examples/Census)
- [ ] Click Actions → Export Asset
- [ ] Verify the export dialog opens without a console error
- [ ] Complete an export to confirm end-to-end functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)