### PR TITLE
Bug #75232, fix SyntaxError when creating organization due to JSON.parse on plain-text STOMP message

### DIFF
--- a/web/projects/em/src/app/app.component.ts
+++ b/web/projects/em/src/app/app.component.ts
@@ -109,7 +109,7 @@ export class AppComponent implements OnInit, OnDestroy {
          this.subscription.add(connection.subscribe(
             "/user/create-org-status-changed",
             (message) => this.zone.run(
-               () => this.showEditOrgMessage(JSON.parse(message.frame.body)))));
+               () => this.showEditOrgMessage(message.frame.body))));
 
          this.subscription.add(connection.subscribe(
             "/user/current-org-changed",


### PR DESCRIPTION
## Summary

When creating a new organization in EM (Security → Users → New Organization → Host Organization), the browser console threw a `SyntaxError` because the frontend tried to `JSON.parse` a plain-text STOMP message.

## Root Cause

The `/user/create-org-status-changed` STOMP subscription in `app.component.ts` called `JSON.parse(message.frame.body)`. However, the backend (`EditOrganizationListener`) sends a plain localized string (e.g., "Starting task...") via Spring's `StringMessageConverter`, which transmits it as unquoted text. `JSON.parse` fails with `SyntaxError: Unexpected token 'S'`.

## Fix

Remove the `JSON.parse` call from the `/user/create-org-status-changed` subscription handler. The message body is already a plain string and is passed directly to `showEditOrgMessage`, which wraps it in `{message: message}` before calling `notify()`.

## Test Plan

- [ ] Create a new organization in EM (Security → Users → New Organization → select Host Organization, enter password, confirm)
- [ ] Verify no `SyntaxError` appears in the browser console
- [ ] Verify the status notification ("Starting..." / "Finished...") is displayed correctly during org creation
- [ ] Verify no regressions in other STOMP-driven notifications (session expiration, license changes, org changed)

Fixes Redmine #75232.