### PR TITLE
feat(wiz): /viewsheet/open returns the primary chart assembly name

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -19,9 +19,14 @@
 package inetsoft.web.wiz.controller;
 
 import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.util.Tool;
 import inetsoft.web.wiz.model.CloseViewsheetRequest;
+import inetsoft.web.wiz.model.OpenViewsheetResult;
 import inetsoft.web.wiz.service.WizVisualizationService;
 import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
@@ -46,11 +51,11 @@ public class ViewsheetRuntimeController {
     *
     * @param identifier the asset entry identifier of the viewsheet
     * @param user       the current principal
-    * @return the runtime ID of the opened viewsheet
+    * @return the runtime id plus the primary chart assembly name of the opened viewsheet
     */
-   @PostMapping(value = "/viewsheet/open", produces = MediaType.TEXT_PLAIN_VALUE)
-   public String openViewsheet(@RequestParam("identifier") String identifier,
-                               Principal user) throws Exception
+   @PostMapping(value = "/viewsheet/open", produces = MediaType.APPLICATION_JSON_VALUE)
+   public OpenViewsheetResult openViewsheet(@RequestParam("identifier") String identifier,
+                                            Principal user) throws Exception
    {
       AssetEntry entry = AssetEntry.createAssetEntry(identifier);
 
@@ -65,7 +70,40 @@ public class ViewsheetRuntimeController {
             "Viewsheet is not in the managed visualizations folder: " + path);
       }
 
-      return viewsheetService.openViewsheet(entry, user, true);
+      String runtimeId = viewsheetService.openViewsheet(entry, user, true);
+
+      OpenViewsheetResult result = new OpenViewsheetResult();
+      result.setRuntimeId(runtimeId);
+      result.setAssemblyName(findChartAssemblyName(runtimeId, user));
+      return result;
+   }
+
+   /**
+    * Resolve the primary chart assembly name of an opened runtime so callers can drive
+    * filter/browse-data/embed without a separate lookup. Prefers a chart assembly; falls
+    * back to the first assembly. Returns null if it cannot be determined (non-fatal).
+    */
+   private String findChartAssemblyName(String runtimeId, Principal user) {
+      try {
+         RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, user);
+         Viewsheet vs = rvs != null ? rvs.getViewsheet() : null;
+         Assembly[] assemblies = vs != null ? vs.getAssemblies() : null;
+
+         if(assemblies == null || assemblies.length == 0) {
+            return null;
+         }
+
+         for(Assembly a : assemblies) {
+            if(a instanceof ChartVSAssembly) {
+               return a.getName();
+            }
+         }
+
+         return assemblies[0].getName();
+      }
+      catch(Exception e) {
+         return null;
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -102,6 +102,7 @@ public class ViewsheetRuntimeController {
          return assemblies[0].getName();
       }
       catch(Exception e) {
+         log.warn("Could not resolve primary chart assembly for runtime {}: {}", runtimeId, e.getMessage());
          return null;
       }
    }
@@ -124,4 +125,6 @@ public class ViewsheetRuntimeController {
    }
 
    private final ViewsheetService viewsheetService;
+   private static final org.slf4j.Logger log =
+      org.slf4j.LoggerFactory.getLogger(ViewsheetRuntimeController.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -29,6 +29,8 @@ import inetsoft.web.wiz.model.CloseViewsheetRequest;
 import inetsoft.web.wiz.model.OpenViewsheetResult;
 import inetsoft.web.wiz.service.WizVisualizationService;
 import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -125,6 +127,5 @@ public class ViewsheetRuntimeController {
    }
 
    private final ViewsheetService viewsheetService;
-   private static final org.slf4j.Logger log =
-      org.slf4j.LoggerFactory.getLogger(ViewsheetRuntimeController.class);
+   private static final Logger log = LoggerFactory.getLogger(ViewsheetRuntimeController.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/OpenViewsheetResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/OpenViewsheetResult.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+/**
+ * Result of opening a saved wiz viewsheet: the runtime id plus the primary chart
+ * assembly name, so callers can drive subsequent runtime operations (filter, browse-data,
+ * embed) without a separate assembly lookup.
+ */
+public class OpenViewsheetResult {
+   public String getRuntimeId() {
+      return runtimeId;
+   }
+
+   public void setRuntimeId(String runtimeId) {
+      this.runtimeId = runtimeId;
+   }
+
+   public String getAssemblyName() {
+      return assemblyName;
+   }
+
+   public void setAssemblyName(String assemblyName) {
+      this.assemblyName = assemblyName;
+   }
+
+   private String runtimeId;
+   private String assemblyName;
+}


### PR DESCRIPTION
`POST /api/wiz/viewsheet/open` returned only the runtime id (text/plain). Callers re-opening a saved visualization need the chart **assembly name** to drive subsequent runtime operations (filter, browse-data, companion-viewer embed), and there's no endpoint to introspect a runtime's assemblies.

Now returns JSON `OpenViewsheetResult { runtimeId, assemblyName }`: after opening, resolve the opened viewsheet's primary chart assembly (first `ChartVSAssembly`, else first assembly; `null` if undeterminable — non-fatal). Verified live: a reopened saved viz returns `{runtimeId, assemblyName}` with the original assembly name preserved across save→reopen.

Enables the viz-chat plugin's `reload_saved_visualization` tool (stylebi-wiz side, separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)