### PR TITLE
Bug #75343, adopt the effective theme id from the save response

### DIFF
--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/presentation-themes-view.component.spec.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/presentation-themes-view.component.spec.ts
@@ -1,0 +1,114 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { MatDialog } from "@angular/material/dialog";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { of } from "rxjs";
+import { DownloadService } from "../../../../../../shared/download/download.service";
+import { CustomThemeModel } from "./custom-theme-model";
+import { PresentationThemesViewComponent } from "./presentation-themes-view.component";
+
+describe("PresentationThemesViewComponent", () => {
+   let component: PresentationThemesViewComponent;
+   let fixture: ComponentFixture<PresentationThemesViewComponent>;
+   let http: HttpTestingController;
+   let dialog: any;
+
+   beforeEach(async () => {
+      dialog = {
+         open: vi.fn(() => ({ afterClosed: () => of(true) }))
+      };
+
+      await TestBed.configureTestingModule({
+         imports: [
+            NoopAnimationsModule,
+            HttpClientTestingModule,
+            PresentationThemesViewComponent],
+         providers: [
+            { provide: MatDialog, useValue: dialog },
+            { provide: DownloadService, useValue: { download: vi.fn() } }
+         ],
+         schemas: [
+            NO_ERRORS_SCHEMA
+         ]
+      })
+      .compileComponents();
+   });
+
+   beforeEach(() => {
+      fixture = TestBed.createComponent(PresentationThemesViewComponent);
+      component = fixture.componentInstance;
+      http = TestBed.inject(HttpTestingController);
+      fixture.detectChanges();
+
+      http.expectOne("../api/em/settings/presentation/themes").flush({ themes: [] });
+      http.expectOne("../api/em/navbar/userInfo").flush({ key: "host-org", value: true });
+      http.expectOne("../api/em/navbar/isMultiTenant").flush(false);
+   });
+
+   afterEach(() => {
+      http.verify();
+   });
+
+   it("should create", () => {
+      expect(component).toBeTruthy();
+   });
+
+   // Bug #75343: renaming a theme changes its id on the server (the id follows the name
+   // when they were initialized equal). The save response carries the effective id and the
+   // component must adopt it, or subsequent delete/download requests use the stale id and 404.
+   it("should adopt the effective theme id from the save response (bug #75343)", () => {
+      const original: CustomThemeModel = { id: "theme1", name: "theme1" } as CustomThemeModel;
+      component.themes = [original];
+      const current: CustomThemeModel = { id: "theme1", name: "theme2" } as CustomThemeModel;
+
+      component.saveTheme(current);
+
+      const putReq = http.expectOne("../api/em/settings/presentation/themes/theme1");
+      expect(putReq.request.method).toBe("PUT");
+      putReq.flush({ id: "theme2", name: "theme2" });
+
+      // the local list and selection must carry the renamed id
+      expect(component.themes.length).toBe(1);
+      expect(component.themes[0].id).toBe("theme2");
+      expect(component.selectedTheme.id).toBe("theme2");
+
+      // delete must target the new id, not the stale one
+      component.deleteTheme(component.selectedTheme.id);
+      const deleteReq = http.expectOne("../api/em/settings/presentation/themes/theme2");
+      expect(deleteReq.request.method).toBe("DELETE");
+      deleteReq.flush(null);
+   });
+
+   it("should keep the current id when the save response has no id (bug #75343)", () => {
+      const original: CustomThemeModel = { id: "theme1", name: "theme1" } as CustomThemeModel;
+      component.themes = [original];
+      const current: CustomThemeModel = { id: "theme1", name: "theme2" } as CustomThemeModel;
+
+      component.saveTheme(current);
+
+      // older servers respond with an empty body
+      http.expectOne("../api/em/settings/presentation/themes/theme1").flush(null);
+
+      expect(component.themes[0].id).toBe("theme1");
+      expect(component.selectedTheme.id).toBe("theme1");
+   });
+});

--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/presentation-themes-view.component.spec.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/presentation-themes-view.component.spec.ts
@@ -91,6 +91,11 @@ describe("PresentationThemesViewComponent", () => {
       expect(component.themes[0].id).toBe("theme2");
       expect(component.selectedTheme.id).toBe("theme2");
 
+      // download must target the new id (checked before delete, which clears the selection)
+      const downloadService = TestBed.inject(DownloadService) as any;
+      component.downloadTheme(component.selectedTheme.id);
+      expect(downloadService.download).toHaveBeenCalledWith(expect.stringContaining("theme2"));
+
       // delete must target the new id, not the stale one
       component.deleteTheme(component.selectedTheme.id);
       const deleteReq = http.expectOne("../api/em/settings/presentation/themes/theme2");

--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/presentation-themes-view.component.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/presentation-themes-view.component.ts
@@ -207,7 +207,7 @@ export class PresentationThemesViewComponent implements OnInit {
    saveTheme(current: CustomThemeModel): void {
       if(!!current) {
          const uri = `../api/em/settings/presentation/themes/${Tool.byteEncode(current.id)}`;
-         this.http.put(uri, current).subscribe(() => {
+         this.http.put<CustomThemeModel>(uri, current).subscribe(model => {
             const newThemes = this.themes.slice();
             const index = newThemes.findIndex(t => t.id === current.id);
 
@@ -215,6 +215,13 @@ export class PresentationThemesViewComponent implements OnInit {
                this.clearSelection();
             }
             else {
+               // renaming a theme may change its id on the server (the id follows the
+               // name when they were initialized equal), so adopt the effective id from
+               // the response or subsequent delete/download/save would target a stale id
+               if(!!model?.id) {
+                  current.id = model.id;
+               }
+
                newThemes[index] = Tool.clone(current);
 
                // if current theme is the new default theme then reset the defaultTheme property of


### PR DESCRIPTION
## Summary

Renaming a custom theme in EM (Settings → Presentation → Themes) and applying made the theme impossible to delete or download: both requests failed with `404 (Not Found)` (e.g. `DELETE /api/em/settings/presentation/themes/b`).

## Root Cause

Theme ids are initialized equal to the theme name at creation (`AddThemeDialogComponent.createId()`). A recent enterprise-side change (Epic 70095) made `ThemeService.updateTheme()` rename the theme's **id** to the new name when the id equaled the old name — but the `PUT /api/em/settings/presentation/themes/{id}` endpoint returned `void`, so the client was never told the id changed. `saveTheme()` kept the stale original id in `themes[]` and `selectedTheme`, and every subsequent delete/download/save request targeted the stale id → 404.

## Fix

`saveTheme()` now types the PUT response as `CustomThemeModel` and adopts the **effective id** returned by the server (after locating the list entry by the old id, before cloning into the list and re-selecting). When the response body is empty (older servers), it falls back to the current id, preserving existing behavior.

Companion enterprise PR (returns the updated model from the endpoint): https://github.com/inetsoft-technology/stylebi-enterprise/pull/PENDING

## Test Plan

- New regression spec `presentation-themes-view.component.spec.ts`:
  - save response with renamed id → local list/selection adopt it and DELETE targets the new id (verified to **fail** against the unfixed component)
  - empty save response → id unchanged (older-server fallback)
- All theme-related em specs pass (6/6); `ng build em` and ESLint clean
- Manual: create theme → rename → Apply → Delete and Download both succeed

Fixes Redmine #75343.