### PR TITLE
Bug #75015 - Tier gantt card tooltips by innermost Y dim and interval dates

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -1421,11 +1421,17 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
          boolean isGantt = GraphTypes.isGantt(chartInfo.getChartType());
          boolean isCandleOrStock = chartInfo instanceof CandleChartInfo;
          boolean isScatter = isScatterPlot(chartInfo);
+         // Innermost Y dim for the gantt card layout; null off-card or when no Y dim.
+         String ganttHeadline = null;
 
          // Gantt: Y-axis is the "row" axis that distinguishes bars, so list
          // Y dims ahead of X dims regardless of binding order in the element.
          if(isGantt) {
             dims = ganttDimsYFirst(dims, chartInfo);
+
+            if(chartInfo.getTooltipStyle() == ChartInfo.TooltipStyle.CARD) {
+               ganttHeadline = ganttInnermostYDim(chartInfo, allfields);
+            }
          }
          // Scatter: the categorical color/shape aesthetic identifies each point,
          // but it lives in an aesthetic frame rather than element.getDims(). Lift
@@ -1456,9 +1462,24 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
                measures, (CandleChartInfo) chartInfo);
          }
 
-         String[][] cols = cardMeasureFirst
-            ? new String[][] {tipMeasures, dims, others}
-            : new String[][] {dims, measures, others};
+         String[][] cols;
+
+         if(cardMeasureFirst) {
+            cols = new String[][] {tipMeasures, dims, others};
+         }
+         // Gantt card: innermost Y dim headlines, the date measures group at
+         // tier-2, and the remaining grouping dims drop to tier-3 below.
+         else if(ganttHeadline != null) {
+            cols = new String[][] {
+               new String[]{ ganttHeadline },
+               measures,
+               ganttContextDims(dims, ganttHeadline),
+               others
+            };
+         }
+         else {
+            cols = new String[][] {dims, measures, others};
+         }
          HashSet<String> added = new HashSet<>();
          Object[] arr = new Object[list.size()];
 
@@ -1582,14 +1603,13 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
          }
 
          // Gantt and scatter present values of equal importance, not a headline
-         // measure. When a real identity dim leads (Gantt task / scatter color
-         // dim) it becomes the tier-1 headline and the values group at tier-2;
-         // a scatter with no identity dim renders every row at a uniform tier
-         // (like the flat default tooltip). Sized here, before appendInfo adds
-         // aesthetics, so only structural rows join the tier-2 group.
-         if(chartInfo.getTooltipStyle() == ChartInfo.TooltipStyle.CARD &&
-            (isGantt || isScatter))
-         {
+         // measure. Sized here, before appendInfo adds aesthetics, so only
+         // structural rows join the tier-2 group.
+         //
+         // Scatter: the color/shape identity dim (if any) leads at tier-1 and the
+         // co-equal coordinate measures + remaining dims group at tier-2; with no
+         // identity dim every row renders at a uniform tier (flat default tooltip).
+         if(chartInfo.getTooltipStyle() == ChartInfo.TooltipStyle.CARD && isScatter) {
             boolean hasIdentityDim = Arrays.stream(dims)
                .anyMatch(d -> d != null && allfields.contains(d));
 
@@ -1598,7 +1618,20 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
                tooltip.setGroupedTiers(true);
                tooltip.setTier2GroupSize(Math.max(0, structuralPairs - 1));
             }
-            else if(isScatter) {
+            else {
+               tooltip.setUniformTier(true);
+            }
+         }
+         // Gantt: the innermost Y dim identifies the hovered bar (tier-1 headline)
+         // and only the Start/End/Milestone dates group at tier-2 as core interval
+         // data; outer Y dims, X dims, and aesthetics fall to tier-3. With no Y dim
+         // there is no bar identity, so render every row at a uniform tier.
+         else if(chartInfo.getTooltipStyle() == ChartInfo.TooltipStyle.CARD && isGantt) {
+            if(ganttHeadline != null) {
+               tooltip.setGroupedTiers(true);
+               tooltip.setTier2GroupSize(measurePairs);
+            }
+            else {
                tooltip.setUniformTier(true);
             }
          }
@@ -2168,6 +2201,38 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
 
       head.addAll(tail);
       return head.toArray(new String[0]);
+   }
+
+   // The innermost (plot-adjacent) Y dim identifies the hovered bar, so it leads
+   // the gantt card tooltip as the tier-1 headline. That is the last RTYField,
+   // which is the inner-most coordinate dimension. Returns null when no Y dim
+   // renders, so the caller falls back to a uniform tier with no headline.
+   static String ganttInnermostYDim(ChartInfo chartInfo, Set<String> allfields) {
+      ChartRef[] yfields = chartInfo.getRTYFields();
+
+      for(int i = yfields.length - 1; i >= 0; i--) {
+         String name = GraphUtil.getName(yfields[i]);
+
+         if(name != null && allfields.contains(name)) {
+            return name;
+         }
+      }
+
+      return null;
+   }
+
+   // Grouping dims minus the headline, preserving ganttDimsYFirst order (outer Y
+   // dims, then X dims) — these render at tier-3 as secondary context.
+   static String[] ganttContextDims(String[] orderedDims, String headline) {
+      List<String> rest = new ArrayList<>(orderedDims.length);
+
+      for(String d : orderedDims) {
+         if(!Objects.equals(d, headline)) {
+            rest.add(d);
+         }
+      }
+
+      return rest.toArray(new String[0]);
    }
 
    private Map<String, ArrayList<Integer>> getRowValuePointMap(List<VisualObject> vos) {

--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -1421,7 +1421,7 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
          boolean isGantt = GraphTypes.isGantt(chartInfo.getChartType());
          boolean isCandleOrStock = chartInfo instanceof CandleChartInfo;
          boolean isScatter = isScatterPlot(chartInfo);
-         // Innermost Y dim for the gantt card layout; null off-card or when no Y dim.
+         // Innermost Y dim that headlines the gantt card; null for non-card style or no Y dim.
          String ganttHeadline = null;
 
          // Gantt: Y-axis is the "row" axis that distinguishes bars, so list
@@ -2221,8 +2221,8 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
       return null;
    }
 
-   // Grouping dims minus the headline, preserving ganttDimsYFirst order (outer Y
-   // dims, then X dims) — these render at tier-3 as secondary context.
+   // Grouping dims minus the headline, for tier-3 context. Caller passes dims in
+   // ganttDimsYFirst order (outer Y dims, then X dims); that order is preserved here.
    static String[] ganttContextDims(String[] orderedDims, String headline) {
       List<String> rest = new ArrayList<>(orderedDims.length);
 

--- a/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
@@ -440,7 +440,7 @@ class ChartToolTipTest {
       tip.addTooltip(palette.put("state"), palette.put("TX"));
       tip.addTooltip(palette.put("product_name"), palette.put("WebCalendar"));
       tip.setGroupedTiers(true);
-      tip.setTier2GroupSize(3);
+      tip.setTier2GroupSize(3); // measurePairs when an interval bar renders Start + End + Milestone
 
       String out = tip.getTooltip(palette);
 
@@ -456,6 +456,34 @@ class ChartToolTipTest {
                  "X dim is secondary context at tier-3");
       assertTrue(out.contains("<div class=\"tt-tier-3\">product_name:&nbsp;WebCalendar"),
                  "Aesthetic dim is secondary context at tier-3");
+      assertFalse(out.contains("tt-tier-4"));
+   }
+
+   @Test
+   void ganttCardMilestonePointGroupsOnlyMilestoneAtTier2() {
+      // A milestone point exposes only Milestone via getVars(), so measurePairs == 1:
+      // the innermost Y dim headlines and Milestone alone sits at tier-2, with the
+      // outer Y dim and X dim at tier-3. Guards the per-element tier-2 sizing.
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.addTooltip(palette.put("DataGroup(city)"), palette.put("A"));
+      tip.addTooltip(palette.put("milestone"), palette.put("2000-10-10"));
+      tip.addTooltip(palette.put("reseller"), palette.put("true"));
+      tip.addTooltip(palette.put("state"), palette.put("TX"));
+      tip.setGroupedTiers(true);
+      tip.setTier2GroupSize(1); // measurePairs for a milestone point
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-1\">DataGroup(city):&nbsp;A"),
+                 "Innermost Y dim is the tier-1 headline");
+      assertTrue(out.contains("<div class=\"tt-tier-2\">milestone:&nbsp;2000-10-10"),
+                 "Milestone alone groups at tier-2 for a milestone point");
+      assertTrue(out.contains("<div class=\"tt-tier-3\">reseller:&nbsp;true"),
+                 "Outer Y dim drops to tier-3");
+      assertTrue(out.contains("<div class=\"tt-tier-3\">state:&nbsp;TX"),
+                 "X dim drops to tier-3");
       assertFalse(out.contains("tt-tier-4"));
    }
 

--- a/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
@@ -424,6 +424,42 @@ class ChartToolTipTest {
    }
 
    @Test
+   void ganttCardGroupsOnlyDatesAtTier2WhenManyDims() {
+      // Multi-dim gantt: the innermost Y dim headlines (tier-1), Start/End/
+      // Milestone group at tier-2 as core interval data, and the outer Y dim, X
+      // dim, and color aesthetic all drop to tier-3 as secondary context. Row
+      // order and tier2GroupSize match what PlotArea emits for the card layout.
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.addTooltip(palette.put("DataGroup(city)"), palette.put("A"));
+      tip.addTooltip(palette.put("orderdate"), palette.put("2000-10-05"));
+      tip.addTooltip(palette.put("end"), palette.put("2000-10-15"));
+      tip.addTooltip(palette.put("milestone"), palette.put("2000-10-10"));
+      tip.addTooltip(palette.put("reseller"), palette.put("true"));
+      tip.addTooltip(palette.put("state"), palette.put("TX"));
+      tip.addTooltip(palette.put("product_name"), palette.put("WebCalendar"));
+      tip.setGroupedTiers(true);
+      tip.setTier2GroupSize(3);
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-1\">DataGroup(city):&nbsp;A"),
+                 "Innermost Y dim is the tier-1 headline");
+      assertTrue(out.contains("<div class=\"tt-tier-2\">orderdate:&nbsp;2000-10-05"));
+      assertTrue(out.contains("<div class=\"tt-tier-2\">end:&nbsp;2000-10-15"));
+      assertTrue(out.contains("<div class=\"tt-tier-2\">milestone:&nbsp;2000-10-10"),
+                 "All three date measures group at tier-2");
+      assertTrue(out.contains("<div class=\"tt-tier-3\">reseller:&nbsp;true"),
+                 "Outer Y dim is secondary context at tier-3");
+      assertTrue(out.contains("<div class=\"tt-tier-3\">state:&nbsp;TX"),
+                 "X dim is secondary context at tier-3");
+      assertTrue(out.contains("<div class=\"tt-tier-3\">product_name:&nbsp;WebCalendar"),
+                 "Aesthetic dim is secondary context at tier-3");
+      assertFalse(out.contains("tt-tier-4"));
+   }
+
+   @Test
    void uniformTierCardRendersAllRowsAtSameTier() {
       // Scatter with no identity dim: the measures are coordinates of equal
       // weight, so every row renders at the same tier with no headline.

--- a/core/src/test/java/inetsoft/report/composition/region/PlotAreaGanttDimsTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/PlotAreaGanttDimsTest.java
@@ -174,6 +174,29 @@ class PlotAreaGanttDimsTest {
       assertFalse(out.contains("tt-tier-4"));
    }
 
+   @Test
+   void ganttCardNoYDimRendersUniformTier() {
+      // No Y dim → ganttInnermostYDim returns null → the card falls back to a
+      // uniform tier: every row at the same tier with no headline, mirroring the
+      // getToolTip fallback. Uniform tier renders all rows at tier-2.
+      ChartInfo info = chartInfoWithY();
+      assertNull(PlotArea.ganttInnermostYDim(info, Set.of("orderdate", "end")));
+
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.addTooltip(palette.put("orderdate"), palette.put("2000-10-05"));
+      tip.addTooltip(palette.put("end"), palette.put("2000-10-15"));
+      tip.setUniformTier(true);
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-2\">orderdate:&nbsp;2000-10-05"));
+      assertTrue(out.contains("<div class=\"tt-tier-2\">end:&nbsp;2000-10-15"));
+      assertFalse(out.contains("tt-tier-1"), "No headline div when no Y dim");
+      assertFalse(out.contains("tt-tier-3"), "Uniform tier keeps every row equal");
+   }
+
    private static ChartInfo chartInfoWithY(String... yFullNames) {
       ChartRef[] refs = new ChartRef[yFullNames.length];
 

--- a/core/src/test/java/inetsoft/report/composition/region/PlotAreaGanttDimsTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/PlotAreaGanttDimsTest.java
@@ -19,12 +19,20 @@ package inetsoft.report.composition.region;
 
 import inetsoft.uql.viewsheet.graph.ChartInfo;
 import inetsoft.uql.viewsheet.graph.ChartRef;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@Tag("core")
 class PlotAreaGanttDimsTest {
    @Test
    void yDimsMoveToHeadXDimsToTail() {
@@ -64,6 +72,106 @@ class PlotAreaGanttDimsTest {
       String[] result = PlotArea.ganttDimsYFirst(new String[0], info);
 
       assertArrayEquals(new String[0], result);
+   }
+
+   @Test
+   void innermostYDimIsLastRTYField() {
+      // The innermost (plot-adjacent) Y dim is the last RTYField; it headlines
+      // the gantt card tooltip as the row that identifies the hovered bar.
+      ChartInfo info = chartInfoWithY("reseller", "datagroup(city)");
+      String result = PlotArea.ganttInnermostYDim(
+         info, Set.of("reseller", "datagroup(city)", "state"));
+
+      assertEquals("datagroup(city)", result);
+   }
+
+   @Test
+   void innermostYDimSkipsFieldsNotRendered() {
+      // Walk outward to the first Y dim that actually renders a tooltip row.
+      ChartInfo info = chartInfoWithY("reseller", "datagroup(city)");
+      String result = PlotArea.ganttInnermostYDim(info, Set.of("reseller"));
+
+      assertEquals("reseller", result);
+   }
+
+   @Test
+   void innermostYDimNullWhenNoYBound() {
+      ChartInfo info = chartInfoWithY();
+      assertNull(PlotArea.ganttInnermostYDim(info, Set.of("state", "city")));
+   }
+
+   @Test
+   void innermostYDimNullWhenNoYInAllfields() {
+      ChartInfo info = chartInfoWithY("reseller");
+      assertNull(PlotArea.ganttInnermostYDim(info, Set.of()));
+   }
+
+   @Test
+   void contextDimsDropHeadlinePreservingOrder() {
+      // ganttDimsYFirst order (outer Y, inner Y, then X); removing the innermost
+      // Y headline leaves outer Y then X as tier-3 context.
+      String[] result = PlotArea.ganttContextDims(
+         new String[] { "reseller", "datagroup(city)", "state", "city" },
+         "datagroup(city)");
+
+      assertArrayEquals(new String[] { "reseller", "state", "city" }, result);
+   }
+
+   @Test
+   void contextDimsUnchangedWhenHeadlineAbsent() {
+      String[] result = PlotArea.ganttContextDims(
+         new String[] { "state", "city" }, "reseller");
+
+      assertArrayEquals(new String[] { "state", "city" }, result);
+   }
+
+   @Test
+   void ganttCardLayoutComposesHeadlineDatesThenContext() {
+      // Exercises the gantt card algorithm end-to-end the way getToolTip wires it:
+      // resolve the innermost-Y headline, order rows [headline, dates, context,
+      // aesthetics], size tier-2 to the date count, then render. Ties the helper
+      // contracts (ganttInnermostYDim/ganttContextDims) to the tier output so a
+      // regression in either the ordering or the grouping is caught together.
+      String[] orderedDims = { "reseller", "datagroup(city)", "state" }; // ganttDimsYFirst order
+      String[] dates = { "orderdate", "end", "milestone" };              // element.getVars()
+      ChartInfo info = chartInfoWithY("reseller", "datagroup(city)");
+      Set<String> allfields = Set.of("reseller", "datagroup(city)", "state",
+         "orderdate", "end", "milestone", "product_name");
+
+      String headline = PlotArea.ganttInnermostYDim(info, allfields);
+      String[] context = PlotArea.ganttContextDims(orderedDims, headline);
+
+      assertEquals("datagroup(city)", headline);
+      assertArrayEquals(new String[] { "reseller", "state" }, context);
+
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.addTooltip(palette.put(headline), palette.put("Piscataway"));
+      tip.addTooltip(palette.put("orderdate"), palette.put("2000-10-22"));
+      tip.addTooltip(palette.put("end"), palette.put("2000-11-01"));
+      tip.addTooltip(palette.put("milestone"), palette.put("2000-10-29"));
+      tip.addTooltip(palette.put("reseller"), palette.put("false"));
+      tip.addTooltip(palette.put("state"), palette.put("NJ"));
+      tip.addTooltip(palette.put("product_name"), palette.put("Web Bridge"));
+      tip.setGroupedTiers(true);
+      tip.setTier2GroupSize(dates.length); // measurePairs
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-1\">datagroup(city):&nbsp;Piscataway"),
+                 "Innermost Y dim headlines at tier-1");
+      assertTrue(out.contains("<div class=\"tt-tier-2\">orderdate:&nbsp;2000-10-22"));
+      assertTrue(out.contains("<div class=\"tt-tier-2\">end:&nbsp;2000-11-01"));
+      assertTrue(out.contains("<div class=\"tt-tier-2\">milestone:&nbsp;2000-10-29"),
+                 "The date measures group at tier-2");
+      assertTrue(out.contains("<div class=\"tt-tier-3\">reseller:&nbsp;false"),
+                 "Outer Y dim drops to tier-3 context");
+      assertTrue(out.contains("<div class=\"tt-tier-3\">state:&nbsp;NJ"),
+                 "X dim drops to tier-3 context");
+      assertTrue(out.contains("<div class=\"tt-tier-3\">product_name:&nbsp;Web Bridge"),
+                 "Aesthetic drops to tier-3 context");
+      assertFalse(out.contains("tt-tier-4"));
    }
 
    private static ChartInfo chartInfoWithY(String... yFullNames) {


### PR DESCRIPTION
## Summary

Refines card-style chart tooltip tiering so a gantt chart's interval data are tiered correctly.

For gantt charts, the previous heuristic (`tier2GroupSize = structuralPairs - 1`) worked only for the simple one-task-dim case. When a gantt bound multiple X and Y grouping dims, every grouping dim except the first landed in tier-2 alongside Start/End/Milestone, diluting the interval data that is the whole point of a gantt, and it headlined the outermost Y dim rather than the innermost one that actually identifies the hovered bar.

## Tier rule (gantt card tooltips)

| Tier | Content | Rationale |
|------|---------|-----------|
| Tier 1 | Innermost Y dim (last `RTYField`) | Identifies the hovered bar |
| Tier 2 | Start / End / Milestone | Core gantt interval data |
| Tier 3 | Outer Y dims + X dims + aesthetics | Secondary grouping context |
| Fallback | No Y dim bound -> uniform tier, no headline | No bar identity to lead |

Tier-2 is sized per hovered element: an interval bar groups Start + End, a milestone point groups Milestone alone, because each element exposes its own dates via `getVars()`. All aesthetics (color, size, text) are tier-3 context.

## Changes

- `PlotArea.java`
  - Resolve `ganttHeadline` (innermost Y dim) for card-style gantt only.
  - Build a gantt-specific card `cols` order: `[headline]`, dates, context dims,
    others. Reuses the same `measures` array reference so the existing
    `cols[k] == measures` guards and the `measurePairs` count are unaffected.
  - Split gantt out of the shared scatter grouping block; gantt sizes tier-2 to
    `measurePairs` with a uniform-tier fallback when no Y dim leads.
  - New helpers `ganttInnermostYDim` and `ganttContextDims`.
- Tests
  - `PlotAreaGanttDimsTest` - helper coverage (innermost resolution incl.
    skip-not-rendered, null on X-only/empty; context-dim removal), plus a
    composition test tying the helpers to the rendered tiers.
  - `ChartToolTipTest` - multi-dim gantt render case.
  - `PlotAreaGanttDimsTest` gains `@Tag("core")` so it runs in the core group.

## Compatibility and scope

No API, serialization, or event-contract change. Output uses the same `tt-tier-N` div vocabulary the frontend already styles; only tier assignment changes. Scatter behavior and default-style gantt tooltips are unchanged. The `dims` reordering is confined to tooltip construction.

## Notable side fix

`PlotAreaGanttDimsTest` lacked `@Tag("core")` and was silently skipped by the core-group surefire run, so its four pre-existing tests never executed. Adding the tag un-skips them.