### PR TITLE
Bug #75331, restore 14px monitoring chart title font size

### DIFF
--- a/web/projects/em/src/app/monitoring/summary/summary-monitoring-view/summary-monitoring-chart-view/_summary-monitoring-chart-view-theme.scss
+++ b/web/projects/em/src/app/monitoring/summary/summary-monitoring-view/summary-monitoring-chart-view/_summary-monitoring-chart-view-theme.scss
@@ -22,8 +22,11 @@
     .mat-mdc-card {
       .mat-mdc-card-header {
         h5 {
+          // Use subtitle-1 (14px) for the chart title. body-2 is now 12px in
+          // the em typography config, which shrank the title after the M1->M2
+          // typography migration (it previously relied on body-2's 14px default).
           font: {
-            size: mat.m2-font-size($config, body-2);
+            size: mat.m2-font-size($config, subtitle-1);
           }
         }
       }


### PR DESCRIPTION
## Summary

On `em/monitoring/summary`, the chart titles (e.g. "Heap Memory Usage") regressed to 12px after the Angular upgrade; they should be 14px. This restores the 14px size.

## Root Cause

The chart-title `<h5>` size is set by `summary-monitoring-chart-view-typography` in `_summary-monitoring-chart-view-theme.scss`, which used `mat.m2-font-size($config, body-2)`.

Before the Angular 17→18 upgrade, `$em-typography-config` did not define `body-2`, so it fell back to Angular Material's M1 default of 14px. The upgrade's typography migration (a) renamed `mat.font-size` → `mat.m2-font-size` and (b) added an explicit `$body-2: 12px` to the config — so the title that referenced `body-2` shrank from 14px to 12px.

## Fix

Point the title mixin at `subtitle-1` (defined as `14px/14px/700` in the em typography config, light and dark), which is the level that resolves to 14px and is semantically appropriate for a title. Only `font-size` is set (as before); weight/family are unchanged.

The shared `body-2` level is intentionally left at 12px so other components that rely on it (tables, file-choosers, dialogs) are unaffected.

## Test Plan

- `ng build em` succeeds (SCSS compiles).
- `ng test em` (301 tests) and `ng lint em` pass.
- Manual: open `em/monitoring/summary` and confirm chart titles render at 14px (both light and dark themes).

Fixes Redmine #75331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)