### PR TITLE
Fix ObjectUnsubscribedError in remaining em components

### DIFF
--- a/web/projects/em/src/app/auditing/auditing-sidenav/auditing-sidenav.component.ts
+++ b/web/projects/em/src/app/auditing/auditing-sidenav/auditing-sidenav.component.ts
@@ -99,7 +99,7 @@ export class AuditingSidenavComponent implements OnInit, OnDestroy {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    isScreenSmall(): boolean {

--- a/web/projects/em/src/app/common/util/scroll-nav/navigation-scrollable/navigation-scrollable.component.ts
+++ b/web/projects/em/src/app/common/util/scroll-nav/navigation-scrollable/navigation-scrollable.component.ts
@@ -56,7 +56,7 @@ export class NavigationScrollableComponent implements OnInit, OnDestroy {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    private onScrolled(): void {

--- a/web/projects/em/src/app/common/util/table/expandable-row-table/expandable-row-table.component.ts
+++ b/web/projects/em/src/app/common/util/table/expandable-row-table/expandable-row-table.component.ts
@@ -136,7 +136,7 @@ export class ExpandableRowTableComponent<T extends TableModel> extends RegularTa
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    get showExpandTable(): boolean {

--- a/web/projects/em/src/app/manage-favorites/manage-favorites.component.ts
+++ b/web/projects/em/src/app/manage-favorites/manage-favorites.component.ts
@@ -66,7 +66,7 @@ export class ManageFavoritesComponent implements OnInit, OnDestroy {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    removeFavorite(favorite: Favorite): void {

--- a/web/projects/em/src/app/monitoring/log/log-monitoring-page/log-monitoring-page.component.ts
+++ b/web/projects/em/src/app/monitoring/log/log-monitoring-page/log-monitoring-page.component.ts
@@ -118,7 +118,7 @@ export class LogMonitoringPageComponent implements OnInit, OnDestroy {
       }
 
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    updateSubscription() {

--- a/web/projects/em/src/app/monitoring/monitoring-sidenav/monitoring-sidenav.component.ts
+++ b/web/projects/em/src/app/monitoring/monitoring-sidenav/monitoring-sidenav.component.ts
@@ -98,7 +98,7 @@ export class MonitoringSidenavComponent implements OnInit, OnDestroy {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    isScreenSmall(): boolean {

--- a/web/projects/em/src/app/navbar/navbar.component.ts
+++ b/web/projects/em/src/app/navbar/navbar.component.ts
@@ -205,7 +205,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    onScrollUpDownStart(event: AnimationEvent): void {

--- a/web/projects/em/src/app/navbar/organization-dropdown.service.ts
+++ b/web/projects/em/src/app/navbar/organization-dropdown.service.ts
@@ -140,7 +140,7 @@ export class OrganizationDropdownService implements OnDestroy  {
 
    ngOnDestroy(): void {
       if(!!this.refreshSubject) {
-         this.refreshSubject.unsubscribe();
+         this.refreshSubject.complete();
          this.refreshSubject = null;
       }
 

--- a/web/projects/em/src/app/search/search-results-view/search-results-view.component.ts
+++ b/web/projects/em/src/app/search/search-results-view/search-results-view.component.ts
@@ -62,6 +62,6 @@ export class SearchResultsViewComponent implements OnInit, OnDestroy {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 }

--- a/web/projects/em/src/app/settings/content/materialized-views/mv-management-view/mv-change.service.ts
+++ b/web/projects/em/src/app/settings/content/materialized-views/mv-management-view/mv-change.service.ts
@@ -31,7 +31,7 @@ export class MVChangeService implements OnDestroy {
   }
 
    ngOnDestroy() {
-      this._changed.unsubscribe();
+      this._changed.complete();
       this.disconnectSocket();
    }
 

--- a/web/projects/em/src/app/settings/content/materialized-views/mv-management-view/mv-management-view.component.ts
+++ b/web/projects/em/src/app/settings/content/materialized-views/mv-management-view/mv-management-view.component.ts
@@ -166,7 +166,7 @@ export class MvManagementViewComponent implements OnInit, OnDestroy {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    selectionChanged(selection: SelectionModel<TableModel>): void {

--- a/web/projects/em/src/app/settings/content/repository/analyze-mv-page/analyze-mv-page.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/analyze-mv-page/analyze-mv-page.component.ts
@@ -227,7 +227,7 @@ export class AnalyzeMvPageComponent implements OnInit, OnDestroy {
 
    ngOnDestroy() {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    analyzeMV() {

--- a/web/projects/em/src/app/settings/content/repository/content-repository-page/content-repository-page.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/content-repository-page/content-repository-page.component.ts
@@ -171,7 +171,7 @@ export class ContentRepositoryPageComponent implements OnInit, OnDestroy {
 
    ngOnDestroy() {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
       this.editorModel.unsubscribe();
       this.service.clearSelectedNodes();
    }

--- a/web/projects/em/src/app/settings/content/repository/content-repository-page/content-repository-page.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/content-repository-page/content-repository-page.component.ts
@@ -172,7 +172,7 @@ export class ContentRepositoryPageComponent implements OnInit, OnDestroy {
    ngOnDestroy() {
       this.destroy$.next();
       this.destroy$.complete();
-      this.editorModel.unsubscribe();
+      this.editorModel.complete();
       this.service.clearSelectedNodes();
    }
 

--- a/web/projects/em/src/app/settings/content/repository/dashboard/repository-dashboard-settings-view/repository-dashboard-settings-view.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/dashboard/repository-dashboard-settings-view/repository-dashboard-settings-view.component.ts
@@ -132,7 +132,7 @@ export class RepositoryDashboardSettingsViewComponent implements OnChanges, OnIn
 
    ngOnDestroy() {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    ngAfterContentChecked() {

--- a/web/projects/em/src/app/settings/content/repository/repository-data-source-folder-settings-view/repository-data-source-folder-settings-view.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/repository-data-source-folder-settings-view/repository-data-source-folder-settings-view.component.ts
@@ -95,7 +95,7 @@ export class RepositoryDataSourceFolderSettingsViewComponent implements OnInit, 
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    ngOnChanges(changes: SimpleChanges): void {

--- a/web/projects/em/src/app/settings/content/repository/repository-folder-settings-view/repository-folder-settings-view.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/repository-folder-settings-view/repository-folder-settings-view.component.ts
@@ -79,7 +79,7 @@ export class RepositoryFolderSettingsViewComponent implements OnChanges, OnDestr
 
    ngOnDestroy() {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    init(): void {

--- a/web/projects/em/src/app/settings/content/repository/repository-tree-data-source.ts
+++ b/web/projects/em/src/app/settings/content/repository/repository-tree-data-source.ts
@@ -140,9 +140,9 @@ export class RepositoryTreeDataSource
    }
 
    ngOnDestroy() {
-      this._data.unsubscribe();
-      this._loading.unsubscribe();
-      this._changed.unsubscribe();
+      this._data.complete();
+      this._loading.complete();
+      this._changed.complete();
       this.disconnectSocket();
    }
 

--- a/web/projects/em/src/app/settings/content/repository/repository-tree-view/repository-tree-view.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/repository-tree-view/repository-tree-view.component.ts
@@ -142,7 +142,7 @@ export class RepositoryTreeViewComponent implements OnInit, OnDestroy, OnChanges
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    ngOnChanges(changes: SimpleChanges) {

--- a/web/projects/em/src/app/settings/email-picker/email-list-dialog/email-list-dialog.component.ts
+++ b/web/projects/em/src/app/settings/email-picker/email-list-dialog/email-list-dialog.component.ts
@@ -145,7 +145,7 @@ export class EmailListDialogComponent implements OnInit, OnDestroy {
    }
 
    ngOnDestroy() {
-      this.searchTextchanges$.unsubscribe();
+      this.searchTextchanges$.complete();
    }
 
    close() {

--- a/web/projects/em/src/app/settings/general/general-settings-page/general-settings-page.component.ts
+++ b/web/projects/em/src/app/settings/general/general-settings-page/general-settings-page.component.ts
@@ -143,7 +143,7 @@ export class GeneralSettingsPageComponent implements OnInit, OnDestroy {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
       this.subscriptions.unsubscribe();
    }
 

--- a/web/projects/em/src/app/settings/presentation/look-and-feel-settings-view/look-and-feel-settings-view.component.ts
+++ b/web/projects/em/src/app/settings/presentation/look-and-feel-settings-view/look-and-feel-settings-view.component.ts
@@ -182,7 +182,7 @@ export class LookAndFeelSettingsViewComponent implements OnInit, OnDestroy {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    editUserFonts() {

--- a/web/projects/em/src/app/settings/presentation/presentation-settings-view/presentation-settings-view.component.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-settings-view/presentation-settings-view.component.ts
@@ -215,7 +215,7 @@ export class PresentationSettingsViewComponent implements OnInit, OnDestroy {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    onModelChanged(changes: PresentationSettingsChanges) {

--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-css-view/theme-css-view.component.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-css-view/theme-css-view.component.ts
@@ -349,7 +349,7 @@ export class ThemeCssViewComponent implements OnInit, OnDestroy, OnChanges {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    ngOnChanges(changes: SimpleChanges): void {

--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-list-view/theme-list-view.component.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-list-view/theme-list-view.component.ts
@@ -87,7 +87,7 @@ export class ThemeListViewComponent implements OnInit, OnDestroy {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    createTheme(): void {

--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-properties-view/theme-properties-view.component.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-properties-view/theme-properties-view.component.ts
@@ -128,7 +128,7 @@ export class ThemePropertiesViewComponent implements OnInit, OnDestroy {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    get defaultThemeGlobalLable(): string {

--- a/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.ts
+++ b/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.ts
@@ -299,7 +299,7 @@ export class ScheduleTaskListComponent implements OnInit, AfterViewInit, OnDestr
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    loadTasks(refreshTaskAndFolder?: boolean): void {

--- a/web/projects/em/src/app/settings/schedule/task-action-pane/backup-file/backup-file.component.ts
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/backup-file/backup-file.component.ts
@@ -188,6 +188,7 @@ export class BackupFileComponent implements OnDestroy {
    ngOnDestroy() {
       this.selectSubscription.unsubscribe();
       this.destroy$.next();
+      this.destroy$.complete();
    }
 
    public get selectedNodes(): RepositoryFlatNode[] {

--- a/web/projects/em/src/app/settings/security/security-provider/authentication-provider-list-page/authentication-provider-list-page.component.ts
+++ b/web/projects/em/src/app/settings/security/security-provider/authentication-provider-list-page/authentication-provider-list-page.component.ts
@@ -82,7 +82,7 @@ export class AuthenticationProviderViewComponent implements OnInit, OnDestroy {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    showProviderDetails(extras?: NavigationExtras) {

--- a/web/projects/em/src/app/settings/security/security-provider/authorization-provider-list-page/authorization-provider-list-page.component.ts
+++ b/web/projects/em/src/app/settings/security/security-provider/authorization-provider-list-page/authorization-provider-list-page.component.ts
@@ -77,7 +77,7 @@ export class AuthorizationProviderListPageComponent implements OnInit, OnDestroy
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    showProviderDetails(extras?: NavigationExtras) {

--- a/web/projects/em/src/app/settings/security/security-settings-page/security-settings-page.component.ts
+++ b/web/projects/em/src/app/settings/security/security-settings-page/security-settings-page.component.ts
@@ -117,7 +117,7 @@ export class SecuritySettingsPageComponent implements OnInit, OnDestroy {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    toggleSecurityEnabled(toggleChange: MatSlideToggleChange) {

--- a/web/projects/em/src/app/settings/security/sso/openid-settings-form/openid-settings-form.component.ts
+++ b/web/projects/em/src/app/settings/security/sso/openid-settings-form/openid-settings-form.component.ts
@@ -149,7 +149,7 @@ export class OpenidSettingsFormComponent implements OnDestroy {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    loadDiscovery(): void {

--- a/web/projects/em/src/app/settings/settings-sidenav/settings-sidenav.component.ts
+++ b/web/projects/em/src/app/settings/settings-sidenav/settings-sidenav.component.ts
@@ -94,7 +94,7 @@ export class SettingsSidenavComponent implements OnInit, OnDestroy {
 
    ngOnDestroy(): void {
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
 
       if(this.loadingSub) {
          this.loadingSub.unsubscribe();

--- a/web/projects/em/src/app/top-scroll/top-scroll-support.ts
+++ b/web/projects/em/src/app/top-scroll/top-scroll-support.ts
@@ -47,7 +47,7 @@ export class TopScrollSupport implements OnDestroy {
    ngOnDestroy(): void {
       this.detach();
       this.destroy$.next();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    attach(element: any): void {

--- a/web/projects/em/src/app/top-scroll/top-scroll.service.ts
+++ b/web/projects/em/src/app/top-scroll/top-scroll.service.ts
@@ -50,7 +50,7 @@ export class TopScrollService implements OnDestroy {
    }
 
    ngOnDestroy(): void {
-      this.scrolled.unsubscribe();
+      this.scrolled.complete();
       this.destroy$.complete();
    }
 

--- a/web/projects/em/src/app/top-scroll/top-scroll.service.ts
+++ b/web/projects/em/src/app/top-scroll/top-scroll.service.ts
@@ -51,7 +51,7 @@ export class TopScrollService implements OnDestroy {
 
    ngOnDestroy(): void {
       this.scrolled.unsubscribe();
-      this.destroy$.unsubscribe();
+      this.destroy$.complete();
    }
 
    get onScroll(): Observable<"up" | "down"> {


### PR DESCRIPTION
## Summary

- Extends the fix from #3827 to all remaining em project components and services that used `destroy$.unsubscribe()` in `ngOnDestroy`
- 27 files updated across the em project

## Root cause

Same root cause as #3827: `Subject.unsubscribe()` sets `closed = true` in RxJS 7, which throws `ObjectUnsubscribedError` when any subsequent code tries to `subscribe()` via `takeUntil(this.destroy$)`. This is reproducible in fast test environments like Vitest where the full component lifecycle can complete quickly, allowing a pending async operation (e.g. `setTimeout`, deferred HTTP response) to fire after `ngOnDestroy` has already closed the Subject.

`Subject.complete()` correctly sets `isStopped = true` but leaves `closed = false`, so new subscriptions still work — they just receive an immediate completion signal.

## Test plan

- [ ] Run `npm run test:em` and confirm no `ObjectUnsubscribedError` appears (specifically the `repository-viewsheet-settings-view.component.spec.ts` test)
- [ ] Confirm existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)