### PR TITLE
Bug #75328, fix out-of-scope SQL for discrete chart measure

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
@@ -811,7 +811,12 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
             })
             .forEach(a -> {
                AggregateRef aref = (AggregateRef) a;
-               DataRef ref2 = cols2.getAttribute(aref.getDataRef().getName());
+               // Match by attribute (alias/attribute, as createAggregateRef does) rather
+               // than by raw qualified name, so the aggregated column is re-qualified to the
+               // discrete mirror table's own column. Otherwise it keeps the base table's
+               // inner alias and ends up out of scope in the generated sub-query (e.g. a
+               // discrete measure with no preceding same-axis dimension). (Bug #75328)
+               DataRef ref2 = AssetUtil.getColumnRefFromAttribute(cols2, aref.getDataRef());
 
                if(ref2 == null) {
                   cols2.addAttribute(aref.getDataRef());


### PR DESCRIPTION
## Summary

A chart measure marked **"discrete"** could fail to paint, with a SQL error in the console. This fixes the column qualifier used in the discrete-aggregate mirror sub-query so the generated SQL is valid.

## Root Cause

For a discrete measure, `ChartVSAQuery.applyDiscreteAggregates()` builds a separate mirror aggregate sub-table (`..._discrete_N`) that is joined back to the detail table. The discrete `AggregateRef` is created against the **base** table's column selection, then re-pointed to the mirror table's column selection `cols2` via a raw qualified-name lookup:

```java
DataRef ref2 = cols2.getAttribute(aref.getDataRef().getName());
```

`ColumnSelection.getAttribute(String)` matches on the full qualified name. When the mirror's column is present under a different qualifier, the lookup returns `null`, the code keeps the base table's inner alias, and the generated sub-query emits:

```sql
(select SUM(customers.customer_id) as "Sum(customer_id)"
 from ( ... ) V_Mcustomers_hart1) V_Mcustomers_hart1_discrete_1
```

`customers` is one nesting level deeper than the sub-query's `FROM` (`V_Mcustomers_hart1`), so it is out of scope and the database throws *"Column 'CUSTOMERS.CUSTOMER_ID' is ... not in any table in the FROM list ... outside the scope."* The chart cannot paint. (This surfaces e.g. for a discrete measure with no preceding same-axis dimension.)

## Fix

Resolve the aggregate's column against the mirror's column selection **by attribute** using `AssetUtil.getColumnRefFromAttribute(cols2, aref.getDataRef())` — the same helper already used in several other places in this class — so the column is correctly re-qualified to the mirror table's own column instead of retaining the base table's deeper alias.

- Grouped-discrete charts (where the old name lookup already matched) resolve to the same column → no behavior change.
- The genuine "column not present" fallback (`cols2.addAttribute(...)`) is preserved, since `getColumnRefFromAttribute` also returns `null` in that case.

## Test Plan

1. Import `chart.vso` (attached to Redmine #75328), open the chart viewsheet in composer.
2. Edit the chart; on the **Y** measure enable the **"discrete"** checkbox; click **Apply**.
3. Verify the chart paints and no SQL error appears in the console (the discrete sub-query now references `V_Mcustomers_hart1.customer_id`).
4. Regression: verified existing grouped-discrete charts still render. `core` module builds; `ChartVSAQueryTest` passes. Manually verified against the original asset on a locally-run server.

Fixes Redmine #75328.