### PR TITLE
Bug #75260, fix Recent popup 400 error by removing duplicate ComposerRecentService provider

### DIFF
--- a/web/projects/portal/src/app/composer/gui/composer-main.component.ts
+++ b/web/projects/portal/src/app/composer/gui/composer-main.component.ts
@@ -245,7 +245,6 @@ const CONFIRM_MESSAGE = {
         LineAnchorService,
         ResizeHandlerService,
         ClipboardService,
-        ComposerRecentService,
         ScriptService,
         ShowHyperlinkService,
         MiniToolbarService,


### PR DESCRIPTION
## Summary

When clicking "Recent" in the Visual Composer, a POST to `/api/composer/asset_tree/check-recent-assets` returned 400 Bad Request, preventing the recently viewed list from loading.

## Root Cause

`ComposerRecentService` was provided in two places after the Angular standalone migration:

1. Route-level in `composer.routes.ts` — the instance `ComposerAppComponent` injects and initializes by setting `currentUser`, which populates `_recentlyViewed`
2. Component-level in `ComposerMainComponent.providers` — a second instance scoped to `ComposerMainComponent` and all its children

`AssetTreePaneComponent` (a child of `ComposerMainComponent`) resolved the component-scoped instance, which never had `currentUser` set. When the user clicked "Recent", `removeNonExistItems()` sent `{ assets: undefined }` — serialized as `{}` — to the server. The Immutables-generated model builder requires the `assets` field and threw during deserialization, causing the 400.

The duplicate was introduced in the standalone migration fix (commit 7086d8a32) which restored services from the deleted `ComposerAppModule`, but `ComposerRecentService` was already present in the route-level providers.

## Fix

Remove `ComposerRecentService` from `ComposerMainComponent.providers`. The route-level provider in `composer.routes.ts` is accessible to all components in the composer route tree, ensuring every injection site resolves to the single properly-initialized instance.

## Test Plan

- Open the Visual Composer
- Click "Recent" in the left sidebar
- Verify the recently viewed assets list loads without errors
- Verify no 400 error in the browser console
- Open and close viewsheets/worksheets and confirm they appear in the Recent list

Fixes Redmine #75260.