### PR TITLE
Bug #75437, null-check resource stream in LocalizationService.getResourceReader

### DIFF
--- a/core/src/main/java/inetsoft/web/service/LocalizationService.java
+++ b/core/src/main/java/inetsoft/web/service/LocalizationService.java
@@ -203,9 +203,14 @@ public class LocalizationService {
       return resource.getURL().openStream();
    }
 
-   public static Reader getResourceReader(String resource) {
-      return new BufferedReader(
-         new InputStreamReader(getResourceStream(resource), StandardCharsets.UTF_8));
+   public static Reader getResourceReader(String resource) throws IOException {
+      InputStream stream = getResourceStream(resource);
+
+      if(stream == null) {
+         throw new FileNotFoundException("Resource not found: " + resource);
+      }
+
+      return new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
    }
 
    private static InputStream getResourceStream(String resource) {


### PR DESCRIPTION
## Summary

- `LocalizationService.getResourceReader(String)` passed the result of `Class.getResourceAsStream()` directly to `new InputStreamReader(...)` without a null check
- When a classpath resource is not found, `getResourceAsStream()` returns `null`, causing a `NullPointerException` in `Reader.<init>` via `InputStreamReader`

## Root Cause

`Class.getResourceAsStream(resource)` returns `null` when the requested resource is not present on the classpath. The non-caching path in `TemplateLocalizationController.getLocalizedResource` (entered when `cache.localized.templates=false`) called `getResourceReader(String)` without any prior existence check, so a missing classpath resource produced an uncaught NPE instead of a proper error response.

## Fix

Added a null check on the stream returned by `getResourceStream(String)` in `LocalizationService.getResourceReader(String)`. If the stream is `null`, a `FileNotFoundException` is thrown (a subtype of `IOException`). Added `throws IOException` to the method signature. The sole caller (`TemplateLocalizationController.getLocalizedResource`) already declares `throws IOException`, so no call-site changes are needed.

## Test Plan

- Build `core` module: `./mvnw clean install -pl core -am -DskipTests` — passes
- Run all `core` unit tests: `./mvnw test -pl core` — 2502 tests pass, 0 failures
- Manually verify that opening a dashboard popup no longer produces a NPE in the logs when `cache.localized.templates=false`

Fixes Redmine #75437.