### PR TITLE
Bug #75354, fix NG0100 error when opening wizard pane

### DIFF
--- a/web/projects/portal/src/app/vs-wizard/gui/object-wizard/wizard-preview-container.component.ts
+++ b/web/projects/portal/src/app/vs-wizard/gui/object-wizard/wizard-preview-container.component.ts
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from "@angular/core";
+import { AfterViewChecked, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnDestroy, Output, ViewChild } from "@angular/core";
 import { AssemblyActionEvent } from "../../../common/action/assembly-action-event";
 import { VSObjectFormatInfoModel } from "../../../common/data/vs-object-format-info-model";
 import { AbstractActionComponent } from "../../../composer/gui/vs/editor/abstract-action-component";
@@ -53,7 +53,7 @@ const GET_MESSAGE_LEVELS_URI = "../api/composer/console-dialog/get-message-level
     styleUrls: ["./wizard-preview-container.component.scss"],
     imports: [FormsModule, InteractContainerDirective, VSCalendar, VSChart, VSCrosstab, VSGauge, VSRangeSlider, VSSelection, VSTable, VSText, StatusBar, MiniToolbar, ConsoleDialogComponent]
 })
-export class WizardPreviewContainer extends AbstractActionComponent {
+export class WizardPreviewContainer extends AbstractActionComponent implements AfterViewChecked, OnDestroy {
    vsObject: VSObjectModel;
    @Input() runtimeId: string;
    @Input() linkuri: string;
@@ -75,14 +75,41 @@ export class WizardPreviewContainer extends AbstractActionComponent {
 
    onAssemblyActionEvent = new EventEmitter<AssemblyActionEvent<VSObjectModel>>();
    messageLevels: string[] = [];
+   miniToolbarLeft = 0;
+   private destroyed = false;
 
    constructor(actionFactory: AssemblyActionFactory,
                private scaleService: ScaleService,
                private miniToolbarService: MiniToolbarService,
                protected modalService: NgbModal,
-               private modelService: ModelService)
+               private modelService: ModelService,
+               private changeDetectorRef: ChangeDetectorRef)
    {
       super(actionFactory);
+   }
+
+   ngAfterViewChecked(): void {
+      // miniToolbarLeft depends on element layout, so it must be read after the view
+      // has been checked rather than during a template binding. Reading it in a bound
+      // getter returns different values across dev-mode change detection passes (0 before
+      // layout, the real offset after), which triggers NG0100. Only re-run change
+      // detection when the value actually changes so detection converges. The detectChanges
+      // is deferred to a microtask so it doesn't re-enter the active change detection pass
+      // synchronously from ngAfterViewChecked. (Bug #75354)
+      const left = this.getMiniToolbarLeft();
+
+      if(this.miniToolbarLeft !== left) {
+         this.miniToolbarLeft = left;
+         Promise.resolve().then(() => {
+            if(!this.destroyed) {
+               this.changeDetectorRef.detectChanges();
+            }
+         });
+      }
+   }
+
+   ngOnDestroy(): void {
+      this.destroyed = true;
    }
 
    @Input()
@@ -149,7 +176,7 @@ export class WizardPreviewContainer extends AbstractActionComponent {
       this.onDescriptionChange.emit(this.description);
    }
 
-   get miniToolbarLeft(): number {
+   private getMiniToolbarLeft(): number {
       let objectOffsetLeft = 0;
 
       if(!!this.assemblyObject && !!this.wizardPreviewContainer) {

--- a/web/projects/portal/src/app/vs-wizard/gui/object-wizard/wizard-preview-container.component.ts
+++ b/web/projects/portal/src/app/vs-wizard/gui/object-wizard/wizard-preview-container.component.ts
@@ -110,6 +110,8 @@ export class WizardPreviewContainer extends AbstractActionComponent implements A
 
    ngOnDestroy(): void {
       this.destroyed = true;
+      // AbstractActionComponent does not currently implement ngOnDestroy. If it
+      // gains one (e.g. to clean up its `subscription`), call super.ngOnDestroy() here.
    }
 
    @Input()


### PR DESCRIPTION
## Summary

Opening the object wizard pane (composer → chart edit pane → "To wizard") popped up an `NG0100 (ExpressionChangedAfterItHasBeenCheckedError)`. This change makes the mini-toolbar's left offset stable across change-detection passes so the error no longer appears.

## Root Cause

In `wizard-preview-container.component.ts`, the `miniToolbarLeft` getter was bound directly in the template (`[left]="miniToolbarLeft"`) and called `getBoundingClientRect()` at evaluation time. That DOM layout read returns different values across Angular's two dev-mode change-detection passes — `0` before layout completes and the real offset (e.g. `27.75`) afterward. The differing values within a single CD cycle violate template-expression purity and throw NG0100. The dev-mode double-check that surfaces this was introduced by the Angular upgrade.

## Fix

- Replaced the template-bound `miniToolbarLeft` getter with a cached numeric field.
- The offset is now recomputed in `ngAfterViewChecked()` (after layout) via a private `getMiniToolbarLeft()` method, and the field is written back only when the value actually changes — so the bound value is stable within every CD cycle.
- `detectChanges()` is deferred to a microtask (`Promise.resolve().then(...)`) so it doesn't re-enter the active change-detection pass synchronously from `ngAfterViewChecked`, and is guarded by a `destroyed` flag (set in `ngOnDestroy`) to avoid a `ViewDestroyedError` if the pane is closed before the microtask runs.

The computed offset is byte-for-byte identical to the previous getter; only the timing of the read changed.

## Test Plan

1. Import the attached `wizard.zip`, open the viewsheet in composer.
2. Open the chart edit pane, click **To wizard**.
3. Verify no NG0100 error popup appears and the mini-toolbar is positioned correctly over the assembly.
4. Regression: confirmed `getToolbarLeft(...)` used by `vs-object-container` and `embed-chart` is a separate method and unaffected. Portal build, lint, and 301 unit tests pass.

Fixes Redmine #75354.