### PR TITLE
Fix intermittent timeout in data-input-pane popup table test

### DIFF
--- a/web/projects/portal/src/app/composer/dialog/vs/data-input-pane.spec.ts
+++ b/web/projects/portal/src/app/composer/dialog/vs/data-input-pane.spec.ts
@@ -166,7 +166,7 @@ describe("Data Input Pane Test", () => {
    });
 
    //Bug #19833
-   it("should input page number on popup table page", () => new Promise<void>((done) => {
+   it("should input page number on popup table page", async () => {
       dataInputPane = <DataInputPane>fixture.componentInstance;
       dataInputPane.model = createModel();
       dataInputPane.model.rowValue = "1";
@@ -191,24 +191,33 @@ describe("Data Input Pane Test", () => {
       fixture.debugElement.query(By.css("span.edit-icon")).nativeElement.click();
       fixture.detectChanges();
 
-      fixture.whenStable().then(() => {
-         let fixedDropdown = document.getElementsByTagName("fixed-dropdown")[0];
-         let pageInput = fixedDropdown.getElementsByTagName("input")[0];
-         let beforeBtns = fixedDropdown.getElementsByTagName("button");
-         expect(beforeBtns[0].disabled).toBeTruthy();
-         expect(beforeBtns[1].disabled).toBeTruthy();
+      // Wait for zone stability: Angular's NgZone triggers applicationRef.tick() when
+      // the zone is stable. The tick renders the dynamically-created FixedDropdownComponent
+      // and the @if(popupTable) content in the ng-template #dropdownMenu embedded view.
+      // Real setTimeout(0) timers (listenerTick from ngOnInit, onOpen from ngAfterViewInit)
+      // fire in registration order; after both settle the zone stabilises and resolves here.
+      await fixture.whenStable();
 
-         pageInput.value = "2";
-         fixture.componentInstance.updatePopupTablePage(new KeyboardEvent("keydown", {key: "enter"}), 2);
-         fixture.detectChanges();
-         expect(pageInput.getAttribute("ng-reflect-model")).toBe("2");
-         expect(beforeBtns[0].disabled).toBeFalsy();
-         expect(beforeBtns[1].disabled).toBeFalsy();
-         let id = fixedDropdown.getElementsByTagName("td")[4].textContent;
-         expect(id.trim()).toBe("11");
-         done();
-      });
-   }));
+      let fixedDropdown = document.getElementsByTagName("fixed-dropdown")[0];
+      let pageInput = fixedDropdown.getElementsByTagName("input")[0];
+      let beforeBtns = fixedDropdown.getElementsByTagName("button");
+      expect(beforeBtns[0].disabled).toBeTruthy();
+      expect(beforeBtns[1].disabled).toBeTruthy();
+
+      pageInput.value = "2";
+      fixture.componentInstance.updatePopupTablePage(new KeyboardEvent("keydown", {key: "enter"}), 2);
+      fixture.detectChanges();
+
+      // Wait for zone stability again so applicationRef.tick() propagates the page change
+      // into the embedded view (updating [ngModel] and [disabled] bindings).
+      await fixture.whenStable();
+
+      expect(pageInput.getAttribute("ng-reflect-model")).toBe("2");
+      expect(beforeBtns[0].disabled).toBeFalsy();
+      expect(beforeBtns[1].disabled).toBeFalsy();
+      let id = fixedDropdown.getElementsByTagName("td")[4].textContent;
+      expect(id.trim()).toBe("11");
+   });
 
    it("row should update when change to expression", () => {
       let model = createModel();


### PR DESCRIPTION
## Summary

- The `should input page number on popup table page` test (Bug #19833) was inconsistently timing out at 5000 ms.
- Root cause: the old `new Promise<void>((done) => { fixture.whenStable().then(() => { ...assertions...; done() }) })` pattern silently swallowed TypeErrors when `whenStable()` resolved before Angular's `applicationRef.tick()` had rendered the dynamically-created `FixedDropdownComponent`'s embedded view (containing the `@if(popupTable)` dropdown content). With `done()` never called, the test timed out.
- Fix: replace with a plain `async` function using `await fixture.whenStable()`, which deterministically waits for zone stability (and therefore for `applicationRef.tick()` to render the embedded view) before running assertions.

## Test plan

- [x] Run the specific spec file 3× in isolation and confirm all 5 tests pass consistently: `ng test --include "**/data-input-pane.spec.ts"`
- [x] Run the full portal unit test suite (`npm run test`) and confirm 300/300 pass with no regressions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)