### PR TITLE
Bug #75329, track mini-toolbar @for by index to stop full DOM recreation

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/mini-toolbar/mini-toolbar.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/mini-toolbar/mini-toolbar.component.html
@@ -25,10 +25,14 @@
       [style.min-width.px]="width"
       [style.justify-content]="alignLeft ? 'flex-start' : null"
       aria-label="Component Toolbar">
-      @for (group of getActions(); track group; let i = $index) {
+      <!-- track by positional index: getActions() returns a freshly-built collection each
+           change-detection pass, so tracking by identity recreated the entire toolbar DOM
+           every pass (NG0956). The toolbar is positional, so index tracking is stable and
+           the inner bindings still re-evaluate per pass. (Bug #75329) -->
+      @for (group of getActions(); track $index; let i = $index) {
         @if (group.visible) {
           <div class="btn-group mini-toolbar-button-group" role="group">
-            @for (action of group.actions; track action; let j = $index) {
+            @for (action of group.actions; track $index; let j = $index) {
               @if (action.visible()) {
                 <button type="button" role="button"
                   class="btn icon-hover-bg btn-sm bg-white2 bd-gray"


### PR DESCRIPTION
## Summary

After the Angular 20→21 upgrade, interacting with a chart in Composer (e.g. hiding/showing an axis) triggered excessive component re-renders. In a dev build this surfaced as repeated **NG0956** warnings from `mini-toolbar.component.html`: *"The configured tracking expression (track by identity) caused re-creation of the entire collection of size 3."*

## Root Cause

The `*ngFor` → `@for` migration produced identity-based tracking over a method-call collection:

```
@for (group of getActions(); track group; ...) {
  @for (action of group.actions; track action; ...) { ... }
}
```

`getActions()` is evaluated on every change-detection pass and returns a freshly-built collection whose group/action references churn between passes. With `track group`/`track action` (object identity), Angular therefore **destroys and recreates the entire toolbar DOM on every change-detection pass** — an expensive operation that the chart's hide-axis layout transitions (many CD passes) amplified into the reported "2-3× slower / excessive re-renders".

(The legacy `*ngFor` had the same implicit identity tracking, so the thrash pre-dated the upgrade — but Angular 21's new NG0956 dev check surfaced it, and it's a real, fixable performance problem either way.)

## Fix

Track both loops by `$index` instead. The toolbar is positional and all inner bindings (`[disabled]`, `title`, `action.icon()`, `isFocused(i, j)`, `(click)="doAction(action, …)"`) are re-evaluated every change-detection pass, so the DOM is reused while content stays correct. This eliminates the per-pass full-DOM recreation (and the NG0956 warning).

## Test Plan

- Open a chart viewsheet in Composer with DevTools console open; hide/show the axis. The repeated `NG0956` warning from `mini-toolbar.component.html` no longer appears, and the toolbar still renders/hovers/clicks normally (verified in a running build).
- `ng build portal` and `ng lint portal` pass.

Fixes Redmine #75329.