### PR TITLE
Bug #75472, Text Layout Designer, unable to delete entire row

### DIFF
--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.html
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.html
@@ -214,6 +214,11 @@
         </div>
 
       </div>
+
+      <!-- Row-level remove: deletes the entire row and its items (bindings dropped, rows shift up) -->
+      <button class="btn btn-xs row-remove-btn ms-1"
+              (click)="removeRow(ri); $event.stopPropagation()"
+              title="_#(Remove Row)">&#215;</button>
     </div>
 
     <div *ngIf="workingRows.length === 0" class="empty-grid-hint p-2 unhighlightable">

--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.html
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.html
@@ -215,7 +215,6 @@
 
       </div>
 
-      <!-- Row-level remove: deletes the entire row and its items (bindings dropped, rows shift up) -->
       <button class="btn btn-xs row-remove-btn ms-1"
               (click)="removeRow(ri); $event.stopPropagation()"
               title="_#(Remove Row)">&#215;</button>

--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.scss
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.scss
@@ -295,6 +295,21 @@
    &:hover { background: #dc3545; color: #fff; }
 }
 
+// Row-level remove button — pinned to the right edge to distinguish it from the
+// per-item remove buttons; matches the item remove button's red-hover affordance.
+.row-remove-btn {
+   margin-left: auto;
+   padding: 0 0.35rem;
+   line-height: 1;
+   font-weight: bold;
+   height: 20px;
+   font-size: 0.8rem;
+   flex-shrink: 0;
+   opacity: 0.6;
+
+   &:hover { background: #dc3545; color: #fff; opacity: 1; }
+}
+
 // ─── Formatting toggles (in properties panel) ───────────────────────────────
 // Fixed square size so B and I render identically — matches icon-button
 // conventions used throughout the binding editor (e.g. move-up/down buttons).

--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.spec.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.spec.ts
@@ -122,4 +122,42 @@ describe("TextLayoutDesignerComponent Unit Test", () => {
       expect(component.textFields.length).toBe(1);
       expect(component.workingRows[0].items[0].fieldIndex).toBe(0);
    });
+
+   it("removeRow deletes the whole row, drops its orphaned fields (highest first) and compacts survivors", () => {
+      const removed = vi.fn();
+      component.onRemoveField.subscribe(removed);
+      component.textFields = [{ fullName: "a" }, { fullName: "b" }, { fullName: "c" }] as any;
+      component.workingRows = [
+         { items: [{ type: component.FIELD, fieldIndex: 0 }, { type: component.FIELD, fieldIndex: 1 }] },
+         { items: [{ type: component.FIELD, fieldIndex: 2 }] }
+      ];
+
+      // delete the first row (holds fields 0 and 1)
+      component.removeRow(0);
+
+      // both orphaned fields dropped, emitted highest index first so host splices stay valid
+      expect(removed.mock.calls.map(c => c[0])).toEqual([1, 0]);
+      expect(component.textFields.map((f: any) => f.fullName)).toEqual(["c"]);
+      // surviving row shifted up; its field index compacted 2 -> 0
+      expect(component.workingRows.length).toBe(1);
+      expect(component.workingRows[0].items[0].fieldIndex).toBe(0);
+   });
+
+   it("removeRow keeps a field still referenced by a surviving row", () => {
+      const removed = vi.fn();
+      component.onRemoveField.subscribe(removed);
+      component.textFields = [{ fullName: "a" }] as any;
+      component.workingRows = [
+         { items: [{ type: component.FIELD, fieldIndex: 0 }] },
+         { items: [{ type: component.FIELD, fieldIndex: 0 }] }
+      ];
+
+      component.removeRow(0);
+
+      // field 0 still used by the surviving row — keep it, no emit
+      expect(removed).not.toHaveBeenCalled();
+      expect(component.textFields.length).toBe(1);
+      expect(component.workingRows.length).toBe(1);
+      expect(component.workingRows[0].items[0].fieldIndex).toBe(0);
+   });
 });

--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.spec.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.spec.ts
@@ -143,6 +143,37 @@ describe("TextLayoutDesignerComponent Unit Test", () => {
       expect(component.workingRows[0].items[0].fieldIndex).toBe(0);
    });
 
+   it("removeRow with only non-field items removes the row without touching textFields", () => {
+      const removed = vi.fn();
+      component.onRemoveField.subscribe(removed);
+      component.textFields = [{ fullName: "a" }] as any;
+      component.workingRows = [
+         { items: [{ type: component.STATIC, text: "hello" }] },
+         { items: [{ type: component.FIELD, fieldIndex: 0 }] }
+      ];
+
+      component.removeRow(0);
+
+      expect(removed).not.toHaveBeenCalled();
+      expect(component.textFields.length).toBe(1);
+      expect(component.workingRows.length).toBe(1);
+   });
+
+   it("removeRow on the last row empties workingRows and drops all fields", () => {
+      const removed = vi.fn();
+      component.onRemoveField.subscribe(removed);
+      component.textFields = [{ fullName: "a" }, { fullName: "b" }] as any;
+      component.workingRows = [
+         { items: [{ type: component.FIELD, fieldIndex: 0 }, { type: component.FIELD, fieldIndex: 1 }] }
+      ];
+
+      component.removeRow(0);
+
+      expect(component.workingRows.length).toBe(0);
+      expect(component.textFields.length).toBe(0);
+      expect(removed.mock.calls.map((c: any) => c[0])).toEqual([1, 0]);
+   });
+
    it("removeRow keeps a field still referenced by a surviving row", () => {
       const removed = vi.fn();
       component.onRemoveField.subscribe(removed);

--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.ts
@@ -398,6 +398,52 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
       this.selectedItemIndex = -1;
    }
 
+   /**
+    * Delete an entire row and all of its items. Rows below shift up automatically. Each FIELD item
+    * in the row drops its backing textFields entry — unless another remaining row still references
+    * the same binding (e.g. the same column placed twice). Orphaned indices are processed highest
+    * first so each onRemoveField emit (which splices the host's authoritative textFields list) does
+    * not shift the indices still pending removal; the remaining FIELD items' fieldIndex is compacted
+    * to match. Mirrors removeFieldItem's single-item orphan/compaction logic.
+    */
+   removeRow(rowIndex: number): void {
+      const row = this.workingRows[rowIndex];
+
+      if(!row) {
+         return;
+      }
+
+      // Remove the row first; remaining rows shift up via splice.
+      this.workingRows.splice(rowIndex, 1);
+
+      // Unique FIELD indices that were in the removed row, now orphaned only if no surviving row
+      // still references them. Sort descending so removals don't invalidate pending indices.
+      const orphaned = Array.from(new Set(
+         row.items
+            .filter(it => it.type === this.FIELD && it.fieldIndex != null)
+            .map(it => it.fieldIndex)))
+         .filter(fi => !this.workingRows.some(
+            r => r.items.some(it => it.type === this.FIELD && it.fieldIndex === fi)))
+         .sort((a, b) => b - a);
+
+      for(const fi of orphaned) {
+         this.textFields = (this.textFields ?? []).filter((_, idx) => idx !== fi);
+
+         for(const r of this.workingRows) {
+            for(const it of r.items) {
+               if(it.type === this.FIELD && it.fieldIndex > fi) {
+                  it.fieldIndex = it.fieldIndex - 1;
+               }
+            }
+         }
+
+         this.onRemoveField.emit(fi);
+      }
+
+      this.selectedRowIndex = -1;
+      this.selectedItemIndex = -1;
+   }
+
    openFieldFormat(item: TextLayoutItemModel): void {
       const fullName = (this.getFieldRef(item)?.dataInfo as any)?.fullName;
 

--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.ts
@@ -380,22 +380,32 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
             r => r.items.some(it => it.type === this.FIELD && it.fieldIndex === fi));
 
          if(!stillReferenced) {
-            this.textFields = (this.textFields ?? []).filter((_, idx) => idx !== fi);
-
-            for(const row of this.workingRows) {
-               for(const it of row.items) {
-                  if(it.type === this.FIELD && it.fieldIndex > fi) {
-                     it.fieldIndex = it.fieldIndex - 1;
-                  }
-               }
-            }
-
-            this.onRemoveField.emit(fi);
+            this.removeOrphanedField(fi);
          }
       }
 
       this.selectedRowIndex = -1;
       this.selectedItemIndex = -1;
+   }
+
+   /**
+    * Drop the orphaned textFields entry at index fi: remove the binding, compact every higher
+    * FIELD item's fieldIndex down by one to match, and tell the host to drop the same index from
+    * its authoritative textFields list. Shared by removeFieldItem and removeRow so the orphan
+    * contract stays in one place.
+    */
+   private removeOrphanedField(fi: number): void {
+      this.textFields = (this.textFields ?? []).filter((_, idx) => idx !== fi);
+
+      for(const r of this.workingRows) {
+         for(const it of r.items) {
+            if(it.type === this.FIELD && it.fieldIndex > fi) {
+               it.fieldIndex = it.fieldIndex - 1;
+            }
+         }
+      }
+
+      this.onRemoveField.emit(fi);
    }
 
    /**
@@ -419,7 +429,7 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
       // Unique FIELD indices that were in the removed row, now orphaned only if no surviving row
       // still references them. Sort descending so removals don't invalidate pending indices.
       const orphaned = Array.from(new Set(
-         row.items
+         (row.items ?? [])
             .filter(it => it.type === this.FIELD && it.fieldIndex != null)
             .map(it => it.fieldIndex)))
          .filter(fi => !this.workingRows.some(
@@ -427,17 +437,7 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
          .sort((a, b) => b - a);
 
       for(const fi of orphaned) {
-         this.textFields = (this.textFields ?? []).filter((_, idx) => idx !== fi);
-
-         for(const r of this.workingRows) {
-            for(const it of r.items) {
-               if(it.type === this.FIELD && it.fieldIndex > fi) {
-                  it.fieldIndex = it.fieldIndex - 1;
-               }
-            }
-         }
-
-         this.onRemoveField.emit(fi);
+         this.removeOrphanedField(fi);
       }
 
       this.selectedRowIndex = -1;


### PR DESCRIPTION
Root Cause:
The Text Layout Designer only provided per-item delete controls (the "X" on each Field/Text/Spacer chip). A row was only removed implicitly, when its last item was deleted. There was no row-level delete action, so the only way to get rid of a row was to manually remove every chip in it one at a time.

Fix:
Added a row-level "X" (Remove Row) button to each row in the Text Layout Designer. Clicking it deletes the entire row and all of its items in one action, and the rows below shift up. Any field bindings used only by that row are dropped from the chart's text fields (a binding that is still referenced by another row is kept), with the remaining field indices compacted to stay in sync. The change is frontend-only (text-layout-designer.component .ts/.html/.scss); the removal is applied to the working copy and only persisted on OK, so Cancel still discards it. Covered by new unit tests.