### PR TITLE
update workflow

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetColumnInfo.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetColumnInfo.java
@@ -18,6 +18,8 @@
 
 package inetsoft.web.wiz.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * Describes one column in the primary worksheet table assembly.
  * <p>
@@ -31,6 +33,7 @@ package inetsoft.web.wiz.model;
  * catalog – DB catalog (may be empty)
  * path    – datasource path (used to match against FieldInfo.source.path)
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorksheetColumnInfo {
    public String getName() {
       return name;

--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetColumnInfo.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetColumnInfo.java
@@ -24,6 +24,8 @@ package inetsoft.web.wiz.model;
  * name    – the underlying DB column name (used to match against FieldInfo.name)
  * alias   – the column identifier as StyleBI knows it in the worksheet;
  * null when the alias equals the DB column name
+ * type    – the column data type (XSchema type, e.g. "string", "integer", "date");
+ * used by the visualization layer to classify dimension vs measure
  * table   – DB table name (used to match against FieldInfo.table)
  * schema  – DB schema (may be empty)
  * catalog – DB catalog (may be empty)
@@ -44,6 +46,14 @@ public class WorksheetColumnInfo {
 
    public void setAlias(String alias) {
       this.alias = alias;
+   }
+
+   public String getType() {
+      return type;
+   }
+
+   public void setType(String type) {
+      this.type = type;
    }
 
    public String getTable() {
@@ -80,6 +90,7 @@ public class WorksheetColumnInfo {
 
    private String name;
    private String alias;
+   private String type;
    private String table;
    private String schema;
    private String catalog;

--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetTableResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetTableResponse.java
@@ -40,6 +40,12 @@ public class WorksheetTableResponse {
    /** Columns exposed by the newly created table. */
    private List<ColumnData> columns;
 
+   /**
+    * Primary-table fields (name, alias, type, source) StyleBI exposes for visualization binding.
+    * Populated only when this table was created with {@code asPrimaryTable = true}; null otherwise.
+    */
+   private List<WorksheetColumnInfo> primaryTableFields;
+
    private boolean success;
    private String errorMessage;
 
@@ -51,6 +57,11 @@ public class WorksheetTableResponse {
 
    public List<ColumnData> getColumns() { return columns; }
    public void setColumns(List<ColumnData> columns) { this.columns = columns; }
+
+   public List<WorksheetColumnInfo> getPrimaryTableFields() { return primaryTableFields; }
+   public void setPrimaryTableFields(List<WorksheetColumnInfo> primaryTableFields) {
+      this.primaryTableFields = primaryTableFields;
+   }
 
    public boolean isSuccess() { return success; }
    public void setSuccess(boolean success) { this.success = success; }

--- a/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
@@ -1174,110 +1174,17 @@ public class GenerateWsService {
       AbstractTableAssembly primaryTable,
       WorksheetConstructionModel model)
    {
-      if(primaryTable == null) {
-         return Collections.emptyList();
-      }
+      // For a physical primary table the DB table name is resolved from the construction model's
+      // fields (falling back to the assembly name); WsServiceHelper applies the assembly-name
+      // fallback when the override is null.
+      String physicalDbTableNameOverride = model.getFields() == null ? null :
+         model.getFields().stream()
+            .filter(f -> f.getTable() != null)
+            .map(f -> f.getTable().getName())
+            .findFirst()
+            .orElse(null);
 
-      ColumnSelection cs = primaryTable.getColumnSelection(false);
-      List<WorksheetColumnInfo> result = new ArrayList<>(cs.getAttributeCount());
-
-      if(primaryTable instanceof PhysicalBoundTableAssembly physTable) {
-         String dbTableName = model.getFields() == null ? physTable.getName() :
-            model.getFields().stream()
-               .filter(f -> f.getTable() != null)
-               .map(f -> f.getTable().getName())
-               .findFirst()
-               .orElse(physTable.getName());
-
-         SourceInfo si = physTable.getSourceInfo();
-         String path = si != null && si.getPrefix() != null ? si.getPrefix() : "";
-         String schema = si != null && si.getProperty(SourceInfo.SCHEMA) != null ? si.getProperty(SourceInfo.SCHEMA) : "";
-         String catalog = si != null && si.getProperty(SourceInfo.CATALOG) != null ? si.getProperty(SourceInfo.CATALOG) : "";
-
-         for(int i = 0; i < cs.getAttributeCount(); i++) {
-            DataRef attr = cs.getAttribute(i);
-
-            // ColumnRef.getAttribute() returns the alias when one is set (StyleBI override).
-            // Go through getDataRef() to reach the underlying AttributeRef and get the true DB column name.
-            DataRef underlying = attr instanceof ColumnRef cr && cr.getDataRef() != null
-               ? cr.getDataRef() : attr;
-            String name = underlying.getAttribute();
-
-            // alias = what c.getAttribute() returns in autoBinding's column filter:
-            // the explicitly-set alias when it differs from the DB column name, null otherwise.
-            String colRefAlias = attr instanceof ColumnRef cr && !Tool.isEmptyString(cr.getAlias())
-               ? cr.getAlias() : null;
-            String alias = colRefAlias != null && !colRefAlias.equals(name) ? colRefAlias : null;
-
-            WorksheetColumnInfo info = new WorksheetColumnInfo();
-            info.setName(name);
-            info.setAlias(alias);
-            info.setTable(dbTableName);
-            info.setSchema(schema);
-            info.setCatalog(catalog);
-            info.setPath(path);
-            result.add(info);
-         }
-      }
-      else {
-         // CompositeTableAssembly: each column's entity is the sub-table assembly name (= DB table name).
-         for(int i = 0; i < cs.getAttributeCount(); i++) {
-            DataRef attr = cs.getAttribute(i);
-            String worksheetColName = attr.getAttribute(); // base alias or DB column name
-            String subTableName = attr.getEntity();
-
-            if(Tool.isEmptyString(subTableName)) {
-               continue;
-            }
-
-            String dbColumnName = worksheetColName; // fallback if sub-table is not a physical table
-            String path = "";
-            String schema = "";
-            String catalog = "";
-
-            Assembly subAssembly = worksheet.getAssembly(subTableName);
-
-            if(subAssembly instanceof PhysicalBoundTableAssembly subPhys) {
-               SourceInfo si = subPhys.getSourceInfo();
-               path = si != null && si.getPrefix() != null ? si.getPrefix() : "";
-               schema = si != null && si.getProperty(SourceInfo.SCHEMA) != null ? si.getProperty(SourceInfo.SCHEMA) : "";
-               catalog = si != null && si.getProperty(SourceInfo.CATALOG) != null ? si.getProperty(SourceInfo.CATALOG) : "";
-
-               // Resolve worksheetColName back to the underlying DB column name.
-               // In WsServiceHelper.initCompositeColumnSelection the join column attribute was set
-               // to the base column's alias (if any) or its attribute. Reverse-map that here.
-               ColumnSelection subCS = subPhys.getColumnSelection(true);
-
-               for(int j = 0; j < subCS.getAttributeCount(); j++) {
-                  DataRef subAttr = subCS.getAttribute(j);
-                  String subAlias = subAttr instanceof ColumnRef sc && !Tool.isEmptyString(sc.getAlias())
-                     ? sc.getAlias() : null;
-                  String subColName = subAlias != null ? subAlias : subAttr.getAttribute();
-
-                  if(worksheetColName.equals(subColName)) {
-                     // Bypass ColumnRef.getAttribute() alias override to get the real DB column name.
-                     DataRef subUnderlying = subAttr instanceof ColumnRef sc && sc.getDataRef() != null
-                        ? sc.getDataRef() : subAttr;
-                     dbColumnName = subUnderlying.getAttribute();
-                     break;
-                  }
-               }
-            }
-
-            String alias = dbColumnName.equals(worksheetColName) ? null : worksheetColName;
-
-            WorksheetColumnInfo info = new WorksheetColumnInfo();
-            info.setName(dbColumnName);
-            info.setAlias(alias);
-            info.setTable(subTableName);
-            info.setSchema(schema);
-            info.setCatalog(catalog);
-            info.setPath(path);
-            result.add(info);
-         }
-      }
-
-      return result;
+      return WsServiceHelper.extractPrimaryTableFields(worksheet, primaryTable, physicalDbTableNameOverride);
    }
 
    private final ViewsheetService viewsheetService;

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -145,8 +145,10 @@ public class WorksheetTableService {
       response.setColumns(columns);
 
       if(request.isAsPrimaryTable()) {
+         String dbTableOverride = request.getPhysicalSource() != null
+            ? request.getPhysicalSource().getTableName() : null;
          response.setPrimaryTableFields(
-            WsServiceHelper.extractPrimaryTableFields(worksheet, table, null));
+            WsServiceHelper.extractPrimaryTableFields(worksheet, table, dbTableOverride));
       }
 
       response.setSuccess(true);

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -143,6 +143,12 @@ public class WorksheetTableService {
       response.setWsId(worksheetEntry.toIdentifier());
       response.setTableName(table.getName());
       response.setColumns(columns);
+
+      if(request.isAsPrimaryTable()) {
+         response.setPrimaryTableFields(
+            WsServiceHelper.extractPrimaryTableFields(worksheet, table, null));
+      }
+
       response.setSuccess(true);
       return response;
    }

--- a/core/src/main/java/inetsoft/web/wiz/service/WsServiceHelper.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsServiceHelper.java
@@ -27,6 +27,7 @@ import inetsoft.uql.erm.*;
 import inetsoft.util.Tool;
 import inetsoft.web.composer.ws.LayoutGraphService;
 import inetsoft.web.composer.ws.event.WSLayoutGraphEvent;
+import inetsoft.web.wiz.model.WorksheetColumnInfo;
 import inetsoft.web.wiz.model.osi.*;
 
 import java.security.Principal;
@@ -62,6 +63,126 @@ final class WsServiceHelper {
       }
 
       return null;
+   }
+
+   /**
+    * Describe the columns of the worksheet's primary (binding) table for the visualization layer.
+    * <p>
+    * For each column:
+    * <ul>
+    *   <li>name  – the underlying DB column name (via {@code ColumnRef.getDataRef()}, bypassing the
+    *       alias override of {@code getAttribute()}).</li>
+    *   <li>alias – the explicitly-set alias when it differs from the DB column name, else null.</li>
+    *   <li>type  – the column data type (XSchema type), used to classify dimension vs measure.</li>
+    * </ul>
+    * {@code alias ?? name} always equals what {@code c.getAttribute()} returns, the key used by
+    * {@code WizAutoBindingService.autoBinding}'s column filter.
+    *
+    * @param physicalDbTableNameOverride when non-null, used as the DB table name for a physical
+    *        primary table (the flat path resolves this from the construction model); null falls back
+    *        to the assembly name.
+    */
+   static List<WorksheetColumnInfo> extractPrimaryTableFields(
+      Worksheet worksheet,
+      AbstractTableAssembly primaryTable,
+      String physicalDbTableNameOverride)
+   {
+      if(primaryTable == null) {
+         return Collections.emptyList();
+      }
+
+      ColumnSelection cs = primaryTable.getColumnSelection(false);
+      List<WorksheetColumnInfo> result = new ArrayList<>(cs.getAttributeCount());
+
+      if(primaryTable instanceof PhysicalBoundTableAssembly physTable) {
+         String dbTableName = physicalDbTableNameOverride != null
+            ? physicalDbTableNameOverride : physTable.getName();
+
+         SourceInfo si = physTable.getSourceInfo();
+         String path = si != null && si.getPrefix() != null ? si.getPrefix() : "";
+         String schema = si != null && si.getProperty(SourceInfo.SCHEMA) != null ? si.getProperty(SourceInfo.SCHEMA) : "";
+         String catalog = si != null && si.getProperty(SourceInfo.CATALOG) != null ? si.getProperty(SourceInfo.CATALOG) : "";
+
+         for(int i = 0; i < cs.getAttributeCount(); i++) {
+            DataRef attr = cs.getAttribute(i);
+
+            // ColumnRef.getAttribute() returns the alias when one is set (StyleBI override).
+            // Go through getDataRef() to reach the underlying AttributeRef and get the true DB column name.
+            DataRef underlying = attr instanceof ColumnRef cr && cr.getDataRef() != null
+               ? cr.getDataRef() : attr;
+            String name = underlying.getAttribute();
+
+            String colRefAlias = attr instanceof ColumnRef cr && !Tool.isEmptyString(cr.getAlias())
+               ? cr.getAlias() : null;
+            String alias = colRefAlias != null && !colRefAlias.equals(name) ? colRefAlias : null;
+
+            WorksheetColumnInfo info = new WorksheetColumnInfo();
+            info.setName(name);
+            info.setAlias(alias);
+            info.setType(attr.getDataType());
+            info.setTable(dbTableName);
+            info.setSchema(schema);
+            info.setCatalog(catalog);
+            info.setPath(path);
+            result.add(info);
+         }
+      }
+      else {
+         // CompositeTableAssembly: each column's entity is the sub-table assembly name (= DB table name).
+         for(int i = 0; i < cs.getAttributeCount(); i++) {
+            DataRef attr = cs.getAttribute(i);
+            String worksheetColName = attr.getAttribute(); // base alias or DB column name
+            String subTableName = attr.getEntity();
+
+            if(Tool.isEmptyString(subTableName)) {
+               continue;
+            }
+
+            String dbColumnName = worksheetColName; // fallback if sub-table is not a physical table
+            String path = "";
+            String schema = "";
+            String catalog = "";
+
+            Assembly subAssembly = worksheet.getAssembly(subTableName);
+
+            if(subAssembly instanceof PhysicalBoundTableAssembly subPhys) {
+               SourceInfo si = subPhys.getSourceInfo();
+               path = si != null && si.getPrefix() != null ? si.getPrefix() : "";
+               schema = si != null && si.getProperty(SourceInfo.SCHEMA) != null ? si.getProperty(SourceInfo.SCHEMA) : "";
+               catalog = si != null && si.getProperty(SourceInfo.CATALOG) != null ? si.getProperty(SourceInfo.CATALOG) : "";
+
+               ColumnSelection subCS = subPhys.getColumnSelection(true);
+
+               for(int j = 0; j < subCS.getAttributeCount(); j++) {
+                  DataRef subAttr = subCS.getAttribute(j);
+                  String subAlias = subAttr instanceof ColumnRef sc && !Tool.isEmptyString(sc.getAlias())
+                     ? sc.getAlias() : null;
+                  String subColName = subAlias != null ? subAlias : subAttr.getAttribute();
+
+                  if(worksheetColName.equals(subColName)) {
+                     DataRef subUnderlying = subAttr instanceof ColumnRef sc && sc.getDataRef() != null
+                        ? sc.getDataRef() : subAttr;
+                     dbColumnName = subUnderlying.getAttribute();
+                     break;
+                  }
+               }
+            }
+
+            String alias = dbColumnName.equals(worksheetColName) ? null : worksheetColName;
+
+            WorksheetColumnInfo info = new WorksheetColumnInfo();
+            info.setName(dbColumnName);
+            info.setAlias(alias);
+            info.setType(attr.getDataType());
+            info.setTable(subTableName);
+            info.setSchema(schema);
+            info.setCatalog(catalog);
+            info.setPath(path);
+            result.add(info);
+         }
+      }
+
+      return result;
    }
 
    static AssetEntry persistWorksheet(ViewsheetService viewsheetService,

--- a/core/src/main/java/inetsoft/web/wiz/service/WsServiceHelper.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsServiceHelper.java
@@ -164,7 +164,7 @@ final class WsServiceHelper {
                schema = si != null && si.getProperty(SourceInfo.SCHEMA) != null ? si.getProperty(SourceInfo.SCHEMA) : "";
                catalog = si != null && si.getProperty(SourceInfo.CATALOG) != null ? si.getProperty(SourceInfo.CATALOG) : "";
 
-               ColumnSelection subCS = subPhys.getColumnSelection(true);
+               ColumnSelection subCS = subPhys.getColumnSelection(false);
 
                for(int j = 0; j < subCS.getAttributeCount(); j++) {
                   DataRef subAttr = subCS.getAttribute(j);

--- a/core/src/main/java/inetsoft/web/wiz/service/WsServiceHelper.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsServiceHelper.java
@@ -77,7 +77,14 @@ final class WsServiceHelper {
     * </ul>
     * {@code alias ?? name} always equals what {@code c.getAttribute()} returns, the key used by
     * {@code WizAutoBindingService.autoBinding}'s column filter.
+    * <p>
+    * Note: {@code type} may be null when a column's data type was never set (e.g. metadata with no
+    * type); consumers must handle null types. Mirror-table primaries yield an empty list (their
+    * columns carry no sub-table entity name).
     *
+    * @param worksheet owning worksheet, used to resolve sub-table source info for composite primary
+    *        tables; may be null only for a physical primary table (it is not dereferenced in that
+    *        path). A null worksheet with a composite primary table leaves source fields unresolved.
     * @param physicalDbTableNameOverride when non-null, used as the DB table name for a physical
     *        primary table (the flat path resolves this from the construction model); null falls back
     *        to the assembly name.
@@ -91,7 +98,7 @@ final class WsServiceHelper {
          return Collections.emptyList();
       }
 
-      ColumnSelection cs = primaryTable.getColumnSelection(false);
+      ColumnSelection cs = primaryTable.getColumnSelection(true);
       List<WorksheetColumnInfo> result = new ArrayList<>(cs.getAttributeCount());
 
       if(primaryTable instanceof PhysicalBoundTableAssembly physTable) {
@@ -128,7 +135,11 @@ final class WsServiceHelper {
          }
       }
       else {
-         // CompositeTableAssembly: each column's entity is the sub-table assembly name (= DB table name).
+         // Non-physical primary table (RelationalJoinTableAssembly and other composites):
+         // each column's entity is the sub-table assembly name, used to resolve the DB table name.
+         // Note: MirrorTableAssembly columns typically lack an entity name and will be skipped
+         // by the Tool.isEmptyString(subTableName) check below, so the result is empty for mirror
+         // primaries.
          for(int i = 0; i < cs.getAttributeCount(); i++) {
             DataRef attr = cs.getAttribute(i);
             String worksheetColName = attr.getAttribute(); // base alias or DB column name
@@ -143,7 +154,9 @@ final class WsServiceHelper {
             String schema = "";
             String catalog = "";
 
-            Assembly subAssembly = worksheet.getAssembly(subTableName);
+            // worksheet may be null only if a caller passes a composite primary table without its
+            // owning worksheet; treat the sub-table as unresolvable and fall back to the column name.
+            Assembly subAssembly = worksheet != null ? worksheet.getAssembly(subTableName) : null;
 
             if(subAssembly instanceof PhysicalBoundTableAssembly subPhys) {
                SourceInfo si = subPhys.getSourceInfo();


### PR DESCRIPTION
1. Remove useless outputs and rename outputs that may cause confusion.
2. Both the `validate_worksheet` and `create worksheet table` workflows output `primaryTableFields`. The `visualizationHintsExtractionNode` uses `primaryTableFields` just like the VS wizard, reducing costs and minimizing the probability of LLM errors.
3. Persist the WS primary table and `primaryTableFields` in `visualization_context`.
4. Use `expandedFieldMapping` to check incremental information: Only when a new field does not exist in `expandedFieldMapping` should the processes of retrieval, schemaMapping, joinAware, etc., be executed. However, when there is a Filter update, the `conditionParser` and `conditionValueCorrector` must always be invoked to correct the condition values recognized from natural language (including highlight conditions), ensuring that subsequent agents such as `conditionFilterAgent` and `highlightAgent` do not need to handle condition value correction.
5. Remove `wsTableName` from `CreateViewsheetArgs`; always use the primary table as the binding source.