### PR TITLE
Bug #75411, fix systemCpuDetail publishing wrong metric source

### DIFF
--- a/core/src/main/java/inetsoft/web/metrics/ScalingMetricsService.java
+++ b/core/src/main/java/inetsoft/web/metrics/ScalingMetricsService.java
@@ -132,7 +132,7 @@ public class ScalingMetricsService {
          ScalingMetricData data = new ScalingMetricData(
             jvmCpu.get(), jvmCpu.calculate(),
             jvmMemory.get(), jvmMemory.calculate(),
-            systemCpu.get(), systemMemory.calculate(),
+            systemCpu.get(), systemCpu.calculate(),
             systemMemory.get(), systemMemory.calculate(),
             scheduler.get(), scheduler.calculate(),
             cacheSwapMemory.get(), cacheSwapMemory.calculate(),


### PR DESCRIPTION
systemMemory.calculate() was passed as the systemCpuDetail argument instead of systemCpu.calculate(), causing the Prometheus inetsoft_scaling_utilizationDetail{scope="container",type="cpu"} gauge to display system memory samples