### PR TITLE
Bug #75270, fix font size in Create Driver dialog

### DIFF
--- a/web/projects/em/src/styles/_theme-dark.scss
+++ b/web/projects/em/src/styles/_theme-dark.scss
@@ -29,6 +29,7 @@ $em-typography-config: mat.m2-define-typography-config(
   $subtitle-1: mat.m2-define-typography-level(14px, 14px, 700, var(--inet-em-font-family)),
   $subtitle-2: mat.m2-define-typography-level(12px, 12px, 700, var(--inet-em-font-family)),
   $body-1: mat.m2-define-typography-level(12px, 20px, 400, var(--inet-em-font-family)),
+  $body-2: mat.m2-define-typography-level(12px, 20px, 400, var(--inet-em-font-family)),
   $button: mat.m2-define-typography-level(12px, 12px, 500, var(--inet-em-font-family))
 );
 

--- a/web/projects/em/src/styles/_theme.scss
+++ b/web/projects/em/src/styles/_theme.scss
@@ -29,6 +29,7 @@ $em-typography-config: mat.m2-define-typography-config(
   $subtitle-1: mat.m2-define-typography-level(14px, 14px, 700, var(--inet-em-font-family)),
   $subtitle-2: mat.m2-define-typography-level(12px, 12px, 700, var(--inet-em-font-family)),
   $body-1: mat.m2-define-typography-level(12px, 20px, 400, var(--inet-em-font-family)),
+  $body-2: mat.m2-define-typography-level(12px, 20px, 400, var(--inet-em-font-family)),
   $button: mat.m2-define-typography-level(12px, 12px, 500, var(--inet-em-font-family))
 );
 


### PR DESCRIPTION
## Summary

Radio button labels ("Upload", "Maven") and stepper header labels ("Select Drivers") in the Create Driver dialog displayed at 14px instead of the correct 12px.

## Root Cause

The `$em-typography-config` in both `styles/_theme.scss` and `styles/_theme-dark.scss` defined `body-1: 12px` but omitted `body-2`, causing it to fall back to Angular Material's default of 14px. After the Angular upgrade, MDC-based components (radio buttons, stepper headers) no longer inherit `font-size` from parent elements — they use CSS custom properties (`--mat-radio-label-text-size`, `--mat-stepper-header-label-text-size`) derived from `body-medium-size`, which maps to `body-2`.

## Fix

Added `$body-2: mat.m2-define-typography-level(12px, 20px, 400, var(--inet-em-font-family))` to `$em-typography-config` in both `styles/_theme.scss` and `styles/_theme-dark.scss`. This is consistent with `$em-form-field-typography-config`, which already defined `body-2: 12px` for form fields and checkboxes.

## Test Plan

- Open `em/settings/content/drivers-and-plugins`
- Click "Create Driver"
- Verify the "Upload" and "Maven" radio button labels are 12px
- Verify the "Select Drivers" stepper header label is 12px
- Verify dark theme shows the same correct font sizes

Fixes Redmine #75270.