### PR TITLE
Bug #75341 - Tier boxplot card tooltips by Median, IQR, and whiskers

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -1917,10 +1917,9 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
       return dims[0];
    }
 
-   // Set X-dim as header (solo-card-with-header renders it as tier-1 subtitle); group OHL at tier-2.
-   private void applyCandleCardHeader(ChartToolTip tooltip, String xDim,
-                                      String[] tipMeasures)
-   {
+   // Lift the dim to the header (rendered as the tier-1 subtitle). Returns true if
+   // the dim was present in the tooltip and lifted, false if it never rendered.
+   private boolean liftDimToHeader(ChartToolTip tooltip, String xDim) {
       String dimName = tips.get(xDim);
 
       if(dimName == null) {
@@ -1933,7 +1932,17 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
       if(xVal >= 0) {
          tooltip.setHeader(xKey, xVal);
          tooltip.removeTooltip(xKey);
+         return true;
       }
+
+      return false;
+   }
+
+   // Set X-dim as header (solo-card-with-header renders it as tier-1 subtitle); group OHL at tier-2.
+   private void applyCandleCardHeader(ChartToolTip tooltip, String xDim,
+                                      String[] tipMeasures)
+   {
+      liftDimToHeader(tooltip, xDim);
 
       // Count only entries that actually landed in the tooltip — skips OHLC names
       // dropped by the allfields filter so aesthetics don't get promoted to tier-2.
@@ -2009,19 +2018,11 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
 
    // Lift the X-dim to the header (rendered as the tier-1 subtitle under the
    // Median headline) and group the IQR at tier-2 so Min/Max drop to tier-3.
+   // If the X-dim never rendered, still group the IQR with no subtitle so the
+   // hierarchy survives, matching the no-X-dim branch.
    private void applyBoxCardHeader(ChartToolTip tooltip, String xDim, int tier2Count) {
-      String dimName = tips.get(xDim);
-
-      if(dimName == null) {
-         dimName = xDim;
-      }
-
-      int xKey = palette.put(dimName);
-      int xVal = tooltip.getTooltipValue(xKey);
-
-      if(xVal >= 0) {
-         tooltip.setHeader(xKey, xVal);
-         tooltip.removeTooltip(xKey);
+      if(!liftDimToHeader(tooltip, xDim) && tier2Count > 0) {
+         tooltip.setGroupedTiers(true);
       }
 
       tooltip.setTier2GroupSize(tier2Count);

--- a/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/PlotArea.java
@@ -1454,12 +1454,20 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
          boolean cardMeasureFirst = cardPutsMeasureFirst(chartInfo, element);
          String[] tipMeasures = measures;
          boolean candleCardLayout = isCandleOrStock && cardMeasureFirst;
+         // Single-measure boxplot only; multiple measures would promote several medians.
+         boolean boxCardLayout = GraphTypes.isBoxplot(chartInfo.getChartType()) &&
+            cardMeasureFirst && boxBaseMeasureCount(measures) == 1;
 
          // Candle/Stock card: Close is the canonical headline price; promote it
          // ahead of OHL so it becomes the tier-1 row.
          if(candleCardLayout) {
             tipMeasures = reorderCandleMeasuresCloseFirst(
                measures, (CandleChartInfo) chartInfo);
+         }
+         // Boxplot card: Median is the canonical center; promote it ahead of the
+         // IQR and whiskers so it becomes the tier-1 row.
+         else if(boxCardLayout) {
+            tipMeasures = reorderBoxMeasuresMedianFirst(measures);
          }
 
          String[][] cols;
@@ -1665,6 +1673,21 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
          if(candleCardLayout && dims.length > 0) {
             applyCandleCardHeader(tooltip, candleHeaderDim(chartInfo.getRTXFields(), dims),
                                   tipMeasures);
+         }
+         // Boxplot card: Median headlines, X-dim subtitles, Q1/Q3 group at tier-2.
+         // Count IQR from added (rendered rows) — prefixed stat names aren't in tips.
+         else if(boxCardLayout) {
+            int q1q3 = boxIqrCount(added);
+
+            if(dims.length > 0) {
+               applyBoxCardHeader(
+                  tooltip, candleHeaderDim(chartInfo.getRTXFields(), dims), q1q3);
+            }
+            // No X dim (a single box): group the IQR with no subtitle.
+            else if(q1q3 > 0) {
+               tooltip.setGroupedTiers(true);
+               tooltip.setTier2GroupSize(q1q3);
+            }
          }
          else if(cardMeasureFirst && dims.length > 0) {
             if(groupMeasuresAtTier2(measures, full2NoCalcNames.keySet(), measurePairs)) {
@@ -1925,6 +1948,83 @@ public class PlotArea extends GridContainerArea implements GraphComponentArea, R
       }
 
       tooltip.setTier2GroupSize(auxCount);
+   }
+
+   // Boxplot card: order the stat columns Median, Q1, Q3, Min, Max so Median
+   // leads at tier-1, the IQR groups at tier-2 and the whiskers fall to tier-3.
+   // egeom.getVars() returns them Max-first; unrecognized names keep their order
+   // at the end. Stat is encoded in the column-name prefix (BoxDataSet.*_PREFIX).
+   static String[] reorderBoxMeasuresMedianFirst(String[] measures) {
+      String[] order = { BoxDataSet.MEDIUM_PREFIX, BoxDataSet.Q25_PREFIX,
+         BoxDataSet.Q75_PREFIX, BoxDataSet.MIN_PREFIX, BoxDataSet.MAX_PREFIX };
+      List<String> remaining = new ArrayList<>();
+
+      for(String m : measures) {
+         if(m != null) {
+            remaining.add(m);
+         }
+      }
+
+      List<String> reordered = new ArrayList<>();
+
+      for(String prefix : order) {
+         for(Iterator<String> it = remaining.iterator(); it.hasNext(); ) {
+            String m = it.next();
+
+            if(m.startsWith(prefix)) {
+               reordered.add(m);
+               it.remove();
+            }
+         }
+      }
+
+      reordered.addAll(remaining);
+      return reordered.toArray(new String[0]);
+   }
+
+   // Distinct base measures behind the box stat columns. >1 means a multi-measure
+   // boxplot, which the dedicated card layout does not handle (it would promote
+   // several medians), so those fall through to the generic measure-first path.
+   static int boxBaseMeasureCount(String[] measures) {
+      Set<String> bases = new HashSet<>();
+
+      for(String m : measures) {
+         if(m != null) {
+            bases.add(BoxDataSet.getBaseName(m));
+         }
+      }
+
+      return bases.size();
+   }
+
+   // Number of IQR (Q1/Q3) stat rows that actually rendered. Counted from the
+   // added set (raw prefixed names) rather than the tips map, which only holds
+   // the base measure name for a boxplot.
+   static int boxIqrCount(Set<String> added) {
+      return (int) added.stream()
+         .filter(n -> n != null &&
+            (n.startsWith(BoxDataSet.Q25_PREFIX) || n.startsWith(BoxDataSet.Q75_PREFIX)))
+         .count();
+   }
+
+   // Lift the X-dim to the header (rendered as the tier-1 subtitle under the
+   // Median headline) and group the IQR at tier-2 so Min/Max drop to tier-3.
+   private void applyBoxCardHeader(ChartToolTip tooltip, String xDim, int tier2Count) {
+      String dimName = tips.get(xDim);
+
+      if(dimName == null) {
+         dimName = xDim;
+      }
+
+      int xKey = palette.put(dimName);
+      int xVal = tooltip.getTooltipValue(xKey);
+
+      if(xVal >= 0) {
+         tooltip.setHeader(xKey, xVal);
+         tooltip.removeTooltip(xKey);
+      }
+
+      tooltip.setTier2GroupSize(tier2Count);
    }
 
    // check if point corresponding to null value should show tooltip.

--- a/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/ChartToolTipTest.java
@@ -459,6 +459,60 @@ class ChartToolTipTest {
    }
 
    @Test
+   void boxSoloCardRespectsIQRTier2Boundary() {
+      // Boxplot card as PlotArea builds it: Median headline, X-dim subtitle, the
+      // IQR (Q1/Q3) grouped at tier-2, and Min/Max + the color aesthetic at tier-3.
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.setHeader(palette.put("Category"), palette.put("Business"));
+      tip.addTooltip(palette.put("Median"), palette.put("15,000"));
+      tip.addTooltip(palette.put("Q1"), palette.put("2,000"));
+      tip.addTooltip(palette.put("Q3"), palette.put("33,750"));
+      tip.addTooltip(palette.put("Min"), palette.put("125"));
+      tip.addTooltip(palette.put("Max"), palette.put("60,000"));
+      tip.addTooltip(palette.put("Region"), palette.put("USA East"));
+      tip.setTier2GroupSize(2);
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-1\">Median:&nbsp;15,000"));
+      assertTrue(out.contains("<div class=\"tt-tier-1 tt-subtitle\">Category:&nbsp;Business"));
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Q1:&nbsp;2,000"));
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Q3:&nbsp;33,750"));
+      assertTrue(out.contains("<div class=\"tt-tier-3\">Min:&nbsp;125"));
+      assertTrue(out.contains("<div class=\"tt-tier-3\">Max:&nbsp;60,000"));
+      assertTrue(out.contains("<div class=\"tt-tier-3\">Region:&nbsp;USA East"),
+                 "color aesthetic drops to tier-3");
+      assertFalse(out.contains("tt-tier-4"));
+   }
+
+   @Test
+   void boxNoXDimGroupsIQRWithoutSubtitle() {
+      // A single box with no X dim: the IQR still groups at tier-2, but there is
+      // no X-dim to lift, so no subtitle.
+      IndexedSet<String> palette = new IndexedSet<>();
+      ChartToolTip tip = new ChartToolTip();
+      tip.setStyle(ChartInfo.TooltipStyle.CARD);
+      tip.setGroupedTiers(true);
+      tip.setTier2GroupSize(2);
+      tip.addTooltip(palette.put("Median"), palette.put("15,000"));
+      tip.addTooltip(palette.put("Q1"), palette.put("2,000"));
+      tip.addTooltip(palette.put("Q3"), palette.put("33,750"));
+      tip.addTooltip(palette.put("Min"), palette.put("125"));
+      tip.addTooltip(palette.put("Max"), palette.put("60,000"));
+
+      String out = tip.getTooltip(palette);
+
+      assertTrue(out.contains("<div class=\"tt-tier-1\">Median:&nbsp;15,000"));
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Q1:&nbsp;2,000"));
+      assertTrue(out.contains("<div class=\"tt-tier-2\">Q3:&nbsp;33,750"));
+      assertTrue(out.contains("<div class=\"tt-tier-3\">Min:&nbsp;125"));
+      assertTrue(out.contains("<div class=\"tt-tier-3\">Max:&nbsp;60,000"));
+      assertFalse(out.contains("tt-subtitle"));
+   }
+
+   @Test
    void soloCardWithoutHeaderKeepsLegacyTierCap() {
       // No header → legacy path: 1, 2, 3, 3, 3...
       IndexedSet<String> palette = new IndexedSet<>();

--- a/core/src/test/java/inetsoft/report/composition/region/PlotAreaCardMeasureFirstTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/PlotAreaCardMeasureFirstTest.java
@@ -337,6 +337,10 @@ class PlotAreaCardMeasureFirstTest {
       // Two measures → two bases → multi-measure boxplot falls through.
       assertEquals(2, PlotArea.boxBaseMeasureCount(new String[] {
          BoxDataSet.MEDIUM_PREFIX + "Total", BoxDataSet.MEDIUM_PREFIX + "Paid" }));
+
+      // A null entry is skipped, not counted.
+      assertEquals(1, PlotArea.boxBaseMeasureCount(new String[] {
+         BoxDataSet.MEDIUM_PREFIX + "Total", null }));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/report/composition/region/PlotAreaCardMeasureFirstTest.java
+++ b/core/src/test/java/inetsoft/report/composition/region/PlotAreaCardMeasureFirstTest.java
@@ -18,6 +18,7 @@
 package inetsoft.report.composition.region;
 
 import inetsoft.graph.aesthetic.*;
+import inetsoft.graph.data.BoxDataSet;
 import inetsoft.graph.data.DataSet;
 import inetsoft.graph.element.GraphElement;
 import inetsoft.graph.element.PointElement;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -285,6 +287,69 @@ class PlotAreaCardMeasureFirstTest {
       // Single plain measure: guard fires on measurePairs <= 1 → no grouping.
       assertFalse(PlotArea.groupMeasuresAtTier2(
          new String[]{ "Sum(A)" }, new HashSet<>(), 1));
+   }
+
+   @Test
+   void reorderBoxMeasuresMedianFirstPutsMedianFirst() {
+      // egeom.getVars() yields the stats Max-first; reorder to Median, Q1, Q3,
+      // Min, Max so Median headlines, the IQR groups, and the whiskers trail.
+      String[] in = { BoxDataSet.MAX_PREFIX + "Total", BoxDataSet.Q75_PREFIX + "Total",
+         BoxDataSet.MEDIUM_PREFIX + "Total", BoxDataSet.Q25_PREFIX + "Total",
+         BoxDataSet.MIN_PREFIX + "Total" };
+
+      assertArrayEquals(new String[] {
+         BoxDataSet.MEDIUM_PREFIX + "Total", BoxDataSet.Q25_PREFIX + "Total",
+         BoxDataSet.Q75_PREFIX + "Total", BoxDataSet.MIN_PREFIX + "Total",
+         BoxDataSet.MAX_PREFIX + "Total" },
+         PlotArea.reorderBoxMeasuresMedianFirst(in));
+   }
+
+   @Test
+   void reorderBoxMeasuresHandlesMissingStatsAndNulls() {
+      // A partial stat set (no Min) and a null entry: survivors stay in priority
+      // order, the null is dropped, no NPE.
+      String[] in = { BoxDataSet.MAX_PREFIX + "T", null, BoxDataSet.MEDIUM_PREFIX + "T",
+         BoxDataSet.Q25_PREFIX + "T" };
+
+      assertArrayEquals(new String[] {
+         BoxDataSet.MEDIUM_PREFIX + "T", BoxDataSet.Q25_PREFIX + "T", BoxDataSet.MAX_PREFIX + "T" },
+         PlotArea.reorderBoxMeasuresMedianFirst(in));
+   }
+
+   @Test
+   void reorderBoxMeasuresPassesThroughNonBoxNames() {
+      // Unrecognized names keep their order after the ranked stats.
+      String[] in = { BoxDataSet.MAX_PREFIX + "T", "Foo", BoxDataSet.MEDIUM_PREFIX + "T" };
+
+      assertArrayEquals(new String[] {
+         BoxDataSet.MEDIUM_PREFIX + "T", BoxDataSet.MAX_PREFIX + "T", "Foo" },
+         PlotArea.reorderBoxMeasuresMedianFirst(in));
+   }
+
+   @Test
+   void boxBaseMeasureCountCountsDistinctBases() {
+      // One measure's five stats → one base; the dedicated layout only applies here.
+      assertEquals(1, PlotArea.boxBaseMeasureCount(new String[] {
+         BoxDataSet.MAX_PREFIX + "Total", BoxDataSet.Q75_PREFIX + "Total",
+         BoxDataSet.MEDIUM_PREFIX + "Total", BoxDataSet.Q25_PREFIX + "Total",
+         BoxDataSet.MIN_PREFIX + "Total" }));
+
+      // Two measures → two bases → multi-measure boxplot falls through.
+      assertEquals(2, PlotArea.boxBaseMeasureCount(new String[] {
+         BoxDataSet.MEDIUM_PREFIX + "Total", BoxDataSet.MEDIUM_PREFIX + "Paid" }));
+   }
+
+   @Test
+   void boxIqrCountCountsQ1Q3FromAdded() {
+      // Counts only the rendered IQR rows; Median/Min/Max and dims don't count.
+      Set<String> added = new HashSet<>(Arrays.asList(
+         BoxDataSet.MEDIUM_PREFIX + "Total", BoxDataSet.Q25_PREFIX + "Total",
+         BoxDataSet.Q75_PREFIX + "Total", BoxDataSet.MIN_PREFIX + "Total",
+         BoxDataSet.MAX_PREFIX + "Total", "Category"));
+      assertEquals(2, PlotArea.boxIqrCount(added));
+
+      assertEquals(0, PlotArea.boxIqrCount(new HashSet<>(Arrays.asList(
+         BoxDataSet.MEDIUM_PREFIX + "Total", "Category"))));
    }
 
    private static ChartInfo chartInfo(ChartInfo.TooltipStyle style, int chartType) {


### PR DESCRIPTION
Gives boxplot card-style tooltips a dedicated information hierarchy.

Previously a boxplot card fell into the generic measure-first path: Max
led at tier-1 and the other statistics plus the category rendered as a
flat list, which buries the primary insight (the median) and gives the
whiskers the same weight as the box body.

New hierarchy for a single-measure boxplot card:
  - Tier-1: Median (center of the distribution)
  - Tier-1 subtitle: the X categorical dim (identifies which box)
  - Tier-2: Q1 / Q3 (the IQR / box body)
  - Tier-3: Min / Max (whiskers) and any color/identity aesthetic

This mirrors the existing candle/stock card model (a canonical stat leads,
the X-dim is the subtitle, the core body groups at tier-2) and is added as
a dedicated branch alongside the candle and gantt branches.

Implementation (all in PlotArea.java):
- Detect a single-measure boxplot and reorder the stat columns
  Median, Q1, Q3, Min, Max (egeom.getVars returns them Max-first).
- Lift the X-dim to the subtitle header and set the tier-2 group size to
  the number of IQR rows that actually rendered, counted from the added
  set rather than the tips map (the prefixed Q25_/Q75_ names are not in
  tips, which holds only the base measure name).
- Reuse the existing candleHeaderDim X-dim selector unchanged.

Scope and behavior:
- Multi-measure boxplots fall through to the existing generic path, so
  there is no change for them.
- A boxplot with no X dim still groups the IQR at tier-2 but shows no
  subtitle.
- Candle/stock and gantt card tooltips are unaffected.