### PR TITLE
Bug #75304, schedule time zone select in portal not consistent with em

### DIFF
--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.component.ts
@@ -753,7 +753,7 @@ export class TaskConditionPane implements OnInit, OnChanges {
       }
 
       if(tz == this.timeZoneOptions[0]) {
-         this.localTimeZoneLabel = new Date().toTimeString().match(/\((.+)\)/)?.[1] ?? "";
+         this.localTimeZoneLabel = new Date().toTimeString().match(/\((.+)\)/)?.[1] || null;
       }
       else {
          this.localTimeZoneLabel = tz.label;
@@ -1246,7 +1246,7 @@ export class TaskConditionPane implements OnInit, OnChanges {
       else {
          if(this.isTimeCondition(this.condition)) {
             this.timeCondition.timeZone = this.localTimeZoneId;
-            this.timeCondition.timeZoneLabel = this.localTimeZoneLabel ?? "";
+            this.timeCondition.timeZoneLabel = this.localTimeZoneLabel || null;
          }
 
          this.form?.get("timeZone")?.enable();
@@ -1254,7 +1254,7 @@ export class TaskConditionPane implements OnInit, OnChanges {
 
       this.timeZoneName = this.serverTimeZone ? this.timeZone :
          this.localTimeZoneLabel != null ? this.localTimeZoneLabel :
-            new Date().toTimeString().match(/\((.+)\)/)?.[1] ?? "";
+            new Date().toTimeString().match(/\((.+)\)/)?.[1] || null;
       this.localTimeZoneOffset = this.timeZoneService.calculateTimezoneOffset(this.localTimeZoneId);
    }
 

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.component.ts
@@ -753,7 +753,7 @@ export class TaskConditionPane implements OnInit, OnChanges {
       }
 
       if(tz == this.timeZoneOptions[0]) {
-         this.localTimeZoneLabel = new Date().toTimeString().match(/\((.+)\)/)[1];
+         this.localTimeZoneLabel = new Date().toTimeString().match(/\((.+)\)/)?.[1] ?? "";
       }
       else {
          this.localTimeZoneLabel = tz.label;
@@ -1201,7 +1201,7 @@ export class TaskConditionPane implements OnInit, OnChanges {
 
       if(!edit || !this.timeCondition?.timeZone || this.serverTimeZone) {
          this.timeZoneName = this.serverTimeZone ? this.timeZone :
-            new Date().toTimeString().match(/\((.+)\)/)[1];
+            new Date().toTimeString().match(/\((.+)\)/)?.[1] ?? "";
       }
    }
 
@@ -1246,6 +1246,7 @@ export class TaskConditionPane implements OnInit, OnChanges {
       else {
          if(this.isTimeCondition(this.condition)) {
             this.timeCondition.timeZone = this.localTimeZoneId;
+            this.timeCondition.timeZoneLabel = this.localTimeZoneLabel ?? "";
          }
 
          this.form?.get("timeZone")?.enable();
@@ -1253,7 +1254,7 @@ export class TaskConditionPane implements OnInit, OnChanges {
 
       this.timeZoneName = this.serverTimeZone ? this.timeZone :
          this.localTimeZoneLabel != null ? this.localTimeZoneLabel :
-            new Date().toTimeString().match(/\((.+)\)/)[1];
+            new Date().toTimeString().match(/\((.+)\)/)?.[1] ?? "";
       this.localTimeZoneOffset = this.timeZoneService.calculateTimezoneOffset(this.localTimeZoneId);
    }
 

--- a/web/projects/portal/src/app/widget/schedule/simple-schedule-dialog.component.ts
+++ b/web/projects/portal/src/app/widget/schedule/simple-schedule-dialog.component.ts
@@ -254,7 +254,8 @@ export class SimpleScheduleDialog implements OnInit, OnDestroy {
          this.timeZoneId = this.model.timeZoneOptions[0].timeZoneId;
          this.form.get("timeZone").setValue(this.timeZoneId);
          this.model.timeConditionModel.timeZone = this.timeZoneId;
-         this.timeZoneLabel = new Date().toTimeString().match(/\((.+)\)/)[1];
+         this.timeZoneLabel = new Date().toTimeString().match(/\((.+)\)/)?.[1] ?? "";
+         this.model.timeConditionModel.timeZoneLabel = this.timeZoneLabel;
       }
 
       if(this.model.emailDeliveryEnabled) {
@@ -618,11 +619,13 @@ export class SimpleScheduleDialog implements OnInit, OnDestroy {
       this.form.get("startTime").setValue(this.startTimeData);
 
       if (tz == this.model.timeZoneOptions[0]) {
-         this.timeZoneLabel = new Date().toTimeString().match(/\((.+)\)/)[1];
+         this.timeZoneLabel = new Date().toTimeString().match(/\((.+)\)/)?.[1] ?? "";
       }
       else {
          this.timeZoneLabel = tz.label;
       }
+
+      this.model.timeConditionModel.timeZoneLabel = this.timeZoneLabel;
    }
 
    convertTimeZone(date: Date): NgbTimeStruct {

--- a/web/projects/portal/src/app/widget/schedule/simple-schedule-dialog.component.ts
+++ b/web/projects/portal/src/app/widget/schedule/simple-schedule-dialog.component.ts
@@ -254,7 +254,7 @@ export class SimpleScheduleDialog implements OnInit, OnDestroy {
          this.timeZoneId = this.model.timeZoneOptions[0].timeZoneId;
          this.form.get("timeZone").setValue(this.timeZoneId);
          this.model.timeConditionModel.timeZone = this.timeZoneId;
-         this.timeZoneLabel = new Date().toTimeString().match(/\((.+)\)/)?.[1] ?? "";
+         this.timeZoneLabel = new Date().toTimeString().match(/\((.+)\)/)?.[1] || null;
          this.model.timeConditionModel.timeZoneLabel = this.timeZoneLabel;
       }
 
@@ -619,7 +619,7 @@ export class SimpleScheduleDialog implements OnInit, OnDestroy {
       this.form.get("startTime").setValue(this.startTimeData);
 
       if (tz == this.model.timeZoneOptions[0]) {
-         this.timeZoneLabel = new Date().toTimeString().match(/\((.+)\)/)?.[1] ?? "";
+         this.timeZoneLabel = new Date().toTimeString().match(/\((.+)\)/)?.[1] || null;
       }
       else {
          this.timeZoneLabel = tz.label;


### PR DESCRIPTION
## Summary

When a schedule task was created in the Portal with a timezone selected (e.g., Samoa Standard Time), the Enterprise Manager displayed a different timezone label for the same task (e.g., "(UTC-11:00) Coordinated Universal Time"). The scheduled time itself was correct, but the timezone name was inconsistent.

## Root Cause

The Portal's schedule condition editor sets the timezone ID (`timeZone`) on the condition model when the user selects a timezone, but never sets the human-readable display label (`timeZoneLabel`). When the EM loads the task, it uses `TimeZoneService.updateTimeZoneOptions()` to reconstruct the label from the stored ID using the local browser's `Intl.DateTimeFormat` API. Since different browsers/OSes can return different display names for the same IANA timezone ID (e.g., `Pacific/Midway` → "Samoa Standard Time" on some platforms, "Coordinated Universal Time" on others), the label shown in EM differed from what the Portal showed.

## Fix

Two Angular components in the Portal are updated to save `timeZoneLabel` alongside `timeZone` when a condition is saved:

- **`simple-schedule-dialog.component.ts`**: `setTimeZone()` and `initForm()` now set `timeConditionModel.timeZoneLabel` from the selected option's display label. The `toTimeString().match()` call is also guarded against null to prevent a crash on browsers that omit parentheses from their timezone string.
- **`task-condition-pane.component.ts`** (portal full schedule editor): `updateTimeZone()` now sets `timeCondition.timeZoneLabel` from the resolved local timezone label. The same null guard is applied to `toTimeString().match()` calls.

With the label stored, `updateTimeZoneOptions()` in the EM uses it to add a correctly-labeled synthetic entry for any timezone ID not already in the server's list, ensuring consistent display.

## Test Plan

- Create a schedule task in the Portal, select a non-default timezone (e.g., Samoa Standard Time), set a start time, and save.
- Open the same task in the Enterprise Manager.
- Verify the timezone name and start time match what was set in the Portal.
- Verify that changing the timezone in the EM condition editor still correctly converts the displayed time.

Fixes Redmine #75304.