### PR TITLE
Bug #75326, apply VS_ASSEMBLY adhoc aggregate filter as HAVING in live mode

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
@@ -3015,9 +3015,19 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
          boolean postConditionHasCubeMeasure =
             "true".equals(table.getProperty("Post_Condition_HasCubeMeasure"));
 
+         // An adhoc filter on a chart aggregate (VS_ASSEMBLY source) places the aggregate
+         // filter (e.g. Sum(customer_id) >= N) in the post-runtime (HAVING) slot of the
+         // wrapping mirror table. The mirror itself is not aggregated (its aggregation is in
+         // the inner table) and the composer preview runs in live mode, so without this check
+         // the guard below would discard that HAVING and the chart would not be filtered.
+         // (Bug #75326, follow-on to #75263)
+         ConditionListWrapper postRtWrapper = table.getPostRuntimeConditionList();
+         boolean hasPostRuntimeCondition = postRtWrapper != null &&
+            postRtWrapper.getConditionList() != null && !postRtWrapper.getConditionList().isEmpty();
+
          if(!postConditionHasCubeMeasure && !table.isAggregate()
             && !AssetQuerySandbox.isEmbeddedMode(mode) && !isSubQuery() && ginfo.isEmpty()
-            && !AssetQuerySandbox.isRuntimeMode(mode))
+            && !AssetQuerySandbox.isRuntimeMode(mode) && !hasPostRuntimeCondition)
          {
             postconds = new ConditionList();
          }


### PR DESCRIPTION
## Summary

In the Visual Composer, selecting a bar in a chart and choosing **Filter** on a *measure* column creates an adhoc range-slider (a `TimeSlider` bound to the aggregate, e.g. `Sum(customer_id)`, with `VS_ASSEMBLY` source = the chart). Dragging the slider had **no effect** on the chart — the bars never filtered, and no error was shown.

This is a follow-on to **#75263** (`f7857bbfc`), which fixed the *routing* of the condition but not its *application* at execution time.

## Root Cause

Verified end-to-end with temporary runtime logging (since removed):

1. The frontend sends the apply event correctly.
2. The selection builds the right condition: `Sum(customer_id) >= N`.
3. `VSAQuery.mergePostCondition()` (the #75263 fix) correctly routes it into the **post-runtime (HAVING)** slot on the chart's wrapping **mirror** table (`originalAggregated=true`).
4. The chart re-executes and `PreAssetQuery.getPostConditionList()` is reached on the mirror, which *does* carry the condition.
5. **But** execution runs in **LIVE_MODE** and the mirror itself is not aggregated (`!table.isAggregate()`, `ginfo.isEmpty()` — the aggregation lives in the mirror's inner table). So the early-return guard in `getPostConditionList()` reset `postconds` to an empty list, **discarding the HAVING** → the chart was never filtered.

## Fix

In `PreAssetQuery.getPostConditionList()`, skip the early-return that discards post conditions when the table actually has a non-empty **post-runtime** condition. When present, it falls through to the existing else-branch that merges design + runtime post conditions and validates them.

```java
ConditionListWrapper postRtWrapper = table.getPostRuntimeConditionList();
boolean hasPostRuntimeCondition = postRtWrapper != null &&
   postRtWrapper.getConditionList() != null && !postRtWrapper.getConditionList().isEmpty();

if(!postConditionHasCubeMeasure && !table.isAggregate()
   && !isEmbeddedMode(mode) && !isSubQuery() && ginfo.isEmpty()
   && !isRuntimeMode(mode) && !hasPostRuntimeCondition)   // <- added term
{
   postconds = new ConditionList();
}
```

The new term only changes behavior when a post-runtime condition exists (the adhoc measure-filter case); with none, the guard is unchanged, so normal live-mode/non-aggregate queries are unaffected.

## Test Plan

- Import the case from the Redmine issue, open the `filter` viewsheet in Composer, select a bar, Filter on the measure, drag the slider — the chart now filters to the states whose `Sum(customer_id)` falls in the selected range (verified in a running build).
- Regression: charts/tables without an adhoc measure filter are unaffected (the new guard term is only true when a post-runtime condition is present).

Related: #75263 (this completes that fix). Fixes Redmine #75326.