### PR TITLE
fix IdentityService failing to initialize in LocalContext after Epic …

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -99,7 +99,7 @@ public class IdentityService {
                           ExternalStorageService externalStorageService,
                           XRepository xRepository,
                           RepletRegistryManager repletRegistryManager,
-                          IgniteSessionRepository sessionRepository)
+                          Optional<IgniteSessionRepository> sessionRepository)
    {
       this.securityEngine = securityEngine;
       this.securityProvider = securityProvider;
@@ -129,7 +129,7 @@ public class IdentityService {
       this.externalStorageService = externalStorageService;
       this.xRepository = xRepository;
       this.repletRegistryManager = repletRegistryManager;
-      this.sessionRepository = sessionRepository;
+      this.sessionRepository = sessionRepository.orElse(null);
    }
 
    private AuthenticationProvider getProvider(String providerName) {
@@ -1716,11 +1716,13 @@ public class IdentityService {
 
       syncIdentity(eprovider, user, oIdentity);
 
-      try {
-         sessionRepository.updatePrincipalRolesAndGroups(oIdentity, user.getRoles(), user.getGroups(), eprovider);
-      }
-      catch(Exception e) {
-         LOG.warn("Failed to update live session principals for user {}", oIdentity, e);
+      if(sessionRepository != null) {
+         try {
+            sessionRepository.updatePrincipalRolesAndGroups(oIdentity, user.getRoles(), user.getGroups(), eprovider);
+         }
+         catch(Exception e) {
+            LOG.warn("Failed to update live session principals for user {}", oIdentity, e);
+         }
       }
 
       return user;


### PR DESCRIPTION
Discovered while adding an e2e test case that requires security to be enabled
  during storage initialization. The setup script called
  client.security { setSecurityEnabled(true) } in the afterAssetsInstalled phase,
  which caused the StorageInitializer container to crash before the server could
  start, making all test cases fail to execute.

  Steps to reproduce:
  1. Write an e2e setup script with client.security { setSecurityEnabled(true) }
     in the afterAssetsInstalled phase
  2. Run the test: npx playwright test tests/browser/sree/portal/repository-change-tree.spec.ts
  3. Observe the container init-storage log —it exits with:
     UnsatisfiedDependencyException: Error creating bean 'localSecurityClientService'
       -> 'securityApiService'
         -> 'identityService': constructor parameter 28:
           No qualifying bean of type
           'inetsoft.web.session.IgniteSessionRepository' available
  4. The container is removed and no test cases run

  Root cause:
  Commit 1b6ae84f (Epic #70095, Distributed Sessions) added IgniteSessionRepository
  as a required constructor parameter (parameter 28) to IdentityService.
  IgniteSessionRepository is an HTTP session management component that exists only
  in the full server Spring context. It is not registered in LocalContext —the
  lightweight Spring context created by ClientFactory.createLocalClient() during
  storage initialization (StorageInitializer).

  The same commit correctly injected ScheduleServer —also absent from LocalContext
  —as Optional<ScheduleServer> with orElse(null). The IgniteSessionRepository
  parameter was added in the same change but was mistakenly left as a required
  dependency instead of following the same Optional pattern.

  Fix:
  Apply the identical Optional<T> pattern already used for ScheduleServer in the
  same constructor:
  - Change parameter type from IgniteSessionRepository to
    Optional<IgniteSessionRepository>
  - Store the field with sessionRepository.orElse(null)
  - Guard the single call site with a null check

  Impact:
  Running server: no behavior change. IgniteSessionRepository is always present
  in the full server context so orElse(null) returns the real bean and
  updatePrincipalRolesAndGroups continues to be called normally when a user's
  roles or groups are modified via EM.
  LocalContext / StorageInitializer: sessionRepository is null. The guarded call
  site is only reached during user role/group updates, which do not occur during
  storage initialization —there are no live HTTP sessions at that point.