### PR TITLE
feat(wiz): enable map recommendations (tag geo columns before recommending)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -24,6 +24,7 @@ import inetsoft.uql.asset.*;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.VSUtil;
 import inetsoft.uql.viewsheet.graph.*;
 import inetsoft.graph.aesthetic.*;
 import inetsoft.uql.viewsheet.graph.aesthetic.ColorPalettes;
@@ -167,6 +168,17 @@ public class WizAutoBindingService {
 
          VSChartInfo tempChartInfo = tempInfo.getTempChart().getVSChartInfo();
          applyFieldConfigs(tempChartInfo, configMap);
+
+         // Tag geographic columns (country/state/city) on the temp chart BEFORE recommending, so the
+         // recommender's MapChartFilter can see them and offer a map. The interactive wizard does
+         // this (VSWizardBindingService.setDefaultGeoColumns) and addChartVSAssembly sets it on the
+         // final assembly, but the recommendation here ran without it — so 'map' was always filtered
+         // out as infeasible for the plugin path.
+         SourceInfo geoSource = tempInfo.getTempChart().getSourceInfo();
+
+         if(geoSource != null) {
+            VSUtil.setDefaultGeoColumns(tempChartInfo, rvs, geoSource.getSource());
+         }
 
          String vizType = request.getVisualizationType();
          List<ExplicitBinding> explicitBindings = request.getExplicitBindings();


### PR DESCRIPTION
## Problem
Requesting a map from the wiz plugin (`visualizationType: "map"`, `intentCategory: "geospatial"`) always fell back to a point chart: `selectionNote: "Requested chart type 'map' is not feasible for this data; used 'point' instead."` even for a `country` dimension.

`WizAutoBindingService` runs the recommender on the temp binding **without tagging geographic columns first**, so `MapChartFilter` finds no `GeoRef` and filters `map` out as infeasible. The interactive wizard (`VSWizardBindingService.setDefaultGeoColumns`) and the final-assembly builder (`addChartVSAssembly`) both set geo columns — only the plugin's recommendation path didn't.

## Fix
Call `VSUtil.setDefaultGeoColumns(tempChartInfo, rvs, source)` before `defaultRecommendationFactory.recommend(...)`, so country/state/city columns are geo-typed and a map becomes a feasible recommendation for the plugin path.

## Verification
Built into the local image; a `country` + measure binding with `intentCategory=geospatial`, `visualizationType=map` now produces a map. (Final reload confirmation pending.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)