### PR TITLE
Bug #75360, remove [disabled] template bindings from size-position-pane

### DIFF
--- a/web/projects/portal/src/app/vsobjects/dialog/size-position-pane.component.html
+++ b/web/projects/portal/src/app/vsobjects/dialog/size-position-pane.component.html
@@ -22,14 +22,14 @@
       <div class="col">
         <div class="form-floating">
           <input type="number" class="form-control" formControlName="top" [(ngModel)]="model.top"
-            placeholder="_#(Top)" [disabled]="!layoutEnabled || model.locked">
+            placeholder="_#(Top)">
           <label>_#(Top)</label>
         </div>
       </div>
       <div class="col layout-col-offset">
         <div class="form-floating">
           <input type="number" class="form-control" formControlName="left" [(ngModel)]="model.left"
-            placeholder="_#(Left)" [disabled]="!layoutEnabled || model.locked">
+            placeholder="_#(Left)">
           <label>_#(Left)</label>
         </div>
       </div>
@@ -37,7 +37,7 @@
         @if (!isGroup && !isViewsheet) {
           <div class="form-floating">
             <input type="number" class="form-control" formControlName="width" [(ngModel)]="model.width"
-              placeholder="_#(Width)" [disabled]="!layoutEnabled || model.locked">
+              placeholder="_#(Width)">
             <label>_#(Width)</label>
           </div>
         }
@@ -46,7 +46,7 @@
         @if (!isGroup && !isViewsheet) {
           <div class="form-floating">
             <input type="number" class="form-control" formControlName="height" [(ngModel)]="model.height"
-              placeholder="_#(Height)" [disabled]="!layoutEnabled || model.locked">
+              placeholder="_#(Height)">
             <label>_#(Height)</label>
           </div>
         }
@@ -75,9 +75,9 @@
         <div class="col-auto">
           <div class="checkbox">
             <div class="form-check">
-              <input id="scaleV" type="checkbox" class="form-check-input" id="scaleV"
+              <input id="scaleV" type="checkbox" class="form-check-input"
                 formControlName="scaleVertical"
-                [(ngModel)]="model.scaleVertical" [disabled]="!layoutEnabled || model.locked"/>
+                [(ngModel)]="model.scaleVertical"/>
               <label class="form-check-label" for="scaleV">
                 _#(Scale vertically when scaling to screen)
               </label>


### PR DESCRIPTION
## Summary

In the Visual Composer, opening the properties dialog for any element triggered the Angular error: "It looks like you're using the disabled attribute with a reactive form directive." This appeared in the Size/Position pane, which is included in every element's properties dialog.

## Root Cause

`size-position-pane.component.html` used `[disabled]="!layoutEnabled || model.locked"` template bindings on five inputs that also had `formControlName` reactive form directives. In Angular 15+, using a `[disabled]` property binding on a reactive form control element is an error — the disabled state must be managed through the `FormControl` itself.

## Fix

Removed the five redundant `[disabled]` template bindings from `size-position-pane.component.html`. The disabled state was already correctly set in `initForm()` via the `FormControl` constructor's `{ value, disabled }` object form, which is the Angular-recommended approach. Also removed a duplicate `id="scaleV"` attribute on the scale-vertically checkbox.

## Test Plan

- Open the composer, add any element (chart, table, text, etc.), and open its properties dialog — the Angular error should no longer appear in the browser console.
- Verify that position/size fields are disabled when the element is in a container or locked, and enabled otherwise.
- Run `npm run test:portal` — all 305 tests pass.
- Run `npm run lint` — no lint errors.

Fixes Redmine #75360.