### PR TITLE
Bug #75262, rebuild column buttons in ngOnChanges to fix stale type icon

### DIFF
--- a/web/projects/portal/src/app/composer/gui/ws/editor/ws-header-cell.component.ts
+++ b/web/projects/portal/src/app/composer/gui/ws/editor/ws-header-cell.component.ts
@@ -132,6 +132,7 @@ export class WSHeaderCell implements OnInit, OnChanges, AfterViewInit {
          this.updateColumnCaption();
          this.updateColumnSourceFields();
          this.updateDisplayName();
+         this.initButtons();
 
          if(this.table instanceof BoundTableAssembly) {
             this.isRest = (this.table as BoundTableAssembly).info.sourceInfo.rest;


### PR DESCRIPTION
## Summary

When a column's data type is changed via the Column Type dialog in the worksheet composer, the column header icon did not update immediately — it still showed the old type. The icon only refreshed after deselecting and reselecting the table.

## Root Cause

`WSHeaderCellComponent.initButtons()` builds the `columnButtons` array, which includes the data-type icon button derived from `colInfo.ref.dataType`. It was called only in `ngOnInit()`, not in `ngOnChanges()`. After the server returned a `WSRefreshAssemblyCommand` with the updated assembly, Angular passed the new `colInfo` via `ngOnChanges`, but `columnButtons` was never rebuilt — leaving the old icon stale until the component was destroyed and recreated on table reselect.

## Fix

Added a call to `initButtons()` inside the `ngOnChanges` guard block that already handles `table` and `colInfo` input changes. This rebuilds the `columnButtons` array (including the type icon) whenever either input changes.

## Test Plan

- [ ] Create a worksheet with an Embedded Table
- [ ] Click the String type icon on a column header and change the type to Boolean
- [ ] Confirm the icon immediately updates to the Boolean icon without needing to deselect/reselect the table
- [ ] Verify other column header icons (sort, visibility, expression) are unaffected
- [ ] Run `npm run test` — all tests pass
- [ ] Run `npm run lint` — no lint errors

Fixes Redmine #75262.