### PR TITLE
Bug #75375, fix NG0955 duplicate track keys in vs-wizard-grid-pane

### DIFF
--- a/web/projects/portal/src/app/vs-wizard/gui/wizard-pane/vs-wizard-grid-pane.component.html
+++ b/web/projects/portal/src/app/vs-wizard/gui/wizard-pane/vs-wizard-grid-pane.component.html
@@ -17,7 +17,7 @@
 -->
 <div class="vs-grid-table">
   <div class="vs-grid-col-container">
-    @for (_ of colRange; track _; let colIndex = $index; let evenCol = $even) {
+    @for (_ of colRange; track colIndex; let colIndex = $index; let evenCol = $even) {
       <div
         class="vs-grid-table-col"
         [style.width.px]="cellWidth"
@@ -26,12 +26,12 @@
     }
   </div>
 
-  @for (_ of rowRange; track _; let rowIndex = $index; let evenRow = $even) {
+  @for (_ of rowRange; track rowIndex; let rowIndex = $index; let evenRow = $even) {
     <div
       class="vs-grid-table-row"
       [class.even-row]="evenRow"
       [class.odd-row]="!evenRow">
-      @for (_ of colRange; track _; let colIndex = $index; let evenCol = $even) {
+      @for (_ of colRange; track colIndex; let colIndex = $index; let evenCol = $even) {
         <div
           class="vs-grid-table-cell txt-primary"
           [class.even-col]="evenCol"


### PR DESCRIPTION
## Summary

After the Angular 21 upgrade, opening the new-viewsheet wizard and clicking **Finish** to reach the grid pane threw `NG0955: The provided track expression resulted in duplicated keys` (key `""` at every index), pointing at `vs-wizard-grid-pane.component.html:29`. The duplicate keys force Angular to rebuild the grid DOM on every change-detection pass, degrading performance.

## Root Cause

The three `@for` loops in `vs-wizard-grid-pane.component.html` (lines 20, 29, 34) tracked by the element value (`track _`). Their collections `colRange`/`rowRange` are `new Array<void>(n)` — count-only arrays whose elements are all `undefined`. So every iteration produced the same track key, violating Angular's unique-key requirement (NG0955). The element `_` is never referenced in the template; only the `$index` aliases (`rowIndex`/`colIndex`) and `$even` are used.

## Fix

Changed the track expression on all three loops from the element value to the per-item index, which is unique:
- `track _` → `track colIndex` (lines 20, 34)
- `track _` → `track rowIndex` (line 29)

`colIndex`/`rowIndex` are the existing `let … = $index` aliases, so the Angular compiler resolves these to the built-in index tracker (equivalent to `track $index`). For a fixed-position grid, index is also the correct stable identity. Template-only change; no component logic affected.

## Test Plan

- Composer → new viewsheet → wizard pane → select a column → click **Finish** → grid pane: confirm no `NG0955` error in the console and the grid renders/performs normally (verified).
- `npm run build` — succeeds (exit 0), all projects incl. `portal`; AOT template compilation validates the `track` syntax.
- `ng lint portal` on the changed file — passes.

Fixes Redmine #75375.