### PR TITLE
Bug #75230, fix null pointer error when deleting user or group in security settings

### DIFF
--- a/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.ts
+++ b/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.ts
@@ -547,13 +547,13 @@ export class UsersSettingsPageComponent implements OnInit, OnDestroy {
    }
 
    private getSameTypeNode0(type: number): SecurityTreeNodeModel {
-      if(type == IdentityType.ROLE && this.model.roles.children.length != 0) {
+      if(type == IdentityType.ROLE && this.model.roles?.children?.length) {
          return this.model.roles.children[0];
       }
-      else if(type == IdentityType.GROUP && this.model.groups.children.length != 0) {
+      else if(type == IdentityType.GROUP && this.model.groups?.children?.length) {
          return this.model.groups.children[0];
       }
-      else if(type == IdentityType.USER && this.model.users.children.length != 0) {
+      else if(type == IdentityType.USER && this.model.users?.children?.length) {
          return this.model.users.children[0];
       }
 


### PR DESCRIPTION
## Summary

Deleting a user or group in EM → Settings → Security → Users threw a `TypeError: Cannot read properties of null (reading 'children')` in `getSameTypeNode0`, preventing the deletion from completing in the UI.

## Root Cause

The Java `SecurityTreeRootModel` marks `users()`, `groups()`, and `roles()` as `@Nullable`, so the backend can return null for any of these fields (e.g. in certain provider configurations). The `getSameTypeNode0` method accessed `.children` on these fields without null guards, causing the crash when one was null.

## Fix

Added optional chaining (`?.`) to all three field accesses in `getSameTypeNode0` so that null model nodes safely short-circuit to `null` instead of throwing.

## Test Plan

- Open EM → Settings → Security → Users
- Create a new user, then delete it — confirm no browser console error and the deletion succeeds
- Repeat for a group — confirm same result
- Confirm existing users/groups/roles continue to display and navigate correctly after deletion

Fixes Redmine #75230.