### PR TITLE
Bug #75252, prevent EM logout when Google OAuth2 SMTP sign-in fails on unlicensed instances

### DIFF
--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -4384,6 +4384,7 @@ em.localeAdd.localelabelInvalid=The Locale Label must not be empty.
 em.login.pwdEmpty=Password field is empty.
 em.mail.hostInvalid=The mail host is not valid
 em.mail.hostRequired=The mail host is required
+em.mail.smtp.authorizeFailed=Authorization failed. Please verify your OAuth settings and try again.
 em.mail.smtp.gmailUser=Gmail Authorization User (Will override From address)
 em.mail.smtp.redirect.uri.description=You must use https://data.inetsoft.com/oauth as the redirect URL for your application.
 em.monitor.clusterDisabled=Cluster servers are not available. This feature is only available in the Enterprise edition.

--- a/web/projects/em/src/app/invalid-session-interceptor.ts
+++ b/web/projects/em/src/app/invalid-session-interceptor.ts
@@ -53,6 +53,13 @@ export class InvalidSessionInterceptor implements HttpInterceptor {
     * session and must not trigger a logout.
     */
    private isSameOrigin(url: string): boolean {
+      // A non-http(s) scheme (e.g. data:, blob:, mailto:) is never one of the
+      // application's own session-bearing responses; treat it as cross-origin so
+      // it cannot trigger a logout.
+      if(/^[a-z][a-z0-9+.-]*:/i.test(url) && !/^https?:/i.test(url)) {
+         return false;
+      }
+
       // relative path (e.g. "../api/...") is always same-origin
       if(!/^(https?:)?\/\//i.test(url)) {
          return true;
@@ -64,6 +71,7 @@ export class InvalidSessionInterceptor implements HttpInterceptor {
          return new URL(absolute).origin === window.location.origin;
       }
       catch(e) {
+         // Malformed URL — treat as cross-origin to avoid spurious logouts.
          return false;
       }
    }

--- a/web/projects/em/src/app/invalid-session-interceptor.ts
+++ b/web/projects/em/src/app/invalid-session-interceptor.ts
@@ -35,14 +35,36 @@ export class InvalidSessionInterceptor implements HttpInterceptor {
       return next.handle(req).pipe(
          tap(
             () => {},
-            error => this.handleInvalidSession(error)
+            error => this.handleInvalidSession(req, error)
          )
       );
    }
 
-   private handleInvalidSession(error: HttpErrorResponse): void {
-      if(error.status === 401 || error.status === 403) {
+   private handleInvalidSession(req: HttpRequest<any>, error: HttpErrorResponse): void {
+      if((error.status === 401 || error.status === 403) && this.isSameOrigin(req.url)) {
          this.logoutService.sessionExpired();
+      }
+   }
+
+   /**
+    * Only the application's own (same-origin) responses indicate an expired
+    * session. A 401/403 from an absolute URL pointing at an external service
+    * (e.g. the OAuth proxy at data.inetsoft.com) is unrelated to the StyleBI
+    * session and must not trigger a logout.
+    */
+   private isSameOrigin(url: string): boolean {
+      // relative path (e.g. "../api/...") is always same-origin
+      if(!/^(https?:)?\/\//i.test(url)) {
+         return true;
+      }
+
+      try {
+         // normalize protocol-relative URLs ("//host/path") before comparing
+         const absolute = url.startsWith("//") ? `${window.location.protocol}${url}` : url;
+         return new URL(absolute).origin === window.location.origin;
+      }
+      catch(e) {
+         return false;
       }
    }
 }

--- a/web/projects/em/src/app/settings/general/email-settings-view/email-settings-view.component.ts
+++ b/web/projects/em/src/app/settings/general/email-settings-view/email-settings-view.component.ts
@@ -25,7 +25,9 @@ import {
    OAuthParameters
 } from "../../../../../../portal/src/app/common/services/oauth-authorization.service";
 import { ScheduleUsersService } from "../../../../../../shared/schedule/schedule-users.service";
+import { Tool } from "../../../../../../shared/util/tool";
 import { FormValidators } from "../../../../../../shared/util/form-validators";
+import { MatSnackBar } from "@angular/material/snack-bar";
 import { Searchable } from "../../../searchable";
 import { IdentityId } from "../../security/users/identity-id";
 import { GeneralSettingsChanges } from "../general-settings-page/general-settings-page.component";
@@ -91,6 +93,7 @@ export class EmailSettingsViewComponent implements OnDestroy {
                private usersService: ScheduleUsersService,
                defaultErrorMatcher: ErrorStateMatcher,
                private httpClient: HttpClient,
+               private snackBar: MatSnackBar,
                private oauthService: OAuthAuthorizationService,)
    {
       this.errorStateMatcher = {
@@ -361,14 +364,25 @@ export class EmailSettingsViewComponent implements OnDestroy {
 
       // The specific parameter we need from the server is the license key
       this.httpClient.post<OAuthParameters>("../api/em/general/settings/email/oauth-params", paramsRequest)
-         .subscribe((authParams) => {
-            this.oauthService.authorize(authParams).subscribe((oAuthTokens) => {
-               const expiration = new Date(oAuthTokens.expiration).getTime();
-               this.form.get("smtpAccessToken").setValue(oAuthTokens.accessToken);
-               this.form.get("smtpRefreshToken").setValue(oAuthTokens.refreshToken);
-               this.form.get("tokenExpiration").setValue(expiration);
-            });
+         .subscribe({
+            next: (authParams) => {
+               this.oauthService.authorize(authParams).subscribe({
+                  next: (oAuthTokens) => {
+                     const expiration = new Date(oAuthTokens.expiration).getTime();
+                     this.form.get("smtpAccessToken").setValue(oAuthTokens.accessToken);
+                     this.form.get("smtpRefreshToken").setValue(oAuthTokens.refreshToken);
+                     this.form.get("tokenExpiration").setValue(expiration);
+                  },
+                  error: () => this.showAuthorizeError()
+               });
+            },
+            error: () => this.showAuthorizeError()
          });
+   }
+
+   private showAuthorizeError() {
+      this.snackBar.open("_#(js:em.mail.smtp.authorizeFailed)", "_#(js:Close)",
+                         {duration: Tool.SNACKBAR_DURATION});
    }
 
    protected readonly SMTPAuthType = SMTPAuthType;

--- a/web/projects/em/src/app/settings/general/email-settings-view/email-settings-view.component.ts
+++ b/web/projects/em/src/app/settings/general/email-settings-view/email-settings-view.component.ts
@@ -376,7 +376,16 @@ export class EmailSettingsViewComponent implements OnDestroy {
                   error: () => this.showAuthorizeError()
                });
             },
-            error: () => this.showAuthorizeError()
+            // The oauth-params POST can fail for reasons unrelated to OAuth
+            // configuration (server 500, network error). Surface the server's
+            // own message when present rather than the misleading "verify your
+            // OAuth settings" text; fall back to it only when there is none.
+            error: (err) => {
+               const message = err?.error?.message;
+               message ? this.snackBar.open(message, "_#(js:Close)",
+                                            {duration: Tool.SNACKBAR_DURATION})
+                       : this.showAuthorizeError();
+            }
          });
    }
 


### PR DESCRIPTION
## Summary

In Enterprise Manager → Settings → General → Email, selecting **Google OAuth2 SMTP** and clicking **"Sign in with Google"** refreshed the page and bounced the admin back to the EM Summary page on opensource/unlicensed StyleBI instances.

## Root Cause

The Google OAuth2 SMTP (and SASL XOAuth2) sign-in flow acquires tokens through InetSoft's hosted OAuth proxy at `https://data.inetsoft.com/login`, which authenticates using the `license.key`. On unlicensed/opensource instances the proxy responds **HTTP 403**. The globally-registered `InvalidSessionInterceptor` taps every `HttpClient` response — including this cross-origin one — and on a 401/403 calls `LogoutService.sessionExpired()`, which does a full `document.location.replace("../sessionexpired?...")`. Since the real server session is still valid, EM bounces back to the Summary page.

Note: this flow is the same in Style Intelligence 13.6/13.7, where it works only because those installs have a valid commercial license that the proxy accepts.

## Fix

- **`invalid-session-interceptor.ts`** — only trigger `sessionExpired()` for **same-origin** responses. A 401/403 from an absolute URL pointing at an external host (e.g. `data.inetsoft.com`) is unrelated to the StyleBI session and no longer logs the EM admin out. (Protocol-relative URLs are normalized before the origin comparison.)
- **`email-settings-view.component.ts`** — `authorize0()` now surfaces a snackbar on authorization failure instead of failing silently.
- **`srinter.properties`** — added `em.mail.smtp.authorizeFailed` message.

This is a symptom-only fix (stop the spurious logout + show a clear error). Completing the OAuth flow still requires a valid commercial license, because the hosted proxy rejects unlicensed requests by design.

## Test Plan

1. Run an unlicensed/opensource (community) server.
2. EM → Settings → General → Email → SMTP Authentication Type → **Google OAuth2 SMTP**.
3. Enter any Gmail user / Client ID / Client Secret and click **"Sign in with Google"**.
4. **Expected:** you stay on the Email settings page and see *"Authorization failed. Please verify your OAuth settings and try again."* — you are **not** logged out / bounced to EM Summary.
5. Regression: same-origin 401/403 responses still trigger the normal session-expiry handling.

Fixes Redmine #75252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)