### PR TITLE
feat(wiz): add saved-visualization verify endpoint (#75485)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -28,6 +28,7 @@ import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.util.Tool;
 import inetsoft.web.wiz.model.CloseViewsheetRequest;
 import inetsoft.web.wiz.model.OpenViewsheetResult;
+import inetsoft.web.wiz.model.VerifyViewsheetResult;
 import inetsoft.web.wiz.service.WizVisualizationService;
 import inetsoft.web.wiz.service.WizVsService;
 import jakarta.validation.Valid;
@@ -131,6 +132,98 @@ public class ViewsheetRuntimeController {
       }
 
       return result;
+   }
+
+   /**
+    * Verify that a saved visualization actually renders: open it into a throwaway runtime,
+    * execute its chart server-side, and report whether it produced data (hasData + rowCount).
+    * When the underlying query failed, the real data-source cause is returned in {@code error}
+    * (hasData=false) rather than thrown — a failed render is the answer, not an exception.
+    * The runtime is always closed before returning, so this is non-destructive and does not
+    * affect the caller's active chart.
+    *
+    * @param identifier the asset entry identifier of the saved visualization
+    * @param user       the current principal
+    * @return the verification result (hasData, rowCount, optional error)
+    */
+   @PostMapping(value = "/viewsheet/verify", produces = MediaType.APPLICATION_JSON_VALUE)
+   public VerifyViewsheetResult verifyViewsheet(@RequestParam("identifier") String identifier,
+                                                @RequestParam(value = "sampleMaxRows", required = false) Integer sampleMaxRows,
+                                                Principal user) throws Exception
+   {
+      AssetEntry entry = AssetEntry.createAssetEntry(identifier);
+
+      if(entry == null) {
+         throw new IllegalArgumentException("Invalid viewsheet identifier: " + identifier);
+      }
+
+      String path = entry.getPath();
+
+      // Accept the same managed folders as openViewsheet (session + saved-components).
+      if(path == null ||
+         !(path.startsWith(WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/") ||
+           path.startsWith(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/")))
+      {
+         throw new IllegalArgumentException(
+            "Viewsheet is not in the managed visualizations folder: " + path);
+      }
+
+      VerifyViewsheetResult result = new VerifyViewsheetResult();
+      result.setViewsheetIdentifier(identifier);
+
+      String runtimeId = viewsheetService.openViewsheet(entry, user, true);
+
+      try {
+         VSAssembly assembly = findChartAssembly(runtimeId, user);
+
+         if(assembly == null) {
+            result.setError("No chart assembly found in the saved visualization");
+            return result;
+         }
+
+         result.setAssemblyName(assembly.getName());
+
+         RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, user);
+
+         if(rvs == null) {
+            result.setError("Runtime viewsheet not found after open");
+            return result;
+         }
+
+         if(sampleMaxRows != null && sampleMaxRows > 0) {
+            try {
+               var bws = rvs.getViewsheet() != null ? rvs.getViewsheet().getBaseWorksheet() : null;
+
+               if(bws != null) {
+                  bws.getWorksheetInfo().setDesignMaxRows(sampleMaxRows);
+               }
+            }
+            catch(Exception ex) {
+               log.warn("Failed to apply sampled-preview cap on verify: {}", ex.getMessage());
+            }
+         }
+
+         try {
+            WizVsService.VerifyResult vr = wizVsService.verifyChartData(rvs, assembly.getName());
+            result.setHasData(vr.hasData());
+            result.setRowCount(vr.rowCount());
+         }
+         catch(IllegalArgumentException e) {
+            // Failed query: surface the real data-source cause instead of throwing.
+            result.setHasData(false);
+            result.setError(e.getMessage());
+         }
+
+         return result;
+      }
+      finally {
+         try {
+            viewsheetService.closeViewsheet(runtimeId, user);
+         }
+         catch(Exception ignore) {
+            log.warn("Failed to close runtime [{}] after verify", runtimeId);
+         }
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/model/VerifyViewsheetResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/VerifyViewsheetResult.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Result of verifying that a saved wiz visualization actually renders: whether the chart
+ * produced data, the row count, and — when the underlying query failed — the real
+ * data-source error. Unlike opening, verification executes the chart server-side so a save
+ * that reopens empty or errors can be detected without a browser embed.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class VerifyViewsheetResult {
+   public String getViewsheetIdentifier() {
+      return viewsheetIdentifier;
+   }
+
+   public void setViewsheetIdentifier(String viewsheetIdentifier) {
+      this.viewsheetIdentifier = viewsheetIdentifier;
+   }
+
+   public String getAssemblyName() {
+      return assemblyName;
+   }
+
+   public void setAssemblyName(String assemblyName) {
+      this.assemblyName = assemblyName;
+   }
+
+   public boolean isHasData() {
+      return hasData;
+   }
+
+   public void setHasData(boolean hasData) {
+      this.hasData = hasData;
+   }
+
+   public int getRowCount() {
+      return rowCount;
+   }
+
+   public void setRowCount(int rowCount) {
+      this.rowCount = rowCount;
+   }
+
+   public String getError() {
+      return error;
+   }
+
+   public void setError(String error) {
+      this.error = error;
+   }
+
+   private String viewsheetIdentifier;
+   private String assemblyName;
+   private boolean hasData;
+   private int rowCount;
+   private String error;
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -812,6 +812,62 @@ public class WizVsService {
       }
    }
 
+   /** Outcome of executing a chart assembly for verification: did it render data, and how many rows. */
+   public record VerifyResult(boolean hasData, int rowCount) {}
+
+   /**
+    * Execute a chart assembly's data to verify the saved visualization actually renders, without
+    * materializing the rows. Surfaces the real data-source error by throwing (via checkFailedQuery)
+    * when the underlying query failed and design sample data was substituted. Returns hasData=false
+    * with rowCount=0 when the sandbox/graph/dataset is simply unavailable.
+    */
+   public VerifyResult verifyChartData(RuntimeViewsheet rvs, String assemblyName) throws Exception {
+      Optional<ViewsheetSandbox> boxOpt = rvs.getViewsheetSandbox();
+
+      if(boxOpt.isEmpty()) {
+         return new VerifyResult(false, 0);
+      }
+
+      ViewsheetSandbox box = boxOpt.get();
+      VGraphPair pair = box.getVGraphPair(assemblyName, true);
+
+      if(pair == null) {
+         return new VerifyResult(false, 0);
+      }
+
+      DataSet dset = pair.getData();
+
+      if(dset == null) {
+         return new VerifyResult(false, 0);
+      }
+
+      // Unwrap dataset wrappers to reach the aggregated data (mirrors extractChartData).
+      DataSet unwrapped = dset;
+
+      while(true) {
+         if(unwrapped instanceof VSDataSet) {
+            break;
+         }
+         else if(unwrapped instanceof PairsDataSet) {
+            unwrapped = ((PairsDataSet) unwrapped).getDataSet();
+         }
+         else if(unwrapped instanceof DataSetFilter) {
+            unwrapped = ((DataSetFilter) unwrapped).getDataSet();
+         }
+         else {
+            break;
+         }
+      }
+
+      if(unwrapped instanceof VSDataSet vds) {
+         // Throws IllegalArgumentException carrying the real cause when the query failed.
+         checkFailedQuery(vds.getTable());
+      }
+
+      int rowCount = dset.getRowCount();
+      return new VerifyResult(rowCount > 0, rowCount);
+   }
+
    /**
     * Extracts tabular data from a Table or Crosstab assembly via its TableLens.
     * Row 0 through headerRowCount-1 are header rows; data begins at headerRowCount.


### PR DESCRIPTION
## Problem (Redmine #75485)

A saved visualization can reopen **empty** or fail at query time with no server-side signal. `/viewsheet/open` deliberately does *not* execute the chart (the browser renders it on demand), so `save_viewsheet` / `reload_saved_visualization` report success even when the chart won't render. The failure is invisible without a browser embed — discovered only when a human says "the chart is empty."

## Change

A non-destructive **verify** path:
- **`WizVsService.verifyChartData(rvs, assembly)`** — executes the chart's data (`getVGraphPair`) and reports `{hasData, rowCount}` without materializing rows; reuses `checkFailedQuery` so a failed query throws the real data-source cause (builds on #75484).
- **`VerifyViewsheetResult`** — `{viewsheetIdentifier, assemblyName, hasData, rowCount, error}`.
- **`ViewsheetRuntimeController` `POST /viewsheet/verify`** — opens the saved id in a throwaway runtime, executes, returns the result (a failed query is reported in `error`, not thrown), and **always closes** the runtime, so it never disturbs the caller's active chart.

Backed by a new wiz-services route (`/v1/visualizations/verify`) and a read-only `verify_visualization` MCP tool in the stylebi-wiz repo (separate PR).

## Verification

Live on a locally-built image:
- Good save → `hasData=true, rowCount=25`
- 0-row save (`WHERE status=999`) → `hasData=false, rowCount=0`
- Runtime opened-executed-**closed** cleanly (non-destructive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)