### PR TITLE
Bug #75189, register cloned table in worksheet before applyDiscreteAggregates

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
@@ -612,15 +612,30 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
          assemblyInfo.getChartDescriptor() : assemblyInfo.getRTChartDescriptor();
 
       desc.setSortOthersLast(cinfo);
+      Worksheet ws = table != null ? table.getWorksheet() : null;
 
       if(table == null || isDetail()) {
          mergeZoomConds(table, null);
+
+         if(table != null) {
+            ws.removeAssembly(table.getName());
+            ws.addAssembly(table);
+         }
+
          return table;
       }
 
       if(groups.size() <= 1) {
          subcols = null;
          mergeZoomConds(table, null);
+
+         // Register the clone in the worksheet before applyDiscreteAggregates. The join table
+         // built inside that method stores child names in tnames[] and resolves them via
+         // ws.getAssembly() at execution time. Without this the local WorksheetWrapper still
+         // holds the original bound table under the same name, so the join would execute
+         // against the unmodified table instead of the clone with chart aggregate/column info.
+         ws.removeAssembly(table.getName());
+         ws.addAssembly(table);
 
          table = applyDiscreteAggregates(table, cinfo);
 
@@ -639,7 +654,6 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
       subcols = new SubColumns[subs.length];
       String ozoomTable = zoomTable;
       TableAssemblyOperator[] ops = new TableAssemblyOperator[subs.length - 1];
-      Worksheet ws = table.getWorksheet();
       int idx = 0;
 
       for(Set group : groups.keySet()) {

--- a/core/src/main/java/inetsoft/report/composition/graph/VSDataSet.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/VSDataSet.java
@@ -726,22 +726,6 @@ public class VSDataSet extends AbstractDataSet implements AttributeDataSet {
          val = hmap3.getInt(col);
       }
 
-      // Fallback: when using Java post-aggregation (SummaryFilter), the column header in the
-      // TableLens is the pre-aggregation column name (e.g. "Product:Total") rather than the
-      // full aggregate name (e.g. "Sum(Product:Total)"). Try looking up the inner column name
-      // extracted from the aggregate formula.
-      // hmap3 (CUBE ref names) is intentionally not checked here: CUBE data sources aggregate
-      // server-side and never go through SummaryFilter, so this path is unreachable for CUBE cols.
-      if(val == HEADER_MAP_DEFAULT_VALUE && isAggregateColumn(col)) {
-         int open = col.indexOf('(');
-         String inner = col.substring(open + 1, col.length() - 1);
-         val = hmap.getInt(inner);
-
-         if(val == HEADER_MAP_DEFAULT_VALUE) {
-            val = hmap2.getInt(inner);
-         }
-      }
-
       idx0 = val == HEADER_MAP_DEFAULT_VALUE ? -1 : val;
       idx0 = idx0 >= ccount ? -1 : idx0;
       return idx0;


### PR DESCRIPTION
RelationalJoinTableAssembly stores child table names and resolves them via ws.getAssembly() at execution time. The clone produced by createTableAssembly was never registered in the local WorksheetWrapper, so applyDiscreteAggregates would find the original unmodified bound table instead, ignoring the chart's aggregate and column configuration.

Move ws.removeAssembly/addAssembly to before applyDiscreteAggregates so the correct object is resolved when discrete measure join tables are built and later executed.

Revert VSDataSet.indexOfHeader0 fallback that stripped aggregate formula wrappers (e.g. "Sum(X)" → "X") when looking up column indices. That workaround was compensating for the wrong table being executed; with the root cause fixed the column headers match directly and the fallback is no longer needed.