### PR TITLE
Bug #75355, fix NG0100 error when reordering rows in logical model editor

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/attribute-editor/logical-model-attribute-editor.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/attribute-editor/logical-model-attribute-editor.component.ts
@@ -133,6 +133,7 @@ export class LogicalModelAttributeEditor implements OnInit, OnDestroy {
    _existNames: string[];
    private inited: boolean = false;
    private subscription: Subscription;
+   private resetPending: any;
 
    @Input() set existNames(existNames: string[]) {
       this._existNames = existNames;
@@ -140,8 +141,11 @@ export class LogicalModelAttributeEditor implements OnInit, OnDestroy {
       if(this.inited) {
          // Defer the reset so the shared form is not mutated during change
          // detection, which would change form.invalid after the parent's
-         // Save button [disabled] binding was checked (NG0100).
-         setTimeout(() => this.resetFormControl(), 0);
+         // Save button [disabled] binding was checked (NG0100). Coalesce rapid
+         // successive changes and cancel on destroy so a stale timer never
+         // mutates the shared parent form after this editor is gone.
+         clearTimeout(this.resetPending);
+         this.resetPending = setTimeout(() => this.resetFormControl(), 0);
       }
    }
 
@@ -183,6 +187,7 @@ export class LogicalModelAttributeEditor implements OnInit, OnDestroy {
    }
 
    ngOnDestroy(): void {
+      clearTimeout(this.resetPending);
       this.unsubscribeForm();
    }
 

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/attribute-editor/logical-model-attribute-editor.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/attribute-editor/logical-model-attribute-editor.component.ts
@@ -138,7 +138,10 @@ export class LogicalModelAttributeEditor implements OnInit, OnDestroy {
       this._existNames = existNames;
 
       if(this.inited) {
-         this.resetFormControl();
+         // Defer the reset so the shared form is not mutated during change
+         // detection, which would change form.invalid after the parent's
+         // Save button [disabled] binding was checked (NG0100).
+         setTimeout(() => this.resetFormControl(), 0);
       }
    }
 

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/entity-pane/logical-model-entity-pane.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/entity-pane/logical-model-entity-pane.component.ts
@@ -46,12 +46,13 @@ export class LogicalModelEntityPane implements AfterViewInit, OnChanges, OnDestr
    private inited: boolean = false;
    private editable: boolean = true;
    private subscription: Subscription;
+   private resetPending: any;
 
    @Input() set form(value: UntypedFormGroup) {
       this._form = value;
 
       if(this.inited) {
-         setTimeout(() => this.resetFormControl(), 0);
+         this.scheduleReset();
       }
    }
 
@@ -118,14 +119,23 @@ export class LogicalModelEntityPane implements AfterViewInit, OnChanges, OnDestr
          // unchanged). Defer the reset so the shared form is not mutated during
          // change detection, which would change form.invalid after the parent's
          // Save button [disabled] binding was checked (NG0100).
-         setTimeout(() => this.resetFormControl(), 0);
+         this.scheduleReset();
       }
       else {
          this.resetFormControl();
       }
    }
 
+   // Coalesce rapid successive deferred resets and cancel any pending one on
+   // destroy, so a stale timer never mutates the shared parent form after this
+   // editor is gone.
+   private scheduleReset(): void {
+      clearTimeout(this.resetPending);
+      this.resetPending = setTimeout(() => this.resetFormControl(), 0);
+   }
+
    ngOnDestroy(): void {
+      clearTimeout(this.resetPending);
       this.unsubscribeForm();
    }
 

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/entity-pane/logical-model-entity-pane.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/entity-pane/logical-model-entity-pane.component.ts
@@ -22,7 +22,7 @@ import {
    Input,
    OnChanges,
    OnDestroy,
-   Output, ViewChild
+   Output, SimpleChanges, ViewChild
 } from "@angular/core";
 import { UntypedFormGroup, Validators, UntypedFormControl, AbstractControl, ValidatorFn, FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { EntityModel } from "../../../../../model/datasources/database/physical-model/logical-model/entity-model";
@@ -108,9 +108,21 @@ export class LogicalModelEntityPane implements AfterViewInit, OnChanges, OnDestr
       }
    }
 
-   ngOnChanges(): void {
-      this.inited = true;
-      this.resetFormControl();
+   ngOnChanges(changes: SimpleChanges): void {
+      if(!this.inited) {
+         this.inited = true;
+         this.resetFormControl();
+      }
+      else if(changes["existNames"] && !changes["entity"]) {
+         // A reorder updates only existNames (the edited entity reference is
+         // unchanged). Defer the reset so the shared form is not mutated during
+         // change detection, which would change form.invalid after the parent's
+         // Save button [disabled] binding was checked (NG0100).
+         setTimeout(() => this.resetFormControl(), 0);
+      }
+      else {
+         this.resetFormControl();
+      }
    }
 
    ngOnDestroy(): void {


### PR DESCRIPTION
## Summary

In the portal Data Model editor (Logical Model), reordering rows with **Move Up**/**Move Down** popped up an Angular console error:

```
ERROR RuntimeError: NG0100: ExpressionChangedAfterItHasBeenCheckedError:
Expression has changed after it was checked. Previous value for 'disabled': 'false'.
Current value: 'true'. Expression location: _LogicalModelComponent component.
  at LogicalModelComponent_Template (logical-model.component.html:28)
```

## Root Cause

The Save button binding is `[disabled]="!isModified || form.invalid"` (`logical-model.component.html:28`). `isModified` is set in `ngDoCheck` and only ever flips to `true` (stable within a change-detection cycle), so the volatile term is `form.invalid`.

The data-model editors share a single `UntypedFormGroup` (passed via `@Input() form`). Reordering rows makes the property pane call `updateExistNames()`, producing a new `existNames` array reference, which synchronously fired the active editor's input handler **during change detection**:

- Entity editor → `LogicalModelEntityPane.ngOnChanges()` → `resetFormControl()`
- Column attribute editor → `LogicalModelAttributeEditor` `existNames` setter → `resetFormControl()`

`resetFormControl()` does `form.removeControl(...)` then `form.addControl(...)` with validators, mutating `form.invalid` mid-cycle — after the parent's `[disabled]` had already been checked. Angular's dev-mode verification pass then detected the change → NG0100. The codebase already deferred this work in the entity pane's `form` setter (`setTimeout(() => this.resetFormControl(), 0)`); these two paths were left synchronous, and the stricter change-detection timing in the Angular upgrade exposed them.

## Fix

Defer `resetFormControl()` out of the current change-detection cycle in the two reorder paths, matching the existing `setTimeout` precedent:

- `logical-model-entity-pane.component.ts`: `ngOnChanges` defers only when `existNames` changed and `entity` did not (the reorder case). Initial render and entity-switch remain synchronous.
- `logical-model-attribute-editor.component.ts`: the `existNames` setter defers `resetFormControl()`.

Initial control creation stays synchronous, so the (un-guarded) attribute-editor template never sees a null control, and validators are still rebuilt — just one macrotask later.

## Test Plan

1. Portal → Data Source/Example/Orders → expand and select **Data Model** → open **Order Model**.
2. Select the end row, click **Move Up** two times; select the end row again and click **Move Up**.
3. Confirm no `NG0100` error appears in the browser console and reordering works.
4. Verify the Save button still enables on changes and validation (duplicate/required name) still works.

Verified locally: portal build succeeds; ESLint clean.

Fixes Redmine #75355.