### PR TITLE
Bug #75429, fix logical model attribute move-up/down corrupting attribute names and rendering duplicates

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/attribute-editor/logical-model-attribute-editor.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/attribute-editor/logical-model-attribute-editor.component.ts
@@ -154,6 +154,12 @@ export class LogicalModelAttributeEditor implements OnInit, OnDestroy {
       const columnChanged: boolean = !this.attribute || value.qualifiedName != this.attribute.qualifiedName;
       const tableChanged: boolean = !this.attribute || value.table != this.attribute.table;
       const formatChanged: boolean = !this.attribute || !Tool.isEquals(value.format, this.attribute.format);
+      // Cancel the stale subscription before switching attributes. The deferred
+      // resetFormControl (scheduleReset) leaves form.valueChanges active across the
+      // transition. Without this unsubscribe, Angular's [ngModel] sync for dataType
+      // triggers valueChanges → apply() writes the old form "name" value onto the
+      // new attribute object, corrupting its name and breaking @for track-by-name.
+      this.unsubscribeForm();
       this._attribute = value;
       this.editable = !!value && !value.baseElement;
 

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/element-tree-node/element-tree-node.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/element-tree-node/element-tree-node.component.html
@@ -75,7 +75,7 @@
         (onMoveUp)="moveAttributeUp(i)"
         (onDeleteEntity)="deleteAttribute(i)"
         (onShiftSelect)="onShiftSelect.emit($event)"
-        (onAttributeOrderChanged)="onAttributeOrderChanged.emit()">
+        (onAttributeOrderChanged)="onAttributeOrderChanged.emit($event)">
       </element-tree-node>
     }
   </div>

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/element-tree-node/element-tree-node.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/element-tree-node/element-tree-node.component.ts
@@ -62,7 +62,7 @@ export class ElementTreeNode implements OnChanges {
    @Output() onShiftSelect: EventEmitter<ElementModel> = new EventEmitter<ElementModel>();
    @Output() onToggleEntity: EventEmitter<{entity: EntityModel, toggle: boolean}> = new EventEmitter<{entity: EntityModel, toggle: boolean}>();
    @Output() nodeDrag = new EventEmitter<any>();
-   @Output() onAttributeOrderChanged: EventEmitter<any> = new EventEmitter<any>();
+   @Output() onAttributeOrderChanged: EventEmitter<{entityIndex: number, oldAttrIndex: number, newAttrIndex: number}> = new EventEmitter();
    focusin: boolean = false;
    expanded: boolean;
    readonly INDENT_SIZE: number = 15;
@@ -273,17 +273,19 @@ export class ElementTreeNode implements OnChanges {
     */
    moveAttributeDown(index: number): void {
       if(index < (<EntityModel>this.node).attributes.length - 1) {
-         let selectedItem = this.getSelectedItem(this.attrIndex);
+         const movedItem = this.selected.find(item =>
+            item.entity == this.entityIndex && item.attribute == index);
+         if(movedItem) { movedItem.attribute++; }
 
-         if(!!selectedItem && selectedItem.entity == this.entityIndex && selectedItem.attribute == index) {
-            selectedItem.attribute++;
-         }
+         const displacedItem = this.selected.find(item =>
+            item.entity == this.entityIndex && item.attribute == index + 1);
+         if(displacedItem) { displacedItem.attribute--; }
 
          const entity: EntityModel = this.node as EntityModel;
-         const temp: any = Tool.clone(entity.attributes[index]);
+         const temp: any = entity.attributes[index];
          entity.attributes[index] = entity.attributes[index + 1];
          entity.attributes[index + 1] = temp;
-         this.onAttributeOrderChanged.emit();
+         this.onAttributeOrderChanged.emit({entityIndex: this.entityIndex, oldAttrIndex: index, newAttrIndex: index + 1});
       }
    }
 
@@ -293,19 +295,19 @@ export class ElementTreeNode implements OnChanges {
     */
    moveAttributeUp(index: number): void {
       if(index > 0) {
-         let selectedItem = this.getSelectedItem(this.attrIndex);
+         const movedItem = this.selected.find(item =>
+            item.entity == this.entityIndex && item.attribute == index);
+         if(movedItem) { movedItem.attribute--; }
 
-         if(!!selectedItem && selectedItem.entity == this.entityIndex
-            && selectedItem.attribute == index)
-         {
-            selectedItem.attribute--;
-         }
+         const displacedItem = this.selected.find(item =>
+            item.entity == this.entityIndex && item.attribute == index - 1);
+         if(displacedItem) { displacedItem.attribute++; }
 
          const entity: EntityModel = this.node as EntityModel;
-         const temp: any = Tool.clone(entity.attributes[index]);
+         const temp: any = entity.attributes[index];
          entity.attributes[index] = entity.attributes[index - 1];
          entity.attributes[index - 1] = temp;
-         this.onAttributeOrderChanged.emit();
+         this.onAttributeOrderChanged.emit({entityIndex: this.entityIndex, oldAttrIndex: index, newAttrIndex: index - 1});
       }
    }
 

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/logical-model-property-pane.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/logical-model-property-pane.component.html
@@ -63,7 +63,7 @@
               (onShiftSelect)="shiftSelect($event)"
               (onToggleEntity)="entityToggle($event)"
               (onDeleteAttribute)="onDeleteAttribute($event)"
-              (onAttributeOrderChanged)="attributeOrderChanged()">
+              (onAttributeOrderChanged)="attributeOrderChanged($event)">
             </element-tree-node>
           }
           <loading-indicator-pane [show]="loading"></loading-indicator-pane>

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/logical-model-property-pane.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/logical-model-property-pane.component.ts
@@ -121,15 +121,9 @@ export class LogicalModelPropertyPane implements OnInit {
    }
 
    attributeOrderChanged(event: {entityIndex: number, oldAttrIndex: number, newAttrIndex: number}) {
-      if(this.editingEle && this.editingEle.entity == event.entityIndex) {
-         if(this.editingEle.attribute == event.oldAttrIndex) {
-            this._editingEle = {...this.editingEle, attribute: event.newAttrIndex};
-         }
-         else if(this.editingEle.attribute == event.newAttrIndex) {
-            this._editingEle = {...this.editingEle, attribute: event.oldAttrIndex};
-         }
-      }
-
+      // _editingEle is the same object reference that element-tree-node mutates via
+      // selectedEles (movedItem.attribute-- / movedItem.attribute++), so the index
+      // is already correct by the time this handler runs — no further adjustment needed.
       this.updateExistNames();
    }
 

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/logical-model-property-pane.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/logical-model-property-pane.component.ts
@@ -120,7 +120,16 @@ export class LogicalModelPropertyPane implements OnInit {
       this.updateExistNames();
    }
 
-   attributeOrderChanged() {
+   attributeOrderChanged(event: {entityIndex: number, oldAttrIndex: number, newAttrIndex: number}) {
+      if(this.editingEle && this.editingEle.entity == event.entityIndex) {
+         if(this.editingEle.attribute == event.oldAttrIndex) {
+            this._editingEle = {...this.editingEle, attribute: event.newAttrIndex};
+         }
+         else if(this.editingEle.attribute == event.newAttrIndex) {
+            this._editingEle = {...this.editingEle, attribute: event.oldAttrIndex};
+         }
+      }
+
       this.updateExistNames();
    }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `logical-model-attribute-editor` leaves `form.valueChanges` subscribed across an attribute switch due to the deferred `resetFormControl` (setTimeout) pattern. Angular's `[ngModel]` sync for `dataType` fires in the same change-detection cycle, triggering `apply()` while the form still holds the previous attribute's `name` value — writing it onto the new attribute object. This corrupts the attribute's name, causing `@for (track attribute.name)` to see a duplicate track key, rendering two copies of the same attribute and losing the other.
- **Secondary**: `moveAttributeUp`/`moveAttributeDown` in `element-tree-node` used `Tool.clone` (creating a new object reference) and searched `selectedEles` with the wrong key (`this.attrIndex = -1` for an entity node), so the selection index was never updated after a reorder.
- **Secondary**: `editingEle.attribute` in the property pane was never adjusted after attribute reordering, leaving the right-panel editor pointed at the wrong attribute.

## Test plan

- [ ] Open `Data Source / Examples / Orders / Data Model / Order Model`, expand the **Order** entity
- [ ] Select **Discount** and click Move Up — tree should show `[Discount, Date, Num, Paid]`, right panel stays on Discount
- [ ] Click **Date** — tree stays `[Discount, Date, Num, Paid]` (no duplicates), right panel shows Date's properties with no duplicate-name error
- [ ] Click Move Down on Discount — tree reverts to `[Date, Discount, Num, Paid]`, right panel follows
- [ ] Verify Move Up / Move Down on first and last attributes are disabled (buttons greyed out)
- [ ] Verify Save persists the new order

🤖 Generated with [Claude Code](https://claude.com/claude-code)