### PR TITLE
Bug #75268, restore gray toolbar background after Angular v20 upgrade

### DIFF
--- a/web/projects/em/src/theme.scss
+++ b/web/projects/em/src/theme.scss
@@ -36,6 +36,10 @@ body {
   margin: 0;
 }
 
+.toolbar-raised-button {
+  --mat-toolbar-container-background-color: #f5f5f5;
+}
+
 .mat-mdc-snack-bar-container .mdc-snackbar__surface {
   background-color: var(--inet-em-accent-A100) !important;
 


### PR DESCRIPTION
## Summary

After upgrading to Angular v20, three `mat-toolbar` elements in the EM displayed a white background instead of the expected gray (`#f5f5f5`).

## Root Cause

Angular Material v20 changed `mat-toolbar` to derive its background color from the M2 `surface` system token, which is `white` for light themes. Previously it came from the `background.app-bar` palette key (`#f5f5f5`). The class `toolbar-raised-button` applied to these toolbars was never explicitly defined in SCSS — the gray background had been provided implicitly by Angular Material's defaults.

## Fix

Added `.toolbar-raised-button { --mat-toolbar-container-background-color: #f5f5f5; }` to `theme.scss` (the light-mode-only stylesheet) to restore the gray background. Placing it in `theme.scss` rather than `styles.scss` ensures the override does not affect the dark theme.

Affected toolbars:
- `data-space-tree-view.component.html`
- `repository-tree-view.component.html`
- `theme-list-view.component.html`

## Test Plan

- [ ] Navigate to `em/settings/content/data-space` and confirm the toolbar has a gray background
- [ ] Navigate to `em/settings/content/repository` and confirm the toolbar has a gray background
- [ ] Navigate to `em/settings/presentation` themes and confirm the toolbar has a gray background
- [ ] Switch to dark mode and confirm the toolbar background is not affected (remains dark)
- [ ] `npm run build` passes
- [ ] `npm run test:em` passes (301 tests)
- [ ] `npm run lint` passes

Fixes Redmine #75268.