### PR TITLE
Bug #75314, provide DataQueryModelService in SQLQueryDialog component

### DIFF
--- a/web/projects/portal/src/app/widget/dialog/sql-query-dialog/sql-query-dialog.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/sql-query-dialog/sql-query-dialog.component.ts
@@ -71,6 +71,7 @@ const CLEAR_MODEL_URI = "../api/composer/ws/sql-query-dialog/clear";
     selector: "sql-query-dialog",
     templateUrl: "sql-query-dialog.component.html",
     styleUrls: ["sql-query-dialog.component.scss"],
+    providers: [DataQueryModelService],
     imports: [ModalHeaderComponent, EnterSubmitDirective, FormsModule, ReactiveFormsModule, InputTrimDirective, SimpleQueryPaneComponent, DatabaseQueryComponent, ApplyButtonComponent]
 })
 export class SQLQueryDialog implements OnInit {


### PR DESCRIPTION
## Summary

- Opening "Edit Query" on a SQL worksheet assembly threw Angular DI error `NG0201: No provider found for DataQueryModelService` in `SQLQueryDialog`
- Added `DataQueryModelService` to `SQLQueryDialog`'s own `providers` array so the service is self-contained regardless of how the dialog is instantiated

## Root Cause

`DataQueryModelService` is `@Injectable()` without `providedIn`. Before the standalone migration it lived in `PortalAppModule.providers`. After migration it was moved to route-level environment injector providers. However, when `SQLQueryDialog` (a standalone component) is dynamically created via `SlideOutService` using `ComponentFactory.create()`, the route's `EnvironmentInjector` is not threaded through to the component, so `DataQueryModelService` cannot be resolved.

## Fix

Added `providers: [DataQueryModelService]` to the `@Component` decorator of `SQLQueryDialog`. This creates one instance per dialog, which is the correct scoping — the service holds RxJS subjects and state that coordinate `SQLQueryDialog` with its child `DatabaseQueryComponent` and descendant pane components within a single query editing session.

## Test Plan

- Open a worksheet containing a SQL query assembly
- Right-click the assembly and select "Edit Query"
- Confirm the SQL query dialog opens without errors
- Verify query editing and saving work correctly
- Confirm no regressions in other worksheet operations

Fixes Redmine #75314.