### PR TITLE
Bug #75434, fix spurious warning when saving another user's ALLSHARE bookmark

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
@@ -228,11 +228,10 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
       }
 
       if("add".equals(action)) {
-         rvs.removeBookmark(name, ownerId, false);
          //add the bookmark
          addBookmark(rvs, name, type, readOnly,
                                      !"add".equals(originalAction) || value.confirmed(), owner,
-                                     commandDispatcher, value, BookmarkRecord.ACTION_TYPE_MODIFY,
+                                     principal, commandDispatcher, value, BookmarkRecord.ACTION_TYPE_MODIFY,
                                      origBookmarkInfo);
       }
       else if("readd".equals(action)) {
@@ -240,7 +239,7 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
          rvs.updateVSBookmark();
          addBookmark(rvs, name, type, readOnly,
                                      !"add".equals(originalAction) || value.confirmed(), owner,
-                                     commandDispatcher, value, BookmarkRecord.ACTION_TYPE_MODIFY,
+                                     principal, commandDispatcher, value, BookmarkRecord.ACTION_TYPE_MODIFY,
                                      origBookmarkInfo);
       }
 
@@ -601,8 +600,18 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
                            CommandDispatcher commandDispatcher, VSEditBookmarkEvent value,
                            String bookmarkActionType, VSBookmarkInfo origBookmarkInfo)
       throws Exception {
+      addBookmark(rvs, bookmarkName, type, readOnly, confirmed, principal, principal,
+                  commandDispatcher, value, bookmarkActionType, origBookmarkInfo);
+   }
+
+   private void addBookmark(RuntimeViewsheet rvs, String bookmarkName, int type,
+                           boolean readOnly, boolean confirmed, Principal principal,
+                           Principal currentPrincipal,
+                           CommandDispatcher commandDispatcher, VSEditBookmarkEvent value,
+                           String bookmarkActionType, VSBookmarkInfo origBookmarkInfo)
+      throws Exception {
       MessageCommand messageCommand = addBookmarkToViewSheet(rvs, bookmarkName, type, readOnly,
-                                                             confirmed, principal);
+                                                             confirmed, principal, currentPrincipal);
       IdentityID pId = principal == null ? null : IdentityID.getIdentityIDFromKey(principal.getName());
 
       if(messageCommand.getType() != MessageCommand.Type.OK) {
@@ -640,8 +649,16 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
                                                 Principal principal)
       throws Exception
    {
+      return addBookmarkToViewSheet(rvs, bookmarkName, type, readOnly, confirmed, principal, principal);
+   }
+
+   public MessageCommand addBookmarkToViewSheet(RuntimeViewsheet rvs, String bookmarkName, int type,
+                                                boolean readOnly, boolean confirmed,
+                                                Principal principal, Principal currentPrincipal)
+      throws Exception
+   {
       Viewsheet vs = rvs.getViewsheet();
-      MessageCommand messageCommand = checkAddBookmark(rvs, bookmarkName, confirmed, principal);
+      MessageCommand messageCommand = checkAddBookmark(rvs, bookmarkName, confirmed, principal, currentPrincipal);
 
       if(messageCommand.getType() != MessageCommand.Type.OK) {
          return messageCommand;
@@ -659,14 +676,22 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
                                           boolean confirmed, Principal principal)
       throws SecurityException
    {
+      return checkAddBookmark(rvs, bookmarkName, confirmed, principal, principal);
+   }
+
+   public MessageCommand checkAddBookmark(RuntimeViewsheet rvs, String bookmarkName,
+                                          boolean confirmed, Principal principal,
+                                          Principal currentPrincipal)
+      throws SecurityException
+   {
       SecurityEngine engine = securityEngine;
       MessageCommand messageCommand = new MessageCommand();
 
-      boolean isGlobalVSPermDenied = SUtil.isDefaultVSGloballyVisible(principal) &&
+      boolean isGlobalVSPermDenied = SUtil.isDefaultVSGloballyVisible(currentPrincipal) &&
                                      !Tool.equals(rvs.getEntry() == null ? "" :
-                                     rvs.getEntry().getOrgID(),((XPrincipal)principal).getOrgId());
+                                     rvs.getEntry().getOrgID(),((XPrincipal)currentPrincipal).getOrgId());
 
-      if(!engine.checkPermission(principal, ResourceType.VIEWSHEET_ACTION, "Bookmark",
+      if(!engine.checkPermission(currentPrincipal, ResourceType.VIEWSHEET_ACTION, "Bookmark",
                                  ResourceAction.READ))
       {
          messageCommand.setMessage(catalog.getString("viewer.viewsheet.security.addbookmark"));

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSBookmarkService.java
@@ -687,9 +687,10 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
       SecurityEngine engine = securityEngine;
       MessageCommand messageCommand = new MessageCommand();
 
-      boolean isGlobalVSPermDenied = SUtil.isDefaultVSGloballyVisible(currentPrincipal) &&
+      boolean isGlobalVSPermDenied = currentPrincipal instanceof XPrincipal &&
+                                     SUtil.isDefaultVSGloballyVisible(currentPrincipal) &&
                                      !Tool.equals(rvs.getEntry() == null ? "" :
-                                     rvs.getEntry().getOrgID(),((XPrincipal)currentPrincipal).getOrgId());
+                                     rvs.getEntry().getOrgID(), ((XPrincipal) currentPrincipal).getOrgId());
 
       if(!engine.checkPermission(currentPrincipal, ResourceType.VIEWSHEET_ACTION, "Bookmark",
                                  ResourceAction.READ))
@@ -712,6 +713,8 @@ public class VSBookmarkService implements ApplicationListener<ProcessBookmarkEve
          messageCommand.setMessage(catalog.getString("common.viewsheet.saveViewsheetDependence"));
          messageCommand.setType(MessageCommand.Type.ERROR);
       }
+      // Use principal (bookmark owner), not currentPrincipal — the "replace?" prompt must check
+      // whether the owner already has a bookmark by this name, not whether the current user does.
       else if(!confirmed && rvs.containsBookmark(bookmarkName, IdentityID.getIdentityIDFromKey(principal.getName()))) {
          messageCommand.setMessage(
                  catalog.getString("viewer.viewsheet.bookmark.replaceWarning", bookmarkName));


### PR DESCRIPTION
When saving a non-readOnly ALLSHARE bookmark owned by a user that no longer exists in the security provider, the permission check in checkAddBookmark was incorrectly using the bookmark owner's bare SRPrincipal instead of the current logged-in user's principal, causing it to fail. Added a currentPrincipal parameter so permission and org-visibility checks always use the actual session user, while the bookmark owner identity is still used for storage. Also removed an erroneous removeBookmark call that was re-introduced during a merge, which could silently delete a bookmark if the subsequent add failed.