### PR TITLE
fix(wiz): fix first aggregate silently dropped when same field has multiple aggregates in mirror table

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -506,7 +506,7 @@ public class WorksheetTableService {
                aggRef.setN(agg.getN());
             }
 
-            info.addAggregate(aggRef);
+            info.addAggregate(aggRef, false);
 
             // AggregateRef has no setAlias(). Expose the alias via a ColumnRef alias so
             // downstream steps can resolve this aggregate column by its friendly name.

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -506,6 +506,9 @@ public class WorksheetTableService {
                aggRef.setN(agg.getN());
             }
 
+            // Pass false to skip name-based dedup — same field can have multiple aggregates
+            // with different formulas (e.g. NthLargest(1) and NthLargest(2)). Each entry
+            // carries a distinct alias, so field-name deduplication is not needed here.
             info.addAggregate(aggRef, false);
 
             // AggregateRef has no setAlias(). Expose the alias via a ColumnRef alias so


### PR DESCRIPTION


Problem
-------
When aggregateInfo.aggregates contains two entries with the same fieldName but different formulas (e.g. NthLargest(1) and NthLargest(2) on the same field, or Max + NthLargest), the earlier entry is silently dropped from the returned columns while the API still returns success:true — a silent data loss.

Root Cause
----------
AggregateInfo.addAggregate(ref) defaults to delSame=true, which does:

  int index = aggregates.indexOf(ref);  // uses equals() for comparison
  if (index >= 0) {
      aggregates.remove(index);         // removes the existing entry
      aggregates.add(index, ref);       // replaces it with the new one
  }

AggregateRef does not override equals(); it inherits AbstractDataRef.equals(), which only compares fieldName (getName0() = entity.attribute) and ignores formula and n. So when a second aggregate shares the same fieldName, indexOf() incorrectly treats it as a duplicate, removes the first aggregate, and replaces it with the second — silently discarding the first.

Note: AggregateRef already provides equalsAggregate() which correctly compares ref + formula + ref2, but addAggregate() uses equals() and never calls it.

Fix
---
Call addAggregate(aggRef, false) to skip the dedup check and simply append.

Each aggregate entry in wiz-services already has a distinct alias, which is registered as the column's friendly name via ColumnRef.setAlias(). The alias is the uniqueness identifier here, so fieldName-based dedup is not needed.

This matches how StyleBI's native AggregateDialogService.getAggregateInfo() handles the same scenario: it also calls addAggregate(agg, false) and relies on a separate secondaryAggregates mechanism only when true deduplication is required.