### PR TITLE
Bug #75482 - Highlight the whole stacked bar column on snap-tooltip hover (inline SVG)

### DIFF
--- a/core/src/test/java/inetsoft/uql/viewsheet/graph/ChartInfoSnapSupportTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/graph/ChartInfoSnapSupportTest.java
@@ -17,10 +17,23 @@
  */
 package inetsoft.uql.viewsheet.graph;
 
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
 class ChartInfoSnapSupportTest {
    @Test
    void lineChartWithDimensionOnX() {
@@ -70,7 +83,8 @@ class ChartInfoSnapSupportTest {
    @Test
    void unsupportedChartTypesAreRejected() {
       for(int type : new int[] { GraphTypes.CHART_PIE, GraphTypes.CHART_POINT,
-                                  GraphTypes.CHART_RADAR, GraphTypes.CHART_TREEMAP }) {
+                                  GraphTypes.CHART_RADAR, GraphTypes.CHART_TREEMAP,
+                                  GraphTypes.CHART_MEKKO }) {
          VSChartInfo info = new VSChartInfo();
          info.setChartType(type);
          info.addXField(new VSChartDimensionRef());

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
@@ -214,6 +214,61 @@ describe("ChartInlineSvgDirective cross-tile dim", () => {
       });
    });
 
+   describe("highlightElements (stacked bar column)", () => {
+      const html = `
+         <svg>
+            <g class="inetsoft-bar" data-row="0" data-col="0"></g>
+            <g class="inetsoft-bar" data-row="1" data-col="0"></g>
+            <g class="inetsoft-bar" data-row="2" data-col="0"></g>
+            <g class="inetsoft-bar-label" data-row="0" data-col="0"></g>
+            <g class="inetsoft-bar-label" data-row="1" data-col="0"></g>
+         </svg>`;
+
+      function activeFlags(host: HTMLElement, sel: string): boolean[] {
+         return Array.from(host.querySelectorAll(sel)).map(e => e.classList.contains("inetsoft-active"));
+      }
+
+      it("activates every segment of the column and its labels", () => {
+         const { dir, host } = makeDirective(html);
+         (dir as any).afterSvgInjected();
+         dir.highlightElements([{ row: 0, col: 0 }, { row: 1, col: 0 }]);
+         // Both hovered segments are active; the third segment stays dimmable.
+         expect(activeFlags(host, ".inetsoft-bar")).toEqual([true, true, false]);
+         expect(activeFlags(host, ".inetsoft-bar-label")).toEqual([true, true]);
+      });
+
+      it("clears the whole active set when the hover ends", () => {
+         vi.useFakeTimers();
+         try {
+            const { dir, host } = makeDirective(html);
+            (dir as any).afterSvgInjected();
+            dir.highlightElements([{ row: 0, col: 0 }, { row: 1, col: 0 }]);
+            dir.highlightElements([]);
+            vi.advanceTimersByTime(ChartInlineSvgDirective["CLEAR_DELAY_MS"]);
+            expect(activeFlags(host, ".inetsoft-bar,.inetsoft-bar-label").some(Boolean)).toBe(false);
+         }
+         finally {
+            vi.useRealTimers();
+         }
+      });
+
+      it("re-targets the active set without leaving stale active segments", () => {
+         const { dir, host } = makeDirective(html);
+         (dir as any).afterSvgInjected();
+         dir.highlightElements([{ row: 0, col: 0 }, { row: 1, col: 0 }]);
+         dir.highlightElements([{ row: 2, col: 0 }]);
+         expect(activeFlags(host, ".inetsoft-bar")).toEqual([false, false, true]);
+      });
+
+      it("honors only the primary on a series-color-dimmed (area/line) tile", () => {
+         const { dir, host } = makeDirective(html);
+         (dir as any).afterSvgInjected();
+         (dir as any).usesSeriesColorDim = true;
+         dir.highlightElements([{ row: 0, col: 0 }, { row: 1, col: 0 }]);
+         expect(activeFlags(host, ".inetsoft-bar")).toEqual([true, false, false]);
+      });
+   });
+
    describe("getRelationEdges + emitRelationHover dedup", () => {
       it("returns this tile's edges as source/target pairs", () => {
          const { dir } = makeDirective("");

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
@@ -260,6 +260,17 @@ describe("ChartInlineSvgDirective cross-tile dim", () => {
          expect(activeFlags(host, ".inetsoft-bar")).toEqual([false, false, true]);
       });
 
+      it("treats a reordered key set as unchanged (no deactivate/reactivate)", () => {
+         const { dir, host } = makeDirective(html);
+         (dir as any).afterSvgInjected();
+         dir.highlightElements([{ row: 0, col: 0 }, { row: 1, col: 0 }]);
+         const deactivateSpy = vi.spyOn(dir as any, "deactivateCurrent");
+         // Same set, different order — sameActiveKeys is order-independent so nothing re-runs.
+         dir.highlightElements([{ row: 1, col: 0 }, { row: 0, col: 0 }]);
+         expect(deactivateSpy).not.toHaveBeenCalled();
+         expect(activeFlags(host, ".inetsoft-bar")).toEqual([true, true, false]);
+      });
+
       it("honors only the primary on a series-color-dimmed (area/line) tile", () => {
          const { dir, host } = makeDirective(html);
          (dir as any).afterSvgInjected();

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
@@ -220,10 +220,17 @@ export class ChartInlineSvgDirective implements OnDestroy {
 
          const keys = pairs.map(p => `${p.row}-${p.col}`);
 
-         if(!this.sameActiveKeys(keys)) {
+         // Area/line/radar tiles dim by series color (setExternalSeriesDim), not the
+         // inetsoft-active class; toggling active on their shared point markers would fight
+         // that, so honor only the primary when a multi-element (stacked) set arrives on such
+         // a tile. Trim here so _activeKeys is written once and sameActiveKeys compares the
+         // value that was actually applied.
+         const activeKeys = this.usesSeriesColorDim && keys.length > 1 ? keys.slice(0, 1) : keys;
+
+         if(!this.sameActiveKeys(activeKeys)) {
             this.deactivateCurrent();
-            this._activeKeys = keys;
-            this.activateKeys(keys);
+            this._activeKeys = activeKeys;
+            this.activateKeys(activeKeys);
          }
       }
       else {
@@ -237,30 +244,17 @@ export class ChartInlineSvgDirective implements OnDestroy {
       }
    }
 
-   /** True when keys match the current active set (same order, same values). */
+   /** True when keys match the current active set, order-independent. */
    private sameActiveKeys(keys: string[]): boolean {
       if(keys.length !== this._activeKeys.length) {
          return false;
       }
 
-      for(let i = 0; i < keys.length; i++) {
-         if(keys[i] !== this._activeKeys[i]) {
-            return false;
-         }
-      }
-
-      return true;
+      const active = new Set(this._activeKeys);
+      return keys.every(k => active.has(k));
    }
 
    private activateKeys(keys: string[]): void {
-      // Area/line/radar dim by series color (setExternalSeriesDim), not the inetsoft-active
-      // class; toggling active on their shared point markers would fight that, so honor only
-      // the primary element when a multi-element (stacked) set arrives on such a tile.
-      if(this.usesSeriesColorDim && keys.length > 1) {
-         keys = keys.slice(0, 1);
-         this._activeKeys = keys;
-      }
-
       let anyFound = false;
 
       for(const key of keys) {

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
@@ -27,7 +27,8 @@ import { takeUntil } from "rxjs/operators";
  *
  * Hover highlighting is handled entirely by server-injected CSS using the :has() selector.
  * JS only needs to toggle the "inetsoft-active" class on the hovered bar element.
- * Call activateKey(row, col) / deactivateKey() from the canvas overlay's mouse-event handler.
+ * Call highlightElement(row, col) / highlightElements(pairs) from the canvas overlay's
+ * mouse-event handler; pass null / an empty array to clear.
  */
 @Directive({
    selector: "[chartInlineSvg]"
@@ -80,8 +81,9 @@ export class ChartInlineSvgDirective implements OnDestroy {
     *  Batik renders each character as a separate <g text-rendering> element with the same
     *  data-row/data-col, so every glyph must be stored and toggled together. */
    private labelGroupMap = new Map<string, Element[]>();
-   /** Key of the currently active element, or null. */
-   private _activeKey: string | null = null;
+   /** Keys of the currently active elements; one for a plain hover, many for a stacked bar
+    *  column (every segment activated together so the whole stack stays undimmed). */
+   private _activeKeys: string[] = [];
    /** Cached SVG root of this tile, used to toggle the cross-tile inetsoft-dim-all class. */
    private svgRootEl: SVGSVGElement | null = null;
    /** Timer handle for debounced deactivation, so fast inter-bar moves don't flash. */
@@ -190,73 +192,114 @@ export class ChartInlineSvgDirective implements OnDestroy {
          this.element.nativeElement.innerHTML = "";
          this.elementGroupMap.clear();
          this.labelGroupMap.clear();
-         this._activeKey = null;
+         this._activeKeys = [];
       }
    }
 
    /**
-    * Highlight the bar at rowIdx+colIdx by toggling the "inetsoft-active" CSS class.
-    * The server-injected :has() rule dims all other bars/labels automatically.
-    * Pass null to clear the highlight. Clearing is debounced so rapid inter-bar moves
-    * don't cause a flash.
+    * Highlight a single data element by rowIdx+colIdx. Thin wrapper over
+    * {@link highlightElements}; pass null to clear.
     */
    highlightElement(rowIdx: number | null, colIdx: number | null): void {
-      const key = rowIdx != null ? `${rowIdx}-${colIdx}` : null;
+      this.highlightElements(rowIdx != null ? [{ row: rowIdx, col: colIdx }] : []);
+   }
 
-      if(key !== null) {
+   /**
+    * Highlight one or more data elements by toggling the "inetsoft-active" CSS class on each.
+    * The server-injected :has() rule dims every other bar/label automatically. A stacked bar
+    * column passes one pair per segment so the whole stack stays undimmed; a plain hover passes
+    * a single pair. Pass an empty array to clear. Clearing is debounced so rapid inter-bar
+    * moves don't cause a flash.
+    */
+   highlightElements(pairs: { row: number, col: number }[]): void {
+      if(pairs.length > 0) {
          if(this.clearHandle !== null) {
             clearTimeout(this.clearHandle);
             this.clearHandle = null;
          }
 
-         if(key !== this._activeKey) {
+         const keys = pairs.map(p => `${p.row}-${p.col}`);
+
+         if(!this.sameActiveKeys(keys)) {
             this.deactivateCurrent();
-            this._activeKey = key;
-            this.activateKey(key);
+            this._activeKeys = keys;
+            this.activateKeys(keys);
          }
       }
       else {
-         if(this._activeKey !== null && this.clearHandle === null) {
+         if(this._activeKeys.length > 0 && this.clearHandle === null) {
             this.clearHandle = setTimeout(() => {
                this.clearHandle = null;
                this.deactivateCurrent();
-               this._activeKey = null;
+               this._activeKeys = [];
             }, ChartInlineSvgDirective.CLEAR_DELAY_MS);
          }
       }
    }
 
-   private activateKey(key: string): void {
-      const el = this.elementGroupMap.get(key);
-      if(el) {
-         // Relation in a split chart: the hovered node's neighbours may live in sibling tiles
-         // this tile's connectivity maps can't see. Emit the node id and let the parent resolve
-         // neighbours from the merged graph and drive every tile via setExternalRelationHighlight.
-         if(this.isRelationChart && this.crossTile) {
-            this.emitRelationHover(el.getAttribute("data-id"));
-            return;
-         }
-         el.classList.add("inetsoft-active");
-         if(el.classList.contains("inetsoft-relation")) {
-            this.activateRelationNeighbors(el);
+   /** True when keys match the current active set (same order, same values). */
+   private sameActiveKeys(keys: string[]): boolean {
+      if(keys.length !== this._activeKeys.length) {
+         return false;
+      }
+
+      for(let i = 0; i < keys.length; i++) {
+         if(keys[i] !== this._activeKeys[i]) {
+            return false;
          }
       }
+
+      return true;
+   }
+
+   private activateKeys(keys: string[]): void {
+      // Area/line/radar dim by series color (setExternalSeriesDim), not the inetsoft-active
+      // class; toggling active on their shared point markers would fight that, so honor only
+      // the primary element when a multi-element (stacked) set arrives on such a tile.
+      if(this.usesSeriesColorDim && keys.length > 1) {
+         keys = keys.slice(0, 1);
+         this._activeKeys = keys;
+      }
+
+      let anyFound = false;
+
+      for(const key of keys) {
+         const el = this.elementGroupMap.get(key);
+
+         if(el) {
+            anyFound = true;
+            // Relation in a split chart: the hovered node's neighbours may live in sibling tiles
+            // this tile's connectivity maps can't see. Emit the node id and let the parent resolve
+            // neighbours from the merged graph and drive every tile via setExternalRelationHighlight.
+            // (Relation hover is always single-key, so returning here is safe.)
+            if(this.isRelationChart && this.crossTile) {
+               this.emitRelationHover(el.getAttribute("data-id"));
+               return;
+            }
+            el.classList.add("inetsoft-active");
+            if(el.classList.contains("inetsoft-relation")) {
+               this.activateRelationNeighbors(el);
+            }
+         }
+
+         const glyphs = this.labelGroupMap.get(key);
+         if(glyphs) glyphs.forEach(g => g.classList.add("inetsoft-active"));
+      }
+
       // A large chart is split into multiple SVG tiles. The hovered data point lives in
       // only one tile, so its inetsoft-active class (and the server's :has() dim rule, which
       // is scoped to a single SVG) never reaches sibling tiles. When this tile holds
-      // hover-managed elements but not the active one, flag its root so server CSS dims them.
+      // hover-managed elements but none of the active set, flag its root so server CSS dims them.
       // Skipped for area/line charts (they dim by series color) and cross-tile relation charts
       // (the parent drives per-tile highlight + dim via setExternalRelationHighlight).
-      else if(this.elementGroupMap.size > 0 && this.svgRootEl && !this.usesSeriesColorDim &&
-              !(this.isRelationChart && this.crossTile)) {
+      if(!anyFound && this.elementGroupMap.size > 0 && this.svgRootEl && !this.usesSeriesColorDim &&
+         !(this.isRelationChart && this.crossTile)) {
          this.svgRootEl.classList.add("inetsoft-dim-all");
       }
-      const glyphs = this.labelGroupMap.get(key);
-      if(glyphs) glyphs.forEach(g => g.classList.add("inetsoft-active"));
    }
 
    private deactivateCurrent(): void {
-      if(this._activeKey === null) return;
+      if(this._activeKeys.length === 0) return;
       // Cross-tile relation: the parent set inetsoft-active/dim-all across tiles, so clearing is
       // its job too — emit the clear and don't strip classes locally (that would fight the parent).
       if(this.isRelationChart && this.crossTile) {
@@ -264,18 +307,22 @@ export class ChartInlineSvgDirective implements OnDestroy {
          return;
       }
       if(this.svgRootEl) this.svgRootEl.classList.remove("inetsoft-dim-all");
-      const el = this.elementGroupMap.get(this._activeKey);
-      if(el) el.classList.remove("inetsoft-active");
+
+      for(const key of this._activeKeys) {
+         const el = this.elementGroupMap.get(key);
+         if(el) el.classList.remove("inetsoft-active");
+         const glyphs = this.labelGroupMap.get(key);
+         if(glyphs) glyphs.forEach(g => g.classList.remove("inetsoft-active"));
+      }
+
       for(const n of this.activeRelationNeighbors) {
          n.classList.remove("inetsoft-active");
       }
       this.activeRelationNeighbors = [];
-      const glyphs = this.labelGroupMap.get(this._activeKey);
-      if(glyphs) glyphs.forEach(g => g.classList.remove("inetsoft-active"));
    }
 
    // Activates neighbor nodes, their connecting edges, and neighbor labels.
-   // The hovered node's own label is activated separately by activateKey() via labelGroupMap,
+   // The hovered node's own label is activated separately by activateKeys() via labelGroupMap,
    // and cleared by deactivateCurrent(). Neighbor labels pushed into activeRelationNeighbors
    // are cleared by the activeRelationNeighbors loop in deactivateCurrent().
    private activateRelationNeighbors(nodeEl: Element): void {
@@ -376,7 +423,7 @@ export class ChartInlineSvgDirective implements OnDestroy {
       this.relationNodeIdMap.clear();
       this.relationEdges = [];
       this.activeRelationNeighbors = [];
-      this._activeKey = null;
+      this._activeKeys = [];
       this.svgRootEl = this.element.nativeElement.querySelector("svg");
 
       // Populate the unified element map from all annotated VO groups.
@@ -441,7 +488,7 @@ export class ChartInlineSvgDirective implements OnDestroy {
          }
       }
 
-      // Build relation connectivity maps so activateKey can highlight connected edges/neighbors.
+      // Build relation connectivity maps so activateKeys can highlight connected edges/neighbors.
       const relationNodes = Array.from(
          this.element.nativeElement.querySelectorAll(".inetsoft-relation") as NodeListOf<Element>);
       this.isRelationChart = relationNodes.length > 0;

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.spec.ts
@@ -453,6 +453,38 @@ describe("ChartPlotArea Integration Tests", () => {
       expect(right.region.index).toBe(0);
    });
 
+   it("collects every stacked segment sharing the hovered bar's X column", () => {
+      const fixture = TestBed.createComponent(TestApp);
+      const debugEl = fixture.debugElement.query(By.css("chart-plot-area"));
+      const component: ChartPlotArea = debugEl.componentInstance;
+      vi.spyOn(component, "getSrc").mockImplementation(() => "");
+      fixture.detectChanges();
+      // All mock regions use metaIdx 0; a single meta entry resolves colIdx for every region.
+      (component as any).model = { regionMetaDictionary: [{ colIdx: 0 }] };
+
+      const regions: any[] = component.chartObject.regions;
+      // Indices 3 (rowIdx 1, y 8-75) and 4 (rowIdx 0, y 75-253) are the two segments
+      // of one stacked column (both x 228-247); no other region shares that X.
+      const column = (component as any).collectColumnRegions(regions[3]);
+      const rows = column.map((r: any) => r.rowIdx).sort();
+      expect(rows).toEqual([0, 1]);
+   });
+
+   it("does not expand a point/ellipse region into a bar column", () => {
+      const fixture = TestBed.createComponent(TestApp);
+      const debugEl = fixture.debugElement.query(By.css("chart-plot-area"));
+      const component: ChartPlotArea = debugEl.componentInstance;
+      vi.spyOn(component, "getSrc").mockImplementation(() => "");
+      fixture.detectChanges();
+      (component as any).model = { regionMetaDictionary: [{ colIdx: 0 }] };
+
+      const point = { segTypes: [[9]], pts: [[[[237, 100], [4, 4]]]], centroid: null,
+         index: 99, tipIdx: 30, rowIdx: 60, valIdx: -1, hyperlinks: [],
+         noselect: false, grouped: false, boundaryIdx: -1 };
+      expect((component as any).isBarLikeRegion(point)).toBe(false);
+      expect((component as any).collectColumnRegions(point)).toEqual([point]);
+   });
+
    it("skips wide area polygons when snapping to the nearest point", () => {
       const fixture = TestBed.createComponent(TestApp);
       const debugEl = fixture.debugElement.query(By.css("chart-plot-area"));

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
@@ -414,6 +414,47 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
       return best;
    }
 
+   // Rectangular bar (RECT or straight-line polygon); excludes ELLIPSE points and LINE marks
+   // so the stacked-column expansion never pulls in non-bar regions.
+   private isBarLikeRegion(region: ChartRegion): boolean {
+      const seg = region.segTypes && region.segTypes[0] ? region.segTypes[0][0] : -1;
+      return seg >= 0 && seg !== ChartTool.ELLIPSE && seg !== ChartTool.LINE;
+   }
+
+   // All bar regions stacked in the same X column as the given region: same X-extent within a
+   // 1.5px tolerance. Stacked segments share the column's left/right edges; grouped bars in
+   // adjacent columns and point/line marks do not. Returns at least the region itself.
+   private collectColumnRegions(region: ChartRegion): ChartRegion[] {
+      const base = this.ptsBoundsX(region);
+
+      if(!base) {
+         return [region];
+      }
+
+      const TOL = 1.5;
+      const minX = base.centerX - base.width / 2;
+      const maxX = base.centerX + base.width / 2;
+      const result: ChartRegion[] = [];
+
+      for(const r of this.chartObject.regions) {
+         if(!r || r.rowIdx < 0 || ChartTool.colIdx(this.model, r) < 0 ||
+            !this.isBarLikeRegion(r))
+         {
+            continue;
+         }
+
+         const b = this.ptsBoundsX(r);
+
+         if(b && Math.abs((b.centerX - b.width / 2) - minX) <= TOL &&
+            Math.abs((b.centerX + b.width / 2) - maxX) <= TOL)
+         {
+            result.push(r);
+         }
+      }
+
+      return result.length > 0 ? result : [region];
+   }
+
    private drawSnapGuideline(pixelX: number): void {
       if(!this.referenceLineCanvas) {
          return;
@@ -597,9 +638,24 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
                ? snapPrimary
                : regions?.find(r => r && r.rowIdx >= 0 &&
                   ChartTool.colIdx(this.model, r) >= 0);
-            const rowIdx = voRegion != null ? voRegion.rowIdx : null;
-            const colIdx = voRegion != null ? ChartTool.colIdx(this.model, voRegion) : null;
-            this.inlineSvgTiles?.forEach(d => d.highlightElement(rowIdx, colIdx));
+
+            // Snap buckets by rowIdx, but each segment of a stacked bar column is a distinct
+            // data row at the same X, so the snap primary is only the segment under the
+            // guideline. Activate every segment of that column so the whole stack stays
+            // undimmed rather than just the snapped one.
+            if(voRegion != null && this.model && this.model.snapTooltip &&
+               this.isBarLikeRegion(voRegion))
+            {
+               const pairs = this.collectColumnRegions(voRegion).map(r => ({
+                  row: r.rowIdx, col: ChartTool.colIdx(this.model, r)
+               }));
+               this.inlineSvgTiles?.forEach(d => d.highlightElements(pairs));
+            }
+            else {
+               const rowIdx = voRegion != null ? voRegion.rowIdx : null;
+               const colIdx = voRegion != null ? ChartTool.colIdx(this.model, voRegion) : null;
+               this.inlineSvgTiles?.forEach(d => d.highlightElement(rowIdx, colIdx));
+            }
          }
       }
       else if(!this.dataTip) {

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
@@ -154,6 +154,9 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
    // Snap: cached X ticks → region indices. Rebuilt on chartObject change.
    private snapXTicks: Array<{ pixelX: number, regionIndices: number[] }> = [];
    private snapXTicksFor: Plot = null;
+   // Snap: cached column key (rounded left/right X edge) → bar regions sharing that column.
+   // Rebuilt alongside snapXTicks so collectColumnRegions is an O(1) lookup, not a full scan.
+   private snapColumnMap = new Map<string, ChartRegion[]>();
 
    @HostBinding("style.cursor") hostCursor: string = "inherit";
    private cursorStyle: string = "inherit";
@@ -237,6 +240,7 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
    // representative so point markers beat wide area polygons.
    private rebuildSnapIndex(): void {
       this.snapXTicks = [];
+      this.snapColumnMap = new Map();
       this.snapXTicksFor = this.chartObject;
 
       if(!this.chartObject || !this.chartObject.regions) {
@@ -279,6 +283,26 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
       this.snapXTicks = Array.from(buckets.values())
          .map(b => ({ pixelX: Math.round(b.bestX), regionIndices: b.regionIndices }))
          .sort((a, b) => a.pixelX - b.pixelX);
+
+      // Group bar regions by column key so a stacked column can be resolved with one lookup.
+      // Same filter as collectColumnRegions (bar-like, valid row/col); keyed by ptsBoundsX so
+      // the key matches what collectColumnRegions computes for the hovered region.
+      for(const r of this.chartObject.regions) {
+         if(!r || r.rowIdx < 0 || !this.isBarLikeRegion(r) ||
+            ChartTool.colIdx(this.model, r) < 0)
+         {
+            continue;
+         }
+
+         const cb = this.ptsBoundsX(r);
+
+         if(cb) {
+            const key = this.columnKey(cb);
+            const arr = this.snapColumnMap.get(key);
+            if(arr) arr.push(r);
+            else this.snapColumnMap.set(key, [r]);
+         }
+      }
    }
 
    // Prefer server centroid; fall back to pts-derived bbox.
@@ -415,44 +439,37 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
    }
 
    // Rectangular bar (RECT or straight-line polygon); excludes ELLIPSE points and LINE marks
-   // so the stacked-column expansion never pulls in non-bar regions.
+   // so the stacked-column expansion never pulls in non-bar regions. Area fills also start with
+   // MOVETO (seg 0) and pass, but findPrimarySnapRegion's width filter keeps a wide area polygon
+   // from becoming the snap primary, and area tiles have an empty elementGroupMap, so this is benign.
    private isBarLikeRegion(region: ChartRegion): boolean {
       const seg = region.segTypes && region.segTypes[0] ? region.segTypes[0][0] : -1;
       return seg >= 0 && seg !== ChartTool.ELLIPSE && seg !== ChartTool.LINE;
    }
 
-   // All bar regions stacked in the same X column as the given region: same X-extent within a
-   // 1.5px tolerance. Stacked segments share the column's left/right edges; grouped bars in
-   // adjacent columns and point/line marks do not. Returns at least the region itself.
+   // Column identity key: rounded left/right X edge. Stacked segments share a column's edges
+   // (Batik emits identical x for them) so they collide on one key; grouped bars in adjacent
+   // columns get distinct keys.
+   private columnKey(bounds: { centerX: number, width: number }): string {
+      return `${Math.round(bounds.centerX - bounds.width / 2)}-` +
+             `${Math.round(bounds.centerX + bounds.width / 2)}`;
+   }
+
+   // All bar regions stacked in the same X column as the given region, via the prebuilt
+   // snapColumnMap. Falls back to just the region when its X bounds can't be resolved (no pts);
+   // callers pass a region with a valid col, so the fallback never yields a col<0 pair.
    private collectColumnRegions(region: ChartRegion): ChartRegion[] {
+      if(this.snapXTicksFor !== this.chartObject) {
+         this.rebuildSnapIndex();
+      }
+
       const base = this.ptsBoundsX(region);
 
       if(!base) {
          return [region];
       }
 
-      const TOL = 1.5;
-      const minX = base.centerX - base.width / 2;
-      const maxX = base.centerX + base.width / 2;
-      const result: ChartRegion[] = [];
-
-      for(const r of this.chartObject.regions) {
-         if(!r || r.rowIdx < 0 || ChartTool.colIdx(this.model, r) < 0 ||
-            !this.isBarLikeRegion(r))
-         {
-            continue;
-         }
-
-         const b = this.ptsBoundsX(r);
-
-         if(b && Math.abs((b.centerX - b.width / 2) - minX) <= TOL &&
-            Math.abs((b.centerX + b.width / 2) - maxX) <= TOL)
-         {
-            result.push(r);
-         }
-      }
-
-      return result.length > 0 ? result : [region];
+      return this.snapColumnMap.get(this.columnKey(base)) ?? [region];
    }
 
    private drawSnapGuideline(pixelX: number): void {
@@ -646,9 +663,9 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
             if(voRegion != null && this.model && this.model.snapTooltip &&
                this.isBarLikeRegion(voRegion))
             {
-               const pairs = this.collectColumnRegions(voRegion).map(r => ({
-                  row: r.rowIdx, col: ChartTool.colIdx(this.model, r)
-               }));
+               const pairs = this.collectColumnRegions(voRegion)
+                  .map(r => ({ row: r.rowIdx, col: ChartTool.colIdx(this.model, r) }))
+                  .filter(p => p.col >= 0);
                this.inlineSvgTiles?.forEach(d => d.highlightElements(pairs));
             }
             else {


### PR DESCRIPTION
Fixes the inline-SVG hover dimming for stacked bar charts when
snap-to-nearest-point tooltips are enabled. Previously, hovering a stacked bar highlighted only the
topmost (snapped) segment and dimmed the rest of that same column. The whole stacked column
now stays undimmed.

Root cause: hover dimming toggles inetsoft-active on the hovered bar, and the server-injected svg:has(.inetsoft-bar.inetsoft-active) .inetsoft-bar:not(.inetsoft-active) rule dims everything else. Each segment of a stacked column is a distinct data row (distinct rowIdx) sharing one X position, and the snap index buckets by rowIdx, so
the snap primary is a single segment. The canvas overlay then activated only that onebar.

Changes (all in community):

chart-plot-area.component.ts — In snap mode, collectColumnRegions() gathers every bar region sharing the hovered bar's X-extent (the stacked column) and passes them to the new highlightElements(). isBarLikeRegion() restricts this to rectangular bar regions (RECT or straight-line polygon), excluding ELLIPSE points and LINE marks,
so non-bar charts are untouched. Non-snap hover and single/grouped bars are unchanged.

chart-inline-svg.directive.ts — Generalized single-element highlighting to a set: highlightElement(row,col) is now a thin wrapper over highlightElements(pairs[]), and the active state is tracked as _activeKeys[] rather than a single key. Cross-tile
inetsoft-dim-all is applied only when none of the active set is present in a tile, which also fixes a latent case where a tile holding an active segment plus the dim-all flag would dim that segment. Area/line/radar tiles (series-color dim) honor only the primary so the class-based highlight does not fight setExternalSeriesDim.

Scope of snap: snap support is already gated server-side
(ChartInfo.supportsSnapTooltip) to non-multi-style line/area/bar charts with an X
dimension, and that flows into the client VSChartModel.snapTooltip flag via
GraphBuilder, so unsupported types (mekko, treemap, candle, box, radar, pie, point,
multi-style, flipped) never reach the column-expansion path.