### PR TITLE
fixed bug 75414.schedule cycle list permission check for STOMP subscriptions

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleCycleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleCycleService.java
@@ -215,7 +215,7 @@ public class ScheduleCycleService {
          if(!securityEngine.checkPermission(principal, ResourceType.SCHEDULE_CYCLE,
                getCyclePermissionID(oldName, orgId), ResourceAction.ACCESS))
          {
-            catalog.getString("em.scheduler.cycle.unauthorized", oldName);
+            throw new SecurityException(catalog.getString("em.scheduler.cycle.unauthorized", oldName));
          }
 
          String newName = model.label();

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleCycleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleCycleService.java
@@ -60,8 +60,7 @@ public class ScheduleCycleService {
       String orgId = OrganizationManager.getInstance().getCurrentOrgID(principal);
 
       for(DataCycleInfo cycleInfo : schedulerMonitoringService.getDataCycleInfos()) {
-         if(securityEngine.checkPermission(principal, ResourceType.SCHEDULE_CYCLE,
-                                           getCyclePermissionID(cycleInfo.getName(), orgId), ResourceAction.ACCESS))
+         if(hasCycleAccess(principal, cycleInfo.getName(), orgId))
          {
             dataCycleInfoList.add(cycleInfo);
          }
@@ -70,6 +69,16 @@ public class ScheduleCycleService {
       return DataCycleListModel.builder()
          .cycles(dataCycleInfoList)
          .build();
+   }
+
+   private boolean hasCycleAccess(Principal principal, String cycleName, String orgId) {
+      SecurityProvider provider = securityEngine.getSecurityProvider();
+      String permissionId = getCyclePermissionID(cycleName, orgId);
+
+      return provider == null || provider.checkPermission(
+         principal, ResourceType.SCHEDULE_CYCLE, permissionId, ResourceAction.ACCESS) ||
+         provider.checkPermission(
+            principal, ResourceType.SCHEDULE_CYCLE, permissionId, ResourceAction.ADMIN);
    }
 
    public ScheduleCycleDialogModel getDialogModel(String cycleName, Principal principal)

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleCycleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleCycleService.java
@@ -75,6 +75,7 @@ public class ScheduleCycleService {
       SecurityProvider provider = securityEngine.getSecurityProvider();
       String permissionId = getCyclePermissionID(cycleName, orgId);
 
+      // A missing security provider means security is disabled, so cycles are unfiltered.
       return provider == null || provider.checkPermission(
          principal, ResourceType.SCHEDULE_CYCLE, permissionId, ResourceAction.ACCESS) ||
          provider.checkPermission(

--- a/core/src/test/java/inetsoft/web/admin/schedule/ScheduleCycleServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/ScheduleCycleServiceTest.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.schedule;
+
+import inetsoft.sree.internal.DataCycleManager;
+import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.security.*;
+import inetsoft.web.admin.content.repository.ResourcePermissionService;
+import inetsoft.web.admin.schedule.model.DataCycleListModel;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ScheduleCycleServiceTest {
+   @Mock private DataCycleManager dataCycleManager;
+   @Mock private ScheduleConditionService scheduleConditionService;
+   @Mock private SchedulerMonitoringService schedulerMonitoringService;
+   @Mock private ResourcePermissionService permissionService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private Principal principal;
+   @Mock private OrganizationManager organizationManager;
+
+   private ScheduleCycleService service;
+   private MockedStatic<SUtil> sutilStatic;
+   private MockedStatic<OrganizationManager> organizationManagerStatic;
+
+   @BeforeEach
+   void setUp() {
+      service = new ScheduleCycleService(
+         dataCycleManager, scheduleConditionService, schedulerMonitoringService,
+         permissionService, securityEngine);
+
+      sutilStatic = mockStatic(SUtil.class, withSettings().lenient());
+      organizationManagerStatic = mockStatic(OrganizationManager.class, withSettings().lenient());
+      sutilStatic.when(SUtil::isMultiTenant).thenReturn(true);
+      organizationManagerStatic.when(OrganizationManager::getInstance).thenReturn(organizationManager);
+      lenient().when(organizationManager.getCurrentOrgID(principal)).thenReturn("host-org");
+      lenient().when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+   }
+
+   @AfterEach
+   void tearDown() {
+      organizationManagerStatic.close();
+      sutilStatic.close();
+   }
+
+   @Test
+   void getCycleInfos_filtersWithSecurityProviderWithoutActiveLoginGuard() throws Exception {
+      DataCycleInfo allowed = new DataCycleInfo("AllowedCycle");
+      DataCycleInfo denied = new DataCycleInfo("DeniedCycle");
+      when(schedulerMonitoringService.getDataCycleInfos())
+         .thenReturn(new DataCycleInfo[] { allowed, denied });
+      when(securityProvider.checkPermission(
+         principal, ResourceType.SCHEDULE_CYCLE,
+         ScheduleCycleService.getCyclePermissionID("AllowedCycle", "host-org"),
+         ResourceAction.ACCESS))
+         .thenReturn(true);
+      when(securityProvider.checkPermission(
+         principal, ResourceType.SCHEDULE_CYCLE,
+         ScheduleCycleService.getCyclePermissionID("DeniedCycle", "host-org"),
+         ResourceAction.ACCESS))
+         .thenReturn(false);
+
+      DataCycleListModel result = service.getCycleInfos(principal);
+
+      assertEquals(List.of(allowed), result.cycles());
+      verify(securityProvider).checkPermission(
+         principal, ResourceType.SCHEDULE_CYCLE,
+         ScheduleCycleService.getCyclePermissionID("AllowedCycle", "host-org"),
+         ResourceAction.ACCESS);
+      verify(securityProvider).checkPermission(
+         principal, ResourceType.SCHEDULE_CYCLE,
+         ScheduleCycleService.getCyclePermissionID("DeniedCycle", "host-org"),
+         ResourceAction.ACCESS);
+      verify(securityEngine, never()).checkPermission(
+         any(), any(ResourceType.class), anyString(), any(ResourceAction.class));
+   }
+
+   @Test
+   void getCycleInfos_includesCycleWhenAdminPermissionIsGranted() throws Exception {
+      DataCycleInfo adminOnly = new DataCycleInfo("AdminOnlyCycle");
+      String permissionId = ScheduleCycleService.getCyclePermissionID("AdminOnlyCycle", "host-org");
+      when(schedulerMonitoringService.getDataCycleInfos()).thenReturn(new DataCycleInfo[] { adminOnly });
+      when(securityProvider.checkPermission(
+         principal, ResourceType.SCHEDULE_CYCLE, permissionId, ResourceAction.ACCESS))
+         .thenReturn(false);
+      when(securityProvider.checkPermission(
+         principal, ResourceType.SCHEDULE_CYCLE, permissionId, ResourceAction.ADMIN))
+         .thenReturn(true);
+
+      DataCycleListModel result = service.getCycleInfos(principal);
+
+      assertEquals(List.of(adminOnly), result.cycles());
+   }
+
+   @Test
+   void getCycleInfos_noSecurityProvider_returnsAllCycles() throws Exception {
+      DataCycleInfo cycle = new DataCycleInfo("Cycle1");
+      when(securityEngine.getSecurityProvider()).thenReturn(null);
+      when(schedulerMonitoringService.getDataCycleInfos()).thenReturn(new DataCycleInfo[] { cycle });
+
+      DataCycleListModel result = service.getCycleInfos(principal);
+
+      assertEquals(List.of(cycle), result.cycles());
+      verifyNoInteractions(securityProvider);
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/schedule/ScheduleCycleServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/ScheduleCycleServiceTest.java
@@ -90,6 +90,7 @@ class ScheduleCycleServiceTest {
       DataCycleListModel result = service.getCycleInfos(principal);
 
       assertEquals(List.of(allowed), result.cycles());
+      assertFalse(result.cycles().contains(denied));
       verify(securityProvider).checkPermission(
          principal, ResourceType.SCHEDULE_CYCLE,
          ScheduleCycleService.getCyclePermissionID("AllowedCycle", "host-org"),
@@ -117,6 +118,27 @@ class ScheduleCycleServiceTest {
       DataCycleListModel result = service.getCycleInfos(principal);
 
       assertEquals(List.of(adminOnly), result.cycles());
+   }
+
+   @Test
+   void getCycleInfos_excludesCycleWhenAccessAndAdminPermissionsAreDenied() throws Exception {
+      DataCycleInfo denied = new DataCycleInfo("DeniedCycle");
+      String permissionId = ScheduleCycleService.getCyclePermissionID("DeniedCycle", "host-org");
+      when(schedulerMonitoringService.getDataCycleInfos()).thenReturn(new DataCycleInfo[] { denied });
+      when(securityProvider.checkPermission(
+         principal, ResourceType.SCHEDULE_CYCLE, permissionId, ResourceAction.ACCESS))
+         .thenReturn(false);
+      when(securityProvider.checkPermission(
+         principal, ResourceType.SCHEDULE_CYCLE, permissionId, ResourceAction.ADMIN))
+         .thenReturn(false);
+
+      DataCycleListModel result = service.getCycleInfos(principal);
+
+      assertEquals(List.of(), result.cycles());
+      verify(securityProvider).checkPermission(
+         principal, ResourceType.SCHEDULE_CYCLE, permissionId, ResourceAction.ACCESS);
+      verify(securityProvider).checkPermission(
+         principal, ResourceType.SCHEDULE_CYCLE, permissionId, ResourceAction.ADMIN);
    }
 
    @Test


### PR DESCRIPTION
Use SecurityProvider permission checks when filtering schedule cycles for the list view so STOMP subscriptions do not
  fail on active-login cache misses. Preserve admin fallback behavior and add tests for provider-based filtering.