### PR TITLE
fix(wiz): raw-data export returns 400 (not 500) on missing table asset entry

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/RawDataService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/RawDataService.java
@@ -35,7 +35,9 @@ import inetsoft.uql.util.XSourceInfo;
 import inetsoft.util.Tool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -92,11 +94,14 @@ public class RawDataService {
       String datasourcePath = requestData.getDatasourcePath();
       AssetEntry tableEntry = requestData.getTable();
 
-      // Fail fast with a diagnosable message when the request carries no table asset entry.
+      // Fail fast with a diagnosable 400 when the request carries no table asset entry.
       // Callers (e.g. the WIZ annotation profiler) may omit it; without this guard setupTable
-      // dereferences a null AssetEntry and throws an opaque NullPointerException.
+      // dereferences a null AssetEntry and throws an opaque NullPointerException (HTTP 500).
+      // The guard runs before any CSV bytes are written, so the response status is not yet
+      // committed and Spring can return a clean 400 Bad Request.
       if(tableEntry == null) {
-         throw new IllegalArgumentException(
+         throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST,
             "Export request for data source \"" + datasourcePath + "\" is missing the table asset entry.");
       }
 

--- a/core/src/test/java/inetsoft/web/wiz/service/RawDataServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/RawDataServiceTest.java
@@ -22,9 +22,12 @@ import inetsoft.uql.asset.AssetRepository;
 import inetsoft.web.wiz.request.ExportDatabaseTableToCsvRequest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.io.ByteArrayOutputStream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,14 +46,16 @@ class RawDataServiceTest {
       request.setDatasourcePath("inventree");
       request.setTable(null); // the plugin/profiler can omit this — must fail cleanly, not NPE
 
-      IllegalArgumentException ex = assertThrows(
-         IllegalArgumentException.class,
+      ResponseStatusException ex = assertThrows(
+         ResponseStatusException.class,
          () -> service.writeDataSourceTableCsvStream(request, null, new ByteArrayOutputStream()));
 
-      // The message must name the data source so the failure is diagnosable (vs. an opaque NPE).
-      assertNotNull(ex.getMessage());
-      assertTrue(ex.getMessage().contains("inventree"),
-                 "exception message should name the data source: " + ex.getMessage());
+      // A missing table asset entry must surface as a clean 400 Bad Request (not an opaque 500 NPE).
+      assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
+      // The reason must name the data source so the failure is diagnosable.
+      assertNotNull(ex.getReason());
+      assertTrue(ex.getReason().contains("inventree"),
+                 "exception reason should name the data source: " + ex.getReason());
 
       // The guard must run before any repository lookup.
       verifyNoInteractions(xrepository);


### PR DESCRIPTION
## Summary

Follow-up to #4044. That PR added a fail-fast guard for a null table `AssetEntry` in `RawDataService.writeDataSourceTableCsvStream`, but it threw `IllegalArgumentException`, which Spring maps to **HTTP 500** — still opaque to callers.

This changes it to `ResponseStatusException(HttpStatus.BAD_REQUEST, ...)` so a missing table asset entry returns a clean **400** with a diagnosable message. The guard runs before any CSV bytes are written, so the response status is not yet committed and the 400 is delivered correctly.

## Why

The WIZ annotation profiler's `prepare_table` calls this export endpoint. When the request lacked the table asset entry, the original code NPE'd (500), and the wiz side silently fell back to stale stats. The wiz side is now fixed (stylebi-wiz#922 resolves the AssetEntry; stylebi-wiz#923 fails loud), so this endpoint won't be hit with a null entry in normal flow — but returning a clean 400 instead of a 500 makes any future/direct misuse self-explanatory.

Resolves stylebi-wiz#925.

## Change

```diff
-import org.springframework.stereotype.Service;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
@@
-      if(tableEntry == null) {
-         throw new IllegalArgumentException(
-            "Export request for data source \"" + datasourcePath + "\" is missing the table asset entry.");
-      }
+      if(tableEntry == null) {
+         throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST,
+            "Export request for data source \"" + datasourcePath + "\" is missing the table asset entry.");
+      }
```