### PR TITLE
Bug #75298 - Restore Card tooltip font hierarchy lost in @for refactor

### DIFF
--- a/web/projects/portal/src/app/graph/objects/chart-area.component.html
+++ b/web/projects/portal/src/app/graph/objects/chart-area.component.html
@@ -136,6 +136,7 @@
           @for (axis of model.axes; track trackByFn($index, axis)) {
             <chart-axis-area
               [wTooltip]="tooltipString"
+              [tooltipCSS]="tooltipCSS"
               [followCursor]="true"
               [waitTime]="0"
               [disableTooltipOnMousedown]="false"
@@ -182,6 +183,7 @@
               [hasEmptyPlotLinkModel]="!!model.emptyPlotLinkModel"
               [previewMode]="previewMode"
               [wTooltip]="tooltipString"
+              [tooltipCSS]="tooltipCSS"
               [followCursor]="true"
               [selected]="selected"
               [waitTime]="0"
@@ -270,6 +272,7 @@
                   [urlPrefix]="urlPrefix"
                   [maxHeight]="getLegendContentHeight(legend, legendObject)"
                   [wTooltip]="tooltipString"
+                  [tooltipCSS]="tooltipCSS"
                   [followCursor]="true"
                   [waitTime]="0"
                   [disableTooltipOnMousedown]="false"


### PR DESCRIPTION
Summary

Card-style chart tooltips rendered with flat default styling instead of the intended 3-level
font hierarchy (tier 1: 16px/600, tier 2: 13px/opacity 0.9, tier 3: 11px/opacity 0.7).

Root cause

The refactor of chart-area.component.html from *ngFor/*ngIf to Angular's @for/@if
control-flow syntax accidentally dropped the [tooltipCSS]="tooltipCSS" binding from all three
[wTooltip] usages. As a result TooltipDirective always used its default
"widget__default-tooltip" value, so the widget__card-tooltip class — which scopes the
.tt-tier-1/2/3 rules in _directives.scss — was never applied.

Fix

Re-added [tooltipCSS]="tooltipCSS" after [wTooltip]="tooltipString" on chart-axis-area,
chart-plot-area, and chart-legend-area. No .ts/.scss changes were needed — the tooltipCSS
property (computed as widget__card-tooltip when model.tooltipStyle === "CARD") and the CSS
rules were both already present.