### PR TITLE
Bug #75469 - Return branded 400 for unsupported viewsheet export output type

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/controller/ExportController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/ExportController.java
@@ -110,6 +110,17 @@ public class ExportController {
          path = Tool.byteDecode(path);
          int format = formatParam.orElse(FileFormatInfo.EXPORT_TYPE_PDF);
          String type = outtypeParam.orElse(null);
+
+         if(type != null && !VSExportService.isSupportedExportType(type)) {
+            LOG.warn("Rejected viewsheet export with unsupported output type \"{}\" for \"{}\" " +
+                        "(user={}, referer={})",
+                     type, path, principal == null ? null : principal.getName(),
+                     request.getHeader("referer"));
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            WebUtils.redirectToErrorPage(response, request, "Unsupported output type: " + type);
+            return;
+         }
+
          boolean exportAllTabbedTables = exportAllTabbedTablesParam.orElse(false);
          boolean expandSelections = expandSelectionsParam.orElse(false);
          boolean current = currentParam.orElse(true);

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSExportService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSExportService.java
@@ -899,6 +899,21 @@ public class VSExportService {
       }
    }
 
+   // check whether ext maps to a known export format without throwing
+   public static boolean isSupportedExportType(String ext) {
+      if(ext == null) {
+         return false;
+      }
+
+      try {
+         getFormatNumberFromExtension(ext);
+         return true;
+      }
+      catch(RuntimeException ignore) {
+         return false;
+      }
+   }
+
    public static final int EXCEL_MAX_ROW = 50000;
    public static final int EXCEL_LIMIT_ROW = 5000;
    private final ViewsheetService viewsheetService;

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSExportService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSExportService.java
@@ -877,6 +877,10 @@ public class VSExportService {
    }
 
    public static int getFormatNumberFromExtension(String ext) {
+      if(ext == null) {
+         throw new RuntimeException("Unsupported output type: null");
+      }
+
       switch(ext.toLowerCase()) {
       case "xlsx":
       case "xls":
@@ -899,17 +903,24 @@ public class VSExportService {
       }
    }
 
-   // check whether ext maps to a known export format without throwing
+   // keep cases in sync with getFormatNumberFromExtension
    public static boolean isSupportedExportType(String ext) {
       if(ext == null) {
          return false;
       }
 
-      try {
-         getFormatNumberFromExtension(ext);
+      switch(ext.toLowerCase()) {
+      case "xlsx":
+      case "xls":
+      case "pptx":
+      case "ppt":
+      case "pdf":
+      case "vso":
+      case "html":
+      case "png":
+      case "csv":
          return true;
-      }
-      catch(RuntimeException ignore) {
+      default:
          return false;
       }
    }

--- a/core/src/test/java/inetsoft/web/viewsheet/service/VSExportServiceTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/service/VSExportServiceTest.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.viewsheet.service;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class VSExportServiceTest {
+   @ParameterizedTest
+   @ValueSource(strings = {"xlsx", "xls", "pptx", "ppt", "pdf", "vso", "html", "png", "csv",
+                           "PDF", "Xlsx"})
+   void supportedTypesAreAccepted(String ext) {
+      assertTrue(VSExportService.isSupportedExportType(ext));
+   }
+
+   @ParameterizedTest
+   @ValueSource(strings = {"excel", "data", "xml", "json", "svg", "txt", "powerpoint", ""})
+   void unsupportedTypesAreRejected(String ext) {
+      assertFalse(VSExportService.isSupportedExportType(ext));
+   }
+
+   @Test
+   void nullTypeIsRejected() {
+      assertFalse(VSExportService.isSupportedExportType(null));
+   }
+
+   @Test
+   void getFormatNumberRejectsUnsupportedTypeWithoutNpe() {
+      assertThrows(RuntimeException.class, () -> VSExportService.getFormatNumberFromExtension("excel"));
+      assertThrows(RuntimeException.class, () -> VSExportService.getFormatNumberFromExtension(null));
+   }
+}


### PR DESCRIPTION
## Summary

Invalid `outtype` values on the viewsheet export endpoint
(`GET /export/viewsheet/**`) returned an HTTP 500 and logged a full stack
trace at ERROR. This change returns a branded HTTP 400 instead and logs a
single WARN that identifies the source of the bad request.

## Problem

`VSExportService.getFormatNumberFromExtension` threw a raw
`RuntimeException` for any unrecognized `outtype`. Because the export runs
through the controller with the request's referer header present (the
normal case when a user clicks an in-app hyperlink), the exception escaped
the handler and was logged at ERROR by the dispatcher servlet as an HTTP
500. The triggering requests come from viewsheet hyperlinks configured
with legacy report output types (`excel`, `data`, `xml`, `json`, `svg`,
`txt`, `powerpoint`), so real user actions were producing 500s and ERROR
log noise.

## Change

- `ExportController.exportViewsheet`: validate `outtype` before doing any
  work. If it is present but unsupported, log a WARN (requested path,
  user, referer), set a 400 status, and forward to the branded error
  page. The viewsheet is no longer opened for a doomed request.
- `VSExportService.isSupportedExportType`: new non-throwing check that
  delegates to the existing extension switch, keeping the supported-type
  list single-sourced. `getFormatNumberFromExtension` keeps its throwing
  contract as a backstop for the service path.
- `VSExportServiceTest`: unit coverage for supported extensions,
  case-insensitivity, the legacy invalid values, empty string, and null.

## Behavior

| | Before | After |
|---|---|---|
| Status | 500 (with referer) | 400 |
| Page | Dispatcher 500 / bare error | Branded error page |
| Log | ERROR + stack trace | Single WARN with path/user/referer |

Valid output types and the no-`outtype` path are unchanged.