### PR TITLE
Bug #75334, use stable @for track keys in EM to stop full DOM recreation

### DIFF
--- a/web/projects/em/src/app/common/util/table/regular-table/regular-table.component.html
+++ b/web/projects/em/src/app/common/util/table/regular-table/regular-table.component.html
@@ -35,7 +35,7 @@
           </mat-checkbox>
         </td>
       </ng-container>
-      @for (col of columns; track col; let i = $index) {
+      @for (col of columns; track col.field; let i = $index) {
         <ng-container [matColumnDef]="col.field">
           <ng-container class="detail-cell">
             <th mat-header-cell class="table-header-col table-col" *matHeaderCellDef mat-sort-header [title]="col.header"> {{col.header}}</th>

--- a/web/projects/em/src/app/monitoring/summary/summary-monitoring-view/summary-monitoring-chart-view/summary-monitoring-chart-view.component.html
+++ b/web/projects/em/src/app/monitoring/summary/summary-monitoring-view/summary-monitoring-chart-view/summary-monitoring-chart-view.component.html
@@ -43,7 +43,7 @@
 
     @if (showLegends) {
       <div class="summary-chart-legends">
-        @for (legend of legends; track legend) {
+        @for (legend of legends; track $index) {
           <div class="summary-chart-legend-item">
             <div class="summary-chart-legend"
               [style.background]="legend.color"

--- a/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.html
+++ b/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.html
@@ -208,7 +208,7 @@
         }
         @if (distributionChart) {
           <map name="distributionChartMap">
-            @for (value of distributionChart.values; track value) {
+            @for (value of distributionChart.values; track $index) {
               <area
                 shape="rect"
                 [coords]="getDistributionValueCoords(value)"


### PR DESCRIPTION
## Summary

Enterprise Manager pages were slow and logged repeated Angular **NG0956** warnings after the Angular 20→21 upgrade: *"The configured tracking expression (track by identity) caused re-creation of the entire collection."* This is the EM counterpart of #75329 (mini-toolbar).

## Root Cause

The `*ngFor` → `@for` migration produced **identity-based** track expressions over collections that are rebuilt on every change-detection pass, so Angular destroys and recreates the entire DOM collection each pass — expensive, and repeated constantly as EM polls/refreshes.

Affected loops (from the attached log):
- `regular-table.component.html` — `@for (col of columns; track col; …)`
- `summary-monitoring-chart-view.component.html` — `@for (legend of legends; track legend)`
- `schedule-task-list.component.html` — `@for (value of distributionChart.values; track value)`

## Fix

Use stable track keys:
- `regular-table`: `track col` → **`track col.field`** (the unique `matColumnDef` key)
- `summary-monitoring-chart-view` legends: `track legend` → **`track $index`** (positional; `SummaryChartLegend` has no id)
- `schedule-task-list` distribution values: `track value` → **`track $index`** (positional)

All are positional/keyed collections whose inner bindings re-evaluate each pass, so DOM is reused while content stays correct.

### Intentionally not changed
- `settings-sidenav.component.html` (in the reporter's log) has **no `@for`** on current main — it uses `@if` blocks; the log line numbers were stale.
- `schedule-task-list.component.html:131` — `@for (field of expandingColumns; track field)` where `expandingColumns` is a `string[]` constant; tracking a primitive string by value is stable, and the log did not flag it.

## Test Plan

- In EM with DevTools console open, exercise Monitoring → Summary (chart legends), a shared `regular-table` view, and Settings → Schedule task list (distribution chart): the `NG0956` warnings no longer appear and the UI renders/works normally (verified in a running build).
- `ng build em` and `ng lint em` pass.

Related: #75329 (Composer counterpart). Fixes Redmine #75334.