### PR TITLE
Bug #75366, add ExportAssetsService to SelectAssetsDialogComponent providers

### DIFF
--- a/web/projects/em/src/app/settings/content/repository/import-export/select-assets-dialog/select-assets-dialog.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/import-export/select-assets-dialog/select-assets-dialog.component.ts
@@ -42,7 +42,7 @@ export interface SelectAssetsDialogData {
     selector: "em-select-assets-dialog",
     templateUrl: "./select-assets-dialog.component.html",
     styleUrls: ["./select-assets-dialog.component.scss"],
-    providers: [RepositoryTreeDataSource],
+    providers: [RepositoryTreeDataSource, ExportAssetsService],
     imports: [ModalHeaderComponent, MatDialogContent, FlatTreeViewComponent, MultiSelectTreeNodeDirective, MatProgressBar, MatDialogActions, MatButton]
 })
 export class SelectAssetsDialogComponent implements OnInit {


### PR DESCRIPTION
## Summary

The 'Select Assets' dialog failed to open when clicking 'Add' in the Export Assets flow in EM. The browser console showed `NG0201: No provider found for '_ExportAssetsService'`.

## Root Cause

`ExportAssetsService` is `@Injectable()` without `providedIn: 'root'`, so it must be explicitly declared in a component's `providers` array. `ExportAssetDialogComponent` provides it in its own `providers`, but when it opens `SelectAssetsDialogComponent` via `MatDialog.open()`, Angular creates the dialog using the environment (root) injector — not the calling component's injector. Before the standalone migration, both components shared an NgModule that provided `ExportAssetsService` to the whole module injector. After the NgModule was removed, `SelectAssetsDialogComponent` had no provider for the service.

## Fix

Added `ExportAssetsService` to `SelectAssetsDialogComponent`'s `providers` array, consistent with the existing pattern in `ExportAssetDialogComponent` and `BackupFileComponent`.

## Test Plan

- Navigate to EM → Settings → Content → Repository
- Click the Action icon on any asset (e.g. Examples/Census) and select Export Assets
- Click the Add button — the Select Assets dialog should open without error
- Select assets and confirm the export flow completes normally

Fixes Redmine #75366.