### PR TITLE
Bug #75401: Use Web Worker timer for STOMP heartbeat and viewsheet server update

### DIFF
--- a/web/projects/portal/src/app/common/services/heartbeat-worker.service.spec.ts
+++ b/web/projects/portal/src/app/common/services/heartbeat-worker.service.spec.ts
@@ -1,0 +1,88 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { TestBed } from "@angular/core/testing";
+import { HeartbeatWorkerService } from "./heartbeat-worker.service";
+
+describe("HeartbeatWorkerService", () => {
+   let service: HeartbeatWorkerService;
+   let messageHandlers: ((e: MessageEvent) => void)[];
+   let postedMessages: any[];
+
+   afterEach(() => {
+      vi.useRealTimers();
+   });
+
+   beforeEach(() => {
+      postedMessages = [];
+      messageHandlers = [];
+      TestBed.configureTestingModule({});
+      service = TestBed.inject(HeartbeatWorkerService);
+      // Inject MockWorker directly — bypasses URL resolution which fails in Vitest/Node
+      const mockWorker = new (class MockWorker {
+         postMessage(data: any): void { postedMessages.push(data); }
+         addEventListener(_type: string, handler: (e: MessageEvent) => void): void { messageHandlers.push(handler); }
+         removeEventListener(_type: string, handler: (e: MessageEvent) => void): void { messageHandlers = messageHandlers.filter(h => h !== handler); }
+         terminate(): void {}
+      })();
+      service["worker"] = mockWorker as any;
+   });
+
+   it("should post start message when subscribed", () => {
+      const sub = service.createHeartbeat("test", 1000).subscribe();
+      expect(postedMessages).toContainEqual({ type: "start", id: "test", intervalMs: 1000 });
+      sub.unsubscribe();
+   });
+
+   it("should post stop message when unsubscribed", () => {
+      const sub = service.createHeartbeat("test", 1000).subscribe();
+      sub.unsubscribe();
+      expect(postedMessages).toContainEqual({ type: "stop", id: "test" });
+   });
+
+   it("should emit when worker posts a matching tick", () => {
+      const ticks: void[] = [];
+      const sub = service.createHeartbeat("test", 1000).subscribe(() => ticks.push(undefined as void));
+      messageHandlers[0](new MessageEvent("message", { data: { type: "tick", id: "test" } }));
+      expect(ticks.length).toBe(1);
+      sub.unsubscribe();
+   });
+
+   it("should not emit for a tick with a different id", () => {
+      const ticks: void[] = [];
+      const sub = service.createHeartbeat("test", 1000).subscribe(() => ticks.push(undefined as void));
+      messageHandlers[0](new MessageEvent("message", { data: { type: "tick", id: "other" } }));
+      expect(ticks.length).toBe(0);
+      sub.unsubscribe();
+   });
+
+   it("should fall back to setInterval when Worker is unavailable", () => {
+      // Use a fresh service instance with no worker injected so the fallback path is exercised
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({});
+      const fallbackService = TestBed.inject(HeartbeatWorkerService);
+      vi.useFakeTimers();
+      const ticks: void[] = [];
+      const sub = fallbackService.createHeartbeat("test", 1000).subscribe(() => ticks.push(undefined as void));
+      vi.advanceTimersByTime(1000);
+      expect(ticks.length).toBe(1);
+      vi.advanceTimersByTime(1000);
+      expect(ticks.length).toBe(2);
+      sub.unsubscribe();
+   });
+});

--- a/web/projects/portal/src/app/common/services/heartbeat-worker.service.spec.ts
+++ b/web/projects/portal/src/app/common/services/heartbeat-worker.service.spec.ts
@@ -72,7 +72,9 @@ describe("HeartbeatWorkerService", () => {
    });
 
    it("should fall back to setInterval when Worker is unavailable", () => {
-      // Use a fresh service instance with no worker injected so the fallback path is exercised
+      // Use a fresh service instance with no worker injected so the fallback path is exercised.
+      // In Node/Vitest, typeof Worker === "undefined", so getWorker() returns null
+      // and createHeartbeat falls through to the setInterval path.
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({});
       const fallbackService = TestBed.inject(HeartbeatWorkerService);

--- a/web/projects/portal/src/app/common/services/heartbeat-worker.service.ts
+++ b/web/projects/portal/src/app/common/services/heartbeat-worker.service.ts
@@ -57,7 +57,7 @@ export class HeartbeatWorkerService implements OnDestroy {
 
          return () => {
             worker.removeEventListener("message", onMessage);
-            worker.postMessage({ type: "stop", id });
+            try { worker.postMessage({ type: "stop", id }); } catch { /* worker already terminated */ }
          };
       });
    }

--- a/web/projects/portal/src/app/common/services/heartbeat-worker.service.ts
+++ b/web/projects/portal/src/app/common/services/heartbeat-worker.service.ts
@@ -1,0 +1,93 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Injectable, OnDestroy } from "@angular/core";
+import { Observable } from "rxjs";
+
+@Injectable({
+   providedIn: "root"
+})
+export class HeartbeatWorkerService implements OnDestroy {
+   private worker: Worker | null = null;
+
+   /**
+    * Returns an Observable that emits once per `intervalMs` milliseconds using a Web Worker
+    * timer, which continues firing even when the browser tab is backgrounded.
+    *
+    * When a Web Worker is in use, `id` must be unique per concurrent heartbeat within this
+    * service instance — it is used to route tick messages back to the correct subscriber.
+    * On the `setInterval` fallback path (when Workers are unavailable), each subscription
+    * gets its own independent interval and `id` is not used for routing.
+    * On unsubscribe the worker interval (or fallback timer) is stopped automatically.
+    */
+   createHeartbeat(id: string, intervalMs: number): Observable<void> {
+      const worker = this.getWorker();
+
+      if(!worker) {
+         return new Observable<void>(subscriber => {
+            const intervalId = setInterval(() => subscriber.next(), intervalMs);
+            return () => clearInterval(intervalId);
+         });
+      }
+
+      return new Observable<void>(subscriber => {
+         const onMessage = (event: MessageEvent) => {
+            if(event.data?.type === "tick" && event.data?.id === id) {
+               subscriber.next();
+            }
+         };
+
+         worker.addEventListener("message", onMessage);
+         worker.postMessage({ type: "start", id, intervalMs });
+
+         return () => {
+            worker.removeEventListener("message", onMessage);
+            worker.postMessage({ type: "stop", id });
+         };
+      });
+   }
+
+   ngOnDestroy(): void {
+      if(this.worker) {
+         this.worker.terminate();
+         this.worker = null;
+      }
+   }
+
+   private getWorker(): Worker | null {
+      if(this.worker) {
+         return this.worker;
+      }
+
+      if(typeof Worker === "undefined") {
+         return null;
+      }
+
+      try {
+         this.worker = new Worker(new URL("../workers/heartbeat.worker", import.meta.url));
+         this.worker.addEventListener("error", () => {
+            this.worker?.terminate();
+            this.worker = null;
+         });
+         return this.worker;
+      }
+      catch {
+         return null;
+      }
+   }
+}

--- a/web/projects/portal/src/app/common/workers/heartbeat.worker.ts
+++ b/web/projects/portal/src/app/common/workers/heartbeat.worker.ts
@@ -1,0 +1,46 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const intervals = new Map<string, ReturnType<typeof setInterval>>();
+
+addEventListener("message", (event: MessageEvent) => {
+   const { type, id, intervalMs } = event.data;
+
+   if(!id || !type) return;
+
+   if(type === "start") {
+      if(!intervalMs || intervalMs <= 0) return;
+
+      if(intervals.has(id)) {
+         clearInterval(intervals.get(id)!);
+      }
+
+      intervals.set(id, setInterval(() => {
+         postMessage({ type: "tick", id });
+      }, intervalMs));
+   }
+   else if(type === "stop") {
+      if(intervals.has(id)) {
+         clearInterval(intervals.get(id)!);
+         intervals.delete(id);
+      }
+   }
+   else {
+      console.warn(`[heartbeat.worker] unknown message type: ${type}`);
+   }
+});

--- a/web/projects/portal/src/app/common/workers/heartbeat.worker.ts
+++ b/web/projects/portal/src/app/common/workers/heartbeat.worker.ts
@@ -26,6 +26,8 @@ addEventListener("message", (event: MessageEvent) => {
    if(type === "start") {
       if(!intervalMs || intervalMs <= 0) return;
 
+      // A second start for the same id replaces the existing interval (timer is restarted).
+      // Callers must use unique ids per concurrent heartbeat to avoid unintended resets.
       if(intervals.has(id)) {
          clearInterval(intervals.get(id)!);
       }

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -415,7 +415,7 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
    set runtimeId(value: string) {
       this._runtimeId = value;
 
-      if(!this.embed) {
+      if(!this.embed && this.dialogService) {
          this.dialogService.container = `.viewer-container[runtime-id="${value}"]`;
       }
    }

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -205,6 +205,7 @@ import { ViewerResizeService } from "./util/viewer-resize.service";
 import { VSUtil } from "./util/vs-util";
 import { VsToolbarButtonDirective } from "./vs-toolbar-button.directive";
 import { BaseHrefService } from "../common/services/base-href.service";
+import { HeartbeatWorkerService } from "../common/services/heartbeat-worker.service";
 import { CurrentUserService } from "../../../../shared/util/current-user.service";
 import { RemoveBookmarksDialog } from "./dialog/remove-bookmarks-dialog.component";
 import { ShareLinkDialog } from "../widget/share/share-link-dialog.component";
@@ -479,7 +480,7 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
    appSize: Dimension = new Dimension(0, 0);
    contextMenu: ActionsContextmenuComponent;
    private initing: boolean = true;
-   private serverUpdateIntervalId: any;
+   private serverUpdateSubscription: Subscription | null = null;
    private _active: boolean = true;
    private _vsConnectionInitialized: boolean = false;
    private _destroyed: boolean = false;
@@ -575,7 +576,8 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
                private assetLoadingService: AssetLoadingService,
                private viewContainerRef: ViewContainerRef,
                private baseHrefService: BaseHrefService,
-               private currentUserService: CurrentUserService)
+               private currentUserService: CurrentUserService,
+               private heartbeatWorkerService: HeartbeatWorkerService)
    {
       super(viewsheetClient, zone, true);
       tooltipConfig.tooltipClass = "top-tooltip";
@@ -1353,23 +1355,25 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
       this.clearServerUpdateInterval();
 
       if(this.updateEnabled) {
-         // clear old server update interval
-         let interval: number = this.touchInterval ? this.touchInterval * 1000 : 60000;
-         this.serverUpdateIntervalId = setInterval(() => {
-            let event = new TouchAssetEvent();
-            event.setDesign(false);
-            event.setChanged(false);
-            event.setUpdate(true);
-            event.setWidth(this.viewerRoot.nativeElement.offsetWidth);
-            event.setHeight(this.viewerRoot.nativeElement.offsetHeight);
-            this.viewsheetClient.sendEvent(TOUCH_ASSET_URI, event);
-         }, interval);
+         const interval: number = this.touchInterval ? this.touchInterval * 1000 : 60000;
+         this.serverUpdateSubscription = this.heartbeatWorkerService
+            .createHeartbeat("viewsheet-update", interval)
+            .subscribe(() => {
+               const event = new TouchAssetEvent();
+               event.setDesign(false);
+               event.setChanged(false);
+               event.setUpdate(true);
+               event.setWidth(this.viewerRoot.nativeElement.offsetWidth);
+               event.setHeight(this.viewerRoot.nativeElement.offsetHeight);
+               this.viewsheetClient.sendEvent(TOUCH_ASSET_URI, event);
+            });
       }
    }
 
    clearServerUpdateInterval(): void {
-      if(this.serverUpdateIntervalId != null && !isNaN(this.serverUpdateIntervalId)) {
-         clearInterval(this.serverUpdateIntervalId);
+      if(this.serverUpdateSubscription) {
+         this.serverUpdateSubscription.unsubscribe();
+         this.serverUpdateSubscription = null;
       }
    }
 

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -1357,7 +1357,7 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
       if(this.updateEnabled) {
          const interval: number = this.touchInterval ? this.touchInterval * 1000 : 60000;
          this.serverUpdateSubscription = this.heartbeatWorkerService
-            .createHeartbeat("viewsheet-update", interval)
+            .createHeartbeat(this.runtimeId + "-viewsheet-update", interval)
             .subscribe(() => {
                const event = new TouchAssetEvent();
                event.setDesign(false);

--- a/web/projects/portal/src/app/vsobjects/viewer-app.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.spec.ts
@@ -582,6 +582,7 @@ describe("ViewerApp Unit Tests", () => {
          assetLoadingService, viewContainerRef, baseHrefService,
          currentUserService as any, heartbeatWorkerService);
 
+      viewerApp.runtimeId = "test-runtime-id";
       viewerApp["updateEnabled"] = true;
       viewerApp.setServerUpdateInterval();
       viewerApp.clearServerUpdateInterval();

--- a/web/projects/portal/src/app/vsobjects/viewer-app.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.spec.ts
@@ -41,6 +41,7 @@ import { DownloadService } from "../../../../shared/download/download.service";
 import { AppInfoService } from "../../../../shared/util/app-info.service";
 import { AssetLoadingService } from "../common/services/asset-loading.service";
 import { BaseHrefService } from "../common/services/base-href.service";
+import { HeartbeatWorkerService } from "../common/services/heartbeat-worker.service";
 import { FirstDayOfWeekService } from "../common/services/first-day-of-week.service";
 import { FullScreenService } from "../common/services/full-screen.service";
 import { PagingControlService } from "../common/services/paging-control.service";
@@ -148,6 +149,7 @@ describe("ViewerApp Unit Tests", () => {
    let assetLoadingService: any;
    let viewContainerRef: any;
    let baseHrefService: any;
+   let heartbeatWorkerService: any;
    let timerService: any;
 
    beforeEach(waitForAsync(() => {
@@ -280,6 +282,11 @@ describe("ViewerApp Unit Tests", () => {
       baseHrefService = {
          getBaseHref: vi.fn(),
       };
+      heartbeatWorkerService = {
+         createHeartbeat: vi.fn().mockReturnValue({
+            subscribe: vi.fn().mockReturnValue({ unsubscribe: vi.fn() })
+         })
+      };
       timerService = {
          defer: vi.fn((fn) => {
             fn();
@@ -341,6 +348,7 @@ describe("ViewerApp Unit Tests", () => {
             { provide: AssetLoadingService, useValue: assetLoadingService },
             { provide: ViewContainerRef, useValue: viewContainerRef },
             { provide: BaseHrefService, useValue: baseHrefService },
+            { provide: HeartbeatWorkerService, useValue: heartbeatWorkerService },
             AppInfoService,
             { provide: TimerService, useValue: timerService },
          ],
@@ -398,7 +406,7 @@ describe("ViewerApp Unit Tests", () => {
          richTextService, viewerToolbarMessageService, mobileToolbarService, mockDocument, composerRecentService,
          pageTabService, pagingControlService, selectionMobileService,
          assetLoadingService, viewContainerRef, baseHrefService,
-         currentUserService as any);
+         currentUserService as any, heartbeatWorkerService);
       const mockChart = TestUtils.createMockVSChartModel("Mock Chart");
       const mockTable = TestUtils.createMockVSTableModel("Mock Table");
       const mockCrosstab = TestUtils.createMockVSCrosstabModel("Mock Crosstab");
@@ -530,6 +538,55 @@ describe("ViewerApp Unit Tests", () => {
       previousBtn = fixture.nativeElement.querySelector("button.viewer-toolbar-btn.viewer-previous-button i");
       expect(previousBtn.classList).not.toContain("icon-disabled");
    }));
+
+   it("should call createHeartbeat when server update interval is set", () => {
+      const subscribeSpy = vi.fn().mockReturnValue({ unsubscribe: vi.fn() });
+      heartbeatWorkerService.createHeartbeat.mockReturnValue({ subscribe: subscribeSpy });
+
+      const currentUserService = { getPortalCurrentUser: vi.fn().mockReturnValue(observableOf(null)) };
+      const viewerApp = new ViewerAppComponent(
+         viewsheetClientService, null, null, null, null, null, null, null,
+         new NgbDatepickerConfig(), null, actionFactory, null, null, formDataService,
+         debounceService, scaleService, contextProvider, viewDataService, fullScreenService, router,
+         renderer, null, sanitizer, titleService, hyperlinkService, viewerResizeService,
+         firstDayOfWeekService, TestBed.inject(NgbTooltipConfig), shareService, null,
+         richTextService, viewerToolbarMessageService, mobileToolbarService, mockDocument, composerRecentService,
+         pageTabService, pagingControlService, selectionMobileService,
+         assetLoadingService, viewContainerRef, baseHrefService,
+         currentUserService as any, heartbeatWorkerService);
+
+      viewerApp["updateEnabled"] = true;
+      viewerApp.setServerUpdateInterval();
+
+      expect(heartbeatWorkerService.createHeartbeat)
+         .toHaveBeenCalledWith("viewsheet-update", 60000);
+      expect(subscribeSpy).toHaveBeenCalled();
+   });
+
+   it("should unsubscribe the server update heartbeat on clear", () => {
+      const unsubscribeSpy = vi.fn();
+      heartbeatWorkerService.createHeartbeat.mockReturnValue({
+         subscribe: vi.fn().mockReturnValue({ unsubscribe: unsubscribeSpy })
+      });
+
+      const currentUserService = { getPortalCurrentUser: vi.fn().mockReturnValue(observableOf(null)) };
+      const viewerApp = new ViewerAppComponent(
+         viewsheetClientService, null, null, null, null, null, null, null,
+         new NgbDatepickerConfig(), null, actionFactory, null, null, formDataService,
+         debounceService, scaleService, contextProvider, viewDataService, fullScreenService, router,
+         renderer, null, sanitizer, titleService, hyperlinkService, viewerResizeService,
+         firstDayOfWeekService, TestBed.inject(NgbTooltipConfig), shareService, null,
+         richTextService, viewerToolbarMessageService, mobileToolbarService, mockDocument, composerRecentService,
+         pageTabService, pagingControlService, selectionMobileService,
+         assetLoadingService, viewContainerRef, baseHrefService,
+         currentUserService as any, heartbeatWorkerService);
+
+      viewerApp["updateEnabled"] = true;
+      viewerApp.setServerUpdateInterval();
+      viewerApp.clearServerUpdateInterval();
+
+      expect(unsubscribeSpy).toHaveBeenCalled();
+   });
 
    //Bug #21287
    it("should show confirm dialog when edit form table", () => {

--- a/web/projects/portal/src/app/vsobjects/viewer-app.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.spec.ts
@@ -555,11 +555,12 @@ describe("ViewerApp Unit Tests", () => {
          assetLoadingService, viewContainerRef, baseHrefService,
          currentUserService as any, heartbeatWorkerService);
 
+      viewerApp.runtimeId = "test-runtime-id";
       viewerApp["updateEnabled"] = true;
       viewerApp.setServerUpdateInterval();
 
       expect(heartbeatWorkerService.createHeartbeat)
-         .toHaveBeenCalledWith("viewsheet-update", 60000);
+         .toHaveBeenCalledWith("test-runtime-id-viewsheet-update", 60000);
       expect(subscribeSpy).toHaveBeenCalled();
    });
 

--- a/web/projects/shared/stomp/stomp-client.service.spec.ts
+++ b/web/projects/shared/stomp/stomp-client.service.spec.ts
@@ -33,7 +33,10 @@ function makeService(constructTracker: Mock) {
    const ssoHeartbeat = { heartbeat: vi.fn() } as any;
    const logout = { logout: vi.fn(), inactivityTimeout: vi.fn() } as any;
    const baseHref = { getBaseHref: vi.fn().mockReturnValue("/") } as any;
-   const service: any = new StompClientService(zone, ssoHeartbeat, logout, baseHref);
+   const heartbeatWorker = {
+      createHeartbeat: vi.fn().mockReturnValue({ subscribe: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }) })
+   } as any;
+   const service: any = new StompClientService(zone, ssoHeartbeat, logout, baseHref, heartbeatWorker);
 
    // Override service.connect to bypass `new StompClient(...)`. Each call
    // creates (or reuses) a fake client per endpoint, mirroring the original

--- a/web/projects/shared/stomp/stomp-client.service.ts
+++ b/web/projects/shared/stomp/stomp-client.service.ts
@@ -22,6 +22,7 @@ import { LogoutService } from "../util/logout.service";
 import { StompClient } from "./stomp-client";
 import { StompClientConnection } from "./stomp-client-connection";
 import { BaseHrefService } from "../../portal/src/app/common/services/base-href.service";
+import { HeartbeatWorkerService } from "../../portal/src/app/common/services/heartbeat-worker.service";
 
 /**
  * Service that encapsulates the communication with a server via the STOMP protocol over
@@ -37,7 +38,8 @@ export class StompClientService {
    private _reloadOnFailure: boolean = false;
 
    constructor(private zone: NgZone, private ssoHeartbeatService: SsoHeartbeatService,
-               private logoutService: LogoutService, private baseHrefService: BaseHrefService)
+               private logoutService: LogoutService, private baseHrefService: BaseHrefService,
+               private heartbeatWorkerService: HeartbeatWorkerService)
    {
    }
 
@@ -51,7 +53,7 @@ export class StompClientService {
                endpoint, (key) => this.onDisconnect(key),
                (error) => this.onReconnectError(error),
                this.ssoHeartbeatService, this.logoutService, em, this.baseHrefService.getBaseHref(),
-               customElement);
+               customElement, this.heartbeatWorkerService.createHeartbeat(endpoint, 25000));
             this.clients.set(endpoint, client);
          }
 

--- a/web/projects/shared/stomp/stomp-client.ts
+++ b/web/projects/shared/stomp/stomp-client.ts
@@ -18,7 +18,7 @@
 import { HttpClient } from "@angular/common/http";
 import { EventEmitter, NgZone } from "@angular/core";
 import { Router } from "@angular/router";
-import { AsyncSubject, Observable, of as observableOf, Subject } from "rxjs";
+import { AsyncSubject, Observable, of as observableOf, Subject, Subscription } from "rxjs";
 import { SsoHeartbeatService } from "../sso/sso-heartbeat.service";
 import { LogoutService } from "../util/logout.service";
 import { StompClientChannel } from "./stomp-client-channel";
@@ -42,6 +42,8 @@ export class StompClient {
    private heartbeat: EventEmitter<any> = new EventEmitter<any>();
    private emClient: boolean = false;
    private redirecting = false;
+   private heartbeatSubscription?: Subscription;
+   private heartbeatSource$?: Observable<void>;
 
    public reloadOnFailure: boolean;
 
@@ -49,9 +51,17 @@ export class StompClient {
                private onReconnectError: (error: string) => any,
                private ssoHeartbeatService: SsoHeartbeatService,
                private logoutService: LogoutService, emClient: boolean, private baseHref: string,
-               private customElement: boolean)
+               private customElement: boolean, heartbeatSource$?: Observable<void>)
    {
       this.emClient = emClient;
+
+      if(heartbeatSource$) {
+         this.heartbeatSource$ = heartbeatSource$;
+         this.heartbeatSubscription = heartbeatSource$.subscribe(() => {
+            this.heartbeat.emit({});
+         });
+      }
+
       this.client = this.createStompClient();
       this.client.connect({},
          () => {
@@ -76,6 +86,7 @@ export class StompClient {
 
                this.connected = false;
                this.pendingConnections = [];
+               this.destroyHeartbeat();
                this.onDisconnect(this.endpoint);
                this.clientSubject.next(null);
                this.clientSubject.complete();
@@ -86,6 +97,16 @@ export class StompClient {
                this.reconnect();
             }
          });
+   }
+
+   private destroyHeartbeat(): void {
+      if(this.heartbeatSubscription) {
+         this.heartbeatSubscription.unsubscribe();
+         this.heartbeatSubscription = null;
+      }
+
+      clearTimeout(this.heartbeatTimeoutId);
+      this.heartbeatTimeoutId = null;
    }
 
    private resetHeartbeatTimer() {
@@ -123,7 +144,9 @@ export class StompClient {
       // too large, stomp default frame size is 16kb
       client.maxWebSocketFrameSize = 64 * 1024;
       client.debug = null; // comment this out to trace the messages
-      this.resetHeartbeatTimer();
+      if(!this.heartbeatSource$) {
+         this.resetHeartbeatTimer();
+      }
       return client;
    }
 
@@ -175,6 +198,7 @@ export class StompClient {
                console.error("Failed to reconnect to server: ", error);
                this.connected = false;
                this.pendingConnections = [];
+               this.destroyHeartbeat();
                this.onDisconnect(this.endpoint);
                this.clientSubject.complete();
             }
@@ -207,6 +231,7 @@ export class StompClient {
          this.client = null;
          this.clientSubject.next(null);
          this.clientSubject.complete();
+         this.destroyHeartbeat();
          this.onDisconnect(this.endpoint);
       }
    }


### PR DESCRIPTION
## Summary

- Introduces `HeartbeatWorkerService` and `heartbeat.worker.ts` — a Web Worker-based timer that fires reliably even when the browser tab is backgrounded, with a `setInterval` fallback when Workers are unavailable
- Replaces the internal `setInterval` in `StompClient` with an optional `heartbeatSource$` observable supplied by `StompClientService` via `HeartbeatWorkerService`
- Replaces the `setInterval`-based viewsheet touch-asset keepalive in `ViewerAppComponent` with `HeartbeatWorkerService.createHeartbeat()`

## Test plan

- [ ] All existing portal and EM tests pass (`npm run test`)
- [ ] New `HeartbeatWorkerService` unit tests cover: start/stop messages to worker, tick routing by id, fallback to `setInterval` when Worker is unavailable
- [ ] New `ViewerAppComponent` tests verify `createHeartbeat` is called and the subscription is unsubscribed on clear
- [ ] Lint passes (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)