### PR TITLE
Bug #75351, align Same-Day date-comparison weeks across years (sequential week-of-year)

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/VSDataSet.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/VSDataSet.java
@@ -818,9 +818,10 @@ public class VSDataSet extends AbstractDataSet implements AttributeDataSet {
       if(obj instanceof DCMergeDatesCell) {
          obj = ((DCMergeDatesCell) obj).getOriginalData();
       }
-      // A WeekOfYear part value can map to a different actual week across years;
-      // use the equivalence cell so the drill condition matches the displayed week
-      // (mirrors the crosstab path, CrossTabFilterUtil.getEquivalenceNewTuple).
+      // A legacy WeekOfYear part value can map to a different actual week across years; use the
+      // equivalence cell so the drill condition matches the displayed week. For Same-Day
+      // sequential-week grouping getEquivalenceCell() returns null (already aligned), leaving
+      // the raw cell. (Bug #75351)
       else if(obj instanceof DCMergeDatePartFilter.MergePartCell) {
          DCMergeDatePartFilter.MergePartCell equivalenceCell =
             ((DCMergeDatePartFilter.MergePartCell) obj).getEquivalenceCell();

--- a/core/src/main/java/inetsoft/report/filter/DCMergeDatePartFilter.java
+++ b/core/src/main/java/inetsoft/report/filter/DCMergeDatePartFilter.java
@@ -23,7 +23,6 @@ import inetsoft.report.lens.AbstractTableLens;
 import inetsoft.uql.asset.DateRangeRef;
 import inetsoft.uql.viewsheet.VSDimensionRef;
 import inetsoft.uql.viewsheet.XDimensionRef;
-import inetsoft.util.CoreTool;
 import inetsoft.util.Tool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -281,44 +280,46 @@ public class DCMergeDatePartFilter extends AbstractTableLens implements TableFil
             return null;
          }
 
-         Calendar cal = CoreTool.calendar.get();
-         cal.setTime((Date) getDateGroupValue());
-
          List<XDimensionRef> mergedRefs = getMergedRefs();
 
          if(mergedRefs == null || mergedRefs.size() == 0) {
             return null;
          }
 
-         int minimalDaysInFirstWeek = cal.getMinimalDaysInFirstWeek();
+         for(int i = 0; i < mergedRefs.size(); i++) {
+            XDimensionRef mergedRef = mergedRefs.get(i);
+            Object value = getValue(i);
 
-         try {
-            for(int i = 0; i < mergedRefs.size(); i++) {
-               XDimensionRef mergedRef = mergedRefs.get(i);
-               Object value = getValue(i);
+            if(mergedRef.getFullName().startsWith("WeekOfYear(") && value instanceof Integer) {
+               int weekMonthOfYear = (Integer) value;
+               // The merged bucket carries one period's week-of-year part value, which can map
+               // to a different actual week in another period's year (e.g. the previous year's
+               // bar shares the current year's bucket). Recompute the part value from this
+               // cell's own date using the same logic as JavaScriptEngine.datePart("wy") for the
+               // non-to-date case -- move to the first day of the week, then month*10 +
+               // weekOfMonth -- so the equivalence cell matches the data/label for the cell's
+               // actual week regardless of the configured first day of week. Deriving from the
+               // stored part value instead (the previous approach) failed when the first day of
+               // week was not Sunday, leaving drill-to-detail one week off. (Bug #75351)
+               Calendar cal = new GregorianCalendar();
+               cal.setFirstDayOfWeek(Tool.getFirstDayOfWeek());
+               cal.setMinimalDaysInFirstWeek(7);
+               cal.setTime((Date) getDateGroupValue());
+               cal.add(Calendar.DATE, -(cal.get(Calendar.DAY_OF_WEEK) - 1));
+               int equivalenceValue =
+                  (cal.get(Calendar.MONTH) + 1) * 10 + cal.get(Calendar.WEEK_OF_MONTH);
 
-               if(mergedRef.getFullName().startsWith("WeekOfYear(") && value instanceof Integer) {
-                  cal.setMinimalDaysInFirstWeek(7);
-                  int weekMonthOfYear = (Integer) value;
-                  cal.set(Calendar.MONTH, weekMonthOfYear / 10 - 1);
-                  cal.set(Calendar.WEEK_OF_MONTH, weekMonthOfYear % 10);
-                  int equivalenceValue = (cal.get(Calendar.MONTH) + 1) * 10 + cal.get(Calendar.WEEK_OF_MONTH);
+               if(weekMonthOfYear != equivalenceValue) {
+                  MergePartCell equivalenceCell = new MergePartCell(this.originalValue);
+                  equivalenceCell.dateGroupValue = dateGroupValue;
+                  equivalenceCell.quarterOfYear = quarterOfYear;
+                  ArrayList<Object> newValues = new ArrayList<>(values);
+                  equivalenceCell.values = newValues;
+                  newValues.set(i, equivalenceValue);
 
-                  if(weekMonthOfYear != equivalenceValue) {
-                     MergePartCell equivalenceCell = new MergePartCell(this.originalValue);
-                     equivalenceCell.dateGroupValue = dateGroupValue;
-                     equivalenceCell.quarterOfYear = quarterOfYear;
-                     ArrayList<Object> newValues = new ArrayList<>(values);
-                     equivalenceCell.values = newValues;
-                     newValues.set(i, equivalenceValue);
-
-                     return equivalenceCell;
-                  }
+                  return equivalenceCell;
                }
             }
-         }
-         finally {
-            cal.setMinimalDaysInFirstWeek(minimalDaysInFirstWeek);
          }
 
          return null;

--- a/core/src/main/java/inetsoft/report/filter/DCMergeDatePartFilter.java
+++ b/core/src/main/java/inetsoft/report/filter/DCMergeDatePartFilter.java
@@ -290,7 +290,13 @@ public class DCMergeDatePartFilter extends AbstractTableLens implements TableFil
             XDimensionRef mergedRef = mergedRefs.get(i);
             Object value = getValue(i);
 
-            if(mergedRef.getFullName().startsWith("WeekOfYear(") && value instanceof Integer) {
+            // Sequential week-of-year ('ww') values already align across periods, so no
+            // equivalence remap is needed (and the month*10 math below would corrupt them).
+            // Only the legacy month*10+weekOfMonth ('wy') encoding needs the remap. (Bug #75351)
+            if(mergedRef.getFullName().startsWith("WeekOfYear(") && value instanceof Integer &&
+               !(mergedRef instanceof VSDimensionRef &&
+                 ((VSDimensionRef) mergedRef).isDcSequentialWeek()))
+            {
                int weekMonthOfYear = (Integer) value;
                // The merged bucket carries one period's week-of-year part value, which can map
                // to a different actual week in another period's year (e.g. the previous year's

--- a/core/src/main/java/inetsoft/uql/viewsheet/VSDimensionRef.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/VSDimensionRef.java
@@ -1883,6 +1883,19 @@ public class VSDimensionRef extends AbstractDataRef implements ContentObject, XD
       this.ignoreDcTemp = ignoreDcTemp;
    }
 
+   /**
+    * Whether this is a date-comparison WeekOfYear part that uses the sequential
+    * week-of-year value (datePart 'ww') rather than the month*10+weekOfMonth encoding,
+    * so the same week aligns across comparison periods. (Bug #75351)
+    */
+   public boolean isDcSequentialWeek() {
+      return dcSequentialWeek;
+   }
+
+   public void setDcSequentialWeek(boolean dcSequentialWeek) {
+      this.dcSequentialWeek = dcSequentialWeek;
+   }
+
    public Integer getForceDcToDateWeekOfMonth() {
       return forceDcToDateWeekOfMonth;
    }
@@ -1892,6 +1905,7 @@ public class VSDimensionRef extends AbstractDataRef implements ContentObject, XD
    }
 
    private boolean ignoreDcTemp;
+   private boolean dcSequentialWeek;
    private static final String PERIOD_PREFIX = "P_";
    private DynamicValue groupValue;
    private DynamicValue rankingOptValue;

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonInfo.java
@@ -352,9 +352,28 @@ public class DateComparisonInfo implements Cloneable, XMLSerializable {
             calcName = "DayOfYear(" + colName + ")";
          }
          else if(partLowLevel == XConstants.WEEK_DATE_GROUP) {
-            expression.append("datePartForceWeekOfMonth('wy', field['");
-            expression.append(colName);
-            expression.append("'], true, " + toDateWeekOfMonth + ")");
+            // Bug #75351: for Same-Day comparison the month*10+weekOfMonth ('wy') encoding
+            // assigns the same relative week a different value across years at month
+            // boundaries, so the previous year's week lands in the wrong x-bucket (or is
+            // dropped) and drill/labels are off by a week. Group by the sequential
+            // week-of-year ('ww') instead, which aligns the Nth week across periods, and mark
+            // the ref so the label decode and drill use the sequential value too. Other
+            // (week-to-date) configs keep the 'wy' encoding and its week-of-month forcing.
+            if(dcInterval != null && dcInterval.getLevel() == SAME_DAY) {
+               expression.append("datePart('ww', field['");
+               expression.append(colName);
+               expression.append("'], true)");
+
+               if(ref instanceof VSDimensionRef) {
+                  ((VSDimensionRef) ref).setDcSequentialWeek(true);
+               }
+            }
+            else {
+               expression.append("datePartForceWeekOfMonth('wy', field['");
+               expression.append(colName);
+               expression.append("'], true, " + toDateWeekOfMonth + ")");
+            }
+
             calcName = "WeekOfYear(" + colName + ")";
          }
       }

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
@@ -1213,11 +1213,24 @@ public class DateComparisonUtil {
                cal.set(Calendar.DAY_OF_WEEK, Tool.getFirstDayOfWeek());
             }
             else if(mergedRef.getFullName().startsWith("WeekOfYear(")) {
-               // WeekOfYear is MMW where MM is month and W is week of month.
-               // @see JavaScriptEngine.datePart().
-               cal.set(Calendar.MONTH, value / 10 - 1);
-               cal.set(Calendar.WEEK_OF_MONTH, value % 10);
-               cal.set(Calendar.DAY_OF_WEEK, Tool.getFirstDayOfWeek());
+               if(mergedRef instanceof VSDimensionRef &&
+                  ((VSDimensionRef) mergedRef).isDcSequentialWeek())
+               {
+                  // Bug #75351: Same-Day comparison groups by the sequential week-of-year
+                  // (datePart 'ww') so weeks align across periods; decode via WEEK_OF_YEAR.
+                  cal.set(Calendar.WEEK_OF_YEAR, value);
+
+                  if(last) {
+                     cal.set(Calendar.DAY_OF_WEEK, Tool.getFirstDayOfWeek());
+                  }
+               }
+               else {
+                  // WeekOfYear is MMW where MM is month and W is week of month.
+                  // @see JavaScriptEngine.datePart().
+                  cal.set(Calendar.MONTH, value / 10 - 1);
+                  cal.set(Calendar.WEEK_OF_MONTH, value % 10);
+                  cal.set(Calendar.DAY_OF_WEEK, Tool.getFirstDayOfWeek());
+               }
             }
          }
          else {

--- a/core/src/test/java/inetsoft/report/filter/DCMergeDatePartFilterTest.java
+++ b/core/src/test/java/inetsoft/report/filter/DCMergeDatePartFilterTest.java
@@ -220,6 +220,60 @@ public class DCMergeDatePartFilterTest {
       }
    }
 
+   // Bug #75351: Same-Day comparison groups by the sequential week-of-year ('ww'), which already
+   // aligns across periods, so getEquivalenceCell() must NOT remap it (the month*10 math would
+   // corrupt a sequential value). A ref flagged dcSequentialWeek must skip the equivalence remap
+   // even in the same non-Sunday boundary scenario where the legacy 'wy' encoding diverges.
+   @Test
+   public void testSequentialWeekSkipsEquivalence() {
+      Locale oldLocale = ThreadContext.getLocale();
+
+      try {
+         ThreadContext.setLocale(Locale.UK);
+         Assertions.assertEquals(Calendar.MONDAY, Tool.getFirstDayOfWeek(),
+                                 "test requires a non-Sunday first day of week");
+
+         Date cellDate = date("2020-02-06");
+         // A sequential week-of-year value (datePart 'ww'), already aligned across periods.
+         int sequentialWeek = sequentialWeekOfYear(cellDate);
+
+         DataSet dataSet = new DefaultDataSet(new Object[][]{
+            { "WeekOfYear(date)", "date" },
+            { sequentialWeek, cellDate },
+            });
+         DataSetTable base = new DataSetTable(dataSet);
+
+         VSDimensionRef partRef = new VSDimensionRef();
+         partRef.setDataRef(new AttributeRef("WeekOfYear(date)"));
+         partRef.setDcSequentialWeek(true);
+         VSDimensionRef dateGroupRef = new VSDimensionRef();
+         dateGroupRef.setDataRef(new AttributeRef("date"));
+
+         DCMergeDatePartFilter filter =
+            new DCMergeDatePartFilter(base, new ArrayList<>(), partRef, dateGroupRef, null);
+
+         Object cell = filter.getObject(base.getHeaderRowCount(), 0);
+         Assertions.assertInstanceOf(DCMergeDatePartFilter.MergePartCell.class, cell);
+
+         DCMergeDatePartFilter.MergePartCell mpc = (DCMergeDatePartFilter.MergePartCell) cell;
+         Assertions.assertNull(mpc.getEquivalenceCell(),
+            "sequential-week part must skip the equivalence remap (it is already aligned)");
+      }
+      finally {
+         ThreadContext.setLocale(oldLocale);
+      }
+   }
+
+   // Mirrors JavaScriptEngine.datePart("ww", date, true): the sequential week-of-year value
+   // (read directly, with no week-start shift).
+   private static int sequentialWeekOfYear(Date dt) {
+      Calendar cal = new GregorianCalendar();
+      cal.setFirstDayOfWeek(Tool.getFirstDayOfWeek());
+      cal.setMinimalDaysInFirstWeek(7);
+      cal.setTime(dt);
+      return cal.get(Calendar.WEEK_OF_YEAR);
+   }
+
    // Mirrors JavaScriptEngine.datePart("wy"): the week part value the data/query use.
    private static int weekOfYearPart(Date dt) {
       Calendar cal = new GregorianCalendar();

--- a/core/src/test/java/inetsoft/report/filter/DCMergeDatePartFilterTest.java
+++ b/core/src/test/java/inetsoft/report/filter/DCMergeDatePartFilterTest.java
@@ -29,6 +29,8 @@ import inetsoft.uql.viewsheet.VSDataRef;
 import inetsoft.uql.viewsheet.VSDimensionRef;
 import inetsoft.uql.viewsheet.XDimensionRef;
 import inetsoft.uql.viewsheet.graph.VSFieldValue;
+import inetsoft.util.ThreadContext;
+import inetsoft.util.Tool;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,8 +40,12 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.Locale;
 
 import static inetsoft.test.XTableUtil.date;
 
@@ -151,5 +157,76 @@ public class DCMergeDatePartFilterTest {
       Assertions.assertNotNull(actual, "field value for the WeekOfYear column should be present");
       Assertions.assertEquals(expected, actual,
                               "drill field value should use the equivalence week, not the displayed part value");
+   }
+
+   // Bug #75351: a merged WeekOfYear bucket carries one period's part value, which can map
+   // to a different actual week in another period's year. getEquivalenceCell() must recompute
+   // the part value from the cell's own date (matching JavaScriptEngine.datePart("wy")), not
+   // from the stored part value. Deriving it from the stored value (the previous approach)
+   // failed when the first day of week was not Sunday, leaving drill-to-detail one week off.
+   @Test
+   public void testWeekOfYearEquivalenceUsesCellDateNonSundayWeekStart() {
+      Locale oldLocale = ThreadContext.getLocale();
+
+      try {
+         // Locale.UK uses Monday as the first day of week (no week.start property set), which
+         // is the configuration under which the previous fix failed.
+         ThreadContext.setLocale(Locale.UK);
+         Assertions.assertEquals(Calendar.MONDAY, Tool.getFirstDayOfWeek(),
+                                 "test requires a non-Sunday first day of week");
+
+         Date cellDate = date("2020-02-06");
+         // The bucket carries the comparison (other-year) period's week part value; here the
+         // 2021 bar's week is shared with the 2020 bar at the same axis position.
+         int storedPartValue = weekOfYearPart(date("2021-02-04"));
+         int actualWeekPart = weekOfYearPart(cellDate);
+
+         Assertions.assertNotEquals(actualWeekPart, storedPartValue,
+            "scenario requires the stored week part to differ from the cell's actual week");
+
+         DataSet dataSet = new DefaultDataSet(new Object[][]{
+            { "WeekOfYear(date)", "date" },
+            { storedPartValue, cellDate },
+            });
+         DataSetTable base = new DataSetTable(dataSet);
+
+         VSDimensionRef partRef = new VSDimensionRef();
+         partRef.setDataRef(new AttributeRef("WeekOfYear(date)"));
+         VSDimensionRef dateGroupRef = new VSDimensionRef();
+         dateGroupRef.setDataRef(new AttributeRef("date"));
+
+         DCMergeDatePartFilter filter =
+            new DCMergeDatePartFilter(base, new ArrayList<>(), partRef, dateGroupRef, null);
+
+         Object cell = filter.getObject(base.getHeaderRowCount(), 0);
+         Assertions.assertInstanceOf(DCMergeDatePartFilter.MergePartCell.class, cell);
+
+         DCMergeDatePartFilter.MergePartCell mpc = (DCMergeDatePartFilter.MergePartCell) cell;
+         Assertions.assertEquals(storedPartValue, ((Number) mpc.getValue(0)).intValue(),
+                                 "cell should carry the stored (other-period) week part value");
+
+         // The previous approach derived the equivalence value from the stored part value and,
+         // for a non-Sunday week start, produced the stored value again -- so getEquivalenceCell
+         // returned null and the drill stayed one week off. The fix derives it from the cell's
+         // actual date, so a corrected cell is now returned with the cell's real week.
+         DCMergeDatePartFilter.MergePartCell equivalenceCell = mpc.getEquivalenceCell();
+         Assertions.assertNotNull(equivalenceCell,
+            "equivalence cell expected when the stored week differs from the cell's actual week");
+         Assertions.assertEquals(actualWeekPart, ((Number) equivalenceCell.getValue(0)).intValue(),
+            "equivalence week must match the cell's actual date, not the stored part value");
+      }
+      finally {
+         ThreadContext.setLocale(oldLocale);
+      }
+   }
+
+   // Mirrors JavaScriptEngine.datePart("wy"): the week part value the data/query use.
+   private static int weekOfYearPart(Date dt) {
+      Calendar cal = new GregorianCalendar();
+      cal.setFirstDayOfWeek(Tool.getFirstDayOfWeek());
+      cal.setMinimalDaysInFirstWeek(7);
+      cal.setTime(dt);
+      cal.add(Calendar.DATE, -(cal.get(Calendar.DAY_OF_WEEK) - 1));
+      return (cal.get(Calendar.MONTH) + 1) * 10 + cal.get(Calendar.WEEK_OF_MONTH);
    }
 }


### PR DESCRIPTION
## Summary

In a Year / **Same Day** date-comparison chart grouped by week, at month-boundary weeks the previous-year bar was missing (or misplaced) and **Show Details returned the wrong week** (e.g. `2020-02-13` instead of `2020-02-06`), with the axis label also off by a week.

## Root Cause

The WeekOfYear grouping used the `month*10 + weekOfMonth` encoding (`datePartForceWeekOfMonth('wy', …)`). At a month boundary the **same relative week gets a different value across years** — e.g. `2021-02-04` → `15` (its week starts Jan 31) but `2020-02-06` → `21` (its week starts Feb 2). So the two years' bars land in **different x-buckets**: the current-year bucket has no comparison bar (compounded by PR #3818's orphan-cell filter, which drops buckets lacking current-year data), and the label/drill resolve a week off.

No calendar `(month, week)` encoding can align a weekly sequence across years (the sequences drift relative to months differently each year) — only a **sequential week-of-year** does.

This is effectively a regression reshaped by PR #3818 (Bug #75152) layered on a pre-existing weekly-alignment gap. PR #3938's drill fix only addressed the detail condition, not the grouping.

## Fix

Group **Same-Day** week comparisons by the **sequential week-of-year** (`datePart('ww')` → `Calendar.WEEK_OF_YEAR`), so the Nth week aligns across periods. A new runtime flag `VSDimensionRef.dcSequentialWeek` marks the generated ref so:
- `DateComparisonUtil.formatPartMergeCell` decodes the label via `WEEK_OF_YEAR` (not the MMW math), and
- `DCMergeDatePartFilter.getEquivalenceCell` skips the cross-year remap (sequential weeks already align; the `month*10` math would corrupt them).

**Scoped to the `SAME_DAY` interval only** — week-to-date and same-week configs keep the `wy` encoding and its week-of-month forcing (the flag defaults false, so all other DC paths are unchanged). Mirrors the existing `ignoreDcTemp` runtime-flag pattern.

This branch also includes an earlier commit that derives the legacy `wy` equivalence from the cell's own date (drill correctness for the MMW path under non-Sunday week starts).

## Test Plan

- Open `Year_SameDay.vso` → the DC chart. At the `2021-02-04` position the **2020 bar now renders**, the axis label / tooltip read `2021-02-04` / `2020-02-06`, and selecting the 2020 bar → **Show Details** returns the `2020-02-06` rows (`18+19+11`). *Verified live on a built server.*
- New regression test `DCMergeDatePartFilterTest.testSequentialWeekSkipsEquivalence` (a sequential-week ref skips the equivalence remap); existing tests still pass (4/4).
- **Reviewer note:** the change is scoped to SAME_DAY; please sanity-check **week-to-date / same-week / crosstab** DC week charts are unaffected (they use the unchanged `wy` path).

Fixes Redmine #75351.

🤖 Generated with [Claude Code](https://claude.com/claude-code)