### PR TITLE
skip user-scoped asset security check during storage initialization

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/deploy/DeployService.java
+++ b/core/src/main/java/inetsoft/web/admin/deploy/DeployService.java
@@ -428,7 +428,9 @@ public class DeployService {
             // if auto save has administrator, support import auto save assets.
             // if no security, only can login em by admin.
          }
-         else if(!noUsers && !securityEngine.isSecurityEnabled()) {
+         else if(!noUsers && !securityEngine.isSecurityEnabled() &&
+                 !"true".equals(System.getProperty("inetsoftStorageInitializing")))
+         {
             throw new Exception(
                Catalog.getCatalog().getString("em.import.userNoSecurity"));
          }


### PR DESCRIPTION
 Discovered while adding an e2e test case that imports a ZIP containing
  admin-scoped viewsheet assets and enables security during storage initialization.
  Even after fixing the IdentityService bean issue, the container still failed to
  start, requiring a workaround of setting security.enabled=true via
  setup.properties in afterPropertiesSet before the ZIP import —in addition to
  calling client.security { setSecurityEnabled(true) } in afterAssetsInstalled.
  This double-step felt wrong and was traced back to a design gap in DeployService.

  Steps to reproduce:
  1. Create a ZIP containing user-scoped assets (scope=4, owner=admin~;~host-org)
  2. Write an e2e setup script with only afterAssetsInstalled:
       afterAssetsInstalled = { context, setup, client ->
          client.viewsheet { addFolder ... }
          client.security { setSecurityEnabled(true) }
       }
  3. Run the test: npx playwright test tests/browser/sree/portal/repository-change-tree.spec.ts
  4. Observe the container init-storage log:
       ERROR DeployService: Cannot import user-scoped assets when security is disabled
       RuntimeException: Failed to import assets from /var/lib/.../assets.zip
  5. The container exits and no test cases run
  6. Workaround required: add a separate afterPropertiesSet step to pre-set
     security.enabled=true before the ZIP import phase, resulting in redundant
     double security configuration across two different phases

  Root cause:
  DeployService.importAssets() has a long-standing check that prevents importing
  user-scoped assets when security is disabled:

    else if(!noUsers && !securityEngine.isSecurityEnabled()) {
        throw new Exception("em.import.userNoSecurity");
    }

  This check was designed for runtime EM deployment —preventing an admin from
  importing user-owned assets into a server where security has been intentionally
  disabled. It is correct in that context.

  However, StorageInitializer also calls DeployService through LocalClient during
  the installAssets phase. When a setup ZIP contains admin-scoped assets, this
  check triggers even though security is actively being configured as part of the
  initialization process, not disabled by choice.

  This was first exposed by Epic #70095 which changed the e2e test ZIP assets from
  anonymous ownership (noUsers=true, check skipped) to admin ownership
  (noUsers=false, check triggered). Before that, setup scripts with
  anonymous-owned ZIPs were unaffected.

  StorageInitializer already sets System.setProperty("inetsoftStorageInitializing",
  "true") in its main() method, providing the exact signal needed to distinguish
  the initialization context from runtime operation. DeployService did not use it.

  Fix:
  Add a guard to skip the check during storage initialization:

    else if(!noUsers && !securityEngine.isSecurityEnabled() &&
            !"true".equals(System.getProperty("inetsoftStorageInitializing")))

  Impact:
  Runtime EM deploy: zero impact. The system property is not set during normal
  server operation so the original check applies unconditionally.
  StorageInitializer: the check is skipped, allowing user-scoped assets to be
  imported regardless of whether security.enabled has been written to properties
  yet. Setup scripts no longer need a separate afterPropertiesSet step to pre-set
  security.enabled=true. A single client.security { setSecurityEnabled(true) }
  call in afterAssetsInstalled is sufficient, consistent with enable-security.groovy.