### PR TITLE
Fix crosstab adhoc filter popup z-index in portal viewer

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
@@ -546,8 +546,10 @@ export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
    }
 
    zIndex(vsObject: VSObjectModel): number {
-      if(this.popService.isPopSource(vsObject.absoluteName) ||
-         this.dataTipService.isDataTipSource(vsObject.absoluteName))
+      const adhocFilter = (<any> vsObject).adhocFilter;
+
+      if(!adhocFilter && (this.popService.isPopSource(vsObject.absoluteName) ||
+         this.dataTipService.isDataTipSource(vsObject.absoluteName)))
       {
          return DateTipHelper.getPopUpSourceZIndex();
       }
@@ -572,6 +574,12 @@ export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
       // Data annotations are rendered in the chart-annotation-overlay so they don't need this boost.
       if(vsObject.assemblyAnnotationModels?.length > 0) {
          zIndex += 5000;
+      }
+
+      // Adhoc filters are temporary VS objects, not VSPopComponent content, but they
+      // still need to paint above the source table/crosstab while preserving container order.
+      if(adhocFilter) {
+         zIndex += DateTipHelper.getPopUpContentBoostZIndex();
       }
 
       return zIndex;


### PR DESCRIPTION
## Summary

- Adhoc filter popups (selection list, range slider) triggered from crosstab/table header cells were rendering behind other assemblies on the viewsheet canvas
- Root cause: `zIndex()` derived the popup's stacking order from `objectFormat.zIndex` alone (typically a low single-digit value set by the server), so any assembly with a higher natural z-index appeared on top
- Fix: additive boost via `getPopUpContentBoostZIndex()` applied to adhocFilter assemblies inside `zIndex()`, keeping the popup above all regular canvas assemblies while preserving relative container ordering
- Guard `!adhocFilter` added to prevent adhocFilter objects from short-circuiting to the pop-source z-index path

## Test plan

- [ ] Open a viewsheet in the portal viewer with a crosstab and other overlapping assemblies (e.g. gauge, chart)
- [ ] Hover over a crosstab header cell to trigger the adhoc filter mini-toolbar, then click the filter icon
- [ ] Confirm the filter popup (selection list or range slider) renders above all other assemblies
- [ ] Confirm the popup closes correctly on outside click
- [ ] Open a pop component or data-tip overlay; confirm the dim canvas still appears correctly and the adhoc filter is not unexpectedly hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)