### PR TITLE
Bug #75353, fix crash when selecting a cell in freehand calc table binding pane

### DIFF
--- a/web/projects/portal/src/app/binding/services/assistant/calc-table-context-helper.ts
+++ b/web/projects/portal/src/app/binding/services/assistant/calc-table-context-helper.ts
@@ -106,14 +106,19 @@ export function getCalcTableRetrievalScriptContext(layout: CalcTableLayout,
 
    const groupCellsSet = new Set<string>();
    const aggregateCellsSet = new Set<string>();
-   let rowNumber = layout.tableRows.length;
-   let colNumber = layout.tableColumns.length;
+   const rowNumber = layout.tableRows.length;
+   const colNumber = layout.tableColumns.length;
 
-   for(let i = 0; i <= rowNumber; i++) {
+   for(let i = 0; i < rowNumber; i++) {
       const row = layout.tableRows[i];
 
-      for(let j = 0; j <= colNumber; j++) {
-         const cell = row.tableCells[j];
+      for(let j = 0; j < colNumber; j++) {
+         const cell = row?.tableCells?.[j];
+
+         if(!cell?.cellPath?.path?.length) {
+            continue;
+         }
+
          const cellPath = cell.cellPath.path[0];
          const binding = cellBindings[cellPath];
          const bindingType = getCellBindingType(binding);


### PR DESCRIPTION
## Summary

Selecting any cell in the freehand (calc table) edit/binding pane threw an uncaught error and popped up an error dialog:

```
Uncaught TypeError: can't access property "cellPath", cell is undefined
  getCalcTableRetrievalScriptContext   calc-table-context-helper.ts
  setCalcTableRetrievalScriptContext   ai-assistant.service.ts
  clickCell                            vs-calc-table-layout.component.ts
```

## Root Cause

`getCalcTableRetrievalScriptContext` in `calc-table-context-helper.ts` iterated cells with off-by-one bounds — `i <= tableRows.length` and `j <= tableColumns.length`. On the last iteration the index equals the array length, so `layout.tableRows[i]` / `row.tableCells[j]` are `undefined`, and dereferencing `cell.cellPath` throws. The function is invoked on every cell click (`clickCell` → `setCalcTableRetrievalScriptContext`), so any cell selection triggered the error. The loop also had no guard against legitimately null/empty cells (the sibling `getCalcTableBindings` filters `cell?.text` for exactly this reason).

## Fix

- Changed both loop bounds from `<=` to `<`.
- Added a null guard (`if(!cell?.cellPath?.path?.length) continue;`) before dereferencing the cell, consistent with the existing null-handling pattern in `getCalcTableBindings`.

Output for valid cells is unchanged — the removed iterations only ever pointed at non-existent cells.

## Test Plan

1. Import the attached freehand viewsheet, open it in the composer.
2. Open the freehand edit pane and select any cell.
3. Confirm no error dialog appears and cell selection works normally.

Regression check: `ai-assistant.service.spec.ts` passes (25/25); portal build succeeds; ESLint clean.

Fixes Redmine #75353.