### PR TITLE
fix(wiz): /viewsheet/open accepts saved-viz (COMPONENTS) folder — restores reopen + companion viewer

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -75,9 +75,14 @@ public class ViewsheetRuntimeController {
       // VISUALIZATION_ROOT_FOLDER_PATH holds the viewsheets used by wiz session messages.
       // VISUALIZATION_COMPONENTS_FOLDER_PATH holds standalone saved visualizations that are
       // visible in the Wiz Portal Visualizations tab and can be combined into a Dashboard.
-      // This endpoint opens session viewsheets, so the guard must check
-      // VISUALIZATION_ROOT_FOLDER_PATH, not VISUALIZATION_COMPONENTS_FOLDER_PATH.
-      if(path == null || !path.startsWith(WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/")) {
+      // Both are reopened through this endpoint: session viewsheets when loading a conversation,
+      // and saved visualizations on reload_saved_visualization / the companion viewer (wiz-services
+      // savedVisualizationService.openSaved posts the COMPONENTS-folder identifier here). Accept
+      // either folder — restricting to ROOT alone rejects every saved chart (blank viewer); see #3901.
+      if(path == null ||
+         !(path.startsWith(WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/") ||
+           path.startsWith(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/")))
+      {
          throw new IllegalArgumentException(
             "Viewsheet is not in the managed visualizations folder: " + path);
       }


### PR DESCRIPTION
## Problem
`4d383b07f` narrowed `/api/wiz/viewsheet/open`'s guard to `VISUALIZATION_ROOT_FOLDER_PATH` only. But wiz-services `savedVisualizationService.openSaved` posts **COMPONENTS-folder** identifiers to this endpoint — that's the path used by `reload_saved_visualization` and the companion viewer. So every saved-visualization reopen now fails with:

```
java.lang.IllegalArgumentException: Viewsheet is not in the managed visualizations folder: visualization-components-…
```

This re-introduces the blank companion-viewer bug that #3901 originally fixed (every reopened saved chart 500s).

## Fix
Accept **either** folder — ROOT (session viewsheets loaded from a conversation) **or** COMPONENTS (reopened saved visualizations). The change is additive, so the conversation-load case @hunterhu intended in `4d383b07f` still works:

```java
if(path == null ||
   !(path.startsWith(VISUALIZATION_ROOT_FOLDER_PATH + "/") ||
     path.startsWith(VISUALIZATION_COMPONENTS_FOLDER_PATH + "/")))
{
   throw new IllegalArgumentException("Viewsheet is not in the managed visualizations folder: " + path);
}
```

## Notes
- @hunterhu — flagging since this touches your `4d383b07f`; please confirm the conversation-load path doesn't actually require rejecting COMPONENTS (it shouldn't — they're disjoint folders).
- Split out of the geo-mapping PR #3983 for independent review. #3983 needs this merged for its saved maps to reopen / render in the viewer.
- Verified: with this fix, `reload_saved_visualization` and the companion viewer reopen saved charts; without it both 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)