### PR TITLE
Bug #75383 - Enable Color picker for legend selections in circle packing charts

### DIFF
--- a/web/projects/portal/src/app/vsobjects/format/vs-formats-pane.component.ts
+++ b/web/projects/portal/src/app/vsobjects/format/vs-formats-pane.component.ts
@@ -301,6 +301,11 @@ export class VSFormatsPane implements OnInit, OnChanges {
                      return false;
                   }
 
+                  // non-circle selections (legend, title, etc.) remain editable
+                  if(vos.length == 0) {
+                     return false;
+                  }
+
                   // innermost circle is same as selecting the text label.
                   const innermost = model.axisFields[model.axisFields.length - 1];
                   const innermostSelected =

--- a/web/projects/portal/src/app/vsobjects/format/vs-formats-pane.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/format/vs-formats-pane.spec.ts
@@ -541,6 +541,44 @@ describe("VS Formats Pane Unit case", () => {
 
    });
 
+   //color should be enabled for legend selection in circle packing chart,
+   //and disabled only when a non-innermost circle (vo) is selected
+   it("check color status for circle packing chart", () => {
+      let chart: VSChartModel = TestUtils.createMockVSChartModel("packing");
+      chart.chartType = GraphTypes.CHART_CIRCLE_PACKING;
+      chart.axisFields = ["OuterDim", "InnerDim"];
+      chart.stringDictionary = ["OuterDim", "InnerDim"];
+      chart.chartSelection = {
+         chartObject: null,
+         regions: null
+      };
+      let region: ChartRegion = TestUtils.createMockChartRegion();
+
+      //select legend (not a circle) - color editable
+      chart.regionMetaDictionary = [{areaType: "legend_content", meaIdx: -1}];
+      chart.chartSelection.chartObject = TestUtils.createMockChartObject("legend_content");
+      chart.chartSelection.regions = [region];
+      vsFormatsPane._focusedAssemblies = [chart];
+      vsFormatsPane.updateProperties();
+      expect(vsFormatsPane.colorDisabled).toBeFalsy();
+
+      //select outer (non-innermost) circle - color disabled
+      chart.regionMetaDictionary = [{areaType: "vo", meaIdx: 0}];
+      chart.chartSelection.chartObject = TestUtils.createMockChartObject("plot_area");
+      chart.chartSelection.regions = [region];
+      vsFormatsPane._focusedAssemblies = [chart];
+      vsFormatsPane.updateProperties();
+      expect(vsFormatsPane.colorDisabled).toBeTruthy();
+
+      //select innermost circle - color editable
+      chart.regionMetaDictionary = [{areaType: "vo", meaIdx: 1}];
+      chart.chartSelection.chartObject = TestUtils.createMockChartObject("plot_area");
+      chart.chartSelection.regions = [region];
+      vsFormatsPane._focusedAssemblies = [chart];
+      vsFormatsPane.updateProperties();
+      expect(vsFormatsPane.colorDisabled).toBeFalsy();
+   });
+
    //Bug #18442 font color should disabled for image
    it("font color should disabled for image", () => {
       let vsformats = new VSFormatsPane(changeDetectorRef, fontService, modelService, modalService,


### PR DESCRIPTION
## Summary

In the composer format pane, the foreground Color picker was disabled
for legend selections on circle packing charts, even though the
Background color picker remained enabled. This change re-enables the
Color picker so legends behave consistently with every other chart type.

## Root cause

isNonEditableChartVOSelected() in vs-formats-pane.component.ts marks a
chart region as non-editable for text color when an outer circle is
selected, since only the innermost circle shows an editable label. It
derived innermostSelected from the selected circle ("vo") regions and
returned !innermostSelected.

A legend selection contains no "vo" regions, so the filtered list was
empty, innermostSelected was false, and the method returned true,
disabling the Color picker. The Background picker was unaffected because
its disable condition is separately guarded in the template.

## Fix

Return false (editable) early when the selection contains no circle
("vo") region. The innermost-circle check now applies only when a circle
is actually selected, so outer-circle selections stay non-editable and
innermost-circle selections stay editable.

## Tests

Added a unit test in vs-formats-pane.spec.ts covering three circle
packing selection paths:
- legend selection -> Color enabled
- outer (non-innermost) circle -> Color disabled
- innermost circle -> Color enabled