### PR TITLE
Bug #75258, provide DataTreeValidatorService in root injector to fix NG0201 when opening Grouping assembly properties

### DIFF
--- a/web/projects/portal/src/app/vsobjects/dialog/data-tree-validator.service.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/data-tree-validator.service.ts
@@ -32,7 +32,9 @@ import { ComponentTool } from "../../common/util/component-tool";
 const GET_PARAMETERS_URI = "../api/vs/bindingtree/getConnectionParameters";
 const SET_CONNECTION_VARIABLES = "../api/composer/asset_tree/set-connection-variables";
 
-@Injectable()
+@Injectable({
+   providedIn: "root"
+})
 export class DataTreeValidatorService {
    constructor(private modelService: ModelService,
                private modalService: NgbModal)


### PR DESCRIPTION
## Summary

Opening the Properties dialog on a Grouping assembly in the worksheet composer threw `NG0201: No provider found for DataTreeValidatorService` after the Angular standalone migration.

## Root Cause

`DataTreeValidatorService` was `@Injectable()` without `providedIn`, so it had to be explicitly provided in the injector chain. It was registered in `composerRoutes` and `portalRoutes` (route-level environment injectors), but when `GroupingDialog` is opened as a modal via `SlideOutService`, the dialog's injector is built from a custom chain that does not include the route-level environment injector. `TreeDropdownComponent` (imported by `GroupingDialog`) injects `DataTreeValidatorService` in its constructor, so it failed to resolve.

## Fix

Changed `@Injectable()` to `@Injectable({ providedIn: 'root' })` on `DataTreeValidatorService`. This matches the fix pattern used for `FormulaEditorService` (Bug #75240), `ErrorHandlerService` (Bug #75236), and `SecurityTreeService` (Bug #75233). The service has no instance state, so promoting it to a root singleton is safe. The existing route-level registrations in `composerRoutes`, `portalRoutes`, and `main-viewer-element.ts` become redundant but harmless.

## Test Plan

- Open the worksheet composer and create a new Grouping assembly
- Right-click the assembly and select Properties
- Confirm the dialog opens without a browser console `NG0201` error
- Confirm other `TreeDropdownComponent` usages (DataInputPane, FormatPresenterPane, LogicalModelAttributeEditor) are unaffected

Fixes Redmine #75258.