### PR TITLE
Bug #75293, add NgIf to LdapProviderViewComponent imports

### DIFF
--- a/web/projects/em/src/app/settings/security/security-provider/ldap-provider-view/ldap-provider-view.component.ts
+++ b/web/projects/em/src/app/settings/security/security-provider/ldap-provider-view/ldap-provider-view.component.ts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import {Component, EventEmitter, Inject, Input, OnDestroy, OnInit, Output} from "@angular/core";
+import { NgIf } from "@angular/common";
 import { AbstractControl, FormGroupDirective, NgForm, UntypedFormControl, UntypedFormGroup, ValidatorFn, Validators, FormsModule, ReactiveFormsModule } from "@angular/forms";
 import {MAT_BOTTOM_SHEET_DATA, MatBottomSheet, MatBottomSheetRef} from "@angular/material/bottom-sheet";
 import { ErrorStateMatcher, MatOption } from "@angular/material/core";
@@ -45,7 +46,7 @@ import { MatCard, MatCardContent, MatCardActions } from "@angular/material/card"
     selector: "em-ldap-provider-view",
     templateUrl: "./ldap-provider-view.component.html",
     styleUrls: ["./ldap-provider-view.component.scss"],
-    imports: [FormsModule, ReactiveFormsModule, MatCard, MatCardContent, MatFormField, MatLabel, MatSelect, MatOption, MatHint, MatInput, MatError, MatCheckbox, MatCardActions, MatButton, MatProgressSpinner, MatIconButton, MatSuffix, MatIcon]
+    imports: [NgIf, FormsModule, ReactiveFormsModule, MatCard, MatCardContent, MatFormField, MatLabel, MatSelect, MatOption, MatHint, MatInput, MatError, MatCheckbox, MatCardActions, MatButton, MatProgressSpinner, MatIconButton, MatSuffix, MatIcon]
 })
 export class LdapProviderViewComponent implements OnInit, OnDestroy {
    @Input() form: UntypedFormGroup;


### PR DESCRIPTION
## Summary

When adding a provider in EM Security settings, the browser console showed NG0303 errors because `LdapProviderViewComponent` was missing `NgIf` in its standalone component `imports` array.

## Root Cause

`LdapProviderViewComponent` uses `*ngIf` on `<mat-error>` elements in its template (as required by the content-projection fix from Bug #75272), but `NgIf` was not included in the component's `@Component.imports` array after the Angular standalone migration. All sibling provider view components that use `*ngIf` (`DatabaseProviderViewComponent`, `AuthenticationProviderDetailViewComponent`, etc.) already had `NgIf` in their imports; this component was missed.

## Fix

Added `NgIf` from `@angular/common` to the import statement and to the `@Component.imports` array of `LdapProviderViewComponent`, consistent with the pattern established by Bug #75272.

## Test Plan

- Navigate to em/settings/security/provider and click "Add Provider"
- Confirm no NG0303 errors appear in the browser console
- Confirm validation error messages display correctly when required fields are left blank
- Confirm no regression on content projection (error messages render in their designated mat-form-field slots)

Fixes Redmine #75293.