### PR TITLE
Bug #75292 - Fix smooth lines truncated before last data point in animated charts

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationInjector.java
@@ -97,16 +97,22 @@ public final class SVGAnimationInjector {
             }
          }
          else if("C".equals(c)) {
+            // Sum sampled sub-segments, not the chord: a curve's arc length exceeds the
+            // straight start→end distance, and underestimating it truncates the dashoffset
+            // draw-on (the tail falls into the dash gap) on smooth lines.
             for(int j = 0; j + 5 < args.size(); j += 6) {
+               double c1x = args.get(j), c1y = args.get(j + 1);
+               double c2x = args.get(j + 2), c2y = args.get(j + 3);
                double ex = args.get(j + 4), ey = args.get(j + 5);
-               totalLen += Math.hypot(ex - cx, ey - cy);
+               totalLen += cubicLen(cx, cy, c1x, c1y, c2x, c2y, ex, ey);
                cx = ex; cy = ey;
             }
          }
          else if("Q".equals(c)) {
             for(int j = 0; j + 3 < args.size(); j += 4) {
+               double c1x = args.get(j), c1y = args.get(j + 1);
                double ex = args.get(j + 2), ey = args.get(j + 3);
-               totalLen += Math.hypot(ex - cx, ey - cy);
+               totalLen += quadLen(cx, cy, c1x, c1y, ex, ey);
                cx = ex; cy = ey;
             }
          }
@@ -117,6 +123,46 @@ public final class SVGAnimationInjector {
       }
 
       return totalLen;
+   }
+
+   // Sub-segments per curve when flattening to arc length. 32 keeps the polyline deficit
+   // well under a pixel for chart-scale curves, within the +2 margin at the call site.
+   private static final int CURVE_FLATTEN_STEPS = 32;
+
+   /** Arc length of a cubic Bezier, approximated by summing CURVE_FLATTEN_STEPS chords. */
+   private static double cubicLen(double x0, double y0, double x1, double y1,
+                                  double x2, double y2, double x3, double y3)
+   {
+      double len = 0, px = x0, py = y0;
+
+      for(int i = 1; i <= CURVE_FLATTEN_STEPS; i++) {
+         double t = (double) i / CURVE_FLATTEN_STEPS, u = 1 - t;
+         double a = u * u * u, b = 3 * u * u * t, c = 3 * u * t * t, d = t * t * t;
+         double nx = a * x0 + b * x1 + c * x2 + d * x3;
+         double ny = a * y0 + b * y1 + c * y2 + d * y3;
+         len += Math.hypot(nx - px, ny - py);
+         px = nx; py = ny;
+      }
+
+      return len;
+   }
+
+   /** Arc length of a quadratic Bezier, approximated by summing CURVE_FLATTEN_STEPS chords. */
+   private static double quadLen(double x0, double y0, double x1, double y1,
+                                 double x2, double y2)
+   {
+      double len = 0, px = x0, py = y0;
+
+      for(int i = 1; i <= CURVE_FLATTEN_STEPS; i++) {
+         double t = (double) i / CURVE_FLATTEN_STEPS, u = 1 - t;
+         double a = u * u, b = 2 * u * t, c = t * t;
+         double nx = a * x0 + b * x1 + c * x2;
+         double ny = a * y0 + b * y1 + c * y2;
+         len += Math.hypot(nx - px, ny - py);
+         px = nx; py = ny;
+      }
+
+      return len;
    }
 
    /**

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationInjector.java
@@ -108,10 +108,29 @@ public final class SVGAnimationInjector {
                cx = ex; cy = ey;
             }
          }
+         else if("c".equals(c)) {
+            // Relative cubic: control points and endpoint are offsets from the current point.
+            for(int j = 0; j + 5 < args.size(); j += 6) {
+               double c1x = cx + args.get(j), c1y = cy + args.get(j + 1);
+               double c2x = cx + args.get(j + 2), c2y = cy + args.get(j + 3);
+               double ex = cx + args.get(j + 4), ey = cy + args.get(j + 5);
+               totalLen += cubicLen(cx, cy, c1x, c1y, c2x, c2y, ex, ey);
+               cx = ex; cy = ey;
+            }
+         }
          else if("Q".equals(c)) {
             for(int j = 0; j + 3 < args.size(); j += 4) {
                double c1x = args.get(j), c1y = args.get(j + 1);
                double ex = args.get(j + 2), ey = args.get(j + 3);
+               totalLen += quadLen(cx, cy, c1x, c1y, ex, ey);
+               cx = ex; cy = ey;
+            }
+         }
+         else if("q".equals(c)) {
+            // Relative quadratic: control point and endpoint are offsets from the current point.
+            for(int j = 0; j + 3 < args.size(); j += 4) {
+               double c1x = cx + args.get(j), c1y = cy + args.get(j + 1);
+               double ex = cx + args.get(j + 2), ey = cy + args.get(j + 3);
                totalLen += quadLen(cx, cy, c1x, c1y, ex, ey);
                cx = ex; cy = ey;
             }
@@ -126,7 +145,8 @@ public final class SVGAnimationInjector {
    }
 
    // Sub-segments per curve when flattening to arc length. 32 keeps the polyline deficit
-   // well under a pixel for chart-scale curves, within the +2 margin at the call site.
+   // well under a pixel for chart-scale curves, within the +2 margin that
+   // SVGAnimationDOMInjector.applyLineDrawAnimation adds to this length for the dasharray.
    private static final int CURVE_FLATTEN_STEPS = 32;
 
    /** Arc length of a cubic Bezier, approximated by summing CURVE_FLATTEN_STEPS chords. */

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationInjectorTest.java
@@ -67,6 +67,45 @@ class SVGAnimationInjectorTest {
    }
 
    @Test
+   void quadArcLengthExceedsChord() {
+      // A bulging quadratic from (0,0) to (100,0). Chord = 100; arc must be measurably longer.
+      String d = "M0,0 Q50,50 100,0";
+      double arc = SVGAnimationInjector.computePathLength(d);
+      double chord = Math.hypot(100, 0);
+      assertTrue(arc > chord + 5,
+                 "quadratic arc length (" + arc + ") should exceed the chord (" + chord + ")");
+   }
+
+   @Test
+   void quadArcLengthMatchesFineFlattening() {
+      // Compare against a much finer manual flattening of the same quadratic.
+      double x0 = 0, y0 = 0, x1 = 50, y1 = 50, x2 = 100, y2 = 0;
+      double ref = 0, px = x0, py = y0;
+      int n = 4000;
+
+      for(int i = 1; i <= n; i++) {
+         double t = (double) i / n, u = 1 - t;
+         double a = u * u, b = 2 * u * t, c = t * t;
+         double nx = a * x0 + b * x1 + c * x2;
+         double ny = a * y0 + b * y1 + c * y2;
+         ref += Math.hypot(nx - px, ny - py);
+         px = nx; py = ny;
+      }
+
+      double arc = SVGAnimationInjector.computePathLength("M0,0 Q50,50 100,0");
+      assertEquals(ref, arc, 0.5);
+   }
+
+   @Test
+   void relativeAndAbsoluteCurvesMeasureEqually() {
+      // Relative c/q must measure the same arc as their absolute C/Q forms.
+      assertEquals(SVGAnimationInjector.computePathLength("M0,0 C0,50 100,50 100,0"),
+                   SVGAnimationInjector.computePathLength("M0,0 c0,50 100,50 100,0"), 1e-6);
+      assertEquals(SVGAnimationInjector.computePathLength("M0,0 Q50,50 100,0"),
+                   SVGAnimationInjector.computePathLength("M0,0 q50,50 100,0"), 1e-6);
+   }
+
+   @Test
    void straightLineUnaffectedByCurveHandling() {
       // No curve commands: result is still the exact polyline length.
       double len = SVGAnimationInjector.computePathLength("M10,10 L10,110");

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationInjectorTest.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util.graphics.animation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link SVGAnimationInjector#computePathLength}.
+ *
+ * <p>Regression coverage for smooth (curved) lines being truncated by the dashoffset
+ * draw-on: a cubic segment's arc length must be measured along the curve, not as the
+ * straight chord, or the dasharray underestimates the path and hides its tail.
+ */
+class SVGAnimationInjectorTest {
+   @Test
+   void straightPathLengthIsChordSum() {
+      // 3-4-5 triangle leg + horizontal leg: 5 + 4 = 9.
+      double len = SVGAnimationInjector.computePathLength("M0,0 L3,4 L7,4");
+      assertEquals(9.0, len, 1e-6);
+   }
+
+   @Test
+   void cubicArcLengthExceedsChord() {
+      // A bulging curve from (0,0) to (100,0). Chord = 100; arc must be measurably longer.
+      String d = "M0,0 C0,50 100,50 100,0";
+      double arc = SVGAnimationInjector.computePathLength(d);
+      double chord = Math.hypot(100, 0);
+      assertTrue(arc > chord + 10,
+                 "curved arc length (" + arc + ") should exceed the chord (" + chord + ")");
+   }
+
+   @Test
+   void cubicArcLengthMatchesFineFlattening() {
+      // Compare against a much finer manual flattening of the same cubic.
+      double x0 = 0, y0 = 0, x1 = 0, y1 = 50, x2 = 100, y2 = 50, x3 = 100, y3 = 0;
+      double ref = 0, px = x0, py = y0;
+      int n = 4000;
+
+      for(int i = 1; i <= n; i++) {
+         double t = (double) i / n, u = 1 - t;
+         double a = u * u * u, b = 3 * u * u * t, c = 3 * u * t * t, dd = t * t * t;
+         double nx = a * x0 + b * x1 + c * x2 + dd * x3;
+         double ny = a * y0 + b * y1 + c * y2 + dd * y3;
+         ref += Math.hypot(nx - px, ny - py);
+         px = nx; py = ny;
+      }
+
+      double arc = SVGAnimationInjector.computePathLength("M0,0 C0,50 100,50 100,0");
+      assertEquals(ref, arc, 0.5);
+   }
+
+   @Test
+   void straightLineUnaffectedByCurveHandling() {
+      // No curve commands: result is still the exact polyline length.
+      double len = SVGAnimationInjector.computePathLength("M10,10 L10,110");
+      assertEquals(100.0, len, 1e-6);
+   }
+}


### PR DESCRIPTION
Summary

Smooth/curved lines on line and area charts stopped short of the final
x-axis data point during the chart draw-on animation. The line stroke appeared to end partway
through the last segment instead of reaching the last point; straight lines drew correctly.

Root cause

The chart rendering is correct — LineVO/AreaVO emit cubic Bézier paths that reach the last
point. The truncation is in the SVG draw-on animation.
SVGAnimationDOMInjector.applyLineDrawAnimation animates a solid line with
stroke-dasharray/stroke-dashoffset, using SVGAnimationInjector.computePathLength as the
length and assuming it is always at least as long as the rendered path.

computePathLength approximated each cubic (C) and quadratic (Q) segment by its straight chord
distance rather than its arc length. A curve's arc is longer than its chord, so for a wiggly
smooth line the computed length under-estimated the true path. The browser lays the dash
pattern along the true arc, so the difference (the tail of the line) landed in the dash gap
and was never painted. Because the animation uses fill-mode: both, the truncation persisted
after the animation finished.

This was latent until the smooth/curved lines feature: before smooth lines, every line path was straight (M/L only),
where chord length equals arc length, so the C/Q branches were never meaningfully exercised.

Fix

computePathLength now measures cubic and quadratic segments by flattening each curve into 32
sampled sub-segments and summing their lengths, restoring the invariant that the dasharray
length is at least the rendered path length (the existing +2 margin covers the sub-pixel
polyline deficit). Straight paths are unchanged. The method has a single caller, so returning
the larger, accurate length is safe.