### PR TITLE
Bug #75336, restore uniform button width in Schedule Classpath dialog (follow-up to #3922)

### DIFF
--- a/web/projects/em/src/app/settings/schedule/schedule-configuration-view/schedule-classpath-dialog/schedule-classpath-dialog.component.scss
+++ b/web/projects/em/src/app/settings/schedule/schedule-configuration-view/schedule-classpath-dialog/schedule-classpath-dialog.component.scss
@@ -92,7 +92,11 @@
           width: 100%;
           margin-bottom: 2.5em;
 
-          .mat-mdc-button {
+          // These buttons are mat-stroked-button, which Material 21 renders as the
+          // "outlined" appearance (.mat-mdc-outlined-button), not .mat-mdc-button. Target
+          // the shared .mat-mdc-button-base host class so width: 100% applies to every
+          // variant and all buttons render at the same width. (Bug #75336)
+          .mat-mdc-button-base {
             margin-bottom: 1.25em;
             width: 100%;
           }


### PR DESCRIPTION
## Summary

In Enterprise Manager → Settings → Schedule → **Schedule Classpath** dialog, the six right-side action buttons (New, Edit, Delete, Move Down, Move Up, Edit Text) render at different widths after the Angular 20→21 / Material 20→21 upgrade — "Move Down" is widest and the others shrink to their label width. They should all be equal width.

This is a follow-up to #3922, which addressed the pane/group level but did not fix the buttons themselves, so the bug was reopened (Redmine #75336).

## Root Cause

The buttons use **both** `mat-button` and `mat-stroked-button`:

```html
<button mat-button mat-stroked-button (click)="newPath()">_#(New)</button>
```

In Material 21, `MatButton._inferAppearance()` checks `mat-stroked-button` **before** `mat-button`, so these buttons resolve to the **`outlined`** appearance and receive the host classes `mdc-button--outlined mat-mdc-outlined-button` — **not** `.mat-mdc-button` (that class is only applied for the `text` appearance).

PR #3922 scoped the button rule to `.mat-mdc-button`:

```scss
.right-button-group {
  width: 100%;
  .mat-mdc-button { width: 100%; }   // never matches outlined buttons
}
```

Because `.mat-mdc-button` never matches these outlined buttons, `width: 100%` was never applied, so each button sized to its content and the widths stayed unequal.

## Fix

Target the shared `.mat-mdc-button-base` host class, which `MatButtonBase` applies to **every** Material button variant (text, outlined, filled, etc.), instead of the appearance-specific `.mat-mdc-button`. `width: 100%` now applies to all six buttons regardless of appearance, so the pane → group → button full-width chain is complete and the buttons render at equal width.

One-line selector change in `schedule-classpath-dialog.component.scss`; no HTML/TS change. Styles remain component-scoped (Angular ViewEncapsulation, rooted at the `.schedule-classpath-dialog` host class), so only the six buttons in this dialog's `.right-button-group` blocks are affected — the left list pane, the search clear button, and the OK/Cancel actions are untouched.

## Test Plan

- Open EM → Settings → Schedule → Settings → Schedule Classpath → **Edit**.
- Confirm New / Edit / Delete / Move Down / Move Up / Edit Text are all the **same width** (matching the pre-upgrade appearance).
- Verified live against a locally built enterprise server: buttons now render uniformly.
- `ng build em` compiles cleanly; `ng lint em` passes.

Fixes Redmine #75336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)