### PR TITLE
fix(wiz): backfill ranking into DimensionFieldInfo response DTO

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.service;
 
+import inetsoft.uql.XCondition;
 import inetsoft.uql.XConstants;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.viewsheet.VSAggregateRef;
@@ -95,16 +96,16 @@ final class WizFieldInfoFactory {
    }
 
    private static void applyRanking(DimensionFieldInfo info, VSDimensionRef dim) {
-      String optValue = dim.getRankingOptionValue();
+      int opt = dim.getRankingOption();
 
-      if(optValue != null && !"0".equals(optValue)) {
+      if(opt != XCondition.NONE) {
          Ranking ranking = new Ranking();
-         ranking.setOptionValue(Integer.parseInt(optValue));
+         ranking.setOptionValue(opt);
 
-         String nValue = dim.getRankingNValue();
+         int n = dim.getRankingN();
 
-         if(nValue != null) {
-            ranking.setRankingN(Integer.parseInt(nValue));
+         if(n != 0) {
+            ranking.setRankingN(n);
          }
 
          ranking.setRankingCol(dim.getRankingColValue());

--- a/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
@@ -24,6 +24,7 @@ import inetsoft.uql.viewsheet.VSDimensionRef;
 import inetsoft.web.binding.model.graph.CalculateInfo;
 import inetsoft.web.wiz.model.DimensionFieldInfo;
 import inetsoft.web.wiz.model.MeasureFieldInfo;
+import inetsoft.web.wiz.model.Ranking;
 
 final class WizFieldInfoFactory {
    private WizFieldInfoFactory() {
@@ -33,6 +34,7 @@ final class WizFieldInfoFactory {
       DimensionFieldInfo info = baseDimensionFieldInfo(dim);
       info.setFullName(dim.getFullName());
       applyDateGroup(info, dim);
+      applyRanking(info, dim);
       return info;
    }
 
@@ -40,6 +42,7 @@ final class WizFieldInfoFactory {
       DimensionFieldInfo info = baseDimensionFieldInfo(dim);
       info.setType(dim.getDataType());
       applyDateGroup(info, dim);
+      applyRanking(info, dim);
       return info;
    }
 
@@ -47,6 +50,7 @@ final class WizFieldInfoFactory {
       DimensionFieldInfo info = baseDimensionFieldInfo(dim);
       info.setFullName(dim.getFullName());
       applyDateGroup(info, dim);
+      applyRanking(info, dim);
       return info;
    }
 
@@ -88,6 +92,24 @@ final class WizFieldInfoFactory {
       DimensionFieldInfo info = new DimensionFieldInfo();
       info.setField(dim.getGroupColumnValue());
       return info;
+   }
+
+   private static void applyRanking(DimensionFieldInfo info, VSDimensionRef dim) {
+      String optValue = dim.getRankingOptionValue();
+
+      if(optValue != null && !"0".equals(optValue)) {
+         Ranking ranking = new Ranking();
+         ranking.setOptionValue(Integer.parseInt(optValue));
+
+         String nValue = dim.getRankingNValue();
+
+         if(nValue != null) {
+            ranking.setRankingN(Integer.parseInt(nValue));
+         }
+
+         ranking.setRankingCol(dim.getRankingColValue());
+         info.setRanking(ranking);
+      }
    }
 
    private static void applyDateGroup(DimensionFieldInfo info, VSDimensionRef dim) {


### PR DESCRIPTION
WizFieldInfoFactory omitted ranking when converting VSDimensionRef to DimensionFieldInfo, so binding.dimensions[].ranking was always null in the create_viewsheet response even when ranking had been applied. Add applyRanking() and call it from all three createDimensionFieldInfo variants (generic, crosstab, chart).