### PR TITLE
Bug #75401, prevent browser tab freeze from expiring viewsheet sessions

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
@@ -1195,7 +1195,7 @@ public abstract class RuntimeSheet {
    private String lowner;           // user who locked it
    private boolean isLockProcessed; // unlocked flag
    private boolean disposed;        // disposed flag
-   long heartbeat = System.currentTimeMillis(); // heartbeat timestamp
+   volatile long heartbeat = System.currentTimeMillis(); // heartbeat timestamp
    private Map<String, Object> prop = new HashMap<>();
    private String previousURL;
 

--- a/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
@@ -75,6 +75,35 @@ public abstract class RuntimeSheet {
    }
 
    /**
+    * Get the heartbeat timeout in milliseconds. A runtime sheet is considered
+    * timed out if no heartbeat has been received within this window. Defaults
+    * to 180000 (3 minutes); configurable via the "viewsheet.heartbeat.timeout"
+    * property. Read on each call so it can be retuned without a restart.
+    */
+   public static long getHeartbeatTimeout() {
+      String property = SreeEnv.getProperty("viewsheet.heartbeat.timeout");
+
+      if(property != null) {
+         try {
+            return Math.max(180000L, Long.parseLong(property));
+         }
+         catch(NumberFormatException ex) {
+            LOG.warn("Invalid value for viewsheet.heartbeat.timeout: '{}', using default 180000ms",
+               property);
+         }
+      }
+
+      return 180000;
+   }
+
+   /**
+    * Check whether a heartbeat timestamp is older than the configured timeout.
+    */
+   static boolean isHeartbeatExpired(long heartbeat, long now) {
+      return heartbeat < now - getHeartbeatTimeout();
+   }
+
+   /**
     * Constructor.
     */
    public RuntimeSheet() {
@@ -162,8 +191,8 @@ public abstract class RuntimeSheet {
    public boolean isTimeout() {
       long now = System.currentTimeMillis();
 
-      // timeout if no heartbeat in 3 minutes
-      if(heartbeat < now - 180000) {
+      // timeout if no heartbeat within the configured window (default 3 minutes)
+      if(isHeartbeatExpired(heartbeat, now)) {
          return true;
       }
 

--- a/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeSheet.java
@@ -1195,7 +1195,7 @@ public abstract class RuntimeSheet {
    private String lowner;           // user who locked it
    private boolean isLockProcessed; // unlocked flag
    private boolean disposed;        // disposed flag
-   private long heartbeat = System.currentTimeMillis(); // heartbeat timestamp
+   long heartbeat = System.currentTimeMillis(); // heartbeat timestamp
    private Map<String, Object> prop = new HashMap<>();
    private String previousURL;
 

--- a/core/src/test/java/inetsoft/report/composition/RuntimeSheetTest.java
+++ b/core/src/test/java/inetsoft/report/composition/RuntimeSheetTest.java
@@ -17,12 +17,22 @@
  */
 package inetsoft.report.composition;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.sree.SreeEnv;
-import inetsoft.test.SreeHome;
+import inetsoft.test.*;
+import inetsoft.uql.asset.AbstractSheet;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Tag("core")
 @SreeHome()
 class RuntimeSheetTest {
    private String saved;
@@ -77,5 +87,45 @@ class RuntimeSheetTest {
       SreeEnv.setProperty("viewsheet.heartbeat.timeout", "600000");
       long now = System.currentTimeMillis();
       assertFalse(RuntimeSheet.isHeartbeatExpired(now - 200000, now));
+   }
+
+   @Test
+   void isTimeoutFreshSheetIsNotTimedOut() {
+      assertFalse(newSheet().isTimeout());
+   }
+
+   @Test
+   void isTimeoutReturnsTrueWhenIdleExceeded() {
+      RuntimeSheet sheet = newSheet();
+      sheet.setAccessed(1L);
+      assertTrue(sheet.isTimeout());
+   }
+
+   @Test
+   void isTimeoutReturnsTrueWhenHeartbeatExpired() {
+      RuntimeSheet sheet = newSheet();
+      sheet.heartbeat = 1L;
+      sheet.setAccessed(System.currentTimeMillis());
+      assertTrue(sheet.isTimeout());
+   }
+
+   @Test
+   void isTimeoutReturnsFalseWhenBothFresh() {
+      RuntimeSheet sheet = newSheet();
+      sheet.setAccessed(System.currentTimeMillis());
+      assertFalse(sheet.isTimeout());
+   }
+
+   private static RuntimeSheet newSheet() {
+      return new RuntimeSheet() {
+         @Override public boolean undo(ChangedAssemblyList clist) { return false; }
+         @Override public boolean redo(ChangedAssemblyList clist) { return false; }
+         @Override public void rollback() {}
+         @Override public AbstractSheet getSheet() { return null; }
+         @Override public int getMode() { return 0; }
+         @Override public boolean isRuntime() { return false; }
+         @Override public boolean isPreview() { return false; }
+         @Override RuntimeSheetState saveState(ObjectMapper mapper) { return null; }
+      };
    }
 }

--- a/core/src/test/java/inetsoft/report/composition/RuntimeSheetTest.java
+++ b/core/src/test/java/inetsoft/report/composition/RuntimeSheetTest.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.composition;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SreeHome()
+class RuntimeSheetTest {
+   private String saved;
+
+   @BeforeEach
+   void saveProperty() {
+      saved = SreeEnv.getProperty("viewsheet.heartbeat.timeout");
+      SreeEnv.setProperty("viewsheet.heartbeat.timeout", null);
+   }
+
+   @AfterEach
+   void restoreProperty() {
+      SreeEnv.setProperty("viewsheet.heartbeat.timeout", saved);
+   }
+
+   @Test
+   void defaultsToThreeMinutesWhenUnset() {
+      assertEquals(180000L, RuntimeSheet.getHeartbeatTimeout());
+   }
+
+   @Test
+   void readsConfiguredValue() {
+      SreeEnv.setProperty("viewsheet.heartbeat.timeout", "600000");
+      assertEquals(600000L, RuntimeSheet.getHeartbeatTimeout());
+   }
+
+   @Test
+   void fallsBackToDefaultOnInvalidValue() {
+      SreeEnv.setProperty("viewsheet.heartbeat.timeout", "not-a-number");
+      assertEquals(180000L, RuntimeSheet.getHeartbeatTimeout());
+   }
+
+   @Test
+   void clampsValuesBelowMinimumToThreeMinutes() {
+      SreeEnv.setProperty("viewsheet.heartbeat.timeout", "0");
+      assertEquals(180000L, RuntimeSheet.getHeartbeatTimeout());
+      SreeEnv.setProperty("viewsheet.heartbeat.timeout", "-1");
+      assertEquals(180000L, RuntimeSheet.getHeartbeatTimeout());
+      SreeEnv.setProperty("viewsheet.heartbeat.timeout", "60000");
+      assertEquals(180000L, RuntimeSheet.getHeartbeatTimeout());
+   }
+
+   @Test
+   void heartbeatExpiresWhenOlderThanTimeout() {
+      long now = System.currentTimeMillis();
+      assertFalse(RuntimeSheet.isHeartbeatExpired(now, now));
+      assertTrue(RuntimeSheet.isHeartbeatExpired(now - 200000, now));
+   }
+
+   @Test
+   void raisedTimeoutKeepsOlderHeartbeatAlive() {
+      SreeEnv.setProperty("viewsheet.heartbeat.timeout", "600000");
+      long now = System.currentTimeMillis();
+      assertFalse(RuntimeSheet.isHeartbeatExpired(now - 200000, now));
+   }
+}

--- a/web/projects/portal/src/app/common/services/keep-awake.service.spec.ts
+++ b/web/projects/portal/src/app/common/services/keep-awake.service.spec.ts
@@ -1,0 +1,76 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { TestBed } from "@angular/core/testing";
+import { KeepAwakeService } from "./keep-awake.service";
+
+describe("KeepAwakeService", () => {
+   let service: KeepAwakeService;
+   let requestSpy: ReturnType<typeof vi.fn>;
+
+   beforeEach(() => {
+      TestBed.configureTestingModule({ providers: [KeepAwakeService] });
+      service = TestBed.inject(KeepAwakeService);
+      // jsdom leaves navigator.locks undefined; install a mock for the
+      // positive paths. request() returns a never-settling promise so the
+      // service's .catch() never fires.
+      requestSpy = vi.fn().mockReturnValue(new Promise(() => {}));
+      (navigator as any).locks = { request: requestSpy };
+   });
+
+   afterEach(() => {
+      delete (navigator as any).locks;
+   });
+
+   it("should request a uniquely-named lock when keepAwake is called", () => {
+      service.keepAwake("rt-1");
+      expect(requestSpy).toHaveBeenCalledWith(
+         "viewsheet-keep-awake-rt-1",
+         expect.objectContaining({ signal: expect.anything() }),
+         expect.any(Function));
+   });
+
+   it("should hold the lock until release aborts it", () => {
+      service.keepAwake("rt-1");
+      const signal = requestSpy.mock.calls[0][1].signal;
+      expect(signal.aborted).toBe(false);
+      service.release();
+      expect(signal.aborted).toBe(true);
+   });
+
+   it("should release a prior lock when keepAwake is called again", () => {
+      service.keepAwake("rt-1");
+      const firstSignal = requestSpy.mock.calls[0][1].signal;
+      service.keepAwake("rt-2");
+      expect(firstSignal.aborted).toBe(true);
+      expect(requestSpy).toHaveBeenLastCalledWith(
+         "viewsheet-keep-awake-rt-2", expect.anything(), expect.any(Function));
+   });
+
+   it("should release the lock on destroy", () => {
+      service.keepAwake("rt-1");
+      const signal = requestSpy.mock.calls[0][1].signal;
+      service.ngOnDestroy();
+      expect(signal.aborted).toBe(true);
+   });
+
+   it("should be a no-op when the Web Locks API is unavailable", () => {
+      delete (navigator as any).locks;
+      expect(() => service.keepAwake("rt-1")).not.toThrow();
+   });
+});

--- a/web/projects/portal/src/app/common/services/keep-awake.service.ts
+++ b/web/projects/portal/src/app/common/services/keep-awake.service.ts
@@ -53,7 +53,11 @@ export class KeepAwakeService implements OnDestroy {
          `viewsheet-keep-awake-${id}`,
          { signal: this.abortController.signal },
          () => new Promise<void>(() => { /* held until aborted */ })
-      ).catch(() => { /* request aborted on release — expected */ });
+      ).catch((err: any) => {
+         if(err?.name !== "AbortError") {
+            console.warn("Unexpected Web Locks error:", err);
+         }
+      });
    }
 
    /** Release the held lock, if any. */

--- a/web/projects/portal/src/app/common/services/keep-awake.service.ts
+++ b/web/projects/portal/src/app/common/services/keep-awake.service.ts
@@ -1,0 +1,70 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Injectable, OnDestroy } from "@angular/core";
+
+/**
+ * Keeps the current tab from being frozen/"slept" by Chrome "Energy Saver"
+ * and Edge "Sleeping Tabs" by holding a Web Lock for the lifetime of an open
+ * runtime viewsheet. A held Web Lock is one of the documented conditions under
+ * which Chromium will not freeze a backgrounded tab, so the viewsheet's
+ * heartbeat keeps firing and the server-side session does not expire.
+ *
+ * Note: this exploits a freeze-exemption that Chromium has signalled may be
+ * replaced by a sanctioned opt-out in future. It is isolated here so it can be
+ * removed cleanly. It does NOT prevent Memory Saver tab *discard*, which fully
+ * unloads the page.
+ */
+@Injectable()
+export class KeepAwakeService implements OnDestroy {
+   private abortController: AbortController | null = null;
+
+   /**
+    * Acquire and hold a uniquely-named Web Lock until released. Releases any
+    * previously-held lock first. No-op if the Web Locks API is unavailable
+    * (old browsers / non-secure contexts).
+    */
+   keepAwake(id: string): void {
+      if(typeof navigator === "undefined" || !navigator.locks) {
+         return;
+      }
+
+      this.release();
+      this.abortController = new AbortController();
+
+      // The lock is held for as long as the callback's promise is unsettled;
+      // it never resolves, so the lock is held until the signal is aborted.
+      navigator.locks.request(
+         `viewsheet-keep-awake-${id}`,
+         { signal: this.abortController.signal },
+         () => new Promise<void>(() => { /* held until aborted */ })
+      ).catch(() => { /* request aborted on release — expected */ });
+   }
+
+   /** Release the held lock, if any. */
+   release(): void {
+      if(this.abortController) {
+         this.abortController.abort();
+         this.abortController = null;
+      }
+   }
+
+   ngOnDestroy(): void {
+      this.release();
+   }
+}

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -811,6 +811,7 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
          this.dashboardName : this.assetId, false);
 
       this.debounceService.cancel(this.runtimeId + "_notify_parent_frame");
+      this.keepAwakeService.release();
 
       if(this.inDashboard && window != window.parent) {
          window.parent.postMessage({"dashboardClosed": this.runtimeId}, "*");

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -206,6 +206,7 @@ import { VSUtil } from "./util/vs-util";
 import { VsToolbarButtonDirective } from "./vs-toolbar-button.directive";
 import { BaseHrefService } from "../common/services/base-href.service";
 import { HeartbeatWorkerService } from "../common/services/heartbeat-worker.service";
+import { KeepAwakeService } from "../common/services/keep-awake.service";
 import { CurrentUserService } from "../../../../shared/util/current-user.service";
 import { RemoveBookmarksDialog } from "./dialog/remove-bookmarks-dialog.component";
 import { ShareLinkDialog } from "../widget/share/share-link-dialog.component";
@@ -282,6 +283,7 @@ export interface ScrollViewportRect {
     styleUrls: ["viewer-app.component.scss"],
     providers: [
         ViewsheetClientService,
+        KeepAwakeService,
         DataTipService,
         AdhocFilterService,
         PopComponentService,
@@ -577,7 +579,8 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
                private viewContainerRef: ViewContainerRef,
                private baseHrefService: BaseHrefService,
                private currentUserService: CurrentUserService,
-               private heartbeatWorkerService: HeartbeatWorkerService)
+               private heartbeatWorkerService: HeartbeatWorkerService,
+               private keepAwakeService: KeepAwakeService)
    {
       super(viewsheetClient, zone, true);
       tooltipConfig.tooltipClass = "top-tooltip";
@@ -2257,6 +2260,7 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
 
       this.viewsheetClient.runtimeId = command.runtimeId;
       this.runtimeId = command.runtimeId;
+      this.keepAwakeService.keepAwake(command.runtimeId);
       this.runtimeIdChange.emit(command.runtimeId);
       command.permissions = command.permissions || [];
       command.permissions.push("Toolbar");

--- a/web/projects/portal/src/app/vsobjects/viewer-app.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.spec.ts
@@ -41,6 +41,7 @@ import { AppInfoService } from "../../../../shared/util/app-info.service";
 import { AssetLoadingService } from "../common/services/asset-loading.service";
 import { BaseHrefService } from "../common/services/base-href.service";
 import { HeartbeatWorkerService } from "../common/services/heartbeat-worker.service";
+import { KeepAwakeService } from "../common/services/keep-awake.service";
 import { FirstDayOfWeekService } from "../common/services/first-day-of-week.service";
 import { FullScreenService } from "../common/services/full-screen.service";
 import { PagingControlService } from "../common/services/paging-control.service";
@@ -144,6 +145,7 @@ describe("ViewerApp Unit Tests", () => {
    let viewContainerRef: any;
    let baseHrefService: any;
    let heartbeatWorkerService: any;
+   let keepAwakeService: any;
    let timerService: any;
 
    beforeEach(waitForAsync(() => {
@@ -281,6 +283,10 @@ describe("ViewerApp Unit Tests", () => {
             subscribe: vi.fn().mockReturnValue({ unsubscribe: vi.fn() })
          })
       };
+      keepAwakeService = {
+         keepAwake: vi.fn(),
+         release: vi.fn()
+      };
       timerService = {
          defer: vi.fn((fn) => {
             fn();
@@ -343,6 +349,7 @@ describe("ViewerApp Unit Tests", () => {
             { provide: ViewContainerRef, useValue: viewContainerRef },
             { provide: BaseHrefService, useValue: baseHrefService },
             { provide: HeartbeatWorkerService, useValue: heartbeatWorkerService },
+            { provide: KeepAwakeService, useValue: keepAwakeService },
             AppInfoService,
             { provide: TimerService, useValue: timerService },
          ],
@@ -356,7 +363,8 @@ describe("ViewerApp Unit Tests", () => {
                {provide: AssemblyActionFactory, useValue: actionFactory},
                {provide: ViewsheetClientService, useValue: viewsheetClientService},
                DataTipService,
-               { provide: FullScreenService, useValue: fullScreenService }
+               { provide: FullScreenService, useValue: fullScreenService },
+               KeepAwakeService
             ]
          }
       });
@@ -494,6 +502,35 @@ describe("ViewerApp Unit Tests", () => {
    //   viewer-app.component.risk.tl.spec.ts — Group 5 "closeViewsheet() non-inTabs path"
    //   covers: confirm dialog when form tables exist, close on ok, no-close on cancel,
    //   direct close when checkFormTables returns false.
+
+   it("should keep the tab awake when the runtime id is set", () => {
+      const fixture = TestBed.createComponent(ViewerAppComponent);
+      const comp = fixture.componentInstance;
+      const keepAwakeSpy = vi.spyOn(
+         fixture.debugElement.injector.get(KeepAwakeService), "keepAwake");
+      // isolate the wiring from showBookmarks' HTTP call
+      vi.spyOn(comp as any, "showBookmarks").mockImplementation(() => {});
+
+      comp.processSetRuntimeIdCommand({ runtimeId: "rt-9", permissions: [] } as any);
+
+      expect(keepAwakeSpy).toHaveBeenCalledWith("rt-9");
+   });
+
+   it("should release the keep-awake lock on destroy", () => {
+      const fixture = TestBed.createComponent(ViewerAppComponent);
+      const releaseSpy = vi.spyOn(
+         fixture.debugElement.injector.get(KeepAwakeService), "release");
+      fixture.destroy();
+      expect(releaseSpy).toHaveBeenCalled();
+   });
+
+   it("should use a separate keep-awake instance per viewer-app (multi-tab safe)", () => {
+      const f1 = TestBed.createComponent(ViewerAppComponent);
+      const f2 = TestBed.createComponent(ViewerAppComponent);
+      const s1 = f1.debugElement.injector.get(KeepAwakeService);
+      const s2 = f2.debugElement.injector.get(KeepAwakeService);
+      expect(s1).not.toBe(s2);
+   });
 
    it("should send and receive viewer toolbar window messages", () => new Promise<void>((done) => {
       window["globalPostParams"] = null; // to resolve global var

--- a/web/projects/portal/src/app/vsobjects/viewer-app.test-fixtures.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.test-fixtures.ts
@@ -89,6 +89,7 @@ import { AssetLoadingService } from "../common/services/asset-loading.service";
 import { BaseHrefService } from "../common/services/base-href.service";
 import { CurrentUserService } from "../../../../shared/util/current-user.service";
 import { HeartbeatWorkerService } from "../common/services/heartbeat-worker.service";
+import { KeepAwakeService } from "../common/services/keep-awake.service";
 import { OpenComposerService } from "../common/services/open-composer.service";
 
 // ---------------------------------------------------------------------------
@@ -253,6 +254,11 @@ export const HEARTBEAT_WORKER_SERVICE_MOCK = {
    removeHeartbeat: vi.fn(),
 };
 
+export const KEEP_AWAKE_SERVICE_MOCK = {
+   keepAwake: vi.fn(),
+   release: vi.fn(),
+};
+
 export const CHECK_FORM_DATA_SERVICE_MOCK = {
    checkFormData: vi.fn().mockReturnValue(of(0)),
    removeObject: vi.fn(),
@@ -405,6 +411,7 @@ export async function renderComponent(opts: RenderOptions = {}): Promise<RenderR
          { provide: BaseHrefService, useValue: { getBaseHref: vi.fn().mockReturnValue("/") } },
          { provide: CurrentUserService, useValue: CURRENT_USER_SERVICE_MOCK },
          { provide: HeartbeatWorkerService, useValue: HEARTBEAT_WORKER_SERVICE_MOCK },
+         { provide: KeepAwakeService, useValue: KEEP_AWAKE_SERVICE_MOCK },
          { provide: OpenComposerService, useValue: { composerOpen: NEVER, openComposerWindow: vi.fn() } },
       ],
       importOverrides: [

--- a/web/projects/portal/src/app/vsobjects/viewer-app.test-fixtures.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.test-fixtures.ts
@@ -354,6 +354,9 @@ export function resetMocks(): void {
 
    ASSET_LOADING_SERVICE_MOCK.setLoading.mockClear();
 
+   KEEP_AWAKE_SERVICE_MOCK.keepAwake.mockClear();
+   KEEP_AWAKE_SERVICE_MOCK.release.mockClear();
+
    MessageDialog.lastMessage = null;
    MessageDialog.lastMessageTS = 0;
 }


### PR DESCRIPTION
## Summary

- Add `KeepAwakeService` that holds a Web Lock (`navigator.locks.request`) for the lifetime of an open viewsheet, preventing Chrome Energy Saver and Edge Sleeping Tabs from freezing the tab and starving the heartbeat timer
- Wire `KeepAwakeService` into `ViewerAppComponent`: lock is acquired in `processSetRuntimeIdCommand` and released automatically via Angular DI lifecycle (component-scoped provider, one instance per viewer)
- Extract configurable heartbeat timeout from `RuntimeSheet.isTimeout()` into `getHeartbeatTimeout()` / `isHeartbeatExpired()` helpers; minimum enforced at 3 minutes (matches RecycleTask sweep interval); misconfigured values are logged as warnings

## Test plan

- [ ] `RuntimeSheetTest` — default (3 min), configured value, invalid value, clamping below minimum, expiry logic
- [ ] `KeepAwakeService` spec — lock acquired with correct name, signal aborted on release, prior lock released on re-acquire, destroyed on `ngOnDestroy`, no-op when Web Locks unavailable
- [ ] `viewer-app.spec.ts` — `keepAwake` called with runtimeId on `processSetRuntimeIdCommand`, `release` called on destroy, separate instance per component

🤖 Generated with [Claude Code](https://claude.ai/claude-code)