### PR TITLE
Merge forward fix for Bug #75427, fix IndexOutOfBoundsException in schedule week distribution

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
@@ -846,7 +846,7 @@ public class ScheduleTaskService {
 
          if(distribution != null) {
             for(TaskDistributionGroup group : distribution.days()) {
-               if(group.index() <0) {
+               if(group.index() <= 0) {
                   continue;
                }
 


### PR DESCRIPTION
A monthly TimeCondition with dayOfWeek=0 (invalid/unset) caused getWeekDistribution to call data.get(-1) because the guard only skipped index < 0. Changed the guard to index <= 0 to also skip the zero case.