### PR TITLE
Worksheet agent pairing — runtime-join foundation (Phase 1, off by default)

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
+++ b/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
@@ -590,6 +590,8 @@ public abstract class WorksheetEngine extends SheetLibraryEngine implements Work
     * fetches the shared runtime the same way getSheet() does, but WITHOUT the
     * per-session SRPrincipal {@code rs.matches(user)} check, so a second login session
     * of the same logical user can join the open runtime. It does NOT relax getSheet().
+    * Like getSheet(id, user, true), it also refreshes the runtime's access time/heartbeat
+    * so the shared runtime is not reaped out from under the paired agent mid-edit.
     *
     * @param runtimeId the runtime worksheet id.
     * @param agentUser the agent (paired) user principal, used only for error reporting.
@@ -605,6 +607,16 @@ public abstract class WorksheetEngine extends SheetLibraryEngine implements Work
       if(!(rs instanceof RuntimeWorksheet)) {
          throw new ExpiredSheetException(runtimeId, agentUser);
       }
+
+      // refresh the access time/heartbeat so the shared runtime is not reaped while the
+      // paired agent is editing it (mirrors what getSheet(..., touch=true) ultimately does
+      // via accessSheet -> rs.access(true)).
+      rs.access(true);
+
+      // audit the pairing bypass so any future unintended caller of this path is visible in
+      // the trail. Never log the pairing code (this method does not receive it).
+      LOG.info("Worksheet pairing access granted (runtime={}, agent={})",
+               runtimeId, agentUser == null ? "?" : agentUser.getName());
 
       return (RuntimeWorksheet) rs;
    }

--- a/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
+++ b/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
@@ -583,6 +583,32 @@ public abstract class WorksheetEngine extends SheetLibraryEngine implements Work
       return rs;
    }
 
+   /**
+    * Pairing-authorized access to a runtime worksheet. The caller
+    * (WorksheetJoinService) must have verified the agent is the same logical user as
+    * the runtime owner via a valid, single-use pairing grant. This intentionally
+    * fetches the shared runtime the same way getSheet() does, but WITHOUT the
+    * per-session SRPrincipal {@code rs.matches(user)} check, so a second login session
+    * of the same logical user can join the open runtime. It does NOT relax getSheet().
+    *
+    * @param runtimeId the runtime worksheet id.
+    * @param agentUser the agent (paired) user principal, used only for error reporting.
+    * @return the shared runtime worksheet.
+    */
+   public RuntimeWorksheet getWorksheetForPairing(String runtimeId, Principal agentUser) {
+      if(!isLocal(runtimeId)) {
+         LOG.error("Getting sheet from non-owner: {}", runtimeId, new Exception("Stack trace"));
+      }
+
+      RuntimeSheet rs = amap.get(runtimeId);
+
+      if(!(rs instanceof RuntimeWorksheet)) {
+         throw new ExpiredSheetException(runtimeId, agentUser);
+      }
+
+      return (RuntimeWorksheet) rs;
+   }
+
    @Override
    public boolean sheetExists(String id) {
       return amap.containsKey(id);

--- a/core/src/main/java/inetsoft/web/composer/ws/assembly/WorksheetEventService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/assembly/WorksheetEventService.java
@@ -67,6 +67,12 @@ public class WorksheetEventService {
                                CommandDispatcher commandDispatcher) throws Exception
    {
       RuntimeWorksheet rws = engine.getWorksheet(id, user);
+      recordSocketSession(rws, commandDispatcher.getSessionId());
+
+      if(rws != null) {
+         rws.setSocketUserName(commandDispatcher.getUserName());
+      }
+
       fixWorksheetMode(rws);
       clearGettingStatedRuntimeWs(rws, gettingStartedCreateQuery);
 
@@ -162,6 +168,13 @@ public class WorksheetEventService {
       }
 
       return id;
+   }
+
+   /** Record the browser's STOMP session on the worksheet runtime so refresh commands can target it. */
+   static void recordSocketSession(RuntimeWorksheet rws, String socketSessionId) {
+      if(rws != null && socketSessionId != null) {
+         rws.setSocketSessionId(socketSessionId);
+      }
    }
 
    private static void clearGettingStatedRuntimeWs(RuntimeWorksheet rws,

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/PairingException.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/PairingException.java
@@ -1,0 +1,5 @@
+package inetsoft.web.wiz.worksheet;
+
+public class PairingException extends Exception {
+   public PairingException(String message) { super(message); }
+}

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/PairingException.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/PairingException.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package inetsoft.web.wiz.worksheet;
 
 public class PairingException extends Exception {

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/PairingGrant.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/PairingGrant.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package inetsoft.web.wiz.worksheet;
 
 /** A single-use authorization binding an agent pairing code to an open worksheet runtime. */

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/PairingGrant.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/PairingGrant.java
@@ -1,0 +1,10 @@
+package inetsoft.web.wiz.worksheet;
+
+/** A single-use authorization binding an agent pairing code to an open worksheet runtime. */
+public record PairingGrant(String code, String runtimeId, String ownerIdentity,
+                           String socketSessionId, long createdAt, long ttlMillis)
+{
+   public boolean isExpired(long now) {
+      return now - createdAt > ttlMillis;
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentBroadcastService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentBroadcastService.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.worksheet;
+
+import inetsoft.report.composition.RuntimeWorksheet;
+import inetsoft.web.composer.ws.command.RefreshWorksheetCommand;
+import inetsoft.web.viewsheet.service.CommandDispatcher;
+import inetsoft.web.viewsheet.service.CommandDispatcherService;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+
+@Service
+public class WorksheetAgentBroadcastService {
+   private final CommandDispatcherService dispatcher;
+
+   public WorksheetAgentBroadcastService(CommandDispatcherService dispatcher) {
+      this.dispatcher = dispatcher;
+   }
+
+   /** Push a refresh to the browser that owns this runtime so its open composer re-renders. */
+   public void broadcastRefresh(RuntimeWorksheet rws, String runtimeId, Principal owner) {
+      String sessionId = rws.getSocketSessionId();
+
+      if(sessionId == null) {
+         return;   // browser not attached; nothing to refresh
+      }
+
+      // Mirror SharedFilterService: target the owner's STOMP session with a runtime-id
+      // header. Intentionally OMIT inetsoftClientId so the Angular client treats the frame
+      // as a broadcast and re-renders.
+      SimpMessageHeaderAccessor headers = SimpMessageHeaderAccessor.create();
+      headers.setSessionId(sessionId);
+      headers.setLeaveMutable(true);
+      headers.setNativeHeader(CommandDispatcher.RUNTIME_ID_ATTR, runtimeId);
+
+      dispatcher.convertAndSendToUser(owner.getName(), CommandDispatcher.COMMANDS_TOPIC,
+                                      RefreshWorksheetCommand.builder().build(),
+                                      headers.getMessageHeaders());
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentBroadcastService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentBroadcastService.java
@@ -50,7 +50,12 @@ public class WorksheetAgentBroadcastService {
       headers.setLeaveMutable(true);
       headers.setNativeHeader(CommandDispatcher.RUNTIME_ID_ATTR, runtimeId);
 
-      dispatcher.convertAndSendToUser(owner.getName(), CommandDispatcher.COMMANDS_TOPIC,
+      // The browser that must re-render is a DIFFERENT login session than the agent
+      // principal; route to the runtime's recorded socket user (set on open), falling
+      // back to the agent owner's name when unknown. Mirrors SharedFilterService.
+      String user = rws.getSocketUserName() != null ? rws.getSocketUserName() : owner.getName();
+
+      dispatcher.convertAndSendToUser(user, CommandDispatcher.COMMANDS_TOPIC,
                                       RefreshWorksheetCommand.builder().build(),
                                       headers.getMessageHeaders());
    }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentEditService.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package inetsoft.web.wiz.worksheet;
 
 import inetsoft.report.composition.RuntimeWorksheet;

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentEditService.java
@@ -1,0 +1,55 @@
+package inetsoft.web.wiz.worksheet;
+
+import inetsoft.report.composition.RuntimeWorksheet;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.TableAssembly;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.DataRef;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+
+/**
+ * End-to-end agent edit: join a paired runtime worksheet, apply one concrete
+ * mutation, and broadcast a refresh to the browser. This proves the
+ * join -> mutate -> broadcast loop; the full mutator set is a later plan.
+ */
+@Service
+public class WorksheetAgentEditService {
+   private final WorksheetJoinService join;
+   private final WorksheetAgentBroadcastService broadcast;
+
+   public WorksheetAgentEditService(WorksheetJoinService join,
+                                    WorksheetAgentBroadcastService broadcast)
+   {
+      this.join = join;
+      this.broadcast = broadcast;
+   }
+
+   /**
+    * Remove a column from a named table assembly in the shared runtime
+    * worksheet, then broadcast a refresh.
+    */
+   public void removeColumn(String code, Principal agent, String tableName, String column)
+      throws PairingException
+   {
+      RuntimeWorksheet rws = join.join(code, agent);
+      Worksheet ws = rws.getWorksheet();
+      Assembly a = ws.getAssembly(tableName);
+
+      if(!(a instanceof TableAssembly t)) {
+         throw new IllegalArgumentException("No table assembly named " + tableName);
+      }
+
+      ColumnSelection cs = t.getColumnSelection(false);
+      DataRef ref = cs.getAttribute(column);
+
+      if(ref != null) {
+         cs.removeAttribute(ref);
+         t.setColumnSelection(cs, false);
+      }
+
+      broadcast.broadcastRefresh(rws, t.getName(), agent);
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentFeature.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentFeature.java
@@ -1,0 +1,14 @@
+package inetsoft.web.wiz.worksheet;
+
+import inetsoft.sree.SreeEnv;
+import org.springframework.stereotype.Component;
+
+/** Off-by-default gate for the worksheet agent pairing capability. */
+@Component
+public class WorksheetAgentFeature {
+   public static final String FLAG = "worksheet.agent.pairing.enabled";
+
+   public boolean isEnabled() {
+      return SreeEnv.getBooleanProperty(FLAG);   // false unless an admin sets it true
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentFeature.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentFeature.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package inetsoft.web.wiz.worksheet;
 
 import inetsoft.sree.SreeEnv;

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetJoinService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetJoinService.java
@@ -1,0 +1,62 @@
+package inetsoft.web.wiz.worksheet;
+
+import inetsoft.report.composition.RuntimeWorksheet;
+import inetsoft.report.composition.WorksheetEngine;
+import inetsoft.sree.security.IdentityID;
+import inetsoft.uql.XPrincipal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import java.security.Principal;
+
+@Service
+public class WorksheetJoinService {
+   private static final Logger LOG = LoggerFactory.getLogger(WorksheetJoinService.class);
+   private final WorksheetPairingService pairing;
+   private final WorksheetEngine engine;
+   private final WorksheetAgentFeature feature;
+
+   public WorksheetJoinService(WorksheetPairingService pairing, WorksheetEngine engine,
+                               WorksheetAgentFeature feature)
+   {
+      this.pairing = pairing;
+      this.engine = engine;
+      this.feature = feature;
+   }
+
+   /** Validate flag + code + same-logical-user, consume it, return the shared runtime. */
+   public RuntimeWorksheet join(String code, Principal agentUser) throws PairingException {
+      if(!feature.isEnabled()) {
+         LOG.warn("Worksheet agent pairing join rejected: feature disabled (user={})",
+                  agentUser == null ? "?" : agentUser.getName());
+         throw new PairingException("Worksheet agent pairing is disabled");
+      }
+
+      PairingGrant grant = pairing.consume(code);
+
+      if(grant == null) {
+         LOG.warn("Worksheet agent pairing join rejected: invalid/expired code (user={})",
+                  agentUser == null ? "?" : agentUser.getName());
+         throw new PairingException("Invalid or expired pairing code");
+      }
+
+      if(!sameLogicalUser(grant.ownerIdentity(), agentUser)) {
+         LOG.warn("Worksheet agent pairing join rejected: user mismatch (owner={}, agent={})",
+                  grant.ownerIdentity(), agentUser == null ? "?" : agentUser.getName());
+         throw new PairingException("Pairing code does not belong to this user");
+      }
+
+      LOG.info("Worksheet agent pairing join granted (runtime={}, user={})",
+               grant.runtimeId(), agentUser.getName());
+      return engine.getWorksheetForPairing(grant.runtimeId(), agentUser);
+   }
+
+   private boolean sameLogicalUser(String ownerIdentity, Principal agentUser) {
+      if(!(agentUser instanceof XPrincipal p)) {
+         return false;
+      }
+
+      IdentityID agentId = IdentityID.getIdentityIDFromKey(p.getName());
+      return ownerIdentity.equals(agentId == null ? p.getName() : agentId.convertToKey());
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetJoinService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetJoinService.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package inetsoft.web.wiz.worksheet;
 
 import inetsoft.report.composition.RuntimeWorksheet;

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetPairingController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetPairingController.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package inetsoft.web.wiz.worksheet;
 
 import inetsoft.sree.security.IdentityID;

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetPairingController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetPairingController.java
@@ -1,0 +1,38 @@
+package inetsoft.web.wiz.worksheet;
+
+import inetsoft.sree.security.IdentityID;
+import inetsoft.uql.XPrincipal;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+import java.security.Principal;
+
+@RestController
+public class WorksheetPairingController {
+   private final WorksheetPairingService pairing;
+   private final WorksheetAgentFeature feature;
+
+   public WorksheetPairingController(WorksheetPairingService pairing,
+                                     WorksheetAgentFeature feature)
+   {
+      this.pairing = pairing;
+      this.feature = feature;
+   }
+
+   /** Browser mints a code for its open runtime. socketSessionId comes from its STOMP session. */
+   public record MintResponse(String code) {}
+
+   @PostMapping("/api/wiz/worksheet/pairing/mint")
+   public MintResponse mint(@RequestParam String runtimeId,
+                            @RequestParam String socketSessionId,
+                            Principal owner)
+   {
+      if(!feature.isEnabled()) {
+         throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Worksheet agent pairing is disabled");
+      }
+      String ownerId = owner instanceof XPrincipal
+         ? IdentityID.getIdentityIDFromKey(owner.getName()).convertToKey()
+         : owner.getName();
+      return new MintResponse(pairing.mint(runtimeId, ownerId, socketSessionId));
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetPairingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetPairingService.java
@@ -1,0 +1,45 @@
+package inetsoft.web.wiz.worksheet;
+
+import org.springframework.stereotype.Service;
+import java.security.SecureRandom;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
+
+/** Mints and validates single-use, short-TTL pairing codes binding an agent to an open runtime. */
+@Service
+public class WorksheetPairingService {
+   public static final long TTL_MILLIS = 5 * 60_000L;   // 5 minutes
+   private static final char[] ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789".toCharArray();
+
+   private final ConcurrentHashMap<String, PairingGrant> grants = new ConcurrentHashMap<>();
+   private final SecureRandom random = new SecureRandom();
+   private final LongSupplier clock;
+
+   public WorksheetPairingService() { this(System::currentTimeMillis); }
+   WorksheetPairingService(LongSupplier clock) { this.clock = clock; }
+
+   public String mint(String runtimeId, String ownerIdentity, String socketSessionId) {
+      String code = newCode();
+      grants.put(code, new PairingGrant(code, runtimeId, ownerIdentity, socketSessionId,
+                                        clock.getAsLong(), TTL_MILLIS));
+      return code;
+   }
+
+   /** Non-destructive lookup. Returns null if absent or expired. */
+   public PairingGrant peek(String code) {
+      PairingGrant g = grants.get(code);
+      return (g == null || g.isExpired(clock.getAsLong())) ? null : g;
+   }
+
+   /** Single-use: removes and returns the grant, or null if absent/expired. */
+   public PairingGrant consume(String code) {
+      PairingGrant g = grants.remove(code);
+      return (g == null || g.isExpired(clock.getAsLong())) ? null : g;
+   }
+
+   private String newCode() {
+      StringBuilder sb = new StringBuilder(8);
+      for(int i = 0; i < 8; i++) sb.append(ALPHABET[random.nextInt(ALPHABET.length)]);
+      return sb.toString();
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetPairingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetPairingService.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package inetsoft.web.wiz.worksheet;
 
 import org.springframework.stereotype.Service;

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetPairingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetPairingService.java
@@ -27,12 +27,20 @@ public class WorksheetPairingService {
 
    /** Non-destructive lookup. Returns null if absent or expired. */
    public PairingGrant peek(String code) {
+      if(code == null) {
+         return null;
+      }
+
       PairingGrant g = grants.get(code);
       return (g == null || g.isExpired(clock.getAsLong())) ? null : g;
    }
 
    /** Single-use: removes and returns the grant, or null if absent/expired. */
    public PairingGrant consume(String code) {
+      if(code == null) {
+         return null;
+      }
+
       PairingGrant g = grants.remove(code);
       return (g == null || g.isExpired(clock.getAsLong())) ? null : g;
    }

--- a/core/src/test/java/inetsoft/web/composer/ws/assembly/WorksheetEventServiceSocketSessionTest.java
+++ b/core/src/test/java/inetsoft/web/composer/ws/assembly/WorksheetEventServiceSocketSessionTest.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.composer.ws.assembly;
+
+import inetsoft.report.composition.RuntimeWorksheet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class WorksheetEventServiceSocketSessionTest {
+   @Test
+   void recordSocketSessionSetsItOnRuntime() {
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      WorksheetEventService.recordSocketSession(rws, "stomp-session-42");
+      verify(rws).setSocketSessionId("stomp-session-42");
+   }
+
+   @Test
+   void recordSocketSessionTolerantOfNulls() {
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      WorksheetEventService.recordSocketSession(rws, null);   // must not throw, must not call setter
+      WorksheetEventService.recordSocketSession(null, "x");   // must not throw
+      verify(rws, never()).setSocketSessionId(any());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/PairingGrantTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/PairingGrantTest.java
@@ -1,0 +1,20 @@
+package inetsoft.web.wiz.worksheet;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class PairingGrantTest {
+   @Test
+   void exposesBoundFieldsAndExpiry() {
+      PairingGrant g = new PairingGrant(
+         "ABC123", "Worksheet/foo-7", "alice~;~host-org", "stomp-sess-1", 1000L, 60_000L);
+      assertEquals("ABC123", g.code());
+      assertEquals("Worksheet/foo-7", g.runtimeId());
+      assertEquals("alice~;~host-org", g.ownerIdentity());
+      assertEquals("stomp-sess-1", g.socketSessionId());
+      assertFalse(g.isExpired(1000L + 59_999L));
+      assertTrue(g.isExpired(1000L + 60_001L));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/PairingGrantTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/PairingGrantTest.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package inetsoft.web.wiz.worksheet;
 
 import org.junit.jupiter.api.Tag;

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/TestPrincipals.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/TestPrincipals.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package inetsoft.web.wiz.worksheet;
 
 import inetsoft.sree.security.IdentityID;

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/TestPrincipals.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/TestPrincipals.java
@@ -1,0 +1,12 @@
+package inetsoft.web.wiz.worksheet;
+
+import inetsoft.sree.security.IdentityID;
+import inetsoft.sree.security.SRPrincipal;
+import java.security.Principal;
+
+final class TestPrincipals {
+   static Principal user(String name, String org) {
+      return new SRPrincipal(new IdentityID(name, org), new IdentityID[0], new String[0], org,
+                             System.nanoTime());   // distinct secureID -> distinct session
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/TestWorksheets.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/TestWorksheets.java
@@ -1,0 +1,33 @@
+package inetsoft.web.wiz.worksheet;
+
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.asset.BoundTableAssembly;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.TableAssembly;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.AttributeRef;
+
+/**
+ * Test fixtures for building concrete worksheets with table assemblies.
+ */
+final class TestWorksheets {
+   private TestWorksheets() {
+   }
+
+   /**
+    * Build a concrete table assembly named {@code name} whose column selection
+    * contains one {@link ColumnRef} per supplied column name. The caller is
+    * responsible for adding it to the worksheet via {@code ws.addAssembly(...)}.
+    */
+   static TableAssembly tableWithColumns(Worksheet ws, String name, String... cols) {
+      BoundTableAssembly table = new BoundTableAssembly(ws, name);
+      ColumnSelection columns = new ColumnSelection();
+
+      for(String col : cols) {
+         columns.addAttribute(new ColumnRef(new AttributeRef(null, col)));
+      }
+
+      table.setColumnSelection(columns, false);
+      return table;
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/TestWorksheets.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/TestWorksheets.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package inetsoft.web.wiz.worksheet;
 
 import inetsoft.uql.ColumnSelection;

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentBroadcastServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentBroadcastServiceTest.java
@@ -66,6 +66,7 @@ class WorksheetAgentBroadcastServiceTest {
 
       RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
       when(rws.getSocketSessionId()).thenReturn("stomp-1");
+      when(rws.getSocketUserName()).thenReturn("browser-user");
       Principal owner = TestPrincipals.user("alice", "host-org");
 
       svc.broadcastRefresh(rws, "Worksheet/foo-7", owner);
@@ -73,7 +74,31 @@ class WorksheetAgentBroadcastServiceTest {
       @SuppressWarnings("unchecked")
       ArgumentCaptor<Map<String, Object>> headers =
          ArgumentCaptor.forClass(Map.class);
-      verify(dispatcher).convertAndSendToUser(eq(owner.getName()), eq("/commands"), any(),
+      // Must target the browser's recorded socket user, NOT the agent owner's name.
+      verify(dispatcher).convertAndSendToUser(eq("browser-user"), eq("/commands"), any(),
+                                              headers.capture());
+      assertEquals("stomp-1", SimpMessageHeaderAccessor.getSessionId(headers.getValue()));
+      assertNull(headers.getValue().get("inetsoftClientId"),
+                 "broadcast must omit inetsoftClientId so the browser accepts it");
+   }
+
+   @Test
+   void fallsBackToOwnerWhenNoSocketUser() {
+      CommandDispatcherService dispatcher = mock(CommandDispatcherService.class);
+      WorksheetAgentBroadcastService svc = new WorksheetAgentBroadcastService(dispatcher);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getSocketSessionId()).thenReturn("stomp-1");
+      when(rws.getSocketUserName()).thenReturn(null);
+      Principal owner = TestPrincipals.user("alice", "host-org");
+
+      svc.broadcastRefresh(rws, "Worksheet/foo-7", owner);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> headers =
+         ArgumentCaptor.forClass(Map.class);
+      // No recorded socket user -> fall back to the agent owner's name.
+      verify(dispatcher).convertAndSendToUser(eq("alice~;~host-org"), eq("/commands"), any(),
                                               headers.capture());
       assertEquals("stomp-1", SimpMessageHeaderAccessor.getSessionId(headers.getValue()));
       assertNull(headers.getValue().get("inetsoftClientId"),

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentBroadcastServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentBroadcastServiceTest.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.worksheet;
+
+import inetsoft.report.composition.RuntimeWorksheet;
+import inetsoft.util.ConfigurationContext;
+import inetsoft.util.DataCacheSweeper;
+import inetsoft.uql.util.XSessionService;
+import inetsoft.web.viewsheet.service.CommandDispatcherService;
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+
+import java.security.Principal;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class WorksheetAgentBroadcastServiceTest {
+   // Building an SRPrincipal (via TestPrincipals.user) resolves an XSessionService Spring
+   // bean; a minimal application context supplying it must be present.
+   private static GenericApplicationContext appContext;
+
+   @BeforeAll
+   static void initContext() {
+      appContext = new GenericApplicationContext();
+      appContext.getBeanFactory().registerSingleton(
+         "dataCacheSweeper", mock(DataCacheSweeper.class));
+      appContext.getBeanFactory().registerSingleton(
+         "xSessionService", new XSessionService());
+      appContext.refresh();
+      ConfigurationContext.getContext().setApplicationContext(appContext);
+   }
+
+   @AfterAll
+   static void tearDownContext() {
+      ConfigurationContext.getContext().setApplicationContext(null);
+
+      if(appContext != null) {
+         appContext.close();
+      }
+   }
+
+   @Test
+   void broadcastsRefreshToOwnerSocketSessionWithoutClientId() {
+      CommandDispatcherService dispatcher = mock(CommandDispatcherService.class);
+      WorksheetAgentBroadcastService svc = new WorksheetAgentBroadcastService(dispatcher);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getSocketSessionId()).thenReturn("stomp-1");
+      Principal owner = TestPrincipals.user("alice", "host-org");
+
+      svc.broadcastRefresh(rws, "Worksheet/foo-7", owner);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> headers =
+         ArgumentCaptor.forClass(Map.class);
+      verify(dispatcher).convertAndSendToUser(eq(owner.getName()), eq("/commands"), any(),
+                                              headers.capture());
+      assertEquals("stomp-1", SimpMessageHeaderAccessor.getSessionId(headers.getValue()));
+      assertNull(headers.getValue().get("inetsoftClientId"),
+                 "broadcast must omit inetsoftClientId so the browser accepts it");
+   }
+
+   @Test
+   void noBroadcastWhenNoSocketSession() {
+      CommandDispatcherService dispatcher = mock(CommandDispatcherService.class);
+      WorksheetAgentBroadcastService svc = new WorksheetAgentBroadcastService(dispatcher);
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getSocketSessionId()).thenReturn(null);
+      svc.broadcastRefresh(rws, "Worksheet/foo-7", TestPrincipals.user("alice", "host-org"));
+      verifyNoInteractions(dispatcher);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentEditServiceTest.java
@@ -1,0 +1,84 @@
+package inetsoft.web.wiz.worksheet;
+
+import inetsoft.report.composition.RuntimeWorksheet;
+import inetsoft.sree.PropertiesEngine;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.asset.TableAssembly;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.util.XSessionService;
+import inetsoft.util.ConfigurationContext;
+import inetsoft.util.DataCacheSweeper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.GenericApplicationContext;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Tag("core")
+class WorksheetAgentEditServiceTest {
+   // new Worksheet() builds a WorksheetInfo which reads SreeEnv (a PropertiesEngine
+   // Spring bean); building an SRPrincipal resolves an XSessionService bean; Mockito's
+   // inline mock maker forces WorksheetEngine static init which resolves DataCacheSweeper.
+   // A minimal application context supplying all three must be present first.
+   private static GenericApplicationContext appContext;
+
+   @BeforeAll
+   static void initContext() {
+      PropertiesEngine props = mock(PropertiesEngine.class);
+      when(props.getProperty(anyString(), anyBoolean())).thenReturn("");
+      when(props.getProperty(anyString())).thenReturn("");
+
+      appContext = new GenericApplicationContext();
+      appContext.getBeanFactory().registerSingleton("propertiesEngine", props);
+      appContext.getBeanFactory().registerSingleton(
+         "dataCacheSweeper", mock(DataCacheSweeper.class));
+      appContext.getBeanFactory().registerSingleton(
+         "xSessionService", new XSessionService());
+      appContext.refresh();
+      ConfigurationContext.getContext().setApplicationContext(appContext);
+   }
+
+   @AfterAll
+   static void tearDownContext() {
+      ConfigurationContext.getContext().setApplicationContext(null);
+
+      if(appContext != null) {
+         appContext.close();
+      }
+   }
+
+   @Test
+   void removeColumnMutatesSharedRuntimeAndBroadcasts() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a", "b");
+      ws.addAssembly(t);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      WorksheetJoinService join = mock(WorksheetJoinService.class);
+      WorksheetAgentBroadcastService broadcast = mock(WorksheetAgentBroadcastService.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      when(join.join("CODE", agent)).thenReturn(rws);
+
+      WorksheetAgentEditService svc = new WorksheetAgentEditService(join, broadcast);
+      svc.removeColumn("CODE", agent, "T", "a");
+
+      ColumnSelection cs = t.getColumnSelection(false);
+      assertNull(cs.getAttribute("a"), "column a removed");
+      assertNotNull(cs.getAttribute("b"), "column b kept");
+      verify(broadcast).broadcastRefresh(eq(rws), any(), eq(agent));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentEditServiceTest.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package inetsoft.web.wiz.worksheet;
 
 import inetsoft.report.composition.RuntimeWorksheet;

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetJoinServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetJoinServiceTest.java
@@ -90,6 +90,17 @@ class WorksheetJoinServiceTest {
    }
 
    @Test
+   void nullCodeIsRejected() {
+      assertThrows(PairingException.class, () -> join.join(null, agent("alice", "host-org")));
+   }
+
+   @Test
+   void nullAgentIsRejected() {
+      String code = pairing.mint("Worksheet/foo-7", new IdentityID("alice", "host-org").convertToKey(), "stomp-1");
+      assertThrows(PairingException.class, () -> join.join(code, null));
+   }
+
+   @Test
    void featureFlagOffRejectsJoinAndDoesNotConsumeCode() {
       when(feature.isEnabled()).thenReturn(false);
       String code = pairing.mint("Worksheet/foo-7", new IdentityID("alice", "host-org").convertToKey(), "stomp-1");

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetJoinServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetJoinServiceTest.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package inetsoft.web.wiz.worksheet;
 
 import inetsoft.report.composition.RuntimeWorksheet;

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetJoinServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetJoinServiceTest.java
@@ -1,0 +1,100 @@
+package inetsoft.web.wiz.worksheet;
+
+import inetsoft.report.composition.RuntimeWorksheet;
+import inetsoft.report.composition.WorksheetEngine;
+import inetsoft.sree.security.IdentityID;
+import inetsoft.uql.util.XSessionService;
+import inetsoft.util.ConfigurationContext;
+import inetsoft.util.DataCacheSweeper;
+import org.junit.jupiter.api.*;
+import org.springframework.context.support.GenericApplicationContext;
+import java.security.Principal;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class WorksheetJoinServiceTest {
+   // WorksheetEngine's static initializer creates a DataCache, which resolves a
+   // DataCacheSweeper Spring bean at class-init time (Mockito's inline mock maker forces
+   // that initialization). Building an SRPrincipal also resolves an XSessionService bean.
+   // A minimal application context supplying both must be present before either class is
+   // touched.
+   private static GenericApplicationContext appContext;
+
+   @BeforeAll
+   static void initContext() {
+      appContext = new GenericApplicationContext();
+      appContext.getBeanFactory().registerSingleton(
+         "dataCacheSweeper", mock(DataCacheSweeper.class));
+      appContext.getBeanFactory().registerSingleton(
+         "xSessionService", new XSessionService());
+      appContext.refresh();
+      ConfigurationContext.getContext().setApplicationContext(appContext);
+   }
+
+   @AfterAll
+   static void tearDownContext() {
+      ConfigurationContext.getContext().setApplicationContext(null);
+
+      if(appContext != null) {
+         appContext.close();
+      }
+   }
+
+   private WorksheetPairingService pairing;
+   private WorksheetEngine engine;
+   private WorksheetAgentFeature feature;
+   private WorksheetJoinService join;
+   private RuntimeWorksheet rws;
+
+   @BeforeEach
+   void setUp() {
+      pairing = new WorksheetPairingService();
+      engine = mock(WorksheetEngine.class);
+      feature = mock(WorksheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);   // flag ON for happy-path tests
+      rws = mock(RuntimeWorksheet.class);
+      join = new WorksheetJoinService(pairing, engine, feature);
+   }
+
+   private Principal agent(String name, String org) {
+      return TestPrincipals.user(name, org);   // same name+org, fresh secureID each call
+   }
+
+   @Test
+   void validCodeSameLogicalUserGrantsRuntime() throws Exception {
+      when(engine.getWorksheetForPairing(eq("Worksheet/foo-7"), any())).thenReturn(rws);
+      String code = pairing.mint("Worksheet/foo-7", new IdentityID("alice", "host-org").convertToKey(), "stomp-1");
+      RuntimeWorksheet result = join.join(code, agent("alice", "host-org"));
+      assertSame(rws, result);
+   }
+
+   @Test
+   void wrongCodeIsRejected() {
+      assertThrows(PairingException.class, () -> join.join("NOPE", agent("alice", "host-org")));
+   }
+
+   @Test
+   void differentLogicalUserIsRejected() {
+      String code = pairing.mint("Worksheet/foo-7", new IdentityID("alice", "host-org").convertToKey(), "stomp-1");
+      assertThrows(PairingException.class, () -> join.join(code, agent("bob", "host-org")));
+   }
+
+   @Test
+   void codeIsConsumedAfterSuccessfulJoin() throws Exception {
+      when(engine.getWorksheetForPairing(any(), any())).thenReturn(rws);
+      String code = pairing.mint("Worksheet/foo-7", new IdentityID("alice", "host-org").convertToKey(), "stomp-1");
+      join.join(code, agent("alice", "host-org"));
+      assertThrows(PairingException.class, () -> join.join(code, agent("alice", "host-org")),
+                   "code must be single-use even on success");
+   }
+
+   @Test
+   void featureFlagOffRejectsJoinAndDoesNotConsumeCode() {
+      when(feature.isEnabled()).thenReturn(false);
+      String code = pairing.mint("Worksheet/foo-7", new IdentityID("alice", "host-org").convertToKey(), "stomp-1");
+      assertThrows(PairingException.class, () -> join.join(code, agent("alice", "host-org")));
+      assertNotNull(pairing.peek(code), "join must short-circuit before consuming the code when disabled");
+      verifyNoInteractions(engine);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetPairingControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetPairingControllerTest.java
@@ -1,0 +1,69 @@
+package inetsoft.web.wiz.worksheet;
+
+import inetsoft.uql.util.XSessionService;
+import inetsoft.util.ConfigurationContext;
+import inetsoft.util.DataCacheSweeper;
+import org.junit.jupiter.api.*;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.web.server.ResponseStatusException;
+import java.security.Principal;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class WorksheetPairingControllerTest {
+   // WorksheetEngine's static initializer creates a DataCache, which resolves a
+   // DataCacheSweeper Spring bean at class-init time (Mockito's inline mock maker forces
+   // that initialization). Building an SRPrincipal also resolves an XSessionService bean.
+   // A minimal application context supplying both must be present before either class is
+   // touched.
+   private static GenericApplicationContext appContext;
+
+   @BeforeAll
+   static void initContext() {
+      appContext = new GenericApplicationContext();
+      appContext.getBeanFactory().registerSingleton(
+         "dataCacheSweeper", mock(DataCacheSweeper.class));
+      appContext.getBeanFactory().registerSingleton(
+         "xSessionService", new XSessionService());
+      appContext.refresh();
+      ConfigurationContext.getContext().setApplicationContext(appContext);
+   }
+
+   @AfterAll
+   static void tearDownContext() {
+      ConfigurationContext.getContext().setApplicationContext(null);
+
+      if(appContext != null) {
+         appContext.close();
+      }
+   }
+
+   @Test
+   void mintBindsOpenRuntimeToOwnerAndSocketSession() {
+      WorksheetPairingService pairing = new WorksheetPairingService();
+      WorksheetAgentFeature feature = mock(WorksheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+      WorksheetPairingController c = new WorksheetPairingController(pairing, feature);
+      Principal owner = TestPrincipals.user("alice", "host-org");
+
+      String code = c.mint("Worksheet/foo-7", "stomp-1", owner).code();
+
+      PairingGrant g = pairing.peek(code);
+      assertEquals("Worksheet/foo-7", g.runtimeId());
+      assertEquals("alice~;~host-org", g.ownerIdentity());
+      assertEquals("stomp-1", g.socketSessionId());
+   }
+
+   @Test
+   void mintRefusedWhenFeatureOff() {
+      WorksheetPairingService pairing = new WorksheetPairingService();
+      WorksheetAgentFeature feature = mock(WorksheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(false);
+      WorksheetPairingController c = new WorksheetPairingController(pairing, feature);
+      Principal owner = TestPrincipals.user("alice", "host-org");
+
+      assertThrows(ResponseStatusException.class,
+                   () -> c.mint("Worksheet/foo-7", "stomp-1", owner));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetPairingControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetPairingControllerTest.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package inetsoft.web.wiz.worksheet;
 
 import inetsoft.uql.util.XSessionService;

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetPairingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetPairingServiceTest.java
@@ -37,4 +37,10 @@ class WorksheetPairingServiceTest {
       now += WorksheetPairingService.TTL_MILLIS + 1;
       assertNull(svc.consume(code), "expired code must not consume");
    }
+
+   @Test
+   void nullCodeDoesNotThrow() {
+      assertNull(svc.consume(null), "consume(null) must return null, not throw");
+      assertNull(svc.peek(null), "peek(null) must return null, not throw");
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetPairingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetPairingServiceTest.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package inetsoft.web.wiz.worksheet;
 
 import org.junit.jupiter.api.*;

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetPairingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetPairingServiceTest.java
@@ -1,0 +1,40 @@
+package inetsoft.web.wiz.worksheet;
+
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class WorksheetPairingServiceTest {
+   private long now;
+   private WorksheetPairingService svc;
+
+   @BeforeEach
+   void setUp() {
+      now = 1_000_000L;
+      svc = new WorksheetPairingService(() -> now);   // injectable clock
+   }
+
+   @Test
+   void mintProducesLookupableCode() {
+      String code = svc.mint("Worksheet/foo-7", "alice~;~host-org", "stomp-1");
+      assertNotNull(code);
+      PairingGrant g = svc.peek(code);
+      assertEquals("Worksheet/foo-7", g.runtimeId());
+      assertEquals("alice~;~host-org", g.ownerIdentity());
+      assertEquals("stomp-1", g.socketSessionId());
+   }
+
+   @Test
+   void consumeIsSingleUse() {
+      String code = svc.mint("Worksheet/foo-7", "alice~;~host-org", "stomp-1");
+      assertNotNull(svc.consume(code));
+      assertNull(svc.consume(code), "second consume must return null");
+   }
+
+   @Test
+   void expiredCodeIsNotConsumable() {
+      String code = svc.mint("Worksheet/foo-7", "alice~;~host-org", "stomp-1");
+      now += WorksheetPairingService.TTL_MILLIS + 1;
+      assertNull(svc.consume(code), "expired code must not consume");
+   }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the StyleBI worksheet-agent feature: lets a second session of the **same logical user** (a Claude-Code agent) join a worksheet `RuntimeWorksheet` the user already has open in the composer, mutate it, and have the browser re-render live — via a **pairing-token-authorized** path, **off by default**.

This is foundational plumbing: there is **no production caller** of join/edit yet (only the `mint` endpoint is exposed), and the whole capability is gated behind `worksheet.agent.pairing.enabled` (false unless an admin sets it).

## What's included
- **`PairingGrant` + `WorksheetPairingService`** — single-use, 5‑min‑TTL pairing codes (SecureRandom, ambiguity-free alphabet, injectable clock).
- **`WorksheetEngine.getWorksheetForPairing`** — a NEW accessor that fetches the shared runtime and **refreshes its heartbeat via `accessSheet`** (so it isn't reaped mid-edit), deliberately bypassing the per-session `SRPrincipal` check. `getSheet`/`matches` are **untouched**.
- **`WorksheetJoinService`** — authorizes the join only when the feature is enabled, the code is valid (single-use), and the agent is the **same logical user** (`IdentityID` name+org). Audited on every grant/reject; never logs the code.
- **`WorksheetAgentFeature`** — the off-by-default flag, enforced in both the join service and the mint endpoint.
- **`WorksheetEventService`** — records the browser's STOMP `socketSessionId`/user on worksheet open (mirrors the viewsheet path).
- **`WorksheetAgentBroadcastService`** — pushes a `RefreshWorksheetCommand` to the browser's recorded socket **user/session** (mirrors `SharedFilterService`; omits `inetsoftClientId` so the client treats it as a broadcast).
- **`WorksheetAgentEditService`** — end-to-end skeleton (join → remove column → broadcast); the full mutator set is Phase 2/3.
- **`WorksheetPairingController`** — the `mint` endpoint (flag-gated, 403 when off).

## Security posture (locked)
- Trust boundary: **same logical user** (name+org), single-use code, 5‑min TTL, audit log.
- **Off by default** behind `worksheet.agent.pairing.enabled`.
- The session-check bypass (`getWorksheetForPairing`) has a single authorized caller (`WorksheetJoinService`) and an engine-level audit log.
- A StyleBI security owner should review the carve-out before the flag is enabled in any shared deployment.

## Test plan
- [x] 20 unit tests green (`./mvnw -o -pl core test -Dtest='inetsoft.web.wiz.worksheet.*Test' -Dgroups=core`): pairing TTL/single-use, same-/different-user join, feature-off (no code consumed), null-code/null-user rejection, socketSessionId recording, broadcast routing (browser user, no clientId, null-session no-op), end-to-end edit.
- [ ] Manual smoke (deferred to Phase 4 e2e): open a worksheet, mint a code, join as the same user from a second session, edit, confirm the composer re-renders.

## Follow-ups (tracked in the Phase 2 plan)
Cluster-shared pairing store + cache-touch propagation, join-once reusable session, controller null-guard hardening, session-derived `socketSessionId` (remove the spoofable param), server-side recompute of dependents, shared test-harness extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)