### PR TITLE
Bug #75420, autoBinding: bind aggregated worksheet table columns

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -133,9 +133,19 @@ public class WizAutoBindingService {
 
                   if(primary instanceof TableAssembly ta) {
                      tableName = primary.getName();
-                     // Use private selection so visibility flags set by applyFieldVisibility
-                     // (which writes to the private selection) are correctly reflected.
-                     ColumnSelection cs = ta.getColumnSelection(false);
+                     // An aggregating table exposes its aggregate-output columns (the group/aggregate
+                     // aliases) ONLY in the public selection; the private selection still holds the
+                     // pre-aggregation base columns. Read public for those so the aggregated columns
+                     // are bindable (e.g. an aggregate-only mirror). The aggregate FLAG is not reliable
+                     // here — the wiz worksheet-construction flow sets aggregateInfo without calling
+                     // setAggregate(true) — so key off a non-empty aggregateInfo, not isAggregate().
+                     // Non-aggregating tables keep using the private selection so visibility flags set
+                     // by applyFieldVisibility (which writes to the private selection) are honored; the
+                     // public selection is regenerated only from visible private columns, so visibility
+                     // is preserved for the aggregating case as well.
+                     AggregateInfo aggInfo = ta.getAggregateInfo();
+                     boolean aggregating = aggInfo != null && !aggInfo.isEmpty();
+                     ColumnSelection cs = ta.getColumnSelection(aggregating);
 
                      for(int i = 0; i < cs.getAttributeCount(); i++) {
                         DataRef ref = cs.getAttribute(i);
@@ -681,13 +691,21 @@ public class WizAutoBindingService {
     * whose name appears as a key in configMap are bound. A fieldConfig naming a column
     * that does not exist in the worksheet is an error (silently binding everything
     * produced junk measures). When fieldConfigs is empty, all visible columns are eligible.
+    *
+    * <p>Columns are matched by their display name ({@link ColumnRef#getDisplayName()} =
+    * alias when set, else attribute) — the same name {@code buildEntryFromColumn} uses to
+    * name the bound entry and the name the caller sees. This matters for aggregate-output
+    * columns: an aggregate ColumnRef's {@code getAttribute()} returns the underlying base
+    * column (e.g. {@code growth_pct}) while its alias carries the output name (e.g.
+    * {@code growth_rate}); matching on the attribute alone would reject the alias the caller
+    * (correctly) supplies in fieldConfigs.
     */
    static List<ColumnRef> selectBindColumns(List<ColumnRef> worksheetColumns,
                                             Map<String, SimpleFieldInfo> configMap)
    {
       if(!configMap.isEmpty()) {
          Set<String> available = worksheetColumns.stream()
-            .map(ColumnRef::getAttribute)
+            .map(ColumnRef::getDisplayName)
             .collect(Collectors.toCollection(LinkedHashSet::new));
          List<String> missing = configMap.keySet().stream()
             .filter(k -> !available.contains(k))
@@ -701,7 +719,7 @@ public class WizAutoBindingService {
          }
 
          return worksheetColumns.stream()
-            .filter(c -> configMap.containsKey(c.getAttribute()))
+            .filter(c -> configMap.containsKey(c.getDisplayName()))
             .collect(Collectors.toList());
       }
 
@@ -815,7 +833,13 @@ public class WizAutoBindingService {
          List<SimpleFieldInfo> details = new ArrayList<>();
 
          for(int i = 0; i < columns.getAttributeCount(); i++) {
-            AssetEntry entry = entryByName.get(columns.getAttribute(i).getAttribute());
+            // entryByName is keyed on WizardRecommenderUtil.getFieldName(entry), which is the
+            // alias-preferred name buildEntryFromColumn assigns. Look up by the same display name
+            // (alias when set, else attribute) so aliased columns — e.g. aggregate outputs — are
+            // not silently dropped from the table detail list.
+            DataRef colRef = columns.getAttribute(i);
+            String name = colRef instanceof ColumnRef cr ? cr.getDisplayName() : colRef.getAttribute();
+            AssetEntry entry = entryByName.get(name);
 
             if(entry != null) {
                details.add(entryToSimpleFieldInfo(entry));

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSelectBindColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSelectBindColumnsTest.java
@@ -36,6 +36,12 @@ class WizAutoBindingServiceSelectBindColumnsTest {
       return new ColumnRef(new AttributeRef(null, name));
    }
 
+   private static ColumnRef aliasedCol(String attribute, String alias) {
+      ColumnRef ref = new ColumnRef(new AttributeRef(null, attribute));
+      ref.setAlias(alias);
+      return ref;
+   }
+
    private static SimpleFieldInfo config(String field) {
       SimpleFieldInfo info = new SimpleFieldInfo();
       info.setField(field);
@@ -66,6 +72,34 @@ class WizAutoBindingServiceSelectBindColumnsTest {
       assertTrue(e.getMessage().contains("actor_nme"));
       assertTrue(e.getMessage().contains("actor_name"));
       assertTrue(e.getMessage().contains("amount"));
+   }
+
+   @Test
+   void aggregateAliasColumnMatchedByDisplayName() {
+      // An aggregate-output column: getAttribute() returns the underlying base column
+      // (growth_pct), while the alias carries the output name (growth_rate). A fieldConfig
+      // keyed by the alias must match (Redmine #75420).
+      List<ColumnRef> columns = List.of(col("band"), aliasedCol("growth_pct", "growth_rate"));
+
+      List<ColumnRef> result = WizAutoBindingService.selectBindColumns(
+         columns, Map.of("band", config("band"), "growth_rate", config("growth_rate")));
+
+      assertEquals(2, result.size());
+      assertTrue(result.stream().anyMatch(c -> "growth_rate".equals(c.getDisplayName())));
+   }
+
+   @Test
+   void aggregateBaseAttributeReportedUnknownWhenAliased() {
+      // When a column is aliased, the base attribute name is no longer a valid binding key;
+      // the error must list the display name (growth_rate), guiding the caller to it.
+      List<ColumnRef> columns = List.of(col("band"), aliasedCol("growth_pct", "growth_rate"));
+
+      IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+         () -> WizAutoBindingService.selectBindColumns(
+            columns, Map.of("growth_pct", config("growth_pct"))));
+
+      assertTrue(e.getMessage().contains("growth_pct"));
+      assertTrue(e.getMessage().contains("growth_rate"));
    }
 
    @Test


### PR DESCRIPTION
## Summary

The Wiz `autoBinding` endpoint (`/viewsheet/autoBinding`) could not bind a chart to the aggregated output columns of a worksheet table. When `wsTableName` was an aggregate-only mirror (e.g. `BandGrowthM`: group by `band`, `Average(growth_pct) AS growth_rate`), the request failed with HTTP 400 — rejecting the aggregate alias as unknown and listing the base, pre-aggregation columns as "available".

## Root Cause

`WizAutoBindingService` read the bindable-column list from the **private** column selection (`getColumnSelection(false)`), which holds a table's pre-aggregation base columns. A table's aggregate-output columns (the group/aggregate aliases) live only in the **public** selection (`AbstractTableAssembly.setColumnSelection` regenerates public from private + `aggregateInfo`, skipping invisible columns). So reading private never saw the aggregated columns.

Two further mismatches surfaced once the public columns were read:
- `selectBindColumns` matched `fieldConfigs` keys against `ColumnRef.getAttribute()`, which returns the underlying base attribute (`growth_pct`) and ignores the alias (`growth_rate`).
- `buildTableVisualization` looked up entries by `getAttribute()` while the entry map is keyed on the alias-preferred display name.

## Fix

- Read the **public** column selection when the table has a non-empty `aggregateInfo`. The aggregate *flag* is not reliable here — the wiz worksheet-construction flow sets `aggregateInfo` without calling `setAggregate(true)` — so the condition keys off a non-empty `aggregateInfo` rather than `isAggregate()`. Non-aggregating tables keep using the private selection (visibility is preserved either way, since public is regenerated only from visible private columns).
- `selectBindColumns` now matches `fieldConfigs` by **display name** (`getDisplayName()` = alias when set, else attribute), aligning it with `buildEntryFromColumn`.
- `buildTableVisualization` looks up entries by display name too, so aliased columns are not silently dropped from the table-visualization fallback.

## Test Plan

- Added two unit tests to `WizAutoBindingServiceSelectBindColumnsTest` covering the aggregate-alias scenario (alias matched by display name; base attribute reported unknown when aliased, with the available list surfacing the alias).
- All 23 `inetsoft.web.wiz.service` autoBinding tests pass (`./mvnw -o test -pl core`).
- `core` module builds cleanly (`./mvnw clean install -pl core -am -DskipTests`).
- End-to-end repro: build a worksheet ending in an aggregate-only mirror and call `autoBinding` with `wsTableName` = that mirror and `fieldConfigs` referencing `band` + `growth_rate` → now binds (HTTP 200) instead of 400.

Fixes Redmine #75420.