### PR TITLE
Bug #75265, fix EM page header background color changing to white after Angular upgrade

### DIFF
--- a/web/projects/em/src/app/page-header/_page-header-theme.scss
+++ b/web/projects/em/src/app/page-header/_page-header-theme.scss
@@ -28,11 +28,11 @@
 
   .em-header-toolbar {
     @if $is-dark {
-      background-color: mat.m2-get-color-from-palette($primary, 80);
+      --mat-toolbar-container-background-color: #{mat.m2-get-color-from-palette($primary, 80)};
       color: mat.m2-get-color-from-palette($foreground, secondary-text);
     }
     @else {
-      background-color: mat.m2-get-color-from-palette($primary, 50);
+      --mat-toolbar-container-background-color: #{mat.m2-get-color-from-palette($primary, 50)};
       color: mat.m2-get-color-from-palette($primary);
     }
 


### PR DESCRIPTION
## Summary

After the Angular version upgrade, the background color of the `em-page-header` toolbar on the EM monitoring page changed from gray to white.

## Root Cause

Angular Material 21's `mat-toolbar` component applies its background via the `background` shorthand CSS property using the `--mat-toolbar-container-background-color` CSS custom property. The global theme sets this custom property to white (the M2 `surface` color). The previous override used `background-color` on the `.em-header-toolbar` class, but the Angular upgrade changed the cascade order so that the component's `background` shorthand (which resets all background sub-properties) now comes after our class rule, overriding it.

## Fix

Instead of setting `background-color`, now sets the `--mat-toolbar-container-background-color` CSS custom property directly on `.em-header-toolbar`. Since CSS custom properties cascade through element inheritance, setting the property on the element itself overrides the global `:root` value regardless of stylesheet order, so the toolbar correctly picks up the gray background.

## Test Plan

- Open the EM monitoring summary page (`/em/monitoring/summary`)
- Verify the page header toolbar has a gray background (not white)
- Verify no regressions in other EM pages with toolbars

Fixes Redmine #75265.