### PR TITLE
Bug #75374, remove trailing slash from allNodes URL in ChooseTableDialog

### DIFF
--- a/web/projects/portal/src/app/portal/dialog/choose-table-dialog/choose-table-dialog.component.ts
+++ b/web/projects/portal/src/app/portal/dialog/choose-table-dialog/choose-table-dialog.component.ts
@@ -31,7 +31,7 @@ import { ModalHeaderComponent } from "../../../widget/modal-header/modal-header.
 
 const VPM_URI: string = "../api/data/vpm/";
 const PHYSICAL_TREE_NODES_URI: string = "../api/data/physicalmodel/tree/nodes";
-const PHYSICAL_TREE_ALL_NODES_URI: string = "../api/data/physicalmodel/tree/allNodes/";
+const PHYSICAL_TREE_ALL_NODES_URI: string = "../api/data/physicalmodel/tree/allNodes";
 const PHYSICAL_TABLE_PATH_URI: string = VPM_URI + "physicalModel/tablePath/";
 
 @Component({


### PR DESCRIPTION
## Summary

In the VPM editor "Choose Table" dialog, typing in the search box triggered a 404 error because the URL constant used to fetch all nodes had a trailing slash that Spring Framework 6 (Spring Boot 3.x) no longer tolerates.

## Root Cause

`PHYSICAL_TREE_ALL_NODES_URI` in `choose-table-dialog.component.ts` was defined with a trailing slash (`../api/data/physicalmodel/tree/allNodes/`). Spring Framework 6 disabled trailing-slash matching by default, so requests to `/api/data/physicalmodel/tree/allNodes/` returned 404. The same endpoint is called without a trailing slash in `database-physical-model.component.ts` and works correctly there.

## Fix

Removed the trailing slash from `PHYSICAL_TREE_ALL_NODES_URI` to match the backend endpoint mapping and align with the existing usage in `database-physical-model.component.ts`.

## Test Plan

- Open portal, navigate to Examples/Orders/Virtual Private Models
- Create or open a VPM condition, click "Choose Table"
- Type in the search box — tree should load without a 404 error in the browser console
- Confirm table selection and saving still works correctly

Fixes Redmine #75374.