### PR TITLE
Bug #75233, provide SecurityTreeService at root to fix NG0201 in add-permission dialog

### DIFF
--- a/web/projects/em/src/app/settings/security/users/security-tree.service.ts
+++ b/web/projects/em/src/app/settings/security/users/security-tree.service.ts
@@ -19,7 +19,7 @@ import { Injectable } from "@angular/core";
 import { SecurityTreeNode } from "../security-tree-view/security-tree-node";
 import { SecurityTreeNodeModel } from "./users-settings-view/security-tree-node-model";
 
-@Injectable()
+@Injectable({ providedIn: "root" })
 export class SecurityTreeService {
    createSecurityTreeNode(node: SecurityTreeNodeModel): SecurityTreeNode {
       let children = null;

--- a/web/projects/em/src/app/settings/security/users/users-settings.routes.ts
+++ b/web/projects/em/src/app/settings/security/users/users-settings.routes.ts
@@ -17,7 +17,6 @@
  */
 import { Routes } from "@angular/router";
 import { ErrorHandlerService } from "../../../common/util/error/error-handler.service";
-import { SecurityTreeService } from "./security-tree.service";
 import { UsersSettingsPageComponent } from "./users-settings-page/users-settings-page.component";
 import { usersSettingsSaveGuard } from "./users-settings-page/users-settings-save.guard";
 
@@ -26,6 +25,6 @@ export const USERS_SETTINGS_ROUTES: Routes = [
       path: "",
       component: UsersSettingsPageComponent,
       canDeactivate: [usersSettingsSaveGuard],
-      providers: [SecurityTreeService, ErrorHandlerService]
+      providers: [ErrorHandlerService]
    }
 ];


### PR DESCRIPTION
## Summary

- `SecurityTreeService` was decorated with `@Injectable()` (no `providedIn`) and only registered in the `UsersSettingsPageComponent` route-level `providers` array after the standalone migration
- When `SecurityTreeDialogComponent` is opened via `MatDialog.open()`, the dialog's overlay injector cannot see route-scoped providers, causing `NG0201: No provider found for SecurityTreeService`
- Fixed by changing to `@Injectable({ providedIn: "root" })` — safe since the service is fully stateless (pure utility method only)
- Removed the now-redundant route-level registration from `users-settings.routes.ts`

## Test plan

- [ ] Open EM → Settings → Security → Actions
- [ ] Select a node (e.g. Cross Join) and uncheck "Deny access to all users"
- [ ] Click "Add" — the add-permission dialog should open without error
- [ ] Verify the Users/Groups/Roles security tree loads correctly in the dialog
- [ ] Verify Users Settings page (Settings → Security → Users) still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)