### PR TITLE
Bug #75370, clear drill-down tabs when navigating to a viewsheet from the repository tree

### DIFF
--- a/web/projects/portal/src/app/viewer/viewer-edit/viewer-edit.component.ts
+++ b/web/projects/portal/src/app/viewer/viewer-edit/viewer-edit.component.ts
@@ -233,7 +233,8 @@ export class ViewerEditComponent implements OnInit, OnDestroy {
 
       const extras: NavigationExtras = {
          skipLocationChange: true,
-         queryParams: queryParams
+         queryParams: queryParams,
+         state: { returnFromEditor: true }
       };
 
       if(this.viewData.portal) {

--- a/web/projects/portal/src/app/viewer/viewer-view/viewer-view.component.ts
+++ b/web/projects/portal/src/app/viewer/viewer-view/viewer-view.component.ts
@@ -102,15 +102,17 @@ export class ViewerViewComponent implements OnInit, OnDestroy, CanComponentDeact
    }
 
    public ngOnInit(): void {
+      // Capture whether we're returning from the binding editor before the async subscribe,
+      // while getCurrentNavigation() is still valid (component activates during navigation).
+      const returnFromEditor = !!this.router.getCurrentNavigation()?.extras.state?.["returnFromEditor"];
+
       this.subscriptions.add(this.route.data.subscribe((data: {
          viewData: ViewData
          principalCommand: SetPrincipalCommand
       }) => {
-         // If a tab for this asset already exists (e.g. returning from binding editor for a
-         // linked/drilled VS), preserve the existing tabs instead of clearing them.
          const existingTab = this.pageTabService.tabs.find(tab => tab.id === data.viewData.assetId);
 
-         if(!existingTab) {
+         if(!existingTab || !returnFromEditor) {
             this.pageTabService.clearTabs();
             const tab: TabInfoModel = {
                id: data.viewData.assetId,


### PR DESCRIPTION
## Summary

When the user clicks a viewsheet in the repository tree while drill-down tabs are open, the viewer now correctly clears those tabs and opens a fresh instance. Previously, the tab-preservation guard in `ViewerViewComponent.ngOnInit()` fired too broadly, also suppressing the clear on tree-click navigations.

## Root Cause

`ViewerViewComponent.ngOnInit()` checked whether a tab for the current assetId already existed in `PageTabService`. If one was found, it skipped `clearTabs()` and just updated the runtimeId. This guard was intended only for the editor-return path (where re-entering the same route should preserve sibling drill-down tabs), but it also triggered when the user navigated to the same viewsheet from the repository tree.

## Fix

- `ViewerEditComponent.closeEditor()` now passes `state: { returnFromEditor: true }` in its `NavigationExtras` when navigating back to the viewer.
- `ViewerViewComponent.ngOnInit()` captures this flag via `this.router.getCurrentNavigation()?.extras.state` at the top of the method (while navigation is still in-flight), then uses `!existingTab || !returnFromEditor` as the condition for clearing tabs. Tabs are only preserved when both an existing tab is found **and** the navigation is an editor return.

## Test Plan

1. Open a viewsheet in the portal that has a hyperlink to a linked viewsheet.
2. Click a hyperlink cell to open the linked viewsheet in a drill-down tab.
3. With the drill-down tab visible, click the original viewsheet again from the repository tree.
4. Verify the drill-down tab interface closes and the viewsheet opens fresh.
5. Open the viewsheet, click Edit on a chart or table to enter the binding editor, then close the editor.
6. Verify the drill-down tabs are still present after returning from the binding editor.

Fixes Redmine #75370.