### PR TITLE
Bug #75355, defer form rebuild for all post-init changes in logical model editor

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/attribute-editor/logical-model-attribute-editor.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/attribute-editor/logical-model-attribute-editor.component.ts
@@ -141,11 +141,8 @@ export class LogicalModelAttributeEditor implements OnInit, OnDestroy {
       if(this.inited) {
          // Defer the reset so the shared form is not mutated during change
          // detection, which would change form.invalid after the parent's
-         // Save button [disabled] binding was checked (NG0100). Coalesce rapid
-         // successive changes and cancel on destroy so a stale timer never
-         // mutates the shared parent form after this editor is gone.
-         clearTimeout(this.resetPending);
-         this.resetPending = setTimeout(() => this.resetFormControl(), 0);
+         // Save button [disabled] binding was checked (NG0100).
+         this.scheduleReset();
       }
    }
 
@@ -159,7 +156,18 @@ export class LogicalModelAttributeEditor implements OnInit, OnDestroy {
       const formatChanged: boolean = !this.attribute || !Tool.isEquals(value.format, this.attribute.format);
       this._attribute = value;
       this.editable = !!value && !value.baseElement;
-      this.resetFormControl();
+
+      if(this.inited) {
+         // Selecting a different attribute after init must defer the form
+         // rebuild for the same reason as existNames: rebuilding synchronously
+         // would change form.invalid after the parent's Save button [disabled]
+         // binding was already checked, throwing NG0100. selectNode/updateFormulas
+         // below do not touch the form, so the deferred reset order is safe.
+         this.scheduleReset();
+      }
+      else {
+         this.resetFormControl();
+      }
 
       if(tableChanged || columnChanged) {
          this.selectNode();
@@ -189,6 +197,14 @@ export class LogicalModelAttributeEditor implements OnInit, OnDestroy {
    ngOnDestroy(): void {
       clearTimeout(this.resetPending);
       this.unsubscribeForm();
+   }
+
+   // Coalesce rapid successive deferred resets and cancel any pending one on
+   // destroy, so a stale timer never mutates the shared parent form after this
+   // editor is gone.
+   private scheduleReset(): void {
+      clearTimeout(this.resetPending);
+      this.resetPending = setTimeout(() => this.resetFormControl(), 0);
    }
 
    /**

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/entity-pane/logical-model-entity-pane.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/entity-pane/logical-model-entity-pane.component.ts
@@ -22,7 +22,7 @@ import {
    Input,
    OnChanges,
    OnDestroy,
-   Output, SimpleChanges, ViewChild
+   Output, ViewChild
 } from "@angular/core";
 import { UntypedFormGroup, Validators, UntypedFormControl, AbstractControl, ValidatorFn, FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { EntityModel } from "../../../../../model/datasources/database/physical-model/logical-model/entity-model";
@@ -109,20 +109,18 @@ export class LogicalModelEntityPane implements AfterViewInit, OnChanges, OnDestr
       }
    }
 
-   ngOnChanges(changes: SimpleChanges): void {
+   ngOnChanges(): void {
       if(!this.inited) {
          this.inited = true;
          this.resetFormControl();
       }
-      else if(changes["existNames"] && !changes["entity"]) {
-         // A reorder updates only existNames (the edited entity reference is
-         // unchanged). Defer the reset so the shared form is not mutated during
-         // change detection, which would change form.invalid after the parent's
-         // Save button [disabled] binding was checked (NG0100).
-         this.scheduleReset();
-      }
       else {
-         this.resetFormControl();
+         // Any post-init input change must defer the form rebuild: a reorder
+         // updates existNames, and selecting a different entity updates entity.
+         // Either way, rebuilding synchronously would mutate the shared form and
+         // change form.invalid after the parent's Save button [disabled] binding
+         // was already checked, throwing NG0100.
+         this.scheduleReset();
       }
    }
 


### PR DESCRIPTION
## Summary

Follow-up to #3936 (which the reporter re-opened — the NG0100 error still reproduced on a post-merge build). Reordering rows in the portal Data Model (Logical Model) editor and then selecting a different row still threw Angular `NG0100 ExpressionChangedAfterItHasBeenCheckedError` on the Save button binding `[disabled]="!isModified || form.invalid"` (`logical-model.component.html:28`).

## Root Cause

The data-model editors share **one** `FormGroup`. Child editors rebuild it via `resetFormControl()` (`removeControl` + `addControl`), which toggles `form.invalid`. Once `isModified` becomes `true` (permanently, after the first reorder), the Save button binding evaluates `form.invalid` every change-detection cycle. The parent checks `[disabled]` **before** its children run; when a child rebuilds the shared form **synchronously during change detection**, `form.invalid` changes after the parent's check → NG0100.

PR #3936 deferred `resetFormControl()` only for the **reorder** path (`existNames` changed, edited element unchanged) and explicitly left the **element-switch** path synchronous:
- `entity-pane.ngOnChanges` → `else` branch (selecting a different entity) → synchronous reset
- `attribute-editor.set attribute` → synchronous reset on every attribute switch

The reporter's repro hits exactly this residual path: after the moves set `isModified = true`, *"select end row again"* switches the edited element, firing the synchronous reset during CD → NG0100.

## Fix

Defer the form rebuild for **all** post-init input changes in both editors, keeping only the initial render synchronous:

- **`logical-model-entity-pane.component.ts`** — `ngOnChanges` now calls `scheduleReset()` for any change after init (covers entity-switch as well as reorder). Removed the now-unused `changes`/`SimpleChanges`.
- **`logical-model-attribute-editor.component.ts`** — the `attribute` setter defers post-init via a shared `scheduleReset()` helper (coalesces rapid changes via `clearTimeout`, cleaned up in `ngOnDestroy`), now also reused by the `existNames` setter.

Initial render stays synchronous (`!inited`), so controls exist before the first template check. Because `removeControl` is also deferred, `formControlName` bindings always resolve to the old controls until the deferred reset runs — no "cannot find control" errors and no flash on open. `selectNode`/`updateFormulas`/`selectFormula` in the attribute setter do not touch the form, so the deferred reset order is safe.

## Test Plan

1. Portal → Data Source / Example / Orders → expand → **Data Model** → **Order Model**
2. Select the end row (Supplier), click **Move Up** twice
3. Select the end row again, click **Move Up**
4. Confirm **no NG0100 error** in the browser console
5. Regression: open a model, edit entity/attribute names (duplicate-name validation still disables Save), reorder, switch between entities/columns/expressions, and save — all behave as before.

Verified locally: portal `ng build` succeeds, ESLint clean, and the reporter's repro no longer throws.

Fixes Redmine #75355.