### PR TITLE
Bug #75263, fix VS_ASSEMBLY adhoc slider applying aggregate filter as WHERE instead of HAVING

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
@@ -337,6 +337,12 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
       // name should start with V_, otherwise PreAssetQuery.getAggregateInfo
       // will return empty
       table.setProperty("Component_Binding_Table", "true");
+      // Register the bindable table (with chart's AggregateInfo) so that the slider
+      // mirror's update() finds this version rather than the original unmodified VS
+      // table from the WorksheetWrapper. (75263)
+      if(ws != null) {
+         ws.addAssembly(table);
+      }
       String mname = Assembly.TABLE_VS + slider.getName() + "_" + table.getName();
       MirrorTableAssembly mirror = new MirrorTableAssembly(ws, mname, table);
       ColumnSelection columns = mirror.getColumnSelection();

--- a/core/src/main/java/inetsoft/report/composition/execution/VSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/VSAQuery.java
@@ -266,6 +266,9 @@ public abstract class VSAQuery {
 
       List<ConditionListWrapper> conds = new ArrayList<>();
       AggregateInfo ainfo = table.getAggregateInfo();
+      // capture before mirror creation — the mirror may have an empty AggregateInfo
+      // even when the underlying table is aggregated, causing isAggregate() to return false
+      boolean originalAggregated = ainfo != null && ainfo.isAggregated();
 
       if(ainfo != null && !ainfo.isEmpty()) {
          ColumnSelection columns = new ColumnSelection();
@@ -311,6 +314,10 @@ public abstract class VSAQuery {
       Worksheet ws = table.getWorksheet();
 
       if(ws != null) {
+         // Register the configured table (which may have chart's AggregateInfo set by
+         // createTableAssembly) so that MirrorTableAssembly.update() finds this version
+         // rather than the original unmodified VS table from the WorksheetWrapper. (75263)
+         ws.addAssembly(table);
          String mname = table.getName() + "_mirror";
          MirrorTableAssembly mirror = new MirrorTableAssembly(ws, mname, table);
          ws.addAssembly(mirror); // need to add to ws for MV transformation. (54096)
@@ -367,7 +374,7 @@ public abstract class VSAQuery {
          }
       }
 
-      if(table.isAggregate() || hasCubeMeasure) {
+      if(table.isAggregate() || originalAggregated || hasCubeMeasure) {
          ConditionListWrapper c = table.getPostRuntimeConditionList();
 
          if(c != null && !c.isEmpty()) {


### PR DESCRIPTION
## Summary

- When a VS_ASSEMBLY TimeSlider is created from a chart aggregate measure bar, moving the slider caused the chart to show multiple raw data rows per dimension value instead of one aggregated bar per group.
- Root cause 1: mergePostCondition re-read AggregateInfo from the mirror table (always empty) rather than the original table, causing isAggregate() to return false and a HAVING condition (Sum(x) >= N) to be downgraded to a WHERE clause applied before aggregation.
- Root cause 2: MirrorTableAssembly.update() looked up the underlying VS table by name from the WorksheetWrapper, finding the original unmodified version (empty AggregateInfo) rather than the configured clone with the chart's GROUP BY and aggregate bindings, causing the mirror's inner query to return raw unaggregated rows.
- Fix: capture originalAggregated before mirror creation in mergePostCondition and use it in the pre/post condition decision; call ws.addAssembly(table) before constructing mirrors in both mergePostCondition and TimeSliderVSAQuery.createAssemblyTable so update() resolves to the correctly configured table.

## Test plan

- [ ] Open a viewsheet with a bar chart bound to a worksheet query with a dimension (e.g. state) and an aggregate measure (e.g. Sum(customer_id))
- [ ] Click a bar to create an adhoc filter — verify a VS_ASSEMBLY RangeSlider appears
- [ ] Move the slider to a non-default range — verify the chart still shows one aggregated bar per dimension value (not multiple raw rows), with states outside the range filtered out
- [ ] Confirm a manually-placed viewsheet RangeSlider (bound to the raw field) still works correctly
- [ ] Confirm charts using Change from previous / date comparison still omit phantom projected facet cells (no regression from bug 75278)

Generated with [Claude Code](https://claude.com/claude-code)
