### PR TITLE
75476, dim out text frame if text layout in use

### DIFF
--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/aesthetic-pane.component.html
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/aesthetic-pane.component.html
@@ -78,7 +78,7 @@
     <div class="unhighlightable aesthetic-row-label">_#(Text)</div>
     <text-field-mc class="fill-width" [bindingModel]="bindingModel" [aggr]="currAggregate"
       [assemblyName]="assemblyName" [objectType]="objectType"
-      [grayedOutValues]="grayedOutValues"
+      [grayedOutValues]="grayedOutValues" [layoutActive]="isLayoutDesignerActive"
       [chartModel]="chartModel" (onUpdateData)="updateData($event)">
     </text-field-mc>
     <ng-container *ngTemplateOutlet="layoutDesignerBtn"></ng-container>
@@ -114,6 +114,7 @@
       <text-field-mc class="fill-width" [bindingModel]="bindingModel" [aggr]="currAggregate"
         [assemblyName]="assemblyName" [objectType]="objectType"
         [grayedOutValues]="grayedOutValues" [assetId]="assetId"
+        [layoutActive]="isLayoutDesignerActive"
         [chartModel]="chartModel" (onUpdateData)="updateData($event)">
       </text-field-mc>
       <ng-container *ngTemplateOutlet="layoutDesignerBtn"></ng-container>

--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-field-mc.component.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-field-mc.component.ts
@@ -43,6 +43,8 @@ import { DropHighlightDirective } from "../../../widget/drophighlight.directive"
 })
 export class TextFieldMc extends AestheticFieldMc implements OnChanges {
    @Input() chartModel: ChartModel;
+   // when a text layout is active, the text field is locked (dimmed, no drop/edit)
+   @Input() layoutActive: boolean = false;
    @Output() onUpdateData: EventEmitter<string> = new EventEmitter<string>();
    measures: string[] = [];
    currentIndex: number = 0;
@@ -142,6 +144,11 @@ export class TextFieldMc extends AestheticFieldMc implements OnChanges {
       }
 
       return !(<AllChartAggregateRef>(this.aggr)).visualPaneStatus.textFieldEditable;
+   }
+
+   // a text layout in use takes over the text field, so lock it out (dim + no drop/edit)
+   protected isEnabled(): boolean {
+      return super.isEnabled() && !this.layoutActive;
    }
 
    protected isEditEnabled(): boolean {


### PR DESCRIPTION
Root Cause:
The text-frame binding control (text-field-mc) in the chart Aesthetic pane had no awareness of whether a text layout was active. Even when a layout was in use (driving the text content), the Text field still rendered fully bright and accepted drag-drops, edits, and field removal — there was no UI signal that the layout had taken over.

Fix:
Added a layoutActive input to text-field-mc and overrode its isEnabled() getter to return false when a layout is active. Because the component's dim styling (.disabled-grayout), drop acceptance (isDropPaneAccept()), and edit/remove gating (_isEditEnabled) all funnel through isEnabled()/_isEnabled, this single change makes the field dim out and become fully non-interactive (no drop highlight, no drop, no edit pencil, no field-chip removal) whenever a layout is in use. The parent aesthetic-pane binds [layoutActive]="isLayoutDesignerActive" — the same condition that lights the Layout Designer button's active indicator — on both the regular chart and relation-chart Text rows. The lock recomputes reactively, so clearing the layout re-enables the field automatically.