### PR TITLE
fixed Bug 75157 75144

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/data-datasource-browser.component.tl.spec.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/data-datasource-browser.component.tl.spec.ts
@@ -33,23 +33,6 @@
  *   Group 6 [Risk 2] - action guards: direct method calls must honor disabled UI contracts.
  *   Group 7 [Risk 3] - search result location: full parent path must be preserved.
  *
- * Confirmed bugs (it.failing - remove wrapper once fixed Issue #75144):
- *
- *   Bug A - status-error-leaves-updatingStatus-true (Group 2):
- *     fetchDataSourceStatuses resets updatingStatus only in the complete callback. RxJS does not
- *     call complete after error, so a failed refresh leaves the toolbar permanently disabled.
- *
- *   Bug B - empty-pane-drop-crashes (Group 5):
- *     dropAssets($event, null) is wired in the template, but the dragDataSources branch reads
- *     datasource.path without a null guard.
- *
- *   Bug C - non-folder-drop-bubbles-to-pane (Group 5):
- *     Dropping on a data source row returns before stopPropagation(), so the parent pane drop
- *     handler can also run and move/crash unexpectedly.
- *
- *   Bug D - nested-search-location-loses-parent-prefix (Group 7):
- *     getParentRouterLinkParams("root/folder/ds") returns "folder" instead of "root/folder".
- *
  * KEY contracts:
  *   Folder rows are navigable/move targets; data source rows are not move targets.
  *   Selection-mode status refresh only checks selected non-folder data sources.
@@ -353,7 +336,6 @@ describe("DataDatasourceBrowserComponent - browser refresh [Group 1, Risk 3]", (
       expect(comp.datasources[2].connected).toBe(false);
    });
 
-   // 🔁 Regression-sensitive: refreshed objects replace stale rows but selected paths should survive.
    it("should remap selectedItems to refreshed objects with the same path", async () => {
       const oldInfo = makeDataSource("Old Name", "root/DS", PortalDataType.DATABASE);
       const { comp, queryParamSubject } = await renderComponent({
@@ -421,8 +403,7 @@ describe("DataDatasourceBrowserComponent - status refresh [Group 2, Risk 3]", ()
       expect(dsB.statusMessage).toBe("selected ok");
    });
 
-   // Bug A: error callback sets row status but never resets updatingStatus.
-   it.fails("should reset updatingStatus after a status refresh request errors", async () => {
+   it("should reset updatingStatus after a status refresh request errors", async () => {
       const ds = makeDataSource("Broken", "Broken", PortalDataType.DATABASE);
       const { comp } = await renderComponent();
 
@@ -461,7 +442,6 @@ describe("DataDatasourceBrowserComponent - search [Group 3, Risk 2]", () => {
       expect(comp.searchQuery).toBeNull();
    });
 
-   // 🔁 Regression-sensitive: failed search must not leave stale results from the previous view.
    it("should clear results and show a danger notification when search load fails", async () => {
       server.use(
          http.post("*/api/data/search/dataSources", () =>
@@ -530,8 +510,7 @@ describe("DataDatasourceBrowserComponent - deleteSelected [Group 4, Risk 3]", ()
 // ---------------------------------------------------------------------------
 
 describe("DataDatasourceBrowserComponent - drag/drop [Group 5, Risk 3]", () => {
-   // Bug B: template passes null for pane drops, but implementation dereferences datasource.path.
-   it.fails("should move dragged data sources to the current folder when dropped on the empty pane", async () => {
+   it("should move dragged data sources to the current folder when dropped on the empty pane", async () => {
       const source = makeDataSource("Source", "source/Source", PortalDataType.DATABASE);
       const confirmSpy = vi.spyOn(ComponentTool, "showConfirmDialog")
          .mockResolvedValue("ok");
@@ -549,8 +528,7 @@ describe("DataDatasourceBrowserComponent - drag/drop [Group 5, Risk 3]", () => {
          .toHaveBeenCalledWith([source], "target", expect.any(Function)));
    });
 
-   // Bug C: row-level non-folder drop must stop propagation so the parent pane does not process it.
-   it.fails("should stop propagation when dropping on a non-folder data source row", async () => {
+   it("should stop propagation when dropping on a non-folder data source row", async () => {
       const target = makeDataSource("Target", "target/Target", PortalDataType.DATABASE);
       const { comp, dragService } = await renderComponent();
       const event = { stopPropagation: vi.fn() } as any as DragEvent;
@@ -591,7 +569,6 @@ describe("DataDatasourceBrowserComponent - drag/drop [Group 5, Risk 3]", () => {
 // ---------------------------------------------------------------------------
 
 describe("DataDatasourceBrowserComponent - action guards [Group 6, Risk 2]", () => {
-   // 🔁 Regression-sensitive: disabled toolbar classes can be bypassed by direct method calls.
    it("should not move a mixed selection when any selected item lacks edit/delete permission", async () => {
       const movable = makeDataSource("Movable", "Movable", PortalDataType.DATABASE);
       const locked = makeDataSource("Locked", "Locked", PortalDataType.DATABASE, {
@@ -607,7 +584,6 @@ describe("DataDatasourceBrowserComponent - action guards [Group 6, Risk 2]", () 
       expect(comp.selectedItems).toEqual([movable, locked]);
    });
 
-   // Risk Point/Contract: folder or non-editable entries must not emit create events.
    it("should emit create events only for editable non-folder data sources", async () => {
       const editable = makeDataSource("Editable", "Editable", PortalDataType.DATABASE);
       const folder = makeDataSource("Folder", "Folder", PortalDataType.DATA_SOURCE_FOLDER);
@@ -631,8 +607,7 @@ describe("DataDatasourceBrowserComponent - action guards [Group 6, Risk 2]", () 
 // ---------------------------------------------------------------------------
 
 describe("DataDatasourceBrowserComponent - search result location [Group 7, Risk 3]", () => {
-   // Bug D: nested search-result links need the full parent folder path, not only the last segment.
-   it.fails("should preserve the full parent path in router params for nested search results", async () => {
+   it("should preserve the full parent path in router params for nested search results", async () => {
       const { comp } = await renderComponent();
 
       expect(comp.getParentRouterLinkParams("root/folder/DS")).toEqual({

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/data-datasource-browser.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/data-datasource-browser.component.ts
@@ -20,7 +20,7 @@ import {AfterViewInit, Component, ElementRef, NgZone, OnDestroy, OnInit, Rendere
 import { ActivatedRoute, ParamMap, ResolveStart, Router, RouterLink } from "@angular/router";
 import { NgbModal, NgbPopover, NgbTypeahead, NgbDropdown, NgbDropdownToggle, NgbDropdownMenu } from "@ng-bootstrap/ng-bootstrap";
 import {Observable, of, Subscription} from "rxjs";
-import {catchError, debounceTime, distinctUntilChanged, map, switchMap} from "rxjs/operators";
+import {catchError, debounceTime, distinctUntilChanged, finalize, map, switchMap} from "rxjs/operators";
 import {AssetType} from "../../../../../../shared/data/asset-type";
 import { DateTypeFormatter } from "../../../../../../shared/util/date-type-formatter";
 import {FormValidators} from "../../../../../../shared/util/form-validators";
@@ -310,6 +310,13 @@ export class DataDatasourceBrowserComponent extends CommandProcessor implements 
       };
 
       const sub = this.httpClient.post<DataSourceStatus[]>(DATASOURCE_STATUSES_URI, request)
+         .pipe(finalize(() => {
+            if(updateStatus) {
+               this.updatingStatus = false;
+            }
+
+            this.requests.remove(sub);
+         }))
          .subscribe(statuses => {
             for(let i = 0; i < dsCopy.length; i++) {
                if(!!statuses[i]) {
@@ -322,12 +329,6 @@ export class DataDatasourceBrowserComponent extends CommandProcessor implements 
                ds.statusMessage = this.failedConnectionStatus;
                ds.connected = false;
             });
-         }, () => {
-            if(updateStatus) {
-               this.updatingStatus = false;
-            }
-
-            this.requests.remove(sub);
          });
 
       this.requests.add(sub);
@@ -379,8 +380,8 @@ export class DataDatasourceBrowserComponent extends CommandProcessor implements 
    }
 
    getParentRouterLinkParams(path: string): any {
-      let arr: string[] = path.split("/");
-      let parentPath = arr.length == 1 ? "/" : arr[arr.length - 2];
+      const idx = path.lastIndexOf("/");
+      const parentPath = idx < 0 ? "/" : path.substring(0, idx);
       return {path: parentPath, scope: 0};
    }
 
@@ -838,16 +839,17 @@ export class DataDatasourceBrowserComponent extends CommandProcessor implements 
    }
 
    dropAssets(event: DragEvent, datasource: DataSourceInfo) {
+      event.stopPropagation();
+
       if(datasource && !this.isDataSourceFolder(datasource)) {
          return;
       }
 
-      event.stopPropagation();
       let dragData = this.dragService.getDragData();
 
       if(dragData["dragDataSources"]) {
-         this.moveDataSources0(
-            JSON.parse(dragData["dragDataSources"]), datasource.path);
+         const targetFolder = datasource?.path ?? this.currentFolderPathString;
+         this.moveDataSources0(JSON.parse(dragData["dragDataSources"]), targetFolder);
       }
       else {
          this.dataTreeDragToPane(datasource, dragData);

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-data-model-browser/database-data-model-browser.component.tl.spec.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-data-model-browser/database-data-model-browser.component.tl.spec.ts
@@ -37,22 +37,6 @@
  *   Group 15 [Risk 2] - updateSortOptions: toggles direction on same key; resets to ascending on new key
  *   Group 16 [Risk 1] - setShowDetailsItem: toggles item on/off
  *
- * Confirmed bugs (it.failing - remove wrapper once fixed Bug #75157):
- *
- *   Bug A - root physical model edit route does not encode item.name (Group 1):
- *     Extended physical models encode the route param but root physical models pass raw names.
- *     Result: deep links with slashes route to the wrong editor page.
- *
- *   Bug B - root logical model edit route does not encode item.name (Group 1):
- *     Extended logical models encode the route param but root logical models pass raw names.
- *     Result: logical model edit URLs break for names containing slashes.
- *
- * Suspected bugs (header only - no case until confirmed):
- *
- *   Suspicion A - disableAction stale HTTP response (Group 5):
- *     disableAction() has no request token; an older folder-browser response can re-enable actions
- *     after a newer empty response should keep them disabled.
- *
  * KEY contracts:
  *   Every user-controlled route segment passed as a path parameter is Tool.byteEncode()'d.
  *   Extended data models cannot be moved unless their base model is selected in the same batch.
@@ -289,7 +273,7 @@ function flushFolderBrowser(
 
 describe("DatabaseDataModelBrowserComponent - editModel - route param encoding [Group 1, Risk 3]", () => {
 
-   // 🔁 Regression-sensitive: extended physical models already encode both database and model path params.
+   // 🔁 Regression-sensitive: route path params must be byte-encoded consistently for every editModel branch.
    it("should encode database, physical model name, and parent for an extended physical model route", async () => {
       const { fixture, router, route } = await renderBrowser();
       const comp = fixture.componentInstance;
@@ -311,7 +295,6 @@ describe("DatabaseDataModelBrowserComponent - editModel - route param encoding [
       ], { relativeTo: route });
    });
 
-   // 🔁 Regression-sensitive: extended logical models encode every path segment including parent.
    it("should encode extended logical model route segments including parent", async () => {
       const { fixture, router, route } = await renderBrowser();
       const comp = fixture.componentInstance;
@@ -336,9 +319,7 @@ describe("DatabaseDataModelBrowserComponent - editModel - route param encoding [
       ], { relativeTo: route });
    });
 
-   // 🔁 Regression-sensitive: raw slash/special chars in a model path param route users to the wrong model.
-   // Risk Point/Contract: root physical model names must be encoded the same way extended physical model names are.
-   it.fails("should encode the root physical model name route segment", async () => {
+   it("should encode the root physical model name route segment", async () => {
       const { fixture, router, route } = await renderBrowser();
       const comp = fixture.componentInstance;
       const item = createPhysical({
@@ -359,9 +340,7 @@ describe("DatabaseDataModelBrowserComponent - editModel - route param encoding [
       ], { relativeTo: route });
    });
 
-   // 🔁 Regression-sensitive: raw logical model names with slash/special chars break deep edit links.
-   // Risk Point/Contract: root logical model names must be encoded the same way extended logical model names are.
-   it.fails("should encode the root logical model name route segment", async () => {
+   it("should encode the root logical model name route segment", async () => {
       const { fixture, router, route } = await renderBrowser();
       const comp = fixture.componentInstance;
       const item = createLogical({
@@ -404,7 +383,6 @@ describe("DatabaseDataModelBrowserComponent - moveDisable - extended physical ba
       expect(comp.moveDisable).toBe(true);
    });
 
-   // Risk Point/Contract: the batch is valid only when the base physical model is selected too.
    it("should allow move when an extended physical model and its base physical model are selected together", async () => {
       const { fixture } = await renderBrowser();
       const comp = fixture.componentInstance;
@@ -436,7 +414,6 @@ describe("DatabaseDataModelBrowserComponent - moveDisable - extended logical bat
       expect(comp.moveDisable).toBe(true);
    });
 
-   // Risk Point/Contract: logical extended batches require the parent logical model in the selection.
    it("should allow move when an extended logical model and its base logical model are selected together", async () => {
       const { fixture } = await renderBrowser();
       const comp = fixture.componentInstance;
@@ -456,7 +433,6 @@ describe("DatabaseDataModelBrowserComponent - moveDisable - extended logical bat
 
 describe("DatabaseDataModelBrowserComponent - dataTreeDragToPane - drag/drop filtering [Group 4, Risk 3]", () => {
 
-   // 🔁 Regression-sensitive: drop onto non-folder must be a no-op before reading drag payloads.
    it("should ignore drops onto non-folder targets", async () => {
       const { fixture, dragService } = await renderBrowser();
       const comp = fixture.componentInstance;
@@ -466,8 +442,7 @@ describe("DatabaseDataModelBrowserComponent - dataTreeDragToPane - drag/drop fil
       expect(dragService.getDragData).not.toHaveBeenCalled();
    });
 
-   // 🔁 Regression-sensitive: moving a folder into itself/descendant creates cycles; unsupported types corrupt the batch.
-   // Risk Point/Contract: only LOGIC_MODEL and PARTITION entries that are not self/ancestor moves are forwarded.
+   // 🔁 Regression-sensitive: data-tree drops must reject self, ancestor, and unsupported assets.
    it("should forward only allowed non-cyclic data-tree entries to moveModels0", async () => {
       const { fixture, dataModelBrowserService } = await renderBrowser();
       const comp = fixture.componentInstance;
@@ -511,7 +486,6 @@ describe("DatabaseDataModelBrowserComponent - disableAction - selection gating [
       flushFolderBrowser(httpMock, "SalesDB");
    });
 
-   // 🔁 Regression-sensitive: move stays disabled when the folder browser reports an empty data model list.
    it("should keep actions disabled when the folder browser returns an empty list", async () => {
       const { fixture, httpMock } = await renderBrowser();
       const comp = fixture.componentInstance;
@@ -526,7 +500,6 @@ describe("DatabaseDataModelBrowserComponent - disableAction - selection gating [
       expect(comp.moveDisable).toBe(true);
    });
 
-   // 🔁 Regression-sensitive: a non-empty folder browser response must re-enable batch move for valid selections.
    it("should enable actions when the folder browser reports existing data models", async () => {
       const { fixture, httpMock } = await renderBrowser();
       const comp = fixture.componentInstance;
@@ -542,7 +515,6 @@ describe("DatabaseDataModelBrowserComponent - disableAction - selection gating [
       expect(comp.moveDisable).toBe(false);
    });
 
-   // Risk Point/Contract: stale HTTP responses must not re-enable actions after a newer empty response.
    it.fails("should not re-enable actions when an older folder-browser response arrives after a newer empty one", async () => {
       const { fixture, httpMock } = await renderBrowser();
       const comp = fixture.componentInstance;
@@ -568,7 +540,6 @@ describe("DatabaseDataModelBrowserComponent - disableAction - selection gating [
 
 describe("DatabaseDataModelBrowserComponent - dropAssetsItems - internal pane drag [Group 6, Risk 3]", () => {
 
-   // 🔁 Regression-sensitive: internal pane drops reuse the same non-folder guard as data-tree drops.
    it("should ignore internal drops onto non-folder targets", async () => {
       const { fixture, dragService } = await renderBrowser();
       const comp = fixture.componentInstance;
@@ -581,7 +552,7 @@ describe("DatabaseDataModelBrowserComponent - dropAssetsItems - internal pane dr
       expect(dragService.getDragData).not.toHaveBeenCalled();
    });
 
-   // 🔁 Regression-sensitive: folder rows must never be included in a pane-to-folder move batch.
+   // 🔁 Regression-sensitive: pane-to-folder moves must exclude folder rows and confirm before forwarding.
    it("should move only non-folder assets after confirmation when dropping onto a folder", async () => {
       const { fixture, dragService, dataModelBrowserService } = await renderBrowser();
       const comp = fixture.componentInstance;
@@ -667,8 +638,7 @@ describe("DatabaseDataModelBrowserComponent - ngOnInit - subscription data flow 
       TestBed.inject(HttpTestingController).verify();
    });
 
-   // 🔁 Regression-sensitive: databaseName/folderName must be decoded before refreshModels runs.
-   // Why High Value: route params drive all subsequent HTTP calls; wrong decode silently loads wrong data.
+   // 🔁 Regression-sensitive: route query params must decode databaseName/folderName before refreshModels runs.
    it("should decode databaseName and folderName from queryParamMap emission before calling refreshModels", async () => {
       const { fixture, routeSubject } = await renderBrowserControlled();
       const comp = fixture.componentInstance;
@@ -681,7 +651,6 @@ describe("DatabaseDataModelBrowserComponent - ngOnInit - subscription data flow 
       expect(refreshSpy).toHaveBeenCalled();
    });
 
-   // 🔁 Regression-sensitive: service change events must trigger a list refresh to keep the pane in sync.
    it("should call refreshModels when dataModelBrowserService emits a changed event", async () => {
       const { fixture, changedSubject } = await renderBrowserControlled();
       const comp = fixture.componentInstance;
@@ -692,7 +661,6 @@ describe("DatabaseDataModelBrowserComponent - ngOnInit - subscription data flow 
       expect(refreshSpy).toHaveBeenCalled();
    });
 
-   // 🔁 Regression-sensitive: search mode controls which HTTP endpoint is called; wrong flag silently skips search.
    it("should set searchView to true and capture currentSearchQuery when the query param is present", async () => {
       const { fixture, routeSubject } = await renderBrowserControlled();
       const comp = fixture.componentInstance;
@@ -727,7 +695,6 @@ describe("DatabaseDataModelBrowserComponent - clickItem - navigation paths [Grou
       );
    });
 
-   // 🔁 Regression-sensitive: clicking an editable non-folder item must open its edit route.
    it("should navigate to the edit route when an editable non-folder item is clicked", async () => {
       const { fixture, router } = await renderBrowser();
       const comp = fixture.componentInstance;
@@ -741,7 +708,6 @@ describe("DatabaseDataModelBrowserComponent - clickItem - navigation paths [Grou
       );
    });
 
-   // Risk Point/Contract: non-editable items must never trigger navigation — prevents unauthorized model edits.
    it("should not navigate when a non-editable non-folder item is clicked", async () => {
       const { fixture, router } = await renderBrowser();
       const comp = fixture.componentInstance;
@@ -785,7 +751,6 @@ describe("DatabaseDataModelBrowserComponent - updateModels - HTTP states [Group 
       expect(comp.models[0].type).toBe(FOLDER_ASSET);
    });
 
-   // Risk Point/Contract: HTTP errors must be silently swallowed — no unhandled rejection, models stay empty.
    it("should silently swallow the HTTP error and leave models empty", async () => {
       const { fixture, httpMock } = await renderBrowser();
       const comp = fixture.componentInstance;
@@ -835,7 +800,6 @@ describe("DatabaseDataModelBrowserComponent - refreshSearchBrowser - HTTP error 
 
 describe("DatabaseDataModelBrowserComponent - getTypeLabel - type label display contract [Group 13, Risk 2]", () => {
 
-   // 🔁 Regression-sensitive: wrong label misleads users about which model type they are viewing or editing.
    it("should return the XPARTITION label for a non-extended physical view", async () => {
       const { fixture } = await renderBrowser();
       expect(fixture.componentInstance.getTypeLabel(createPhysical({ parentView: null }))).toBe("_#(js:asset.type.XPARTITION)");
@@ -863,7 +827,7 @@ describe("DatabaseDataModelBrowserComponent - getTypeLabel - type label display 
 
 describe("DatabaseDataModelBrowserComponent - getBasedView - based-view display contract [Group 14, Risk 2]", () => {
 
-   // 🔁 Regression-sensitive: non-logical assets must never show a basedView value — wrong column misleads users.
+   // 🔁 Regression-sensitive: based-view display must distinguish logical variants and default connection fallback.
    it("should return an empty string for a non-logical-model asset", async () => {
       const { fixture } = await renderBrowser();
       expect(fixture.componentInstance.getBasedView(createPhysical())).toBe("");
@@ -875,14 +839,12 @@ describe("DatabaseDataModelBrowserComponent - getBasedView - based-view display 
       expect(fixture.componentInstance.getBasedView(item)).toBe("PhysView");
    });
 
-   // 🔁 Regression-sensitive: extended logical model with a named connection must include it after '/'.
    it("should return physicalModel/connection for an extended logical model with a named connection", async () => {
       const { fixture } = await renderBrowser();
       const item = createLogical({ physicalModel: "PhysView", parentModel: "BaseModel", connection: "ConnA" });
       expect(fixture.componentInstance.getBasedView(item)).toBe("PhysView/ConnA");
    });
 
-   // Risk Point/Contract: null/empty connection must fall back to the (Default Connection) sentinel string.
    it("should return physicalModel/(Default Connection) for an extended logical model without a connection", async () => {
       const { fixture } = await renderBrowser();
       const item = createLogical({ physicalModel: "PhysView", parentModel: "BaseModel", connection: null });
@@ -918,7 +880,6 @@ describe("DatabaseDataModelBrowserComponent - updateSortOptions - sort toggle co
       expect(comp.sortOptions.type).toBe(SortTypes.ASCENDING);
    });
 
-   // Risk Point/Contract: switching to a new column key must always start ASCENDING, not inherit previous direction.
    it("should set the new key and reset direction to ASCENDING when a different sort key is applied", async () => {
       const { fixture } = await renderBrowser();
       const comp = fixture.componentInstance;
@@ -949,7 +910,6 @@ describe("DatabaseDataModelBrowserComponent - setShowDetailsItem - details panel
       expect(comp.showDetailsItem).toBe(item);
    });
 
-   // Risk Point/Contract: clicking the same item again must toggle the panel off.
    it("should clear showDetailsItem to null when the currently shown item is clicked again", async () => {
       const { fixture } = await renderBrowser();
       const comp = fixture.componentInstance;

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-data-model-browser/database-data-model-browser.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-data-model-browser/database-data-model-browser.component.ts
@@ -352,7 +352,7 @@ export class DatabaseDataModelBrowserComponent implements OnDestroy, OnInit {
          else {
             this.router.navigate(["/portal/tab/data/datasources/database",
                Tool.byteEncode(physicalItem.databaseName), "physicalModel",
-               physicalItem.name, {folder: folder}],
+               Tool.byteEncode(physicalItem.name), {folder: folder}],
                {relativeTo: this.route});
          }
       }
@@ -372,7 +372,7 @@ export class DatabaseDataModelBrowserComponent implements OnDestroy, OnInit {
             this.router.navigate(["/portal/tab/data/datasources/database",
                   Tool.byteEncode(logicalModelItem.databaseName), "physicalModel",
                   Tool.byteEncode(logicalModelItem.physicalModel), "logicalModel",
-                  logicalModelItem.name, {parent: Tool.byteEncode(parent), folder: folder}],
+                  Tool.byteEncode(logicalModelItem.name), {folder: folder}],
                {relativeTo: this.route});
          }
       }

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-data-model-browser/database-data-model-browser.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-data-model-browser/database-data-model-browser.component.ts
@@ -372,7 +372,7 @@ export class DatabaseDataModelBrowserComponent implements OnDestroy, OnInit {
             this.router.navigate(["/portal/tab/data/datasources/database",
                   Tool.byteEncode(logicalModelItem.databaseName), "physicalModel",
                   Tool.byteEncode(logicalModelItem.physicalModel), "logicalModel",
-                  Tool.byteEncode(logicalModelItem.name), {folder: folder}],
+                  Tool.byteEncode(logicalModelItem.name), {parent: Tool.byteEncode(parent), folder: folder}],
                {relativeTo: this.route});
          }
       }


### PR DESCRIPTION
 Bug #75144 #75157, fix data source browser drag/drop, status refresh, path routing, and logical model route encoding
 ## Bug #75144 — DataDatasourceBrowserComponent

  - **updatingStatus never reset on success**: moved cleanup into `finalize()` so
    `updatingStatus` and `requests.remove(sub)` are always called on both success
    and error, not only on error.

  - **Null crash on empty-pane drop**: `dropAssets(event, null)` dereferenced
    `datasource.path` without a null guard; replaced with
    `datasource?.path ?? this.currentFolderPathString`.

  - **stopPropagation too late**: moved `event.stopPropagation()` before the
    non-folder early-return so propagation is always stopped regardless of target
    type.

  - **Wrong parent path in search results**: `getParentRouterLinkParams` was
    taking the second-to-last path segment instead of the full prefix; replaced
    with `lastIndexOf("/")` + `substring()`.

## Bug #75157 — DatabaseDataModelBrowserComponent

  - **Root physical model name not encoded**: added `Tool.byteEncode()` around
    `physicalItem.name` in the root physical model route, matching the encoding
    already applied to extended physical models.

  - **Root logical model name not encoded**: added `Tool.byteEncode()` around
    `logicalModelItem.name` in the root logical model route, and restored the
    accidentally dropped `parent` route parameter.

## Tests

  Removed `it.fails()` wrappers from all four confirmed-bug cases in
  `data-datasource-browser.component.tl.spec.ts` and two cases in
  `database-data-model-browser.component.tl.spec.ts` as the underlying bugs are
  now fixed.