### PR TITLE
fix: preserve table aliases when rebuilding SQL query from model

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/util/JDBCUtil.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/util/JDBCUtil.java
@@ -1147,9 +1147,11 @@ public class JDBCUtil {
    }
 
    /**
-    * Gets the names of the selected tables.
+    * Gets a map of alias → source-name for the selected tables.
+    * If a table has no alias, the source name is used as the key.
     *
-    * @return the table names.
+    * @param tablesMap the selected table (source-name → AssetEntry) map.
+    * @return a LinkedHashMap keyed by alias (or source name when no alias), mapping to source name.
     */
    public static Map<String, String> getTableNameAliasMap(Map<String, AssetEntry> tablesMap) {
       ArrayList<AssetEntry> tables = new ArrayList<>(tablesMap.values());

--- a/core/src/main/java/inetsoft/uql/jdbc/util/JDBCUtil.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/util/JDBCUtil.java
@@ -1053,17 +1053,17 @@ public class JDBCUtil {
       UniformSQL sql = new UniformSQL();
       sql.setDataSource(dataSource);
       sql.setSqlQuery(true);
-      String[] tables = JDBCUtil.getTableNames(tablesMap);
+      Map<String, String> tableNameAliasMap = JDBCUtil.getTableNameAliasMap(tablesMap);
 
-      for(String table : tables) {
-         SelectTable selectTable = sql.addTable(table);
-         AssetEntry tableEntry = tablesMap.get(table);
+      tableNameAliasMap.forEach((alias, name) ->{
+         SelectTable selectTable = sql.addTable(alias, name);
+         AssetEntry tableEntry = tablesMap.get(name);
 
          if(tableEntry != null) {
             selectTable.setCatalog(tableEntry.getProperty(XSourceInfo.CATALOG));
             selectTable.setSchema(tableEntry.getProperty(XSourceInfo.SCHEMA));
          }
-      }
+      });
 
       String quote = XUtil.getQuote(dataSource);
       JDBCSelection selection = new JDBCSelection();
@@ -1151,13 +1151,15 @@ public class JDBCUtil {
     *
     * @return the table names.
     */
-   public static String[] getTableNames(Map<String, AssetEntry> tablesMap) {
+   public static Map<String, String> getTableNameAliasMap(Map<String, AssetEntry> tablesMap) {
       ArrayList<AssetEntry> tables = new ArrayList<>(tablesMap.values());
-
-      String[] result = new String[tables.size()];
+      Map<String, String> result = new LinkedHashMap<>();
 
       for(int i = 0; i < tables.size(); i++) {
-         result[i] = tables.get(i).getProperty("source");
+         String name = tables.get(i).getProperty("source");
+         String alias = tables.get(i).getAlias();
+         alias = Tool.isEmptyString(alias) ? name : alias;
+         result.put(alias, name);
       }
 
       return result;

--- a/core/src/main/java/inetsoft/uql/jdbc/util/JDBCUtil.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/util/JDBCUtil.java
@@ -1055,11 +1055,11 @@ public class JDBCUtil {
       sql.setSqlQuery(true);
       Map<String, String> tableNameAliasMap = JDBCUtil.getTableNameAliasMap(tablesMap);
 
-      tableNameAliasMap.forEach((alias, name) ->{
+      tableNameAliasMap.forEach((alias, name) -> {
          SelectTable selectTable = sql.addTable(alias, name);
          AssetEntry tableEntry = tablesMap.get(name);
 
-         if(tableEntry != null) {
+         if(selectTable != null && tableEntry != null) {
             selectTable.setCatalog(tableEntry.getProperty(XSourceInfo.CATALOG));
             selectTable.setSchema(tableEntry.getProperty(XSourceInfo.SCHEMA));
          }

--- a/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
@@ -2390,7 +2390,14 @@ public class QueryManagerService {
          }
 
          String alias = selectTable.getAlias();
-         alias = alias == null ? tableName : alias;
+
+         if(!Tool.isEmptyString(alias)) {
+            entry.setAlias(alias);
+         }
+         else {
+            alias = tableName;
+         }
+
          runtimeQuery.addSelectedTable(alias, entry);
       }
    }


### PR DESCRIPTION
Replace getTableNames() with getTableNameAliasMap() to carry alias→source mappings into createSQL(), and sync SelectTable alias back to AssetEntry in initQuerySelectedTables() so aliases are retained on query reload.