### PR TITLE
Merge forward fix for Bug #75402, fix thread contention bottlenecks identified in thread dumps

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/ContentRepositoryTreeService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/ContentRepositoryTreeService.java
@@ -955,6 +955,7 @@ public class ContentRepositoryTreeService {
 
       boolean repositoryFolderExists = false;
       boolean worksheetFolderExists = false;
+      final List<String> allFolders = Arrays.asList(registry.getAllFolders(true));
 
       // add the folders from the replet registry
       for(Map.Entry<AssetEntry, List<AssetEntry>> parentEntry : parentEntries.entrySet()) {
@@ -966,7 +967,12 @@ public class ContentRepositoryTreeService {
                .map(AssetEntry::getPath)
                .collect(Collectors.toSet());
             final String path = parent.getPath();
-            Arrays.stream(registry.getFolders(path, true))
+            final boolean root = path == null || path.equals("/");
+            allFolders.stream()
+               .filter(folder -> {
+                  int index = folder.lastIndexOf('/');
+                  return index == -1 ? root : Tool.equals(path, folder.substring(0, index));
+               })
                .filter(folder -> !children.contains(folder))
                .map(folder -> new AssetEntry(AssetRepository.GLOBAL_SCOPE,
                                              AssetEntry.Type.REPOSITORY_FOLDER,

--- a/core/src/main/java/inetsoft/web/security/SessionAccessDispatcher.java
+++ b/core/src/main/java/inetsoft/web/security/SessionAccessDispatcher.java
@@ -44,17 +44,23 @@ public final class SessionAccessDispatcher {
                              Supplier<Map<String, Object>> sessionAttributes)
    {
       if(!listeners.isEmpty()) {
+         String id = sessionId.get();
+         boolean shouldFire = false;
+
          synchronized(lastAccess) {
-            String id = sessionId.get();
             long now = System.currentTimeMillis();
             Long last = lastAccess.get(id);
 
             if(last == null || now - last > 30000L) {
                lastAccess.put(id, now);
-               SessionAccessEvent event = new SessionAccessEvent(
-                  source, principal.get(), id, sessionAttributes.get());
-               queue.offer(event); // NOSONAR queue is unbounded
+               shouldFire = true;
             }
+         }
+
+         if(shouldFire) {
+            SessionAccessEvent event = new SessionAccessEvent(
+               source, principal.get(), id, sessionAttributes.get());
+            queue.offer(event); // NOSONAR queue is unbounded
          }
       }
    }


### PR DESCRIPTION
SessionAccessDispatcher: move sessionId.get(), principal.get(), and sessionAttributes.get() (Ignite deserialization) outside the synchronized block. The lock now only guards the in-memory lastAccess map check, eliminating a bottleneck that was blocking 100+ HTTP threads.

ContentRepositoryTreeService: replace per-folder calls to registry.getFolders() during tree traversal with single up-front calls to getAllFolders(), reducing RepletRegistry lock acquisitions from O(folders) to 1 per request.