### PR TITLE
Bug #75443, fix physical view drag-to-join failing after Angular upgrade

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/common-components/join-node-graph/join-node-graph.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/common-components/join-node-graph/join-node-graph.component.ts
@@ -18,7 +18,7 @@
 import { HttpClient, HttpParams } from "@angular/common/http";
 import {
    AfterViewInit, Component, ElementRef, EventEmitter, HostBinding, HostListener, Input,
-   Optional, Output, ViewChild,
+   OnChanges, Optional, Output, SimpleChanges, ViewChild,
 } from "@angular/core";
 import { NgbModal, NgbModalOptions } from "@ng-bootstrap/ng-bootstrap";
 import { AssemblyActionGroup } from "../../../../../../common/action/assembly-action-group";
@@ -56,7 +56,7 @@ const EDIT_QUERY_TABLE_PROPERTIES = "../api/data/datasource/query/table/properti
         "../../../../../../composer/gui/ws/jsplumb/jsplumb-shared.scss"],
     imports: [NgClass]
 })
-export class JoinNodeGraphComponent implements AfterViewInit {
+export class JoinNodeGraphComponent implements AfterViewInit, OnChanges {
    @Input() runtimeId: string;
    @Input() graph: GraphModel;
    @Input() graphEndpoints: any[];
@@ -83,6 +83,16 @@ export class JoinNodeGraphComponent implements AfterViewInit {
                @Optional() private physicalModelService: DataPhysicalModelService,
                private readonly fixedDropdownService: FixedDropdownService)
    {
+   }
+
+   // When the parent's ngOnChanges resets this.nodes/{} and deletes all jsPlumb endpoints,
+   // reused @for-tracked instances skip ngAfterViewInit. Re-register here so every node
+   // is back in the parent's lookup map and its endpoints are restored.
+   ngOnChanges(changes: SimpleChanges): void {
+      if(changes["graph"] && !changes["graph"].isFirstChange() && this.nodeGraph) {
+         this.endPointsInit();
+         this.onRegisterNode.emit([this.graph, this.nodeGraph.nativeElement]);
+      }
    }
 
    ngAfterViewInit(): void {


### PR DESCRIPTION
## Summary

- Angular's `@for` block (Angular 17+) reuses `join-node-graph` instances when `track graph.node.id` matches, so reused instances skip `ngAfterViewInit`
- When `physical-model-network-graph.ngOnChanges` fires (e.g. a second table is selected), it clears `this.nodes = {}` and calls `jsp.deleteEveryEndpoint()` — but only **newly-created** nodes re-register via `ngAfterViewInit`; reused nodes lose their endpoints permanently
- This causes `checkJoinCompatibility` to only see the single newly-registered node and show "There are no other tables to join with", preventing join creation via drag

## Fix

Added `ngOnChanges` to `JoinNodeGraphComponent`. When the `graph` input changes on a **reused** instance (`!isFirstChange()`), the component re-runs `endPointsInit()` and emits `onRegisterNode`, restoring its jsPlumb endpoints and re-inserting itself into the parent's node lookup map. New components are unaffected (guarded by `isFirstChange()`).

## Test plan

- [ ] Create a new data source and physical view
- [ ] Select two or more tables
- [ ] Drag from an endpoint on one table to another — join edit pane should open (no "no other tables" warning)
- [ ] Verify existing joins still display and are clickable after saving and reopening the physical view

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
