### PR TITLE
Restore schedule tab UI lost when 563ab05dd overwrote PR #3733 files

### DIFF
--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.html
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.html
@@ -423,7 +423,7 @@
                       !!form.controls['attachmentName'].errors['containsInvalidWindowsChars']) {
                       <span class="invalid-feedback"
                         >
-                        schedule.task.name.invalid)
+                        _#(schedule.task.name.invalid)
                       </span>
                     }
                   </div>

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.html
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.html
@@ -16,11 +16,10 @@
 ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 @if (action && form) {
-  <div class="action-accordion-content">
-    <form [formGroup]="form">
+  <form [formGroup]="form" class="action-accordion-form">
       @if (isDashboard) {
-        <div class="card m-1">
-          <div class="card-body">
+        <div class="card action-accordion-card">
+          <div class="card-body action-accordion-card__body">
             <label class="form-check-label card-title">_#(Bookmarks)</label>
             <div class="action-accordion__row-start row">
               <div class="col form-floating">
@@ -37,7 +36,7 @@
               </div>
             </div>
             <div class="action-accordion__row-start row">
-              <div class="col-10">
+              <div class="col-10 action-accordion-bookmark-list-col">
                 <generic-selectable-list [itemList]="bookmarkList"
                   [selectedIndex]="selectedBookmarkListIndex"
                 (selectedIndexChange)="editBookmark($event)"></generic-selectable-list>
@@ -61,8 +60,8 @@
         </div>
       }
       @if (model.notificationEmailEnabled) {
-        <div class="card m-1">
-          <div class="card-body">
+        <div class="card action-accordion-card">
+          <div class="card-body action-accordion-card__body">
             <div class="form-check form-switch action-accordion__section-toggle">
               <input class="form-check-input" type="checkbox" role="switch" id="notification"
                 [ngModelOptions]="{standalone: true}"
@@ -144,8 +143,8 @@
         </div>
       }
       @if (model.emailDeliveryEnabled) {
-        <div class="card m-1">
-          <div class="card-body">
+        <div class="card action-accordion-card">
+          <div class="card-body action-accordion-card__body">
             <div class="form-check form-switch action-accordion__section-toggle">
               <input class="form-check-input" type="checkbox" role="switch" id="deliverEmail"
                 [ngModelOptions]="{standalone: true}"
@@ -463,8 +462,8 @@
         </div>
       }
       @if (model.saveToDiskEnabled) {
-        <div class="card m-1">
-          <div class="card-body">
+        <div class="card action-accordion-card">
+          <div class="card-body action-accordion-card__body">
             <div class="form-check form-switch action-accordion__section-toggle">
               <input class="form-check-input" type="checkbox" role="switch" id="saveToServer"
                 [ngModelOptions]="{standalone: true}"
@@ -675,8 +674,8 @@
           </div>
         </div>
       }
-      <div class="card m-1">
-        <div class="card-body">
+      <div class="card action-accordion-card">
+        <div class="card-body action-accordion-card__body">
           <label class="form-check-label card-title">_#(Creation Parameters)</label>
           <parameter-table [(parameters)]="parameters"
             [parameterNames]="allParameters"
@@ -701,8 +700,8 @@
       </div>
     </div>
     @if (!!highlights && highlights.length > 0) {
-      <div class="card m-1">
-        <div class="card-body">
+      <div class="card action-accordion-card">
+        <div class="card-body action-accordion-card__body">
           <label class="form-check-label card-title">_#(Alert)</label>
           <div class="form-check form-switch action-accordion__section-toggle">
             <input class="form-check-input" type="checkbox" role="switch" name="underHighlightCondition"
@@ -758,7 +757,6 @@
       </div>
     }
   </form>
-</div>
 }
 <ng-template #emailAddrDialog let-close="close" let-dismiss="dismiss">
   <email-addr-dialog (onCommit)="close($event)" (onCancel)="dismiss($event)"

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/task-action-pane.component.html
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/task-action-pane.component.html
@@ -70,11 +70,11 @@
       </button>
       <button type="button" class="btn btn-secondary" (click)="save(true)"
       [disabled]="!isValid()">_#(Save)</button>
-      <button type="button" class="btn btn-secondary ms-2" (click)="closeEditor.emit(model)">
+      <button type="button" class="btn btn-secondary" (click)="closeEditor.emit(model)">
         _#(Close)
       </button>
       @if (newTask) {
-        <button type="button" class="btn btn-secondary ms-2" (click)="cancelTask.emit()">
+        <button type="button" class="btn btn-secondary" (click)="cancelTask.emit()">
           _#(Cancel)
         </button>
       }
@@ -89,19 +89,19 @@
   </div>
   <div class="task-action-pane__list-footer">
     <button type="button" class="btn btn-secondary" (click)="addAction()">_#(Add)</button>
-    <button type="button" class="btn btn-secondary ms-2" (click)="copyAction()"
+    <button type="button" class="btn btn-secondary" (click)="copyAction()"
     [disabled]="selectedActions.length != 1 || model.actions.length < 1">_#(Copy)</button>
     <button type="button" class="btn btn-secondary delete-button-id" (click)="deleteAction()"
     [disabled]="selectedActions.length < 1 || model.actions.length < 1">_#(Delete)</button>
-    <button type="button" class="btn btn-secondary ms-2"
+    <button type="button" class="btn btn-secondary"
       [disabled]="selectedActions.length != 1 || model.actions.length < 1"
     (click)="editAction()">_#(Edit)</button>
-    <button type="button" class="btn btn-secondary ms-2"
+    <button type="button" class="btn btn-secondary"
     (click)="save(true)">_#(Save)</button>
-    <button type="button" class="btn btn-secondary ms-2"
+    <button type="button" class="btn btn-secondary"
     (click)="closeEditor.emit(model)">_#(Close)</button>
     @if (newTask) {
-      <button type="button" class="btn btn-secondary ms-2" (click)="cancelTask.emit()">
+      <button type="button" class="btn btn-secondary" (click)="cancelTask.emit()">
         _#(Cancel)
       </button>
     }

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/task-action-pane.component.html
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/task-action-pane.component.html
@@ -16,10 +16,10 @@
 ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 @if (!listView && !!form) {
-  <div class="container-fluid p-1">
+  <div class="task-action-pane">
     <form [formGroup]="form" class="task-action-pane__form">
       <div class="row task-action-pane__selector-row">
-        <div class="col-8 form-floating">
+        <div class="col-8 form-floating task-action-pane__selector-col">
           @if (action.actionType == 'ViewsheetAction' && model.viewsheetEnabled) {
             <div class="input-group input-with-actions scheduler-form"
               >
@@ -70,11 +70,11 @@
       </button>
       <button type="button" class="btn btn-secondary" (click)="save(true)"
       [disabled]="!isValid()">_#(Save)</button>
-      <button type="button" class="btn btn-default ms-2" (click)="closeEditor.emit(model)">
+      <button type="button" class="btn btn-secondary ms-2" (click)="closeEditor.emit(model)">
         _#(Close)
       </button>
       @if (newTask) {
-        <button type="button" class="btn btn-default ms-2" (click)="cancelTask.emit()">
+        <button type="button" class="btn btn-secondary ms-2" (click)="cancelTask.emit()">
           _#(Cancel)
         </button>
       }
@@ -89,19 +89,19 @@
   </div>
   <div class="task-action-pane__list-footer">
     <button type="button" class="btn btn-secondary" (click)="addAction()">_#(Add)</button>
-    <button type="button" class="btn btn-default ms-2" (click)="copyAction()"
+    <button type="button" class="btn btn-secondary ms-2" (click)="copyAction()"
     [disabled]="selectedActions.length != 1 || model.actions.length < 1">_#(Copy)</button>
     <button type="button" class="btn btn-secondary delete-button-id" (click)="deleteAction()"
     [disabled]="selectedActions.length < 1 || model.actions.length < 1">_#(Delete)</button>
-    <button type="button" class="btn btn-default ms-2"
+    <button type="button" class="btn btn-secondary ms-2"
       [disabled]="selectedActions.length != 1 || model.actions.length < 1"
     (click)="editAction()">_#(Edit)</button>
-    <button type="button" class="btn btn-default ms-2"
+    <button type="button" class="btn btn-secondary ms-2"
     (click)="save(true)">_#(Save)</button>
-    <button type="button" class="btn btn-default ms-2"
+    <button type="button" class="btn btn-secondary ms-2"
     (click)="closeEditor.emit(model)">_#(Close)</button>
     @if (newTask) {
-      <button type="button" class="btn btn-default ms-2" (click)="cancelTask.emit()">
+      <button type="button" class="btn btn-secondary ms-2" (click)="cancelTask.emit()">
         _#(Cancel)
       </button>
     }

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/options/task-options-pane.component.html
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/options/task-options-pane.component.html
@@ -16,8 +16,8 @@
 ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <form [formGroup]="form">
-  <div class="container-fluid">
-    <div class="row shell-form-row--field">
+  <div class="task-options-pane">
+    <div class="row shell-form-row--field task-options-pane__row">
       <div class="col">
         <div class="form-check">
           <input class="form-check-input" type="checkbox" [(ngModel)]="_model.enabled" id="enabled"
@@ -38,7 +38,7 @@
         </div>
       </div>
     </div>
-    <div class="row shell-form-row--field">
+    <div class="row shell-form-row--field task-options-pane__row">
       <div class="col">
         <div class="form-floating">
           <div class="input-group task-options-pane__date-group">
@@ -51,7 +51,7 @@
               (click)="startDatePicker.toggle(); endDatePicker.close()" type="button">
               <span class="calendar-icon icon-size-medium align-middle"></span>
             </button>
-            <button type="button" class="input-group-button btn btn-default"
+            <button type="button" class="input-group-button btn btn-secondary task-options-pane__action-button"
               (click)="clearStartDate()">
               _#(Clear)
             </button>
@@ -60,7 +60,7 @@
         </div>
       </div>
     </div>
-    <div class="row shell-form-row--field">
+    <div class="row shell-form-row--field task-options-pane__row">
       <div class="col">
         <div class="form-floating">
           <div class="input-group task-options-pane__date-group">
@@ -74,7 +74,7 @@
               (click)="endDatePicker.toggle(); startDatePicker.close()" type="button">
               <span class="calendar-icon icon-size-medium align-middle"></span>
             </button>
-            <button type="button" class="input-group-button btn btn-default"
+            <button type="button" class="input-group-button btn btn-secondary task-options-pane__action-button"
               (click)="clearEndDate()">
               _#(Clear)
             </button>
@@ -89,13 +89,13 @@
       </div>
     </div>
 
-    <div class="row shell-form-row--field">
+    <div class="row shell-form-row--field task-options-pane__row">
       <div class="col form-floating">
         <custom-select [options]="timeZoneSelectOptions" formControlName="timeZone"></custom-select>
         <label>_#(Time Zone)</label>
       </div>
     </div>
-    <div class="row shell-form-row--field">
+    <div class="row shell-form-row--field task-options-pane__row">
       <div class="col form-floating">
         <div class="input-group btn-group task-options-pane__execute-as-group">
           <custom-select class="w-auto"
@@ -113,15 +113,15 @@
               </div>
             }
           </div>
-          <button type="button" class="input-group-button btn btn-default"
+          <button type="button" class="input-group-button btn btn-secondary task-options-pane__action-button"
           (click)="clearUser()" [disabled]="disableExecuteAs()">_#(Clear)</button>
-          <button type="button" class="input-group-button btn btn-default"
+          <button type="button" class="input-group-button btn btn-secondary task-options-pane__action-button"
           [disabled]="disableExecuteAs()" (click)="openExecuteAsDialog()">_#(Select)</button>
         </div>
         <label>_#(Execute As)</label>
       </div>
     </div>
-    <div class="row shell-form-row--field">
+    <div class="row shell-form-row--field task-options-pane__row">
       <div class="col form-floating">
         <custom-select [options]="localeSelectOptions"
                          [(ngModel)]="locale"
@@ -130,14 +130,14 @@
         <label>_#(Locale)</label>
       </div>
     </div>
-    <div class="row shell-form-row--field" [style.display]="_model.securityEnabled ? null : 'none'">
+    <div class="row shell-form-row--field task-options-pane__row" [style.display]="_model.securityEnabled ? null : 'none'">
       <div class="col form-floating">
         <input class="form-control" [ngModel]="_model.ownerAlias ? _model.ownerAlias : _model.owner"
           [disabled]="true" [ngModelOptions]="{standalone: true}">
         <label>_#(Owner)</label>
       </div>
     </div>
-    <div class="row shell-form-row--field">
+    <div class="row shell-form-row--field task-options-pane__row">
       <div class="col form-floating">
         <input type="text" class="form-control" [(ngModel)]="_model.description"
           [ngModelOptions]="{standalone: true}">
@@ -149,11 +149,11 @@
         [disabled]="!form.valid || !parentForm.valid">
         _#(Save)
       </button>
-      <button type="button" class="btn btn-default" (click)="closeEditor.emit(_model)">
+      <button type="button" class="btn btn-secondary" (click)="closeEditor.emit(_model)">
         _#(Close)
       </button>
       @if (newTask) {
-        <button type="button" class="btn btn-default" (click)="cancelTask.emit()">
+        <button type="button" class="btn btn-secondary" (click)="cancelTask.emit()">
           _#(Cancel)
         </button>
       }

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/options/task-options-pane.component.scss
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/options/task-options-pane.component.scss
@@ -74,6 +74,7 @@
 
 .task-options-pane__action-button {
   flex: 0 0 auto;
+  margin-bottom: 0;
 }
 
 .task-options-pane__footer {

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.html
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.html
@@ -16,23 +16,58 @@
 ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <div class="portal-schedule-task-list">
-  <div class="d-flex align-items-center portal-task-tool-bar">
-    <button class="d-flex btn btn-sm btn-light-no-bg me-1"
-      (click)="changeShowType(!showTasksAsList)"
-      [title]="showTasksAsList ? '_#(schedule.task.toggle.toFolderView)' : '_#(schedule.task.toggle.toListView)'">
-      <i class="menu-sandwich-icon"></i>
-      <span class="visually-hidden">
-        {{showTasksAsList ? "_#(schedule.task.toggle.toFolderView)" : "_#(schedule.task.toggle.toListView)"}}
-      </span>
-    </button>
-    <h6 class="mb-0">_#(Tasks)</h6>
+  <div class="schedule-task-list-header">
+    @if (showSchedulerHealth) {
+      <div class="schedule-task-list-header__status">
+        <div class="schedule-task-list-header__status-label">_#(Scheduler Status)</div>
+        <div class="schedule-task-list-header__status-pill" [ngClass]="schedulerHealthPillClass">
+          {{ schedulerHealth?.statusLabel }}
+        </div>
+        <button type="button" class="btn btn-secondary schedule-task-list-header__status-action"
+                (click)="refreshSchedulerHealth()"
+                [disabled]="schedulerHealthLoading">
+          _#(Refresh Status)
+        </button>
+        @if (schedulerHealth?.detailMessage) {
+          <div class="schedule-task-list-header__status-message">
+            {{ schedulerHealth.detailMessage }}
+          </div>
+        }
+      </div>
+    }
+    <div class="schedule-task-list-header__actions" [class.disable-actions-fade]="loading">
+      <button type="button" class="btn btn-primary" (click)="newTask()" [disabled]="!isCreateTaskEnabled()">_#(New Task)</button>
+      <button type="button" class="btn btn-secondary" (click)="loadTasks(true)">_#(Refresh List)</button>
+      <button type="button" class="btn btn-secondary"
+              (click)="moveTasks()"
+              [disabled]="(showTasksAsList || !removeEnable())">
+        _#(Move)
+      </button>
+      <button type="button" class="btn btn-secondary"
+              (click)="removeItems()" [disabled]="!removeEnable()">
+        _#(Delete)
+      </button>
+    </div>
   </div>
   <div class="portal-task-list-container">
     <div class="portal-task-list-items">
       <split-pane [sizes]="[INIT_TREE_PANE_SIZE, 100 - INIT_TREE_PANE_SIZE]"
-        class="split-pane" [minSize]="0" [snapOffset]="0"
-        [gutterSize]="1" [fullWidth]="true">
+                  class="split-pane" [minSize]="0" [snapOffset]="0"
+                  [gutterSize]="22" (onDragEnd)="splitPaneDragEnd()" [fullWidth]="true">
         <div class="pane data-tree-pane" [style.height.px]="treeHeight">
+          <div class="schedule-view-toggle">
+            <button type="button"
+                    class="btn btn-secondary schedule-view-toggle__button"
+                    (click)="changeShowType(true)">
+              _#(Show as List)
+            </button>
+          </div>
+          <span class="collapse-pane-button icon-size-small" aria-hidden="true"
+                (click)="changeShowType(!showTasksAsList)">
+            <i aria-hidden="true"
+               [class.chevron-circle-arrow-left-icon]="!showTasksAsList"
+               [class.chevron-circle-arrow-right-icon]="showTasksAsList"></i>
+          </span>
           @if (rootNode && !showTasksAsList) {
             <tree #tree
               [root]="rootNode"
@@ -80,7 +115,7 @@
                 </thead>
                 <tbody [style.height.px]="tableHeight">
                   @for (task of tasks; track task.name) {
-                    <tr class="task-row" [class.selected]="selectedItems.includes(task.name)"
+                    <tr class="task-row" [class.task-row--selected]="selectedItems.includes(task.name)"
                       (dragstart)="dragTask($event, task)" [draggable]="true"
                       (dragover)="$event.preventDefault();"
                       (dragenter)="$event.preventDefault()">
@@ -137,18 +172,5 @@
         </div>
       </split-pane>
     </div>
-  </div>
-  <div class="schedule-task-list-actions m-2" [class.disable-actions-fade]="loading">
-    <button type="button" class="btn btn-primary" (click)="newTask()" [disabled]="!isCreateTaskEnabled()">_#(New Task)</button>
-    <button type="button" class="btn btn-default ms-2" (click)="loadTasks(true)">_#(Refresh List)</button>
-    <button type="button" class="btn btn-default ms-2"
-      (click)="moveTasks()"
-      [disabled]="(showTasksAsList || !removeEnable())">
-      _#(Move)
-    </button>
-    <button type="button" class="btn btn-default ms-2"
-      (click)="removeItems()" [disabled]="!removeEnable()">
-      _#(Delete)
-    </button>
   </div>
 </div>

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.html
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.html
@@ -108,7 +108,7 @@
                     [enableUnsorted]="true" (sortTypeChanged)="changeSortType($event)">_#(Status)</th>
                     <th class="run-time-container" sortColumn [sortKey]="'lastRunTime'" [data]="tasks" [sortType]="sortType"
                     [enableUnsorted]="true" (sortTypeChanged)="changeSortType($event)">_#(Last Run End)</th>
-                    <th class="schedele-container" sortColumn [sortKey]="'schedule'" [data]="tasks" [sortType]="sortType"
+                    <th class="schedule-container" sortColumn [sortKey]="'schedule'" [data]="tasks" [sortType]="sortType"
                     [enableUnsorted]="true" (sortTypeChanged)="changeSortType($event)">_#(Schedule)</th>
                     <th class="actiones-container">_#(Actions)</th>
                   </tr>


### PR DESCRIPTION
The Angular standalone migration (563ab05dd) was authored against pre-PR file states. When merged into epic-74519 after PR #3733 landed, it silently reverted BEM class additions, re-introduced bootstrap classes, and wiped structural sections.

Fixes across 5 schedule components:

action-accordion.component.html
- Remove spurious <div class="action-accordion-content"> wrapper introduced by the migration; the form's height:0/flex-grow:1 only works when it is a direct child of the host flex container, so the wrapper caused the entire accordion to collapse to zero height
- Restore card BEM classes (action-accordion-card, action-accordion-card__body) lost to card m-1 regression

task-action-pane.component.html
- Restore task-action-pane wrapper class (was container-fluid p-1), required by component SCSS for flex layout and accordion sizing
- Restore task-action-pane__selector-col on dashboard picker column
- btn-default → btn-secondary (7 instances)

task-options-pane.component.html + .scss
- Restore task-options-pane wrapper class (was container-fluid)
- Restore task-options-pane__row on all 8 field rows
- btn-default → btn-secondary on Clear/Close/Cancel buttons
- Add margin-bottom: 0 to .task-options-pane__action-button

schedule-task-list.component.html
- Restore scheduler health status header (schedule-task-list-header with status pill, Refresh Status button, detail message) — the entire section was absent from HEAD despite the TS component still exposing schedulerHealth, showSchedulerHealth, and refreshSchedulerHealth()
- Restore schedule-view-toggle + collapse-pane chevron button in tree pane
- Restore gutterSize="22" and onDragEnd handler on split-pane
- task-row--selected class (was [class.selected])
- btn-default → btn-secondary; remove orphaned action footer div