### PR TITLE
Bug #75302 - Candle card tooltip subtitle uses X-axis date dim, not Y-axis dim

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -1660,9 +1660,11 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
             }
          }
 
-         // Lift only dims[0]; nested X-dims stay as regular rows (matches captureCombinedCardHeader).
+         // Lift the X-axis period dim (e.g. the date), not dims[0]; a Y-axis
+         // grouping dim like bullOrbear must not steal the subtitle slot.
          if(candleCardLayout && dims.length > 0) {
-            applyCandleCardHeader(tooltip, dims[0], tipMeasures);
+            applyCandleCardHeader(tooltip, candleHeaderDim(chartInfo.getRTXFields(), dims),
+                                  tipMeasures);
          }
          else if(cardMeasureFirst && dims.length > 0) {
             if(groupMeasuresAtTier2(measures, full2NoCalcNames.keySet(), measurePairs)) {
@@ -1867,6 +1869,30 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
 
    private String nameOf(ChartRef ref) {
       return ref == null ? null : GraphUtil.getName(ref);
+   }
+
+   // The X-axis period dim (e.g. the date) headlines as the tier-1 subtitle; Y-axis
+   // and other grouping dims stay as tier-3 context. Picks the innermost X dimension
+   // so nested categorical X still resolves to the per-candle period. Falls back to
+   // dims[0] when no X dimension is present in the tooltip dims.
+   static String candleHeaderDim(ChartRef[] xfields, String[] dims) {
+      String xDim = null;
+
+      for(ChartRef ref : xfields) {
+         if(ref != null && !GraphUtil.isMeasure(ref)) {
+            xDim = GraphUtil.getName(ref);
+         }
+      }
+
+      if(xDim != null) {
+         for(String d : dims) {
+            if(xDim.equals(d)) {
+               return xDim;
+            }
+         }
+      }
+
+      return dims[0];
    }
 
    // Set X-dim as header (solo-card-with-header renders it as tier-1 subtitle); group OHL at tier-2.

--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -1872,22 +1872,21 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
    }
 
    // The X-axis period dim (e.g. the date) headlines as the tier-1 subtitle; Y-axis
-   // and other grouping dims stay as tier-3 context. Picks the innermost X dimension
-   // so nested categorical X still resolves to the per-candle period. Falls back to
-   // dims[0] when no X dimension is present in the tooltip dims.
+   // and other grouping dims stay as tier-3 context. Scans X fields inner-to-outer
+   // and returns the most granular one that actually reached the tooltip dims, so
+   // nested categorical X resolves to the per-candle period. Falls back to dims[0]
+   // only when no X dimension reached the tooltip dims.
    static String candleHeaderDim(ChartRef[] xfields, String[] dims) {
-      String xDim = null;
+      Set<String> dimSet = new HashSet<>(Arrays.asList(dims));
 
-      for(ChartRef ref : xfields) {
+      for(int i = xfields.length - 1; i >= 0; i--) {
+         ChartRef ref = xfields[i];
+
          if(ref != null && !GraphUtil.isMeasure(ref)) {
-            xDim = GraphUtil.getName(ref);
-         }
-      }
+            String name = GraphUtil.getName(ref);
 
-      if(xDim != null) {
-         for(String d : dims) {
-            if(xDim.equals(d)) {
-               return xDim;
+            if(name != null && dimSet.contains(name)) {
+               return name;
             }
          }
       }

--- a/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
@@ -18,10 +18,13 @@
 package inetsoft.report.composition.region;
 
 import inetsoft.uql.viewsheet.graph.ChartInfo;
+import inetsoft.uql.viewsheet.graph.ChartRef;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @Tag("core")
 class ChartToolTipTest {
@@ -306,6 +309,50 @@ class ChartToolTipTest {
       assertTrue(out.contains("<div class=\"tt-tier-3\">bullOrbear:&nbsp;Bullish"),
                  "Aesthetic dims past the OHL group drop to tier-3");
       assertFalse(out.contains("tt-tier-4"), "Tiers must cap at 3");
+   }
+
+   @Test
+   void candleHeaderPicksXDimNotYDim() {
+      // X=Week(date) dim, Y=bullOrbear dim. The header must be the X period dim,
+      // never the Y grouping dim, regardless of element.getDims() order.
+      String[] dims = { "bullOrbear", "Week(date)" }; // Y-dim first (the bug case)
+      ChartRef[] xfields = { dimRef("Week(date)") };
+      assertEquals("Week(date)", PlotArea.candleHeaderDim(xfields, dims));
+   }
+
+   @Test
+   void candleHeaderPicksInnermostXDim() {
+      String[] dims = { "Year", "Week(date)", "bullOrbear" };
+      ChartRef[] xfields = { dimRef("Year"), dimRef("Week(date)") };
+      assertEquals("Week(date)", PlotArea.candleHeaderDim(xfields, dims));
+   }
+
+   @Test
+   void candleHeaderSkipsMeasureXFields() {
+      // A measure on X is not a period identifier; fall through to the X dimension.
+      String[] dims = { "bullOrbear", "Week(date)" };
+      ChartRef[] xfields = { measureRef(), dimRef("Week(date)") };
+      assertEquals("Week(date)", PlotArea.candleHeaderDim(xfields, dims));
+   }
+
+   @Test
+   void candleHeaderFallsBackToFirstDimWhenNoXDim() {
+      String[] dims = { "bullOrbear" };
+      ChartRef[] xfields = {}; // X has only measures or nothing
+      assertEquals("bullOrbear", PlotArea.candleHeaderDim(xfields, dims));
+   }
+
+   private static ChartRef dimRef(String name) {
+      ChartRef ref = mock(ChartRef.class);
+      when(ref.isMeasure()).thenReturn(false);
+      when(ref.getFullName()).thenReturn(name);
+      return ref;
+   }
+
+   private static ChartRef measureRef() {
+      ChartRef ref = mock(ChartRef.class);
+      when(ref.isMeasure()).thenReturn(true);
+      return ref;
    }
 
    @Test

--- a/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
@@ -328,6 +328,15 @@ class ChartToolTipTest {
    }
 
    @Test
+   void candleHeaderFallsBackToOuterXDimWhenInnermostAbsent() {
+      // Week(date) is innermost in xfields but never reached the tooltip dims;
+      // promote the next-outer X dim (Year), never the Y-axis dim.
+      String[] dims = { "bullOrbear", "Year" };
+      ChartRef[] xfields = { dimRef("Year"), dimRef("Week(date)") };
+      assertEquals("Year", PlotArea.candleHeaderDim(xfields, dims));
+   }
+
+   @Test
    void candleHeaderSkipsMeasureXFields() {
       // A measure on X is not a period identifier; fall through to the X dimension.
       String[] dims = { "bullOrbear", "Week(date)" };


### PR DESCRIPTION
## Summary

- On a candle/stock card tooltip with a Y-axis dimension binding (e.g. `bullOrbear` splitting Bullish/Bearish), the period dim `Week(date)` was buried at tier-3 while the Y-axis grouping dim took the tier-1 subtitle slot. The date is the per-candle identity and belongs directly under the Close headline.
- Follow-up to Bug #75026: that change introduced the candle card header but lifted `dims[0]` positionally. `element.getDims()` returns both the X period dim and any Y grouping dim, so `dims[0]` could resolve to the wrong dim.
- The tooltip now always promotes the X-axis date dim as the subtitle; Y-axis and other grouping dims stay at tier-3 as supplementary context.

## Root cause

`PlotArea.getToolTip0` passed `dims[0]` to `applyCandleCardHeader`. `dims` comes from `element.getDims()`, which contains every element dimension. With a Y-axis dimension bound, `dims[0]` resolved to that grouping dim (`bullOrbear`) instead of the X period dim, so `bullOrbear` was lifted to the tier-1 subtitle and `Week(date)` dropped to tier-3.

`applyCandleCardHeader` itself was correct; the defect was purely which dim it was handed.

## What changed

`PlotArea`:

- New `candleHeaderDim(ChartRef[] xfields, String[] dims)` helper: returns the innermost X-axis dimension name (skips measures via `GraphUtil.isMeasure`), falling back to `dims[0]` only when no X dimension is present. Nested categorical X still resolves to the per-candle period (the innermost X dim).
- The candle branch now calls `applyCandleCardHeader(tooltip, candleHeaderDim(chartInfo.getRTXFields(), dims), tipMeasures)`. Uses the runtime X fields (`getRTXFields`) so the field names match the runtime `dims` from `element.getDims()` — consistent with the sibling `reorderCandleMeasuresCloseFirst`, which matches runtime measures against `getRT*Field()`. This avoids a silent fallback to `dims[0]` when the runtime date level diverges from design (date comparison, dynamic levels).

No change to `applyCandleCardHeader`, `reorderCandleMeasuresCloseFirst`, tier counting, or any non-candle path.

Resulting tooltip on the binding from the bug report (`Week(date)` X-axis dim, OHLC measures, `bullOrbear` Y-axis dim):

```
Last(close, date): 179.4        tier-1 (headline)
Week(date): 2025-02-23          tier-1 subtitle
First(open, date): 181.3        tier-2
Max(high): 182.8                tier-2
Min(low): 178.3                 tier-2
bullOrbear: Bearish             tier-3
```
