### PR TITLE
fix(wiz): honor requested chart type stored in prefInfos

### DIFF
--- a/core/src/main/java/inetsoft/web/vswizard/handler/VSWizardBindingHandler.java
+++ b/core/src/main/java/inetsoft/web/vswizard/handler/VSWizardBindingHandler.java
@@ -833,7 +833,15 @@ public class VSWizardBindingHandler {
                                          SourceInfo source, CommandDispatcher dispatcher)
       throws Exception
    {
-      int idx = getSelectedSubTypeIdx(model);
+      // Chart recommendations select across the combined chartInfos ++ prefInfos space (resolved
+      // below). getSelectedSubTypeIdx clamps against subTypes, which span only chartInfos, so a
+      // preference-scored type stored in prefInfos was being reset to chartInfos[0] — silently
+      // turning a requested point (or any pref-only type) into the default bar. Resolve over the
+      // full space so the selected sub-type is honored.
+      int idx = WizChartInfoIndex.resolve(
+         model.getSelectedIndex(),
+         model.getChartInfos() != null ? model.getChartInfos().size() : 0,
+         model.getPrefInfos() != null ? model.getPrefInfos().size() : 0);
 
       if(idx == -1) {
          throw new MessageException("No valid subtype for chart!");

--- a/core/src/main/java/inetsoft/web/vswizard/handler/WizChartInfoIndex.java
+++ b/core/src/main/java/inetsoft/web/vswizard/handler/WizChartInfoIndex.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.vswizard.handler;
+
+/**
+ * Index resolution for a chart recommendation's selected sub-type across the combined
+ * {@code chartInfos ++ prefInfos} index space used by the wiz auto-binding path.
+ *
+ * <p>Kept as a standalone, state-free class (no static initializer) so the pure logic is unit
+ * testable without bootstrapping {@link VSWizardBindingHandler}'s app-dependent static context.
+ */
+final class WizChartInfoIndex {
+   private WizChartInfoIndex() {
+   }
+
+   /**
+    * Resolves the selected index for a chart recommendation across the combined
+    * {@code chartInfos ++ prefInfos} index space (see {@code VSWizardBindingHandler.addChartVSAssembly}).
+    *
+    * <p>Unlike the subType-based clamp in {@code getSelectedSubTypeIdx}, this does NOT clamp against
+    * {@code subTypes} — those span only {@code chartInfos}, so a preference-scored chart type stored
+    * in {@code prefInfos} (selectedIndex &ge; {@code chartInfosSize}) would otherwise be reset to
+    * {@code chartInfos[0]}, silently turning a requested type (e.g. point) into the default bar.
+    *
+    * @return the selected index in {@code [0, chartInfosSize + prefInfosSize)}, or {@code -1} when
+    *         there are no infos at all (preserving the "No valid subtype for chart!" guard).
+    */
+   static int resolve(int selectedIndex, int chartInfosSize, int prefInfosSize) {
+      int total = Math.max(0, chartInfosSize) + Math.max(0, prefInfosSize);
+
+      if(total == 0) {
+         return -1;
+      }
+
+      return selectedIndex >= 0 && selectedIndex < total ? selectedIndex : 0;
+   }
+}

--- a/core/src/test/java/inetsoft/web/vswizard/handler/WizChartInfoIndexTest.java
+++ b/core/src/test/java/inetsoft/web/vswizard/handler/WizChartInfoIndexTest.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.vswizard.handler;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for {@link WizChartInfoIndex#resolve(int, int, int)}, the index resolver that lets
+ * {@code VSWizardBindingHandler.addChartVSAssembly} build the chart sub-type a caller actually
+ * selected across the combined {@code chartInfos ++ prefInfos} space.
+ */
+@Tag("core")
+class WizChartInfoIndexTest {
+   @Test
+   void indexWithinChartInfosIsReturnedUnchanged() {
+      // chartInfos=[0,1,2], prefInfos=[3,4]; selecting chartInfos[1] stays 1.
+      assertEquals(1, WizChartInfoIndex.resolve(1, 3, 2));
+   }
+
+   @Test
+   void indexIntoPrefInfosIsHonored() {
+      // The bug: a preference-scored type (e.g. "point") lives in prefInfos at combined index
+      // chartInfosSize+i. It must be honored, NOT clamped to chartInfos[0] (the default bar).
+      assertEquals(3, WizChartInfoIndex.resolve(3, 3, 2));
+      assertEquals(4, WizChartInfoIndex.resolve(4, 3, 2));
+   }
+
+   @Test
+   void outOfRangeIndexClampsToZero() {
+      // total = 3 + 2 = 5, so index 5 is out of range -> first info.
+      assertEquals(0, WizChartInfoIndex.resolve(5, 3, 2));
+   }
+
+   @Test
+   void negativeIndexClampsToZeroWhenInfosExist() {
+      assertEquals(0, WizChartInfoIndex.resolve(-1, 3, 0));
+   }
+
+   @Test
+   void noInfosReturnsMinusOne() {
+      // Preserves the "No valid subtype for chart!" guard in addChartVSAssembly.
+      assertEquals(-1, WizChartInfoIndex.resolve(0, 0, 0));
+      assertEquals(-1, WizChartInfoIndex.resolve(-1, 0, 0));
+   }
+
+   @Test
+   void prefInfosOnlyIsHonored() {
+      // No base chartInfos, only preference-scored infos: index 0 and 1 are both valid.
+      assertEquals(0, WizChartInfoIndex.resolve(0, 0, 2));
+      assertEquals(1, WizChartInfoIndex.resolve(1, 0, 2));
+   }
+}


### PR DESCRIPTION
## Problem
A caller-requested chart type was silently ignored. autoBinding with `visualizationType: "point"` (country × genre × rental count) returned a result that **reported** `point` but **rendered** a stacked bar, with no `selectionNote`.

## Root cause
`WizAutoBindingService` selects the primary chart recommendation across the combined `chartInfos ++ prefInfos` index space (preference-scored types live in `prefInfos`). But `VSWizardBindingHandler.addChartVSAssembly` derived its sub-type index from `getSelectedSubTypeIdx`, which clamps the index against `subTypes` — and `subTypes` is built 1:1 with `chartInfos` only (`VSChartDefaultRecommendationFactory`). A type stored in `prefInfos` at index `chartInfos.size()+i` is therefore `>= subTypes.size()` → clamped to `0` → `chartInfos[0]` (the default bar). Meanwhile the response type comes from `getSelectedChartInfo`, which reads the combined space — hence "reports point, builds bar".

## Fix
Extract the combined-space index resolution into a pure, state-free `WizChartInfoIndex.resolve(selectedIndex, chartInfosSize, prefInfosSize)` (no `subTypes` clamp; returns `-1` only when there are no infos, preserving the existing "No valid subtype for chart!" guard) and call it from `addChartVSAssembly`. Kept as a standalone class so the logic is unit-testable without bootstrapping the handler's app-dependent static context.

## Tests
`WizChartInfoIndexTest` — 6 cases incl. the prefInfos-index case. Green.

## Verification
Built the image and confirmed end-to-end: a `point` request for country × genre × rental count now renders as a heatmap grid instead of a stacked bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)