### PR TITLE
Bug #75186, fix cloud runner Ignite cache mode mismatch when joining cluster

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/cloudrunner/ScheduleTaskCloudJob.java
+++ b/core/src/main/java/inetsoft/sree/schedule/cloudrunner/ScheduleTaskCloudJob.java
@@ -224,6 +224,7 @@ public class ScheduleTaskCloudJob implements InterruptableJob {
       clusterConfig.setMulticastEnabled(false);
       clusterConfig.setTcpMembers(cluster.getClusterAddresses().toArray(new String[0]));
       clusterConfig.setClientMode(true);
+      clusterConfig.setMinNodes(config.getCluster().getMinNodes());
       copyRootCA(config.getCluster(), clusterConfig);
    }
 


### PR DESCRIPTION
Copy minNodes from the server's ClusterConfig into the cloud runner's config so that getDefaultCacheMode() returns the same CacheMode (PARTITIONED vs REPLICATED) as the server, preventing an Ignite AtomicConfiguration conflict on cluster join.