### PR TITLE
Bug #75234, fix floating labels hidden in filled form fields after Angular Material 21 upgrade

### DIFF
--- a/web/projects/em/src/_app-theme.scss
+++ b/web/projects/em/src/_app-theme.scss
@@ -260,9 +260,11 @@
 // inetsoft-form-field-outline-typography commented out below in case we really need such
 // extra customization
 .mat-mdc-form-field {
-  // prevent the float label from not showing when density is low
-  mdc-textfield.$minimum-height-for-filled-label: 34px;
   @include mat.form-field-density(-5); // -5 is currently the smallest density
+  // At density -5 the container height (36px) is below Angular Material's 52px threshold,
+  // which causes --mat-form-field-filled-label-display to be set to none. Override to keep
+  // floating labels visible in filled-appearance form fields.
+  --mat-form-field-filled-label-display: block;
 
   &.mat-form-field-appearance-outline:not(.mat-mdc-paginator-page-size-select) {
     padding-bottom: .75em;


### PR DESCRIPTION
## Summary

- `mat.form-field-density(-5)` in `_app-theme.scss` emits `--mat-form-field-filled-label-display: none` in Angular Material 21 because the 36px container height falls below AM's hardcoded 52px threshold that triggers label suppression for `fill`-appearance form fields
- The previous workaround (`mdc-textfield.$minimum-height-for-filled-label: 34px`) used invalid SASS module-variable syntax inside a CSS rule block and had no effect in modern SASS
- Fix: after the density include, override `--mat-form-field-filled-label-display: block` so floating labels remain visible across all filled form fields in the EM

## Test plan

- [ ] Open EM → Security Settings → SSO tab, select SAML — floating labels appear in the SAML form fields
- [ ] Switch to OIDC — floating labels appear in all OpenID Connect form fields
- [ ] Switch to Custom — floating labels appear in the Logout URL and Logout Path fields
- [ ] Open Security Settings → Sign In With Google — floating labels appear
- [ ] Verify other EM pages with form fields are not regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)