### PR TITLE
fix(wiz): worksheet/binding robustness - named expressions, hidden join keys, strict fieldConfigs, no fabricated data

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -800,7 +800,7 @@ public abstract class AssetQuery extends PreAssetQuery {
                      expressionException = exc;
                   }
 
-                  base = getDesignTableLens(vars);
+                  base = getDesignTableLens(vars, true);
                }
                else {
                   throw ex;
@@ -836,7 +836,7 @@ public abstract class AssetQuery extends PreAssetQuery {
                   }
 
                   LOG.warn("Failed to get table data: " + ex.getMessage(), ex);
-                  base = getDesignTableLens(vars);
+                  base = getDesignTableLens(vars, true);
                }
                else {
                   throw ex;

--- a/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
@@ -112,8 +112,18 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
          TableLens base = ((TableFilter2) data).getTable();
 
          if(base instanceof XNodeMetaTable) {
+            boolean failedQuery = ((XNodeMetaTable) base).isFailedQueryDefault();
             ChartMetaTableGenerator gen = new ChartMetaTableGenerator((XNodeMetaTable) base);
             base = gen.generate(chart);
+
+            // The generated sample data replaces the meta table, which would otherwise
+            // erase the failed-query marker. Preserve it as a table property so callers
+            // that must not serve fabricated data can still detect the failed query.
+            if(failedQuery && base instanceof AbstractTableLens) {
+               ((AbstractTableLens) base).setProperty(
+                  XNodeMetaTable.FAILED_QUERY_PROPERTY, "true");
+            }
+
             ((TableFilter2) data).setTable(base);
          }
       }

--- a/core/src/main/java/inetsoft/report/internal/XNodeMetaTable.java
+++ b/core/src/main/java/inetsoft/report/internal/XNodeMetaTable.java
@@ -288,6 +288,14 @@ public class XNodeMetaTable extends AbstractTableLens {
    }
 
    /**
+    * Table property used to preserve the failed-query marker when this meta table is
+    * replaced by generated sample data (e.g. ChartMetaTableGenerator), so callers that
+    * must not serve fabricated data can still detect the failed query downstream.
+    */
+   public static final String FAILED_QUERY_PROPERTY =
+      XNodeMetaTable.class.getName() + ".failedQueryDefault";
+
+   /**
     * Table data descriptor.
     */
    public final class TableDataDescriptor2 extends DefaultTableDataDescriptor {

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
@@ -21,10 +21,14 @@ package inetsoft.web.wiz.controller;
 import inetsoft.web.wiz.model.*;
 import inetsoft.web.wiz.service.WizAutoBindingService;
 import inetsoft.web.wiz.service.WizVsService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/wiz")
@@ -37,10 +41,10 @@ public class WizViewsheetController {
    }
 
    @PostMapping(value = "/viewsheet/create", produces = MediaType.APPLICATION_JSON_VALUE)
-   public CreateViewsheetResult createViewsheet(@RequestBody CreateVisualizationModel model,
-                                                Principal user) throws Exception
+   public ResponseEntity<?> createViewsheet(@RequestBody CreateVisualizationModel model,
+                                            Principal user)
    {
-      return wizVsService.createViewsheet(model, user);
+      return run("create viewsheet", () -> wizVsService.createViewsheet(model, user));
    }
 
    @PostMapping("/viewsheet/validateBinding")
@@ -51,17 +55,13 @@ public class WizViewsheetController {
    }
 
    @PostMapping(value = "/viewsheet/autoBinding", produces = MediaType.APPLICATION_JSON_VALUE)
-   public AutoBindingResponse autoBinding(@RequestBody AutoBindingRequest request,
-                                          Principal user) throws Exception
-   {
-      return wizAutoBindingService.autoBinding(request, user);
+   public ResponseEntity<?> autoBinding(@RequestBody AutoBindingRequest request, Principal user) {
+      return run("run autoBinding", () -> wizAutoBindingService.autoBinding(request, user));
    }
 
    @PostMapping(value = "/viewsheet/changeType", produces = MediaType.APPLICATION_JSON_VALUE)
-   public CreateViewsheetResult changeType(@RequestBody ChangeTypeRequest request,
-                                           Principal user) throws Exception
-   {
-      return wizAutoBindingService.changeType(request, user);
+   public ResponseEntity<?> changeType(@RequestBody ChangeTypeRequest request, Principal user) {
+      return run("change chart type", () -> wizAutoBindingService.changeType(request, user));
    }
 
    @PostMapping(value = "/viewsheet/format", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -85,6 +85,26 @@ public class WizViewsheetController {
       wizVsService.deleteViewsheet(identifier, user);
    }
 
+   @FunctionalInterface
+   private interface ControllerAction {
+      Object run() throws Exception;
+   }
+
+   private ResponseEntity<?> run(String action, ControllerAction body) {
+      try {
+         return ResponseEntity.ok(body.run());
+      }
+      catch(IllegalArgumentException e) {
+         return ResponseEntity.badRequest().body(Map.of("error", String.valueOf(e.getMessage())));
+      }
+      catch(Exception e) {
+         LOG.error("Failed to {}", action, e);
+         return ResponseEntity.internalServerError()
+            .body(Map.of("error", "An unexpected error occurred. Please try again."));
+      }
+   }
+
    private final WizVsService wizVsService;
    private final WizAutoBindingService wizAutoBindingService;
+   private static final Logger LOG = LoggerFactory.getLogger(WizViewsheetController.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
@@ -262,8 +262,8 @@ public class GenerateWsService {
       return new WorksheetBuildResult(worksheet, table);
    }
 
-   private boolean isJoinKeyRepresented(Collection<WorksheetConstructionModel.QueryField> fields,
-                                        WorksheetConstructionModel.TableInfo table, String key)
+   private static boolean isJoinKeyRepresented(Collection<WorksheetConstructionModel.QueryField> fields,
+                                               WorksheetConstructionModel.TableInfo table, String key)
    {
       if(Tool.isEmptyString(key)) {
          return true;
@@ -278,11 +278,17 @@ public class GenerateWsService {
       );
    }
 
-   private void addJoinKeyField(Collection<WorksheetConstructionModel.QueryField> fields,
-                                WorksheetConstructionModel.TableInfo table, String key)
+   static void addJoinKeyField(Collection<WorksheetConstructionModel.QueryField> fields,
+                               WorksheetConstructionModel.TableInfo table, String key)
    {
       if(!isJoinKeyRepresented(fields, table, key)) {
-         fields.add(new WorksheetConstructionModel.QueryField(table, key));
+         WorksheetConstructionModel.QueryField keyField =
+            new WorksheetConstructionModel.QueryField(table, key);
+         // A synthesized key exists only to satisfy the join; hide it so the
+         // worksheet output (and autoBinding, which binds every visible column)
+         // never sees it as a bindable field.
+         keyField.setVisible(false);
+         fields.add(keyField);
       }
    }
 
@@ -592,7 +598,7 @@ public class GenerateWsService {
 
       for(WorksheetConstructionModel.QueryField field : modelFields) {
          if(Boolean.FALSE.equals(field.getVisible())) {
-            String fieldName = field.getAlias() != null ? field.getAlias() : field.getFieldName();
+            String fieldName = field.getAlias() != null ? field.getAlias() : field.getUnqualifiedFieldName();
             WorksheetConstructionModel.TableInfo table = field.getTable();
             fieldName = table != null ? table.getName() + "." + fieldName : fieldName;
             DataRef ref = columnSelection.getAttribute(fieldName);

--- a/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
@@ -838,7 +838,7 @@ public class GenerateWsService {
          dataRef = ref;
       }
       else {
-         ExpressionRef expressionRef = new ExpressionRef(null, field.getFieldName());
+         ExpressionRef expressionRef = new ExpressionRef(null, resolveExpressionName(field));
          expressionRef.setExpression(field.getExpression());
          dataRef = expressionRef;
       }
@@ -854,6 +854,23 @@ public class GenerateWsService {
       }
 
       return columnRef;
+   }
+
+   /**
+    * Resolve the name for an expression column: fieldName, falling back to alias.
+    * An expression column with neither is unnamed ("Column [0]") and can never be
+    * matched by fieldConfigs, so reject it at validation time instead.
+    */
+   static String resolveExpressionName(WorksheetConstructionModel.QueryField field) {
+      String name = !Tool.isEmptyString(field.getFieldName())
+         ? field.getFieldName() : field.getAlias();
+
+      if(Tool.isEmptyString(name)) {
+         throw new IllegalArgumentException(
+            "Expression field requires a fieldName or alias: " + field.getExpression());
+      }
+
+      return name;
    }
 
    private void applySourceInfo(AbstractTableAssembly table,

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -147,21 +147,8 @@ public class WizAutoBindingService {
             .collect(Collectors.toMap(SimpleFieldInfo::getField, f -> f, (a, b) -> a));
 
          final String tableNameFinal = tableName;
-         List<WorksheetColumnInfo> vizFields = request.getVisualizationUsedFields();
-         List<ColumnRef> bindColumns;
-
-         if(vizFields != null && !vizFields.isEmpty()) {
-            Set<String> vizFieldNames = vizFields.stream()
-               .map(col -> col.getAlias() != null && !col.getAlias().isEmpty()
-                  ? col.getAlias() : col.getName())
-               .collect(Collectors.toSet());
-            bindColumns = worksheetColumns.stream()
-               .filter(c -> vizFieldNames.contains(c.getAttribute()))
-               .collect(Collectors.toList());
-         }
-         else {
-            bindColumns = worksheetColumns;
-         }
+         List<ColumnRef> bindColumns =
+            selectBindColumns(worksheetColumns, request.getVisualizationUsedFields(), configMap);
 
          AssetEntry[] entries = bindColumns.stream()
             .map(col -> buildEntryFromColumn(col, worksheetPath, tableNameFinal))
@@ -433,6 +420,51 @@ public class WizAutoBindingService {
             LOG.warn("Ignoring format '{}' for non-date/non-numeric field '{}'", format, fc.getField());
          }
       }
+   }
+
+   // ── Bind-column selection ────────────────────────────────────────────────────
+
+   /**
+    * Decide which worksheet columns autoBinding may bind.
+    * Precedence: explicit visualizationUsedFields (chat-app path) > fieldConfigs
+    * (plugin path) > all visible columns. A fieldConfig naming a column that does
+    * not exist is an error: silently binding everything produced junk measures.
+    */
+   static List<ColumnRef> selectBindColumns(List<ColumnRef> worksheetColumns,
+                                            List<WorksheetColumnInfo> vizFields,
+                                            Map<String, SimpleFieldInfo> configMap)
+   {
+      if(vizFields != null && !vizFields.isEmpty()) {
+         Set<String> vizFieldNames = vizFields.stream()
+            .map(col -> col.getAlias() != null && !col.getAlias().isEmpty()
+               ? col.getAlias() : col.getName())
+            .collect(Collectors.toSet());
+         return worksheetColumns.stream()
+            .filter(c -> vizFieldNames.contains(c.getAttribute()))
+            .collect(Collectors.toList());
+      }
+
+      if(!configMap.isEmpty()) {
+         Set<String> available = worksheetColumns.stream()
+            .map(ColumnRef::getAttribute)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+         List<String> missing = configMap.keySet().stream()
+            .filter(k -> !available.contains(k))
+            .sorted()
+            .collect(Collectors.toList());
+
+         if(!missing.isEmpty()) {
+            throw new IllegalArgumentException(
+               "Unknown field(s) in fieldConfigs: " + missing +
+               ". Available worksheet columns: " + available);
+         }
+
+         return worksheetColumns.stream()
+            .filter(c -> configMap.containsKey(c.getAttribute()))
+            .collect(Collectors.toList());
+      }
+
+      return worksheetColumns;
    }
 
    // ── Chart preference helpers ──────────────────────────────────────────────────

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -23,6 +23,10 @@ import inetsoft.analytic.composition.event.VSEventUtil;
 import inetsoft.graph.data.*;
 import inetsoft.report.composition.graph.GraphUtil;
 import inetsoft.report.TableLens;
+import inetsoft.report.internal.Util;
+import inetsoft.report.internal.XNodeMetaTable;
+import inetsoft.report.lens.AbstractTableLens;
+import inetsoft.uql.XTable;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.report.composition.graph.VGraphPair;
@@ -578,6 +582,37 @@ public class WizVsService {
    }
 
    /**
+    * Throws if the lens chain contains failed-query fallback data. When a live query fails
+    * (e.g. a computed-column expression that is invalid SQL for the data source), AssetQuery
+    * substitutes design-time sample data instead of erroring, and the chart path replaces
+    * that meta table with generated sample rows (name1/999.99). The wiz path must surface
+    * the failure instead of returning fabricated rows as if they were real query results.
+    */
+   private static void checkFailedQuery(XTable lens) {
+      if(lens == null) {
+         return;
+      }
+
+      List<XTable> allTables = new ArrayList<>();
+      Util.listNestedTable(lens, XTable.class, allTables);
+
+      for(XTable t : allTables) {
+         // Two signals, depending on the path: the worksheet/table path surfaces the raw
+         // design meta table (isFailedQueryDefault); the chart path replaces it with
+         // generated sample data carrying FAILED_QUERY_PROPERTY (see ChartVSAQuery).
+         boolean failed = t instanceof XNodeMetaTable meta && meta.isFailedQueryDefault()
+            || t instanceof AbstractTableLens atl
+               && atl.getProperty(XNodeMetaTable.FAILED_QUERY_PROPERTY) != null;
+
+         if(failed) {
+            throw new IllegalArgumentException(
+               "Worksheet query failed — a computed-column expression or filter is invalid " +
+               "for the data source. Check the worksheet's expression columns.");
+         }
+      }
+   }
+
+   /**
     * Extracts aggregated chart data from the viewsheet sandbox after the assembly is created.
     * Returns a result with null headers/rows if data is unavailable (best-effort).
     */
@@ -620,6 +655,10 @@ public class WizVsService {
             }
          }
 
+         if(dset instanceof VSDataSet vds) {
+            checkFailedQuery(vds.getTable());
+         }
+
          int colCount = dset.getColCount();
          int rowCount = dset.getRowCount();
          int limit = Math.min(rowCount, MAX_ROWS);
@@ -651,6 +690,14 @@ public class WizVsService {
          }
 
          return result;
+      }
+      catch(IllegalArgumentException e) {
+         // Failed-query fallback detected: propagate instead of returning fabricated data.
+         if(box != null) {
+            box.clearGraph(assemblyName);
+         }
+
+         throw e;
       }
       catch(Exception e) {
          LOG.warn("Failed to extract chart data after viewsheet creation for assembly '{}': {}",
@@ -722,6 +769,8 @@ public class WizVsService {
             return new CreateViewsheetResult();
          }
 
+         checkFailedQuery(table);
+
          int colCount = table.getColCount();
          int headerRows = table.getHeaderRowCount();
 
@@ -755,6 +804,10 @@ public class WizVsService {
          }
 
          return result;
+      }
+      catch(IllegalArgumentException e) {
+         // Failed-query fallback detected: propagate instead of returning fabricated data.
+         throw e;
       }
       catch(Exception e) {
          LOG.warn("Failed to extract table data after viewsheet creation for assembly '{}': {}",

--- a/core/src/test/java/inetsoft/web/wiz/service/GenerateWsServiceFieldTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/GenerateWsServiceFieldTest.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.web.wiz.model.WorksheetConstructionModel;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag("core")
+class GenerateWsServiceFieldTest {
+   @Test
+   void expressionNameUsesFieldNameWhenPresent() {
+      WorksheetConstructionModel.QueryField field = new WorksheetConstructionModel.QueryField();
+      field.setExpression("concat(field['a'], field['b'])");
+      field.setFieldName("full_name");
+      field.setAlias("other_alias");
+
+      assertEquals("full_name", GenerateWsService.resolveExpressionName(field));
+   }
+
+   @Test
+   void expressionNameFallsBackToAlias() {
+      WorksheetConstructionModel.QueryField field = new WorksheetConstructionModel.QueryField();
+      field.setExpression("concat(field['a'], field['b'])");
+      field.setFieldName("");
+      field.setAlias("full_name");
+
+      assertEquals("full_name", GenerateWsService.resolveExpressionName(field));
+   }
+
+   @Test
+   void expressionWithoutNameOrAliasThrows() {
+      WorksheetConstructionModel.QueryField field = new WorksheetConstructionModel.QueryField();
+      field.setExpression("concat(field['a'], field['b'])");
+
+      IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+         () -> GenerateWsService.resolveExpressionName(field));
+      assertEquals(true, e.getMessage().contains("fieldName or alias"));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/GenerateWsServiceFieldTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/GenerateWsServiceFieldTest.java
@@ -21,6 +21,9 @@ import inetsoft.web.wiz.model.WorksheetConstructionModel;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -54,5 +57,45 @@ class GenerateWsServiceFieldTest {
       IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
          () -> GenerateWsService.resolveExpressionName(field));
       assertEquals(true, e.getMessage().contains("fieldName or alias"));
+   }
+
+   @Test
+   void synthesizedJoinKeyIsInvisible() {
+      WorksheetConstructionModel.SourceInfo source = new WorksheetConstructionModel.SourceInfo();
+      source.setType("DATABASE");
+      source.setPath("postgres");
+      source.setSchema("public");
+      WorksheetConstructionModel.TableInfo table = new WorksheetConstructionModel.TableInfo();
+      table.setName("rental");
+      table.setSource(source);
+
+      List<WorksheetConstructionModel.QueryField> fields = new ArrayList<>();
+      GenerateWsService.addJoinKeyField(fields, table, "rental_id");
+
+      assertEquals(1, fields.size());
+      assertEquals("rental_id", fields.get(0).getFieldName());
+      assertEquals(Boolean.FALSE, fields.get(0).getVisible());
+   }
+
+   @Test
+   void declaredJoinKeyKeepsItsVisibility() {
+      WorksheetConstructionModel.SourceInfo source = new WorksheetConstructionModel.SourceInfo();
+      source.setType("DATABASE");
+      source.setPath("postgres");
+      source.setSchema("public");
+      WorksheetConstructionModel.TableInfo table = new WorksheetConstructionModel.TableInfo();
+      table.setName("rental");
+      table.setSource(source);
+
+      WorksheetConstructionModel.QueryField declared =
+         new WorksheetConstructionModel.QueryField(table, "rental_id");
+      declared.setVisible(true);
+      List<WorksheetConstructionModel.QueryField> fields =
+         new ArrayList<>(List.of(declared));
+
+      GenerateWsService.addJoinKeyField(fields, table, "rental_id");
+
+      assertEquals(1, fields.size());            // not re-added
+      assertEquals(Boolean.TRUE, fields.get(0).getVisible());  // untouched
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSelectBindColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSelectBindColumnsTest.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.web.wiz.model.SimpleFieldInfo;
+import inetsoft.web.wiz.model.WorksheetColumnInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("core")
+class WizAutoBindingServiceSelectBindColumnsTest {
+   private static ColumnRef col(String name) {
+      return new ColumnRef(new AttributeRef(null, name));
+   }
+
+   private static SimpleFieldInfo config(String field) {
+      SimpleFieldInfo info = new SimpleFieldInfo();
+      info.setField(field);
+      return info;
+   }
+
+   private static WorksheetColumnInfo vizField(String name, String alias) {
+      WorksheetColumnInfo info = new WorksheetColumnInfo();
+      info.setName(name);
+      info.setAlias(alias);
+      return info;
+   }
+
+   @Test
+   void vizFieldsTakePrecedenceOverFieldConfigs() {
+      List<ColumnRef> columns = List.of(col("actor_name"), col("amount"), col("rental_id"));
+
+      List<ColumnRef> result = WizAutoBindingService.selectBindColumns(
+         columns,
+         List.of(vizField("amount", null)),
+         Map.of("actor_name", config("actor_name")));
+
+      assertEquals(1, result.size());
+      assertEquals("amount", result.get(0).getAttribute());
+   }
+
+   @Test
+   void fieldConfigsFilterBindColumns() {
+      List<ColumnRef> columns = List.of(col("actor_name"), col("amount"), col("rental_id"));
+
+      List<ColumnRef> result = WizAutoBindingService.selectBindColumns(
+         columns,
+         List.of(),
+         Map.of("actor_name", config("actor_name"), "amount", config("amount")));
+
+      assertEquals(2, result.size());
+      assertTrue(result.stream().anyMatch(c -> "actor_name".equals(c.getAttribute())));
+      assertTrue(result.stream().anyMatch(c -> "amount".equals(c.getAttribute())));
+   }
+
+   @Test
+   void unknownFieldConfigThrowsWithAvailableColumns() {
+      List<ColumnRef> columns = List.of(col("actor_name"), col("amount"));
+
+      IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+         () -> WizAutoBindingService.selectBindColumns(
+            columns, List.of(), Map.of("actor_nme", config("actor_nme"))));
+
+      assertTrue(e.getMessage().contains("actor_nme"));
+      assertTrue(e.getMessage().contains("actor_name"));
+      assertTrue(e.getMessage().contains("amount"));
+   }
+
+   @Test
+   void emptyConfigsBindAllColumns() {
+      List<ColumnRef> columns = List.of(col("actor_name"), col("amount"));
+
+      List<ColumnRef> result =
+         WizAutoBindingService.selectBindColumns(columns, List.of(), Map.of());
+
+      assertEquals(2, result.size());
+   }
+
+   @Test
+   void nullVizFieldsTreatedAsAbsent() {
+      List<ColumnRef> columns = List.of(col("actor_name"), col("amount"));
+
+      List<ColumnRef> result = WizAutoBindingService.selectBindColumns(
+         columns, null, Map.of("amount", config("amount")));
+
+      assertEquals(1, result.size());
+      assertEquals("amount", result.get(0).getAttribute());
+   }
+}


### PR DESCRIPTION
## Summary
Four fixes for defects found building multi-join charts with computed columns through the wiz API, all **verified live** against sakila/postgres on a locally-rebuilt image:

1. **Expression columns** (`GenerateWsService`): the expression column's name falls back fieldName → alias; both blank → `/ws/generate` `errorMessage`. Was: an empty `fieldName` produced an unnamed `Column [0]` that `fieldConfigs` could never match, even with an alias set. Also fixes `applyFieldVisibility` to look up by unqualified name so an already-qualified synthesized key isn't double-qualified.
2. **Join keys** (`GenerateWsService`): auto-added join-key columns are now `visible:false`. Was: visible, then bound as junk `Sum(actor_id)` measures.
3. **Strict fieldConfigs** (`WizAutoBindingService`): bind-column selection is `visualizationUsedFields > fieldConfigs > all visible`; a fieldConfig naming a nonexistent column → 400 listing the available columns. `autoBinding`/`create`/`changeType` adopt the `ResponseEntity` error pattern from `WizVisualizationController`.
4. **No fabricated data** (`AssetQuery`/`ChartVSAQuery`/`XNodeMetaTable`/`WizVsService`): when a live query fails (e.g. a computed-column expression that is invalid SQL for the data source), the wiz API previously returned a successful chart with `hasData:true` over fabricated sample rows (`name1`/`999.99`). Root cause: `XSessionManager` swallows the SQL error → `AssetQuery` substitutes the design meta table (`isFailedQueryDefault=true`) → **`ChartVSAQuery` replaces that meta table with generated sample data, erasing the marker**. Fix: `ChartVSAQuery` preserves the marker across the swap as a table property (`XNodeMetaTable.FAILED_QUERY_PROPERTY`); the wiz extraction path walks the result lens chain (`Util.listNestedTable`) and 400s with "Worksheet query failed" on either signal. The two exception-path fallbacks in `AssetQuery` now also pass `failedQueryDefault=true`, matching the null-return fallback. Composer design-mode behavior unchanged (legit design/metadata meta tables are unmarked and never throw).

## Test plan
- [x] New JUnit (10 tests, `@Tag("core")`): `GenerateWsServiceFieldTest`, `WizAutoBindingServiceSelectBindColumnsTest` — all pass.
- [x] Live matrix on rebuilt image (sakila/postgres), all five scenarios:
  - Empty-name expression → `validate_worksheet` returns `ok:false` with the naming error; alias-fallback validates ✅
  - **Invalid `+` string-concat expression → `create_viewsheet` returns a 400 "Worksheet query failed" error — no fabricated rows** ✅
  - Unknown fieldConfig name → 400 listing available columns ✅
  - Actor-gross worksheet **without** manually hidden join keys → clean `actor_name × Sum(amount)` binding, real data, no junk `Sum(actor_id)` measures ✅
  - Happy-path top-10 chart renders + saves ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)