### PR TITLE
Bug #75280, fix adhoc filter popup not visible when crosstab is in max mode

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.html
@@ -17,7 +17,8 @@
 -->
 @for (vsObject of vsInfo.vsObjects; track trackByName(i, vsObject); let i = $index) {
   @if (isObjectRendered(vsObject)) {
-    <div [style.display]="isMaxModeHidden(vsObject) ? 'none' : 'block'">
+    <div [style.display]="isMaxModeHidden(vsObject) ? 'none' : 'block'"
+         [class.max-mode-view-filter]="isFilterInMaxModeView(vsObject)">
       <div class="focus-assembly {{getAssemblyAsClass(vsObject)}}"
         [id]="getAssemblyDivId(vsObject)"
         VSDataTip [dataTipName]="vsObject.absoluteName"

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.scss
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.scss
@@ -64,3 +64,8 @@
 .pop-component-bg {
   position: absolute;
 }
+
+.max-mode-view-filter {
+  position: fixed;
+  z-index: 9910 !important;
+}

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
@@ -263,6 +263,14 @@ export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
          (!!model.container && this.dataTipService.isDataTipVisible(model.container));
    }
 
+   isFilterInMaxModeView(model: VSObjectModel): boolean {
+      if(!this.viewer || !(<any> model).adhocFilter) {
+         return false;
+      }
+
+      return !!this.vsInfo?.vsObjects.find(v => v["maxMode"]);
+   }
+
    isMiniToolbarVisible(model: VSObjectModel): boolean {
       if(model.containerType === "VSSelectionContainer" ||
          (<any> model).dropdown || (<any> model).dropdownCalendar)


### PR DESCRIPTION
## Summary

- In the portal viewer, adhoc filter popups (created by right-clicking a crosstab or table in enlarged/max mode and selecting Filter) were rendered behind the enlarged assembly due to an insufficient z-index.
- The composer already handled this via a `max-mode-view-filter` CSS class (`position: fixed; z-index: 9910 !important`) applied to adhoc filter wrappers. Applied the same pattern to `vs-object-container` for the viewer context.
- Added `isFilterInMaxModeView()` method that returns `true` when in viewer/preview mode, the assembly has `adhocFilter = true`, and at least one assembly is in max mode.

## Test plan

- [ ] Open a viewsheet in the portal with a crosstab and a selection container
- [ ] Click the "Show Enlarged" icon on the crosstab toolbar to enter max mode
- [ ] Right-click a dimension or measure cell and select "Filter"
- [ ] Confirm the filter popup (SelectionList or RangeSlider) appears above the enlarged table
- [ ] Confirm the filter popup works correctly (values are selectable, filter is applied)
- [ ] Confirm the filter popup does not appear incorrectly when not in max mode (no regression)
- [ ] Confirm freehand table (CalcTable) filter in max mode still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
