### PR TITLE
Bug #75365, fix snackbar font size and duplicate name error type in EM

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -1629,7 +1629,7 @@ public class IdentityService {
 
          if(Tool.contains(identityIds, new IdentityID(name, oldID.orgID))) {
             final String err = Catalog.getCatalog().getString("common.duplicateName");
-            throw new Exception(err);
+            throw new MessageException(err);
          }
 
          actionRecord.setActionError("new name:" + name);

--- a/web/projects/em/src/theme-dark.scss
+++ b/web/projects/em/src/theme-dark.scss
@@ -46,6 +46,7 @@ body {
 
   .mat-mdc-snack-bar-label {
     color: var(--inet-em-light-primary-text);
+    font-size: 14px;
   }
 }
 

--- a/web/projects/em/src/theme.scss
+++ b/web/projects/em/src/theme.scss
@@ -45,6 +45,7 @@ body {
 
   .mat-mdc-snack-bar-label {
     color: var(--inet-em-dark-primary-text);
+    font-size: 14px;
   }
 }
 


### PR DESCRIPTION
## Summary

- Restores snackbar label font size to 14px in both EM light and dark themes, lost during the Angular Material MDC typography migration (M1→M2 changed `body-medium` token default from 14px to 12px)
- Changes `throw new Exception(err)` to `throw new MessageException(err)` in `IdentityService.getIdentityInfoRecord` so the duplicate-name validation error is handled by `AdminExceptionHandler` as a known user-facing condition (displayed as "Error: Duplicate name found!") rather than an unexpected server error (previously displayed as "Exception: Duplicate name found!")

## Test plan

- [ ] In EM, attempt to rename a user to a name that already exists; verify snackbar shows "Error: Duplicate name found!" at 14px font
- [ ] Verify snackbar font size is 14px in both light and dark EM themes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)