### PR TITLE
Bug #75345, fix sort icon not displaying in table and crosstab headers

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-crosstab.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-crosstab.component.html
@@ -177,20 +177,22 @@
                           [safeFont]="_cell.vsFormatModel.font"
                           [dataTip]="model.dataTip"
                           [dataTipOnClick]="model.isTipOnClick">
-                          @if (sortEnable(_cell) && model.sortOnHeader && !vsWizard) {
-                            <i sortButton
-                              title="_#(Sort Column)"
-                              class="sort-button vs-header-cell-button-sort hover-bg-secondary"
-                              [class.col-sorted]="isColSorted(_cell)"
-                              [class.sort-ascending-icon]="isSorted(_cell.field, 'asc')"
-                              [class.sort-descending-icon]="isSorted(_cell.field, 'desc')"
-                              [class.sort-value-ascending-icon]="isSorted(_cell.field, 'val-asc')"
-                              [class.sort-value-descending-icon]="isSorted(_cell.field, 'val-desc')"
-                              [class.sort-icon]="isSorted(_cell.field, 'none')"
-                              (click)="sortColumn(_cell, $event)"
-                              aria-hidden="true">
-                            </i>
-                          }
+                          <ng-container ngProjectAs="[sortButton]">
+                            @if (sortEnable(_cell) && model.sortOnHeader && !vsWizard) {
+                              <i sortButton
+                                title="_#(Sort Column)"
+                                class="sort-button vs-header-cell-button-sort hover-bg-secondary"
+                                [class.col-sorted]="isColSorted(_cell)"
+                                [class.sort-ascending-icon]="isSorted(_cell.field, 'asc')"
+                                [class.sort-descending-icon]="isSorted(_cell.field, 'desc')"
+                                [class.sort-value-ascending-icon]="isSorted(_cell.field, 'val-asc')"
+                                [class.sort-value-descending-icon]="isSorted(_cell.field, 'val-desc')"
+                                [class.sort-icon]="isSorted(_cell.field, 'none')"
+                                (click)="sortColumn(_cell, $event)"
+                                aria-hidden="true">
+                              </i>
+                            }
+                          </ng-container>
                         </td>
                       }
                     }
@@ -272,20 +274,22 @@
                           [style.color]="_cell.vsFormatModel.foreground"
                           [style.background]="_cell.vsFormatModel.background"
                           [safeFont]="_cell.vsFormatModel.font">
-                          @if (sortEnable(_cell) && !model.sortOnHeader && model.sortAggregate && model.timeSeriesNames.length == 0 && !vsWizard) {
-                            <i sortButton
-                              title="_#(Sort Column)"
-                              class="sort-button vs-header-cell-button-sort hover-bg-secondary"
-                              [class.col-sorted]="isColSorted(_cell)"
-                              [class.sort-ascending-icon]="isSorted(_cell.field, 'asc')"
-                              [class.sort-descending-icon]="isSorted(_cell.field, 'desc')"
-                              [class.sort-value-ascending-icon]="isSorted(_cell.field, 'val-asc')"
-                              [class.sort-value-descending-icon]="isSorted(_cell.field, 'val-desc')"
-                              [class.sort-icon]="isSorted(_cell.field, 'none')"
-                              (click)="sortColumn(_cell, $event)"
-                              aria-hidden="true">
-                            </i>
-                          }
+                          <ng-container ngProjectAs="[sortButton]">
+                            @if (sortEnable(_cell) && !model.sortOnHeader && model.sortAggregate && model.timeSeriesNames.length == 0 && !vsWizard) {
+                              <i sortButton
+                                title="_#(Sort Column)"
+                                class="sort-button vs-header-cell-button-sort hover-bg-secondary"
+                                [class.col-sorted]="isColSorted(_cell)"
+                                [class.sort-ascending-icon]="isSorted(_cell.field, 'asc')"
+                                [class.sort-descending-icon]="isSorted(_cell.field, 'desc')"
+                                [class.sort-value-ascending-icon]="isSorted(_cell.field, 'val-asc')"
+                                [class.sort-value-descending-icon]="isSorted(_cell.field, 'val-desc')"
+                                [class.sort-icon]="isSorted(_cell.field, 'none')"
+                                (click)="sortColumn(_cell, $event)"
+                                aria-hidden="true">
+                              </i>
+                            }
+                          </ng-container>
                         </td>
                       }
                     }
@@ -378,20 +382,22 @@
                           [dataTip]="model.dataTip"
                           [dataTipOnClick]="model.isTipOnClick"
                           [class.visible-cell]="getCellHeight(_cell.row, _cell) > 0">
-                          @if (sortEnable(_cell) && !model.sortOnHeader && !isAggregate(_cell.field) && model.sortDimension && !vsWizard) {
-                            <i sortButton
-                              title="_#(Sort Column)"
-                              class="sort-button vs-header-cell-button-sort hover-bg-secondary"
-                              [class.col-sorted]="isColSorted(_cell)"
-                              [class.sort-ascending-icon]="isSorted(_cell.field, 'asc')"
-                              [class.sort-descending-icon]="isSorted(_cell.field, 'desc')"
-                              [class.sort-value-ascending-icon]="isSorted(_cell.field, 'val-asc')"
-                              [class.sort-value-descending-icon]="isSorted(_cell.field, 'val-desc')"
-                              [class.sort-icon]="isSorted(_cell.field, 'none')"
-                              (click)="sortColumn(_cell, $event)"
-                              aria-hidden="true">
-                            </i>
-                          }
+                          <ng-container ngProjectAs="[sortButton]">
+                            @if (sortEnable(_cell) && !model.sortOnHeader && !isAggregate(_cell.field) && model.sortDimension && !vsWizard) {
+                              <i sortButton
+                                title="_#(Sort Column)"
+                                class="sort-button vs-header-cell-button-sort hover-bg-secondary"
+                                [class.col-sorted]="isColSorted(_cell)"
+                                [class.sort-ascending-icon]="isSorted(_cell.field, 'asc')"
+                                [class.sort-descending-icon]="isSorted(_cell.field, 'desc')"
+                                [class.sort-value-ascending-icon]="isSorted(_cell.field, 'val-asc')"
+                                [class.sort-value-descending-icon]="isSorted(_cell.field, 'val-desc')"
+                                [class.sort-icon]="isSorted(_cell.field, 'none')"
+                                (click)="sortColumn(_cell, $event)"
+                                aria-hidden="true">
+                              </i>
+                            }
+                          </ng-container>
                         </td>
                       }
                     }
@@ -476,20 +482,22 @@
                           [safeFont]="_cell.vsFormatModel.font"
                           [dataTip]="model.dataTip"
                           [dataTipOnClick]="model.isTipOnClick">
-                          @if (sortDimensionEnable(_cell) && !vsWizard) {
-                            <i sortButton
-                              title="_#(Sort Column)"
-                              class="sort-button vs-header-cell-button-sort hover-bg-secondary"
-                              [class.col-sorted]="isColSorted(_cell)"
-                              [class.sort-ascending-icon]="isSorted(_cell.field, 'asc')"
-                              [class.sort-descending-icon]="isSorted(_cell.field, 'desc')"
-                              [class.sort-value-ascending-icon]="isSorted(_cell.field, 'val-asc')"
-                              [class.sort-value-descending-icon]="isSorted(_cell.field, 'val-desc')"
-                              [class.sort-icon]="isSorted(_cell.field, 'none')"
-                              (click)="sortColumn(_cell, $event)"
-                              aria-hidden="true">
-                            </i>
-                          }
+                          <ng-container ngProjectAs="[sortButton]">
+                            @if (sortDimensionEnable(_cell) && !vsWizard) {
+                              <i sortButton
+                                title="_#(Sort Column)"
+                                class="sort-button vs-header-cell-button-sort hover-bg-secondary"
+                                [class.col-sorted]="isColSorted(_cell)"
+                                [class.sort-ascending-icon]="isSorted(_cell.field, 'asc')"
+                                [class.sort-descending-icon]="isSorted(_cell.field, 'desc')"
+                                [class.sort-value-ascending-icon]="isSorted(_cell.field, 'val-asc')"
+                                [class.sort-value-descending-icon]="isSorted(_cell.field, 'val-desc')"
+                                [class.sort-icon]="isSorted(_cell.field, 'none')"
+                                (click)="sortColumn(_cell, $event)"
+                                aria-hidden="true">
+                              </i>
+                            }
+                          </ng-container>
                         </td>
                       }
                     }

--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.html
@@ -180,20 +180,22 @@
                       outOfZone (onDragover)="dragOverTable($event, j)"
                       (drop)="dropOnTable($event)"
                       [draggable]="isDraggable(true)" (dragstart)="dragStart($event, j)">
-                      @if (isHeaderSortEnabled() && !vsWizard) {
-                        <i sortButton
-                          [class.col-sorted]="isHeaderSortVisible(_cell)"
-                          [class.sort-ascending-icon]="isSorted(_cell.col, 'asc')"
-                          [class.sort-descending-icon]="isSorted(_cell.col, 'desc')"
-                          [class.sort-icon]="isSorted(_cell.col, 'none')"
-                          class="sort-button vs-header-cell-button-sort hover-bg-secondary" aria-hidden="true"
-                          title="_#(viewer.viewsheet.table.sortColumn)"
-                          (click)="sortColumn($event, _cell)">
-                          @if (displaySortNumber(_cell) > 0) {
-                            <label class="sort-number">{{displaySortNumber(_cell)}}</label>
-                          }
-                        </i>
-                      }
+                      <ng-container ngProjectAs="[sortButton]">
+                        @if (isHeaderSortEnabled() && !vsWizard) {
+                          <i sortButton
+                            [class.col-sorted]="isHeaderSortVisible(_cell)"
+                            [class.sort-ascending-icon]="isSorted(_cell.col, 'asc')"
+                            [class.sort-descending-icon]="isSorted(_cell.col, 'desc')"
+                            [class.sort-icon]="isSorted(_cell.col, 'none')"
+                            class="sort-button vs-header-cell-button-sort hover-bg-secondary" aria-hidden="true"
+                            title="_#(viewer.viewsheet.table.sortColumn)"
+                            (click)="sortColumn($event, _cell)">
+                            @if (displaySortNumber(_cell) > 0) {
+                              <label class="sort-number">{{displaySortNumber(_cell)}}</label>
+                            }
+                          </i>
+                        }
+                      </ng-container>
                       <div class="chip" title="_#(Chip)"></div>
                     </td>
                   }


### PR DESCRIPTION
## Summary

After the Angular 20→21 upgrade, the sort icon in table and crosstab column headers no longer displayed in the viewer.

## Root Cause

The sort icon (`<i sortButton ...>`) is rendered through content projection: `vs-table-cell.component.html` projects it via `<ng-content select="[sortButton]">`. The Angular control-flow migration (commit b667af680) converted the `*ngIf` on the icon element into an `@if` block. Content inside built-in control-flow blocks no longer matches named `ng-content` selectors — it is projected only into the default slot, and `vs-table-cell` has no default `<ng-content>`, so the icon was silently dropped.

## Fix

Wrap each `@if` block in `<ng-container ngProjectAs="[sortButton]">` (the canonical Angular pattern for projecting conditional content with built-in control flow). 5 sites: 1 in `vs-table.component.html`, 4 in `vs-crosstab.component.html`. No logic, binding, or condition changes.

## Test Plan

- `ng build portal` succeeds
- `ng test` for vs-table.spec.ts and vs-crosstab.component.spec.ts: 9/9 pass
- `npm run lint` passes
- Manually verified in the viewer: hovering a table/crosstab column header shows the sort icon again, and clicking cycles asc/desc with the icon updating (including value-sort variants on crosstab aggregates)

Fixes Redmine #75345.