### PR TITLE
fix(embed): render chart on fresh open, not just after resize

### DIFF
--- a/web/projects/portal/src/app/embed/chart/embed-chart.component.ts
+++ b/web/projects/portal/src/app/embed/chart/embed-chart.component.ts
@@ -323,6 +323,15 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
 
       this.vsObjectActions = new EmbedChartActions(this.vsObject, null,
          this.contextProvider, false, null, null, this.miniToolbarService);
+
+      // As an Angular Elements custom element, this component's view is not refreshed by the
+      // zone tick that wraps websocket command processing. Without an explicit detectChanges,
+      // the template @if (vsObject && runtimeId) is never re-evaluated on a fresh open, so
+      // <vs-chart> is never created and its model setter never requests the chart areas
+      // (/events/vschart/areas) — leaving the plot null and the chart blank until some DOM
+      // event (e.g. a window resize) happens to trigger change detection. Force CD here so the
+      // chart mounts and renders on open.
+      this.cdRef.detectChanges();
    }
 
    // noinspection JSUnusedGlobalSymbols
@@ -341,6 +350,10 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
       this.vsObject.active = true;
       this.vsObjectActions = new EmbedChartActions(this.vsObject, null,
          this.contextProvider, false, null, null, this.miniToolbarService);
+
+      // See processAddVSObjectCommand: force change detection so the embed view updates outside
+      // of a DOM event (custom-element views are not covered by the command-processing zone tick).
+      this.cdRef.detectChanges();
    }
 
    // noinspection JSUnusedGlobalSymbols


### PR DESCRIPTION
## Problem
The embedded chart (StyleBI live-preview / companion viewer) rendered **blank on a fresh page load or reload, and only painted after a window resize**.

## Root cause
`EmbedChartComponent` is an Angular **Elements custom element** whose view is **not refreshed by the NgZone tick** that wraps websocket command processing. `processAddVSObjectCommand` set `vsObject` but never ran change detection, so the template `@if (vsObject && runtimeId)` was never re-evaluated on open:

- `<vs-chart>` was never created, so its model setter never fired the `/events/vschart/areas` request that loads the plot.
- `AddVSObjectCommand` delivers only a shell model (`plot: null`, `axes: []`); the plot materializes from that areas request.
- A window resize fires the `(resized)` DOM binding, which **does** run change detection → `<vs-chart>` mounts → requests its plot → paints. Hence "blank until resize."

The lone pre-existing manual `cdRef.detectChanges()` (connection path) was the tell that change detection is manual in this component.

## Fix
Call `this.cdRef.detectChanges()` after `vsObject` is set in `processAddVSObjectCommand` and `processRefreshVSObjectCommand`, so the embed view updates (and the chart mounts + requests its plot) on open without depending on a later DOM event.

## Verification
Reproduced on the live deployment and confirmed the chart now paints on initial load and on reload (no resize needed), against the unmodified server. Diagnosed via headless STOMP-over-SockJS replay (server delivers complete data on open) + DevTools WS-Messages capture (on open the client sent `/events/open` and `/events/vs/refresh/assembly` but never `/events/vschart/areas`; the latter is sent only after a resize) — pinpointing the missing change detection as the broken link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)