### PR TITLE
feat(wiz): apply value-sort in create path (sortByCol + ranking auto-derive)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/DimensionFieldInfo.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/DimensionFieldInfo.java
@@ -53,8 +53,17 @@ public class DimensionFieldInfo extends SimpleFieldInfo {
       this.timeSeries = timeSeries;
    }
 
+   public String getSortByCol() {
+      return sortByCol;
+   }
+
+   public void setSortByCol(String sortByCol) {
+      this.sortByCol = sortByCol;
+   }
+
    private String dateGroupLevel;
    private Ranking ranking;
    private String fullName;
    private boolean timeSeries = false;
+   private String sortByCol;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -639,6 +639,40 @@ public class WizAutoBindingService {
       }
    }
 
+   /** Effective sort applied to a dimension ref: (order, sortByCol). Either may be null. */
+   record DimensionSort(Integer order, String sortByCol) {}
+
+   /**
+    * Resolves the effective value-sort for a dimension. Explicit caller order always wins.
+    * When no explicit order is given, a top-N ranking derives value-descending sort and a
+    * bottom-N ranking derives value-ascending sort, both keyed by the ranking column (unless
+    * the caller supplied an explicit sortByCol). timeSeries dimensions get no auto-derive
+    * because createGroupRef discards value-sort for them.
+    */
+   static DimensionSort computeDimensionSort(Integer explicitOrder, String explicitSortByCol,
+                                             Ranking ranking, boolean timeSeries)
+   {
+      Integer order = explicitOrder;
+      String sortByCol = explicitSortByCol;
+
+      if(order == null && ranking != null && !timeSeries) {
+         int opt = ranking.getOptionValue();
+
+         if(opt == 9) {
+            order = XConstants.SORT_VALUE_DESC;
+         }
+         else if(opt == 10) {
+            order = XConstants.SORT_VALUE_ASC;
+         }
+
+         if(order != null && (sortByCol == null || sortByCol.isBlank())) {
+            sortByCol = ranking.getRankingCol();
+         }
+      }
+
+      return new DimensionSort(order, sortByCol);
+   }
+
    private void applyFieldConfig(ChartRef ref, Map<String, SimpleFieldInfo> configMap) {
       String fieldName = WizardRecommenderUtil.getChartRefFieldName(ref);
       SimpleFieldInfo fc = configMap.get(fieldName);
@@ -648,6 +682,10 @@ public class WizAutoBindingService {
       }
 
       if(ref instanceof VSChartDimensionRef dim) {
+         Ranking ranking = null;
+         String explicitSortByCol = null;
+         boolean timeSeries = false;
+
          if(fc instanceof DimensionFieldInfo dimFc) {
             if(dimFc.getRanking() != null) {
                Ranking r = dimFc.getRanking();
@@ -672,10 +710,21 @@ public class WizAutoBindingService {
                            dimFc.getDateGroupLevel(), dimFc.getField());
                }
             }
+
+            ranking = dimFc.getRanking();
+            explicitSortByCol = dimFc.getSortByCol();
+            timeSeries = dimFc.isTimeSeries();
          }
 
-         if(fc.getOrder() != null) {
-            dim.setOrder(fc.getOrder());
+         DimensionSort sort =
+            computeDimensionSort(fc.getOrder(), explicitSortByCol, ranking, timeSeries);
+
+         if(sort.sortByCol() != null && !sort.sortByCol().isBlank()) {
+            dim.setSortByColValue(sort.sortByCol());
+         }
+
+         if(sort.order() != null) {
+            dim.setOrder(sort.order());
          }
       }
       else if(ref instanceof VSChartAggregateRef agg) {

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceValueSortTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceValueSortTest.java
@@ -82,4 +82,12 @@ class WizAutoBindingServiceValueSortTest {
       assertNull(s.order());
       assertNull(s.sortByCol());
    }
+
+   @Test
+   void explicitOrderAndExplicitSortByColBothKept() {
+      DimensionSort s = WizAutoBindingService.computeDimensionSort(
+         XConstants.SORT_DESC, "Max(amount)", ranking(9, "Sum(total_price)"), false);
+      assertEquals(XConstants.SORT_DESC, s.order());
+      assertEquals("Max(amount)", s.sortByCol());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceValueSortTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceValueSortTest.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.XConstants;
+import inetsoft.web.wiz.model.Ranking;
+import inetsoft.web.wiz.service.WizAutoBindingService.DimensionSort;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@Tag("core")
+class WizAutoBindingServiceValueSortTest {
+   private static Ranking ranking(int optionValue, String col) {
+      Ranking r = new Ranking();
+      r.setOptionValue(optionValue);
+      r.setRankingN(25);
+      r.setRankingCol(col);
+      return r;
+   }
+
+   @Test
+   void topNRankingDerivesValueDescSort() {
+      DimensionSort s = WizAutoBindingService.computeDimensionSort(
+         null, null, ranking(9, "Sum(total_price)"), false);
+      assertEquals(XConstants.SORT_VALUE_DESC, s.order());
+      assertEquals("Sum(total_price)", s.sortByCol());
+   }
+
+   @Test
+   void bottomNRankingDerivesValueAscSort() {
+      DimensionSort s = WizAutoBindingService.computeDimensionSort(
+         null, null, ranking(10, "Sum(total_price)"), false);
+      assertEquals(XConstants.SORT_VALUE_ASC, s.order());
+      assertEquals("Sum(total_price)", s.sortByCol());
+   }
+
+   @Test
+   void explicitOrderWinsOverRanking() {
+      DimensionSort s = WizAutoBindingService.computeDimensionSort(
+         XConstants.SORT_DESC, null, ranking(9, "Sum(total_price)"), false);
+      assertEquals(XConstants.SORT_DESC, s.order());
+      assertNull(s.sortByCol());
+   }
+
+   @Test
+   void explicitSortByColKeptWithDerivedOrder() {
+      DimensionSort s = WizAutoBindingService.computeDimensionSort(
+         null, "Max(amount)", ranking(9, "Sum(total_price)"), false);
+      assertEquals(XConstants.SORT_VALUE_DESC, s.order());
+      assertEquals("Max(amount)", s.sortByCol());
+   }
+
+   @Test
+   void timeSeriesSkipsAutoDerive() {
+      DimensionSort s = WizAutoBindingService.computeDimensionSort(
+         null, null, ranking(9, "Sum(total_price)"), true);
+      assertNull(s.order());
+      assertNull(s.sortByCol());
+   }
+
+   @Test
+   void noRankingNoOrderYieldsNothing() {
+      DimensionSort s = WizAutoBindingService.computeDimensionSort(null, null, null, false);
+      assertNull(s.order());
+      assertNull(s.sortByCol());
+   }
+}


### PR DESCRIPTION
## What

`WizAutoBindingService.applyFieldConfig` applied a dimension's `ranking` and `order`, but never a sort-by column — so value-sort (`order` 17/18) was a silent no-op (`VSChartDimensionRef.createGroupRef` bails when `getSortByCol()` is empty). A top-N ranking selected the top values but the bars rendered unsorted.

This change:
- Adds `sortByCol` to `DimensionFieldInfo`.
- Adds a pure helper `computeDimensionSort(explicitOrder, explicitSortByCol, ranking, timeSeries)` that resolves the effective `(order, sortByCol)`:
  - explicit caller `order` always wins;
  - else a top-N ranking (optionValue 9) → `SORT_VALUE_DESC` (18), bottom-N (10) → `SORT_VALUE_ASC` (17), keyed by `rankingCol`;
  - `timeSeries` dimensions skip auto-derive (they stay time-ordered).
- Wires it into `applyFieldConfig`, calling `dim.setSortByColValue(...)` + `dim.setOrder(...)`. Preserves the prior behavior that a plain fieldInfo on a dimension ref still gets its explicit order.

This mirrors the in-place field-edit path's documented ranking→sort rule.

## Testing

- 7 unit tests (`WizAutoBindingServiceValueSortTest`): top-N→DESC, bottom-N→ASC, explicit-order-wins, explicit-sortByCol-kept, timeSeries-skip, no-ranking→null, explicit-order+explicit-sortByCol.
- End-to-end on a locally rebuilt image: a top-25 ranking renders bars descending by `Sum(total_price)` (914K→8.6K); explicit `order:17` flips to ascending — proving `order`/`sortByCol` are honored through to render.

## Note on base

Branched on `fix/rawdataservice-null-table-guard` because the change builds on that branch's `applyFieldConfig` structure. Re-target to `stylebi-wiz-main` once the parent merges.