### PR TITLE
wiz: resolved-binding echo + strict explicit pins

### DIFF
--- a/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartCombinationUtil.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartCombinationUtil.java
@@ -197,6 +197,12 @@ public class ChartCombinationUtil {
    private static ChartInfosResult getChartInfosWithScores(int n, List<ChartTypeFilter> filters,
                                                             ChartPreference pref)
    {
+      // Pins must be visible during scoring: getClassyInfo prunes score<0 candidates at
+      // generation time, so the aesthetic-guard relaxation has to fire inside getScore.
+      if(pref != null && !pref.isEmpty()) {
+         filters.forEach(f -> f.setPinnedSlots(pref.getSlotFields()));
+      }
+
       getChartCombination(n, filters);
 
       List<ChartInfo> allDefaultInfos = new ArrayList<>();
@@ -205,7 +211,7 @@ public class ChartCombinationUtil {
 
       filters.forEach(f -> {
          if(pref != null) {
-            ChartTypeFilter.FilterResult result = f.filterWithPreference(pref);
+            ChartTypeFilter.FilterResult result = f.filterWithConstraints(pref);
             baseScores.putAll(f.getScores());
 
             result.defaultRanked.stream()

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartCombinationUtil.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartCombinationUtil.java
@@ -199,6 +199,11 @@ public class ChartCombinationUtil {
    {
       // Pins must be visible during scoring: getClassyInfo prunes score<0 candidates at
       // generation time, so the aesthetic-guard relaxation has to fire inside getScore.
+      //
+      // Pins are broadcast to ALL filters by slot name, including map/geo filters
+      // (MapChartFilter, ContourMapChartFilter) where x/y mean longitude/latitude rather
+      // than user-facing fields. A geo pin like x=country simply won't match there, so
+      // geo candidates drop out of prefInfos — expected, not a bug.
       if(pref != null && !pref.isEmpty()) {
          filters.forEach(f -> f.setPinnedSlots(pref.getSlotFields()));
       }

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartTypeFilter.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartTypeFilter.java
@@ -233,6 +233,9 @@ public class ChartTypeFilter {
       case "shape" -> addAestheticName(names, info.getShapeField());
       case "size" -> addAestheticName(names, info.getSizeField());
       case "text" -> addAestheticName(names, info.getTextField());
+      // Non-chart slots (crosstab rows/cols/aggregates/details) are intentionally a no-op:
+      // a chart VSChartInfo has no such slots, so there is nothing to bind here. Those pins
+      // are enforced on the crosstab path, not in this chart filter.
       default -> { }
       }
 
@@ -283,11 +286,15 @@ public class ChartTypeFilter {
    /**
     * Aesthetic cardinality caps for the given chart, in slot order {color, shape, size}.
     * Mirrors the (previously inline) thresholds in getAestheticScore — shape is 5 for
-    * line / 16 for point, size is 200 for word cloud — and is shared with the
-    * post-selection warning in WizAutoBindingService so notes never claim a cap the
-    * scorer didn't apply.
+    * line / 16 for point, size is 200 for word cloud. It is intended to be the single
+    * source of truth for these caps, so a future post-selection warning can report the
+    * same threshold the scorer applied.
     */
    public static int[] aestheticCaps(VSChartInfo info) {
+      if(info == null) {
+         return new int[] { 40, 8, 10 };
+      }
+
       int maxShapes = 8;
       int maxSize = 10;
 

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartTypeFilter.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartTypeFilter.java
@@ -189,6 +189,123 @@ public class ChartTypeFilter {
       return WizardRecommenderUtil.getChartRefFieldName(ref);
    }
 
+   // ── Strict explicit pins ──────────────────────────────────────────────────────
+   // Slot-name → field names the user pinned there. When set, (a) readability guards
+   // in getAestheticScore are relaxed for pinned placements (warn, don't veto), and
+   // (b) filterWithConstraints() keeps only candidates satisfying EVERY pin.
+   private Map<String, Set<String>> pinnedSlots = Collections.emptyMap();
+
+   public void setPinnedSlots(Map<String, Set<String>> pinnedSlots) {
+      this.pinnedSlots = pinnedSlots == null ? Collections.emptyMap() : pinnedSlots;
+   }
+
+   private boolean isPinnedTo(String slot, DataRef ref) {
+      Set<String> fields = pinnedSlots.get(slot);
+      return fields != null && ref != null && fields.contains(getRefFieldName(ref));
+   }
+
+   /**
+    * True iff every pinned (slot, field) pair is realized by this candidate.
+    * Per-pin set containment (NOT a bonus-count equality: a field bound twice in one
+    * slot would make a count exceed the pin total and wrongly drop a satisfying candidate).
+    */
+   protected boolean satisfiesPins(VSChartInfo info, Map<String, Set<String>> slotFields) {
+      for(Map.Entry<String, Set<String>> e : slotFields.entrySet()) {
+         Set<String> bound = boundFieldNames(info, e.getKey());
+
+         if(!bound.containsAll(e.getValue())) {
+            return false;
+         }
+      }
+
+      return true;
+   }
+
+   /** Field names currently bound to the given slot of this candidate. */
+   private Set<String> boundFieldNames(VSChartInfo info, String slot) {
+      Set<String> names = new HashSet<>();
+
+      switch(slot) {
+      case "x" -> addRefNames(names, info.getXFields());
+      case "y" -> addRefNames(names, info.getYFields());
+      case "group" -> addRefNames(names, info.getGroupFields());
+      case "color" -> addAestheticName(names, info.getColorField());
+      case "shape" -> addAestheticName(names, info.getShapeField());
+      case "size" -> addAestheticName(names, info.getSizeField());
+      case "text" -> addAestheticName(names, info.getTextField());
+      default -> { }
+      }
+
+      return names;
+   }
+
+   private void addRefNames(Set<String> names, ChartRef[] refs) {
+      if(refs != null) {
+         for(ChartRef ref : refs) {
+            if(ref != null) {
+               names.add(getRefFieldName(ref));
+            }
+         }
+      }
+   }
+
+   private void addAestheticName(Set<String> names, AestheticRef aref) {
+      if(aref != null && aref.getDataRef() != null) {
+         names.add(getRefFieldName(aref.getDataRef()));
+      }
+   }
+
+   /**
+    * Like {@link #filterWithPreference} but pins are CONSTRAINTS: the prefRanked list
+    * contains only candidates satisfying every pin, sorted by base score.
+    */
+   protected FilterResult filterWithConstraints(ChartPreference pref) {
+      List<ChartInfo> defaultList = filter();
+
+      if(pref == null || pref.isEmpty() || infos.isEmpty()) {
+         return new FilterResult(defaultList, Collections.emptyList());
+      }
+
+      Map<String, Set<String>> slotFields = pref.getSlotFields();
+      List<ChartCombinationUtil.ScoredInfo> satisfying = new ArrayList<>();
+
+      for(ChartInfo info : infos) {
+         if(info instanceof VSChartInfo vsci && satisfiesPins(vsci, slotFields)) {
+            satisfying.add(new ChartCombinationUtil.ScoredInfo(
+               info, scores.getOrDefault(info.hashCode(), 0)));
+         }
+      }
+
+      satisfying.sort(Comparator.comparingInt(ChartCombinationUtil.ScoredInfo::getScore).reversed());
+      return new FilterResult(defaultList, satisfying);
+   }
+
+   /**
+    * Aesthetic cardinality caps for the given chart, in slot order {color, shape, size}.
+    * Mirrors the (previously inline) thresholds in getAestheticScore — shape is 5 for
+    * line / 16 for point, size is 200 for word cloud — and is shared with the
+    * post-selection warning in WizAutoBindingService so notes never claim a cap the
+    * scorer didn't apply.
+    */
+   public static int[] aestheticCaps(VSChartInfo info) {
+      int maxShapes = 8;
+      int maxSize = 10;
+
+      if(GraphTypes.isLine(info.getChartType())) {
+         maxShapes = 5;
+      }
+      else if(GraphTypes.isPoint(info.getChartType())) {
+         maxShapes = 16;
+
+         // word cloud
+         if(info.getTextField() != null) {
+            maxSize = 200;
+         }
+      }
+
+      return new int[] { 40, maxShapes, maxSize };
+   }
+
    /**
     * Get the scores from chart info (hash) to it's score.
     */
@@ -552,23 +669,10 @@ public class ChartTypeFilter {
       // high-cardinality dimension to color/shape/size is infeasible (unreadable legend) whether or
       // not auto-ordering is on. Only the graduated ordering *preference* depends on autoOrder.
       int score = 0;
-      int maxShapes = 8;
-      int maxSize = 10;
-
-      if(GraphTypes.isLine(info.getChartType())) {
-         maxShapes = 5;
-      }
-      else if(GraphTypes.isPoint(info.getChartType())) {
-         maxShapes = 16;
-
-         // word cloud
-         if(info.getTextField() != null) {
-            maxSize = 200;
-         }
-      }
 
       AestheticRef[] arefs = { info.getColorField(), info.getShapeField(), info.getSizeField() };
-      int[] maxN = { 40, maxShapes, maxSize };
+      int[] maxN = aestheticCaps(info);
+      String[] slotNames = { "color", "shape", "size" };
 
       for(int i = 0; i < arefs.length; i++) {
          AestheticRef aref = arefs[i];
@@ -577,6 +681,11 @@ public class ChartTypeFilter {
             ChartRef ref = (ChartRef) aref.getDataRef();
 
             if(ref instanceof VSChartDimensionRef) {
+               // user pinned this dimension here: readability is a warning upstream, not a veto
+               if(isPinnedTo(slotNames[i], ref)) {
+                  continue;
+               }
+
                int n = getCardinality(ref);
                double max = autoOrder ? maxN[i] : (maxN[i] * 1.5);
 

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartTypeFilter.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartTypeFilter.java
@@ -261,6 +261,11 @@ public class ChartTypeFilter {
    /**
     * Like {@link #filterWithPreference} but pins are CONSTRAINTS: the prefRanked list
     * contains only candidates satisfying every pin, sorted by base score.
+    *
+    * <p>defaultRanked intentionally remains the FULL candidate universe (same as
+    * {@link #filter()}), NOT the pin-satisfying subset. Pins only constrain the primary
+    * selection (driven by prefRanked); the recommendation list shown to the user lists
+    * every feasible chart type so they can still switch to a type the pins don't fit.
     */
    protected FilterResult filterWithConstraints(ChartPreference pref) {
       List<ChartInfo> defaultList = filter();

--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -23,11 +23,13 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.util.Tool;
 import inetsoft.web.wiz.model.CloseViewsheetRequest;
 import inetsoft.web.wiz.model.OpenViewsheetResult;
 import inetsoft.web.wiz.service.WizVisualizationService;
+import inetsoft.web.wiz.service.WizVsService;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,8 +44,11 @@ import java.security.Principal;
 @RequestMapping("/api/wiz")
 public class ViewsheetRuntimeController {
 
-   public ViewsheetRuntimeController(ViewsheetService viewsheetService) {
+   public ViewsheetRuntimeController(ViewsheetService viewsheetService,
+                                     WizVsService wizVsService)
+   {
       this.viewsheetService = viewsheetService;
+      this.wizVsService = wizVsService;
    }
 
    /**
@@ -79,16 +84,24 @@ public class ViewsheetRuntimeController {
 
       OpenViewsheetResult result = new OpenViewsheetResult();
       result.setRuntimeId(runtimeId);
-      result.setAssemblyName(findChartAssemblyName(runtimeId, user));
+
+      VSAssembly assembly = findChartAssembly(runtimeId, user);
+
+      if(assembly != null) {
+         result.setAssemblyName(assembly.getName());
+         result.setBinding(wizVsService.collectFlatBinding(assembly));
+      }
+
       return result;
    }
 
    /**
-    * Resolve the primary chart assembly name of an opened runtime so callers can drive
-    * filter/browse-data/embed without a separate lookup. Prefers a chart assembly; falls
-    * back to the first assembly. Returns null if it cannot be determined (non-fatal).
+    * Resolve the primary chart assembly of an opened runtime so callers can drive
+    * filter/browse-data/embed (and echo its binding) without a separate lookup. Prefers a
+    * chart assembly; falls back to the first assembly. Returns null if it cannot be
+    * determined (non-fatal).
     */
-   private String findChartAssemblyName(String runtimeId, Principal user) {
+   private VSAssembly findChartAssembly(String runtimeId, Principal user) {
       try {
          RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, user);
          Viewsheet vs = rvs != null ? rvs.getViewsheet() : null;
@@ -99,12 +112,12 @@ public class ViewsheetRuntimeController {
          }
 
          for(Assembly a : assemblies) {
-            if(a instanceof ChartVSAssembly) {
-               return a.getName();
+            if(a instanceof ChartVSAssembly chart) {
+               return chart;
             }
          }
 
-         return assemblies[0].getName();
+         return assemblies[0] instanceof VSAssembly vsa ? vsa : null;
       }
       catch(Exception e) {
          log.warn("Could not resolve primary chart assembly for runtime {}: {}", runtimeId, e.getMessage());
@@ -130,5 +143,6 @@ public class ViewsheetRuntimeController {
    }
 
    private final ViewsheetService viewsheetService;
+   private final WizVsService wizVsService;
    private static final Logger log = LoggerFactory.getLogger(ViewsheetRuntimeController.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -117,6 +117,8 @@ public class ViewsheetRuntimeController {
             }
          }
 
+         // No chart found: fall back to the first assembly if it's a VSAssembly. A non-VSAssembly
+         // first assembly yields null (the response omits the binding) rather than a name we can't use.
          return assemblies[0] instanceof VSAssembly vsa ? vsa : null;
       }
       catch(Exception e) {

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
@@ -66,17 +66,13 @@ public class WizViewsheetController {
    }
 
    @PostMapping(value = "/viewsheet/format", produces = MediaType.APPLICATION_JSON_VALUE)
-   public CreateViewsheetResult setChartFormat(@RequestBody ChartFormatRequest request,
-                                               Principal user) throws Exception
-   {
-      return wizAutoBindingService.setChartFormat(request, user);
+   public ResponseEntity<?> setChartFormat(@RequestBody ChartFormatRequest request, Principal user) {
+      return run("set chart format", () -> wizAutoBindingService.setChartFormat(request, user));
    }
 
    @PostMapping(value = "/viewsheet/colors", produces = MediaType.APPLICATION_JSON_VALUE)
-   public CreateViewsheetResult setChartColors(@RequestBody ChartColorsRequest request,
-                                               Principal user) throws Exception
-   {
-      return wizAutoBindingService.setChartColors(request, user);
+   public ResponseEntity<?> setChartColors(@RequestBody ChartColorsRequest request, Principal user) {
+      return run("set chart colors", () -> wizAutoBindingService.setChartColors(request, user));
    }
 
    @DeleteMapping("/viewsheet")
@@ -97,19 +93,25 @@ public class WizViewsheetController {
       }
       // Must precede the IllegalArgumentException catch below (it is a subclass), else it is shadowed.
       catch(UnsatisfiableBindingException e) {
+         // Map.of rejects null values, and String.valueOf(null) would emit the literal
+         // string "null"; coerce absent fields to "" so the JSON body stays meaningful.
          return ResponseEntity.badRequest().body(Map.of(
             "error", "unsatisfiable explicit binding",
-            "pin", Map.of("role", String.valueOf(e.getRole()), "field", String.valueOf(e.getField())),
-            "reason", String.valueOf(e.getReason())));
+            "pin", Map.of("role", nullToEmpty(e.getRole()), "field", nullToEmpty(e.getField())),
+            "reason", nullToEmpty(e.getReason())));
       }
       catch(IllegalArgumentException e) {
-         return ResponseEntity.badRequest().body(Map.of("error", String.valueOf(e.getMessage())));
+         return ResponseEntity.badRequest().body(Map.of("error", nullToEmpty(e.getMessage())));
       }
       catch(Exception e) {
          LOG.error("Failed to {}", action, e);
          return ResponseEntity.internalServerError()
             .body(Map.of("error", "An unexpected error occurred. Please try again."));
       }
+   }
+
+   private static String nullToEmpty(String value) {
+      return value == null ? "" : value;
    }
 
    private final WizVsService wizVsService;

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
@@ -29,7 +29,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/wiz")
@@ -95,10 +97,22 @@ public class WizViewsheetController {
       catch(UnsatisfiableBindingException e) {
          // Map.of rejects null values, and String.valueOf(null) would emit the literal
          // string "null"; coerce absent fields to "" so the JSON body stays meaningful.
-         return ResponseEntity.badRequest().body(Map.of(
-            "error", "unsatisfiable explicit binding",
-            "pin", Map.of("role", nullToEmpty(e.getRole()), "field", nullToEmpty(e.getField())),
-            "reason", nullToEmpty(e.getReason())));
+         Map<String, Object> errorBody = new LinkedHashMap<>();
+         errorBody.put("error", "unsatisfiable explicit binding");
+
+         // A set-conflict failure carries every pin (no single culprit); report them all
+         // as "pins". A single-pin failure carries just role/field; report it as "pin".
+         if(!e.getPins().isEmpty()) {
+            errorBody.put("pins", e.getPins().stream()
+               .map(p -> Map.of("role", nullToEmpty(p.role()), "field", nullToEmpty(p.field())))
+               .collect(Collectors.toList()));
+         }
+         else {
+            errorBody.put("pin", Map.of("role", nullToEmpty(e.getRole()), "field", nullToEmpty(e.getField())));
+         }
+
+         errorBody.put("reason", nullToEmpty(e.getReason()));
+         return ResponseEntity.badRequest().body(errorBody);
       }
       catch(IllegalArgumentException e) {
          return ResponseEntity.badRequest().body(Map.of("error", nullToEmpty(e.getMessage())));

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
@@ -19,6 +19,7 @@
 package inetsoft.web.wiz.controller;
 
 import inetsoft.web.wiz.model.*;
+import inetsoft.web.wiz.service.UnsatisfiableBindingException;
 import inetsoft.web.wiz.service.WizAutoBindingService;
 import inetsoft.web.wiz.service.WizVsService;
 import org.slf4j.Logger;
@@ -93,6 +94,13 @@ public class WizViewsheetController {
    private ResponseEntity<?> run(String action, ControllerAction body) {
       try {
          return ResponseEntity.ok(body.run());
+      }
+      // Must precede the IllegalArgumentException catch below (it is a subclass), else it is shadowed.
+      catch(UnsatisfiableBindingException e) {
+         return ResponseEntity.badRequest().body(Map.of(
+            "error", "unsatisfiable explicit binding",
+            "pin", Map.of("role", String.valueOf(e.getRole()), "field", String.valueOf(e.getField())),
+            "reason", String.valueOf(e.getReason())));
       }
       catch(IllegalArgumentException e) {
          return ResponseEntity.badRequest().body(Map.of("error", String.valueOf(e.getMessage())));

--- a/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
@@ -17,10 +17,16 @@
  */
 package inetsoft.web.wiz.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Request body for {@code POST /api/wiz/viewsheet/format} — applies chart-level FORMAT properties
  * (axis titles, y-axis scale, legend placement) to an existing runtime chart and re-renders it.
  * All format fields are optional; only the non-null ones are applied (a no-op field is left as-is).
+ * The axis getters need explicit {@code @JsonProperty} names: Jackson's bean-naming rule lowercases
+ * the leading consecutive capitals of {@code getXAxisTitle} to property {@code xaxisTitle}, which
+ * silently rejects the camelCase {@code xAxisTitle} the wiz-services client sends
+ * (FAIL_ON_UNKNOWN_PROPERTIES → HttpMessageNotReadableException → 400).
  */
 public class ChartFormatRequest {
    public String getWizRuntimeId() { return wizRuntimeId; }
@@ -32,21 +38,27 @@ public class ChartFormatRequest {
    public String getViewsheetIdentifier() { return viewsheetIdentifier; }
    public void setViewsheetIdentifier(String viewsheetIdentifier) { this.viewsheetIdentifier = viewsheetIdentifier; }
 
+   @JsonProperty("xAxisTitle")
    public String getXAxisTitle() { return xAxisTitle; }
    public void setXAxisTitle(String xAxisTitle) { this.xAxisTitle = xAxisTitle; }
 
+   @JsonProperty("yAxisTitle")
    public String getYAxisTitle() { return yAxisTitle; }
    public void setYAxisTitle(String yAxisTitle) { this.yAxisTitle = yAxisTitle; }
 
+   @JsonProperty("yAxisMin")
    public Double getYAxisMin() { return yAxisMin; }
    public void setYAxisMin(Double yAxisMin) { this.yAxisMin = yAxisMin; }
 
+   @JsonProperty("yAxisMax")
    public Double getYAxisMax() { return yAxisMax; }
    public void setYAxisMax(Double yAxisMax) { this.yAxisMax = yAxisMax; }
 
+   @JsonProperty("yAxisIncrement")
    public Double getYAxisIncrement() { return yAxisIncrement; }
    public void setYAxisIncrement(Double yAxisIncrement) { this.yAxisIncrement = yAxisIncrement; }
 
+   @JsonProperty("yAxisLogarithmic")
    public Boolean getYAxisLogarithmic() { return yAxisLogarithmic; }
    public void setYAxisLogarithmic(Boolean yAxisLogarithmic) { this.yAxisLogarithmic = yAxisLogarithmic; }
 

--- a/core/src/main/java/inetsoft/web/wiz/model/CreateViewsheetResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/CreateViewsheetResult.java
@@ -145,12 +145,22 @@ public class CreateViewsheetResult {
     * Flat representation of an assembly's data binding.
     * All dimension refs are collected into {@code dimensions} regardless of which
     * axis/role they occupy in the original binding; likewise for {@code measures}.
+    * {@code slots} reports the RESOLVED placement (which slot each field landed in);
+    * {@code notes} carries structured decisions (e.g. a readability guard overridden
+    * because the user pinned the field).
     */
    @JsonInclude(JsonInclude.Include.NON_NULL)
    public static class FlatBinding {
       public FlatBinding(List<DimensionFieldInfo> dimensions, List<MeasureFieldInfo> measures) {
+         this(dimensions, measures, null);
+      }
+
+      public FlatBinding(List<DimensionFieldInfo> dimensions, List<MeasureFieldInfo> measures,
+                         Map<String, Object> slots)
+      {
          this.dimensions = dimensions;
          this.measures = measures;
+         this.slots = slots;
       }
 
       public List<DimensionFieldInfo> getDimensions() {
@@ -161,7 +171,46 @@ public class CreateViewsheetResult {
          return measures;
       }
 
+      /** Resolved slot placement: list-valued for x/y/group, string-or-null for aesthetics. */
+      public Map<String, Object> getSlots() {
+         return slots;
+      }
+
+      public List<BindingNote> getNotes() {
+         return notes;
+      }
+
+      public void setNotes(List<BindingNote> notes) {
+         this.notes = notes;
+      }
+
       private final List<DimensionFieldInfo> dimensions;
       private final List<MeasureFieldInfo> measures;
+      private final Map<String, Object> slots;
+      private List<BindingNote> notes;
+   }
+
+   /** A structured binding decision surfaced to the caller. */
+   @JsonInclude(JsonInclude.Include.NON_NULL)
+   public static class BindingNote {
+      public BindingNote(String field, String role, boolean honored, String severity, String reason) {
+         this.field = field;
+         this.role = role;
+         this.honored = honored;
+         this.severity = severity;
+         this.reason = reason;
+      }
+
+      public String getField() { return field; }
+      public String getRole() { return role; }
+      public boolean isHonored() { return honored; }
+      public String getSeverity() { return severity; }
+      public String getReason() { return reason; }
+
+      private final String field;
+      private final String role;
+      private final boolean honored;
+      private final String severity;
+      private final String reason;
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/CreateViewsheetResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/CreateViewsheetResult.java
@@ -151,10 +151,6 @@ public class CreateViewsheetResult {
     */
    @JsonInclude(JsonInclude.Include.NON_NULL)
    public static class FlatBinding {
-      public FlatBinding(List<DimensionFieldInfo> dimensions, List<MeasureFieldInfo> measures) {
-         this(dimensions, measures, null);
-      }
-
       public FlatBinding(List<DimensionFieldInfo> dimensions, List<MeasureFieldInfo> measures,
                          Map<String, Object> slots)
       {

--- a/core/src/main/java/inetsoft/web/wiz/model/OpenViewsheetResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/OpenViewsheetResult.java
@@ -40,6 +40,15 @@ public class OpenViewsheetResult {
       this.assemblyName = assemblyName;
    }
 
+   public CreateViewsheetResult.FlatBinding getBinding() {
+      return binding;
+   }
+
+   public void setBinding(CreateViewsheetResult.FlatBinding binding) {
+      this.binding = binding;
+   }
+
    private String runtimeId;
    private String assemblyName;
+   private CreateViewsheetResult.FlatBinding binding;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/OpenViewsheetResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/OpenViewsheetResult.java
@@ -18,11 +18,14 @@
 
 package inetsoft.web.wiz.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * Result of opening a saved wiz viewsheet: the runtime id plus the primary chart
  * assembly name, so callers can drive subsequent runtime operations (filter, browse-data,
  * embed) without a separate assembly lookup.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OpenViewsheetResult {
    public String getRuntimeId() {
       return runtimeId;

--- a/core/src/main/java/inetsoft/web/wiz/service/UnsatisfiableBindingException.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/UnsatisfiableBindingException.java
@@ -17,12 +17,38 @@
  */
 package inetsoft.web.wiz.service;
 
+import java.util.List;
+
 /** An explicit binding pin that cannot be honored. Maps to HTTP 400 with a structured body. */
 public class UnsatisfiableBindingException extends IllegalArgumentException {
+   /** A single offending pin (role + field) for the multi-pin set-conflict case. */
+   public record Pin(String role, String field) {}
+
+   /**
+    * Single-pin failure: this specific pin is invalid on its own (unknown slot,
+    * wrong field type, missing field, etc.). The body names this one pin.
+    */
    public UnsatisfiableBindingException(String role, String field, String reason) {
-      super("unsatisfiable explicit binding: " + role + "=" + field + " (" + reason + ")");
+      // Use a placeholder for null role/field so the log message reads
+      // "<missing>=amount" rather than "null=amount".
+      super("unsatisfiable explicit binding: " + orMissing(role) + "=" + orMissing(field)
+               + " (" + reason + ")");
       this.role = role;
       this.field = field;
+      this.pins = List.of();
+      this.reason = reason;
+   }
+
+   /**
+    * Set-conflict failure: the pins cannot all be satisfied together, and no single
+    * pin is necessarily the culprit (each may be individually valid). The body reports
+    * every pin so the client isn't misled into "fixing" a pin that is already valid.
+    */
+   public UnsatisfiableBindingException(List<Pin> pins, String reason) {
+      super("unsatisfiable explicit bindings: " + pins + " (" + reason + ")");
+      this.role = null;
+      this.field = null;
+      this.pins = pins == null ? List.of() : List.copyOf(pins);
       this.reason = reason;
    }
 
@@ -34,11 +60,21 @@ public class UnsatisfiableBindingException extends IllegalArgumentException {
       return field;
    }
 
+   /** The full set of conflicting pins, or empty for a single-pin failure. */
+   public List<Pin> getPins() {
+      return pins;
+   }
+
    public String getReason() {
       return reason;
    }
 
+   private static String orMissing(String value) {
+      return value != null ? value : "<missing>";
+   }
+
    private final String role;
    private final String field;
+   private final List<Pin> pins;
    private final String reason;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/UnsatisfiableBindingException.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/UnsatisfiableBindingException.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+/** An explicit binding pin that cannot be honored. Maps to HTTP 400 with a structured body. */
+public class UnsatisfiableBindingException extends IllegalArgumentException {
+   public UnsatisfiableBindingException(String role, String field, String reason) {
+      super("unsatisfiable explicit binding: " + role + "=" + field + " (" + reason + ")");
+      this.role = role;
+      this.field = field;
+      this.reason = reason;
+   }
+
+   public String getRole() {
+      return role;
+   }
+
+   public String getField() {
+      return field;
+   }
+
+   public String getReason() {
+      return reason;
+   }
+
+   private final String role;
+   private final String field;
+   private final String reason;
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -193,8 +193,12 @@ public class WizAutoBindingService {
                && selectedRec instanceof VSChartRecommendation vcr
                && (vcr.getPrefInfos() == null || vcr.getPrefInfos().isEmpty()))
             {
-               ExplicitBinding firstPin = explicitBindings.get(0);
-               throw new UnsatisfiableBindingException(firstPin.getRole(), firstPin.getField(),
+               // The conflict is between the pins AS A SET — any single pin may be valid on
+               // its own — so report all of them rather than blaming the first.
+               List<UnsatisfiableBindingException.Pin> pins = explicitBindings.stream()
+                  .map(b -> new UnsatisfiableBindingException.Pin(b.getRole(), b.getField()))
+                  .collect(Collectors.toList());
+               throw new UnsatisfiableBindingException(pins,
                   "no chart combination supports this placement for the bound fields");
             }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -32,10 +32,12 @@ import inetsoft.util.Tool;
 import inetsoft.web.vswizard.handler.VSWizardBindingHandler;
 import inetsoft.web.vswizard.model.VSWizardData;
 import inetsoft.web.vswizard.model.recommender.*;
+import inetsoft.web.vswizard.recommender.ChartRecommenderUtil;
 import inetsoft.web.vswizard.recommender.VSDefaultRecommendationFactory;
 import inetsoft.web.vswizard.recommender.WizardRecommenderUtil;
 import inetsoft.web.vswizard.recommender.chart.ChartCombinationUtil;
 import inetsoft.web.vswizard.recommender.chart.ChartPreference;
+import inetsoft.web.vswizard.recommender.chart.ChartTypeFilter;
 import inetsoft.web.viewsheet.service.CommandDispatcher;
 import inetsoft.web.vswizard.service.VSWizardTemporaryInfoService;
 import inetsoft.uql.viewsheet.graph.Calculator;
@@ -162,6 +164,9 @@ public class WizAutoBindingService {
 
          String vizType = request.getVisualizationType();
          List<ExplicitBinding> explicitBindings = request.getExplicitBindings();
+         // Fail fast on impossible pins (unknown slot/field, measure→dimension-only slot, etc.)
+         // before running the recommender, so the caller gets a structured 400.
+         validateExplicitBindings(explicitBindings, configMap, entries);
          ChartPreference pref = buildChartPreference(explicitBindings);
          VSWizardData wizardData = new VSWizardData(entries, tempInfo, pref);
          VSRecommendationModel model = defaultRecommendationFactory.recommend(wizardData, rvs, user);
@@ -179,6 +184,19 @@ public class WizAutoBindingService {
 
             String intentCategory = request.getIntentCategory();
             selectedRec = selectPrimaryRecommendation(model, vizType, explicitBindings, intentCategory);
+
+            // Strict pins: when explicit bindings are present and the selected chart has NO
+            // pin-satisfying candidate (prefInfos empty/null — the constraints filter rejected every
+            // combination for these fields), there is no honest placement. Fail with a 400 rather
+            // than rendering an unconstrained chart that ignores the pins.
+            if(explicitBindings != null && !explicitBindings.isEmpty()
+               && selectedRec instanceof VSChartRecommendation vcr
+               && (vcr.getPrefInfos() == null || vcr.getPrefInfos().isEmpty()))
+            {
+               ExplicitBinding firstPin = explicitBindings.get(0);
+               throw new UnsatisfiableBindingException(firstPin.getRole(), firstPin.getField(),
+                  "no chart combination supports this placement for the bound fields");
+            }
 
             // Mirror the wizard path: call updatePrimaryAssembly on autoBindingRvs so it gets
             // the same full setup (calc field registration, format, legend, temp assembly cleanup).
@@ -223,6 +241,18 @@ public class WizAutoBindingService {
             if(Tool.isEmptyString(visualizationResult.getRuntimeId())) {
                visualizationResult.setRuntimeId(request.getWizRuntimeId());
             }
+
+            // Readability warnings: a PINNED aesthetic dimension whose cardinality exceeds the slot
+            // cap renders but may be unreadable. The recommender already respected caps on UNPINNED
+            // slots, so warn only for pinned ones. Honored stays true — we kept the user's pin.
+            if(explicitBindings != null && !explicitBindings.isEmpty()
+               && primaryAssembly instanceof ChartVSAssembly chartAsm
+               && chartAsm.getVSChartInfo() != null
+               && visualizationResult.getBinding() != null)
+            {
+               addReadabilityWarnings(visualizationResult.getBinding(), chartAsm.getVSChartInfo(),
+                                      explicitBindings, entries);
+            }
          }
 
          // Phase 4: build response.
@@ -237,10 +267,14 @@ public class WizAutoBindingService {
 
          // Tell the caller when a requested type could not be honored, so it can explain the
          // substitution to the user instead of the swap happening silently.
-         if(vizType != null && primary != null && !requestedTypeAvailable(vizType, model)) {
-            resp.setSelectionNote(
-               "Requested chart type '" + vizType + "' is not feasible for this data; used '" +
-               primary.getVisualizationType() + "' instead.");
+         boolean pinsPresent = explicitBindings != null && !explicitBindings.isEmpty();
+
+         if(vizType != null && primary != null && !requestedTypeAvailable(vizType, model, pinsPresent)) {
+            resp.setSelectionNote(pinsPresent
+               ? "Requested chart type '" + vizType + "' has no candidate honoring the explicit " +
+                 "bindings; used '" + primary.getVisualizationType() + "' instead."
+               : "Requested chart type '" + vizType + "' is not feasible for this data; used '" +
+                 primary.getVisualizationType() + "' instead.");
          }
 
          succeeded = true;
@@ -312,6 +346,12 @@ public class WizAutoBindingService {
       for(ChartRef ref : chartInfo.getYFields()) {
          applyFieldConfig(ref, configMap);
       }
+
+      // Aesthetics carry the same per-field config (title/format, ranking/aggregate) as x/y.
+      applyAestheticFieldConfig(chartInfo.getColorField(), configMap);
+      applyAestheticFieldConfig(chartInfo.getShapeField(), configMap);
+      applyAestheticFieldConfig(chartInfo.getSizeField(), configMap);
+      applyAestheticFieldConfig(chartInfo.getTextField(), configMap);
    }
 
    private void applyAestheticFieldConfig(AestheticRef aestheticRef,
@@ -319,6 +359,64 @@ public class WizAutoBindingService {
    {
       if(aestheticRef != null && aestheticRef.getDataRef() instanceof ChartRef ref) {
          applyFieldConfig(ref, configMap);
+      }
+   }
+
+   // ── Post-selection readability warnings ──────────────────────────────────────
+
+   /**
+    * Adds a warning {@link CreateViewsheetResult.BindingNote} for each PINNED aesthetic dimension
+    * whose distinct-value count exceeds the chart's cap for that slot. Caps come from
+    * {@link ChartTypeFilter#aestheticCaps(VSChartInfo)} (index 0=color, 1=shape, 2=size) and
+    * cardinality from {@link ChartRecommenderUtil#getCardinality(ChartRef, AssetEntry[])} — the same
+    * source the recommender's getAestheticScore uses. Notes are appended to any existing binding notes.
+    */
+   private void addReadabilityWarnings(CreateViewsheetResult.FlatBinding binding, VSChartInfo ci,
+                                       List<ExplicitBinding> pins, AssetEntry[] entries)
+   {
+      int[] caps = ChartTypeFilter.aestheticCaps(ci);
+      List<CreateViewsheetResult.BindingNote> notes = new ArrayList<>();
+
+      addCapWarning(notes, "color", ci.getColorField(), caps[0], pins, entries);
+      addCapWarning(notes, "shape", ci.getShapeField(), caps[1], pins, entries);
+      addCapWarning(notes, "size", ci.getSizeField(), caps[2], pins, entries);
+
+      if(!notes.isEmpty()) {
+         List<CreateViewsheetResult.BindingNote> existing = binding.getNotes();
+
+         if(existing != null && !existing.isEmpty()) {
+            List<CreateViewsheetResult.BindingNote> merged = new ArrayList<>(existing);
+            merged.addAll(notes);
+            binding.setNotes(merged);
+         }
+         else {
+            binding.setNotes(notes);
+         }
+      }
+   }
+
+   private void addCapWarning(List<CreateViewsheetResult.BindingNote> notes, String slot,
+                              AestheticRef aref, int cap, List<ExplicitBinding> pins,
+                              AssetEntry[] entries)
+   {
+      if(aref == null || !(aref.getDataRef() instanceof VSChartDimensionRef dim)) {
+         return;
+      }
+
+      String field = WizardRecommenderUtil.getChartRefFieldName(dim);
+      boolean pinned = pins.stream()
+         .anyMatch(p -> slot.equals(p.getRole()) && Objects.equals(field, p.getField()));
+
+      if(!pinned) {
+         return;
+      }
+
+      int n = ChartRecommenderUtil.getCardinality(dim, entries);
+
+      if(n > cap) {
+         notes.add(new CreateViewsheetResult.BindingNote(field, slot, true, "warning",
+            "cardinality " + n + " exceeds " + slot + " cap " + cap +
+            "; legend may be unreadable — consider a roll-up"));
       }
    }
 
@@ -468,6 +566,82 @@ public class WizAutoBindingService {
    }
 
    // ── Chart preference helpers ──────────────────────────────────────────────────
+
+   // Slot vocabularies. A role appearing in NEITHER set is an unknown slot.
+   // Chart slots (x/y/group/color/shape/size/text) are the ones the constraints filter enforces;
+   // rows/cols/aggregates/details are crosstab/table roles that we ACCEPT as known (so a
+   // crosstab-role pin does not 400 as "unknown") even though the chart filter does not enforce them.
+   private static final Set<String> DIMENSION_SLOTS =
+      Set.of("x", "y", "color", "shape", "size", "text", "group", "rows", "cols", "details");
+   private static final Set<String> MEASURE_SLOTS =
+      Set.of("x", "y", "color", "size", "text", "aggregates");
+
+   /**
+    * Validates explicit binding pins up front, before recommendation, so impossible pins fail fast
+    * with a structured 400 instead of silently producing a different chart. No-op on empty pins.
+    *
+    * <p>Field existence is checked against {@code configMap} when field configs are provided
+    * (plugin path), else against the worksheet {@code entries} (chat-app path). Measure/dimension
+    * slot-compatibility is only enforced when the field's type is known from its config; a field
+    * validated against entries alone has unknown measure/dimension role here, so the type check is
+    * skipped (the recommender's constraints filter still rejects truly impossible placements).
+    */
+   static void validateExplicitBindings(List<ExplicitBinding> bindings,
+                                        Map<String, SimpleFieldInfo> configMap,
+                                        AssetEntry[] entries)
+   {
+      if(bindings == null || bindings.isEmpty()) {
+         return;
+      }
+
+      Set<String> entryFieldNames = entries == null ? Collections.emptySet()
+         : Arrays.stream(entries)
+            .map(WizardRecommenderUtil::getFieldName)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+      for(ExplicitBinding eb : bindings) {
+         String role = eb.getRole();
+         String field = eb.getField();
+
+         if(role == null) {
+            throw new UnsatisfiableBindingException(null, field, "missing slot/role");
+         }
+
+         if(field == null) {
+            throw new UnsatisfiableBindingException(role, null, "missing field");
+         }
+
+         // unknown slot: role belongs to neither the dimension- nor the measure-capable set.
+         if(!DIMENSION_SLOTS.contains(role) && !MEASURE_SLOTS.contains(role)) {
+            throw new UnsatisfiableBindingException(role, field, "unknown slot");
+         }
+
+         SimpleFieldInfo fc = configMap != null ? configMap.get(field) : null;
+         boolean hasConfigs = configMap != null && !configMap.isEmpty();
+
+         // Field existence: prefer fieldConfigs (plugin path), else the worksheet entries.
+         if(hasConfigs) {
+            if(fc == null) {
+               throw new UnsatisfiableBindingException(role, field, "field not in fieldConfigs");
+            }
+         }
+         else if(!entryFieldNames.contains(field)) {
+            throw new UnsatisfiableBindingException(role, field, "field not in worksheet columns");
+         }
+
+         // Measure/dimension slot-compatibility — only when the field's type is known from its config.
+         if(fc instanceof MeasureFieldInfo && !MEASURE_SLOTS.contains(role)) {
+            throw new UnsatisfiableBindingException(
+               role, field, "measure cannot be placed in dimension-only slot");
+         }
+
+         if(fc instanceof DimensionFieldInfo && !DIMENSION_SLOTS.contains(role)) {
+            throw new UnsatisfiableBindingException(
+               role, field, "dimension cannot be placed in measure-only slot");
+         }
+      }
+   }
 
    private static ChartPreference buildChartPreference(List<ExplicitBinding> bindings) {
       if(bindings == null || bindings.isEmpty()) {
@@ -700,14 +874,19 @@ public class WizAutoBindingService {
                                                                String intentCategory)
    {
       List<VSObjectRecommendation> recs = model.getRecommendationList();
+      boolean pinsPresent = explicitBindings != null && !explicitBindings.isEmpty();
 
       if(vizType != null) {
-         VSObjectRecommendation found = findRecByType(vizType, model);
+         VSObjectRecommendation found = findRecByType(vizType, model, pinsPresent);
 
          if(found == null && !recs.isEmpty()) {
             LOG.debug("Requested vizType '{}' not found in recommendations; returning top recommendation", vizType);
          }
 
+         // When pins are present and the requested type has no pin-satisfying candidate, fall back to
+         // the best SATISFYING candidate (selectTopRecommendation walks prefInfos first) rather than
+         // the unconstrained chartInfos — never silently bypass the pins. The selectionNote on the
+         // response (driven by requestedTypeAvailable, also pin-aware) reports the substitution.
          return found != null ? found : selectTopRecommendation(recs, intentCategory);
       }
 
@@ -715,7 +894,7 @@ public class WizAutoBindingService {
          String inferredType = inferNonChartVizType(explicitBindings);
 
          if(inferredType != null) {
-            VSObjectRecommendation found = findRecByType(inferredType, model);
+            VSObjectRecommendation found = findRecByType(inferredType, model, pinsPresent);
 
             if(found != null) {
                return found;
@@ -730,10 +909,12 @@ public class WizAutoBindingService {
     * Finds the recommendation matching {@code vizType} and sets {@code selectedIndex}
     * on {@link VSChartRecommendation} when a specific chart sub-type is requested.
     */
-   private VSObjectRecommendation findRecByType(String vizType, VSRecommendationModel model) {
+   private VSObjectRecommendation findRecByType(String vizType, VSRecommendationModel model,
+                                                boolean pinsPresent)
+   {
       for(VSObjectRecommendation rec : model.getRecommendationList()) {
          if(isChartVizType(vizType) && rec instanceof VSChartRecommendation cr) {
-            if(setChartIndexForType(cr, vizType)) {
+            if(setChartIndexForType(cr, vizType, pinsPresent)) {
                return cr;
             }
          }
@@ -795,8 +976,15 @@ public class WizAutoBindingService {
       return null;
    }
 
-   /** Sets {@code selectedIndex} on {@code vcr} for the best chart matching {@code explicitChartType}. */
-   private boolean setChartIndexForType(VSChartRecommendation vcr, String explicitChartType) {
+   /**
+    * Sets {@code selectedIndex} on {@code vcr} for the best chart matching {@code explicitChartType}.
+    * When {@code pinsPresent}, the unconstrained {@code chartInfos} fallback is skipped: prefInfos
+    * already contains ONLY pin-satisfying candidates, so falling through to chartInfos would
+    * silently bypass the pins. A false return then lets the caller pick the best satisfying candidate.
+    */
+   private boolean setChartIndexForType(VSChartRecommendation vcr, String explicitChartType,
+                                        boolean pinsPresent)
+   {
       List<ChartCombinationUtil.ScoredInfo> prefInfos = vcr.getPrefInfos();
       List<ChartInfo> chartInfos = vcr.getChartInfos();
       int chartInfosSize = chartInfos != null ? chartInfos.size() : 0;
@@ -808,6 +996,11 @@ public class WizAutoBindingService {
                return true;
             }
          }
+      }
+
+      // Pins present: do NOT scan unconstrained chartInfos (silent-bypass guard).
+      if(pinsPresent) {
+         return false;
       }
 
       if(chartInfos != null) {
@@ -1153,7 +1346,9 @@ public class WizAutoBindingService {
     * but, unlike findRecByType, does not mutate any {@code selectedIndex}. Used only to decide
     * whether a requested type was honored, so a substitution can be reported.
     */
-   private boolean requestedTypeAvailable(String vizType, VSRecommendationModel model) {
+   private boolean requestedTypeAvailable(String vizType, VSRecommendationModel model,
+                                          boolean pinsPresent)
+   {
       if(vizType == null || model == null) {
          return false;
       }
@@ -1168,6 +1363,12 @@ public class WizAutoBindingService {
                      return true;
                   }
                }
+            }
+
+            // Pins present: only pin-satisfying prefInfos count as "available" — the unconstrained
+            // chartInfos were never eligible, so a match there is still a substitution (note it).
+            if(pinsPresent) {
+               continue;
             }
 
             List<ChartInfo> chartInfos = cr.getChartInfos();
@@ -1381,8 +1582,9 @@ public class WizAutoBindingService {
          return result;
       }
 
-      // 3. Select the recommendation for the requested type.
-      VSObjectRecommendation selectedRec = findRecByType(visualizationType, model);
+      // 3. Select the recommendation for the requested type. changeType is an explicit user type
+      // switch (no explicit-binding pins in play), so the unconstrained chartInfos fallback is fine.
+      VSObjectRecommendation selectedRec = findRecByType(visualizationType, model, false);
 
       if(selectedRec == null) {
          selectedRec = model.getRecommendationList().stream()

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -549,6 +549,11 @@ public class WizVsService {
       }
 
       CreateViewsheetResult result = executeAndExtract(rvs, assembly);
+
+      if(result != null) {
+         result.setBinding(collectFlatBinding(assembly));
+      }
+
       boolean metadataMode = vs.getViewsheetInfo().isMetadata();
       result.setHasData(computeHasData(metadataMode, result));
       return result;
@@ -872,7 +877,7 @@ public class WizVsService {
     * Builds a {@link CreateViewsheetResult.FlatBinding} from the assembly's current binding.
     * Returns null for assembly types that carry no aggregate binding (e.g. Table, Image).
     */
-   private CreateViewsheetResult.FlatBinding collectFlatBinding(VSAssembly assembly) {
+   public CreateViewsheetResult.FlatBinding collectFlatBinding(VSAssembly assembly) {
       if(assembly instanceof ChartVSAssembly chart) {
          return collectChartFlatBinding(chart.getVSChartInfo());
       }
@@ -955,7 +960,54 @@ public class WizVsService {
          return null;
       }
 
-      return new CreateViewsheetResult.FlatBinding(dimensions, measures);
+      return new CreateViewsheetResult.FlatBinding(dimensions, measures, collectChartSlots(info));
+   }
+
+   /**
+    * Resolved slot placement for a chart: which slot each bound field landed in.
+    * Reads the RUNTIME refs when present (the renderer reads getRT*Fields(); design and
+    * runtime can diverge — mekko trims X at runtime, drill visibility, period-calendar
+    * injects a runtime dim), falling back to design refs before execution.
+    * Measure refs are reported as their full aggregate name ("Sum(amount)") to match
+    * the rankingCol convention; dimensions by field name.
+    */
+   static Map<String, Object> collectChartSlots(VSChartInfo info) {
+      Map<String, Object> slots = new LinkedHashMap<>();
+      slots.put("x", slotNames(rtOrDesign(info.getRTXFields(), info.getXFields())));
+      slots.put("y", slotNames(rtOrDesign(info.getRTYFields(), info.getYFields())));
+      slots.put("group", slotNames(rtOrDesign(info.getRTGroupFields(), info.getGroupFields())));
+      slots.put("color", aestheticSlotName(info.getColorField()));
+      slots.put("shape", aestheticSlotName(info.getShapeField()));
+      slots.put("size", aestheticSlotName(info.getSizeField()));
+      slots.put("text", aestheticSlotName(info.getTextField()));
+      return slots;
+   }
+
+   private static ChartRef[] rtOrDesign(ChartRef[] rt, ChartRef[] design) {
+      return rt != null && rt.length > 0 ? rt : design;
+   }
+
+   private static List<String> slotNames(ChartRef[] refs) {
+      List<String> names = new ArrayList<>();
+
+      if(refs != null) {
+         for(ChartRef ref : refs) {
+            if(ref != null) {
+               names.add(slotName(ref));
+            }
+         }
+      }
+
+      return names;
+   }
+
+   private static String slotName(DataRef ref) {
+      return ref instanceof VSChartAggregateRef agg ? agg.getFullName()
+         : WizardRecommenderUtil.getChartRefFieldName(ref);
+   }
+
+   private static String aestheticSlotName(AestheticRef aref) {
+      return aref == null || aref.getDataRef() == null ? null : slotName(aref.getDataRef());
    }
 
    /**
@@ -1074,7 +1126,31 @@ public class WizVsService {
          return null;
       }
 
-      return new CreateViewsheetResult.FlatBinding(dimensions, measures);
+      Map<String, Object> slots = new LinkedHashMap<>();
+      slots.put("rows", refSlotNames(cinfo.getDesignRowHeaders()));
+      slots.put("cols", refSlotNames(cinfo.getDesignColHeaders()));
+      slots.put("aggregates", refSlotNames(cinfo.getDesignAggregates()));
+
+      return new CreateViewsheetResult.FlatBinding(dimensions, measures, slots);
+   }
+
+   /**
+    * Collects slot names from an arbitrary {@link DataRef} array, applying the same
+    * field-name convention as {@link #slotName(DataRef)} (measures by full aggregate
+    * name, dimensions by field name). Used for crosstab row/col/aggregate slots.
+    */
+   private static List<String> refSlotNames(DataRef[] refs) {
+      List<String> names = new ArrayList<>();
+
+      if(refs != null) {
+         for(DataRef ref : refs) {
+            if(ref != null) {
+               names.add(slotName(ref));
+            }
+         }
+      }
+
+      return names;
    }
 
    /**
@@ -1129,7 +1205,10 @@ public class WizVsService {
          info.setNOrP(ref.getN());
       }
 
-      return new CreateViewsheetResult.FlatBinding(List.of(), List.of(info));
+      Map<String, Object> slots = new LinkedHashMap<>();
+      slots.put("value", ref.getFullName());
+
+      return new CreateViewsheetResult.FlatBinding(List.of(), List.of(info), slots);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -551,6 +551,8 @@ public class WizVsService {
       CreateViewsheetResult result = executeAndExtract(rvs, assembly);
 
       if(result != null) {
+         // Order matters: executeAndExtract runs executeView above, which populates the
+         // chart's RT refs. collectFlatBinding prefers RT refs, so it must come after.
          result.setBinding(collectFlatBinding(assembly));
       }
 
@@ -876,6 +878,11 @@ public class WizVsService {
    /**
     * Builds a {@link CreateViewsheetResult.FlatBinding} from the assembly's current binding.
     * Returns null for assembly types that carry no aggregate binding (e.g. Table, Image).
+    *
+    * <p>For charts, slot collection prefers RT refs, which are only populated after the
+    * viewsheet has executed (executeView). Callers using a cold RVS get design refs via
+    * fallback — accurate enough for the echo, but the slots are not RT-resolved. Call
+    * after execution when RT-accurate slots are required.
     */
    public CreateViewsheetResult.FlatBinding collectFlatBinding(VSAssembly assembly) {
       if(assembly instanceof ChartVSAssembly chart) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1002,7 +1002,7 @@ public class WizVsService {
    }
 
    private static String slotName(DataRef ref) {
-      return ref instanceof VSChartAggregateRef agg ? agg.getFullName()
+      return ref instanceof VSAggregateRef agg ? agg.getFullName()
          : WizardRecommenderUtil.getChartRefFieldName(ref);
    }
 
@@ -1126,12 +1126,21 @@ public class WizVsService {
          return null;
       }
 
+      return new CreateViewsheetResult.FlatBinding(dimensions, measures, collectCrosstabSlots(cinfo));
+   }
+
+   /**
+    * Resolved slot placement for a crosstab: row/col header dimensions and aggregate
+    * measures. Measure refs are reported as their full aggregate name ("Sum(amount)")
+    * to match the chart {@code measures} list and the rankingCol convention; dimensions
+    * by field name.
+    */
+   static Map<String, Object> collectCrosstabSlots(VSCrosstabInfo cinfo) {
       Map<String, Object> slots = new LinkedHashMap<>();
       slots.put("rows", refSlotNames(cinfo.getDesignRowHeaders()));
       slots.put("cols", refSlotNames(cinfo.getDesignColHeaders()));
       slots.put("aggregates", refSlotNames(cinfo.getDesignAggregates()));
-
-      return new CreateViewsheetResult.FlatBinding(dimensions, measures, slots);
+      return slots;
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/vswizard/recommender/chart/ChartTypeFilterPinsTest.java
+++ b/core/src/test/java/inetsoft/web/vswizard/recommender/chart/ChartTypeFilterPinsTest.java
@@ -1,0 +1,170 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.vswizard.recommender.chart;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.uql.viewsheet.graph.VSAestheticRef;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pure-logic unit tests for the strict-pin support added to {@link ChartTypeFilter}:
+ *  - aestheticCaps() cardinality thresholds per chart type (static, no instance needed), and
+ *  - satisfiesPins() per-pin set containment (exercised through a concrete base-class instance,
+ *    which transitively covers the private boundFieldNames/isPinnedTo helpers).
+ *
+ * Uses the Spring/@SreeHome harness because constructing a VSChartInfo with dimension/aggregate
+ * refs triggers GDefaults/SreeEnv init that throws ShutdownException in a plain JVM.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class ChartTypeFilterPinsTest {
+   // ── aestheticCaps (public static) ─────────────────────────────────────────────
+   @Test
+   void aestheticCapsDefaultsForBarChart() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_BAR);
+
+      assertArrayEquals(new int[]{ 40, 8, 10 }, ChartTypeFilter.aestheticCaps(info),
+         "default caps {color 40, shape 8, size 10}");
+   }
+
+   @Test
+   void aestheticCapsShapeFiveForLine() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_LINE);
+
+      assertArrayEquals(new int[]{ 40, 5, 10 }, ChartTypeFilter.aestheticCaps(info),
+         "line chart caps shape cardinality at 5");
+   }
+
+   @Test
+   void aestheticCapsShapeSixteenForPoint() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_POINT);
+
+      assertArrayEquals(new int[]{ 40, 16, 10 }, ChartTypeFilter.aestheticCaps(info),
+         "point chart caps shape cardinality at 16");
+   }
+
+   @Test
+   void aestheticCapsSizeTwoHundredForWordCloud() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_POINT);
+
+      VSAestheticRef text = new VSAestheticRef();
+      text.setDataRef(dimension("category"));
+      info.setTextField(text);
+
+      assertArrayEquals(new int[]{ 40, 16, 200 }, ChartTypeFilter.aestheticCaps(info),
+         "point + text field (word cloud) raises size cap to 200");
+   }
+
+   @Test
+   void aestheticCapsNullInfoReturnsDefaults() {
+      assertArrayEquals(new int[]{ 40, 8, 10 }, ChartTypeFilter.aestheticCaps(null),
+         "null info returns the default caps without dereferencing it");
+   }
+
+   // ── satisfiesPins (protected; needs a concrete instance) ──────────────────────
+   @Test
+   void satisfiesPinsContainmentOnColorSlot() {
+      ChartTypeFilter filter = newFilter();
+
+      VSChartInfo candidate = new VSChartInfo();
+      VSAestheticRef color = new VSAestheticRef();
+      color.setDataRef(dimension("country"));
+      candidate.setColorField(color);
+
+      assertTrue(filter.satisfiesPins(candidate, Map.of("color", Set.of("country"))),
+         "color=country satisfies a pin for color:{country}");
+      assertFalse(filter.satisfiesPins(candidate, Map.of("color", Set.of("region"))),
+         "color=country does NOT satisfy a pin for color:{region}");
+   }
+
+   @Test
+   void satisfiesPinsEmptyPinSetTriviallySatisfied() {
+      ChartTypeFilter filter = newFilter();
+
+      // candidate has nothing bound to color, but the pin asks for no specific field
+      VSChartInfo candidate = new VSChartInfo();
+
+      assertTrue(filter.satisfiesPins(candidate, Map.of("color", Set.of())),
+         "an empty pin set (color:{}) is trivially satisfied (containsAll of empty)");
+   }
+
+   @Test
+   void satisfiesPinsFieldBoundTwiceStillSatisfiesSinglePin() {
+      ChartTypeFilter filter = newFilter();
+
+      // The doc comment's case: a field appearing twice in one slot still satisfies a single
+      // pin for it. This is containment, not a count — duplicates must not over-shoot and drop
+      // a satisfying candidate. boundFieldNames is a Set, so two x-fields named "month" collapse
+      // to one name, and the pin for x:{month} is satisfied.
+      VSChartInfo candidate = new VSChartInfo();
+      candidate.addXField(dimension("month"));
+      candidate.addXField(aggregate("month", "Count"));
+
+      assertTrue(filter.satisfiesPins(candidate, Map.of("x", Set.of("month"))),
+         "a field bound twice in one slot still satisfies a single pin for that field");
+   }
+
+   /**
+    * The base ChartTypeFilter is concrete; satisfiesPins reads only the candidate passed to it,
+    * never the temp template. So a minimal empty temp is enough to construct an instance
+    * (initValues -> getDateCount iterates the empty getXFields()).
+    */
+   private static ChartTypeFilter newFilter() {
+      return new ChartTypeFilter(new AssetEntry[0], new VSChartInfo(), true);
+   }
+
+   private static VSChartDimensionRef dimension(String field) {
+      VSChartDimensionRef dim = new VSChartDimensionRef();
+      dim.setGroupColumnValue(field);
+      return dim;
+   }
+
+   private static VSChartAggregateRef aggregate(String column, String formula) {
+      VSChartAggregateRef agg = new VSChartAggregateRef();
+      agg.setColumnValue(column);
+      agg.setFormulaValue(formula);
+      agg.setAggregated(true);
+      return agg;
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/model/ChartFormatRequestTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/ChartFormatRequestTest.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Locks the wire contract of {@code POST /api/wiz/viewsheet/format}: the camelCase axis
+ * property names the wiz-services client sends (xAxisTitle, yAxisMin, ...) must bind, even
+ * though Jackson's default bean-naming would canonicalize getXAxisTitle to "xaxisTitle".
+ * Regression test for the live 400 (HttpMessageNotReadableException) hit 2026-06-05.
+ */
+@Tag("core")
+class ChartFormatRequestTest {
+   @Test
+   void camelCaseAxisPropertiesDeserialize() throws Exception {
+      // FAIL_ON_UNKNOWN_PROPERTIES mirrors the server's strict binding that produced the 400
+      ObjectMapper mapper = new ObjectMapper()
+         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+
+      ChartFormatRequest req = mapper.readValue(
+         """
+         { "wizRuntimeId": "rt-1", "assemblyName": "Chart1",
+           "xAxisTitle": "Gross", "yAxisTitle": "Actor",
+           "yAxisMin": 0.5, "yAxisMax": 100.0, "yAxisIncrement": 10.0,
+           "yAxisLogarithmic": true, "legendPosition": "top" }
+         """,
+         ChartFormatRequest.class);
+
+      assertEquals("rt-1", req.getWizRuntimeId());
+      assertEquals("Gross", req.getXAxisTitle());
+      assertEquals("Actor", req.getYAxisTitle());
+      assertEquals(0.5, req.getYAxisMin());
+      assertEquals(100.0, req.getYAxisMax());
+      assertEquals(10.0, req.getYAxisIncrement());
+      assertEquals(Boolean.TRUE, req.getYAxisLogarithmic());
+      assertEquals("top", req.getLegendPosition());
+   }
+
+   @Test
+   void setterBindsThroughTheRenamedProperty() throws Exception {
+      // The explicit @JsonProperty on the getter must rename the whole accessor group
+      // (getter + setter), not split it into two properties.
+      ObjectMapper mapper = new ObjectMapper();
+      ChartFormatRequest req = mapper.readValue("{ \"xAxisTitle\": \"T\" }", ChartFormatRequest.class);
+      assertEquals("T", req.getXAxisTitle());
+      assertTrue(mapper.writeValueAsString(req).contains("\"xAxisTitle\":\"T\""));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/BindingSlotsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/BindingSlotsTest.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.graph.ChartRef;
+import inetsoft.uql.viewsheet.graph.VSAestheticRef;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * collectChartSlots reports which slot each bound field landed in, reading the runtime
+ * refs the renderer actually consumes (getRT*Fields()) and falling back to design refs
+ * before execution. Dimensions are reported by field name; measures by their full
+ * aggregate name ("Sum(amount)") to match the rankingCol convention.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class BindingSlotsTest {
+   @Test
+   void chartSlotsReportResolvedPlacement() {
+      VSChartInfo info = new VSChartInfo();
+      info.addXField(dimension("actor_name"));
+      info.addYField(aggregate("amount", "Sum"));
+
+      VSAestheticRef color = new VSAestheticRef();
+      color.setDataRef(dimension("country"));
+      info.setColorField(color);
+
+      Map<String, Object> slots = WizVsService.collectChartSlots(info);
+
+      assertEquals(List.of("actor_name"), slots.get("x"),
+         "dimension on x reported by field name");
+      // Measures are reported as their full aggregate name to match the rankingCol convention.
+      assertEquals(List.of("Sum(amount)"), slots.get("y"),
+         "measure on y reported as full aggregate name");
+      assertEquals("country", slots.get("color"),
+         "aesthetic dimension reported by field name");
+      assertNull(slots.get("shape"), "unbound aesthetic slot is null");
+   }
+
+   @Test
+   void runtimeRefsWinOverDesignRefs() {
+      VSChartInfo info = new VSChartInfo();
+      info.addXField(dimension("design_field"));
+      info.setRTXFields(new ChartRef[]{ dimension("rt_field") });
+
+      Map<String, Object> slots = WizVsService.collectChartSlots(info);
+
+      assertEquals(List.of("rt_field"), slots.get("x"),
+         "runtime refs (what the renderer reads) win over design refs");
+   }
+
+   private static VSChartDimensionRef dimension(String field) {
+      VSChartDimensionRef dim = new VSChartDimensionRef();
+      dim.setGroupColumnValue(field);
+      return dim;
+   }
+
+   private static VSChartAggregateRef aggregate(String column, String formula) {
+      VSChartAggregateRef agg = new VSChartAggregateRef();
+      agg.setColumnValue(column);
+      agg.setFormulaValue(formula);
+      agg.setAggregated(true);
+      return agg;
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/BindingSlotsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/BindingSlotsTest.java
@@ -20,6 +20,11 @@ package inetsoft.web.wiz.service;
 import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.viewsheet.VSAggregateRef;
+import inetsoft.uql.viewsheet.VSCrosstabInfo;
+import inetsoft.uql.viewsheet.VSDimensionRef;
 import inetsoft.uql.viewsheet.graph.ChartRef;
 import inetsoft.uql.viewsheet.graph.VSAestheticRef;
 import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
@@ -82,6 +87,43 @@ class BindingSlotsTest {
 
       assertEquals(List.of("rt_field"), slots.get("x"),
          "runtime refs (what the renderer reads) win over design refs");
+   }
+
+   @Test
+   void crosstabAggregateSlotUsesFullAggregateName() {
+      VSCrosstabInfo cinfo = new VSCrosstabInfo();
+      cinfo.setDesignRowHeaders(new DataRef[]{ crosstabDimension("actor_name") });
+      cinfo.setDesignColHeaders(new DataRef[]{ crosstabDimension("country") });
+      cinfo.setDesignAggregates(new DataRef[]{ crosstabAggregate("amount", "Sum") });
+
+      Map<String, Object> slots = WizVsService.collectCrosstabSlots(cinfo);
+
+      assertEquals(List.of("actor_name"), slots.get("rows"),
+         "row header dimension reported by field name");
+      assertEquals(List.of("country"), slots.get("cols"),
+         "col header dimension reported by field name");
+      // The fix: crosstab design aggregates are plain VSAggregateRef (not
+      // VSChartAggregateRef); the aggregates slot must still report the full
+      // aggregate name to line up with the measures list / rankingCol convention.
+      assertEquals(List.of("Sum(amount)"), slots.get("aggregates"),
+         "crosstab aggregate reported as full aggregate name, not the bare column");
+   }
+
+   private static VSDimensionRef crosstabDimension(String field) {
+      VSDimensionRef dim = new VSDimensionRef();
+      dim.setGroupColumnValue(field);
+      // crosstab dimensions are plain VSDimensionRef, so the slot name resolves via
+      // getAttribute() (not the VSChartDimensionRef branch); back it with the column.
+      dim.setDataRef(new AttributeRef(field));
+      return dim;
+   }
+
+   private static VSAggregateRef crosstabAggregate(String column, String formula) {
+      VSAggregateRef agg = new VSAggregateRef();
+      agg.setColumnValue(column);
+      agg.setFormulaValue(formula);
+      agg.setAggregated(true);
+      return agg;
    }
 
    private static VSChartDimensionRef dimension(String field) {

--- a/core/src/test/java/inetsoft/web/wiz/service/ExplicitBindingValidationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/ExplicitBindingValidationTest.java
@@ -74,6 +74,21 @@ class ExplicitBindingValidationTest {
    }
 
    @Test
+   void measureOnGroupSlotThrows() {
+      // group is dimension-only (in DIMENSION_SLOTS but not MEASURE_SLOTS); a measure
+      // pinned there must be rejected just like shape.
+      Map<String, SimpleFieldInfo> configs = Map.of("amount", measure("amount"));
+
+      UnsatisfiableBindingException e = assertThrows(UnsatisfiableBindingException.class,
+         () -> WizAutoBindingService.validateExplicitBindings(
+            List.of(pin("group", "amount")), configs, null));
+
+      assertEquals("group", e.getRole());
+      assertEquals("amount", e.getField());
+      assertTrue(e.getReason().contains("dimension-only"));
+   }
+
+   @Test
    void unknownFieldThrows() {
       Map<String, SimpleFieldInfo> configs = Map.of("amount", measure("amount"));
 

--- a/core/src/test/java/inetsoft/web/wiz/service/ExplicitBindingValidationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/ExplicitBindingValidationTest.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.web.wiz.model.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class ExplicitBindingValidationTest {
+   private static ExplicitBinding pin(String role, String field) {
+      ExplicitBinding eb = new ExplicitBinding();
+      eb.setRole(role);
+      eb.setField(field);
+      return eb;
+   }
+
+   private static MeasureFieldInfo measure(String field) {
+      MeasureFieldInfo info = new MeasureFieldInfo();
+      info.setField(field);
+      return info;
+   }
+
+   private static DimensionFieldInfo dimension(String field) {
+      DimensionFieldInfo info = new DimensionFieldInfo();
+      info.setField(field);
+      return info;
+   }
+
+   @Test
+   void unknownSlotThrows() {
+      Map<String, SimpleFieldInfo> configs = Map.of("amount", measure("amount"));
+
+      UnsatisfiableBindingException e = assertThrows(UnsatisfiableBindingException.class,
+         () -> WizAutoBindingService.validateExplicitBindings(
+            List.of(pin("bogus", "amount")), configs, null));
+
+      assertEquals("bogus", e.getRole());
+      assertEquals("amount", e.getField());
+      assertTrue(e.getReason().contains("unknown slot"));
+   }
+
+   @Test
+   void measureOnDimensionOnlySlotThrows() {
+      // shape is a dimension-only aesthetic; a measure cannot be placed there.
+      Map<String, SimpleFieldInfo> configs = Map.of("amount", measure("amount"));
+
+      UnsatisfiableBindingException e = assertThrows(UnsatisfiableBindingException.class,
+         () -> WizAutoBindingService.validateExplicitBindings(
+            List.of(pin("shape", "amount")), configs, null));
+
+      assertEquals("shape", e.getRole());
+      assertEquals("amount", e.getField());
+   }
+
+   @Test
+   void unknownFieldThrows() {
+      Map<String, SimpleFieldInfo> configs = Map.of("amount", measure("amount"));
+
+      UnsatisfiableBindingException e = assertThrows(UnsatisfiableBindingException.class,
+         () -> WizAutoBindingService.validateExplicitBindings(
+            List.of(pin("x", "missing_field")), configs, null));
+
+      assertEquals("missing_field", e.getField());
+   }
+
+   @Test
+   void validPinsPass() {
+      Map<String, SimpleFieldInfo> configs = Map.of(
+         "amount", measure("amount"),
+         "category", dimension("category"));
+
+      assertDoesNotThrow(() -> WizAutoBindingService.validateExplicitBindings(
+         List.of(pin("y", "amount"), pin("color", "category")), configs, null));
+   }
+
+   @Test
+   void emptyBindingsNoOp() {
+      assertDoesNotThrow(() -> WizAutoBindingService.validateExplicitBindings(
+         List.of(), Map.of(), null));
+      assertDoesNotThrow(() -> WizAutoBindingService.validateExplicitBindings(
+         null, null, null));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/ExplicitBindingValidationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/ExplicitBindingValidationTest.java
@@ -89,6 +89,21 @@ class ExplicitBindingValidationTest {
    }
 
    @Test
+   void dimensionOnMeasureOnlySlotThrows() {
+      // aggregates is measure-only (in MEASURE_SLOTS but not DIMENSION_SLOTS); a
+      // dimension pinned there must be rejected, symmetric with the group case.
+      Map<String, SimpleFieldInfo> configs = Map.of("category", dimension("category"));
+
+      UnsatisfiableBindingException e = assertThrows(UnsatisfiableBindingException.class,
+         () -> WizAutoBindingService.validateExplicitBindings(
+            List.of(pin("aggregates", "category")), configs, null));
+
+      assertEquals("aggregates", e.getRole());
+      assertEquals("category", e.getField());
+      assertTrue(e.getReason().contains("measure-only"));
+   }
+
+   @Test
    void unknownFieldThrows() {
       Map<String, SimpleFieldInfo> configs = Map.of("amount", measure("amount"));
 

--- a/core/src/test/java/inetsoft/web/wiz/service/ExplicitBindingValidationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/ExplicitBindingValidationTest.java
@@ -131,4 +131,41 @@ class ExplicitBindingValidationTest {
       assertDoesNotThrow(() -> WizAutoBindingService.validateExplicitBindings(
          null, null, null));
    }
+
+   @Test
+   void setConflictExceptionReportsAllPins() {
+      // The set-conflict constructor carries every pin so the 400 body can list them all,
+      // rather than blaming the first pin (which may be individually valid).
+      List<UnsatisfiableBindingException.Pin> pins = List.of(
+         new UnsatisfiableBindingException.Pin("color", "country"),
+         new UnsatisfiableBindingException.Pin("size", "amount"));
+      UnsatisfiableBindingException e = new UnsatisfiableBindingException(pins, "no combination");
+
+      assertEquals(pins, e.getPins());
+      assertNull(e.getRole());
+      assertNull(e.getField());
+      assertEquals("no combination", e.getReason());
+   }
+
+   @Test
+   void singlePinExceptionHasEmptyPinList() {
+      // The single-pin constructor leaves getPins() empty so the controller emits "pin"
+      // (role/field) rather than the "pins" array.
+      UnsatisfiableBindingException e =
+         new UnsatisfiableBindingException("shape", "amount", "dimension-only");
+
+      assertTrue(e.getPins().isEmpty());
+      assertEquals("shape", e.getRole());
+      assertEquals("amount", e.getField());
+   }
+
+   @Test
+   void nullRoleRendersAsPlaceholderInMessage() {
+      // A null role/field must not surface as the literal "null" in the log message.
+      UnsatisfiableBindingException e =
+         new UnsatisfiableBindingException(null, "amount", "missing slot/role");
+
+      assertFalse(e.getMessage().contains("null"));
+      assertTrue(e.getMessage().contains("<missing>=amount"));
+   }
 }


### PR DESCRIPTION
## Summary

Two changes fixing the 2026-06-05 incident class (a `color=country` pin silently dropped by the cardinality guard, with nothing in the response reporting where fields actually landed):

**Change 1 — observability.** Every chart-shaped result echoes the resolved binding:
- `FlatBinding` gains `slots` (resolved placement: list-valued x/y/group, string-or-null aesthetics; crosstab rows/cols/aggregates; output value) and structured `notes` (`{field, role, honored, severity, reason}`).
- `collectChartSlots` reads the **runtime** refs with design fallback — the renderer reads RT refs, and design/runtime can diverge (mekko X-trim, drill, period calendar). The echo reports the rendered truth.
- `binding` is now populated at every result site: create path, `fetchAssemblyData` (colors/format/changeType/filter), and the open-saved endpoint (`ViewsheetRuntimeController` now injects `WizVsService`; `collectFlatBinding` is public).

**Change 2 — authority.** `explicitBindings` become constraints:
- Pins are plumbed into `ChartTypeFilter` **before** combination generation (`getClassyInfo` prunes score<0 candidates at generation, so post-hoc filtering can't work); the aesthetic cardinality veto relaxes to a warning for pinned placements; `filterWithConstraints` keeps only pin-satisfying candidates for primary selection.
- Upfront validation (unknown slot, field not bound, measure on a dimension-only slot) and an empty satisfying set both raise `UnsatisfiableBindingException` → HTTP 400 `{error, pin: {role, field}, reason}`.
- `visualizationType` stays a preference: a type with no pin-satisfying candidate substitutes the best satisfying type and reports it via `selectionNote`. The unconstrained-fallback path in `setChartIndexForType`/`findRecByType` is disabled under pins (that fall-through was the silent-bypass path).
- Post-selection cap warnings share one `aestheticCaps(info)` helper with the scorer (caps vary by chart type), so notes never claim a cap the scorer didn't apply.
- `applyFieldConfigs` now also covers aesthetic refs (pinned color dimension keeps its fieldConfig).

**Drive-by fix:** `ChartFormatRequest`'s six axis properties (`xAxisTitle`, `yAxisMin`, …) were unreachable — Jackson's consecutive-capitals rule canonicalized `getXAxisTitle` to `xaxisTitle`, so the camelCase client body failed strict binding with a 400. Pinned the wire names with `@JsonProperty` + round-trip contract test.

## Tests

- `BindingSlotsTest` (3), `ChartTypeFilterPinsTest` (8), `ExplicitBindingValidationTest` (5), `ChartFormatRequestTest` (2) — all pass.
- Live matrix on a local Jib image against the incident's sakila worksheet, 6/6:
  1. `color=country` (108 values) pinned → rendered with country on color + warning note "cardinality 108 exceeds color cap 40" (no silent fallback)
  2. + `visualizationType: "bar"` → pin held; `selectionNote: "... no candidate honoring the explicit bindings; used 'bar_stack' instead"`
  3. `country_group` (9 values) pinned → honored, no warning
  4. `binding.slots` accurate on create / changeType / colors / format / filter / open-saved
  5. `shape=amount` (measure) → 400 `{error, pin, reason}` before any chart is created
  6. no pins → recommendation identical to before, slots echoed, no notes
  (Matrix ran on the image before the ChartFormatRequest commit; that fix is locked by the round-trip unit test — the live matrix exercised the format path via `legendPosition`.)

## Notes for reviewers

- Known pre-existing issue surfaced by the matrix (NOT addressed here): save-after-filter fails — the filter path clones the primary assembly to `<name>_1` in the runtime viewsheet, but `WizVisualizationService.saveVisualization` resolves the assembly against the **persisted** viewsheet → "Assembly not found in source ViewSheet". Will file separately.
- Companion TS PR: inetsoft-technology/stylebi-wiz#814 (wiz-services passthrough + plugin surface + skill docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)