### PR TITLE
Bug #75257, fix worksheet column header wrapping in Angular @for

### DIFF
--- a/web/projects/portal/src/app/composer/gui/ws/editor/ws-details-table-data.component.scss
+++ b/web/projects/portal/src/app/composer/gui/ws/editor/ws-details-table-data.component.scss
@@ -37,6 +37,7 @@
 .ws-table-headers {
   position: relative;
   z-index: 1;
+  display: flex;
 }
 
 .table-data {


### PR DESCRIPTION
## Summary

- Worksheet column headers in the details pane were wrapping incorrectly after the Angular 20→21 upgrade migrated the template from `*ngFor` to the new `@for` control flow.

## Root Cause

The `@for` block introduces whitespace text nodes between adjacent rendered elements. The `<ws-header-cell>` components use `display: inline-block` on their host, so these whitespace nodes accumulated as gaps across columns and pushed the last header cell past the container width, causing it to wrap to the next line. Without `overflow: hidden` on the container, the wrapped cell appeared visually in the data row area.

## Fix

Changed `.ws-table-headers` in `ws-details-table-data.component.scss` to use `display: flex`. Flex containers ignore whitespace text nodes between items entirely, so headers are laid out correctly with no gaps and no wrapping.

## Test Plan

- Open the Composer and open the customers worksheet (or any worksheet with multiple columns)
- Verify all column headers appear in a single row, aligned with their data columns
- Verify hover/active borders on column headers display correctly
- Verify the "wrap column headers" toggle still works

Fixes Redmine #75257.