### PR TITLE
Bug #75477 - Fix pie/donut SVG entrance animation for faceted, no-measure, and tiled charts

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -21,6 +21,8 @@ import inetsoft.util.graphics.SVGSupport;
 import org.w3c.dom.*;
 
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -450,48 +452,155 @@ public class SVGAnimationDOMInjector {
          return;
       }
 
-      // Detect and reclassify the donut center-hole overlay; returns {cx,cy,innerR} or null.
-      double[] holeParams = preprocessDonutHole(svgRoot);
-
-      // Extract pie center from the first arc path's "L cx cy Z" hub point.
-      double[] pieCenter = null;
-
-      for(Element slice : slices) {
-         String d = slice.getAttribute("d");
-         if(d.contains("A")) {
-            pieCenter = extractPieCenter(d);
-            break;
-         }
-      }
-
-      // Each arc slice sweeps in by animating the CSS "d" property via per-slice @keyframes.
-      // This creates the wheel/clock effect: slices grow one at a time in angular (DOM) order.
-      //
-      // The from-state is the same path structure (M A L Z) but with the arc endpoint equal
-      // to the start point — a zero-length arc that encloses no area.  CSS path interpolation
-      // requires both from/to to share the same command sequence, so this matches exactly.
-      //
-      // One keyframe per ~5° keeps the leading arc edge on the outer circle at every frame.
-      // The large-arc flag is recomputed per keyframe so la=1 slices animate without artifacts.
-      //
-      // 3D pie faces: multiple arc-containing paths share the same startX (one per 3D face of
-      // each logical slice).  We deduplicate by startX so all faces of the same slice receive
-      // the same animation delay, keeping the 3D faces in sync during the sweep.
-      final double SLICE_DUR = AnimationConstants.PIE_SLICE_DURATION;
+      // Detect and reclassify donut center-hole overlays; a faceted donut has one per panel.
+      List<double[]> holes = preprocessDonutHoles(svgRoot);
 
       appendStyle(svgRoot, doc, "@keyframes inetsoft-pie-fade{from{opacity:0}to{opacity:1}}");
 
-      // groupKeys: unique arc startX values in DOM encounter order.
-      // Used for (a) arcIdx deduplication and (b) non-arc path delay matching.
-      List<Double> groupKeys  = new ArrayList<>();
-      // groupRefSY: M-point Y of the topmost (first-encountered) path in each group.
-      // For 3D pies the top-face is rendered first and has the smallest M-point Y.
-      // Used in Pass 2 to compute the per-face cy offset so each face's arc keypoints
-      // trace its own offset ellipse rather than the shared top-face ellipse.
-      List<Double> groupRefSY = new ArrayList<>();
+      // A faceted chart packs one pie per panel into one SVG.  Partition by center so each pie
+      // animates around its own center — a single global center mangles every other panel
+      // (the broken-after-first-pie symptom).
+      List<PiePanel> panels = partitionPiePanels(slices);
 
-      // Pass 1: compute deduplicated arcIdx for each slice.
-      // Multiple paths sharing the same startX (3D faces) all get the same arcIdx.
+      // The tile's drawable size (null if unknown).  Used per panel to detect a pie that is
+      // larger than the tile (split across tiles), which must fall back to the opacity fade.
+      double[] viewport = svgViewport(svgRoot);
+
+      // Shared across panels: a single keyframe-name counter (so @keyframes names stay unique)
+      // and one buffer flushed as a single <style> block after all panels are processed.
+      int[] kfCounter = { 0 };
+      StringBuilder cssKeyframes = new StringBuilder();
+      double maxEndTime = 0;
+
+      for(PiePanel panel : panels) {
+         // Match this panel to its donut hole (nearest hole center within the hole radius).
+         double[] hole = panel.center == null ? null : nearestHole(holes, panel.center);
+         // A pie that doesn't fit in its tile is clipped across tiles; the sweep can't survive
+         // that, so fall back to the opacity fade.  All panels begin at t=0 (facets in parallel).
+         boolean tiled = isPanelTiled(panel, viewport);
+         double endTime = animatePiePanel(panel.slices, panel.center, hole, tiled,
+                                          cssKeyframes, kfCounter);
+         maxEndTime = Math.max(maxEndTime, endTime);
+      }
+
+      if(!cssKeyframes.isEmpty()) {
+         appendStyle(svgRoot, doc, cssKeyframes.toString());
+      }
+
+      // Center text (donut label/value): fade in after every panel has finished sweeping.
+      double centerTextDelay = maxEndTime + 0.1;
+
+      for(Element textGroup : textGroups) {
+         mergeStyle(textGroup, String.format(java.util.Locale.US,
+            "opacity:0;animation:inetsoft-pie-fade %.2fs %s %.2fs both",
+            AnimationConstants.PIE_TEXT_DURATION, AnimationConstants.PIE_FADE_EASING, centerTextDelay));
+      }
+   }
+
+   /**
+    * The drawable size {@code {width,height}} of an SVG tile in user units, from its {@code
+    * viewBox} (preferred) or {@code width}/{@code height} attributes, or null if neither is set.
+    */
+   private static double[] svgViewport(Element svgRoot) {
+      String viewBox = svgRoot.getAttribute("viewBox");
+
+      if(viewBox != null && !viewBox.isEmpty()) {
+         Matcher m = Pattern.compile("-?[0-9]*\\.?[0-9]+").matcher(viewBox);
+         double[] n = new double[4];
+         int i = 0;
+         while(i < 4 && m.find()) n[i++] = Double.parseDouble(m.group());
+         if(i == 4 && n[2] > 0 && n[3] > 0) return new double[]{ n[2], n[3] };
+      }
+
+      double w = parseLength(svgRoot.getAttribute("width"));
+      double h = parseLength(svgRoot.getAttribute("height"));
+      return w > 0 && h > 0 ? new double[]{ w, h } : null;
+   }
+
+   /** Parse a leading numeric length (ignoring a unit suffix like {@code px}); 0 if absent. */
+   private static double parseLength(String s) {
+      if(s == null) return 0;
+      Matcher m = Pattern.compile("-?[0-9]*\\.?[0-9]+").matcher(s);
+      return m.find() ? Double.parseDouble(m.group()) : 0;
+   }
+
+   /**
+    * Returns true when this pie does not fully fit within the tile — it is split/clipped across
+    * SVG tiles (oversized, or straddling a tile seam), so the geometric sweep cannot be used.
+    * The pie circle (center ± radius) is mapped to the tile's coordinate space via the slice
+    * transform and tested for containment in the viewport.  A normal pie, and each panel of a
+    * non-tiled facet chart, sits inside its tile, so this stays false for them.
+    */
+   private static boolean isPanelTiled(PiePanel panel, double[] viewport) {
+      if(viewport == null || panel.center == null || panel.slices.isEmpty()) {
+         return false;
+      }
+
+      double cx = panel.center[0], cy = panel.center[1], r = panel.radius;
+      double[] ctm = elementCTM(panel.slices.get(0));
+      double[] box = { Double.MAX_VALUE, Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE };
+      expandBounds(box, ctm, cx - r, cy - r);
+      expandBounds(box, ctm, cx + r, cy - r);
+      expandBounds(box, ctm, cx - r, cy + r);
+      expandBounds(box, ctm, cx + r, cy + r);
+
+      // 2px tolerance absorbs the sub-pixel tile-translate offset; a tiled pie overflows far more.
+      return box[0] < -2 || box[1] < -2 || box[2] > viewport[0] + 2 || box[3] > viewport[1] + 2;
+   }
+
+   /** Affine matrix mapping {@code node}'s local coordinates to the SVG root, from ancestor transforms. */
+   private static double[] elementCTM(Node node) {
+      double[] ctm = IDENTITY_MATRIX.clone();
+
+      for(Node n = node; n instanceof Element e; n = n.getParentNode()) {
+         String tf = e.getAttribute("transform");
+
+         if(!tf.isEmpty()) {
+            ctm = composeMatrix(parseSVGTransform(tf), ctm);
+         }
+      }
+
+      return ctm;
+   }
+
+   /**
+    * Animate the slices of a single pie panel (one facet) around the given {@code pieCenter}.
+    *
+    * <p>Each arc slice sweeps in by animating its CSS "d" via per-slice @keyframes (the wheel
+    * effect: slices grow one at a time in angular order).  The from-state is the same M-A-L-Z
+    * structure with the arc endpoint equal to the start (a zero-length arc) — CSS path
+    * interpolation requires both ends to share the command sequence.  One keyframe per ~5° keeps
+    * the leading edge on the outer circle, with the large-arc flag recomputed per keyframe.
+    *
+    * <p>When {@code tiled} (the pie is clipped across SVG tiles), the sweep's rewritten "d" can't
+    * survive the per-tile clip, so we fall back to the staggered opacity fade — like donuts —
+    * which only animates opacity and leaves the (correctly clipped) wedge geometry intact.
+    *
+    * <p>@keyframes rules are appended to the shared {@code cssKeyframes} buffer (flushed once by
+    * the caller) and named via the shared {@code kfCounter} so names stay unique across panels.
+    *
+    * @return the time (seconds) at which this panel's last slice finishes animating.
+    */
+   private static double animatePiePanel(List<Element> slices, double[] pieCenter,
+                                         double[] holeParams, boolean tiled,
+                                         StringBuilder cssKeyframes, int[] kfCounter)
+   {
+      final double SLICE_DUR = AnimationConstants.PIE_SLICE_DURATION;
+      // Tolerance (radians, ~0.06°) for treating two arc start angles as the same logical slice.
+      // Large enough to absorb coordinate rounding between a slice's 3D faces, small enough not to
+      // merge distinct wedges (adjacent slice starts differ by the in-between slice's full sweep).
+      final double ANGLE_GROUP_EPS = 0.001;
+
+      // Group slices into logical slices by start angle (from each slice's own hub), which drives
+      // the one-at-a-time wheel via groupBegin.  Angle (not start x) keeps symmetric no-measure
+      // pies sequenced: two mirror-angle slices share a start x but have distinct angles.  A 3D
+      // slice's faces share the angle (each is the top face shifted down by the depth), so they
+      // merge into one group and stay in sync.  groupKeys keeps a representative start x per
+      // group for findDepthFaceDelay (non-arc depth quads).
+      List<Double> groupKeys   = new ArrayList<>();
+      List<Double> groupAngles = new ArrayList<>();
+
+      // Pass 1: compute the logical-slice arcIdx for each slice.
       int[] sliceArcIdx = new int[slices.size()];
       Arrays.fill(sliceArcIdx, -1);
 
@@ -500,21 +609,28 @@ public class SVGAnimationDOMInjector {
          if(!d.contains("A")) continue;
 
          double startX = extractMStartX(d);
-         double[] arcRef = extractArcParams(d);
-         double startY = arcRef != null ? arcRef[1] : 0.0;
+         double[] arc = extractArcParams(d);
+         double[] hub = extractPieCenter(d);
+         double angle = arc != null && hub != null
+            ? Math.atan2(arc[1] - hub[1], arc[0] - hub[0]) : 0;
 
          int existingIdx = -1;
-         for(int j = 0; j < groupKeys.size(); j++) {
-            if(Math.abs(groupKeys.get(j) - startX) <= 0.01) {
+         for(int j = 0; j < groupAngles.size(); j++) {
+            // Wrap-safe angular comparison so a start near ±π still matches its own faces.
+            double diff = angle - groupAngles.get(j);
+            while(diff > Math.PI) diff -= 2 * Math.PI;
+            while(diff < -Math.PI) diff += 2 * Math.PI;
+
+            if(Math.abs(diff) <= ANGLE_GROUP_EPS) {
                existingIdx = j;
                break;
             }
          }
 
          if(existingIdx < 0) {
-            existingIdx = groupKeys.size();
+            existingIdx = groupAngles.size();
+            groupAngles.add(angle);
             groupKeys.add(startX);
-            groupRefSY.add(startY);
          }
 
          sliceArcIdx[si] = existingIdx;
@@ -522,26 +638,17 @@ public class SVGAnimationDOMInjector {
 
       int numArcGroups = groupKeys.size();
 
-      // Fallback for donut/pie charts rendered with bezier curves (C/Q commands) instead of
-      // SVG arc commands (A).  Some renderers approximate arcs as cubic bezier splines, so
-      // d.contains("A") is false for every slice and groupKeys stays empty.  In that case
-      // we cannot do the SMIL arc-sweep animation, so apply staggered opacity fade instead.
-      if(numArcGroups == 0) {
+      // Staggered opacity fade (no "d" rewrite) instead of the arc-sweep when either the slices
+      // are bezier-approximated arcs (no "A", e.g. donut rings) so the sweep is impossible, or
+      // the pie is clipped across tiles where the sweep's rewritten "d" would not survive.
+      if(numArcGroups == 0 || tiled) {
          for(int si = 0; si < slices.size(); si++) {
             mergeStyle(slices.get(si), String.format(java.util.Locale.US,
                "opacity:0;animation:inetsoft-pie-fade %.2fs %s %.2fs both",
                AnimationConstants.PIE_FADE_DURATION, AnimationConstants.PIE_FADE_EASING, si * SLICE_DUR));
          }
 
-         double centerTextDelay = slices.size() * SLICE_DUR + 0.1;
-
-         for(Element textGroup : textGroups) {
-            mergeStyle(textGroup, String.format(java.util.Locale.US,
-               "opacity:0;animation:inetsoft-pie-fade %.2fs %s %.2fs both",
-               AnimationConstants.PIE_TEXT_DURATION, AnimationConstants.PIE_FADE_EASING, centerTextDelay));
-         }
-
-         return;
+         return slices.size() * SLICE_DUR;
       }
 
       // Pass 1.5: compute sweep angle (degrees) for each arc group so durations can be
@@ -602,12 +709,8 @@ public class SVGAnimationDOMInjector {
 
       double totalAnimEndTime = cumulativeBegin; // = sum of all groupDurations
 
-      // Pass 2: apply animations.
-      // Per-slice @keyframes rules are collected here and flushed in one <style> block after
-      // the loop to avoid one appendStyle call per slice.
-      int sliceKeyframeIdx = 0;
-      StringBuilder cssKeyframes = new StringBuilder();
-
+      // Pass 2: apply animations.  Per-slice @keyframes rules are appended to the shared
+      // cssKeyframes buffer (flushed once by the caller) and named via the shared kfCounter.
       for(int si = 0; si < slices.size(); si++) {
          Element slice = slices.get(si);
          String d = slice.getAttribute("d");
@@ -633,13 +736,17 @@ public class SVGAnimationDOMInjector {
             double[] arc = extractArcParams(d);
 
             if(arc != null) {
-               // For 3D pies there are multiple faces per logical slice: the top elliptical face
-               // (M-point Y ≈ groupRefSY) and one or more depth/side faces (M-point Y > refSY).
-               //
-               // Depth/side faces are left fully opaque with no animation — they remain visible
-               // throughout so the slice is never see-through.  Only the top face sweeps.
-               double sy_ref = groupRefSY.get(myArcIdx);
-               boolean isDepthFace = arc[1] > sy_ref + 1.0;
+               // Sweep around the slice's own hub (its "L cx cy Z" point): the pie center for a
+               // flat slice, the depth-offset center for a 3D face.  Per-slice (vs a center
+               // reconstructed from a sibling's Y) stays correct when two symmetric slices share a
+               // start x-coordinate — common in a no-measure pie.
+               double[] hub = extractPieCenter(d);
+               double cx = hub != null ? hub[0] : pieCenter[0];
+               double cy = hub != null ? hub[1] : pieCenter[1];
+
+               // A 3D depth/side face (hub below the pie center) stays opaque without sweeping, so
+               // the slice is never see-through; only the top face sweeps.
+               boolean isDepthFace = hub != null && hub[1] > pieCenter[1] + 1.0;
 
                if(isDepthFace) {
                   // Arc depth face: snap to full opacity when this slice's sweep begins.
@@ -666,13 +773,6 @@ public class SVGAnimationDOMInjector {
                double rx = arc[2], ry = arc[3];
                double xrot = arc[4], sw = arc[6];
                double exFull = arc[7], eyFull = arc[8];
-               double cx = pieCenter[0];
-               // Each 3D face is offset downward from the top face by the 3D depth.
-               // Using the top-face cy for all faces makes depth-face keypoints trace the
-               // top ellipse instead of their own offset ellipse, causing outer-edge misalignment.
-               // Per-face cy = topCenter_y + (this_face_M_y - topFace_M_y) places the arc
-               // keypoints on each face's own correctly offset ellipse.
-               double cy = pieCenter[1] + (sy - groupRefSY.get(myArcIdx));
 
                double startAngle = Math.atan2(sy - cy, sx - cx);
                double endAngle   = Math.atan2(eyFull - cy, exFull - cx);
@@ -728,7 +828,7 @@ public class SVGAnimationDOMInjector {
                // CSS d-property animation requires path() wrapper around each SVG path string.
                // Keyframe percentages are equally spaced in time (one per ~5° angular step),
                // and linear timing between keyframes traces the arc edge correctly.
-               String kfName = "inetsoft-pie-sweep-" + sliceKeyframeIdx++;
+               String kfName = "inetsoft-pie-sweep-" + kfCounter[0]++;
                String[] paths = values.toString().split(";");
                cssKeyframes.append("@keyframes ").append(kfName).append("{");
 
@@ -751,18 +851,227 @@ public class SVGAnimationDOMInjector {
             AnimationConstants.PIE_FADE_DURATION, AnimationConstants.PIE_FADE_EASING, delay));
       }
 
-      if(!cssKeyframes.isEmpty()) {
-         appendStyle(svgRoot, doc, cssKeyframes.toString());
+      return totalAnimEndTime;
+   }
+
+   /**
+    * A single pie within a (possibly faceted) chart: its hub center and the slice paths that
+    * converge to it.  {@code center} is null only when no arc hub could be found anywhere
+    * (e.g. a bezier-approximated pie), in which case the panel holds every slice and animates
+    * with the staggered opacity fallback.
+    */
+   private static final class PiePanel {
+      double[] center;
+      double radius;
+      final List<Element> slices = new ArrayList<>();
+   }
+
+   /**
+    * Partition pie slices into panels (one per facet) by each slice's pie center.
+    *
+    * <p>The center is the slice's own hub: for an arc wedge it is the {@code "L cx cy Z"} point
+    * (see {@link #extractPieCenter}); for a bezier donut ring it is the intersection of the two
+    * radial edges (see {@link #extractRingCenter}).  All slices of one pie share the same center,
+    * while distinct facet panels never overlap and so are more than one radius apart; clustering
+    * centers with a per-pie-radius threshold therefore groups each pie cleanly.  Facet position
+    * is baked into the slice coordinates (the chart transform is shared across facets), so the
+    * raw center separates facets directly.  DOM order is preserved within each panel — the wheel
+    * order and arc-group encounter order depend on it.
+    *
+    * <p>Slices with no recoverable center (3D side quads) are assigned in a second pass to the
+    * nearest panel by centroid.  If no center is found anywhere, one center-less panel holds all
+    * slices, preserving the legacy single-pie path.
+    */
+   private static List<PiePanel> partitionPiePanels(List<Element> slices) {
+      List<PiePanel> panels = new ArrayList<>();
+      boolean[] assigned = new boolean[slices.size()];
+
+      // Pass A: slices with a recoverable center establish or join panels, in DOM order.
+      for(int i = 0; i < slices.size(); i++) {
+         String d = slices.get(i).getAttribute("d");
+         double[] center;
+         double r;
+
+         if(d.contains("A")) {
+            center = extractPieCenter(d);
+            double[] arc = extractArcParams(d);
+            r = arc != null ? Math.max(Math.abs(arc[2]), Math.abs(arc[3])) : 0;
+         }
+         else {
+            center = extractRingCenter(d);
+            r = center != null ? ringRadius(d, center) : 0;
+         }
+
+         if(center == null) {
+            continue;
+         }
+
+         PiePanel best = null;
+         double bestDist = Double.MAX_VALUE;
+
+         for(PiePanel p : panels) {
+            double dist = Math.hypot(center[0] - p.center[0], center[1] - p.center[1]);
+            // Same pie when within the larger of the two radii: one pie's slices all share its
+            // center, while separate panels are more than a radius apart.
+            double thresh = Math.max(r, p.radius);
+
+            if(dist <= thresh && dist < bestDist) {
+               best = p;
+               bestDist = dist;
+            }
+         }
+
+         if(best == null) {
+            best = new PiePanel();
+            best.center = center;
+            best.radius = r;
+            panels.add(best);
+         }
+         else {
+            best.radius = Math.max(best.radius, r);
+         }
+
+         best.slices.add(slices.get(i));
+         assigned[i] = true;
       }
 
-      // Center text (donut label/value): fade in after ALL slices have finished sweeping.
-      double centerTextDelay = totalAnimEndTime + 0.1;
-
-      for(Element textGroup : textGroups) {
-         mergeStyle(textGroup, String.format(java.util.Locale.US,
-            "opacity:0;animation:inetsoft-pie-fade %.2fs %s %.2fs both",
-            AnimationConstants.PIE_TEXT_DURATION, AnimationConstants.PIE_FADE_EASING, centerTextDelay));
+      // No center anywhere: one center-less panel preserves the legacy single-pie path.
+      if(panels.isEmpty()) {
+         PiePanel only = new PiePanel();
+         only.slices.addAll(slices);
+         panels.add(only);
+         return panels;
       }
+
+      // Pass B: assign remaining slices (e.g. 3D depth quads) to the nearest panel by centroid.
+      for(int i = 0; i < slices.size(); i++) {
+         if(assigned[i]) {
+            continue;
+         }
+
+         double[] b = SVGAnimationInjector.parseBarBounds(slices.get(i).getAttribute("d"));
+         double cx = (b[0] + b[2]) / 2, cy = (b[1] + b[3]) / 2;
+         PiePanel best = panels.get(0);
+         double bestDist = Double.MAX_VALUE;
+
+         for(PiePanel p : panels) {
+            double dist = Math.hypot(cx - p.center[0], cy - p.center[1]);
+
+            if(dist < bestDist) {
+               best = p;
+               bestDist = dist;
+            }
+         }
+
+         best.slices.add(slices.get(i));
+      }
+
+      return panels;
+   }
+
+   /**
+    * Compute the center of a bezier donut ring slice.  Batik renders a donut slice as a filled
+    * {@link java.awt.geom.Area}: an outer arc (bezier), a radial line ({@code L}) inward to the
+    * inner radius, an inner arc (bezier), then a closing {@code Z} back to the start.  The two
+    * radial edges — the explicit {@code L} (outer end → inner start) and the closing {@code Z}
+    * (inner end → start) — both pass through the pie center, so their intersection is the center.
+    *
+    * @return {@code {cx, cy}}, or null when the path is not a ring (no {@code L}, parallel edges).
+    */
+   private static double[] extractRingCenter(String d) {
+      if(d == null) {
+         return null;
+      }
+
+      int li = d.indexOf('L');
+      int zi = d.lastIndexOf('Z');
+
+      if(li < 0 || zi < 0 || zi < li) {
+         return null;
+      }
+
+      double[] start    = firstPoint(d.substring(0, li));   // outer start (M point), angle 1
+      double[] outerEnd = lastPoint(d.substring(0, li));     // outer arc end, angle 2
+      double[] innerStart = firstPoint(d.substring(li + 1)); // inner start (L point), angle 2
+      double[] innerEnd = lastPoint(d.substring(0, zi));     // inner arc end, angle 1
+
+      if(start == null || outerEnd == null || innerStart == null || innerEnd == null) {
+         return null;
+      }
+
+      // Radial edge 1: start ↔ innerEnd (angle 1).  Radial edge 2: outerEnd ↔ innerStart (angle 2).
+      return lineIntersect(start, innerEnd, outerEnd, innerStart);
+   }
+
+   /** Outer radius of a ring slice: the largest distance from {@code center} to its endpoints. */
+   private static double ringRadius(String d, double[] center) {
+      double max = 0;
+      Matcher m = Pattern.compile("-?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?")
+                         .matcher(d.replace(',', ' '));
+      List<Double> nums = new ArrayList<>();
+      while(m.find()) nums.add(Double.parseDouble(m.group()));
+
+      for(int i = 0; i + 1 < nums.size(); i += 2) {
+         max = Math.max(max, Math.hypot(nums.get(i) - center[0], nums.get(i + 1) - center[1]));
+      }
+
+      return max;
+   }
+
+   /** First (x,y) number pair in a path fragment, or null. */
+   private static double[] firstPoint(String s) {
+      Matcher m = Pattern.compile("-?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?")
+                         .matcher(s.replace(',', ' '));
+      if(!m.find()) return null;
+      double x = Double.parseDouble(m.group());
+      if(!m.find()) return null;
+      return new double[]{ x, Double.parseDouble(m.group()) };
+   }
+
+   /** Last (x,y) number pair in a path fragment, or null. */
+   private static double[] lastPoint(String s) {
+      Matcher m = Pattern.compile("-?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?")
+                         .matcher(s.replace(',', ' '));
+      List<Double> nums = new ArrayList<>();
+      while(m.find()) nums.add(Double.parseDouble(m.group()));
+      int n = nums.size();
+      return n >= 2 ? new double[]{ nums.get(n - 2), nums.get(n - 1) } : null;
+   }
+
+   /** Intersection of line (a,b) with line (c,e), or null if (near-)parallel. */
+   private static double[] lineIntersect(double[] a, double[] b, double[] c, double[] e) {
+      double x1 = a[0], y1 = a[1], x2 = b[0], y2 = b[1];
+      double x3 = c[0], y3 = c[1], x4 = e[0], y4 = e[1];
+      double den = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4);
+
+      if(Math.abs(den) < 1e-9) {
+         return null;
+      }
+
+      double pre = x1 * y2 - y1 * x2, post = x3 * y4 - y3 * x4;
+      double px = (pre * (x3 - x4) - (x1 - x2) * post) / den;
+      double py = (pre * (y3 - y4) - (y1 - y2) * post) / den;
+      return new double[]{ px, py };
+   }
+
+   /**
+    * Return the donut hole {@code {cx,cy,r}} whose center is nearest {@code center} and within
+    * its own radius, or null when no hole encloses the panel center (a flat, non-donut pie).
+    */
+   private static double[] nearestHole(List<double[]> holes, double[] center) {
+      double[] best = null;
+      double bestDist = Double.MAX_VALUE;
+
+      for(double[] h : holes) {
+         double dist = Math.hypot(h[0] - center[0], h[1] - center[1]);
+
+         if(dist <= h[2] && dist < bestDist) {
+            best = h;
+            bestDist = dist;
+         }
+      }
+
+      return best;
    }
 
    // -------------------------------------------------------------------------
@@ -2785,17 +3094,19 @@ public class SVGAnimationDOMInjector {
    // -------------------------------------------------------------------------
 
    /**
-    * Scan {@code inetsoft-bar} annotation groups for the donut center-hole overlay
-    * (an annotation whose only shape descendant is a {@code <circle>}).
+    * Scan {@code inetsoft-bar} annotation groups for donut center-hole overlays
+    * (an annotation whose only shape descendant is a {@code <circle>}).  A faceted donut chart
+    * has one such overlay per panel.
     *
-    * <p>When found, reclassifies the group to {@code inetsoft-bar-hole} and pins its opacity to 1
-    * via an inline {@code !important} style so it is immune to any class-based dim rule.
+    * <p>Each one found is reclassified to {@code inetsoft-bar-hole} and has its opacity pinned to
+    * 1 via an inline {@code !important} style so it is immune to any class-based dim rule.
     *
-    * @return {@code {cx, cy, innerR}} in the group's local coordinate system, or {@code null}
-    *         when the SVG is not a donut chart.
+    * @return one {@code {cx, cy, innerR}} (group-local coordinates) per hole found; empty when
+    *         the SVG is not a donut chart.
     */
-   private static double[] preprocessDonutHole(Element svgRoot) {
+   private static List<double[]> preprocessDonutHoles(Element svgRoot) {
       List<Element> annotBars = collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_BAR);
+      List<double[]> holes = new ArrayList<>();
 
       for(Element g : annotBars) {
          Element circle = findDescendantCircle(g);
@@ -2804,7 +3115,7 @@ public class SVGAnimationDOMInjector {
             continue;
          }
 
-         // This is the donut center-hole overlay.
+         // This is a donut center-hole overlay.
          g.setAttribute("class", SVGSupport.ANNOTATION_DONUT_HOLE);
          String existing = g.getAttribute("style");
          String holeStyle = "opacity:1!important";
@@ -2816,11 +3127,11 @@ public class SVGAnimationDOMInjector {
          double r  = parseAttr(circle, "r");
 
          if(r > 0) {
-            return new double[]{ cx, cy, r };
+            holes.add(new double[]{ cx, cy, r });
          }
       }
 
-      return null;
+      return holes;
    }
 
    /**

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -468,6 +468,7 @@ public class SVGAnimationDOMInjector {
 
       // Shared across panels: a single keyframe-name counter (so @keyframes names stay unique)
       // and one buffer flushed as a single <style> block after all panels are processed.
+      // int[] is a one-element box so the counter can be mutated by reference inside the loop.
       int[] kfCounter = { 0 };
       StringBuilder cssKeyframes = new StringBuilder();
       double maxEndTime = 0;
@@ -498,8 +499,9 @@ public class SVGAnimationDOMInjector {
    }
 
    /**
-    * The drawable size {@code {width,height}} of an SVG tile in user units, from its {@code
-    * viewBox} (preferred) or {@code width}/{@code height} attributes, or null if neither is set.
+    * The drawable region {@code {minX,minY,width,height}} of an SVG tile in user units, from its
+    * {@code viewBox} (preferred, origin included) or {@code width}/{@code height} attributes
+    * (origin 0,0), or null if neither is set.
     */
    private static double[] svgViewport(Element svgRoot) {
       String viewBox = svgRoot.getAttribute("viewBox");
@@ -509,12 +511,12 @@ public class SVGAnimationDOMInjector {
          double[] n = new double[4];
          int i = 0;
          while(i < 4 && m.find()) n[i++] = Double.parseDouble(m.group());
-         if(i == 4 && n[2] > 0 && n[3] > 0) return new double[]{ n[2], n[3] };
+         if(i == 4 && n[2] > 0 && n[3] > 0) return new double[]{ n[0], n[1], n[2], n[3] };
       }
 
       double w = parseLength(svgRoot.getAttribute("width"));
       double h = parseLength(svgRoot.getAttribute("height"));
-      return w > 0 && h > 0 ? new double[]{ w, h } : null;
+      return w > 0 && h > 0 ? new double[]{ 0, 0, w, h } : null;
    }
 
    /** Parse a leading numeric length (ignoring a unit suffix like {@code px}); 0 if absent. */
@@ -537,6 +539,8 @@ public class SVGAnimationDOMInjector {
       }
 
       double cx = panel.center[0], cy = panel.center[1], r = panel.radius;
+      // All slices of one panel share the same ancestor transform (the chart-level flip/translate),
+      // so the first slice's CTM maps the whole pie into tile coordinates.
       double[] ctm = elementCTM(panel.slices.get(0));
       double[] box = { Double.MAX_VALUE, Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE };
       expandBounds(box, ctm, cx - r, cy - r);
@@ -544,8 +548,10 @@ public class SVGAnimationDOMInjector {
       expandBounds(box, ctm, cx - r, cy + r);
       expandBounds(box, ctm, cx + r, cy + r);
 
-      // 2px tolerance absorbs the sub-pixel tile-translate offset; a tiled pie overflows far more.
-      return box[0] < -2 || box[1] < -2 || box[2] > viewport[0] + 2 || box[3] > viewport[1] + 2;
+      // viewport = {minX, minY, width, height}.  2px tolerance absorbs the sub-pixel
+      // tile-translate offset; a tiled pie overflows the drawable region by far more.
+      double minX = viewport[0], minY = viewport[1], w = viewport[2], h = viewport[3];
+      return box[0] < minX - 2 || box[1] < minY - 2 || box[2] > minX + w + 2 || box[3] > minY + h + 2;
    }
 
    /** Affine matrix mapping {@code node}'s local coordinates to the SVG root, from ancestor transforms. */
@@ -875,12 +881,14 @@ public class SVGAnimationDOMInjector {
     * while distinct facet panels never overlap and so are more than one radius apart; clustering
     * centers with a per-pie-radius threshold therefore groups each pie cleanly.  Facet position
     * is baked into the slice coordinates (the chart transform is shared across facets), so the
-    * raw center separates facets directly.  DOM order is preserved within each panel — the wheel
-    * order and arc-group encounter order depend on it.
+    * raw center separates facets directly.  Arc slices keep DOM order within each panel — the
+    * wheel order and arc-group encounter order depend on it.
     *
     * <p>Slices with no recoverable center (3D side quads) are assigned in a second pass to the
-    * nearest panel by centroid.  If no center is found anywhere, one center-less panel holds all
-    * slices, preserving the legacy single-pie path.
+    * nearest panel by centroid, appended after the arc slices.  Their relative order does not
+    * affect the wheel sequence (they are snapped, not swept), so re-ordering them is harmless.
+    * If no center is found anywhere, one center-less panel holds all slices, preserving the
+    * legacy single-pie path.
     */
    private static List<PiePanel> partitionPiePanels(List<Element> slices) {
       List<PiePanel> panels = new ArrayList<>();
@@ -1003,7 +1011,12 @@ public class SVGAnimationDOMInjector {
       return lineIntersect(start, innerEnd, outerEnd, innerStart);
    }
 
-   /** Outer radius of a ring slice: the largest distance from {@code center} to its endpoints. */
+   /**
+    * Outer radius of a ring slice: the largest distance from {@code center} to any path number
+    * pair.  Bezier control points are included, so this is an upper bound on the true outer
+    * radius — safe here since it is only a panel-merge threshold (too large merges nothing extra
+    * given facet spacing far exceeds one radius).
+    */
    private static double ringRadius(String d, double[] center) {
       double max = 0;
       Matcher m = Pattern.compile("-?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?")
@@ -1038,10 +1051,10 @@ public class SVGAnimationDOMInjector {
       return n >= 2 ? new double[]{ nums.get(n - 2), nums.get(n - 1) } : null;
    }
 
-   /** Intersection of line (a,b) with line (c,e), or null if (near-)parallel. */
-   private static double[] lineIntersect(double[] a, double[] b, double[] c, double[] e) {
-      double x1 = a[0], y1 = a[1], x2 = b[0], y2 = b[1];
-      double x3 = c[0], y3 = c[1], x4 = e[0], y4 = e[1];
+   /** Intersection of line (p1,p2) with line (p3,p4), or null if (near-)parallel. */
+   private static double[] lineIntersect(double[] p1, double[] p2, double[] p3, double[] p4) {
+      double x1 = p1[0], y1 = p1[1], x2 = p2[0], y2 = p2[1];
+      double x3 = p3[0], y3 = p3[1], x4 = p4[0], y4 = p4[1];
       double den = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4);
 
       if(Math.abs(den) < 1e-9) {
@@ -1685,7 +1698,7 @@ public class SVGAnimationDOMInjector {
    /** Extract all numbers (including negatives and decimals) from a path data fragment. */
    private static double[] parsePathNumbers(String s) {
       java.util.regex.Matcher m =
-         java.util.regex.Pattern.compile("-?[0-9]+(?:\\.[0-9]+)?").matcher(s);
+         java.util.regex.Pattern.compile("-?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?").matcher(s);
       List<Double> nums = new ArrayList<>();
       while(m.find()) nums.add(Double.parseDouble(m.group()));
       double[] arr = new double[nums.size()];

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -1365,4 +1365,406 @@ class SVGAnimationDOMInjectorTest {
       assertTrue(pointStyle == null || pointStyle.isEmpty(),
                  "combo chart point overlay must not receive a fade without the gantt flag");
    }
+
+   // -------------------------------------------------------------------------
+   // Faceted pie animation tests
+   // -------------------------------------------------------------------------
+
+   /**
+    * Adds a pie slice as a Batik-style {@code <path stroke="none">} wedge of the form
+    * {@code M sx sy A rx ry 0 la sw ex ey L cx cy Z}, where (cx,cy) is the pie hub.
+    *
+    * @return the slice path element
+    */
+   private static Element addPieSlice(Document doc, double sx, double sy, double r,
+                                      int la, int sw, double ex, double ey,
+                                      double cx, double cy)
+   {
+      return addPieSliceTo(doc.getDocumentElement(), doc, sx, sy, r, la, sw, ex, ey, cx, cy);
+   }
+
+   /** As {@link #addPieSlice} but appends the slice to a given parent (e.g. a transformed group). */
+   private static Element addPieSliceTo(Element parent, Document doc, double sx, double sy, double r,
+                                        int la, int sw, double ex, double ey, double cx, double cy)
+   {
+      Element path = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "path");
+      path.setAttribute("stroke", "none");
+      path.setAttribute("d", String.format(Locale.US,
+         "M%.4f %.4f A%.4f %.4f 0 %d %d %.4f %.4f L%.4f %.4f Z",
+         sx, sy, r, r, la, sw, ex, ey, cx, cy));
+      parent.appendChild(path);
+      return path;
+   }
+
+   /**
+    * Adds a realistic bezier donut ring slice ({@code M …C… L …C… Z}, no arc command, no center
+    * hub) whose two radial edges intersect at (cx,cy) — the shape real donut slices take, since
+    * they are a filled Area serialized by Batik as cubic beziers.  The slice spans the given
+    * start angle to start+sweep (degrees) between innerR=10 and outerR=30, so different slices of
+    * the same donut share the center while the bezier control points differ.
+    */
+   private static Element addRingSlice(Document doc, double cx, double cy,
+                                       double startDeg, double sweepDeg)
+   {
+      double a1 = Math.toRadians(startDeg), a2 = Math.toRadians(startDeg + sweepDeg);
+      double oR = 30, iR = 10;
+      double oSx = cx + oR * Math.cos(a1), oSy = cy + oR * Math.sin(a1);   // outer start (a1)
+      double oEx = cx + oR * Math.cos(a2), oEy = cy + oR * Math.sin(a2);   // outer end   (a2)
+      double iSx = cx + iR * Math.cos(a2), iSy = cy + iR * Math.sin(a2);   // inner start (a2)
+      double iEx = cx + iR * Math.cos(a1), iEy = cy + iR * Math.sin(a1);   // inner end   (a1)
+      Element svg = doc.getDocumentElement();
+      Element path = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "path");
+      path.setAttribute("stroke", "none");
+      // The C control points are arbitrary (only endpoints feed center recovery); the L and Z
+      // edges are the two radials that intersect at (cx,cy).
+      path.setAttribute("d", String.format(Locale.US,
+         "M%.4f %.4f C%.4f %.4f %.4f %.4f %.4f %.4f L%.4f %.4f C%.4f %.4f %.4f %.4f %.4f %.4f Z",
+         oSx, oSy, oSx, oSy, oEx, oEy, oEx, oEy, iSx, iSy, iSx, iSy, iEx, iEy, iEx, iEy));
+      svg.appendChild(path);
+      return path;
+   }
+
+   /** Adds a donut center-hole overlay: a {@code <g class="inetsoft-bar">} wrapping a circle. */
+   private static Element addHoleOverlay(Document doc, double cx, double cy, double r) {
+      Element svg = doc.getDocumentElement();
+      Element g = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
+      g.setAttribute("class", SVGSupport.ANNOTATION_BAR);
+      Element circle = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "circle");
+      circle.setAttribute("cx", String.valueOf(cx));
+      circle.setAttribute("cy", String.valueOf(cy));
+      circle.setAttribute("r", String.valueOf(r));
+      g.appendChild(circle);
+      svg.appendChild(g);
+      return g;
+   }
+
+   /** Parses the final {@code "L cx cy Z"} hub point from a slice path. */
+   private static double[] parseHub(String d) {
+      Matcher m = Pattern.compile(
+         "L\\s*(-?\\d+\\.?\\d*)\\s+(-?\\d+\\.?\\d*)\\s*Z").matcher(d);
+      double[] hub = null;
+
+      while(m.find()) {
+         hub = new double[]{ Double.parseDouble(m.group(1)), Double.parseDouble(m.group(2)) };
+      }
+
+      return hub;
+   }
+
+   /** Extracts the {@code inetsoft-pie-sweep-N} keyframe name referenced by a slice's style. */
+   private static String sweepKeyframeName(String style) {
+      Matcher m = Pattern.compile("inetsoft-pie-sweep-\\d+").matcher(style);
+      return m.find() ? m.group() : null;
+   }
+
+   /** Asserts every arc endpoint in the named sweep keyframe lies on the circle (cx,cy,r). */
+   private static void assertSweepOnCircle(String css, String kfName,
+                                           double cx, double cy, double r)
+   {
+      String block = keyframeBlock(css, kfName);
+      Matcher pm = Pattern.compile("path\\('([^']*)'\\)").matcher(block);
+      int checked = 0;
+
+      while(pm.find()) {
+         String path = pm.group(1);
+         String arc = path.substring(path.indexOf('A'), path.indexOf('L'));
+         Matcher nm = Pattern.compile("-?\\d+\\.?\\d*").matcher(arc);
+         List<Double> nums = new ArrayList<>();
+         while(nm.find()) nums.add(Double.parseDouble(nm.group()));
+         double ex = nums.get(nums.size() - 2), ey = nums.get(nums.size() - 1);
+         assertEquals(r, Math.hypot(ex - cx, ey - cy), 0.5,
+                      kfName + " arc endpoint must stay on circle around (" + cx + "," + cy + ")");
+         checked++;
+      }
+
+      assertTrue(checked >= 2, "expected multiple sweep keyframes for " + kfName);
+   }
+
+   /** Returns the body of the named {@code @keyframes} rule via brace matching. */
+   private static String keyframeBlock(String css, String name) {
+      int header = css.indexOf("@keyframes " + name + "{");
+      assertTrue(header >= 0, "keyframes rule " + name + " must exist");
+      int open = css.indexOf('{', header);
+      int depth = 0;
+
+      for(int i = open; i < css.length(); i++) {
+         if(css.charAt(i) == '{') depth++;
+         else if(css.charAt(i) == '}' && --depth == 0) return css.substring(open + 1, i);
+      }
+
+      return "";
+   }
+
+   /**
+    * Two pie panels rendered into one SVG (a facet chart) must each sweep around their OWN hub.
+    * Pre-fix, a single global center was used for every slice, so the second panel's wedges
+    * collapsed/cut across the interior — this asserts each slice keeps its own hub center.
+    */
+   @Test
+   void facetedPie_eachPanelSweepsAroundOwnCenter() throws Exception {
+      Document doc = newDocument();
+      // Panel 1: center (100,100), r=80. Panel 2: center (400,100), r=80. Two slices each.
+      Element a = addPieSlice(doc, 180, 100, 80, 0, 1, 100, 180, 100, 100);
+      Element b = addPieSlice(doc, 100, 180, 80, 0, 1,  20, 100, 100, 100);
+      Element c = addPieSlice(doc, 480, 100, 80, 0, 1, 400, 180, 400, 100);
+      Element e = addPieSlice(doc, 400, 180, 80, 0, 1, 320, 100, 400, 100);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      // Each slice's rewritten from-state must retain its OWN panel center as the hub.
+      assertArrayEquals(new double[]{100, 100}, parseHub(a.getAttribute("d")), 0.01,
+                        "panel-1 slice must keep hub (100,100)");
+      assertArrayEquals(new double[]{400, 100}, parseHub(c.getAttribute("d")), 0.01,
+                        "panel-2 slice must keep hub (400,100), not the global first-pie center");
+
+      // Distinct keyframe names for all four arc slices (no cross-panel collision).
+      Set<String> names = new HashSet<>();
+      for(Element s : List.of(a, b, c, e)) {
+         names.add(sweepKeyframeName(s.getAttribute("style")));
+      }
+      assertEquals(4, names.size(), "each slice must reference a unique sweep keyframe");
+
+      // Panel-2 slice keyframe endpoints must lie on the circle around (400,100), radius 80.
+      String css = allStyleContent(doc.getDocumentElement());
+      String block = keyframeBlock(css, sweepKeyframeName(c.getAttribute("style")));
+      Matcher pm = Pattern.compile("path\\('([^']*)'\\)").matcher(block);
+      int checked = 0;
+
+      while(pm.find()) {
+         String path = pm.group(1);
+         String arc = path.substring(path.indexOf('A'), path.indexOf('L'));
+         Matcher nm = Pattern.compile("-?\\d+\\.?\\d*").matcher(arc);
+         List<Double> nums = new ArrayList<>();
+         while(nm.find()) nums.add(Double.parseDouble(nm.group()));
+         double ex = nums.get(nums.size() - 2), ey = nums.get(nums.size() - 1);
+         assertEquals(80.0, Math.hypot(ex - 400, ey - 100), 0.5,
+                      "panel-2 arc endpoint must stay on its own outer circle");
+         checked++;
+      }
+
+      assertTrue(checked >= 2, "expected multiple sweep keyframes for the panel-2 slice");
+   }
+
+   /** In a facet pie every panel begins sweeping at t=0 (panels animate in parallel). */
+   @Test
+   void facetedPie_panelsAnimateInParallel() throws Exception {
+      Document doc = newDocument();
+      Element a = addPieSlice(doc, 180, 100, 80, 0, 1, 100, 180, 100, 100);
+      addPieSlice(doc, 100, 180, 80, 0, 1, 20, 100, 100, 100);
+      Element c = addPieSlice(doc, 480, 100, 80, 0, 1, 400, 180, 400, 100);
+      addPieSlice(doc, 400, 180, 80, 0, 1, 320, 100, 400, 100);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      // The first slice of each panel (its first arc group) begins at delay 0.
+      assertEquals(0.0, parseDelay(a.getAttribute("style")), 0.001,
+                   "panel-1 first slice must begin at t=0");
+      assertEquals(0.0, parseDelay(c.getAttribute("style")), 0.001,
+                   "panel-2 first slice must also begin at t=0 (parallel, not after panel 1)");
+   }
+
+   /** A faceted donut: each panel must be matched to its OWN center-hole and animate as a ring. */
+   @Test
+   void facetedDonut_eachPanelMatchedToOwnHole() throws Exception {
+      Document doc = newDocument();
+      // Full wedges (hub = center) plus a separate hole overlay per panel (the donut pattern).
+      addPieSlice(doc, 180, 100, 80, 0, 1, 100, 180, 100, 100);
+      Element c = addPieSlice(doc, 480, 100, 80, 0, 1, 400, 180, 400, 100);
+      Element hole1 = addHoleOverlay(doc, 100, 100, 30);
+      Element hole2 = addHoleOverlay(doc, 400, 100, 30);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      // Both overlays reclassified to the donut-hole class.
+      assertEquals(SVGSupport.ANNOTATION_DONUT_HOLE, hole1.getAttribute("class"));
+      assertEquals(SVGSupport.ANNOTATION_DONUT_HOLE, hole2.getAttribute("class"));
+
+      // Panel-2 slice must animate as a ring (two arcs: outer + inner) — proving it was matched
+      // to hole2 rather than left as a center-spoke wedge (a single arc).
+      long arcCount = c.getAttribute("d").chars().filter(ch -> ch == 'A').count();
+      assertEquals(2, arcCount, "panel-2 donut slice must be a ring (outer + inner arc)");
+   }
+
+   /**
+    * A flat pie with symmetric slices (the no-measure case) has slices whose start points share
+    * an x-coordinate (mirror angles about the horizontal axis).  Each such slice must still sweep
+    * around the true pie center.  Pre-fix, the startX grouping merged them and reconstructed a
+    * bogus center from another slice's Y, collapsing the wedge into a gap.
+    */
+   @Test
+   void flatPie_symmetricSlicesSweepAroundOwnCenter() throws Exception {
+      Document doc = newDocument();
+      // Pie center (200,200), r=100. Slice B starts at +60deg, slice A at -60deg: both have
+      // start x = 250, so the startX grouping would merge them. B is added first.
+      Element b = addPieSlice(doc, 250, 286.60254, 100, 0, 1, 165.79799, 293.96926, 200, 200);
+      Element a = addPieSlice(doc, 250, 113.39746, 100, 0, 1, 298.48078, 182.63518, 200, 200);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      // Both slices keep the true pie center as their hub (not a borrowed Y from the other slice).
+      assertArrayEquals(new double[]{200, 200}, parseHub(a.getAttribute("d")), 0.01,
+                        "upper mirror slice must sweep around the true center, not a bogus one");
+      assertArrayEquals(new double[]{200, 200}, parseHub(b.getAttribute("d")), 0.01,
+                        "lower mirror slice must sweep around the true center");
+
+      // Both must actually sweep (neither misclassified as a 3D depth face), around (200,200).
+      String css = allStyleContent(doc.getDocumentElement());
+      String kfA = sweepKeyframeName(a.getAttribute("style"));
+      String kfB = sweepKeyframeName(b.getAttribute("style"));
+      assertNotNull(kfA, "upper mirror slice must receive a sweep animation");
+      assertNotNull(kfB, "lower mirror slice must receive a sweep animation");
+      assertSweepOnCircle(css, kfA, 200, 200, 100);
+      assertSweepOnCircle(css, kfB, 200, 200, 100);
+   }
+
+   /**
+    * Symmetric slices that share a start x-coordinate must still animate one-at-a-time: keying
+    * the wheel sequence on the start angle (not the start x) keeps mirror slices on distinct
+    * sequential delays.  Pre-fix the shared startX merged them onto one delay (simultaneous).
+    */
+   @Test
+   void flatPie_symmetricSlicesAnimateSequentially() throws Exception {
+      Document doc = newDocument();
+      // Both start at x=250 (mirror angles +/-60deg about the horizontal). B added first.
+      Element b = addPieSlice(doc, 250, 286.60254, 100, 0, 1, 165.79799, 293.96926, 200, 200);
+      Element a = addPieSlice(doc, 250, 113.39746, 100, 0, 1, 298.48078, 182.63518, 200, 200);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      double delayB = parseDelay(b.getAttribute("style"));
+      double delayA = parseDelay(a.getAttribute("style"));
+      assertEquals(0.0, delayB, 0.001, "first slice in DOM order begins the wheel at t=0");
+      assertTrue(delayA > delayB + 0.001,
+                 "the mirror slice must follow sequentially, not animate at the same time: " +
+                 "delayA=" + delayA + ", delayB=" + delayB);
+   }
+
+   /**
+    * Real donut slices are bezier rings (a filled Area) with no arc command, no center hub, and
+    * NO separate hole overlay — the hole is the empty ring center.  Facet position is baked into
+    * the absolute coordinates.  A faceted donut must animate its panels in parallel: each facet,
+    * identified by the intersection of its slices' radial edges, staggers from t=0.  Pre-fix, all
+    * ring slices fell into one global sequence, so later facets started only after earlier facets
+    * finished — the reported "each plot renders sequentially" symptom.
+    */
+   @Test
+   void facetedDonut_bezierRingsAnimatePanelsInParallel() throws Exception {
+      Document doc = newDocument();
+      // Facet 1 centered at (100,100); facet 2 at (400,100). Two ring slices each, no overlays.
+      Element f1s0 = addRingSlice(doc, 100, 100, 0, 90);
+      Element f1s1 = addRingSlice(doc, 100, 100, 90, 90);
+      Element f2s0 = addRingSlice(doc, 400, 100, 0, 90);
+      Element f2s1 = addRingSlice(doc, 400, 100, 90, 90);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      double step = AnimationConstants.PIE_SLICE_DURATION;
+      // Each facet restarts the stagger at 0 — both first slices begin together.
+      assertEquals(0.0, parseDelay(f1s0.getAttribute("style")), 0.001,
+                   "facet 1 first slice begins at t=0");
+      assertEquals(0.0, parseDelay(f2s0.getAttribute("style")), 0.001,
+                   "facet 2 first slice must also begin at t=0, not after facet 1");
+      // Within each facet the slices still stagger one after another.
+      assertEquals(step, parseDelay(f1s1.getAttribute("style")), 0.001,
+                   "facet 1 second slice staggers within its own panel");
+      assertEquals(step, parseDelay(f2s1.getAttribute("style")), 0.001,
+                   "facet 2 second slice staggers within its own panel");
+   }
+
+   /**
+    * A pie larger than the tile (split/clipped across SVG tiles) must fall back to the opacity
+    * fade and NOT rewrite slice geometry: the arc sweep's rewritten {@code d} does not survive
+    * per-tile clipping (the exploded/malformed-final-state bug), whereas a pure opacity fade
+    * leaves the correct (statically clipped) wedge intact.
+    */
+   @Test
+   void largePie_tiledFallsBackToFade() throws Exception {
+      Document doc = newDocument();   // viewBox 0 0 800 600
+      // Pie center (600,300), r=500 → bbox width 1000 > 800 (viewport): larger than the tile.
+      Element a = addPieSlice(doc, 1100, 300, 500, 0, 1, 600, 800, 600, 300);
+      Element b = addPieSlice(doc, 600, 800, 500, 0, 1, 100, 300, 600, 300);
+      String origA = a.getAttribute("d");
+      String origB = b.getAttribute("d");
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      for(Element s : List.of(a, b)) {
+         String style = s.getAttribute("style");
+         assertTrue(style.contains("inetsoft-pie-fade"), "tiled pie slice must use the opacity fade");
+         assertFalse(style.contains("inetsoft-pie-sweep"),
+                     "tiled pie slice must NOT use the geometric sweep");
+      }
+      // Geometry must be untouched (still the original full wedge, not a rewritten from-state).
+      assertEquals(origA, a.getAttribute("d"), "fade must not rewrite slice d");
+      assertEquals(origB, b.getAttribute("d"), "fade must not rewrite slice d");
+   }
+
+   /** A normal-size pie (fits within the tile viewport) must still use the wheel-sweep. */
+   @Test
+   void normalPie_usesSweep() throws Exception {
+      Document doc = newDocument();   // viewBox 0 0 800 600
+      // Pie center (400,300), r=100 → bbox width 200 < 800: fits in the tile.
+      Element a = addPieSlice(doc, 500, 300, 100, 0, 1, 400, 400, 400, 300);
+      Element b = addPieSlice(doc, 400, 400, 100, 0, 1, 300, 300, 400, 300);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      assertTrue(a.getAttribute("style").contains("inetsoft-pie-sweep"),
+                 "normal-size pie must keep the wheel-sweep");
+   }
+
+   /**
+    * A pie small enough to fit a tile by size but positioned (via its parent transform) so it
+    * straddles/exceeds the tile must also fall back to the fade: containment is tested in the
+    * tile's coordinate space, not just by extent.  Covers the faceted-and-tiled seam case.
+    */
+   @Test
+   void pieClippedByTileViaTransform_fallsBackToFade() throws Exception {
+      Document doc = newDocument();   // viewBox 0 0 800 600
+      // Small pie (center 100,100, r=80) inside a group translated so it spills past x=800.
+      Element g = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
+      g.setAttribute("transform", "translate(760,0)");
+      doc.getDocumentElement().appendChild(g);
+      Element a = addPieSliceTo(g, doc, 180, 100, 80, 0, 1, 100, 180, 100, 100);
+      Element b = addPieSliceTo(g, doc, 100, 180, 80, 0, 1, 20, 100, 100, 100);
+      String origA = a.getAttribute("d");
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      assertTrue(a.getAttribute("style").contains("inetsoft-pie-fade"),
+                 "pie straddling the tile edge must use the fade");
+      assertFalse(a.getAttribute("style").contains("inetsoft-pie-sweep"),
+                  "pie straddling the tile edge must NOT use the sweep");
+      assertEquals(origA, a.getAttribute("d"), "fade must not rewrite slice d");
+   }
+
+   /**
+    * A faceted 3D pie (top arc face + non-arc depth quad per panel) must animate every slice,
+    * with each top face sweeping around its own panel center.
+    */
+   @Test
+   void faceted3DPie_assignsDepthFacesAndSweepsPerPanel() throws Exception {
+      Document doc = newDocument();
+      Element top1 = addPieSlice(doc, 180, 100, 80, 0, 1, 100, 160, 100, 100);
+      Element top2 = addPieSlice(doc, 480, 100, 80, 0, 1, 400, 160, 400, 100);
+      // Depth quads (no arc) under each panel's footprint.
+      Element depth1 = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "path");
+      depth1.setAttribute("stroke", "none");
+      depth1.setAttribute("d", "M100 160 L180 100 L180 120 L100 180 Z");
+      doc.getDocumentElement().appendChild(depth1);
+      Element depth2 = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "path");
+      depth2.setAttribute("stroke", "none");
+      depth2.setAttribute("d", "M400 160 L480 100 L480 120 L400 180 Z");
+      doc.getDocumentElement().appendChild(depth2);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      assertArrayEquals(new double[]{400, 100}, parseHub(top2.getAttribute("d")), 0.01,
+                        "panel-2 top face must sweep around its own center");
+      // Every slice (top faces and depth quads) must receive an animation.
+      for(Element s : List.of(top1, top2, depth1, depth2)) {
+         assertTrue(s.getAttribute("style").contains("animation:"),
+                    "every 3D pie face must receive an animation, including depth quads");
+      }
+   }
 }

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -1412,14 +1412,19 @@ class SVGAnimationDOMInjectorTest {
       double oEx = cx + oR * Math.cos(a2), oEy = cy + oR * Math.sin(a2);   // outer end   (a2)
       double iSx = cx + iR * Math.cos(a2), iSy = cy + iR * Math.sin(a2);   // inner start (a2)
       double iEx = cx + iR * Math.cos(a1), iEy = cy + iR * Math.sin(a1);   // inner end   (a1)
+      // Cubic control points along the tangents (k = 4/3·tan(sweep/4)), the standard bezier arc
+      // approximation Batik emits — so the path is a real curved ring, not degenerate lines.
+      double ko = 4.0 / 3.0 * Math.tan((a2 - a1) / 4), ki = 4.0 / 3.0 * Math.tan((a1 - a2) / 4);
+      double oc1x = oSx - ko * oR * Math.sin(a1), oc1y = oSy + ko * oR * Math.cos(a1);
+      double oc2x = oEx + ko * oR * Math.sin(a2), oc2y = oEy - ko * oR * Math.cos(a2);
+      double ic1x = iSx - ki * iR * Math.sin(a2), ic1y = iSy + ki * iR * Math.cos(a2);
+      double ic2x = iEx + ki * iR * Math.sin(a1), ic2y = iEy - ki * iR * Math.cos(a1);
       Element svg = doc.getDocumentElement();
       Element path = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "path");
       path.setAttribute("stroke", "none");
-      // The C control points are arbitrary (only endpoints feed center recovery); the L and Z
-      // edges are the two radials that intersect at (cx,cy).
       path.setAttribute("d", String.format(Locale.US,
          "M%.4f %.4f C%.4f %.4f %.4f %.4f %.4f %.4f L%.4f %.4f C%.4f %.4f %.4f %.4f %.4f %.4f Z",
-         oSx, oSy, oSx, oSy, oEx, oEy, oEx, oEy, iSx, iSy, iSx, iSy, iEx, iEy, iEx, iEy));
+         oSx, oSy, oc1x, oc1y, oc2x, oc2y, oEx, oEy, iSx, iSy, ic1x, ic1y, ic2x, ic2y, iEx, iEy));
       svg.appendChild(path);
       return path;
    }
@@ -1669,6 +1674,11 @@ class SVGAnimationDOMInjectorTest {
                    "facet 1 second slice staggers within its own panel");
       assertEquals(step, parseDelay(f2s1.getAttribute("style")), 0.001,
                    "facet 2 second slice staggers within its own panel");
+      // Bezier ring slices must take the opacity-fade path, never the arc sweep.
+      assertFalse(f1s0.getAttribute("style").contains("inetsoft-pie-sweep"),
+                  "bezier ring slice must not use the geometric sweep");
+      assertFalse(f2s0.getAttribute("style").contains("inetsoft-pie-sweep"),
+                  "bezier ring slice must not use the geometric sweep");
    }
 
    /**


### PR DESCRIPTION
The inline-SVG pie/donut entrance animation (epic-74519) assumed a single,
normal-sized pie. This PR reworks the pie branch of `SVGAnimationDOMInjector`
so it renders correctly for faceted, no-measure, and tiled charts.

### Issues fixed

1. **Faceted pie — broken after the first pie.** A single global center was used for every slice, so only the pie whose hub matched it animated correctly; the others swept around a foreign point and were mangled. Slices are now partitioned into one panel per pie (clustered by each slice's own center) and each pie animates around its own center.

2. **Faceted donut — panels animated sequentially instead of all at once.**
Real donut slices are bezier rings (a filled `java.awt.geom.Area`, no arc command, no center hub), so hub-based partitioning collapsed all facets into one global sequence. The center of a ring slice is recovered as the intersection of its two radial edges (the explicit `L` and the closing `Z`), so donut facets partition like pies and animate in parallel.

3. **No-measure (symmetric) pie — gaps and simultaneous slices.** Symmetric pies have mirror-angle slices that share a start x-coordinate. The old grouping (by start x) merged them onto one delay, and the old center reconstruction borrowed a sibling slice's Y, collapsing wedges into gaps. Grouping now keys on each slice's start angle (from its own hub), and the
sweep uses each slice's own hub, so slices render correctly and animate one-at-a-time.

4. **Large/tiled pie (> 1024px) — exploded/malformed.** A chart larger than a tile is split into clipped SVG tiles. The sweep rewrites each slice's `d`, which doesn't survive per-tile clipping, so the animated result was wrong even though the static render was correct (and donuts were unaffected because they fade). A pie that doesn't fit its tile is now detected per panel — the pie circle (`center ± radius`) is mapped to the tile coordinate space via the slice transform and tested for containment in the viewport — and falls back to the opacity fade (no `d` rewrite). Containment also covers a small pie that straddles a tile seam.

### Approach

- Per-panel partitioning by recovered center (arc hub for wedges, radial-edge intersection for bezier rings); each panel animates independently from t=0.
- Sweep geometry uses each slice's own hub; logical-slice grouping is angle-based (keeps the wheel order; merges 3D faces of one slice).
- Tiled pies fall back to the existing opacity fade; the wheel-sweep is kept for normal and faceted pies.
- Reuses the existing affine-transform helpers (`composeMatrix`, `parseSVGTransform`, `expandBounds`) for the containment check — no new matrix code.

### Scope

- Only the pie branch of `SVGAnimationDOMInjector` changes; the public `injectAnimation(Element, String)` signature is unchanged (single caller, `BatikSVGSupport`).
- No public API, serialized format, or CSS class-name changes.

### Testing

- Added regression tests for each case (faceting, no-measure geometry, sequencing, bezier-donut faceting, tiled fallback, tile-seam straddle, plus the normal-pie-sweep boundary). 