### PR TITLE
Bug #75346, fix viewsheet hyperlink not opening in composer preview

### DIFF
--- a/web/projects/portal/src/app/viewer/viewer-view/viewer-view.component.ts
+++ b/web/projects/portal/src/app/viewer/viewer-view/viewer-view.component.ts
@@ -53,6 +53,7 @@ import { ViewData } from "../view-data";
 import { Tool } from "../../../../../shared/util/tool";
 import { map, mergeMap } from "rxjs/operators";
 import { ModelService } from "../../widget/services/model.service";
+import { ShowHyperlinkService } from "../../vsobjects/show-hyperlink.service";
 import { PageTabComponent } from "./page-tab.component";
 
 
@@ -60,11 +61,14 @@ import { PageTabComponent } from "./page-tab.component";
     selector: "v-viewer-view",
     templateUrl: "viewer-view.component.html",
     styleUrls: ["viewer-view.component.scss"],
-    providers: [{
+    providers: [
+        ShowHyperlinkService,
+        {
             provide: ContextProvider,
             useFactory: ViewerContextProviderFactory,
             deps: [[new Optional(), ComposerToken], [new Optional(), EmbedToken]]
-        }],
+        }
+    ],
     imports: [ViewerAppComponent, PageTabComponent]
 })
 export class ViewerViewComponent implements OnInit, OnDestroy, CanComponentDeactivate, AfterViewChecked {

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -321,7 +321,6 @@ export interface ScrollViewportRect {
         ComposerRecentService,
         SelectionMobileService,
         MiniToolbarService,
-        ShowHyperlinkService,
         {
             provide: RichTextService,
             useClass: CKEditorRichTextService,


### PR DESCRIPTION
ShowHyperlinkService was provided in both ComposerMainComponent and ViewerAppComponent, creating two separate instances. ComposerMainComponent subscribed to showLinkSheetSubject on its own instance, but VS objects inside ViewerAppComponent emitted on the shadowed instance, so the subscription never fired and the hyperlink appeared to do nothing.

Remove ShowHyperlinkService from ViewerAppComponent.providers so children resolve it from the nearest parent: ComposerMainComponent in the composer, ViewerViewComponent in the portal viewer (where it is now provided), and the element root in the embed context.