### PR TITLE
Bug #75285: Reject datasource creation when parent folder does not exist

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/DatabaseDatasourcesService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/DatabaseDatasourcesService.java
@@ -399,6 +399,11 @@ public class DatabaseDatasourcesService {
       if(dataSource == null) {
          // Create the dataSource - path is the parent folder's path
          fullName = fullName.startsWith("/") ? fullName.substring(1) : fullName;
+
+         if(!fullName.isEmpty() && registry.getDataSourceFolder(fullName) == null) {
+            return new ConnectionStatus("Invalid Folder");
+         }
+
          fullName += !fullName.isEmpty() ? "/" + name : name;
 
          if(registry.getDataSourceFolder(fullName) != null) {

--- a/core/src/main/java/inetsoft/web/portal/data/DatasourcesBaseService.java
+++ b/core/src/main/java/inetsoft/web/portal/data/DatasourcesBaseService.java
@@ -329,7 +329,8 @@ public abstract class DatasourcesBaseService {
       if(!StringUtils.isEmpty(folder) && !"/".equals(folder) &&
          dataSourceRegistry.getDataSourceFolder(folder) == null)
       {
-         throw new FileNotFoundException("Parent folder does not exist: " + folder);
+         throw new MessageException(
+            Catalog.getCatalog().getString("data.datasources.invalidParentFolder"));
       }
 
       if(StringUtils.isEmpty(folder) || "/".equals(folder)) {

--- a/core/src/main/java/inetsoft/web/portal/data/DatasourcesBaseService.java
+++ b/core/src/main/java/inetsoft/web/portal/data/DatasourcesBaseService.java
@@ -326,6 +326,12 @@ public abstract class DatasourcesBaseService {
       boolean newSourcePermission = false;
       boolean folderPermission;
 
+      if(!StringUtils.isEmpty(folder) && !"/".equals(folder) &&
+         dataSourceRegistry.getDataSourceFolder(folder) == null)
+      {
+         throw new FileNotFoundException("Parent folder does not exist: " + folder);
+      }
+
       if(StringUtils.isEmpty(folder) || "/".equals(folder)) {
          folderPermission = securityEngine.checkPermission(
             principal, ResourceType.DATA_SOURCE_FOLDER, "/", ResourceAction.WRITE);

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -3789,6 +3789,7 @@ data.datasources.duplicateDataSourceName=A data source with that name already ex
 data.datasources.enterAValidName=Data Source name cannot contain special characters.
 data.datasources.enterDataSourceName=Data Source name is required.
 data.datasources.findDataSourceError=Datasource does not exist\!
+data.datasources.invalidParentFolder=The specified parent folder does not exist. To create a data source at the root level, use an empty path.
 data.datasources.getDataSourceError=An error prevented the datasource from being updated.
 data.datasources.loginError=Login failed. Check the username and password.
 data.datasources.manageDrivers=Manage Drivers

--- a/web/projects/shared/util/datasource/data-source-settings-page.ts
+++ b/web/projects/shared/util/datasource/data-source-settings-page.ts
@@ -331,6 +331,9 @@ export abstract class DataSourceSettingsPage implements OnInit, OnDestroy {
          else if(connection && connection.status === "Datasource Lost") {
             this.showMessage("_#(js:data.datasources.saveDataSourceLost)");
          }
+         else if(connection && connection.status === "Invalid Folder") {
+            this.showMessage("_#(js:data.datasources.invalidParentFolder)");
+         }
          else {
             this.afterDatabaseSave();
          }


### PR DESCRIPTION
﻿## Summary

- Added backend validation in DatabaseDatasourcesService.saveDatabaseDefinition that rejects datasource creation when the specified parent folder path is non-empty but does not exist in the registry
- Returns ConnectionStatus("Invalid Folder") in this case, preventing phantom datasources from being silently stored at inaccessible paths
- Added corresponding error handler in the Angular DataSourceSettingsPage base class to display the error to the user
- Added i18n string data.datasources.invalidParentFolder with a message that also documents the correct empty-string path for root-level creation

**Root cause:** POST /api/data/databases?path=Data%20Source&create=true was accepted silently. "Data Source" is only the display label for the root node (whose real path is "/"), not an actual folder. The datasource was stored at "Data Source/{name}" -- a path invisible in the GUI tree.

**Correct API call for root-level creation:** POST /api/data/databases?path=&create=true

## Test plan

- [ ] POST /api/data/databases?path=Data%20Source&create=true returns {"status":"Invalid Folder"}
- [ ] POST /api/data/databases?path=&create=true creates datasource at root and it appears in the tree
- [ ] POST /api/data/databases?path=RealFolder&create=true still works when RealFolder exists
- [ ] Creating a datasource through the normal GUI flow still works

Generated with Claude Code
