### PR TITLE
feat(wiz): "sql query table" worksheet type (raw SQL / window functions)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetTableRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetTableRequest.java
@@ -58,6 +58,16 @@ public class WorksheetTableRequest {
    /** Expression columns (only valid on non-aggregated mirror tables). */
    private List<ExpressionColumnInfo> expressionColumns;
 
+   // ─── SQL-query-table field ────────────────────────────────────────────────
+
+   /**
+    * Raw SQL SELECT for {@code tableType == "sql query table"}. Bound as a
+    * {@link inetsoft.uql.asset.SQLBoundTableAssembly} against
+    * {@code physicalSource.datasourcePath}, so window functions / CTEs / any
+    * dialect SQL execute directly on the database. Other tables can join/mirror it.
+    */
+   private String sqlExpression;
+
    // ─── Mirror / join base tables ────────────────────────────────────────────
 
    /** Names of already-created tables in this worksheet to use as bases. */
@@ -104,6 +114,9 @@ public class WorksheetTableRequest {
 
    public List<ExpressionColumnInfo> getExpressionColumns() { return expressionColumns; }
    public void setExpressionColumns(List<ExpressionColumnInfo> expressionColumns) { this.expressionColumns = expressionColumns; }
+
+   public String getSqlExpression() { return sqlExpression; }
+   public void setSqlExpression(String sqlExpression) { this.sqlExpression = sqlExpression; }
 
    public List<String> getBaseTables() { return baseTables; }
    public void setBaseTables(List<String> baseTables) { this.baseTables = baseTables; }

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -23,14 +23,19 @@ import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.AssetUtil;
+import inetsoft.uql.asset.internal.SQLBoundTableAssemblyInfo;
 import inetsoft.uql.erm.*;
 import inetsoft.uql.jdbc.JDBCDataSource;
+import inetsoft.uql.jdbc.JDBCQuery;
+import inetsoft.uql.jdbc.UniformSQL;
+import inetsoft.uql.jdbc.util.JDBCUtil;
 import inetsoft.uql.jdbc.util.SQLTypes;
 import inetsoft.uql.schema.UserVariable;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.util.Tool;
 import inetsoft.web.composer.ws.LayoutGraphService;
 import inetsoft.web.composer.ws.joins.InnerJoinService;
+import inetsoft.web.portal.controller.database.QueryManagerService;
 import inetsoft.web.wiz.model.*;
 import inetsoft.web.wiz.model.osi.*;
 import inetsoft.web.wiz.request.GetDatabaseTableMetaRequest;
@@ -51,6 +56,8 @@ import static inetsoft.web.wiz.service.WizDateLevelUtil.getDateGroupLevel;
  *   <li>{@code mirror table}   — {@link MirrorTableAssembly} over an existing worksheet table,
  *       with optional aggregation and expression columns</li>
  *   <li>{@code relational join table} — {@link RelationalJoinTableAssembly} over existing tables</li>
+ *   <li>{@code sql query table} — {@link SQLBoundTableAssembly} bound to a raw SQL SELECT
+ *       (window functions / CTEs / any dialect SQL execute on the database)</li>
  * </ul>
  */
 @Service
@@ -60,12 +67,16 @@ public class WorksheetTableService {
                                 MetadataApiService metadataApiService,
                                 InnerJoinService innerJoinService,
                                 LayoutGraphService layoutGraphService,
+                                QueryManagerService queryManagerService,
+                                XRepository xrepository,
                                 ObjectMapper objectMapper)
    {
       this.viewsheetService = viewsheetService;
       this.metadataApiService = metadataApiService;
       this.innerJoinService = innerJoinService;
       this.layoutGraphService = layoutGraphService;
+      this.queryManagerService = queryManagerService;
+      this.xrepository = xrepository;
       this.objectMapper = objectMapper;
    }
 
@@ -357,6 +368,7 @@ public class WorksheetTableService {
          case "physical table"        -> buildPhysicalTable(worksheet, request, user);
          case "mirror table"          -> buildMirrorTable(worksheet, request);
          case "relational join table" -> buildJoinTable(worksheet, request);
+         case "sql query table"       -> buildSqlTable(worksheet, request);
          default -> throw new IllegalArgumentException("Unknown tableType: " + tableType);
       };
 
@@ -422,6 +434,72 @@ public class WorksheetTableService {
       // Expression columns are only meaningful on non-aggregated mirror tables;
       // log a warning but don't fail if someone passes them here.
       applyExpressionColumns(table, request.getExpressionColumns());
+
+      worksheet.addAssembly(table);
+      return table;
+   }
+
+   /**
+    * Build a {@link SQLBoundTableAssembly} from a raw SQL SELECT. The query is pushed to the
+    * database verbatim, so window functions, CTEs, non-equi joins and any dialect-specific SQL
+    * work — unlike the physical/mirror/join model, whose generated SQL can't express them.
+    * Other tables can mirror/join the result by name.
+    */
+   private AbstractTableAssembly buildSqlTable(Worksheet worksheet, WorksheetTableRequest request)
+      throws Exception
+   {
+      String sqlString = request.getSqlExpression();
+      WorksheetTableRequest.PhysicalSource src = request.getPhysicalSource();
+
+      if(sqlString == null || sqlString.isBlank()) {
+         throw new IllegalArgumentException("sqlExpression is required for sql query table");
+      }
+
+      if(src == null || src.getDatasourcePath() == null) {
+         throw new IllegalArgumentException(
+            "physicalSource.datasourcePath is required for sql query table");
+      }
+
+      String dsName = src.getDatasourcePath();
+      JDBCDataSource ds = metadataApiService.getJDBCDatasource(dsName);
+
+      SQLBoundTableAssembly table = new SQLBoundTableAssembly(worksheet, request.getTableName());
+
+      UniformSQL sql = new UniformSQL();
+      sql.setDataSource(ds);
+
+      // Block until the SQL string is parsed; SQLProcessor calls notifyAll() in its parse finally
+      // block. Bounded wait so a parse that never notifies can't hang the request thread — the
+      // column resolution below falls back to executing the query for output metadata.
+      synchronized(sql) {
+         sql.setParseSQL(true);
+         sql.setSQLString(sqlString, true);
+         sql.wait(30000);
+      }
+
+      JDBCQuery query = new JDBCQuery();
+      query.setUserQuery(true);
+      query.setDataSource(ds);
+      query.setSQLDefinition(sql);
+
+      SQLBoundTableAssemblyInfo info = (SQLBoundTableAssemblyInfo) table.getInfo();
+      info.setQuery(query);
+      info.setSourceInfo(new SourceInfo(SourceInfo.PHYSICAL_TABLE, dsName, dsName));
+
+      Object session = viewsheetService.getAssetRepository().getSession();
+      JDBCUtil.fixUniformSQLInfo(sql, xrepository, session, ds);
+
+      ColumnSelection columns =
+         queryManagerService.getColumnSelection(query, new VariableTable(), table, session, null);
+
+      if(columns == null || columns.getAttributeCount() == 0) {
+         throw new IllegalArgumentException(
+            "Could not resolve any columns from sqlExpression — check the SQL is a valid SELECT for datasource '" +
+            dsName + "'.");
+      }
+
+      table.setColumnSelection(columns);
+      table.setSQLEdited(false);
 
       worksheet.addAssembly(table);
       return table;
@@ -1082,5 +1160,7 @@ public class WorksheetTableService {
    private final MetadataApiService metadataApiService;
    private final InnerJoinService innerJoinService;
    private final LayoutGraphService layoutGraphService;
+   private final QueryManagerService queryManagerService;
+   private final XRepository xrepository;
    private final ObjectMapper objectMapper;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -498,6 +498,20 @@ public class WorksheetTableService {
             dsName + "'.");
       }
 
+      // StyleBI's SQL parser captures selection aliases with surrounding double-quotes (e.g.
+      // "seller_state"). Expose a clean column name via an applied alias — this leaves each column's
+      // underlying ref (which maps to the SQL result) untouched, so data still binds.
+      for(int i = 0; i < columns.getAttributeCount(); i++) {
+         if(columns.getAttribute(i) instanceof ColumnRef cr) {
+            String nm = cr.getName();
+
+            if(nm != null && nm.length() >= 2 && nm.startsWith("\"") && nm.endsWith("\"")) {
+               cr.setAlias(nm.substring(1, nm.length() - 1));
+               cr.setApplyingAlias(true);
+            }
+         }
+      }
+
       table.setColumnSelection(columns);
       table.setSQLEdited(false);
 


### PR DESCRIPTION
## Summary

The `/ws/table` physical/mirror/join model can't express **window functions** (`ROW_NUMBER()/RANK() OVER (PARTITION BY …)`), **per-group top-N**, CTEs, or aggregation over **non-equi joins** — they silently no-op or fail at SQL generation.

Adds `tableType: "sql query table"`:
- `WorksheetTableRequest.sqlExpression` — a raw SQL `SELECT`.
- `WorksheetTableService.buildSqlTable()` — binds it as a `SQLBoundTableAssembly` against `physicalSource.datasourcePath` (modeled on `SQLQueryDialogService`: `UniformSQL` parse + `JDBCUtil.fixUniformSQLInfo`, columns resolved via `QueryManagerService.getColumnSelection`). Injects `QueryManagerService` + `XRepository`. Other tables can mirror/join the result by name.

Companion TS/plugin/docs change: **stylebi-wiz#898**.

## Test plan
Built the local StyleBI image with this change and ran, through the viz-chat plugin, **top 3 product categories per seller state**:
`ROW_NUMBER() OVER (PARTITION BY seller_state ORDER BY SUM(price) DESC)` filtered `rnk <= 3` → **57 correct rows** (e.g. PR: computers_accessories · sports_leisure · furniture_decor). Previously this no-op'd to null / 0 rows.

Note: result column names currently come back quoted (e.g. `"seller_state"`) — minor cosmetic follow-up (strip surrounding quotes in the column resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)