### PR TITLE
feat(wiz): AI geo-mapping backend — choropleth detect/apply + reopen-guard fix

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
@@ -82,12 +83,12 @@ public class WizViewsheetController {
    }
 
    @PostMapping(value = "/viewsheet/geo/detect", produces = MediaType.APPLICATION_JSON_VALUE)
-   public ResponseEntity<?> geoDetect(@RequestBody GeoDetectRequest request, Principal user) {
+   public ResponseEntity<?> geoDetect(@Valid @RequestBody GeoDetectRequest request, Principal user) {
       return run("geo detect", () -> wizGeoService.detect(request, user));
    }
 
    @PostMapping(value = "/viewsheet/geo/apply", produces = MediaType.APPLICATION_JSON_VALUE)
-   public ResponseEntity<?> geoApply(@RequestBody GeoApplyRequest request, Principal user) {
+   public ResponseEntity<?> geoApply(@Valid @RequestBody GeoApplyRequest request, Principal user) {
       return run("geo apply", () -> wizGeoService.apply(request, user));
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
@@ -20,6 +20,7 @@ package inetsoft.web.wiz.controller;
 
 import inetsoft.web.wiz.model.*;
 import inetsoft.web.wiz.service.WizAutoBindingService;
+import inetsoft.web.wiz.service.WizGeoService;
 import inetsoft.web.wiz.service.WizVsService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,10 +35,12 @@ import java.util.Map;
 @RequestMapping("/api/wiz")
 public class WizViewsheetController {
    public WizViewsheetController(WizVsService wizVsService,
-                                  WizAutoBindingService wizAutoBindingService)
+                                  WizAutoBindingService wizAutoBindingService,
+                                  WizGeoService wizGeoService)
    {
       this.wizVsService = wizVsService;
       this.wizAutoBindingService = wizAutoBindingService;
+      this.wizGeoService = wizGeoService;
    }
 
    @PostMapping(value = "/viewsheet/create", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -78,6 +81,16 @@ public class WizViewsheetController {
       return wizAutoBindingService.setChartColors(request, user);
    }
 
+   @PostMapping(value = "/viewsheet/geo/detect", produces = MediaType.APPLICATION_JSON_VALUE)
+   public ResponseEntity<?> geoDetect(@RequestBody GeoDetectRequest request, Principal user) {
+      return run("geo detect", () -> wizGeoService.detect(request, user));
+   }
+
+   @PostMapping(value = "/viewsheet/geo/apply", produces = MediaType.APPLICATION_JSON_VALUE)
+   public ResponseEntity<?> geoApply(@RequestBody GeoApplyRequest request, Principal user) {
+      return run("geo apply", () -> wizGeoService.apply(request, user));
+   }
+
    @DeleteMapping("/viewsheet")
    public void deleteViewsheet(@RequestParam("identifier") String identifier,
                                Principal user) throws Exception
@@ -106,5 +119,6 @@ public class WizViewsheetController {
 
    private final WizVsService wizVsService;
    private final WizAutoBindingService wizAutoBindingService;
+   private final WizGeoService wizGeoService;
    private static final Logger LOG = LoggerFactory.getLogger(WizViewsheetController.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/GeoApplyRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/GeoApplyRequest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotBlank;
 
 import java.util.List;
 import java.util.Map;
@@ -77,8 +78,11 @@ public class GeoApplyRequest {
       this.viewsheetIdentifier = viewsheetIdentifier;
    }
 
+   @NotBlank
    private String runtimeId;
+   @NotBlank
    private String assemblyName;
+   @NotBlank
    private String column;
    /** dataValue -> geoCode (or display label, resolved to a geoCode by the service). */
    private Map<String, String> mappings;

--- a/core/src/main/java/inetsoft/web/wiz/model/GeoApplyRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/GeoApplyRequest.java
@@ -69,6 +69,14 @@ public class GeoApplyRequest {
       this.drop = drop;
    }
 
+   public String getViewsheetIdentifier() {
+      return viewsheetIdentifier;
+   }
+
+   public void setViewsheetIdentifier(String viewsheetIdentifier) {
+      this.viewsheetIdentifier = viewsheetIdentifier;
+   }
+
    private String runtimeId;
    private String assemblyName;
    private String column;
@@ -76,4 +84,9 @@ public class GeoApplyRequest {
    private Map<String, String> mappings;
    /** Values intentionally left unmatched. */
    private List<String> drop;
+   /**
+    * Optional session viewsheet asset identifier. When present, the resolved feature mappings are
+    * persisted back to this asset so a saved map keeps them.
+    */
+   private String viewsheetIdentifier;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/GeoApplyRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/GeoApplyRequest.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Request body for {@code POST /api/wiz/viewsheet/geo/apply}.
+ * Applies manual value-to-geoCode {@code mappings} on the geographic {@code column} of the chart
+ * {@code assemblyName}, and treats {@code drop} values as intentionally unmatched.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GeoApplyRequest {
+   public String getRuntimeId() {
+      return runtimeId;
+   }
+
+   public void setRuntimeId(String runtimeId) {
+      this.runtimeId = runtimeId;
+   }
+
+   public String getAssemblyName() {
+      return assemblyName;
+   }
+
+   public void setAssemblyName(String assemblyName) {
+      this.assemblyName = assemblyName;
+   }
+
+   public String getColumn() {
+      return column;
+   }
+
+   public void setColumn(String column) {
+      this.column = column;
+   }
+
+   public Map<String, String> getMappings() {
+      return mappings;
+   }
+
+   public void setMappings(Map<String, String> mappings) {
+      this.mappings = mappings;
+   }
+
+   public List<String> getDrop() {
+      return drop;
+   }
+
+   public void setDrop(List<String> drop) {
+      this.drop = drop;
+   }
+
+   private String runtimeId;
+   private String assemblyName;
+   private String column;
+   /** dataValue -> geoCode (or display label, resolved to a geoCode by the service). */
+   private Map<String, String> mappings;
+   /** Values intentionally left unmatched. */
+   private List<String> drop;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/GeoApplyResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/GeoApplyResponse.java
@@ -24,6 +24,9 @@ import java.util.List;
  * {@code status} is "complete" when no originally-unmatched values remain, else "partial".
  */
 public class GeoApplyResponse {
+   public static final String STATUS_COMPLETE = "complete";
+   public static final String STATUS_PARTIAL  = "partial";
+
    public String getStatus() {
       return status;
    }

--- a/core/src/main/java/inetsoft/web/wiz/model/GeoApplyResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/GeoApplyResponse.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import java.util.List;
+
+/**
+ * Response for {@code POST /api/wiz/viewsheet/geo/apply}.
+ * {@code status} is "complete" when no originally-unmatched values remain, else "partial".
+ */
+public class GeoApplyResponse {
+   public String getStatus() {
+      return status;
+   }
+
+   public void setStatus(String status) {
+      this.status = status;
+   }
+
+   public List<String> getStillUnmatched() {
+      return stillUnmatched;
+   }
+
+   public void setStillUnmatched(List<String> stillUnmatched) {
+      this.stillUnmatched = stillUnmatched;
+   }
+
+   private String status;
+   private List<String> stillUnmatched;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/GeoDetectRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/GeoDetectRequest.java
@@ -58,9 +58,22 @@ public class GeoDetectRequest {
       this.geoType = geoType;
    }
 
+   public String getViewsheetIdentifier() {
+      return viewsheetIdentifier;
+   }
+
+   public void setViewsheetIdentifier(String viewsheetIdentifier) {
+      this.viewsheetIdentifier = viewsheetIdentifier;
+   }
+
    private String runtimeId;
    private String assemblyName;
    private String column;
    /** Optional explicit map type (e.g. "World", "U.S."); when absent, auto-detected. */
    private String geoType;
+   /**
+    * Optional session viewsheet asset identifier. When present, the map conversion is persisted
+    * back to this asset (save_viewsheet reads from storage, not the live runtime).
+    */
+   private String viewsheetIdentifier;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/GeoDetectRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/GeoDetectRequest.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Request body for {@code POST /api/wiz/viewsheet/geo/detect}.
+ * Marks {@code column} on the chart {@code assemblyName} geographic and auto-detects
+ * its geo type/layer + matching against built-in features.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GeoDetectRequest {
+   public String getRuntimeId() {
+      return runtimeId;
+   }
+
+   public void setRuntimeId(String runtimeId) {
+      this.runtimeId = runtimeId;
+   }
+
+   public String getAssemblyName() {
+      return assemblyName;
+   }
+
+   public void setAssemblyName(String assemblyName) {
+      this.assemblyName = assemblyName;
+   }
+
+   public String getColumn() {
+      return column;
+   }
+
+   public void setColumn(String column) {
+      this.column = column;
+   }
+
+   public String getGeoType() {
+      return geoType;
+   }
+
+   public void setGeoType(String geoType) {
+      this.geoType = geoType;
+   }
+
+   private String runtimeId;
+   private String assemblyName;
+   private String column;
+   /** Optional explicit map type (e.g. "World", "U.S."); when absent, auto-detected. */
+   private String geoType;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/GeoDetectRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/GeoDetectRequest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotBlank;
 
 /**
  * Request body for {@code POST /api/wiz/viewsheet/geo/detect}.
@@ -66,8 +67,11 @@ public class GeoDetectRequest {
       this.viewsheetIdentifier = viewsheetIdentifier;
    }
 
+   @NotBlank
    private String runtimeId;
+   @NotBlank
    private String assemblyName;
+   @NotBlank
    private String column;
    /** Optional explicit map type (e.g. "World", "U.S."); when absent, auto-detected. */
    private String geoType;

--- a/core/src/main/java/inetsoft/web/wiz/model/GeoDetectResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/GeoDetectResponse.java
@@ -55,6 +55,14 @@ public class GeoDetectResponse {
       this.unmatched = unmatched;
    }
 
+   public String getLayerName() {
+      return layerName;
+   }
+
+   public void setLayerName(String layerName) {
+      this.layerName = layerName;
+   }
+
    public List<String> getCandidateFeatures() {
       return candidateFeatures;
    }
@@ -65,6 +73,7 @@ public class GeoDetectResponse {
 
    private String geoType;
    private int layer;
+   private String layerName;
    private int matchedCount;
    private List<String> unmatched;
    private List<String> candidateFeatures;

--- a/core/src/main/java/inetsoft/web/wiz/model/GeoDetectResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/GeoDetectResponse.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import java.util.List;
+
+/**
+ * Response for {@code POST /api/wiz/viewsheet/geo/detect}.
+ */
+public class GeoDetectResponse {
+   public String getGeoType() {
+      return geoType;
+   }
+
+   public void setGeoType(String geoType) {
+      this.geoType = geoType;
+   }
+
+   public int getLayer() {
+      return layer;
+   }
+
+   public void setLayer(int layer) {
+      this.layer = layer;
+   }
+
+   public int getMatchedCount() {
+      return matchedCount;
+   }
+
+   public void setMatchedCount(int matchedCount) {
+      this.matchedCount = matchedCount;
+   }
+
+   public List<String> getUnmatched() {
+      return unmatched;
+   }
+
+   public void setUnmatched(List<String> unmatched) {
+      this.unmatched = unmatched;
+   }
+
+   public List<String> getCandidateFeatures() {
+      return candidateFeatures;
+   }
+
+   public void setCandidateFeatures(List<String> candidateFeatures) {
+      this.candidateFeatures = candidateFeatures;
+   }
+
+   private String geoType;
+   private int layer;
+   private int matchedCount;
+   private List<String> unmatched;
+   private List<String> candidateFeatures;
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizGeoMappingResolver.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizGeoMappingResolver.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import java.util.*;
+
+/** Pure helper: which originally-unmatched geo values remain after applying provided mappings + drops. */
+final class WizGeoMappingResolver {
+   private WizGeoMappingResolver() {}
+
+   static Set<String> stillUnmatched(Set<String> unmatched, Map<String,String> applied, Set<String> dropped) {
+      Set<String> remaining = new LinkedHashSet<>(unmatched);
+      remaining.removeAll(applied.keySet());
+      remaining.removeAll(dropped == null ? Set.of() : dropped);
+      return remaining;
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizGeoMappingResolver.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizGeoMappingResolver.java
@@ -23,7 +23,7 @@ import java.util.*;
 final class WizGeoMappingResolver {
    private WizGeoMappingResolver() {}
 
-   static Set<String> stillUnmatched(Set<String> unmatched, Map<String,String> applied, Set<String> dropped) {
+   static Set<String> stillUnmatched(Set<String> unmatched, Map<String, String> applied, Set<String> dropped) {
       Set<String> remaining = new LinkedHashSet<>(unmatched);
       remaining.removeAll(applied.keySet());
       remaining.removeAll(dropped == null ? Set.of() : dropped);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
@@ -169,6 +169,7 @@ public class WizGeoService {
       GeoDetectResponse response = new GeoDetectResponse();
       response.setGeoType(geoType);
       response.setLayer(layer);
+      response.setLayerName(MapData.getLayerName(layer));
       response.setMatchedCount(Math.max(0, distinct - unmatched.size()));
       response.setUnmatched(new ArrayList<>(unmatched));
       response.setCandidateFeatures(candidateFeatures(layer));
@@ -252,7 +253,7 @@ public class WizGeoService {
          WizGeoMappingResolver.stillUnmatched(originalUnmatched, applied, dropped);
 
       GeoApplyResponse response = new GeoApplyResponse();
-      response.setStatus(stillUnmatched.isEmpty() ? "complete" : "partial");
+      response.setStatus(stillUnmatched.isEmpty() ? GeoApplyResponse.STATUS_COMPLETE : GeoApplyResponse.STATUS_PARTIAL);
       response.setStillUnmatched(new ArrayList<>(stillUnmatched));
 
       // Persist the resolved feature mappings to the session asset so a saved map keeps them.
@@ -281,7 +282,7 @@ public class WizGeoService {
          }
       }
       catch(Exception ex) {
-         LOG.warn("Failed to persist geo viewsheet to {}: {}", viewsheetIdentifier, ex.getMessage());
+         LOG.error("Failed to persist geo viewsheet to {}: {}", viewsheetIdentifier, ex.getMessage());
       }
    }
 
@@ -472,7 +473,7 @@ public class WizGeoService {
       for(int r = 0; r < source.getRowCount(); r++) {
          Object v = source.getData(colIndex, r);
 
-         if(v != null) {
+         if(!Tool.isEmptyString(Tool.toString(v))) {
             distinct.add(Tool.toString(v));
          }
       }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
@@ -1,0 +1,312 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.graph.data.DataSet;
+import inetsoft.graph.geo.solver.NameTable;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.report.composition.graph.GraphUtil;
+import inetsoft.report.internal.graph.MapData;
+import inetsoft.report.internal.graph.MapHelper;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.graph.FeatureMapping;
+import inetsoft.uql.viewsheet.graph.GeographicOption;
+import inetsoft.uql.viewsheet.graph.VSChartGeoRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.util.Tool;
+import inetsoft.web.binding.handler.VSChartHandler;
+import inetsoft.web.wiz.model.GeoApplyRequest;
+import inetsoft.web.wiz.model.GeoApplyResponse;
+import inetsoft.web.wiz.model.GeoDetectRequest;
+import inetsoft.web.wiz.model.GeoDetectResponse;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * Deterministic geo-binding service for the wiz AI plugin.
+ *
+ * <p>{@link #detect} marks a chart dimension geographic, runs StyleBI's built-in
+ * auto-detection of map type + layer + feature matching, and reports which values
+ * failed to match plus the candidate features for the detected layer.
+ *
+ * <p>{@link #apply} records manual value-to-geoCode mappings supplied by the caller
+ * and reports which originally-unmatched values still remain.
+ *
+ * <p>The sequence mirrors the interactive {@code ChangeGeographicService} /
+ * {@code VSMapHandler} flow but is headless (no command dispatcher / UI commands).
+ */
+@Service
+public class WizGeoService {
+   public WizGeoService(ViewsheetService viewsheetService, VSChartHandler chartHandler) {
+      this.viewsheetService = viewsheetService;
+      this.chartHandler = chartHandler;
+   }
+
+   /**
+    * Marks {@code column} geographic on the chart and auto-detects its geo type/layer + matching.
+    */
+   public GeoDetectResponse detect(GeoDetectRequest request, Principal user) throws Exception {
+      RuntimeViewsheet rvs = getRuntimeViewsheet(request.getRuntimeId(), user);
+      Viewsheet vs = rvs.getViewsheet();
+      ChartVSAssembly chart = getChart(vs, request.getAssemblyName());
+      ViewsheetSandbox box = getSandbox(rvs);
+
+      ChartVSAssemblyInfo ainfo = (ChartVSAssemblyInfo) chart.getVSAssemblyInfo();
+      VSChartInfo cinfo = ainfo.getVSChartInfo();
+      SourceInfo sourceInfo = ainfo.getSourceInfo();
+      String refName = request.getColumn();
+
+      if(Tool.isEmptyString(refName)) {
+         throw new IllegalArgumentException("column is required");
+      }
+
+      // 1. Mark the dimension geographic (adds a VSChartGeoRef to the design geo columns).
+      chartHandler.changeGeographic(cinfo, refName, VSChartHandler.SET_GEOGRAPHIC, true);
+      // fixMapInfo is part of the confirmed sequence; for "set" it is a no-op that returns false
+      // (it only strips x/y/geo fields on "clear"). Kept for parity with the interactive flow.
+      chartHandler.fixMapInfo(cinfo, refName, VSChartHandler.SET_GEOGRAPHIC);
+
+      // 2. Build runtime geo columns and execute the chart to obtain the data set.
+      chartHandler.updateAllGeoColumns(box, vs, chart);
+      DataSet source = chartHandler.getChartData(box, chart);
+
+      if(source == null) {
+         throw new IllegalStateException("Failed to execute chart data for geo detection");
+      }
+
+      // 3. Auto-detect type/layer and seed the (lazy, empty) feature mapping on the geo ref.
+      chartHandler.autoDetect(vs, sourceInfo, cinfo, refName, source);
+
+      VSChartGeoRef geoRef = getGeoRef(cinfo, refName);
+
+      if(geoRef == null) {
+         throw new IllegalStateException("Geographic column '" + refName + "' not found after detection");
+      }
+
+      GeographicOption option = geoRef.getGeographicOption();
+      FeatureMapping mapping = option.getMapping();
+      int layer = option.getLayer();
+      String geoType = mapping != null ? mapping.getType() : cinfo.getMeasureMapType();
+
+      // 4. Compute unmatched values + matched count.
+      int colIndex = GraphUtil.indexOfHeader(source, refName);
+      Set<String> unmatched = new LinkedHashSet<>(
+         MapHelper.getUnMatchedValues(source, colIndex, mapping, cinfo).keySet());
+      int distinct = distinctValueCount(source, colIndex);
+
+      GeoDetectResponse response = new GeoDetectResponse();
+      response.setGeoType(geoType);
+      response.setLayer(layer);
+      response.setMatchedCount(Math.max(0, distinct - unmatched.size()));
+      response.setUnmatched(new ArrayList<>(unmatched));
+      response.setCandidateFeatures(candidateFeatures(layer));
+      return response;
+   }
+
+   /**
+    * Applies manual value-to-geoCode mappings on the geographic column and reports remaining
+    * unmatched values.
+    */
+   public GeoApplyResponse apply(GeoApplyRequest request, Principal user) throws Exception {
+      RuntimeViewsheet rvs = getRuntimeViewsheet(request.getRuntimeId(), user);
+      Viewsheet vs = rvs.getViewsheet();
+      ChartVSAssembly chart = getChart(vs, request.getAssemblyName());
+      ViewsheetSandbox box = getSandbox(rvs);
+
+      ChartVSAssemblyInfo ainfo = (ChartVSAssemblyInfo) chart.getVSAssemblyInfo();
+      VSChartInfo cinfo = ainfo.getVSChartInfo();
+      SourceInfo sourceInfo = ainfo.getSourceInfo();
+      String refName = request.getColumn();
+
+      if(Tool.isEmptyString(refName)) {
+         throw new IllegalArgumentException("column is required");
+      }
+
+      // Refresh runtime geo columns + data so the geo ref and its mapping are available.
+      chartHandler.updateAllGeoColumns(box, vs, chart);
+      DataSet source = chartHandler.getChartData(box, chart);
+
+      VSChartGeoRef geoRef = getGeoRef(cinfo, refName);
+
+      if(geoRef == null) {
+         throw new IllegalArgumentException(
+            "Column '" + refName + "' is not geographic; run geo/detect first");
+      }
+
+      GeographicOption option = geoRef.getGeographicOption();
+      FeatureMapping mapping = option.getMapping();
+
+      if(mapping == null) {
+         throw new IllegalStateException("Geographic column '" + refName + "' has no feature mapping");
+      }
+
+      String type = mapping.getType();
+      int layer = mapping.getLayer();
+
+      // Originally-unmatched values BEFORE applying the manual mappings.
+      Set<String> originalUnmatched = source == null
+         ? new LinkedHashSet<>()
+         : new LinkedHashSet<>(MapHelper.getUnMatchedValues(
+            source, GraphUtil.indexOfHeader(source, refName), mapping, cinfo).keySet());
+
+      // Apply each mapping. The supplied value is a geoCode; if a caller passed a display label,
+      // resolve it to a geoCode via getGeoCodeByLabel.
+      Map<String, String> requested = request.getMappings() != null
+         ? request.getMappings() : Collections.emptyMap();
+      Map<String, String> applied = new LinkedHashMap<>();
+
+      for(Map.Entry<String, String> e : requested.entrySet()) {
+         String value = e.getKey();
+         String code = e.getValue();
+
+         if(value == null || code == null) {
+            continue;
+         }
+
+         String resolved = resolveGeoCode(type, layer, code);
+         mapping.addMapping(value, resolved);
+         applied.put(value, resolved);
+      }
+
+      Set<String> dropped = request.getDrop() != null
+         ? new LinkedHashSet<>(request.getDrop()) : new LinkedHashSet<>();
+
+      Set<String> stillUnmatched =
+         WizGeoMappingResolver.stillUnmatched(originalUnmatched, applied, dropped);
+
+      GeoApplyResponse response = new GeoApplyResponse();
+      response.setStatus(stillUnmatched.isEmpty() ? "complete" : "partial");
+      response.setStillUnmatched(new ArrayList<>(stillUnmatched));
+      return response;
+   }
+
+   // ── helpers ──────────────────────────────────────────────────────────────────
+
+   private RuntimeViewsheet getRuntimeViewsheet(String runtimeId, Principal user) throws Exception {
+      if(Tool.isEmptyString(runtimeId)) {
+         throw new IllegalArgumentException("runtimeId is required");
+      }
+
+      RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, user);
+
+      if(rvs == null || rvs.getViewsheet() == null) {
+         throw new IllegalStateException("Runtime viewsheet not found: " + runtimeId);
+      }
+
+      return rvs;
+   }
+
+   private ChartVSAssembly getChart(Viewsheet vs, String assemblyName) {
+      if(Tool.isEmptyString(assemblyName)) {
+         throw new IllegalArgumentException("assemblyName is required");
+      }
+
+      if(!(vs.getAssembly(assemblyName) instanceof ChartVSAssembly chart)) {
+         throw new IllegalArgumentException("Chart assembly not found: " + assemblyName);
+      }
+
+      return chart;
+   }
+
+   private ViewsheetSandbox getSandbox(RuntimeViewsheet rvs) {
+      Optional<ViewsheetSandbox> box = rvs.getViewsheetSandbox();
+
+      if(box.isEmpty()) {
+         throw new IllegalStateException("ViewsheetSandbox is empty");
+      }
+
+      return box.get();
+   }
+
+   /**
+    * Resolves the geographic ref for {@code refName} from the runtime geo columns. Mirrors the
+    * (package-private) {@code VSChartHandler.getGeoRef} via the public {@code getRTGeoColumns}.
+    */
+   private VSChartGeoRef getGeoRef(VSChartInfo cinfo, String refName) {
+      DataRef ref = cinfo.getRTGeoColumns().getAttribute(refName);
+
+      if(ref instanceof VSChartGeoRef geoRef) {
+         return geoRef;
+      }
+
+      // Fall back to the design geo columns in case the runtime columns are not yet built.
+      ref = cinfo.getGeoColumns().getAttribute(refName);
+      return ref instanceof VSChartGeoRef geoRef ? geoRef : null;
+   }
+
+   /** Treats {@code code} as a geoCode; if it is a display label, resolves it to a geoCode. */
+   private String resolveGeoCode(String type, int layer, String code) {
+      NameTable names = MapData.getNameTable(layer);
+
+      if(names != null && names.getNames().contains(code)) {
+         // Already a valid geoCode.
+         return code;
+      }
+
+      String resolved = MapHelper.getGeoCodeByLabel(type, layer, code);
+      return resolved != null ? resolved : code;
+   }
+
+   /** Distinct number of non-null values in the geo column. */
+   private int distinctValueCount(DataSet source, int colIndex) {
+      if(colIndex < 0) {
+         return 0;
+      }
+
+      Set<String> distinct = new HashSet<>();
+
+      for(int r = 0; r < source.getRowCount(); r++) {
+         Object v = source.getData(colIndex, r);
+
+         if(v != null) {
+            distinct.add(Tool.toString(v));
+         }
+      }
+
+      return distinct.size();
+   }
+
+   /** Candidate feature display labels for the given layer's name table. */
+   private List<String> candidateFeatures(int layer) {
+      NameTable names = MapData.getNameTable(layer);
+
+      if(names == null) {
+         return Collections.emptyList();
+      }
+
+      List<String> labels = new ArrayList<>();
+
+      for(String code : names.getNames()) {
+         String label = names.getLabel(code);
+         labels.add(label != null ? label : code);
+      }
+
+      return labels;
+   }
+
+   private final ViewsheetService viewsheetService;
+   private final VSChartHandler chartHandler;
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
@@ -173,7 +173,7 @@ public class WizGeoService {
       int distinct = distinctValueCount(source, colIndex);
 
       GeoDetectResponse response = new GeoDetectResponse();
-      response.setGeoType(geoType);
+      response.setGeoType(geoType != null ? geoType : "");
       response.setLayer(layer);
       response.setLayerName(MapData.getLayerName(layer));
       response.setMatchedCount(Math.max(0, distinct - unmatched.size()));

--- a/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
@@ -111,6 +111,12 @@ public class WizGeoService {
       }
 
       // 3. Auto-detect type/layer and seed the (lazy, empty) feature mapping on the geo ref.
+      //    Pre-seed the map type when the caller supplied one; autoDetect skips type detection
+      //    if a valid type is already present on the chart info.
+      if(!Tool.isEmptyString(request.getGeoType())) {
+         cinfo.setMeasureMapType(request.getGeoType());
+      }
+
       chartHandler.autoDetect(vs, sourceInfo, cinfo, refName, source);
 
       VSChartGeoRef geoRef = getGeoRef(cinfo, refName);
@@ -220,7 +226,7 @@ public class WizGeoService {
       int layer = mapping.getLayer();
 
       if(source == null) {
-         throw new IllegalStateException("Failed to execute chart data for geo detection");
+         throw new IllegalStateException("Failed to execute chart data for geo apply");
       }
 
       // Originally-unmatched values BEFORE applying the manual mappings.
@@ -302,24 +308,22 @@ public class WizGeoService {
          return;
       }
 
-      // Find the category dimension (the non-geo dimension), wherever the conversion put it: a
-      // mis-assigned geo field, an axis, or a group slot. Strip those non-geo dims off their slots.
+      // Guard before any mutations.
+      DataRef geoColRef = mapInfo.getGeoColumns().getAttribute(geoColumn);
+
+      if(!(geoColRef instanceof ChartRef geoChartRef)) {
+         LOG.warn("Unable to fix geo binding: geo column '{}' not found in geoColumns", geoColumn);
+         return;
+      }
+
+      // Safe to mutate now.
       ChartRef category = firstNonGeoGeoField(mapInfo, geoColumn);
       category = stripNonGeoDims(mapInfo, Slot.X, geoColumn, category);
       category = stripNonGeoDims(mapInfo, Slot.Y, geoColumn, category);
       category = stripNonGeoDims(mapInfo, Slot.GROUP, geoColumn, category);
 
-      // Geo field := the detected column, taken from the option-carrying geo-columns ref.
-      DataRef geoColRef = mapInfo.getGeoColumns().getAttribute(geoColumn);
-
-      if(geoColRef instanceof ChartRef geoChartRef) {
-         mapInfo.removeGeoFields();
-         mapInfo.addGeoField((ChartRef) geoChartRef.clone());
-      }
-      else {
-         LOG.warn("Unable to fix geo binding: invalid geo column reference");
-         return;
-      }
+      mapInfo.removeGeoFields();
+      mapInfo.addGeoField((ChartRef) geoChartRef.clone());
 
       // A polygon map can't use the shape aesthetic; drop it (the region often lands there).
       mapInfo.setShapeField(null);
@@ -459,6 +463,11 @@ public class WizGeoService {
       }
 
       String resolved = MapHelper.getGeoCodeByLabel(type, layer, code);
+
+      if(resolved == null) {
+         LOG.warn("Could not resolve '{}' to a geoCode for type={} layer={}; using as-is", code, type, layer);
+      }
+
       return resolved != null ? resolved : code;
    }
 
@@ -481,7 +490,7 @@ public class WizGeoService {
       return distinct.size();
    }
 
-   /** Candidate feature display labels for the given layer's name table. */
+   /** Candidate feature display labels for the given layer's name table, capped at {@value MAX_CANDIDATES}. */
    private List<String> candidateFeatures(int layer) {
       NameTable names = MapData.getNameTable(layer);
 
@@ -489,15 +498,13 @@ public class WizGeoService {
          return Collections.emptyList();
       }
 
-      List<String> labels = new ArrayList<>();
-
-      for(String code : names.getNames()) {
-         String label = names.getLabel(code);
-         labels.add(label != null ? label : code);
-      }
-
-      return labels;
+      return names.getNames().stream()
+         .limit(MAX_CANDIDATES)
+         .map(code -> { String label = names.getLabel(code); return label != null ? label : code; })
+         .collect(java.util.stream.Collectors.toList());
    }
+
+   private static final int MAX_CANDIDATES = 500;
 
    private final ViewsheetService viewsheetService;
    private final VSChartHandler chartHandler;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
@@ -18,21 +18,32 @@
 package inetsoft.web.wiz.service;
 
 import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.graph.aesthetic.GShape;
+import inetsoft.graph.aesthetic.StaticShapeFrame;
 import inetsoft.graph.data.DataSet;
 import inetsoft.graph.geo.solver.NameTable;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.report.composition.graph.GraphUtil;
+import inetsoft.report.internal.graph.ChangeChartTypeProcessor;
 import inetsoft.report.internal.graph.MapData;
 import inetsoft.report.internal.graph.MapHelper;
+import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.XDimensionRef;
+import inetsoft.uql.viewsheet.graph.ChartRef;
 import inetsoft.uql.viewsheet.graph.FeatureMapping;
+import inetsoft.uql.viewsheet.graph.GeoRef;
 import inetsoft.uql.viewsheet.graph.GeographicOption;
+import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.uql.viewsheet.graph.VSAestheticRef;
+import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
 import inetsoft.uql.viewsheet.graph.VSChartGeoRef;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.uql.viewsheet.graph.VSMapInfo;
 import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
 import inetsoft.util.Tool;
 import inetsoft.web.binding.handler.VSChartHandler;
@@ -40,6 +51,8 @@ import inetsoft.web.wiz.model.GeoApplyRequest;
 import inetsoft.web.wiz.model.GeoApplyResponse;
 import inetsoft.web.wiz.model.GeoDetectRequest;
 import inetsoft.web.wiz.model.GeoDetectResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.security.Principal;
@@ -111,7 +124,43 @@ public class WizGeoService {
       int layer = option.getLayer();
       String geoType = mapping != null ? mapping.getType() : cinfo.getMeasureMapType();
 
-      // 4. Compute unmatched values + matched count.
+      // 4. Convert the chart to a MAP if it is not one already. This mirrors the product's
+      //    "set column geographic -> change chart type to Map" flow: marking the column
+      //    geographic (step 1) populates the geo columns + auto-detected mapping, and
+      //    ChangeChartTypeProcessor builds the VSMapInfo, moving the geo dimension into a
+      //    geo field. The plugin's create path can't offer a map at recommend time (geo
+      //    columns aren't tagged until the chart's data is executed), so the conversion
+      //    happens here, where the data is already available.
+      if(!(cinfo instanceof VSMapInfo)) {
+         int oldType = cinfo.getRTChartType() != 0 ? cinfo.getRTChartType() : cinfo.getChartType();
+         VSChartInfo converted = (VSChartInfo) new ChangeChartTypeProcessor(
+            oldType, GraphTypes.CHART_MAP, null, cinfo).process();
+
+         if(converted instanceof VSMapInfo mapInfo) {
+            // Re-home the bindings deterministically: geo field = the detected column (carrying its
+            // auto-detected GeographicOption), and the remaining categorical dimension on color so
+            // the map renders as a choropleth. ChangeChartTypeProcessor's geo-field heuristic
+            // ("first dim on x") mis-assigns when the geo column wasn't on x (e.g. it was on shape),
+            // so we do not rely on its slot assignment.
+            fixMapBinding(mapInfo, refName);
+
+            if(!Tool.isEmptyString(geoType)) {
+               mapInfo.setMeasureMapType(geoType);
+            }
+
+            // Assign visual frames for the (re-homed) aesthetic fields. ChangeChartTypeProcessor
+            // already ran this once, but BEFORE we moved the category onto color — without it the
+            // color field has a null VisualFrame and graph generation NPEs ("graph.gen.failed").
+            GraphUtil.fixVisualFrames(mapInfo);
+
+            chart.setVSChartInfo(mapInfo);
+            cinfo = mapInfo;
+            // Rebuild the runtime geo columns so the map's RT structures reflect the new info.
+            chartHandler.updateAllGeoColumns(box, vs, chart);
+         }
+      }
+
+      // 5. Compute unmatched values + matched count.
       int colIndex = GraphUtil.indexOfHeader(source, refName);
       Set<String> unmatched = new LinkedHashSet<>(
          MapHelper.getUnMatchedValues(source, colIndex, mapping, cinfo).keySet());
@@ -123,6 +172,10 @@ public class WizGeoService {
       response.setMatchedCount(Math.max(0, distinct - unmatched.size()));
       response.setUnmatched(new ArrayList<>(unmatched));
       response.setCandidateFeatures(candidateFeatures(layer));
+
+      // Persist the converted map back to the session asset so save_viewsheet (which reads from
+      // storage, not the live runtime) captures the map type + geo binding.
+      persistViewsheet(vs, request.getViewsheetIdentifier(), user);
       return response;
    }
 
@@ -200,10 +253,143 @@ public class WizGeoService {
       GeoApplyResponse response = new GeoApplyResponse();
       response.setStatus(stillUnmatched.isEmpty() ? "complete" : "partial");
       response.setStillUnmatched(new ArrayList<>(stillUnmatched));
+
+      // Persist the resolved feature mappings to the session asset so a saved map keeps them.
+      persistViewsheet(vs, request.getViewsheetIdentifier(), user);
       return response;
    }
 
    // ── helpers ──────────────────────────────────────────────────────────────────
+
+   /**
+    * Writes the (mutated) runtime viewsheet back to its session asset so save_viewsheet — which
+    * reads the source viewsheet from the asset repository, not the live runtime — captures the
+    * geo binding / map conversion. No-op when no identifier is supplied. Mirrors the in-place
+    * persistence used by the apply-filter flow.
+    */
+   private void persistViewsheet(Viewsheet vs, String viewsheetIdentifier, Principal user) {
+      if(Tool.isEmptyString(viewsheetIdentifier)) {
+         return;
+      }
+
+      try {
+         AssetEntry entry = AssetEntry.createAssetEntry(viewsheetIdentifier);
+
+         if(entry != null) {
+            viewsheetService.setViewsheet(vs, entry, user, true, true);
+         }
+      }
+      catch(Exception ex) {
+         LOG.warn("Failed to persist geo viewsheet to {}: {}", viewsheetIdentifier, ex.getMessage());
+      }
+   }
+
+   /**
+    * Forces the converted map's binding to the choropleth we want: the detected geographic column is
+    * the sole geo field (carrying its auto-detected {@link GeographicOption}), and the remaining
+    * categorical dimension drives the fill color.
+    *
+    * <p>This does not trust {@code ChangeChartTypeProcessor}'s slot assignment: its geo-field
+    * heuristic moves the "first dimension on x" to the geo field, which mis-binds when the geo
+    * column was on a different slot (e.g. shape) — in the "most-popular category per region" case it
+    * wrongly makes the <em>category</em> the geo field and leaves the region on shape. We re-home
+    * explicitly off the known geo column name.
+    */
+   private void fixMapBinding(VSMapInfo mapInfo, String geoColumn) {
+      if(geoColumn == null) {
+         return;
+      }
+
+      // Find the category dimension (the non-geo dimension), wherever the conversion put it: a
+      // mis-assigned geo field, an axis, or a group slot. Strip those non-geo dims off their slots.
+      ChartRef category = firstNonGeoGeoField(mapInfo, geoColumn);
+      category = stripNonGeoDims(mapInfo, Slot.X, geoColumn, category);
+      category = stripNonGeoDims(mapInfo, Slot.Y, geoColumn, category);
+      category = stripNonGeoDims(mapInfo, Slot.GROUP, geoColumn, category);
+
+      // Geo field := the detected column, taken from the option-carrying geo-columns ref.
+      DataRef geoColRef = mapInfo.getGeoColumns().getAttribute(geoColumn);
+
+      if(geoColRef instanceof ChartRef geoChartRef) {
+         mapInfo.removeGeoFields();
+         mapInfo.addGeoField((ChartRef) geoChartRef.clone());
+      }
+
+      // A polygon map can't use the shape aesthetic; drop it (the region often lands there).
+      mapInfo.setShapeField(null);
+
+      // Category := color, as a plain categorical dimension (the source may have been a geo ref).
+      // Both candidate sources (a mis-assigned geo field or an axis/group dim) are VSChartDimensionRefs.
+      if(category instanceof VSChartDimensionRef catDim && mapInfo.getColorField() == null) {
+         VSChartDimensionRef colorDim = new VSChartDimensionRef(catDim.getDataRef());
+         // Carry the binding value so the color ref is fully formed (matches a native dimension ref);
+         // without it the column resolves only lazily and a saved copy can lose the binding.
+         colorDim.setGroupColumnValue(catDim.getGroupColumnValue());
+         VSAestheticRef color = new VSAestheticRef();
+         color.setDataRef(colorDim);
+         mapInfo.setColorField(color);
+      }
+
+      // Render filled polygons (a choropleth) rather than point markers: with no point-layer geo
+      // field and no size field, set a NIL static shape frame so the regions fill instead of
+      // drawing a shape at each centroid. Mirrors MapChartFilter.createChartInfo.
+      if(!hasPointField(mapInfo) && mapInfo.getSizeField() == null) {
+         mapInfo.setShapeFrame(new StaticShapeFrame(GShape.NIL));
+      }
+   }
+
+   /** True if any geo field is bound at a point (non-polygon) layer. */
+   private boolean hasPointField(VSMapInfo mapInfo) {
+      for(ChartRef f : mapInfo.getGeoFields()) {
+         if(f instanceof GeoRef geo && geo.getGeographicOption() != null &&
+            MapData.isPointLayer(geo.getGeographicOption().getLayer()))
+         {
+            return true;
+         }
+      }
+
+      return false;
+   }
+
+   private enum Slot { X, Y, GROUP }
+
+   /** The first geo FIELD whose name is not the geo column (a dimension the conversion mis-assigned). */
+   private ChartRef firstNonGeoGeoField(VSMapInfo mapInfo, String geoColumn) {
+      for(ChartRef gf : mapInfo.getGeoFields()) {
+         if(gf != null && !geoColumn.equals(gf.getName())) {
+            return gf;
+         }
+      }
+
+      return null;
+   }
+
+   /** Removes non-geo dimensions from the given slot; returns the category (first found, or prior). */
+   private ChartRef stripNonGeoDims(VSMapInfo mapInfo, Slot slot, String geoColumn, ChartRef category) {
+      ChartRef[] fields = switch(slot) {
+         case X -> mapInfo.getXFields();
+         case Y -> mapInfo.getYFields();
+         case GROUP -> mapInfo.getGroupFields();
+      };
+
+      for(int i = fields.length - 1; i >= 0; i--) {
+         ChartRef ref = fields[i];
+
+         if(ref instanceof XDimensionRef && !geoColumn.equals(ref.getName())) {
+            if(category == null) {
+               category = ref;
+            }
+
+            switch(slot) {
+               case X -> mapInfo.removeXField(i);
+               case Y -> mapInfo.removeYField(i);
+               case GROUP -> mapInfo.removeGroupField(i);
+            }
+         }
+      }
+
+      return category;
+   }
 
    private RuntimeViewsheet getRuntimeViewsheet(String runtimeId, Principal user) throws Exception {
       if(Tool.isEmptyString(runtimeId)) {
@@ -309,4 +495,6 @@ public class WizGeoService {
 
    private final ViewsheetService viewsheetService;
    private final VSChartHandler chartHandler;
+
+   private static final Logger LOG = LoggerFactory.getLogger(WizGeoService.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
@@ -191,7 +191,6 @@ public class WizGeoService {
 
       ChartVSAssemblyInfo ainfo = (ChartVSAssemblyInfo) chart.getVSAssemblyInfo();
       VSChartInfo cinfo = ainfo.getVSChartInfo();
-      SourceInfo sourceInfo = ainfo.getSourceInfo();
       String refName = request.getColumn();
 
       if(Tool.isEmptyString(refName)) {
@@ -219,10 +218,12 @@ public class WizGeoService {
       String type = mapping.getType();
       int layer = mapping.getLayer();
 
+      if(source == null) {
+         throw new IllegalStateException("Failed to execute chart data for geo detection");
+      }
+
       // Originally-unmatched values BEFORE applying the manual mappings.
-      Set<String> originalUnmatched = source == null
-         ? new LinkedHashSet<>()
-         : new LinkedHashSet<>(MapHelper.getUnMatchedValues(
+      Set<String> originalUnmatched = new LinkedHashSet<>(MapHelper.getUnMatchedValues(
             source, GraphUtil.indexOfHeader(source, refName), mapping, cinfo).keySet());
 
       // Apply each mapping. The supplied value is a geoCode; if a caller passed a display label,
@@ -313,6 +314,10 @@ public class WizGeoService {
       if(geoColRef instanceof ChartRef geoChartRef) {
          mapInfo.removeGeoFields();
          mapInfo.addGeoField((ChartRef) geoChartRef.clone());
+      }
+      else {
+         LOG.warn("Unable to fix geo binding: invalid geo column reference");
+         return;
       }
 
       // A polygon map can't use the shape aesthetic; drop it (the region often lands there).

--- a/core/src/test/java/inetsoft/web/wiz/service/WizGeoMappingResolverTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizGeoMappingResolverTest.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("core")
+class WizGeoMappingResolverTest {
+   @Test
+   void appliedPlusDroppedClearsAllUnmatched() {
+      Set<String> unmatched = new LinkedHashSet<>(List.of("Runion", "Zzz"));
+      Map<String, String> applied = Map.of("Runion", "FR-RE");
+      Set<String> dropped = Set.of("Zzz");
+
+      Set<String> remaining = WizGeoMappingResolver.stillUnmatched(unmatched, applied, dropped);
+
+      assertTrue(remaining.isEmpty(), "expected no remaining unmatched values, got " + remaining);
+   }
+
+   @Test
+   void unappliedUndroppedValueRemains() {
+      Set<String> unmatched = new LinkedHashSet<>(List.of("Runion", "Foo"));
+      Map<String, String> applied = Map.of("Runion", "FR-RE");
+      Set<String> dropped = Set.of();
+
+      Set<String> remaining = WizGeoMappingResolver.stillUnmatched(unmatched, applied, dropped);
+
+      assertEquals(Set.of("Foo"), remaining);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizGeoMappingResolverTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizGeoMappingResolverTest.java
@@ -48,4 +48,32 @@ class WizGeoMappingResolverTest {
 
       assertEquals(Set.of("Foo"), remaining);
    }
+
+   @Test
+   void nullDroppedDoesNotThrow() {
+      Set<String> unmatched = new LinkedHashSet<>(List.of("Runion"));
+      Map<String, String> applied = Map.of("Runion", "FR-RE");
+
+      Set<String> remaining = WizGeoMappingResolver.stillUnmatched(unmatched, applied, null);
+
+      assertTrue(remaining.isEmpty());
+   }
+
+   @Test
+   void appliedValueNotInUnmatchedHasNoEffect() {
+      Set<String> unmatched = new LinkedHashSet<>(List.of("Foo"));
+      Map<String, String> applied = Map.of("Unknown", "XX-00");
+      Set<String> dropped = Set.of();
+
+      Set<String> remaining = WizGeoMappingResolver.stillUnmatched(unmatched, applied, dropped);
+
+      assertEquals(Set.of("Foo"), remaining);
+   }
+
+   @Test
+   void emptyUnmatchedReturnsEmpty() {
+      Set<String> remaining = WizGeoMappingResolver.stillUnmatched(Set.of(), Map.of(), Set.of());
+
+      assertTrue(remaining.isEmpty());
+   }
 }


### PR DESCRIPTION
Backend for the wiz AI geographic-map feature: build a country choropleth shaded by a category (e.g. most-popular film genre per country), with unmatched names auto-resolved by Claude.

## What's here
**Geo service (`WizGeoService`, DTOs, `WizViewsheetController`, `WizGeoMappingResolver` + test)**
- `geo/detect`: marks a column geographic → updateAllGeoColumns → executes data → autoDetect → reports `{ geoType, layer, matchedCount, unmatched, candidateFeatures }`.
- `geo/apply`: records resolved value→geoCode mappings + drops, reports `stillUnmatched`.

**Real map rendering (this is what made it work end-to-end):**
- Convert the runtime chart to a `VSMapInfo` via `ChangeChartTypeProcessor` (the product's "set geographic → change type to Map" path — the recommender can't offer a map at recommend time since a string geo column isn't tagged yet, so `create_viewsheet(map)` was substituted to point).
- `fixMapBinding()` re-homes bindings deterministically off the detected column: **geo = country** (carrying its auto-detected `GeographicOption`), **color = the category** (fully-formed dimension ref). The processor's "first dim on x" heuristic otherwise mis-binds when the geo column was on shape.
- NIL static shape frame when no point/size field → **filled polygons (choropleth)**, not centroid markers (mirrors `MapChartFilter`).
- `GraphUtil.fixVisualFrames` after re-homing → the color aesthetic gets a `CategoricalColorFrame` (a null frame caused `graph.gen.failed` at render).
- **Persistence:** `save_viewsheet` reads the source viewsheet from the asset repository, not the live runtime, so the map conversion + resolved mappings were lost on save. `geo/detect`+`geo/apply` now persist the converted runtime back to the session asset (`setViewsheet`) via a new `viewsheetIdentifier` on the request DTOs.

## ⚠️ Separate fix included — needs @hunterhu review
Second commit (`fix(wiz): accept saved-viz folder in /viewsheet/open`) reverts the narrowing in `4d383b07f`: that commit restricted `/api/wiz/viewsheet/open` to the ROOT folder, but wiz-services `savedVisualizationService.openSaved` posts COMPONENTS-folder identifiers there (reload + companion viewer), so it rejected **every saved chart** ("not in the managed visualizations folder"), re-introducing the blank-viewer bug #3901 fixed. The fix is **additive** (accept ROOT *or* COMPONENTS) so the conversation-load case still works. Happy to split this into its own PR if preferred.

## Verification
Built (full reactor, `local-rebase46`) and verified end-to-end on sakila: `Mode(genre)`-by-country worksheet → create → `geo/detect` (World, 91/108 auto-matched) → resolve 15 + drop 2 → `geo/apply` complete → save → reopen → **rendered PNG shows a filled choropleth, each country shaded by its top genre**. Java compiles (`mvnw -pl community/core test-compile`); `WizGeoMappingResolverTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)