### PR TITLE
feat(wiz): recommender improvements + in-place chart properties (titles/scale/legend/colors)

### DIFF
--- a/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartTypeFilter.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartTypeFilter.java
@@ -548,10 +548,9 @@ public class ChartTypeFilter {
    // If auto order, we will put col with less cardinality to color, but is not auto order,
    // ignore it.
    protected int getAestheticScore(VSChartInfo info) {
-      if(!autoOrder) {
-         return 0;
-      }
-
+      // Note: the hard over-cap guard below applies regardless of autoOrder — binding a
+      // high-cardinality dimension to color/shape/size is infeasible (unreadable legend) whether or
+      // not auto-ordering is on. Only the graduated ordering *preference* depends on autoOrder.
       int score = 0;
       int maxShapes = 8;
       int maxSize = 10;
@@ -584,7 +583,7 @@ public class ChartTypeFilter {
                if(n > max) {
                   return -1000;
                }
-               else {
+               else if(autoOrder) {
                   score -= n * 4 / max;
                }
             }

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/chart/MapChartFilter.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/chart/MapChartFilter.java
@@ -281,7 +281,11 @@ public class MapChartFilter extends ChartTypeFilter {
 
    @Override
    protected int getScore(ChartInfo chart) {
-      return 1000;
+      // Geo data should clearly prefer a map, but not by a sentinel score that dwarfs every other
+      // type (which made map the top recommendation for any field set containing a geo field, and
+      // flattened the relative scores of all non-map candidates). A strong boost over PRIMARY_SCORE
+      // keeps map winning for genuine geo bindings while leaving the other candidates comparable.
+      return PRIMARY_SCORE + 10;
    }
 
    private int getLayer(ChartRef ref) {

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/chart/MapChartFilter.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/chart/MapChartFilter.java
@@ -281,11 +281,14 @@ public class MapChartFilter extends ChartTypeFilter {
 
    @Override
    protected int getScore(ChartInfo chart) {
-      // Geo data should clearly prefer a map, but not by a sentinel score that dwarfs every other
-      // type (which made map the top recommendation for any field set containing a geo field, and
-      // flattened the relative scores of all non-map candidates). A strong boost over PRIMARY_SCORE
-      // keeps map winning for genuine geo bindings while leaving the other candidates comparable.
-      return PRIMARY_SCORE + 10;
+      // A geo binding is a STRONG, deliberate signal: geographic columns are never auto-detected here
+      // — they exist only because the user explicitly marked the column geographic (getGeoColumns is
+      // populated by the setGeographic action). So map should win comfortably whenever a geo field is
+      // bound. We use a strong multiple of PRIMARY_SCORE rather than the old sentinel 1000: high
+      // enough to clearly beat bar (~23) and a time-series line (~30), but low enough that the other
+      // candidates keep meaningful relative scores in the candidate menu (vs. the sentinel, which
+      // flattened every non-map candidate to ~0).
+      return PRIMARY_SCORE * 2;
    }
 
    private int getLayer(ChartRef ref) {

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
@@ -71,6 +71,13 @@ public class WizViewsheetController {
       return wizAutoBindingService.setChartFormat(request, user);
    }
 
+   @PostMapping(value = "/viewsheet/colors", produces = MediaType.APPLICATION_JSON_VALUE)
+   public CreateViewsheetResult setChartColors(@RequestBody ChartColorsRequest request,
+                                               Principal user) throws Exception
+   {
+      return wizAutoBindingService.setChartColors(request, user);
+   }
+
    @DeleteMapping("/viewsheet")
    public void deleteViewsheet(@RequestParam("identifier") String identifier,
                                Principal user) throws Exception

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
@@ -64,6 +64,13 @@ public class WizViewsheetController {
       return wizAutoBindingService.changeType(request, user);
    }
 
+   @PostMapping(value = "/viewsheet/format", produces = MediaType.APPLICATION_JSON_VALUE)
+   public CreateViewsheetResult setChartFormat(@RequestBody ChartFormatRequest request,
+                                               Principal user) throws Exception
+   {
+      return wizAutoBindingService.setChartFormat(request, user);
+   }
+
    @DeleteMapping("/viewsheet")
    public void deleteViewsheet(@RequestParam("identifier") String identifier,
                                Principal user) throws Exception

--- a/core/src/main/java/inetsoft/web/wiz/model/AutoBindingResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/AutoBindingResponse.java
@@ -20,6 +20,7 @@ package inetsoft.web.wiz.model;
 import inetsoft.web.vswizard.model.recommender.VSObjectRecommendation;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Response body for {@code POST /api/wiz/viewsheet/autoBinding}.
@@ -73,6 +74,14 @@ public class AutoBindingResponse {
       this.selectionNote = selectionNote;
    }
 
+   public Map<String, Integer> getFieldCardinalities() {
+      return fieldCardinalities;
+   }
+
+   public void setFieldCardinalities(Map<String, Integer> fieldCardinalities) {
+      this.fieldCardinalities = fieldCardinalities;
+   }
+
    /**
     * All candidate visualizations: charts ordered by vsWizard score, then table (always),
     * crosstab (only when both dimensions and measures are present),
@@ -114,4 +123,12 @@ public class AutoBindingResponse {
     * the requested type was honored or none was requested.
     */
    private String selectionNote;
+
+   /**
+    * Distinct-value counts (cardinality) for the selected non-date dimension fields, keyed by field
+    * name. Lets the caller spot high-cardinality dimensions (e.g. 600 cities) and switch to top-N
+    * ranking or a roll-up instead of an unreadable chart. Empty when cardinality was not computed
+    * (the recommender only samples it for field sets of 9 or fewer) or no such dimension was bound.
+    */
+   private Map<String, Integer> fieldCardinalities;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/AutoBindingResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/AutoBindingResponse.java
@@ -57,6 +57,22 @@ public class AutoBindingResponse {
       this.visualizationResult = visualizationResult;
    }
 
+   public List<ChartTypeCandidate> getCandidates() {
+      return candidates;
+   }
+
+   public void setCandidates(List<ChartTypeCandidate> candidates) {
+      this.candidates = candidates;
+   }
+
+   public String getSelectionNote() {
+      return selectionNote;
+   }
+
+   public void setSelectionNote(String selectionNote) {
+      this.selectionNote = selectionNote;
+   }
+
    /**
     * All candidate visualizations: charts ordered by vsWizard score, then table (always),
     * crosstab (only when both dimensions and measures are present),
@@ -84,4 +100,18 @@ public class AutoBindingResponse {
     * calls so the primary assembly is updated in place. Null when primary is null.
     */
    private CreateViewsheetResult visualizationResult;
+
+   /**
+    * Feasibility-filtered chart-type menu, flattened from {@link #recommendations} into named,
+    * scored entries (highest score first). The caller picks the final type from this menu; only
+    * types the recommender found feasible for the current fields appear here.
+    */
+   private List<ChartTypeCandidate> candidates;
+
+   /**
+    * Set only when a requested {@code visualizationType} could not be honored and a different type
+    * was substituted (e.g. "requested 'pie' is not feasible for this data; used 'bar'"). Null when
+    * the requested type was honored or none was requested.
+    */
+   private String selectionNote;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/ChartColorsRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChartColorsRequest.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Request body for {@code POST /api/wiz/viewsheet/colors} — sets chart COLORS in place on an existing
+ * runtime chart and re-renders. The color mode is chosen from the chart's color binding; provide the
+ * fields that match (static for no color binding; palette/list/categoryColors for a dimension on color;
+ * paletteName as a gradient for a measure on color). All color fields are optional.
+ */
+public class ChartColorsRequest {
+   public String getWizRuntimeId() { return wizRuntimeId; }
+   public void setWizRuntimeId(String wizRuntimeId) { this.wizRuntimeId = wizRuntimeId; }
+
+   public String getAssemblyName() { return assemblyName; }
+   public void setAssemblyName(String assemblyName) { this.assemblyName = assemblyName; }
+
+   public String getViewsheetIdentifier() { return viewsheetIdentifier; }
+   public void setViewsheetIdentifier(String viewsheetIdentifier) { this.viewsheetIdentifier = viewsheetIdentifier; }
+
+   /** Hex #RRGGBB — one color for the measure(s) when no field is on the color aesthetic. */
+   public String getStaticColor() { return staticColor; }
+   public void setStaticColor(String staticColor) { this.staticColor = staticColor; }
+
+   /** A named palette (validated against ColorPalettes.getPaletteNames()); categorical or gradient by binding. */
+   public String getPaletteName() { return paletteName; }
+   public void setPaletteName(String paletteName) { this.paletteName = paletteName; }
+
+   /** Ordered custom palette of hex colors (categorical). */
+   public List<String> getColorList() { return colorList; }
+   public void setColorList(List<String> colorList) { this.colorList = colorList; }
+
+   /** Per-category overrides: dimension value -> hex (categorical). */
+   public Map<String, String> getCategoryColors() { return categoryColors; }
+   public void setCategoryColors(Map<String, String> categoryColors) { this.categoryColors = categoryColors; }
+
+   private String wizRuntimeId;
+   private String assemblyName;
+   private String viewsheetIdentifier;
+   private String staticColor;
+   private String paletteName;
+   private List<String> colorList;
+   private Map<String, String> categoryColors;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+/**
+ * Request body for {@code POST /api/wiz/viewsheet/format} — applies chart-level FORMAT properties
+ * (axis titles, y-axis scale, legend placement) to an existing runtime chart and re-renders it.
+ * All format fields are optional; only the non-null ones are applied (a no-op field is left as-is).
+ */
+public class ChartFormatRequest {
+   public String getWizRuntimeId() { return wizRuntimeId; }
+   public void setWizRuntimeId(String wizRuntimeId) { this.wizRuntimeId = wizRuntimeId; }
+
+   public String getAssemblyName() { return assemblyName; }
+   public void setAssemblyName(String assemblyName) { this.assemblyName = assemblyName; }
+
+   public String getViewsheetIdentifier() { return viewsheetIdentifier; }
+   public void setViewsheetIdentifier(String viewsheetIdentifier) { this.viewsheetIdentifier = viewsheetIdentifier; }
+
+   public String getXAxisTitle() { return xAxisTitle; }
+   public void setXAxisTitle(String xAxisTitle) { this.xAxisTitle = xAxisTitle; }
+
+   public String getYAxisTitle() { return yAxisTitle; }
+   public void setYAxisTitle(String yAxisTitle) { this.yAxisTitle = yAxisTitle; }
+
+   public Double getYAxisMin() { return yAxisMin; }
+   public void setYAxisMin(Double yAxisMin) { this.yAxisMin = yAxisMin; }
+
+   public Double getYAxisMax() { return yAxisMax; }
+   public void setYAxisMax(Double yAxisMax) { this.yAxisMax = yAxisMax; }
+
+   public Double getYAxisIncrement() { return yAxisIncrement; }
+   public void setYAxisIncrement(Double yAxisIncrement) { this.yAxisIncrement = yAxisIncrement; }
+
+   public Boolean getYAxisLogarithmic() { return yAxisLogarithmic; }
+   public void setYAxisLogarithmic(Boolean yAxisLogarithmic) { this.yAxisLogarithmic = yAxisLogarithmic; }
+
+   /** none | top | right | bottom | left | in_place (case-insensitive); null leaves the legend unchanged. */
+   public String getLegendPosition() { return legendPosition; }
+   public void setLegendPosition(String legendPosition) { this.legendPosition = legendPosition; }
+
+   /** The runtime viewsheet that holds the live chart (the plugin's active-chart runtimeId). */
+   private String wizRuntimeId;
+   /** The chart assembly name within that runtime. */
+   private String assemblyName;
+   /** Optional — carried back on the result so a subsequent save keeps the same identifier. */
+   private String viewsheetIdentifier;
+
+   private String xAxisTitle;
+   private String yAxisTitle;
+   private Double yAxisMin;
+   private Double yAxisMax;
+   private Double yAxisIncrement;
+   private Boolean yAxisLogarithmic;
+   private String legendPosition;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/ChartTypeCandidate.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChartTypeCandidate.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+/**
+ * One entry in the feasibility-filtered chart-type menu returned by
+ * {@code POST /api/wiz/viewsheet/autoBinding}. Each candidate is a chart type the recommender
+ * found feasible for the current fields, with its relative score, so the caller (the LLM) can make
+ * the final type choice from a product-accurate menu instead of guessing blind.
+ */
+public class ChartTypeCandidate {
+   public ChartTypeCandidate() {
+   }
+
+   public ChartTypeCandidate(String type, double score) {
+      this.type = type;
+      this.score = score;
+   }
+
+   /** The chart-type name (same vocabulary as {@code change_chart_type}, e.g. "bar", "line", "pie"). */
+   public String getType() {
+      return type;
+   }
+
+   public void setType(String type) {
+      this.type = type;
+   }
+
+   /** Relative fit score in [0,1] (recommender score, normalized). Higher = better fit; for ordering only. */
+   public double getScore() {
+      return score;
+   }
+
+   public void setScore(double score) {
+      this.score = score;
+   }
+
+   private String type;
+   private double score;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/CreateViewsheetResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/CreateViewsheetResult.java
@@ -117,6 +117,14 @@ public class CreateViewsheetResult {
       this.autoBindingRuntimeId = autoBindingRuntimeId;
    }
 
+   public String getNote() {
+      return note;
+   }
+
+   public void setNote(String note) {
+      this.note = note;
+   }
+
    private List<String> headers;
    private List<Map<String, Object>> rows;
    private FlatBinding binding;
@@ -127,6 +135,7 @@ public class CreateViewsheetResult {
    private Boolean hasData;
    /** Echoed back so the client can reuse the recommendation RVS on the next changeType call. */
    private String autoBindingRuntimeId;
+   private String note;
 
    // -------------------------------------------------------------------------
    // Nested model

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -1408,6 +1408,111 @@ public class WizAutoBindingService {
    }
 
    /**
+    * Applies chart-level FORMAT properties (axis titles, y-axis scale, legend placement) to an
+    * existing runtime chart and re-renders it. Only the non-null request fields are applied; the
+    * rest of the chart is left untouched. Returns the re-executed chart's sampled data (the format
+    * change affects the rendered chart, not the underlying rows).
+    */
+   public CreateViewsheetResult setChartFormat(ChartFormatRequest request, Principal user)
+      throws Exception
+   {
+      RuntimeViewsheet rvs = viewsheetService.getViewsheet(request.getWizRuntimeId(), user);
+
+      if(rvs == null || rvs.getViewsheet() == null) {
+         throw new Exception("Chart runtime not found: " + request.getWizRuntimeId());
+      }
+
+      VSAssembly assembly = rvs.getViewsheet().getAssembly(request.getAssemblyName());
+
+      if(!(assembly instanceof ChartVSAssembly chart)) {
+         throw new Exception("Chart assembly not found: " + request.getAssemblyName());
+      }
+
+      var info = chart.getChartInfo();
+      ChartDescriptor desc = info.getChartDescriptor();
+      VSChartInfo vsChartInfo = info.getVSChartInfo();
+
+      // Axis titles
+      if(desc != null && desc.getTitlesDescriptor() != null) {
+         TitlesDescriptor titles = desc.getTitlesDescriptor();
+
+         if(request.getXAxisTitle() != null && titles.getXTitleDescriptor() != null) {
+            titles.getXTitleDescriptor().setTitleValue(request.getXAxisTitle());
+         }
+
+         if(request.getYAxisTitle() != null && titles.getYTitleDescriptor() != null) {
+            titles.getYTitleDescriptor().setTitleValue(request.getYAxisTitle());
+         }
+      }
+
+      // Y-axis scale — applied to each bound measure's axis descriptor.
+      boolean scaleChange = request.getYAxisMin() != null || request.getYAxisMax() != null ||
+         request.getYAxisIncrement() != null || request.getYAxisLogarithmic() != null;
+
+      if(scaleChange && vsChartInfo != null && vsChartInfo.getYFields() != null) {
+         for(ChartRef yref : vsChartInfo.getYFields()) {
+            if(yref == null || yref.getAxisDescriptor() == null) {
+               continue;
+            }
+
+            AxisDescriptor ax = yref.getAxisDescriptor();
+
+            if(request.getYAxisMin() != null) {
+               ax.setMinimum(request.getYAxisMin());
+            }
+
+            if(request.getYAxisMax() != null) {
+               ax.setMaximum(request.getYAxisMax());
+            }
+
+            if(request.getYAxisIncrement() != null) {
+               ax.setIncrement(request.getYAxisIncrement());
+            }
+
+            if(request.getYAxisLogarithmic() != null) {
+               ax.setLogarithmicScale(request.getYAxisLogarithmic());
+            }
+         }
+      }
+
+      // Legend placement
+      if(request.getLegendPosition() != null && desc != null && desc.getLegendsDescriptor() != null) {
+         desc.getLegendsDescriptor().setLayout(legendLayout(request.getLegendPosition()));
+      }
+
+      // Invalidate the cached runtime descriptor so the change regenerates on re-execute.
+      info.setRTChartDescriptor(null);
+
+      CreateViewsheetResult result =
+         wizVsService.fetchAssemblyData(request.getWizRuntimeId(), request.getAssemblyName(), user);
+
+      if(result == null) {
+         result = new CreateViewsheetResult();
+      }
+
+      result.setRuntimeId(request.getWizRuntimeId());
+      result.setAssemblyName(request.getAssemblyName());
+
+      if(request.getViewsheetIdentifier() != null) {
+         result.setViewsheetIdentifier(request.getViewsheetIdentifier());
+      }
+
+      return result;
+   }
+
+   /** Maps a legend-position string to a {@link LegendsDescriptor} layout constant (defaults to RIGHT). */
+   private static int legendLayout(String position) {
+      return switch(position.toLowerCase()) {
+         case "none" -> LegendsDescriptor.NO_LEGEND;
+         case "top" -> LegendsDescriptor.TOP;
+         case "bottom" -> LegendsDescriptor.BOTTOM;
+         case "left" -> LegendsDescriptor.LEFT;
+         case "in_place" -> LegendsDescriptor.IN_PLACE;
+         default -> LegendsDescriptor.RIGHT;
+      };
+   }
+
+   /**
     * Calls updatePrimaryAssembly on {@code rvs} to mirror the full wizard setup path
     * (calc field registration, format, legend, temp assembly cleanup), then returns the
     * resulting temp assembly. The caller must have already set {@code selectedIndex} on

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -231,6 +231,7 @@ public class WizAutoBindingService {
          resp.setAutoBindingRuntimeId(autoBindingRuntimeId);
          resp.setVisualizationResult(visualizationResult);
          resp.setCandidates(buildChartTypeCandidates(recommendations));
+         resp.setFieldCardinalities(buildFieldCardinalities(entries));
 
          // Tell the caller when a requested type could not be honored, so it can explain the
          // substitution to the user instead of the swap happening silently.
@@ -1022,6 +1023,35 @@ public class WizAutoBindingService {
          .map(e -> new ChartTypeCandidate(e.getKey(), Math.round((e.getValue() / denom) * 100.0) / 100.0))
          .sorted(Comparator.comparingDouble(ChartTypeCandidate::getScore).reversed())
          .collect(Collectors.toList());
+   }
+
+   /**
+    * Collects the distinct-value counts the recommender sampled onto the selected dimension entries
+    * (set by {@code WizardRecommenderUtil.refreshCardinalityAndHierarchy} during recommend()), keyed
+    * by the same field name the client binds with. Skips entries without a cardinality property
+    * (date dimensions, measures, or field sets too large for the recommender to sample).
+    */
+   private Map<String, Integer> buildFieldCardinalities(AssetEntry[] entries) {
+      Map<String, Integer> out = new LinkedHashMap<>();
+
+      if(entries == null) {
+         return out;
+      }
+
+      for(AssetEntry entry : entries) {
+         String card = entry.getProperty("cardinality");
+
+         if(card != null) {
+            try {
+               out.put(WizardRecommenderUtil.getFieldName(entry), Integer.parseInt(card));
+            }
+            catch(NumberFormatException ignore) {
+               // non-numeric cardinality property; skip
+            }
+         }
+      }
+
+      return out;
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -230,6 +230,15 @@ public class WizAutoBindingService {
          resp.setPrimary(primary);
          resp.setAutoBindingRuntimeId(autoBindingRuntimeId);
          resp.setVisualizationResult(visualizationResult);
+         resp.setCandidates(buildChartTypeCandidates(recommendations));
+
+         // Tell the caller when a requested type could not be honored, so it can explain the
+         // substitution to the user instead of the swap happening silently.
+         if(vizType != null && primary != null && !requestedTypeAvailable(vizType, model)) {
+            resp.setSelectionNote(
+               "Requested chart type '" + vizType + "' is not feasible for this data; used '" +
+               primary.getVisualizationType() + "' instead.");
+         }
 
          succeeded = true;
          return resp;
@@ -958,6 +967,117 @@ public class WizAutoBindingService {
 
    private boolean isChartVizType(String vizType) {
       return vizType != null && !NON_CHART_VIZ_TYPES.contains(vizType);
+   }
+
+   /**
+    * Flattens the recommendation list into a feasibility-filtered, named chart-type menu (highest
+    * fit first). Chart candidates and their scores come from each {@link VSChartRecommendation}'s
+    * prefInfos; table/crosstab/gauge/text appear once each when feasible. Scores are normalized to
+    * [0,1] for ordering only. Every entry is a type the recommender found feasible for the fields.
+    */
+   private List<ChartTypeCandidate> buildChartTypeCandidates(List<VSObjectRecommendation> recommendations) {
+      if(recommendations == null || recommendations.isEmpty()) {
+         return Collections.emptyList();
+      }
+
+      // type name -> best raw score seen for that type (preserve first-seen order for ties)
+      Map<String, Integer> best = new LinkedHashMap<>();
+
+      for(VSObjectRecommendation rec : recommendations) {
+         if(rec instanceof VSChartRecommendation vcr) {
+            List<ChartCombinationUtil.ScoredInfo> prefInfos = vcr.getPrefInfos();
+
+            if(prefInfos != null) {
+               for(ChartCombinationUtil.ScoredInfo si : prefInfos) {
+                  String type = getChartTypeString(si.getInfo().getChartType());
+
+                  if(type != null) {
+                     best.merge(type, si.getScore(), Math::max);
+                  }
+               }
+            }
+         }
+         else if(rec instanceof VSCrosstabRecommendation cr && cr.getCrosstabInfo() != null) {
+            best.putIfAbsent("crosstab", 0);
+         }
+         else if(rec instanceof VSTableRecommendation) {
+            best.putIfAbsent("table", 0);
+         }
+         else if(rec instanceof VSGaugeRecommendation gr && gr.getDataRef() != null) {
+            best.putIfAbsent("gauge", 0);
+         }
+         else if(rec instanceof VSTextRecommendation tr && tr.getDataRef() != null) {
+            best.putIfAbsent("text", 0);
+         }
+      }
+
+      if(best.isEmpty()) {
+         return Collections.emptyList();
+      }
+
+      int max = best.values().stream().mapToInt(Integer::intValue).max().orElse(0);
+      double denom = max > 0 ? max : 1.0;
+
+      return best.entrySet().stream()
+         .map(e -> new ChartTypeCandidate(e.getKey(), Math.round((e.getValue() / denom) * 100.0) / 100.0))
+         .sorted(Comparator.comparingDouble(ChartTypeCandidate::getScore).reversed())
+         .collect(Collectors.toList());
+   }
+
+   /**
+    * Side-effect-free check of whether {@code vizType} is satisfiable by some recommendation.
+    * Mirrors {@link #findRecByType} (including the donut/area aliasing in {@link #chartTypeMatches})
+    * but, unlike findRecByType, does not mutate any {@code selectedIndex}. Used only to decide
+    * whether a requested type was honored, so a substitution can be reported.
+    */
+   private boolean requestedTypeAvailable(String vizType, VSRecommendationModel model) {
+      if(vizType == null || model == null) {
+         return false;
+      }
+
+      for(VSObjectRecommendation rec : model.getRecommendationList()) {
+         if(isChartVizType(vizType) && rec instanceof VSChartRecommendation cr) {
+            List<ChartCombinationUtil.ScoredInfo> prefInfos = cr.getPrefInfos();
+
+            if(prefInfos != null) {
+               for(ChartCombinationUtil.ScoredInfo si : prefInfos) {
+                  if(chartTypeMatches(vizType, si.getInfo())) {
+                     return true;
+                  }
+               }
+            }
+
+            List<ChartInfo> chartInfos = cr.getChartInfos();
+
+            if(chartInfos != null) {
+               for(ChartInfo ci : chartInfos) {
+                  if(chartTypeMatches(vizType, ci)) {
+                     return true;
+                  }
+               }
+            }
+         }
+         else if("crosstab".equals(vizType) && rec instanceof VSCrosstabRecommendation cr) {
+            if(cr.getCrosstabInfo() != null) {
+               return true;
+            }
+         }
+         else if("table".equals(vizType) && rec instanceof VSTableRecommendation) {
+            return true;
+         }
+         else if("gauge".equals(vizType) && rec instanceof VSGaugeRecommendation gr) {
+            if(gr.getDataRef() != null) {
+               return true;
+            }
+         }
+         else if("text".equals(vizType) && rec instanceof VSTextRecommendation tr) {
+            if(tr.getDataRef() != null) {
+               return true;
+            }
+         }
+      }
+
+      return false;
    }
 
    // ── Chart type string mapping (inverse of WizVsService.getChartType) ─────────

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -44,7 +44,9 @@ import inetsoft.web.wiz.model.*;
 import inetsoft.web.wiz.model.BindingInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.awt.*;
 import java.security.Principal;
@@ -412,6 +414,9 @@ public class WizAutoBindingService {
 
             if(tf != null) {
                tf.setFormat(new XFormatInfo(fmtType, format));
+            }
+            else {
+               LOG.warn("Field '{}' has no text format; format '{}' not applied", fc.getField(), format);
             }
          }
          else {
@@ -1479,8 +1484,18 @@ public class WizAutoBindingService {
       }
 
       // Legend placement
+      String note = null;
+
       if(request.getLegendPosition() != null && desc != null && desc.getLegendsDescriptor() != null) {
-         desc.getLegendsDescriptor().setLayout(legendLayout(request.getLegendPosition()));
+         int layout = legendLayout(request.getLegendPosition());
+
+         if(layout < 0) {
+            note = "Unknown legendPosition '" + request.getLegendPosition() +
+               "'; valid: none, top, right, bottom, left, in_place. Legend left unchanged.";
+         }
+         else {
+            desc.getLegendsDescriptor().setLayout(layout);
+         }
       }
 
       // Invalidate the cached runtime descriptor so the change regenerates on re-execute.
@@ -1500,18 +1515,23 @@ public class WizAutoBindingService {
          result.setViewsheetIdentifier(request.getViewsheetIdentifier());
       }
 
+      if(note != null) {
+         result.setNote(note);
+      }
+
       return result;
    }
 
-   /** Maps a legend-position string to a {@link LegendsDescriptor} layout constant (defaults to RIGHT). */
+   /** Maps a legend-position string to a {@link LegendsDescriptor} layout constant; -1 if unknown. */
    private static int legendLayout(String position) {
       return switch(position.toLowerCase()) {
          case "none" -> LegendsDescriptor.NO_LEGEND;
          case "top" -> LegendsDescriptor.TOP;
+         case "right" -> LegendsDescriptor.RIGHT;
          case "bottom" -> LegendsDescriptor.BOTTOM;
          case "left" -> LegendsDescriptor.LEFT;
          case "in_place" -> LegendsDescriptor.IN_PLACE;
-         default -> LegendsDescriptor.RIGHT;
+         default -> -1;
       };
    }
 
@@ -1546,7 +1566,12 @@ public class WizAutoBindingService {
 
       if(colorField == null || colorField.getDataRef() == null) {
          if(request.getStaticColor() != null) {
-            applyStaticColor(vsChartInfo, parseColor(request.getStaticColor()));
+            if(vsChartInfo == null) {
+               note = "Chart has no binding info; static color could not be applied.";
+            }
+            else {
+               applyStaticColor(vsChartInfo, parseColor(request.getStaticColor()));
+            }
          }
 
          if(request.getPaletteName() != null || request.getColorList() != null ||
@@ -1592,14 +1617,14 @@ public class WizAutoBindingService {
          return;
       }
 
-      java.util.List<ChartRef> refs = new java.util.ArrayList<>();
+      List<ChartRef> refs = new ArrayList<>();
 
       if(vsChartInfo.getYFields() != null) {
-         refs.addAll(java.util.Arrays.asList(vsChartInfo.getYFields()));
+         refs.addAll(Arrays.asList(vsChartInfo.getYFields()));
       }
 
       if(vsChartInfo.getXFields() != null) {
-         refs.addAll(java.util.Arrays.asList(vsChartInfo.getXFields()));
+         refs.addAll(Arrays.asList(vsChartInfo.getXFields()));
       }
 
       for(ChartRef ref : refs) {
@@ -1618,11 +1643,13 @@ public class WizAutoBindingService {
          CategoricalColorFrame palette = ColorPalettes.getPalette(request.getPaletteName());
 
          if(palette == null) {
-            throw new IllegalArgumentException("Unknown palette '" + request.getPaletteName() +
-               "'. Valid palettes: " + String.join(", ", ColorPalettes.getPaletteNames()));
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unknown palette '" +
+               request.getPaletteName() + "'. Valid palettes: " +
+               String.join(", ", ColorPalettes.getPaletteNames()));
          }
 
-         colorField.setVisualFrame(palette);
+         // Clone: getPalette() returns the shared singleton frame; never set/mutate it directly.
+         colorField.setVisualFrame((CategoricalColorFrame) palette.clone());
       }
 
       if(request.getColorList() != null && !request.getColorList().isEmpty()) {
@@ -1671,7 +1698,7 @@ public class WizAutoBindingService {
    private String applyGradient(AestheticRef colorField, ChartColorsRequest request) {
       if(request.getColorList() != null || request.getCategoryColors() != null) {
          return "This chart has a measure on color (a continuous scale), so colorList/categoryColors " +
-            "don't apply. Use paletteName with a gradient name (e.g. Blues, Reds, Greens, RdYlBu, RdYlGn, Heat).";
+            "don't apply. Use paletteName with a gradient name (e.g. " + VALID_GRADIENTS + ").";
       }
 
       if(request.getStaticColor() != null) {
@@ -1680,20 +1707,21 @@ public class WizAutoBindingService {
       }
 
       if(request.getPaletteName() == null) {
-         return "No gradient provided. Pass paletteName with a gradient name " +
-            "(Blues, Reds, Greens, RdYlBu, RdYlGn, Heat).";
+         return "No gradient provided. Pass paletteName with a gradient name (" + VALID_GRADIENTS + ").";
       }
 
       ColorFrame gradient = gradientFrameForName(request.getPaletteName());
 
       if(gradient == null) {
-         return "Unknown gradient '" + request.getPaletteName() +
-            "'. Valid gradients: Blues, Reds, Greens, RdYlBu, RdYlGn, Heat.";
+         return "Unknown gradient '" + request.getPaletteName() + "'. Valid gradients: " + VALID_GRADIENTS + ".";
       }
 
       colorField.setVisualFrame(gradient);
       return null;
    }
+
+   /** The named gradients accepted by {@link #gradientFrameForName} (kept in sync with that switch). */
+   private static final String VALID_GRADIENTS = "Blues, Reds, Greens, RdYlBu, RdYlGn, Heat";
 
    /** Maps a gradient name to its concrete frame (case-insensitive); null when unknown. */
    private static ColorFrame gradientFrameForName(String name) {
@@ -1714,7 +1742,8 @@ public class WizAutoBindingService {
          return Color.decode(hex.trim());
       }
       catch(NumberFormatException e) {
-         throw new IllegalArgumentException("Invalid hex color '" + hex + "' (expected #RRGGBB)");
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+            "Invalid hex color '" + hex + "' (expected #RRGGBB)");
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -372,6 +372,49 @@ public class WizAutoBindingService {
             }
          }
       }
+
+      // Common to dimensions and measures: a display title (axis/legend/series label) and a
+      // number/date display format. Applies to whichever ref kind matched above.
+      applyTitleAndFormat(ref, fc);
+   }
+
+   /**
+    * Applies the field's display title (as the ref caption) and number/date format (as the ref's
+    * text format) when set in the field config. The format type is inferred from the field's data
+    * type: date types use a DateFormat pattern, numeric types a DecimalFormat pattern; other types
+    * are left unformatted (a pattern there would be ambiguous).
+    */
+   private void applyTitleAndFormat(ChartRef ref, SimpleFieldInfo fc) {
+      String title = fc.getTitle();
+
+      if(title != null && !title.isEmpty()) {
+         if(ref instanceof VSDimensionRef dim) {
+            dim.setCaption(title);
+         }
+         else if(ref instanceof VSAggregateRef agg) {
+            agg.setCaption(title);
+         }
+      }
+
+      String format = fc.getFormat();
+
+      if(format != null && !format.isEmpty()) {
+         String dtype = fc.getType();
+         String fmtType = XSchema.isDateType(dtype) ? XConstants.DATE_FORMAT
+            : XSchema.isNumericType(dtype) ? XConstants.DECIMAL_FORMAT
+            : null;
+
+         if(fmtType != null) {
+            CompositeTextFormat tf = ref.getTextFormat();
+
+            if(tf != null) {
+               tf.setFormat(new XFormatInfo(fmtType, format));
+            }
+         }
+         else {
+            LOG.warn("Ignoring format '{}' for non-date/non-numeric field '{}'", format, fc.getField());
+         }
+      }
    }
 
    // ── Chart preference helpers ──────────────────────────────────────────────────

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -25,6 +25,9 @@ import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.graph.*;
+import inetsoft.graph.aesthetic.*;
+import inetsoft.uql.viewsheet.graph.aesthetic.ColorPalettes;
+import java.awt.Color;
 import inetsoft.util.Tool;
 import inetsoft.web.vswizard.handler.VSWizardBindingHandler;
 import inetsoft.web.vswizard.model.VSWizardData;
@@ -1510,6 +1513,209 @@ public class WizAutoBindingService {
          case "in_place" -> LegendsDescriptor.IN_PLACE;
          default -> LegendsDescriptor.RIGHT;
       };
+   }
+
+   /**
+    * Sets chart COLORS in place on an existing runtime chart and re-renders. The mode is chosen from
+    * the chart's color binding:
+    *   - no field on color  -> static: staticColor applies to each measure ref.
+    *   - dimension on color -> categorical: paletteName / colorList / categoryColors apply.
+    *   - measure on color   -> gradient: paletteName resolves to a named gradient frame.
+    * Returns a {@code note} on the result when a requested color could not be applied to the current
+    * binding (in-place only — the caller should recreate with the right field on color).
+    */
+   public CreateViewsheetResult setChartColors(ChartColorsRequest request, Principal user)
+      throws Exception
+   {
+      RuntimeViewsheet rvs = viewsheetService.getViewsheet(request.getWizRuntimeId(), user);
+
+      if(rvs == null || rvs.getViewsheet() == null) {
+         throw new Exception("Chart runtime not found: " + request.getWizRuntimeId());
+      }
+
+      VSAssembly assembly = rvs.getViewsheet().getAssembly(request.getAssemblyName());
+
+      if(!(assembly instanceof ChartVSAssembly chart)) {
+         throw new Exception("Chart assembly not found: " + request.getAssemblyName());
+      }
+
+      var info = chart.getChartInfo();
+      VSChartInfo vsChartInfo = info.getVSChartInfo();
+      AestheticRef colorField = vsChartInfo == null ? null : vsChartInfo.getColorField();
+      String note = null;
+
+      if(colorField == null || colorField.getDataRef() == null) {
+         if(request.getStaticColor() != null) {
+            applyStaticColor(vsChartInfo, parseColor(request.getStaticColor()));
+         }
+
+         if(request.getPaletteName() != null || request.getColorList() != null ||
+            request.getCategoryColors() != null)
+         {
+            note = "This chart has no color dimension, so a palette/per-category colors can't apply. " +
+               "Recreate with a dimension on the color aesthetic (fieldConfigs/explicitBindings), or use staticColor.";
+         }
+      }
+      else if(colorField.getDataRef() instanceof VSChartAggregateRef) {
+         note = applyGradient(colorField, request);
+      }
+      else {
+         note = applyCategoricalColors(colorField, request);
+      }
+
+      info.setRTChartDescriptor(null);
+
+      CreateViewsheetResult result =
+         wizVsService.fetchAssemblyData(request.getWizRuntimeId(), request.getAssemblyName(), user);
+
+      if(result == null) {
+         result = new CreateViewsheetResult();
+      }
+
+      result.setRuntimeId(request.getWizRuntimeId());
+      result.setAssemblyName(request.getAssemblyName());
+
+      if(request.getViewsheetIdentifier() != null) {
+         result.setViewsheetIdentifier(request.getViewsheetIdentifier());
+      }
+
+      if(note != null) {
+         result.setNote(note);
+      }
+
+      return result;
+   }
+
+   /** Applies a single static color to every bound measure (aggregate) ref. */
+   private void applyStaticColor(VSChartInfo vsChartInfo, Color color) {
+      if(vsChartInfo == null) {
+         return;
+      }
+
+      java.util.List<ChartRef> refs = new java.util.ArrayList<>();
+
+      if(vsChartInfo.getYFields() != null) {
+         refs.addAll(java.util.Arrays.asList(vsChartInfo.getYFields()));
+      }
+
+      if(vsChartInfo.getXFields() != null) {
+         refs.addAll(java.util.Arrays.asList(vsChartInfo.getXFields()));
+      }
+
+      for(ChartRef ref : refs) {
+         if(ref instanceof VSChartAggregateRef agg) {
+            agg.setColorFrame(new StaticColorFrame(color));
+         }
+      }
+   }
+
+   /**
+    * Applies categorical colors to a dimension that is bound to the color aesthetic. Returns a note
+    * if none of the categorical fields were provided.
+    */
+   private String applyCategoricalColors(AestheticRef colorField, ChartColorsRequest request) {
+      if(request.getPaletteName() != null) {
+         CategoricalColorFrame palette = ColorPalettes.getPalette(request.getPaletteName());
+
+         if(palette == null) {
+            throw new IllegalArgumentException("Unknown palette '" + request.getPaletteName() +
+               "'. Valid palettes: " + String.join(", ", ColorPalettes.getPaletteNames()));
+         }
+
+         colorField.setVisualFrame(palette);
+      }
+
+      if(request.getColorList() != null && !request.getColorList().isEmpty()) {
+         CategoricalColorFrame frame = asCategoricalFrame(colorField);
+         Color[] colors = request.getColorList().stream()
+            .map(WizAutoBindingService::parseColor)
+            .toArray(Color[]::new);
+         frame.setDefaultColors(colors);
+         colorField.setVisualFrame(frame);
+      }
+
+      if(request.getCategoryColors() != null && !request.getCategoryColors().isEmpty()) {
+         CategoricalColorFrame frame = asCategoricalFrame(colorField);
+
+         for(Map.Entry<String, String> e : request.getCategoryColors().entrySet()) {
+            frame.setColor(e.getKey(), parseColor(e.getValue()));
+         }
+
+         colorField.setVisualFrame(frame);
+      }
+
+      if(request.getStaticColor() != null) {
+         return "staticColor was ignored: this chart has a color dimension. Use paletteName, " +
+            "colorList, or categoryColors to color the categories.";
+      }
+
+      if(request.getPaletteName() == null && request.getColorList() == null &&
+         request.getCategoryColors() == null)
+      {
+         return "No categorical color provided. Pass paletteName, colorList, or categoryColors.";
+      }
+
+      return null;
+   }
+
+   /** Returns the color field's current CategoricalColorFrame, or a fresh one if it isn't categorical. */
+   private CategoricalColorFrame asCategoricalFrame(AestheticRef colorField) {
+      VisualFrame frame = colorField.getVisualFrame();
+      return frame instanceof CategoricalColorFrame cat ? cat : new CategoricalColorFrame();
+   }
+
+   /**
+    * Applies a named gradient when a measure is on the color aesthetic. Only paletteName is meaningful
+    * for a continuous color scale; colorList/categoryColors return a note.
+    */
+   private String applyGradient(AestheticRef colorField, ChartColorsRequest request) {
+      if(request.getColorList() != null || request.getCategoryColors() != null) {
+         return "This chart has a measure on color (a continuous scale), so colorList/categoryColors " +
+            "don't apply. Use paletteName with a gradient name (e.g. Blues, Reds, Greens, RdYlBu, RdYlGn, Heat).";
+      }
+
+      if(request.getStaticColor() != null) {
+         return "staticColor was ignored: this chart uses a measure-driven color scale. Use paletteName " +
+            "with a gradient name.";
+      }
+
+      if(request.getPaletteName() == null) {
+         return "No gradient provided. Pass paletteName with a gradient name " +
+            "(Blues, Reds, Greens, RdYlBu, RdYlGn, Heat).";
+      }
+
+      ColorFrame gradient = gradientFrameForName(request.getPaletteName());
+
+      if(gradient == null) {
+         return "Unknown gradient '" + request.getPaletteName() +
+            "'. Valid gradients: Blues, Reds, Greens, RdYlBu, RdYlGn, Heat.";
+      }
+
+      colorField.setVisualFrame(gradient);
+      return null;
+   }
+
+   /** Maps a gradient name to its concrete frame (case-insensitive); null when unknown. */
+   private static ColorFrame gradientFrameForName(String name) {
+      return switch(name.trim().toLowerCase()) {
+         case "blues" -> new BluesColorFrame();
+         case "reds" -> new RedsColorFrame();
+         case "greens" -> new GreensColorFrame();
+         case "rdylbu" -> new RdYlBuColorFrame();
+         case "rdylgn" -> new RdYlGnColorFrame();
+         case "heat" -> new HeatColorFrame();
+         default -> null;
+      };
+   }
+
+   /** Parses a #RRGGBB hex string into a Color; throws on a malformed value. */
+   private static Color parseColor(String hex) {
+      try {
+         return Color.decode(hex.trim());
+      }
+      catch(NumberFormatException e) {
+         throw new IllegalArgumentException("Invalid hex color '" + hex + "' (expected #RRGGBB)");
+      }
    }
 
    /**


### PR DESCRIPTION
## Summary

Wiz autoBinding/recommender improvements + the StyleBI server side of in-place chart properties (Tiers 1–3) for the `stylebi-viz-chat` plugin. All changes are in `core/.../web/wiz` and `web/vswizard`; no enterprise dependencies.

### Recommender / autoBinding
- **Candidate menu + selection note** — `autoBinding` returns a feasibility-filtered, named/scored chart-type menu, and a `selectionNote` when a requested `visualizationType` was infeasible and substituted (was a silent swap).
- **Per-dimension cardinality** — returns `fieldCardinalities` (distinct counts the recommender already samples) so callers can switch to top-N/roll-up instead of unreadable charts.
- **Map score** — `MapChartFilter` returns `PRIMARY_SCORE*2` instead of a `1000` sentinel: map still wins for (always-explicit) geo bindings but no longer flattens every other candidate's score.
- **Aesthetic cap** — `getAestheticScore` enforces the high-cardinality hard cap even when `autoOrder` is off (was disabled).

### Chart properties
- **Tier 1** — `applyFieldConfig` now applies fieldConfig `title` (ref caption) and `format` (DecimalFormat/DateFormat by type), which were previously ignored.
- **Tier 2** — `POST /api/wiz/viewsheet/format`: axis titles, y-axis scale (min/max/increment/log), legend placement, applied to the runtime chart + re-rendered.
- **Tier 3** — `POST /api/wiz/viewsheet/colors`: static color, named/custom palette, per-category overrides, named gradient; mode auto-selected from the color binding; in-place only (returns a `note` to guide recreate when the needed color binding is absent). Adds `ChartColorsRequest` + a `note` field on `CreateViewsheetResult`.

## Testing
- `core` compiles clean (Java 21). No unit-test harness exists for these wiz/recommender services; verified by compile + live smoke on a locally-built image (`local-rebase10`).

## Notes
- Base: `stylebi-wiz-main-rebase`. Consuming this in the published image requires the usual superproject submodule bump after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
