### PR TITLE
Bug #75325, convert all conditions when toggling Show Server Time Zone

### DIFF
--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.component.ts
@@ -1224,8 +1224,44 @@ export class TaskConditionPane implements OnInit, OnChanges {
             this.convertToTimeZone(this.serverTimeZoneOffset, this.localTimeZoneOffset);
          }
 
+         // also convert the other conditions of a multi-condition task so their times are
+         // displayed in the new time zone when edited later (Bug #75325). each condition is
+         // converted using its own time zone offset, which may differ from the current one.
+         this.convertOtherConditions(this.serverTimeZone);
+
          this.updateTimeZone();
          LocalStorage.setItem(TZ_STORAGE_KEY, this.serverTimeZone + "");
+      }
+   }
+
+   /**
+    * Converts the times of the task's other time conditions (not currently being edited)
+    * between their own time zone and the server time zone.
+    */
+   private convertOtherConditions(toServerTimeZone: boolean): void {
+      if(!this.model || !this.model.conditions) {
+         return;
+      }
+
+      for(const cond of this.model.conditions) {
+         if(cond === this.condition || !this.isTimeCondition(cond)) {
+            continue;
+         }
+
+         const timeCondition = <TimeConditionModel> cond;
+         const condTzOffset =
+            this.timeZoneService.calculateTimezoneOffset(timeCondition.timeZone);
+
+         if(condTzOffset == this.serverTimeZoneOffset) {
+            continue;
+         }
+
+         if(toServerTimeZone) {
+            this.convertTimeCondition(timeCondition, condTzOffset, this.serverTimeZoneOffset);
+         }
+         else {
+            this.convertTimeCondition(timeCondition, this.serverTimeZoneOffset, condTzOffset);
+         }
       }
    }
 

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.spec.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.spec.ts
@@ -34,7 +34,6 @@ import {
    TimeConditionModel,
    TimeConditionType
 } from "../../../../../../../shared/schedule/model/time-condition-model";
-import { TimeZoneModel } from "../../../../../../../shared/schedule/model/time-zone-model";
 import { ScheduleTaskNamesService } from "../../../../../../../shared/schedule/schedule-task-names.service";
 import { TestUtils } from "../../../../common/test/test-utils";
 import { ComponentTool } from "../../../../common/util/component-tool";
@@ -505,6 +504,15 @@ describe("Task Condition Pane Unit Test", () => {
       expect(cond1.hour).toBe(6);
       expect(cond1.minute).toBe(30);
       expect(cond2.hour).toBe(6);
+      expect(cond2.minute).toBe(30);
+
+      // toggling back to local must run the reverse path (convertOtherConditions(false))
+      // and restore every condition to its original 02:30 EDT
+      taskConditionPane.changeServerTimeZone(false);
+
+      expect(cond1.hour).toBe(2);
+      expect(cond1.minute).toBe(30);
+      expect(cond2.hour).toBe(2);
       expect(cond2.minute).toBe(30);
    });
 

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.spec.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.spec.ts
@@ -34,6 +34,7 @@ import {
    TimeConditionModel,
    TimeConditionType
 } from "../../../../../../../shared/schedule/model/time-condition-model";
+import { TimeZoneModel } from "../../../../../../../shared/schedule/model/time-zone-model";
 import { ScheduleTaskNamesService } from "../../../../../../../shared/schedule/schedule-task-names.service";
 import { TestUtils } from "../../../../common/test/test-utils";
 import { ComponentTool } from "../../../../common/util/component-tool";
@@ -461,6 +462,50 @@ describe("Task Condition Pane Unit Test", () => {
       taskConditionPane.copyCondition();
 
       expect(taskConditionPane.model.conditions.length).toBe(2);
+   });
+
+   // Bug #75325: toggling "Show Server Time Zone" while editing one condition must also
+   // convert the other conditions of the task so their times display in the server zone
+   // when later edited; otherwise a sibling shows its raw local time labeled as the server
+   // zone.
+   it("should convert all conditions when switching to server time zone (bug #75325)", () => {
+      // deterministic offset-shift stub (the default harness stubs convertTime to identity,
+      // which would hide the conversion). value shifts by (newTz - oldTz).
+      taskConditionPane.convertTime = vi.fn().mockImplementation((value, oldTz, newTz) => {
+         const shifted = value.hour + (newTz - oldTz) / (60 * 60 * 1000);
+         return { hour: ((shifted % 24) + 24) % 24, minute: value.minute, second: value.second };
+      });
+
+      const utcOffset = 0;
+      const easternOffset = -4 * 60 * 60 * 1000; // EDT = UTC-4
+      // both conditions stored at 02:30 in Eastern; server zone is UTC
+      const cond1 = {
+         conditionType: "TimeCondition", type: TimeConditionType.EVERY_DAY,
+         label: "Condition 1", timeZone: "America/New_York",
+         hour: 2, minute: 30, second: 0
+      } as TimeConditionModel;
+      const cond2 = {
+         conditionType: "TimeCondition", type: TimeConditionType.EVERY_DAY,
+         label: "Condition 2", timeZone: "America/New_York",
+         hour: 2, minute: 30, second: 0
+      } as TimeConditionModel;
+
+      taskConditionPane.model.conditions = [cond1, cond2];
+      (taskConditionPane as any).conditionIndex = 0;
+      taskConditionPane.serverTimeZone = false;
+      (taskConditionPane as any).serverTimeZoneOffset = utcOffset;
+      (taskConditionPane as any).localTimeZoneOffset = easternOffset;
+
+      // calculateTimezoneOffset is environment dependent; force Eastern for the siblings
+      taskConditionPane["timeZoneService"].calculateTimezoneOffset = vi.fn(() => easternOffset);
+
+      taskConditionPane.changeServerTimeZone(true);
+
+      // both the edited condition and the sibling must convert 02:30 EDT -> 06:30 UTC
+      expect(cond1.hour).toBe(6);
+      expect(cond1.minute).toBe(30);
+      expect(cond2.hour).toBe(6);
+      expect(cond2.minute).toBe(30);
    });
 
    //Bug #19860 should keep last condition


### PR DESCRIPTION
## Summary

In the portal schedule editor, toggling **Show Server Time Zone** on a multi-condition task only converted the condition currently being edited. Sibling conditions kept their raw local times, so opening one afterward showed an unconverted time mislabeled as the server zone (e.g. a condition stored at 02:30 Eastern displayed as `02:30 Coordinated Universal Time` instead of `06:30 Coordinated Universal Time`).

## Root Cause

`changeServerTimeZone()` → `convertToTimeZone()` iterates `this.timeConditions`, a Set containing only the five per-type stash conditions plus the currently-edited condition — never the other entries of `model.conditions`. Re-opening a sibling via `editCondition()` → `initTimeZone(true)` → `changeServerTimeZone(true)` is then a no-op because `serverTimeZone` is already `true` (`changed == false`), so siblings are never converted. Each `TimeCondition`'s `hour`/`minute` are interpreted in its own `timeZone` on the server, so an unconverted sibling renders incorrectly under the server zone.

## Fix

In `changeServerTimeZone()`, after the existing `convertToTimeZone(...)` call, also convert the task's other time conditions via a new `convertOtherConditions()` method. It iterates `model.conditions`, skips the currently-edited condition (same object reference) and non-time (chained) conditions, computes each sibling's own offset from its `timeZone`, skips siblings already in the server zone, and reuses the existing `convertTimeCondition()` with the correct direction. This restores a uniform invariant: flag on → all conditions display in server time; flag off → each in its own zone. No double conversion occurs because the per-type stash entries are deep clones (`Tool.clone`), disjoint from `model.conditions` entries.

## Test Plan

- New regression test in `task-condition-pane.spec.ts`: two conditions stored at 02:30 Eastern, server zone UTC; toggling on converts both the edited condition and the sibling to 06:30. Verified to **fail** before the fix (`expected 2 to be 6`) and pass after.
- `ng build portal` succeeds; ESLint clean on changed files.
- Manual: open a multi-condition task → set condition #2 to 02:30 Eastern → check "Show Server Time Zone" while editing condition #1 → open condition #2 → shows 06:30 UTC.

Fixes Redmine #75325.