### PR TITLE
fix(wiz): surface the real data-source error from create_viewsheet (#75484)

### DIFF
--- a/core/src/main/java/inetsoft/report/XSessionManager.java
+++ b/core/src/main/java/inetsoft/report/XSessionManager.java
@@ -522,6 +522,10 @@ public class XSessionManager {
             qvars.copyParameters((XPrincipal) user);
          }
 
+         // Start each execution clean so a stale cause from a prior failed query on this
+         // (possibly pooled) thread is not mis-attributed to a later one.
+         inetsoft.report.internal.XNodeMetaTable.LAST_FAILED_QUERY_MESSAGE.remove();
+
          try {
             node = getXNode(qvars, query, user, queries, item);
             HashMap map = fixHintMaxRow(node, query);
@@ -553,6 +557,10 @@ public class XSessionManager {
                       query, qvars, user, ex);
             Tool.addUserWarning(Catalog.getCatalog().getString("common.table.getDataFailed") +
                                 ": " + ex.getMessage());
+            // Carry the real cause so the failed-query design table built downstream can surface
+            // it (e.g. the wiz auto-binding path) instead of a generic "query failed" message.
+            inetsoft.report.internal.XNodeMetaTable.LAST_FAILED_QUERY_MESSAGE.set(
+               rootCauseMessage(ex));
 
             if(Boolean.TRUE.equals(qvars.get("__is_scheduler__"))) {
                throw ex;
@@ -565,6 +573,25 @@ public class XSessionManager {
          removeQueryInfo(queryId);
          qvars.remove(XQuery.HINT_TOUCH_TIMESTAMP);
       }
+   }
+
+   /**
+    * The message of the deepest (root) cause of a throwable, used to surface the underlying
+    * data-source error (e.g. "column X does not exist") rather than a wrapper message.
+    */
+   private static String rootCauseMessage(Throwable t) {
+      if(t == null) {
+         return null;
+      }
+
+      Throwable root = t;
+
+      while(root.getCause() != null && root.getCause() != root) {
+         root = root.getCause();
+      }
+
+      String msg = root.getMessage();
+      return msg != null && !msg.isBlank() ? msg.trim() : null;
    }
 
    private TableLens buildXTable(XQuery query, XNode node, String queryId,

--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -801,6 +801,7 @@ public abstract class AssetQuery extends PreAssetQuery {
                   }
 
                   base = getDesignTableLens(vars, true);
+                  setFailedQueryMessage(base, expressionException);
                }
                else {
                   throw ex;
@@ -837,6 +838,7 @@ public abstract class AssetQuery extends PreAssetQuery {
 
                   LOG.warn("Failed to get table data: " + ex.getMessage(), ex);
                   base = getDesignTableLens(vars, true);
+                  setFailedQueryMessage(base, ex);
                }
                else {
                   throw ex;
@@ -1031,6 +1033,29 @@ public abstract class AssetQuery extends PreAssetQuery {
    }
 
    /**
+    * Record the underlying failure cause on a failed-query design table so callers can surface
+    * the real error (e.g. the JDBC/SQL message) instead of a generic "query failed" message.
+    * Uses the root cause's message when available. No-op when the base is not a meta table.
+    */
+   private static void setFailedQueryMessage(TableLens base, Throwable cause) {
+      if(!(base instanceof XNodeMetaTable) || cause == null) {
+         return;
+      }
+
+      Throwable root = cause;
+
+      while(root.getCause() != null && root.getCause() != root) {
+         root = root.getCause();
+      }
+
+      String msg = root.getMessage();
+
+      if(msg != null && !msg.isBlank()) {
+         ((XNodeMetaTable) base).setFailedQueryMessage(msg.trim());
+      }
+   }
+
+   /**
     * Get the design mode table lens.
     * @param vars the specified variable table.
     */
@@ -1078,6 +1103,19 @@ public abstract class AssetQuery extends PreAssetQuery {
       XTypeNode output = getXTypeNode(columns);
 
       TableLens base = new XNodeMetaTable(output, failedQueryDefault);
+
+      // When this is a failed-query substitute, carry the underlying cause (captured where the
+      // live query failed, e.g. XSessionManager) so callers can surface the real error instead of
+      // a generic "query failed" message. Consume the thread-local so it is not reused.
+      if(failedQueryDefault) {
+         String cause = XNodeMetaTable.LAST_FAILED_QUERY_MESSAGE.get();
+
+         if(cause != null && !cause.isBlank()) {
+            ((XNodeMetaTable) base).setFailedQueryMessage(cause);
+            XNodeMetaTable.LAST_FAILED_QUERY_MESSAGE.remove();
+         }
+      }
+
       TableDataDescriptor desc = base.getDescriptor();
       XNodeMetaTable.TableDataDescriptor2 desc2 =
          desc instanceof XNodeMetaTable.TableDataDescriptor2

--- a/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
@@ -113,15 +113,21 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
 
          if(base instanceof XNodeMetaTable) {
             boolean failedQuery = ((XNodeMetaTable) base).isFailedQueryDefault();
+            // Capture the underlying failure cause before the meta table is replaced, so it
+            // can be surfaced to callers instead of a generic "query failed" message.
+            String failedQueryMessage = ((XNodeMetaTable) base).getFailedQueryMessage();
             ChartMetaTableGenerator gen = new ChartMetaTableGenerator((XNodeMetaTable) base);
             base = gen.generate(chart);
 
             // The generated sample data replaces the meta table, which would otherwise
             // erase the failed-query marker. Preserve it as a table property so callers
-            // that must not serve fabricated data can still detect the failed query.
+            // that must not serve fabricated data can still detect the failed query. Carry
+            // the real cause as the property value when known (else the legacy "true" flag).
             if(failedQuery && base instanceof AbstractTableLens) {
                ((AbstractTableLens) base).setProperty(
-                  XNodeMetaTable.FAILED_QUERY_PROPERTY, "true");
+                  XNodeMetaTable.FAILED_QUERY_PROPERTY,
+                  failedQueryMessage != null && !failedQueryMessage.isBlank()
+                     ? failedQueryMessage : "true");
             }
 
             ((TableFilter2) data).setTable(base);

--- a/core/src/main/java/inetsoft/report/internal/XNodeMetaTable.java
+++ b/core/src/main/java/inetsoft/report/internal/XNodeMetaTable.java
@@ -288,12 +288,35 @@ public class XNodeMetaTable extends AbstractTableLens {
    }
 
    /**
+    * The underlying failure cause (e.g. the JDBC/SQL error message) captured when the live
+    * query failed and this design meta table was substituted in its place. May be null when
+    * no specific cause was available. Used to surface the real error to callers instead of a
+    * generic "query failed" message.
+    */
+   public String getFailedQueryMessage() {
+      return failedQueryMessage;
+   }
+
+   public void setFailedQueryMessage(String failedQueryMessage) {
+      this.failedQueryMessage = failedQueryMessage;
+   }
+
+   /**
     * Table property used to preserve the failed-query marker when this meta table is
     * replaced by generated sample data (e.g. ChartMetaTableGenerator), so callers that
     * must not serve fabricated data can still detect the failed query downstream.
     */
    public static final String FAILED_QUERY_PROPERTY =
       XNodeMetaTable.class.getName() + ".failedQueryDefault";
+
+   /**
+    * The underlying cause (JDBC/SQL message) of the most recent failed query on this thread.
+    * Set where the live query fails and is swallowed (e.g. XSessionManager), then consumed when
+    * the failed-query design table is built (AssetQuery.getDesignTableLens) so the real error can
+    * be surfaced instead of a generic "query failed" message. Short-lived: cleared on consume and
+    * at the start of each query execution.
+    */
+   public static final ThreadLocal<String> LAST_FAILED_QUERY_MESSAGE = new ThreadLocal<>();
 
    /**
     * Table data descriptor.
@@ -398,4 +421,5 @@ public class XNodeMetaTable extends AbstractTableLens {
    private Object[] examplers;
    private transient TableDataDescriptor descriptor;
    private boolean failedQueryDefault;
+   private String failedQueryMessage;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -634,7 +634,8 @@ public class WizVsService {
     * that meta table with generated sample rows (name1/999.99). The wiz path must surface
     * the failure instead of returning fabricated rows as if they were real query results.
     */
-   private static void checkFailedQuery(XTable lens) {
+   // package-private for testing
+   static void checkFailedQuery(XTable lens) {
       if(lens == null) {
          return;
       }
@@ -643,19 +644,54 @@ public class WizVsService {
       Util.listNestedTable(lens, XTable.class, allTables);
 
       for(XTable t : allTables) {
-         // Two signals, depending on the path: the worksheet/table path surfaces the raw
-         // design meta table (isFailedQueryDefault); the chart path replaces it with
-         // generated sample data carrying FAILED_QUERY_PROPERTY (see ChartVSAQuery).
-         boolean failed = t instanceof XNodeMetaTable meta && meta.isFailedQueryDefault()
-            || t instanceof AbstractTableLens atl
-               && atl.getProperty(XNodeMetaTable.FAILED_QUERY_PROPERTY) != null;
+         String cause = failedQueryCause(t);
 
-         if(failed) {
-            throw new IllegalArgumentException(
-               "Worksheet query failed — a computed-column expression or filter is invalid " +
-               "for the data source. Check the worksheet's expression columns.");
+         if(cause != null) {
+            throw new IllegalArgumentException(failedQueryError(cause));
          }
       }
+   }
+
+   /**
+    * Detect a failed-query table and return its underlying cause. Two signals, depending on the
+    * path: the worksheet/table path surfaces the raw design meta table (isFailedQueryDefault);
+    * the chart path replaces it with generated sample data carrying FAILED_QUERY_PROPERTY (see
+    * ChartVSAQuery). Returns null when the table is not a failed query, an empty string when it
+    * failed but no specific cause was captured, or the cause message (e.g. the JDBC/SQL error).
+    */
+   static String failedQueryCause(XTable t) {
+      if(t instanceof XNodeMetaTable meta && meta.isFailedQueryDefault()) {
+         String cause = meta.getFailedQueryMessage();
+         return cause == null ? "" : cause;
+      }
+
+      if(t instanceof AbstractTableLens atl) {
+         Object prop = atl.getProperty(XNodeMetaTable.FAILED_QUERY_PROPERTY);
+
+         if(prop != null) {
+            // The property value carries the real cause; "true" is the legacy bare flag.
+            return prop instanceof String s && !"true".equals(s) && !s.isBlank() ? s : "";
+         }
+      }
+
+      return null;
+   }
+
+   /**
+    * Compose the user-facing failed-query error, appending the underlying data-source cause
+    * (e.g. "column X does not exist") when known so the caller can fix the real problem instead
+    * of guessing at expression columns.
+    */
+   static String failedQueryError(String cause) {
+      String message =
+         "Worksheet query failed — a computed-column expression or filter is invalid " +
+         "for the data source. Check the worksheet's expression columns.";
+
+      if(cause != null && !cause.isBlank()) {
+         message += " (cause: " + cause + ")";
+      }
+
+      return message;
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceCheckFailedQueryTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceCheckFailedQueryTest.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.report.internal.XNodeMetaTable;
+import inetsoft.report.lens.DefaultTableLens;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The failed-query error must surface the underlying data-source cause (the real JDBC/SQL error)
+ * when the failed-query table carries one, instead of only the generic "query failed" text.
+ * Regression for the swallowed-error bug (Redmine #75484).
+ */
+@Tag("core")
+class WizVsServiceCheckFailedQueryTest {
+   @Test
+   void surfacesUnderlyingCauseFromProperty() {
+      // The chart path replaces the failed meta table with generated sample data and carries the
+      // real cause as the FAILED_QUERY_PROPERTY value (see ChartVSAQuery).
+      DefaultTableLens lens = new DefaultTableLens(1, 1);
+      lens.setProperty(XNodeMetaTable.FAILED_QUERY_PROPERTY,
+                       "ERROR: column company_company.supplier_id does not exist");
+
+      String cause = WizVsService.failedQueryCause(lens);
+      assertTrue("ERROR: column company_company.supplier_id does not exist".equals(cause),
+                 "should extract the cause from the property, was: " + cause);
+
+      String message = WizVsService.failedQueryError(cause);
+      // The original generic guidance is preserved...
+      assertTrue(message.contains("Worksheet query failed"),
+                 "should keep the generic guidance, was: " + message);
+      // ...and the real cause is appended so the caller can act on it.
+      assertTrue(message.contains("company_company.supplier_id does not exist"),
+                 "should surface the underlying cause, was: " + message);
+   }
+
+   @Test
+   void stillReportsFailureWithGenericWhenNoCause() {
+      // Legacy bare "true" flag (no cause captured): still detected as failed, but no "(cause:".
+      DefaultTableLens lens = new DefaultTableLens(1, 1);
+      lens.setProperty(XNodeMetaTable.FAILED_QUERY_PROPERTY, "true");
+
+      String cause = WizVsService.failedQueryCause(lens);
+      assertTrue("".equals(cause), "failed-with-no-cause should be empty string, was: " + cause);
+
+      String message = WizVsService.failedQueryError(cause);
+      assertTrue(message.contains("Worksheet query failed"),
+                 "should keep the generic guidance, was: " + message);
+      assertFalse(message.contains("(cause:"),
+                  "should not append an empty cause, was: " + message);
+   }
+
+   @Test
+   void returnsNullForCleanTable() {
+      DefaultTableLens lens = new DefaultTableLens(1, 1);
+      assertNull(WizVsService.failedQueryCause(lens),
+                 "a table with no failed-query marker is not a failure");
+   }
+}


### PR DESCRIPTION
## Problem (Redmine #75484)

When a worksheet query failed, the wiz auto-binding path threw a fixed generic message — *"a computed-column expression or filter is invalid for the data source. Check the worksheet's expression columns."* — regardless of the real cause. The actual JDBC/SQL error (e.g. `column "x" does not exist`) was only logged inside the container and never returned, so a deployed user — with no log access — got a misleading diagnosis and no path forward.

## Root cause

The live query fails and is **swallowed in `XSessionManager.getXNodeTableLens`** (logged, returns a null table). `AssetQuery` then substitutes a failed-query design meta table with no exception in hand, so the cause was already gone before `WizVsService.checkFailedQuery` ran. The wiz-services plugin already propagates whatever StyleBI returns — StyleBI just returned nothing useful.

## Fix — thread the cause through (5 files)

- **`XNodeMetaTable`** — instance `failedQueryMessage` + a short-lived `LAST_FAILED_QUERY_MESSAGE` thread-local bridge.
- **`XSessionManager`** — capture the root-cause message in the swallowing catch; clear the bridge at each execution start (avoids stale reuse on pooled threads).
- **`AssetQuery.getDesignTableLens`** — consume the bridge into the failed meta table (covers all failure paths); also capture the in-hand exception on the expression/generic catches.
- **`ChartVSAQuery`** — carry the cause as the `FAILED_QUERY_PROPERTY` value instead of the bare `"true"` flag (existing readers only null-check it).
- **`WizVsService.checkFailedQuery`** — append `(cause: …)` when known; extracted pure helpers (`failedQueryCause` / `failedQueryError`) for unit testing.

## Verification

- Unit test `WizVsServiceCheckFailedQueryTest` (cause-from-property / generic-when-no-cause / clean-table) — 3/3 green via `mvn -o -pl community/core test`.
- Live end-to-end on a locally-built image: a SQL query table selecting a non-existent column now returns
  `create_viewsheet: Failed to create viewsheet: Worksheet query failed — … Check the worksheet's expression columns. (cause: ERROR: column "this_column_does_not_exist" does not exist  Position: 201)`
- Regression: valid charts still render (25 rows, no spurious error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)