### PR TITLE
Bug #75346, fix viewsheet hyperlink broken after Angular upgrade

### DIFF
--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -330,7 +330,6 @@ export interface ScrollViewportRect {
         VSTabService,
         ViewDataService,
         FirstDayOfWeekService,
-        PageTabService
     ],
     imports: [NgIf, PagingControlComponent, OutOfZoneDirective, VsToolbarButtonDirective, FixedDropdownDirective, DefaultFocusDirective, EnterClickDirective, NgFor, BlockMouseDirective, ViewerMobileToolbarComponent, VsBookmarkPaneComponent, InteractContainerDirective, ViewerFormatPane, VSObjectContainer, StatusBar, VSLoadingDisplay, ExportDialog, EmailDialog, ScheduleDialog, BookmarkPropertyDialog, VariableInputDialog, ShareEmailDialogComponent, ShareGoogleChatDialog, ShareSlackDialog, ShareLinkDialog, RemoveBookmarksDialog, NotificationsComponent]
 })


### PR DESCRIPTION
PageTabService was listed in both app.config.ts (root injector) and ViewerAppComponent.providers (component injector), causing two separate instances. ViewerViewComponent initialized tabs on the root instance, but ShowHyperlinkService (provided inside ViewerAppComponent) received the component-level instance which never had currentTab set, so clicking a _self viewsheet hyperlink crashed with "Cannot set properties of null (setting 'runtimeId')".

Removing PageTabService from ViewerAppComponent.providers ensures ShowHyperlinkService uses the same root instance that ViewerViewComponent initializes.