### PR TITLE
Bug #75381, fix NaN being published to CloudWatch as a scaling metric

### DIFF
--- a/core/src/main/java/inetsoft/web/metrics/ScalingMetric.java
+++ b/core/src/main/java/inetsoft/web/metrics/ScalingMetric.java
@@ -32,6 +32,10 @@ public abstract class ScalingMetric {
    public final void update() {
       double nextValue = calculate();
 
+      if(Double.isNaN(nextValue) || nextValue < 0D) {
+         nextValue = 0D;
+      }
+
       if(movingAverage) {
          buffer[writePos++] = nextValue;
 


### PR DESCRIPTION
ScalingMetric.update() now clamps NaN and negative values from calculate() to 0 before buffering, preventing NaN from propagating through the moving average into getServerUtilization(). Sources include getCpuLoad()/-1.0 "not available" returns and 0/0 division in CacheSwapWaitScalingMetric when the threshold is 0. CloudWatchMetricsPublisher.pushMetrics() additionally guards against non-finite values at the publish boundary to avoid a CloudWatch 400.