### PR TITLE
fix(wiz): apply requested type to JS expression columns in applyExpressionColumns

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -411,6 +411,10 @@ public class WorksheetTableService {
          ColumnRef colRef = new ColumnRef(expr);
          colRef.setSQL(col.isSql());
 
+         if(col.getType() != null) {
+            colRef.setDataType(col.getType());
+         }
+
          if(col.getAlias() != null) {
             colRef.setAlias(col.getAlias());
          }


### PR DESCRIPTION


The type field on ExpressionColumnInfo was deserialized correctly but never written to the ColumnRef. Without setDataType(), ColumnRef.getDataType() fell through to ExpressionRef -> AbstractDataRef.getDataType() which always returns XSchema.STRING, causing every JS expression column to report dataType "string" regardless of what the caller specified.

Fix: call colRef.setDataType(col.getType()) when a type is present. ColumnRef.setDataType() already validates the value via XSchema.isPrimitiveType() so no additional guard is needed.