### PR TITLE
Bug #75359 - Restore legend round-corner options lost in merge

### DIFF
--- a/web/projects/portal/src/app/graph/dialog/legend-format-general-pane.component.html
+++ b/web/projects/portal/src/app/graph/dialog/legend-format-general-pane.component.html
@@ -58,6 +58,16 @@
       <div class="col-auto">
         <color-editor [(color)]="model.fillColor" data-test="legend-border-color"></color-editor>
       </div>
+      <div class="checkbox col-auto">
+        <div class="form-check">
+          <input type="checkbox" class="form-check-input" id="roundCorners"
+            [ngModelOptions]="{standalone: true}"
+            [(ngModel)]="model.roundCorners">
+          <label class="form-check-label" for="roundCorners">
+            _#(Round Corner)
+          </label>
+        </div>
+      </div>
     </div>
   </fieldset>
   <fieldset>
@@ -74,6 +84,18 @@
           </div>
         }
       </div>
+      @if (model.symbolRoundCornersVisible) {
+        <div class="checkbox col-auto">
+          <div class="form-check">
+            <input type="checkbox" class="form-check-input" id="symbolRoundCorners"
+              [ngModelOptions]="{standalone: true}"
+              [(ngModel)]="model.symbolRoundCorners">
+            <label class="form-check-label" for="symbolRoundCorners">
+              _#(Round Symbol Corner)
+            </label>
+          </div>
+        </div>
+      }
     </div>
   </fieldset>
   @if (model.notShowNullVisible) {

--- a/web/projects/portal/src/app/graph/objects/chart-legend-container.component.html
+++ b/web/projects/portal/src/app/graph/objects/chart-legend-container.component.html
@@ -33,7 +33,8 @@
     [style.width.px]="legend.bounds.width"
     [style.height.px]="legend.bounds.height"
     [style.background]="background"
-    [style.border]="legend.border">
+    [style.border]="legend.border"
+    [style.border-radius]="legend.roundCorners ? '10px' : null">
     <ng-content></ng-content>
     @if (isMoving && !isResizing) {
       <div


### PR DESCRIPTION
## Summary

Restores legend round-corner functionality that was accidentally dropped
during merge commit 563ab05dd (origin/main into epic-74519). The merge
kept the incoming version of two templates, which had not yet received
these features, while the corresponding model fields remained in place.
The result was that the Round Corner and Round Symbol Corner checkboxes
vanished from the Legend Properties dialog, and the legend border no
longer rendered with rounded corners even when the flag was set.

## Changes

- legend-format-general-pane.component.html: re-add the Round Corner
  checkbox (model.roundCorners) and the Round Symbol Corner checkbox
  (model.symbolRoundCorners, guarded by model.symbolRoundCornersVisible).
- chart-legend-container.component.html: re-add the
  [style.border-radius]="legend.roundCorners ? '10px' : null" binding so
  a rounded legend border actually renders.

Both edits use the current @if control-flow syntax to match the
post-merge codebase style.

## Notes

The changes are additive and logically equivalent to the pre-merge
version (19387c26c). No backend, model, or contract changes were needed;
the LegendContainer and LegendFormatGeneralPaneModel fields, and their
Java counterparts, were untouched by the merge.