### PR TITLE
Bug #75261, fix date picker selecting today instead of selected date

### DIFF
--- a/web/projects/portal/src/app/widget/date-type-editor/date-picker.component.html
+++ b/web/projects/portal/src/app/widget/date-type-editor/date-picker.component.html
@@ -56,9 +56,9 @@
         </tr>
       </thead>
       <tbody>
-        @for (cell of loadCalender(dateTime.months, dateTime.years); track cell) {
+        @for (cell of calendarCells; track $index) {
           <tr>
-            @for (day of cell; track day) {
+            @for (day of cell; track $index) {
               <td>
                 @if (day > 0) {
                   <div (mousedown)="selectDay(day)" class="day-div hover-bg-secondary"

--- a/web/projects/portal/src/app/widget/date-type-editor/date-picker.component.ts
+++ b/web/projects/portal/src/app/widget/date-type-editor/date-picker.component.ts
@@ -67,7 +67,7 @@ export class DatePickerComponent implements OnInit, OnChanges {
    }
 
    ngOnChanges(changes: SimpleChanges): void {
-      if(changes["dateTime"] && this.dateTime) {
+      if(changes["dateTime"] && !changes["dateTime"].isFirstChange() && this.dateTime) {
          this.updateCalendar();
       }
    }

--- a/web/projects/portal/src/app/widget/date-type-editor/date-picker.component.ts
+++ b/web/projects/portal/src/app/widget/date-type-editor/date-picker.component.ts
@@ -15,7 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { Component, EventEmitter, HostListener, Input, Output } from "@angular/core";
+import { Component, EventEmitter, HostListener, Input, OnChanges, OnInit,
+         Output, SimpleChanges } from "@angular/core";
 import { NgbDatepickerConfig } from "@ng-bootstrap/ng-bootstrap";
 import { DateTypeFormatter } from "../../../../../shared/util/date-type-formatter";
 import { TimeInstant } from "../../common/data/time-instant";
@@ -30,13 +31,14 @@ import { BlockMouseDirective } from "../mouse-event/block-mouse.directive";
     styleUrls: ["./date-picker.component.scss"],
     imports: [BlockMouseDirective, FormsModule]
 })
-export class DatePickerComponent {
+export class DatePickerComponent implements OnInit, OnChanges {
    @Input() promptTime: boolean = false;
    @Input() dateTime: TimeInstant;
    @Output() onCommit = new EventEmitter<string>();
    @Output() valueChanged = new EventEmitter<{value: string, changeType: DateTimeChangeType}>();
    format: string = DateTypeFormatter.ISO_8601_DATE_FORMAT;
    years: any[] = this.getOptionYears();
+   calendarCells: number[][] = [];
    months: any[] = [
       {value: 0, label: "_#(js:January)"},
       {value: 1, label: "_#(js:February)"},
@@ -58,6 +60,18 @@ export class DatePickerComponent {
    constructor(private ngbDatepickerConfig: NgbDatepickerConfig) {
    }
 
+   ngOnInit(): void {
+      if(this.dateTime) {
+         this.updateCalendar();
+      }
+   }
+
+   ngOnChanges(changes: SimpleChanges): void {
+      if(changes["dateTime"] && this.dateTime) {
+         this.updateCalendar();
+      }
+   }
+
    get dateHeaders(): string[] {
       const firstDoW = this.ngbDatepickerConfig.firstDayOfWeek;
       return [0, 1, 2, 3, 4, 5, 6].map(n => this._dateHeaders[(n + firstDoW) % 7]);
@@ -77,7 +91,11 @@ export class DatePickerComponent {
       return years;
    }
 
-   loadCalender(month, year): any {
+   private updateCalendar(): void {
+      this.calendarCells = this.buildCalendarCells(this.dateTime.months, this.dateTime.years);
+   }
+
+   private buildCalendarCells(month: number, year: number): number[][] {
       month = +month;
       year = +year;
       const cells: number[][] = [];
@@ -126,16 +144,19 @@ export class DatePickerComponent {
 
    selectYear(year: number) {
       this.dateTime.years = year;
+      this.updateCalendar();
       this.dateValueChanged(DateTimeChangeType.YEAR);
    }
 
    selectMonth(month: number) {
       this.dateTime.months = month;
+      this.updateCalendar();
       this.dateValueChanged(DateTimeChangeType.MONTH);
    }
 
    private dateValueChanged(changeType: DateTimeChangeType) {
-      this.onCommit.emit(this.formatTimeString(this.dateTime));
-      this.valueChanged.emit({value: this.formatTimeString(this.dateTime), changeType: changeType});
+      const formatted = this.formatTimeString(this.dateTime);
+      this.onCommit.emit(formatted);
+      this.valueChanged.emit({value: formatted, changeType: changeType});
    }
 }

--- a/web/projects/portal/src/app/widget/date-type-editor/date-time-picker.component.ts
+++ b/web/projects/portal/src/app/widget/date-type-editor/date-time-picker.component.ts
@@ -62,7 +62,11 @@ export class DateTimePickerComponent implements OnInit {
       this.initTime(this.dateTime);
 
       if(this.emitAutoSet && autoSetCurrent) {
-         this.dateTimeValueChange(DateTimeChangeType.AUTO);
+         // Defer emission to avoid NG0100 when this component is initialized inside a
+         // fixed dropdown whose view is attached to applicationRef outside the normal
+         // component tree — synchronous emission during ngOnInit triggers a second CD
+         // pass on the already-checked parent, causing ExpressionChangedAfterItHasBeenCheckedError.
+         Promise.resolve().then(() => this.dateTimeValueChange(DateTimeChangeType.AUTO));
       }
    }
 
@@ -99,7 +103,8 @@ export class DateTimePickerComponent implements OnInit {
    }
 
    dateTimeValueChange(changeType: DateTimeChangeType) {
-      this.onCommit.emit(this.formatTimeString(this.dateTime));
-      this.valueChanged.emit({value: this.formatTimeString(this.dateTime), changeType: changeType});
+      const formatted = this.formatTimeString(this.dateTime);
+      this.onCommit.emit(formatted);
+      this.valueChanged.emit({value: formatted, changeType: changeType});
    }
 }

--- a/web/projects/portal/src/app/widget/date-type-editor/date-time-picker.component.ts
+++ b/web/projects/portal/src/app/widget/date-type-editor/date-time-picker.component.ts
@@ -19,6 +19,7 @@ import {
    Component,
    EventEmitter,
    Input,
+   OnDestroy,
    OnInit,
    Output,
 } from "@angular/core";
@@ -38,7 +39,7 @@ import { DatePickerComponent } from "./date-picker.component";
     TimeValueEditorComponent
 ]
 })
-export class DateTimePickerComponent implements OnInit {
+export class DateTimePickerComponent implements OnInit, OnDestroy {
    @Input() promptTime: boolean;
    @Input() promptDate: boolean = true;
    @Input() date: string = "";
@@ -49,6 +50,7 @@ export class DateTimePickerComponent implements OnInit {
    timeFormat: string = DateTypeFormatter.ISO_8601_TIME_FORMAT;
    selectTime: string;
    dateTime: TimeInstant;
+   private destroyed = false;
 
    ngOnInit(): void {
       let autoSetCurrent = false;
@@ -66,8 +68,16 @@ export class DateTimePickerComponent implements OnInit {
          // fixed dropdown whose view is attached to applicationRef outside the normal
          // component tree — synchronous emission during ngOnInit triggers a second CD
          // pass on the already-checked parent, causing ExpressionChangedAfterItHasBeenCheckedError.
-         Promise.resolve().then(() => this.dateTimeValueChange(DateTimeChangeType.AUTO));
+         Promise.resolve().then(() => {
+            if(!this.destroyed) {
+               this.dateTimeValueChange(DateTimeChangeType.AUTO);
+            }
+         });
       }
+   }
+
+   ngOnDestroy(): void {
+      this.destroyed = true;
    }
 
    initTime(dateTime: TimeInstant): void {


### PR DESCRIPTION
## Summary

- Selecting a date in the calendar date picker for a schedule task Creation Parameter always placed today's date in the input instead of the selected date
- Console errors NG0100 (ExpressionChangedAfterItHasBeenCheckedError) and NG0956 (track by identity caused re-creation) appeared on every calendar open

## Root Cause

Three interacting issues in `DatePickerComponent` and `DateTimePickerComponent`:

1. `loadCalender()` was called directly in the `@for` template expression. It returns a new array on every call, so Angular's `track cell` (track by identity) destroyed and recreated all calendar cell DOM nodes — including their Angular event listeners — on every change-detection cycle (NG0956).

2. In `DateTimePickerComponent.ngOnInit()`, when `emitAutoSet=true` and the initial date was empty, `dateTimeValueChange()` was called synchronously. Because this component is created inside a `FixedDropdownService` embedded view attached to `ApplicationRef` outside the normal component tree, this synchronous emission triggered a second CD pass on the already-checked parent, causing NG0100.

3. The inner `@for (day of cell; track day)` used `track day` where `day = -1` repeats for empty cells in each row, causing further tracking instability.

Zone.js triggers change detection after each event listener during DOM event bubbling. The continuous NG0956-driven DOM re-creation left the calendar day `<div>` elements without Angular `(mousedown)` event listeners, so clicking a day never fired `selectDay()` — meaning the input kept today's date set by the `emitAutoSet` auto-initialization.

## Fix

- `DatePickerComponent`: pre-compute `calendarCells` into a stable field, updated only in `ngOnInit`, `ngOnChanges` (when the `dateTime` input reference changes), and when the user changes month/year via `selectMonth`/`selectYear`. Template uses `calendarCells; track $index` for both loops, eliminating NG0956 and the event-listener loss.
- `DateTimePickerComponent`: wrapped the `emitAutoSet` emission in `Promise.resolve().then(...)` to defer it past the current CD cycle, eliminating NG0100.

## Test Plan

- [ ] Open schedule task editor → Add Parameter → select type Date → click calendar icon
- [ ] Select a date other than today → verify the selected date appears in the input
- [ ] Verify no NG0100 or NG0956 console errors appear
- [ ] Repeat with type Date Time Instant
- [ ] Verify changing month and year in the calendar correctly re-renders the grid

Fixes Redmine #75261.