### PR TITLE
Bug #75291, fix 500 error and blank panel for schedule tasks in folders in EM repository

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/ResourcePermissionController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/ResourcePermissionController.java
@@ -99,7 +99,7 @@ public class ResourcePermissionController {
       boolean allowed;
 
       if(resource.getType() == ResourceType.SCHEDULE_TASK) {
-         ScheduleTask task = scheduleManager.getScheduleTask(path);
+         ScheduleTask task = scheduleManager.getScheduleTask(resource.getPath());
          allowed = task != null &&
             ScheduleManager.hasTaskPermission(task.getOwner(), principal, scheduleTaskAction);
       }

--- a/core/src/main/java/inetsoft/web/admin/content/repository/ResourcePermissionService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/ResourcePermissionService.java
@@ -585,9 +585,16 @@ public class ResourcePermissionService {
          type = ResourceType.CUBE;
          resourcePath = getCubeResourceName(path);
          break;
-      case RepositoryEntry.SCHEDULE_TASK:
+      case RepositoryEntry.SCHEDULE_TASK: {
          type = ResourceType.SCHEDULE_TASK;
+         int slashIdx = resourcePath.lastIndexOf('/');
+
+         if(slashIdx >= 0) {
+            resourcePath = resourcePath.substring(slashIdx + 1);
+         }
+
          break;
+      }
       case RepositoryEntry.SCHEDULE_TASK | RepositoryEntry.FOLDER:
          type = ResourceType.SCHEDULE_TASK_FOLDER;
          break;

--- a/web/projects/em/src/app/settings/content/repository/repository-editor-page/repository-editor-page.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/repository-editor-page/repository-editor-page.component.ts
@@ -147,6 +147,7 @@ export class RepositoryEditorPageComponent implements OnChanges, OnInit {
          type === RepositoryEntryType.CUBE ||
          type === RepositoryEntryType.DATA_SOURCE_FOLDER && path === "/" ||
          type === RepositoryEntryType.SCHEDULE_TASK_FOLDER && path === "/" ||
+         type === RepositoryEntryType.SCHEDULE_TASK ||
          this.repositoryService.isDataModelFolderEntry(type)) {
          return "permission";
       }


### PR DESCRIPTION
## Summary

- **500 error**: The EM Content Repository permission endpoint received the full tree node path (`f1/admin:Task1`) for a schedule task in a folder, but `ScheduleManager.getScheduleTask()` expects the bare task ID (`admin:Task1`). This caused `task == null` → permission denied → 500.
- **Blank panel**: `editorType` in `repository-editor-page.component.ts` had no case for `SCHEDULE_TASK`, so it returned `null` and the `@switch` fell through to an empty default, rendering nothing even when the API succeeded.

### Changes

- `ResourcePermissionService.getRepositoryResourceType`: strip folder prefix from `resourcePath` for `SCHEDULE_TASK` so `resource.getPath()` returns the bare task ID.
- `ResourcePermissionController.checkPermission`: use `resource.getPath()` (stripped task ID) instead of the raw `path` request parameter when looking up the task.
- `repository-editor-page.component.ts`: add `SCHEDULE_TASK` to the `'permission'` branch in `editorType` so the permission editor renders for task nodes.

## Test plan

- [ ] Open EM → Content → Repository, expand Schedule Tasks, create a folder, place a task inside it
- [ ] Click the task node — permission editor should open (no 500, no blank panel)
- [ ] Verify permissions can be saved via the POST endpoint
- [ ] Click a root-level schedule task (not in a folder) — permission editor should also open correctly
- [ ] Verify schedule task folder nodes still open the folder settings editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)