### PR TITLE
fix(wiz): open saved visualizations from the components folder (fixes blank companion viewer)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -67,7 +67,10 @@ public class ViewsheetRuntimeController {
 
       String path = entry.getPath();
 
-      if(path == null || !path.startsWith(WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/")) {
+      // Saved wiz visualizations live under VISUALIZATION_COMPONENTS_FOLDER_PATH (where save/list/tree
+      // persist them) — not the ROOT folder. The guard was checking the wrong constant, rejecting
+      // every saved chart.
+      if(path == null || !path.startsWith(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/")) {
          throw new IllegalArgumentException(
             "Viewsheet is not in the managed visualizations folder: " + path);
       }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -91,8 +91,11 @@ public class WizAutoBindingService {
 
       if(Tool.isEmptyString(autoBindingRuntimeId)) {
          Viewsheet.WizInfo wizInfo = new Viewsheet.WizInfo(true, null, null);
+         // worksheetPath is the worksheet's full asset IDENTIFIER (e.g. "1^2^__NULL__^path^org"),
+         // not a bare path — parse it with createAssetEntry, else getSheet finds nothing and the
+         // recommender gets an empty worksheet (zero recommendations).
          AssetEntry wsEntry = !Tool.isEmptyString(worksheetPath)
-            ? new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, worksheetPath, null)
+            ? AssetEntry.createAssetEntry(worksheetPath)
             : null;
          autoBindingRuntimeId = viewsheetService.openTemporaryViewsheet(null, wsEntry, user, wizInfo);
          createdAutoBindingRvs = true;
@@ -110,8 +113,7 @@ public class WizAutoBindingService {
          List<ColumnRef> worksheetColumns = new ArrayList<>();
 
          if(!Tool.isEmptyString(worksheetPath)) {
-            AssetEntry wsEntry = new AssetEntry(
-               AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, worksheetPath, null);
+            AssetEntry wsEntry = AssetEntry.createAssetEntry(worksheetPath);
 
             try {
                AbstractSheet sheet = engine.getSheet(wsEntry, user, true, AssetContent.ALL);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -476,8 +476,9 @@ public class WizVsService {
       String title = config.getTitle() != null && !config.getTitle().isEmpty()
          ? config.getTitle()
          : "vs_" + System.currentTimeMillis();
-      AssetEntry sourceWs = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET,
-         config.getData().getSource(), null);
+      // config.getData().getSource() is the worksheet's full asset IDENTIFIER, not a bare path —
+      // parse it with createAssetEntry, else getSheet returns null ("Cannot find worksheet").
+      AssetEntry sourceWs = AssetEntry.createAssetEntry(config.getData().getSource());
       AbstractSheet sheet = engine.getSheet(sourceWs, user, true, AssetContent.ALL);
 
       if(!(sheet instanceof Worksheet worksheet)) {


### PR DESCRIPTION
## Fixes the blank companion viewer

`/viewsheet/open` (used by the companion viewer's reopen-saved path and `reload_saved_visualization`) guarded the path against `VISUALIZATION_ROOT_FOLDER_PATH`, but saved wiz visualizations live under `VISUALIZATION_COMPONENTS_FOLDER_PATH` (where save/list/tree persist them). So opening any saved chart threw `Viewsheet is not in the managed visualizations folder` — which the wiz auth filter's broad `catch(Exception)` then **masked as a 401 'Authentication error'**.

Fix: the guard checks the components folder. Verified: `POST /api/wiz/viewsheet/open` now returns 200 with a fresh runtime + chart assembly, and the companion viewer renders the saved chart.

Pairs with stylebi-wiz (getCurrentChart reopens the saved viz into a live runtime).

Follow-up (not in this PR): the auth filter wraps `chain.doFilter` in `catch(Exception)`, mislabeling downstream controller errors as auth failures — worth narrowing so real errors surface as 500s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)