### PR TITLE
Bug #75384 - Fix duplicate chart bindings when toggling Stack in the chart type picker

### DIFF
--- a/web/projects/portal/src/app/binding/widget/chart-type-button.component.spec.ts
+++ b/web/projects/portal/src/app/binding/widget/chart-type-button.component.spec.ts
@@ -71,4 +71,32 @@ describe("chart type button component unit case", () => {
 
       expect(editorService.changeChartType).toHaveBeenCalledTimes(1);
    });
+
+   it("sends changeChartType only once when the Apply button re-enters toggled", () => {
+      button.chartType = GraphTypes.CHART_BAR;
+      button.multiStyles = false;
+      button.stackMeasures = false;
+      button.refName = undefined;
+      button.dropdown = { close: vi.fn(() => button.toggled(false)) } as any;
+
+      // Apply button emits (apply) -> toggled(false)
+      button.toggled(false);
+
+      expect(editorService.changeChartType).toHaveBeenCalledTimes(1);
+   });
+
+   it("resets the guard after a no-op so a later change still fires", () => {
+      button.chartType = GraphTypes.CHART_BAR_STACK;   // unchanged from bindingModel
+      button.multiStyles = false;
+      button.stackMeasures = false;
+      button.refName = undefined;
+      button.dropdown = { close: vi.fn() } as any;
+
+      button.changeChartType();
+      expect(editorService.changeChartType).toHaveBeenCalledTimes(0);
+
+      button.chartType = GraphTypes.CHART_BAR;          // now a real change
+      button.changeChartType();
+      expect(editorService.changeChartType).toHaveBeenCalledTimes(1);
+   });
 });

--- a/web/projects/portal/src/app/binding/widget/chart-type-button.component.spec.ts
+++ b/web/projects/portal/src/app/binding/widget/chart-type-button.component.spec.ts
@@ -1,0 +1,74 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
+import { of } from "rxjs";
+import { GraphTypes } from "../../common/graph-types";
+import { ChartEditorService } from "../services/chart/chart-editor.service";
+import { ChartTypeButton } from "./chart-type-button.component";
+
+describe("chart type button component unit case", () => {
+   let fixture: ComponentFixture<ChartTypeButton>;
+   let button: ChartTypeButton;
+   let editorService: any;
+
+   beforeEach(() => {
+      editorService = {
+         getCustomChartTypes: vi.fn(() => of([])),
+         getChartStyles: vi.fn(() => of({ styles: [], stackStyles: [] })),
+         changeChartType: vi.fn(),
+         bindingModel: {
+            chartType: GraphTypes.CHART_BAR_STACK,
+            multiStyles: false,
+            stackMeasures: false,
+            separated: true,
+            xfields: [],
+            yfields: [],
+            geoFields: [],
+            groupFields: []
+         }
+      };
+
+      TestBed.configureTestingModule({
+         imports: [ChartTypeButton],
+         providers: [
+            { provide: ChartEditorService, useValue: editorService },
+            { provide: NgbModal, useValue: { open: vi.fn() } }
+         ]
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(ChartTypeButton);
+      button = fixture.componentInstance;
+   });
+
+   // Bug: disabling stack created duplicate bindings because closing the dropdown
+   // re-fired openChange -> toggled -> changeChartType, sending the event twice and
+   // racing on the shared chart info in the backend.
+   it("sends changeChartType only once when closing re-enters toggled", () => {
+      button.chartType = GraphTypes.CHART_BAR;
+      button.multiStyles = false;
+      button.stackMeasures = false;
+      button.refName = undefined;
+      // simulate the dropdown close synchronously re-triggering the close handler
+      button.dropdown = { close: vi.fn(() => button.toggled(false)) } as any;
+
+      button.changeChartType();
+
+      expect(editorService.changeChartType).toHaveBeenCalledTimes(1);
+   });
+});

--- a/web/projects/portal/src/app/binding/widget/chart-type-button.component.ts
+++ b/web/projects/portal/src/app/binding/widget/chart-type-button.component.ts
@@ -44,6 +44,7 @@ export class ChartTypeButton {
    @Output() onChange = new EventEmitter<any>();
    @ViewChild(FixedDropdownDirective) dropdown: FixedDropdownDirective;
    url: string = "/api/adhoc/chart/changeChartType";
+   private applying = false;
    private outsideClickListener: () => any;
    customChartTypes: string[];
    chartStyles: ChartStylesModel;
@@ -89,8 +90,21 @@ export class ChartTypeButton {
    }
 
    changeChartType(): void {
-      this.checkValid();
-      this.dropdown.close();
+      // closing the dropdown re-fires openChange -> toggled -> changeChartType
+      // synchronously; guard against re-entry so the event is only sent once
+      if(this.applying) {
+         return;
+      }
+
+      this.applying = true;
+
+      try {
+         this.checkValid();
+         this.dropdown.close();
+      }
+      finally {
+         this.applying = false;
+      }
    }
 
    checkValid(): void {

--- a/web/projects/portal/src/app/binding/widget/chart-type-button.component.ts
+++ b/web/projects/portal/src/app/binding/widget/chart-type-button.component.ts
@@ -90,7 +90,7 @@ export class ChartTypeButton {
    }
 
    changeChartType(): void {
-      // closing the dropdown re-fires openChange -> toggled -> changeChartType
+      // Apply and dropdown-close both re-fire openChange -> toggled -> changeChartType
       // synchronously; guard against re-entry so the event is only sent once
       if(this.applying) {
          return;


### PR DESCRIPTION


# Summary

Disabling (or enabling) the Stack option in the chart type picker created duplicate bindings in the X / Y / + panes of the chart editor. The fix prevents the chart type button from sending the changeChartType event more than once per user action.

# Root cause

changeChartType() in chart-type-button.component.ts calls this.dropdown.close(). The dropdown directive's close() synchronously emits openChange(false), which is bound to toggled(), which calls changeChartType() again. The binding model has not been refreshed yet, so checkValid() still detects a pending change and sends a second changeChartType event (the Apply button makes this worse).

The duplicate events are delivered on separate STOMP inbound threads and processed concurrently on the same shared VSChartInfo. The change-type pipeline mutates the binding without per-viewsheet serialization, and ChangeChartDataProcessor.sortRefs does a non-atomic removeXFields()/addXField(); two interleaved runs therefore leave
the x/y fields duplicated. A single-threaded run never reproduces it, which is why it only appears under the concurrent double-send.

# Fix

Add a re-entrancy guard in changeChartType() so the synchronous close -> openChange -> toggled -> changeChartType cycle cannot send the event a second time. The guard is reset in a finally block, so every genuine user action still sends exactly once.

# Testing

Added chart-type-button.component.spec.ts which simulates dropdown.close() re-entering toggled and asserts changeChartType is sent exactly once.