### PR TITLE
Bug #75054 - Emphasize stack total in solo card tooltip

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
+++ b/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
@@ -174,7 +174,6 @@ public class ChartToolTip implements DataSerializable {
    private String renderGroupedSoloCard(IndexedSet<String> palette) {
       StringBuilder buffer = new StringBuilder();
       int pairsRendered = 0;
-      // Emphasize the stack total as a footer total, matching the combined-card path.
       int stackTotalIdx = findStackTotalIndex(palette);
 
       for(int i = 0; i < tooltips.size(); i += 2) {

--- a/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
+++ b/core/src/main/java/inetsoft/report/composition/region/ChartToolTip.java
@@ -138,15 +138,7 @@ public class ChartToolTip implements DataSerializable {
          tier++;
       }
 
-      if(stackTotalIdx >= 0) {
-         String label = palette.get(tooltips.get(stackTotalIdx));
-         String value = (stackTotalIdx + 1) < tooltips.size()
-            ? palette.get(tooltips.get(stackTotalIdx + 1)) : "";
-         buffer.append("<div class=\"tt-tier-1 tt-stack-total\">")
-               .append(label).append(ChartToolTip.COLON).append(value)
-               .append("</div>");
-      }
-
+      appendStackTotal(buffer, palette, stackTotalIdx);
       return buffer.toString();
    }
 
@@ -154,6 +146,7 @@ public class ChartToolTip implements DataSerializable {
    // equal weight) when no identity dim leads — mirrors the flat default tooltip.
    private String renderUniformCard(IndexedSet<String> palette) {
       StringBuilder buffer = new StringBuilder();
+      int stackTotalIdx = findStackTotalIndex(palette);
 
       for(int i = 0; i < tooltips.size(); i += 2) {
          int keyIdx = tooltips.get(i);
@@ -162,11 +155,16 @@ public class ChartToolTip implements DataSerializable {
             continue;
          }
 
+         if(i == stackTotalIdx) {
+            continue;
+         }
+
          String label = palette.get(keyIdx);
          String value = (i + 1) < tooltips.size() ? palette.get(tooltips.get(i + 1)) : "";
          appendTier(buffer, 2, label + ChartToolTip.COLON + value);
       }
 
+      appendStackTotal(buffer, palette, stackTotalIdx);
       return buffer.toString();
    }
 
@@ -176,11 +174,18 @@ public class ChartToolTip implements DataSerializable {
    private String renderGroupedSoloCard(IndexedSet<String> palette) {
       StringBuilder buffer = new StringBuilder();
       int pairsRendered = 0;
+      // Emphasize the stack total as a footer total, matching the combined-card path.
+      int stackTotalIdx = findStackTotalIndex(palette);
 
       for(int i = 0; i < tooltips.size(); i += 2) {
          int keyIdx = tooltips.get(i);
 
          if(keyIdx == -1) {
+            continue;
+         }
+
+         // Skip here so the total doesn't take the tier-1 slot or shift tier-2 grouping.
+         if(i == stackTotalIdx) {
             continue;
          }
 
@@ -207,10 +212,25 @@ public class ChartToolTip implements DataSerializable {
          pairsRendered++;
       }
 
+      appendStackTotal(buffer, palette, stackTotalIdx);
       return buffer.toString();
    }
 
-   // Match by name rather than position so callers that skip moveTotalToBottom still work.
+   // Footer total, emphasized.
+   private void appendStackTotal(StringBuilder buffer, IndexedSet<String> palette, int stackTotalIdx) {
+      if(stackTotalIdx < 0) {
+         return;
+      }
+
+      String label = palette.get(tooltips.get(stackTotalIdx));
+      String value = (stackTotalIdx + 1) < tooltips.size()
+         ? palette.get(tooltips.get(stackTotalIdx + 1)) : "";
+      buffer.append("<div class=\"tt-tier-1 tt-stack-total\">")
+            .append(label).append(ChartToolTip.COLON).append(value)
+            .append("</div>");
+   }
+
+   // Match by name, not position — the total isn't always the last pair.
    private int findStackTotalIndex(IndexedSet<String> palette) {
       if(stackTotalName == null || stackTotalName.isEmpty()) {
          return -1;

--- a/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
@@ -198,14 +198,17 @@ class ChartToolTipTest {
       tip.setUniformTier(true);
       tip.addTooltip(palette.put("Sum(Order Number)"), palette.put("398.8K"));
       tip.addTooltip(palette.put("Total"), palette.put("1.8M"));
+      tip.addTooltip(palette.put("Region"), palette.put("West"));
       tip.setStackTotalName("Total");
 
       String out = tip.getTooltip(palette);
 
       assertTrue(out.contains("<div class=\"tt-tier-2\">Sum(Order Number):&nbsp;398.8K"),
                  "Uniform rows render at tier-2");
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Region:&nbsp;West"),
+                 "Row after the total stays at tier-2, not consumed by it");
       assertTrue(out.endsWith("<div class=\"tt-tier-1 tt-stack-total\">Total:&nbsp;1.8M</div>"),
-                 "Uniform card must emphasize the stack total at the end");
+                 "Uniform card must emphasize the stack total at the end even when not last");
       int totalCount = out.split("Total:&nbsp;1\\.8M", -1).length - 1;
       assertEquals(1, totalCount, "Stack total must appear exactly once");
    }

--- a/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
@@ -140,6 +140,77 @@ class ChartToolTipTest {
    }
 
    @Test
+   void groupedSoloCardWithHeaderEmphasizesStackTotal() {
+      // Single-measure stacked bar: PlotArea lifts the X-dim to the header and
+      // routes to the grouped solo card. The stack total must be emphasized.
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.setHeader(palette.put("Year(Order Date)"), palette.put("2022"));
+      tip.addTooltip(palette.put("Sum(Order Number)"), palette.put("398.8K"));
+      tip.addTooltip(palette.put("Total"), palette.put("1.8M"));
+      tip.addTooltip(palette.put("Employee"), palette.put("Sue"));
+      tip.setStackTotalName("Total");
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-1\">Sum(Order Number):&nbsp;398.8K"),
+                 "Hovered measure stays at tier-1");
+      assertTrue(out.contains("<div class=\"tt-tier-1 tt-subtitle\">Year(Order Date):&nbsp;2022"),
+                 "X-dim renders as the tier-1 subtitle");
+      assertTrue(out.endsWith("<div class=\"tt-tier-1 tt-stack-total\">Total:&nbsp;1.8M</div>"),
+                 "Grouped solo card must emphasize the stack total at the end");
+      int totalCount = out.split("Total:&nbsp;1\\.8M", -1).length - 1;
+      assertEquals(1, totalCount, "Stack total must appear exactly once");
+   }
+
+   @Test
+   void groupedSoloCardEmphasizesStackTotalNotLastInList() {
+      // The stack total is added before aesthetics in PlotArea, so it is not the
+      // last pair. findStackTotalIndex matches by name, so it is still pulled out.
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.setGroupedTiers(true);
+      tip.setTier2GroupSize(1);
+      tip.addTooltip(palette.put("Sum(Order Number)"), palette.put("398.8K"));
+      tip.addTooltip(palette.put("Total"), palette.put("1.8M"));
+      tip.addTooltip(palette.put("Employee"), palette.put("Sue"));
+      tip.setStackTotalName("Total");
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-1\">Sum(Order Number):&nbsp;398.8K"),
+                 "Hovered measure stays at tier-1");
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Employee:&nbsp;Sue"),
+                 "Aesthetic that followed the total in the list is not consumed by it");
+      assertTrue(out.endsWith("<div class=\"tt-tier-1 tt-stack-total\">Total:&nbsp;1.8M</div>"),
+                 "Total emphasized at the end even though it was not last in the list");
+      int totalCount = out.split("Total:&nbsp;1\\.8M", -1).length - 1;
+      assertEquals(1, totalCount, "Stack total must appear exactly once");
+   }
+
+   @Test
+   void uniformCardEmphasizesStackTotal() {
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.setUniformTier(true);
+      tip.addTooltip(palette.put("Sum(Order Number)"), palette.put("398.8K"));
+      tip.addTooltip(palette.put("Total"), palette.put("1.8M"));
+      tip.setStackTotalName("Total");
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Sum(Order Number):&nbsp;398.8K"),
+                 "Uniform rows render at tier-2");
+      assertTrue(out.endsWith("<div class=\"tt-tier-1 tt-stack-total\">Total:&nbsp;1.8M</div>"),
+                 "Uniform card must emphasize the stack total at the end");
+      int totalCount = out.split("Total:&nbsp;1\\.8M", -1).length - 1;
+      assertEquals(1, totalCount, "Stack total must appear exactly once");
+   }
+
+   @Test
    void setStyleNullDefaultsToLegacyStyle() {
       ChartToolTip tip = new ChartToolTip();
       tip.setStyle(null);


### PR DESCRIPTION
Problem

On a solo card tooltip (when the combined tooltip is not enabled), the
stack-total row (e.g. Total: 1.8M) renders as a plain, grey tier instead of an
emphasized footer with the tt-stack-total class.

Root cause

For a single-measure stacked bar, PlotArea calls captureCombinedCardHeader
(setHeader); for multi-measure it calls setGroupedTiers(true). Both route
renderCard to renderGroupedSoloCard, which rendered every pair, including the
total, as a plain tier with no emphasis.

Fix

Apply the find/skip/emphasize logic to renderGroupedSoloCard and
renderUniformCard, and extract the shared footer emit into appendStackTotal.
The total is matched by name (reusing findStackTotalIndex) rather than by
position, since PlotArea adds it before aesthetic rows and it is therefore not
always the last pair. The skip happens before the tier assignment so the total
does not take the tier-1 headline slot or shift tier-2 grouping.