### PR TITLE
Bug #75433, save embedded VS to repository when HOME bookmark is saved

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
@@ -138,6 +138,7 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
 
          try {
             engine.setViewsheet(vs0, vsEntry0, principal, true, true);
+            saveEmbeddedViewsheets(vs0, engine, principal);
          }
          finally {
             if(rvs.isViewer()) {
@@ -1039,6 +1040,34 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
       }
 
       return matchingTasks;
+   }
+
+   private void saveEmbeddedViewsheets(Viewsheet vs, ViewsheetService engine,
+                                        Principal principal)
+   {
+      for(Assembly assembly : vs.getAssemblies()) {
+         if(assembly instanceof Viewsheet embeddedVs) {
+            AssetEntry embeddedEntry = embeddedVs.getEntry();
+
+            if(embeddedEntry != null) {
+               Viewsheet cloned = embeddedVs.clone();
+
+               if(cloned != null) {
+                  // Clear parent so isEmbedded()=false and writeXML persists inner assemblies
+                  cloned.setViewsheet(null);
+
+                  try {
+                     engine.setViewsheet(cloned, embeddedEntry, principal, true, false);
+                  }
+                  catch(Exception ex) {
+                     LOG.warn("Failed to save embedded viewsheet for HOME bookmark: {}", embeddedEntry, ex);
+                  }
+
+                  saveEmbeddedViewsheets(embeddedVs, engine, principal);
+               }
+            }
+         }
+      }
    }
 
    private final ViewsheetService viewsheetService;

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
@@ -1043,7 +1043,7 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
    }
 
    private void saveEmbeddedViewsheets(Viewsheet vs, ViewsheetService engine,
-                                        Principal principal)
+                                       Principal principal)
    {
       for(Assembly assembly : vs.getAssemblies()) {
          if(assembly instanceof Viewsheet embeddedVs) {
@@ -1057,14 +1057,16 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
                   cloned.setViewsheet(null);
 
                   try {
+                     // updateDependency=false: saving embedded VS runtime state does not change the dependency graph
                      engine.setViewsheet(cloned, embeddedEntry, principal, true, false);
                   }
                   catch(Exception ex) {
                      LOG.warn("Failed to save embedded viewsheet for HOME bookmark: {}", embeddedEntry, ex);
                   }
-
-                  saveEmbeddedViewsheets(embeddedVs, engine, principal);
                }
+
+               // Always recurse so deeply-nested embedded VSes are visited even if cloning this level failed
+               saveEmbeddedViewsheets(embeddedVs, engine, principal);
             }
          }
       }


### PR DESCRIPTION
## Summary

When the HOME bookmark is saved for a viewsheet that contains embedded VS (VIEWSHEET_ASSET) assemblies, the embedded VS's inner assemblies were not being persisted to their own repository entries. This caused HOME navigation to restore stale state (e.g., a previously cleared chart zoom would reappear after reopening the viewsheet).

## Root Cause

`Viewsheet.writeXML` skips writing inner assemblies when `isEmbedded()=true`:

```java
if(!isEmbedded() || snapshotExport) {
    writer.println("<assemblies>");
    ...
}
```

When HOME is saved, `engine.setViewsheet(vs0, vsEntry0, ...)` saves the outer VS via `writeXML`. Because embedded VS assemblies have their parent set (`isEmbedded()=true`), their inner charts are never written to the repository. On the next session open, the embedded VS is loaded from its own (unmodified) repository entry — retaining the old state.

## Fix

After saving the outer VS, also save each embedded VS to its own repository entry. Each embedded VS is cloned and its parent reference is cleared (`setViewsheet(null)`) so that `isEmbedded()=false` and `writeXML` serializes the inner assemblies. The method recurses to handle nested embedded VSes.

## Test Plan

- Open a viewsheet containing an embedded VS with a chart
- Zoom in on a chart inside the embedded VS
- Clear the zoom
- Save the HOME bookmark
- Close and reopen the viewsheet (new session)
- Navigate to HOME — chart should not be zoomed

Fixes Redmine #75433.