### PR TITLE
fix(wiz): honor crosstab rows/cols pins in autoBinding

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -220,6 +220,15 @@ public class WizAutoBindingService {
                if(primaryAssembly instanceof ChartVSAssembly chartAsm && chartAsm.getVSChartInfo() != null) {
                   applyFieldConfigs(chartAsm.getVSChartInfo(), configMap);
                }
+               // The crosstab recommender decides row/col header placement itself and ignores
+               // rows/cols pins (ChartPreference, the only pin channel into the recommender, models
+               // chart slots — x/y/color/... — not rows/cols). Honor those pins here by moving the
+               // pinned fields into the row- vs column-header groups on the rendered binding.
+               else if(primaryAssembly instanceof CrosstabVSAssembly crosstabAsm &&
+                       crosstabAsm.getVSCrosstabInfo() != null)
+               {
+                  applyCrosstabHeaderPins(crosstabAsm.getVSCrosstabInfo(), explicitBindings);
+               }
             }
          }
 
@@ -364,6 +373,136 @@ public class WizAutoBindingService {
       applyAestheticFieldConfig(chartInfo.getShapeField(), configMap);
       applyAestheticFieldConfig(chartInfo.getSizeField(), configMap);
       applyAestheticFieldConfig(chartInfo.getTextField(), configMap);
+   }
+
+   /**
+    * Honor rows/cols explicitBindings pins on a crosstab. The recommender assigns row/col header
+    * placement on its own and the pin channel into it (ChartPreference) has no rows/cols slots, so
+    * such pins are otherwise dropped. This repartitions the existing header dimensions: a field
+    * pinned to "rows"/"cols" moves to that group (in pin order); any unpinned field keeps its
+    * current group. Design and runtime headers are kept in sync. No-op when there are no pins.
+    */
+   private void applyCrosstabHeaderPins(VSCrosstabInfo cinfo, List<ExplicitBinding> bindings) {
+      List<String> rowPins = pinnedHeaderFields(bindings, "rows");
+      List<String> colPins = pinnedHeaderFields(bindings, "cols");
+
+      if(rowPins.isEmpty() && colPins.isEmpty()) {
+         return;
+      }
+
+      DataRef[][] design = repartitionHeaders(
+         cinfo.getDesignRowHeaders(), cinfo.getDesignColHeaders(), rowPins, colPins);
+      cinfo.setDesignRowHeaders(design[0]);
+      cinfo.setDesignColHeaders(design[1]);
+
+      DataRef[] rtRows = cinfo.getRuntimeRowHeaders();
+      DataRef[] rtCols = cinfo.getRuntimeColHeaders();
+
+      // Runtime headers are normally re-derived from design at execution, but update them in
+      // lockstep when already populated so the placement is correct regardless of execution path.
+      if(rtRows != null && rtRows.length > 0 || rtCols != null && rtCols.length > 0) {
+         DataRef[][] runtime = repartitionHeaders(rtRows, rtCols, rowPins, colPins);
+         cinfo.setRuntimeRowHeaders(runtime[0]);
+         cinfo.setRuntimeColHeaders(runtime[1]);
+      }
+   }
+
+   /** Field names pinned to the given crosstab role, in binding order (deduplicated). */
+   static List<String> pinnedHeaderFields(List<ExplicitBinding> bindings, String role) {
+      if(bindings == null) {
+         return Collections.emptyList();
+      }
+
+      List<String> fields = new ArrayList<>();
+
+      for(ExplicitBinding b : bindings) {
+         if(b != null && role.equals(b.getRole()) && !Tool.isEmptyString(b.getField()) &&
+            !fields.contains(b.getField()))
+         {
+            fields.add(b.getField());
+         }
+      }
+
+      return fields;
+   }
+
+   /**
+    * Repartition crosstab header dimensions across rows/cols per the pin lists. Pinned fields are
+    * placed in their target group first (in pin order); unpinned fields keep their original group
+    * and relative order. Matching is case-insensitive on the dimension's column value. Returns
+    * {@code {newRowHeaders, newColHeaders}}.
+    */
+   static DataRef[][] repartitionHeaders(DataRef[] rows, DataRef[] cols,
+                                         List<String> rowPins, List<String> colPins)
+   {
+      LinkedHashMap<String, DataRef> byName = new LinkedHashMap<>();
+      List<String> origRows = new ArrayList<>();
+      List<String> origCols = new ArrayList<>();
+
+      if(rows != null) {
+         for(DataRef r : rows) {
+            String key = headerFieldKey(r);
+            byName.put(key, r);
+            origRows.add(key);
+         }
+      }
+
+      if(cols != null) {
+         for(DataRef c : cols) {
+            String key = headerFieldKey(c);
+            byName.put(key, c);
+            origCols.add(key);
+         }
+      }
+
+      List<DataRef> newRows = new ArrayList<>();
+      List<DataRef> newCols = new ArrayList<>();
+      Set<String> placed = new HashSet<>();
+
+      for(String f : rowPins) {
+         String key = f.toLowerCase();
+
+         if(byName.containsKey(key) && placed.add(key)) {
+            newRows.add(byName.get(key));
+         }
+      }
+
+      for(String f : colPins) {
+         String key = f.toLowerCase();
+
+         if(byName.containsKey(key) && placed.add(key)) {
+            newCols.add(byName.get(key));
+         }
+      }
+
+      // Unpinned dimensions stay in their original group, preserving order.
+      for(String key : origRows) {
+         if(placed.add(key)) {
+            newRows.add(byName.get(key));
+         }
+      }
+
+      for(String key : origCols) {
+         if(placed.add(key)) {
+            newCols.add(byName.get(key));
+         }
+      }
+
+      return new DataRef[][] { newRows.toArray(new DataRef[0]), newCols.toArray(new DataRef[0]) };
+   }
+
+   /** Lowercased field key for a crosstab header dimension, for case-insensitive pin matching. */
+   static String headerFieldKey(DataRef ref) {
+      String name = null;
+
+      if(ref instanceof VSDimensionRef dim && !Tool.isEmptyString(dim.getGroupColumnValue())) {
+         name = dim.getGroupColumnValue();
+      }
+      else if(ref != null) {
+         name = ref.getName();
+      }
+
+      return name == null ? "" : name.toLowerCase();
    }
 
    private void applyAestheticFieldConfig(AestheticRef aestheticRef,

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceCrosstabPinsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceCrosstabPinsTest.java
@@ -1,0 +1,122 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.viewsheet.VSDimensionRef;
+import inetsoft.web.wiz.model.ExplicitBinding;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the crosstab rows/cols pin handling added to WizAutoBindingService. Exercises the
+ * pure repartition helpers directly — no recommender / sandbox needed — since the recommender
+ * itself cannot honor rows/cols pins (ChartPreference has no such slots), so the service
+ * repartitions the rendered crosstab headers from the explicitBindings.
+ */
+@Tag("core")
+class WizAutoBindingServiceCrosstabPinsTest {
+   private static DataRef dim(String field) {
+      VSDimensionRef ref = mock(VSDimensionRef.class);
+      when(ref.getGroupColumnValue()).thenReturn(field);
+      return ref;
+   }
+
+   private static ExplicitBinding pin(String role, String field) {
+      ExplicitBinding b = new ExplicitBinding();
+      b.setRole(role);
+      b.setField(field);
+      return b;
+   }
+
+   private static List<String> keys(DataRef[] refs) {
+      return java.util.Arrays.stream(refs)
+         .map(WizAutoBindingService::headerFieldKey)
+         .collect(java.util.stream.Collectors.toList());
+   }
+
+   @Test
+   void swapsRowsAndCols() {
+      // Recommender's (undesired) layout: category on rows, country on cols.
+      DataRef[] rows = { dim("category") };
+      DataRef[] cols = { dim("country") };
+
+      DataRef[][] out = WizAutoBindingService.repartitionHeaders(
+         rows, cols, List.of("country"), List.of("category"));
+
+      assertEquals(List.of("country"), keys(out[0]), "country pinned to rows");
+      assertEquals(List.of("category"), keys(out[1]), "category pinned to cols");
+   }
+
+   @Test
+   void unpinnedDimensionsKeepTheirGroupAndOrder() {
+      DataRef[] rows = { dim("a"), dim("b") };
+      DataRef[] cols = { dim("c") };
+
+      // Pin only c -> rows; a and b are unpinned and must stay on rows in original order.
+      DataRef[][] out = WizAutoBindingService.repartitionHeaders(
+         rows, cols, List.of("c"), List.of());
+
+      assertEquals(List.of("c", "a", "b"), keys(out[0]));
+      assertEquals(List.of(), keys(out[1]));
+   }
+
+   @Test
+   void matchingIsCaseInsensitive() {
+      DataRef[] rows = { dim("Category") };
+      DataRef[] cols = { dim("Country") };
+
+      DataRef[][] out = WizAutoBindingService.repartitionHeaders(
+         rows, cols, List.of("COUNTRY"), List.of("category"));
+
+      assertEquals(List.of("country"), keys(out[0]));
+      assertEquals(List.of("category"), keys(out[1]));
+   }
+
+   @Test
+   void rowPinWinsWhenFieldPinnedToBothRolesAndNullArraysAreSafe() {
+      DataRef[] rows = { dim("x") };
+
+      DataRef[][] out = WizAutoBindingService.repartitionHeaders(
+         rows, null, List.of("x"), List.of("x"));
+
+      assertEquals(List.of("x"), keys(out[0]));
+      assertEquals(List.of(), keys(out[1]));
+   }
+
+   @Test
+   void pinnedHeaderFieldsFiltersByRoleInOrderAndDeduplicates() {
+      List<ExplicitBinding> bindings = List.of(
+         pin("rows", "country"),
+         pin("cols", "category"),
+         pin("rows", "state"),
+         pin("rows", "country")); // duplicate -> ignored
+
+      assertEquals(List.of("country", "state"),
+                   WizAutoBindingService.pinnedHeaderFields(bindings, "rows"));
+      assertEquals(List.of("category"),
+                   WizAutoBindingService.pinnedHeaderFields(bindings, "cols"));
+      assertTrue(WizAutoBindingService.pinnedHeaderFields(null, "rows").isEmpty());
+   }
+}


### PR DESCRIPTION
## Problem
`explicitBindings` with role `rows`/`cols` were silently dropped for crosstabs. They are funneled into `ChartPreference`, which only models chart slots (`x/y/group/color/shape/size/text`) and has no rows/cols concept — so the recommender chose header placement on its own. In practice a high-cardinality dimension (e.g. `country`, 108 values) landed on **columns**, producing an unreadable wide crosstab, with no API lever to swap it.

## Fix
After the recommender renders the crosstab, repartition its **design + runtime** row/col headers per the `rows`/`cols` pins — mirroring the existing `applyFieldConfigs` post-processing for chart assemblies:

- pinned fields go to their target group in pin order;
- unpinned dimensions keep their original group and relative order;
- matching is case-insensitive on the dimension's column value;
- a `rows` pin wins a rows-vs-cols tie;
- **no-op when there are no pins**, so existing behavior is unchanged.

New `else if (primaryAssembly instanceof CrosstabVSAssembly …)` branch in the create path calls `applyCrosstabHeaderPins()`, backed by pure static helpers `repartitionHeaders()` / `pinnedHeaderFields()` / `headerFieldKey()`.

### Side benefit: per-group top-N
StyleBI scopes top-N ranking by the dimension hierarchy. Controlling the **outer (row)** dimension via a pin therefore makes a top-N ranking on the **inner** dimension behave per-group. Concrete result — "top 3 movie categories per country" (rentals) now ranks within each country (US → Documentary/Sports/Drama, India → Action/Sports/Documentary, China → Animation/Family/Drama), instead of repeating the global top-3 for every country.

## Tests
`WizAutoBindingServiceCrosstabPinsTest` (pure unit, `@Tag("core")`) — swap rows↔cols, unpinned-field retention, case-insensitivity, tie/null-array safety, and pin extraction. 5/5 pass.

## Verification
Built into a local image and verified end-to-end through the viz-chat MCP `create_viewsheet` path: `rows=country`/`cols=category` now places `country` on rows; response headers flip to `[country, category, count]`; per-country top-3 matches a direct SQL `ROW_NUMBER() OVER (PARTITION BY country …)` query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)