### PR TITLE
fix(crosstab): null-safe CSS-type check fixes blank crosstab data load

### DIFF
--- a/core/src/main/java/inetsoft/report/style/XTableStyle.java
+++ b/core/src/main/java/inetsoft/report/style/XTableStyle.java
@@ -1076,7 +1076,10 @@ public class XTableStyle extends TableStyle {
 
       if(this instanceof CSSTableStyle) {
          CSSParameter sheetParam = ((CSSTableStyle) this).getSheetParam();
-         vsLens = sheetParam != null && sheetParam.getCSSType().equals(CSSConstants.VIEWSHEET);
+         // getCSSType() may be null (e.g. a viewsheet whose sheet CSS param has no type set);
+         // compare constant-first so a null type is a no-match instead of an NPE. A null type here
+         // aborted crosstab data loading ("Error loading data ... CSSParameter.getCSSType() is null").
+         vsLens = sheetParam != null && CSSConstants.VIEWSHEET.equals(sheetParam.getCSSType());
       }
 
       // only get the css height if there is no base height specified


### PR DESCRIPTION
## Problem
A wiz-created crosstab rendered **blank** in the companion viewer (frame + title, empty grid). The WebSocket delivered a `MessageCommand` error during data load:

```
Error loading data. Data source may have changed: Cannot invoke "String.equals(Object)"
because the return value of "inetsoft.util.css.CSSParameter.getCSSType()" is null
```

`XTableStyle.getRowHeight` (in the table-lens render path) did:
```java
vsLens = sheetParam != null && sheetParam.getCSSType().equals(CSSConstants.VIEWSHEET);
```
When the sheet `CSSParameter` has no type set, `getCSSType()` is null → NPE → the data load aborts → empty grid. (Normal dashboard crosstabs happen to have a non-null sheet CSS type, so they render; the wiz crosstab's is null.)

## Fix
Compare constant-first so a null type is a no-match instead of an NPE:
```java
vsLens = sheetParam != null && CSSConstants.VIEWSHEET.equals(sheetParam.getCSSType());
```
This matches the null-safe `getCSSType()` comparisons already used elsewhere (`FormatInfo`, `AbstractVSExporter`, and the `Tool.equals` call sites). General robustness fix — not wiz-specific.

## Verification
Built into the local image; the wiz crosstab then loads data and renders instead of erroring. (Pending final reload confirmation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)