### PR TITLE
Bug #75227, fix TypeError when typing in email dialog before tree data loads

### DIFF
--- a/web/projects/em/src/app/settings/email-picker/email-list-dialog/email-list-dialog.component.ts
+++ b/web/projects/em/src/app/settings/email-picker/email-list-dialog/email-list-dialog.component.ts
@@ -345,7 +345,7 @@ export class EmailListDialogComponent implements OnInit, OnDestroy {
    }
 
    private searchEmailTree(roots: EmailNode[], searchStr: string): EmailNode[] {
-      if(!searchStr) {
+      if(!searchStr || !roots) {
          return roots;
       }
 


### PR DESCRIPTION
## Summary

When a user opens the Select Emails dialog from the EM security/users page and types in the email input, a `TypeError: Cannot read properties of undefined (reading 'filter')` was thrown in `searchEmailTree`.

## Root Cause

`originalDataSource` is only populated after an async HTTP call in `ngOnInit()` (when `autocompleteEmails` is true). If the user types before that call completes — or if `autocompleteEmails` is false so the call never runs — `originalDataSource` remains `undefined`. The `searchTextchanges$` subscription passes `Tool.clone(this.originalDataSource)` (which resolves to `undefined`) into `searchEmailTree` as `roots`, which then crashes on `roots.filter(...)`.

## Fix

Added a `!roots` guard to the early-return condition in `searchEmailTree` so the method safely returns when `roots` is undefined, matching the existing guard for an empty `searchStr`.

## Test Plan

- Open `em/settings/security/users`
- Select the `admin` user and click "Select Emails"
- Type in the email input field — no console error should appear
- Verify the search/filter behavior still works after the email tree has loaded

Fixes Redmine #75227.