### PR TITLE
Bug #75228, provide DataQueryModelService in composerRoutes to fix NG0201 when opening DB query dialog

### DIFF
--- a/web/projects/portal/src/app/composer/composer.routes.ts
+++ b/web/projects/portal/src/app/composer/composer.routes.ts
@@ -44,6 +44,7 @@ import { composerResolver } from "./services/composer-resolver.service";
 import { SelectionContainerChildrenService } from "../vsobjects/objects/selection/services/selection-container-children.service";
 import { VSTrapService } from "../vsobjects/util/vs-trap.service";
 import { WsChangeService } from "./gui/ws/editor/ws-change.service";
+import { DataQueryModelService } from "../portal/data/data-datasource-browser/datasources-database/database-query/data-query-model.service";
 
 export const composerRoutes: Routes = [
    {
@@ -78,6 +79,7 @@ export const composerRoutes: Routes = [
          { provide: CodemirrorService, useClass: DefaultCodemirrorService },
          ChatService,
          { provide: CHAT_API_KEY, useValue: "5ba3fdd5c666d426648af5c9/default" },
+         DataQueryModelService,
       ]
    }
 ];


### PR DESCRIPTION
## Summary

After the Angular upgrade and standalone migration, opening the DB query dialog from the worksheet wizard in the composer threw `NG0201: No provider found for DataQueryModelService`.

## Root Cause

`DataQueryModelService` is `@Injectable()` without `providedIn: 'root'`, so it must be explicitly provided in the route-level injector. It was already provided in `portalRoutes` but was missing from `composerRoutes`. When the composer runs (using `composerRoutes` with `ComposerAppComponent` as root), `SQLQueryDialog` and `DatabaseQueryComponent` both inject `DataQueryModelService` and fail to find it in the injector chain.

## Fix

Added `DataQueryModelService` to the `providers` array in `composerRoutes`, matching the existing pattern in `portalRoutes`. This gives the service route-scoped lifetime within the composer session.

## Test Plan

- Open the composer and create a new worksheet
- Select a database data source to open the DB query dialog
- Confirm the dialog opens without the `NG0201` error
- Confirm the portal DB query flow is unaffected

Fixes Redmine #75228.