### PR TITLE
Mark SQL Query Tables as Advanced Editing

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -529,7 +529,7 @@ public class WorksheetTableService {
       }
 
       table.setColumnSelection(columns);
-      table.setSQLEdited(false);
+      table.setAdvancedEditing(true);
 
       worksheet.addAssembly(table);
       return table;


### PR DESCRIPTION
SQL Query Tables should always be created in Advanced Editing mode. Claude-generated SQL may contain constructs such as aggregations, GROUP BY clauses, window functions, and table aliases that are not supported by Basic mode. By using Advanced Editing mode, the SQL is executed as-is by the database, ensuring these queries work correctly.

Queries:
哪些客户同时购买过系统中价格最高和最低的商品？
每个客户最后一次订单中的商品总数