### PR TITLE
Bug #75295, fix tight label spacing in filled form fields

### DIFF
--- a/web/projects/em/src/_app-theme.scss
+++ b/web/projects/em/src/_app-theme.scss
@@ -273,6 +273,10 @@
   // which causes --mat-form-field-filled-label-display to be set to none. Override to keep
   // floating labels visible in filled-appearance form fields.
   --mat-form-field-filled-label-display: block;
+  // When the label is suppressed, Angular Material also reduces the padding-top to the
+  // no-label value (6px). Override to the correct density-5 value with label shown:
+  // 24px - (56px - 36px) / 2 = 14px.
+  --mat-form-field-filled-with-label-container-padding-top: 14px;
 
   &.mat-form-field-appearance-outline:not(.mat-mdc-paginator-page-size-select) {
     padding-bottom: .75em;


### PR DESCRIPTION
## Summary

Labels on filled-appearance `mat-form-field` elements (e.g. "Pick an SSO Provider", "Scopes", "Name Claim" on the SSO settings page) appeared with almost no vertical space between the label and the field content.

## Root Cause

`mat.form-field-density(-5)` emits a 36px container height, which falls below Angular Material 21's 52px threshold for label suppression in filled form fields. When the label is suppressed, Angular Material sets two CSS variables together:

- `--mat-form-field-filled-label-display: none`
- `--mat-form-field-filled-with-label-container-padding-top: 6px` (the no-label padding)

Bug #75234 restored label visibility by overriding the first variable to `block`, but the second variable was left at 6px. With labels visible but only 6px of top padding, the floating label had no room and overlapped the field content.

## Fix

Added `--mat-form-field-filled-with-label-container-padding-top: 14px` alongside the existing display override in `_app-theme.scss`. The 14px is derived from Angular Material's own formula for density -5 with labels shown: `24px - (56px - 36px) / 2 = 14px`.

## Test Plan

- Open `em/settings/security/sso`, select "OpenID Connect" and verify the spacing between "Pick an SSO Provider", "Scopes", and "Name Claim" labels and their respective controls is no longer tight
- Verify other EM pages with filled form fields (e.g. general settings, schedule, security) still display correctly
- All 301 EM unit tests pass

Fixes Redmine #75295.