### PR TITLE
Bug #75436, fix cross-org import bookmark conflict detection and resolution

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/DeployManagerService.java
+++ b/core/src/main/java/inetsoft/sree/internal/DeployManagerService.java
@@ -1104,7 +1104,7 @@ public class DeployManagerService {
                   VSBookmarkInfo importedInfo = imported.getBookmarkInfo(bName);
                   conflicts.add(BookmarkConflict.builder()
                      .viewsheetPath(entry.getPath())
-                     .user(userName)
+                     .user(userID.convertToKey())
                      .userLabel(userID.getName())
                      .bookmarkName(bName)
                      .existingCreated(existingInfo.getCreateTime())

--- a/core/src/main/java/inetsoft/uql/asset/AssetEntry.java
+++ b/core/src/main/java/inetsoft/uql/asset/AssetEntry.java
@@ -2065,7 +2065,11 @@ public class AssetEntry implements AssetObject, Comparable<AssetEntry>, DataSeri
       newEntry.hash = -1;
       newEntry.cachedName = null;
 
-      if(name.equals("")) {
+      if(newEntry.user != null) {
+         newEntry.user = new IdentityID(newEntry.user.name, orgID);
+      }
+
+      if(name.isEmpty()) {
          return newEntry;
       }
 

--- a/core/src/main/java/inetsoft/util/dep/ViewsheetAsset.java
+++ b/core/src/main/java/inetsoft/util/dep/ViewsheetAsset.java
@@ -513,11 +513,12 @@ public class ViewsheetAsset extends AbstractSheetAsset implements FolderChangeab
             if(resolutions != null) {
                // Remove names where the admin chose to keep the existing (current) bookmark.
                for(String bName : new ArrayList<>(Arrays.asList(imported.getBookmarks()))) {
-                  String key = entry.getPath() + "|" + name + "|" + bName;
+                  String userKey = identityID.convertToKey();
+                  String key = entry.getPath() + "|" + userKey + "|" + bName;
                   boolean keepCurrent = Boolean.FALSE.equals(resolutions.get(key)) ||
                      // INITIAL_STATE follows the HOME_BOOKMARK resolution — no separate key.
                      (VSBookmark.INITIAL_STATE.equals(bName) &&
-                        Boolean.FALSE.equals(resolutions.get(entry.getPath() + "|" + name + "|" + VSBookmark.HOME_BOOKMARK)));
+                        Boolean.FALSE.equals(resolutions.get(entry.getPath() + "|" + userKey + "|" + VSBookmark.HOME_BOOKMARK)));
 
                   if(keepCurrent) {
                      imported.removeBookmark(bName);


### PR DESCRIPTION
When a site admin imports a viewsheet into a different org, bookmark conflicts were not detected and resolutions were not applied because user org IDs were not updated to the target org in several places:

- cloneAssetEntry(String orgID, String name) updated the entry's orgID but never updated the embedded user's orgID, causing getVSBookmarkEntry to return null on the USER_SCOPE owner check. Fixed by creating a new IdentityID with the target orgID before the early return, consistent with the Organization overload.

- BookmarkConflict.user was set from the raw JAR userName (stale org) instead of the org-updated userID.convertToKey(), breaking resolution map lookups during import.

- ViewsheetAsset.parseContent built the resolution lookup key with the raw XML name instead of the org-updated identityID.convertToKey(), causing keepCurrent resolutions to never match and always import over the existing bookmark.