### PR TITLE
fix(wiz): resolve worksheet by identifier (createAssetEntry) — restores chart creation

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -91,8 +91,11 @@ public class WizAutoBindingService {
 
       if(Tool.isEmptyString(autoBindingRuntimeId)) {
          Viewsheet.WizInfo wizInfo = new Viewsheet.WizInfo(true, null, null);
+         // worksheetPath is the worksheet's full asset IDENTIFIER (e.g. "1^2^__NULL__^path^org"),
+         // not a bare path — parse it with createAssetEntry, else getSheet finds nothing and the
+         // recommender gets an empty worksheet (zero recommendations).
          AssetEntry wsEntry = !Tool.isEmptyString(worksheetPath)
-            ? new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, worksheetPath, null)
+            ? AssetEntry.createAssetEntry(worksheetPath)
             : null;
          autoBindingRuntimeId = viewsheetService.openTemporaryViewsheet(null, wsEntry, user, wizInfo);
          createdAutoBindingRvs = true;
@@ -110,8 +113,7 @@ public class WizAutoBindingService {
          List<ColumnRef> worksheetColumns = new ArrayList<>();
 
          if(!Tool.isEmptyString(worksheetPath)) {
-            AssetEntry wsEntry = new AssetEntry(
-               AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, worksheetPath, null);
+            AssetEntry wsEntry = AssetEntry.createAssetEntry(worksheetPath);
 
             try {
                AbstractSheet sheet = engine.getSheet(wsEntry, user, true, AssetContent.ALL);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -476,8 +476,9 @@ public class WizVsService {
       String title = config.getTitle() != null && !config.getTitle().isEmpty()
          ? config.getTitle()
          : "vs_" + System.currentTimeMillis();
-      AssetEntry sourceWs = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET,
-         config.getData().getSource(), null);
+      // config.getData().getSource() is the worksheet's full asset IDENTIFIER, not a bare path —
+      // parse it with createAssetEntry, else getSheet returns null ("Cannot find worksheet").
+      AssetEntry sourceWs = AssetEntry.createAssetEntry(config.getData().getSource());
       AbstractSheet sheet = engine.getSheet(sourceWs, user, true, AssetContent.ALL);
 
       if(!(sheet instanceof Worksheet worksheet)) {


### PR DESCRIPTION
## Critical fix — restores wiz chart creation

A main-merge reverted the #3853 fix: `autoBinding` and `resolveSourceContext` built the worksheet `AssetEntry` with `new AssetEntry(GLOBAL_SCOPE, WORKSHEET, wsId, null)`, treating the full asset **identifier** as a bare path. `getSheet` then found nothing → empty worksheet → **zero recommendations → "could not build a chart"** (and `Cannot find worksheet` on the output-viewsheet path).

Re-applies `AssetEntry.createAssetEntry(...)` at all **three** worksheet-lookup sites (WizAutoBindingService ×2, WizVsService.resolveSourceContext ×1).

**Impact:** without this, *every* wiz/plugin `create_viewsheet` fails. Verified end-to-end: `POST /api/wiz/v1/viewsheets` now returns a rendered chart (HTTP 201, visualizationType, sampled rows).

Pairs with stylebi-wiz: wiz-services must send `worksheetPath` (the request field was renamed from `worksheetId` upstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)