### PR TITLE
Bug #75229, toolbox missing bound worksheet tables after Angular upgrade

### DIFF
--- a/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.ts
@@ -197,7 +197,6 @@ const COLLECT_PARAMS_URI = "/events/vs/collectParameters";
             provide: ChartService,
             useExisting: VSChartService
         },
-        VSBindingTreeService,
         ChatService
     ],
     imports: [OutOfZoneDirective, MobileToolbarComponent, Rulers, SelectionBoxDirective, ActionsContextmenuAnchorDirective, InteractContainerDirective, NgStyle, EditableObjectContainer, ComposerSelectionContainerChildren, LayoutPane, PlaceholderDragElement, StatusBar, FormsModule, VSLoadingDisplay, VSSavingDisplay, NotificationsComponent, VariableInputDialog, ConsoleDialogComponent]
@@ -1286,7 +1285,9 @@ export class VSPane extends CommandProcessor implements OnInit, OnDestroy, After
          return;
       }
 
-      this.treeService.resetTreeModel(command.treeModel, false);
+      if(this.vs?.isFocused) {
+         this.treeService.resetTreeModel(command.treeModel, false);
+      }
    }
 
    /**


### PR DESCRIPTION
## Summary

After the Angular standalone migration, the Toolbox pane in the Visual Composer did not show the bound worksheet table assemblies when a viewsheet with a data source was opened. The canvas showed \"Error: miss worksheet or db tables node\".

## Root Cause

`VSPane.providers[]` contained `VSBindingTreeService`, creating a component-level instance per tab. The route-level providers in `composer.routes.ts` register a separate singleton aliased as `BindingTreeService`. The toolbox's `ComposerBindingTree` injects `BindingTreeService` (route-level instance), while `VSPane.processRefreshBindingTreeCommand` updated the component-level instance. The two instances were disconnected, so the toolbox never received the tree model.

## Fix

- Remove `VSBindingTreeService` from `VSPane.providers[]` so all panes share the route-level singleton that the toolbox already observes via the `BindingTreeService` alias. The service is already provided at the route level in `composer.routes.ts` so no injection error is introduced.
- Add an `isFocused` guard in `processRefreshBindingTreeCommand` so a background tab's initial-load response cannot overwrite the focused tab's tree in the shared service, preventing a multi-tab race condition.

## Test Plan

- Open the composer (`/app/composer`)
- Create a new viewsheet and select the `Examples/Analysis` worksheet
- Click OK — the toolbox pane should show the bound worksheet table assemblies
- Open a second viewsheet tab with a different bound worksheet; switch between tabs and verify the toolbox updates correctly for each

Fixes Redmine #75229.