### PR TITLE
Exclude cloud-runner from classpath to fix AOT class loading conflict

### DIFF
--- a/docker/src/main/docker/files/bin/start-scheduler.sh
+++ b/docker/src/main/docker/files/bin/start-scheduler.sh
@@ -26,15 +26,15 @@ then
     JAVA_OPTS=$(echo "$JAVA_OPTS" | envsubst)
 fi
 
-# Exclude inetsoft-server and inetsoft-enterprise-server from the classpath.
+# Exclude inetsoft-server, inetsoft-enterprise-server, and inetsoft-cloud-runner from the classpath.
 # Spring AOT generates __BeanDefinitions classes whose method signatures differ per
 # application context. When those JARs share a flat classpath with inetsoft-schedule-server,
 # the JVM may load the wrong version of these classes, causing NoSuchMethodError at startup.
-# Those two JARs are web server apps with no role in scheduler execution.
+# Those JARs are web server and cloud task runner apps with no role in scheduler execution.
 JAVA_CP="/usr/local/inetsoft/classes"
 for jar in /usr/local/inetsoft/libs/*.jar; do
     case "$(basename "$jar")" in
-        inetsoft-server-*.jar|inetsoft-enterprise-server-*.jar) ;;
+        inetsoft-server-*.jar|inetsoft-enterprise-server-*.jar|inetsoft-cloud-runner-*.jar) ;;
         *) JAVA_CP="$JAVA_CP:$jar" ;;
     esac
 done

--- a/docker/src/main/docker/files/bin/start-server.sh
+++ b/docker/src/main/docker/files/bin/start-server.sh
@@ -24,16 +24,16 @@ then
     JAVA_OPTS=$(echo "$JAVA_OPTS" | envsubst)
 fi
 
-# Exclude inetsoft-schedule-server from the classpath.
+# Exclude inetsoft-schedule-server and inetsoft-cloud-runner from the classpath.
 # Spring AOT generates __BeanDefinitions classes whose method signatures differ per
-# application context. When that JAR shares a flat classpath with inetsoft-server or
+# application context. When those JARs share a flat classpath with inetsoft-server or
 # inetsoft-enterprise-server, the JVM may load the wrong version of these classes,
 # causing NoSuchMethodError at startup.
-# inetsoft-schedule-server is the scheduler app with no role in server execution.
+# Those two JARs are the scheduler and cloud task runner apps with no role in server execution.
 JAVA_CP="/usr/local/inetsoft/classes"
 for jar in /usr/local/inetsoft/libs/*.jar; do
     case "$(basename "$jar")" in
-        inetsoft-schedule-server-*.jar) ;;
+        inetsoft-schedule-server-*.jar|inetsoft-cloud-runner-*.jar) ;;
         *) JAVA_CP="$JAVA_CP:$jar" ;;
     esac
 done


### PR DESCRIPTION
inetsoft-cloud-runner is an independent Spring Boot application, and its AOT compilation artifacts share the same class names as those of inetsoft-enterprise-server but with different content. Since the Docker image flattens all JAR files into the same directory, the ClassLoader loads classes in alphabetical order when the server starts. As cloud-runner (starting with "c") comes before enterprise-server (starting with "e"), the server incorrectly loads the AOT classes from cloud-runner, resulting in a NoSuchMethodError at startup and causing the server to crash and restart repeatedly. The fix: in start-server.sh and start-scheduler.sh, following the existing exclusion pattern for inetsoft-schedule-server, add inetsoft-cloud-runner-*.jar to the classpath exclusion list as well.