### PR TITLE
fix(wiz): fail fast on null table asset entry in raw-data export

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/RawDataService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/RawDataService.java
@@ -90,6 +90,16 @@ public class RawDataService {
       throws Exception
    {
       String datasourcePath = requestData.getDatasourcePath();
+      AssetEntry tableEntry = requestData.getTable();
+
+      // Fail fast with a diagnosable message when the request carries no table asset entry.
+      // Callers (e.g. the WIZ annotation profiler) may omit it; without this guard setupTable
+      // dereferences a null AssetEntry and throws an opaque NullPointerException.
+      if(tableEntry == null) {
+         throw new IllegalArgumentException(
+            "Export request for data source \"" + datasourcePath + "\" is missing the table asset entry.");
+      }
+
       XDataSource dataSource = xrepository.getDataSource(datasourcePath);
 
       if(!(dataSource instanceof JDBCDataSource)) {
@@ -102,7 +112,6 @@ public class RawDataService {
       query.setDataSource(dataSource);
       query.setMaxRows(RAW_DATA_MAX_ROW);
 
-      AssetEntry tableEntry = requestData.getTable();
       setupTable(query, tableEntry, principal);
 
       AssetRepository assetRepository = AssetUtil.getAssetRepository(false);

--- a/core/src/test/java/inetsoft/web/wiz/service/RawDataServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/RawDataServiceTest.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.XRepository;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.web.wiz.request.ExportDatabaseTableToCsvRequest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@Tag("core")
+class RawDataServiceTest {
+   @Test
+   void rejectsRequestWithNullTableEntryWithClearMessageAndWithoutTouchingRepository() throws Exception {
+      XRepository xrepository = mock(XRepository.class);
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      RawDataService service = new RawDataService(xrepository, assetRepository);
+
+      ExportDatabaseTableToCsvRequest request = new ExportDatabaseTableToCsvRequest();
+      request.setDatasourcePath("inventree");
+      request.setTable(null); // the plugin/profiler can omit this — must fail cleanly, not NPE
+
+      IllegalArgumentException ex = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.writeDataSourceTableCsvStream(request, null, new ByteArrayOutputStream()));
+
+      // The message must name the data source so the failure is diagnosable (vs. an opaque NPE).
+      assertNotNull(ex.getMessage());
+      assertTrue(ex.getMessage().contains("inventree"),
+                 "exception message should name the data source: " + ex.getMessage());
+
+      // The guard must run before any repository lookup.
+      verifyNoInteractions(xrepository);
+   }
+}


### PR DESCRIPTION
## Problem

`RawDataService.writeDataSourceTableCsvStream` reads `requestData.getTable()` and passes it straight to `setupTable`, which dereferences it:

```java
String name = table.getProperty("source_with_no_quote"); // line 129
```

When a caller omits the table asset entry (e.g. the WIZ annotation profiler exporting raw rows for a freshly-registered datasource), `table` is `null` and this throws an opaque NPE that surfaces to clients as a 500 with no actionable detail:

```
java.lang.NullPointerException: Cannot invoke "inetsoft.uql.asset.AssetEntry.getProperty(String)" because "table" is null
    at inetsoft.web.wiz.service.RawDataService.setupTable(RawDataService.java:129)
    at inetsoft.web.wiz.service.RawDataService.writeDataSourceTableCsvStream(RawDataService.java:106)
```

## Fix

Validate the table asset entry at the top of `writeDataSourceTableCsvStream`, before any repository lookup, and throw an `IllegalArgumentException` that names the data source. Defensive hardening — the calling client should also send the entry, but the server should fail diagnosably rather than NPE.

## Testing

Added `RawDataServiceTest` (JUnit 5 + Mockito, `@Tag("core")`): a request with a null table entry throws `IllegalArgumentException` whose message names the data source, and the guard runs before any `XRepository` interaction. `mvn -pl community/core -Dtest=RawDataServiceTest test` → BUILD SUCCESS, 1/1 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)