### PR TITLE
Bug #75238, provide FirstDayOfWeekService in DatepickerComponent to fix NG0201 when selecting Run Once condition

### DIFF
--- a/web/projects/em/src/app/common/util/datepicker/datepicker.component.ts
+++ b/web/projects/em/src/app/common/util/datepicker/datepicker.component.ts
@@ -21,6 +21,7 @@ import { DateAdapter, MAT_DATE_FORMATS } from "@angular/material/core";
 import { DateTypeFormatter } from "../../../../../../shared/util/date-type-formatter";
 import { Subscription } from "rxjs";
 import { DayjsDateAdapter } from "./dayjs-date-adapter.service";
+import { FirstDayOfWeekService } from "../../../../../../portal/src/app/common/services/first-day-of-week.service";
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import { MatIcon } from "@angular/material/icon";
@@ -50,6 +51,7 @@ export const DEFAULT_FORMATS = {
     providers: [
         { provide: DateAdapter, useClass: DayjsDateAdapter },
         { provide: MAT_DATE_FORMATS, useValue: DEFAULT_FORMATS },
+        FirstDayOfWeekService,
     ],
     imports: [
     MatFormField,


### PR DESCRIPTION
## Summary

- `DayjsDateAdapter` injects `FirstDayOfWeekService` in its constructor, but `DatepickerComponent` did not include `FirstDayOfWeekService` in its `providers` array
- After the standalone migration removed `DatepickerModule`, the service was only registered at the schedule route level, which is not reliably accessible from `DatepickerComponent`'s own NodeInjector
- Added `FirstDayOfWeekService` directly to `DatepickerComponent`'s providers, making it self-contained — matches the fix applied to `DateTimePickerComponent` in bug #75239

## Test plan

- [ ] Open EM → Settings → Schedule → create or edit a task
- [ ] Select the "Run Once" condition type
- [ ] Verify the date picker renders without errors in the browser console
- [ ] Verify no `NG0201: No provider found for _FirstDayOfWeekService` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)