### PR TITLE
Bug #75366, add ExportAssetsService to SelectAssetsDialogComponent providers

### DIFF
--- a/web/projects/em/src/app/settings/content/repository/import-export/select-assets-dialog/select-assets-dialog.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/import-export/select-assets-dialog/select-assets-dialog.component.ts
@@ -42,7 +42,7 @@ export interface SelectAssetsDialogData {
     selector: "em-select-assets-dialog",
     templateUrl: "./select-assets-dialog.component.html",
     styleUrls: ["./select-assets-dialog.component.scss"],
-    providers: [RepositoryTreeDataSource],
+    providers: [RepositoryTreeDataSource, ExportAssetsService],
     imports: [ModalHeaderComponent, MatDialogContent, FlatTreeViewComponent, MultiSelectTreeNodeDirective, MatProgressBar, MatDialogActions, MatButton]
 })
 export class SelectAssetsDialogComponent implements OnInit {


### PR DESCRIPTION
## Summary

- The 'Select Assets' dialog failed to open when exporting assets from the EM repository page
- Fixed by adding `ExportAssetsService` to the `providers` array of `SelectAssetsDialogComponent`

## Root Cause

After the Angular standalone component migration, `ExportAssetsService` was no longer provided at a module level. `SelectAssetsDialogComponent` injects it but did not declare it in its own `providers`, causing Angular to throw `NG0201: No provider found for ExportAssetsService` when the dialog was opened.

## Fix

Add `ExportAssetsService` to the `providers` array in `SelectAssetsDialogComponent`'s `@Component` decorator alongside the existing `RepositoryTreeDataSource`.

## Test Plan

- [ ] Open `em/settings/content/repository`
- [ ] Click the Action icon on an asset (e.g. Examples/Census) and select "Export Assets"
- [ ] Click the "Add" button — confirm the Select Assets dialog opens without console errors
- [ ] Verify asset selection and export completes successfully

Fixes Redmine #75366.