### PR TITLE
Bug #75055 - Mute solo card tooltip subtitle to match combined card

### DIFF
--- a/web/projects/portal/src/scss/internal/_directives.scss
+++ b/web/projects/portal/src/scss/internal/_directives.scss
@@ -276,6 +276,7 @@ table.scrollable-table {
     font-weight: 400;
     margin-top: 2px;
     letter-spacing: 0.02em;
+    opacity: 0.65;
   }
 
   // Stack total sits at the bottom as the summary headline; bump it slightly


### PR DESCRIPTION
On a solo card tooltip, the X-dim that is lifted to the subtitle rendered at
full strength dark text instead of as a de-emphasized caption. The
.tt-tier-1.tt-subtitle rule set only font size, weight, and letter-spacing,
with no opacity, unlike the combined card's .tt-tier-2.tt-subtitle which is
opacity 0.65.

Add opacity 0.65 to .tt-tier-1.tt-subtitle so the solo subtitle matches the
combined card's muted caption styling.