### PR TITLE
Bug #75332, restore 14px section title size in organization editor

### DIFF
--- a/web/projects/em/src/app/settings/security/property-table-view/property-table-view.component.scss
+++ b/web/projects/em/src/app/settings/security/property-table-view/property-table-view.component.scss
@@ -19,6 +19,13 @@ table {
   width: 100%;
 }
 
+// The label is raw text in mat-card-header, which Material assigns no typography
+// token to, so it inherits the ambient size. Restore the 14px title size lost in
+// the Angular/Material typography migration.
+.mat-mdc-card-header {
+  font-size: 14px;
+}
+
 .table-container {
   flex: 1 1 auto;
   overflow-y: auto;

--- a/web/projects/em/src/app/settings/security/security-table-view/security-table-view.component.scss
+++ b/web/projects/em/src/app/settings/security/security-table-view/security-table-view.component.scss
@@ -19,6 +19,13 @@ table {
   width: 100%;
 }
 
+// The label is raw text in mat-card-header, which Material assigns no typography
+// token to, so it inherits the ambient size. Restore the 14px title size lost in
+// the Angular/Material typography migration.
+.mat-mdc-card-header {
+  font-size: 14px;
+}
+
 .table-container {
   flex: 1 1 auto;
   overflow-y: auto;


### PR DESCRIPTION
## Summary

On `em/settings/security/users`, selecting an Organization showed the "Members", "Administrator Permissions", and "Properties" section titles at 12px; they should be 14px. This restores 14px.

## Root Cause

All three titles render as raw text inside a Material card header:
- `security-table-view.component.html` → `<mat-card-header>{{label}}</mat-card-header>` ("Members" and "Administrator Permissions")
- `property-table-view.component.html` → `<mat-card-header>{{label}}</mat-card-header>` ("Properties")

Angular Material's card typography (`@angular/material/card/_m2-card.scss`) only assigns font tokens to `.mat-mdc-card-title` and `.mat-mdc-card-subtitle` — not to raw text in `.mat-mdc-card-header`. So the label inherits the ambient font size, which dropped from 14px to 12px after the M2 typography migration, with nothing to restore it.

## Fix

Set the card-header label to 14px in the two components that render these section titles (`security-table-view.component.scss` and `property-table-view.component.scss`). Each template contains exactly one `<mat-card-header>` (the label), and the element is in the component's own template, so the component-scoped rule matches it directly.

## Test Plan

- `ng build em` succeeds (SCSS compiles).
- `ng test em` (301 tests) and `ng lint em` pass.
- Manual: open `em/settings/security/users`, select an Organization (e.g. "Host Organization"), and confirm the "Members", "Administrator Permissions", and "Properties" titles render at 14px.

Fixes Redmine #75332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)