### PR TITLE
fix(wiz): apply fieldConfigs ranking/aggregate to the rendered chart

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -183,6 +183,12 @@ public class WizAutoBindingService {
             // the same full setup (calc field registration, format, legend, temp assembly cleanup).
             if(selectedRec != null) {
                primaryAssembly = refreshVisualizationBinding(selectedRec, rvs, user);
+
+               // The recommender rebuilds dimensions without the temp chart's ranking/aggregate
+               // config, so re-apply fieldConfigs to the RENDERED binding before it executes.
+               if(primaryAssembly instanceof ChartVSAssembly chartAsm && chartAsm.getVSChartInfo() != null) {
+                  applyFieldConfigs(chartAsm.getVSChartInfo(), configMap);
+               }
             }
          }
 


### PR DESCRIPTION
## Problem
A "top 10 cities by sales" request rendered **all 597** cities — dimension ranking (top-N) from `fieldConfigs` was ignored. Same for explicit `aggregateFormula`.

## Root cause
`autoBinding` applies `fieldConfigs` (ranking, aggregate, dateGroupLevel) to the **temp** chart, but the recommender's `refreshVisualizationBinding` rebuilds the **rendered** chart's dimensions from the recommendation — without that config — so it was silently dropped. (The visible `Sum(measure)` was the recommender's default aggregate, not the honored fieldConfig.)

## Fix
After `refreshVisualizationBinding`, re-apply `applyFieldConfigs` to the rendered `ChartVSAssembly`'s `VSChartInfo` before it executes.

## Verification
Top-10-by-`Sum(amount)` now returns exactly 10 rows (was 597), rendered correctly in the companion viewer. Ranking fieldConfig contract: `optionValue=9` (TOP_N), `rankingN=10`, `rankingCol="Sum(amount)"` (the aggregated measure ref name).

Follow-up to #3839 (worksheet-identifier resolution), same autoBinding flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)