### PR TITLE
Bug #75362, register DefaultCodemirrorService at app root in EM

### DIFF
--- a/web/projects/em/src/app/settings/security/security-provider/custom-provider-view/custom-provider-view.component.ts
+++ b/web/projects/em/src/app/settings/security/security-provider/custom-provider-view/custom-provider-view.component.ts
@@ -34,9 +34,6 @@ import { CodemirrorService } from "../../../../../../../shared/util/codemirror/c
 import { CustomProviderModel } from "../security-provider-model/custom-provider-model";
 import { take } from "rxjs/operators";
 import { Subscription } from "rxjs";
-import {
-   DefaultCodemirrorService
-} from "../../../../../../../shared/util/codemirror/default-codemirror.service";
 import { MatInput } from "@angular/material/input";
 import { MatFormField, MatLabel } from "@angular/material/form-field";
 
@@ -44,11 +41,6 @@ import { MatFormField, MatLabel } from "@angular/material/form-field";
     selector: "em-custom-provider-view",
     templateUrl: "./custom-provider-view.component.html",
     styleUrls: ["./custom-provider-view.component.scss"],
-    providers: [{
-            provide: CodemirrorService,
-            useClass: DefaultCodemirrorService,
-            deps: []
-        }],
     imports: [FormsModule, ReactiveFormsModule, MatFormField, MatInput, MatLabel]
 })
 export class CustomProviderViewComponent implements OnInit, AfterViewInit, AfterViewChecked, OnDestroy {

--- a/web/projects/em/src/app/settings/security/sso/custom-sso-form/custom-sso-form.component.ts
+++ b/web/projects/em/src/app/settings/security/sso/custom-sso-form/custom-sso-form.component.ts
@@ -23,7 +23,6 @@ import {
 import {GuiTool} from "../../../../../../../portal/src/app/common/util/gui-tool";
 import {CodemirrorService} from "../../../../../../../shared/util/codemirror/codemirror.service";
 import {CustomSSOAttributesModel} from "../sso-settings-model";
-import {DefaultCodemirrorService} from "../../../../../../../shared/util/codemirror/default-codemirror.service";
 import { MatInput } from "@angular/material/input";
 import { MatFormField, MatLabel } from "@angular/material/form-field";
 
@@ -34,11 +33,6 @@ import { MatRadioGroup, MatRadioButton } from "@angular/material/radio";
     selector: "em-custom-sso-form",
     templateUrl: "./custom-sso-form.component.html",
     styleUrls: ["./custom-sso-form.component.scss"],
-    providers: [{
-            provide: CodemirrorService,
-            useClass: DefaultCodemirrorService,
-            deps: []
-        }],
     imports: [MatRadioGroup, FormsModule, MatRadioButton, MatFormField, MatInput, MatLabel]
 })
 export class CustomSsoFormComponent implements OnInit, AfterViewInit, AfterViewChecked, OnDestroy {

--- a/web/projects/em/src/main.ts
+++ b/web/projects/em/src/main.ts
@@ -37,6 +37,8 @@ import { RouteReuseStrategy } from "@angular/router";
 import { ScheduleTaskNamesService } from "../../shared/schedule/schedule-task-names.service";
 import { ScheduleUsersService } from "../../shared/schedule/schedule-users.service";
 import { SsoHeartbeatService } from "../../shared/sso/sso-heartbeat.service";
+import { CodemirrorService } from "../../shared/util/codemirror/codemirror.service";
+import { DefaultCodemirrorService } from "../../shared/util/codemirror/default-codemirror.service";
 import { AppComponent } from "./app/app.component";
 import { APP_ROUTES } from "./app/app.routes";
 import { CustomRouteReuseStrategy } from "./app/custom-route-reuse-strategy";
@@ -52,6 +54,7 @@ bootstrapApplication(AppComponent, {
       httpInterceptorProviders,
       ScheduleUsersService,
       ScheduleTaskNamesService,
+      { provide: CodemirrorService, useClass: DefaultCodemirrorService },
       { provide: RouteReuseStrategy, useClass: CustomRouteReuseStrategy },
       provideAnimations(),
       provideHttpClient(withInterceptorsFromDi()),

--- a/web/projects/portal/src/app/composer/composer.routes.ts
+++ b/web/projects/portal/src/app/composer/composer.routes.ts
@@ -23,8 +23,6 @@ import { BindingService } from "../binding/services/binding.service";
 import { VSBindingService } from "../binding/services/vs-binding.service";
 import { BindingTreeService } from "../binding/widget/binding-tree/binding-tree.service";
 import { VSBindingTreeService } from "../binding/widget/binding-tree/vs-binding-tree.service";
-import { DefaultCodemirrorService } from "../../../../shared/util/codemirror/default-codemirror.service";
-import { CodemirrorService } from "../../../../shared/util/codemirror/codemirror.service";
 import { UIContextService } from "../common/services/ui-context.service";
 import { FileUploadService } from "../common/services/file-upload.service";
 import { ModelService } from "../widget/services/model.service";
@@ -76,7 +74,6 @@ export const composerRoutes: Routes = [
          WsChangeService,
          ComposerRecentService,
          NgbModal,
-         { provide: CodemirrorService, useClass: DefaultCodemirrorService },
          ChatService,
          { provide: CHAT_API_KEY, useValue: "5ba3fdd5c666d426648af5c9/default" },
          DataQueryModelService,

--- a/web/projects/portal/src/app/portal/portal.routes.ts
+++ b/web/projects/portal/src/app/portal/portal.routes.ts
@@ -20,8 +20,6 @@ import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { MonitoringDataService } from "../../../../em/src/app/monitoring/monitoring-data.service";
 import { ScheduleTaskNamesService } from "../../../../shared/schedule/schedule-task-names.service";
 import { PORTAL, ScheduleUsersService } from "../../../../shared/schedule/schedule-users.service";
-import { CodemirrorService } from "../../../../shared/util/codemirror/codemirror.service";
-import { DefaultCodemirrorService } from "../../../../shared/util/codemirror/default-codemirror.service";
 import { UIContextService } from "../common/services/ui-context.service";
 import { DataTreeValidatorService } from "../vsobjects/dialog/data-tree-validator.service";
 import { DebounceService } from "../widget/services/debounce.service";
@@ -124,7 +122,6 @@ export const portalRoutes: Routes = [
          DataSourcesTreeActionsService,
          UIContextService,
          NgbModal,
-         { provide: CodemirrorService, useClass: DefaultCodemirrorService },
          DataQueryModelService
       ],
       children: [

--- a/web/projects/portal/src/app/viewer/viewer.routes.ts
+++ b/web/projects/portal/src/app/viewer/viewer.routes.ts
@@ -17,8 +17,6 @@
  */
 import { Routes, UrlMatchResult, UrlSegment } from "@angular/router";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
-import { CodemirrorService } from "../../../../shared/util/codemirror/codemirror.service";
-import { DefaultCodemirrorService } from "../../../../shared/util/codemirror/default-codemirror.service";
 import { canComponentDeactivate } from "../../../../shared/util/guard/can-component-deactivate.service";
 import { globalParameterGuard } from "../../../../shared/util/guard/global-parameter-guard.service";
 import { UIContextService } from "../common/services/ui-context.service";
@@ -131,7 +129,6 @@ export const viewerRoutes: Routes = [
          UIContextService,
          HideNavService,
          NgbModal,
-         { provide: CodemirrorService, useClass: DefaultCodemirrorService }
       ],
       children: [
          {


### PR DESCRIPTION
## Summary

- The Formula Editor dialog in the EM Scheduler (Action tab > Creation Parameters > Value Type = Expression) threw console errors and failed to render the CodeMirror editor
- Registers `DefaultCodemirrorService` once at the `bootstrapApplication` root in `em/src/main.ts`, matching the pattern already used by `portal/app.config.ts`
- Removes the now-redundant component-level providers from `CustomProviderViewComponent` and `CustomSsoFormComponent` in EM, and route-level providers from three portal routes

## Root Cause

The EM standalone migration (commit `cb25c520c`) removed the `WidgetModule` which held the `{ provide: CodemirrorService, useClass: DefaultCodemirrorService }` provider. Without this override, Angular's DI resolved `CodemirrorService` to the base stub whose `getEcmaScriptDefs()` returns `null`, causing `initCodeMirror()` to throw `TypeError: Cannot read properties of null (reading '0')` at line 167 of `script-pane.component.ts`. The cascading `refresh()` error in `ngAfterViewChecked` followed because `codemirrorInstance` was never assigned.

## Fix

Add `{ provide: CodemirrorService, useClass: DefaultCodemirrorService }` to the `bootstrapApplication` providers in `em/src/main.ts`. Remove the redundant same-provider entries that had been scattered across two EM components and three portal route configs.

## Test Plan

- [ ] Open EM > Settings > Schedule Tasks, create a task, go to the Action tab, click Add in Creation Parameters, click the Value Type icon and select Expression — Formula Editor should open with CodeMirror rendering correctly and no console errors
- [ ] Verify the Custom SSO form and Custom Provider form in EM Security still render their CodeMirror editors correctly
- [ ] Verify the Portal composer, portal route, and viewer route still render script/formula editors correctly
- [ ] 103/103 EM Vitest test suites pass (`npm run test:em`)
- [ ] Lint clean (`npm run lint`)

Fixes Redmine #75362.