### PR TITLE
Bug #75247, fix excessive whitespace in Create Driver dialog stepper

### DIFF
--- a/web/projects/em/src/app/settings/content/drivers-and-plugins/plugins-view/create-driver-dialog/create-driver-dialog.component.scss
+++ b/web/projects/em/src/app/settings/content/drivers-and-plugins/plugins-view/create-driver-dialog/create-driver-dialog.component.scss
@@ -45,6 +45,11 @@ em-create-driver-dialog {
       align-items: stretch;
       flex-grow: 1;
 
+      > .mat-horizontal-stepper-header-container {
+        flex-grow: 0;
+        flex-shrink: 0;
+      }
+
       .mat-horizontal-content-container {
         display: flex;
         flex-direction: column;
@@ -57,7 +62,8 @@ em-create-driver-dialog {
           align-items: stretch;
           flex-grow: 1;
 
-          &.mat-horizontal-stepper-content-inactive {
+          &.mat-horizontal-stepper-content-previous,
+          &.mat-horizontal-stepper-content-next {
             flex-grow: 0;
             flex-shrink: 1;
           }


### PR DESCRIPTION
## Summary

The Create Driver dialog in EM Settings > Content > Drivers and Plugins showed excessive vertical whitespace: the stepper header row was pushed down from the top, and the step content area had a large blank space above it. This was a regression from the Angular Material upgrade to v21.

## Root Cause

Two Angular Material 21 breaking changes affected the custom flex layout in `create-driver-dialog.component.scss`:

1. **Renamed inactive step class**: `mat-horizontal-stepper-content-inactive` no longer exists. In AM21, inactive steps get `mat-horizontal-stepper-content-previous` or `mat-horizontal-stepper-content-next` instead. The custom SCSS relied on the old class to apply `flex-grow: 0` to inactive steps; without it, all three step content divs claimed equal vertical space in the flex column, creating invisible blank areas.

2. **Header container rendered as direct column-flex child**: In AM21, when no `headerPrefix` is set (the normal case for this dialog), `mat-horizontal-stepper-header-container` is a direct child of `mat-horizontal-stepper-wrapper` (the column-flex container). AM21's CSS gives it `flex-grow: 1`, causing it to consume half the dialog height and push the step indicators down.

## Fix

- Updated the inactive step selector from `mat-horizontal-stepper-content-inactive` to `mat-horizontal-stepper-content-previous, mat-horizontal-stepper-content-next`.
- Added `flex-grow: 0; flex-shrink: 0` on `> .mat-horizontal-stepper-header-container` (direct child only, to avoid affecting the `headerPrefix` case where it is a row-flex child).

## Test Plan

- Open EM > Settings > Content > Drivers and Plugins
- Click "Create Driver"
- Verify the stepper header (Upload Files / Select Drivers / Configure Plugin) appears directly below the modal title with no excess whitespace
- Upload a JAR file and click Next
- Verify the Select Drivers step shows the driver class list without excess whitespace above it
- Complete the wizard and confirm normal function

Fixes Redmine #75247.