### PR TITLE
Bug #75418, bar charts should default to rectangular shapes without rounded corners

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/PlotDescriptor.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/PlotDescriptor.java
@@ -1854,8 +1854,7 @@ public class PlotDescriptor implements AssetObject, ContentObject {
    private boolean fillGapWithDash = true;
    private CompositeTextFormat errorFormat;
    private double pieRatio = 0;
-   // By design, new bar charts default to rounded corners; parseXML overrides to 0 for saved charts.
-   private static final double DEFAULT_BAR_CORNER_RADIUS = 0.3;
+   private static final double DEFAULT_BAR_CORNER_RADIUS = 0;
    private double barCornerRadius = DEFAULT_BAR_CORNER_RADIUS;
    private boolean barRoundAllCorners = false;
    private boolean oneLine = false;


### PR DESCRIPTION
## Summary

Cherry-pick of the fix from the main branch (#4023) to v1.1.x.

Bar charts were defaulting to rounded corners (30% radius) when they should default to regular rectangular shapes.

## Root Cause

`PlotDescriptor.DEFAULT_BAR_CORNER_RADIUS` was set to `0.3`, causing every newly created bar chart to initialize with 30% rounded corners on the value end of each bar.

## Fix

Changed `DEFAULT_BAR_CORNER_RADIUS` from `0.3` to `0`. Existing saved charts are unaffected — `parseXML` always reads and restores the explicitly stored `barCornerRadius` attribute value.

## Test Plan

- Create a new bar chart and confirm bars render with rectangular (no rounded) corners by default
- Open an existing chart that previously had rounded corners and confirm it still renders with rounded corners

Community PR (main): https://github.com/inetsoft-technology/stylebi/pull/4023

Fixes Redmine #75418.