### PR TITLE
Bug #75338, restore required-field errors in Time Range editor dialog

### DIFF
--- a/web/projects/em/src/app/settings/schedule/schedule-configuration-page/time-range-editor/time-range-editor.component.ts
+++ b/web/projects/em/src/app/settings/schedule/schedule-configuration-page/time-range-editor/time-range-editor.component.ts
@@ -37,7 +37,9 @@ import { MatInput } from "@angular/material/input";
 import { MatFormField, MatLabel, MatError } from "@angular/material/form-field";
 import { MatCard, MatCardContent } from "@angular/material/card";
 import { MatTabGroup, MatTab } from "@angular/material/tabs";
+import { ErrorStateMatcher } from "@angular/material/core";
 import { ModalHeaderComponent } from "../../../../common/util/modal-header/modal-header.component";
+import { EmErrorStateMatcher } from "../../../../common/util/error/em-error-state-matcher";
 import { NgIf } from "@angular/common";
 
 export interface TimeRangeData {
@@ -50,6 +52,10 @@ export interface TimeRangeData {
     templateUrl: "./time-range-editor.component.html",
     styleUrls: ["./time-range-editor.component.scss"],
     encapsulation: ViewEncapsulation.None,
+    // This dialog is opened via MatDialog, which uses the root injector and does
+    // not inherit the schedule route's EmErrorStateMatcher provider. Provide it
+    // here so required-field errors display eagerly (Bug #75338).
+    providers: [{ provide: ErrorStateMatcher, useClass: EmErrorStateMatcher }],
     imports: [NgIf, ModalHeaderComponent, MatDialogContent, FormsModule, ReactiveFormsModule, MatTabGroup, MatTab, MatCard, MatCardContent, MatFormField, MatLabel, MatInput, MatError, MatCheckbox, ResourcePermissionComponent, MatDialogActions, MatButton]
 })
 export class TimeRangeEditorComponent implements OnInit {


### PR DESCRIPTION
## Summary

In EM → Settings → Schedule → Time Ranges → Add, the "Start Time is required" / "End Time is required" (and Name) validation errors stopped appearing when the fields are empty on dialog open. Restored the eager error display.

## Root Cause

Regression from the EM standalone-bootstrap migration (commit `cb25c520c`). EM uses a custom `EmErrorStateMatcher` whose `isErrorState()` returns `control.invalid` with no touched/dirty gate, so required errors display eagerly on open. Previously `schedule.module.ts` (an NgModule) both declared `TimeRangeEditorComponent` and provided `{ provide: ErrorStateMatcher, useClass: EmErrorStateMatcher }` at module level, which the dialog inherited.

The migration removed that module and moved the provider to the **schedule route** (`schedule.routes.ts`). The Time Range editor is opened via `MatDialog` (with no `viewContainerRef`/`injector` in its config), so it is created against the **root injector** and does not inherit route-level providers. It fell back to Angular Material's default touched-gated `ErrorStateMatcher`, which only shows errors after a control is touched/dirty/submitted — so a freshly-opened dialog with empty Start/End Time showed no errors.

(This is not the `@if`-projection regression class; the `mat-error`s here correctly use `*ngIf`.)

## Fix

Provide `EmErrorStateMatcher` at the **component level** on `TimeRangeEditorComponent`:

```ts
providers: [{ provide: ErrorStateMatcher, useClass: EmErrorStateMatcher }],
```

Component providers are part of the component's element injector, which the dialog's `MatFormField`/`MatInput` children resolve against — restoring eager error display for all three fields (Name, Start Time, End Time) regardless of how the dialog is instantiated. Scoped to this dialog; not provided at root to avoid changing error behavior app-wide.

## Test Plan

- `ng build em` succeeds; ESLint clean on the changed file.
- Manual: EM → Settings → Schedule → Time Ranges → **Add** → leave Start Time / End Time empty → confirm "The start time is required" and "The end time is required" errors appear (matching the pre-regression behavior).

## Note

Other dialogs opened the same way from the schedule route may share this latent provider-inheritance gap; this PR fixes only the reported Time Range editor (minimal scope).

Fixes Redmine #75338.