### PR TITLE
Bug #75340, show required-field warnings immediately in Server Location dialog

### DIFF
--- a/web/projects/em/src/app/settings/schedule/schedule-configuration-page/server-location-editor/server-location-editor.component.ts
+++ b/web/projects/em/src/app/settings/schedule/schedule-configuration-page/server-location-editor/server-location-editor.component.ts
@@ -18,10 +18,12 @@
 import { Component, HostListener, Inject, OnInit } from "@angular/core";
 import { UntypedFormBuilder, UntypedFormGroup, ValidationErrors, Validators, FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { MatCheckboxChange, MatCheckbox } from "@angular/material/checkbox";
+import { ErrorStateMatcher } from "@angular/material/core";
 import { MAT_DIALOG_DATA, MatDialogRef, MatDialogContent, MatDialogActions } from "@angular/material/dialog";
 import { ServerPathInfoModel } from "../../../../../../../portal/src/app/vsobjects/model/server-path-info-model";
 import { ServerLocation } from "../../../../../../../shared/schedule/model/server-location";
 import { FormValidators } from "../../../../../../../shared/util/form-validators";
+import { EmErrorStateMatcher } from "../../../../common/util/error/em-error-state-matcher";
 import { MatButton } from "@angular/material/button";
 
 import { MatInput } from "@angular/material/input";
@@ -40,6 +42,7 @@ export interface ServerLocationData {
     selector: "em-server-location-editor",
     templateUrl: "./server-location-editor.component.html",
     styleUrls: ["./server-location-editor.component.scss"],
+    providers: [{ provide: ErrorStateMatcher, useClass: EmErrorStateMatcher }],
     imports: [NgIf, ModalHeaderComponent, MatDialogContent, FormsModule, ReactiveFormsModule, MatCard, MatCardContent, MatFormField, MatLabel, MatInput, MatError, MatCheckbox, MatDialogActions, MatButton]
 })
 export class ServerLocationEditorComponent implements OnInit {


### PR DESCRIPTION
## Summary

In Enterprise Manager → `em/settings/schedule/settings` → **Server Save Paths** → **Add**, the required-field warnings ("The label is required" / "The path is required") no longer appeared immediately when the Server Location editor dialog opened. They only showed after a field was touched.

## Root Cause

`EmErrorStateMatcher` overrides Material's default `ErrorStateMatcher` to show errors whenever a control is `invalid` (rather than only after it is touched/dirty). After the Angular standalone-components conversion (commit `9acc3d730`), this provider was moved from the `schedule` NgModule to a route-level provider in `schedule.routes.ts`.

`ServerLocationEditorComponent` is opened via `MatDialog.open(...)` without a `viewContainerRef`/`injector`, so the dialog's injector parents to `MatDialog`'s (root) injector and does **not** inherit the route-level provider. Material then fell back to the default matcher, which only shows errors after a field is touched — so a freshly opened dialog showed no warnings.

## Fix

Provide `EmErrorStateMatcher` directly at the component level on `ServerLocationEditorComponent`, so the eager invalid-state matcher applies regardless of injector hierarchy. No template changes were needed — the `mat-error` elements already exist.

## Test Plan

1. Open `em/settings/schedule/settings`.
2. Under **Server Save Paths**, click **Add**.
3. Verify "The label is required" and "The path is required" warnings appear immediately under the Label and Path fields.
4. Confirm duplicate-label / duplicate-path validation still works when entering values.
5. Regression: confirm validation behavior on non-dialog schedule pages is unchanged.

Verified: `ng build em` ✓, `ng test em` (301 tests) ✓, `ng lint em` ✓.

Fixes Redmine #75340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)