### PR TITLE
Bug #75387 - Fix alias validation feedback in viewsheet options pane

### DIFF
--- a/web/projects/portal/src/app/composer/dialog/vs/viewsheet-options-pane.component.html
+++ b/web/projects/portal/src/app/composer/dialog/vs/viewsheet-options-pane.component.html
@@ -116,9 +116,9 @@
                         (valueChange)="model.maxRows = $event"
                         [invalid]="!!form.controls['maxRows'].errors">
             </number-stepper>
-            <span class="invalid-feedback d-block" *ngIf="form.controls['maxRows'].errors">
-              The sample size should be non-zero integer.
-            </span>
+            @if(form.controls['maxRows'].errors) {
+              <span class="invalid-feedback d-block">The sample size should be non-zero integer.</span>
+            }
           </div>
           <div class="col-6 d-flex flex-column">
             <label class="form-label">_#(Snap Grid)</label>
@@ -126,9 +126,9 @@
                         (valueChange)="model.snapGrid = $event"
                         [invalid]="!!form.controls['snapGrid'].errors">
             </number-stepper>
-            <span class="invalid-feedback d-block" *ngIf="form.controls['snapGrid'].errors">
-              _#(composer.vs.options.snapGrid)
-            </span>
+            @if(form.controls['snapGrid'].errors) {
+              <span class="invalid-feedback d-block">_#(composer.vs.options.snapGrid)</span>
+            }
           </div>
         </div>
       </fieldset>
@@ -138,9 +138,11 @@
           <div class="col-12">
             <div class="form-floating">
               <input type="text" formControlName="alias" class="form-control" placeholder="_#(Alias)" [(ngModel)]="model.alias"
-                [class.is-invalid]="form.controls['alias'].errors && (form.controls['alias'].errors['containsSpecialChars'] || form.controls['alias'].errors['doesNotStartWithNumber'])"/>
+                [class.is-invalid]="form.controls['alias'].errors && form.controls['alias'].errors['doesNotStartWithNumberOrLetter']"/>
               <label><span>_#(Alias)</span></label>
-              <span class="invalid-feedback d-block">_#(viewer.nameSpecialChar)</span>
+              @if(form.controls['alias'].errors && form.controls['alias'].errors['doesNotStartWithNumberOrLetter']) {
+                <span class="invalid-feedback d-block">_#(viewer.nameSpecialChar)</span>
+              }
             </div>
           </div>
         </div>
@@ -175,9 +177,9 @@
                         (valueChange)="model.touchInterval = $event"
                         [invalid]="!!form.controls['touchInterval'].errors">
             </number-stepper>
-            <span class="invalid-feedback d-block" *ngIf="form.controls['touchInterval'].errors">
-              _#(composer.vs.options.refreshIntervalValid)
-            </span>
+            @if(form.controls['touchInterval'].errors) {
+              <span class="invalid-feedback d-block">_#(composer.vs.options.refreshIntervalValid)</span>
+            }
           </div>
         </div>
         <div class="row shell-form-row--field">

--- a/web/projects/portal/src/app/composer/dialog/vs/viewsheet-options-pane.component.html
+++ b/web/projects/portal/src/app/composer/dialog/vs/viewsheet-options-pane.component.html
@@ -116,7 +116,7 @@
                         (valueChange)="model.maxRows = $event"
                         [invalid]="!!form.controls['maxRows'].errors">
             </number-stepper>
-            @if(form.controls['maxRows'].errors) {
+            @if (form.controls['maxRows'].errors) {
               <span class="invalid-feedback d-block">The sample size should be non-zero integer.</span>
             }
           </div>
@@ -126,7 +126,7 @@
                         (valueChange)="model.snapGrid = $event"
                         [invalid]="!!form.controls['snapGrid'].errors">
             </number-stepper>
-            @if(form.controls['snapGrid'].errors) {
+            @if (form.controls['snapGrid'].errors) {
               <span class="invalid-feedback d-block">_#(composer.vs.options.snapGrid)</span>
             }
           </div>
@@ -140,7 +140,7 @@
               <input type="text" formControlName="alias" class="form-control" placeholder="_#(Alias)" [(ngModel)]="model.alias"
                 [class.is-invalid]="form.controls['alias'].errors && form.controls['alias'].errors['doesNotStartWithNumberOrLetter']"/>
               <label><span>_#(Alias)</span></label>
-              @if(form.controls['alias'].errors && form.controls['alias'].errors['doesNotStartWithNumberOrLetter']) {
+              @if (form.controls['alias'].errors && form.controls['alias'].errors['doesNotStartWithNumberOrLetter']) {
                 <span class="invalid-feedback d-block">_#(viewer.nameSpecialChar)</span>
               }
             </div>
@@ -177,7 +177,7 @@
                         (valueChange)="model.touchInterval = $event"
                         [invalid]="!!form.controls['touchInterval'].errors">
             </number-stepper>
-            @if(form.controls['touchInterval'].errors) {
+            @if (form.controls['touchInterval'].errors) {
               <span class="invalid-feedback d-block">_#(composer.vs.options.refreshIntervalValid)</span>
             }
           </div>

--- a/web/projects/portal/src/app/composer/dialog/vs/viewsheet-options-pane.spec.ts
+++ b/web/projects/portal/src/app/composer/dialog/vs/viewsheet-options-pane.spec.ts
@@ -152,4 +152,23 @@ describe("Viewsheet Options Pane Unit Test", () => {
       fixture.detectChanges();
       expect(dataSize.getAttribute("class")).toContain("is-invalid");
    });
+
+   // Bug #75387 alias warning must not show until the value is actually invalid
+   it("alias validation feedback only shows for an invalid alias", () => {
+      const aliasInput = fixture.nativeElement.querySelector("input[ng-reflect-name=alias]");
+      const feedback = () => fixture.nativeElement.querySelector(".form-floating .invalid-feedback");
+
+      expect(aliasInput.classList).not.toContain("is-invalid");
+      expect(feedback()).toBeNull();
+
+      vsOptionPane.form.get("alias").setValue("-abc");
+      fixture.detectChanges();
+      expect(aliasInput.classList).toContain("is-invalid");
+      expect(feedback()).not.toBeNull();
+
+      vsOptionPane.form.get("alias").setValue("abc");
+      fixture.detectChanges();
+      expect(aliasInput.classList).not.toContain("is-invalid");
+      expect(feedback()).toBeNull();
+   });
 });


### PR DESCRIPTION
## Summary

Fixes the Alias field in the composer Dashboard Options (Viewsheet
Options) pane showing the "Name cannot contain special characters"
warning immediately on open, even though the user never clicked into
the input.

## Root cause

viewsheet-options-pane is a standalone component, and its
@Component.imports lists neither CommonModule nor NgIf. The top-level
@if (model && form) works because @if is Angular's built-in control
flow, but every *ngIf in the template silently desugars to an
<ng-template [ngIf]="…"> that, with no NgIf directive present, is never
instantiated.

As a result:
- The alias feedback span had no working *ngIf and relied on its
  d-block class, so it rendered unconditionally.
- The maxRows, snapGrid, and touchInterval feedback messages never
  rendered at all.
- The red invalid border kept working because [class.is-invalid] is a
  plain attribute binding that needs no import.

A secondary latent bug: the alias [class.is-invalid] checked the
containsSpecialChars / doesNotStartWithNumber error keys, but the
control's validator (doesNotStartWithNumberOrLetter) never emits those,
so the border never appeared for a genuinely invalid alias.

## Changes

- Convert the four invalid-feedback spans (maxRows, snapGrid, alias,
  touchInterval) from *ngIf to the built-in @if control flow, matching
  the existing @if usage in the same template. No import change needed.
- Correct the alias [class.is-invalid] and @if conditions to use the
  doesNotStartWithNumberOrLetter error key emitted by the validator.

## Behavior after fix

- Empty or valid alias: no border, no message.
- Alias starting with a special character (e.g. "-123"): red border and
  the "Name cannot contain special characters" message both appear.
- The maxRows / snap grid / refresh interval validation messages now
  display correctly when invalid.