### PR TITLE
Bug #75442 - Animate gantt milestone markers and labels on chart load

### DIFF
--- a/core/src/main/java/inetsoft/graph/element/PointElement.java
+++ b/core/src/main/java/inetsoft/graph/element/PointElement.java
@@ -39,8 +39,9 @@ import java.util.*;
 @TernClass(url = "#cshid=PointElement")
 public class PointElement extends StackableElement {
    /**
-    * Hint marking this point element as a gantt milestone marker, a string of true or false.
-    * Used to tag the milestone value label for the SVG entrance animation.
+    * Hint marking this point element as a gantt milestone marker; the value is {@code "true"}
+    * when set, absent otherwise. Used to tag the milestone value label for the SVG entrance
+    * animation.
     */
    public static final String HINT_GANTT_MILESTONE = "gantt_milestone";
 

--- a/core/src/main/java/inetsoft/graph/element/PointElement.java
+++ b/core/src/main/java/inetsoft/graph/element/PointElement.java
@@ -39,6 +39,12 @@ import java.util.*;
 @TernClass(url = "#cshid=PointElement")
 public class PointElement extends StackableElement {
    /**
+    * Hint marking this point element as a gantt milestone marker, a string of true or false.
+    * Used to tag the milestone value label for the SVG entrance animation.
+    */
+   public static final String HINT_GANTT_MILESTONE = "gantt_milestone";
+
+   /**
     * Create an empty element. Dims and vars must be added explicitly.
     */
    public PointElement() {

--- a/core/src/main/java/inetsoft/graph/visual/PointVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/PointVO.java
@@ -285,6 +285,15 @@ public class PointVO extends ElementVO {
 
       PointElement elem = (PointElement) ((ElementGeometry) getGeometry()).getElement();
 
+      // Tag gantt milestone value labels with a dedicated class so the SVG injector fades them in
+      // with the milestone marker. A separate class (not the bar label) keeps them out of the
+      // bar hover-dim rule so they are never dimmed when hovering a bar.
+      if("true".equals(elem.getHint(PointElement.HINT_GANTT_MILESTONE))) {
+         vtext.setSvgAnnotation(SVGSupport.ANNOTATION_POINT_LABEL, Map.of(
+            SVGSupport.ATTR_ROW, String.valueOf(getRowIndex()),
+            SVGSupport.ATTR_COL, String.valueOf(getColIndex())));
+      }
+
       // make sure word cloud is not drawn in the neighboring area
       if(elem.isWordCloud()) {
          String key = "__cached_textClip" + CoreTool.arrayToString(gobj.getTuple());

--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -3801,6 +3801,7 @@ public abstract class GraphGenerator {
 
             PointElement point = new PointElement();
             point.setShapeFrame(frame);
+            point.setHint(PointElement.HINT_GANTT_MILESTONE, "true");
             elements.add(point);
          }
       }

--- a/core/src/main/java/inetsoft/report/composition/graph/VGraphPair.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/VGraphPair.java
@@ -2459,6 +2459,15 @@ public class VGraphPair {
          if(!has3DBarVO(graph)) {
             String hint = SVGSupport.ANIMATION_GROW;
             if(hasStackedBarVO(graph)) hint += ":" + SVGSupport.ANIMATION_FLAG_STACKED;
+
+            // Gantt bars are an IntervalElement; the milestone marker is a separate PointElement.
+            // The bar branch is selected before hasPointVO, so flag gantt to fade the milestone
+            // marker and its label after the bars. Keyed on the milestone element so the flag and
+            // the label tagging in PointVO derive from the same signal.
+            if(hasGanttMilestoneVO(graph)) {
+               hint += ":" + SVGSupport.ANIMATION_FLAG_GANTT;
+            }
+
             g.setRenderingHint(SVGSupport.ANIMATION_KEY, hint);
          }
       }
@@ -2631,6 +2640,22 @@ public class VGraphPair {
          Visualizable v = graph.getVisual(i);
          if(v instanceof PointVO) return true;
          if(v instanceof GraphVO && hasPointVO(((GraphVO) v).getVGraph())) return true;
+      }
+      return false;
+   }
+
+   private static boolean hasGanttMilestoneVO(VGraph graph) {
+      for(int i = 0; i < graph.getVisualCount(); i++) {
+         Visualizable v = graph.getVisual(i);
+
+         if(v instanceof PointVO &&
+            "true".equals(((ElementGeometry) ((PointVO) v).getGeometry()).getElement()
+               .getHint(PointElement.HINT_GANTT_MILESTONE)))
+         {
+            return true;
+         }
+
+         if(v instanceof GraphVO && hasGanttMilestoneVO(((GraphVO) v).getVGraph())) return true;
       }
       return false;
    }

--- a/core/src/main/java/inetsoft/report/composition/graph/VGraphPair.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/VGraphPair.java
@@ -2648,11 +2648,13 @@ public class VGraphPair {
       for(int i = 0; i < graph.getVisualCount(); i++) {
          Visualizable v = graph.getVisual(i);
 
-         if(v instanceof PointVO &&
-            "true".equals(((ElementGeometry) ((PointVO) v).getGeometry()).getElement()
-               .getHint(PointElement.HINT_GANTT_MILESTONE)))
-         {
-            return true;
+         if(v instanceof PointVO pvo) {
+            // PointGeometry extends ElementGeometry, so the cast is always safe.
+            GraphElement elem = ((ElementGeometry) pvo.getGeometry()).getElement();
+
+            if("true".equals(elem.getHint(PointElement.HINT_GANTT_MILESTONE))) {
+               return true;
+            }
          }
 
          if(v instanceof GraphVO && hasGanttMilestoneVO(((GraphVO) v).getVGraph())) return true;

--- a/core/src/main/java/inetsoft/util/graphics/SVGSupport.java
+++ b/core/src/main/java/inetsoft/util/graphics/SVGSupport.java
@@ -67,6 +67,9 @@ public interface SVGSupport {
    /** Stacked bar chart. Example hint: "grow:stacked". */
    String ANIMATION_FLAG_STACKED = "stacked";
 
+   /** Gantt chart: milestone points fade in after the bars. Example hint: "grow:gantt". */
+   String ANIMATION_FLAG_GANTT = "gantt";
+
    // -------------------------------------------------------------------------
    // Semantic annotation constants (stamped on <g> elements during rendering)
    // -------------------------------------------------------------------------
@@ -85,6 +88,8 @@ public interface SVGSupport {
    String ANNOTATION_LABEL      = "inetsoft-bar-label";
    /** CSS class for point/scatter annotation groups ({@code <g class="inetsoft-point" ...>}). */
    String ANNOTATION_POINT      = "inetsoft-point";
+   /** CSS class for gantt milestone value labels. Faded with the marker but never hover-dimmed. */
+   String ANNOTATION_POINT_LABEL = "inetsoft-point-label";
    /** CSS class for candlestick annotation groups ({@code <g class="inetsoft-candle" ...>}). */
    String ANNOTATION_CANDLE     = "inetsoft-candle";
    /** CSS class for box-plot annotation groups ({@code <g class="inetsoft-box" ...>}). */

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -130,6 +130,31 @@ public class SVGAnimationDOMInjector {
             double lineDelay = lastBarDelay + AnimationConstants.DURATION + AnimationConstants.READY_BUFFER;
             injectParetoLineAnimation(paretoLines, svgRoot, doc, lineDelay);
          }
+
+         // Gantt charts have interval bars plus a milestone point marker (a separate PointElement).
+         // Fade the milestones in after the last bar finishes, matching the bar-label timing.
+         Set<String> flags = new HashSet<>(Arrays.asList(animHint.split(":")));
+
+         if(flags.contains(SVGSupport.ANIMATION_FLAG_GANTT)) {
+            double milestoneDelay = lastBarDelay + AnimationConstants.DURATION + AnimationConstants.READY_BUFFER;
+            String milestoneAnimStyle = String.format(java.util.Locale.US,
+               "opacity:0;animation:inetsoft-bar-fade %.2fs %s %.2fs both",
+               AnimationConstants.DURATION, AnimationConstants.EASING, milestoneDelay);
+
+            // A2 pattern: animate inner children so the annotation group's own opacity stays free
+            // (point markers gate hover dimming on the .ready class; labels are never dimmed).
+            List<Element> milestones = collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_POINT);
+
+            for(Element milestone : milestones) {
+               applyAnimStyleToChildren(milestone, milestoneAnimStyle);
+            }
+
+            List<Element> milestoneLabels = collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_POINT_LABEL);
+
+            for(Element label : milestoneLabels) {
+               applyAnimStyleToChildren(label, milestoneAnimStyle);
+            }
+         }
       }
 
       // Signal to the Angular directive that animation was injected so it can schedule .ready.
@@ -2721,13 +2746,14 @@ public class SVGAnimationDOMInjector {
          // A1 chart types: animation is applied directly to the annotation group that is also
          // the hover target. The .ready gate prevents hover dim from conflicting with the
          // group's own animation fill-mode during the entrance animation (~0.9s gate).
-         "svg.ready .inetsoft-point,svg.ready .inetsoft-candle,svg.ready .inetsoft-box," +
+         "svg.ready .inetsoft-point,svg.ready .inetsoft-point-label,svg.ready .inetsoft-candle,svg.ready .inetsoft-box," +
          "svg.ready .inetsoft-treemap,svg.ready .inetsoft-mekko," +
          "svg.ready .inetsoft-treemap-label,svg.ready .inetsoft-mekko-label," +
          "svg.ready .inetsoft-radar" +
          "{transition:" + tr + "}" +
-         // Point dimming.
-         "svg.ready:has(.inetsoft-point.inetsoft-active) .inetsoft-point:not(.inetsoft-active)" +
+         // Point dimming (markers + their value labels).
+         "svg.ready:has(.inetsoft-point.inetsoft-active) .inetsoft-point:not(.inetsoft-active)," +
+         "svg.ready:has(.inetsoft-point.inetsoft-active) .inetsoft-point-label:not(.inetsoft-active)" +
          "{opacity:" + dim + "!important}" +
          // Candlestick dimming.
          "svg.ready:has(.inetsoft-candle.inetsoft-active) .inetsoft-candle:not(.inetsoft-active)" +
@@ -2744,7 +2770,8 @@ public class SVGAnimationDOMInjector {
          "svg.ready:has(.inetsoft-mekko.inetsoft-active) .inetsoft-mekko-label:not(.inetsoft-active)" +
          "{opacity:" + dim + "!important}" +
          // Cross-tile dim for A1 types (same ready gate as their :has() rules above).
-         "svg.ready.inetsoft-dim-all .inetsoft-point,svg.ready.inetsoft-dim-all .inetsoft-candle," +
+         "svg.ready.inetsoft-dim-all .inetsoft-point,svg.ready.inetsoft-dim-all .inetsoft-point-label," +
+         "svg.ready.inetsoft-dim-all .inetsoft-candle," +
          "svg.ready.inetsoft-dim-all .inetsoft-box,svg.ready.inetsoft-dim-all .inetsoft-treemap," +
          "svg.ready.inetsoft-dim-all .inetsoft-mekko,svg.ready.inetsoft-dim-all .inetsoft-treemap-label," +
          "svg.ready.inetsoft-dim-all .inetsoft-mekko-label" +

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -133,9 +133,9 @@ public class SVGAnimationDOMInjector {
 
          // Gantt charts have interval bars plus a milestone point marker (a separate PointElement).
          // Fade the milestones in after the last bar finishes, matching the bar-label timing.
-         Set<String> flags = new HashSet<>(Arrays.asList(animHint.split(":")));
-
-         if(flags.contains(SVGSupport.ANIMATION_FLAG_GANTT)) {
+         // The base hint is the first token and ":" is the separator, so a ":gantt" substring
+         // match is unambiguous (no base hint or other flag contains "gantt").
+         if(animHint.contains(":" + SVGSupport.ANIMATION_FLAG_GANTT)) {
             double milestoneDelay = lastBarDelay + AnimationConstants.DURATION + AnimationConstants.READY_BUFFER;
             String milestoneAnimStyle = String.format(java.util.Locale.US,
                "opacity:0;animation:inetsoft-bar-fade %.2fs %s %.2fs both",

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -1164,6 +1164,8 @@ class SVGAnimationDOMInjectorTest {
                    "milestone label must fade in sync with the milestone marker");
 
       // Bar hover must NOT dim milestone labels; point hover MUST dim other milestone labels.
+      // These rules are emitted globally by appendHoverCSS (not gated on the gantt flag); the
+      // assertions guard that the point-label class is wired into the correct hover rule.
       String css = allStyleContent(doc.getDocumentElement());
       assertFalse(css.contains(".inetsoft-bar.inetsoft-active) .inetsoft-point-label"),
                   "bar hover must not dim milestone labels");
@@ -1184,6 +1186,36 @@ class SVGAnimationDOMInjectorTest {
          SVGSupport.ANIMATION_GROW + ":" + SVGSupport.ANIMATION_FLAG_GANTT));
       assertTrue(doc.getDocumentElement().hasAttribute("data-animated"),
                  "data-animated must be set even when there is no milestone point");
+   }
+
+   /**
+    * A stacked gantt (multi-resource task bars) produces the {@code grow:stacked:gantt} hint.
+    * The gantt flag must still be detected regardless of position, so the milestone fades after
+    * the bars exactly as in the unstacked case.
+    */
+   @Test
+   void gantt_stackedMilestoneFadesAfterBars() throws Exception {
+      Document doc = newDocument();
+      Element bar0 = addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR,
+                                   Map.of("row", "0", "col", "0", "orient", "h"),
+                                   0,   0, 200, 50);
+      Element bar1 = addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR,
+                                   Map.of("row", "1", "col", "0", "orient", "h"),
+                                   0, 100, 200, 50);
+      Element milestone = addAnnotGroup(doc, SVGSupport.ANNOTATION_POINT,
+                                        Map.of("row", "0", "col", "0", "size", "9"),
+                                        150, 50, 10, 10);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(),
+         SVGSupport.ANIMATION_GROW + ":" + SVGSupport.ANIMATION_FLAG_STACKED +
+         ":" + SVGSupport.ANIMATION_FLAG_GANTT);
+
+      String milestoneStyle = firstChildStyle(milestone);
+      assertNotNull(milestoneStyle, "milestone inner child must receive an animation style");
+      double lastBarDelay = Math.max(parseDelay(firstChildStyle(bar0)),
+                                     parseDelay(firstChildStyle(bar1)));
+      assertTrue(parseDelay(milestoneStyle) >= lastBarDelay + AnimationConstants.DURATION - 0.01,
+                 "milestone must start after the last bar finishes for grow:stacked:gantt");
    }
 
    /**

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -1112,4 +1112,98 @@ class SVGAnimationDOMInjectorTest {
       assertEquals("0", label.getAttribute("data-row"),
                    "fallback must match cell A (row=0), the nearest centre");
    }
+
+   // -------------------------------------------------------------------------
+   // Gantt milestone animation tests
+   // -------------------------------------------------------------------------
+
+   /**
+    * Gantt charts carry the {@code grow:gantt} hint.  The milestone marker ({@code inetsoft-point})
+    * must fade in after the last bar finishes — delay ≥ lastBarDelay + DURATION.
+    */
+   @Test
+   void gantt_milestoneFadesAfterBars() throws Exception {
+      Document doc = newDocument();
+      // Horizontal gantt bars staggered top→bottom by Y center.
+      Element bar0 = addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR,
+                                   Map.of("row", "0", "col", "0", "orient", "h"),
+                                   0,   0, 200, 50);
+      Element bar1 = addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR,
+                                   Map.of("row", "1", "col", "0", "orient", "h"),
+                                   0, 100, 200, 50);
+      // Milestone diamond marker.
+      Element milestone = addAnnotGroup(doc, SVGSupport.ANNOTATION_POINT,
+                                        Map.of("row", "0", "col", "0", "size", "9"),
+                                        150, 50, 10, 10);
+      // Milestone value label (PointVO tags it with the dedicated point-label annotation).
+      Element milestoneLabel = addAnnotGroup(doc, SVGSupport.ANNOTATION_POINT_LABEL,
+                                             Map.of("row", "0", "col", "0"),
+                                             150, 35, 30, 12);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(),
+         SVGSupport.ANIMATION_GROW + ":" + SVGSupport.ANIMATION_FLAG_GANTT);
+
+      String milestoneStyle = firstChildStyle(milestone);
+      assertNotNull(milestoneStyle, "milestone inner child must receive an animation style");
+      assertTrue(milestoneStyle.contains("inetsoft-bar-fade"),
+                 "milestone must reuse the bar fade keyframe");
+
+      double lastBarDelay = Math.max(parseDelay(firstChildStyle(bar0)),
+                                     parseDelay(firstChildStyle(bar1)));
+      double milestoneDelay = parseDelay(milestoneStyle);
+      assertTrue(milestoneDelay >= lastBarDelay + AnimationConstants.DURATION - 0.01,
+                 "milestone must start after the last bar finishes: milestone=" + milestoneDelay +
+                 ", lastBar=" + lastBarDelay);
+
+      // The milestone label must fade in sync with the milestone marker (same delay).
+      String labelStyle = firstChildStyle(milestoneLabel);
+      assertNotNull(labelStyle, "milestone label inner child must receive an animation style");
+      assertTrue(labelStyle.contains("inetsoft-bar-fade"),
+                 "milestone label must use the bar fade keyframe");
+      assertEquals(milestoneDelay, parseDelay(labelStyle), 0.01,
+                   "milestone label must fade in sync with the milestone marker");
+
+      // Bar hover must NOT dim milestone labels; point hover MUST dim other milestone labels.
+      String css = allStyleContent(doc.getDocumentElement());
+      assertFalse(css.contains(".inetsoft-bar.inetsoft-active) .inetsoft-point-label"),
+                  "bar hover must not dim milestone labels");
+      assertTrue(css.contains(".inetsoft-point.inetsoft-active) .inetsoft-point-label:not(.inetsoft-active)"),
+                 "point hover must dim other milestone labels");
+   }
+
+   /** Gantt with no milestone field has no {@code inetsoft-point} group; injection must no-op cleanly. */
+   @Test
+   void gantt_noMilestone_noError() throws Exception {
+      Document doc = newDocument();
+      addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR,
+                    Map.of("row", "0", "col", "0", "orient", "h"),
+                    0, 0, 200, 50);
+
+      assertDoesNotThrow(() -> SVGAnimationDOMInjector.injectAnimation(
+         doc.getDocumentElement(),
+         SVGSupport.ANIMATION_GROW + ":" + SVGSupport.ANIMATION_FLAG_GANTT));
+      assertTrue(doc.getDocumentElement().hasAttribute("data-animated"),
+                 "data-animated must be set even when there is no milestone point");
+   }
+
+   /**
+    * A combo bar+point chart (plain {@code grow} hint, no gantt flag) must NOT animate its
+    * point overlay — the milestone fade is strictly gated on the gantt flag.
+    */
+   @Test
+   void combo_barPoint_noGanttFlag_pointsNotAnimated() throws Exception {
+      Document doc = newDocument();
+      addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR,
+                    Map.of("row", "0", "col", "0", "orient", "v"),
+                    0, 0, 50, 200);
+      Element point = addAnnotGroup(doc, SVGSupport.ANNOTATION_POINT,
+                                    Map.of("row", "0", "col", "0", "size", "9"),
+                                    20, 20, 10, 10);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_GROW);
+
+      String pointStyle = firstChildStyle(point);
+      assertTrue(pointStyle == null || pointStyle.isEmpty(),
+                 "combo chart point overlay must not receive a fade without the gantt flag");
+   }
 }

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
@@ -174,6 +174,46 @@ describe("ChartInlineSvgDirective cross-tile dim", () => {
       });
    });
 
+   describe("milestone point label activation (gantt)", () => {
+      // <svg> sets svgRootEl; two milestone markers + labels keyed by data-row/col.
+      const html = `
+         <svg>
+            <g class="inetsoft-point" data-row="0" data-col="0"></g>
+            <g class="inetsoft-point-label" data-row="0" data-col="0"></g>
+            <g class="inetsoft-point" data-row="1" data-col="0"></g>
+            <g class="inetsoft-point-label" data-row="1" data-col="0"></g>
+         </svg>`;
+
+      function activeFlags(host: HTMLElement, sel: string): boolean[] {
+         return Array.from(host.querySelectorAll(sel)).map(e => e.classList.contains("inetsoft-active"));
+      }
+
+      it("activates the hovered point's own label so it is not dimmed", () => {
+         const { dir, host } = makeDirective(html);
+         (dir as any).afterSvgInjected();
+
+         dir.highlightElement(0, 0);
+         // The hovered marker and its label are active; the other row stays inactive (dimmable).
+         expect(activeFlags(host, ".inetsoft-point")).toEqual([true, false]);
+         expect(activeFlags(host, ".inetsoft-point-label")).toEqual([true, false]);
+      });
+
+      it("clears the label active class when the hover ends", () => {
+         vi.useFakeTimers();
+         try {
+            const { dir, host } = makeDirective(html);
+            (dir as any).afterSvgInjected();
+            dir.highlightElement(0, 0);
+            dir.highlightElement(null, null);
+            vi.advanceTimersByTime(ChartInlineSvgDirective["CLEAR_DELAY_MS"]);
+            expect(activeFlags(host, ".inetsoft-point,.inetsoft-point-label").some(Boolean)).toBe(false);
+         }
+         finally {
+            vi.useRealTimers();
+         }
+      });
+   });
+
    describe("getRelationEdges + emitRelationHover dedup", () => {
       it("returns this tile's edges as source/target pairs", () => {
          const { dir } = makeDirective("");

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
@@ -458,8 +458,8 @@ export class ChartInlineSvgDirective implements OnDestroy {
       }
 
       // Build label map from server-annotated label elements for all chart types that have
-      // external text groups matched to data elements (bar, treemap/sunburst/icicle, mekko).
-      for(const labelClass of [".inetsoft-bar-label", ".inetsoft-treemap-label", ".inetsoft-mekko-label", ".inetsoft-relation-label"]) {
+      // external text groups matched to data elements (bar, point/gantt-milestone, treemap/sunburst/icicle, mekko).
+      for(const labelClass of [".inetsoft-bar-label", ".inetsoft-point-label", ".inetsoft-treemap-label", ".inetsoft-mekko-label", ".inetsoft-relation-label"]) {
          const labels = Array.from(
             this.element.nativeElement.querySelectorAll(labelClass) as NodeListOf<Element>);
 


### PR DESCRIPTION
## Summary

Gantt charts are built from task bars (IntervalElement, rendered as
inetsoft-bar) plus a milestone marker (PointElement, rendered as
inetsoft-point). The inline-SVG entrance-animation dispatch chooses one
animation branch per chart and checks hasBarVO before hasPointVO, so a gantt
chart always took the bar branch and the milestone markers — and their value
labels — popped in instantly while the bars faded. This change fades the
milestone marker and its label in after the bars, and makes their hover-dim
behavior consistent.

## Changes

Backend (core)
- SVGSupport: add the ANIMATION_FLAG_GANTT hint flag and the
  ANNOTATION_POINT_LABEL annotation class.
- PointElement: add the HINT_GANTT_MILESTONE marker hint.
- GraphGenerator: set HINT_GANTT_MILESTONE on the gantt milestone PointElement.
- PointVO: tag the milestone value label with ANNOTATION_POINT_LABEL when the
  hint is present, mirroring how BarVO tags bar value labels.
- VGraphPair: append the gantt flag to the grow hint when the graph contains a
  milestone PointElement (new hasGanttMilestoneVO helper). Keying on the
  element rather than the chart type means the flag and the label tagging in
  PointVO derive from the same signal.

Injector (utils/inetsoft-xml-formats)
- SVGAnimationDOMInjector: when the gantt flag is set, fade the inetsoft-point
  markers and inetsoft-point-label labels in after the last bar, reusing the
  bar-fade keyframe at the same delay the bar value labels use.
- Hover CSS: hovering a milestone point now dims the other points and their
  labels; the point-label class is added to the point dim, transition, and
  cross-tile rules. The bar hover rule is unchanged, so bar hover never dims
  milestone markers or labels.

Frontend (portal)
- chart-inline-svg.directive: add inetsoft-point-label to the label lookup map
  so the hovered milestone point keeps its own label lit while the others dim.

## Behavior

- Milestone markers and value labels fade in together, after the task bars.
- Bar hover: milestone markers and labels are not dimmed (consistent — neither
  dims).
- Milestone-point hover: other milestone markers and labels dim; the hovered
  point keeps its marker and label fully visible.
- Combo bar+point charts and scatter charts are unaffected (no milestone hint,
  no point-label elements).