### PR TITLE
Bug #75322, do not apply maxrows clause to where subqueries on Derby

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/DerbyHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/DerbyHelper.java
@@ -135,6 +135,26 @@ public class DerbyHelper extends SQLHelper {
       return super.supportsOperation(op);
    }
 
+   /**
+    * Check if supports an operation.
+    * @param op the specified operation.
+    * @param info the advanced information.
+    * @return <tt>true</tt> if supports, <tt>false</tt> otherwise.
+    */
+   @Override
+   public boolean supportsOperation(String op, String info) {
+      // the maxrows clause wraps the query in 'select * from (...) fetch first
+      // n rows only' (see generateMaxRowsClause), and derby only allows
+      // 'select *' in EXISTS and NOT EXISTS subqueries (error 42X38), so the
+      // maxrows clause must not be applied to a where subquery (e.g. IN /
+      // NOT IN). (Bug #75322)
+      if(MAXROWS.equals(op) && WHERE_SUBQUERY.equals(info)) {
+         return false;
+      }
+
+      return super.supportsOperation(op, info);
+   }
+
    @Override
    public String generateOrderByClause() {
       // derby throws exception with 'order by' in sub query

--- a/core/src/test/java/inetsoft/uql/jdbc/DerbyHelperTest.java
+++ b/core/src/test/java/inetsoft/uql/jdbc/DerbyHelperTest.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.jdbc;
+
+import inetsoft.test.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link DerbyHelper}.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+public class DerbyHelperTest {
+   // Bug #75322. Derby only allows 'select *' in EXISTS and NOT EXISTS
+   // subqueries (error 42X38), so the maxrows clause, which wraps the query
+   // in 'select * from (...) fetch first n rows only', must not be applied
+   // to a where subquery (e.g. IN / NOT IN).
+   @Test
+   void maxRowsNotSupportedInWhereSubquery() {
+      DerbyHelper helper = new DerbyHelper();
+      assertFalse(helper.supportsOperation(SQLHelper.MAXROWS, SQLHelper.WHERE_SUBQUERY));
+   }
+
+   // the maxrows clause is still supported outside of where subqueries.
+   @Test
+   void maxRowsSupportedOutsideWhereSubquery() {
+      DerbyHelper helper = new DerbyHelper();
+      assertTrue(helper.supportsOperation(SQLHelper.MAXROWS, null));
+      assertTrue(helper.supportsOperation(SQLHelper.MAXROWS));
+   }
+}


### PR DESCRIPTION
## Summary

Showing live data for a worksheet table with a subquery condition (e.g. `PRODUCT_ID` *not one of* → `NOT IN (subquery)`) against a Derby data source failed with:

```
java.sql.SQLSyntaxErrorException: 'SELECT *' only allowed in EXISTS and NOT EXISTS subqueries.
```

## Root Cause

In live mode, `PreAssetQuery.mergeOthers()` applies a preview row limit to a merged WHERE subquery by setting `HINT_OUTPUT_MAXROWS`, gated by `helper.supportsOperation(SQLHelper.MAXROWS, SQLHelper.WHERE_SUBQUERY)`. The `info` flag exists so dialects can veto maxrows inside WHERE subqueries, but `DerbyHelper` never overrode the two-arg `supportsOperation`, and the base implementation ignores `info`.

`DerbyHelper.generateMaxRowsClause()` implements the row limit by wrapping the query in `select * from (...) fetch first n rows only`. When that wrapper lands inside an `IN`/`NOT IN` subquery, Derby rejects it with error 42X38, since Derby only allows `SELECT *` in EXISTS/NOT EXISTS subqueries.

## Fix

Override `supportsOperation(String op, String info)` in `DerbyHelper` to return `false` for `(MAXROWS, WHERE_SUBQUERY)`, so the maxrows hint is never applied to WHERE subqueries on Derby. Top-level maxrows behavior and all other dialects are unchanged.

## Test Plan

- Added `DerbyHelperTest` covering the new override and the preserved top-level maxrows behavior (`./mvnw test -pl core -Dtest=DerbyHelperTest` — passes).
- Manual verification with the case from the Redmine issue: import the `subquery condition` worksheet, show live data of `PRODUCTS1` — data loads without the SQL error.
- Regression check: tables/previews without subquery conditions on Derby still apply the preview row limit (top-level `fetch first n rows only` unchanged).

Fixes Redmine #75322.