### PR TITLE
Bug #75349: Fix collapsible monitoring tables disappearing when rolled up

### DIFF
--- a/web/projects/em/src/app/common/util/table/table-view.component.html
+++ b/web/projects/em/src/app/common/util/table/table-view.component.html
@@ -62,11 +62,9 @@
 @if (matTableDataSource && collapsible && tableInfo) {
   <mat-expansion-panel class="table-container"
     [expanded]="expanded">
-    @if (tableInfo.title) {
-      <mat-expansion-panel-header class="light-gray-bg table-cell-padding-sm m-0">
-        <mat-panel-title>{{tableInfo.title}}</mat-panel-title>
-      </mat-expansion-panel-header>
-    }
+    <mat-expansion-panel-header *ngIf="tableInfo.title" class="light-gray-bg table-cell-padding-sm m-0">
+      <mat-panel-title>{{tableInfo.title}}</mat-panel-title>
+    </mat-expansion-panel-header>
     <mat-card appearance="outlined" class="mat-elevation-z0">
       <mat-card-content>
         @if (expandableRow) {

--- a/web/projects/em/src/app/common/util/table/table-view.component.spec.ts
+++ b/web/projects/em/src/app/common/util/table/table-view.component.spec.ts
@@ -17,7 +17,7 @@
  */
 
 import { CommonModule } from "@angular/common";
-import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { Component, NO_ERRORS_SCHEMA } from "@angular/core";
 import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
 import { MatCheckboxModule } from "@angular/material/checkbox";
 import { MatExpansionModule } from "@angular/material/expansion";
@@ -33,6 +33,16 @@ const tableInfo: TableInfo = {
    selectionEnabled: false,
    title: ""
 };
+
+@Component({
+   standalone: true,
+   imports: [TableView],
+   template: `<em-table-view [collapsible]="true" [dataSource]="data" [tableInfo]="info"></em-table-view>`
+})
+class TestHostComponent {
+   data: any[] = [];
+   info: TableInfo = { columns: [], selectionEnabled: false, title: "My Title" };
+}
 
 describe("TableViewComponent", () => {
    let component: TableView<any>;
@@ -63,5 +73,23 @@ describe("TableViewComponent", () => {
 
    it("should create", () => {
       expect(component).toBeTruthy();
+   });
+
+   // Bug #75349: when a collapsible table has a title, the panel header (which
+   // carries the rollup toggle) must be projected into the expansion panel's
+   // always-visible header slot, NOT into the collapsible body. If it lands in
+   // the body, clicking the toggle collapses the header along with the content
+   // and the whole element disappears.
+   it("should project the panel header outside the collapsible content (bug #75349)", () => {
+      const hostFixture = TestBed.createComponent(TestHostComponent);
+      hostFixture.detectChanges();
+
+      const el: HTMLElement = hostFixture.nativeElement;
+      const header = el.querySelector("mat-expansion-panel-header");
+      const content = el.querySelector(".mat-expansion-panel-content");
+
+      expect(header).toBeTruthy();
+      // The header must not be nested inside the collapsible content region.
+      expect(content?.contains(header)).toBeFalsy();
    });
 });


### PR DESCRIPTION
## Symptom

The monitoring tables (Cache, Queries, Viewsheets, Users) have an accordion toggle at the top to roll them up. Clicking the toggle made the **entire element disappear** — header, toggle, and table — with no way to bring it back.

## Root Cause

Regression from the Angular 20→21 upgrade (#3809); specifically an instance of the defect class fixed in Bug #75272 (#3840) that was missed by that pass.

In `table-view.component.html`, the `mat-expansion-panel-header` of the collapsible variant was wrapped in an `@if` block:

```html
@if (tableInfo.title) {
  <mat-expansion-panel-header ...>
    <mat-panel-title>{{tableInfo.title}}</mat-panel-title>
  </mat-expansion-panel-header>
}
```

`mat-expansion-panel` projects its header via a **named slot** — `<ng-content select="mat-expansion-panel-header">` — which sits *outside* the collapsible region, while the default `<ng-content>` slot sits *inside* the animated `.mat-expansion-panel-content` region.

Content projection matches against the **top-level nodes** of the component's content. In Angular 21 an `@if` block is itself the top-level node — an opaque container that only matches the wildcard slot. The header therefore failed to match `select="mat-expansion-panel-header"` and was projected into the **default slot inside the collapsible body**.

The header's click handler still toggled the panel (it gets the panel reference via DI, independent of where it renders), so clicking the toggle collapsed the body — which now contained the header itself. Material's CSS rule

```css
.mat-expansion-panel-content[style*="visibility: hidden"] * { visibility: hidden !important; }
```

then hid everything, including the only control that could re-expand the panel.

Since `em-table-view` is shared, every collapsible monitoring table was affected.

## Why not keep `@if`?

`@if` is the preferred modern control-flow syntax, but named-slot content projection is the one documented case where it cannot be used (angular/angular#52414). Both `@if` variants were verified empirically against the new regression test:

| Variant | Result |
|---|---|
| `@if (...) { <mat-expansion-panel-header> }` | ❌ header lands inside collapsible body (the bug) |
| `@if (...) { <mat-expansion-panel-header ngProjectAs="mat-expansion-panel-header"> }` | ❌ still fails — `ngProjectAs` is on a node *inside* the block, not on the top-level node, so it never participates in slot matching |
| `<mat-expansion-panel-header *ngIf="tableInfo.title">` | ✅ header projected into the correct slot |

`*ngIf` works because the compiler preserves the host element's selector/attributes on the generated template for projection matching. This is also the exact fix pattern established codebase-wide by Bug #75272 (#3840) for `mat-label`/`mat-error`/`mat-hint`/`matSuffix` etc., so this change keeps the codebase consistent. The only `@if`-preserving alternative would be duplicating the entire `<mat-expansion-panel>` into with-title/without-title branches.

## Fix

Replace the `@if` wrapper with `*ngIf` on the `mat-expansion-panel-header` element itself (`NgIf` was already in the component's imports).

## Testing

- Added a regression test (host component with `[collapsible]="true"` and a title) asserting the rendered `mat-expansion-panel-header` is **not** nested inside `.mat-expansion-panel-content`. Fails before the fix (`content.contains(header) === true`), passes after.
- Ran all consumer specs (cache/queries/viewsheets/users/cluster/log monitoring views, collapsible-container, regular/expandable-row/table-view tables): **11/11 pass**, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)