### PR TITLE
Bug #75327, guard against undefined originalDataSource in email list dialog tree

### DIFF
--- a/web/projects/em/src/app/settings/email-picker/email-list-dialog/email-list-dialog.component.ts
+++ b/web/projects/em/src/app/settings/email-picker/email-list-dialog/email-list-dialog.component.ts
@@ -111,7 +111,11 @@ export class EmailListDialogComponent implements OnInit, OnDestroy {
 
          if(!strs || !(strs.some((str) => this.emailIdentities.indexOf(str) == -1))) {
             this.treeControl.collapseAll();
-            this.dataSource.data = this.originalDataSource;
+
+            if(this.originalDataSource) {
+               this.dataSource.data = this.originalDataSource;
+            }
+
             return;
          }
 
@@ -138,6 +142,10 @@ export class EmailListDialogComponent implements OnInit, OnDestroy {
             distinctUntilChanged()
          )
          .subscribe((val: string) => {
+            if(!this.originalDataSource) {
+               return;
+            }
+
             let splits: string[] = val.split(",");
             let searchStr = splits[splits.length - 1];
             this.dataSource.data = this.searchEmailTree(Tool.clone(this.originalDataSource), searchStr);


### PR DESCRIPTION
MatTreeFlattener.flattenNodes in Angular Material 21 no longer null-checks its input, so assigning undefined to dataSource.data now throws. This happened in two cases: when autocompleteEmails is false (edit identity view) so originalDataSource is never populated, and as a race condition when the user types before the getEmailList() HTTP response arrives.