### PR TITLE
Update CLAUDE.md to reflect Angular 21, Vitest replacing Jest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,9 @@ npm install
 npm run build          # Dev build: portal, em, elements, viewer-element
 npm run build:prod     # Production build
 npm run build:watch    # Watch mode (portal + em only)
-npm run test           # Jest tests (portal project)
-npm run test:em        # Jest tests (em project)
-npm run test:watch     # Jest watch mode
+npm run test           # Vitest tests (portal project)
+npm run test:em        # Vitest tests (em project)
+npm run test:watch     # Vitest watch mode
 npm run lint           # ESLint
 npm run verify         # Lint + tests
 ```
@@ -61,7 +61,7 @@ npm run verify         # Lint + tests
 
 ```bash
 cd web
-npx jest path/to/spec.ts
+npx vitest run path/to/spec.ts
 ```
 
 ## Maven Module Structure
@@ -162,4 +162,4 @@ JDBC connectors (MySQL, PostgreSQL, Oracle, SQL Server, Snowflake, etc.) and non
 ./mvnw test -pl server        # Run server tests
 ```
 
-**TypeScript**: Jest via Angular CLI. Test files are `*.spec.ts` colocated with source.
+**TypeScript**: Vitest via Angular CLI. Test files are `*.spec.ts` colocated with source.


### PR DESCRIPTION
## Summary

- Update Angular and Angular Material version references from 15.2.x to 21.2.x
- Update TypeScript reference from 4.9.4 to 5.9.x and RxJS from 6.6.7 to 7.8.x
- Replace all Jest references with Vitest (including npm script comments, single-file run command, and testing section)

## Test plan

- [ ] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)