### PR TITLE
Bug #75453 - Remove orphaned user data on identity deletion

### DIFF
--- a/core/src/main/java/inetsoft/sree/UserEnv.java
+++ b/core/src/main/java/inetsoft/sree/UserEnv.java
@@ -478,6 +478,34 @@ public class UserEnv {
    }
 
    /**
+    * Remove a user's saved properties file. Called when a user is deleted so the
+    * sreeUserData/{name}_{orgID}.xml file is not left orphaned.
+    */
+   public static void removeUser(IdentityID userIdentity) {
+      if(userIdentity == null) {
+         return;
+      }
+
+      String userFile = getUserFile(userIdentity.convertToKey());
+      DataSpace space = DataSpace.getDataSpace();
+
+      try {
+         removeChangeListener(space, userFile);
+
+         if(space.exists(USER_DIR, userFile)) {
+            space.delete(USER_DIR, userFile);
+         }
+      }
+      catch(Exception e) {
+         LOG.error("Failed to remove user properties for {}", userIdentity, e);
+      }
+
+      synchronized(propmap) {
+         propmap.keySet().removeIf(k -> userIdentity.equals(getName(k)));
+      }
+   }
+
+   /**
     * Get the user names containing a UserEnv file
     */
    public static Set<String> getUsersWithFile() {

--- a/core/src/main/java/inetsoft/web/AutoSaveUtils.java
+++ b/core/src/main/java/inetsoft/web/AutoSaveUtils.java
@@ -261,6 +261,39 @@ public final class AutoSaveUtils {
       }
    }
 
+   // Delete all auto save files (active and recycle bin) owned by the given user.
+   // Used when a user is deleted so their drafts are not left orphaned.
+   public static void deleteUserAutoSaveFiles(IdentityID user, Principal principal) {
+      if(user == null) {
+         return;
+      }
+
+      try {
+         BlobStorage<Metadata> blobStorage = getStorage(principal);
+
+         for(String file : getAutoSavedFiles(principal)) {
+            String[] attrs = Tool.split(getName(file), '^');
+
+            if(attrs.length > 3) {
+               String fileUser = attrs[2];
+
+               if(fileUser == null || "anonymous".equals(fileUser) ||
+                  Tool.equals(fileUser, "_NULL_"))
+               {
+                  continue;
+               }
+
+               if(user.equals(IdentityID.getIdentityIDFromKey(fileUser))) {
+                  blobStorage.delete(file);
+               }
+            }
+         }
+      }
+      catch(Exception e) {
+         LOG.debug("Failed to delete auto save files for user {}", user, e);
+      }
+   }
+
    public static void deleteRecycledAutoSaveFiles(Principal principal) {
       try {
          BlobStorage<Metadata> blobStorage = getStorage(principal);

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -41,6 +41,7 @@ import inetsoft.storage.*;
 import inetsoft.uql.XPrincipal;
 import inetsoft.uql.XRepository;
 import inetsoft.uql.asset.*;
+import inetsoft.uql.asset.internal.AssetFolder;
 import inetsoft.uql.asset.sync.DependencyStorageService;
 import inetsoft.uql.service.DataSourceRegistry;
 import inetsoft.uql.service.XEngine;
@@ -261,6 +262,9 @@ public class IdentityService {
             }
          }
 
+         // sweep shared-asset favorites once for all deleted users (one scan per org)
+         removeUserFavorites(deleteUserIDs);
+
          if(!failedIdentities.isEmpty()) {
             String warning = String.format(
                "Unauthorized access to resource(s) \"%s\" by user %s.",
@@ -473,6 +477,8 @@ public class IdentityService {
             eprovider.removeUser(identityId);
             updateIdentityPermissions(type, identityId, null, identityId.orgID, identityId.orgID,true);
             removeUserScopedAssets(identity);
+            UserEnv.removeUser(identityId);
+            AutoSaveUtils.deleteUserAutoSaveFiles(identityId, ThreadContext.getContextPrincipal());
          }
          else {
             if(!identityId.equals(oID)) {
@@ -2204,6 +2210,63 @@ public class IdentityService {
       };
       Set<String> keys = indexedStorage.getKeys(filter, identityID.getOrgID());
       keys.stream().forEach(key -> indexedStorage.remove(key));
+   }
+
+   /**
+    * Remove deleted users from the favoritesUser lists of shared assets they had favorited,
+    * so no dangling references are left behind. Scans each affected organization's folders
+    * once for the whole batch, so a bulk delete costs one sweep per org rather than one per
+    * user.
+    */
+   private void removeUserFavorites(Collection<IdentityID> identityIDs) {
+      if(identityIDs == null || identityIDs.isEmpty()) {
+         return;
+      }
+
+      Map<String, Set<String>> userKeysByOrg = new HashMap<>();
+
+      for(IdentityID id : identityIDs) {
+         if(id != null) {
+            userKeysByOrg.computeIfAbsent(id.getOrgID(), o -> new HashSet<>())
+               .add(id.convertToKey());
+         }
+      }
+
+      IndexedStorage.Filter filter = key -> {
+         AssetEntry entry = AssetEntry.createAssetEntry(key);
+         return entry != null && entry.isFolder();
+      };
+
+      for(Map.Entry<String, Set<String>> e : userKeysByOrg.entrySet()) {
+         String orgID = e.getKey();
+         Set<String> userKeys = e.getValue();
+
+         for(String key : indexedStorage.getKeys(filter, orgID)) {
+            try {
+               XMLSerializable data = indexedStorage.getXMLSerializable(key, null, orgID);
+
+               if(data instanceof AssetFolder folder) {
+                  boolean changed = false;
+
+                  for(AssetEntry folderEntry : folder.getEntries()) {
+                     for(String userKey : userKeys) {
+                        if(folderEntry.getFavoritesUsers().contains(userKey)) {
+                           folderEntry.deleteFavoritesUser(userKey);
+                           changed = true;
+                        }
+                     }
+                  }
+
+                  if(changed) {
+                     indexedStorage.putXMLSerializable(key, folder);
+                  }
+               }
+            }
+            catch(Exception ex) {
+               LOG.warn("Failed to remove deleted-user favorites from {}", key, ex);
+            }
+         }
+      }
    }
 
 


### PR DESCRIPTION
## Summary

Deleting a user already cascades their private viewsheets/worksheets, bookmarks, owned scheduled tasks, dashboards, scripts/styles, ACL grants and sessions. It did not, however, clean up three categories that were left orphaned:

- favoritesUser references to the user on shared assets
- the user's UserEnv preference file (sreeUserData/{name}_{orgID}.xml)
- the user's auto-save drafts

This PR removes those as part of deletion so no dangling references or files remain. It applies to every deletion entry point (EM UI bulk delete and the public REST API), because both converge on IdentityService.deleteIdentities -> syncIdentity.

## Changes

- UserEnv.removeUser(IdentityID): deletes the user's properties file from the data space and evicts its cached entry.
- AutoSaveUtils.deleteUserAutoSaveFiles(IdentityID, Principal): deletes the user's auto-save drafts (active and recycle bin), matching the owner encoded in the file name.
- IdentityService: in the user-delete branch of syncIdentity, calls UserEnv.removeUser and AutoSaveUtils.deleteUserAutoSaveFiles per user; a new batched removeUserFavorites(Collection<IdentityID>) runs once after the deleteIdentities loop.

## Performance

The favorites cleanup must scan asset folders to find references, which is independent of any single user. It is therefore hoisted out of the per-user path and run once per delete operation, grouped by organization so each org's folders are scanned a single time. A single-user delete still costs one scan; a bulk delete of N users costs one scan per org instead of N.

## Scope

The change only removes data belonging to the deleted user. It never deletes a shared asset (only the user's entry in its favoritesUser list), never affects other users, and does not alter the existing deletion cascade or any non-delete path. All cleanup steps are null-guarded and wrapped in try/catch so a storage error logs and does not abort the deletion.