### PR TITLE
Bug #75297 - Preserve combined tooltip when switching through an unsupported chart type

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -285,8 +285,8 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
       Map pointValueMap = null; // maps point values to pointVO indexes in the vos list
       Map textValueMap = null; // maps text value indexes to textVO indexes in the vos list
 
-      if(chartInfo != null && chartInfo.isCombinedToolTip() && chartInfo.getToolTip() == null &&
-         !chartInfo.isMultiStyles())
+      if(chartInfo != null && chartInfo.isCombinedToolTip() && chartInfo.supportsCombinedTooltip() &&
+         chartInfo.getToolTip() == null && !chartInfo.isMultiStyles())
       {
          pointValueMap = getRowValuePointMap(vos);
          textValueMap  = getRowValueTextMap(vos);
@@ -3925,7 +3925,8 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
    private boolean showMeasureTotal() {
       List<ChartAggregateRef> list = chartInfo.getAestheticAggregateRefs(true);
 
-      return chartInfo != null && chartInfo.isCombinedToolTip() && !chartInfo.isSeparatedGraph() &&
+      return chartInfo != null && chartInfo.isCombinedToolTip() && chartInfo.supportsCombinedTooltip() &&
+         !chartInfo.isSeparatedGraph() &&
          !GraphTypeUtil.isStackMeasures(this.chartInfo, null) && list.size() > 1;
    }
 

--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -3923,9 +3923,13 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
     * @return true if need display measure name for stack total tooltip.
     */
    private boolean showMeasureTotal() {
+      if(chartInfo == null) {
+         return false;
+      }
+
       List<ChartAggregateRef> list = chartInfo.getAestheticAggregateRefs(true);
 
-      return chartInfo != null && chartInfo.isCombinedToolTip() && chartInfo.supportsCombinedTooltip() &&
+      return chartInfo.isCombinedToolTip() && chartInfo.supportsCombinedTooltip() &&
          !chartInfo.isSeparatedGraph() &&
          !GraphTypeUtil.isStackMeasures(this.chartInfo, null) && list.size() > 1;
    }

--- a/core/src/main/java/inetsoft/report/internal/graph/ChangeChartTypeProcessor.java
+++ b/core/src/main/java/inetsoft/report/internal/graph/ChangeChartTypeProcessor.java
@@ -284,15 +284,6 @@ public class ChangeChartTypeProcessor extends ChangeChartProcessor {
          else {
             info.setChartType(newType);
 
-            if(info instanceof  VSChartInfo) {
-               // clear combined tooltip for types that don't support it; mirrors supportsCombinedTooltip()
-               if(!GraphTypes.isLine(newType) && !GraphTypes.isArea(newType) &&
-                  !GraphTypes.isBar(newType))
-               {
-                  ((VSChartInfo) info).setCombinedToolTipValue(false);
-               }
-            }
-
             // if it's waterfall, only keep one measure in chart info
             if(GraphTypes.isWaterfall(newType)) {
                checkMeasureRefs(info);

--- a/core/src/test/java/inetsoft/report/internal/graph/ChangeChartTypeCombinedTooltipTest.java
+++ b/core/src/test/java/inetsoft/report/internal/graph/ChangeChartTypeCombinedTooltipTest.java
@@ -53,6 +53,8 @@ class ChangeChartTypeCombinedTooltipTest {
    @Test
    void switchToUnsupportingTypeKeepsCombinedTooltip() {
       assertPreserved(GraphTypes.CHART_LINE_STACK, GraphTypes.CHART_PIE);
+      assertPreserved(GraphTypes.CHART_LINE, GraphTypes.CHART_POINT);
+      assertPreserved(GraphTypes.CHART_LINE_STACK, GraphTypes.CHART_RADAR);
    }
 
    @Test

--- a/core/src/test/java/inetsoft/report/internal/graph/ChangeChartTypeCombinedTooltipTest.java
+++ b/core/src/test/java/inetsoft/report/internal/graph/ChangeChartTypeCombinedTooltipTest.java
@@ -29,8 +29,10 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * A chart-type change must keep the combined-tooltip design value for any type
- * that still supports it (line/area/bar) and drop it for types that do not.
+ * A chart-type change must preserve the combined-tooltip design value across every
+ * type switch, matching snap-tooltip. Rendering is gated by supportsCombinedTooltip(),
+ * so a value retained on an unsupported type stays dormant and is restored when the
+ * chart is switched back to a supporting type.
  */
 @SreeHome
 @Tag("core")
@@ -49,18 +51,26 @@ class ChangeChartTypeCombinedTooltipTest {
    }
 
    @Test
-   void switchToUnsupportingTypeClearsCombinedTooltip() {
-      assertCleared(GraphTypes.CHART_LINE_STACK, GraphTypes.CHART_PIE);
+   void switchToUnsupportingTypeKeepsCombinedTooltip() {
+      assertPreserved(GraphTypes.CHART_LINE_STACK, GraphTypes.CHART_PIE);
+   }
+
+   @Test
+   void roundTripThroughUnsupportingTypeKeepsCombinedTooltip() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_BAR);
+      info.setCombinedToolTipValue(true);
+
+      new ChangeChartTypeProcessor(GraphTypes.CHART_BAR, GraphTypes.CHART_POINT, null, info).process();
+      new ChangeChartTypeProcessor(GraphTypes.CHART_POINT, GraphTypes.CHART_LINE, null, info).process();
+
+      assertTrue(info.getCombinedToolTipValue(),
+                 "combined tooltip must survive bar -> point -> line");
    }
 
    private static void assertPreserved(int oldType, int newType) {
       assertTrue(changeType(oldType, newType),
                  "combined tooltip must survive " + oldType + " -> " + newType);
-   }
-
-   private static void assertCleared(int oldType, int newType) {
-      assertFalse(changeType(oldType, newType),
-                  "combined tooltip must be cleared for " + oldType + " -> " + newType);
    }
 
    private static boolean changeType(int oldType, int newType) {


### PR DESCRIPTION
Switching a chart to a type that does not support combined tooltips
(point, pie, etc.) permanently cleared the combined-tooltip setting. A
user who enabled Combined on a bar chart, switched to point, then back to
line found Combined turned off, while Snap to nearest data point survived
the same round trip. The two options should behave the same way.

The combined-tooltip value was being cleared defensively because the
render path did not check whether the chart type supports it. This change
gates rendering instead of destroying the value:

- ChangeChartTypeProcessor no longer calls setCombinedToolTipValue(false)
  when switching to a type that does not support combined tooltips. The
  design value is preserved across every type change, like snap-tooltip.
- PlotArea now checks supportsCombinedTooltip() at the two sites that
  consume isCombinedToolTip() (the combined point/text tooltip map and the
  stack-total measure check), mirroring the supportsSnapTooltip() gate
  GraphBuilder already applies to snap. A value retained on an unsupported
  type stays dormant and renders again only when the type supports it.

Combined tooltips render on the same chart types as before; the only
change is that the user's setting is no longer lost when passing through
an unsupported type.

Testing:

ChangeChartTypeCombinedTooltipTest now asserts the combined-tooltip value
is preserved on a switch to an unsupporting type, with a new
bar -> point -> line round-trip test. The existing supporting-type
preservation cases are unchanged.