### PR TITLE
Bug #75364, show annotation context menu on right-click for chart data annotations

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
@@ -783,6 +783,14 @@ export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
       else {
          vsObject.selectedAnnotations = [ann.absoluteName];
       }
+
+      if(mouseEvent.button === 2) {
+         const vsObjectIndex = this.vsInfo.vsObjects.indexOf(vsObject);
+
+         if(vsObjectIndex >= 0 && this.vsObjectActions[vsObjectIndex]) {
+            this.showContextMenu(mouseEvent, this.vsObjectActions[vsObjectIndex]);
+         }
+      }
    }
 
    isChartAnnotationSelected(ann: VSAnnotationModel, vsObject: VSObjectModel): boolean {


### PR DESCRIPTION
## Summary

- Chart data annotations could not show the right-click context menu (Edit / Format / Remove)
- Fixed by calling `showContextMenu` from `annotationMouseSelect` when a right-click is detected

## Root Cause

Chart data annotations are rendered in a `.chart-annotation-overlay` div that is a sibling of — not inside — the `vs-object-parent-container` divs that carry the `(contextmenu)` event handler. This structure was introduced in the Epic 70095 (Distributed Sessions) to avoid CSS stacking context issues.

Previously, data annotations used `ngProjectAs="vs-annotation"` to project into the `vs-object-parent-container` div so that right-click events would bubble to the `contextmenu` handler and call `showContextMenu`. After they were moved to the overlay, the `contextmenu` event no longer reaches that handler, so no context menu appeared.

## Fix

In `annotationMouseSelect` in `vs-object-container.component.ts`, after updating `selectedAnnotations`, detect a right-click (`button === 2`) and explicitly call `showContextMenu` with the correct `vsObjectActions` entry for the chart. The `AbstractVSActions` base class already includes annotation Edit/Format/Remove menu actions that become visible when `model.selectedAnnotations` is non-empty — which it is by the time `showContextMenu` is called.

## Test Plan

- Enable security on a local instance
- Import a viewsheet with a chart, add a data annotation point
- Save to a bookmark, switch to that bookmark
- Right-click the annotation — confirm the Edit / Format / Remove context menu appears
- Verify assembly annotations (inside the chart) still show the context menu correctly
- Verify right-clicking non-annotation chart areas still shows the chart context menu

Fixes Redmine #75364.