### PR TITLE
Bug #75403 - Restore inline-SVG chart rendering dropped in Angular 20->21 migration

### DIFF
--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.html
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.html
@@ -66,8 +66,7 @@
               (onLoaded)="loaded(true, tile)"
               (onError)="loaded(false, tile)">
             </div>
-          }
-          @else {
+          } @else {
             <img [chartImage]="getSrc(tile, container)"
               (onLoading)="loading(tile)"
               (onLoaded)="loaded(true, tile)"
@@ -90,8 +89,7 @@
                 [chartInlineSvg]="panSnapshot"
                 (onLoaded)="panImgLoaded()">
               </div>
-            }
-            @else {
+            } @else {
               <img (onLoaded)="panImgLoaded()"
                 [chartImage]="panSnapshot">
             }

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.html
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.html
@@ -59,10 +59,20 @@
           [style.width.px]="tile.bounds.width"
           [style.height.px]="tile.bounds.height">
           <!-- <div class="loading-hint" *ngIf="!tile.loaded"></div> -->
-          <img [chartImage]="getSrc(tile, container)"
-            (onLoading)="loading(tile)"
-            (onLoaded)="loaded(true, tile)"
-            (onError)="loaded(false, tile)">
+          @if (inlineSvg) {
+            <div class="chart-plot-area__inline-svg"
+              [chartInlineSvg]="getSrc(tile, container)"
+              (onLoading)="loading(tile)"
+              (onLoaded)="loaded(true, tile)"
+              (onError)="loaded(false, tile)">
+            </div>
+          }
+          @else {
+            <img [chartImage]="getSrc(tile, container)"
+              (onLoading)="loading(tile)"
+              (onLoaded)="loaded(true, tile)"
+              (onError)="loaded(false, tile)">
+          }
           <!-- use nature size to avoid scaling image
           [style.width.px]="tile.bounds.width"
           [style.height.px]="tile.bounds.height"
@@ -75,8 +85,16 @@
             [style.left.px]="tile.bounds.x + panX"
             [style.width.px]="tile.bounds.width"
             [style.height.px]="tile.bounds.height">
-            <img (onLoaded)="panImgLoaded()"
-              [chartImage]="panSnapshot">
+            @if (inlineSvg) {
+              <div class="chart-plot-area__inline-svg"
+                [chartInlineSvg]="panSnapshot"
+                (onLoaded)="panImgLoaded()">
+              </div>
+            }
+            @else {
+              <img (onLoaded)="panImgLoaded()"
+                [chartImage]="panSnapshot">
+            }
             <!-- use nature size to avoid scaling image
             [style.width.px]="tile.bounds.width"
             [style.height.px]="tile.bounds.height"

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.spec.ts
@@ -33,7 +33,9 @@ import { ChartObject } from "../model/chart-object";
 import { Plot } from "../model/plot";
 import { ChartTool } from "../model/chart-tool";
 import { ChartService } from "../services/chart.service";
+import { ChartConfigService } from "../services/chart-config.service";
 import { ChartPlotArea } from "./chart-plot-area.component";
+import { ChartInlineSvgDirective } from "./chart-inline-svg.directive";
 
 @Component({
    selector: "test-app",
@@ -471,6 +473,21 @@ describe("ChartPlotArea Integration Tests", () => {
       // Cursor at 200 is the wide polygon's center but should snap to the point.
       const primary = (component as any).findPrimarySnapRegion([narrowIdx, wideIdx], 200, 25);
       expect(primary.region.index).toBe(narrowIdx);
+   });
+
+   it("attaches the inline-svg directive when inlineSvg is enabled", () => {
+      TestBed.inject(ChartConfigService).inlineSvg = true;
+      const fixture = TestBed.createComponent(TestApp);
+      const debugEl = fixture.debugElement.query(By.css("chart-plot-area"));
+      const component: ChartPlotArea = debugEl.componentInstance;
+      vi.spyOn(component, "getSrc").mockImplementation(() => "");
+      fixture.detectChanges();
+
+      // Directive must be registered in the component imports, else [chartInlineSvg]
+      // binds to nothing and the plot never inlines (hover dimming breaks).
+      expect(fixture.debugElement.query(By.directive(ChartInlineSvgDirective))).toBeTruthy();
+      expect(fixture.debugElement.query(By.css(".chart-plot-area__tile img"))).toBeNull();
+      expect(component.inlineSvgTiles.length).toBeGreaterThan(0);
    });
 
    it.skip("should be able to select regions", () => {

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
@@ -68,7 +68,7 @@ import { OutOfZoneDirective } from "../../widget/directive/out-of-zone.directive
             useExisting: ChartPlotArea
         }],
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [SelectionBoxDirective, OutOfZoneDirective, ChartImageDirective]
+    imports: [SelectionBoxDirective, OutOfZoneDirective, ChartImageDirective, ChartInlineSvgDirective]
 })
 export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChanges {
    @Input() dataTip: string;


### PR DESCRIPTION
## Summary

With `graph.svg.inline=true`, charts rendered as an opaque `<img>` rather than
inline SVG, so chart hover dimming did not work. The entrance "animations" that
appeared to work were just the image fade-in (CSS inside the SVG runs even when
it's loaded in an `<img>`), not the real SVG bar-grow — which masked the
regression.

## Root cause

The Angular 20->21 migration (b667af680) regressed two parts of the inline-SVG
feature originally added in 825ddc3ac:

- `chart-plot-area.component.html` was rewritten to the new `@if`/`@for` control
flow and lost the `inlineSvg` branch, leaving only `<img [chartImage]>`.
- `ChartInlineSvgDirective` was dropped from the standalone component's
`imports`, so even with the template binding restored, `[chartInlineSvg]`
silently bound to nothing — the `<div>` rendered but the directive never attached
and never inlined the SVG.

Inline SVG is required for hover dimming: the directive toggles `inetsoft-active`
on the hovered element and the server-injected `:has()` CSS dims the others.
Inside an `<img>`, the SVG is an opaque replaced element, so external JS and CSS
cannot reach it.

## Changes

- `chart-plot-area.component.html`: when `inlineSvg` is enabled, render `<div
[chartInlineSvg]="getSrc(...)">` instead of `<img [chartImage]="getSrc(...)">`
for both the plot tile and the pan double-buffer.
- `chart-plot-area.component.ts`: register `ChartInlineSvgDirective` in the
component `imports`.
- `chart-plot-area.component.spec.ts`: regression test asserting the directive
attaches when `inlineSvg` is on.