### PR TITLE
Bug #75368, fix VSTable @for track (NG0955 / change-detection freeze)

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/abstract-vsobject.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/abstract-vsobject.component.ts
@@ -190,12 +190,6 @@ export abstract class AbstractVSObject<T extends VSObjectModel> extends CommandP
       return index;
    }
 
-   // For use in ngFor to prevent excessive DOM manipulation due to component creation/destruction.
-   // The child views will still be checked for changes.
-   public trackByConstant(index, item) {
-      return 0;
-   }
-
    /**
     * Add an assembly level annotation to this component
     */

--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.html
@@ -138,11 +138,11 @@
           [style.z-index]="1">
           <table>
             <tbody>
-              @for (_header of tableHeaders; track trackByConstant(i, _header); let i = $index) {
+              @for (_header of tableHeaders; track $index; let i = $index) {
                 <tr
                   [class.hidden-row]="getRowHeight(i) <= 0"
                   [style.height.px]="getHeaderRowHeight(i)">
-                  @for (_cell of _header; track trackByConstant(j, _cell); let j = $index) {
+                  @for (_cell of _header; track $index; let j = $index) {
                     <td vs-table-cell
                       class="table-cell"
                       [cell]="_cell"
@@ -221,11 +221,11 @@
             [class.table-focus-row]="rowHoverable()"
             [class.cursor-pointer]="rowHoverable() && viewer">
             <tbody>
-              @for (_row of tableData; track trackByConstant(i, _row); let i = $index; let firstRow = $first) {
+              @for (_row of tableData; track $index; let i = $index; let firstRow = $first) {
                 <tr
                   [class.hidden-row]="getRowHeight(indexToRow(i)) <= 0"
                   [style.height.px]="getRowHeight(indexToRow(i))">
-                  @for (_cell of _row; track trackByConstant(j, _cell); let j = $index) {
+                  @for (_cell of _row; track $index; let j = $index) {
                     <td vs-table-cell
                       class="table-cell"
                       valign="top"

--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.ts
@@ -1228,9 +1228,9 @@ export class VSTable extends BaseTable<VSTableModel> implements OnInit, OnDestro
 
    /** @inheritDoc */
    protected positionDataAnnotations(): boolean {
-      // Since *ngFor was changed to use trackByConstant, this component's cells QueryList no longer
-      // updates on scroll events or loadTableData commands. Added a setTimeout to wait an extra tick
-      // for the cell values to update to correctly display annotations.
+      // The @for blocks reuse cell DOM by position (track $index), so this component's cells
+      // QueryList does not always update synchronously on scroll events or loadTableData commands.
+      // Wait an extra tick for the cell values to update to correctly display annotations.
       this.zone.run(() => {
          setTimeout(() => {
             const lt = this.positionAnnotationsToCell(this.model.leftTopAnnotations,


### PR DESCRIPTION
## Summary

On a viewsheet page containing a data table (VSTable), changing a dropdown could freeze the page (0 fps, ~100ms change detection; `_VSTable` the slowest component at ~40ms). The browser console showed **NG0955: duplicated keys for a given collection** (track keys all `"0"`).

## Root Cause

The VSTable header/row/cell `@for` loops tracked items with `AbstractVSObject.trackByConstant`, which returns `0` for **every** item. A constant `trackBy` was a valid `*ngFor` "reuse DOM by position, don't recreate" optimization before the Angular 20→21 upgrade, but Angular 21's `@for` requires the track expression to **uniquely identify** items. A constant produces duplicate keys → **NG0955** → Angular cannot reconcile the collection and destroys/recreates the row/cell DOM on every change-detection pass. That makes each VSTable check ~40ms, so when a dropdown change schedules a `setTimeout` refresh the page freezes.

## Fix

Track the four VSTable `@for` loops by `$index` instead of `trackByConstant`. This yields unique keys (eliminating NG0955) while **preserving reuse-by-position**, which is the correct semantics for the server-side virtual-scroll table — the visible window's row/cell DOM is reused and bindings updated as the user scrolls (object-identity tracking would instead recreate every node on each scroll, which is worse).

Also removed the now-unused `trackByConstant` helper from `AbstractVSObject` (no remaining references; `trackByIdx` is retained) and updated the stale comment in `positionDataAnnotations`. The annotation `setTimeout` is unchanged.

## Test Plan

- Open a page with a data table (e.g. **Examples/Return Analysis**), change the "Dropdown Selection to Filter" dropdown repeatedly → page stays smooth, **no freeze**, and **no `NG0955`** in the console.
- Verified: `ng build portal` compiles cleanly, `ng lint portal` passes, and `vs-table.spec.ts` passes (8/8).

Fixes Redmine #75368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)