### PR TITLE
fix(wiz): setChartColors/setChartFormat changes never render — clear stale VGraph cache and paint runtime refs

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -1543,6 +1543,12 @@ public class WizAutoBindingService {
       // Invalidate the cached runtime descriptor so the change regenerates on re-execute.
       info.setRTChartDescriptor(null);
 
+      // The cached VGraphPair holds a reference to this same VSChartInfo, so the sandbox's
+      // staleness check (equalsContent against itself) can never detect the in-place mutation
+      // above. Clear the cached graph explicitly — mirroring VSChartDataHandler — or every
+      // subsequent render (including brand-new embed connections) serves the stale graph.
+      rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(request.getAssemblyName()));
+
       CreateViewsheetResult result =
          wizVsService.fetchAssemblyData(request.getWizRuntimeId(), request.getAssemblyName(), user);
 
@@ -1632,6 +1638,12 @@ public class WizAutoBindingService {
 
       info.setRTChartDescriptor(null);
 
+      // The cached VGraphPair holds a reference to this same VSChartInfo, so the sandbox's
+      // staleness check (equalsContent against itself) can never detect the in-place mutation
+      // above. Clear the cached graph explicitly — mirroring VSChartDataHandler — or every
+      // subsequent render (including brand-new embed connections) serves the stale graph.
+      rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(request.getAssemblyName()));
+
       CreateViewsheetResult result =
          wizVsService.fetchAssemblyData(request.getWizRuntimeId(), request.getAssemblyName(), user);
 
@@ -1653,7 +1665,12 @@ public class WizAutoBindingService {
       return result;
    }
 
-   /** Applies a single static color to every bound measure (aggregate) ref. */
+   /**
+    * Applies a single static color to every bound measure (aggregate) ref — both the design
+    * refs (so the change persists across runtime regeneration and save) and the runtime refs
+    * (the renderer reads getRTYFields()/getRTXFields(), clones made at execution time, so
+    * painting only the design refs would leave the next render on the old color).
+    */
    private void applyStaticColor(VSChartInfo vsChartInfo, Color color) {
       if(vsChartInfo == null) {
          return;
@@ -1667,6 +1684,14 @@ public class WizAutoBindingService {
 
       if(vsChartInfo.getXFields() != null) {
          refs.addAll(Arrays.asList(vsChartInfo.getXFields()));
+      }
+
+      if(vsChartInfo.getRTYFields() != null) {
+         refs.addAll(Arrays.asList(vsChartInfo.getRTYFields()));
+      }
+
+      if(vsChartInfo.getRTXFields() != null) {
+         refs.addAll(Arrays.asList(vsChartInfo.getRTXFields()));
       }
 
       for(ChartRef ref : refs) {

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartColorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartColorsTest.java
@@ -1,0 +1,151 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.graph.aesthetic.ColorFrame;
+import inetsoft.graph.aesthetic.StaticColorFrame;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.graph.ChartRef;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.web.wiz.model.ChartColorsRequest;
+import inetsoft.web.wiz.model.CreateViewsheetResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.Color;
+import java.security.Principal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * setChartColors mutates the runtime chart info in place. The sandbox's cached VGraphPair
+ * holds a reference to that same VSChartInfo, so its staleness check (equalsContent against
+ * itself) can never detect the mutation — the service MUST explicitly clear the cached graph
+ * or every subsequent render (including brand-new embed connections) serves the stale colors.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizAutoBindingServiceSetChartColorsTest {
+   private WizAutoBindingService service;
+   private ViewsheetSandbox box;
+   private VSChartAggregateRef yAgg;
+   private VSChartAggregateRef rtYAgg;
+
+   @BeforeEach
+   void setUp() throws Exception {
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      WizVsService wizVsService = mock(WizVsService.class);
+      // collaborators not used by setChartColors; their classes can't be initialized in
+      // a plain unit-test environment (no Spring context), so pass null instead of mocks.
+      service = new WizAutoBindingService(
+         viewsheetService, null, null, null, null, wizVsService);
+
+      // Real Viewsheet/assembly/info objects need SreeEnv (Spring context), so mock the
+      // whole chain and hand the service a mock measure ref to capture the applied frame.
+      yAgg = mock(VSChartAggregateRef.class);
+      rtYAgg = mock(VSChartAggregateRef.class);
+      VSChartInfo vsChartInfo = mock(VSChartInfo.class);
+      when(vsChartInfo.getColorField()).thenReturn(null);
+      when(vsChartInfo.getYFields()).thenReturn(new ChartRef[] { yAgg });
+      when(vsChartInfo.getXFields()).thenReturn(new ChartRef[0]);
+      when(vsChartInfo.getRTYFields()).thenReturn(new ChartRef[] { rtYAgg });
+      when(vsChartInfo.getRTXFields()).thenReturn(new ChartRef[0]);
+
+      ChartVSAssemblyInfo info = mock(ChartVSAssemblyInfo.class);
+      when(info.getVSChartInfo()).thenReturn(vsChartInfo);
+
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getChartInfo()).thenReturn(info);
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly("vs_1")).thenReturn(chart);
+
+      box = mock(ViewsheetSandbox.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+      when(viewsheetService.getViewsheet(anyString(), any())).thenReturn(rvs);
+      when(wizVsService.fetchAssemblyData(anyString(), anyString(), any(Principal.class)))
+         .thenReturn(new CreateViewsheetResult());
+   }
+
+   private static ChartColorsRequest staticRed() {
+      ChartColorsRequest request = new ChartColorsRequest();
+      request.setWizRuntimeId("rt-1");
+      request.setAssemblyName("vs_1");
+      request.setStaticColor("#d62728");
+      return request;
+   }
+
+   @Test
+   void staticColorIsAppliedToTheMeasureRef() throws Exception {
+      service.setChartColors(staticRed(), null);
+
+      ArgumentCaptor<ColorFrame> captor = ArgumentCaptor.forClass(ColorFrame.class);
+      verify(yAgg).setColorFrame(captor.capture());
+      StaticColorFrame frame = assertInstanceOf(StaticColorFrame.class, captor.getValue());
+      assertEquals(new Color(0xd6, 0x27, 0x28), frame.getColor(),
+         "staticColor must land on the bound measure's color frame");
+   }
+
+   @Test
+   void staticColorIsAppliedToTheRuntimeMeasureRefTheRendererActuallyReads() throws Exception {
+      // The renderer (VSFrameVisitor.getAggregates) reads getRTYFields()/getRTXFields() — the
+      // runtime clones — not the design refs. Painting only the design refs leaves the next
+      // render (even after a cache clear) on the old color.
+      service.setChartColors(staticRed(), null);
+
+      ArgumentCaptor<ColorFrame> captor = ArgumentCaptor.forClass(ColorFrame.class);
+      verify(rtYAgg).setColorFrame(captor.capture());
+      StaticColorFrame frame = assertInstanceOf(StaticColorFrame.class, captor.getValue());
+      assertEquals(new Color(0xd6, 0x27, 0x28), frame.getColor(),
+         "staticColor must also land on the runtime measure ref used for rendering");
+   }
+
+   @Test
+   void staticColorClearsTheCachedGraphSoTheChangeActuallyRenders() throws Exception {
+      service.setChartColors(staticRed(), null);
+
+      verify(box).clearGraph("vs_1");
+   }
+}


### PR DESCRIPTION
## Problem

The plugin's `set_chart_colors` returned 200 with correct data, but the chart kept its old color **forever** — through viewer refreshes, hard reloads, and brand-new embed connections.

## Root cause (two stacked bugs)

1. **The VGraph cache is identity-blind to in-place mutations.** `VGraphPair` stores a *reference* to the live `VSChartInfo` (`cinfo = ainfo.getVSChartInfo()` — only the descriptor is cloned). `ViewsheetSandbox.getVGraphPair`'s staleness check then runs `Tool.equalsContent(pair.getChartInfo(), chart.getVSChartInfo())` — the same object on both sides — so it can never detect the mutation, and the pre-change cached graph is served to every client indefinitely. The native aesthetic controllers never hit this because they clear the graph explicitly; `setChartColors`/`setChartFormat` did not.

2. **`applyStaticColor` painted refs the renderer never reads.** `VSFrameVisitor.getAggregates` reads `getRTYFields()/getRTXFields()` — runtime clones made at execution time — while the static color was applied only to the design refs. Even with the cache cleared (verified empirically), the regenerated graph stayed on the old color.

The categorical/gradient paths mutate the shared `AestheticRef` the renderer reads directly, so they only need the cache clear.

## Fix

- `setChartColors` + `setChartFormat`: clear the cached graph for the assembly after the in-place mutation (`setChartFormat`'s y-axis scale options live on chart-info-owned `AxisDescriptor`s, so it has the same exposure).
- `applyStaticColor`: apply the frame to both design and runtime measure refs.

## Verification

- New `WizAutoBindingServiceSetChartColorsTest` (3 tests, each red without its fix half): static color lands on the design ref, lands on the runtime ref the renderer reads, and `clearGraph` is invoked.
- Full `inetsoft.web.wiz.**` suite: 26/26.
- End-to-end on a local image: created the top-10 bar chart via the plugin flow, applied `staticColor #d62728`, screenshotted the companion viewer headlessly — bars render red on a fresh connection (previously blue through any number of refreshes).

Known limitation (out of scope): connected embed clients aren't pushed a refresh command by the REST call; they pick up the change on reconnect. The companion-viewer Refresh button is being fixed in stylebi-wiz to force that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)