### PR TITLE
75470, Text Layout Designer dragging indicator needed

### DIFF
--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.html
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.html
@@ -13,45 +13,19 @@
         + _#(Add Row)
       </button>
 
-      <!-- Palette: only connects TO row lists; sorting disabled so chips can't be rearranged -->
-      <div class="element-palette"
-           cdkDropList
-           [id]="PALETTE_LIST_ID"
-           [cdkDropListData]="paletteItems"
-           [cdkDropListConnectedTo]="rowItemListIds"
-           [cdkDropListSortingDisabled]="true"
-           cdkDropListOrientation="horizontal">
+      <!-- Palette: native-draggable chips. Dropped into a row via the shared insertion
+           line; the chip stays put in the palette (native drag leaves the source DOM). -->
+      <div class="element-palette">
         <span class="palette-label unhighlightable me-1">_#(Elements):</span>
-        <!--
-          Each chip uses a two-layer pattern to keep the chip permanently visible:
-          1. Static display div — pure HTML, never touched by CDK, always visible.
-          2. Transparent overlay div — the actual cdkDrag element, positioned on top.
-             CDK hides/moves the overlay during drag; the static chip underneath
-             remains unaffected, so the palette never appears empty.
-        -->
-        <div *ngFor="let chip of paletteItems; trackBy: trackByIndex" class="palette-chip-slot">
-          <!-- Static chip: always visible in the palette -->
-          <div class="palette-chip"
-               [class.text-chip]="chip.type === STATIC"
-               [class.spacer-chip]="chip.type === SPACING">
-            <i *ngIf="chip.type === STATIC" class="text-icon icon-size-small me-1" aria-hidden="true"></i>
-            <span class="unhighlightable">{{ chip.label }}</span>
-          </div>
-          <!-- Transparent CDK drag overlay — covers the chip, handles dragging -->
-          <div class="palette-drag-overlay"
-               cdkDrag
-               [cdkDragData]="chip">
-            <ng-template cdkDragPreview>
-              <div class="palette-chip"
-                   [class.text-chip]="chip.type === STATIC"
-                   [class.spacer-chip]="chip.type === SPACING">
-                <i *ngIf="chip.type === STATIC" class="text-icon icon-size-small me-1" aria-hidden="true"></i>
-                <span>{{ chip.label }}</span>
-              </div>
-            </ng-template>
-            <!-- Empty placeholder: nothing replaces the overlay while dragging -->
-            <ng-template cdkDragPlaceholder></ng-template>
-          </div>
+        <div *ngFor="let chip of paletteItems; trackBy: trackByIndex"
+             class="palette-chip"
+             [class.text-chip]="chip.type === STATIC"
+             [class.spacer-chip]="chip.type === SPACING"
+             draggable="true"
+             (dragstart)="onPaletteDragStart($event, chip)"
+             (dragend)="onInternalDragEnd()">
+          <i *ngIf="chip.type === STATIC" class="text-icon icon-size-small me-1" aria-hidden="true"></i>
+          <span class="unhighlightable">{{ chip.label }}</span>
         </div>
       </div>
     </div>
@@ -123,33 +97,34 @@
       <!-- Row-level drag handle (hamburger ≡) -->
       <span class="row-drag-handle" cdkDragHandle title="_#(Drag to Reorder Row)">&#9776;</span>
 
-      <!-- Item list: connects to sibling rows only, NOT to palette -->
-      <div class="row-items"
-           cdkDropList
-           [id]="'items-' + ri"
-           [cdkDropListData]="row.items"
-           [cdkDropListConnectedTo]="rowItemListIds"
-           cdkDropListOrientation="horizontal"
-           (cdkDropListDropped)="onItemDroppedInRow($event, ri)">
+      <!-- Item list: native drag/drop; the green divider lines are the drop indicator -->
+      <div class="row-items">
 
-        <div *ngFor="let item of row.items; let ii = index; trackBy: trackByIndex"
-             class="layout-item"
-             cdkDrag
-             [cdkDragData]="item"
+        <ng-container *ngFor="let item of row.items; let ii = index; trackBy: trackByIndex">
+        <!-- Insertion line: green when a dragged binding-tree field would drop before this item -->
+        <div class="layout-divider" [class.bg-success]="isDropTarget(ri, ii)"
+             (dragenter)="onDividerDragEnter(ri, ii)"></div>
+
+        <div class="layout-item"
+             draggable="true"
+             (dragstart)="onItemDragStart($event, ri, ii)"
+             (dragend)="onInternalDragEnd()"
              [class.field-item]="item.type === FIELD"
              [class.static-item]="item.type === STATIC"
              [class.spacing-item]="item.type === SPACING"
              [class.item-selected]="isItemSelected(ri, ii)"
+             [class.item-dragging]="isDraggingItem(ri, ii)"
              (click)="selectItem(ri, ii); $event.stopPropagation()">
 
           <!-- FIELD bound to a real textFields entry: render as chart-fieldmc chip (like TextFieldMc).
                Layout is consistent with the other chips: [six-dot drag handle] [content] [format] [remove]. -->
           <ng-container *ngIf="item.type === FIELD && getFieldRef(item) as boundField">
-            <span class="item-drag-handle drag-dots" cdkDragHandle title="_#(Drag)">&#10303;</span>
+            <span class="item-drag-handle drag-dots" title="_#(Drag)">&#10303;</span>
             <!-- Use the canonical aesthetic chip (same as the Text well) so the field has the
-                 working edit menu (change aggregate / value type / convert). Suppress its native
-                 draggable so CDK row-drag stays in control. The allaggregate sentinel routes edits
-                 through onChangeAesthetic (not changeChartRef); the host round-trips the model. -->
+                 working edit menu (change aggregate / value type / convert). Suppress native drag
+                 within the chip so dragging it doesn't start an item move — the field is dragged
+                 via the six-dot handle instead. The allaggregate sentinel routes edits through
+                 onChangeAesthetic (not changeChartRef); the host round-trips the model. -->
             <div class="field-chip-wrap" (dragstart)="$event.stopPropagation(); $event.preventDefault()">
               <chart-aesthetic-mc
                 [field]="boundField"
@@ -174,7 +149,7 @@
 
           <!-- FIELD whose index can't be resolved (pending host round-trip): label + format + remove -->
           <ng-container *ngIf="item.type === FIELD && !getFieldRef(item)">
-            <span class="item-drag-handle drag-dots" cdkDragHandle title="_#(Drag)">&#10303;</span>
+            <span class="item-drag-handle drag-dots" title="_#(Drag)">&#10303;</span>
             <span class="item-label unhighlightable">{{ getFieldLabel(item) }}</span>
             <button class="btn btn-xs item-format-btn ms-1"
                     (click)="openFieldFormat(item); $event.stopPropagation()"
@@ -188,7 +163,7 @@
 
           <!-- STATIC: six-dot drag handle + text preview + format button -->
           <ng-container *ngIf="item.type === STATIC">
-            <span class="item-drag-handle drag-dots" cdkDragHandle title="_#(Drag)">&#10303;</span>
+            <span class="item-drag-handle drag-dots" title="_#(Drag)">&#10303;</span>
             <span class="item-label unhighlightable text-preview">{{ item.text || '...' }}</span>
             <button class="btn btn-xs item-format-btn ms-1"
                     (click)="openStaticItemFormat(item); $event.stopPropagation()"
@@ -199,7 +174,7 @@
 
           <!-- SPACING: six-dot drag handle + compact number input (no format icon) -->
           <ng-container *ngIf="item.type === SPACING">
-            <span class="item-drag-handle drag-dots" cdkDragHandle title="_#(Drag)">&#10303;</span>
+            <span class="item-drag-handle drag-dots" title="_#(Drag)">&#10303;</span>
             <input type="number" class="spacing-amount-input"
                    [(ngModel)]="item.spacingAmount" min="0" max="200" step="1"
                    title="_#(Spacing)"
@@ -212,6 +187,11 @@
                   (click)="removeItem(ri, ii); $event.stopPropagation()"
                   title="_#(Remove)">&#215;</button>
         </div>
+        </ng-container>
+
+        <!-- Trailing insertion line (and the only divider when the row is empty) -->
+        <div class="layout-divider" [class.bg-success]="isDropTarget(ri, row.items.length)"
+             (dragenter)="onDividerDragEnter(ri, row.items.length)"></div>
 
       </div>
     </div>

--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.html
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.html
@@ -101,9 +101,9 @@
       <div class="row-items">
 
         <ng-container *ngFor="let item of row.items; let ii = index; trackBy: trackByIndex">
-        <!-- Insertion line: green when a dragged binding-tree field would drop before this item -->
-        <div class="layout-divider" [class.bg-success]="isDropTarget(ri, ii)"
-             (dragenter)="onDividerDragEnter(ri, ii)"></div>
+          <!-- Insertion line: green when a dragged binding-tree field would drop before this item -->
+          <div class="layout-divider" [class.bg-success]="isDropTarget(ri, ii)"
+               (dragenter)="onDividerDragEnter(ri, ii)"></div>
 
         <div class="layout-item"
              draggable="true"

--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.scss
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.scss
@@ -48,11 +48,6 @@
 
 .palette-label { font-size: 0.8rem; opacity: 0.7; }
 
-.palette-chip-slot {
-   position: relative;      // needed so the overlay can be positioned absolutely
-   display: inline-flex;
-}
-
 .palette-chip {
    display: inline-flex;
    align-items: center;
@@ -61,17 +56,10 @@
    font-size: 0.85rem;
    user-select: none;
    border: 1px dashed #aaa;
+   cursor: grab;
 
    &.text-chip   { background: #fff3cd; }
    &.spacer-chip { background: #e2e3e5; }
-}
-
-// Transparent CDK drag overlay — sits on top of .palette-chip, handles drag.
-// CDK hides/moves this element during drag; the static .palette-chip beneath stays visible.
-.palette-drag-overlay {
-   position: absolute;
-   inset: 0;
-   cursor: grab;
 }
 
 // ─── Properties panel ───────────────────────────────────────────────────────
@@ -310,13 +298,31 @@
    &.active { background: var(--inet-primary-color, #0d6efd); color: #fff; }
 }
 
-// ─── CDK drag-and-drop visual cues ─────────────────────────────────────────
+// ─── Drop insertion indicator ────────────────────────────────────────────────
+// Every in-designer drag (binding-tree field, item reorder, palette insert) is a
+// native HTML5 drag, so existing chips never shift — only this thin green line moves
+// between them. A .layout-divider sits before each item and after the last; it is
+// transparent until it is the active drop target, when Bootstrap's .bg-success turns
+// it green. Bounded to chip height and centred within the row.
+.layout-divider {
+   align-self: center;
+   flex: 0 0 auto;
+   width: 3px;
+   height: 22px;
+   border-radius: 2px;
+}
+
+// The item being dragged is dimmed so it's clear what is moving.
+.layout-item.item-dragging { opacity: 0.4; }
+
+// ─── CDK drag-and-drop visual cues (whole-row reordering only) ───────────────
 
 .cdk-drag-preview {
    box-shadow: 0 4px 12px rgba(0,0,0,0.2);
    opacity: 0.9;
 }
 
+// Faded clone of the row while it is being reordered.
 .cdk-drag-placeholder { opacity: 0.3; }
 
 .cdk-drop-list-dragging .layout-item:not(.cdk-drag-placeholder) {

--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.spec.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.spec.ts
@@ -58,7 +58,7 @@ describe("TextLayoutDesignerComponent Unit Test", () => {
       component.textFields = [];               // no bound fields resolved yet
       component.workingRows = [{ items: [] }];
 
-      component.onBindingTreeDrop(dropEvent("state"), 0, true);
+      component.onBindingTreeDrop(dropEvent("state"), 0, 0);
 
       // host is told to append the real (aggregated) binding
       expect(spy).toHaveBeenCalledWith(
@@ -81,8 +81,8 @@ describe("TextLayoutDesignerComponent Unit Test", () => {
       component.textFields = [];
       component.workingRows = [{ items: [] }];
 
-      component.onBindingTreeDrop(dropEvent("a"), 0, true);
-      component.onBindingTreeDrop(dropEvent("b"), 0, true);
+      component.onBindingTreeDrop(dropEvent("a"), 0, 0);
+      component.onBindingTreeDrop(dropEvent("b"), 0, 1);
 
       expect(component.workingRows[0].items.map((i: any) => i.fieldIndex)).toEqual([0, 1]);
    });
@@ -104,6 +104,45 @@ describe("TextLayoutDesignerComponent Unit Test", () => {
       expect(removed).toHaveBeenCalledWith(1);
       expect(component.textFields.map((f: any) => f.fullName)).toEqual(["a", "c"]);
       expect(component.workingRows[0].items.map((i: any) => i.fieldIndex)).toEqual([0, 1]);
+   });
+
+   it("moves an item within a row, adjusting the target for the removal shift", () => {
+      component.workingRows = [{ items: [
+         { type: component.STATIC, text: "a" },
+         { type: component.STATIC, text: "b" },
+         { type: component.STATIC, text: "c" }
+      ] }];
+
+      // drag item 0 ("a") to the divider after "c" (insert-before index 3)
+      (component as any).moveItem(0, 0, 0, 3);
+
+      expect(component.workingRows[0].items.map((i: any) => i.text)).toEqual(["b", "c", "a"]);
+   });
+
+   it("moves an item to another row and drops the emptied source row", () => {
+      component.workingRows = [
+         { items: [{ type: component.STATIC, text: "a" }] },
+         { items: [{ type: component.STATIC, text: "b" }] }
+      ];
+
+      // drag the only item of row 0 to the front of row 1
+      (component as any).moveItem(0, 0, 1, 0);
+
+      // source row removed; surviving row has both items in order
+      expect(component.workingRows.length).toBe(1);
+      expect(component.workingRows[0].items.map((i: any) => i.text)).toEqual(["a", "b"]);
+   });
+
+   it("inserts a palette item at the indicated position", () => {
+      component.workingRows = [{ items: [
+         { type: component.STATIC, text: "a" },
+         { type: component.STATIC, text: "b" }
+      ] }];
+
+      (component as any).insertPaletteItem(component.SPACING, 0, 1);
+
+      const types = component.workingRows[0].items.map((i: any) => i.type);
+      expect(types).toEqual([component.STATIC, component.SPACING, component.STATIC]);
    });
 
    it("does not drop the textField when another item still references it", () => {

--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.spec.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.spec.ts
@@ -106,6 +106,25 @@ describe("TextLayoutDesignerComponent Unit Test", () => {
       expect(component.workingRows[0].items.map((i: any) => i.fieldIndex)).toEqual([0, 1]);
    });
 
+   it("sets the drop indicator when a divider is entered and clears on dragend", () => {
+      component.workingRows = [{ items: [{ type: component.STATIC, text: "a" }] }];
+
+      component.onDividerDragEnter(0, 1);
+      expect(component.isDropTarget(0, 1)).toBe(true);
+      expect(component.isDropTarget(0, 0)).toBe(false);
+
+      component.onInternalDragEnd();
+      expect(component.isDropTarget(0, 1)).toBe(false);
+   });
+
+   it("isDraggingItem matches only the active item drag", () => {
+      (component as any).internalDrag = { kind: "item", rowIndex: 0, itemIndex: 0 };
+
+      expect(component.isDraggingItem(0, 0)).toBe(true);
+      expect(component.isDraggingItem(0, 1)).toBe(false);
+      expect(component.isDraggingItem(1, 0)).toBe(false);
+   });
+
    it("moves an item within a row, adjusting the target for the removal shift", () => {
       component.workingRows = [{ items: [
          { type: component.STATIC, text: "a" },

--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.ts
@@ -129,15 +129,22 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
 
          this.ngZone.run(() => {
             if(drag) {
-               // Internal reorder / palette insert — needs a resolved insertion point.
-               if(targetRow >= 0 && targetIndex >= 0) {
+               // Internal reorder / palette insert. Prefer the indicator position; if the drop
+               // landed off every divider (e.g. directly on a chip), fall back to the row under
+               // the cursor + append — consistent with the binding-tree branch below, so the
+               // drop is never silently swallowed.
+               const rowIndex = targetRow >= 0 ? targetRow : this.getRowIndexFromEvent(event);
+
+               if(rowIndex >= 0) {
                   event.preventDefault();
+                  const insertIndex = targetIndex >= 0
+                     ? targetIndex : this.workingRows[rowIndex].items.length;
 
                   if(drag.kind === "palette") {
-                     this.insertPaletteItem(drag.paletteType, targetRow, targetIndex);
+                     this.insertPaletteItem(drag.paletteType, rowIndex, insertIndex);
                   }
                   else {
-                     this.moveItem(drag.rowIndex, drag.itemIndex, targetRow, targetIndex);
+                     this.moveItem(drag.rowIndex, drag.itemIndex, rowIndex, insertIndex);
                   }
                }
             }
@@ -168,7 +175,7 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
       // Clear the insertion line when the drag truly leaves the grid — not when the cursor
       // merely moves between child elements inside it (relatedTarget still within the grid).
       this.gridDragleaveHandler = (event: DragEvent) => {
-         const related = (event as any).relatedTarget as Node;
+         const related = event.relatedTarget as Node | null;
          if(!related || !this.layoutGridRef.nativeElement.contains(related)) {
             this.ngZone.run(() => this.clearDropIndicator());
          }
@@ -398,7 +405,7 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
       this.onCancel.emit();
    }
 
-   onBindingTreeDrop(event: DragEvent, rowIndex: number, insertIndex: number = 0): void {
+   onBindingTreeDrop(event: DragEvent, rowIndex: number, insertIndex: number = -1): void {
       event.preventDefault();
       event.stopPropagation();
 
@@ -421,9 +428,11 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
          return;
       }
 
-      // Clamp the requested insert position to the row's current item count.
+      // Clamp the requested insert position to the row's current item count. A negative
+      // insertIndex is the "append" sentinel (the default), preserving the original intent.
+      const itemCount = this.workingRows[rowIndex].items.length;
       const clampedIndex = Math.max(
-         0, Math.min(insertIndex, this.workingRows[rowIndex].items.length));
+         0, Math.min(insertIndex < 0 ? itemCount : insertIndex, itemCount));
 
       // Build the field client-side and add it synchronously (the host appends it to textFields
       // and passes the new array back via [textFields]). No server round-trip, so the new field's

--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.ts
@@ -27,7 +27,7 @@ import {
    Output,
    ViewChild
 } from "@angular/core";
-import { CdkDragDrop, moveItemInArray, transferArrayItem } from "@angular/cdk/drag-drop";
+import { CdkDragDrop, moveItemInArray } from "@angular/cdk/drag-drop";
 import { Tool } from "../../../../../../../shared/util/tool";
 import { TextLayoutModel, TextLayoutRowModel, TextLayoutItemModel } from "../../../../common/data/visual-frame-model";
 import { AestheticInfo } from "../../../data/chart/aesthetic-info";
@@ -66,11 +66,21 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
    selectedRowIndex: number = -1;
    selectedItemIndex: number = -1;
 
+   // Drop indicator for native HTML5 drags (binding-tree field, item reorder, palette
+   // insert): which row and insert position the green line is shown at. -1 = none.
+   dropRowIndex: number = -1;
+   dropItemIndex: number = -1;
+
+   // Active internal (within-designer) native drag — distinguishes an item reorder or
+   // palette insert from a binding-tree field drop (which has no internalDrag). null = none.
+   private internalDrag:
+      | { kind: "item"; rowIndex: number; itemIndex: number }
+      | { kind: "palette"; paletteType: number }
+      | null = null;
+
    readonly FIELD = 0;
    readonly STATIC = 1;
    readonly SPACING = 2;
-
-   readonly PALETTE_LIST_ID = "palette-list";
 
    paletteItems: { type: number; label: string }[] = [];
 
@@ -84,6 +94,7 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
    private gridDragoverHandler: (e: DragEvent) => void;
    private gridDragenterHandler: (e: DragEvent) => void;
    private gridDropHandler: (e: DragEvent) => void;
+   private gridDragleaveHandler: (e: DragEvent) => void;
 
    constructor(private ngZone: NgZone) {}
 
@@ -112,10 +123,39 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
       };
 
       this.gridDropHandler = (event: DragEvent) => {
-         const rowIndex = this.getRowIndexFromEvent(event);
-         if(rowIndex >= 0) {
-            this.ngZone.run(() => this.onBindingTreeDrop(event, rowIndex, true));
-         }
+         const drag = this.internalDrag;
+         const targetRow = this.dropRowIndex;
+         const targetIndex = this.dropItemIndex;
+
+         this.ngZone.run(() => {
+            if(drag) {
+               // Internal reorder / palette insert — needs a resolved insertion point.
+               if(targetRow >= 0 && targetIndex >= 0) {
+                  event.preventDefault();
+
+                  if(drag.kind === "palette") {
+                     this.insertPaletteItem(drag.paletteType, targetRow, targetIndex);
+                  }
+                  else {
+                     this.moveItem(drag.rowIndex, drag.itemIndex, targetRow, targetIndex);
+                  }
+               }
+            }
+            else {
+               // Field dragged in from the binding tree. Prefer the indicator position;
+               // fall back to the row under the cursor + append if no divider was entered.
+               const rowIndex = targetRow >= 0 ? targetRow : this.getRowIndexFromEvent(event);
+
+               if(rowIndex >= 0) {
+                  const insertIndex = targetRow >= 0 && targetIndex >= 0
+                     ? targetIndex : this.workingRows[rowIndex].items.length;
+                  this.onBindingTreeDrop(event, rowIndex, insertIndex);
+               }
+            }
+
+            this.internalDrag = null;
+            this.clearDropIndicator();
+         });
       };
 
       this.gridDragenterHandler = (event: DragEvent) => {
@@ -125,11 +165,21 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
          }
       };
 
+      // Clear the insertion line when the drag truly leaves the grid — not when the cursor
+      // merely moves between child elements inside it (relatedTarget still within the grid).
+      this.gridDragleaveHandler = (event: DragEvent) => {
+         const related = (event as any).relatedTarget as Node;
+         if(!related || !this.layoutGridRef.nativeElement.contains(related)) {
+            this.ngZone.run(() => this.clearDropIndicator());
+         }
+      };
+
       this.ngZone.runOutsideAngular(() => {
          const el = this.layoutGridRef.nativeElement;
          el.addEventListener("dragenter", this.gridDragenterHandler);
          el.addEventListener("dragover", this.gridDragoverHandler);
          el.addEventListener("drop", this.gridDropHandler);
+         el.addEventListener("dragleave", this.gridDragleaveHandler);
       });
    }
 
@@ -139,6 +189,7 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
          el.removeEventListener("dragenter", this.gridDragenterHandler);
          el.removeEventListener("dragover", this.gridDragoverHandler);
          el.removeEventListener("drop", this.gridDropHandler);
+         el.removeEventListener("dragleave", this.gridDragleaveHandler);
       }
    }
 
@@ -151,6 +202,24 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
          el = el.parentElement;
       }
       return -1;
+   }
+
+   // ── Drop insertion indicator (native binding-tree drag) ───────────────────
+
+   /** True when the green insertion line should show before item `k` of row `ri`. */
+   isDropTarget(ri: number, k: number): boolean {
+      return this.dropRowIndex === ri && this.dropItemIndex === k;
+   }
+
+   /** Record where a dragged binding-tree field would be inserted (drives the line). */
+   onDividerDragEnter(ri: number, k: number): void {
+      this.dropRowIndex = ri;
+      this.dropItemIndex = k;
+   }
+
+   private clearDropIndicator(): void {
+      this.dropRowIndex = -1;
+      this.dropItemIndex = -1;
    }
 
    /** Resolve the bound AestheticInfo for a FIELD item from its fieldIndex. */
@@ -209,46 +278,96 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
       return this.getSelectedRow()?.horizontalAlign ?? "left";
    }
 
-   // ── CDK drop-list IDs ────────────────────────────────────────────────────
+   // ── Native drag-and-drop: items + palette ─────────────────────────────────
+   // Items and palette chips use native HTML5 drag (not CDK) so existing chips never
+   // shift during a drag — only the thin insertion line moves between them, exactly
+   // like dragging a field in from the binding tree. (Rows still reorder via CDK from
+   // the hamburger handle; CDK only intercepts native drag from that handle, so item
+   // drags inside a row are unaffected.)
 
-   /** IDs of the row item lists only — palette is NOT included so row items can't drop onto it. */
-   get rowItemListIds(): string[] {
-      return this.workingRows.map((_, i) => `items-${i}`);
+   onItemDragStart(event: DragEvent, rowIndex: number, itemIndex: number): void {
+      this.internalDrag = { kind: "item", rowIndex, itemIndex };
+
+      if(event.dataTransfer) {
+         event.dataTransfer.effectAllowed = "move";
+         // Firefox requires data on the transfer for the drag to start.
+         event.dataTransfer.setData("text", "");
+      }
    }
 
-   // ── Drag-and-drop handlers ───────────────────────────────────────────────
+   onPaletteDragStart(event: DragEvent, chip: { type: number }): void {
+      this.internalDrag = { kind: "palette", paletteType: chip.type };
 
-   onItemDroppedInRow(event: CdkDragDrop<any[]>, rowIndex: number): void {
-      if(event.previousContainer.id === this.PALETTE_LIST_ID) {
-         // Palette drag: create a new item — do NOT transfer (palette chips stay)
-         const template = event.previousContainer.data[event.previousIndex];
-         const newItem: TextLayoutItemModel = template.type === this.STATIC
-            ? { type: this.STATIC, text: "", fontSize: 10, bold: false, italic: false }
-            : { type: this.SPACING, spacingAmount: 10 };
-         this.workingRows[rowIndex].items.splice(event.currentIndex, 0, newItem);
-         // Restore palette data (CDK may have moved it — reset to keep chips always present)
-         this.paletteItems = [
-            { type: this.STATIC, label: "_#(Text)" },
-            { type: this.SPACING, label: "_#(Spacer)" }
-         ];
-         if(newItem.type === this.STATIC) {
-            this.selectedRowIndex = rowIndex;
-            this.selectedItemIndex = event.currentIndex;
-         }
+      if(event.dataTransfer) {
+         event.dataTransfer.effectAllowed = "move";
+         event.dataTransfer.setData("text", "");
       }
-      else if(event.previousContainer === event.container) {
-         moveItemInArray(event.container.data, event.previousIndex, event.currentIndex);
+   }
+
+   onInternalDragEnd(): void {
+      this.internalDrag = null;
+      this.clearDropIndicator();
+   }
+
+   /** True while this item is the one being dragged (so the template can dim it). */
+   isDraggingItem(rowIndex: number, itemIndex: number): boolean {
+      return this.internalDrag?.kind === "item"
+         && this.internalDrag.rowIndex === rowIndex
+         && this.internalDrag.itemIndex === itemIndex;
+   }
+
+   /** Move an existing item to a new row/position (insert-before `toIndex`). */
+   private moveItem(fromRow: number, fromIndex: number, toRow: number, toIndex: number): void {
+      const src = this.workingRows[fromRow];
+      const dst = this.workingRows[toRow];   // capture before any row removal
+
+      if(!src || !dst) {
+         return;
       }
-      else {
-         transferArrayItem(
-            event.previousContainer.data,
-            event.container.data,
-            event.previousIndex,
-            event.currentIndex
-         );
-         this.workingRows = this.workingRows.filter(r => r.items.length > 0);
-         this.selectedRowIndex = -1;
-         this.selectedItemIndex = -1;
+
+      const [item] = src.items.splice(fromIndex, 1);
+
+      if(!item) {
+         return;
+      }
+
+      // Removing from earlier in the same row shifts the target position down by one.
+      let target = toIndex;
+
+      if(src === dst && fromIndex < toIndex) {
+         target = toIndex - 1;
+      }
+
+      target = Math.max(0, Math.min(target, dst.items.length));
+      dst.items.splice(target, 0, item);
+
+      // Drop an emptied source row (never the row we just inserted into).
+      if(src !== dst && src.items.length === 0) {
+         this.workingRows.splice(fromRow, 1);
+      }
+
+      this.selectedRowIndex = -1;
+      this.selectedItemIndex = -1;
+   }
+
+   /** Insert a new STATIC/SPACING item from the palette at `toIndex`. */
+   private insertPaletteItem(type: number, toRow: number, toIndex: number): void {
+      const row = this.workingRows[toRow];
+
+      if(!row) {
+         return;
+      }
+
+      const newItem: TextLayoutItemModel = type === this.STATIC
+         ? { type: this.STATIC, text: "", fontSize: 10, bold: false, italic: false }
+         : { type: this.SPACING, spacingAmount: 10 };
+
+      const idx = Math.max(0, Math.min(toIndex, row.items.length));
+      row.items.splice(idx, 0, newItem);
+
+      if(newItem.type === this.STATIC) {
+         this.selectedRowIndex = toRow;
+         this.selectedItemIndex = idx;
       }
    }
 
@@ -279,7 +398,7 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
       this.onCancel.emit();
    }
 
-   onBindingTreeDrop(event: DragEvent, rowIndex: number, insertAtEnd: boolean = true): void {
+   onBindingTreeDrop(event: DragEvent, rowIndex: number, insertIndex: number = 0): void {
       event.preventDefault();
       event.stopPropagation();
 
@@ -302,7 +421,9 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
          return;
       }
 
-      const insertIndex = insertAtEnd ? this.workingRows[rowIndex].items.length : 0;
+      // Clamp the requested insert position to the row's current item count.
+      const clampedIndex = Math.max(
+         0, Math.min(insertIndex, this.workingRows[rowIndex].items.length));
 
       // Build the field client-side and add it synchronously (the host appends it to textFields
       // and passes the new array back via [textFields]). No server round-trip, so the new field's
@@ -310,7 +431,7 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
       const newIndex = this.textFields?.length ?? 0;
 
       this.workingRows[rowIndex].items.splice(
-         insertIndex, 0, { type: this.FIELD, fieldIndex: newIndex });
+         clampedIndex, 0, { type: this.FIELD, fieldIndex: newIndex });
 
       // Optimistically reflect the append in our own [textFields] so a second rapid drop computes
       // the next index correctly — the host re-passes [textFields] only on the next change-detection
@@ -318,7 +439,7 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
       // appends this same field object, so the eventual @Input replacement is consistent.
       this.textFields = [...(this.textFields ?? []), field];
 
-      this.onAddField.emit({ field, insertRow: rowIndex, insertIndex });
+      this.onAddField.emit({ field, insertRow: rowIndex, insertIndex: clampedIndex });
    }
 
    /**


### PR DESCRIPTION
Root Cause:
The Text Layout Designer had no visual indicator of where a dragged element would land. New columns dragged in from the binding tree used native HTML5 drag with no insertion feedback at all, and the in-designer chip/palette dragging used Angular CDK drag-drop, which indicates position by shifting the surrounding chips around rather than showing a clean insertion point.

Fix:
Added a thin green insertion line (matching the regular chart binding area) that appears in the gap between elements during a drag. To keep the feedback consistent and stop the chips from shifting, the in-designer item and palette dragging was converted from CDK to the same native HTML5 drag used for new columns - so all drag types now show the same insertion line and existing chips stay in place. Whole-row reordering still uses the row's hamburger handle.