### PR TITLE
Bug #75255, fix NG0955 duplicate track keys in vs-calctable @for loops

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-calctable.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-calctable.component.html
@@ -104,7 +104,7 @@
             [style.left.px]="-getColumnWidthSum(0, model.headerColCount - 1) - (isFullHorizontalWrapper ? 0 : scrollX)">
             <table>
               <colgroup>
-              @for (colWidth of getColGroupColWidths(); track colWidth) {
+              @for (colWidth of getColGroupColWidths(); track $index) {
                 @if (colWidth > 0) {
                   <col [style.width.px]="colWidth">
                 }
@@ -207,7 +207,7 @@
           [style.left.px]="(isFullHorizontalWrapper ? 0 : -scrollX) - getColumnWidthSum(0, model.headerColCount - 1)">
           <table>
             <colgroup>
-            @for (colWidth of getColGroupColWidths(); track colWidth) {
+            @for (colWidth of getColGroupColWidths(); track $index) {
               @if (colWidth > 0) {
                 <col [style.width.px]="colWidth">
               }
@@ -267,7 +267,7 @@
                     }
                   }
                 }
-                @for (_emptyCell of emptyHeaderCells[i]; track _emptyCell; let j = $index) {
+                @for (_emptyCell of emptyHeaderCells[i]; track $index; let j = $index) {
                   @if (_emptyCell) {
                     <td class="empty-cell"></td>
                   }
@@ -409,7 +409,7 @@
                   </td>
                 }
               }
-              @for (_emptyCell of emptyHeaderCells[i]; track _emptyCell; let j = $index) {
+              @for (_emptyCell of emptyHeaderCells[i]; track $index; let j = $index) {
                 @if (_emptyCell) {
                   <td class="empty-cell"></td>
                 }


### PR DESCRIPTION
## Summary

- Four `@for` loops in `vs-calctable.component.html` used non-unique track expressions, causing Angular NG0955 errors when a CalcTable was present in the viewsheet and a component properties dialog was opened.

## Root Cause

The following track expressions produced duplicate keys:
- `track colWidth` (lines 107, 210): multiple columns can share the same pixel width (e.g., 29px)
- `track _emptyCell` (lines 270, 412): `_emptyCell` is a boolean; multiple `false` values produce the duplicate key `"false"`

Angular's `@for` block requires unique keys within each iteration.

## Fix

Changed all four track expressions to use `$index`, which is always unique within a loop:
- `track colWidth` → `track $index`
- `track _emptyCell` → `track $index`

## Test Plan

- [ ] Open the composer with a viewsheet containing a CalcTable
- [ ] Open any VS component's properties dialog (e.g., chart properties)
- [ ] Verify no NG0955 error appears in the browser console
- [ ] Verify the CalcTable renders correctly

Note: The secondary script-pane crash (`script-pane.component.ts:322`) reported in the same issue is a separate problem (CodemirrorService stub in root injector) already addressed by PR #3849.

Fixes Redmine #75255.