### PR TITLE
fix(wiz): sql-query-table typing, GROUP BY ordinal, recommender, full-data, filters (#75456–#75460)

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/JDBCQueryCacheNormalizer.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/JDBCQueryCacheNormalizer.java
@@ -66,6 +66,26 @@ public class JDBCQueryCacheNormalizer {
          return false;
       }
 
+      // Sorting the SELECT columns reorders them, which invalidates any positional GROUP BY
+      // <ordinal> reference (the parser keeps group-by ordinals literal — unlike ORDER BY
+      // ordinals, which are resolved to column names). Reordering "select a, count(*) ... group
+      // by 1" to "select count(*), a ... group by 1" makes the ordinal point at the aggregate
+      // and the database rejects it. Skip column-sort normalization for such queries so the
+      // original column order (and the ordinal it refers to) is preserved. An ordinal is held as
+      // an Integer in-memory but is deserialized as a numeric String when the worksheet is
+      // reloaded (UniformSQL.parseXML), so guard against both forms.
+      Object[] groupBy = usql.getGroupBy();
+
+      if(groupBy != null) {
+         for(Object g : groupBy) {
+            if(g instanceof Integer ||
+               g instanceof String && ((String) g).matches("\\d+"))
+            {
+               return false;
+            }
+         }
+      }
+
       if(StringUtils.isEmpty(sqlString)) {
          return true;
       }

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/ChartRecommenderUtil.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/ChartRecommenderUtil.java
@@ -480,17 +480,45 @@ public final class ChartRecommenderUtil {
          String refName = WizardRecommenderUtil.getRefName(ref);
 
          if(Tool.equals(columnValue, refName)) {
+            int cardinality;
+
             if(WizardRecommenderUtil.isDimension(entry) &&
                XSchema.isDateType(entry.getProperty("dtype"))) {
-               return getDateCardinality(ref, entry);
+               cardinality = getDateCardinality(ref, entry);
+            }
+            else {
+               cardinality = Integer.parseInt(
+                  Optional.ofNullable(entry.getProperty("cardinality")).orElse("0"));
             }
 
-            Optional<String> cardinality = Optional.ofNullable(entry.getProperty("cardinality"));
-            return Integer.parseInt(cardinality.orElse("0"));
+            // A dimension carrying a top-/bottom-N ranking only shows N values, so its effective
+            // cardinality for chart feasibility is min(distinct, N). The ranking is recorded on the
+            // entry (as "topN") before recommendation; honoring it here keeps a ranked high-
+            // cardinality dimension chartable instead of vetoing it down to a table.
+            return capByRanking(cardinality, entry);
          }
       }
 
       return 0;
+   }
+
+   private static int capByRanking(int cardinality, AssetEntry entry) {
+      String topN = entry.getProperty("topN");
+
+      if(topN != null) {
+         try {
+            int n = Integer.parseInt(topN);
+
+            if(n > 0 && n < cardinality) {
+               return n;
+            }
+         }
+         catch(NumberFormatException ignore) {
+            // not a valid count; fall through to the raw cardinality
+         }
+      }
+
+      return cardinality;
    }
 
    private static int getDateCardinality(ChartRef ref, AssetEntry entry) {

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/WizardRecommenderUtil.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/WizardRecommenderUtil.java
@@ -482,6 +482,39 @@ public final class WizardRecommenderUtil {
     * @param tname      the table name.
     * @param dimEntries the selected dimension fields.
     */
+   /**
+    * #75460: a dimension carrying a top-/bottom-N ranking only ever shows N values, so its
+    * EFFECTIVE cardinality for chart feasibility is min(distinct, N) — not the full distinct count.
+    * The rank count is stamped on the entry as "topN" before recommendation
+    * ({@link inetsoft.web.wiz.service.WizAutoBindingService#buildEntryFromColumn}). Cap both the
+    * recorded cardinality and its percentage at the source so every feasibility gate (whichever
+    * property it reads) treats the ranked dimension as low-cardinality and keeps it chartable
+    * instead of vetoing the chart down to a table.
+    */
+   private static void capCardinalityByRanking(AssetEntry entry, CardinalityData data) {
+      String topN = entry.getProperty("topN");
+
+      if(topN == null) {
+         return;
+      }
+
+      try {
+         int n = Integer.parseInt(topN);
+
+         if(n <= 0 || n >= data.getCardinality()) {
+            return;
+         }
+
+         entry.setProperty("cardinality", String.valueOf(n));
+         int dataSetSize = Math.max(data.getDataSetSize(), n);
+         double pct = Math.min(data.getCardinalityPercentage(), (double) n / dataSetSize * 100.0);
+         entry.setProperty("cardinalityPercentage", String.valueOf(pct));
+      }
+      catch(NumberFormatException ignore) {
+         // not a valid count; leave the measured cardinality untouched
+      }
+   }
+
    private static List<AssetEntry> updateCardinalityInfo(ViewsheetSandbox box,
                                                          VSTemporaryInfo temporaryInfo,
                                                          String tname, List<AssetEntry> dimEntries)
@@ -497,6 +530,7 @@ public final class WizardRecommenderUtil {
             entry.setProperty("cardinality", data.getCardinality() + "");
             entry.setProperty("cardinalityPercentage", data.getCardinalityPercentage() + "");
             entry.setProperty("dataSetSize", data.getDataSetSize() + "");
+            capCardinalityByRanking(entry, data);
             list.add(entry);
          }
       }

--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -62,6 +62,7 @@ public class ViewsheetRuntimeController {
     */
    @PostMapping(value = "/viewsheet/open", produces = MediaType.APPLICATION_JSON_VALUE)
    public OpenViewsheetResult openViewsheet(@RequestParam("identifier") String identifier,
+                                            @RequestParam(value = "sampleMaxRows", required = false) Integer sampleMaxRows,
                                             Principal user) throws Exception
    {
       AssetEntry entry = AssetEntry.createAssetEntry(identifier);
@@ -97,6 +98,36 @@ public class ViewsheetRuntimeController {
       if(assembly != null) {
          result.setAssemblyName(assembly.getName());
          result.setBinding(wizVsService.collectFlatBinding(assembly));
+      }
+
+      // #75456: sampled-preview mode for the live viewer. The reopened runtime renders on demand when
+      // the browser embeds it; set the source worksheet's design-max cap now (before that render) and
+      // drop any pre-rendered full-data result so the embed aggregates at most sampleMaxRows rows.
+      // null/<=0 = full data (the default; the persisted worksheet is already uncapped).
+      if(sampleMaxRows != null && sampleMaxRows > 0) {
+         try {
+            RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, user);
+            var bws = rvs != null && rvs.getViewsheet() != null
+               ? rvs.getViewsheet().getBaseWorksheet() : null;
+
+            if(bws != null) {
+               bws.getWorksheetInfo().setDesignMaxRows(sampleMaxRows);
+               rvs.getViewsheetSandbox().ifPresent(box -> {
+                  box.cancelAllQueries();
+
+                  if(assembly != null) {
+                     try {
+                        box.resetDataMap(assembly.getName());
+                     }
+                     catch(Exception ignore) {
+                     }
+                  }
+               });
+            }
+         }
+         catch(Exception ex) {
+            log.warn("Failed to apply sampled-preview cap on open: {}", ex.getMessage());
+         }
       }
 
       return result;

--- a/core/src/main/java/inetsoft/web/wiz/model/AutoBindingRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/AutoBindingRequest.java
@@ -127,6 +127,19 @@ public class AutoBindingRequest {
    }
 
    /**
+    * #75456: row cap for sampled-preview mode. Null or &lt;=0 = full data (default; the agent
+    * always omits this). &gt;0 = aggregate at most this many detail rows for a faster preview on
+    * heavy sources, at the cost of approximate Sum/Count.
+    */
+   public Integer getSampleMaxRows() {
+      return sampleMaxRows;
+   }
+
+   public void setSampleMaxRows(Integer sampleMaxRows) {
+      this.sampleMaxRows = sampleMaxRows;
+   }
+
+   /**
     * Recommendation-computation RVS ID. Null on first call; returned by the server
     * and passed back on subsequent calls to reuse the same RVS.
     */
@@ -151,4 +164,9 @@ public class AutoBindingRequest {
     * Specifies which table within the worksheet to bind.
     */
    private String wsTableName;
+
+   /**
+    * #75456: sampled-preview row cap; null/&lt;=0 = full data (default).
+    */
+   private Integer sampleMaxRows;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/CreateViewsheetResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/CreateViewsheetResult.java
@@ -77,6 +77,22 @@ public class CreateViewsheetResult {
       this.truncated = truncated;
    }
 
+   public Boolean getSampled() {
+      return sampled;
+   }
+
+   public void setSampled(Boolean sampled) {
+      this.sampled = sampled;
+   }
+
+   public Integer getSampleMaxRows() {
+      return sampleMaxRows;
+   }
+
+   public void setSampleMaxRows(Integer sampleMaxRows) {
+      this.sampleMaxRows = sampleMaxRows;
+   }
+
    public String getRuntimeId() {
       return runtimeId;
    }
@@ -129,6 +145,11 @@ public class CreateViewsheetResult {
    private List<Map<String, Object>> rows;
    private FlatBinding binding;
    private Boolean truncated;
+   // #75456: true when the source worksheet had a finite design-mode sample cap in effect
+   // (sampled-preview mode), so aggregates were computed over at most sampleMaxRows detail
+   // rows and Sum/Count may be approximate. Null/absent in full-data mode (the default).
+   private Boolean sampled;
+   private Integer sampleMaxRows;
    private String runtimeId;
    private String assemblyName;
    private String viewsheetIdentifier;

--- a/core/src/main/java/inetsoft/web/wiz/model/CreateVisualizationModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/CreateVisualizationModel.java
@@ -83,11 +83,25 @@ public class CreateVisualizationModel {
       this.keepCondition = keepCondition;
    }
 
+   /**
+    * #75456: row cap for sampled-preview mode. Null or &lt;=0 = full data (the default and the
+    * agent path); &gt;0 = aggregate at most this many detail rows (faster on heavy/non-mergeable
+    * sources, but Sum/Count may be approximate).
+    */
+   public Integer getSampleMaxRows() {
+      return sampleMaxRows;
+   }
+
+   public void setSampleMaxRows(Integer sampleMaxRows) {
+      this.sampleMaxRows = sampleMaxRows;
+   }
+
    private String visualizationType;
    private VisualizationConfig config;
    private String runtimeId;
    private String viewsheetIdentifier;
    private VisualizationConditionModel conditionModel;
+   private Integer sampleMaxRows;
    private transient VSAssembly primaryAssembly;
    private transient boolean keepCondition;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetConstructionModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetConstructionModel.java
@@ -333,13 +333,36 @@ public class WorksheetConstructionModel {
       UNION, INTERSECT, EXCEPT
    }
 
+   @JsonIgnoreProperties(ignoreUnknown = true)
    public static class Condition {
       private String field;
-      private FilterOperator operator;
-      private Object value; // String or String[]
+      // #75457: the operation vocabulary used by the rest of the wiz condition API (apply_filter,
+      // preAggregateCondition): EQUAL_TO, GREATER_THAN, LESS_THAN, ONE_OF, BETWEEN, LIKE,
+      // STARTING_WITH, CONTAINS, NULL, DATE_IN. (Previously this model expected an `operator` enum
+      // of EQ/GT/... which the plugin never sends, so every filter 400'd on deserialization.)
+      private String operation;
+      // Inclusive bound for GREATER_THAN/LESS_THAN (>= / <=).
+      private Boolean equal;
+      private Object value; // String or List<String>
       private ConditionOperator conditionOperator;
       private int conditionLevel;
       private boolean negated;
+
+      public String getOperation() {
+         return operation;
+      }
+
+      public void setOperation(String operation) {
+         this.operation = operation;
+      }
+
+      public Boolean getEqual() {
+         return equal;
+      }
+
+      public void setEqual(Boolean equal) {
+         this.equal = equal;
+      }
 
       public boolean isNegated() {
          return negated;
@@ -355,14 +378,6 @@ public class WorksheetConstructionModel {
 
       public void setField(String field) {
          this.field = field;
-      }
-
-      public FilterOperator getOperator() {
-         return operator;
-      }
-
-      public void setOperator(FilterOperator operator) {
-         this.operator = operator;
       }
 
       public Object getValue() {

--- a/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
@@ -165,6 +165,14 @@ public class GenerateWsService {
       }
 
       Worksheet worksheet = originWs != null ? originWs : new Worksheet();
+
+      // #75456: wiz produces analytical charts that aggregate over the worksheet's output. The
+      // WorksheetInfo constructor seeds inputmax from the design-mode sample cap
+      // (asset.sample.maxrows, default 50000); when the underlying query returns more detail rows
+      // than that, the chart aggregates only the capped prefix and Sum/Count silently under-count
+      // (averages/proportions survive, so it hides). Wiz analytics default to full data — 0 =
+      // unlimited. (Sampled-preview mode will pass a non-zero cap here in a follow-up.)
+      worksheet.getWorksheetInfo().setDesignMaxRows(0);
       AbstractTableAssembly table = null;
       List<WorksheetConstructionModel.QueryField> fields = new ArrayList<>(model.getFields());
 

--- a/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
@@ -27,6 +27,7 @@ import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.uql.erm.*;
 import inetsoft.uql.jdbc.JDBCDataSource;
 import inetsoft.uql.jdbc.util.SQLTypes;
+import inetsoft.uql.XCondition;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.util.Tool;
 import inetsoft.web.composer.ws.LayoutGraphService;
@@ -845,13 +846,17 @@ public class GenerateWsService {
          }
 
          AssetCondition assetCondition = new AssetCondition();
-         // addConditionValue adds every element of a list value, so a multi-value IN (-> ONE_OF)
-         // carries all values rather than only the first (the old IN -> CONTAINS mapping bug).
-         addConditionValue(assetCondition, filter.getValue());
+         String dataType = attributeRef.getDataType();
+         assetCondition.setType(dataType);
+         // #75457: the filter carries the operation vocabulary used across the wiz condition API
+         // (EQUAL_TO/GREATER_THAN/ONE_OF/BETWEEN/...) with an explicit `equal` inclusive-bound flag.
+         assetCondition.setOperation(filterOperation(filter.getOperation()));
+         assetCondition.setEqual(Boolean.TRUE.equals(filter.getEqual()));
          assetCondition.setNegated(filter.isNegated());
-         assetCondition.setOperation(WizFilterOperation.operation(filter.getOperator()));
-         assetCondition.setEqual(WizFilterOperation.isInclusiveBound(filter.getOperator()));
-         assetCondition.setType(attributeRef.getDataType());
+         // #75457: convert each value to the column's declared type (e.g. a date string -> Timestamp)
+         // rather than passing a raw string and relying on string-vs-typed coercion at SQL-gen time.
+         // A multi-value ONE_OF / BETWEEN carries every element.
+         addTypedConditionValue(assetCondition, filter.getValue(), dataType);
          conditionList.append(new ConditionItem(attributeRef, assetCondition, level));
          appended = true;
       }
@@ -1126,6 +1131,67 @@ public class GenerateWsService {
       }
       else {
          condition.addValue(value);
+      }
+   }
+
+   /**
+    * #75457: map the wiz filter operation vocabulary (shared with apply_filter / preAggregateCondition)
+    * to a StyleBI XCondition operation. The inclusive-bound (>= / <=) case is carried by the separate
+    * `equal` flag, not by a distinct operation.
+    */
+   private int filterOperation(String operation) {
+      if(operation == null) {
+         throw new IllegalArgumentException("filter operation is required");
+      }
+
+      return switch(operation) {
+         case "EQUAL_TO" -> XCondition.EQUAL_TO;
+         case "ONE_OF" -> XCondition.ONE_OF;
+         case "GREATER_THAN" -> XCondition.GREATER_THAN;
+         case "LESS_THAN" -> XCondition.LESS_THAN;
+         case "BETWEEN" -> XCondition.BETWEEN;
+         case "LIKE" -> XCondition.LIKE;
+         case "STARTING_WITH" -> XCondition.STARTING_WITH;
+         case "CONTAINS" -> XCondition.CONTAINS;
+         case "NULL" -> XCondition.NULL;
+         case "DATE_IN" -> XCondition.DATE_IN;
+         default -> throw new IllegalArgumentException("Unknown filter operation: " + operation);
+      };
+   }
+
+   /**
+    * #75457: add filter value(s) converted to the column's declared type. Every element of a list
+    * value is added (so ONE_OF / BETWEEN carry all values).
+    */
+   private void addTypedConditionValue(AssetCondition condition, Object value, String dataType) {
+      if(value instanceof List<?> list) {
+         for(Object v : list) {
+            condition.addValue(convertConditionValue(v, dataType));
+         }
+      }
+      else if(value != null) {
+         condition.addValue(convertConditionValue(value, dataType));
+      }
+   }
+
+   /**
+    * #75457: parse the JSON value (a String over the wire) into the column's declared type using
+    * StyleBI's own converter, so a date column gets a Date rather than a raw String — removing the
+    * string-vs-typed coercion guesswork at SQL-generation time. Falls back to the raw value when the
+    * string can't be parsed for that type (the query engine still coerces it), so this never
+    * regresses a value that previously round-tripped.
+    */
+   private Object convertConditionValue(Object value, String dataType) {
+      if(value == null || dataType == null) {
+         return value;
+      }
+
+      try {
+         Object converted = Tool.getData(dataType, value);
+         return converted != null ? converted : value;
+      }
+      catch(Exception ex) {
+         return value;
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -171,7 +171,7 @@ public class WizAutoBindingService {
             selectBindColumns(worksheetColumns, configMap);
 
          AssetEntry[] entries = bindColumns.stream()
-            .map(col -> buildEntryFromColumn(col, worksheetId, tableNameFinal))
+            .map(col -> buildEntryFromColumn(col, worksheetId, tableNameFinal, configMap))
             .toArray(AssetEntry[]::new);
 
          bindingHandler.updateTemporaryFields(rvs, entries, tempInfo);
@@ -337,7 +337,8 @@ public class WizAutoBindingService {
 
    // ── AssetEntry building ──────────────────────────────────────────────────────
 
-   private AssetEntry buildEntryFromColumn(ColumnRef col, String wsPath, String tableName) {
+   private AssetEntry buildEntryFromColumn(ColumnRef col, String wsPath, String tableName,
+                                           Map<String, SimpleFieldInfo> configMap) {
       String alias = col.getAlias();
       String colName = (alias != null && !alias.isEmpty()) ? alias : col.getAttribute();
       String path = (wsPath != null && tableName != null)
@@ -351,7 +352,25 @@ public class WizAutoBindingService {
       String dtype = col.getDataType() != null ? col.getDataType() : XSchema.STRING;
       entry.setProperty("dtype", dtype);
 
-      boolean isMeasure = XSchema.isNumericType(dtype) && !XSchema.isDateType(dtype);
+      // The caller's fieldConfig is authoritative about dimension vs measure. Honor it: a declared
+      // measure (e.g. DistinctCount/Count over a string id) is a measure regardless of operand
+      // type — otherwise the recommender would classify it by dtype, treat the aggregated id as a
+      // high-cardinality dimension, and degrade the chart to a raw table. A declared dimension
+      // (e.g. a numeric year/code grouped as a category) is likewise kept a dimension. Fall back
+      // to the dtype heuristic only when the field has no explicit config.
+      SimpleFieldInfo fc = configMap != null ? configMap.get(colName) : null;
+      boolean isMeasure;
+
+      if(fc instanceof MeasureFieldInfo) {
+         isMeasure = true;
+      }
+      else if(fc instanceof DimensionFieldInfo) {
+         isMeasure = false;
+      }
+      else {
+         isMeasure = XSchema.isNumericType(dtype) && !XSchema.isDateType(dtype);
+      }
+
       setRefType(entry, isMeasure);
       return entry;
    }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.service;
 
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.internal.graph.ChangeChartTypeProcessor;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.erm.DataRef;
@@ -194,6 +195,9 @@ public class WizAutoBindingService {
          List<VSObjectRecommendation> recommendations = Collections.emptyList();
          VSObjectRecommendation selectedRec = null;
          VSAssembly primaryAssembly = null;
+         // #75460: set when an explicit chart type the recommender substituted away is force-applied,
+         // so the response reports the honored type and skips the "not feasible" substitution note.
+         String forcedTypeName = null;
 
          if(model != null) {
             recommendations = model.getRecommendationList().stream()
@@ -228,6 +232,16 @@ public class WizAutoBindingService {
                // The recommender rebuilds dimensions without the temp chart's ranking/aggregate
                // config, so re-apply fieldConfigs to the RENDERED binding before it executes.
                if(primaryAssembly instanceof ChartVSAssembly chartAsm && chartAsm.getVSChartInfo() != null) {
+                  // Honor an explicit chart type the recommender substituted away (no pins in play;
+                  // the pinned case is governed by the strict-pins guard above). Convert before
+                  // applying fieldConfigs so the aggregate/ranking/format land on the final binding.
+                  if(vizType != null && isChartVizType(vizType)
+                     && (explicitBindings == null || explicitBindings.isEmpty())
+                     && !requestedTypeAvailable(vizType, model, false))
+                  {
+                     forcedTypeName = applyForcedChartType(chartAsm, vizType);
+                  }
+
                   applyFieldConfigs(chartAsm.getVSChartInfo(), configMap);
                }
                // The crosstab recommender decides row/col header placement itself and ignores
@@ -291,6 +305,13 @@ public class WizAutoBindingService {
 
          // Phase 4: build response.
          RecommendedVisualization primary = recommendationToVisualization(selectedRec, entries, worksheetId);
+
+         // When we force-applied an explicit type (#75460), report the honored type, not the
+         // recommender's substitute that `primary` was derived from.
+         if(forcedTypeName != null && primary != null) {
+            primary.setVisualizationType(forcedTypeName);
+         }
+
          AutoBindingResponse resp = new AutoBindingResponse();
          resp.setRecommendations(recommendations);
          resp.setPrimary(primary);
@@ -303,7 +324,8 @@ public class WizAutoBindingService {
          // substitution to the user instead of the swap happening silently.
          boolean pinsPresent = explicitBindings != null && !explicitBindings.isEmpty();
 
-         if(vizType != null && primary != null && !requestedTypeAvailable(vizType, model, pinsPresent)) {
+         if(vizType != null && primary != null && forcedTypeName == null
+            && !requestedTypeAvailable(vizType, model, pinsPresent)) {
             resp.setSelectionNote(pinsPresent
                ? "Requested chart type '" + vizType + "' has no candidate honoring the explicit " +
                  "bindings; used '" + primary.getVisualizationType() + "' instead."
@@ -372,6 +394,20 @@ public class WizAutoBindingService {
       }
 
       setRefType(entry, isMeasure);
+
+      // A top-/bottom-N ranking on a dimension means only N values are shown, so its EFFECTIVE
+      // cardinality for chart-feasibility is N — not the full distinct count. The recommender runs
+      // before fieldConfigs are applied, so record the rank count on the entry; getCardinality caps
+      // by it (see ChartRecommenderUtil.getCardinality) so a ranked high-cardinality dimension stays
+      // chartable instead of being vetoed down to a table.
+      if(fc instanceof DimensionFieldInfo dimFc && dimFc.getRanking() != null) {
+         int n = dimFc.getRanking().getRankingN();
+
+         if(n > 0) {
+            entry.setProperty("topN", String.valueOf(n));
+         }
+      }
+
       return entry;
    }
 
@@ -1603,6 +1639,130 @@ public class WizAutoBindingService {
          case GraphTypes.CHART_MAP -> "map";
          default -> null;
       };
+   }
+
+   /** Inverse of {@link #getChartTypeString}: a frontend chart-type name → GraphTypes constant, or
+    *  -1 when the name is unknown or not a (non-geo) chart type. Map types are excluded because the
+    *  geo conversion is handled separately (see {@link WizGeoService}). */
+   private static int graphTypeForName(String vizType) {
+      if(vizType == null) {
+         return -1;
+      }
+
+      return switch(vizType) {
+         case "bar" -> GraphTypes.CHART_BAR;
+         case "bar_stack" -> GraphTypes.CHART_BAR_STACK;
+         case "3d_bar" -> GraphTypes.CHART_3D_BAR;
+         case "3d_bar_stack" -> GraphTypes.CHART_3D_BAR_STACK;
+         case "area" -> GraphTypes.CHART_AREA;
+         case "area_stack" -> GraphTypes.CHART_AREA_STACK;
+         case "point" -> GraphTypes.CHART_POINT;
+         case "point_stack" -> GraphTypes.CHART_POINT_STACK;
+         case "step_area" -> GraphTypes.CHART_STEP_AREA;
+         case "step_area_stack" -> GraphTypes.CHART_STEP_AREA_STACK;
+         case "interval" -> GraphTypes.CHART_INTERVAL;
+         case "line" -> GraphTypes.CHART_LINE;
+         case "line_stack" -> GraphTypes.CHART_LINE_STACK;
+         case "step_line" -> GraphTypes.CHART_STEP;
+         case "step_line_stack" -> GraphTypes.CHART_STEP_STACK;
+         case "jump_line" -> GraphTypes.CHART_JUMP;
+         case "pie" -> GraphTypes.CHART_PIE;
+         case "3d_pie" -> GraphTypes.CHART_3D_PIE;
+         case "donut" -> GraphTypes.CHART_DONUT;
+         case "radar" -> GraphTypes.CHART_RADAR;
+         case "filled_radar" -> GraphTypes.CHART_FILL_RADAR;
+         case "scatter_contour" -> GraphTypes.CHART_SCATTER_CONTOUR;
+         case "stock" -> GraphTypes.CHART_STOCK;
+         case "candle" -> GraphTypes.CHART_CANDLE;
+         case "boxplot" -> GraphTypes.CHART_BOXPLOT;
+         case "waterfall" -> GraphTypes.CHART_WATERFALL;
+         case "pareto" -> GraphTypes.CHART_PARETO;
+         case "treemap" -> GraphTypes.CHART_TREEMAP;
+         case "sunburst" -> GraphTypes.CHART_SUNBURST;
+         case "circle_packing" -> GraphTypes.CHART_CIRCLE_PACKING;
+         case "icircle" -> GraphTypes.CHART_ICICLE;
+         case "marimekko" -> GraphTypes.CHART_MEKKO;
+         case "gantt" -> GraphTypes.CHART_GANTT;
+         case "funnel" -> GraphTypes.CHART_FUNNEL;
+         case "tree" -> GraphTypes.CHART_TREE;
+         case "network" -> GraphTypes.CHART_NETWORK;
+         case "circular_network" -> GraphTypes.CHART_CIRCULAR;
+         default -> -1;
+      };
+   }
+
+   /**
+    * Honor an explicitly-requested chart type the recommender substituted away. The recommender
+    * only surfaces types it scores as a good fit; when the user explicitly asks for a renderable
+    * type it did not surface (e.g. a line over an ordered categorical axis, or a funnel), convert
+    * the built binding to it via the product's {@link ChangeChartTypeProcessor} so the explicit
+    * request wins instead of being silently swapped. Returns the applied chart-type name when a
+    * conversion happened, otherwise {@code null} (left as the recommender's choice).
+    */
+   private String applyForcedChartType(ChartVSAssembly chartAsm, String vizType) {
+      VSChartInfo cinfo = chartAsm.getVSChartInfo();
+
+      if(cinfo == null) {
+         return null;
+      }
+
+      int newType = graphTypeForName(vizType);
+
+      if(newType < 0 || GraphTypes.isGeo(newType)) {
+         return null;
+      }
+
+      int oldType = cinfo.getRTChartType() != 0 ? cinfo.getRTChartType() : cinfo.getChartType();
+
+      if(oldType == newType) {
+         return null;
+      }
+
+      try {
+         cinfo.clearRuntime();
+         VSChartInfo converted =
+            (VSChartInfo) new ChangeChartTypeProcessor(oldType, newType, null, cinfo).process();
+
+         // For line/area/point conversions, prefer the conventional vertical layout (dimension on
+         // x, measure on y). The substituted type the recommender built may have been a HORIZONTAL
+         // bar (measure on x, for a high-cardinality category), which after conversion reads as a
+         // sideways line/area. Only swap when x is all-measure and y is all-dimension.
+         if(GraphTypes.isLine(newType) || GraphTypes.isArea(newType) || GraphTypes.isPoint(newType)) {
+            normalizeVerticalAxes(converted);
+         }
+
+         chartAsm.setVSChartInfo(converted);
+         return getChartTypeString(newType);
+      }
+      catch(Exception e) {
+         LOG.warn("Could not force chart type '{}' (kept recommender choice): {}", vizType, e.getMessage());
+         LOG.debug("force chart type stack trace", e);
+         return null;
+      }
+   }
+
+   /** Swap x/y so a dimension-on-x, measure-on-y (vertical) layout is used — only when x holds
+    *  exclusively measures and y exclusively dimensions (the horizontal layout a high-cardinality
+    *  bar substitute produces). No-op otherwise. */
+   private static void normalizeVerticalAxes(VSChartInfo info) {
+      ChartRef[] x = info.getXFields();
+      ChartRef[] y = info.getYFields();
+
+      if(x.length == 0 || y.length == 0) {
+         return;
+      }
+
+      boolean xAllMeasure = Arrays.stream(x).allMatch(r -> r instanceof VSChartAggregateRef);
+      boolean yAllDim = Arrays.stream(y).allMatch(r -> r instanceof VSChartDimensionRef);
+
+      if(xAllMeasure && yAllDim) {
+         List<ChartRef> oldX = new ArrayList<>(Arrays.asList(x));
+         List<ChartRef> oldY = new ArrayList<>(Arrays.asList(y));
+         info.removeXFields();
+         info.removeYFields();
+         oldY.forEach(info::addXField);
+         oldX.forEach(info::addYField);
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -256,6 +256,9 @@ public class WizAutoBindingService {
             vsModel.setPrimaryAssembly(primaryAssembly);
             vsModel.setRuntimeId(request.getWizRuntimeId());
             vsModel.setViewsheetIdentifier(request.getViewsheetIdentifier());
+            // #75456: carry the data-mode (full vs sampled) into the render so the chart aggregates
+            // the chosen amount of data; null/<=0 = full (the agent always omits this).
+            vsModel.setSampleMaxRows(request.getSampleMaxRows());
 
             WizVsService.PostAssemblyHook hook = (wizRvs, asm) -> {
                if(asm instanceof ChartVSAssembly) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -284,7 +284,8 @@ public class WizVsService {
                result = new CreateViewsheetResult();
             }
             else {
-               result = executeAndExtract(rvs, assembly);
+               int sampleMaxRows = model.getSampleMaxRows() != null ? model.getSampleMaxRows() : 0;
+               result = executeAndExtract(rvs, assembly, sampleMaxRows);
                boolean metadataMode = rvs.getViewsheet().getViewsheetInfo().isMetadata();
                result.setHasData(computeHasData(metadataMode, result));
             }
@@ -432,7 +433,7 @@ public class WizVsService {
          rvs.setViewsheet(targetVs);
 
          // Execute to validate; result is not needed.
-         executeAndExtract(rvs, assembly);
+         executeAndExtract(rvs, assembly, model.getSampleMaxRows() != null ? model.getSampleMaxRows() : 0);
 
          return runtimeId;
       }
@@ -513,7 +514,8 @@ public class WizVsService {
     * Executes the sandbox view for {@code assembly} and extracts the result data.
     * Dispatches to the appropriate extract method based on assembly type.
     */
-   private CreateViewsheetResult executeAndExtract(RuntimeViewsheet rvs, VSAssembly assembly)
+   private CreateViewsheetResult executeAndExtract(RuntimeViewsheet rvs, VSAssembly assembly,
+                                                   int sampleMaxRows)
       throws Exception
    {
       Optional<ViewsheetSandbox> viewsheetSandbox = rvs.getViewsheetSandbox();
@@ -522,7 +524,29 @@ public class WizVsService {
          throw new IllegalStateException("ViewsheetSandbox is empty");
       }
 
-      viewsheetSandbox.get().executeView(assembly.getName(), true);
+      ViewsheetSandbox box = viewsheetSandbox.get();
+
+      // #75456: cancel + data-mode. Truly abort any in-flight query left over from a prior render
+      // (e.g. a slow full-data query the user is superseding by toggling to sampled) at the source
+      // — cancelAllQueries() -> QueryManager.cancel() -> Statement.cancel() — rather than leaving it
+      // running. Then apply the requested row cap to the source worksheet so the (re)render
+      // aggregates the chosen amount of data, dropping cached results so the new cap is honored.
+      // sampleMaxRows <= 0 = full data (the default and the agent path).
+      box.cancelAllQueries();
+      var bws = rvs.getViewsheet() != null ? rvs.getViewsheet().getBaseWorksheet() : null;
+
+      if(bws != null) {
+         bws.getWorksheetInfo().setDesignMaxRows(Math.max(sampleMaxRows, 0));
+
+         try {
+            box.resetDataMap(assembly.getName());
+            box.clearGraph(assembly.getName());
+         }
+         catch(Exception ignore) {
+         }
+      }
+
+      box.executeView(assembly.getName(), true);
 
       if(assembly instanceof ChartVSAssembly) {
          return extractChartData(rvs, assembly.getName());
@@ -559,7 +583,11 @@ public class WizVsService {
          return new CreateViewsheetResult();
       }
 
-      CreateViewsheetResult result = executeAndExtract(rvs, assembly);
+      // #75456: preserve the current data-mode on this lazy re-fetch path — pass the design-max
+      // already set on the source worksheet (no-op for full; keeps sampled mode sampled).
+      var fetchWs = vs.getBaseWorksheet();
+      int curMax = fetchWs != null ? fetchWs.getWorksheetInfo().getDesignMaxRows() : 0;
+      CreateViewsheetResult result = executeAndExtract(rvs, assembly, curMax);
 
       if(result != null) {
          // Order matters: executeAndExtract runs executeView above, which populates the
@@ -705,6 +733,22 @@ public class WizVsService {
 
          if(rowCount > MAX_ROWS) {
             result.setTruncated(true);
+         }
+
+         // #75456: if the source worksheet had a finite design-mode sample cap in effect
+         // (sampled-preview mode), the chart aggregated at most that many detail rows, so Sum/Count
+         // may be approximate. Flag it so the caller can warn. Full-data mode (the default) sets the
+         // worksheet design-max to 0 (unlimited) -> no flag. Best-effort; absence just means no warning.
+         try {
+            var bws = rvs.getViewsheet() != null ? rvs.getViewsheet().getBaseWorksheet() : null;
+            int dmax = bws != null ? bws.getWorksheetInfo().getDesignMaxRows() : 0;
+
+            if(dmax > 0) {
+               result.setSampled(true);
+               result.setSampleMaxRows(dmax);
+            }
+         }
+         catch(Exception ignore) {
          }
 
          return result;

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -32,6 +32,9 @@ import inetsoft.uql.jdbc.util.JDBCUtil;
 import inetsoft.uql.jdbc.util.SQLTypes;
 import inetsoft.uql.schema.UserVariable;
 import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.schema.XTypeNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import inetsoft.util.Tool;
 import inetsoft.web.composer.ws.LayoutGraphService;
 import inetsoft.web.composer.ws.joins.InnerJoinService;
@@ -504,6 +507,13 @@ public class WorksheetTableService {
             dsName + "'.");
       }
 
+      // The parsed UniformSQL selection only carries types for base table columns it can resolve
+      // from catalog metadata; aggregates, window functions and subquery-passthrough columns get
+      // no type, so each would default to "string" (ColumnRef's fallback) and a numeric measure
+      // would be misread as a dimension by the chart recommender. Overlay the real result types
+      // from the query's output metadata (ResultSetMetaData).
+      applySqlResultTypes(columns, query, session);
+
       // StyleBI's SQL parser captures selection aliases with surrounding double-quotes (e.g.
       // "seller_state"). Expose a clean column name via an applied alias — this leaves each column's
       // underlying ref (which maps to the SQL result) untouched, so data still binds.
@@ -523,6 +533,56 @@ public class WorksheetTableService {
 
       worksheet.addAssembly(table);
       return table;
+   }
+
+   /**
+    * Overlay real column data types (from the query's ResultSetMetaData) onto a SQL-bound table's
+    * column selection. The SQL parser only types base catalog columns; without this, aggregates,
+    * window functions and subquery-passthrough columns default to "string" (ColumnRef's fallback)
+    * and a numeric measure binds as a dimension. Types are matched positionally — the parsed
+    * selection order equals the result-set order — with a name-based fallback when the counts differ.
+    */
+   private void applySqlResultTypes(ColumnSelection columns, JDBCQuery query, Object session) {
+      try {
+         XTypeNode meta = query.getOutputTypeForNonParseableSQL(
+            new XTypeNode("table"), new VariableTable(), session);
+
+         if(meta == null || meta.getChildCount() == 0) {
+            return;
+         }
+
+         int n = columns.getAttributeCount();
+         boolean byIndex = meta.getChildCount() == n;
+         Map<String, String> byName = new HashMap<>();
+
+         for(int i = 0; i < meta.getChildCount(); i++) {
+            XTypeNode node = (XTypeNode) meta.getChild(i);
+
+            if(node.getName() != null && node.getType() != null) {
+               byName.putIfAbsent(node.getName(), node.getType());
+            }
+         }
+
+         for(int i = 0; i < n; i++) {
+            if(!(columns.getAttribute(i) instanceof ColumnRef cr)) {
+               continue;
+            }
+
+            String type = byIndex ? ((XTypeNode) meta.getChild(i)).getType() : null;
+
+            if(type == null || type.isEmpty()) {
+               type = byName.get(cr.getName());
+            }
+
+            if(type != null && !type.isEmpty()) {
+               cr.setDataType(type);
+            }
+         }
+      }
+      catch(Exception ex) {
+         // Best-effort: a metadata failure leaves the parser-derived types (worst case "string").
+         LOG.debug("Failed to resolve SQL result types for sql query table", ex);
+      }
    }
 
    private AbstractTableAssembly buildMirrorTable(Worksheet worksheet,
@@ -1183,4 +1243,6 @@ public class WorksheetTableService {
    private final QueryManagerService queryManagerService;
    private final XRepository xrepository;
    private final ObjectMapper objectMapper;
+
+   private static final Logger LOG = LoggerFactory.getLogger(WorksheetTableService.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -108,6 +108,12 @@ public class WorksheetTableService {
          worksheetEntry = null;
       }
 
+      // #75456: default wiz analytics to full data. The WorksheetInfo constructor seeds inputmax
+      // from the design-mode sample cap (asset.sample.maxrows, default 50000); a chart that
+      // aggregates a table whose query returns more detail rows than that silently under-counts
+      // Sum/Count. 0 = unlimited. (Sampled-preview mode will pass a non-zero cap here in a follow-up.)
+      worksheet.getWorksheetInfo().setDesignMaxRows(0);
+
       // 2. Build the table assembly.
       AbstractTableAssembly table = buildTable(worksheet, request, user);
 


### PR DESCRIPTION
Server-side (StyleBI) follow-up fixes from the olist plugin test run. Targets `stylebi-wiz-main-rebase` (the wiz integration base). The wiz-services/portal/plugin side is in a companion PR on `stylebi-wiz`.

## #75456 — full-data aggregation by default + sampled-preview switch
- Worksheets default to full data (`setDesignMaxRows(0)`); a `sampleMaxRows` switch caps the preview on demand (with true query cancel of the prior run). Applied at worksheet creation and on `/viewsheet/open` for the live viewer toggle.

## #75457 — worksheet filters usable
- `Condition` model: accept the `operation`/`equal` vocabulary the plugin actually sends (+ `@JsonIgnoreProperties`); convert each condition value to the column's declared type (`Tool.getData`, e.g. date string → Timestamp) instead of comparing strings against typed columns.

## #75458 — sql-query-table column types
- SQL-bound table columns all defaulted to `string` (parser typemap empty for aggregates/derived columns), so numeric measures bound as dimensions and charts degraded to tables. Overlay real `ResultSetMetaData` types onto the column selection.

## #75459 — GROUP BY ordinal survives cache column-sort
- `JDBCQueryCacheNormalizer` sorts SELECT columns for cache-keying, which invalidated a literal `GROUP BY <ordinal>` (the ordinal pointed at the wrong column → DB error → silent sample-data fallback). Skip column-sort normalization when the query groups by an ordinal.

## #75460 — recommender field classification, ranking-aware feasibility, explicit chart type
1. Honor the caller's explicit `fieldType` (a `DistinctCount`/`Count` over a string id binds as a measure, not a high-cardinality dimension → no more silent table fallback).
2. A top-N `ranking` on a dimension now caps its effective cardinality at N **before** chart feasibility, so a ranked high-cardinality dimension renders a top-N bar instead of a table (and the ranking limits rows).
3. An explicitly-requested renderable chart type the recommender didn't surface is force-applied via `ChangeChartTypeProcessor` (line/area/point normalized to a vertical layout) instead of being silently substituted.

All changes runtime-verified against the local StyleBI image. Redmine: #75456, #75457, #75458, #75459, #75460.

🤖 Generated with [Claude Code](https://claude.com/claude-code)