### PR TITLE
Bug #75388, show data cycle list when monitoring is off

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleCycleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleCycleService.java
@@ -59,7 +59,7 @@ public class ScheduleCycleService {
       List<DataCycleInfo> dataCycleInfoList = new ArrayList<>();
       String orgId = OrganizationManager.getInstance().getCurrentOrgID(principal);
 
-      for(DataCycleInfo cycleInfo : schedulerMonitoringService.getCycleInfo()) {
+      for(DataCycleInfo cycleInfo : schedulerMonitoringService.getDataCycleInfos()) {
          if(securityEngine.checkPermission(principal, ResourceType.SCHEDULE_CYCLE,
                                            getCyclePermissionID(cycleInfo.getName(), orgId), ResourceAction.ACCESS))
          {

--- a/core/src/main/java/inetsoft/web/admin/schedule/SchedulerMonitoringService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/SchedulerMonitoringService.java
@@ -203,13 +203,23 @@ public class SchedulerMonitoringService
    }
 
    /**
-    * Get Datacycle infos from DataCycleManager.
+    * Get Datacycle infos from DataCycleManager. Used for monitoring metrics, so the
+    * result is gated by the current monitoring level.
     */
    public DataCycleInfo[] getCycleInfo() {
       if(!isLevelQualified("cycleInfo")) {
          return new DataCycleInfo[0];
       }
 
+      return getDataCycleInfos();
+   }
+
+   /**
+    * Get Datacycle infos from DataCycleManager regardless of the monitoring level.
+    * The data cycle list is configuration (not runtime monitoring data), so the EM
+    * settings page must be able to read it even when monitoring is off.
+    */
+   public DataCycleInfo[] getDataCycleInfos() {
       String orgId = OrganizationManager.getInstance().getCurrentOrgID();
       Enumeration<String> cycles = cycleManager.getDataCycles(orgId);
       ScheduleCondition scond;


### PR DESCRIPTION
## Summary

In Enterprise Manager → Settings → Schedule → **Data Cycles**, the cycle list rendered empty whenever the `monitor.level` property was set to `OFF`. The list now loads regardless of the monitoring level.

## Root Cause

The Data Cycles settings list is fetched via `ScheduleCycleService.getCycleInfos()`, which iterated `SchedulerMonitoringService.getCycleInfo()`. That method is monitoring-gated:

```java
public DataCycleInfo[] getCycleInfo() {
   if(!isLevelQualified("cycleInfo")) {
      return new DataCycleInfo[0];   // empty when monitor.level = OFF
   }
   ...
}
```

`"cycleInfo"` is only present in `lowAttrs`, so `isLevelQualified("cycleInfo")` is `false` at `monitor.level=OFF` and `true` at LOW/MEDIUM/HIGH — the list worked at every level except OFF.

The data cycle list is **configuration** (which cycles exist, read from `DataCycleManager`), not runtime monitoring data, so it must be visible in the settings page independent of the monitoring level. The same method is also used to populate monitoring metrics (`getCurrentMetrics` → `metrics.setCycleInfo(...)`), where gating by level is correct.

## Fix

Split the two concerns in `SchedulerMonitoringService`:

- New **ungated** `getDataCycleInfos()` containing the cycle enumeration.
- `getCycleInfo()` keeps the monitor-level gate and delegates to `getDataCycleInfos()` (monitoring-metrics behavior unchanged).
- `ScheduleCycleService.getCycleInfos()` (the EM settings list) now calls the ungated `getDataCycleInfos()`.

No API signature changes; no frontend changes.

## Test Plan

1. Set `monitor.level = OFF` in EM.
2. Go to **Settings → Schedule → Data Cycles** → the configured cycles list now populates (was empty before).
3. Set `monitor.level` to LOW/MEDIUM/HIGH → list still populates (no regression).
4. **Status** monitoring tab / metrics still respect the monitor level (cycle metrics gated as before).

Verified locally by running the server with `monitor.level=OFF`: the cycle list displays correctly. Existing `ScheduleCycleControllerTest` and `MonitorLevelControllerTest` pass; `community/core` compiles clean.

Fixes Redmine #75388.