### PR TITLE
fix(wiz): resolve worksheet by identifier in autoBinding/createViewsheet

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -86,8 +86,10 @@ public class WizAutoBindingService {
 
       if(Tool.isEmptyString(autoBindingRuntimeId)) {
          Viewsheet.WizInfo wizInfo = new Viewsheet.WizInfo(true, null, null);
+         // worksheetId is an AssetEntry identifier (from GenerateWsService's toIdentifier()),
+         // not a bare path — parse it rather than passing it as the path argument.
          AssetEntry wsEntry = !Tool.isEmptyString(worksheetId)
-            ? new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, worksheetId, null)
+            ? AssetEntry.createAssetEntry(worksheetId)
             : null;
          autoBindingRuntimeId = viewsheetService.openTemporaryViewsheet(null, wsEntry, user, wizInfo);
          createdAutoBindingRvs = true;
@@ -105,8 +107,7 @@ public class WizAutoBindingService {
          List<ColumnRef> worksheetColumns = new ArrayList<>();
 
          if(!Tool.isEmptyString(worksheetId)) {
-            AssetEntry wsEntry = new AssetEntry(
-               AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, worksheetId, null);
+            AssetEntry wsEntry = AssetEntry.createAssetEntry(worksheetId);
 
             try {
                AbstractSheet sheet = engine.getSheet(wsEntry, user, true, AssetContent.ALL);
@@ -140,7 +141,15 @@ public class WizAutoBindingService {
             .collect(Collectors.toMap(SimpleFieldInfo::getField, f -> f, (a, b) -> a));
 
          final String tableNameFinal = tableName;
-         AssetEntry[] entries = worksheetColumns.stream()
+         // When the caller specifies fieldConfigs, bind ONLY those fields. Otherwise join-key
+         // columns (added to the worksheet to satisfy the join, but not requested) leak in as
+         // spurious Sum() measures. With no fieldConfigs, fall back to all worksheet columns.
+         List<ColumnRef> bindColumns = configMap.isEmpty()
+            ? worksheetColumns
+            : worksheetColumns.stream()
+                 .filter(c -> configMap.containsKey(c.getAttribute()))
+                 .collect(Collectors.toList());
+         AssetEntry[] entries = bindColumns.stream()
             .map(col -> buildEntryFromColumn(col, worksheetId, tableNameFinal))
             .toArray(AssetEntry[]::new);
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -480,8 +480,9 @@ public class WizVsService {
       AssetEntry sourceWs;
 
       try {
-         sourceWs = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET,
-                                   config.getData().getSource(), null);
+         // config.getData().getSource() is a worksheet IDENTIFIER (AssetEntry.toIdentifier()),
+         // not a bare path — parse it rather than treating it as a path.
+         sourceWs = AssetEntry.createAssetEntry(config.getData().getSource());
       }
       catch(Exception e) {
          throw new IllegalArgumentException("Datasource is invalid", e);


### PR DESCRIPTION
## Problem
`/viewsheet/autoBinding` returned empty bindings ("could not build a chart"), and on the fallback path a `StringIndexOutOfBoundsException` in `AssetEntry.getParentPath` surfaced to callers as a spurious "Authentication error". This made the viz-chat plugin unable to create any chart.

## Root cause
`GenerateWsService` returns `wsId` as `AssetEntry.toIdentifier()` (`scope^type^path^…^org`), but three call sites rebuilt the entry with `new AssetEntry(GLOBAL_SCOPE, WORKSHEET, wsId, null)` — passing the whole identifier as the **path** argument. `engine.getSheet(...)` then returns `null`, so the recommender sees zero worksheet columns → no binding.

## Fix
- Parse the identifier with `AssetEntry.createAssetEntry(wsId)` at all three sites: `WizAutoBindingService` (Phase-1 `openTemporaryViewsheet` + worksheet load) and `WizVsService.resolveSourceContext`.
- Bind only the caller's `fieldConfigs` columns when provided, so join-key columns (added to satisfy the join, not requested) don't leak in as spurious `Sum()` measures. Falls back to all worksheet columns when no `fieldConfigs` given.

## Verification
Reproduced + verified against a locally-built image: `sales-by-city` (payment→customer→address→city join) now renders `[city, Sum(amount)]` with 597 real rows as a bar chart. Previously: empty/no chart.

## Review notes
- The `fieldConfigs` binding filter changes autoBinding behavior **only when fieldConfigs are supplied** (otherwise unchanged) — please sanity-check other autoBinding callers.
- Verified at the API/rendering level, not via automated tests — please run the suite.
- Known follow-up (separate): `applyFieldConfigs` runs before the recommender assigns X/Y fields, so dimension ranking / explicit aggregate from `fieldConfigs` aren't applied to the rendered chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)