### PR TITLE
Bug #75452 - Stagger line/stacked-line load animation per series

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -858,20 +858,18 @@ public class SVGAnimationDOMInjector {
                                                             List<Element> annotAreas,
                                                             Element svgRoot, Document doc)
    {
-      // Line rank: data-series column index → 0-based rank.
-      // getColIndex() starts at 1 in some charts; TreeSet + sequential rank normalizes to 0-based.
-      // In a facet chart the same column indices repeat across panels; TreeSet deduplicates them.
-      TreeSet<Integer> lineColSet = new TreeSet<>();
+      // Line rank: composite data-series + data-color key, first-seen DOM order → 0-based rank.
+      // data-series alone (getColIndex()) collapses when one measure is split by a color/group
+      // dimension — all those LineVO share the same measure column index, so every line would
+      // rank 0 and animate at once (the same problem documented for area below).  Adding
+      // data-color distinguishes color-dimension series, while data-series still separates
+      // distinct measures that happen to share a color.
+      LinkedHashMap<String, Integer> lineSeriesRank = new LinkedHashMap<>();
 
       for(Element g : annotLines) {
-         lineColSet.add(parseIntAttr(g, "data-" + SVGSupport.ATTR_SERIES, 0));
-      }
-
-      Map<Integer, Integer> lineSeriesRank = new LinkedHashMap<>();
-      int rank = 0;
-
-      for(int col : lineColSet) {
-         lineSeriesRank.put(col, rank++);
+         String key = g.getAttribute("data-" + SVGSupport.ATTR_SERIES) + "|" +
+                      g.getAttribute("data-" + SVGSupport.ATTR_COLOR);
+         lineSeriesRank.putIfAbsent(key, lineSeriesRank.size());
       }
 
       // Area rank: data-color in DOM first-seen order.
@@ -920,8 +918,9 @@ public class SVGAnimationDOMInjector {
             seriesIdx = areaColorRank.getOrDefault(color, 0);
          }
          else {
-            int col = parseIntAttr(g, "data-" + SVGSupport.ATTR_SERIES, 0);
-            seriesIdx = lineSeriesRank.getOrDefault(col, 0);
+            String key = g.getAttribute("data-" + SVGSupport.ATTR_SERIES) + "|" +
+                         g.getAttribute("data-" + SVGSupport.ATTR_COLOR);
+            seriesIdx = lineSeriesRank.getOrDefault(key, 0);
          }
 
          double delay = AnimationConstants.staggerDelay(seriesIdx, numSeries);
@@ -1454,22 +1453,6 @@ public class SVGAnimationDOMInjector {
       }
       catch(NumberFormatException e) {
          return null;
-      }
-   }
-
-   /** Read an integer attribute from an element, returning {@code defaultVal} if absent/invalid. */
-   private static int parseIntAttr(Element el, String attr, int defaultVal) {
-      String v = el.getAttribute(attr);
-
-      if(v.isEmpty()) {
-         return defaultVal;
-      }
-
-      try {
-         return Integer.parseInt(v);
-      }
-      catch(NumberFormatException e) {
-         return defaultVal;
       }
    }
 

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -864,7 +864,7 @@ public class SVGAnimationDOMInjector {
       // rank 0 and animate at once (the same problem documented for area below).  Adding
       // data-color distinguishes color-dimension series, while data-series still separates
       // distinct measures that happen to share a color.
-      LinkedHashMap<String, Integer> lineSeriesRank = new LinkedHashMap<>();
+      Map<String, Integer> lineSeriesRank = new LinkedHashMap<>();
 
       for(Element g : annotLines) {
          String key = g.getAttribute("data-" + SVGSupport.ATTR_SERIES) + "|" +
@@ -876,7 +876,7 @@ public class SVGAnimationDOMInjector {
       // AreaVO.getColIndex() is unreliable for ordering — in stacked area charts all AreaVO
       // instances share the same measure column index.  data-color is unique per series and
       // preserves DOM (visual) order, so it gives the correct stagger without extra metadata.
-      LinkedHashMap<String, Integer> areaColorRank = new LinkedHashMap<>();
+      Map<String, Integer> areaColorRank = new LinkedHashMap<>();
 
       for(Element g : annotAreas) {
          String color = g.getAttribute("data-" + SVGSupport.ATTR_COLOR);
@@ -2324,10 +2324,9 @@ public class SVGAnimationDOMInjector {
     * Parse the {@code data-<attr>} integer attribute of an element, returning {@code 0} on
     * missing or malformed values.
     *
-    * <p><b>Note:</b> this overload automatically prepends {@code "data-"} to {@code attr}.
+    * <p><b>Note:</b> this method automatically prepends {@code "data-"} to {@code attr}.
     * Pass a short name like {@code SVGSupport.ATTR_LEVEL} (not {@code "data-level"}) or the
-    * attribute read will be {@code "data-data-level"}.  The 3-arg overload takes the full
-    * attribute name as-is and should be used when the caller already holds the full name.
+    * attribute read will be {@code "data-data-level"}.
     */
    private static int parseIntAttr(Element el, String attr) {
       String v = el.getAttribute("data-" + attr);

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -1134,6 +1134,39 @@ class SVGAnimationDOMInjectorTest {
    }
 
    /**
+    * In a facet chart the same series (same data-series + data-color) repeats across panels.
+    * Repeated keys must dedup to a stable rank so the series count is not inflated: same-key
+    * lines in different panels must share a delay, and the rank spacing must stay at the
+    * two-series spacing (STAGGER_WINDOW), not a four-series spacing.
+    */
+   @Test
+   void facetPanelsWithRepeatedSeries_dedupToStableRank() throws Exception {
+      Document doc = newDocument();
+      Element svg = doc.getDocumentElement();
+
+      // Panel 1: series A then series B.
+      Element p1a = addLineSeries(doc, svg, "34,211,238",  "0", "M0,50 L50,40 L100,30 L150,20");
+      Element p1b = addLineSeries(doc, svg, "167,139,250", "0", "M0,40 L50,30 L100,20 L150,10");
+      // Panel 2: same two series repeated.
+      Element p2a = addLineSeries(doc, svg, "34,211,238",  "0", "M200,50 L250,40 L300,30 L350,20");
+      Element p2b = addLineSeries(doc, svg, "167,139,250", "0", "M200,40 L250,30 L300,20 L350,10");
+
+      SVGAnimationDOMInjector.injectAnimation(svg, SVGSupport.ANIMATION_LINE);
+
+      double d1a = parseDelay(firstDescendantPathOf(p1a).getAttribute("style"));
+      double d1b = parseDelay(firstDescendantPathOf(p1b).getAttribute("style"));
+      double d2a = parseDelay(firstDescendantPathOf(p2a).getAttribute("style"));
+      double d2b = parseDelay(firstDescendantPathOf(p2b).getAttribute("style"));
+
+      assertEquals(d1a, d2a, 0.01, "same series across panels must share a delay (stable rank)");
+      assertEquals(d1b, d2b, 0.01, "same series across panels must share a delay (stable rank)");
+      // Two distinct series → spacing is the full STAGGER_WINDOW.  A dedup failure would inflate
+      // numSeries to 4 and shrink this spacing to STAGGER_WINDOW/3.
+      assertEquals(AnimationConstants.STAGGER_WINDOW, d1b - d1a, 0.01,
+         "series count must not be inflated by repeated facet keys");
+   }
+
+   /**
     * Adds a standalone {@code inetsoft-line} annotation group (outer g → inner g → path) to the
     * SVG root.  No paired area, modeling a pure line/stacked-line chart.
     *

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -1065,6 +1065,100 @@ class SVGAnimationDOMInjectorTest {
          "a ghost-fill element must be inserted into the SVG root for a regular line");
    }
 
+   // -------------------------------------------------------------------------
+   // Line series stagger — multiple lines must draw one at a time
+   // -------------------------------------------------------------------------
+
+   /**
+    * Lines split from a single measure by a color dimension share the same {@code data-series}
+    * column index but carry distinct {@code data-color}s.  They must rank as separate series so
+    * each draws on its own staggered delay, matching area/stacked-area behavior — ranking by
+    * {@code data-series} alone would collapse them to one rank and draw them all at once.
+    */
+   @Test
+   void colorDimensionLines_drawStaggered() throws Exception {
+      Document doc = newDocument();
+      Element svg = doc.getDocumentElement();
+
+      Element l0 = addLineSeries(doc, svg, "34,211,238",  "0", "M0,50 L50,40 L100,30 L150,20");
+      Element l1 = addLineSeries(doc, svg, "167,139,250", "0", "M0,40 L50,30 L100,20 L150,10");
+      Element l2 = addLineSeries(doc, svg, "96,165,250",  "0", "M0,30 L50,20 L100,10 L150,5");
+
+      SVGAnimationDOMInjector.injectAnimation(svg, SVGSupport.ANIMATION_LINE);
+
+      double d0 = parseDelay(firstDescendantPathOf(l0).getAttribute("style"));
+      double d1 = parseDelay(firstDescendantPathOf(l1).getAttribute("style"));
+      double d2 = parseDelay(firstDescendantPathOf(l2).getAttribute("style"));
+
+      assertTrue(d0 < d1 && d1 < d2,
+         "color-dimension lines must draw on increasing staggered delays: " +
+         "d0=" + d0 + ", d1=" + d1 + ", d2=" + d2);
+      // Three series spread across STAGGER_WINDOW: last starts at the full window.
+      assertEquals(AnimationConstants.STAGGER_WINDOW, d2 - d0, 0.01,
+         "last series must start at STAGGER_WINDOW relative to the first");
+   }
+
+   /**
+    * Lines from distinct measures (distinct {@code data-series}) must remain separately ranked
+    * and staggered — confirms the composite-key ranking does not regress the multi-measure case.
+    */
+   @Test
+   void multiMeasureLines_drawStaggered() throws Exception {
+      Document doc = newDocument();
+      Element svg = doc.getDocumentElement();
+
+      Element l0 = addLineSeries(doc, svg, "34,211,238",  "0", "M0,50 L50,40 L100,30 L150,20");
+      Element l1 = addLineSeries(doc, svg, "167,139,250", "1", "M0,40 L50,30 L100,20 L150,10");
+
+      SVGAnimationDOMInjector.injectAnimation(svg, SVGSupport.ANIMATION_LINE);
+
+      double d0 = parseDelay(firstDescendantPathOf(l0).getAttribute("style"));
+      double d1 = parseDelay(firstDescendantPathOf(l1).getAttribute("style"));
+
+      assertEquals(AnimationConstants.STAGGER_WINDOW, d1 - d0, 0.01,
+         "second measure must be delayed by STAGGER_WINDOW relative to the first");
+   }
+
+   /** A single line is the only series, so it draws immediately with no stagger delay. */
+   @Test
+   void singleLine_drawsWithoutDelay() throws Exception {
+      Document doc = newDocument();
+      Element svg = doc.getDocumentElement();
+
+      Element l0 = addLineSeries(doc, svg, "34,211,238", "0", "M0,50 L50,40 L100,30 L150,20");
+
+      SVGAnimationDOMInjector.injectAnimation(svg, SVGSupport.ANIMATION_LINE);
+
+      assertEquals(0, parseDelay(firstDescendantPathOf(l0).getAttribute("style")), 0.01,
+         "a single line series must draw with no stagger delay");
+   }
+
+   /**
+    * Adds a standalone {@code inetsoft-line} annotation group (outer g → inner g → path) to the
+    * SVG root.  No paired area, modeling a pure line/stacked-line chart.
+    *
+    * @return the outer {@code inetsoft-line} annotation group
+    */
+   private static Element addLineSeries(Document doc, Element svg,
+                                        String color, String series, String lineD)
+   {
+      Element lineAnnot = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
+      lineAnnot.setAttribute("class", SVGSupport.ANNOTATION_LINE);
+      lineAnnot.setAttribute("data-" + SVGSupport.ATTR_COLOR, color);
+      lineAnnot.setAttribute("data-" + SVGSupport.ATTR_SERIES, series);
+
+      Element inner = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
+      Element linePath = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "path");
+      linePath.setAttribute("d", lineD);
+      linePath.setAttribute("fill", "none");
+
+      inner.appendChild(linePath);
+      lineAnnot.appendChild(inner);
+      svg.appendChild(lineAnnot);
+
+      return lineAnnot;
+   }
+
    /**
     * Count direct {@code <path>} children of {@code parent} that have a translucent rgba fill
     * (the signature of injected ghost fill polygons).


### PR DESCRIPTION
## Summary

On chart load, line and stacked-line charts animated all their lines at the same
time when the lines were produced by a color or group dimension over a single
measure. Area and stacked-area charts in the same situation already drew one series
at a time, staggered across the animation window. This change makes line charts
match that behavior.

## Root cause

In SVGAnimationDOMInjector.injectLineAnimationFromAnnotations, the per-series
stagger delay is staggerDelay(seriesIdx, numSeries). Line series were ranked by
data-series, which is the measure column index (ElementVO.getColIndex()). When one
measure is split by a color/group dimension, every line shares the same measure
column index, so all lines collapsed to a single rank, numSeries became 1, and every
line got a zero delay. Area fills already avoided this by ranking on data-color,
which is unique per series.

## Fix

Rank line series by a composite data-series + data-color key in first-seen DOM
order, mirroring how area fills are ranked. The data-color component distinguishes
color-dimension series, while the data-series component still separates distinct
measures that happen to share a color. Facet panels that repeat the same key dedup
to a stable rank. LineVO already stamps data-color per series, so no backend or
rendering change is needed, and the area animation path is untouched.

## Tests

Added tests for the color-dimension stagger (the fixed case), the multi-measure case
(regression guard), and a single-line chart (no delay). Also removed a parseIntAttr
overload whose only caller was the replaced ranking code.