### PR TITLE
Performance: reduce Ignite write churn in RuntimeSheetCache

### DIFF
--- a/build-tools/cluster-proxy-annotations/src/main/java/inetsoft/cluster/ClusterWriteMethod.java
+++ b/build-tools/cluster-proxy-annotations/src/main/java/inetsoft/cluster/ClusterWriteMethod.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.cluster;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks a {@link ClusterProxyMethod} method as a mutation — one that modifies the
+ * RuntimeSheet state and requires the session to be written back to the distributed cache.
+ * {@code SheetWriteAspect} intercepts calls to methods with this annotation and
+ * triggers an async write-back via {@code WorksheetService.writeSheet()}.
+ *
+ * <p><strong>Contract:</strong> the annotated method must have a
+ * {@code @ClusterProxyKey String} as its first parameter. {@code SheetWriteAspect}
+ * extracts the sheet ID from {@code args[0]}; if {@code args[0]} is not a
+ * {@code String}, the write is skipped and a warning is logged.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ClusterWriteMethod {
+}

--- a/build-tools/cluster-proxy-annotations/src/main/java/inetsoft/cluster/apt/ClusterAnnotationProcessor.java
+++ b/build-tools/cluster-proxy-annotations/src/main/java/inetsoft/cluster/apt/ClusterAnnotationProcessor.java
@@ -114,8 +114,10 @@ public class ClusterAnnotationProcessor extends AbstractProcessor {
          }
       }
 
+      boolean writeMethod = MoreElements.isAnnotationPresent(methodElement, ClusterWriteMethod.class);
       ProxyMethod proxyMethod = new ProxyMethod(
-         methodName, callableClassName, returnType, cacheName, keyParam, params, exceptions);
+         methodName, callableClassName, returnType, cacheName, keyParam, params, exceptions,
+         writeMethod);
       proxyClass.getMethods().add(proxyMethod);
    }
 

--- a/build-tools/cluster-proxy-annotations/src/main/java/inetsoft/cluster/apt/ProxyMethod.java
+++ b/build-tools/cluster-proxy-annotations/src/main/java/inetsoft/cluster/apt/ProxyMethod.java
@@ -25,7 +25,8 @@ import java.util.Objects;
 
 public final class ProxyMethod {
    public ProxyMethod(String name, String callableClassName, String returnType, String cacheName,
-                      String keyParam, List<ProxyParameter> parameters, List<String> exceptions)
+                      String keyParam, List<ProxyParameter> parameters, List<String> exceptions,
+                      boolean writeMethod)
    {
       this.name = name;
       this.callableClassName = callableClassName;
@@ -35,6 +36,7 @@ public final class ProxyMethod {
       this.keyParam = keyParam;
       this.parameters = new DecoratedCollection<>(parameters);
       this.exceptions = new DecoratedCollection<>(exceptions);
+      this.writeMethod = writeMethod;
    }
 
    public String getName() {
@@ -67,6 +69,10 @@ public final class ProxyMethod {
 
    public DecoratedCollection<String> getExceptions() {
       return exceptions;
+   }
+
+   public boolean isWriteMethod() {
+      return writeMethod;
    }
 
    @Override
@@ -109,4 +115,5 @@ public final class ProxyMethod {
    private final String keyParam;
    private final DecoratedCollection<ProxyParameter> parameters;
    private final DecoratedCollection<String> exceptions;
+   private final boolean writeMethod;
 }

--- a/build-tools/cluster-proxy-annotations/src/main/resources/inetsoft/cluster/apt/Proxy.java.mustache
+++ b/build-tools/cluster-proxy-annotations/src/main/resources/inetsoft/cluster/apt/Proxy.java.mustache
@@ -35,7 +35,16 @@ public class {{proxySimpleName}} {
 
          try {
             {{targetClass}} service = inetsoft.util.ConfigurationContext.getContext().lookupProxyTarget({{targetClass}}.class);
+            {{#writeMethod}}
+            {{{returnType}}} _callResult = service.{{name}}({{#parameters}}{{^first}}, {{/first}}{{value.getter}}{{/parameters}});
+            inetsoft.util.ConfigurationContext.getContext()
+               .getSpringBean(inetsoft.report.composition.WorksheetService.class)
+               .writeSheet({{keyParam}});
+            return _callResult;
+            {{/writeMethod}}
+            {{^writeMethod}}
             return service.{{name}}({{#parameters}}{{^first}}, {{/first}}{{value.getter}}{{/parameters}});
+            {{/writeMethod}}
          }
          finally {
             serviceProxyContext.postprocess();

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -759,6 +759,13 @@
     </dependency>
 
     <dependency>
+      <groupId>com.inetsoft.stylebi.build</groupId>
+      <artifactId>cluster-proxy-annotations</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.soabase.record-builder</groupId>
       <artifactId>record-builder-processor</artifactId>
       <scope>provided</scope>

--- a/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
@@ -503,11 +503,11 @@ public abstract class RuntimeSheet {
          List<String> values = new ArrayList<>();
 
          for(int i = 0; i < points.size(); i++) {
-            AbstractSheet sheet = points.get(i);
+            String[] classAndXml = points.getXmlForState(i);
 
-            if(sheet != null) {
-               values.add(sheet.getClass().getName());
-               values.add(saveXml(sheet));
+            if(classAndXml != null) {
+               values.add(classAndXml[0]);
+               values.add(classAndXml[1]);
             }
          }
 
@@ -840,6 +840,24 @@ public abstract class RuntimeSheet {
          }
       }
 
+      // Returns {className, xml} for saveState without calling access() or validate().
+      // Avoids the swap-in round-trip (decompress + DOM parse + object + reserialize)
+      // for checkpoints that are already on disk.
+      String[] getXmlForState(int index) {
+         XSwappableSheet swappable = values.get(index);
+
+         synchronized(swappable) {
+            String className = swappable.sheetClassName;
+            String xml = swappable.getXml();
+
+            if(className == null || xml == null) {
+               return null;
+            }
+
+            return new String[]{ className, xml };
+         }
+      }
+
       @SuppressWarnings("removal")
       @Override
       protected void finalize() throws Throwable {
@@ -855,6 +873,7 @@ public abstract class RuntimeSheet {
    public static final class XSwappableSheet extends XSwappable {
       public XSwappableSheet(AbstractSheet sheet, XPrincipal contextPrincipal) {
          this.sheet = sheet;
+         this.sheetClassName = sheet != null ? sheet.getClass().getName() : null;
          this.contextPrincipal = contextPrincipal;
          this.contextOrgId = OrganizationContextHolder.getCurrentOrgId();
          this.valid = true;
@@ -1060,7 +1079,63 @@ public abstract class RuntimeSheet {
          return sheet;
       }
 
+      // Returns the sheet's XML for saveState serialization without triggering validate().
+      // If the sheet is in memory, serializes to XML directly.
+      // If the sheet is swapped and is a Worksheet, falls back to validate() + writeXML() to
+      // produce non-ISTEMP XML — _swap() writes the .tdat with Worksheet.setIsTEMP(true), and
+      // storing that raw XML in Ignite causes SnapshotEmbeddedTableAssembly to reference temp
+      // paths local to this node when another node restores an undo checkpoint.
+      // For other sheet types (Viewsheet etc.), reads the .tdat file directly, skipping the
+      // DOM parse + object construction + re-serialize round-trip.
+      String getXml() {
+         if(valid) {
+            if(sheet == null) {
+               return null;
+            }
+
+            StringWriter buffer = new StringWriter();
+            PrintWriter writer = new PrintWriter(buffer);
+            sheet.writeXML(writer);
+            writer.flush();
+            return buffer.toString();
+         }
+
+         // Worksheet checkpoints are written with Worksheet.setIsTEMP(true) by _swap().
+         // Fall back to validate() + writeXML() so Ignite receives non-ISTEMP XML.
+         if(Worksheet.class.getName().equals(sheetClassName)) {
+            validate(false);
+
+            if(sheet == null) {
+               return null;
+            }
+
+            StringWriter buffer = new StringWriter();
+            PrintWriter writer = new PrintWriter(buffer);
+            sheet.writeXML(writer);
+            writer.flush();
+            return buffer.toString();
+         }
+
+         File file = getFile(prefix + ".tdat");
+
+         if(!file.exists()) {
+            LOG.warn("Swap file missing for checkpoint serialization: {}", file);
+            return null;
+         }
+
+         try(InputStream in = Tool.createUncompressInputStream(new FileInputStream(file))) {
+            String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            // Strip the XML declaration written by _swap() — saveState stores element XML only.
+            return xml.replaceFirst("^<\\?xml[^?]*\\?>\\s*", "");
+         }
+         catch(Exception e) {
+            LOG.error("Failed to read swapped sheet XML for state serialization", e);
+            return null;
+         }
+      }
+
       private AbstractSheet sheet;
+      private final String sheetClassName;
       private final XPrincipal contextPrincipal;
       private final String contextOrgId;
       private boolean valid;

--- a/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
@@ -1086,7 +1086,10 @@ public abstract class RuntimeSheet {
       // storing that raw XML in Ignite causes SnapshotEmbeddedTableAssembly to reference temp
       // paths local to this node when another node restores an undo checkpoint.
       // For other sheet types (Viewsheet etc.), reads the .tdat file directly, skipping the
-      // DOM parse + object construction + re-serialize round-trip.
+      // DOM parse + object construction + re-serialize round-trip. The ISTEMP flag set by
+      // _swap() is a ThreadLocal read exclusively by SnapshotEmbeddedTableAssembly, which is
+      // a Worksheet-only class — Viewsheet.writeXML() never consults it, so raw .tdat bytes
+      // for non-Worksheet checkpoints are safe to store in Ignite without re-serialization.
       String getXml() {
          if(valid) {
             if(sheet == null) {

--- a/core/src/main/java/inetsoft/report/composition/RuntimeSheetCache.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeSheetCache.java
@@ -470,27 +470,28 @@ public class RuntimeSheetCache
          lock.readLock().unlock();
       }
 
-      // A residual race window exists between the readLock release and putAsync(): remove()
-      // could complete in that interval, leaving a one-entry orphan in accessTimeMap.
-      // The orphan is bounded (one 8-byte entry per closed session) and is cleaned up by
-      // the next remove() or clear() for the same key.
+      // Residual race: remove() could complete between the lock release and putAsync(),
+      // leaving a one-entry orphan in accessTimeMap. The orphan is bounded (8 bytes)
+      // and is cleaned up by the next remove() or clear() for the same key.
       accessTimeMap.putAsync(getAffinityKey(id), time);
    }
 
    /**
-    * Inserts all entries into local memory and the distributed session cache.
-    * Note: accessTimeMap is NOT populated here. This method has no active callers in the
-    * current codebase and exists only to satisfy the Map interface contract. If it is ever
-    * used to bulk-insert sessions, callers must separately populate accessTimeMap to ensure
-    * access times survive a subsequent node restart or rebalance.
+    * Inserts all entries into local memory, the distributed session cache, and accessTimeMap.
+    * This method has no active callers in the current codebase and exists only to satisfy
+    * the Map interface contract.
     */
    @Override
    public void putAll(Map<? extends String, ? extends RuntimeSheet> m) {
       Map<AffinityKey<String>, CompressedSheetState> states =
          new TreeMap<>(Comparator.comparing(AffinityKey::key));
 
+      Map<AffinityKey<String>, Long> accessTimes = new HashMap<>();
+
       for(Map.Entry<? extends String, ? extends RuntimeSheet> e : m.entrySet()) {
-         states.put(getAffinityKey(e.getKey()), compressState(e.getValue().saveState(mapper)));
+         AffinityKey<String> key = getAffinityKey(e.getKey());
+         states.put(key, compressState(e.getValue().saveState(mapper)));
+         accessTimes.put(key, e.getValue().getLastAccessed());
       }
 
       lock.writeLock().lock();
@@ -504,6 +505,7 @@ public class RuntimeSheetCache
       }
 
       cache.putAllAsync(states);
+      accessTimeMap.putAllAsync(accessTimes);
    }
 
    @Override

--- a/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
+++ b/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
@@ -165,6 +165,7 @@ public abstract class WorksheetEngine extends SheetLibraryEngine implements Work
       affinityExecutor.shutdownNow();
 
       try {
+         debouncer.close();
          amap.close();
       }
       catch(Exception e) {

--- a/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
+++ b/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
@@ -162,6 +162,7 @@ public abstract class WorksheetEngine extends SheetLibraryEngine implements Work
    @Override
    public void dispose() {
       engine.dispose();
+      affinityExecutor.shutdownNow();
 
       try {
          amap.close();
@@ -684,6 +685,23 @@ public abstract class WorksheetEngine extends SheetLibraryEngine implements Work
       return null;
    }
 
+   @Override
+   public void writeSheet(String id) {
+      // Debounce writes to at most once per second per session. Captures state at fire time
+      // so the write reflects all mutations that landed in the debounce window.
+      debouncer.debounce("writeSheet_" + id, 1L, TimeUnit.SECONDS, () -> {
+         RuntimeSheet rs = amap.get(id);
+
+         if(rs != null) {
+            CompletableFuture.runAsync(() -> amap.put(id, rs), affinityExecutor)
+               .exceptionally(e -> {
+                  LOG.error("Failed to write sheet {} to distributed cache", id, e);
+                  return null;
+               });
+         }
+      });
+   }
+
    private void accessSheet(String id, boolean touch) {
       RuntimeSheet rs = amap.get(id);
 
@@ -763,6 +781,7 @@ public abstract class WorksheetEngine extends SheetLibraryEngine implements Work
          executionMap.setCompleted(id);
       }
 
+      debouncer.cancel("writeSheet_" + id);
       amap.remove(id);
       emap.remove(id);
       clearPreviewTarget(rsheet, id);

--- a/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
+++ b/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
@@ -59,6 +59,7 @@ public abstract class WorksheetEngine extends SheetLibraryEngine implements Work
    public WorksheetEngine(AssetRepository engine, Cluster cluster) throws RemoteException {
       this.cluster = cluster;
       cluster.registerSpringProxyPartitionedCache(CACHE_NAME);
+      cluster.getCache(RuntimeSheetCache.ACCESS_TIME_MAP_NAME);
       amap = new RuntimeSheetCache(cluster, CACHE_NAME);
       emap = new ConcurrentHashMap<>();
       executionMap = new ExecutionMap();
@@ -694,7 +695,11 @@ public abstract class WorksheetEngine extends SheetLibraryEngine implements Work
          RuntimeSheet rs = amap.get(id);
 
          if(rs != null) {
-            CompletableFuture.runAsync(() -> amap.put(id, rs), affinityExecutor)
+            CompletableFuture.runAsync(() -> {
+               if(amap.containsKey(id)) {
+                  amap.put(id, rs);
+               }
+            }, affinityExecutor)
                .exceptionally(e -> {
                   LOG.error("Failed to write sheet {} to distributed cache", id, e);
                   return null;
@@ -1166,6 +1171,7 @@ public abstract class WorksheetEngine extends SheetLibraryEngine implements Work
                      executionMap.setCompleted(id);
                   }
 
+                  debouncer.cancel("writeSheet_" + id);
                   amap.remove(id);
                   emap.remove(id);
                   clearPreviewTarget(rs, id);

--- a/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
+++ b/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
@@ -59,6 +59,7 @@ public abstract class WorksheetEngine extends SheetLibraryEngine implements Work
    public WorksheetEngine(AssetRepository engine, Cluster cluster) throws RemoteException {
       this.cluster = cluster;
       cluster.registerSpringProxyPartitionedCache(CACHE_NAME);
+      cluster.registerSpringProxyPartitionedCache(RuntimeSheetCache.ACCESS_TIME_MAP_NAME);
       cluster.getCache(RuntimeSheetCache.ACCESS_TIME_MAP_NAME);
       amap = new RuntimeSheetCache(cluster, CACHE_NAME);
       emap = new ConcurrentHashMap<>();
@@ -162,11 +163,17 @@ public abstract class WorksheetEngine extends SheetLibraryEngine implements Work
     */
    @Override
    public void dispose() {
-      engine.dispose();
-      affinityExecutor.shutdownNow();
-
       try {
          debouncer.close();
+      }
+      catch(Exception e) {
+         LOG.warn("Failed to close debouncer", e);
+      }
+
+      affinityExecutor.shutdownNow();
+      engine.dispose();
+
+      try {
          amap.close();
       }
       catch(Exception e) {

--- a/core/src/main/java/inetsoft/report/composition/WorksheetService.java
+++ b/core/src/main/java/inetsoft/report/composition/WorksheetService.java
@@ -62,6 +62,8 @@ public interface WorksheetService {
 
    void putRuntimeSheet(String id, RuntimeSheet rs);
 
+   void writeSheet(String id);
+
    /**
     * Dispose the worksheet service.
     */

--- a/core/src/main/java/inetsoft/web/binding/VSChartBindingService.java
+++ b/core/src/main/java/inetsoft/web/binding/VSChartBindingService.java
@@ -117,6 +117,7 @@ public class VSChartBindingService {
       return type;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public BindingModel setChartBinding(@ClusterProxyKey String vsId, String assemblyName,
                                        ChartBindingModel cmodel, Principal principal) throws Exception
@@ -200,6 +201,7 @@ public class VSChartBindingService {
       return mapHandler.getGeoData(rvs, chart, refName);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Map<String, Object> changeMapType(@ClusterProxyKey String vsId,
                                             String assemblyName, String type, String layerstr,
@@ -215,6 +217,7 @@ public class VSChartBindingService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public BindingModel convertChartRef(
       @ClusterProxyKey String vsId, String assemblyName, String refName,
       int type, Principal principal) throws Exception
@@ -228,6 +231,7 @@ public class VSChartBindingService {
       return bindingService.createModel(assembly);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Map<String, Object> getMappingData(@ClusterProxyKey String vsId,
                                              String assemblyName, ChartGeoRefModel geo,
@@ -266,6 +270,7 @@ public class VSChartBindingService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public BindingModel setGeographic(@ClusterProxyKey String vsId,
                                      String assemblyName,
                                      String refName, boolean isDim,

--- a/core/src/main/java/inetsoft/web/binding/VSFormulaService.java
+++ b/core/src/main/java/inetsoft/web/binding/VSFormulaService.java
@@ -129,6 +129,7 @@ public class VSFormulaService {
       }
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void modifyAggregateField(@ClusterProxyKey String vsId, String assemblyName, String tname,
                                     Map<String, AggregateRefModel> model, Principal principal) throws Exception

--- a/core/src/main/java/inetsoft/web/binding/controller/ChangeChartAestheticService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ChangeChartAestheticService.java
@@ -65,6 +65,7 @@ public class ChangeChartAestheticService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void changeChartAesthetic(@ClusterProxyKey String id, ChangeChartRefEvent event,
                                     Principal principal, CommandDispatcher dispatcher,
                                     String linkUri) throws Exception

--- a/core/src/main/java/inetsoft/web/binding/controller/ChangeChartDataService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ChangeChartDataService.java
@@ -64,6 +64,7 @@ public class ChangeChartDataService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void changeChartData(@ClusterProxyKey String id,
                                ChangeChartRefEvent event,
                                Principal principal, CommandDispatcher dispatcher,

--- a/core/src/main/java/inetsoft/web/binding/controller/ChangeChartRefService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ChangeChartRefService.java
@@ -67,6 +67,7 @@ public class ChangeChartRefService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void changeChartRef(@ClusterProxyKey String id, ChangeChartRefEvent event,
                               Principal principal, CommandDispatcher dispatcher,
                               String linkUri) throws Exception

--- a/core/src/main/java/inetsoft/web/binding/controller/ChangeChartTypeService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ChangeChartTypeService.java
@@ -82,6 +82,7 @@ public class ChangeChartTypeService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void changeChartType(@ClusterProxyKey String id, ChangeChartTypeEvent event,
                                Principal principal, CommandDispatcher dispatcher,
                                String linkUri) throws Exception

--- a/core/src/main/java/inetsoft/web/binding/controller/ChangeGeographicService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ChangeGeographicService.java
@@ -93,6 +93,7 @@ public class ChangeGeographicService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void changeGeographic(@ClusterProxyKey String id, ChangeGeographicEvent event,
                                 Principal principal, CommandDispatcher dispatcher,
                                 String linkUri) throws Exception

--- a/core/src/main/java/inetsoft/web/binding/controller/ChangeSeparateStatusService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ChangeSeparateStatusService.java
@@ -56,6 +56,7 @@ public class ChangeSeparateStatusService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void changeSeparateStatus(@ClusterProxyKey String id, ChangeSeparateStatusEvent event,
                                     Principal principal, CommandDispatcher dispatcher,
                                     String linkUri) throws Exception

--- a/core/src/main/java/inetsoft/web/binding/controller/ConvertChartRefService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ConvertChartRefService.java
@@ -90,6 +90,7 @@ public class ConvertChartRefService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void convertChartRef(@ClusterProxyKey String id, ConvertChartRefEvent event,
                                Principal principal, CommandDispatcher dispatcher,
                                String linkUri) throws Exception

--- a/core/src/main/java/inetsoft/web/binding/controller/ConvertTableRefControllerService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ConvertTableRefControllerService.java
@@ -51,6 +51,7 @@ public class ConvertTableRefControllerService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void convertTableRef(@ClusterProxyKey String id, ConvertTableRefEvent event,
                                Principal principal, CommandDispatcher dispatcher) throws Exception
    {

--- a/core/src/main/java/inetsoft/web/binding/controller/ModifyAggregateFieldService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ModifyAggregateFieldService.java
@@ -46,6 +46,7 @@ public class ModifyAggregateFieldService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void modifyAggregateField(@ClusterProxyKey String id, ModifyAggregateFieldEvent event,
                                     Principal principal) throws Exception
    {
@@ -80,6 +81,7 @@ public class ModifyAggregateFieldService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void removeAggregateField(@ClusterProxyKey String id, ModifyAggregateFieldEvent event, Principal principal) throws Exception {
       RuntimeViewsheet rvs = viewsheetService.getViewsheet(id, principal);
       Viewsheet vs = rvs.getViewsheet();

--- a/core/src/main/java/inetsoft/web/binding/controller/ModifyCalculateFieldService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ModifyCalculateFieldService.java
@@ -86,6 +86,7 @@ public class ModifyCalculateFieldService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void modifyCalculateField(@ClusterProxyKey String id, ModifyCalculateFieldEvent event,
                                     Principal principal, CommandDispatcher dispatcher,
                                     String linkUri)

--- a/core/src/main/java/inetsoft/web/binding/controller/SwapXYBindingService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/SwapXYBindingService.java
@@ -60,6 +60,7 @@ public class SwapXYBindingService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void swapXYBinding(@ClusterProxyKey String id, ChangeSeparateStatusEvent event,
                              Principal principal, CommandDispatcher dispatcher,
                              String linkUri) throws Exception

--- a/core/src/main/java/inetsoft/web/binding/controller/VSBindingModelService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/VSBindingModelService.java
@@ -172,6 +172,7 @@ public class VSBindingModelService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void setBinding(@ClusterProxyKey String id, ApplyVSAssemblyInfoEvent event,
                           Principal principal, CommandDispatcher dispatcher) throws Exception
    {

--- a/core/src/main/java/inetsoft/web/binding/controller/VSTableLayoutService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/VSTableLayoutService.java
@@ -136,6 +136,7 @@ public class VSTableLayoutService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void changeColumnValue(@ClusterProxyKey String id, ChangeColumnValueEvent event,
                                  String linkUri, Principal principal, CommandDispatcher dispatcher)
       throws Exception
@@ -174,6 +175,7 @@ public class VSTableLayoutService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void setCellBinding(@ClusterProxyKey String id, SetCellBindingEvent event,
                               Principal principal, CommandDispatcher dispatcher) throws Exception
    {
@@ -240,6 +242,7 @@ public class VSTableLayoutService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void modifyLayout(@ClusterProxyKey String id, ModifyTableLayoutEvent event,
                             Principal principal, CommandDispatcher dispatcher) throws Exception
    {
@@ -260,6 +263,7 @@ public class VSTableLayoutService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void copyCut(@ClusterProxyKey String id, CopyCutCalcCellEvent event,
                        Principal principal, CommandDispatcher dispatcher) throws Exception
    {
@@ -330,6 +334,7 @@ public class VSTableLayoutService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void resizeCalcTableCell(@ClusterProxyKey String id, ResizeCalcTableCellEvent event, Principal principal,
                                    CommandDispatcher dispatcher) throws Exception
    {

--- a/core/src/main/java/inetsoft/web/binding/dnd/controller/VSCalcTableDndService.java
+++ b/core/src/main/java/inetsoft/web/binding/dnd/controller/VSCalcTableDndService.java
@@ -68,6 +68,7 @@ public class VSCalcTableDndService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void addRemoveColumns(@ClusterProxyKey String runtimeVS, VSDndEvent event, Principal principal,
                                 String linkUri, CommandDispatcher dispatcher) throws Exception
    {
@@ -89,6 +90,7 @@ public class VSCalcTableDndService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void addColumns(@ClusterProxyKey String runtimeId, VSDndEvent event, Principal principal,
                           String linkUri, CommandDispatcher dispatcher) throws Exception
    {
@@ -132,6 +134,7 @@ public class VSCalcTableDndService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void removeColumns(@ClusterProxyKey String runtimeId, VSDndEvent event, Principal principal,
                              String linkUri, CommandDispatcher dispatcher) throws Exception
    {

--- a/core/src/main/java/inetsoft/web/binding/dnd/controller/VSChartDndService.java
+++ b/core/src/main/java/inetsoft/web/binding/dnd/controller/VSChartDndService.java
@@ -68,6 +68,7 @@ public class VSChartDndService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void addRemoveColumns(@ClusterProxyKey String runtimeId, VSDndEvent event,
                                 Principal principal,String linkUri, CommandDispatcher dispatcher) throws Exception
    {
@@ -87,6 +88,7 @@ public class VSChartDndService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void addColumns(@ClusterProxyKey String runtimeId, VSDndEvent event, Principal principal,
                           String linkUri, CommandDispatcher dispatcher) throws Exception
    {
@@ -180,6 +182,7 @@ public class VSChartDndService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void removeColumns(@ClusterProxyKey String runtimeId, VSDndEvent event, Principal principal,
                              String linkUri, CommandDispatcher dispatcher) throws Exception
    {

--- a/core/src/main/java/inetsoft/web/binding/dnd/controller/VSCrosstabDndService.java
+++ b/core/src/main/java/inetsoft/web/binding/dnd/controller/VSCrosstabDndService.java
@@ -83,6 +83,7 @@ public class VSCrosstabDndService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void dnd(@ClusterProxyKey String runtimeId, VSDndEvent event, Principal principal,
                    String linkUri, CommandDispatcher dispatcher) throws Exception
    {
@@ -205,6 +206,7 @@ public class VSCrosstabDndService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void dndFromTree(@ClusterProxyKey String runtimeId, VSDndEvent event, Principal principal,
                            String linkUri, CommandDispatcher dispatcher) throws Exception
    {

--- a/core/src/main/java/inetsoft/web/binding/dnd/controller/VSTableDndService.java
+++ b/core/src/main/java/inetsoft/web/binding/dnd/controller/VSTableDndService.java
@@ -67,6 +67,7 @@ public class VSTableDndService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void dnd(@ClusterProxyKey String runtimeId, VSDndEvent event, Principal principal,
                    String linkUri, CommandDispatcher dispatcher) throws Exception
    {
@@ -164,6 +165,7 @@ public class VSTableDndService {
 
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void dndFromTree(@ClusterProxyKey String runtimeId, VSDndEvent event, Principal principal,
                            @LinkUri String linkUri, CommandDispatcher dispatcher) throws Exception
    {
@@ -225,6 +227,7 @@ public class VSTableDndService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void dndTotree(@ClusterProxyKey String runtimeId, VSDndEvent event, Principal principal,
                          @LinkUri String linkUri, CommandDispatcher dispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/binding/service/VSBindingService.java
+++ b/core/src/main/java/inetsoft/web/binding/service/VSBindingService.java
@@ -112,6 +112,7 @@ public class VSBindingService {
 
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void insertChild(@ClusterProxyKey String vsId, InsertSelectionChildEvent event, String linkUri,
                            Principal principal, CommandDispatcher dispatcher, boolean doThrow)
       throws Exception
@@ -232,6 +233,7 @@ public class VSBindingService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void changeBinding(@ClusterProxyKey String runtimeId, ChangeVSObjectBindingEvent event,
                              Principal principal, CommandDispatcher dispatcher, String linkUri) throws Exception
    {
@@ -385,6 +387,7 @@ public class VSBindingService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public String commit(@ClusterProxyKey String vsId, String assemblyName,
                         String editMode, String originalMode,
                         Principal principal)

--- a/core/src/main/java/inetsoft/web/composer/ComposerControllerErrorHandlerService.java
+++ b/core/src/main/java/inetsoft/web/composer/ComposerControllerErrorHandlerService.java
@@ -48,6 +48,7 @@ public class ComposerControllerErrorHandlerService {
       return coreLifecycleService.waitForMV(e, rvs, dispatcher);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void handleInvalidDependencyRollback(@ClusterProxyKey String runtimeId, Principal principal) {
       RuntimeSheet rs = viewsheetService.getSheet(runtimeId, principal);

--- a/core/src/main/java/inetsoft/web/composer/ConsoleDialogMessageService.java
+++ b/core/src/main/java/inetsoft/web/composer/ConsoleDialogMessageService.java
@@ -59,6 +59,7 @@ public class ConsoleDialogMessageService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Boolean saveConsoleMessageLevels(@ClusterProxyKey String runtimeId, SaveConsoleMessageLevelsEvent event,
                                                                               Principal principal)

--- a/core/src/main/java/inetsoft/web/composer/RuntimeSheetTransformService.java
+++ b/core/src/main/java/inetsoft/web/composer/RuntimeSheetTransformService.java
@@ -34,6 +34,7 @@ public class RuntimeSheetTransformService {
       this.viewsheetService = viewsheetService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void updateRenameInfos(@ClusterProxyKey String id,
                                  AssetEntry entry, List<RenameInfo> renameInfos) {

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/ComposerViewsheetService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/ComposerViewsheetService.java
@@ -86,6 +86,7 @@ public class ComposerViewsheetService {
       this.sessionService = sessionService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void newViewsheet(@ClusterProxyKey String runtimeId,
                             NewViewsheetEvent event, Principal principal,
@@ -118,6 +119,7 @@ public class ComposerViewsheetService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Boolean saveViewsheet(@ClusterProxyKey String runtimeId,
                                 SaveSheetEvent event, Principal principal,
@@ -200,6 +202,7 @@ public class ComposerViewsheetService {
       }
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void closeViewsheet(@ClusterProxyKey String runtimeId, CloseSheetEvent event, Principal principal) throws Exception {
       RuntimeViewsheet rvs;
@@ -236,6 +239,7 @@ public class ComposerViewsheetService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public String previewViewsheet(@ClusterProxyKey String runtimeId, OpenPreviewViewsheetEvent event,
                                 Principal principal,
@@ -364,6 +368,7 @@ public class ComposerViewsheetService {
       }
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Boolean refreshPreviewViewsheet(@ClusterProxyKey String runtimeId,
                                        OpenPreviewViewsheetEvent event,
@@ -442,6 +447,7 @@ public class ComposerViewsheetService {
       }
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void refreshViewsheet(@ClusterProxyKey String runtimeId, OpenViewsheetEvent event,
                                 Principal principal, CommandDispatcher dispatcher,
@@ -514,6 +520,7 @@ public class ComposerViewsheetService {
       return "";
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void checkMV(@ClusterProxyKey String runtimeId, CheckMVEvent event, Principal principal,
                        CommandDispatcher dispatcher, String linkUri)

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/ComposerViewsheetService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/ComposerViewsheetService.java
@@ -202,7 +202,6 @@ public class ComposerViewsheetService {
       }
    }
 
-   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void closeViewsheet(@ClusterProxyKey String runtimeId, CloseSheetEvent event, Principal principal) throws Exception {
       RuntimeViewsheet rvs;

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/ExportControllerService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/ExportControllerService.java
@@ -65,6 +65,7 @@ public class ExportControllerService {
       this.binaryTransferService = binaryTransferService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public ViewsheetExportResult exportViewsheet(@ClusterProxyKey String runtimeId, int format, String type, boolean matchesAssetIdFormat,
                                                 boolean match, boolean expandSelections, boolean current,

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/FormatPainterService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/FormatPainterService.java
@@ -476,6 +476,7 @@ public class FormatPainterService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void setFormat(@ClusterProxyKey String runtimeId, FormatVSObjectEvent event,
                          Principal principal,
                          CommandDispatcher commandDispatcher, String linkUri)

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutControllerService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutControllerService.java
@@ -68,6 +68,7 @@ public class VSLayoutControllerService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void changeViewsheetLayout(@ClusterProxyKey String id,
                                      String currLayout,
                                      String layoutName,
@@ -137,6 +138,7 @@ public class VSLayoutControllerService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void layoutUndo(@ClusterProxyKey String runtimeId, String parentRuntimeId,
                           String layoutName, Principal principal, String linkUri,
                           CommandDispatcher dispatcher)
@@ -170,6 +172,7 @@ public class VSLayoutControllerService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void layoutRedo(@ClusterProxyKey String runtimeId, String parentRuntimeId,
                           String layoutName, Principal principal,
                           String linkUri, CommandDispatcher dispatcher)
@@ -203,6 +206,7 @@ public class VSLayoutControllerService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void moveResizeLayoutObjects(@ClusterProxyKey String runtimeId,
                                        String focusedLayoutName,
                                        MoveResizeLayoutObjectsEvent event,
@@ -289,6 +293,7 @@ public class VSLayoutControllerService {
 
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void addObject(@ClusterProxyKey String runtimeId,
                          String focusedLayoutName,
                          AddVSLayoutObjectEvent event,
@@ -372,6 +377,7 @@ public class VSLayoutControllerService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void removeObject(@ClusterProxyKey String runtimeId,
                             String focusedLayoutName,
                             RemoveVSLayoutObjectEvent event,
@@ -486,6 +492,7 @@ public class VSLayoutControllerService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Boolean setTextPropertyDialogModel(@ClusterProxyKey String runtimeId,
                                           String focusedLayoutName,
                                           int region,
@@ -588,6 +595,7 @@ public class VSLayoutControllerService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Boolean setImagePropertyDialogModel(@ClusterProxyKey String runtimeId,
                                            String focusedLayoutName,
                                            int region,
@@ -658,6 +666,7 @@ public class VSLayoutControllerService {
 
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Boolean setTableLayoutPropertyDialogModel(@ClusterProxyKey String runtimeId,
                                                     String focusedLayoutName,
                                                     int region,

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
@@ -963,6 +963,7 @@ public class VSLayoutService {
       return psize;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void makeUndoable(@ClusterProxyKey String id, Principal principal,
                             CommandDispatcher dispatcher, String focusedLayoutName)

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/CalcTablePropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/CalcTablePropertyDialogService.java
@@ -323,6 +323,7 @@ public class CalcTablePropertyDialogService {
       return approxVisibleCols;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setCalcTablePropertyModel(@ClusterProxyKey String runtimeId,
                                          String objectId,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/CalendarPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/CalendarPropertyDialogService.java
@@ -198,6 +198,7 @@ public class CalendarPropertyDialogService {
       return trap;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setCalendarPropertyModel(@ClusterProxyKey String runtimeId, String objectId,
                                         CalendarPropertyDialogModel value, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ChartPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ChartPropertyDialogService.java
@@ -327,6 +327,7 @@ public class ChartPropertyDialogService {
       return trap;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setChartPropertyModel(@ClusterProxyKey String runtimeId, String objectId,
                                      ChartPropertyDialogModel value, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/CrosstabPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/CrosstabPropertyDialogService.java
@@ -239,6 +239,7 @@ public class CrosstabPropertyDialogService {
       return trap;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setCrosstabPropertyModel(@ClusterProxyKey String runtimeId, String objectId,
                                         CrosstabPropertyDialogModel value, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/DateComparisonDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/DateComparisonDialogService.java
@@ -100,6 +100,7 @@ public class DateComparisonDialogService {
       return model;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void clearDateComparison(@ClusterProxyKey String runtimeId, String assemblyName, String linkUri,
                                    Principal principal, CommandDispatcher dispatcher) throws Exception
@@ -164,6 +165,7 @@ public class DateComparisonDialogService {
       return model;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setDateComparison(@ClusterProxyKey String runtimeId, String assemblyName,
                                  DateComparisonInfo comparisonInfo, String shareAssembly,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/GaugePropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/GaugePropertyDialogService.java
@@ -203,6 +203,7 @@ public class GaugePropertyDialogService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setGaugePropertyDialogModel(@ClusterProxyKey String runtimeId, String objectId,
                                            GaugePropertyDialogModel value, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/GroupContainerPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/GroupContainerPropertyDialogService.java
@@ -140,6 +140,7 @@ public class GroupContainerPropertyDialogService {
       return groupContainerPropertyDialog;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setGroupContainerPropertyDialogModel(@ClusterProxyKey String runtimeId, String objectId,
                                                     GroupContainerPropertyDialogModel value, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/HideColumnsDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/HideColumnsDialogService.java
@@ -77,6 +77,7 @@ public class HideColumnsDialogService {
          .build();
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setColumnOptionDialogModel(@ClusterProxyKey String runtimeId, String objectId,
                                           HideColumnsDialogModel model, Principal principal,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/HighlightDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/HighlightDialogService.java
@@ -401,6 +401,7 @@ public class HighlightDialogService {
       return false;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setHighlightDialogModel(@ClusterProxyKey String runtimeId, String objectId,
                                        HighlightDialogModel model, String linkUri, Principal principal,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/HyperlinkDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/HyperlinkDialogService.java
@@ -235,6 +235,7 @@ public class HyperlinkDialogService {
       return model;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setHyperlinkDialogModel(@ClusterProxyKey String runtimeId, String objectId, HyperlinkDialogModel model,
                                        @LinkUri String linkUri, Principal principal, CommandDispatcher dispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ImagePreviewPaneService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ImagePreviewPaneService.java
@@ -72,6 +72,7 @@ public class ImagePreviewPaneService {
       return dataTransfer;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public TreeNodeModel uploadImage(@ClusterProxyKey String runtimeId, String mpfName,
                                     BinaryTransfer dataTransfer, Principal principal) throws Exception
@@ -105,6 +106,7 @@ public class ImagePreviewPaneService {
       }
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Boolean deleteImage(@ClusterProxyKey String runtimeId, String name,
                               Principal principal) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ImagePropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ImagePropertyDialogService.java
@@ -224,6 +224,7 @@ public class ImagePropertyDialogService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setImagePropertyDialogModel(@ClusterProxyKey String runtimeId, String objectId,
                                            ImagePropertyDialogModel value, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/LayoutOptionDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/LayoutOptionDialogService.java
@@ -65,6 +65,7 @@ public class LayoutOptionDialogService {
       this.coreLifecycleService = coreLifecycleService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setLayoutOptionDialogModel(@ClusterProxyKey String runtimeId,
                                           LayoutOptionDialogModel model,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/LinePropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/LinePropertyDialogService.java
@@ -108,6 +108,7 @@ public class LinePropertyDialogService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setLinePropertyDialogModel(@ClusterProxyKey String runtimeId, String objectId,
                                           LinePropertyDialogModel value, String linkUri, Principal principal,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/OvalPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/OvalPropertyDialogService.java
@@ -139,6 +139,7 @@ public class OvalPropertyDialogService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setOvalPropertyDialogModel(@ClusterProxyKey String runtimeId, String objectId,
                                           OvalPropertyDialogModel value, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/PresenterPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/PresenterPropertyDialogService.java
@@ -162,6 +162,7 @@ public class PresenterPropertyDialogService {
          .build();
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setPresenterDialogModel(@ClusterProxyKey String runtimeId, String objectId, int row,
                                        int col, boolean layout, int layoutRegion,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/RangeSliderPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/RangeSliderPropertyDialogService.java
@@ -215,6 +215,7 @@ public class RangeSliderPropertyDialogService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setRangeSliderPropertyModel(@ClusterProxyKey String runtimeId, String objectId,
                                            RangeSliderPropertyDialogModel value, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/RectanglePropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/RectanglePropertyDialogService.java
@@ -138,6 +138,7 @@ public class RectanglePropertyDialogService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setRectanglePropertyDialogModel(@ClusterProxyKey String runtimeId, String objectId,
                                                RectanglePropertyDialogModel value, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/RegionPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/RegionPropertyDialogService.java
@@ -100,6 +100,7 @@ public class RegionPropertyDialogService {
          axisIdx, field, plotDesc.isFacetGrid(), vs.isMaxMode());
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setAxisPropertyDialogModel(@ClusterProxyKey String runtimeId, String objectId, String axisType,
                                           int index, String field, AxisPropertyDialogModel value, String linkUri,
@@ -197,6 +198,7 @@ public class RegionPropertyDialogService {
                                                          descriptor, legendIdx);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setLegendFormatDialogModel(@ClusterProxyKey String runtimeId, String objectId,
                                           int index, LegendFormatDialogModel value, String linkUri,
@@ -261,6 +263,7 @@ public class RegionPropertyDialogService {
       return new TitleFormatDialogModel(titleDesc, oldTitle);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setTitleFormatDialogModel(@ClusterProxyKey String runtimeId, String objectId,
                                          String axisType, TitleFormatDialogModel value, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/SaveViewsheetDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/SaveViewsheetDialogService.java
@@ -204,6 +204,7 @@ public class SaveViewsheetDialogService {
       return validator;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void saveViewsheet(@ClusterProxyKey String runtimeId, SaveViewsheetDialogModel model,
                              String linkUri, Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/SelectionContainerPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/SelectionContainerPropertyDialogService.java
@@ -107,6 +107,7 @@ public class SelectionContainerPropertyDialogService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setSelectionContainerPropertyModel(@ClusterProxyKey String runtimeId, String objectId,
                                                   SelectionContainerPropertyDialogModel value,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/SelectionListPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/SelectionListPropertyDialogService.java
@@ -177,6 +177,7 @@ public class SelectionListPropertyDialogService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setSelectionListPropertyModel(@ClusterProxyKey String runtimeId, String objectId,
                                              SelectionListPropertyDialogModel value, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/SelectionTreePropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/SelectionTreePropertyDialogService.java
@@ -204,6 +204,7 @@ public class SelectionTreePropertyDialogService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setSelectionTreePropertyModel(@ClusterProxyKey String runtimeId, String objectId,
                                              SelectionTreePropertyDialogModel value, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/SubmitPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/SubmitPropertyDialogService.java
@@ -105,6 +105,7 @@ public class SubmitPropertyDialogService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setSubmitPropertyDialogModel(@ClusterProxyKey String runtimeId, String objectId,
                                             SubmitPropertyDialogModel value, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/TabPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/TabPropertyDialogService.java
@@ -114,6 +114,7 @@ public class TabPropertyDialogService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setTabPropertyDialogModel(@ClusterProxyKey String runtimeId, String objectId,
                                          TabPropertyDialogModel value, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/TableViewPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/TableViewPropertyDialogService.java
@@ -154,6 +154,7 @@ public class TableViewPropertyDialogService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setTablePropertyModel(@ClusterProxyKey String runtimeId, String objectId,
                                      TableViewPropertyDialogModel value, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/TextPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/TextPropertyDialogService.java
@@ -183,6 +183,7 @@ public class TextPropertyDialogService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setTextPropertyDialogModel(@ClusterProxyKey String runtimeId, String objectId,
                                           TextPropertyDialogModel value, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/VSConditionDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/VSConditionDialogService.java
@@ -166,6 +166,7 @@ public class VSConditionDialogService {
       return model;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setModel(@ClusterProxyKey String runtimeId, String assemblyName,
                         VSConditionDialogModel model, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetObjectPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetObjectPropertyDialogService.java
@@ -91,6 +91,7 @@ public class ViewsheetObjectPropertyDialogService {
       return model.build();
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setViewsheetPropertyModel(@ClusterProxyKey String runtimeId, String objectId,
                                          ViewsheetObjectPropertyDialogModel model, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogService.java
@@ -260,6 +260,7 @@ public class ViewsheetPropertyDialogService {
       return vsModel.build();
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public String setViewsheetInfo(@ClusterProxyKey String runtimeId, ViewsheetPropertyDialogModel value,
                                 Principal principal, CommandDispatcher commandDispatcher, String linkUri,
@@ -541,6 +542,7 @@ public class ViewsheetPropertyDialogService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public ConvertToWorksheetResponseModel convertLogicModelToWorksheet(@ClusterProxyKey String runtimeId,
                                                                        Principal principal) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ClipboardControllerService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ClipboardControllerService.java
@@ -74,6 +74,7 @@ public class ClipboardControllerService {
       this.vsObjectPropertyService = vsObjectPropertyService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void copyOrCut(@ClusterProxyKey String runtimeId, CopyVSObjectsEvent event,
                          Principal principal, CommandDispatcher dispatcher, String linkUri) throws Exception
@@ -129,6 +130,7 @@ public class ClipboardControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void pasteObject(@ClusterProxyKey String runtimeId, int x, int y, Principal principal,
                            CommandDispatcher dispatcher, String linkUri) throws Exception
@@ -421,6 +423,7 @@ public class ClipboardControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void pasteHighlight(@ClusterProxyKey String runtimeId, PasteHighlightEvent event,
                               Principal principal, CommandDispatcher dispatcher, @LinkUri String linkUri) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerAdhocFilterService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerAdhocFilterService.java
@@ -64,6 +64,7 @@ public class ComposerAdhocFilterService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void addTableFilter(@ClusterProxyKey String runtimeId, FilterTableEvent event,
                               Principal principal, String linkUri, CommandDispatcher dispatcher) throws Exception
    {
@@ -183,6 +184,7 @@ public class ComposerAdhocFilterService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void addChartFilter(@ClusterProxyKey String runtimeId, FilterChartEvent event,
                               Principal principal, String linkUri,
                               CommandDispatcher dispatcher) throws Exception
@@ -215,6 +217,7 @@ public class ComposerAdhocFilterService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void moveAdhocFilter(@ClusterProxyKey String runtimeId, VSObjectEvent event, Principal principal,
                                String linkUri, CommandDispatcher dispatcher) throws Exception
    {

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerCurrentSelectionService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerCurrentSelectionService.java
@@ -44,6 +44,7 @@ public class ComposerCurrentSelectionService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void setTitleRatio(@ClusterProxyKey String runtimeId, double ratio,
                              VSObjectEvent event, Principal principal,
                              CommandDispatcher dispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerGroupColumnsService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerGroupColumnsService.java
@@ -63,6 +63,7 @@ public class ComposerGroupColumnsService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void group(@ClusterProxyKey String runtimeId, GroupFieldsEvent event, String linkUri,
                      Principal principal, CommandDispatcher dispatcher) throws Exception
    {

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerGroupService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerGroupService.java
@@ -61,6 +61,7 @@ public class ComposerGroupService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void groupComponents(@ClusterProxyKey String runtimeId, GroupVSObjectsEvent event, String linkUri,
                                Principal principal, CommandDispatcher dispatcher) throws Exception
    {
@@ -246,6 +247,7 @@ public class ComposerGroupService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void ungroup(@ClusterProxyKey String runtimeId, String objectName, String linkUri,
                        Principal principal, CommandDispatcher dispatcher) throws Exception
    {

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerObjectService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerObjectService.java
@@ -76,6 +76,7 @@ public class ComposerObjectService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void addNewObject(@ClusterProxyKey String vsId, AddNewVSObjectEvent event, Principal principal,
                             CommandDispatcher dispatcher, String linkUri) throws Exception
    {
@@ -121,6 +122,7 @@ public class ComposerObjectService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void resizeObject(@ClusterProxyKey String vsId, ResizeVSObjectEvent event,
                             Principal principal, CommandDispatcher dispatcher,
                             String linkUri) throws Exception
@@ -314,6 +316,7 @@ public class ComposerObjectService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void moveObjects(@ClusterProxyKey String vsId, MultiMoveVsObjectEvent multiEvent,
                            Principal principal, CommandDispatcher dispatcher,String linkUri)
       throws Exception
@@ -331,6 +334,7 @@ public class ComposerObjectService {
 
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void moveObject(@ClusterProxyKey String vsId, MoveVSObjectEvent event,
                           Principal principal, CommandDispatcher dispatcher,
                           String linkUri) throws Exception
@@ -380,6 +384,7 @@ public class ComposerObjectService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void copyObject(@ClusterProxyKey String vsId, CopyVSObjectsEvent event,
                           Principal principal, CommandDispatcher dispatcher, String linkUri) throws Exception
    {
@@ -425,6 +430,7 @@ public class ComposerObjectService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void resizeObjectTitle(@ClusterProxyKey String vsId, ResizeVSObjectTitleEvent event,
                                  Principal principal, CommandDispatcher dispatcher,
                                  String linkUri) throws Exception
@@ -444,6 +450,7 @@ public class ComposerObjectService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void removeSelectedObjects(@ClusterProxyKey String vsId, RemoveVSObjectsEvent event,
                                      String linkUri, Principal principal,
                                      CommandDispatcher dispatcher) throws Exception
@@ -515,6 +522,7 @@ public class ComposerObjectService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void removeObject(@ClusterProxyKey String vsId, String objectName, String linkUri, Principal principal,
                             CommandDispatcher dispatcher) throws Exception
    {
@@ -593,6 +601,7 @@ public class ComposerObjectService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void changeZIndex(@ClusterProxyKey String vsId, ChangeVSObjectLayerEvent event, Principal principal,
                             CommandDispatcher dispatcher) throws Exception
    {
@@ -616,6 +625,7 @@ public class ComposerObjectService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void changeTitle(@ClusterProxyKey String vsId, ChangeVSObjectTextEvent event, Principal principal,
                            CommandDispatcher dispatcher) throws Exception
    {
@@ -675,6 +685,7 @@ public class ComposerObjectService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void changeLockState(@ClusterProxyKey String vsId, LockVSObjectEvent event,
                                Principal principal, CommandDispatcher dispatcher) throws Exception
    {
@@ -701,6 +712,7 @@ public class ComposerObjectService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void moveFromContainer(@ClusterProxyKey String runtimeId, MoveVSObjectEvent event, Principal principal,
                                  CommandDispatcher dispatcher, String linkUri) throws Exception
    {

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerRangeSliderService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerRangeSliderService.java
@@ -46,6 +46,7 @@ public class ComposerRangeSliderService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void convertCSComponent(@ClusterProxyKey String vsId, ConvertToRangeSliderEvent event,
                                   Principal principal, CommandDispatcher dispatcher, String linkUri) throws Exception
    {

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerVSSelectionListService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerVSSelectionListService.java
@@ -52,6 +52,7 @@ public class ComposerVSSelectionListService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void changeColCount(@ClusterProxyKey String vsId, int count, VSObjectEvent event,
                               Principal principal, CommandDispatcher dispatcher) throws Exception
    {
@@ -85,6 +86,7 @@ public class ComposerVSSelectionListService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void updateCellHeight(@ClusterProxyKey String vsId, VSSetCellHeightEvent event,
                                 Principal principal, CommandDispatcher dispatcher) throws Exception
    {
@@ -106,6 +108,7 @@ public class ComposerVSSelectionListService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void updateMeasureSize(@ClusterProxyKey String vsId, VSSetMeasuresEvent event,
                                  Principal principal, CommandDispatcher dispatcher) throws Exception
    {
@@ -126,6 +129,7 @@ public class ComposerVSSelectionListService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void removeColumnByDrag(@ClusterProxyKey String vsId, VSDndEvent event, Principal principal,
                                   String linkUri, CommandDispatcher dispatcher) throws Exception
    {
@@ -166,6 +170,7 @@ public class ComposerVSSelectionListService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void convertToRangeSlider(@ClusterProxyKey String vsId, ConvertToRangeSliderEvent event,
                                     Principal principal, CommandDispatcher dispatcher, String linkUri) throws Exception
    {

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerVSTableService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerVSTableService.java
@@ -92,6 +92,7 @@ public class ComposerVSTableService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void changeColumnTitle(@ClusterProxyKey String vsId,  int row, int col,
                                  ChangeVSObjectTextEvent event, Principal principal,
                                  CommandDispatcher dispatcher, String linkUri) throws Exception
@@ -227,6 +228,7 @@ public class ComposerVSTableService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void changeCellText(@ClusterProxyKey String vsId, ChangeVSTableCellsTextEvent event,
                               Principal principal, String linkUri, CommandDispatcher dispatcher) throws Exception
    {
@@ -271,6 +273,7 @@ public class ComposerVSTableService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void deleteColumns(@ClusterProxyKey String vsId, RemoveTableColumnsEvent event, Principal principal,
                              CommandDispatcher dispatcher, String linkUri) throws Exception
    {
@@ -333,6 +336,7 @@ public class ComposerVSTableService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void hideColumns(@ClusterProxyKey String vsId, ShowHideCrosstabColumnsEvent event,
                            Principal principal, CommandDispatcher dispatcher, String linkUri) throws Exception
    {
@@ -385,6 +389,7 @@ public class ComposerVSTableService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void resetTableLayout(@ClusterProxyKey String vsId, RemoveTableColumnsEvent event,
                                 Principal principal, CommandDispatcher dispatcher) throws Exception
    {
@@ -415,6 +420,7 @@ public class ComposerVSTableService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void resizeTableCell(@ClusterProxyKey String vsId, ResizeTableCellEvent event,
                                Principal principal, String linkUri, CommandDispatcher dispatcher) throws Exception
    {
@@ -427,6 +433,7 @@ public class ComposerVSTableService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void changeColumnWidth(@ClusterProxyKey String vsId, ResizeTableColumnEvent event,
                                  Principal principal, String linkUri, CommandDispatcher dispatcher) throws Exception
    {
@@ -437,6 +444,7 @@ public class ComposerVSTableService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void changeRowHeight(@ClusterProxyKey String vsId, ResizeTableRowEvent event, Principal principal,
                                String linkUri,CommandDispatcher dispatcher) throws Exception
    {
@@ -448,6 +456,7 @@ public class ComposerVSTableService {
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   @ClusterWriteMethod
    public Void convertToFreehandTable(@ClusterProxyKey String vsId, ConvertToFreehandTableEvent event,
                                       Principal principal, String linkUri, CommandDispatcher dispatcher) throws Exception
    {

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSLineService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSLineService.java
@@ -47,6 +47,7 @@ public class VSLineService {
       this.vsAssemblyInfoHandler = vsAssemblyInfoHandler;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void resize(@ClusterProxyKey String vsId, ResizeVSLineEvent event, Principal principal,
                       CommandDispatcher dispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSTextService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSTextService.java
@@ -52,6 +52,7 @@ public class VSTextService {
       this.vsLayoutService = vsLayoutService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void changeText(@ClusterProxyKey String runtimeId, ChangeVSObjectTextEvent event,
                           String linkUri, Principal principal, CommandDispatcher dispatcher)
@@ -75,6 +76,7 @@ public class VSTextService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Boolean changeText(@ClusterProxyKey String runtimeId, String focusedLayoutName,
                              int region, ChangeVSObjectTextEvent event, String linkUri,

--- a/core/src/main/java/inetsoft/web/composer/ws/CancelLoadingService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/CancelLoadingService.java
@@ -42,6 +42,7 @@ public class CancelLoadingService extends WorksheetControllerService{
       this.xRepository = xRepository;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void cancelLoading(
       @ClusterProxyKey String runtimeId,

--- a/core/src/main/java/inetsoft/web/composer/ws/ChangeDependencyService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/ChangeDependencyService.java
@@ -51,6 +51,7 @@ public class ChangeDependencyService extends WorksheetControllerService{
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void changeDependency(
       @ClusterProxyKey String runtimeId, WSChangeDependencyEvent event, Principal principal,

--- a/core/src/main/java/inetsoft/web/composer/ws/CloseWorksheetService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/CloseWorksheetService.java
@@ -42,6 +42,7 @@ public class CloseWorksheetService extends WorksheetControllerService {
       this.runtimeViewsheetManager = runtimeViewsheetManager;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void closeWorksheet(@ClusterProxyKey String runtimeId, Principal principal) throws Exception {
       RuntimeWorksheet rws = getRuntimeWorksheet(runtimeId, principal);

--- a/core/src/main/java/inetsoft/web/composer/ws/CloseWorksheetService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/CloseWorksheetService.java
@@ -42,7 +42,6 @@ public class CloseWorksheetService extends WorksheetControllerService {
       this.runtimeViewsheetManager = runtimeViewsheetManager;
    }
 
-   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void closeWorksheet(@ClusterProxyKey String runtimeId, Principal principal) throws Exception {
       RuntimeWorksheet rws = getRuntimeWorksheet(runtimeId, principal);

--- a/core/src/main/java/inetsoft/web/composer/ws/ConcatenateTablesService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/ConcatenateTablesService.java
@@ -48,6 +48,7 @@ public class ConcatenateTablesService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void concatenateTables(
       @ClusterProxyKey String runtimeId,
@@ -61,6 +62,7 @@ public class ConcatenateTablesService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void addSubTable(
       @ClusterProxyKey String runtimeId,

--- a/core/src/main/java/inetsoft/web/composer/ws/ConvertEmbeddedService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/ConvertEmbeddedService.java
@@ -47,6 +47,7 @@ public class ConvertEmbeddedService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void convertEmbedded(
       @ClusterProxyKey String runtimeId,

--- a/core/src/main/java/inetsoft/web/composer/ws/DeleteColumnsService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/DeleteColumnsService.java
@@ -81,6 +81,7 @@ public class DeleteColumnsService extends WorksheetControllerService {
       }
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void deleteColumns(
       @ClusterProxyKey String runtimeId,

--- a/core/src/main/java/inetsoft/web/composer/ws/DeleteDataService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/DeleteDataService.java
@@ -41,6 +41,7 @@ public class DeleteDataService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void deleteData(
       @ClusterProxyKey String runtimeId, WSDeleteDataEvent event, Principal principal,

--- a/core/src/main/java/inetsoft/web/composer/ws/DragColumnsService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/DragColumnsService.java
@@ -39,6 +39,7 @@ public class DragColumnsService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void dragColumns(
       @ClusterProxyKey String runtimeId,

--- a/core/src/main/java/inetsoft/web/composer/ws/InsertColumnsService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/InsertColumnsService.java
@@ -55,6 +55,7 @@ public class InsertColumnsService extends WorksheetControllerService {
       return validateInsertColumns0(rws, event, principal, null);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void insertColumns(
       @ClusterProxyKey String runtimeId,

--- a/core/src/main/java/inetsoft/web/composer/ws/InsertDataService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/InsertDataService.java
@@ -48,6 +48,7 @@ public class InsertDataService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void insertData(
       @ClusterProxyKey String runtimeId,

--- a/core/src/main/java/inetsoft/web/composer/ws/LayoutGraphService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/LayoutGraphService.java
@@ -46,6 +46,7 @@ public class LayoutGraphService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void layoutGraph(@ClusterProxyKey String runtimeId,
                            WSLayoutGraphEvent event, Principal principal,

--- a/core/src/main/java/inetsoft/web/composer/ws/MirrorAutoUpdateService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/MirrorAutoUpdateService.java
@@ -39,6 +39,7 @@ public class MirrorAutoUpdateService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void toggleAutoUpdate(
       @ClusterProxyKey String runtimeId,

--- a/core/src/main/java/inetsoft/web/composer/ws/OpenWorksheetControllerService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/OpenWorksheetControllerService.java
@@ -41,6 +41,7 @@ public class OpenWorksheetControllerService {
       this.runtimeViewsheetManager = runtimeViewsheetManager;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void processNewWorksheet(@ClusterProxyKey String runtimeId, Principal principal,
                                    CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/PasteAssembliesService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/PasteAssembliesService.java
@@ -48,6 +48,7 @@ public class PasteAssembliesService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void pasteAssemblies(
       @ClusterProxyKey String runtimeId,

--- a/core/src/main/java/inetsoft/web/composer/ws/RenameColumnService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/RenameColumnService.java
@@ -70,6 +70,7 @@ public class RenameColumnService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void renameColumn(
       @ClusterProxyKey String runtimeId,

--- a/core/src/main/java/inetsoft/web/composer/ws/ReplaceColumnsService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/ReplaceColumnsService.java
@@ -100,6 +100,7 @@ public class ReplaceColumnsService extends WorksheetControllerService {
       return builder.build();
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void replaceColumns(@ClusterProxyKey String runtimeId, WSReplaceColumnsEvent event,
                               Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/ResizeColumnService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/ResizeColumnService.java
@@ -41,6 +41,7 @@ public class ResizeColumnService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void resizeColumn(@ClusterProxyKey String runtimeId, WSResizeColumnEvent event,
                             Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/SetColumnIndexService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/SetColumnIndexService.java
@@ -40,6 +40,7 @@ public class SetColumnIndexService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setColumnIndex(@ClusterProxyKey String runtimeId, WSSetColumnIndexEvent event,
                               Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/SetColumnVisibleService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/SetColumnVisibleService.java
@@ -52,6 +52,7 @@ public class SetColumnVisibleService extends WorksheetControllerService {
       this.dataRefModelFactoryService = dataRefModelFactoryService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setColumnVisibility(@ClusterProxyKey String runtimeId, WSSetColumnVisibilityEvent event,
                                    Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/SortColumnService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/SortColumnService.java
@@ -42,6 +42,7 @@ public class SortColumnService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void sortColumn(@ClusterProxyKey String runtimeId, WSSortColumnEvent event,
                           Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/TableModeService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/TableModeService.java
@@ -55,6 +55,7 @@ public class TableModeService extends WorksheetControllerService {
       this.assetDataCache = assetDataCache;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setDefaultMode(@ClusterProxyKey String runtimeId, WSAssemblyEvent event,
                               Principal principal, CommandDispatcher commandDispatcher) throws Exception
@@ -73,6 +74,7 @@ public class TableModeService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setDependencyJoinTableToDefaultMode(@ClusterProxyKey String runtimeId,
                                                    WSRefreshAssemblyEvent event, Principal principal,
@@ -93,6 +95,7 @@ public class TableModeService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setLiveMode(@ClusterProxyKey String runtimeId, WSAssemblyEvent event,
                            Principal principal, CommandDispatcher commandDispatcher) throws Exception
@@ -110,6 +113,7 @@ public class TableModeService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setFullMode(@ClusterProxyKey String runtimeId, WSAssemblyEvent event, Principal principal,
                            CommandDispatcher commandDispatcher) throws Exception
@@ -143,6 +147,7 @@ public class TableModeService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setDetailMode(@ClusterProxyKey String runtimeId, WSAssemblyEvent event,
                              Principal principal, CommandDispatcher commandDispatcher) throws Exception
@@ -165,6 +170,7 @@ public class TableModeService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setRuntime(@ClusterProxyKey String runtimeId, WSSetRuntimeEvent event,
                           Principal principal, CommandDispatcher commandDispatcher) throws Exception
@@ -185,6 +191,7 @@ public class TableModeService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setEditMode(@ClusterProxyKey String runtimeId, WSAssemblyEvent event,
                            Principal principal, CommandDispatcher commandDispatcher) throws Exception
@@ -207,6 +214,7 @@ public class TableModeService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void refreshLiveData(@ClusterProxyKey String runtimeId, WSAssemblyEvent event,
                                Principal principal, CommandDispatcher commandDispatcher) throws Exception
@@ -249,6 +257,7 @@ public class TableModeService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void refreshData(@ClusterProxyKey String runtimeId, WSRefreshAssemblyEvent event,
                            Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/UpdateMirrorService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/UpdateMirrorService.java
@@ -44,6 +44,7 @@ public class UpdateMirrorService extends WorksheetControllerService {
       this.assetDataCache = assetDataCache;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void updateMirror(@ClusterProxyKey String runtimeId, WSAssemblyEvent event,
                             Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/WSEditTableDataService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/WSEditTableDataService.java
@@ -52,6 +52,7 @@ public class WSEditTableDataService extends WorksheetControllerService {
       this.assetDataCache = assetDataCache;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void editTableData(@ClusterProxyKey String runtimeId,  WSEditTableDataEvent event,
                              Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/WSLoadTableDataService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/WSLoadTableDataService.java
@@ -56,6 +56,7 @@ public class WSLoadTableDataService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void loadWSTableData(@ClusterProxyKey String runtimeId, String assemblyName,
                                WSLoadTableDataEvent event, Principal principal,

--- a/core/src/main/java/inetsoft/web/composer/ws/WSMirrorService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/WSMirrorService.java
@@ -43,6 +43,7 @@ public class WSMirrorService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void addMirrorAssembly(@ClusterProxyKey String runtimeId, WSAssemblyEvent event,
                                  Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/WSMoveAssembliesService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/WSMoveAssembliesService.java
@@ -42,6 +42,7 @@ public class WSMoveAssembliesService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void offsetAssemblies(@ClusterProxyKey String runtimeId, WSMoveAssembliesEvent event,
                                 Principal principal, CommandDispatcher commandDispatcher) throws Exception
@@ -69,6 +70,7 @@ public class WSMoveAssembliesService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void relocateAssemblies(@ClusterProxyKey String runtimeId, WSRelocateAssembliesEvent event,
                                   Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/WSMoveSchemaTableService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/WSMoveSchemaTableService.java
@@ -43,6 +43,7 @@ public class WSMoveSchemaTableService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void moveSchemas(@ClusterProxyKey String runtimeId, WSMoveSchemaTablesEvent event,
                            Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/WSPrimaryService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/WSPrimaryService.java
@@ -44,6 +44,7 @@ public class WSPrimaryService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setAsPrimary(@ClusterProxyKey String runtiemId, WSAssemblyEvent event,
                             Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/WSQueryService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/WSQueryService.java
@@ -46,6 +46,7 @@ public class WSQueryService extends WorksheetControllerService {
       this.assetDataCache = assetDataCache;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void runQuery(@ClusterProxyKey String runtimeId, WSAssemblyEvent event, Principal principal,
                         CommandDispatcher commandDispatcher) throws Exception
@@ -97,6 +98,7 @@ public class WSQueryService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void stopQuery(@ClusterProxyKey String runtimeId, WSAssemblyEvent event,
                          Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/WSRemoveAssembliesService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/WSRemoveAssembliesService.java
@@ -78,6 +78,7 @@ public class WSRemoveAssembliesService extends WorksheetControllerService {
       }
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void removeAssemblies(@ClusterProxyKey String runtimeId, WSRemoveAssembliesEvent event,
                                 Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/WSRenameAssemblyService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/WSRenameAssemblyService.java
@@ -42,6 +42,7 @@ public class WSRenameAssemblyService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void renameAssembly(@ClusterProxyKey String runtimeId, WSRenameAssemblyEvent event,
                               Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/WSResizeSchemaTableService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/WSResizeSchemaTableService.java
@@ -43,6 +43,7 @@ public class WSResizeSchemaTableService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void resizeSchemaTable(@ClusterProxyKey String runtimeId, WSResizeSchemaTableEvent event,
                                  Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/WSRotateService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/WSRotateService.java
@@ -44,6 +44,7 @@ public class WSRotateService extends WorksheetControllerService{
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void addRotateAssembly(@ClusterProxyKey String runtimeId, WSAssemblyEvent event,
                                  Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/WorksheetOpenAssetService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/WorksheetOpenAssetService.java
@@ -89,6 +89,7 @@ public class WorksheetOpenAssetService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void openAsset(@ClusterProxyKey String runtimeId, OpenAssetEvent event,
                          Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/assembly/WorksheetEventService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/assembly/WorksheetEventService.java
@@ -61,6 +61,7 @@ public class WorksheetEventService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public String openWorksheet(@ClusterProxyKey String id, Principal user, AssetEntry entry,
                                boolean openAutoSaved, boolean gettingStartedCreateQuery,

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/AggregateDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/AggregateDialogService.java
@@ -208,6 +208,7 @@ public class AggregateDialogService extends WorksheetControllerService {
       availableColumns.add(refModel);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setAggregateInfo(@ClusterProxyKey String runtimeId, AggregateDialogModel model,
                                 Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/AssemblyConditionDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/AssemblyConditionDialogService.java
@@ -230,6 +230,7 @@ public class AssemblyConditionDialogService extends WorksheetControllerService {
       return model;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setModel(@ClusterProxyKey String runtimeId, String assemblyName,
                         AssemblyConditionDialogModel model, Principal principal,

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/ColumnDescriptionDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/ColumnDescriptionDialogService.java
@@ -45,6 +45,7 @@ public class ColumnDescriptionDialogService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void updateColumnType(@ClusterProxyKey String runtimeId, WSColumnDescriptionEvent event,
                                 Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/ColumnTypeDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/ColumnTypeDialogService.java
@@ -54,6 +54,7 @@ public class ColumnTypeDialogService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public String updateColumnType(@ClusterProxyKey String runtimeId, WSColumnTypeEvent event,
                                   Principal principal) throws Exception
@@ -178,6 +179,7 @@ public class ColumnTypeDialogService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void updateColumnType(@ClusterProxyKey String runtimeId, WSColumnTypeEvent event,
                                 Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/ConcatentationTypeDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/ConcatentationTypeDialogService.java
@@ -75,6 +75,7 @@ public class ConcatentationTypeDialogService extends WorksheetControllerService 
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void updateConcatenationType(@ClusterProxyKey String runtimeId, ConcatenationTypeDialogModel model,
                                        Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/EmbeddedTableDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/EmbeddedTableDialogService.java
@@ -59,6 +59,7 @@ public class EmbeddedTableDialogService extends WorksheetControllerService {
       return model;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void createEmbeddedTable(@ClusterProxyKey String runtimeId, EmbeddedTableDialogModel model,
                                    Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/ExpressionDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/ExpressionDialogService.java
@@ -286,6 +286,7 @@ public class ExpressionDialogService extends WorksheetControllerService {
       return builder.build();
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setModel(@ClusterProxyKey String runtimeId, ExpressionDialogModel model, Principal principal,
                         CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/GroupingAssemblyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/GroupingAssemblyDialogService.java
@@ -124,6 +124,7 @@ public class GroupingAssemblyDialogService extends WorksheetControllerService {
       return model;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setGroupingAssemblyDialogProperties(@ClusterProxyKey String runtimeId,
                                                    GroupingAssemblyDialogModel model,

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/ImportCSVDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/ImportCSVDialogService.java
@@ -90,6 +90,7 @@ public class ImportCSVDialogService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setImportCSVDialogModel(@ClusterProxyKey String runtimeId,
                                        ImportCSVDialogModel model, Principal principal,

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/ReorderColumnsDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/ReorderColumnsDialogService.java
@@ -100,6 +100,7 @@ public class ReorderColumnsDialogService extends WorksheetControllerService {
       return cols;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void reorderColumns(@ClusterProxyKey String runtimeId, ReorderColumnsDialogModel model,
                               String tableName, Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/ReorderSubtableService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/ReorderSubtableService.java
@@ -47,6 +47,7 @@ public class ReorderSubtableService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void reorderSubtables(@ClusterProxyKey String runtimeId, ReorderSubtablesEvent event,
                                 Principal principal, CommandDispatcher commandDispatcher) throws Exception
@@ -88,6 +89,7 @@ public class ReorderSubtableService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void reorderJoinTable(@ClusterProxyKey String runtimeId, WSMergeAddJoinTableEvent event,
                                 Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/SQLQueryDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/SQLQueryDialogService.java
@@ -131,6 +131,7 @@ public class SQLQueryDialogService {
       return browseDataController.process(rws.getAssetQuerySandbox());
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setModel(@ClusterProxyKey String runtimeId, SQLQueryDialogModel model,
                         Principal principal, CommandDispatcher commandDispatcher)

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/SaveWorksheetDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/SaveWorksheetDialogService.java
@@ -109,6 +109,7 @@ public class SaveWorksheetDialogService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void saveWorksheet(@ClusterProxyKey String runtimeId, SaveWorksheetDialogModel model,
                              Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/SortColumnDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/SortColumnDialogService.java
@@ -156,6 +156,7 @@ public class SortColumnDialogService extends WorksheetControllerService {
       return model;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setSortInfo(@ClusterProxyKey String runtimeId, SortColumnDialogModel model,
                            Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/TablePropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/TablePropertyDialogService.java
@@ -84,6 +84,7 @@ public class TablePropertyDialogService extends WorksheetControllerService {
       }
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void saveProperties(@ClusterProxyKey String runtimeId, TablePropertyDialogModel model,
                               Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/TableUnpivotDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/TableUnpivotDialogService.java
@@ -52,6 +52,7 @@ public class TableUnpivotDialogService extends WorksheetControllerService {
       this.vsLayoutService = vsLayoutService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void createUnpivotTable(@ClusterProxyKey String runtimeId, WSUnpivotDialogEvent event, Principal principal, CommandDispatcher commandDispatcher) throws Exception
    {
@@ -89,6 +90,7 @@ public class TableUnpivotDialogService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void changeUnpivotTableRowHeaders(@ClusterProxyKey String runtimeId, WSUnpivotDialogEvent event,
                                             Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/TabularQueryDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/TabularQueryDialogService.java
@@ -115,6 +115,7 @@ public class TabularQueryDialogService extends WorksheetControllerService {
       return model;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setModel(@ClusterProxyKey String runtimeId, TabularQueryDialogModel model,
                         Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/VPMPrincipalDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/VPMPrincipalDialogService.java
@@ -86,6 +86,7 @@ public class VPMPrincipalDialogService extends WorksheetControllerService {
       return builder.build();
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setVPMPrincipalModel(@ClusterProxyKey String runtimeId, VPMPrincipalDialogModel model,
                                     CommandDispatcher commandDispatcher, Principal principal) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/ValueRangeService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/ValueRangeService.java
@@ -123,6 +123,7 @@ public class ValueRangeService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void editValueRange(@ClusterProxyKey String runtimeId, ValueRangeDialogModel model,
                               String tableName, Principal principal,  CommandDispatcher commandDispatcher) throws Exception
@@ -161,6 +162,7 @@ public class ValueRangeService extends WorksheetControllerService {
       return builder.build();
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void newValueRange(@ClusterProxyKey String runtimeId, ValueRangeDialogModel model,
                              String tableName, String fromColumn, Principal principal,

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/VariableAssemblyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/VariableAssemblyDialogService.java
@@ -165,6 +165,7 @@ public class VariableAssemblyDialogService extends WorksheetControllerService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setVariableAssemblyProperties(@ClusterProxyKey String runtimeId,
                                              VariableAssemblyDialogModel model, Principal principal,

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/VariableInputDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/VariableInputDialogService.java
@@ -60,6 +60,7 @@ public class VariableInputDialogService extends WorksheetControllerService {
       return res == null ? new ArrayList<>() : res.varInfos();
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void restoreVariable(@ClusterProxyKey String runtimeId, Principal principal) throws Exception {
       RuntimeWorksheet rws = getRuntimeWorksheet(runtimeId, principal);
@@ -70,6 +71,7 @@ public class VariableInputDialogService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void initVariableInfos(@ClusterProxyKey String runtimeId, WSCollectVariablesOverEvent event, Principal principal,
       CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/WorksheetPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/WorksheetPropertyDialogService.java
@@ -55,6 +55,7 @@ public class WorksheetPropertyDialogService extends WorksheetControllerService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setWorksheetInfo(@ClusterProxyKey String runtimeId, WorksheetPropertyDialogModel model,
                                 Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/joins/CrossJoinService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/joins/CrossJoinService.java
@@ -59,6 +59,7 @@ public class CrossJoinService extends WorksheetControllerService {
       this.service = service;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void executeCrossjoinAssemblies(@ClusterProxyKey String runtimeId, Principal principal,
                                    CommandDispatcher dispatcher, String linkUri, String tableName) throws Exception
@@ -75,6 +76,7 @@ public class CrossJoinService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void doCrossJoin(@ClusterProxyKey String runtimeId, WSCrossJoinEvent event, Principal principal,
       CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/joins/DeleteSubTableService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/joins/DeleteSubTableService.java
@@ -43,6 +43,7 @@ public class DeleteSubTableService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void deleteSubTable(@ClusterProxyKey String runtimeId, WSDeleteSubtablesEvent event,
                               Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/joins/EquiJoinService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/joins/EquiJoinService.java
@@ -44,6 +44,7 @@ public class EquiJoinService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setEquiJoin(@ClusterProxyKey String runtimeId, WSEquiJoinEvent event, Principal principal,
                            CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/joins/InnerJoinService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/joins/InnerJoinService.java
@@ -51,6 +51,7 @@ public class InnerJoinService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void editInnerJoin(@ClusterProxyKey String runtimeId, WSInnerJoinEvent event,
                              Principal principal, CommandDispatcher commandDispatcher) throws Exception
@@ -82,6 +83,7 @@ public class InnerJoinService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void dragTableIntoJoinSchema(@ClusterProxyKey String runtimeId,
                                        WSDropTableIntoJoinSchemaEvent event, Principal principal,
@@ -99,6 +101,7 @@ public class InnerJoinService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void joinTables(@ClusterProxyKey String runtimeId, WSJoinTablesEvent event,
                           Principal principal, CommandDispatcher commandDispatcher) throws Exception
@@ -135,6 +138,7 @@ public class InnerJoinService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void joinTablePair(@ClusterProxyKey String runtimeId, WSJoinTablePairEvent event,
                              Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/joins/JoinViewService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/joins/JoinViewService.java
@@ -38,6 +38,7 @@ public class JoinViewService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void openJoin(@ClusterProxyKey String runtimeId, Principal principal) throws Exception {
       final RuntimeWorksheet rws = super.getRuntimeWorksheet(runtimeId, principal);
@@ -46,6 +47,7 @@ public class JoinViewService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void cancelJoin(@ClusterProxyKey String runtimeId, Principal principal, CommandDispatcher dispatcher) throws Exception {
       final RuntimeWorksheet rws = super.getRuntimeWorksheet(runtimeId, principal);

--- a/core/src/main/java/inetsoft/web/composer/ws/joins/MergeJoinService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/joins/MergeJoinService.java
@@ -47,6 +47,7 @@ public class MergeJoinService extends WorksheetControllerService {
       super(viewsheetService, dataSourceRegistry);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void doMergeJoin(@ClusterProxyKey String runtimeId, WSMergeJoinEvent event, Principal principal,
                            CommandDispatcher commandDispatcher) throws Exception
@@ -71,6 +72,7 @@ public class MergeJoinService extends WorksheetControllerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void addJoinTable(@ClusterProxyKey String runtimeId, WSMergeAddJoinTableEvent event,
                             Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/composer/ws/service/SaveWorksheetService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/service/SaveWorksheetService.java
@@ -68,6 +68,7 @@ public class SaveWorksheetService extends WorksheetControllerService {
       this.renameTransformHandler = renameTransformHandler;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Boolean saveWorksheet(@ClusterProxyKey String runtimeId, SaveSheetEvent event,
                                 Principal principal, CommandDispatcher commandDispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/viewsheet/EventAspectService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/EventAspectService.java
@@ -64,6 +64,9 @@ public class EventAspectService {
          }
 
          if(textVSAssembly != null) {
+            // No @ClusterWriteMethod: the warning text assembly is a transient UI element
+            // re-evaluated from scratch on every execution pass. Any node will reposition it
+            // correctly on the next event, so this mutation does not need Ignite persistence.
             vs.adjustWarningTextPosition();
             coreLifecycleService.addDeleteVSObject(rvs, textVSAssembly, commandDispatcher);
             coreLifecycleService.refreshVSAssembly(rvs, textVSAssembly, commandDispatcher);

--- a/core/src/main/java/inetsoft/web/viewsheet/SheetWriteAspect.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/SheetWriteAspect.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.viewsheet;
+
+import inetsoft.report.composition.WorksheetService;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Serializes the RuntimeSheet to the distributed Ignite cache after genuine mutation methods.
+ * Only fires on methods annotated with {@link ClusterWriteMethod}, keeping read-only paths at
+ * zero serialization overhead.
+ */
+@Component
+@Aspect
+public class SheetWriteAspect {
+   public SheetWriteAspect(WorksheetService worksheetService) {
+      this.worksheetService = worksheetService;
+   }
+
+   @AfterReturning("@annotation(inetsoft.cluster.ClusterWriteMethod)")
+   public void writeSheet(JoinPoint joinPoint) {
+      Object[] args = joinPoint.getArgs();
+
+      if(args.length > 0 && args[0] instanceof String id) {
+         worksheetService.writeSheet(id);
+      }
+      else if(args.length > 0) {
+         LOG.warn("@ClusterWriteMethod on {} has a non-String first argument {}; " +
+                  "distributed cache write skipped. The annotated method must have " +
+                  "@ClusterProxyKey String as its first parameter.",
+                  joinPoint.getSignature(), args[0] == null ? "null" : args[0].getClass().getName());
+      }
+   }
+
+   private final WorksheetService worksheetService;
+   private static final Logger LOG = LoggerFactory.getLogger(SheetWriteAspect.class);
+}

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/DelayVisibilityService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/DelayVisibilityService.java
@@ -44,6 +44,7 @@ public class DelayVisibilityService {
       this.lifecycleService = coreLifecycleService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void onShowDelayedVisibility(@ClusterProxyKey String runtimeId, DelayVisibilityEvent event,
                                        Principal principal, CommandDispatcher dispatcher)

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/ImportXLSControllerService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/ImportXLSControllerService.java
@@ -54,6 +54,7 @@ public class ImportXLSControllerService {
       return viewsheetService.getViewsheet(runtimeId, principal) != null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void processXLSUpload(@ClusterProxyKey String vsId, String type, String linkUri,
                                 Principal principal, CommandDispatcher dispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/OnClickService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/OnClickService.java
@@ -59,6 +59,7 @@ public class OnClickService {
       this.inputService = inputService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void onConfirm(@ClusterProxyKey String vsId, String name, String x, String y,
                          boolean isConfirm, VSOnClickEvent confirmEvent, String linkUri,
@@ -120,6 +121,7 @@ public class OnClickService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void onClick(@ClusterProxyKey String vsId, String name, String x, String y, VSSubmitEvent submitEvent,
                        String linkUri, Principal principal, CommandDispatcher dispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/UndoRedoService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/UndoRedoService.java
@@ -51,6 +51,7 @@ public class UndoRedoService {
       this.wizardViewsheetService = wizardViewsheetService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void undo(@ClusterProxyKey String vsId, Principal principal, String linkUri,
                     CommandDispatcher dispatcher) throws Exception
@@ -94,6 +95,7 @@ public class UndoRedoService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void redo(@ClusterProxyKey String vsId, Principal principal, String linkUri,
                     CommandDispatcher dispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/VSCalendarService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/VSCalendarService.java
@@ -52,6 +52,7 @@ public class VSCalendarService {
       this.viewsheetService = viewsheetService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void toggleRangeComparison(@ClusterProxyKey String vsId, String assemblyName,
                                      ToggleRangeComparisonEvent event, String linkUri, Principal principal,
@@ -73,6 +74,7 @@ public class VSCalendarService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void toggleYearView(@ClusterProxyKey String vsId, String assemblyName,
                               ToggleYearViewEvent event, String linkUri,
@@ -97,6 +99,7 @@ public class VSCalendarService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void clearCalendar(@ClusterProxyKey String vsId, String assemblyName,
                              Principal principal, CommandDispatcher dispatcher,
@@ -113,6 +116,7 @@ public class VSCalendarService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void toggleDoubleCalendar(@ClusterProxyKey String vsId, String assemblyName,
                                     ToggleDoubleCalendarEvent event, String linkUri,
@@ -196,6 +200,7 @@ public class VSCalendarService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void applyCalendar(@ClusterProxyKey String vsId, String assemblyName, CalendarSelectionEvent event,
                              Principal principal, CommandDispatcher dispatcher, String linkUri) throws Exception

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/VSCollectParametersService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/VSCollectParametersService.java
@@ -65,6 +65,7 @@ public class VSCollectParametersService {
       this.xRepository = xRepository;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void collectParameters(@ClusterProxyKey String vsId, CollectParametersOverEvent event,
                                  Principal principal, String linkUri,CommandDispatcher dispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/VSDataTipService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/VSDataTipService.java
@@ -53,6 +53,7 @@ public class VSDataTipService {
       this.viewsheetService = viewsheetService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void applyDataTip(@ClusterProxyKey String runtimeId, OpenDataTipEvent event,
                             Principal principal, String linkUri, CommandDispatcher dispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshService.java
@@ -100,6 +100,10 @@ public class VSRefreshService {
       return null;
    }
 
+   // @ClusterWriteMethod required: when userRefresh=true this calls replaceCheckpoint(), which
+   // updates the undo stack with the current viewsheet state — persistent session state that
+   // must be visible to other cluster nodes.
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void refreshViewsheet(@ClusterProxyKey String id, VSRefreshEvent event, Principal principal,
                                 CommandDispatcher commandDispatcher, String linkUri) throws Exception

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/VSTabService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/VSTabService.java
@@ -42,6 +42,7 @@ public class VSTabService {
       this.viewsheetService = viewsheetService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void changeTab(@ClusterProxyKey  String vsId, String name, ChangeTabStateEvent event,
                          String linkUri, Principal principal, CommandDispatcher dispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/annotation/VSAnnotationAddService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/annotation/VSAnnotationAddService.java
@@ -51,6 +51,7 @@ public class VSAnnotationAddService {
    /**
     * Add an annotation to the runtime viewsheet.
     **/
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void addAnnotation(@ClusterProxyKey String id, final AddAnnotationEvent event,
                              final String linkUri, final Principal principal,

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/annotation/VSAnnotationFormatService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/annotation/VSAnnotationFormatService.java
@@ -80,6 +80,7 @@ public class VSAnnotationFormatService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void updateFormat(@ClusterProxyKey String id, UpdateAnnotationFormatEvent event,
                             Principal principal, String linkUri, CommandDispatcher dispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/annotation/VSAnnotationRemoveService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/annotation/VSAnnotationRemoveService.java
@@ -39,6 +39,7 @@ public class VSAnnotationRemoveService {
       this.service = service;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void removeAnnotation(@ClusterProxyKey String id, RemoveAnnotationEvent event,
                                 String linkUri,Principal principal, CommandDispatcher dispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/annotation/VSAnnotationToggleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/annotation/VSAnnotationToggleService.java
@@ -39,6 +39,7 @@ public class VSAnnotationToggleService {
       this.service = service;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void toggleAnnotationStatus(@ClusterProxyKey String id, ToggleAnnotationStatusEvent event,
                                       Principal principal, String linkUri, CommandDispatcher dispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/annotation/VSAnnotationUpdateService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/annotation/VSAnnotationUpdateService.java
@@ -44,6 +44,7 @@ public class VSAnnotationUpdateService {
       this.annotationService = annotationService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void updateAnnotation(@ClusterProxyKey String id, UpdateAnnotationEvent event,
                                 Principal principal, String linkUri, CommandDispatcher dispatcher) throws Exception
@@ -93,6 +94,7 @@ public class VSAnnotationUpdateService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void updateAnnotationEndpoint(@ClusterProxyKey String id, UpdateAnnotationEvent event,
                                         Principal principal,

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartAxesVisibilityService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartAxesVisibilityService.java
@@ -49,6 +49,7 @@ public class VSChartAxesVisibilityService extends VSChartControllerService<VSCha
    }
 
    @Override
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void eventHandler(@ClusterProxyKey String runtimeId,
                             VSChartAxesVisibilityEvent event, 

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartAxisResizeService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartAxisResizeService.java
@@ -43,6 +43,7 @@ public class VSChartAxisResizeService  extends VSChartControllerService<VSChartA
    }
 
    @Override
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void eventHandler(@ClusterProxyKey String runtimeId,
                             VSChartAxisResizeEvent event,

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartBrushService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartBrushService.java
@@ -58,6 +58,7 @@ public class VSChartBrushService extends VSChartControllerService<VSChartBrushEv
    }
 
    @Override
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void eventHandler(@ClusterProxyKey String runtimeId,
                             VSChartBrushEvent event,

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartDrillActionService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartDrillActionService.java
@@ -61,6 +61,7 @@ public class VSChartDrillActionService extends VSChartControllerService<VSChartD
    }
 
    @Override
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void eventHandler(@ClusterProxyKey String runtimeId,
                             VSChartDrillActionEvent event,

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartDrillService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartDrillService.java
@@ -58,6 +58,7 @@ public class VSChartDrillService extends VSChartControllerService<VSChartDrillEv
 
    // from analytic.composition.event.DrillEvent.process()
    @Override
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void eventHandler(@ClusterProxyKey String runtimeId,
                             VSChartDrillEvent event,

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartLegendsVisibilityService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartLegendsVisibilityService.java
@@ -57,6 +57,7 @@ public class VSChartLegendsVisibilityService extends VSChartControllerService<VS
    }
 
    @Override
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void eventHandler(@ClusterProxyKey String runtimeId,
                             VSChartLegendsVisibilityEvent event,

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartMapService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartMapService.java
@@ -59,6 +59,7 @@ public class VSChartMapService {
       this.viewsheetService = viewsheetService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void zoomIn(@ClusterProxyKey String runtimeId,
                       VSMapZoomEvent event,
@@ -70,6 +71,7 @@ public class VSChartMapService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void pan(@ClusterProxyKey String runtimeId,
                    VSMapPanEvent event,
@@ -115,6 +117,7 @@ public class VSChartMapService {
       }
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void clear(@ClusterProxyKey String runtimeId,
                      VSMapPanEvent event,

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartMaxModeService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartMaxModeService.java
@@ -45,6 +45,7 @@ public class VSChartMaxModeService extends VSChartControllerService<VSChartEvent
    }
 
    @Override
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void eventHandler(@ClusterProxyKey String runtimeId,
                             VSChartEvent event,

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartMoveLegendService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartMoveLegendService.java
@@ -46,6 +46,7 @@ public class VSChartMoveLegendService extends VSChartControllerService<VSChartLe
    }
 
    @Override
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void eventHandler(@ClusterProxyKey String runtimeId,
                             VSChartLegendRelocateEvent event,

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartPlotResizeService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartPlotResizeService.java
@@ -43,6 +43,7 @@ public class VSChartPlotResizeService extends VSChartControllerService<VSChartPl
    }
 
    @Override
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void eventHandler(@ClusterProxyKey  String runtimeId, VSChartPlotResizeEvent event,
                             String linkUri, Principal principal, CommandDispatcher dispatcher) throws Exception

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartResizeLegendService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartResizeLegendService.java
@@ -45,6 +45,7 @@ public class VSChartResizeLegendService extends VSChartControllerService<VSChart
    }
 
    @Override
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void eventHandler(@ClusterProxyKey String runtimeId,
                             VSChartLegendResizeEvent event,

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartShowDataService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartShowDataService.java
@@ -123,6 +123,7 @@ public class VSChartShowDataService extends VSChartControllerService<VSChartShow
       return format;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setColWidth(@ClusterProxyKey String vsId, String assemblyName, int columnIndex,
                            int width, Principal principal) throws Exception

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartShowDetailsService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartShowDetailsService.java
@@ -132,6 +132,7 @@ public class VSChartShowDetailsService extends VSChartControllerService<VSChartS
       return format;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setColWidth(@ClusterProxyKey String vsId, String assemblyName, int columnIndex,
                            int width, Principal principal) throws Exception

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartSortAxisService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartSortAxisService.java
@@ -51,6 +51,7 @@ public class VSChartSortAxisService extends VSChartControllerService<VSChartSort
    }
 
    @Override
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void eventHandler(@ClusterProxyKey String runtimeId,
                             VSChartSortAxisEvent event,

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartTitlesVisibilityService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartTitlesVisibilityService.java
@@ -46,6 +46,7 @@ public class VSChartTitlesVisibilityService extends VSChartControllerService<VSC
    }
 
    @Override
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void eventHandler(@ClusterProxyKey String runtimeId,
                             VSChartTitlesVisibilityEvent event,

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartZoomService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartZoomService.java
@@ -57,6 +57,7 @@ public class VSChartZoomService extends VSChartControllerService<VSChartZoomEven
    }
 
    @Override
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void eventHandler(@ClusterProxyKey String runtimeId,
                             VSChartZoomEvent event,

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/table/BaseTableSortColumnService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/table/BaseTableSortColumnService.java
@@ -55,6 +55,7 @@ public class BaseTableSortColumnService extends BaseTableService<SortColumnEvent
    }
 
    @Override
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void eventHandler(@ClusterProxyKey String runtimeId,
                             SortColumnEvent event,
@@ -87,6 +88,7 @@ public class BaseTableSortColumnService extends BaseTableService<SortColumnEvent
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void sortColumnAction(@ClusterProxyKey String runtimeId,
                                 SortColumnEvent event, Principal principal,

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/table/CrosstabDrillActionService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/table/CrosstabDrillActionService.java
@@ -51,6 +51,7 @@ public class CrosstabDrillActionService extends BaseTableDrillService<BaseTableD
    }
 
    @Override
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void eventHandler(@ClusterProxyKey String runtimeId,
                             BaseTableDrillEvent event,

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/table/CrosstabDrillService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/table/CrosstabDrillService.java
@@ -43,6 +43,7 @@ public class CrosstabDrillService extends BaseTableDrillService<DrillEvent> {
    }
 
    @Override
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void eventHandler(@ClusterProxyKey String runtimeId,
                             DrillEvent event,
@@ -56,6 +57,7 @@ public class CrosstabDrillService extends BaseTableDrillService<DrillEvent> {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void drill(@ClusterProxyKey String runtimeId, DrillCellsEvent event, Principal principal,
                      CommandDispatcher dispatcher, String linkUri)

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/table/VSFormTableService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/table/VSFormTableService.java
@@ -57,6 +57,7 @@ public class VSFormTableService {
       this.coreLifecycleService = coreLifecycleService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void addRow(@ClusterProxyKey String id, InsertTableRowEvent event, @LinkUri String linkUri,
                       CommandDispatcher dispatcher, Principal principal)
@@ -99,6 +100,7 @@ public class VSFormTableService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void deleteRows(@ClusterProxyKey String runtimeId, DeleteTableRowsEvent event, String linkUri,
                           CommandDispatcher dispatcher, Principal principal) throws Exception
@@ -129,6 +131,7 @@ public class VSFormTableService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void changeFormInput(@ClusterProxyKey String id, ChangeFormTableCellInputEvent event,
                                String linkUri, CommandDispatcher dispatcher, Principal principal)
@@ -288,6 +291,7 @@ public class VSFormTableService {
       return val;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void applyChanges(@ClusterProxyKey String id, ApplyFormChangesEvent event,
                             String linkUri, CommandDispatcher dispatcher,

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/table/VSTableMaxModeService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/table/VSTableMaxModeService.java
@@ -42,6 +42,7 @@ public class VSTableMaxModeService {
       this.coreLifecycleService = coreLifecycleService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void toggleMaxMode(@ClusterProxyKey String id, MaxTableEvent event, Principal principal, @LinkUri String linkUri,
                              CommandDispatcher dispatcher)

--- a/core/src/main/java/inetsoft/web/viewsheet/service/MaxModeAssemblyService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/MaxModeAssemblyService.java
@@ -39,6 +39,7 @@ public class MaxModeAssemblyService {
       this.viewsheetService =   viewsheetService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void toggleMaxMode(@ClusterProxyKey String vsId, String assemblyName, Dimension maxSize,
                              CommandDispatcher dispatcher, String linkUri, Principal principal)

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
@@ -87,6 +87,7 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
       }
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void saveBookmark(@ClusterProxyKey String runtimeId, VSEditBookmarkEvent value,
                             Principal principal, CommandDispatcher commandDispatcher, String linkUri) throws Exception
@@ -244,6 +245,7 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void addBookmark(@ClusterProxyKey String runtimeId, VSEditBookmarkEvent value,
                            Principal principal, CommandDispatcher commandDispatcher, String linkUri) throws Exception
@@ -262,6 +264,7 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void deleteBookmark(@ClusterProxyKey String runtimeId, VSEditBookmarkEvent value,
                               Principal principal, CommandDispatcher commandDispatcher, String linkUri) throws Exception
@@ -320,6 +323,7 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void deleteMatchedBookmarks(@ClusterProxyKey String runtimeId, VSDeletedMatchedBookmarksEvent event,
                                       Principal principal, CommandDispatcher commandDispatcher, @LinkUri String linkUri) throws Exception
@@ -407,6 +411,7 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void editBookmark(@ClusterProxyKey String runtimeId, VSEditBookmarkEvent value, Principal principal,
                             CommandDispatcher commandDispatcher, @LinkUri String linkUri) throws Exception
@@ -518,6 +523,7 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
       return allBookmarks.toArray(new VSBookmarkInfoModel[0]);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void gotoBookmark(@ClusterProxyKey String runtimeId, VSEditBookmarkEvent value,
                             Principal principal, CommandDispatcher commandDispatcher, String linkUri) throws Exception
@@ -534,6 +540,7 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setDefaultBookmark(@ClusterProxyKey String runtimeId, VSEditBookmarkEvent value,
                                   Principal principal, CommandDispatcher commandDispatcher, String linkUri) throws Exception

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
@@ -103,6 +103,7 @@ public class VSInputService {
     *
     * @throws Exception if the selection could not be applied.
     */
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void singleApplySelection(@ClusterProxyKey String vsId, String assemblyName, Object selectedObject,
                                     Principal principal, CommandDispatcher dispatcher,
@@ -124,6 +125,7 @@ public class VSInputService {
       rvs.getViewsheetSandbox().ifPresent(ViewsheetSandbox::detachScriptEvent);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void multiApplySelection(@ClusterProxyKey String vsId, String[] assemblyNames, Object[] selectedObjects, Principal principal,
                                    CommandDispatcher dispatcher, @LinkUri String linkUri)
@@ -145,6 +147,7 @@ public class VSInputService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void applySelection(@ClusterProxyKey String vsId, VSListInputSelectionEvent event,
                               Principal principal, CommandDispatcher dispatcher,
@@ -190,6 +193,7 @@ public class VSInputService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public String setDetailHeight(@ClusterProxyKey String runtimeId, String objectId,
                                  double height, Principal principal) throws Exception
@@ -214,6 +218,7 @@ public class VSInputService {
    }
 
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void onConfirm(@ClusterProxyKey String vsId, String name, String x, String y, boolean isConfirm,
                          VSOnClickEvent confirmEvent, String linkUri, Principal principal, CommandDispatcher dispatcher) throws Exception
@@ -274,6 +279,7 @@ public class VSInputService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void onClick(@ClusterProxyKey String vsId, String name, String x, String y, VSSubmitEvent submitEvent,
                        String linkUri, Principal principal, CommandDispatcher dispatcher) throws Exception
@@ -437,6 +443,7 @@ public class VSInputService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setCheckboxPropertyModel(@ClusterProxyKey String vsId, String objectId,
                                         CheckboxPropertyDialogModel value,String linkUri,
@@ -586,6 +593,7 @@ public class VSInputService {
       return vsSortingDialogModel;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setVSSortingDialogModel(@ClusterProxyKey String vsId, String objectId,
                                        VSSortingDialogModel model,Principal principal,
@@ -741,6 +749,7 @@ public class VSInputService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setTextInputPropertyDialogModel(@ClusterProxyKey String vsId, String objectId,
                                                TextInputPropertyDialogModel value, String linkUri,
@@ -948,6 +957,7 @@ public class VSInputService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setSliderPropertyDialogModel(@ClusterProxyKey String vsId, String objectId,
                                             SliderPropertyDialogModel value,String linkUri, Principal principal,
@@ -1181,6 +1191,7 @@ public class VSInputService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setRadioButtonPropertyModel(@ClusterProxyKey String vsId, String objectId,
                                            RadioButtonPropertyDialogModel value, String linkUri,
@@ -1534,6 +1545,7 @@ public class VSInputService {
       return model;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setColumnOptionDialogModel(@ClusterProxyKey String vsId, String objectId, int col,
                                           ColumnOptionDialogModel model, Principal principal,
@@ -1860,6 +1872,7 @@ public class VSInputService {
       assemblyInfo.setListBindingInfo(listBindingInfo);
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setComboboxPropertyDialogModel(@ClusterProxyKey String vsId, String objectId,
                                               ComboboxPropertyDialogModel value, String linkUri,
@@ -2146,6 +2159,7 @@ public class VSInputService {
       return result;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setSpinnerPropertyDialogModel(@ClusterProxyKey String vsId, String objectId,
                                              SpinnerPropertyDialogModel value, String linkUri,

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSLifecycleControllerService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSLifecycleControllerService.java
@@ -46,6 +46,7 @@ public class VSLifecycleControllerService {
 
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Map<String, String[]> setRuntimeParameters(@ClusterProxyKey String runtimeId,
                                                      Map<String, String[]> parameters, Principal principal) throws Exception
@@ -100,6 +101,7 @@ public class VSLifecycleControllerService {
       return parameters;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void openReturnedViewsheet(@ClusterProxyKey String rid, Principal principal, String linkUri,
                                       OpenViewsheetEvent event, CommandDispatcher dispatcher)

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSSelectionContainerService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSSelectionContainerService.java
@@ -61,6 +61,7 @@ public class VSSelectionContainerService {
       this.assemblyInfoHandler = vsAssemblyInfoHandler;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void applySelection(@ClusterProxyKey String vsId, String assemblyName,
                               MoveSelectionChildEvent event, Principal principal,
@@ -81,6 +82,7 @@ public class VSSelectionContainerService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void applySelection(@ClusterProxyKey String vsId, String assemblyName,
                               HideSelectionListEvent event, String linkUri,

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSSelectionService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSSelectionService.java
@@ -68,6 +68,7 @@ public class VSSelectionService {
     * @param assemblyName the name of the selection assembly.
     * @param event        the event to apply.
     */
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void applySelection(@ClusterProxyKey String runtimeId, String assemblyName,
                               ApplySelectionListEvent event, Principal principal,
@@ -105,6 +106,7 @@ public class VSSelectionService {
     * @param assemblyName the name of the selection tree assembly.
     * @param event        the event to apply
     */
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void selectSubtree(@ClusterProxyKey String runtimeId, String assemblyName,
                              ApplySelectionListEvent event, Principal principal,
@@ -171,6 +173,7 @@ public class VSSelectionService {
     *
     * @param assemblyName the name of the selection assembly.
     */
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void unselectAll(@ClusterProxyKey String runtimeId, String assemblyName, Principal principal,
                            CommandDispatcher dispatcher, String linkUri) throws Exception {
@@ -218,6 +221,7 @@ public class VSSelectionService {
       });
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void toggleSelectionStyle(@ClusterProxyKey String runtimeId, String assemblyName,
                                     Principal principal, CommandDispatcher dispatcher, String linkUri) throws Exception
@@ -258,6 +262,7 @@ public class VSSelectionService {
     * @param assemblyName the name of the selection assembly.
     * @param event        the sort event.
     */
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void sortSelection(@ClusterProxyKey String runtimeId, String assemblyName,
                              SortSelectionListEvent event, Principal principal,
@@ -527,6 +532,7 @@ public class VSSelectionService {
       }
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void updateVisibleValues(@ClusterProxyKey String runtimeId, String assemblyName,
                                    ApplyExpandedSelectionTreeEvent event, Principal principal,

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSCloseObjectWizardService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSCloseObjectWizardService.java
@@ -71,6 +71,7 @@ public class VSCloseObjectWizardService {
       this.temporaryInfoService = temporaryInfoService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void closeHandle(@ClusterProxyKey String vsId, boolean save, CloseObjectWizardEvent event,
                            String linkUri, Principal principal,

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardBindingService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardBindingService.java
@@ -126,6 +126,7 @@ public class VSWizardBindingService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void bindingTreeNodeChanged(@ClusterProxyKey String id, RefreshBindingFieldsEvent event,
                                       CommandDispatcher dispatcher, Principal principal,
@@ -188,6 +189,7 @@ public class VSWizardBindingService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void refreshBindingRefs(@ClusterProxyKey String id, RefreshBindingFieldsEvent event,
                                   CommandDispatcher dispatcher, Principal principal,
@@ -284,6 +286,7 @@ public class VSWizardBindingService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void refreshBindingInfo(@ClusterProxyKey String id, UpdateVsWizardBindingEvent event,
                                   CommandDispatcher dispatcher, Principal principal,
@@ -332,6 +335,7 @@ public class VSWizardBindingService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void updateColumns(@ClusterProxyKey String id, UpdateColumnsEvent event,
                              CommandDispatcher dispatcher, Principal principal,

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardConvertColumnService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardConvertColumnService.java
@@ -107,6 +107,7 @@ public class VSWizardConvertColumnService {
       return trapInfo.showWarning();
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void convertColumn(@ClusterProxyKey String id, ConvertColumnEvent event,
                              Principal principal, CommandDispatcher dispatcher)

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardDialogService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardDialogService.java
@@ -52,6 +52,7 @@ public class VSWizardDialogService {
       this.temporaryInfoService = temporaryInfoService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void createRuntimeSheet(@ClusterProxyKey String runtimeId, String linkUri,
                                   CommandDispatcher dispatcher, Principal principal) throws Exception
@@ -75,6 +76,7 @@ public class VSWizardDialogService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public String createRuntimeSheet0(@ClusterProxyKey String runtimeId, boolean viewer,
                                      boolean temporarySheet, Principal principal) throws Exception
@@ -87,6 +89,7 @@ public class VSWizardDialogService {
       return nrid;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void closeVSWizard(@ClusterProxyKey String runtimeId, CloseVsWizardEvent event,
                              CommandDispatcher dispatcher, Principal principal) throws Exception

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardFormatService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardFormatService.java
@@ -51,6 +51,7 @@ public class VSWizardFormatService {
       this.temporaryInfoService = temporaryInfoService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void updateFormat(@ClusterProxyKey String id, SetWizardBindingFormatEvent event,
                             CommandDispatcher dispatcher, Principal principal, String linkUri) throws Exception

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardObjectService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardObjectService.java
@@ -83,6 +83,7 @@ public class VSWizardObjectService {
       this.assetDataCache = assetDataCache;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void openViewsheetWizardObject(@ClusterProxyKey String vsId, OpenWizardObjectEvent event, Principal principal,
                                          CommandDispatcher dispatcher, @LinkUri String linkUri)
@@ -423,6 +424,7 @@ public class VSWizardObjectService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void updateObjectByTempAssembly(@ClusterProxyKey String rid, UpdateWizardObjectEvent event, Principal principal,
                                           CommandDispatcher dispatcher, String linkUri) throws Exception
@@ -527,6 +529,7 @@ public class VSWizardObjectService {
       }
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void switchToMeta(@ClusterProxyKey String id, SwitchToMetaModeEvent event,
                             Principal principal) throws Exception

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardObjectToolbarService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardObjectToolbarService.java
@@ -46,6 +46,7 @@ public class VSWizardObjectToolbarService {
    }
 
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void gotoFullEditor(@ClusterProxyKey String id,
       @RequestParam(value = "assemblyName", required = false) String assemblyName,

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardPreviewService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardPreviewService.java
@@ -50,6 +50,7 @@ public class VSWizardPreviewService {
       this.temporaryInfoService = temporaryInfoService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void changeDescription(@ClusterProxyKey String id, ChangeVSObjectTextEvent event,
                                  CommandDispatcher dispatcher, Principal principal)
@@ -70,6 +71,7 @@ public class VSWizardPreviewService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void setPreviewPaneSize(@ClusterProxyKey String id, SetPreviewPaneSizeEvent event,
                                   CommandDispatcher dispatcher, String linkUri,

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardVisualizationService.java
@@ -53,6 +53,7 @@ public class VSWizardVisualizationService {
       this.temporaryInfoService = temporaryInfoService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void changeSelectedType(@ClusterProxyKey String id, ChangeVisualizationTypeEvent event,
                                   CommandDispatcher dispatcher, Principal principal,

--- a/core/src/main/java/inetsoft/web/vswizard/controller/WizardDeleteObjectService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/WizardDeleteObjectService.java
@@ -42,6 +42,7 @@ public class WizardDeleteObjectService {
       this.wizardVsObjectService = wizardVsObjectService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void removeObject(@ClusterProxyKey String vsId, RemoveVSObjectsEvent event, String linkUri,
                             Principal principal, CommandDispatcher commandDispatcher)

--- a/core/src/main/java/inetsoft/web/vswizard/controller/WizardInsertObjectService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/WizardInsertObjectService.java
@@ -39,6 +39,7 @@ public class WizardInsertObjectService {
       this.wizardVsObjectService = wizardVSObjectService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void addTextObject(@ClusterProxyKey String vId, AddNewVSObjectEvent event, String linkUri,
                              Principal principal, CommandDispatcher commandDispatcher)

--- a/core/src/main/java/inetsoft/web/vswizard/controller/WizardObjectMoveService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/WizardObjectMoveService.java
@@ -42,6 +42,7 @@ public class WizardObjectMoveService {
       this.engine = engine;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void moveObject(@ClusterProxyKey String vId, MoveVSObjectEvent event, String linkUri,
                           Principal principal, CommandDispatcher commandDispatcher) throws Exception
@@ -71,6 +72,7 @@ public class WizardObjectMoveService {
       return null;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void moveObjects(@ClusterProxyKey String vId, MultiMoveVsObjectEvent multiEvent,
                            Principal principal, CommandDispatcher dispatcher,String linkUri)

--- a/core/src/main/java/inetsoft/web/vswizard/controller/WizardObjectResizeService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/WizardObjectResizeService.java
@@ -41,6 +41,7 @@ public class WizardObjectResizeService {
       this.wizardVSObjectService = wizardVSObjectService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void resizeObject(@ClusterProxyKey String vID, ResizeVSObjectEvent event, @LinkUri String linkUri,
                             Principal principal, CommandDispatcher commandDispatcher)

--- a/core/src/main/java/inetsoft/web/vswizard/controller/WizardPaneService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/WizardPaneService.java
@@ -42,6 +42,7 @@ public class WizardPaneService {
       this.wizardViewsheetService = wizardViewsheetService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void refreshWizardViewsheet(@ClusterProxyKey String vsId, Principal principal, String linkUri,
                                       boolean isFormGridPane, CommandDispatcher commandDispatcher)

--- a/core/src/main/java/inetsoft/web/vswizard/controller/WizardUploadImageService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/WizardUploadImageService.java
@@ -50,6 +50,7 @@ public class WizardUploadImageService {
       this.vsObjectService = vsObjectService;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public VSObjectModel uploadImage(@ClusterProxyKey String runtimeId, String assemblyName,
                                     MultipartFile mpf, Principal principal) throws Exception

--- a/core/src/main/java/inetsoft/web/vswizard/service/VSWizardDataService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/service/VSWizardDataService.java
@@ -72,6 +72,7 @@ public class VSWizardDataService {
       return sourceChangeMessage;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Boolean treeCheckTrap(@ClusterProxyKey String vsId, AssetEntry[] entries,
                                 SourceInfo source, Principal principal)
@@ -132,6 +133,7 @@ public class VSWizardDataService {
       return trap;
    }
 
+   @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Boolean aggregateCheckTrap(@ClusterProxyKey String id, ChartBindingModel tempChartModel ,
                                      Principal principal)


### PR DESCRIPTION
## Summary

This PR reduces unnecessary Ignite cluster write traffic originating from the `RuntimeSheetCache`, improving performance under concurrent viewsheet/worksheet load. (Merged from branch performance-runtimesheetcache).

- **Separate access-time tracking**: Introduced a lightweight `accessTimeMap` (session ID → timestamp, 8 bytes per entry) so that `get()` no longer triggers a full `CompressedSheetState` write to Ignite on every session access. Access-time updates are debounced and written asynchronously.

- **Write-gated persistence**: Added `@ClusterWriteMethod` annotation and `SheetWriteAspect` (Spring AOP `@AfterReturning`) so that Ignite state is only written back after methods that genuinely mutate session state. The cluster-proxy annotation processor was updated to emit explicit `writeSheet()` calls in generated remote proxies, maintaining the same gate for cross-node invocations. Approximately 334 annotations were applied across 192 service files covering the full composer, binding, worksheet, and wizard layers.

- **Write debounce**: A 1-second trailing-edge debounce on `writeSheet()` coalesces rapid mutation sequences (e.g., multiple property dialog saves) into a single Ignite `put` per session window, consistent with original access-time write debouncer.

- **Checkpoint serialization optimization**: `RuntimeSheet.XSwappableSheet.getXml()` now reads serialized checkpoint bytes directly from the `.tdat` swap file instead of deserializing and re-serializing the full DOM on every `saveState()` call. The swap-file passthrough avoids an unnecessary deserialize/re-serialize round-trip that was previously performed for all checkpoints, when the raw bytes from the .tdat file are sufficient except for the specific case of worksheets with embedded table data which require re-serialization to strip the ISTEMP flag.

- **Bug fixes**: Fixed a session resurrection race where a pending debounced write could re-insert a disposed session after `closeSheet()` removed it; fixed a thread pool leak where `affinityExecutor` was not shut down on `WorksheetEngine.dispose()`.

## Test plan

- [ ] Build passes: `./mvnw clean install -DskipTests -pl core`
- [ ] Two-node cluster: open a viewsheet on node A, mutate state in the composer, route the next request to node B, confirm state is preserved
- [ ] Verify Ignite write rate drops significantly under concurrent read-heavy load compared to main
- [ ] Undo/redo still functions correctly across node boundaries after composer edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)