### PR TITLE
Bug #75281, fix search icon position and missing label in themes CSS filter

### DIFF
--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-css-view/theme-css-view.component.html
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-css-view/theme-css-view.component.html
@@ -24,16 +24,12 @@
       <mat-form-field color="accent" class="flex-row full-width">
         <mat-label>_#(Filter)</mat-label>
         <input matInput #portalSearch placeholder="_#(Filter)" (keyup)="filterTable($event.target.value, true)">
-        @if (portalSearch.value) {
-          <button mat-icon-button matSuffix
-            title="_#(Clear)" aria-label="_#(Clear)"
-            (click)="portalSearch.value=''; filterTable(portalSearch.value, true)">
-            <mat-icon fontSet="ineticons" fontIcon="shape-cross-icon"></mat-icon>
-          </button>
-        }
-        @if (!portalSearch.value) {
-          <mat-icon matSuffix fontSet="ineticons" fontIcon="search-icon"></mat-icon>
-        }
+        <button mat-icon-button matSuffix *ngIf="portalSearch.value"
+          title="_#(Clear)" aria-label="_#(Clear)"
+          (click)="portalSearch.value=''; filterTable(portalSearch.value, true)">
+          <mat-icon fontSet="ineticons" fontIcon="shape-cross-icon"></mat-icon>
+        </button>
+        <mat-icon matSuffix *ngIf="!portalSearch.value" fontSet="ineticons" fontIcon="search-icon"></mat-icon>
       </mat-form-field>
       <div class="table-container flex-col">
         <table mat-table [dataSource]="portalCssDataSource" matSort [trackBy]="trackByFn">
@@ -114,16 +110,12 @@
       <mat-form-field color="accent" class="flex-row full-width">
         <mat-label>_#(Filter)</mat-label>
         <input matInput #emSearch placeholder="_#(Filter)" (keyup)="filterTable($event.target.value, false)">
-        @if (emSearch.value) {
-          <button mat-icon-button matSuffix
-            title="_#(Clear)" aria-label="_#(Clear)"
-            (click)="emSearch.value=''; filterTable(emSearch.value, false)">
-            <mat-icon fontSet="ineticons" fontIcon="shape-cross-icon"></mat-icon>
-          </button>
-        }
-        @if (!emSearch.value) {
-          <mat-icon matSuffix fontSet="ineticons" fontIcon="search-icon"></mat-icon>
-        }
+        <button mat-icon-button matSuffix *ngIf="emSearch.value"
+          title="_#(Clear)" aria-label="_#(Clear)"
+          (click)="emSearch.value=''; filterTable(emSearch.value, false)">
+          <mat-icon fontSet="ineticons" fontIcon="shape-cross-icon"></mat-icon>
+        </button>
+        <mat-icon matSuffix *ngIf="!emSearch.value" fontSet="ineticons" fontIcon="search-icon"></mat-icon>
       </mat-form-field>
       <div class="table-container flex-col">
         <table mat-table [dataSource]="emCssDataSource" matSort>


### PR DESCRIPTION
## Summary

- In EM > Settings > Presentation > Themes > CSS tab, the filter form fields showed two visual regressions: the \"Filter\" label was not visible and the search icon appeared on the left instead of the right

## Root Cause

The `matSuffix` elements (search icon and clear button) in both the Portal and EM filter fields were wrapped in `@if` blocks. Angular's `@if` interposes an embedded view between the component host and its projected content, preventing named-slot content projection from resolving at compile time. This caused the search icon to render outside its designated suffix slot and broke the form field layout entirely (including the label). This is the same NG8011 issue fixed across 73 other templates in Bug #75272, but the `matSuffix` elements in this file were missed (only the `mat-error` elements were fixed at that time).

## Fix

Replace `@if` wrapping around `matSuffix` elements with `*ngIf` directly on the elements in both filter form fields. `NgIf` was already imported in the component.

## Test Plan

- Open EM > Settings > Presentation > Themes, create or select a theme, switch to the CSS tab
- Verify the \"Filter\" label is visible in the Portal section filter field
- Verify the search icon appears on the right side of the filter field
- Type text in the filter field and verify the clear (X) button appears on the right
- Click the clear button and verify the search icon returns and filtering is cleared
- Verify the same behavior for the Enterprise Manager section filter field
- Verify no regressions in other EM pages with form fields

Fixes Redmine #75281.