### PR TITLE
Bug #75335, fix value-type icon position in dynamic value editor

### DIFF
--- a/web/projects/em/src/app/widget/dynamic-combo-box.component.html
+++ b/web/projects/em/src/app/widget/dynamic-combo-box.component.html
@@ -22,22 +22,18 @@
         <mat-label>_#(Value)</mat-label>
         <input matInput type="text" [placeholder]="getPromptString()" formControlName="value"
           [matAutocomplete]="auto">
-        @if (!array) {
-          <button matSuffix mat-icon-button aria-label="_#(Value Type)"
-            title="_#(Value Type)" [matMenuTriggerFor]="typeMenu" (click)="closeAutoComplete($event)">
-            <mat-icon fontSet="ineticons" class="icon-size-medium" fontIcon="function-and-variable-icon"></mat-icon>
-          </button>
-        }
-        @if (!array && isDate) {
-          <button matSuffix mat-icon-button aria-label="_#(Select a Date)"
-            title="_#(Select a Date)"
-            #menuTrigger="matMenuTrigger"
-            [matMenuTriggerFor]="dateMenu"
-            (menuOpened)="onDateMenuOpened()"
-            >
-            <mat-icon fontSet="ineticons" fontIcon="calendar-icon"></mat-icon>
-          </button>
-        }
+        <button matSuffix mat-icon-button *ngIf="!array" aria-label="_#(Value Type)"
+          title="_#(Value Type)" [matMenuTriggerFor]="typeMenu" (click)="closeAutoComplete($event)">
+          <mat-icon fontSet="ineticons" class="icon-size-medium" fontIcon="function-and-variable-icon"></mat-icon>
+        </button>
+        <button matSuffix mat-icon-button *ngIf="!array && isDate" aria-label="_#(Select a Date)"
+          title="_#(Select a Date)"
+          #menuTrigger="matMenuTrigger"
+          [matMenuTriggerFor]="dateMenu"
+          (menuOpened)="onDateMenuOpened()"
+          >
+          <mat-icon fontSet="ineticons" fontIcon="calendar-icon"></mat-icon>
+        </button>
         <mat-error *ngIf="hasError">
           {{getErrorMessage()}}
         </mat-error>
@@ -48,12 +44,10 @@
         <mat-label>_#(Value)</mat-label>
         <input matInput type="number" placeholder="_#(Value)" formControlName="value"
           [matAutocomplete]="auto">
-        @if (!array) {
-          <button matSuffix mat-icon-button aria-label="_#(Value Type)"
-            title="_#(Value Type)" [matMenuTriggerFor]="typeMenu" (click)="closeAutoComplete($event)">
-            <mat-icon fontSet="ineticons" class="icon-size-medium" fontIcon="function-and-variable-icon"></mat-icon>
-          </button>
-        }
+        <button matSuffix mat-icon-button *ngIf="!array" aria-label="_#(Value Type)"
+          title="_#(Value Type)" [matMenuTriggerFor]="typeMenu" (click)="closeAutoComplete($event)">
+          <mat-icon fontSet="ineticons" class="icon-size-medium" fontIcon="function-and-variable-icon"></mat-icon>
+        </button>
         <mat-error *ngIf="hasError">
           {{getErrorMessage()}}
         </mat-error>
@@ -63,18 +57,14 @@
       <mat-form-field appearance="outline" color="accent">
         <mat-label>_#(Value)</mat-label>
         <input matInput type="text" placeholder="_#(Value)" formControlName="value">
-        @if (type == ComboMode.EXPRESSION && !array) {
-          <button matSuffix mat-icon-button
-            (click)="showFormulaEditor()">
-            <mat-icon fontSet="ineticons" class="icon-size-medium" fontIcon="formula-edit-icon"></mat-icon>
-          </button>
-        }
-        @if (!array) {
-          <button matSuffix mat-icon-button aria-label="_#(Value Type)"
-            title="_#(Value Type)" [matMenuTriggerFor]="typeMenu" (click)="closeAutoComplete($event)">
-            <mat-icon fontSet="ineticons" class="icon-size-medium" fontIcon="function-and-variable-icon"></mat-icon>
-          </button>
-        }
+        <button matSuffix mat-icon-button *ngIf="type == ComboMode.EXPRESSION && !array"
+          (click)="showFormulaEditor()">
+          <mat-icon fontSet="ineticons" class="icon-size-medium" fontIcon="formula-edit-icon"></mat-icon>
+        </button>
+        <button matSuffix mat-icon-button *ngIf="!array" aria-label="_#(Value Type)"
+          title="_#(Value Type)" [matMenuTriggerFor]="typeMenu" (click)="closeAutoComplete($event)">
+          <mat-icon fontSet="ineticons" class="icon-size-medium" fontIcon="function-and-variable-icon"></mat-icon>
+        </button>
       </mat-form-field>
     }
     <mat-autocomplete #auto="matAutocomplete">


### PR DESCRIPTION
## Summary

In the EM scheduler "Add Parameter" dialog (Action tab → Creation Parameters → Add), the value-type-toggle icon rendered at the top-left of an enlarged Value box instead of as a suffix at the right end of the field. Restored correct suffix placement.

## Root Cause

Regression from the Angular 20→21 upgrade (commit `b667af680`). The dynamic value editor `em-dynamic-combo-box` renders `<button matSuffix mat-icon-button>` icons inside `<mat-form-field>`. The upgrade converted these from `<button *ngIf="…" matSuffix>` to `@if (…) { <button matSuffix> }`. In Angular 21, wrapping a **named content-projection target** (`matSuffix`) in an `@if` block breaks the projection — the button is no longer placed in the form field's suffix slot and instead renders as ordinary content at the start of the field, enlarging it.

This is the same defect class as Bug #75272, whose follow-up converted the `mat-error`/`mat-label` projections in this same file back to `*ngIf` but **missed the five `matSuffix` buttons**.

## Fix

Converted all five `@if`-wrapped `<button matSuffix>` elements in `dynamic-combo-box.component.html` back to `<button matSuffix *ngIf="…">`, the pattern established by #75272 — restoring suffix-slot projection. Conditions are preserved verbatim (`!array`; `!array && isDate`; `!array`; `type == ComboMode.EXPRESSION && !array`; `!array`). `NgIf` is already in the component's imports. The three `@if` blocks wrapping whole `<mat-form-field>` elements are correctly left as-is (a form field is a standalone component, not a projected slot).

## Test Plan

- `ng build em` succeeds; ESLint clean on the changed template.
- Manual: EM → new task → **Action** tab → **Creation Parameters** → **Add** → confirm the value-type-toggle icon appears at the right end of the Value field (vertically centered), not at the top-left of an enlarged box. The same editor is used by other dynamic value inputs, which are corrected too.

Fixes Redmine #75335.