### PR TITLE
fix(wiz): worksheet multi-value IN filter + multi-condition junctions

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
@@ -912,8 +912,8 @@ public class GenerateWsService {
                                List<WorksheetConstructionModel.Condition> conditions)
    {
       ConditionList conditionList = new ConditionList();
-      table.setPreConditionList(conditionList);
       ColumnSelection columnSelection = table.getColumnSelection();
+      boolean appended = false;
 
       for(WorksheetConstructionModel.Condition filter : conditions) {
          DataRef attributeRef = columnSelection.getAttribute(filter.getField());
@@ -922,56 +922,31 @@ public class GenerateWsService {
             continue;
          }
 
-         WorksheetConstructionModel.FilterOperator filterOperator = filter.getOperator();
-         List<Integer> conditionOperator = getConditionOperator(filterOperator);
+         int level = filter.getConditionLevel();
 
-         for(Integer op : conditionOperator) {
-            AssetCondition assetCondition = new AssetCondition();
-            addConditionValue(assetCondition, filter.getValue());
-            assetCondition.setNegated(filter.isNegated());
-            assetCondition.setOperation(op);
-            assetCondition.setType(attributeRef.getDataType());
-            conditionList.append(new ConditionItem(attributeRef, assetCondition, filter.getConditionLevel()));
+         // A ConditionList must alternate ConditionItem / JunctionOperator entries. Insert the
+         // junction joining this condition to the previous one (AND/OR from the model) before the
+         // item — without it, StyleBI casts the next ConditionItem as a JunctionOperator and a
+         // multi-condition filter fails with a ClassCastException.
+         if(appended) {
+            int junction = filter.getConditionOperator() == WorksheetConstructionModel.ConditionOperator.OR
+               ? JunctionOperator.OR : JunctionOperator.AND;
+            conditionList.append(new JunctionOperator(junction, level));
          }
+
+         AssetCondition assetCondition = new AssetCondition();
+         // addConditionValue adds every element of a list value, so a multi-value IN (-> ONE_OF)
+         // carries all values rather than only the first (the old IN -> CONTAINS mapping bug).
+         addConditionValue(assetCondition, filter.getValue());
+         assetCondition.setNegated(filter.isNegated());
+         assetCondition.setOperation(WizFilterOperation.operation(filter.getOperator()));
+         assetCondition.setEqual(WizFilterOperation.isInclusiveBound(filter.getOperator()));
+         assetCondition.setType(attributeRef.getDataType());
+         conditionList.append(new ConditionItem(attributeRef, assetCondition, level));
+         appended = true;
       }
 
       table.setPreConditionList(conditionList);
-   }
-
-   private List<Integer> getConditionOperator(WorksheetConstructionModel.FilterOperator filterOperator) {
-      List<Integer> ops = new ArrayList<>();
-
-      if(Objects.requireNonNull(filterOperator) == WorksheetConstructionModel.FilterOperator.EQ) {
-         ops.add(XCondition.EQUAL_TO);
-      }
-      else if(filterOperator == WorksheetConstructionModel.FilterOperator.GT) {
-         ops.add(XCondition.GREATER_THAN);
-      }
-      else if(filterOperator == WorksheetConstructionModel.FilterOperator.GE) {
-         ops.add(XCondition.EQUAL_TO);
-         ops.add(XCondition.GREATER_THAN);
-      }
-      else if(filterOperator == WorksheetConstructionModel.FilterOperator.LT) {
-         ops.add(XCondition.LESS_THAN);
-      }
-      else if(filterOperator == WorksheetConstructionModel.FilterOperator.LE) {
-         ops.add(XCondition.EQUAL_TO);
-         ops.add(XCondition.LESS_THAN);
-      }
-      else if(filterOperator == WorksheetConstructionModel.FilterOperator.IN) {
-         ops.add(XCondition.CONTAINS);
-      }
-      else if(filterOperator == WorksheetConstructionModel.FilterOperator.BETWEEN) {
-         ops.add(XCondition.BETWEEN);
-      }
-      else if(filterOperator == WorksheetConstructionModel.FilterOperator.LIKE) {
-         ops.add(XCondition.LIKE);
-      }
-      else {
-         throw new IllegalArgumentException("Unknown filter operator: " + filterOperator);
-      }
-
-      return ops;
    }
 
    private void applyOrderBy(AbstractTableAssembly table,

--- a/core/src/main/java/inetsoft/web/wiz/service/WizFilterOperation.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizFilterOperation.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.XCondition;
+import inetsoft.web.wiz.model.WorksheetConstructionModel.FilterOperator;
+
+/**
+ * Maps a worksheet-model {@link FilterOperator} to a StyleBI {@link XCondition} operation.
+ *
+ * <p>Standalone, pure, and state-free so the mapping is unit testable without bootstrapping
+ * {@link GenerateWsService}. The notable fix here is {@code IN -> ONE_OF}: it previously mapped to
+ * {@code CONTAINS} (a single-value substring match), which only honored the first value of a
+ * multi-value IN filter.
+ */
+final class WizFilterOperation {
+   private WizFilterOperation() {
+   }
+
+   /**
+    * The XCondition operation code for a worksheet filter operator. {@code IN} maps to
+    * {@link XCondition#ONE_OF} (multi-value in-list); {@code GE}/{@code LE} map to the strict
+    * comparison op and rely on {@link #isInclusiveBound} to add the equal flag.
+    */
+   static int operation(FilterOperator op) {
+      return switch(op) {
+         case EQ -> XCondition.EQUAL_TO;
+         case GT, GE -> XCondition.GREATER_THAN;
+         case LT, LE -> XCondition.LESS_THAN;
+         case IN -> XCondition.ONE_OF;
+         case BETWEEN -> XCondition.BETWEEN;
+         case LIKE -> XCondition.LIKE;
+      };
+   }
+
+   /**
+    * {@code GE} (>=) and {@code LE} (<=) are inclusive bounds, expressed as GREATER_THAN/LESS_THAN
+    * with the XCondition "equal" flag set — a single condition item, not two.
+    */
+   static boolean isInclusiveBound(FilterOperator op) {
+      return op == FilterOperator.GE || op == FilterOperator.LE;
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizFilterOperationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizFilterOperationTest.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.XCondition;
+import inetsoft.web.wiz.model.WorksheetConstructionModel.FilterOperator;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("core")
+class WizFilterOperationTest {
+   @Test
+   void inMapsToOneOfNotContains() {
+      // The bug: IN mapped to CONTAINS (single-value substring), honoring only the first value of a
+      // multi-value IN filter. It must be ONE_OF (multi-value in-list).
+      assertEquals(XCondition.ONE_OF, WizFilterOperation.operation(FilterOperator.IN));
+      assertNotEquals(XCondition.CONTAINS, WizFilterOperation.operation(FilterOperator.IN));
+   }
+
+   @Test
+   void comparisonOperatorsMapToStrictOps() {
+      assertEquals(XCondition.EQUAL_TO, WizFilterOperation.operation(FilterOperator.EQ));
+      assertEquals(XCondition.GREATER_THAN, WizFilterOperation.operation(FilterOperator.GT));
+      assertEquals(XCondition.GREATER_THAN, WizFilterOperation.operation(FilterOperator.GE));
+      assertEquals(XCondition.LESS_THAN, WizFilterOperation.operation(FilterOperator.LT));
+      assertEquals(XCondition.LESS_THAN, WizFilterOperation.operation(FilterOperator.LE));
+      assertEquals(XCondition.BETWEEN, WizFilterOperation.operation(FilterOperator.BETWEEN));
+      assertEquals(XCondition.LIKE, WizFilterOperation.operation(FilterOperator.LIKE));
+   }
+
+   @Test
+   void onlyGeLeAreInclusiveBounds() {
+      assertTrue(WizFilterOperation.isInclusiveBound(FilterOperator.GE));
+      assertTrue(WizFilterOperation.isInclusiveBound(FilterOperator.LE));
+      assertFalse(WizFilterOperation.isInclusiveBound(FilterOperator.GT));
+      assertFalse(WizFilterOperation.isInclusiveBound(FilterOperator.LT));
+      assertFalse(WizFilterOperation.isInclusiveBound(FilterOperator.EQ));
+      assertFalse(WizFilterOperation.isInclusiveBound(FilterOperator.IN));
+   }
+}


### PR DESCRIPTION
## Problem
`GenerateWsService.applyCondition` (the worksheet `filters`/WHERE builder) produced wrong conditions:
- **`IN` → `XCondition.CONTAINS`** (a single-value substring match) → a multi-value `IN` applied only the **first** value (e.g. a 12-country `IN` returned only "United States").
- It appended only `ConditionItem`s with **no `JunctionOperator`** between them, so 2+ conditions — or the `GE`/`LE` two-op expansion — failed in StyleBI with `class inetsoft.uql.ConditionItem cannot be cast to class inetsoft.uql.JunctionOperator`.

Net: there was no working way to scope a worksheet to a multi-value set or combine WHERE conditions.

## Fix
- `IN` → `XCondition.ONE_OF` (`addConditionValue` already adds every element of a list value, so all values carry).
- `GE`/`LE` → `GREATER_THAN`/`LESS_THAN` with the `equal` flag (a single condition item, instead of two items that also cast-errored).
- Insert a `JunctionOperator` (AND/OR from the model's `conditionOperator`) between successive condition items at their `conditionLevel`.
- Operator mapping extracted to a pure, state-free `WizFilterOperation` for unit testing.

## Tests
`WizFilterOperationTest` (3 tests: `IN`→`ONE_OF` not `CONTAINS`, comparison ops, inclusive-bound flag). Green; `community/core` compiles.

## Note
The `having` builder (`getHavingConditionOperator`/`applyHavingCondition`) has the same latent junction/two-op pattern; out of scope here but worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)