### PR TITLE
Merge forward fix for Bug #75284, fix text/output assembly showing stale value after selection list change

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -2135,13 +2135,6 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
 
          processScriptAssociation(entry, clist, vs.getScriptDependings());
          processSelections(entry, clist, true, false, new HashSet<>());
-
-         // processSelections() above may have changed conditions so cached data in dmap
-         // should not be reused when output assemblies are subsequently executed.
-         // mirrors the same clearing done in the reset() path. (same rationale as ~line 1586)
-         for(AssemblyEntry dataEntry : clist.getDataList()) {
-            resetDataMap(dataEntry.getName());
-         }
       }
       catch(DependencyCycleException ex) {
          List<Exception> exs = WorksheetService.ASSET_EXCEPTIONS.get();
@@ -2152,6 +2145,13 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
       }
       finally {
          schanged.set(null);
+      }
+
+      // processSelections() above may have changed conditions so cached data in dmap
+      // should not be reused when output assemblies are subsequently executed.
+      // mirrors the same clearing done in the reset() path (see reset()).
+      for(AssemblyEntry dataEntry : clist.getDataList()) {
+         resetDataMap(dataEntry.getName());
       }
    }
 

--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -2135,6 +2135,13 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
 
          processScriptAssociation(entry, clist, vs.getScriptDependings());
          processSelections(entry, clist, true, false, new HashSet<>());
+
+         // processSelections() above may have changed conditions so cached data in dmap
+         // should not be reused when output assemblies are subsequently executed.
+         // mirrors the same clearing done in the reset() path. (same rationale as ~line 1586)
+         for(AssemblyEntry dataEntry : clist.getDataList()) {
+            resetDataMap(dataEntry.getName());
+         }
       }
       catch(DependencyCycleException ex) {
          List<Exception> exs = WorksheetService.ASSET_EXCEPTIONS.get();


### PR DESCRIPTION
Output assemblies bound to selection-filtered tables were displaying results one change behind. When a selection list fires INPUT_DATA_CHANGED in processChange0, executeOutput reads from dmap before processSelections has updated the runtime condition list, caching the previous query result into the assembly value. On the next change the stale dmap entry is used again, keeping the display permanently one step behind.

Fix mirrors the existing dmap clearing already done in the reset() path (line ~1586): after processSelections() runs in processChange0, clear dmap for all entries in clist.getDataList() so that the subsequent execute() call in PlaceholderService re-fetches with the updated conditions.