### PR TITLE
fix(wiz): make a reopened saved visualization re-bindable in place (#75486)

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
@@ -5551,6 +5551,10 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
       return wizInfo;
    }
 
+   public void setWizInfo(WizInfo wizInfo) {
+      this.wizInfo = wizInfo;
+   }
+
    public void syncWizData(Viewsheet source) {
       this.wizInfo = source.getWizInfo();
       this.chatSessionId = source.getChatSessionId();

--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -100,6 +100,30 @@ public class ViewsheetRuntimeController {
          result.setBinding(wizVsService.collectFlatBinding(assembly));
       }
 
+      // #75486: make a reopened saved viz re-bindable in place. Return its base worksheet
+      // identifier (update_binding re-runs autoBinding against this worksheet), and ensure the
+      // runtime carries WizInfo — a plain reopen does not configure it, so getValidatedViewsheet
+      // would otherwise reject the re-bind with "Runtime Viewsheet does not have WizInfo
+      // configured". These viewsheets live in the managed wiz folders (validated above), so marking
+      // the reopened runtime as a wiz visualization is correct. Idempotent: only set when missing.
+      try {
+         RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, user);
+         Viewsheet vs = rvs != null ? rvs.getViewsheet() : null;
+
+         if(vs != null) {
+            if(vs.getBaseEntry() != null) {
+               result.setWorksheetIdentifier(vs.getBaseEntry().toIdentifier());
+            }
+
+            if(vs.getWizInfo() == null) {
+               vs.setWizInfo(new Viewsheet.WizInfo(true, null, null));
+            }
+         }
+      }
+      catch(Exception ex) {
+         log.warn("Could not configure reopened wiz runtime {} for re-binding: {}", runtimeId, ex.getMessage());
+      }
+
       // #75456: sampled-preview mode for the live viewer. The reopened runtime renders on demand when
       // the browser embeds it; set the source worksheet's design-max cap now (before that render) and
       // drop any pre-rendered full-data result so the embed aggregates at most sampleMaxRows rows.

--- a/core/src/main/java/inetsoft/web/wiz/model/OpenViewsheetResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/OpenViewsheetResult.java
@@ -51,7 +51,18 @@ public class OpenViewsheetResult {
       this.binding = binding;
    }
 
+   public String getWorksheetIdentifier() {
+      return worksheetIdentifier;
+   }
+
+   public void setWorksheetIdentifier(String worksheetIdentifier) {
+      this.worksheetIdentifier = worksheetIdentifier;
+   }
+
    private String runtimeId;
    private String assemblyName;
    private CreateViewsheetResult.FlatBinding binding;
+   // The reopened viewsheet's base worksheet identifier, so callers can re-bind in place
+   // (update_binding re-runs autoBinding against this worksheet) without rebuilding. See #75486.
+   private String worksheetIdentifier;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1302,8 +1302,13 @@ public class WizVsService {
 
          String existingPath = entry.getPath();
 
+         // Accept both managed folders: ROOT holds session viewsheets, COMPONENTS holds standalone
+         // saved visualizations (the Wiz Portal Visualizations tab). A reloaded saved viz being
+         // re-bound in place (#75486) lives in COMPONENTS, so restricting to ROOT alone rejected
+         // every saved-chart re-bind (mirrors the open endpoint's #3901 fix).
          if(existingPath == null ||
-            !existingPath.startsWith(WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/"))
+            !(existingPath.startsWith(WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/") ||
+              existingPath.startsWith(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/")))
          {
             throw new IllegalArgumentException(
                "viewsheetIdentifier points outside the managed visualizations folder: " + existingPath);


### PR DESCRIPTION
## Problem (Redmine #75486)

After `reload_saved_visualization`, `update_binding` failed — a trivial edit (reverse sort, change aggregate) on a reloaded saved chart required a full recreate-from-worksheet. Three gates blocked in-place re-bind:
1. no backing worksheet id was returned on reopen;
2. the reopened runtime lacked **WizInfo** (`update_binding` → *"Runtime Viewsheet does not have WizInfo configured"*);
3. the persist guard rejected the saved id's folder.

## Change

- **`ViewsheetRuntimeController` `/viewsheet/open`** — return the base worksheet identifier (`OpenViewsheetResult.worksheetIdentifier`) so callers can re-bind against it; and **configure WizInfo on the reopened runtime when missing** (a plain reopen doesn't set it). These viewsheets are in the managed wiz folders, so marking them wiz visualizations is correct; idempotent.
- **`Viewsheet.setWizInfo`** — setter so the reopen path can configure it.
- **`WizVsService.persistViewsheet`** — accept the `visualization-components-…` folder in addition to ROOT for an existing `viewsheetIdentifier` (a saved viz lives in COMPONENTS; ROOT-only rejected every saved-chart re-bind — mirrors the open endpoint's #3901 fix).

Paired with stylebi-wiz: reload returns `worksheetIdentifier`, the plugin stores it as `wsId`, and `update_binding` re-runs autoBinding against it.

## Verification

Live on a locally-built image: open a saved viz → `worksheetIdentifier` returned; then `update_binding` (Sum→Average) re-binds **in place** — 25 rows, saved identifier preserved, no recreate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)