### PR TITLE
Bug #75316, fix data cycle task not found in cloud runner mode

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/DataCycleManager.java
+++ b/core/src/main/java/inetsoft/sree/internal/DataCycleManager.java
@@ -142,6 +142,12 @@ public class DataCycleManager
       String orgId = Util.getOrgIdFromEventSource(evt.getSource());
 
       if(MVManager.MV_CHANGE_EVENT.equals(name) || RepletRegistry.CHANGE_EVENT.equals(name)) {
+         // cloud-runner nodes are short-lived task executors; their Ignite client
+         // may be shutting down when MVChangedMessage fires after task completion
+         if(System.getProperty("ScheduleTaskRunner") != null) {
+            return;
+         }
+
          generateTasks(null, orgId != null ? new Organization(new IdentityID(orgId, orgId)) : null,
                        true, false);
       }
@@ -265,13 +271,6 @@ public class DataCycleManager
          if(Scheduler.getSchedulerCount() != 1 &&
             "true".equals(System.getProperty("ScheduleServer")))
          {
-            return;
-         }
-
-         // cloud-runner nodes are short-lived task executors; they don't maintain
-         // pregenerated tasks and their Ignite client may be shutting down when this
-         // is triggered by an MVChangedMessage after task completion
-         if(System.getProperty("ScheduleTaskRunner") != null) {
             return;
          }
 


### PR DESCRIPTION
## Summary

Data cycle tasks failed when executed via the Docker cloud runner in a multi-tenant environment because `DataCycleManager.generateTasks()` returned early on cloud runner nodes, preventing task lookup before execution.

## Root Cause

`DataCycleManager.generateTasks()` contained a guard that returned immediately when the `ScheduleTaskRunner` system property was set (i.e., on cloud runner nodes). This guard was intended to prevent reactive task regeneration triggered by `MVChangedMessage` events after task completion — a safe optimization since cloud runner nodes are short-lived and their Ignite client may be shutting down at that point.

However, the guard was placed in `generateTasks()` itself rather than in the caller that handles the reactive event (`propertyChange()`). This meant that when `CloudRunnerContext.findScheduleTask()` called `DataCycleManager.getTasks(orgID)`, which in turn called `generateTasks()` to populate the task list for that org, the method returned immediately — always producing an empty list. As a side effect, `orgPregeneratedTaskLoadedStatus` was still set to `true` in the `finally` block, so subsequent calls for the same org also skipped generation, making the task permanently unfindable. The cloud runner then reported "Could not find schedule task" and the data cycle failed.

## Fix

Moved the `ScheduleTaskRunner` early-return guard from `generateTasks()` to `propertyChange()`, which is the only reactive path triggered by `MVChangedMessage` and `RepletRegistry.CHANGE_EVENT`. This preserves the original intent (skip regeneration on cloud runner nodes after task completion) while allowing `getTasks()` → `generateTasks()` to work correctly during task lookup.

## Test Plan

- [ ] Run a data cycle in the cluster-test Docker Compose environment (single server + Docker cloud runner)
- [ ] Confirm the MV task is found and executes successfully
- [ ] Confirm no regression in non-cloud-runner scheduling (standard scheduler task lookup still works)

Fixes Redmine #75316.