### PR TITLE
Bug #75412 - Fix chart hover highlighting and dimming across tiled inline SVG charts

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -2703,9 +2703,20 @@ public class SVGAnimationDOMInjector {
          "svg:has(.inetsoft-bar.inetsoft-active) .inetsoft-bar:not(.inetsoft-active)," +
          "svg:has(.inetsoft-bar.inetsoft-active) .inetsoft-bar-label:not(.inetsoft-active)" +
          "{opacity:" + dim + "!important}" +
-         "svg:has(.inetsoft-relation.inetsoft-active) .inetsoft-relation:not(.inetsoft-active)," +
-         "svg:has(.inetsoft-relation.inetsoft-active) .inetsoft-relation-edge:not(.inetsoft-active)," +
-         "svg:has(.inetsoft-relation.inetsoft-active) .inetsoft-relation-label:not(.inetsoft-active)" +
+         // Trigger on an active node OR an active edge: when a chart is split into tiles, a tile
+         // may hold only an edge incident to the hovered node (its neighbour node lives in another
+         // tile), and that tile must still dim its non-active elements.
+         "svg:has(.inetsoft-relation.inetsoft-active,.inetsoft-relation-edge.inetsoft-active) .inetsoft-relation:not(.inetsoft-active)," +
+         "svg:has(.inetsoft-relation.inetsoft-active,.inetsoft-relation-edge.inetsoft-active) .inetsoft-relation-edge:not(.inetsoft-active)," +
+         "svg:has(.inetsoft-relation.inetsoft-active,.inetsoft-relation-edge.inetsoft-active) .inetsoft-relation-label:not(.inetsoft-active)" +
+         "{opacity:" + dim + "!important}" +
+         // Cross-tile dim: a large chart is split into multiple SVG tiles and the hovered
+         // element lives in only one of them. The :has() rules above are scoped to a single
+         // SVG and cannot reach sibling tiles, so the directive marks the other tiles' SVG
+         // roots with inetsoft-dim-all to dim their (non-active) elements too.
+         "svg.inetsoft-dim-all .inetsoft-bar,svg.inetsoft-dim-all .inetsoft-bar-label," +
+         "svg.inetsoft-dim-all .inetsoft-relation,svg.inetsoft-dim-all .inetsoft-relation-edge," +
+         "svg.inetsoft-dim-all .inetsoft-relation-label" +
          "{opacity:" + dim + "!important}" +
          // A1 chart types: animation is applied directly to the annotation group that is also
          // the hover target. The .ready gate prevents hover dim from conflicting with the
@@ -2731,6 +2742,12 @@ public class SVGAnimationDOMInjector {
          // Mekko + label dimming.
          "svg.ready:has(.inetsoft-mekko.inetsoft-active) .inetsoft-mekko:not(.inetsoft-active)," +
          "svg.ready:has(.inetsoft-mekko.inetsoft-active) .inetsoft-mekko-label:not(.inetsoft-active)" +
+         "{opacity:" + dim + "!important}" +
+         // Cross-tile dim for A1 types (same ready gate as their :has() rules above).
+         "svg.ready.inetsoft-dim-all .inetsoft-point,svg.ready.inetsoft-dim-all .inetsoft-candle," +
+         "svg.ready.inetsoft-dim-all .inetsoft-box,svg.ready.inetsoft-dim-all .inetsoft-treemap," +
+         "svg.ready.inetsoft-dim-all .inetsoft-mekko,svg.ready.inetsoft-dim-all .inetsoft-treemap-label," +
+         "svg.ready.inetsoft-dim-all .inetsoft-mekko-label" +
          "{opacity:" + dim + "!important}" +
          // Area/line hover uses JS-only inline style.opacity (no inetsoft-active class is set).
          // CSS :has(.inetsoft-area.inetsoft-active) rules are not used because CSS :has()

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -257,6 +257,21 @@ class SVGAnimationDOMInjectorTest {
    }
 
    @Test
+   void hoverCssCrossTileDimRulesPresent() throws Exception {
+      Document doc = newDocument();
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_TREEMAP);
+      String css = allStyleContent(doc.getDocumentElement());
+
+      // When a chart is split into multiple SVG tiles, the directive flags tiles that do not
+      // contain the hovered element with inetsoft-dim-all so they dim too (the :has() rules are
+      // scoped to a single SVG). Bar/pie tiles use the non-ready-gated rule; A1 types are gated.
+      assertTrue(css.contains("svg.inetsoft-dim-all .inetsoft-bar"),
+                 "hover CSS must contain cross-tile dim rule for bar/pie");
+      assertTrue(css.contains("svg.ready.inetsoft-dim-all .inetsoft-treemap"),
+                 "hover CSS must contain ready-gated cross-tile dim rule for A1 types");
+   }
+
+   @Test
    void hoverCssTransitionIsUniform() throws Exception {
       Document doc = newDocument();
       SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_TREEMAP);

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
@@ -1,0 +1,174 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { ElementRef } from "@angular/core";
+import { ChartInlineSvgDirective } from "./chart-inline-svg.directive";
+
+function makeDirective(html: string): { dir: ChartInlineSvgDirective, host: HTMLElement } {
+   const host = document.createElement("div");
+   host.innerHTML = html;
+   const dir = new ChartInlineSvgDirective(new ElementRef(host), {} as any);
+   return { dir, host };
+}
+
+function opacities(host: HTMLElement, selector: string): string[] {
+   return Array.from(host.querySelectorAll<HTMLElement>(selector)).map(e => e.style.opacity);
+}
+
+describe("ChartInlineSvgDirective cross-tile dim", () => {
+   describe("setExternalSeriesDim (area/line, keyed on data-color)", () => {
+      const html = `
+         <div class="inetsoft-area" data-color="1,2,3"></div>
+         <div class="inetsoft-line" data-color="1,2,3"></div>
+         <div class="inetsoft-area" data-color="9,9,9"></div>
+         <div class="inetsoft-point" data-color="9,9,9"></div>`;
+      const sel = ".inetsoft-area,.inetsoft-line,.inetsoft-point";
+
+      it("dims only the elements whose data-color differs from the active value", () => {
+         const { dir, host } = makeDirective(html);
+         dir.setExternalSeriesDim("1,2,3");
+         // matching series stays at full opacity; the other series is dimmed.
+         expect(opacities(host, sel)).toEqual(["", "", "0.2", "0.2"]);
+      });
+
+      it("clears all opacity when passed null", () => {
+         const { dir, host } = makeDirective(html);
+         dir.setExternalSeriesDim("1,2,3");
+         dir.setExternalSeriesDim(null);
+         expect(opacities(host, sel)).toEqual(["", "", "", ""]);
+      });
+
+      it("re-targets the active series when the value changes", () => {
+         const { dir, host } = makeDirective(html);
+         dir.setExternalSeriesDim("1,2,3");
+         dir.setExternalSeriesDim("9,9,9");
+         expect(opacities(host, sel)).toEqual(["0.2", "0.2", "", ""]);
+      });
+   });
+
+   describe("setExternalSeriesDim (radar, keyed on data-row)", () => {
+      it("dims by data-row when configured for radar", () => {
+         const { dir, host } = makeDirective(`
+            <div class="inetsoft-radar" data-row="0"></div>
+            <div class="inetsoft-radar" data-row="1"></div>
+            <div class="inetsoft-point" data-row="1"></div>`);
+         (dir as any).dimKeyAttr = "data-row";
+         (dir as any).dimTargetSelector = ".inetsoft-radar,.inetsoft-point";
+         dir.setExternalSeriesDim("1");
+         expect(opacities(host, ".inetsoft-radar,.inetsoft-point")).toEqual(["0.2", "", ""]);
+      });
+   });
+
+   describe("emitSeriesDim dedup", () => {
+      it("emits only when the value actually changes", () => {
+         const { dir } = makeDirective("");
+         const emitted: (string | null)[] = [];
+         dir.seriesDimChange.subscribe(v => emitted.push(v));
+         (dir as any).emitSeriesDim("a");
+         (dir as any).emitSeriesDim("a");
+         (dir as any).emitSeriesDim(null);
+         (dir as any).emitSeriesDim(null);
+         (dir as any).emitSeriesDim("a");
+         // A leave (null) between two hovers of the same series re-emits, so a re-enter is
+         // never swallowed by the dedup — the parent's debounce relies on this.
+         expect(emitted).toEqual(["a", null, "a"]);
+      });
+   });
+
+   describe("setExternalRelationHighlight", () => {
+      const html = `
+         <div class="inetsoft-relation" data-id="A" data-row="0" data-col="0"></div>
+         <div class="inetsoft-relation" data-id="B" data-row="1" data-col="0"></div>
+         <div class="inetsoft-relation" data-id="C" data-row="2" data-col="0"></div>
+         <div class="inetsoft-relation-edge" data-source="A" data-target="B"></div>
+         <div class="inetsoft-relation-edge" data-source="B" data-target="C"></div>
+         <div class="inetsoft-relation-label" data-row="1" data-col="0"></div>
+         <div class="inetsoft-relation-label" data-row="2" data-col="0"></div>`;
+
+      function activeFlags(host: HTMLElement, sel: string): boolean[] {
+         return Array.from(host.querySelectorAll(sel)).map(e => e.classList.contains("inetsoft-active"));
+      }
+
+      it("activates the hovered node, its neighbours, incident edges and their labels", () => {
+         const { dir, host } = makeDirective(html);
+         (dir as any).svgRootEl = host;
+         dir.setExternalRelationHighlight(new Set(["B", "A", "C"]), "B");
+         expect(activeFlags(host, ".inetsoft-relation")).toEqual([true, true, true]);
+         expect(activeFlags(host, ".inetsoft-relation-edge")).toEqual([true, true]);
+         expect(activeFlags(host, ".inetsoft-relation-label")).toEqual([true, true]);
+         expect(host.classList.contains("inetsoft-dim-all")).toBe(false);
+      });
+
+      it("dim-alls a tile that holds no active element", () => {
+         const { dir, host } = makeDirective(`
+            <div class="inetsoft-relation" data-id="X" data-row="0" data-col="0"></div>
+            <div class="inetsoft-relation" data-id="Y" data-row="1" data-col="0"></div>`);
+         (dir as any).svgRootEl = host;
+         dir.setExternalRelationHighlight(new Set(["A", "B"]), "A");
+         expect(activeFlags(host, ".inetsoft-relation")).toEqual([false, false]);
+         expect(host.classList.contains("inetsoft-dim-all")).toBe(true);
+      });
+
+      it("does not dim-all a tile holding only an edge incident to the hovered node", () => {
+         // The neighbour node lives in another tile; here only node Q (unrelated) and the
+         // passing-through A->Z edge exist. The active edge must keep the tile un-dim-alled so
+         // the server :has() rule dims Q while the edge stays lit.
+         const { dir, host } = makeDirective(`
+            <div class="inetsoft-relation" data-id="Q" data-row="0" data-col="0"></div>
+            <div class="inetsoft-relation-edge" data-source="A" data-target="Z"></div>`);
+         (dir as any).svgRootEl = host;
+         dir.setExternalRelationHighlight(new Set(["A", "Z"]), "A");
+         expect(host.querySelector(".inetsoft-relation")!.classList.contains("inetsoft-active")).toBe(false);
+         expect(host.querySelector(".inetsoft-relation-edge")!.classList.contains("inetsoft-active")).toBe(true);
+         expect(host.classList.contains("inetsoft-dim-all")).toBe(false);
+      });
+
+      it("clears all active classes and dim-all on null", () => {
+         const { dir, host } = makeDirective(html);
+         (dir as any).svgRootEl = host;
+         dir.setExternalRelationHighlight(new Set(["A", "B", "C"]), "B");
+         host.classList.add("inetsoft-dim-all");
+         dir.setExternalRelationHighlight(null, null);
+         expect(activeFlags(host, ".inetsoft-relation,.inetsoft-relation-edge,.inetsoft-relation-label")
+            .some(Boolean)).toBe(false);
+         expect(host.classList.contains("inetsoft-dim-all")).toBe(false);
+      });
+   });
+
+   describe("getRelationEdges + emitRelationHover dedup", () => {
+      it("returns this tile's edges as source/target pairs", () => {
+         const { dir } = makeDirective("");
+         (dir as any).relationEdges = [
+            { el: document.createElement("div"), sourceId: "A", targetId: "B" },
+            { el: document.createElement("div"), sourceId: "B", targetId: "C" }
+         ];
+         expect(dir.getRelationEdges()).toEqual([
+            { source: "A", target: "B" }, { source: "B", target: "C" }]);
+      });
+
+      it("emits relationHover only when the node id changes", () => {
+         const { dir } = makeDirective("");
+         const emitted: (string | null)[] = [];
+         dir.relationHover.subscribe(v => emitted.push(v));
+         (dir as any).emitRelationHover("A");
+         (dir as any).emitRelationHover("A");
+         (dir as any).emitRelationHover(null);
+         (dir as any).emitRelationHover("A");
+         expect(emitted).toEqual(["A", null, "A"]);
+      });
+   });
+});

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
@@ -89,6 +89,31 @@ describe("ChartInlineSvgDirective cross-tile dim", () => {
       });
    });
 
+   describe("cross-tile dim-all lifecycle", () => {
+      it("clears inetsoft-dim-all on a sibling tile when the hover ends", () => {
+         vi.useFakeTimers();
+         try {
+            const { dir, host } = makeDirective(
+               `<div class="inetsoft-bar" data-row="1" data-col="0"></div>`);
+            // A loaded sibling tile: holds bar elements but not the element being hovered.
+            (dir as any).svgRootEl = host;
+            (dir as any).elementGroupMap = new Map([["1-0", host.querySelector(".inetsoft-bar")]]);
+
+            // Hover a data point that lives in another tile (key absent from this tile's map).
+            dir.highlightElement(0, 0);
+            expect(host.classList.contains("inetsoft-dim-all")).toBe(true);
+
+            // Mouse leaves the chart: the parent calls highlightElement(null, null) on every tile.
+            dir.highlightElement(null, null);
+            vi.advanceTimersByTime(200);
+            expect(host.classList.contains("inetsoft-dim-all")).toBe(false);
+         }
+         finally {
+            vi.useRealTimers();
+         }
+      });
+   });
+
    describe("setExternalRelationHighlight", () => {
       const html = `
          <div class="inetsoft-relation" data-id="A" data-row="0" data-col="0"></div>

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
@@ -767,12 +767,15 @@ export class ChartInlineSvgDirective implements OnDestroy {
     * never coexist in one SVG.
     */
    private setupRadarSeriesHover(radarGroups: Element[]): void {
+      // Single-tile radar dims via server CSS :hover alone; no JS coordination needed.
       if(!this.crossTile) {
          return;
       }
 
       this.usesSeriesColorDim = true;
       this.dimKeyAttr = "data-row";
+      // Radar has no external label annotation class (labels render inside the polygon/point
+      // groups), so dimming the polygons and vertex points covers every radar element.
       this.dimTargetSelector = ".inetsoft-radar,.inetsoft-point";
 
       const points = Array.from(

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
@@ -50,7 +50,25 @@ export class ChartInlineSvgDirective implements OnDestroy {
    @Output() onLoading = new EventEmitter<void>();
    @Output() onLoaded = new EventEmitter<void>();
    @Output() onError = new EventEmitter<void>();
+   /** Emits the data-color of the hovered area/line series (null on clear) so the parent can
+    *  mirror the dim across sibling tiles of a split chart. Only emitted in cross-tile mode. */
+   @Output() seriesDimChange = new EventEmitter<string | null>();
+   /** Emits the data-id of the hovered relation/tree node (null on clear). The parent resolves
+    *  neighbours from the merged cross-tile graph and drives every tile, since a node's neighbours
+    *  may be rendered in sibling tiles this tile's connectivity maps can't see. Cross-tile only. */
+   @Output() relationHover = new EventEmitter<string | null>();
+   /** True when this chart is split into multiple SVG tiles. In that mode area/line hover only
+    *  detects the active series and emits its color; opacity is applied solely by the parent via
+    *  setExternalSeriesDim so every tile dims consistently (geometry-based local dim can't reach
+    *  sibling SVGs). */
+   @Input() crossTile = false;
    private _url: string = null;
+   /** Last color emitted via seriesDimChange, to suppress duplicate emits. */
+   private _emittedSeriesColor: string | null = null;
+   /** Last node id emitted via relationHover, to suppress duplicate emits. */
+   private _emittedRelationId: string | null = null;
+   /** True when this tile holds relation/tree nodes; gates the cross-tile relation path. */
+   private isRelationChart = false;
 
    /**
     * Unified map from "rowIdx-colIdx" to the annotated SVG group for that data point,
@@ -64,6 +82,8 @@ export class ChartInlineSvgDirective implements OnDestroy {
    private labelGroupMap = new Map<string, Element[]>();
    /** Key of the currently active element, or null. */
    private _activeKey: string | null = null;
+   /** Cached SVG root of this tile, used to toggle the cross-tile inetsoft-dim-all class. */
+   private svgRootEl: SVGSVGElement | null = null;
    /** Timer handle for debounced deactivation, so fast inter-bar moves don't flash. */
    private clearHandle: ReturnType<typeof setTimeout> | null = null;
    /** Timer handle for Retry-After retry, stored so it can be cancelled on destroy. */
@@ -82,6 +102,15 @@ export class ChartInlineSvgDirective implements OnDestroy {
    private areaSeriesCache: Array<{localX: number, localY: number}[]> = [];
    /** Index into areaSeries of the currently highlighted series, or -1. */
    private activeSeriesIdx: number = -1;
+   /** True for area/line/radar charts, which dim by series key (setExternalSeriesDim) rather than
+    *  the inetsoft-active/inetsoft-dim-all class mechanism. Prevents the class-based cross-tile
+    *  dim from fighting the key-based one over shared .inetsoft-point markers. */
+   private usesSeriesColorDim = false;
+   /** Attribute identifying a series for cross-tile dim: data-color for area/line, data-row for
+    *  radar. The value is stable across a split chart's SVG tiles. */
+   private dimKeyAttr = "data-color";
+   /** Selector for the elements setExternalSeriesDim dims (per chart type). */
+   private dimTargetSelector = ".inetsoft-area,.inetsoft-line,.inetsoft-point";
    /** SVG element that holds area mousemove/mouseleave listeners, kept for cleanup. */
    private areaHoverSvgEl: SVGSVGElement | null = null;
    private areaMouseMoveHandler: ((e: MouseEvent) => void) | null = null;
@@ -200,10 +229,27 @@ export class ChartInlineSvgDirective implements OnDestroy {
    private activateKey(key: string): void {
       const el = this.elementGroupMap.get(key);
       if(el) {
+         // Relation in a split chart: the hovered node's neighbours may live in sibling tiles
+         // this tile's connectivity maps can't see. Emit the node id and let the parent resolve
+         // neighbours from the merged graph and drive every tile via setExternalRelationHighlight.
+         if(this.isRelationChart && this.crossTile) {
+            this.emitRelationHover(el.getAttribute("data-id"));
+            return;
+         }
          el.classList.add("inetsoft-active");
          if(el.classList.contains("inetsoft-relation")) {
             this.activateRelationNeighbors(el);
          }
+      }
+      // A large chart is split into multiple SVG tiles. The hovered data point lives in
+      // only one tile, so its inetsoft-active class (and the server's :has() dim rule, which
+      // is scoped to a single SVG) never reaches sibling tiles. When this tile holds
+      // hover-managed elements but not the active one, flag its root so server CSS dims them.
+      // Skipped for area/line charts (they dim by series color) and cross-tile relation charts
+      // (the parent drives per-tile highlight + dim via setExternalRelationHighlight).
+      else if(this.elementGroupMap.size > 0 && this.svgRootEl && !this.usesSeriesColorDim &&
+              !(this.isRelationChart && this.crossTile)) {
+         this.svgRootEl.classList.add("inetsoft-dim-all");
       }
       const glyphs = this.labelGroupMap.get(key);
       if(glyphs) glyphs.forEach(g => g.classList.add("inetsoft-active"));
@@ -211,6 +257,13 @@ export class ChartInlineSvgDirective implements OnDestroy {
 
    private deactivateCurrent(): void {
       if(this._activeKey === null) return;
+      // Cross-tile relation: the parent set inetsoft-active/dim-all across tiles, so clearing is
+      // its job too — emit the clear and don't strip classes locally (that would fight the parent).
+      if(this.isRelationChart && this.crossTile) {
+         this.emitRelationHover(null);
+         return;
+      }
+      if(this.svgRootEl) this.svgRootEl.classList.remove("inetsoft-dim-all");
       const el = this.elementGroupMap.get(this._activeKey);
       if(el) el.classList.remove("inetsoft-active");
       for(const n of this.activeRelationNeighbors) {
@@ -311,6 +364,12 @@ export class ChartInlineSvgDirective implements OnDestroy {
       this.teardownLineSeriesHover();
       this.areaSeries = [];
       this.activeSeriesIdx = -1;
+      this.usesSeriesColorDim = false;
+      this.dimKeyAttr = "data-color";
+      this.dimTargetSelector = ".inetsoft-area,.inetsoft-line,.inetsoft-point";
+      this._emittedSeriesColor = null;
+      this.isRelationChart = false;
+      this._emittedRelationId = null;
 
       this.elementGroupMap.clear();
       this.labelGroupMap.clear();
@@ -318,6 +377,7 @@ export class ChartInlineSvgDirective implements OnDestroy {
       this.relationEdges = [];
       this.activeRelationNeighbors = [];
       this._activeKey = null;
+      this.svgRootEl = this.element.nativeElement.querySelector("svg");
 
       // Populate the unified element map from all annotated VO groups.
       // Each CSS class corresponds to a different chart type; the CSS class on the stored
@@ -353,6 +413,7 @@ export class ChartInlineSvgDirective implements OnDestroy {
          // interior areas. pointer-events:none on the container is kept (set in the host
          // component's SCSS); events outside polygon hit areas pass through to the canvas.
          this.element.nativeElement.style.zIndex = "1";
+         this.setupRadarSeriesHover(radarGroups);
       }
       else if(areaFillGroups.length > 0) {
          // Area chart — raise SVG above canvas overlay and enable pointer-events on the SVG
@@ -383,6 +444,7 @@ export class ChartInlineSvgDirective implements OnDestroy {
       // Build relation connectivity maps so activateKey can highlight connected edges/neighbors.
       const relationNodes = Array.from(
          this.element.nativeElement.querySelectorAll(".inetsoft-relation") as NodeListOf<Element>);
+      this.isRelationChart = relationNodes.length > 0;
       for(const n of relationNodes) {
          const nodeId = n.getAttribute("data-id");
          if(nodeId) this.relationNodeIdMap.set(nodeId, n);
@@ -448,6 +510,8 @@ export class ChartInlineSvgDirective implements OnDestroy {
 
       if(this.areaSeries.length === 0) return;
 
+      this.usesSeriesColorDim = true;
+
       // Pre-sample each line path in SVG local coordinates so mousemove hit-testing can avoid
       // repeated getPointAtLength() calls. getPointAtLength is O(path-length) in all browsers;
       // at 60 fps with multiple series that compounds quickly. Pre-sampling once at load time
@@ -478,7 +542,7 @@ export class ChartInlineSvgDirective implements OnDestroy {
 
       this.areaHoverSvgEl = svgEl;
       this.areaMouseMoveHandler = (e: MouseEvent) => this.onAreaMouseMove(e);
-      this.areaMouseLeaveHandler = () => this.deactivateArea();
+      this.areaMouseLeaveHandler = () => { this.deactivateArea(); this.emitSeriesDim(null); };
       svgEl.addEventListener("mousemove", this.areaMouseMoveHandler);
       svgEl.addEventListener("mouseleave", this.areaMouseLeaveHandler);
    }
@@ -610,6 +674,8 @@ export class ChartInlineSvgDirective implements OnDestroy {
 
       if(seriesMap.size === 0) return;
 
+      this.usesSeriesColorDim = true;
+
       // allElems intentionally spans the entire SVG (all panels). Hovering a series dims
       // every element outside that series, including sibling panels in a faceted chart.
       // This is deliberate: cross-panel dimming focuses attention on the hovered panel.
@@ -625,6 +691,11 @@ export class ChartInlineSvgDirective implements OnDestroy {
 
       const clearDim = () => {
          this.lineSeriesClearTimer = null;
+         // Cross-tile: opacity is managed by the parent via setExternalSeriesDim; just emit clear.
+         if(this.crossTile) {
+            this.emitSeriesDim(null);
+            return;
+         }
          for(const elem of allElems) {
             (elem as HTMLElement).style.removeProperty("opacity");
          }
@@ -632,11 +703,19 @@ export class ChartInlineSvgDirective implements OnDestroy {
 
       for(const [, series] of seriesMap) {
          const seriesSet = new Set<Element>([...series.lines, ...series.points]);
+         const seriesColor = [...series.lines, ...series.points]
+            .map(e => e.getAttribute("data-color")).find(c => c) ?? null;
 
          const enterHandler = () => {
             if(this.lineSeriesClearTimer !== null) {
                clearTimeout(this.lineSeriesClearTimer);
                this.lineSeriesClearTimer = null;
+            }
+            // Cross-tile: emit the active color so the parent dims every tile uniformly; the
+            // per-SVG loop below cannot reach sibling tiles holding the rest of each series.
+            if(this.crossTile) {
+               this.emitSeriesDim(seriesColor);
+               return;
             }
             for(const elem of allElems) {
                if(!seriesSet.has(elem)) {
@@ -678,6 +757,60 @@ export class ChartInlineSvgDirective implements OnDestroy {
       // entirely. In both cases, resetting the style would be a no-op.
    }
 
+   /**
+    * Cross-tile radar hover. Single-tile radar dims entirely via server CSS :hover, which is
+    * scoped to one SVG and cannot reach sibling tiles of a split chart. In cross-tile mode we add
+    * JS listeners that emit the hovered series' data-row (radar's stable series key); the parent
+    * mirrors the dim onto every tile via setExternalSeriesDim. Listeners cover both polygon groups
+    * and their vertex points (points sit on top, so the mouse may enter a point without crossing
+    * the polygon interior). Reuses the line-series abort controller/timer — radar and line charts
+    * never coexist in one SVG.
+    */
+   private setupRadarSeriesHover(radarGroups: Element[]): void {
+      if(!this.crossTile) {
+         return;
+      }
+
+      this.usesSeriesColorDim = true;
+      this.dimKeyAttr = "data-row";
+      this.dimTargetSelector = ".inetsoft-radar,.inetsoft-point";
+
+      const points = Array.from(
+         this.element.nativeElement.querySelectorAll(".inetsoft-point") as NodeListOf<Element>);
+      const targets = [...radarGroups, ...points];
+
+      if(targets.length === 0) {
+         return;
+      }
+
+      const ac = new AbortController();
+      this.lineSeriesAbortController = ac;
+
+      const enter = (el: Element) => {
+         if(this.lineSeriesClearTimer !== null) {
+            clearTimeout(this.lineSeriesClearTimer);
+            this.lineSeriesClearTimer = null;
+         }
+         this.emitSeriesDim(el.getAttribute("data-row"));
+      };
+
+      const leave = () => {
+         if(this.lineSeriesClearTimer !== null) {
+            clearTimeout(this.lineSeriesClearTimer);
+         }
+         this.lineSeriesClearTimer = setTimeout(() => {
+            this.lineSeriesClearTimer = null;
+            this.emitSeriesDim(null);
+         }, ChartInlineSvgDirective.CLEAR_DELAY_MS);
+      };
+
+      for(const el of targets) {
+         (el as HTMLElement).style.pointerEvents = "all";
+         el.addEventListener("mouseenter", () => enter(el), { signal: ac.signal } as AddEventListenerOptions);
+         el.addEventListener("mouseleave", leave, { signal: ac.signal } as AddEventListenerOptions);
+      }
+   }
+
    private onAreaMouseMove(e: MouseEvent): void {
       // Collect screen y for every series. getScreenYAtX returns NaN when the mouse x is
       // outside that path's x-range (> 20px beyond path endpoints) — cross-panel paths
@@ -708,7 +841,14 @@ export class ChartInlineSvgDirective implements OnDestroy {
          this.deactivateArea();
          this.activeSeriesIdx = nearestIdx;
 
-         if(nearestIdx >= 0) {
+         // Cross-tile: don't dim locally — emit the active color so the parent dims every tile
+         // (including this one) uniformly. The geometry-based local dim below cannot reach the
+         // sibling SVGs that hold the rest of each series.
+         if(this.crossTile) {
+            this.emitSeriesDim(nearestIdx >= 0
+               ? this.areaSeries[nearestIdx].fillGroup.getAttribute("data-color") : null);
+         }
+         else if(nearestIdx >= 0) {
             // Dim only same-panel series (those with a valid y at this mouse x).
             // Cross-panel series (yValues[i] === null) keep full opacity — no contamination.
             for(let i = 0; i < this.areaSeries.length; i++) {
@@ -721,12 +861,118 @@ export class ChartInlineSvgDirective implements OnDestroy {
    }
 
    private deactivateArea(): void {
-      if(this.activeSeriesIdx >= 0) {
+      // In cross-tile mode opacity is managed only by setExternalSeriesDim, so leave it alone.
+      if(this.activeSeriesIdx >= 0 && !this.crossTile) {
          for(const s of this.areaSeries) {
             (s.fillGroup as HTMLElement).style.opacity = "";
             (s.lineGroup as HTMLElement).style.opacity = "";
          }
-         this.activeSeriesIdx = -1;
+      }
+      this.activeSeriesIdx = -1;
+   }
+
+   /** Emit seriesDimChange only when the active color actually changes, to suppress duplicates. */
+   private emitSeriesDim(color: string | null): void {
+      if(color !== this._emittedSeriesColor) {
+         this._emittedSeriesColor = color;
+         this.seriesDimChange.emit(color);
+      }
+   }
+
+   /** Emit relationHover only when the active node id changes, to suppress duplicates. */
+   private emitRelationHover(id: string | null): void {
+      if(id !== this._emittedRelationId) {
+         this._emittedRelationId = id;
+         this.relationHover.emit(id);
+      }
+   }
+
+   /** This tile's relation edges as source/target id pairs, for the parent to merge into the
+    *  cross-tile connectivity graph. */
+   getRelationEdges(): { source: string, target: string }[] {
+      return this.relationEdges.map(e => ({ source: e.sourceId, target: e.targetId }));
+   }
+
+   /**
+    * Highlight this tile's share of a relation hover, driven by the parent so neighbours render
+    * correctly across a split chart's SVGs. Nodes whose data-id is in activeIds (the hovered node
+    * plus its neighbours) and edges incident to hoveredId get inetsoft-active; their labels too.
+    * A tile with at least one active element relies on the server :has() rule to dim the rest; a
+    * tile with none gets inetsoft-dim-all so it dims fully. Pass null to clear.
+    */
+   setExternalRelationHighlight(activeIds: Set<string> | null, hoveredId: string | null): void {
+      const nodes = Array.from(this.element.nativeElement
+         .querySelectorAll(".inetsoft-relation") as NodeListOf<Element>);
+      const edges = Array.from(this.element.nativeElement
+         .querySelectorAll(".inetsoft-relation-edge") as NodeListOf<Element>);
+      const labels = Array.from(this.element.nativeElement
+         .querySelectorAll(".inetsoft-relation-label") as NodeListOf<Element>);
+
+      if(activeIds == null) {
+         for(const el of [...nodes, ...edges, ...labels]) el.classList.remove("inetsoft-active");
+         this.svgRootEl?.classList.remove("inetsoft-dim-all");
+         return;
+      }
+
+      let anyActive = false;
+      const activeRowCols = new Set<string>();
+
+      for(const node of nodes) {
+         const id = node.getAttribute("data-id");
+         if(id != null && activeIds.has(id)) {
+            node.classList.add("inetsoft-active");
+            anyActive = true;
+            const r = node.getAttribute("data-row"), c = node.getAttribute("data-col");
+            if(r != null && c != null) activeRowCols.add(`${r}-${c}`);
+         }
+         else {
+            node.classList.remove("inetsoft-active");
+         }
+      }
+
+      for(const edge of edges) {
+         const s = edge.getAttribute("data-source"), t = edge.getAttribute("data-target");
+         if(hoveredId != null && (s === hoveredId || t === hoveredId)) {
+            edge.classList.add("inetsoft-active");
+            anyActive = true;
+         }
+         else {
+            edge.classList.remove("inetsoft-active");
+         }
+      }
+
+      for(const label of labels) {
+         const r = label.getAttribute("data-row"), c = label.getAttribute("data-col");
+         if(r != null && c != null && activeRowCols.has(`${r}-${c}`)) {
+            label.classList.add("inetsoft-active");
+         }
+         else {
+            label.classList.remove("inetsoft-active");
+         }
+      }
+
+      if(this.svgRootEl) {
+         this.svgRootEl.classList.toggle("inetsoft-dim-all", !anyActive);
+      }
+   }
+
+   /**
+    * Dim this tile's series elements whose dimKeyAttr value differs from activeValue, leaving the
+    * matching (hovered) series at full opacity. Pass null to clear. Called by the parent for every
+    * tile so the hovered series stays highlighted consistently across a split chart's SVGs. The
+    * key is data-color for area/line and data-row for radar — both stable across tiles.
+    */
+   setExternalSeriesDim(activeValue: string | null): void {
+      const elems = this.element.nativeElement.querySelectorAll(
+         this.dimTargetSelector) as NodeListOf<Element>;
+
+      for(const el of Array.from(elems) as Element[]) {
+         if(activeValue != null && el.getAttribute(this.dimKeyAttr) !== activeValue) {
+            (el as HTMLElement).style.setProperty("opacity", "0.2", "important");
+         }
+         else {
+            (el as HTMLElement).style.removeProperty("opacity");
+         }
       }
    }
 

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.html
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.html
@@ -62,6 +62,9 @@
           @if (inlineSvg) {
             <div class="chart-plot-area__inline-svg"
               [chartInlineSvg]="getSrc(tile, container)"
+              [crossTile]="chartObject.tiles.length > 1"
+              (seriesDimChange)="onSeriesDimChange($event, tile)"
+              (relationHover)="onRelationHover($event, tile)"
               (onLoading)="loading(tile)"
               (onLoaded)="loaded(true, tile)"
               (onError)="loaded(false, tile)">

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.spec.ts
@@ -524,4 +524,169 @@ describe("ChartPlotArea Integration Tests", () => {
       // Chart select region should have been called
       expect(selectRegionSpy).toHaveBeenCalled();
    });
+
+   describe("cross-tile series dim coordination", () => {
+      function setup() {
+         const fixture = TestBed.createComponent(TestApp);
+         const component: ChartPlotArea =
+            fixture.debugElement.query(By.css("chart-plot-area")).componentInstance;
+         vi.spyOn(component, "getSrc").mockImplementation(() => "");
+         fixture.detectChanges();
+         const tileA = { setExternalSeriesDim: vi.fn() };
+         const tileB = { setExternalSeriesDim: vi.fn() };
+         // QueryList exposes forEach; an array stands in for the test.
+         (component as any).inlineSvgTiles = [tileA, tileB];
+         return { component, tileA, tileB };
+      }
+
+      it("applies the dim to every tile when a tile reports a color", () => {
+         const { component, tileA, tileB } = setup();
+         const t1 = {} as any;
+         component.onSeriesDimChange("1,2,3", t1);
+         expect(tileA.setExternalSeriesDim).toHaveBeenCalledWith("1,2,3");
+         expect(tileB.setExternalSeriesDim).toHaveBeenCalledWith("1,2,3");
+         expect((component as any).activeDimTile).toBe(t1);
+      });
+
+      // Crossing a tile boundary, the leaving tile's null and the entering tile's color can
+      // arrive in either order. A null from a tile that is not the active source must not clear
+      // the dim the active tile just set.
+      it("ignores a null from a tile that is not the active source", () => {
+         vi.useFakeTimers();
+         try {
+            const { component, tileA, tileB } = setup();
+            const t1 = {} as any, t2 = {} as any;
+            component.onSeriesDimChange("c", t1);
+            tileA.setExternalSeriesDim.mockClear();
+            tileB.setExternalSeriesDim.mockClear();
+            component.onSeriesDimChange(null, t2);
+            vi.advanceTimersByTime(500);
+            expect(tileA.setExternalSeriesDim).not.toHaveBeenCalledWith(null);
+            expect(tileB.setExternalSeriesDim).not.toHaveBeenCalledWith(null);
+            expect((component as any).activeDimTile).toBe(t1);
+         }
+         finally {
+            vi.useRealTimers();
+         }
+      });
+
+      it("debounces a clear from the active tile and cancels it on re-hover", () => {
+         vi.useFakeTimers();
+         try {
+            const { component, tileA } = setup();
+            const t1 = {} as any;
+            component.onSeriesDimChange("c", t1);
+            component.onSeriesDimChange(null, t1);
+            component.onSeriesDimChange("c", t1);
+            tileA.setExternalSeriesDim.mockClear();
+            vi.advanceTimersByTime(500);
+            expect(tileA.setExternalSeriesDim).not.toHaveBeenCalledWith(null);
+         }
+         finally {
+            vi.useRealTimers();
+         }
+      });
+
+      it("clears every tile after the debounce when the active tile leaves", () => {
+         vi.useFakeTimers();
+         try {
+            const { component, tileA, tileB } = setup();
+            const t1 = {} as any;
+            component.onSeriesDimChange("c", t1);
+            tileA.setExternalSeriesDim.mockClear();
+            tileB.setExternalSeriesDim.mockClear();
+            component.onSeriesDimChange(null, t1);
+            expect(tileA.setExternalSeriesDim).not.toHaveBeenCalled();
+            vi.advanceTimersByTime(150);
+            expect(tileA.setExternalSeriesDim).toHaveBeenCalledWith(null);
+            expect(tileB.setExternalSeriesDim).toHaveBeenCalledWith(null);
+            expect((component as any).activeDimTile).toBeNull();
+         }
+         finally {
+            vi.useRealTimers();
+         }
+      });
+
+      it("cancels a pending dim-clear timer on cleanup", () => {
+         vi.useFakeTimers();
+         try {
+            const { component, tileA } = setup();
+            const t1 = {} as any;
+            component.onSeriesDimChange("c", t1);
+            component.onSeriesDimChange(null, t1);
+            (component as any).cleanup();
+            tileA.setExternalSeriesDim.mockClear();
+            vi.advanceTimersByTime(500);
+            expect(tileA.setExternalSeriesDim).not.toHaveBeenCalledWith(null);
+         }
+         finally {
+            vi.useRealTimers();
+         }
+      });
+   });
+
+   describe("cross-tile relation highlight coordination", () => {
+      function setup(edgesA: any[] = [], edgesB: any[] = []) {
+         const fixture = TestBed.createComponent(TestApp);
+         const component: ChartPlotArea =
+            fixture.debugElement.query(By.css("chart-plot-area")).componentInstance;
+         vi.spyOn(component, "getSrc").mockImplementation(() => "");
+         fixture.detectChanges();
+         const tileA = { getRelationEdges: vi.fn(() => edgesA), setExternalRelationHighlight: vi.fn() };
+         const tileB = { getRelationEdges: vi.fn(() => edgesB), setExternalRelationHighlight: vi.fn() };
+         (component as any).inlineSvgTiles = [tileA, tileB];
+         return { component, tileA, tileB };
+      }
+
+      // Connectivity is split across tiles: N->M lives in tile A, N->P in tile B. Hovering N must
+      // resolve both neighbours by merging every tile's edges, then broadcast to all tiles.
+      it("merges edges across tiles to resolve neighbours and broadcasts the active set", () => {
+         const { component, tileA, tileB } = setup(
+            [{ source: "N", target: "M" }], [{ source: "N", target: "P" }]);
+         const t = {} as any;
+         component.onRelationHover("N", t);
+         const [ids, hoveredId] = tileA.setExternalRelationHighlight.mock.calls[0];
+         expect(hoveredId).toBe("N");
+         expect([...(ids as Set<string>)].sort()).toEqual(["M", "N", "P"]);
+         expect(tileB.setExternalRelationHighlight).toHaveBeenCalledWith(ids, "N");
+         expect((component as any).activeRelationTile).toBe(t);
+      });
+
+      it("ignores a null from a tile that is not the active source", () => {
+         vi.useFakeTimers();
+         try {
+            const { component, tileA } = setup([{ source: "N", target: "M" }]);
+            const t1 = {} as any, t2 = {} as any;
+            component.onRelationHover("N", t1);
+            tileA.setExternalRelationHighlight.mockClear();
+            component.onRelationHover(null, t2);
+            vi.advanceTimersByTime(500);
+            expect(tileA.setExternalRelationHighlight).not.toHaveBeenCalledWith(null, null);
+            expect((component as any).activeRelationTile).toBe(t1);
+         }
+         finally {
+            vi.useRealTimers();
+         }
+      });
+
+      it("clears every tile after the debounce when the active tile leaves", () => {
+         vi.useFakeTimers();
+         try {
+            const { component, tileA, tileB } = setup([{ source: "N", target: "M" }]);
+            const t1 = {} as any;
+            component.onRelationHover("N", t1);
+            tileA.setExternalRelationHighlight.mockClear();
+            tileB.setExternalRelationHighlight.mockClear();
+            component.onRelationHover(null, t1);
+            expect(tileA.setExternalRelationHighlight).not.toHaveBeenCalled();
+            vi.advanceTimersByTime(150);
+            expect(tileA.setExternalRelationHighlight).toHaveBeenCalledWith(null, null);
+            expect(tileB.setExternalRelationHighlight).toHaveBeenCalledWith(null, null);
+            expect((component as any).activeRelationTile).toBeNull();
+         }
+         finally {
+            vi.useRealTimers();
+         }
+      });
+   });
 });

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
@@ -138,6 +138,19 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
 
    private readonly debounceKey: string = "chart_dataTipEvent";
 
+   // Cross-tile area/line hover: the hovered tile reports the active series color; we mirror the
+   // dim onto every tile so the hovered series stays highlighted across a split chart's SVGs.
+   private seriesDimClearTimer: ReturnType<typeof setTimeout> | null = null;
+   // Tile currently driving the cross-tile dim, so a stale null from a tile the cursor already
+   // left (the events can arrive in either order) doesn't clear the dim the new tile just set.
+   private activeDimTile: ChartTile | null = null;
+
+   // Cross-tile relation/tree hover: the hovered tile reports the node id; we resolve neighbours
+   // from the graph merged across every tile (a node's neighbours may be in sibling tiles) and
+   // drive each tile's highlight. Same debounce + active-tile guard as the series dim above.
+   private relationDimClearTimer: ReturnType<typeof setTimeout> | null = null;
+   private activeRelationTile: ChartTile | null = null;
+
    // Snap: cached X ticks → region indices. Rebuilt on chartObject change.
    private snapXTicks: Array<{ pixelX: number, regionIndices: number[] }> = [];
    private snapXTicksFor: Plot = null;
@@ -183,6 +196,16 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
 
    protected cleanup(): void {
       this.destroyed = true;
+
+      if(this.seriesDimClearTimer !== null) {
+         clearTimeout(this.seriesDimClearTimer);
+         this.seriesDimClearTimer = null;
+      }
+
+      if(this.relationDimClearTimer !== null) {
+         clearTimeout(this.relationDimClearTimer);
+         this.relationDimClearTimer = null;
+      }
    }
 
    private emitFlyover(chartSelection: ChartSelection): void {
@@ -462,8 +485,24 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
       // display different values in the mobile state in different browsers. (Bug #60440)
       if((<any> event).button === 0) {
          const mevent: MouseEvent = <MouseEvent> event;
-         let eventX = mevent.offsetX + this.scrollLeft;
-         let eventY = mevent.offsetY + this.scrollTop;
+         let eventX: number;
+         let eventY: number;
+
+         if(this.inlineSvg) {
+            // Inline area/line/radar SVG tiles are raised above the overlay canvas with
+            // pointer-events:all, so they — not the canvas — become the event target and
+            // offsetX/offsetY are measured from the hovered tile's origin, not the plot. That
+            // left-shifts the X for every tile past the first, putting the snap line and tooltip
+            // in the wrong tile. Derive plot coordinates from the overlay canvas rect instead,
+            // matching onContextMenu's convention.
+            const rect = this.objectCanvas.nativeElement.getBoundingClientRect();
+            eventX = (mevent.clientX - rect.left) / this.viewsheetScale + this.scrollLeft;
+            eventY = (mevent.clientY - rect.top) / this.viewsheetScale + this.scrollTop;
+         }
+         else {
+            eventX = mevent.offsetX + this.scrollLeft;
+            eventY = mevent.offsetY + this.scrollTop;
+         }
          let regions: ChartRegion[] = this.getTreeRegions(eventX, eventY);
          let snapPrimary: ChartRegion = null;
 
@@ -755,6 +794,86 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
       if(this.inlineSvg) {
          this.inlineSvgTiles?.forEach(d => d.highlightElement(null, null));
       }
+   }
+
+   /**
+    * Mirror an area/line series hover (reported by the tile under the cursor) onto every tile so
+    * the hovered series stays highlighted across a split chart's separate SVGs. A non-null color
+    * applies immediately; a clear is debounced so moving the cursor between adjacent tiles does
+    * not flash the dim off. A null from a tile that is no longer the active source is ignored —
+    * when crossing a tile boundary the leave (null) and enter (color) can arrive in either order.
+    */
+   onSeriesDimChange(color: string | null, tile: ChartTile): void {
+      if(color != null) {
+         if(this.seriesDimClearTimer !== null) {
+            clearTimeout(this.seriesDimClearTimer);
+            this.seriesDimClearTimer = null;
+         }
+
+         this.activeDimTile = tile;
+         this.inlineSvgTiles?.forEach(d => d.setExternalSeriesDim(color));
+      }
+      else if(tile === this.activeDimTile && this.seriesDimClearTimer === null) {
+         this.seriesDimClearTimer = setTimeout(() => {
+            this.seriesDimClearTimer = null;
+            this.activeDimTile = null;
+            this.inlineSvgTiles?.forEach(d => d.setExternalSeriesDim(null));
+         }, 150);
+      }
+   }
+
+   /**
+    * Mirror a relation/tree node hover across a split chart's tiles. The hovered tile only reports
+    * the node id; neighbours are resolved from the edge graph merged across every tile (a node's
+    * neighbours may be rendered in sibling tiles), then each tile highlights its share. Clearing is
+    * debounced and guarded by the active source tile, mirroring onSeriesDimChange — the leave (null)
+    * and the next enter (id) can arrive in either order when crossing a tile boundary.
+    */
+   onRelationHover(nodeId: string | null, tile: ChartTile): void {
+      if(nodeId != null) {
+         if(this.relationDimClearTimer !== null) {
+            clearTimeout(this.relationDimClearTimer);
+            this.relationDimClearTimer = null;
+         }
+
+         const adjacency = this.buildRelationAdjacency();
+         const activeIds = new Set<string>([nodeId]);
+         adjacency.get(nodeId)?.forEach(n => activeIds.add(n));
+         this.activeRelationTile = tile;
+         this.inlineSvgTiles?.forEach(d => d.setExternalRelationHighlight(activeIds, nodeId));
+      }
+      else if(tile === this.activeRelationTile && this.relationDimClearTimer === null) {
+         this.relationDimClearTimer = setTimeout(() => {
+            this.relationDimClearTimer = null;
+            this.activeRelationTile = null;
+            this.inlineSvgTiles?.forEach(d => d.setExternalRelationHighlight(null, null));
+         }, 150);
+      }
+   }
+
+   // Merge every tile's relation edges into one undirected adjacency map. Each tile holds only its
+   // own slice of the graph, so neighbour resolution must span all tiles. Rebuilt per node change
+   // (emitRelationHover dedups, so this is not per-mousemove) to stay correct after data refresh.
+   private buildRelationAdjacency(): Map<string, Set<string>> {
+      const adjacency = new Map<string, Set<string>>();
+
+      const link = (a: string, b: string) => {
+         let set = adjacency.get(a);
+         if(!set) {
+            set = new Set();
+            adjacency.set(a, set);
+         }
+         set.add(b);
+      };
+
+      this.inlineSvgTiles?.forEach(d => {
+         for(const edge of d.getRelationEdges()) {
+            link(edge.source, edge.target);
+            link(edge.target, edge.source);
+         }
+      });
+
+      return adjacency;
    }
 
    public updateChartObject(oldObj?: Plot): void {

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
@@ -814,6 +814,9 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
          this.inlineSvgTiles?.forEach(d => d.setExternalSeriesDim(color));
       }
       else if(tile === this.activeDimTile && this.seriesDimClearTimer === null) {
+         // Separate from the directive's CLEAR_DELAY_MS (which debounces moving between elements
+         // within one tile): this debounces the cross-tile clear so a tile-boundary crossing
+         // (leave then enter) doesn't flash the dim off. Intentionally independent layers.
          this.seriesDimClearTimer = setTimeout(() => {
             this.seriesDimClearTimer = null;
             this.activeDimTile = null;


### PR DESCRIPTION
 ## Summary

With `graph.svg.inline=true`, a chart whose plot exceeds `ChartArea.MAX_IMAGE_SIZE` (1024px) is rendered as a grid of separate `<svg>` tiles. Every hover interaction was scoped to a single SVG, so at tile boundaries hovering a data point:

- left other tiles' elements undimmed (pie/bar/treemap/etc. and
area/line/radar),
- for relation/tree charts, dimmed real neighbours that happened to live in
a sibling tile instead of highlighting them,
- and placed the snap reference line and tooltip in the wrong tile.

This PR coordinates hover across tiles for each chart-type hover mechanism, plus fixes the pointer-coordinate bug.

## Changes

**Class-based dimming** (pie/bar, point, candle, box, treemap/sunburst/icicle, circle-packing, mekko, relation): tiles that don't contain the hovered element are flagged with `inetsoft-dim-all`; the server emits matching `svg.inetsoft-dim-all` rules so those tiles dim too. The existing `:has()` rules only reach one SVG.

**Series dimming** (area/line/radar): the hovered tile detects the active series and emits its cross-tile-stable key (`data-color` for area/line, `data-row` for radar). The parent mirrors the dim onto every tile via `setExternalSeriesDim`, so the hovered series stays fully lit and the rest dim consistently.

**Relation/tree neighbour highlighting:** a node's neighbours can render in sibling tiles, so the parent merges every tile's edges into one adjacency map, resolves the neighbour set, and drives each tile via `setExternalRelationHighlight`. The server relation `:has()` trigger now fires on an active node OR edge, so a tile holding only a pass-through incident edge still dims its non-active elements.

**Snap line / tooltip coordinate:** area/line/radar inline SVG tiles are raised above the overlay canvas with `pointer-events:all`, so
`offsetX/offsetY` were measured from the hovered tile's origin, left-shifting X for every tile past the first. `onMove` now derives plot
coordinates from the overlay canvas rect (the same convention `onContextMenu` already uses).

## Correctness notes

- Cross-tile-boundary event ordering (one tile's leave/clear arriving before or after the next tile's enter) is handled by a debounced clear guarded by the active source tile, so the dim never flashes off or clears prematurely.
- Single-tile charts and non-inline (image) rendering are unchanged — all new behaviour is gated on `crossTile` (`tiles.length > 1`) / `inlineSvg`.

## Tests

- Directive spec: `setExternalSeriesDim` (color/row keying, clear), `setExternalRelationHighlight` (node/edge/label activation, dim-all on neighbourless tiles, edge-only tiles, clear), emit dedup.
- Component spec: cross-tile series and relation coordination including the merge, both cross-boundary orderings, debounce, and timer cleanup.
- Server CSS rule test for the cross-tile dim rules.