### PR TITLE
Bug #75227, fix TypeError when typing in email dialog before tree data loads

### DIFF
--- a/web/projects/em/src/app/settings/email-picker/email-list-dialog/email-list-dialog.component.ts
+++ b/web/projects/em/src/app/settings/email-picker/email-list-dialog/email-list-dialog.component.ts
@@ -345,7 +345,7 @@ export class EmailListDialogComponent implements OnInit, OnDestroy {
    }
 
    private searchEmailTree(roots: EmailNode[], searchStr: string): EmailNode[] {
-      if(!searchStr) {
+      if(!searchStr || !roots) {
          return roots;
       }
 


### PR DESCRIPTION
## Summary

When typing in the email picker dialog before the email tree has finished loading, a `TypeError` was thrown because `searchEmailTree` was called with `roots` as `undefined` or `null`.

## Root Cause

In `email-list-dialog.component.ts`, the `searchEmailTree` method only checked `if(!searchStr)` before returning `roots`. If `roots` was not yet populated (tree data still loading), calling `.filter()` or iterating over it caused a `TypeError`.

## Fix

Added a `!roots` guard alongside the existing `!searchStr` check so the method returns early when the tree data is not yet available.

## Test Plan

- [ ] Open the email picker dialog in EM
- [ ] Begin typing in the search field immediately before the email tree finishes loading
- [ ] Verify no `TypeError` appears in the browser console
- [ ] Verify the search functions correctly once the tree data has loaded

Fixes Redmine #75227.