### PR TITLE
bug-75296: DB authentication provider read operations fail safe on invalid config

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/AuthenticationProviderService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/AuthenticationProviderService.java
@@ -343,7 +343,7 @@ public class AuthenticationProviderService extends BaseSubscribeChangeHandler {
       try {
          String msg = withProviderFromModel(model, provider ->
             provider.isPresent() ? null :
-            Catalog.getCatalog().getString("em.security.testlogin.note4"));
+            Catalog.getCatalog().getString("em.security.testlogin.note4"), true);
 
          if(msg != null) {
             return msg;
@@ -638,20 +638,22 @@ public class AuthenticationProviderService extends BaseSubscribeChangeHandler {
       UserRoleListModel.Builder builder = UserRoleListModel.builder();
 
       if(model.providerType() == SecurityProviderType.DATABASE) {
-         AuthenticationProvider provider = getProviderFromModel(model).orElse(null);
-         if(provider instanceof DatabaseAuthenticationProvider) {
-            setIgnoreCache(provider, true);
-            Map<IdentityID, IdentityID[]> userRoles =
-               ((DatabaseAuthenticationProvider) provider).getAllUserRoles();
-            setIgnoreCache(provider, false);
+         return withProviderFromModel(model, optProvider -> {
+            if(optProvider.orElse(null) instanceof DatabaseAuthenticationProvider dbProvider) {
+               setIgnoreCache(dbProvider, true);
+               Map<IdentityID, IdentityID[]> userRoles = dbProvider.getAllUserRoles();
+               setIgnoreCache(dbProvider, false);
 
-            for(Map.Entry<IdentityID, IdentityID[]> e : userRoles.entrySet()) {
-               builder.addList(UserRolesModel.builder()
-                                  .user(e.getKey())
-                                  .addRoles(e.getValue())
-                                  .build());
+               for(Map.Entry<IdentityID, IdentityID[]> e : userRoles.entrySet()) {
+                  builder.addList(UserRolesModel.builder()
+                                     .user(e.getKey())
+                                     .addRoles(e.getValue())
+                                     .build());
+               }
             }
-         }
+
+            return builder.build();
+         });
       }
 
       return builder.build();
@@ -705,7 +707,23 @@ public class AuthenticationProviderService extends BaseSubscribeChangeHandler {
    }
 
    private <T> T withProviderFromModel(AuthenticationProviderModel model, Function<Optional<AuthenticationProvider>, T> fn) throws Exception {
-      Optional<AuthenticationProvider> provider = getProviderFromModel(model);
+      return withProviderFromModel(model, fn, false);
+   }
+
+   private <T> T withProviderFromModel(AuthenticationProviderModel model, Function<Optional<AuthenticationProvider>, T> fn, boolean rethrowCreationException) throws Exception {
+      Optional<AuthenticationProvider> provider;
+
+      try {
+         provider = getProviderFromModel(model);
+      }
+      catch(Exception e) {
+         if(rethrowCreationException) {
+            throw e;
+         }
+
+         LOG.warn("Could not create authentication provider from model", e);
+         return fn.apply(Optional.empty());
+      }
 
       try {
          return fn.apply(provider);


### PR DESCRIPTION
## Summary

- withProviderFromModel now catches exceptions thrown during provider creation and passes Optional.empty() to the downstream function instead of propagating a 500 error
- All read operation lambdas (getRoles, getUsers, getGroups, getOrganizations, etc.) already handle Optional.empty() by returning empty results, so they silently return nothing when the DB provider is misconfigured
- testConnection, addProvider, and updateProvider call getProviderFromModel directly and are unaffected -- they still surface errors to the user as expected

## Root Cause

When a Database Authentication Provider is not fully configured, the UI calls read endpoints (e.g. /api/em/security/get-roles) before setup is complete. getProviderFromModel unconditionally calls testConnection() for DATABASE providers, which throws SQLException (e.g. "driver class is not defined") that propagated as an unhandled 500.

## Test plan

- Configure a Database Authentication Provider with a missing driver class -- roles/users/groups panels should load empty without error
- Explicit Test Connection with invalid DB config should still return an error message to the user
- Fully configured DB provider should still load roles/users/groups correctly

Generated with Claude Code
