### PR TITLE
Bug #75336, restore uniform button width in Schedule Classpath dialog

### DIFF
--- a/web/projects/em/src/app/settings/schedule/schedule-configuration-view/schedule-classpath-dialog/schedule-classpath-dialog.component.scss
+++ b/web/projects/em/src/app/settings/schedule/schedule-configuration-view/schedule-classpath-dialog/schedule-classpath-dialog.component.scss
@@ -88,9 +88,7 @@
         flex-direction: column;
 
         .right-button-group {
-          // explicitly fill the pane width so every button shares the same
-          // width; the Material 21 upgrade changed the surrounding flex
-          // structural styles so the group divs no longer stretch implicitly. (Bug #75336)
+          // Material 21 no longer implicitly stretches flex children; set width explicitly. (Bug #75336)
           width: 100%;
           margin-bottom: 2.5em;
 

--- a/web/projects/em/src/app/settings/schedule/schedule-configuration-view/schedule-classpath-dialog/schedule-classpath-dialog.component.scss
+++ b/web/projects/em/src/app/settings/schedule/schedule-configuration-view/schedule-classpath-dialog/schedule-classpath-dialog.component.scss
@@ -81,12 +81,17 @@
 
       .right-button-pane{
         height: 100%;
+        width: 100%;
         display: flex;
         flex-shrink: 1;
         flex-grow: 1;
         flex-direction: column;
 
         .right-button-group {
+          // explicitly fill the pane width so every button shares the same
+          // width; the Material 21 upgrade changed the surrounding flex
+          // structural styles so the group divs no longer stretch implicitly. (Bug #75336)
+          width: 100%;
           margin-bottom: 2.5em;
 
           .mat-mdc-button {


### PR DESCRIPTION
## Summary

In Enterprise Manager → Settings → Schedule → "Schedule Classpath" dialog, the right-side action buttons (New, Edit, Delete, Move Down, Move Up, Edit Text) lost their uniform width after the Angular 20→21 / Material 20→21 upgrade. They should all be the same width as the widest ("Move Down").

## Root Cause

The buttons are laid out in three `<div class="right-button-group">` blocks inside `.right-button-pane` (a flex column). Each button already has `width: 100%`, so within a group the buttons stay equal — but the layout relied on the flex default `align-items: stretch` to stretch each group div to the full pane width. The Material 21 structural style changes (e.g. `mat-card` flex layout) broke that implicit stretch, so each group div collapsed to its own content width and buttons across groups no longer matched.

## Fix

In `schedule-classpath-dialog.component.scss`, explicitly set `width: 100%` on `.right-button-pane` and `.right-button-group` instead of relying on the flex stretch default. This restores the chain pane → group → button at full width, so all six buttons render at the same width. No HTML/TS change.

## Test Plan

- Open EM → Settings → Schedule → Schedule Classpath → Edit; confirm New / Edit / Delete / Move Down / Move Up / Edit Text are all the same width (matching the pre-upgrade appearance).
- The component SCSS compiles cleanly (verified with the sass compiler).
- Change is scoped to this dialog (selector rooted at the `.schedule-classpath-dialog` host class); the left list pane and other components are unaffected.

Fixes Redmine #75336.