### PR TITLE
Bug #75028 - Fix legend symbol overlapping the legend border when symbol size is large

### DIFF
--- a/core/src/main/java/inetsoft/graph/guide/legend/Legend.java
+++ b/core/src/main/java/inetsoft/graph/guide/legend/Legend.java
@@ -371,7 +371,8 @@ public abstract class Legend extends BoundedContainer {
          double itemh = item0 == null ? 20 : item0.getPreferredHeight();
 
          contentW = w;
-         contentH = getItems().length * itemh;
+         // bottom inset so the last row's symbol isn't flush with the border when scrolled
+         contentH = getItems().length * itemh + GAP;
          contentX = x;
          contentY = title != null ?
             y + h - title.getSize().getHeight() - GAP - contentH :

--- a/core/src/test/java/inetsoft/graph/guide/legend/LegendContentInsetTest.java
+++ b/core/src/test/java/inetsoft/graph/guide/legend/LegendContentInsetTest.java
@@ -98,19 +98,24 @@ class LegendContentInsetTest {
          Legend legend = (Legend) group.getVisual(i);
          Rectangle2D content = legend.getContentPreferredBounds();
          double lastRowBottom = Double.MAX_VALUE;
+         boolean foundItem = false;
 
          for(LegendItem[] row : legend.getItems()) {
             for(LegendItem it : row) {
                if(it != null) {
                   lastRowBottom = Math.min(lastRowBottom, it.getBounds().getY());
+                  foundItem = true;
                }
             }
          }
 
-         // content bottom must sit below the last row by at least a few px (the bottom inset)
+         assertTrue(foundItem, "legend[" + i + "] has no items — test misconfigured");
+
+         // Y increases upward here, so content.getY() is the bottom edge. it must sit below
+         // the last row by ~GAP (4); 3.5 absorbs floating-point rounding.
          assertTrue(lastRowBottom - content.getY() >= 3.5,
             "legend[" + i + "] missing bottom inset: lastRowBottom=" + lastRowBottom
-               + " contentBottom=" + content.getY());
+               + " contentBottomEdge=" + content.getY());
       }
    }
 }

--- a/core/src/test/java/inetsoft/graph/guide/legend/LegendContentInsetTest.java
+++ b/core/src/test/java/inetsoft/graph/guide/legend/LegendContentInsetTest.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.graph.guide.legend;
+
+import inetsoft.graph.EGraph;
+import inetsoft.graph.GraphConstants;
+import inetsoft.graph.Plotter;
+import inetsoft.graph.VGraph;
+import inetsoft.graph.aesthetic.CategoricalColorFrame;
+import inetsoft.graph.aesthetic.CategoricalShapeFrame;
+import inetsoft.graph.coord.RectCoord;
+import inetsoft.graph.data.DefaultDataSet;
+import inetsoft.graph.element.IntervalElement;
+import inetsoft.graph.scale.CategoricalScale;
+import inetsoft.graph.scale.LinearScale;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.geom.Rectangle2D;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards the bottom inset in {@link Legend#getContentPreferredBounds()}. The content bounds
+ * (which size the viewer's scrollable content tile) must leave a gap below the last row so its
+ * symbol doesn't sit flush against the bottom border when the content is scrolled to the end.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class LegendContentInsetTest {
+   @Test
+   void contentBoundsLeaveBottomInsetBelowLastRow() {
+      DefaultDataSet data = new DefaultDataSet(new Object[][]{
+         { "Cat", "State", "Region", "m1" },
+         { "A", "CA", "West",  10.0 },
+         { "B", "NY", "East",  20.0 },
+         { "C", "TX", "South", 15.0 },
+         { "D", "FL", "South", 25.0 },
+         { "E", "WA", "West",  30.0 },
+         { "F", "IL", "Mid",   12.0 },
+      });
+
+      CategoricalScale xScale = new CategoricalScale("Cat");
+      xScale.init(data);
+      LinearScale yScale = new LinearScale("m1");
+      yScale.init(data);
+
+      IntervalElement element = new IntervalElement();
+      element.addDim("Cat");
+      element.addVar("m1");
+
+      CategoricalColorFrame color = new CategoricalColorFrame("State");
+      color.init(data);
+      color.getLegendSpec().setSymbolSize(50);
+      color.getLegendSpec().setBorder(GraphConstants.THIN_LINE);
+      element.setColorFrame(color);
+
+      CategoricalShapeFrame shape = new CategoricalShapeFrame("Region");
+      shape.init(data);
+      shape.getLegendSpec().setSymbolSize(50);
+      shape.getLegendSpec().setBorder(GraphConstants.THIN_LINE);
+      element.setShapeFrame(shape);
+
+      EGraph egraph = new EGraph();
+      egraph.addElement(element);
+      egraph.setCoordinate(new RectCoord(xScale, yScale));
+      egraph.setLegendLayout(GraphConstants.RIGHT);
+
+      VGraph vgraph = Plotter.getPlotter(egraph).plotAndLayout(data, 0, 0, 600, 260);
+      LegendGroup group = vgraph.getLegendGroup();
+
+      for(int i = 0; i < group.getVisualCount(); i++) {
+         Legend legend = (Legend) group.getVisual(i);
+         Rectangle2D content = legend.getContentPreferredBounds();
+         double lastRowBottom = Double.MAX_VALUE;
+
+         for(LegendItem[] row : legend.getItems()) {
+            for(LegendItem it : row) {
+               if(it != null) {
+                  lastRowBottom = Math.min(lastRowBottom, it.getBounds().getY());
+               }
+            }
+         }
+
+         // content bottom must sit below the last row by at least a few px (the bottom inset)
+         assertTrue(lastRowBottom - content.getY() >= 3.5,
+            "legend[" + i + "] missing bottom inset: lastRowBottom=" + lastRowBottom
+               + " contentBottom=" + content.getY());
+      }
+   }
+}

--- a/web/projects/portal/src/app/graph/objects/chart-legend-container.component.scss
+++ b/web/projects/portal/src/app/graph/objects/chart-legend-container.component.scss
@@ -25,6 +25,8 @@
 
 .chart-legend-wrapper {
   position: absolute;
+  // clip symbol tiles to the bordered box; inner area keeps overflow-y:auto for scrolling
+  overflow: hidden;
 }
 
 .chart-legend__canvas {


### PR DESCRIPTION
## Summary

Fixes legend symbols overlapping the legend border. When a legend has a large
symbol size and a border, and two legends are stacked vertically, the upper
legend's symbols overflowed past its bottom border and leaked into the legend
below.

## Cause

In the viewer, each legend is a CSS-bordered wrapper containing a fixed-height
content area that holds a server-rendered tile of the full item list (sized from
Legend.getContentPreferredBounds). When a legend is allocated less height than
its content needs (two legends sharing limited space), the full-height content
exceeds the allocated legend bounds. The bordered wrapper had no clipping, so
the overflow row painted past the bottom border into the adjacent legend.

## Changes

- chart-legend-container.component.scss: add overflow: hidden to
  .chart-legend-wrapper so legend content is clipped to the bordered box. The
  inner content area keeps its overflow-y:auto, so items beyond the visible
  height are still scrollable.
- Legend.getContentPreferredBounds: add a bottom inset (GAP) below the last row
  so the last symbol isn't flush against the bottom border when scrolled to the
  end, matching the existing top/left insets.
- Add LegendContentInsetTest covering the bottom inset.