### PR TITLE
Bug #75231, fix NG0201 and script tab crash in checkbox property dialog after standalone migration

### DIFF
--- a/web/projects/portal/src/app/app.config.ts
+++ b/web/projects/portal/src/app/app.config.ts
@@ -22,6 +22,8 @@ import { provideAnimations } from "@angular/platform-browser/animations";
 import { routes } from "./app.routes";
 import { SsoHeartbeatService } from "../../../shared/sso/sso-heartbeat.service";
 import { SsoHeartbeatInterceptor } from "../../../shared/sso/sso-heartbeat-interceptor";
+import { DefaultCodemirrorService } from "../../../shared/util/codemirror/default-codemirror.service";
+import { CodemirrorService } from "../../../shared/util/codemirror/codemirror.service";
 import { CsrfInterceptor } from "./common/services/csrf-interceptor";
 import { DateLevelExamplesService } from "./common/services/date-level-examples.service";
 import { FirstDayOfWeekService } from "./common/services/first-day-of-week.service";
@@ -57,6 +59,7 @@ export const appConfig: ApplicationConfig = {
       ModelService,
       DebounceService,
       DomService,
+      { provide: CodemirrorService, useClass: DefaultCodemirrorService },
       { provide: UrlSerializer, useClass: StandardUrlSerializer },
       { provide: HTTP_INTERCEPTORS, useClass: HttpDebounceInterceptor, multi: true },
       { provide: HTTP_INTERCEPTORS, useClass: HttpParamsCodecInterceptor, multi: true },

--- a/web/projects/portal/src/app/vsobjects/dialog/data-tree-validator.service.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/data-tree-validator.service.spec.ts
@@ -1,0 +1,29 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { TestBed } from "@angular/core/testing";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { DataTreeValidatorService } from "./data-tree-validator.service";
+
+describe("DataTreeValidatorService", () => {
+   it("should be injectable from root without explicit providers", () => {
+      TestBed.configureTestingModule({
+         imports: [HttpClientTestingModule]
+      });
+      expect(() => TestBed.inject(DataTreeValidatorService)).not.toThrow();
+   });
+});

--- a/web/projects/portal/src/app/vsobjects/dialog/data-tree-validator.service.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/data-tree-validator.service.ts
@@ -32,7 +32,9 @@ import { ComponentTool } from "../../common/util/component-tool";
 const GET_PARAMETERS_URI = "../api/vs/bindingtree/getConnectionParameters";
 const SET_CONNECTION_VARIABLES = "../api/composer/asset_tree/set-connection-variables";
 
-@Injectable()
+@Injectable({
+   providedIn: "root"
+})
 export class DataTreeValidatorService {
    constructor(private modelService: ModelService,
                private modalService: NgbModal)

--- a/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.spec.ts
+++ b/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { CodemirrorService } from "../../../../../../shared/util/codemirror/codemirror.service";
+import { FormulaFunctionAnalyzerService } from "./formula-function-analyzer.service";
+import { HelpUrlService } from "../../help-link/help-url.service";
+import { ScriptPane } from "./script-pane.component";
+
+describe("ScriptPane", () => {
+   let fixture: ComponentFixture<ScriptPane>;
+
+   const makeCodemirrorService = (defs: object[] | null) => ({
+      getEcmaScriptDefs: vi.fn(() => defs),
+      createTernServer: vi.fn(() => ({ options: { typeTip: "", hintDelay: 0 }, destroy: vi.fn() })),
+      createCodeMirrorInstance: vi.fn(() => ({
+         setValue: vi.fn(),
+         getValue: vi.fn(() => ""),
+         focus: vi.fn(),
+         setCursor: vi.fn(),
+         lineCount: vi.fn(() => 0),
+         lastLine: vi.fn(() => ""),
+         on: vi.fn(),
+         toTextArea: vi.fn(),
+         getLine: vi.fn(() => ""),
+         refresh: vi.fn(),
+         getCursor: vi.fn(() => ({ line: 0, ch: 0 }))
+      })),
+      hasToken: vi.fn(() => false)
+   });
+
+   beforeEach(() => {
+      TestBed.configureTestingModule({
+         imports: [ScriptPane],
+         providers: [FormulaFunctionAnalyzerService, HelpUrlService],
+         schemas: [NO_ERRORS_SCHEMA]
+      });
+   });
+
+   it("should initialize without error when CodemirrorService returns null defs", () => {
+      TestBed.overrideComponent(ScriptPane, {
+         set: { providers: [{ provide: CodemirrorService, useValue: makeCodemirrorService(null) }] }
+      });
+
+      vi.spyOn(Element.prototype, "getClientRects").mockReturnValue({
+         length: 1,
+         0: new DOMRect(0, 0, 100, 100),
+         item: () => new DOMRect(0, 0, 100, 100),
+         [Symbol.iterator]: function*() { yield new DOMRect(0, 0, 100, 100); }
+      } as any);
+
+      fixture = TestBed.createComponent(ScriptPane);
+      expect(() => fixture.detectChanges()).not.toThrow();
+   });
+});

--- a/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.spec.ts
+++ b/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.spec.ts
@@ -1,6 +1,6 @@
 /*
  * This file is part of StyleBI.
- * Copyright (C) 2024  InetSoft Technology
+ * Copyright (C) 2024-2026  InetSoft Technology
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.spec.ts
+++ b/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.spec.ts
@@ -17,9 +17,11 @@
  */
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { of } from "rxjs";
 import { CodemirrorService } from "../../../../../../shared/util/codemirror/codemirror.service";
 import { FormulaFunctionAnalyzerService } from "./formula-function-analyzer.service";
 import { HelpUrlService } from "../../help-link/help-url.service";
+import { ScriptSettingsService } from "./script-settings.service";
 import { ScriptPane } from "./script-pane.component";
 
 describe("ScriptPane", () => {
@@ -47,7 +49,11 @@ describe("ScriptPane", () => {
    beforeEach(() => {
       TestBed.configureTestingModule({
          imports: [ScriptPane],
-         providers: [FormulaFunctionAnalyzerService, HelpUrlService],
+         providers: [
+            FormulaFunctionAnalyzerService,
+            { provide: HelpUrlService, useValue: { getScriptHelpUrl: () => of(""), getHelpUrl: () => of("") } },
+            { provide: ScriptSettingsService, useValue: { isCursorTop: () => of(false) } }
+         ],
          schemas: [NO_ERRORS_SCHEMA]
       });
    });

--- a/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.ts
@@ -399,6 +399,11 @@ export class ScriptPane implements AfterViewInit, AfterViewChecked, OnInit, OnDe
 
                   this.ternServer?.complete(cm);
                   const completion = cm.state.completionActive;
+
+                  if(!completion) {
+                     return;
+                  }
+
                   const pick = completion.pick;
                   const select = completion.select;
                   completion.pick = function(data, i) {

--- a/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.ts
@@ -311,27 +311,30 @@ export class ScriptPane implements AfterViewInit, AfterViewChecked, OnInit, OnDe
                completeSingle: false
             };
             config.extraKeys = {
-               "Ctrl-O": (cm) => this.ternServer.showDocs(cm, cm.getCursor()),
-               "Ctrl-Space": (cm) => this.ternServer.complete(cm),
-               "Alt-/": (cm) => this.ternServer.complete(cm),
+               "Ctrl-O": (cm) => this.ternServer?.showDocs(cm, cm.getCursor()),
+               "Ctrl-Space": (cm) => this.ternServer?.complete(cm),
+               "Alt-/": (cm) => this.ternServer?.complete(cm),
                "Ctrl-/": "toggleComment"
             };
 
             const defs = this.codemirrorService.getEcmaScriptDefs();
-            delete (defs[0]["Date"]["prototype"]).toJSON;
 
-            if(this.scriptDefinitions) {
-               defs.push(this.scriptDefinitions);
+            if(defs) {
+               delete (defs[0]["Date"]["prototype"]).toJSON;
+
+               if(this.scriptDefinitions) {
+                  defs.push(this.scriptDefinitions);
+               }
+
+               this.ternServer = this.codemirrorService.createTernServer({
+                  defs: defs,
+                  useWorker: false,
+                  queryOptions: {completions: {guess: false}}
+               });
+
+               this.ternServer.options.typeTip = this.docTooltip;
+               this.ternServer.options.hintDelay = 17000;
             }
-
-            this.ternServer = this.codemirrorService.createTernServer({
-               defs: defs,
-               useWorker: false,
-               queryOptions: {completions: {guess: false}}
-            });
-
-            this.ternServer.options.typeTip = this.docTooltip;
-            this.ternServer.options.hintDelay = 17000;
          }
 
          this.codemirrorInstance = this.codemirrorService.createCodeMirrorInstance(

--- a/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.ts
@@ -367,7 +367,7 @@ export class ScriptPane implements AfterViewInit, AfterViewChecked, OnInit, OnDe
 
          if(!this.sql) {
             this.codemirrorInstance.on(
-               "cursorActivity", (cm) => this.ternServer.updateArgHints(cm));
+               "cursorActivity", (cm) => this.ternServer?.updateArgHints(cm));
          }
 
          this.codemirrorInstance.on("inputRead", (cm, changeObj) => {
@@ -397,7 +397,7 @@ export class ScriptPane implements AfterViewInit, AfterViewChecked, OnInit, OnDe
                      this.cancelAutocomplete = null;
                   }
 
-                  this.ternServer.complete(cm);
+                  this.ternServer?.complete(cm);
                   const completion = cm.state.completionActive;
                   const pick = completion.pick;
                   const select = completion.select;
@@ -422,7 +422,7 @@ export class ScriptPane implements AfterViewInit, AfterViewChecked, OnInit, OnDe
                }
                else {
                   this.delayAutocomplete(() => {
-                     this.ternServer.complete(cm);
+                     this.ternServer?.complete(cm);
                   });
                }
             }

--- a/web/projects/portal/src/app/widget/fixed-dropdown/fixed-dropdown-ref.ts
+++ b/web/projects/portal/src/app/widget/fixed-dropdown/fixed-dropdown-ref.ts
@@ -44,6 +44,7 @@ export class DropdownRef {
          const width = bounds.width > 0 ? bounds.width : elem.scrollWidth;
          const height = bounds.height > 0 ? bounds.height : elem.scrollHeight;
          dropdown.dropdownBounds = new Rectangle(bounds.left, bounds.top, width, height);
+         dropdownCmptRef.changeDetectorRef.detectChanges();
          this.stackService.push(dropdown);
       });
    }


### PR DESCRIPTION
## Summary

- `DataTreeValidatorService` was `@Injectable()` with no scope, relying on a now-removed NgModule to provide it. After the standalone migration nothing provided it, causing NG0201 when the Data tab rendered `TreeDropdownComponent`. Fixed by adding `providedIn: "root"`.
- `ScriptPane` injects `CodemirrorService`, whose root-injector instance is the null stub. `NgbModal` creates dialogs in the root injector context, outside any route scope, so the `{ provide: CodemirrorService, useClass: DefaultCodemirrorService }` override in `composer.routes.ts` was invisible to those dialogs. Fixed by adding the same override to `appConfig` in `app.config.ts`.
- Added a null guard in `script-pane.component.ts` around `getEcmaScriptDefs()` and optional chaining on the `ternServer` key handlers as defense-in-depth.

## Test plan

- [ ] Open the checkbox property dialog in the composer
- [ ] Click the Data tab — should open without error
- [ ] Click the Script tab — should open without error and CodeMirror should initialize (Ctrl-Space autocomplete works)
- [ ] Verify no regressions in other property dialogs with script panes

🤖 Generated with [Claude Code](https://claude.com/claude-code)