### PR TITLE
Bug #75252, prevent EM logout when Google OAuth2 SMTP sign-in fails on unlicensed instances (v1.1.x)

### DIFF
--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -4370,6 +4370,7 @@ em.localeAdd.localelabelInvalid=The Locale Label must not be empty.
 em.login.pwdEmpty=Password field is empty.
 em.mail.hostInvalid=The mail host is not valid
 em.mail.hostRequired=The mail host is required
+em.mail.smtp.authorizeFailed=Authorization failed. Please verify your OAuth settings and try again.
 em.mail.smtp.gmailUser=Gmail Authorization User (Will override From address)
 em.mail.smtp.redirect.uri.description=You must use https://data.inetsoft.com/oauth as the redirect URL for your application.
 em.monitor.clusterDisabled=Cluster servers are not available. This feature is only available in the Enterprise edition.

--- a/web/projects/em/src/app/invalid-session-interceptor.ts
+++ b/web/projects/em/src/app/invalid-session-interceptor.ts
@@ -41,14 +41,44 @@ export class InvalidSessionInterceptor implements HttpInterceptor {
       return next.handle(req).pipe(
          tap(
             () => {},
-            error => this.handleInvalidSession(error)
+            error => this.handleInvalidSession(req, error)
          )
       );
    }
 
-   private handleInvalidSession(error: HttpErrorResponse): void {
-      if(error.status === 401 || error.status === 403) {
+   private handleInvalidSession(req: HttpRequest<any>, error: HttpErrorResponse): void {
+      if((error.status === 401 || error.status === 403) && this.isSameOrigin(req.url)) {
          this.logoutService.sessionExpired();
+      }
+   }
+
+   /**
+    * Only the application's own (same-origin) responses indicate an expired
+    * session. A 401/403 from an absolute URL pointing at an external service
+    * (e.g. the OAuth proxy at data.inetsoft.com) is unrelated to the StyleBI
+    * session and must not trigger a logout.
+    */
+   private isSameOrigin(url: string): boolean {
+      // A non-http(s) scheme (e.g. data:, blob:, mailto:) is never one of the
+      // application's own session-bearing responses; treat it as cross-origin so
+      // it cannot trigger a logout.
+      if(/^[a-z][a-z0-9+.-]*:/i.test(url) && !/^https?:/i.test(url)) {
+         return false;
+      }
+
+      // relative path (e.g. "../api/...") is always same-origin
+      if(!/^(https?:)?\/\//i.test(url)) {
+         return true;
+      }
+
+      try {
+         // normalize protocol-relative URLs ("//host/path") before comparing
+         const absolute = url.startsWith("//") ? `${window.location.protocol}${url}` : url;
+         return new URL(absolute).origin === window.location.origin;
+      }
+      catch(e) {
+         // Malformed URL — treat as cross-origin to avoid spurious logouts.
+         return false;
       }
    }
 }

--- a/web/projects/em/src/app/settings/general/email-settings-view/email-settings-view.component.ts
+++ b/web/projects/em/src/app/settings/general/email-settings-view/email-settings-view.component.ts
@@ -32,7 +32,9 @@ import {
    OAuthParameters
 } from "../../../../../../portal/src/app/common/services/oauth-authorization.service";
 import { ScheduleUsersService } from "../../../../../../shared/schedule/schedule-users.service";
+import { Tool } from "../../../../../../shared/util/tool";
 import { FormValidators } from "../../../../../../shared/util/form-validators";
+import { MatSnackBar } from "@angular/material/snack-bar";
 import { Searchable } from "../../../searchable";
 import { IdentityId } from "../../security/users/identity-id";
 import { GeneralSettingsChanges } from "../general-settings-page/general-settings-page.component";
@@ -88,6 +90,7 @@ export class EmailSettingsViewComponent implements OnDestroy {
                private usersService: ScheduleUsersService,
                defaultErrorMatcher: ErrorStateMatcher,
                private httpClient: HttpClient,
+               private snackBar: MatSnackBar,
                private oauthService: OAuthAuthorizationService,)
    {
       this.errorStateMatcher = {
@@ -358,14 +361,34 @@ export class EmailSettingsViewComponent implements OnDestroy {
 
       // The specific parameter we need from the server is the license key
       this.httpClient.post<OAuthParameters>("../api/em/general/settings/email/oauth-params", paramsRequest)
-         .subscribe((authParams) => {
-            this.oauthService.authorize(authParams).subscribe((oAuthTokens) => {
-               const expiration = new Date(oAuthTokens.expiration).getTime();
-               this.form.get("smtpAccessToken").setValue(oAuthTokens.accessToken);
-               this.form.get("smtpRefreshToken").setValue(oAuthTokens.refreshToken);
-               this.form.get("tokenExpiration").setValue(expiration);
-            });
+         .subscribe({
+            next: (authParams) => {
+               this.oauthService.authorize(authParams).subscribe({
+                  next: (oAuthTokens) => {
+                     const expiration = new Date(oAuthTokens.expiration).getTime();
+                     this.form.get("smtpAccessToken").setValue(oAuthTokens.accessToken);
+                     this.form.get("smtpRefreshToken").setValue(oAuthTokens.refreshToken);
+                     this.form.get("tokenExpiration").setValue(expiration);
+                  },
+                  error: () => this.showAuthorizeError()
+               });
+            },
+            // The oauth-params POST can fail for reasons unrelated to OAuth
+            // configuration (server 500, network error). Surface the server's
+            // own message when present rather than the misleading "verify your
+            // OAuth settings" text; fall back to it only when there is none.
+            error: (err) => {
+               const message = err?.error?.message;
+               message ? this.snackBar.open(message, "_#(js:Close)",
+                                            {duration: Tool.SNACKBAR_DURATION})
+                       : this.showAuthorizeError();
+            }
          });
+   }
+
+   private showAuthorizeError() {
+      this.snackBar.open("_#(js:em.mail.smtp.authorizeFailed)", "_#(js:Close)",
+                         {duration: Tool.SNACKBAR_DURATION});
    }
 
    protected readonly SMTPAuthType = SMTPAuthType;


### PR DESCRIPTION
## Summary

Cherry-pick of #3933 (merged to `main`) onto the `v1.1.x` release branch, per the plan in Redmine #75252 ("fix on main and then cherry-pick to v1.1.x").

## Root Cause

In opensource/unlicensed StyleBI, selecting **Google OAuth2 SMTP** and clicking **Sign in with Google** bounced the admin back to the EM Summary page instead of completing (or cleanly failing) the OAuth flow.

The token exchange goes through InetSoft's hosted OAuth proxy (`data.inetsoft.com`), which rejects unlicensed requests with HTTP 403. The global `InvalidSessionInterceptor` taps every `HttpClient` response and, on any 401/403 — including this cross-origin call — invokes `LogoutService.sessionExpired()`, doing a full redirect to `../sessionexpired`. Because the real EM session was still valid, the admin was bounced to the EM Summary page.

## Fix

- `invalid-session-interceptor.ts`: only trigger `sessionExpired()` for **same-origin** 401/403 responses; a 401/403 from an external host (e.g. `data.inetsoft.com`) no longer logs the EM admin out. Protocol-relative and non-http(s) URLs are normalized/handled before the origin comparison.
- `email-settings-view.component.ts`: `authorize0()` now surfaces a snackbar on authorization failure instead of failing silently (prefers the server message when present).
- `srinter.properties`: added the `em.mail.smtp.authorizeFailed` message.

This is a symptom fix: it stops the spurious logout and shows a clear error. Completing the OAuth flow on an opensource instance still requires a valid `data.inetsoft.com` API key (generatable via **Settings > General > API Key**, `/em/settings/general#api-key`) — as confirmed by the reporter on the issue.

## Test Plan

- In EM, **Settings > General > Email**, choose **Google OAuth2 SMTP** and click **Sign in with Google** on an instance without a configured API key: the admin stays on the Email settings page and sees "Authorization failed. Please verify your OAuth settings and try again." — no logout/bounce to EM Summary.
- With a valid `data.inetsoft.com` API key configured, the sign-in completes normally.
- Regression: a genuine same-origin 401/403 still triggers the normal session-expired redirect.

Original (main) PR: https://github.com/inetsoft-technology/stylebi/pull/3933

Fixes Redmine #75252.