### PR TITLE
Bug #75337, hide LDAP under multi-tenancy and fix empty-host LDAP error

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
@@ -510,7 +510,9 @@ public abstract class LdapAuthenticationProvider
       // guard against an empty host so we fail with a clear message instead of
       // letting createContext() build a malformed URL (e.g. "://:0") that throws
       // an unhandled IllegalArgumentException (Bug #75337)
-      if(getHost() == null || getHost().trim().isEmpty()) {
+      String host = getHost();
+
+      if(host == null || host.trim().isEmpty()) {
          throw new SRSecurityException("LDAP host is required");
       }
 

--- a/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
@@ -512,7 +512,7 @@ public abstract class LdapAuthenticationProvider
       // an unhandled IllegalArgumentException (Bug #75337)
       String host = getHost();
 
-      if(host == null || host.trim().isEmpty()) {
+      if(host == null || host.isBlank()) {
          throw new SRSecurityException("LDAP host is required");
       }
 

--- a/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/ldap/LdapAuthenticationProvider.java
@@ -507,6 +507,13 @@ public abstract class LdapAuthenticationProvider
     */
    @Override
    public void checkParameters() throws SRSecurityException {
+      // guard against an empty host so we fail with a clear message instead of
+      // letting createContext() build a malformed URL (e.g. "://:0") that throws
+      // an unhandled IllegalArgumentException (Bug #75337)
+      if(getHost() == null || getHost().trim().isEmpty()) {
+         throw new SRSecurityException("LDAP host is required");
+      }
+
       flushContextPool();
 
       try {

--- a/core/src/main/java/inetsoft/web/admin/AdminExceptionHandler.java
+++ b/core/src/main/java/inetsoft/web/admin/AdminExceptionHandler.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.admin;
 
+import inetsoft.sree.security.SRSecurityException;
 import inetsoft.sree.security.SecurityException;
 import inetsoft.util.Catalog;
 import inetsoft.util.MessageException;
@@ -129,6 +130,24 @@ public class AdminExceptionHandler {
 
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
          .body(handleGenericException(e));
+   }
+
+   /**
+    * Error handler for security/configuration errors such as an LDAP provider
+    * with incomplete connection settings. Returns the error message to the
+    * client without logging it as an unexpected server error.
+    */
+   @ExceptionHandler(SRSecurityException.class)
+   @ResponseBody
+   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+   @ApiResponses({
+      @ApiResponse(
+         responseCode = "500",
+         description = "A security configuration error occurred.")
+   })
+   public GenericError handleSecurityConfigError(SRSecurityException e) {
+      LOG.debug("Security configuration error", e);
+      return new GenericError(e);
    }
 
    /**

--- a/core/src/test/java/inetsoft/sree/security/ldap/GenericLdapAuthenticationProviderTest.java
+++ b/core/src/test/java/inetsoft/sree/security/ldap/GenericLdapAuthenticationProviderTest.java
@@ -481,6 +481,18 @@ class GenericLdapAuthenticationProviderTest {
       }
    }
 
+   // Bug #75337: an empty host must fail fast with a clear error instead of
+   // letting createContext() build a malformed URL ("://:0") that throws an
+   // unhandled IllegalArgumentException.
+   @Test
+   void testCheckParametersRequiresHost() {
+      provider.setHost("");
+      SRSecurityException ex = assertThrows(
+         SRSecurityException.class, () -> provider.checkParameters());
+      assertTrue(ex.getMessage().toLowerCase().contains("host"),
+                 "expected a host-required message but got: " + ex.getMessage());
+   }
+
    private void waitForCache() {
       Awaitility.await()
          .atMost(Duration.ofMinutes(1L))

--- a/core/src/test/java/inetsoft/sree/security/ldap/GenericLdapAuthenticationProviderTest.java
+++ b/core/src/test/java/inetsoft/sree/security/ldap/GenericLdapAuthenticationProviderTest.java
@@ -485,6 +485,7 @@ class GenericLdapAuthenticationProviderTest {
    // letting createContext() build a malformed URL ("://:0") that throws an
    // unhandled IllegalArgumentException.
    @Test
+   @Order(17)
    void testCheckParametersRequiresHost() {
       provider.setHost("");
       SRSecurityException ex = assertThrows(

--- a/web/projects/em/src/app/settings/security/security-provider/authentication-provider-detail-view/authentication-provider-detail-view.component.html
+++ b/web/projects/em/src/app/settings/security/security-provider/authentication-provider-detail-view/authentication-provider-detail-view.component.html
@@ -40,7 +40,7 @@
               <mat-label>_#(Provider Type)</mat-label>
               <mat-select placeholder="_#(Provider Type)" formControlName="providerType">
                 <mat-option [value]="SecurityProviderType.FILE">_#(em.common.security.defaultProvider)</mat-option>
-                @if (model?.ldapProviderEnabled) {
+                @if (model?.ldapProviderEnabled && !isMultiTenant) {
                   <mat-option
                   [value]="SecurityProviderType.LDAP">_#(em.common.security.ldapProvider)</mat-option>
                 }


### PR DESCRIPTION
## Summary

Two related problems in the EM authentication-provider UI under Security + Multi-Tenancy:
1. The **LDAP** provider type still appeared in the "Add authentication provider" dropdown under multi-tenancy (it must be hidden).
2. Clicking get/edit roles for a new LDAP provider with an empty host threw `java.lang.IllegalArgumentException: Expected scheme name at index 0: ://:0`, surfacing as an "Unexpected error" 500.

## Root Cause

**Issue 1 (frontend):** `authentication-provider-detail-view.component.ts#initNewProvider()` bakes `model.ldapProviderEnabled = !this.isMultiTenant` for new providers, but the parent (`authentication-provider-detail-page`) resolves `isMultiTenant` asynchronously (`GET /api/em/navbar/isMultiTenant`) and renders the child unconditionally. At the child's `ngOnInit`, `isMultiTenant` is still the default `false`, so `ldapProviderEnabled` is baked `true` and never recomputed → the template's `@if (model?.ldapProviderEnabled)` keeps LDAP visible under MT. (Existing providers are fine — the backend sets the flag via `!enterprise || !SUtil.isMultiTenant()`.)

**Issue 2 (backend):** `getRolesForNewProvider → getRoles → getProviderFromModel → LdapAuthenticationProvider.checkParameters() → ADAuthenticationProvider.createContext()` builds `ldap://:0` from an empty host/port and throws an unhandled `IllegalArgumentException`. `checkParameters()` only catches `CommunicationException`/`AuthenticationException`/`NamingException`, and `SRSecurityException` (which `extends Exception`, not `MessageException`) hits `AdminExceptionHandler`'s generic path → logs "Unexpected error" + stack → 500.

## Fix

1. **`authentication-provider-detail-view.component.html`** — gate the LDAP option on the live input: `@if (model?.ldapProviderEnabled && !isMultiTenant)`. The `isMultiTenant` `@Input` updates via change detection once the parent's HTTP resolves, so LDAP correctly hides under MT for new providers. DB/Custom options and existing-provider behavior are unchanged.
2. **`LdapAuthenticationProvider.checkParameters()`** — fail fast with `SRSecurityException("LDAP host is required")` when the host is null/blank, before `createContext()`. Prevents the malformed URL for both AD and generic LDAP. (`testConnection` already catches `SRSecurityException`, so its behavior is unchanged/improved.)
3. **`AdminExceptionHandler`** — add `@ExceptionHandler(SRSecurityException.class)` that returns a clean `GenericError` (the message) and logs at DEBUG, so admin endpoints (get-roles/users/groups) render security-config errors cleanly instead of "Unexpected error" 500s.

## Test Plan

- New `GenericLdapAuthenticationProviderTest.testCheckParametersRequiresHost` asserts an empty host throws `SRSecurityException` mentioning "host" (runs in the slow LDAP suite in CI).
- `mvnw compile -pl core` and core test-compile pass; `ng build em` and ESLint pass; `authentication-provider-detail-view` spec passes.
- Manual: (1) Security + Multi-Tenancy → Add authentication provider → LDAP option absent. (2) Add LDAP provider, empty host, click get/edit roles → clean "LDAP host is required" message, no `://:0` error.

Fixes Redmine #75337.