### PR TITLE
Bug #75299, fix focused form field label color in EM

### DIFF
--- a/web/projects/em/src/_app-theme.scss
+++ b/web/projects/em/src/_app-theme.scss
@@ -186,23 +186,6 @@
     }
   }
 
-  // float label colors on focus
-  .mat-mdc-form-field.mat-primary {
-    .mdc-text-field--focused:not(.mdc-text-field--disabled):not(.mdc-text-field--invalid) {
-      .mdc-floating-label {
-        color: mat.m2-get-color-from-palette($primary, 500, 0);
-      }
-    }
-  }
-
-  .mat-mdc-form-field.mat-accent {
-    .mdc-text-field--focused:not(.mdc-text-field--disabled):not(.mdc-text-field--invalid) {
-      .mdc-floating-label {
-        color: mat.m2-get-color-from-palette($accent, 500, 0);
-      }
-    }
-  }
-
   .mat-mdc-form-field-hint {
     color: rgba($on-surface, if($is-dark-theme, 0.7, 0.6));
   }


### PR DESCRIPTION
## Summary

When clicking an outlined form field with `color="accent"` in the EM (e.g. AI Integration settings), the floating label showed black instead of orange when the field was focused.

## Root Cause

`_app-theme.scss` contained two custom rules inside `em-app-theme()` intended to color the floating label on focus, but both used `mat.m2-get-color-from-palette($accent, 500, 0)` with **opacity = 0**. Because the EM palette uses CSS custom properties (`var(--inet-em-accent-500)`), Angular Material 21's `m2-get-color-from-palette` compiles this to `color-mix(in srgb, var(--inet-em-accent-500) 0, transparent)` — effectively transparent/broken. These rules had higher CSS specificity (0,6,0) than Angular Material's token-based rules (0,4,0), overriding the correct accent orange with a broken value.

## Fix

Removed the two broken "float label colors on focus" rule blocks. Angular Material 21 already correctly handles the focused label color via the `--mat-form-field-outlined-focus-label-text-color` CSS token, emitting `color-mix(in srgb, var(--inet-em-accent-500) 87%, transparent)` for `.mat-mdc-form-field.mat-accent`. The removed rules were redundant and broken.

## Test Plan

- Navigate to EM → Settings → Presentation → AI Integration
- Click any of the URL/title fields (e.g. "AI Assistant Internal URL")
- Verify the floating label turns orange when focused
- Verify no regressions in disabled, invalid, or hover states for form fields throughout the EM

Fixes Redmine #75299.