### PR TITLE
Bug #75317, make DataPhysicalModelService optional in JoinNodeGraphComponent

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/common-components/join-node-graph/join-node-graph.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/common-components/join-node-graph/join-node-graph.component.ts
@@ -18,7 +18,7 @@
 import { HttpClient, HttpParams } from "@angular/common/http";
 import {
    AfterViewInit, Component, ElementRef, EventEmitter, HostBinding, HostListener, Input,
-   Output, ViewChild,
+   Optional, Output, ViewChild,
 } from "@angular/core";
 import { NgbModal, NgbModalOptions } from "@ng-bootstrap/ng-bootstrap";
 import { AssemblyActionGroup } from "../../../../../../common/action/assembly-action-group";
@@ -80,7 +80,7 @@ export class JoinNodeGraphComponent implements AfterViewInit {
    constructor(private nodeGraph: ElementRef,
                private modalService: NgbModal,
                private http: HttpClient,
-               private physicalModelService: DataPhysicalModelService,
+               @Optional() private physicalModelService: DataPhysicalModelService,
                private readonly fixedDropdownService: FixedDropdownService)
    {
    }
@@ -340,6 +340,10 @@ export class JoinNodeGraphComponent implements AfterViewInit {
    }
 
    private showAliasDialog(oldAlias?: string): void {
+      if(!this.physicalModelService) {
+         return;
+      }
+
       const dialog = ComponentTool.showDialog(this.modalService, InputNameDialog, (alias) => {
          let params = new HttpParams()
             .set("runtimeId", this.runtimeId)


### PR DESCRIPTION
## Summary

When dragging a table to the query pane in the Worksheet Composer (Advanced Query mode), Angular threw `NG0201: No provider found for DataPhysicalModelService`, crashing the page.

## Root Cause

`JoinNodeGraphComponent` unconditionally injected `DataPhysicalModelService` in its constructor. This service is provided in the Portal data route but not in the Composer route. The component is shared between the physical model graph (portal data tab, service available) and the query network graph (worksheet composer, service not available), so rendering it in the composer context caused a DI failure.

## Fix

Added `@Optional()` to the `DataPhysicalModelService` constructor parameter in `JoinNodeGraphComponent`. Also added an explicit null guard at the top of `showAliasDialog()`, which accesses the service synchronously. All other usages of the service in the component are already guarded by `dataType === DataType.PHYSICAL` checks that evaluate to false in the query context.

## Test Plan

- Open the Worksheet Composer, create a worksheet, add a query using a data source (e.g. Orders Query), select Advanced Query, and drag a table to the edit pane — confirm no console error and the graph renders correctly.
- Open the Portal data tab, edit a physical model, verify the graph pane still works: tables render, joins can be created, alias actions work.

Fixes Redmine #75317.