### PR TITLE
fixed bug 75173

### DIFF
--- a/core/src/main/java/inetsoft/web/metrics/PublishMetricsTask.java
+++ b/core/src/main/java/inetsoft/web/metrics/PublishMetricsTask.java
@@ -65,6 +65,10 @@ public class PublishMetricsTask implements Runnable, Serializable {
          total += map.getOrDefault(node, 0d);
       }
 
+      if(count == 0) {
+         return;
+      }
+
       total = total / count;
       publishMetric(total);
    }


### PR DESCRIPTION
 The root cause: in PublishMetricsTask.run() (line 68), when cluster.getClusterNodes() returns an empty set at startup (before
  nodes register), count stays 0 and Java double division 0.0 / 0 produces NaN. CloudWatch rejects any metric datum with a NaN
  value.

  Fix: added an early return when count == 0 — if there are no cluster nodes yet, there's nothing meaningful to publish, so we
  skip the call entirely rather than sending an invalid value to CloudWatch.

  This happens specifically at startup when the cluster node list is temporarily empty before the local node has registered
  itself.