### PR TITLE
Bug #75453 - Remove orphaned user data on identity deletion

### DIFF
--- a/core/src/main/java/inetsoft/sree/UserEnv.java
+++ b/core/src/main/java/inetsoft/sree/UserEnv.java
@@ -478,6 +478,34 @@ public class UserEnv {
    }
 
    /**
+    * Remove a user's saved properties file. Called when a user is deleted so the
+    * sreeUserData/{name}_{orgID}.xml file is not left orphaned.
+    */
+   public static void removeUser(IdentityID userIdentity) {
+      if(userIdentity == null) {
+         return;
+      }
+
+      String userFile = getUserFile(userIdentity.convertToKey());
+      DataSpace space = DataSpace.getDataSpace();
+
+      try {
+         removeChangeListener(space, userFile);
+
+         if(space.exists(USER_DIR, userFile)) {
+            space.delete(USER_DIR, userFile);
+         }
+      }
+      catch(Exception e) {
+         LOG.warn("Failed to remove user properties for {}", userIdentity, e);
+      }
+
+      synchronized(propmap) {
+         propmap.keySet().removeIf(k -> userIdentity.equals(getName(k)));
+      }
+   }
+
+   /**
     * Get the user names containing a UserEnv file
     */
    public static Set<String> getUsersWithFile() {

--- a/core/src/main/java/inetsoft/sree/UserEnv.java
+++ b/core/src/main/java/inetsoft/sree/UserEnv.java
@@ -495,13 +495,13 @@ public class UserEnv {
          if(space.exists(USER_DIR, userFile)) {
             space.delete(USER_DIR, userFile);
          }
+
+         synchronized(propmap) {
+            propmap.keySet().removeIf(k -> userIdentity.equals(getName(k)));
+         }
       }
       catch(Exception e) {
          LOG.warn("Failed to remove user properties for {}", userIdentity, e);
-      }
-
-      synchronized(propmap) {
-         propmap.keySet().removeIf(k -> userIdentity.equals(getName(k)));
       }
    }
 

--- a/core/src/main/java/inetsoft/web/AutoSaveUtils.java
+++ b/core/src/main/java/inetsoft/web/AutoSaveUtils.java
@@ -261,6 +261,46 @@ public final class AutoSaveUtils {
       }
    }
 
+   // Delete all auto save files (active and recycle bin) owned by the given user.
+   // Used when a user is deleted so their drafts are not left orphaned.
+   public static void deleteUserAutoSaveFiles(IdentityID user) {
+      if(user == null) {
+         return;
+      }
+
+      try {
+         // resolve the bucket from the deleted user's org, not the caller's,
+         // so a site admin deleting a cross-org user still finds their drafts
+         BlobStorage<Metadata> blobStorage = getStorage(user.getOrgID());
+
+         for(String file : blobStorage.paths().collect(Collectors.toList())) {
+            String[] attrs = Tool.split(getName(file), '^');
+
+            if(attrs.length > 3) {
+               String fileUser = attrs[2];
+
+               if(fileUser == null || "anonymous".equals(fileUser) ||
+                  Tool.equals(fileUser, "_NULL_"))
+               {
+                  continue;
+               }
+
+               if(user.equals(IdentityID.getIdentityIDFromKey(fileUser))) {
+                  try {
+                     blobStorage.delete(file);
+                  }
+                  catch(Exception e) {
+                     LOG.warn("Failed to delete auto save file {} for user {}", file, user, e);
+                  }
+               }
+            }
+         }
+      }
+      catch(Exception e) {
+         LOG.warn("Failed to delete auto save files for user {}", user, e);
+      }
+   }
+
    public static void deleteRecycledAutoSaveFiles(Principal principal) {
       try {
          BlobStorage<Metadata> blobStorage = getStorage(principal);
@@ -329,8 +369,10 @@ public final class AutoSaveUtils {
          principal = ThreadContext.getContextPrincipal();
       }
 
-      String orgId = OrganizationManager.getInstance().getCurrentOrgID(principal);
+      return getStorage(OrganizationManager.getInstance().getCurrentOrgID(principal));
+   }
 
+   static BlobStorage<Metadata> getStorage(String orgId) {
       if(orgId == null) {
          orgId = OrganizationManager.getInstance().getCurrentOrgID();
       }

--- a/core/src/main/java/inetsoft/web/AutoSaveUtils.java
+++ b/core/src/main/java/inetsoft/web/AutoSaveUtils.java
@@ -261,8 +261,10 @@ public final class AutoSaveUtils {
       }
    }
 
-   // Delete all auto save files (active and recycle bin) owned by the given user.
-   // Used when a user is deleted so their drafts are not left orphaned.
+   /**
+    * Delete all auto save files (active and recycle bin) owned by the given user.
+    * Used when a user is deleted so their drafts are not left orphaned.
+    */
    public static void deleteUserAutoSaveFiles(IdentityID user) {
       if(user == null) {
          return;
@@ -271,7 +273,7 @@ public final class AutoSaveUtils {
       try {
          // resolve the bucket from the deleted user's org, not the caller's,
          // so a site admin deleting a cross-org user still finds their drafts
-         BlobStorage<Metadata> blobStorage = getStorage(user.getOrgID());
+         BlobStorage<Metadata> blobStorage = getStorageForOrg(user.getOrgID());
 
          for(String file : blobStorage.paths().collect(Collectors.toList())) {
             String[] attrs = Tool.split(getName(file), '^');
@@ -369,10 +371,10 @@ public final class AutoSaveUtils {
          principal = ThreadContext.getContextPrincipal();
       }
 
-      return getStorage(OrganizationManager.getInstance().getCurrentOrgID(principal));
+      return getStorageForOrg(OrganizationManager.getInstance().getCurrentOrgID(principal));
    }
 
-   static BlobStorage<Metadata> getStorage(String orgId) {
+   static BlobStorage<Metadata> getStorageForOrg(String orgId) {
       if(orgId == null) {
          orgId = OrganizationManager.getInstance().getCurrentOrgID();
       }

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -41,6 +41,7 @@ import inetsoft.storage.*;
 import inetsoft.uql.XPrincipal;
 import inetsoft.uql.XRepository;
 import inetsoft.uql.asset.*;
+import inetsoft.uql.asset.internal.AssetFolder;
 import inetsoft.uql.asset.sync.DependencyStorageService;
 import inetsoft.uql.service.DataSourceRegistry;
 import inetsoft.uql.service.XEngine;
@@ -238,7 +239,6 @@ public class IdentityService {
                }
 
                if(type == Identity.USER) {
-                  deleteUserIDs.add(identityId);
                   logoutSession(identityId);
                }
 
@@ -246,6 +246,12 @@ public class IdentityService {
 
                syncIdentity(provider, identityId != null ? new DefaultIdentity(identityId, type) :
                   new DefaultIdentity(), null);
+
+               // only mark as deleted after syncIdentity succeeds, so favorites
+               // aren't stripped for users whose deletion failed
+               if(type == Identity.USER) {
+                  deleteUserIDs.add(identityId);
+               }
             }
             catch(Exception ex) {
                actionRecord.setActionStatus(ActionRecord.ACTION_STATUS_FAILURE);
@@ -260,6 +266,9 @@ public class IdentityService {
                }
             }
          }
+
+         // sweep shared-asset favorites once for all deleted users (one scan per org)
+         removeUserFavorites(deleteUserIDs);
 
          if(!failedIdentities.isEmpty()) {
             String warning = String.format(
@@ -473,6 +482,8 @@ public class IdentityService {
             eprovider.removeUser(identityId);
             updateIdentityPermissions(type, identityId, null, identityId.orgID, identityId.orgID,true);
             removeUserScopedAssets(identity);
+            UserEnv.removeUser(identityId);
+            AutoSaveUtils.deleteUserAutoSaveFiles(identityId);
          }
          else {
             if(!identityId.equals(oID)) {
@@ -2204,6 +2215,63 @@ public class IdentityService {
       };
       Set<String> keys = indexedStorage.getKeys(filter, identityID.getOrgID());
       keys.stream().forEach(key -> indexedStorage.remove(key));
+   }
+
+   /**
+    * Remove deleted users from the favoritesUser lists of shared assets they had favorited,
+    * so no dangling references are left behind. Scans each affected organization's folders
+    * once for the whole batch, so a bulk delete costs one sweep per org rather than one per
+    * user.
+    */
+   private void removeUserFavorites(Collection<IdentityID> identityIDs) {
+      if(identityIDs == null || identityIDs.isEmpty()) {
+         return;
+      }
+
+      Map<String, Set<String>> userKeysByOrg = new HashMap<>();
+
+      for(IdentityID id : identityIDs) {
+         if(id != null) {
+            userKeysByOrg.computeIfAbsent(id.getOrgID(), o -> new HashSet<>())
+               .add(id.convertToKey());
+         }
+      }
+
+      IndexedStorage.Filter filter = key -> {
+         AssetEntry entry = AssetEntry.createAssetEntry(key);
+         return entry != null && entry.isFolder();
+      };
+
+      for(Map.Entry<String, Set<String>> e : userKeysByOrg.entrySet()) {
+         String orgID = e.getKey();
+         Set<String> userKeys = e.getValue();
+
+         for(String key : indexedStorage.getKeys(filter, orgID)) {
+            try {
+               XMLSerializable data = indexedStorage.getXMLSerializable(key, null, orgID);
+
+               if(data instanceof AssetFolder folder) {
+                  boolean changed = false;
+
+                  for(AssetEntry folderEntry : folder.getEntries()) {
+                     for(String userKey : userKeys) {
+                        if(folderEntry.getFavoritesUsers().contains(userKey)) {
+                           folderEntry.deleteFavoritesUser(userKey);
+                           changed = true;
+                        }
+                     }
+                  }
+
+                  if(changed) {
+                     indexedStorage.putXMLSerializable(key, folder);
+                  }
+               }
+            }
+            catch(Exception ex) {
+               LOG.warn("Failed to remove deleted-user favorites from {}", key, ex);
+            }
+         }
+      }
    }
 
 

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -2288,6 +2288,10 @@ public class IdentityService {
             try {
                favorites.remove(id.convertToKey()).get(10L, TimeUnit.SECONDS);
             }
+            catch(InterruptedException e) {
+               Thread.currentThread().interrupt();
+               LOG.warn("Interrupted while removing EM favorites for deleted user {}", id, e);
+            }
             catch(Exception e) {
                LOG.warn("Failed to remove EM favorites for deleted user {}", id, e);
             }

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -2265,7 +2265,10 @@ public class IdentityService {
                   }
 
                   if(changed) {
-                     indexedStorage.putXMLSerializable(key, folder);
+                     OrganizationManager.runInOrgScope(orgID, () -> {
+                        indexedStorage.putXMLSerializable(key, folder);
+                        return null;
+                     });
                   }
                }
             }

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -2228,10 +2228,12 @@ public class IdentityService {
          return;
       }
 
+      removeUserEMFavorites(identityIDs);
+
       Map<String, Set<String>> userKeysByOrg = new HashMap<>();
 
       for(IdentityID id : identityIDs) {
-         if(id != null) {
+         if(id != null && id.getOrgID() != null) {
             userKeysByOrg.computeIfAbsent(id.getOrgID(), o -> new HashSet<>())
                .add(id.convertToKey());
          }
@@ -2269,6 +2271,25 @@ public class IdentityService {
             }
             catch(Exception ex) {
                LOG.warn("Failed to remove deleted-user favorites from {}", key, ex);
+            }
+         }
+      }
+   }
+
+   /**
+    * Remove the deleted users' EM admin-panel favorites, which are stored per
+    * identity key in the emFavorites store and would otherwise be orphaned.
+    */
+   private void removeUserEMFavorites(Collection<IdentityID> identityIDs) {
+      KeyValueStorage<FavoriteList> favorites = keyValueStorageManager.getStorage("emFavorites");
+
+      for(IdentityID id : identityIDs) {
+         if(id != null) {
+            try {
+               favorites.remove(id.convertToKey()).get(10L, TimeUnit.SECONDS);
+            }
+            catch(Exception e) {
+               LOG.warn("Failed to remove EM favorites for deleted user {}", id, e);
             }
          }
       }

--- a/core/src/test/java/inetsoft/sree/UserEnvTest.java
+++ b/core/src/test/java/inetsoft/sree/UserEnvTest.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.sree;
+
+import inetsoft.sree.security.IdentityID;
+import inetsoft.util.DataSpace;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class UserEnvTest {
+   private static final String USER_DIR = "sreeUserData";
+
+   @Test
+   void removeUser_nullIdentity_noDataSpaceAccess() {
+      try(MockedStatic<DataSpace> ds = mockStatic(DataSpace.class)) {
+         UserEnv.removeUser(null);
+         ds.verify(DataSpace::getDataSpace, never());
+      }
+   }
+
+   @Test
+   void removeUser_deletesExistingFile() {
+      IdentityID alice = new IdentityID("alice", "org1");
+      String userFile = "alice_org1.xml";
+      DataSpace space = mock(DataSpace.class);
+      when(space.exists(USER_DIR, userFile)).thenReturn(true);
+
+      try(MockedStatic<DataSpace> ds = mockStatic(DataSpace.class)) {
+         ds.when(DataSpace::getDataSpace).thenReturn(space);
+         UserEnv.removeUser(alice);
+         verify(space).delete(USER_DIR, userFile);
+      }
+   }
+
+   @Test
+   void removeUser_fileMissing_noDelete() {
+      IdentityID alice = new IdentityID("alice", "org1");
+      DataSpace space = mock(DataSpace.class);
+      when(space.exists(USER_DIR, "alice_org1.xml")).thenReturn(false);
+
+      try(MockedStatic<DataSpace> ds = mockStatic(DataSpace.class)) {
+         ds.when(DataSpace::getDataSpace).thenReturn(space);
+         UserEnv.removeUser(alice);
+         verify(space, never()).delete(anyString(), anyString());
+      }
+   }
+
+   @Test
+   void removeUser_deleteFails_doesNotThrow() {
+      IdentityID alice = new IdentityID("alice", "org1");
+      DataSpace space = mock(DataSpace.class);
+      when(space.exists(USER_DIR, "alice_org1.xml")).thenReturn(true);
+      when(space.delete(USER_DIR, "alice_org1.xml")).thenThrow(new RuntimeException("boom"));
+
+      try(MockedStatic<DataSpace> ds = mockStatic(DataSpace.class)) {
+         ds.when(DataSpace::getDataSpace).thenReturn(space);
+         assertDoesNotThrow(() -> UserEnv.removeUser(alice));
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/AutoSaveUtilsTest.java
+++ b/core/src/test/java/inetsoft/web/AutoSaveUtilsTest.java
@@ -1,0 +1,93 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web;
+
+import inetsoft.sree.security.IdentityID;
+import inetsoft.storage.BlobStorage;
+import inetsoft.storage.BlobStorageManager;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class AutoSaveUtilsTest {
+   @Test
+   void deleteUserAutoSaveFiles_nullUser_noStorageAccess() {
+      try(MockedStatic<BlobStorageManager> bsm = mockStatic(BlobStorageManager.class)) {
+         AutoSaveUtils.deleteUserAutoSaveFiles(null);
+         bsm.verifyNoInteractions();
+      }
+   }
+
+   @Test
+   @SuppressWarnings("unchecked")
+   void deleteUserAutoSaveFiles_deletesOnlyMatchingUserFiles() throws Exception {
+      IdentityID alice = new IdentityID("alice", "org1");
+      IdentityID bob = new IdentityID("bob", "org1");
+      String aliceFile = "0^VIEWSHEET^" + alice.convertToKey() + "^dashboard1";
+      String aliceRecycled = AutoSaveUtils.RECYCLE_PREFIX + "0^VIEWSHEET^" +
+         alice.convertToKey() + "^dashboard2";
+      String bobFile = "0^VIEWSHEET^" + bob.convertToKey() + "^dashboard3";
+      String anonFile = "0^VIEWSHEET^anonymous^dashboard4";
+      String nullFile = "0^VIEWSHEET^_NULL_^dashboard5";
+      String shortFile = "0^VIEWSHEET^onlythree";
+
+      BlobStorage<AutoSaveUtils.Metadata> blobStorage = mock(BlobStorage.class);
+      when(blobStorage.paths()).thenReturn(Stream.of(
+         aliceFile, aliceRecycled, bobFile, anonFile, nullFile, shortFile));
+
+      try(MockedStatic<BlobStorageManager> bsm = mockStatic(BlobStorageManager.class)) {
+         BlobStorageManager manager = mock(BlobStorageManager.class);
+         bsm.when(BlobStorageManager::getInstance).thenReturn(manager);
+         when(manager.<AutoSaveUtils.Metadata>getStorage(anyString(), anyBoolean()))
+            .thenReturn(blobStorage);
+
+         AutoSaveUtils.deleteUserAutoSaveFiles(alice);
+
+         verify(blobStorage).delete(aliceFile);
+         verify(blobStorage).delete(aliceRecycled);
+         verify(blobStorage, times(2)).delete(anyString());
+      }
+   }
+
+   @Test
+   @SuppressWarnings("unchecked")
+   void deleteUserAutoSaveFiles_oneFailedDelete_continuesWithOthers() throws Exception {
+      IdentityID alice = new IdentityID("alice", "org1");
+      String file1 = "0^VIEWSHEET^" + alice.convertToKey() + "^dashboard1";
+      String file2 = "0^VIEWSHEET^" + alice.convertToKey() + "^dashboard2";
+
+      BlobStorage<AutoSaveUtils.Metadata> blobStorage = mock(BlobStorage.class);
+      when(blobStorage.paths()).thenReturn(Stream.of(file1, file2));
+      doThrow(new java.io.IOException("boom")).doNothing().when(blobStorage).delete(anyString());
+
+      try(MockedStatic<BlobStorageManager> bsm = mockStatic(BlobStorageManager.class)) {
+         BlobStorageManager manager = mock(BlobStorageManager.class);
+         bsm.when(BlobStorageManager::getInstance).thenReturn(manager);
+         when(manager.<AutoSaveUtils.Metadata>getStorage(anyString(), anyBoolean()))
+            .thenReturn(blobStorage);
+
+         assertDoesNotThrow(() -> AutoSaveUtils.deleteUserAutoSaveFiles(alice));
+         verify(blobStorage, times(2)).delete(anyString());
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/security/IdentityServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/security/IdentityServiceTest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.admin.security;
 
 import inetsoft.sree.security.IdentityID;
+import inetsoft.sree.security.OrganizationContextHolder;
 import inetsoft.storage.KeyValueStorage;
 import inetsoft.storage.KeyValueStorageManager;
 import inetsoft.uql.asset.AssetEntry;
@@ -97,6 +98,36 @@ class IdentityServiceTest {
       assertTrue(theirs.getFavoritesUsers().contains(bob.convertToKey()),
                  "bob's favorite must be untouched");
       verify(indexedStorage).putXMLSerializable("folderKey", folder);
+   }
+
+   @Test
+   void removeUserFavorites_writeScopedToTargetOrg() throws Exception {
+      IdentityID alice = new IdentityID("alice", "org1");
+      AssetFolder folder = new AssetFolder();
+      folder.addEntry(entryWithFavorites(alice));
+
+      when(indexedStorage.getKeys(any(), eq("org1"))).thenReturn(Set.of("folderKey"));
+      when(indexedStorage.getXMLSerializable(eq("folderKey"), isNull(), eq("org1")))
+         .thenReturn(folder);
+
+      String[] orgAtWrite = new String[1];
+      doAnswer(inv -> {
+         orgAtWrite[0] = OrganizationContextHolder.getCurrentOrgId();
+         return null;
+      }).when(indexedStorage).putXMLSerializable(eq("folderKey"), any());
+
+      // simulate a caller whose thread context is a different org
+      OrganizationContextHolder.setCurrentOrgId("callerOrg");
+
+      try {
+         invokeRemoveUserFavorites(List.of(alice));
+      }
+      finally {
+         OrganizationContextHolder.setCurrentOrgId(null);
+      }
+
+      assertEquals("org1", orgAtWrite[0],
+                   "write must run in the target user's org, not the caller's");
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/admin/security/IdentityServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/security/IdentityServiceTest.java
@@ -1,0 +1,169 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.security;
+
+import inetsoft.sree.security.IdentityID;
+import inetsoft.storage.KeyValueStorage;
+import inetsoft.storage.KeyValueStorageManager;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.internal.AssetFolder;
+import inetsoft.util.IndexedStorage;
+import org.junit.jupiter.api.*;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Covers the orphaned-favorites cleanup that runs during user deletion:
+ * removeUserFavorites (asset favorites in IndexedStorage) and removeUserEMFavorites
+ * (EM admin-panel favorites in the emFavorites KeyValueStorage).
+ *
+ * The service is created without invoking its constructor and only the two storage
+ * dependencies these methods touch are injected, so the tests stay decoupled from
+ * the rest of the service's wiring.
+ */
+@Tag("core")
+class IdentityServiceTest {
+   private IndexedStorage indexedStorage;
+   private KeyValueStorageManager keyValueStorageManager;
+   private KeyValueStorage<?> emFavorites;
+   private IdentityService service;
+
+   @BeforeEach
+   void setUp() {
+      indexedStorage = mock(IndexedStorage.class);
+      keyValueStorageManager = mock(KeyValueStorageManager.class);
+      emFavorites = mock(KeyValueStorage.class);
+
+      doReturn(emFavorites).when(keyValueStorageManager).getStorage("emFavorites");
+      doReturn(CompletableFuture.completedFuture(null)).when(emFavorites).remove(anyString());
+
+      service = mock(IdentityService.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+      ReflectionTestUtils.setField(service, "indexedStorage", indexedStorage);
+      ReflectionTestUtils.setField(service, "keyValueStorageManager", keyValueStorageManager);
+      // LOG is a final instance field set by the constructor, which the mock bypasses
+      ReflectionTestUtils.setField(service, "LOG",
+                                   org.slf4j.LoggerFactory.getLogger(IdentityService.class));
+   }
+
+   @Test
+   void removeUserFavorites_emptyInput_noStorageAccess() throws Exception {
+      invokeRemoveUserFavorites(Collections.emptyList());
+
+      verifyNoInteractions(indexedStorage);
+      verifyNoInteractions(keyValueStorageManager);
+   }
+
+   @Test
+   void removeUserFavorites_removesUserKeyFromMatchingFolderEntry() throws Exception {
+      IdentityID alice = new IdentityID("alice", "org1");
+      IdentityID bob = new IdentityID("bob", "org1");
+
+      AssetEntry mine = entryWithFavorites(alice);
+      AssetEntry theirs = entryWithFavorites(bob);
+      AssetFolder folder = new AssetFolder();
+      folder.addEntry(mine);
+      folder.addEntry(theirs);
+
+      when(indexedStorage.getKeys(any(), eq("org1"))).thenReturn(Set.of("folderKey"));
+      when(indexedStorage.getXMLSerializable(eq("folderKey"), isNull(), eq("org1")))
+         .thenReturn(folder);
+
+      invokeRemoveUserFavorites(List.of(alice));
+
+      assertFalse(mine.getFavoritesUsers().contains(alice.convertToKey()),
+                  "alice's favorite should be removed");
+      assertTrue(theirs.getFavoritesUsers().contains(bob.convertToKey()),
+                 "bob's favorite must be untouched");
+      verify(indexedStorage).putXMLSerializable("folderKey", folder);
+   }
+
+   @Test
+   void removeUserFavorites_unmodifiedFolder_notRewritten() throws Exception {
+      IdentityID alice = new IdentityID("alice", "org1");
+      IdentityID bob = new IdentityID("bob", "org1");
+
+      AssetFolder folder = new AssetFolder();
+      folder.addEntry(entryWithFavorites(bob));
+
+      when(indexedStorage.getKeys(any(), eq("org1"))).thenReturn(Set.of("folderKey"));
+      when(indexedStorage.getXMLSerializable(eq("folderKey"), isNull(), eq("org1")))
+         .thenReturn(folder);
+
+      invokeRemoveUserFavorites(List.of(alice));
+
+      verify(indexedStorage, never()).putXMLSerializable(anyString(), any());
+   }
+
+   @Test
+   void removeUserFavorites_nullOrgUser_skipsAssetScan() throws Exception {
+      IdentityID noOrg = new IdentityID("legacy", null);
+
+      invokeRemoveUserFavorites(List.of(noOrg));
+
+      verify(indexedStorage, never()).getKeys(any(), any());
+      verify(emFavorites).remove(noOrg.convertToKey());
+   }
+
+   @Test
+   void removeUserEMFavorites_removesEachUserKey() throws Exception {
+      IdentityID alice = new IdentityID("alice", "org1");
+      IdentityID bob = new IdentityID("bob", "org2");
+
+      invokeRemoveUserEMFavorites(List.of(alice, bob));
+
+      verify(emFavorites).remove(alice.convertToKey());
+      verify(emFavorites).remove(bob.convertToKey());
+   }
+
+   @Test
+   void removeUserEMFavorites_storageFailure_doesNotThrow() throws Exception {
+      IdentityID alice = new IdentityID("alice", "org1");
+      Future<?> failing = mock(Future.class);
+      when(failing.get(anyLong(), any()))
+         .thenThrow(new ExecutionException(new RuntimeException("boom")));
+      doReturn(failing).when(emFavorites).remove(anyString());
+
+      assertDoesNotThrow(() -> invokeRemoveUserEMFavorites(List.of(alice)));
+   }
+
+   private static AssetEntry entryWithFavorites(IdentityID user) {
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, "/" + user.getName(), user);
+      entry.addFavoritesUser(user.convertToKey());
+      return entry;
+   }
+
+   private void invokeRemoveUserFavorites(Collection<IdentityID> ids) throws Exception {
+      Method m = IdentityService.class.getDeclaredMethod("removeUserFavorites", Collection.class);
+      m.setAccessible(true);
+      m.invoke(service, ids);
+   }
+
+   private void invokeRemoveUserEMFavorites(Collection<IdentityID> ids) throws Exception {
+      Method m = IdentityService.class.getDeclaredMethod("removeUserEMFavorites", Collection.class);
+      m.setAccessible(true);
+      m.invoke(service, ids);
+   }
+}


### PR DESCRIPTION
## Summary

Deleting a user already cascades their private viewsheets/worksheets, bookmarks, owned scheduled
tasks, dashboards, scripts/styles, ACL grants and sessions. It did not, however, clean up three
categories that were left orphaned:

- favoritesUser references to the user on shared assets
- the user's UserEnv preference file (sreeUserData/{name}_{orgID}.xml)
- the user's auto-save drafts

This PR removes those as part of deletion so no dangling references or files remain. It applies to
every deletion entry point (EM UI bulk delete and the public REST API), because both converge on
IdentityService.deleteIdentities -> syncIdentity.

## Changes

- UserEnv.removeUser(IdentityID): deletes the user's properties file from the data space and
evicts its cached entry.
- AutoSaveUtils.deleteUserAutoSaveFiles(IdentityID): deletes the user's auto-save drafts (active
and recycle bin), matching the owner encoded in the file name. The auto-save bucket is resolved
from the deleted user's organization, so a site admin deleting a user in another org still removes
that user's drafts. A new package-private getStorage(String orgId) overload keeps the bucket-key
format in a single place.
- IdentityService: in the user-delete branch of syncIdentity, calls UserEnv.removeUser and
AutoSaveUtils.deleteUserAutoSaveFiles per user; a new batched
removeUserFavorites(Collection<IdentityID>) runs once after the deleteIdentities loop. A user is
only recorded for favorites cleanup after its syncIdentity deletion succeeds, so favorites are
never stripped for a user whose deletion failed.

## Performance

The favorites cleanup must scan asset folders to find references, which is independent of any
single user. It is therefore hoisted out of the per-user path and run once per delete operation,
grouped by organization so each org's folders are scanned a single time. A single-user delete
still costs one scan; a bulk delete of N users costs one scan per org instead of N.

## Scope

The change only removes data belonging to the deleted user. It never deletes a shared asset (only
the user's entry in its favoritesUser list), never affects other users, and does not alter the
existing deletion cascade or any non-delete path. All cleanup steps are null-guarded and wrapped
in try/catch so a storage error logs at WARN and does not abort the deletion; auto-save deletes
are guarded per file so one failed delete does not skip the rest.