### PR TITLE
Bug #75333, use $index track keys for chart legend and annotation loops

### DIFF
--- a/web/projects/portal/src/app/graph/objects/chart-area.component.html
+++ b/web/projects/portal/src/app/graph/objects/chart-area.component.html
@@ -244,7 +244,7 @@
               (click)="selectLegendBackground($event)">
             </div>
           }
-          @for (legend of model.legends; track legendTrackByFn($index, legend)) {
+          @for (legend of model.legends; track $index) {
             <chart-legend-container
               class="chart-legend-container"
               [chartContainer]="chartContainer"

--- a/web/projects/portal/src/app/graph/objects/chart-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-area.component.ts
@@ -1493,14 +1493,6 @@ export class ChartArea implements OnInit, OnChanges, OnDestroy {
       return index;
    }
 
-   legendTrackByFn(index: number, item: any): string {
-      if (!!item?.field) {
-         return item.field;
-      }
-
-      return item.legendIndex;
-   }
-
    get chartContainerVisible(): boolean {
       return !!this.model && (this.noData || this.model.invalid || this.emptyChart ||
          this.paintNoDataChart() || this.vsChartModel.empty) || !(this.model && this.model.invalid) && this.imageError;

--- a/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.html
@@ -173,7 +173,7 @@
                     showDetails($event.sortInfo, $event.format, $event.column, $event.str, $event.detailStyle, $event.dndInfo, $event.newColName, $event.toggleHide)">
     </vs-preview-table>
     @if (enableAnnotation) {
-      @for (annotationModel of model.assemblyAnnotationModels; track annotationModel) {
+      @for (annotationModel of model.assemblyAnnotationModels; track $index) {
         <vs-annotation
           [model]="annotationModel"
           [actions]="actions"


### PR DESCRIPTION
## Summary

Performing chart actions in the composer caused UI flashing and input lag, with the console logging `NG0955` (duplicated track keys — key `"0"`) and `NG0956` (track-by-identity full re-creation). Two `@for` loops in the chart render path used non-unique track keys, forcing Angular to destroy and recreate the entire collection on every chart update. Switched both to `track $index` so Angular reuses DOM nodes in place.

## Root Cause

Regression from the Angular 20→21 control-flow migration (`*ngFor` → `@for`):

- **NG0955** — `graph/objects/chart-area.component.html:247` used `track legendTrackByFn($index, legend)`. `legendTrackByFn` returned `item.field || item.legendIndex`; `LegendContainer.field` is a string (empty for many legends) and `legendIndex` is a number, so the key collapsed to the constant `0` for every legend → duplicate keys → full reconciliation. This was the only value-returning track expression in the entire portal.
- **NG0956** — `vsobjects/objects/chart/vs-chart.component.html:176` used `track annotationModel` (object identity) on `model.assemblyAnnotationModels`, which is rebuilt with new object references on each chart refresh → identity changes every cycle → full re-creation.

(The similar-looking `chart-axis-area.component.html:93` `track trackByFn(i, op); let i = $index` is correct — Angular 21 hoists the `let i = $index` alias into the track scope, verified against the shipped compiler — and was left unchanged.)

## Fix

- `chart-area.component.html:247`: `track legendTrackByFn($index, legend)` → `track $index`
- `chart-area.component.ts`: removed the now-unused `legendTrackByFn` method (no other references)
- `vs-chart.component.html:176`: `track annotationModel` → `track $index`

Both collections are re-emitted whole from server models each render, so positional `$index` gives stable, unique keys enabling in-place rebinding — matching every sibling chart loop (facets/axes/titles/tiles/legendObjects already track by `$index`). The child components (`chart-legend-container` via `ngOnChanges`, `vs-annotation` via its OnPush `@Input` setter) re-read all state from their model input, so reused DOM nodes rebind correctly with no stale data.

## Test Plan

- `ng build portal` succeeds; ESLint clean on changed files; vs-chart spec compiles/passes.
- Manual: in the composer, perform chart actions (drag fields, change aesthetics, brush/zoom) and confirm the console no longer logs NG0955/NG0956 and the chart no longer flashes or lags.

Fixes Redmine #75333.