### PR TITLE
Bug #75380, fix NPE and Kryo underflow in swappable table under concurrency

### DIFF
--- a/core/src/main/java/inetsoft/uql/table/AbstractTableColumn.java
+++ b/core/src/main/java/inetsoft/uql/table/AbstractTableColumn.java
@@ -68,13 +68,14 @@ public abstract class AbstractTableColumn implements XTableColumn, XSerializable
 
       if(buf0 != null) {
          ByteBuffer buf = XSwapUtil.compressByteBuffer(buf0);
-         swapsize = buf.remaining();
+         int size = buf.remaining();
 
          if(isCountRW) {
-            monitor.countWrite(swapsize, XSwappableMonitor.DATA);
+            monitor.countWrite(size, XSwappableMonitor.DATA);
          }
 
          fc.write(buf);
+         swapsize = size;
          ByteBufferPool.releaseByteBuffer(buf0);
          invalidate();
       }

--- a/core/src/main/java/inetsoft/uql/table/XTableFragment.java
+++ b/core/src/main/java/inetsoft/uql/table/XTableFragment.java
@@ -452,6 +452,10 @@ public final class XTableFragment extends XSwappable {
    }
 
    public final synchronized XTableColumnCreator addObject(int col, Object val) {
+      if(disposed) {
+         return null;
+      }
+
       XTableColumn column = columns[col].addObject(val);
 
       if(column != null) {


### PR DESCRIPTION
## Summary

- Fix `NullPointerException` in `XObjectColumn.ensureCapacity()` caused by a race between `FormulaTableLens.dispose()` and `addRow()`
- Fix `KryoBufferUnderflowException` caused by `swapsize` being set before a swap file write that may fail due to `ClosedByInterruptException`

## Root Cause

**NPE:** `FormulaTableLens.dispose()` uses `synchronized(this)` while `moreRows()` uses a separate `ReentrantLock`, so they can run concurrently. `dispose()` calls `rows.dispose()` which eventually calls `XTableFragment.dispose()`, nulling all column `arr` fields and `columns`. Meanwhile `addRow()` iterates over columns without holding `rlock`, so a subsequent `table.addObject()` call sees the disposed fragment state and throws NPE.

**KryoBufferUnderflow:** `AbstractTableColumn.swap()` set `swapsize = buf.remaining()` before `fc.write(buf)`. If a `ClosedByInterruptException` interrupts the write, `swapsize` holds the full expected size with zero bytes on disk. On the next XSwapper pass the column is invalidated with this wrong `swapsize`, causing `load()` to map the wrong number of bytes and Kryo to fail with a buffer underflow.

## Fix

- `XTableFragment.addObject()`: check `disposed` flag at entry (both methods are synchronized on the same fragment, so the flag is always current) and return null early, skipping column access on a disposed fragment.
- `AbstractTableColumn.swap()`: capture the buffer size in a local variable, write first, then assign `swapsize` only on success. If the write throws, `swapsize` stays 0 and `load()` returns early with a warning instead of reading corrupt data.

## Test Plan

- Build: `./mvnw clean install -pl core -am -DskipTests` — passes
- Tests: `./mvnw test -pl core` — 2495 tests pass, 0 failures
- Manual: verified under concurrent load scenario described in the Redmine issue

Fixes Redmine #75380.