### PR TITLE
Bug #75323, only list output columns of a subquery table in the subquery condition dialog

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/AbstractTableAssembly.java
+++ b/core/src/main/java/inetsoft/uql/asset/AbstractTableAssembly.java
@@ -528,7 +528,10 @@ public abstract class AbstractTableAssembly extends AbstractWSAssembly implement
          AggregateInfo aggregateInfo =
             getRealAggregateInfo() == null ? ginfo : getRealAggregateInfo();
 
-         // generate public column selection if not a crosstab
+         // Generate the public (output) column selection if not a crosstab. For a crosstab
+         // the output columns are dynamic (pivoted at runtime), so the public selection is
+         // left empty here; TableAssemblyInfo.getPublicColumnSelection() then lazily falls
+         // back to the visible private columns, so callers still get a non-empty list.
          if(!isCrosstab()) {
             ColumnSelection ocolumns = new ColumnSelection();
             // Snapshot the selection to avoid IndexOutOfBoundsException if another thread

--- a/core/src/main/java/inetsoft/uql/asset/internal/TableAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/asset/internal/TableAssemblyInfo.java
@@ -93,9 +93,15 @@ public class TableAssemblyInfo extends WSAssemblyInfo {
     * @return the public column selection of the table assembly.
     */
    public ColumnSelection getPublicColumnSelection() {
-      // is a null selection?
+      // The "null" property is set to "false" once a public selection has been generated
+      // (see AbstractTableAssembly.setColumnSelection). nflag is true when that has not
+      // happened yet — e.g. for a crosstab, whose public selection is intentionally left
+      // empty because its output columns are pivoted at runtime.
       boolean nflag = !"false".equals(oselection.getProperty("null"));
 
+      // Fallback: when no public selection was generated, derive one from the visible
+      // private (input) columns so callers (e.g. the subquery condition dialog) get a
+      // usable column list instead of an empty one.
       if(oselection.getAttributeCount() == 0 && nflag) {
          oselection = iselection.clone();
 

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/AssemblyConditionDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/AssemblyConditionDialogService.java
@@ -113,13 +113,19 @@ public class AssemblyConditionDialogService extends WorksheetControllerService {
 
          if(assembly instanceof TableAssembly) {
             SubqueryTableModel subqueryTableModel = new SubqueryTableModel();
+            boolean currentTable = assembly.equals(tableAssembly);
             subqueryTableModel.setName(assembly.getName());
             subqueryTableModel.setDescription(
                ((TableAssembly) assembly).getDescription());
+            // only the output (public) columns of a subquery table can be used
+            // in a subquery condition (e.g. the aggregate columns of an
+            // aggregated table); the current table's columns are only used as
+            // the main attribute of a correlated subquery, so it keeps the
+            // full (private) column selection. (Bug #75323)
             subqueryTableModel.setColumns(ConditionUtil.getDataRefModelsFromColumnSelection(
-               ((TableAssembly) assembly).getColumnSelection(),
+               ((TableAssembly) assembly).getColumnSelection(!currentTable),
                this.dataRefModelFactoryService, 0));
-            subqueryTableModel.setCurrentTable(assembly.equals(tableAssembly));
+            subqueryTableModel.setCurrentTable(currentTable);
             subqueryTableModels.add(subqueryTableModel);
          }
       }

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/AssemblyConditionDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/AssemblyConditionDialogService.java
@@ -117,13 +117,8 @@ public class AssemblyConditionDialogService extends WorksheetControllerService {
             subqueryTableModel.setName(assembly.getName());
             subqueryTableModel.setDescription(
                ((TableAssembly) assembly).getDescription());
-            // only the output (public) columns of a subquery table can be used
-            // in a subquery condition (e.g. the aggregate columns of an
-            // aggregated table); the current table's columns are only used as
-            // the main attribute of a correlated subquery, so it keeps the
-            // full (private) column selection. (Bug #75323)
             subqueryTableModel.setColumns(ConditionUtil.getDataRefModelsFromColumnSelection(
-               ((TableAssembly) assembly).getColumnSelection(!currentTable),
+               getSubqueryColumns((TableAssembly) assembly, currentTable),
                this.dataRefModelFactoryService, 0));
             subqueryTableModel.setCurrentTable(currentTable);
             subqueryTableModels.add(subqueryTableModel);
@@ -390,6 +385,22 @@ public class AssemblyConditionDialogService extends WorksheetControllerService {
    private ConditionList getConditionList(ConditionListWrapper wrapper) {
       return wrapper == null ? null :
          (ConditionList) wrapper.getConditionList().clone();
+   }
+
+   /**
+    * Resolve which columns of a candidate table to offer in the subquery condition dialog.
+    *
+    * <p>A candidate table exposes its PUBLIC (output) columns — e.g. the aggregate columns
+    * of an aggregated table — because only output columns can be referenced inside a
+    * subquery. The current table keeps its FULL (private) selection because its columns are
+    * used as the main attribute of a correlated subquery, not as subquery output. (Bug #75323)
+    *
+    * <p>Crosstab tables don't eagerly generate a public column selection, but
+    * {@code TableAssemblyInfo.getPublicColumnSelection()} lazily falls back to the visible
+    * private columns, so a crosstab candidate still lists its columns rather than nothing.
+    */
+   static ColumnSelection getSubqueryColumns(TableAssembly assembly, boolean currentTable) {
+      return assembly.getColumnSelection(!currentTable);
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/composer/ws/dialog/AssemblyConditionDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/ws/dialog/AssemblyConditionDialogServiceTest.java
@@ -1,0 +1,138 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.ws.dialog;
+
+import inetsoft.test.*;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.asset.*;
+import inetsoft.uql.erm.AttributeRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression coverage for the subquery condition dialog column selection (Bug #75323):
+ * candidate tables must expose their public (output) columns, while the current table
+ * keeps its full (private) selection.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class AssemblyConditionDialogServiceTest {
+   private static ColumnRef col(String name) {
+      ColumnRef ref = new ColumnRef(new AttributeRef(name));
+      ref.setVisible(true);
+      return ref;
+   }
+
+   private static Set<String> names(ColumnSelection sel) {
+      Set<String> names = new HashSet<>();
+
+      for(int i = 0; i < sel.getAttributeCount(); i++) {
+         names.add(sel.getAttribute(i).getName());
+      }
+
+      return names;
+   }
+
+   @Test
+   void currentTableUsesPrivateCandidatesUsePublic() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = new EmbeddedTableAssembly(ws, "t");
+      ColumnSelection priv = new ColumnSelection();
+      priv.addAttribute(col("a"));
+      priv.addAttribute(col("b"));
+      t.setColumnSelection(priv, false);
+
+      // The current table keeps the private selection; candidates use the public one.
+      // Guards against reverting to the no-arg getColumnSelection() (== private) for candidates.
+      assertSame(t.getColumnSelection(false),
+                 AssemblyConditionDialogService.getSubqueryColumns(t, true),
+                 "current table must use the private (full) column selection");
+      assertSame(t.getColumnSelection(true),
+                 AssemblyConditionDialogService.getSubqueryColumns(t, false),
+                 "candidate tables must use the public (output) column selection");
+   }
+
+   @Test
+   void aggregatedCandidateListsOutputColumnsNotRawDetail() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly agg = new EmbeddedTableAssembly(ws, "agg");
+      ColumnRef state = col("state");
+      ColumnRef id = col("id");
+      ColumnRef sales = col("sales");
+
+      ColumnSelection priv = new ColumnSelection();
+      priv.addAttribute(state);
+      priv.addAttribute(id);
+      priv.addAttribute(sales);
+
+      AggregateInfo aggInfo = new AggregateInfo();
+      aggInfo.addGroup(new GroupRef(state));
+      aggInfo.addAggregate(new AggregateRef(sales, AggregateFormula.SUM));
+      agg.setAggregateInfo(aggInfo);
+      agg.setColumnSelection(priv, false);   // regenerates the public (output) selection
+
+      // Candidate → public output columns: the grouped/aggregated columns, not raw "id".
+      Set<String> candidate = names(AssemblyConditionDialogService.getSubqueryColumns(agg, false));
+      assertTrue(candidate.contains("state"), "grouped column should be an output column");
+      assertTrue(candidate.contains("sales"), "aggregated column should be an output column");
+      assertFalse(candidate.contains("id"),
+                  "non-aggregated detail column must not appear in subquery output columns");
+
+      // Current table → full private selection still includes the raw detail column.
+      Set<String> current = names(AssemblyConditionDialogService.getSubqueryColumns(agg, true));
+      assertTrue(current.contains("id"), "current table must keep its full detail columns");
+   }
+
+   @Test
+   void crosstabCandidateFallsBackToVisibleColumns() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly cross = new EmbeddedTableAssembly(ws, "cross");
+      ColumnSelection priv = new ColumnSelection();
+      priv.addAttribute(col("state"));
+      priv.addAttribute(col("city"));
+      priv.addAttribute(col("sales"));
+
+      AggregateInfo cInfo = new AggregateInfo();
+      cInfo.setCrosstab(true);
+      cInfo.addGroup(new GroupRef(col("state")));
+      cInfo.addGroup(new GroupRef(col("city")));   // >1 group required by isCrosstab()
+      cInfo.addAggregate(new AggregateRef(col("sales"), AggregateFormula.SUM));
+      cross.setAggregateInfo(cInfo);
+      cross.setColumnSelection(priv, false);
+
+      assertTrue(cross.isCrosstab(), "table should be a crosstab");
+
+      // A crosstab has no eagerly-built public selection, but getPublicColumnSelection()
+      // falls back to the visible private columns, so the candidate is not empty.
+      ColumnSelection candidate = AssemblyConditionDialogService.getSubqueryColumns(cross, false);
+      assertTrue(candidate.getAttributeCount() > 0,
+                 "crosstab candidate must fall back to visible columns, not an empty list");
+   }
+}


### PR DESCRIPTION
## Summary

In the worksheet composer's assembly condition dialog, the "In column" dropdown of the subquery editor listed **all** base columns of the selected subquery table. For a table in aggregate mode (e.g. a single `Average(CUSTOMER_ID)` aggregate with no groups), the table's actual output is a single column, and only that column should be offered. Selecting a non-output column produced a broken multi-column subquery at runtime.

## Root Cause

`AssemblyConditionDialogService.createAssemblyConditionDialogModel()` built each `SubqueryTableModel`'s column list from the table's **private** column selection (`getColumnSelection()`), which contains all base columns regardless of the table's aggregate state.

A subquery always executes with the table's aggregate info applied (`PreAssetQuery.getAggregateInfo()` returns it whenever `isSubQuery()` is true), so the columns a subquery can supply are exactly its **public** column selection — the visible columns filtered to groups/aggregates when aggregate info is non-empty (the same contract mirror tables consume).

## Fix

Use `getColumnSelection(!currentTable)` when building the subquery table models: the public selection for subquery candidate tables, while the current table's entry keeps the private selection (it is only used to offer `mainAttribute` choices for correlated subqueries, which operate on the current table's detail columns).

The save path is unaffected: the chosen column is resolved by name against the subquery table's private selection, and public columns share the same names.

## Test Plan

- Import the case from the Redmine issue; open worksheet `subquery condition column` in composer; add a subquery condition on `CUSTOMERS2` with subquery `CUSTOMERS1` — the "In column" dropdown now lists only the single aggregate output column (verified manually).
- Regression: subquery tables without aggregation still list all visible columns; correlated subquery `mainAttribute` choices (current table) are unchanged; saving/loading existing subquery conditions resolves columns as before.
- `./mvnw test -pl core -Dtest=ConditionValueModelTest` passes.

Fixes Redmine #75323.