### PR TITLE
Bug #75422, fix remaining Angular @for bare-object track expressions (NG0956)

### DIFF
--- a/web/projects/em/src/app/auditing/audit-dependent-assets/audit-dependent-assets.component.html
+++ b/web/projects/em/src/app/auditing/audit-dependent-assets/audit-dependent-assets.component.html
@@ -20,7 +20,7 @@
     <mat-form-field appearance="outline" color="accent" class="flex">
       <mat-label>_#(Target Asset Type)</mat-label>
       <mat-select formControlName="selectedTargetType">
-        @for (type of targetTypes; track type) {
+        @for (type of targetTypes; track type.value) {
           <mat-option [value]="type.value">{{type.label}}</mat-option>
         }
       </mat-select>
@@ -28,7 +28,7 @@
     <mat-form-field appearance="outline" color="accent" class="flex margin-left">
       <mat-label>_#(Target Asset User)</mat-label>
       <mat-select formControlName="selectedTargetUser">
-        @for (user of targetUsers; track user) {
+        @for (user of targetUsers; track user.value) {
           <mat-option [value]="user.value">{{user.label}}</mat-option>
         }
       </mat-select>
@@ -36,7 +36,7 @@
     <mat-form-field appearance="outline" color="accent" class="flex margin-left">
       <mat-label>_#(Target Asset Names)</mat-label>
       <mat-select formControlName="selectedTargetAssets" multiple>
-        @for (asset of targetAssets; track asset) {
+        @for (asset of targetAssets; track asset.assetId) {
           <mat-option [value]="asset.assetId">{{asset.label}}</mat-option>
         }
       </mat-select>
@@ -44,7 +44,7 @@
     <mat-form-field appearance="outline" color="accent" class="flex margin-left">
       <mat-label>_#(Dependent Asset Types)</mat-label>
       <mat-select formControlName="selectedDependentTypes" multiple>
-        @for (type of dependentTypes; track type) {
+        @for (type of dependentTypes; track type.value) {
           <mat-option [value]="type.value">{{type.label}}</mat-option>
         }
       </mat-select>
@@ -52,7 +52,7 @@
     <mat-form-field appearance="outline" color="accent" class="flex margin-left">
       <mat-label>_#(Dependent Asset Users)</mat-label>
       <mat-select formControlName="selectedDependentUsers" multiple>
-        @for (user of dependentUsers; track user) {
+        @for (user of dependentUsers; track user.value) {
           <mat-option [value]="user.value">{{user.label}}</mat-option>
         }
       </mat-select>

--- a/web/projects/em/src/app/auditing/audit-identity-info/audit-identity-info.component.html
+++ b/web/projects/em/src/app/auditing/audit-identity-info/audit-identity-info.component.html
@@ -22,7 +22,7 @@
       <mat-form-field appearance="outline" color="accent" class="flex">
         <mat-label>_#(Identity Organizations)</mat-label>
         <mat-select formControlName="selectedOrganizations" multiple>
-          @for (org of organizations; track org; let i = $index) {
+          @for (org of organizations; track org.name; let i = $index) {
             <mat-option [value]="org.orgID">{{organizations[i].name}}</mat-option>
           }
         </mat-select>

--- a/web/projects/em/src/app/auditing/audit-inactive-resource/audit-inactive-resource.component.html
+++ b/web/projects/em/src/app/auditing/audit-inactive-resource/audit-inactive-resource.component.html
@@ -31,7 +31,7 @@
     <mat-form-field appearance="outline" color="accent" class="flex margin-left">
       <mat-label>_#(Resource Types)</mat-label>
       <mat-select formControlName="selectedTypes" multiple>
-        @for (type of objectTypes; track type) {
+        @for (type of objectTypes; track type.value) {
           <mat-option [value]="type.value">{{getAssetTypeLabel(type.label)}}</mat-option>
         }
       </mat-select>

--- a/web/projects/em/src/app/auditing/audit-required-assets/audit-required-assets.component.html
+++ b/web/projects/em/src/app/auditing/audit-required-assets/audit-required-assets.component.html
@@ -20,7 +20,7 @@
     <mat-form-field appearance="outline" color="accent" class="flex">
       <mat-label>_#(Target Asset Type)</mat-label>
       <mat-select formControlName="selectedDependentType">
-        @for (type of dependentTypes; track type) {
+        @for (type of dependentTypes; track type.value) {
           <mat-option [value]="type.value">{{type.label}}</mat-option>
         }
       </mat-select>
@@ -28,7 +28,7 @@
     <mat-form-field appearance="outline" color="accent" class="flex margin-left">
       <mat-label>_#(Target Asset User)</mat-label>
       <mat-select formControlName="selectedDependentUser">
-        @for (user of dependentUsers; track user) {
+        @for (user of dependentUsers; track user.value) {
           <mat-option [value]="user.value">{{user.label}}</mat-option>
         }
       </mat-select>
@@ -36,7 +36,7 @@
     <mat-form-field appearance="outline" color="accent" class="flex margin-left">
       <mat-label>_#(Target Asset Names)</mat-label>
       <mat-select formControlName="selectedDependentAssets" multiple>
-        @for (asset of dependentAssets; track asset) {
+        @for (asset of dependentAssets; track asset.assetId) {
           <mat-option [value]="asset.assetId">{{asset.label}}</mat-option>
         }
       </mat-select>
@@ -44,7 +44,7 @@
     <mat-form-field appearance="outline" color="accent" class="flex margin-left">
       <mat-label>_#(Required Asset Types)</mat-label>
       <mat-select formControlName="selectedTargetTypes" multiple>
-        @for (type of targetTypes; track type) {
+        @for (type of targetTypes; track type.value) {
           <mat-option [value]="type.value">{{type.label}}</mat-option>
         }
       </mat-select>
@@ -52,7 +52,7 @@
     <mat-form-field appearance="outline" color="accent" class="flex margin-left">
       <mat-label>_#(Required Asset Users)</mat-label>
       <mat-select formControlName="selectedTargetUsers" multiple>
-        @for (user of targetUsers; track user) {
+        @for (user of targetUsers; track user.value) {
           <mat-option [value]="user.value">{{user.label}}</mat-option>
         }
       </mat-select>

--- a/web/projects/em/src/app/auditing/audit-schedule-history/audit-schedule-history.component.html
+++ b/web/projects/em/src/app/auditing/audit-schedule-history/audit-schedule-history.component.html
@@ -30,7 +30,7 @@
     <mat-form-field appearance="outline" color="accent" class="flex margin-left">
       <mat-label>_#(Tasks and Cycles)</mat-label>
       <mat-select formControlName="selectedTasks" multiple (selectionChange)="clearFolders($event)">
-        @for (task of tasks; track task) {
+        @for (task of tasks; track task.assetId) {
           <mat-option [value]="task.assetId">{{task.label}}</mat-option>
         }
       </mat-select>

--- a/web/projects/em/src/app/auditing/audit-table-view/audit-table-view.component.html
+++ b/web/projects/em/src/app/auditing/audit-table-view/audit-table-view.component.html
@@ -41,7 +41,7 @@
 <div class="mat-elevation-z8 margin-top audit-table-view">
   @if (!!displayedColumns) {
     <table mat-table [dataSource]="dataSource" matSort (matSortChange)="changeSort($event)">
-      @for (renderer of columnRenderers; track renderer) {
+      @for (renderer of columnRenderers; track renderer.name) {
         <ng-container [matColumnDef]="renderer.name">
           <th mat-header-cell *matHeaderCellDef mat-sort-header>{{renderer.label}}</th>
           <td mat-cell *matCellDef="let row">

--- a/web/projects/em/src/app/monitoring/log/log-monitoring-view/log-monitoring-view.component.html
+++ b/web/projects/em/src/app/monitoring/log/log-monitoring-view/log-monitoring-view.component.html
@@ -21,7 +21,7 @@
       <mat-form-field class="log-file-name">
         <mat-label>_#(Log File)</mat-label>
         <mat-select [(value)]="model.selectedLog"  [compareWith]="compareLogFileModel" (selectionChange)="refreshLog.emit()">
-          @for (log of model.logFiles; track log) {
+          @for (log of model.logFiles; track $index) {
             <mat-option [value]="log">{{log.logFile}}</mat-option>
           }
         </mat-select>

--- a/web/projects/em/src/app/monitoring/summary/summary-monitoring-page/summary-monitoring-page.component.html
+++ b/web/projects/em/src/app/monitoring/summary/summary-monitoring-page/summary-monitoring-page.component.html
@@ -225,7 +225,7 @@
                 <th>_#(Active):</th>
                 <td>{{reverseProxyModel.active}}</td>
               </tr>
-              @for (header of reverseProxyModel.requestHeaders | keyvalue; track header) {
+              @for (header of reverseProxyModel.requestHeaders | keyvalue; track header.key) {
                 <tr>
                   <th>{{header.key}}:</th>
                   <td>{{header.value}}</td>

--- a/web/projects/em/src/app/page-header/page-header.component.html
+++ b/web/projects/em/src/app/page-header/page-header.component.html
@@ -39,7 +39,7 @@
       </button>
     </mat-form-field>
     <mat-autocomplete #auto="matAutocomplete" (optionSelected)="onSelectOrg($event)">
-      @for (org of searchResults; track org; let i = $index) {
+      @for (org of searchResults; track org.id; let i = $index) {
         <mat-option class="dropdownItem" [value]="org.name" [class.mdc-list-item--selected]="isSelected(org.name)">
           {{ org.name }}
         </mat-option>

--- a/web/projects/em/src/app/settings/content/content-settings-view/content-settings-view.component.html
+++ b/web/projects/em/src/app/settings/content/content-settings-view/content-settings-view.component.html
@@ -17,7 +17,7 @@
 -->
 <div class="content-settings-page">
   <nav mat-tab-nav-bar mat-stretch-tabs="false" class="nav-bar-scroll" [tabPanel]="tabPanel">
-    @for (link of visibleLinks; track link) {
+    @for (link of visibleLinks; track link.path) {
       <a mat-tab-link class="mat-tab-link-label"
         [routerLink]="link.path"
         routerLinkActive #rla="routerLinkActive"

--- a/web/projects/em/src/app/settings/content/drivers-and-plugins/plugins-view/create-driver-dialog/create-driver-dialog.component.html
+++ b/web/projects/em/src/app/settings/content/drivers-and-plugins/plugins-view/create-driver-dialog/create-driver-dialog.component.html
@@ -25,7 +25,7 @@
           <mat-radio-button value="upload">_#(Upload)</mat-radio-button>
           <div>
             <mat-list>
-              @for (file of uploadForm.controls['uploadFiles']?.value; track file) {
+              @for (file of uploadForm.controls['uploadFiles']?.value; track file.name) {
                 <mat-list-item>
                   <div class="fileListItem">
                     <div class="flex-row">

--- a/web/projects/em/src/app/settings/content/materialized-views/mv-management-view/mv-management-view.component.html
+++ b/web/projects/em/src/app/settings/content/materialized-views/mv-management-view/mv-management-view.component.html
@@ -88,7 +88,7 @@
                 [class.sort-ascending-icon]="setCycleNameSort === SortTypes.ASCENDING"></i>
               </div>
               <mat-option value="">_#(None)</mat-option>
-              @for (cyc of setCycle; track cyc) {
+              @for (cyc of setCycle; track cyc.name) {
                 <mat-option [value]="cyc.name">{{ cyc.label }}</mat-option>
               }
             </mat-select>

--- a/web/projects/em/src/app/settings/content/repository/repository-data-source-folder-settings-view/repository-data-source-folder-settings-view.component.html
+++ b/web/projects/em/src/app/settings/content/repository/repository-data-source-folder-settings-view/repository-data-source-folder-settings-view.component.html
@@ -48,7 +48,7 @@
                   </mat-form-field>
                   @if (model?.folderMeta) {
                     <div>
-                      @for (metaItem of model.folderMeta.metaItems; track metaItem) {
+                      @for (metaItem of model.folderMeta.metaItems; track metaItem.assetTypeLabel) {
                         <span class="badge">
                           {{metaItem.assetTypeLabel}}: {{metaItem.assetCount}}
                         </span>

--- a/web/projects/em/src/app/settings/content/repository/repository-folder-settings-view/repository-folder-settings-view.component.html
+++ b/web/projects/em/src/app/settings/content/repository/repository-folder-settings-view/repository-folder-settings-view.component.html
@@ -70,7 +70,7 @@
               </form>
               @if (model?.folderMeta) {
                 <div>
-                  @for (metaItem of model.folderMeta.metaItems; track metaItem) {
+                  @for (metaItem of model.folderMeta.metaItems; track metaItem.assetTypeLabel) {
                     <span class="badge">
                       {{metaItem.assetTypeLabel}}: {{metaItem.assetCount}}
                     </span>

--- a/web/projects/em/src/app/settings/content/repository/repository-tree-view/repository-tree-view.component.html
+++ b/web/projects/em/src/app/settings/content/repository/repository-tree-view/repository-tree-view.component.html
@@ -86,7 +86,7 @@
   <div class="treeStatus">
     @if (this.selectedNodes?.length == 1) {
       @let metaEntries = selectedNodes[0].getNodeMetaMap().entries();
-      @for (metaTypeEntry of metaEntries; track metaTypeEntry) {
+      @for (metaTypeEntry of metaEntries; track metaTypeEntry[0]) {
         <span class="treeStatusItem">
           <span class="badge">{{metaTypeEntry[0]}}: {{metaTypeEntry[1]}}
           </span>

--- a/web/projects/em/src/app/settings/general/general-settings-page/general-settings-page.component.html
+++ b/web/projects/em/src/app/settings/general/general-settings-page/general-settings-page.component.html
@@ -95,7 +95,7 @@
     </em-navigation-scrollable>
     <div class="general-settings-nav">
       <mat-nav-list dense>
-        @for (link of navLinks; track link) {
+        @for (link of navLinks; track link.id) {
           <a
             mat-list-item
             [attr.id]="link.id + '-navlink'"

--- a/web/projects/em/src/app/settings/presentation/export-menu-options-view/export-menu-options-view.component.html
+++ b/web/projects/em/src/app/settings/presentation/export-menu-options-view/export-menu-options-view.component.html
@@ -24,7 +24,7 @@
 
   <mat-card-content>
     <div class="flex-row">
-      @for (option of options; track option) {
+      @for (option of options; track option.name) {
         <mat-checkbox class="checkbox-container margin-bottom-sm" [(ngModel)]="option.value" (change)="optionsChanged.emit(options)" labelPosition="after">
           {{option.description}}
         </mat-checkbox>

--- a/web/projects/em/src/app/settings/presentation/look-and-feel-settings-view/edit-fonts-dialog/edit-fonts-dialog.component.html
+++ b/web/projects/em/src/app/settings/presentation/look-and-feel-settings-view/edit-fonts-dialog/edit-fonts-dialog.component.html
@@ -49,7 +49,7 @@
         <td mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
           <div class="font-element-detail"
             [@detailExpand]="element === expandedElement ? 'expanded' : 'collapsed'">
-            @for (_fontFace of element.fontFaces; track _fontFace; let _i = $index) {
+            @for (_fontFace of element.fontFaces; track _fontFace.identifier; let _i = $index) {
               <div>
                 <button mat-icon-button title="_#(Remove Font Face)" aria-label="_#(Remove Font Face)"
                   (click)="removeFontFace(element, _i)">

--- a/web/projects/em/src/app/settings/presentation/portal-integration-view/portal-integration-view.component.html
+++ b/web/projects/em/src/app/settings/presentation/portal-integration-view/portal-integration-view.component.html
@@ -50,7 +50,7 @@
               </button>
             </section>
             <section class="flex-row">
-              @for (tab of model.tabs; track tab; let i = $index) {
+              @for (tab of model.tabs; track tab.name; let i = $index) {
                 <mat-card class="tab-block portal-card">
                   <mat-card-subtitle class="visible-subtitle">
                     <h4 class="tab-name mat-subtitle-2">{{tab.label}}</h4>

--- a/web/projects/em/src/app/settings/presentation/presentation-data-source-visibility-settings/add-data-source-type-dialog/add-data-source-type-dialog.component.html
+++ b/web/projects/em/src/app/settings/presentation/presentation-data-source-visibility-settings/add-data-source-type-dialog/add-data-source-type-dialog.component.html
@@ -21,7 +21,7 @@
   <mat-form-field appearance="outline" color="accent">
     <mat-label>_#(Data Source Type)</mat-label>
     <mat-select formControlName="dataSource" placeholder="_#(Data Source Type)">
-      @for (type of listings; track type) {
+      @for (type of listings; track type.key) {
         <mat-option [value]="type.key">{{type.value}}</mat-option>
       }
     </mat-select>

--- a/web/projects/em/src/app/settings/presentation/presentation-data-source-visibility-settings/presentation-data-source-visibility-settings-view.component.html
+++ b/web/projects/em/src/app/settings/presentation/presentation-data-source-visibility-settings/presentation-data-source-visibility-settings-view.component.html
@@ -34,7 +34,7 @@
           <span>_#(em.presentation.dataSource.emptyVisibleList)</span>
         }
         <section class="flex-row">
-          @for (dataSource of model.visibleDataSources; track dataSource; let i = $index) {
+          @for (dataSource of model.visibleDataSources; track dataSource.key; let i = $index) {
             <mat-card class="tab-block portal-card">
               <mat-card-subtitle class="visible-subtitle">
                 <h4 class="tab-name mat-subtitle-2">{{dataSource.value}}</h4>
@@ -67,7 +67,7 @@
           <span>_#(em.presentation.dataSource.emptyHiddenList)</span>
         }
         <section class="flex-row">
-          @for (dataSource of model.hiddenDataSources; track dataSource; let i = $index) {
+          @for (dataSource of model.hiddenDataSources; track dataSource.key; let i = $index) {
             <mat-card class="tab-block portal-card">
               <mat-card-subtitle class="visible-subtitle">
                 <h4 class="tab-name mat-subtitle-2">{{dataSource.value}}</h4>

--- a/web/projects/em/src/app/settings/presentation/presentation-nav-view/presentation-nav-view.component.html
+++ b/web/projects/em/src/app/settings/presentation/presentation-nav-view/presentation-nav-view.component.html
@@ -17,7 +17,7 @@
 -->
 <div class="presentation-settings-page">
   <nav mat-tab-nav-bar mat-stretch-tabs="false" class="nav-bar-scroll" [tabPanel]="tabPanel">
-    @for (link of visibleLinks; track link) {
+    @for (link of visibleLinks; track link.path) {
       <a mat-tab-link class="mat-tab-link-label"
         [routerLink]="link.path"
         routerLinkActive #rla="routerLinkActive"

--- a/web/projects/em/src/app/settings/presentation/presentation-settings-view/presentation-settings-view.component.html
+++ b/web/projects/em/src/app/settings/presentation/presentation-settings-view/presentation-settings-view.component.html
@@ -147,7 +147,7 @@
   </em-navigation-scrollable>
   <div class="presentation-settings-nav">
     <mat-nav-list dense>
-      @for (link of navLinks; track link) {
+      @for (link of navLinks; track link.id) {
         <a
           mat-list-item
           [attr.id]="link.id + '-navlink'"

--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-list-view/theme-list-view.component.html
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-list-view/theme-list-view.component.html
@@ -38,7 +38,7 @@
   <div class="theme-list" emTopScroll>
     <div class="theme-list__container">
       <mat-action-list class="flat-tree">
-        @for (theme of themes; track theme) {
+        @for (theme of themes; track theme.id) {
           <div class="flat-tree-node" [class.selected]="theme.id == selectedTheme?.id">
             <a
               mat-list-item

--- a/web/projects/em/src/app/settings/presentation/webmap-settings-view/webmap-settings-view.component.html
+++ b/web/projects/em/src/app/settings/presentation/webmap-settings-view/webmap-settings-view.component.html
@@ -49,7 +49,7 @@
               <mat-form-field>
                 <mat-label>_#(Mapbox Style)</mat-label>
                 <mat-select formControlName="mapboxStyle" placeholder="_#(Mapbox Style)">
-                  @for (style of model?.mapboxStyles; track style) {
+                  @for (style of model?.mapboxStyles; track style.id) {
                     <mat-option [value]="style.id"
                     [title]="style.name">{{style.name}}</mat-option>
                   }

--- a/web/projects/em/src/app/settings/properties/property-settings-view/property-settings-view.component.html
+++ b/web/projects/em/src/app/settings/properties/property-settings-view/property-settings-view.component.html
@@ -46,7 +46,7 @@
                   <mat-icon fontSet="ineticons" fontIcon="shape-cross-icon"></mat-icon>
                 </button>
                 <mat-autocomplete #auto="matAutocomplete">
-                  @for (prop of editPropertyAutocomplete | async; track prop) {
+                  @for (prop of editPropertyAutocomplete | async; track prop.propertyName) {
                     <mat-option
                       [value]="prop.propertyName" (click)="setPropertyName(prop)">
                       {{prop.propertyName}}
@@ -80,7 +80,7 @@
                     <mat-icon fontSet="ineticons" fontIcon="shape-cross-icon"></mat-icon>
                   </button>
                   <mat-autocomplete #valueAuto="matAutocomplete">
-                    @for (option of valueOptions; track option) {
+                    @for (option of valueOptions; track $index) {
                       <mat-option
                         [value]="option.value" (click)="editingRow.propertyValue = option.value">
                         {{option.label}}

--- a/web/projects/em/src/app/settings/schedule/schedule-settings-page/schedule-settings-page.component.html
+++ b/web/projects/em/src/app/settings/schedule/schedule-settings-page/schedule-settings-page.component.html
@@ -16,7 +16,7 @@
 ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <nav mat-tab-nav-bar mat-stretch-tabs="false" [tabPanel]="tabPanel">
-  @for (link of visibleLinks; track link) {
+  @for (link of visibleLinks; track link.path) {
     <a
       mat-tab-link
       [routerLink]="link.path"

--- a/web/projects/em/src/app/settings/schedule/schedule-task-editor-page/schedule-task-editor-page.component.html
+++ b/web/projects/em/src/app/settings/schedule/schedule-task-editor-page/schedule-task-editor-page.component.html
@@ -85,7 +85,7 @@
             <mat-card appearance="outlined">
               <mat-card-content>
                 <mat-nav-list dense>
-                  @for (action of actionItems; track action; let i = $index) {
+                  @for (action of actionItems; track action.id; let i = $index) {
                     <mat-list-item [class.mat-active]="selectedActionIndex === i" (click)="selectAction(i)">
                       <a class="list-label" [class.mat-error]="!action.valid" [matTooltip]="action.label">
                         {{ action.label }}

--- a/web/projects/em/src/app/settings/schedule/task-action-pane/backup-file/backup-file.component.html
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/backup-file/backup-file.component.html
@@ -75,7 +75,7 @@
         </div>
         <mat-card appearance="outlined" class="flex-col flex-grow-1 list-container">
           <mat-list>
-            @for (asset of selectedEntities; track asset) {
+            @for (asset of selectedEntities; track $index) {
               <mat-list-item
                 [class.selected]="entitySelection.includes(asset)"
                 (click)="selectEntity(asset, $event)">

--- a/web/projects/em/src/app/settings/schedule/task-action-pane/delivery-emails/delivery-emails.component.html
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/delivery-emails/delivery-emails.component.html
@@ -64,7 +64,7 @@
         <mat-form-field appearance="outline" color="accent">
           <mat-label>_#(Format)</mat-label>
           <mat-select formControlName="format" placeholder="_#(Format)" (selectionChange)="changeFormat()">
-            @for (format of mailFormats; track format) {
+            @for (format of mailFormats; track format.type) {
               <mat-option [value]="format.type">{{format.label}}</mat-option>
             }
           </mat-select>

--- a/web/projects/em/src/app/settings/schedule/task-action-pane/server-save/server-save.component.html
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/server-save/server-save.component.html
@@ -31,7 +31,7 @@
             <div class="format-container">
               <mat-form-field appearance="outline" color="accent">
                 <mat-select [(value)]="element.format" placeholder="#(Select Format)" (valueChange)="fireServerSaveChanged()" [required]="true">
-                  @for (format of formats; track format) {
+                  @for (format of formats; track format.type) {
                     <mat-option [value]="format.type">{{format.label}}</mat-option>
                   }
                 </mat-select>
@@ -69,7 +69,7 @@
                     @if (hasLocations) {
                       <mat-form-field floatLabel="never" appearance="outline" color="accent">
                         <mat-select [formControlName]="i" (selectionChange)="locationPathChanged(i)" placeholder="_#(Location)" [required]="true">
-                          @for (location of locations; track location) {
+                          @for (location of locations; track location.path) {
                             <mat-option [value]="location.path">{{location.label}}</mat-option>
                           }
                         </mat-select>

--- a/web/projects/em/src/app/settings/schedule/task-action-pane/viewsheet-action-editor/viewsheet-action-editor.component.html
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/viewsheet-action-editor/viewsheet-action-editor.component.html
@@ -68,7 +68,7 @@
         <td mat-cell *matCellDef="let element; let i = index">
           <mat-form-field floatLabel="never" appearance="outline" color="accent">
             <mat-select [(value)]="selectedBookmarks[i]" placeholder="_#(Select Bookmark)" [compareWith]="compareBookmark" (valueChange)="fireModelChanged()">
-              @for (bookmark of bookmarks | async; track bookmark) {
+              @for (bookmark of bookmarks | async; track $index) {
                 <mat-option [value]="bookmark">{{bookmark.label}}
                 </mat-option>
               }

--- a/web/projects/em/src/app/settings/schedule/task-condition-pane/task-condition-pane.component.html
+++ b/web/projects/em/src/app/settings/schedule/task-condition-pane/task-condition-pane.component.html
@@ -20,7 +20,7 @@
     <mat-form-field appearance="outline" color="accent">
       <mat-label>_#(Condition Type)</mat-label>
       <mat-select placeholder="_#(Condition Type)" [(value)]="selectedConditionType" (selectionChange)="changeConditionType()">
-        @for (type of conditionTypes; track type) {
+        @for (type of conditionTypes; track $index) {
           <mat-option [value]="type">{{type.label}}</mat-option>
         }
       </mat-select>

--- a/web/projects/em/src/app/settings/schedule/task-options-pane/execute-as-dialog.component.html
+++ b/web/projects/em/src/app/settings/schedule/task-options-pane/execute-as-dialog.component.html
@@ -31,7 +31,7 @@
       <input matInput placeholder="" formControlName="idName"
         [matAutocomplete]="auto">
       <mat-autocomplete #auto="matAutocomplete">
-        @for (id of filteredIdentities | async; track id) {
+        @for (id of filteredIdentities | async; track id.name) {
           <mat-option [value]="id.name">{{id.name}}</mat-option>
         }
       </mat-autocomplete>

--- a/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.html
+++ b/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.html
@@ -89,7 +89,7 @@
             <input matInput placeholder="_#(Owner)" formControlName="owner"
               [matAutocomplete]="auto" (change)="fireModelChanged()">
             <mat-autocomplete #auto="matAutocomplete" (optionSelected)="fireModelChanged()">
-              @for (user of filteredUsers | async; track user) {
+              @for (user of filteredUsers | async; track user.identityID.name) {
                 <mat-option [value]="user.identityID.name">{{ user.identityID.name }}</mat-option>
               }
             </mat-autocomplete>

--- a/web/projects/em/src/app/settings/security/security-list-view/security-list-view.component.html
+++ b/web/projects/em/src/app/settings/security/security-list-view/security-list-view.component.html
@@ -16,7 +16,7 @@
 ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <mat-list>
-  @for (provider of providers; track provider; let i = $index; let first = $first; let last = $last) {
+  @for (provider of providers; track provider.name; let i = $index; let first = $first; let last = $last) {
     <mat-list-item class="list-item"
       [draggable]="true" [disableRipple]="true"
       (dragenter)="dragEnter($event)"

--- a/web/projects/em/src/app/settings/security/security-provider/input-query-params-dialog/input-query-params-dialog.component.html
+++ b/web/projects/em/src/app/settings/security/security-provider/input-query-params-dialog/input-query-params-dialog.component.html
@@ -17,7 +17,7 @@
 -->
 <h3 mat-dialog-title>{{ title }}</h3>
 <div mat-dialog-content>
-  @for (queryParam of params; track queryParam) {
+  @for (queryParam of params; track queryParam.name) {
     <mat-form-field appearance="outline" color="accent">
       <mat-label>{{queryParam.name}}</mat-label>
       <input matInput [placeholder]="queryParam.name" [(ngModel)]="queryParam.value"/>

--- a/web/projects/em/src/app/settings/security/sso/sso-settings-page/sso-settings-page.component.html
+++ b/web/projects/em/src/app/settings/security/sso/sso-settings-page/sso-settings-page.component.html
@@ -42,7 +42,7 @@
                     placeholder="_#(None)"
                     #roleSelection
                     multiple>
-                    @for (role of roles; track role) {
+                    @for (role of roles; track role.name) {
                       <mat-option [value]="role.name">{{role.label}}</mat-option>
                     }
                   </mat-select>

--- a/web/projects/em/src/app/settings/security/users/edit-identity-view/edit-identity-view.component.html
+++ b/web/projects/em/src/app/settings/security/users/edit-identity-view/edit-identity-view.component.html
@@ -134,7 +134,7 @@
                   <mat-label>_#(Theme)</mat-label>
                   <mat-select formControlName="theme">
                     <mat-option value="">_#(Default)</mat-option>
-                    @for (theme of themes; track theme) {
+                    @for (theme of themes; track theme.id) {
                       <mat-option [value]="theme.id">
                         {{theme.name}}
                       </mat-option>

--- a/web/projects/em/src/app/settings/security/users/users-settings-view/create-organization-dialog.component.html
+++ b/web/projects/em/src/app/settings/security/users/users-settings-view/create-organization-dialog.component.html
@@ -32,7 +32,7 @@
         </button>
       </mat-form-field>
       <mat-autocomplete #auto="matAutocomplete" (optionSelected)="onSelectOrg($event)">
-        @for (org of searchResults; track org; let i = $index) {
+        @for (org of searchResults; track org.id; let i = $index) {
           <mat-option class="dropdownItem" [value]="org.id" [class.mdc-list-item--selected]="isSelected(org.id)">
             {{org.name}}
           </mat-option>

--- a/web/projects/em/src/app/widget/dynamic-combo-box.component.html
+++ b/web/projects/em/src/app/widget/dynamic-combo-box.component.html
@@ -69,7 +69,7 @@
       </mat-form-field>
     }
     <mat-autocomplete #auto="matAutocomplete">
-      @for (value of values; track value) {
+      @for (value of values; track value.value) {
         <mat-option [value]="value.value"
         [class.selected]="selectedOption(value.value)">{{value.label}}</mat-option>
       }

--- a/web/projects/portal/src/app/binding/widget/range-slider.component.html
+++ b/web/projects/portal/src/app/binding/widget/range-slider.component.html
@@ -46,7 +46,7 @@
     </div>
 
     <!-- Tick dots -->
-    @for (tick of ticks; track tick) {
+    @for (tick of ticks; track tick.left) {
       <div class="slider-tick" [style.left]="tick.left"></div>
     }
 

--- a/web/projects/portal/src/app/binding/widget/slider.component.html
+++ b/web/projects/portal/src/app/binding/widget/slider.component.html
@@ -25,7 +25,7 @@
       [class.is-dragging]="isDragging"
       (mousedown)="mouseDown($event)">
     </div>
-    @for (tick of ticks; track tick) {
+    @for (tick of ticks; track tick.left) {
       <div class="slider-tick" [style.left]="tick.left"></div>
     }
     <div class="slider-value" [style.left]="labelLeft">{{sliderLabel}}</div>

--- a/web/projects/portal/src/app/composer/dialog/vs/data-input-pane.component.html
+++ b/web/projects/portal/src/app/composer/dialog/vs/data-input-pane.component.html
@@ -162,7 +162,7 @@
                   </td>
                 }
               </tr>
-              @for (row of popupTable.pageData; track row; let i = $index) {
+              @for (row of popupTable.pageData; track $index; let i = $index) {
                 <tr>
                   <td class="popup-table-cell bd-gray">
                     {{getRowIndex(i)}}

--- a/web/projects/portal/src/app/composer/dialog/vs/filters-pane.component.html
+++ b/web/projects/portal/src/app/composer/dialog/vs/filters-pane.component.html
@@ -29,7 +29,7 @@
                 </tr>
               </thead>
               <tbody>
-                @for (filter of model.filters; track filter; let _i = $index) {
+                @for (filter of model.filters; track filter.column; let _i = $index) {
                   <tr>
                     <td class="filters-col" [class.selected]="isFilterSelected(_i)"
                       (click)="selectFilter(_i, $event)">
@@ -60,7 +60,7 @@
                 </tr>
               </thead>
               <tbody>
-                @for (filter of model.sharedFilters; track filter; let _i = $index) {
+                @for (filter of model.sharedFilters; track filter.column; let _i = $index) {
                   <tr
                     [class.selected]="isSharedFilterSelected(_i)"
                     (click)="selectSharedFilter(_i, $event)">

--- a/web/projects/portal/src/app/composer/dialog/vs/filters-pane.component.html
+++ b/web/projects/portal/src/app/composer/dialog/vs/filters-pane.component.html
@@ -29,7 +29,7 @@
                 </tr>
               </thead>
               <tbody>
-                @for (filter of model.filters; track filter.column; let _i = $index) {
+                @for (filter of model.filters; track $index; let _i = $index) {
                   <tr>
                     <td class="filters-col" [class.selected]="isFilterSelected(_i)"
                       (click)="selectFilter(_i, $event)">
@@ -60,7 +60,7 @@
                 </tr>
               </thead>
               <tbody>
-                @for (filter of model.sharedFilters; track filter.column; let _i = $index) {
+                @for (filter of model.sharedFilters; track $index; let _i = $index) {
                   <tr
                     [class.selected]="isSharedFilterSelected(_i)"
                     (click)="selectSharedFilter(_i, $event)">

--- a/web/projects/portal/src/app/composer/dialog/vs/localization-pane.component.html
+++ b/web/projects/portal/src/app/composer/dialog/vs/localization-pane.component.html
@@ -49,7 +49,7 @@
                   </tr>
                 </thead>
                 <tbody style="height: 20em">
-                  @for (component of model.localized; track component) {
+                  @for (component of model.localized; track component.name) {
                     <tr
                       [class.selected]="isLocalizedSelected(component)"
                       (click)="selectLocalized($event, component)">

--- a/web/projects/portal/src/app/composer/dialog/vs/viewsheet-print-layout-dialog.component.html
+++ b/web/projects/portal/src/app/composer/dialog/vs/viewsheet-print-layout-dialog.component.html
@@ -30,7 +30,7 @@
               <div class="form-floating col-12">
                 <select class="form-control" [(ngModel)]="model.paperSize"
                   [ngModelOptions]="{standalone: true}" (change)="initForm()">
-                  @for (paperSize of paper; track paperSize) {
+                  @for (paperSize of paper; track paperSize.value) {
                     <option [value]="paperSize.value">{{paperSize.label}}</option>
                   }
                 </select>
@@ -94,7 +94,7 @@
             <div class="form-row-float-label form-row">
               <div class="form-floating col-auto">
                 <select class="form-control unit_select_id" [ngModel]="model.units" (ngModelChange)="unitChanged($event)" [ngModelOptions]="{standalone: true}">
-                  @for (measurement of measurementsView; track measurement) {
+                  @for (measurement of measurementsView; track measurement.value) {
                     <option [value]="measurement.value">
                       {{measurement.label}}
                     </option>

--- a/web/projects/portal/src/app/composer/dialog/ws/aggregate-pane.component.html
+++ b/web/projects/portal/src/app/composer/dialog/ws/aggregate-pane.component.html
@@ -16,7 +16,7 @@
 ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <form ngNoForm (submit)="$event.preventDefault()" class="form-horizontal">
-  @for (_row of rows; track _j; let _j = $index) {
+  @for (_row of rows; track $index; let _j = $index) {
     <div class="form-row-float-label row">
       <div class="col">
         <div class="row">

--- a/web/projects/portal/src/app/composer/gui/ws/editor/merge/ws-merge-join-editor-pane.component.html
+++ b/web/projects/portal/src/app/composer/gui/ws/editor/merge/ws-merge-join-editor-pane.component.html
@@ -17,7 +17,7 @@
 -->
 <div class="merge-join-container" (mousedown)="focusMergeTable($event)">
   <div class="merge-join-subtable-container">
-    @for (_subtable of subtables; track _i; let _i = $index; let _last = $last) {
+    @for (_subtable of subtables; track $index; let _i = $index; let _last = $last) {
       <merge-join-subtable
                          [ngClass]="{'bg-highlight-color insert-left': dropInfo?.currentInsertionIndex === _i,
                                      'insert-right br-highlight': dropInfo?.currentInsertionIndex === _i + 1 && _last}"

--- a/web/projects/portal/src/app/graph/dialog/alias-pane.component.html
+++ b/web/projects/portal/src/app/graph/dialog/alias-pane.component.html
@@ -25,7 +25,7 @@
         </tr>
       </thead>
       <tbody>
-        @for (_val of model.aliasList; track _val; let _i = $index) {
+        @for (_val of model.aliasList; track _val.value; let _i = $index) {
           <tr (click)="selectedIndex = _i"
             [class.selected]="_i === selectedIndex">
             <td>

--- a/web/projects/portal/src/app/graph/dialog/chart-plot-options-pane.component.html
+++ b/web/projects/portal/src/app/graph/dialog/chart-plot-options-pane.component.html
@@ -417,7 +417,7 @@
           <select class="form-control" [(ngModel)]="model.webMapStyle"
             [attr.disabled]="!model.webMap ? '' : null"
             [ngModelOptions]="{standalone: true}">
-            @for (style of model.mapboxStyles; track style) {
+            @for (style of model.mapboxStyles; track style.id) {
               <option [ngValue]="style.id">
                 {{style.name}}
               </option>

--- a/web/projects/portal/src/app/graph/dialog/chart-target-lines-pane.component.html
+++ b/web/projects/portal/src/app/graph/dialog/chart-target-lines-pane.component.html
@@ -22,7 +22,7 @@
       <div class="row">
         <div class="col-9 p-0 target-container">
           <div class="list-group">
-            @for (_chartTarget of model.chartTargets; track _chartTarget; let _idx = $index) {
+            @for (_chartTarget of model.chartTargets; track $index; let _idx = $index) {
               <a class="list-group-item"
                 (click)="select(_idx, $event)" [class.selected]="selectedIndexes.indexOf(_idx) >= 0">
                 {{_chartTarget.targetString}}

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/datasources-database.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/datasources-database.component.html
@@ -491,7 +491,7 @@
                               </tr>
                             </thead>
                             <tbody>
-                              @for (properties of database.info.poolProperties | keyvalue; track $index) {
+                              @for (properties of database.info.poolProperties | keyvalue; track properties.key) {
                                 <tr class="pool-property-row row"
                                   (mousedown)="selectProperty($event, properties)"
                                   [class.selected]="isSelectedProperty(properties)">

--- a/web/projects/portal/src/app/viewer/viewer-view/page-tab.component.html
+++ b/web/projects/portal/src/app/viewer/viewer-view/page-tab.component.html
@@ -29,7 +29,7 @@
     (scroll)="refreshScroll()">
     @if (tabs.length > 1) {
       <ul class="nav nav-tabs tabs-bottom">
-        @for (tab of tabs; track tab) {
+        @for (tab of tabs; track tab.id) {
           <li class="nav-item hover-bg-secondary"
             [title]="tab.tooltip"
             [class.active]="tab.isFocused"

--- a/web/projects/portal/src/app/viewer/viewer-view/viewer-view.component.html
+++ b/web/projects/portal/src/app/viewer/viewer-view/viewer-view.component.html
@@ -19,7 +19,7 @@
   <div class="viewer-view-container">
     <div class="page-tab-content">
       <!-- use a for loop to ensure that the viewer-app gets re-created when the asset ID changes -->
-      @for (tab of tabs; track tab) {
+      @for (tab of tabs; track tab.id) {
         <viewer-app #viewerApp
           [class.viewer-app--active]="isActiveTab(tab)"
           [active]="isActiveTab(tab)"

--- a/web/projects/portal/src/app/vs-wizard/gui/wizard-pane/vs-wizard-grid-pane.component.html
+++ b/web/projects/portal/src/app/vs-wizard/gui/wizard-pane/vs-wizard-grid-pane.component.html
@@ -17,7 +17,7 @@
 -->
 <div class="vs-grid-table">
   <div class="vs-grid-col-container">
-    @for (_ of colRange; track colIndex; let colIndex = $index; let evenCol = $even) {
+    @for (_ of colRange; track $index; let colIndex = $index; let evenCol = $even) {
       <div
         class="vs-grid-table-col"
         [style.width.px]="cellWidth"
@@ -26,12 +26,12 @@
     }
   </div>
 
-  @for (_ of rowRange; track rowIndex; let rowIndex = $index; let evenRow = $even) {
+  @for (_ of rowRange; track $index; let rowIndex = $index; let evenRow = $even) {
     <div
       class="vs-grid-table-row"
       [class.even-row]="evenRow"
       [class.odd-row]="!evenRow">
-      @for (_ of colRange; track colIndex; let colIndex = $index; let evenCol = $even) {
+      @for (_ of colRange; track $index; let colIndex = $index; let evenCol = $even) {
         <div
           class="vs-grid-table-cell txt-primary"
           [class.even-col]="evenCol"

--- a/web/projects/portal/src/app/vsobjects/bookmark/vs-bookmark-pane.component.html
+++ b/web/projects/portal/src/app/vsobjects/bookmark/vs-bookmark-pane.component.html
@@ -64,7 +64,7 @@
       </li>
     </ul>
   </div>
-  @for (bookmark of vsBookmarkList; track bookmark) {
+  @for (bookmark of vsBookmarkList; track bookmark.name) {
     @if (bookmarkVisible(bookmark)) {
       <li class="dropdown-item bookmark-item hover-bg-primary"
         [class.bg-bold-selected]="bookmark.currentBookmark"

--- a/web/projects/portal/src/app/vsobjects/dialog/date-comparison-dialog/date-comparison-pane.component.html
+++ b/web/projects/portal/src/app/vsobjects/dialog/date-comparison-dialog/date-comparison-pane.component.html
@@ -51,7 +51,7 @@
       <legend>_#(Display)</legend>
       <div class="form-row-float-label row">
         <div class="col-11 d-flex justify-content-between">
-          @for (option of comparisonOption; track option; let i = $index) {
+          @for (option of comparisonOption; track option.value; let i = $index) {
             <div class="option form-check">
               <input type="radio" class="form-check-input"
                 [ngModelOptions]="{standalone: true}"

--- a/web/projects/portal/src/app/vsobjects/dialog/graph/chart-line-pane.component.html
+++ b/web/projects/portal/src/app/vsobjects/dialog/graph/chart-line-pane.component.html
@@ -85,7 +85,7 @@
           <select class="form-control" [ngModelOptions]="{standalone: true}"
             placeholder="_#(Trend Line)"
             [(ngModel)]="model.trendLineType" (change)="setEnabled()">
-          @for (_option of trendlineOptions; track _option) {
+          @for (_option of trendlineOptions; track _option.value) {
             <option
             [value]="_option.value">{{_option.label}}</option>
           }

--- a/web/projects/portal/src/app/vsobjects/objects/output/gauge/vs-gauge.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/output/gauge/vs-gauge.component.html
@@ -64,7 +64,7 @@
     [assemblyLoading]="true"></vs-loading-display>
   }
   @if (viewer) {
-    @for (annotationModel of model.assemblyAnnotationModels; track annotationModel) {
+    @for (annotationModel of model.assemblyAnnotationModels; track annotationModel.absoluteName) {
       <vs-annotation
         [model]="annotationModel"
         [actions]="actions"

--- a/web/projects/portal/src/app/vsobjects/objects/output/image/vs-image.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/output/image/vs-image.component.html
@@ -84,7 +84,7 @@
       </div>
     </div>
     @if (viewer) {
-      @for (annotationModel of model.assemblyAnnotationModels; track annotationModel) {
+      @for (annotationModel of model.assemblyAnnotationModels; track annotationModel.absoluteName) {
         <vs-annotation
           [model]="annotationModel"
           [actions]="actions"

--- a/web/projects/portal/src/app/vsobjects/objects/output/text/vs-text.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/output/text/vs-text.component.html
@@ -102,7 +102,7 @@
       }
     </div>
     @if (viewer) {
-      @for (annotationModel of model.assemblyAnnotationModels; track annotationModel) {
+      @for (annotationModel of model.assemblyAnnotationModels; track annotationModel.absoluteName) {
         <vs-annotation
           [actions]="actions"
           [model]="annotationModel"

--- a/web/projects/portal/src/app/vsobjects/objects/shape/vs-line.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/shape/vs-line.component.html
@@ -101,7 +101,7 @@
       </div>
     }
     @if (viewer) {
-      @for (annotationModel of model.assemblyAnnotationModels; track annotationModel) {
+      @for (annotationModel of model.assemblyAnnotationModels; track annotationModel.absoluteName) {
         <vs-annotation
           [model]="annotationModel"
           [actions]="actions"

--- a/web/projects/portal/src/app/vsobjects/objects/shape/vs-oval.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/shape/vs-oval.component.html
@@ -64,7 +64,7 @@
             [attr.x2]="linearGradientEndX"
             [attr.y2]="linearGradientEndY"
             spreadMethod="pad">
-            @for (gradientColor of model.objectFormat.gradientColor.colors; track gradientColor) {
+            @for (gradientColor of model.objectFormat.gradientColor.colors; track $index) {
               <stop
                 [attr.offset]="gradientColor.offset/100" [attr.stop-color]="gradientColor.color"
                 [attr.stop-opacity]="model.objectFormat.alpha"/>
@@ -77,7 +77,7 @@
             cx="50%" cy="50%"
             fx="50%" y2="50%"
             spreadMethod="pad">
-            @for (gradientColor of model.objectFormat.gradientColor.colors; track gradientColor) {
+            @for (gradientColor of model.objectFormat.gradientColor.colors; track $index) {
               <stop
                 [attr.offset]="gradientColor.offset/100" [attr.stop-color]="gradientColor.color"
                 [attr.stop-opacity]="model.objectFormat.alpha"/>
@@ -126,7 +126,7 @@
       </div>
     }
     @if (viewer) {
-      @for (annotationModel of model.assemblyAnnotationModels; track annotationModel) {
+      @for (annotationModel of model.assemblyAnnotationModels; track annotationModel.absoluteName) {
         <vs-annotation
           [model]="annotationModel"
           [actions]="actions"

--- a/web/projects/portal/src/app/vsobjects/objects/shape/vs-rectangle.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/shape/vs-rectangle.component.html
@@ -45,7 +45,7 @@
             [attr.x2]="linearGradientEndX"
             [attr.y2]="linearGradientEndY"
             spreadMethod="pad">
-            @for (gradientColor of model.objectFormat.gradientColor.colors; track gradientColor) {
+            @for (gradientColor of model.objectFormat.gradientColor.colors; track $index) {
               <stop
                 [attr.offset]="gradientColor.offset/100" [attr.stop-color]="gradientColor.color"
                 [attr.stop-opacity]="model.objectFormat.alpha"/>
@@ -58,7 +58,7 @@
             cx="50%" cy="50%"
             fx="50%" y2="50%"
             spreadMethod="pad">
-            @for (gradientColor of model.objectFormat.gradientColor.colors; track gradientColor) {
+            @for (gradientColor of model.objectFormat.gradientColor.colors; track $index) {
               <stop
                 [attr.offset]="gradientColor.offset/100" [attr.stop-color]="gradientColor.color"
                 [attr.stop-opacity]="model.objectFormat.alpha"/>
@@ -105,7 +105,7 @@
       </div>
     }
     @if (viewer) {
-      @for (annotationModel of model.assemblyAnnotationModels; track annotationModel) {
+      @for (annotationModel of model.assemblyAnnotationModels; track annotationModel.absoluteName) {
         <vs-annotation
           [model]="annotationModel"
           [actions]="actions"

--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-calctable.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-calctable.component.html
@@ -450,7 +450,7 @@
     <vs-hidden-annotation [annotations]="model.assemblyAnnotationModels"></vs-hidden-annotation>
   </div>
   <div class="annotation-container">
-    @for (annotationModel of model.assemblyAnnotationModels; track $index) {
+    @for (annotationModel of model.assemblyAnnotationModels; track annotationModel.absoluteName) {
       <vs-annotation
         [model]="annotationModel"
         [actions]="actions"
@@ -465,7 +465,7 @@
 }
 @if (enableAnnotation) {
   <div class="annotation-container">
-    @for (annotationModel of model.leftTopAnnotations; track $index) {
+    @for (annotationModel of model.leftTopAnnotations; track annotationModel.absoluteName) {
       @if (annotationModel.cellOffset) {
         <div
           class="annotation-cell-container"
@@ -486,7 +486,7 @@
 @if (enableAnnotation) {
   <div class="annotation-container"
     [style.left.px]="-scrollX">
-    @for (annotationModel of model.rightTopAnnotations; track annotationModel) {
+    @for (annotationModel of model.rightTopAnnotations; track annotationModel.absoluteName) {
       @if (annotationModel.cellOffset) {
         <div
           class="annotation-cell-container"
@@ -511,7 +511,7 @@
 @if (enableAnnotation) {
   <div class="annotation-container"
     [style.top.px]="-scrollY" [style.left.px]="isFullHorizontalWrapper ? -scrollX : 'unset'">
-    @for (annotationModel of model.leftBottomAnnotations; track annotationModel) {
+    @for (annotationModel of model.leftBottomAnnotations; track annotationModel.absoluteName) {
       @if (annotationModel.cellOffset && isCellLoaded(annotationModel)) {
         <div
           class="annotation-cell-container"
@@ -540,7 +540,7 @@
     class="annotation-container"
     [style.top.px]="-scrollY"
     [style.left.px]="-scrollX">
-    @for (annotationModel of model.rightBottomAnnotations; track annotationModel) {
+    @for (annotationModel of model.rightBottomAnnotations; track annotationModel.absoluteName) {
       @if (annotationModel.cellOffset && isCellLoaded(annotationModel)) {
         <div
           class="annotation-cell-container"

--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-crosstab.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-crosstab.component.html
@@ -539,7 +539,7 @@
         <vs-hidden-annotation [annotations]="model.assemblyAnnotationModels"></vs-hidden-annotation>
       </div>
       <div class="annotation-container">
-        @for (annotationModel of model.assemblyAnnotationModels; track annotationModel) {
+        @for (annotationModel of model.assemblyAnnotationModels; track annotationModel.absoluteName) {
           <vs-annotation
             [model]="annotationModel"
             [actions]="actions"
@@ -554,7 +554,7 @@
     }
     @if (enableAnnotation) {
       <div class="annotation-container">
-        @for (annotationModel of model.leftTopAnnotations; track annotationModel) {
+        @for (annotationModel of model.leftTopAnnotations; track annotationModel.absoluteName) {
           @if (annotationModel.cellOffset) {
             <div
               class="annotation-cell-container"
@@ -578,7 +578,7 @@
     @if (enableAnnotation) {
       <div class="annotation-container"
         [style.left.px]="-scrollX">
-        @for (annotationModel of model.rightTopAnnotations; track annotationModel) {
+        @for (annotationModel of model.rightTopAnnotations; track annotationModel.absoluteName) {
           @if (annotationModel.cellOffset) {
             <div
               class="annotation-cell-container"
@@ -605,7 +605,7 @@
       <div class="annotation-container"
         [style.top.px]="-scrollY"
         [style.left.px]="isFullHorizontalWrapper ? -scrollX : 'unset'">
-        @for (annotationModel of model.leftBottomAnnotations; track annotationModel) {
+        @for (annotationModel of model.leftBottomAnnotations; track annotationModel.absoluteName) {
           @if (annotationModel.cellOffset && isCellLoaded(annotationModel)) {
             <div
               class="annotation-cell-container"
@@ -634,7 +634,7 @@
         class="annotation-container"
         [style.top.px]="-scrollY"
         [style.left.px]="-scrollX">
-        @for (annotationModel of model.rightBottomAnnotations; track annotationModel) {
+        @for (annotationModel of model.rightBottomAnnotations; track annotationModel.absoluteName) {
           @if (annotationModel.cellOffset && isCellLoaded(annotationModel)) {
             <div
               class="annotation-cell-container"

--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.html
@@ -314,7 +314,7 @@
         <vs-hidden-annotation [annotations]="model.assemblyAnnotationModels"></vs-hidden-annotation>
       </div>
       <div class="annotation-container">
-        @for (annotationModel of model.assemblyAnnotationModels; track annotationModel) {
+        @for (annotationModel of model.assemblyAnnotationModels; track annotationModel.absoluteName) {
           <vs-annotation
             [model]="annotationModel"
             [actions]="actions"
@@ -331,7 +331,7 @@
       <div
         class="annotation-container"
         [style.left.px]="-scrollX">
-        @for (annotationModel of model.leftTopAnnotations; track annotationModel) {
+        @for (annotationModel of model.leftTopAnnotations; track annotationModel.absoluteName) {
           @if (annotationModel.cellOffset) {
             <div
               class="annotation-cell-container"
@@ -358,7 +358,7 @@
         class="annotation-container"
         [style.top.px]="-scrollY"
         [style.left.px]="-scrollX">
-        @for (annotationModel of model.leftBottomAnnotations; track annotationModel) {
+        @for (annotationModel of model.leftBottomAnnotations; track annotationModel.absoluteName) {
           @if (annotationModel.cellOffset && isCellLoaded(annotationModel)) {
             <div
               class="annotation-cell-container"

--- a/web/projects/portal/src/app/vsobjects/objects/viewer-mobile-toolbar/viewer-mobile-toolbar.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/viewer-mobile-toolbar/viewer-mobile-toolbar.component.html
@@ -78,13 +78,13 @@
     </button>
     <ng-template #mobileSandwichDropdown>
       <div class="dropdown-menu show" role="menu">
-        @for (group of actions.menuActions; track group) {
+        @for (group of actions.menuActions; track $index) {
           @if (group.visible) {
             @if (actions.requiresMenuSeparator(group) && group.visible) {
               <div class="dropdown-divider"
               ></div>
             }
-            @for (action of group.actions; track action) {
+            @for (action of group.actions; track $index) {
               @if (action.visible()) {
                 <a role="menuitem" class="dropdown-item"
                   [class.disable-link]="!action.enabled()"

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.html
@@ -379,13 +379,13 @@
 }
 <!-- Chart data annotations rendered outside all VS object stacking contexts -->
 <div class="chart-annotation-overlay">
-  @for (vsObject of vsInfo.vsObjects; track vsObject; let i = $index) {
+  @for (vsObject of vsInfo.vsObjects; track vsObject.absoluteName; let i = $index) {
     @if (vsObject.objectType === 'VSChart' && viewer && !context.binding &&
       !$any(vsObject).maxMode && !!$any(vsObject).plot) {
       <div [style.top.px]="getVsObjectPosition(vsObject, i, true)"
         [style.left.px]="getVsObjectPosition(vsObject, i, false)"
         style="position: absolute;">
-        @for (ann of getChartDataAnnotations(vsObject); track ann) {
+        @for (ann of getChartDataAnnotations(vsObject); track ann.absoluteName) {
           <vs-annotation
             [model]="ann"
             [vsInfo]="vsInfo"

--- a/web/projects/portal/src/app/widget/toolbar/toolbar-group/toolbar-group.component.html
+++ b/web/projects/portal/src/app/widget/toolbar/toolbar-group/toolbar-group.component.html
@@ -75,7 +75,7 @@
 }
 @if (!asMenu) {
   <div class="btn-group" role="group" [attr.aria-label]="actionGroup.label">
-    @for (action of actionGroup.actions; track action) {
+    @for (action of actionGroup.actions; track action.label) {
       <ng-template #toolTipContentNoMenu>
         <div class="composer-tooltip" [innerHTML]="action.tooltip()"></div>
       </ng-template>

--- a/web/projects/portal/src/app/widget/toolbar/toolbar-group/toolbar-group.component.html
+++ b/web/projects/portal/src/app/widget/toolbar/toolbar-group/toolbar-group.component.html
@@ -75,7 +75,7 @@
 }
 @if (!asMenu) {
   <div class="btn-group" role="group" [attr.aria-label]="actionGroup.label">
-    @for (action of actionGroup.actions; track action.label) {
+    @for (action of actionGroup.actions; track $index) {
       <ng-template #toolTipContentNoMenu>
         <div class="composer-tooltip" [innerHTML]="action.tooltip()"></div>
       </ng-template>


### PR DESCRIPTION
## Summary

- Follow-up to #3979 (Bug #75361): fixes the remaining Angular template files that still track `@for` loop items by object identity, triggering NG0956 warnings and causing unnecessary DOM rebuilds on every change detection cycle
- All bare-object `track` expressions replaced with either a stable primitive property (`name`, `id`, `path`, `key`, etc.) or `track $index` where no stable unique identifier exists
- Template-only changes — no TypeScript, no logic
- 71 files changed across `portal` and `em` projects

Fixes Redmine #75422.

## Test Plan

- [x] `npm run build` passes with no template compilation errors
- [x] `npm run test` — 736 tests pass, 21 expected failures (matching PR #3979 baseline)
- [x] `npm run lint` — all files pass linting

🤖 Generated with [Claude Code](https://claude.com/claude-code)