### PR TITLE
Bug #75351, fix Show Details date for Year-week date comparison charts

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/VSDataSet.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/VSDataSet.java
@@ -834,11 +834,9 @@ public class VSDataSet extends AbstractDataSet implements AttributeDataSet {
       if(obj instanceof DCMergeDatesCell) {
          obj = ((DCMergeDatesCell) obj).getOriginalData();
       }
-      // For a WeekOfYear date-comparison part cell, the displayed part value (e.g.
-      // "January week 5") may resolve to a different actual week in the comparison
-      // period's year. Use the equivalence cell so the drill-to-detail condition
-      // targets the same week the axis label/data represent, matching the crosstab
-      // path (CrossTabFilterUtil.getEquivalenceNewTuple).
+      // A WeekOfYear part value can map to a different actual week across years;
+      // use the equivalence cell so the drill condition matches the displayed week
+      // (mirrors the crosstab path, CrossTabFilterUtil.getEquivalenceNewTuple).
       else if(obj instanceof DCMergeDatePartFilter.MergePartCell) {
          DCMergeDatePartFilter.MergePartCell equivalenceCell =
             ((DCMergeDatePartFilter.MergePartCell) obj).getEquivalenceCell();

--- a/core/src/main/java/inetsoft/report/composition/graph/VSDataSet.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/VSDataSet.java
@@ -834,6 +834,19 @@ public class VSDataSet extends AbstractDataSet implements AttributeDataSet {
       if(obj instanceof DCMergeDatesCell) {
          obj = ((DCMergeDatesCell) obj).getOriginalData();
       }
+      // For a WeekOfYear date-comparison part cell, the displayed part value (e.g.
+      // "January week 5") may resolve to a different actual week in the comparison
+      // period's year. Use the equivalence cell so the drill-to-detail condition
+      // targets the same week the axis label/data represent, matching the crosstab
+      // path (CrossTabFilterUtil.getEquivalenceNewTuple).
+      else if(obj instanceof DCMergeDatePartFilter.MergePartCell) {
+         DCMergeDatePartFilter.MergePartCell equivalenceCell =
+            ((DCMergeDatePartFilter.MergePartCell) obj).getEquivalenceCell();
+
+         if(equivalenceCell != null) {
+            obj = equivalenceCell;
+         }
+      }
 
       VSFieldValue pair = new VSFieldValue(col, obj, true);
       pair.setStringData(obj instanceof String);

--- a/core/src/test/java/inetsoft/report/filter/DCMergeDatePartFilterTest.java
+++ b/core/src/test/java/inetsoft/report/filter/DCMergeDatePartFilterTest.java
@@ -20,11 +20,15 @@ package inetsoft.report.filter;
 
 import inetsoft.graph.data.DataSet;
 import inetsoft.graph.data.DefaultDataSet;
+import inetsoft.report.composition.graph.VSDataSet;
 import inetsoft.report.lens.DataSetTable;
 import inetsoft.test.*;
 import inetsoft.uql.XTable;
 import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.viewsheet.VSDataRef;
 import inetsoft.uql.viewsheet.VSDimensionRef;
+import inetsoft.uql.viewsheet.XDimensionRef;
+import inetsoft.uql.viewsheet.graph.VSFieldValue;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,7 +37,9 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static inetsoft.test.XTableUtil.date;
 
@@ -62,5 +68,87 @@ public class DCMergeDatePartFilterTest {
                                                                       col3Ref, null, null);
       XTable deserializedTable = TestSerializeUtils.serializeAndDeserialize(originalTable);
       Assertions.assertEquals(DCMergeDatePartFilter.class, deserializedTable.getClass());
+   }
+
+   // Bug #75351: for a WeekOfYear date-comparison part cell whose displayed week
+   // maps to a different actual week across the period's year, VSDataSet must use
+   // the equivalence cell so the drill-to-detail condition targets the same week
+   // the axis/data represent (matching the crosstab path).
+   @Test
+   public void testWeekOfYearEquivalenceFieldValue() {
+      // Cover many month/week combinations so at least one part value diverges
+      // from its equivalence value (week 5/6 rolling into the next month under
+      // minimalDaysInFirstWeek=7).
+      List<Object[]> rows = new ArrayList<>();
+      rows.add(new Object[]{ "WeekOfYear(date)", "date" });
+
+      for(int year = 2019; year <= 2022; year++) {
+         for(int month = 1; month <= 12; month++) {
+            for(int week = 4; week <= 6; week++) {
+               String mm = month < 10 ? "0" + month : Integer.toString(month);
+               rows.add(new Object[]{ month * 10 + week, date(year + "-" + mm + "-15") });
+            }
+         }
+      }
+
+      DataSet dataSet = new DefaultDataSet(rows.toArray(new Object[0][]));
+      DataSetTable base = new DataSetTable(dataSet);
+
+      VSDimensionRef partRef = new VSDimensionRef();
+      partRef.setDataRef(new AttributeRef("WeekOfYear(date)"));
+      VSDimensionRef dateGroupRef = new VSDimensionRef();
+      dateGroupRef.setDataRef(new AttributeRef("date"));
+
+      List<XDimensionRef> noExtraRefs = new ArrayList<>();
+      DCMergeDatePartFilter filter =
+         new DCMergeDatePartFilter(base, noExtraRefs, partRef, dateGroupRef, null);
+
+      // Locate the first row whose part cell has a diverging equivalence cell.
+      int divergingRow = -1;       // VSDataSet row index (header excluded)
+      String expected = null;      // field value rendered from the equivalence cell
+      String original = null;      // field value rendered from the original cell
+
+      for(int r = base.getHeaderRowCount(); r < base.getRowCount(); r++) {
+         Object cell = filter.getObject(r, 0);
+
+         if(cell instanceof DCMergeDatePartFilter.MergePartCell) {
+            DCMergeDatePartFilter.MergePartCell mpc = (DCMergeDatePartFilter.MergePartCell) cell;
+            DCMergeDatePartFilter.MergePartCell equivalenceCell = mpc.getEquivalenceCell();
+
+            if(equivalenceCell != null) {
+               divergingRow = r - base.getHeaderRowCount();
+               // Render the field value exactly as getFieldValue() would, so the
+               // comparison is independent of the cell's string formatting.
+               expected = new VSFieldValue("WeekOfYear(date)", equivalenceCell, true)
+                  .getFieldValue().getValue();
+               original = new VSFieldValue("WeekOfYear(date)", mpc, true)
+                  .getFieldValue().getValue();
+               break;
+            }
+         }
+      }
+
+      Assertions.assertTrue(divergingRow >= 0,
+                            "expected at least one WeekOfYear row whose equivalence cell diverges");
+      Assertions.assertNotEquals(original, expected,
+                                 "equivalence cell should differ from the original part cell");
+
+      VSDataSet vsDataSet = new VSDataSet(filter, new VSDataRef[]{ partRef, dateGroupRef });
+      VSFieldValue[][] fieldValues = vsDataSet.getFieldValues(
+         divergingRow, new String[]{ "WeekOfYear(date)" }, new String[]{ "WeekOfYear(date)" },
+         false, false);
+
+      String actual = null;
+
+      for(VSFieldValue[] tuple : fieldValues) {
+         for(VSFieldValue fv : tuple) {
+            if("WeekOfYear(date)".equals(fv.getFieldName())) {
+               actual = fv.getFieldValue().getValue();
+            }
+         }
+      }
+
+      Assertions.assertEquals(expected, actual,
+                              "drill field value should use the equivalence week, not the displayed part value");
    }
 }

--- a/core/src/test/java/inetsoft/report/filter/DCMergeDatePartFilterTest.java
+++ b/core/src/test/java/inetsoft/report/filter/DCMergeDatePartFilterTest.java
@@ -148,6 +148,7 @@ public class DCMergeDatePartFilterTest {
          }
       }
 
+      Assertions.assertNotNull(actual, "field value for the WeekOfYear column should be present");
       Assertions.assertEquals(expected, actual,
                               "drill field value should use the equivalence week, not the displayed part value");
    }


### PR DESCRIPTION
## Summary

On a Date Comparison chart configured for Year-over-year with a WeekOfYear context (e.g. same day-of-week across years, grouped by week), clicking a prior-year bar and choosing **Show Details** returned rows for a date one week off from the bar's label/tooltip — e.g. the bar labeled `2020-02-06` drilled to `2020-02-13`.

## Root Cause

DC week buckets are keyed by date *part* values — `WeekOfYear` (encoded `MM*10 + weekOfMonth`) and `DayOfWeek` — carried in a `DCMergeDatePartFilter.MergePartCell`. The same `(month, week-of-month)` part value can resolve to a different actual week across years, so `MergePartCell.getEquivalenceCell()` recomputes the WeekOfYear value against the comparison period's year and returns a corrected cell when it differs.

The axis-label path and the **crosstab** drill path apply this correction (`CrossTabFilterUtil.getEquivalenceNewTuple` → `getEquivalenceCell()`), but the **chart** drill-to-detail path did not: `VSDataSet.getFieldValue()` built the detail field value from the raw (uncorrected) `MergePartCell`, so the Show-Details condition targeted the wrong (raw) week.

Confirmed by replicating StyleBI's `datePart("wy")` + `getEquivalenceCell` logic: the bucket's WeekOfYear part `15` (Jan, week 5) normalizes on 2020 to Feb week 1 (equivalence value `21`), both reconstructing to `2020-02-06` — the correct date.

## Fix

In `VSDataSet.getFieldValue()` (the chart drill-to-detail field extractor), when the cell is a `DCMergeDatePartFilter.MergePartCell` and `getEquivalenceCell()` returns non-null, use the equivalence cell — so the part value fed into the detail condition matches the displayed/data week, mirroring the crosstab path.

`getEquivalenceCell()` returns null unless a `WeekOfYear` merged ref's recomputed value diverges (and the period value is a Date), so non-WeekOfYear DC configs and non-diverging weeks are unaffected. Rendering is unaffected — `getFieldValues` only feeds selection/Show-Details/brush, not plotting.

## Test Plan

1. Import `Year_SameDay.vso`, open in composer (DC: previous 1 year, Same Day, granularity Day, context Week).
2. Select the 2020 bar at the `2021-02-04` / `2020-02-06` position (value 48) and click **Show Details**.
3. Detail rows should be for **`2020-02-06`** (quantities 18 + 19 + 11 = 48), not `2020-02-13`.

Verified on a community server: Show Details now returns `2020-02-06`, matching the bar value. Existing `DCMergeDatePartFilterTest` passes.

Fixes Redmine #75351.

🤖 Generated with [Claude Code](https://claude.com/claude-code)