### PR TITLE
Bug #75294 - Keep Snap to nearest data point enabled when Combined is off

### DIFF
--- a/web/projects/portal/src/app/widget/dialog/tip-customize-dialog/tip-customize-dialog.component.spec.ts
+++ b/web/projects/portal/src/app/widget/dialog/tip-customize-dialog/tip-customize-dialog.component.spec.ts
@@ -1,0 +1,87 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { TipCustomizeDialog } from "./tip-customize-dialog.component";
+import { TipCustomizeDialogModel } from "./tip-customize-dialog-model";
+
+describe("TipCustomizeDialog snap/combined state machine", () => {
+   let dialog: TipCustomizeDialog;
+
+   const createModel = (overrides: Partial<TipCustomizeDialogModel> = {}): TipCustomizeDialogModel => ({
+      customRB: "DEFAULT",
+      combinedTip: false,
+      combinedSupported: true,
+      customTip: "",
+      dataRefList: [],
+      availableTipValues: [],
+      snapTooltip: false,
+      snapSupported: true,
+      ...overrides
+   });
+
+   const initWith = (model: TipCustomizeDialogModel) => {
+      dialog = new TipCustomizeDialog(null as any, null as any);
+      dialog.model = model;
+      dialog.ngOnChanges(<any> { model: {} });
+   };
+
+   it("keeps snap enabled when Combined is turned off", () => {
+      initWith(createModel({ combinedTip: true, snapTooltip: true }));
+
+      dialog.form.get("combinedTip").setValue(false);
+
+      expect(dialog.form.get("snapTooltip").enabled).toBe(true);
+   });
+
+   it("enables and checks snap when Combined is turned on", () => {
+      initWith(createModel());
+
+      dialog.form.get("combinedTip").setValue(true);
+
+      const snap = dialog.form.get("snapTooltip");
+      expect(snap.enabled).toBe(true);
+      expect(snap.value).toBe(true);
+   });
+
+   it("re-enables snap when switching from NONE to CUSTOM", () => {
+      initWith(createModel({ customRB: "NONE" }));
+      expect(dialog.form.get("snapTooltip").disabled).toBe(true);
+
+      dialog.form.get("customRB").setValue("CUSTOM");
+
+      expect(dialog.form.get("snapTooltip").enabled).toBe(true);
+   });
+
+   it("disables and clears snap when switching to NONE", () => {
+      initWith(createModel({ snapTooltip: true }));
+
+      dialog.form.get("customRB").setValue("NONE");
+
+      const snap = dialog.form.get("snapTooltip");
+      expect(snap.disabled).toBe(true);
+      expect(snap.value).toBe(false);
+   });
+
+   it("keeps snap disabled when snap is not supported", () => {
+      initWith(createModel({ snapSupported: false }));
+      expect(dialog.form.get("snapTooltip").disabled).toBe(true);
+
+      dialog.form.get("combinedTip").setValue(true);
+
+      expect(dialog.form.get("snapTooltip").disabled).toBe(true);
+   });
+});

--- a/web/projects/portal/src/app/widget/dialog/tip-customize-dialog/tip-customize-dialog.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/tip-customize-dialog/tip-customize-dialog.component.ts
@@ -73,6 +73,9 @@ export class TipCustomizeDialog implements OnChanges {
             this.form.get("customTip").enable();
             this.form.get("combinedTip").disable();
             this.form.get("combinedTip").setValue(false);
+            if(this.model.snapSupported) {
+               snap.enable();
+            }
          }
          else if(custom == "NONE") {
             this.form.get("customTip").disable();
@@ -93,14 +96,10 @@ export class TipCustomizeDialog implements OnChanges {
       });
 
       this.form.get("combinedTip").valueChanges.subscribe(combined => {
-         const snap = this.form.get("snapTooltip");
          if(combined && this.model.snapSupported) {
+            const snap = this.form.get("snapTooltip");
             snap.enable();
             snap.setValue(true);
-         }
-         else if(!combined) {
-            snap.disable();
-            snap.setValue(false);
          }
       });
 


### PR DESCRIPTION
Unchecking the Combined option in the chart tooltip customize dialog
incorrectly disabled the Snap to nearest data point checkbox. The two
options are independent: snap applies in the Default/Auto and Custom
tooltip modes whether or not tooltips are combined, and is only
irrelevant when the tooltip mode is None or the chart type does not
support snapping.

Changes in tip-customize-dialog.component.ts:

- Remove the branch in the Combined value-change handler that disabled
  and cleared snap when Combined was turned off. Turning Combined on
  still enables and checks snap, since a combined tooltip inherently
  snaps to a data point.
- Restore enabling snap in the Custom branch of the tooltip-mode handler,
  so snap is re-enabled when switching from None to Custom rather than
  staying stuck disabled.

After the change, snap's enabled state is governed solely by the existing
snapDisabled rule (tooltip mode is not None and snap is supported), which
never references Combined.

Testing:

Added tip-customize-dialog.component.spec.ts covering: snap stays enabled
when Combined is turned off, Combined on enables and checks snap, None to
Custom re-enables snap, switching to None disables and clears snap, and
snap stays disabled when not supported.