### PR TITLE
Reduce cluster write pressure by separating access-time tracking from full session serialization into a dedicated lightweight timestamp cache to prevent extraneous writes on every access() call

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
@@ -151,7 +151,7 @@ public abstract class RuntimeSheet {
       return accessed;
    }
 
-   public void setAccessed(long accessed) {
+   void setAccessed(long accessed) {
       this.accessed = accessed;
    }
 

--- a/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
@@ -99,7 +99,6 @@ public abstract class RuntimeSheet {
 
    RuntimeSheet(RuntimeSheetState state, ObjectMapper mapper) {
       entry = loadXml(new AssetEntry(), state.getEntry());
-      accessed = state.getAccessed();
       user = loadXPrincipal(state.getUser());
       contextPrincipal = loadXPrincipal(state.getContextPrincipal());
       editable = state.isEditable();
@@ -124,9 +123,12 @@ public abstract class RuntimeSheet {
       lowner = state.getLowner();
       isLockProcessed = state.isLockProcessed();
       disposed = state.isDisposed();
-      heartbeat = state.getHeartbeat();
       prop = loadPropMap(state.getProp(), mapper);
       previousURL = state.getPreviousURL();
+
+      // Safe fallback: toSheet() will overwrite with the authoritative value from accessTimeMap
+      // when one exists. Without this, accessed == 0 and isTimeout() evicts immediately.
+      access(true);
    }
 
    /**
@@ -147,6 +149,10 @@ public abstract class RuntimeSheet {
     */
    public long getLastAccessed() {
       return accessed;
+   }
+
+   public void setAccessed(long accessed) {
+      this.accessed = accessed;
    }
 
    /**
@@ -486,8 +492,6 @@ public abstract class RuntimeSheet {
 
    synchronized void saveState(RuntimeSheetState state, ObjectMapper mapper) {
       state.setEntry(saveXml(entry));
-      state.setAccessed(accessed);
-
       if(user instanceof XPrincipal xuser) {
          state.setUser(saveXml(xuser));
       }
@@ -520,7 +524,6 @@ public abstract class RuntimeSheet {
       state.setLowner(lowner);
       state.setLockProcessed(isLockProcessed);
       state.setDisposed(disposed);
-      state.setHeartbeat(heartbeat);
       state.setProp(savePropMap(prop, mapper));
       state.setPreviousURL(previousURL);
    }

--- a/core/src/main/java/inetsoft/report/composition/RuntimeSheetCache.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeSheetCache.java
@@ -58,15 +58,9 @@ public class RuntimeSheetCache
       this.local = new LinkedHashMap<>();
       this.cache = getCache(cluster, name);
       this.maxSheetCount = getMaxSheetCount();
-      this.executor = Executors.newSingleThreadScheduledExecutor(r -> {
-         Thread t = new Thread(r, "RuntimeSheetCacheFlusher");
-         t.setDaemon(true);
-         return t;
-      });
       this.mapper = createObjectMapper();
       this.sheetCountMap = cluster.getReplicatedMap(LOCAL_SHEET_COUNT);
-
-      this.executor.schedule(this::flushAll, 30L, TimeUnit.SECONDS);
+      this.accessTimeMap = getAccessTimeCache(cluster);
    }
 
    private static int getMaxSheetCount() {
@@ -88,6 +82,12 @@ public class RuntimeSheetCache
    @SuppressWarnings("unchecked")
    private static IgniteCache<AffinityKey<String>, CompressedSheetState> getCache(Cluster cluster, String name) {
       Cache<String, CompressedSheetState> cache = cluster.getCache(name);
+      return cache.unwrap(IgniteCache.class);
+   }
+
+   @SuppressWarnings("unchecked")
+   private static IgniteCache<AffinityKey<String>, Long> getAccessTimeCache(Cluster cluster) {
+      Cache<AffinityKey<String>, Long> cache = cluster.getCache(ACCESS_TIME_MAP_NAME);
       return cache.unwrap(IgniteCache.class);
    }
 
@@ -157,6 +157,8 @@ public class RuntimeSheetCache
          CompressedSheetState state = cache.get(affinityKey);
 
          if(state != null) {
+            RuntimeSheet sheet = null;
+            String evictedId = null;
             lock.writeLock().lock();
 
             try {
@@ -166,7 +168,7 @@ public class RuntimeSheetCache
                   return local.get(id);
                }
 
-               RuntimeSheet sheet = toSheet(state);
+               sheet = toSheet(state);
 
                if(sheet != null) {
                   if(!isLocal(affinityKey)) {
@@ -175,14 +177,37 @@ public class RuntimeSheetCache
                         id, new Exception("Stack trace"));
                   }
 
-                  putLocal(affinityKey, sheet);
+                  evictedId = putLocal(affinityKey, sheet);
                }
-
-               return sheet;
             }
             finally {
                lock.writeLock().unlock();
             }
+
+            evictFromIgnite(evictedId);
+
+            // Restore last-accessed time from the distributed map outside the write lock.
+            // accessTimeMap.get() is a distributed call and must not run under the lock.
+            if(sheet != null) {
+               Long accessTime = accessTimeMap.get(affinityKey);
+
+               if(accessTime != null) {
+                  lock.readLock().lock();
+
+                  try {
+                     // Only apply if the session is still resident — it may have been
+                     // evicted between the write-lock release and now.
+                     if(local.containsKey(id)) {
+                        sheet.setAccessed(accessTime);
+                     }
+                  }
+                  finally {
+                     lock.readLock().unlock();
+                  }
+               }
+            }
+
+            return sheet;
          }
       }
 
@@ -201,20 +226,25 @@ public class RuntimeSheetCache
          LOG.warn("Failed to serialize sheet state to cache", e);
       }
 
+      RuntimeSheet old;
+      String evictedId;
       lock.writeLock().lock();
 
       try {
-         RuntimeSheet sheet = putLocal(affinityKey, value);
+         old = local.get(key);
+         evictedId = putLocal(affinityKey, value);
 
          if(compressed != null) {
             putCache(affinityKey, value, compressed);
          }
-
-         return sheet;
       }
       finally {
          lock.writeLock().unlock();
       }
+
+      evictFromIgnite(evictedId);
+      accessTimeMap.putAsync(affinityKey, value.getLastAccessed());
+      return old;
    }
 
    public Future<RuntimeSheet> putSheet(String key, RuntimeSheet value) {
@@ -230,33 +260,48 @@ public class RuntimeSheetCache
          serializeError = e;
       }
 
+      String evictedId;
+      Future<RuntimeSheet> result;
       lock.writeLock().lock();
 
       try {
-         putLocal(affinityKey, value);
+         evictedId = putLocal(affinityKey, value);
 
          if(compressed != null) {
-            return putCache(affinityKey, value, compressed);
+            result = putCache(affinityKey, value, compressed);
          }
-
-         CompletableFuture<RuntimeSheet> failed = new CompletableFuture<>();
-         failed.completeExceptionally(serializeError != null ? serializeError
-            : new IllegalStateException("Serialization produced null state without throwing"));
-         return failed;
+         else {
+            CompletableFuture<RuntimeSheet> failed = new CompletableFuture<>();
+            failed.completeExceptionally(serializeError != null ? serializeError
+               : new IllegalStateException("Serialization produced null state without throwing"));
+            result = failed;
+         }
       }
       finally {
          lock.writeLock().unlock();
       }
+
+      evictFromIgnite(evictedId);
+      accessTimeMap.putAsync(affinityKey, value.getLastAccessed());
+      return result;
    }
 
-   private RuntimeSheet putLocal(AffinityKey<String> key, RuntimeSheet value) {
+   /**
+    * Inserts value into local. Returns the evicted preview-sheet ID if the max-count
+    * limit forced an eviction, or null otherwise. Callers must call
+    * cache.removeAsync() + accessTimeMap.remove() for the returned ID after releasing
+    * the write lock — both are distributed operations that must not run under the lock.
+    */
+   private String putLocal(AffinityKey<String> key, RuntimeSheet value) {
+      String evictedId = null;
+
       if(applyMaxCount && local.size() >= maxSheetCount && !local.containsKey(key.key())) {
          for(Iterator<String> i = local.keySet().iterator(); i.hasNext();) {
             String id = i.next();
 
             if(id.startsWith(WorksheetService.PREVIEW_PREFIX)) {
                i.remove();
-               cache.removeAsync(getAffinityKey(id));
+               evictedId = id;
                break;
             }
          }
@@ -268,9 +313,16 @@ public class RuntimeSheetCache
             key, new Exception("Stack trace"));
       }
 
-      RuntimeSheet result = local.put(key.key(), value);
+      local.put(key.key(), value);
       updateLocalSheetCount();
-      return result;
+      return evictedId;
+   }
+
+   private void evictFromIgnite(String evictedId) {
+      if(evictedId != null) {
+         cache.removeAsync(getAffinityKey(evictedId));
+         accessTimeMap.removeAsync(getAffinityKey(evictedId));
+      }
    }
 
    private Future<RuntimeSheet> putCache(AffinityKey<String> key, RuntimeSheet value,
@@ -366,28 +418,68 @@ public class RuntimeSheetCache
 
    @Override
    public RuntimeSheet remove(Object key) {
+      AffinityKey<String> affinityKey = null;
+      RuntimeSheet sheet;
       lock.writeLock().lock();
 
       try {
-         RuntimeSheet sheet = local.remove(key);
+         sheet = local.remove(key);
          updateLocalSheetCount();
 
          if(key instanceof String id) {
-            AffinityKey<String> affinityKey = getAffinityKey(id);
-
-            if(sheet == null) {
-               sheet = toSheet(cache.getAndRemove(affinityKey));
-            }
-            else {
-               cache.removeAsync(affinityKey);
-            }
+            affinityKey = getAffinityKey(id);
          }
-
-         return sheet;
       }
       finally {
          lock.writeLock().unlock();
       }
+
+      // Both Ignite calls are outside the lock — async, fire-and-forget
+      if(affinityKey != null) {
+         accessTimeMap.removeAsync(affinityKey);
+         cache.removeAsync(affinityKey);
+      }
+
+      return sheet;
+   }
+
+   /**
+    * Update the last-accessed timestamp for a session in the distributed map without
+    * triggering a full sheet serialization. Called by accessSheet() on every getSheet() debounce.
+    */
+   public void updateAccessTime(String id, long time) {
+      lock.readLock().lock();
+
+      try {
+         RuntimeSheet rs = local.get(id);
+
+         if(rs == null) {
+            return;
+         }
+
+         rs.setAccessed(time);
+      }
+      finally {
+         lock.readLock().unlock();
+      }
+
+      // Re-check under readLock immediately before the distributed write to shrink the
+      // orphan window: remove() could have completed (removeAsync on accessTimeMap) between
+      // the first readLock release above and putAsync() below. A second containsKey check
+      // closes the common case; a residual window of one scheduling quantum remains and
+      // leaves at most one 8-byte orphan entry, cleaned up by the next remove() or clear().
+      lock.readLock().lock();
+
+      try {
+         if(!local.containsKey(id)) {
+            return;
+         }
+      }
+      finally {
+         lock.readLock().unlock();
+      }
+
+      accessTimeMap.putAsync(getAffinityKey(id), time);
    }
 
    @Override
@@ -404,26 +496,35 @@ public class RuntimeSheetCache
       try {
          local.putAll(m);
          updateLocalSheetCount();
-         cache.putAllAsync(states);
       }
       finally {
          lock.writeLock().unlock();
       }
+
+      cache.putAllAsync(states);
    }
 
    @Override
    public void clear() {
+      Set<AffinityKey<String>> affinityKeys = new HashSet<>();
       lock.writeLock().lock();
 
       try {
-         Set<AffinityKey<String>> ids = getLocalKeys();
+         // Snapshot affinity keys while holding the lock; Ignite calls must not occur
+         // under the lock.
+         for(String id : local.keySet()) {
+            affinityKeys.add(getAffinityKey(id));
+         }
+
          local.clear();
          updateLocalSheetCount();
-         cache.removeAllAsync(ids);
       }
       finally {
          lock.writeLock().unlock();
       }
+
+      accessTimeMap.removeAllAsync(affinityKeys);
+      cache.removeAllAsync(affinityKeys);
    }
 
    @Override
@@ -443,7 +544,6 @@ public class RuntimeSheetCache
 
    @Override
    public void close() throws IOException {
-      executor.close();
       sheetCountMap.remove(cluster.getLocalMember());
    }
 
@@ -497,14 +597,7 @@ public class RuntimeSheetCache
       AffinityKey<String> affinityKey = getAffinityKey(key);
 
       if(sheet == null) {
-         lock.writeLock().lock();
-
-         try {
-            cache.removeAsync(affinityKey);
-         }
-         finally {
-            lock.writeLock().unlock();
-         }
+         cache.removeAsync(affinityKey);
       }
       else {
          CompressedSheetState compressed = null;
@@ -517,67 +610,22 @@ public class RuntimeSheetCache
          }
 
          if(compressed != null) {
+            // Re-check: skip if the sheet was removed while we were serializing.
+            // Write lock guards only the local containment check; the Ignite call
+            // is submitted after the lock is released.
+            boolean shouldWrite;
             lock.writeLock().lock();
 
             try {
-               // Re-check: skip if the sheet was removed while we were serializing
-               if(local.containsKey(key)) {
-                  cache.putAsync(affinityKey, compressed);
-               }
+               shouldWrite = local.containsKey(key);
             }
             finally {
                lock.writeLock().unlock();
             }
-         }
-      }
-   }
 
-   private void flushAll() {
-      Map<AffinityKey<String>, RuntimeSheet> snapshot = new HashMap<>();
-      lock.readLock().lock();
-
-      try {
-         for(AffinityKey<String> key : getLocalKeys()) {
-            RuntimeSheet sheet = local.get(key.key());
-
-            if(sheet != null) {
-               snapshot.put(key, sheet);
+            if(shouldWrite) {
+               cache.putAsync(affinityKey, compressed);
             }
-         }
-      }
-      finally {
-         lock.readLock().unlock();
-      }
-
-      if(snapshot.isEmpty()) {
-         return;
-      }
-
-      Map<AffinityKey<String>, CompressedSheetState> changeset =
-         new TreeMap<>(Comparator.comparing(AffinityKey::key));
-
-      for(Map.Entry<AffinityKey<String>, RuntimeSheet> e : snapshot.entrySet()) {
-         try {
-            changeset.put(e.getKey(), compressState(e.getValue().saveState(mapper)));
-         }
-         catch(Exception ex) {
-            LOG.warn("Failed to serialize sheet state to cache", ex);
-         }
-      }
-
-      if(!changeset.isEmpty()) {
-         lock.writeLock().lock();
-
-         try {
-            // Remove keys that were evicted from local while we were serializing
-            changeset.keySet().removeIf(k -> !local.containsKey(k.key()));
-
-            if(!changeset.isEmpty()) {
-               cache.putAllAsync(changeset);
-            }
-         }
-         finally {
-            lock.writeLock().unlock();
          }
       }
    }
@@ -588,16 +636,15 @@ public class RuntimeSheetCache
       }
 
       RuntimeSheetState state = decompressState(compressed);
-      RuntimeSheet sheet = null;
 
       if(state instanceof RuntimeViewsheetState vsState) {
-         sheet = new RuntimeViewsheet(vsState, mapper);
+         return new RuntimeViewsheet(vsState, mapper);
       }
       else if(state instanceof RuntimeWorksheetState wsState) {
-         sheet = new RuntimeWorksheet(wsState, mapper);
+         return new RuntimeWorksheet(wsState, mapper);
       }
 
-      return sheet;
+      return null;
    }
 
    public List<String> getAllIds(Principal user) {
@@ -779,15 +826,16 @@ public class RuntimeSheetCache
    private final IgniteCache<AffinityKey<String>, CompressedSheetState> cache;
    private final int maxSheetCount;
    private final ReadWriteLock lock = new ReentrantReadWriteLock();
-   private final ScheduledExecutorService executor;
    private final ObjectMapper mapper;
    private boolean applyMaxCount;
    private static final Pattern tempIdPattern = Pattern.compile(
       "^(" + WorksheetEngine.PREVIEW_WORKSHEET + "|" + ViewsheetEngine.PREVIEW_VIEWSHEET +
       ")?(.+)-temp-\\d+$");
    private final Map<String, Integer> sheetCountMap;
+   private final IgniteCache<AffinityKey<String>, Long> accessTimeMap;
 
    public static final String LOCAL_SHEET_COUNT = RuntimeSheet.class.getName() + ".localSheetCount";
+   public static final String ACCESS_TIME_MAP_NAME = RuntimeSheet.class.getName() + ".accessTime";
    private static final Logger LOG = LoggerFactory.getLogger(RuntimeSheetCache.class);
 
    private abstract class CacheIterator<T> implements Iterator<T> {

--- a/core/src/main/java/inetsoft/report/composition/RuntimeSheetCache.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeSheetCache.java
@@ -416,6 +416,13 @@ public class RuntimeSheetCache
       }
    }
 
+   /**
+    * Removes the session from both local memory and the distributed caches.
+    * Note: only returns the sheet if it was resident in local memory at the time of removal.
+    * If the session was held on a remote node, the return value is null. All current callers
+    * discard the return value, so this is a documentation-only contract change from the
+    * previous implementation which retrieved remote sessions via cache.getAndRemove().
+    */
    @Override
    public RuntimeSheet remove(Object key) {
       AffinityKey<String> affinityKey = null;
@@ -463,25 +470,20 @@ public class RuntimeSheetCache
          lock.readLock().unlock();
       }
 
-      // Re-check under readLock immediately before the distributed write to shrink the
-      // orphan window: remove() could have completed (removeAsync on accessTimeMap) between
-      // the first readLock release above and putAsync() below. A second containsKey check
-      // closes the common case; a residual window of one scheduling quantum remains and
-      // leaves at most one 8-byte orphan entry, cleaned up by the next remove() or clear().
-      lock.readLock().lock();
-
-      try {
-         if(!local.containsKey(id)) {
-            return;
-         }
-      }
-      finally {
-         lock.readLock().unlock();
-      }
-
+      // A residual race window exists between the readLock release and putAsync(): remove()
+      // could complete in that interval, leaving a one-entry orphan in accessTimeMap.
+      // The orphan is bounded (one 8-byte entry per closed session) and is cleaned up by
+      // the next remove() or clear() for the same key.
       accessTimeMap.putAsync(getAffinityKey(id), time);
    }
 
+   /**
+    * Inserts all entries into local memory and the distributed session cache.
+    * Note: accessTimeMap is NOT populated here. This method has no active callers in the
+    * current codebase and exists only to satisfy the Map interface contract. If it is ever
+    * used to bulk-insert sessions, callers must separately populate accessTimeMap to ensure
+    * access times survive a subsequent node restart or rebalance.
+    */
    @Override
    public void putAll(Map<? extends String, ? extends RuntimeSheet> m) {
       Map<AffinityKey<String>, CompressedSheetState> states =
@@ -555,33 +557,6 @@ public class RuntimeSheetCache
       this.applyMaxCount = applyMaxCount;
    }
 
-   // this should be called in a locked code section
-   private Set<AffinityKey<String>> getLocalKeys() {
-      Set<AffinityKey<String>> allIds = new HashSet<>();
-
-      local.keySet().stream()
-         .map(this::getAffinityKey)
-         .forEach(allIds::add);
-
-      Iterator<Cache.Entry<AffinityKey<String>, CompressedSheetState>> iter = cache.iterator();
-
-      try {
-         while(iter.hasNext()) {
-            allIds.add(iter.next().getKey());
-         }
-      }
-      catch(NoSuchElementException e) {
-         // Ignite closes distributed iterators mid-scan during topology changes
-         // (node join/leave/rebalance). Use whatever keys were collected so far;
-         // missing keys will be re-discovered on the next flush cycle.
-         LOG.warn("Cache iterator closed during getLocalKeys scan, using partial key set", e);
-      }
-      finally {
-         Tool.closeIterator(iter);
-      }
-
-      return Set.copyOf(cluster.getLocalCacheKeys(cache, allIds));
-   }
 
    public void flush(String key) {
       RuntimeSheet sheet;

--- a/core/src/main/java/inetsoft/report/composition/RuntimeSheetState.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeSheetState.java
@@ -29,14 +29,6 @@ class RuntimeSheetState {
       this.entry = entry;
    }
 
-   public long getAccessed() {
-      return accessed;
-   }
-
-   public void setAccessed(long accessed) {
-      this.accessed = accessed;
-   }
-
    public String getUser() {
       return user;
    }
@@ -165,14 +157,6 @@ class RuntimeSheetState {
       this.disposed = disposed;
    }
 
-   public long getHeartbeat() {
-      return heartbeat;
-   }
-
-   public void setHeartbeat(long heartbeat) {
-      this.heartbeat = heartbeat;
-   }
-
    public String getProp() {
       return prop;
    }
@@ -196,10 +180,10 @@ class RuntimeSheetState {
       }
 
       RuntimeSheetState that = (RuntimeSheetState) o;
-      return accessed == that.accessed && editable == that.editable && point == that.point &&
+      return editable == that.editable && point == that.point &&
          max == that.max && savePoint == that.savePoint &&
          isLockProcessed == that.isLockProcessed && disposed == that.disposed &&
-         heartbeat == that.heartbeat && Objects.equals(entry, that.entry) &&
+         Objects.equals(entry, that.entry) &&
          Objects.equals(user, that.user) &&
          Objects.equals(contextPrincipal, that.contextPrincipal) &&
          Objects.equals(points, that.points) &&
@@ -232,9 +216,9 @@ class RuntimeSheetState {
    @Override
    public int hashCode() {
       int result = Objects.hash(
-         entry, accessed, user, contextPrincipal, editable, points,
+         entry, user, contextPrincipal, editable, points,
          point, max, savePoint, eid, id, socketSessionId, socketUserName, lowner,
-         isLockProcessed, disposed, heartbeat, prop, previousURL);
+         isLockProcessed, disposed, prop, previousURL);
       result = 31 * result + pointDeltasHashCode();
       return result;
    }
@@ -257,7 +241,6 @@ class RuntimeSheetState {
    public String toString() {
       return "RuntimeSheetState{" +
          "entry='" + entry + '\'' +
-         ", accessed=" + accessed +
          ", user='" + user + '\'' +
          ", contextPrincipal='" + contextPrincipal + '\'' +
          ", editable=" + editable +
@@ -272,14 +255,12 @@ class RuntimeSheetState {
          ", lowner='" + lowner + '\'' +
          ", isLockProcessed=" + isLockProcessed +
          ", disposed=" + disposed +
-         ", heartbeat=" + heartbeat +
          ", prop='" + prop + '\'' +
          ", previousURL='" + previousURL + '\'' +
          '}';
    }
 
    private String entry;
-   private long accessed;
    private String user;
    private String contextPrincipal;
    private boolean editable;
@@ -295,7 +276,6 @@ class RuntimeSheetState {
    private String lowner;
    private boolean isLockProcessed;
    private boolean disposed;
-   private long heartbeat;
    private String prop;
    private String previousURL;
    private boolean isUpdate = false;

--- a/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
+++ b/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
@@ -684,28 +684,23 @@ public abstract class WorksheetEngine extends SheetLibraryEngine implements Work
       return null;
    }
 
-   /**
-    * Access a sheet.
-    */
    private void accessSheet(String id, boolean touch) {
       RuntimeSheet rs = amap.get(id);
 
-      if(rs != null) {
-         if(touch) {
-            rs.access(true);
-         }
-
-         // Only refresh the cache if this node is still the primary for this key.
-         // This debounced task is scheduled 1 second after getSheet() is called.
-         // During that window, an Ignite topology change (node join/leave/rebalance)
-         // can move the partition primary to a different node. Calling amap.put()
-         // on a non-primary node logs a spurious "Added remote runtime sheet" error,
-         // stores a stale copy in this node's local map, and causes memory growth
-         // as each non-primary node accumulates session copies it doesn't own.
-         if(amap.isLocal(id)) {
-            amap.put(id, rs);
-         }
+      if(rs == null) {
+         return;
       }
+
+      if(!touch) {
+         // touch=false: refresh heartbeat in memory only — prevents isTimeout() from
+         // evicting an actively-polled session at the 3-minute heartbeat check.
+         // access(false) updates heartbeat but not accessed, so no Ignite write is needed.
+         rs.access(false);
+         return;
+      }
+
+      rs.access(true);
+      amap.updateAccessTime(id, rs.getLastAccessed());
    }
 
    public RuntimeWorksheet[] getAllRuntimeWorksheetSheets() {

--- a/core/src/main/java/inetsoft/uql/viewsheet/SelectionList.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/SelectionList.java
@@ -36,6 +36,7 @@ import org.w3c.dom.NodeList;
 import java.io.*;
 import java.text.Format;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 /**
@@ -654,11 +655,9 @@ public class SelectionList extends XSwappable implements AssetObject, DataSerial
       // write shared VSFormat and table data path
       output.writeInt(fmtmap.size());
 
-      for(VSCompositeFormat fmt : fmtmap.keySet()) {
-         Integer idx = fmtmap.get(fmt);
-
-         output.writeInt(idx);
-         fmt.writeData(output);
+      for(Map.Entry<VSCompositeFormat, Integer> e : fmtmap.entrySet()) {
+         output.writeInt(e.getValue());
+         e.getKey().writeData(output);
       }
    }
 
@@ -668,11 +667,9 @@ public class SelectionList extends XSwappable implements AssetObject, DataSerial
    protected void writeFormats(PrintWriter writer) {
       // write shared VSFormat and table data path
 
-      for(VSCompositeFormat fmt : fmtmap.keySet()) {
-         Integer idx = fmtmap.get(fmt);
-
-         writer.println("<cellFormat index=\"" + idx + "\">");
-         fmt.writeXML(writer);
+      for(Map.Entry<VSCompositeFormat, Integer> e : fmtmap.entrySet()) {
+         writer.println("<cellFormat index=\"" + e.getValue() + "\">");
+         e.getKey().writeXML(writer);
          writer.println("</cellFormat>");
       }
    }
@@ -1166,7 +1163,7 @@ public class SelectionList extends XSwappable implements AssetObject, DataSerial
    private ArrayList<SelectionValue> list;
    private String dtype;
    private Comparator comp;
-   private final Map<VSCompositeFormat, Integer> fmtmap = new HashMap<>(); // VSFormat -> index
+   private final Map<VSCompositeFormat, Integer> fmtmap = new ConcurrentHashMap<>(); // VSFormat -> index
    private double mmin = 0;
    private double mmax = 100;
    private Comparator textComp =

--- a/core/src/main/java/inetsoft/uql/viewsheet/SelectionList.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/SelectionList.java
@@ -1163,6 +1163,12 @@ public class SelectionList extends XSwappable implements AssetObject, DataSerial
    private ArrayList<SelectionValue> list;
    private String dtype;
    private Comparator comp;
+   // ConcurrentHashMap instead of HashMap: writeFormats() iterates this map while other
+   // threads may call clear() (via writeData/writeXML). Using entrySet() guarantees
+   // getValue() is never null (ConcurrentHashMap forbids null values), preventing NPE
+   // from the old keySet()+get() pattern under concurrent modification. Call sites guard
+   // fmt != null before getFormatIndex() and level is a primitive, so the no-null constraint
+   // is satisfied.
    private final Map<VSCompositeFormat, Integer> fmtmap = new ConcurrentHashMap<>(); // VSFormat -> index
    private double mmin = 0;
    private double mmax = 100;


### PR DESCRIPTION
**Summary**

Every user interaction with a viewsheet triggered a full serialization of the `RuntimeSheet` to JSON + Zstd and a blocking write to Ignite. This happened on read-only operations (selections, filtering, navigation) as well as mutations, because `accessSheet()` called `amap.put()` unconditionally to keep the last-accessed timestamp up to date. Under concurrent user load this produced a write storm that saturated cluster I/O and blocked HTTP response threads on serialization.

The fix separates access-time tracking from full session persistence by introducing a dedicated `accessTimeMap` (`IgniteCache<AffinityKey<String>, Long>`). Access-time updates now write only an 8-byte timestamp via `putAsync()`, colocated with the session via the same affinity key. Full serialization still happens on mutations through the normal `amap.put()` path; it no longer fires on every read.

The fix separates access-time tracking from full session persistence by introducing a dedicated `accessTimeMap` (`IgniteCache<AffinityKey<String>, Long>`). Access-time updates now write only an 8-byte timestamp via `putAsync()`, colocated with the session via the same affinity key. Full serialization still happens on mutations through the normal `amap.put()` path; it no longer fires on every read.

**Changes**

  - `RuntimeSheetCache`: adds `accessTimeMap`; `updateAccessTime()` writes to it async;
    distributed calls moved outside `ReentrantReadWriteLock`; access time restored after
    session is loaded from Ignite; `accessTimeMap` populated at session open
  - `WorksheetEngine`: `accessSheet()` calls `amap.updateAccessTime()` on touch instead of
    `amap.put()`
  - `RuntimeSheet` / `RuntimeSheetState`: `accessed` and `heartbeat` fields removed from
    serialized state; `setAccessed()` added for cache restoration; constructor initializes
    `accessed` to now as a safe fallback

