### PR TITLE
fix(wiz): fix extractColumnsFromSelection returning only one aggregate when same field has multiple aggregates

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -511,15 +511,14 @@ public class WorksheetTableService {
             DataRef aggColumn;
 
             if(occurrence == 1) {
-               // First aggregate for this field: reuse the existing column and set alias.
-               aggColumn = column;
+               // First aggregate for this field: use the private column directly so that
+               // aggColumn and the alias target are the same object (avoids relying on
+               // cs / privateCs sharing identical ColumnRef instances).
+               DataRef privateCol = privateCs.getAttribute(agg.getFieldName());
+               aggColumn = privateCol != null ? privateCol : column;
 
-               if(agg.getAlias() != null) {
-                  DataRef col = privateCs.getAttribute(agg.getFieldName());
-
-                  if(col instanceof ColumnRef columnRef) {
-                     columnRef.setAlias(agg.getAlias());
-                  }
+               if(agg.getAlias() != null && privateCol instanceof ColumnRef columnRef) {
+                  columnRef.setAlias(agg.getAlias());
                }
             }
             else {
@@ -527,10 +526,20 @@ public class WorksheetTableService {
                // column so each AggregateRef has a distinct entry in the private column
                // selection. Without this, setColumnSelection()'s getAggregate() loop only
                // finds one match per field and the remaining aggregates are silently lost.
-               String colName = agg.getAlias() != null
+               String entity = column instanceof ColumnRef cr ? cr.getEntity() : null;
+               String baseName = agg.getAlias() != null
                   ? agg.getAlias()
                   : column.getName() + "_" + occurrence;
-               ExpressionRef expRef = new ExpressionRef(null, colName);
+
+               // Bump suffix until the name is free in privateCs to avoid silent duplicates.
+               String colName = baseName;
+               int suffix = 2;
+
+               while(privateCs.getAttribute(colName) != null) {
+                  colName = baseName + "_" + suffix++;
+               }
+
+               ExpressionRef expRef = new ExpressionRef(entity, colName);
                expRef.setExpression("field['" + column.getName() + "']");
                ColumnRef syntheticCol = new ColumnRef(expRef);
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -481,6 +481,13 @@ public class WorksheetTableService {
       }
 
       if(aggregates != null) {
+         // Tracks how many aggregates have been registered for each fieldName so far.
+         // The first occurrence reuses the existing ColumnRef; subsequent ones need a
+         // dedicated synthetic column so setColumnSelection()'s getAggregate() loop
+         // can find a distinct match for each AggregateRef (mirrors the approach in
+         // AggregateDialogService.updateAggregateInfo()).
+         Map<String, Integer> fieldOccurrenceCount = new HashMap<>();
+
          for(WorksheetTableRequest.AggregateFieldInfo agg : aggregates) {
             DataRef column = cs.getAttribute(agg.getFieldName());
 
@@ -500,7 +507,42 @@ public class WorksheetTableService {
                secondaryCol = cs.getAttribute(agg.getSecondaryField());
             }
 
-            AggregateRef aggRef = new AggregateRef(column, secondaryCol, formula);
+            int occurrence = fieldOccurrenceCount.merge(agg.getFieldName(), 1, Integer::sum);
+            DataRef aggColumn;
+
+            if(occurrence == 1) {
+               // First aggregate for this field: reuse the existing column and set alias.
+               aggColumn = column;
+
+               if(agg.getAlias() != null) {
+                  DataRef col = privateCs.getAttribute(agg.getFieldName());
+
+                  if(col instanceof ColumnRef columnRef) {
+                     columnRef.setAlias(agg.getAlias());
+                  }
+               }
+            }
+            else {
+               // Second+ aggregate on the same field: create a synthetic ExpressionRef
+               // column so each AggregateRef has a distinct entry in the private column
+               // selection. Without this, setColumnSelection()'s getAggregate() loop only
+               // finds one match per field and the remaining aggregates are silently lost.
+               String colName = agg.getAlias() != null
+                  ? agg.getAlias()
+                  : column.getName() + "_" + occurrence;
+               ExpressionRef expRef = new ExpressionRef(null, colName);
+               expRef.setExpression("field['" + column.getName() + "']");
+               ColumnRef syntheticCol = new ColumnRef(expRef);
+
+               if(column instanceof ColumnRef cr) {
+                  syntheticCol.setDataType(cr.getDataType());
+               }
+
+               privateCs.addAttribute(syntheticCol);
+               aggColumn = syntheticCol;
+            }
+
+            AggregateRef aggRef = new AggregateRef(aggColumn, secondaryCol, formula);
 
             if(agg.getN() != null && formula.hasN()) {
                aggRef.setN(agg.getN());
@@ -510,16 +552,6 @@ public class WorksheetTableService {
             // with different formulas (e.g. NthLargest(1) and NthLargest(2)). Each entry
             // carries a distinct alias, so field-name deduplication is not needed here.
             info.addAggregate(aggRef, false);
-
-            // AggregateRef has no setAlias(). Expose the alias via a ColumnRef alias so
-            // downstream steps can resolve this aggregate column by its friendly name.
-            if(agg.getAlias() != null) {
-               DataRef col = privateCs.getAttribute(agg.getFieldName());
-
-               if(col instanceof ColumnRef columnRef) {
-                  columnRef.setAlias(agg.getAlias());
-               }
-            }
          }
       }
 


### PR DESCRIPTION


Root cause
----------
After the previous fix (addAggregate with false), AggregateInfo correctly holds multiple AggregateRefs for the same field. However, extractColumnsFromSelection still returned only one aggregate column because of a second bug in the alias assignment and public ColumnSelection rebuild logic.

The alias for each aggregate was written via:
  privateCs.getAttribute(fieldName).setAlias(alias)

Both aggregates on the same field resolve to the same ColumnRef in privateCs, so the second setAlias() call overwrites the first. Both AggregateRefs also point to the same ColumnRef object.

When AbstractTableAssembly.setColumnSelection(privateCs, false) rebuilds the public ColumnSelection, it iterates over privateCs and calls aggregateInfo.getAggregate(column) for each column. Because there is only ONE ColumnRef for ORDER_DATE in privateCs, getAggregate() is only called once for that field — returning the first match — and the second AggregateRef is never promoted to the public ColumnSelection, causing it to disappear from the results.

Fix
---
Track occurrence count per fieldName. For the first aggregate, reuse the existing ColumnRef from the column selection and set its alias (existing behavior). For the second and subsequent aggregates on the same field, create a dedicated synthetic ExpressionRef-based ColumnRef (with the alias as its name and "field['fieldName']" as its expression), add it to the private column selection, and use it as the AggregateRef's column.

This ensures each AggregateRef has a distinct ColumnRef entry in the private column selection, so the engine's getAggregate() loop finds a separate match for each one and all aggregate columns appear in the public ColumnSelection.

This mirrors AggregateDialogService.updateAggregateInfo() in StyleBI core, which uses the same ExpressionRef wrapping technique for secondary aggregates on the same field.