### PR TITLE
Bug #75253, fix relation chart node text/size wrong for target nodes spanning multiple months

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
@@ -1420,6 +1420,51 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
          }
       }
 
+      // For relation charts, nodeColorField and nodeSizeField that are VSDimensionRefs are
+      // excluded from getAestheticRefs() to avoid GROUP BY row-splitting per target node
+      // (a dimension like MonthOfYear spanning two months produces multiple rows per node,
+      // causing node text/size measures to reflect only the first-encountered month).
+      // Add them back here as MAX aggregates so color/size frames still have the column
+      // available, using MAX as a consistent representative value per (Source, Target) group.
+      // Skipped for detail view: ainfo.clear() discards all aggregates in that path anyway.
+      if(!isDetail() && cinfo instanceof RelationVSChartInfo) {
+         RelationVSChartInfo rinfo = (RelationVSChartInfo) cinfo;
+         List<AestheticRef> nodeAestheticRefs = new ArrayList<>();
+         nodeAestheticRefs.add(rinfo.getNodeColorField());
+         nodeAestheticRefs.add(rinfo.getNodeSizeField());
+
+         for(AestheticRef nodeARef : nodeAestheticRefs) {
+            if(nodeARef == null || !(nodeARef.getDataRef() instanceof VSDimensionRef)) {
+               continue;
+            }
+
+            VSDimensionRef nodeDim = (VSDimensionRef) nodeARef.getDataRef();
+            GroupRef nodeGroup = nodeDim.createGroupRef(cols);
+
+            if(nodeGroup == null) {
+               continue;
+            }
+
+            ColumnRef nodeCol = (ColumnRef) nodeGroup.getDataRef();
+            int existingIdx = cols.indexOfAttribute(nodeCol);
+
+            if(existingIdx >= 0) {
+               nodeCol = (ColumnRef) cols.getAttribute(existingIdx);
+               cols.removeAttribute(existingIdx);
+            }
+
+            if(!colsSet.contains(nodeCol)) {
+               nodeCol.setVisible(true);
+               cols.addAttribute(counter++, nodeCol);
+               colsSet.add(nodeCol);
+            }
+
+            if(!ainfo.containsGroup(nodeCol) && !ainfo.containsAggregate(nodeCol)) {
+               ainfo.addAggregate(new AggregateRef(nodeCol, AggregateFormula.MAX));
+            }
+         }
+      }
+
       // @by billh, flag indicates whether to merge aggregate info to query
       // regardless of ranking condition. If ranking condition exists but it's
       // defined at the inner most dimension, it's also safe enough to merge

--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/AbstractChartInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/AbstractChartInfo.java
@@ -282,11 +282,16 @@ public abstract class AbstractChartInfo implements ChartInfo, AssetObject {
       list.add(aggr.getTextField());
 
       if(aggr instanceof RelationChartInfo) {
+         AestheticRef nodeColorField = ((RelationChartInfo) aggr).getNodeColorField();
          AestheticRef nodeSizeField = ((RelationChartInfo) aggr).getNodeSizeField();
 
-         // VSDimensionRef nodeSizeField is excluded here; ChartVSAQuery adds it back as a
-         // MAX aggregate to prevent extra GROUP BY rows per relation chart target node.
-         // VSAggregateRef nodeSizeField flows through the normal aggregate path unchanged.
+         // VSDimensionRef nodeColorField and nodeSizeField are excluded here; ChartVSAQuery
+         // adds them back as MAX aggregates to prevent extra GROUP BY rows per relation chart
+         // target node. VSAggregateRef variants flow through the normal aggregate path unchanged.
+         if(nodeColorField == null || !(nodeColorField.getDataRef() instanceof VSDimensionRef)) {
+            list.add(nodeColorField);
+         }
+
          if(nodeSizeField == null || !(nodeSizeField.getDataRef() instanceof VSDimensionRef)) {
             list.add(nodeSizeField);
          }

--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/AbstractChartInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/AbstractChartInfo.java
@@ -282,8 +282,14 @@ public abstract class AbstractChartInfo implements ChartInfo, AssetObject {
       list.add(aggr.getTextField());
 
       if(aggr instanceof RelationChartInfo) {
-         list.add(((RelationChartInfo) aggr).getNodeColorField());
-         list.add(((RelationChartInfo) aggr).getNodeSizeField());
+         AestheticRef nodeSizeField = ((RelationChartInfo) aggr).getNodeSizeField();
+
+         // VSDimensionRef nodeSizeField is excluded here; ChartVSAQuery adds it back as a
+         // MAX aggregate to prevent extra GROUP BY rows per relation chart target node.
+         // VSAggregateRef nodeSizeField flows through the normal aggregate path unchanged.
+         if(nodeSizeField == null || !(nodeSizeField.getDataRef() instanceof VSDimensionRef)) {
+            list.add(nodeSizeField);
+         }
       }
 
       return list.stream().filter(a -> a != null).collect(Collectors.toList());


### PR DESCRIPTION
## Summary

- Relation chart nodes whose `Node Color` or `Node Size` binding used a dimension (e.g. `MonthOfYear`) that spans two calendar months (e.g. week 36 covers Aug and Sep) showed wrong node text/size values — only one month's pre-aggregated average was reflected instead of the true aggregate across all records.
- Root cause: `getAestheticRefs()` added these dimension fields to the chart query GROUP BY, producing multiple dataset rows per `(Source, Target)` node. `RelationElement.createGeometry()` keeps only the first geometry per target node, silently discarding all subsequent month-rows.
- Fix: exclude `VSDimensionRef` `nodeColorField` and `nodeSizeField` from `getAestheticRefs()` (so they no longer enter GROUP BY). `ChartVSAQuery` re-adds them as `MAX` aggregates after the main refs loop (non-detail path only), keeping the column available for color/size frame rendering while collapsing to one row per `(Source, Target)`.

## Test plan

- [ ] Open a relation chart with `Source = QuarterOfYear`, `Target = WeekOfYear`, `Node Color = MonthOfYear`, `Node Text = Average(Product:Price)`
- [ ] Confirm nodes for weeks that span two months (e.g. Q3 W36 Aug/Sep, Q2 W18 Apr/May) now show the correct average across all months' records
- [ ] Confirm single-month nodes are unchanged
- [ ] Confirm node colors still render using MonthOfYear (legend entries present)
- [ ] Bind `Node Size` to a plain dimension and confirm node size values are also correct for multi-month target nodes
- [ ] Verify detail view of a relation chart still functions correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)