### PR TITLE
Bug #75313, fix MV creation deadlock caused by Ignite public pool starvation

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
@@ -1728,16 +1728,9 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
    private static IgniteCompute getIgniteCompute(Ignite igniteInstance, ClusterGroup clusterGroup, int level) {
       int poolLevel = level % IGNITE_EXECUTE_POOL_COUNT;
 
-      if(poolLevel == 0) {
-         return clusterGroup != null ? igniteInstance.compute(clusterGroup) : igniteInstance.compute();
-      }
-      else {
-         poolLevel -= 1;
-
-         return clusterGroup != null ?
-            igniteInstance.compute(clusterGroup).withExecutor(getIgniteExecutePoolName(poolLevel)) :
-            igniteInstance.compute().withExecutor(getIgniteExecutePoolName(poolLevel));
-      }
+      return clusterGroup != null ?
+         igniteInstance.compute(clusterGroup).withExecutor(getIgniteExecutePoolName(poolLevel)) :
+         igniteInstance.compute().withExecutor(getIgniteExecutePoolName(poolLevel));
    }
 
    @Override


### PR DESCRIPTION
getIgniteCompute() fell through to the default public pool when level % IGNITE_EXECUTE_POOL_COUNT == 0. MVCallable tasks submitted via Cluster.submit() would block on BlobStorage.putBlob() waiting for SingletonCallableTask results, whose completion is delivered by ServiceTaskResultListener — also on the public pool. With all public threads occupied by blocked MVCallable tasks, the listeners could never run, causing 60s timeouts and failed MV creation.

Fix: always route through a named custom executor in getIgniteCompute(), keeping the public pool free for message listener callbacks.