### PR TITLE
Fix bug-75205: Reuse prevMirror for shared physical tables to restore cross-filtering in Composer merge

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
@@ -94,12 +94,12 @@ public class WsMergeService {
 
                if(prevMirror == null) {
                   // Unexpected: ensureBaseHasPrevMirror should always create the mirror.
-                  // Log a warning so the unexpected state is visible, then fall back to a
-                  // name-only mapping so the assembly is at least wired up rather than lost.
+                  // Do not map srcBound to the missing name — that would insert a dangling
+                  // reference into wsRenameMap and silently corrupt downstream joins.
+                  // Log and skip; the assembly remains unmapped in this merge pass.
                   LOG.warn("prevMirror '{}' not found in dashWS after ensureBaseHasPrevMirror; " +
-                           "falling back to name-only mapping for '{}'",
+                           "skipping rename mapping for '{}'",
                            prevMirrorName, srcBound.getName());
-                  wsRenameMap.put(srcBound.getName(), prevMirrorName);
                   continue;
                }
 
@@ -156,6 +156,11 @@ public class WsMergeService {
                   boolean prevHasAggregation = prevAggr != null && !prevAggr.isEmpty();
 
                   if(prevHasConditions || prevHasAggregation) {
+                     // Stack a mirror of prevMirror so chart2 goes through the shared node
+                     // and receives runtime cross-chart filter propagation. Note: because
+                     // cleanMirror is stacked on prevMirror, chart2 will also see prevMirror's
+                     // design-time conditions/aggregation — this is an inherent consequence of
+                     // sharing the node, and is acceptable for the cross-filter use case.
                      String cleanMirrorName = ensureUniqueName(prevMirrorName, dashWS);
                      MirrorTableAssembly cleanMirror = new MirrorTableAssembly(dashWS, cleanMirrorName, prevMirror);
                      cleanMirror.setColumnSelection(srcBound.getColumnSelection(true).clone(), true);
@@ -279,7 +284,8 @@ public class WsMergeService {
          ? existingTable.getPreConditionList() : new ConditionList();
       ConditionListWrapper postconds = existingTable.getPostConditionList() != null
          ? existingTable.getPostConditionList() : new ConditionList();
-      AggregateInfo aggr = (AggregateInfo) existingTable.getAggregateInfo().clone();
+      AggregateInfo existingAggr = existingTable.getAggregateInfo();
+      AggregateInfo aggr = existingAggr != null ? (AggregateInfo) existingAggr.clone() : new AggregateInfo();
       ColumnSelection origCols = existingTable.getColumnSelection(true).clone();
 
       // Rename the base to "{name}_base", freeing the original name for the mirror.

--- a/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
@@ -109,31 +109,31 @@ public class WsMergeService {
                                        (srcPost != null && !srcPost.isEmpty());
                boolean hasAggregation = srcAggr != null && !srcAggr.isEmpty();
 
-               if(hasConditions || hasAggregation) {
+               if(prevMirror == null) {
+                  // Unexpected state — fall back to name-only mapping
+                  wsRenameMap.put(srcBound.getName(), prevMirrorName);
+               }
+               else if(hasConditions || hasAggregation) {
                   // srcBound carries its own conditions or aggregation. Stack a mirror of
                   // prevMirror (not _base) so that runtime filters applied to prevMirror
                   // propagate through this mirror and on to any join that references it,
                   // preserving cross-chart filter interaction while retaining srcBound's
                   // conditions and aggregation.
-                  if(prevMirror == null) {
-                     // Unexpected state — fall back to name-only mapping
-                     wsRenameMap.put(srcBound.getName(), prevMirrorName);
-                  }
-                  else {
-                     String condMirrorName = ensureUniqueName(prevMirrorName, dashWS);
-                     MirrorTableAssembly condMirror = new MirrorTableAssembly(dashWS, condMirrorName, prevMirror);
-                     condMirror.setColumnSelection(srcBound.getColumnSelection(true).clone(), true);
-                     condMirror.setPreConditionList(srcPre != null ? (ConditionListWrapper) srcPre.clone() : new ConditionList());
-                     condMirror.setPostConditionList(srcPost != null ? (ConditionListWrapper) srcPost.clone() : new ConditionList());
-                     condMirror.setAggregateInfo(srcAggr != null ? (AggregateInfo) srcAggr.clone() : new AggregateInfo());
-                     condMirror.setProperty(PROP_WIZ_MERGED, "true");
-                     dashWS.addAssembly(condMirror);
-                     wsRenameMap.put(srcBound.getName(), condMirrorName);
-                  }
+                  String condMirrorName = ensureUniqueName(prevMirrorName, dashWS);
+                  MirrorTableAssembly condMirror = new MirrorTableAssembly(dashWS, condMirrorName, prevMirror);
+                  condMirror.setColumnSelection(srcBound.getColumnSelection(true).clone(), true);
+                  condMirror.setPreConditionList(srcPre != null ? (ConditionListWrapper) srcPre.clone() : new ConditionList());
+                  condMirror.setPostConditionList(srcPost != null ? (ConditionListWrapper) srcPost.clone() : new ConditionList());
+                  condMirror.setAggregateInfo(srcAggr != null ? (AggregateInfo) srcAggr.clone() : new AggregateInfo());
+                  condMirror.setProperty(PROP_WIZ_MERGED, "true");
+                  dashWS.addAssembly(condMirror);
+                  wsRenameMap.put(srcBound.getName(), condMirrorName);
                }
                else {
-                  // No conditions or aggregation — reuse prevMirror directly so the join
-                  // table shares the same node as chart1's binding, enabling cross-chart
+                  // srcBound has no conditions or aggregation: reuse prevMirror directly.
+                  // srcBound's own column selection is not applied here — prevMirror's
+                  // expanded union selection (refreshed above) is used instead, which is
+                  // required for both charts to share a single node and enable cross-chart
                   // filter interaction.
                   wsRenameMap.put(srcBound.getName(), prevMirrorName);
                }

--- a/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
@@ -34,6 +34,15 @@ import java.util.*;
  * (enabling cross-chart filter interaction). A new {@link MirrorTableAssembly} (tagged with
  * {@link #PROP_WIZ_MERGED}) is created on top of prevMirror only when the incoming table
  * carries its own conditions or aggregation that must be isolated.</p>
+ *
+ * <p><b>Known limitation — condition stacking:</b> When two charts share the same physical
+ * table and each has its own design-time pre/post conditions, chart2's condMirror is stacked
+ * on prevMirror (which already carries chart1's conditions). Because MirrorTableAssembly
+ * evaluates its own conditions on top of the mirrored table's result, chart2 is effectively
+ * filtered by chart1's conditions AND chart2's conditions combined. This is an inherent
+ * trade-off of sharing the node for cross-chart filter propagation; stacking on the bare
+ * {@code _base} would break that propagation. Callers should be aware that merging two charts
+ * with conflicting static filters on the same physical table may yield unexpected results.</p>
  */
 @Service
 public class WsMergeService {
@@ -90,7 +99,10 @@ public class WsMergeService {
                   ? baseName.substring(0, baseName.length() - 5)
                   : baseName;
 
-               TableAssembly prevMirror = (TableAssembly) dashWS.getAssembly(prevMirrorName);
+               Assembly prevAssembly = dashWS.getAssembly(prevMirrorName);
+               // Use instanceof guard rather than a raw cast: a name collision could place a
+               // non-table assembly at prevMirrorName, which would throw ClassCastException.
+               TableAssembly prevMirror = prevAssembly instanceof TableAssembly ta ? ta : null;
 
                if(prevMirror == null) {
                   // Unexpected: ensureBaseHasPrevMirror should always create the mirror.
@@ -104,7 +116,9 @@ public class WsMergeService {
                }
 
                // After mergeColumns may have added new columns to the base, refresh
-               // prevMirror's column selection so downstream mirrors and joins can see them.
+               // prevMirror's column selection so stacked mirrors (condMirror / cleanMirror)
+               // can see all columns transitively, even when they override their own selection.
+               // This runs unconditionally before the branch so any code path below benefits.
                ColumnSelection baseColumns = existingTable.getColumnSelection(true);
                ColumnSelection mirrorColumns = prevMirror.getColumnSelection(true).clone();
 
@@ -136,6 +150,11 @@ public class WsMergeService {
                   condMirror.setColumnSelection(srcBound.getColumnSelection(true).clone(), true);
                   condMirror.setPreConditionList(srcPre != null ? (ConditionListWrapper) srcPre.clone() : new ConditionList());
                   condMirror.setPostConditionList(srcPost != null ? (ConditionListWrapper) srcPost.clone() : new ConditionList());
+                  // MirrorTableAssembly.getAggregateInfo() returns its own field, not the
+                  // mirrored table's. Setting new AggregateInfo() when srcAggr is null means
+                  // "no additional aggregation on this mirror" — it does not suppress
+                  // prevMirror's aggregation. Verified: AbstractTableAssembly.getAggregateInfo()
+                  // returns ginfo (own field) at all levels; there is no inherited aggregation.
                   condMirror.setAggregateInfo(srcAggr != null ? (AggregateInfo) srcAggr.clone() : new AggregateInfo());
                   condMirror.setProperty(PROP_WIZ_MERGED, "true");
                   dashWS.addAssembly(condMirror);
@@ -171,9 +190,12 @@ public class WsMergeService {
                   else {
                      // prevMirror has no design-time conditions or aggregation — reuse it
                      // directly. srcBound's own column selection is not applied here —
-                     // prevMirror's expanded union selection (refreshed above) is used
-                     // instead, required for both charts to share a single node and enable
-                     // cross-chart filter interaction.
+                     // prevMirror's expanded union selection (refreshed above) is used instead,
+                     // required for both charts to share a single node and enable cross-chart
+                     // filter interaction. Side effect: chart1 (which also points to prevMirror)
+                     // gains visibility into chart2's columns. This is acceptable: the wiz
+                     // portal always requests explicit column sets, so extra visible columns in
+                     // the shared node do not affect chart1's rendered output.
                      wsRenameMap.put(srcBound.getName(), prevMirrorName);
                   }
                }

--- a/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
@@ -20,6 +20,8 @@ package inetsoft.web.wiz.service;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.erm.DataRef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -41,6 +43,8 @@ public class WsMergeService {
     * Used to identify wiz-managed mirrors without relying on name prefixes.
     */
    public static final String PROP_WIZ_MERGED = "wiz.merged";
+
+   private static final Logger LOG = LoggerFactory.getLogger(WsMergeService.class);
 
    /**
     * Merges all WSAssemblies from {@code vizWS} into {@code dashWS} and returns a map of
@@ -78,6 +82,9 @@ public class WsMergeService {
             if(existingTable != null) {
                ensureBaseHasPrevMirror(dashWS, existingTable, vsRenameMap);
                mergeColumns(existingTable, srcBound);
+               // renameAssembly (called inside ensureBaseHasPrevMirror) mutates the
+               // assembly name in-place, so existingTable.getName() now returns the
+               // new "_base"-suffixed name.
                String baseName = existingTable.getName();
                String prevMirrorName = baseName.endsWith("_base")
                   ? baseName.substring(0, baseName.length() - 5)
@@ -87,7 +94,11 @@ public class WsMergeService {
 
                if(prevMirror == null) {
                   // Unexpected: ensureBaseHasPrevMirror should always create the mirror.
-                  // Fall back to a name-only mapping so the assembly is at least wired up.
+                  // Log a warning so the unexpected state is visible, then fall back to a
+                  // name-only mapping so the assembly is at least wired up rather than lost.
+                  LOG.warn("prevMirror '{}' not found in dashWS after ensureBaseHasPrevMirror; " +
+                           "falling back to name-only mapping for '{}'",
+                           prevMirrorName, srcBound.getName());
                   wsRenameMap.put(srcBound.getName(), prevMirrorName);
                   continue;
                }
@@ -131,12 +142,35 @@ public class WsMergeService {
                   wsRenameMap.put(srcBound.getName(), condMirrorName);
                }
                else {
-                  // srcBound has no conditions or aggregation: reuse prevMirror directly.
-                  // srcBound's own column selection is not applied here — prevMirror's
-                  // expanded union selection (refreshed above) is used instead, which is
-                  // required for both charts to share a single node and enable cross-chart
-                  // filter interaction.
-                  wsRenameMap.put(srcBound.getName(), prevMirrorName);
+                  // srcBound has no conditions or aggregation of its own. Before reusing
+                  // prevMirror directly, check whether prevMirror carries design-time
+                  // conditions or aggregation from the first chart. If so, stack a clean
+                  // mirror of prevMirror so chart2 is not silently coupled to chart1's
+                  // design-time filters, while runtime filter propagation through the
+                  // shared prevMirror node is still preserved.
+                  ConditionListWrapper prevPre = prevMirror.getPreConditionList();
+                  ConditionListWrapper prevPost = prevMirror.getPostConditionList();
+                  AggregateInfo prevAggr = prevMirror.getAggregateInfo();
+                  boolean prevHasConditions = (prevPre != null && !prevPre.isEmpty()) ||
+                                              (prevPost != null && !prevPost.isEmpty());
+                  boolean prevHasAggregation = prevAggr != null && !prevAggr.isEmpty();
+
+                  if(prevHasConditions || prevHasAggregation) {
+                     String cleanMirrorName = ensureUniqueName(prevMirrorName, dashWS);
+                     MirrorTableAssembly cleanMirror = new MirrorTableAssembly(dashWS, cleanMirrorName, prevMirror);
+                     cleanMirror.setColumnSelection(srcBound.getColumnSelection(true).clone(), true);
+                     cleanMirror.setProperty(PROP_WIZ_MERGED, "true");
+                     dashWS.addAssembly(cleanMirror);
+                     wsRenameMap.put(srcBound.getName(), cleanMirrorName);
+                  }
+                  else {
+                     // prevMirror has no design-time conditions or aggregation — reuse it
+                     // directly. srcBound's own column selection is not applied here —
+                     // prevMirror's expanded union selection (refreshed above) is used
+                     // instead, required for both charts to share a single node and enable
+                     // cross-chart filter interaction.
+                     wsRenameMap.put(srcBound.getName(), prevMirrorName);
+                  }
                }
                continue;
             }

--- a/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of StyleBI.
  * Copyright (C) 2026  InetSoft Technology
  *
@@ -83,24 +83,29 @@ public class WsMergeService {
                   ? baseName.substring(0, baseName.length() - 5)
                   : baseName;
 
-               // After mergeColumns may have added new columns to the base, refresh
-               // prevMirror's column selection so downstream mirrors and joins can see them.
                TableAssembly prevMirror = (TableAssembly) dashWS.getAssembly(prevMirrorName);
 
-               if(prevMirror != null) {
-                  ColumnSelection baseColumns = existingTable.getColumnSelection(true);
-                  ColumnSelection mirrorColumns = prevMirror.getColumnSelection(true).clone();
-
-                  for(int i = 0; i < baseColumns.getAttributeCount(); i++) {
-                     DataRef col = baseColumns.getAttribute(i);
-
-                     if(mirrorColumns.getAttribute(col.getName()) == null) {
-                        mirrorColumns.addAttribute(col);
-                     }
-                  }
-
-                  prevMirror.setColumnSelection(mirrorColumns, true);
+               if(prevMirror == null) {
+                  // Unexpected: ensureBaseHasPrevMirror should always create the mirror.
+                  // Fall back to a name-only mapping so the assembly is at least wired up.
+                  wsRenameMap.put(srcBound.getName(), prevMirrorName);
+                  continue;
                }
+
+               // After mergeColumns may have added new columns to the base, refresh
+               // prevMirror's column selection so downstream mirrors and joins can see them.
+               ColumnSelection baseColumns = existingTable.getColumnSelection(true);
+               ColumnSelection mirrorColumns = prevMirror.getColumnSelection(true).clone();
+
+               for(int i = 0; i < baseColumns.getAttributeCount(); i++) {
+                  DataRef col = baseColumns.getAttribute(i);
+
+                  if(mirrorColumns.getAttribute(col.getName()) == null) {
+                     mirrorColumns.addAttribute(col);
+                  }
+               }
+
+               prevMirror.setColumnSelection(mirrorColumns, true);
 
                ConditionListWrapper srcPre = srcBound.getPreConditionList();
                ConditionListWrapper srcPost = srcBound.getPostConditionList();
@@ -109,11 +114,7 @@ public class WsMergeService {
                                        (srcPost != null && !srcPost.isEmpty());
                boolean hasAggregation = srcAggr != null && !srcAggr.isEmpty();
 
-               if(prevMirror == null) {
-                  // Unexpected state — fall back to name-only mapping
-                  wsRenameMap.put(srcBound.getName(), prevMirrorName);
-               }
-               else if(hasConditions || hasAggregation) {
+               if(hasConditions || hasAggregation) {
                   // srcBound carries its own conditions or aggregation. Stack a mirror of
                   // prevMirror (not _base) so that runtime filters applied to prevMirror
                   // propagate through this mirror and on to any join that references it,

--- a/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of StyleBI.
  * Copyright (C) 2026  InetSoft Technology
  *
@@ -28,9 +28,10 @@ import java.util.*;
  * Worksheet-level merge utilities shared by AddVisualizationService and GenerateWsService.
  *
  * <p>Core rule: each {@link BoundTableAssembly} appears only once in the target worksheet.
- * Different queries that share the same physical table each get their own
- * {@link MirrorTableAssembly} (tagged with {@link #PROP_WIZ_MERGED}) that carries
- * independent column selections, conditions, and aggregation.</p>
+ * Queries that share the same physical table reuse the shared prevMirror where possible
+ * (enabling cross-chart filter interaction). A new {@link MirrorTableAssembly} (tagged with
+ * {@link #PROP_WIZ_MERGED}) is created on top of prevMirror only when the incoming table
+ * carries its own conditions or aggregation that must be isolated.</p>
  */
 @Service
 public class WsMergeService {
@@ -49,7 +50,8 @@ public class WsMergeService {
     * <ul>
     *   <li>If a matching table already exists in dashWS (same data source): expand the base
     *       with any new columns, ensure it has a "prev" mirror for the first visualization,
-    *       and create a new mirror for the current visualization.</li>
+    *       then reuse that mirror directly (no conditions/aggregation) or stack a new mirror
+    *       on top of it (has conditions/aggregation) for the current visualization.</li>
     *   <li>Otherwise: clone the assembly, resolve name conflicts, and add it directly.</li>
     * </ul>
     *
@@ -81,28 +83,58 @@ public class WsMergeService {
                   ? baseName.substring(0, baseName.length() - 5)
                   : baseName;
 
+               // After mergeColumns may have added new columns to the base, refresh
+               // prevMirror's column selection so downstream mirrors and joins can see them.
+               TableAssembly prevMirror = (TableAssembly) dashWS.getAssembly(prevMirrorName);
+
+               if(prevMirror != null) {
+                  ColumnSelection baseColumns = existingTable.getColumnSelection(true);
+                  ColumnSelection mirrorColumns = prevMirror.getColumnSelection(true).clone();
+
+                  for(int i = 0; i < baseColumns.getAttributeCount(); i++) {
+                     DataRef col = baseColumns.getAttribute(i);
+
+                     if(mirrorColumns.getAttribute(col.getName()) == null) {
+                        mirrorColumns.addAttribute(col);
+                     }
+                  }
+
+                  prevMirror.setColumnSelection(mirrorColumns, true);
+               }
+
                ConditionListWrapper srcPre = srcBound.getPreConditionList();
                ConditionListWrapper srcPost = srcBound.getPostConditionList();
+               AggregateInfo srcAggr = srcBound.getAggregateInfo();
+               boolean hasConditions = (srcPre != null && !srcPre.isEmpty()) ||
+                                       (srcPost != null && !srcPost.isEmpty());
+               boolean hasAggregation = srcAggr != null && !srcAggr.isEmpty();
 
-               if((srcPre != null && !srcPre.isEmpty()) || (srcPost != null && !srcPost.isEmpty())) {
-                  // srcBound carries its own conditions. Stack a mirror of prevMirror (not
-                  // _base) so that runtime filters applied to prevMirror propagate through
-                  // this mirror and on to any join that references it, preserving cross-chart
-                  // filter interaction while retaining srcBound's conditions.
-                  WSAssembly prevMirror = (WSAssembly) dashWS.getAssembly(prevMirrorName);
-                  String condMirrorName = ensureUniqueName(prevMirrorName, dashWS);
-                  MirrorTableAssembly condMirror = new MirrorTableAssembly(dashWS, condMirrorName, prevMirror);
-                  condMirror.setColumnSelection(srcBound.getColumnSelection(true).clone(), true);
-                  condMirror.setPreConditionList(srcPre != null ? (ConditionListWrapper) srcPre.clone() : new ConditionList());
-                  condMirror.setPostConditionList(srcPost != null ? (ConditionListWrapper) srcPost.clone() : new ConditionList());
-                  condMirror.setAggregateInfo((AggregateInfo) srcBound.getAggregateInfo().clone());
-                  condMirror.setProperty(PROP_WIZ_MERGED, "true");
-                  dashWS.addAssembly(condMirror);
-                  wsRenameMap.put(srcBound.getName(), condMirrorName);
+               if(hasConditions || hasAggregation) {
+                  // srcBound carries its own conditions or aggregation. Stack a mirror of
+                  // prevMirror (not _base) so that runtime filters applied to prevMirror
+                  // propagate through this mirror and on to any join that references it,
+                  // preserving cross-chart filter interaction while retaining srcBound's
+                  // conditions and aggregation.
+                  if(prevMirror == null) {
+                     // Unexpected state — fall back to name-only mapping
+                     wsRenameMap.put(srcBound.getName(), prevMirrorName);
+                  }
+                  else {
+                     String condMirrorName = ensureUniqueName(prevMirrorName, dashWS);
+                     MirrorTableAssembly condMirror = new MirrorTableAssembly(dashWS, condMirrorName, prevMirror);
+                     condMirror.setColumnSelection(srcBound.getColumnSelection(true).clone(), true);
+                     condMirror.setPreConditionList(srcPre != null ? (ConditionListWrapper) srcPre.clone() : new ConditionList());
+                     condMirror.setPostConditionList(srcPost != null ? (ConditionListWrapper) srcPost.clone() : new ConditionList());
+                     condMirror.setAggregateInfo(srcAggr != null ? (AggregateInfo) srcAggr.clone() : new AggregateInfo());
+                     condMirror.setProperty(PROP_WIZ_MERGED, "true");
+                     dashWS.addAssembly(condMirror);
+                     wsRenameMap.put(srcBound.getName(), condMirrorName);
+                  }
                }
                else {
-                  // No conditions on srcBound — reuse prevMirror directly so the join table
-                  // shares the same node as chart1's binding, enabling cross-chart interaction.
+                  // No conditions or aggregation — reuse prevMirror directly so the join
+                  // table shares the same node as chart1's binding, enabling cross-chart
+                  // filter interaction.
                   wsRenameMap.put(srcBound.getName(), prevMirrorName);
                }
                continue;

--- a/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
@@ -76,8 +76,35 @@ public class WsMergeService {
             if(existingTable != null) {
                ensureBaseHasPrevMirror(dashWS, existingTable, vsRenameMap);
                mergeColumns(existingTable, srcBound);
-               String curMirrorName = createVizMirror(dashWS, existingTable, srcBound);
-               wsRenameMap.put(srcBound.getName(), curMirrorName);
+               String baseName = existingTable.getName();
+               String prevMirrorName = baseName.endsWith("_base")
+                  ? baseName.substring(0, baseName.length() - 5)
+                  : baseName;
+
+               ConditionListWrapper srcPre = srcBound.getPreConditionList();
+               ConditionListWrapper srcPost = srcBound.getPostConditionList();
+
+               if((srcPre != null && !srcPre.isEmpty()) || (srcPost != null && !srcPost.isEmpty())) {
+                  // srcBound carries its own conditions. Stack a mirror of prevMirror (not
+                  // _base) so that runtime filters applied to prevMirror propagate through
+                  // this mirror and on to any join that references it, preserving cross-chart
+                  // filter interaction while retaining srcBound's conditions.
+                  WSAssembly prevMirror = (WSAssembly) dashWS.getAssembly(prevMirrorName);
+                  String condMirrorName = ensureUniqueName(prevMirrorName, dashWS);
+                  MirrorTableAssembly condMirror = new MirrorTableAssembly(dashWS, condMirrorName, prevMirror);
+                  condMirror.setColumnSelection(srcBound.getColumnSelection(true).clone(), true);
+                  condMirror.setPreConditionList(srcPre != null ? (ConditionListWrapper) srcPre.clone() : new ConditionList());
+                  condMirror.setPostConditionList(srcPost != null ? (ConditionListWrapper) srcPost.clone() : new ConditionList());
+                  condMirror.setAggregateInfo((AggregateInfo) srcBound.getAggregateInfo().clone());
+                  condMirror.setProperty(PROP_WIZ_MERGED, "true");
+                  dashWS.addAssembly(condMirror);
+                  wsRenameMap.put(srcBound.getName(), condMirrorName);
+               }
+               else {
+                  // No conditions on srcBound — reuse prevMirror directly so the join table
+                  // shares the same node as chart1's binding, enabling cross-chart interaction.
+                  wsRenameMap.put(srcBound.getName(), prevMirrorName);
+               }
                continue;
             }
          }
@@ -226,37 +253,6 @@ public class WsMergeService {
       }
 
       base.setColumnSelection(baseColumns, true);
-   }
-
-   /**
-    * Creates a MirrorTableAssembly in {@code dashWS} that points at {@code base} and
-    * carries only the columns/conditions/aggregation of {@code srcTable}.
-    *
-    * @return the name of the created mirror assembly
-    */
-   private String createVizMirror(Worksheet dashWS, BoundTableAssembly base,
-                                   BoundTableAssembly srcTable)
-   {
-      // Derive naming prefix from base: strip "_base" suffix to recover the original name,
-      // then ensureUniqueName to get "Query_1", "Query_2", etc.
-      String baseName = base.getName();
-      String namePrefix = baseName.endsWith("_base")
-         ? baseName.substring(0, baseName.length() - 5)
-         : baseName;
-      String mirrorName = ensureUniqueName(namePrefix, dashWS);
-      ColumnSelection vizCols = srcTable.getColumnSelection(true).clone();
-
-      MirrorTableAssembly mirror = new MirrorTableAssembly(dashWS, mirrorName, base);
-      mirror.setColumnSelection(vizCols, true);
-      ConditionListWrapper srcPre = srcTable.getPreConditionList();
-      ConditionListWrapper srcPost = srcTable.getPostConditionList();
-      mirror.setPreConditionList(srcPre != null ? (ConditionListWrapper) srcPre.clone() : new ConditionList());
-      mirror.setPostConditionList(srcPost != null ? (ConditionListWrapper) srcPost.clone() : new ConditionList());
-      mirror.setAggregateInfo((AggregateInfo) srcTable.getAggregateInfo().clone());
-      mirror.setProperty(PROP_WIZ_MERGED, "true");
-      dashWS.addAssembly(mirror);
-
-      return mirrorName;
    }
 
    /**


### PR DESCRIPTION
When merging multiple charts into Composer, `WsMergeService.mergeWorksheet()` calls `createVizMirror()` for each source table that shares the same physical table as `dashWS`, generating an independent new mirror. As a result, the binding of chart1 (`Customer Information` prevMirror) and the table used for JOIN in chart2 (`Customer Information_1` mirror) become two parallel sibling nodes that do not affect each other, breaking cross-filtering. The fix is to remove the `createVizMirror()` call and directly map the source table name in `vizWS` to the existing `prevMirror` (i.e., the original name before `_base` renaming), so that the JOIN in chart2 and the binding in chart1 share the same node, thereby enabling interaction.