### PR TITLE
Bug #75490, remove window message listener on destroy to prevent accumulation

### DIFF
--- a/web/projects/portal/src/app/portal/app.component.tl.spec.ts
+++ b/web/projects/portal/src/app/portal/app.component.tl.spec.ts
@@ -45,28 +45,40 @@
  * plain vi.fn() mock returning of(...), preventing any real HTTP traffic from reaching MSW.
  */
 
+/**
+ * PortalAppComponent — single pass
+ *
+ * Risk-first coverage:
+ *   Group 1 [Risk 3]  — ngOnDestroy: window.removeEventListener called for 'message' with same
+ *                        reference as addEventListener; not called before destroy
+ *
+ * Suspected bugs: none remaining after Bug #75490 fix.
+ *
+ * Out of scope this pass: full portal model loading, routing, UI rendering.
+ */
+
 import { DOCUMENT } from "@angular/common";
 import { HttpClient } from "@angular/common/http";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { Title } from "@angular/platform-browser";
 import { ActivatedRoute, Router } from "@angular/router";
-import { render } from "@testing-library/angular";
 import { NgbDatepickerConfig, NgbModal } from "@ng-bootstrap/ng-bootstrap";
+import { render } from "@testing-library/angular";
 import { of } from "rxjs";
-
 import { AiAssistantService } from "../../../../shared/ai-assistant/ai-assistant.service";
-import { AiAssistantDialogService } from "../common/services/ai-assistant-dialog.service";
-import { LicenseInfoService } from "../common/services/license-info.service";
-import { FirstDayOfWeekService } from "../common/services/first-day-of-week.service";
-import { OpenComposerService } from "../common/services/open-composer.service";
 import { LogoutService } from "../../../../shared/util/logout.service";
-import { HideNavService } from "./services/hide-nav.service";
-import { PortalModelService } from "./services/portal-model.service";
-import { HistoryBarService } from "./services/history-bar.service";
-import { PortalTabsService } from "./services/portal-tabs.service";
-import { CurrentRouteService } from "./services/current-route.service";
+import { AiAssistantDialogService } from "../common/services/ai-assistant-dialog.service";
+import { FirstDayOfWeekService } from "../common/services/first-day-of-week.service";
+import { LicenseInfoService } from "../common/services/license-info.service";
+import { OpenComposerService } from "../common/services/open-composer.service";
 import { GettingStartedService } from "../widget/dialog/getting-started-dialog/service/getting-started.service";
+
 import { PortalAppComponent } from "./app.component";
+import { CurrentRouteService } from "./services/current-route.service";
+import { HideNavService } from "./services/hide-nav.service";
+import { HistoryBarService } from "./services/history-bar.service";
+import { PortalModelService } from "./services/portal-model.service";
+import { PortalTabsService } from "./services/portal-tabs.service";
 
 // ── Minimal portal model stub — satisfies property access in the ngOnInit HTTP subscription ──
 
@@ -84,6 +96,9 @@ const PORTAL_MODEL_STUB = {
 };
 
 // ── Component-level provider mocks (replaces all constructor-injected services) ──────────────
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
 
 function makeProviders() {
    return [
@@ -130,14 +145,72 @@ function makeProviders() {
 }
 
 async function renderComponent() {
-   return render(PortalAppComponent, {
-      schemas:            [NO_ERRORS_SCHEMA],
-      componentImports:   [], // strips RouterOutlet/RouterLink/AiAssistantPanel etc. from imports;
-      componentProviders: makeProviders(), // NO_ERRORS_SCHEMA silences unknown-element errors
+   const result = await render(PortalAppComponent, {
+      schemas: [NO_ERRORS_SCHEMA],
+      componentImports: [],
+      providers: makeProviders(),
    });
+   return {
+      fixture: result.fixture,
+      comp: result.fixture.componentInstance as PortalAppComponent,
+   };
 }
 
-afterEach(() => vi.restoreAllMocks());
+afterEach(() => {
+   vi.restoreAllMocks();
+   document.body.className = document.body.className.replace(/\bapp-loaded\b/g, "").trim();
+});
+
+// ---------------------------------------------------------------------------
+// Group 1: ngOnDestroy — 'message' listener removed via stored reference
+// ---------------------------------------------------------------------------
+
+describe("PortalAppComponent — ngOnDestroy: 'message' listener cleanup", () => {
+   // 🔁 Regression-sensitive: Bug #75490 — without a stored reference, removeEventListener is
+   // a no-op and listeners accumulate across navigations, firing handleMessageEvent N times per
+   // postMessage and leaking component instances.
+   it("should call window.removeEventListener for 'message' on destroy", async () => {
+      const addSpy    = vi.spyOn(window, "addEventListener");
+      const removeSpy = vi.spyOn(window, "removeEventListener");
+
+      const { fixture } = await renderComponent();
+
+      const addCount    = addSpy.mock.calls.filter(c => c[0] === "message").length;
+      const removeBefore = removeSpy.mock.calls.filter(c => c[0] === "message").length;
+      expect(addCount).toBeGreaterThanOrEqual(1);
+      expect(removeBefore).toBe(0);
+
+      fixture.destroy();
+
+      const removeCount = removeSpy.mock.calls.filter(c => c[0] === "message").length;
+      expect(removeCount).toBe(addCount);
+   });
+
+   it("should pass the same function reference to removeEventListener as to addEventListener", async () => {
+      const addSpy    = vi.spyOn(window, "addEventListener");
+      const removeSpy = vi.spyOn(window, "removeEventListener");
+
+      for(let i = 0; i < 3; i++) {
+         const { fixture } = await renderComponent();
+         fixture.destroy();
+      }
+
+      const adds    = addSpy.mock.calls.filter(([type]) => type === "message").length;
+      const removes = removeSpy.mock.calls.filter(([type]) => type === "message").length;
+
+      const addedRef   = addSpy.mock.calls.find(c => c[0] === "message")?.[1];
+      const removedRef = removeSpy.mock.calls.find(c => c[0] === "message")?.[1];
+      expect(addedRef).toBeDefined();
+      expect(removedRef).toBe(addedRef);
+   });
+
+   it("should not remove the 'message' listener before the component is destroyed", async () => {
+      const removeSpy = vi.spyOn(window, "removeEventListener");
+      await renderComponent();
+      const removeCount = removeSpy.mock.calls.filter(c => c[0] === "message").length;
+      expect(removeCount).toBe(0);
+   });
+});
 
 // ── Baseline: verify ngOnInit registers the message listener ──────────────────
 
@@ -206,3 +279,4 @@ describe("PortalAppComponent — Bug C: window 'message' listener leak (app.comp
       }).not.toThrow();
    });
 });
+

--- a/web/projects/portal/src/app/portal/app.component.tl.spec.ts
+++ b/web/projects/portal/src/app/portal/app.component.tl.spec.ts
@@ -41,8 +41,10 @@
  *     - After the fix: the inner expect passes → it.fails is marked ❌ (remove .fails)
  *
  * MSW note: vitest-setup-tl.ts starts MSW with onUnhandledRequest:"error", so all HTTP
- * requests must be intercepted. This file replaces HttpClient via componentProviders with a
- * plain vi.fn() mock returning of(...), preventing any real HTTP traffic from reaching MSW.
+ * requests must be intercepted. This file replaces HttpClient via providers (module-level
+ * injector) with a plain vi.fn() mock returning of(...), preventing any real HTTP traffic from
+ * reaching MSW. Using providers (vs componentProviders) is safe here because every injected
+ * service is replaced with a mock — no real Angular DI scoping distinctions apply.
  */
 
 /**
@@ -195,13 +197,10 @@ describe("PortalAppComponent — ngOnDestroy: 'message' listener cleanup", () =>
          fixture.destroy();
       }
 
-      const adds    = addSpy.mock.calls.filter(([type]) => type === "message").length;
-      const removes = removeSpy.mock.calls.filter(([type]) => type === "message").length;
-
-      const addedRef   = addSpy.mock.calls.find(c => c[0] === "message")?.[1];
-      const removedRef = removeSpy.mock.calls.find(c => c[0] === "message")?.[1];
-      expect(addedRef).toBeDefined();
-      expect(removedRef).toBe(addedRef);
+      const addedRefs   = addSpy.mock.calls.filter(c => c[0] === "message").map(c => c[1]);
+      const removedRefs = removeSpy.mock.calls.filter(c => c[0] === "message").map(c => c[1]);
+      expect(addedRefs.length).toBe(3);
+      addedRefs.forEach((ref, i) => expect(removedRefs[i]).toBe(ref));
    });
 
    it("should not remove the 'message' listener before the component is destroyed", async () => {
@@ -220,6 +219,17 @@ describe("PortalAppComponent — ngOnDestroy: 'message' listener cleanup", () =>
 
       expect(handlerSpy).not.toHaveBeenCalled();
    });
+
+   it("handleMessageEvent does not throw on null or unknown data payloads", async () => {
+      const { fixture } = await renderComponent();
+      const comp = fixture.componentInstance;
+
+      expect(() => {
+         comp.handleMessageEvent({ data: null } as any);
+         comp.handleMessageEvent({ data: {} } as any);
+         comp.handleMessageEvent({ data: { event: "unknown" } } as any);
+      }).not.toThrow();
+   });
 });
 
 // ── Baseline: verify ngOnInit registers the message listener ──────────────────
@@ -233,60 +243,6 @@ describe("PortalAppComponent — Baseline: message listener registration", () =>
 
       const messageCalls = addSpy.mock.calls.filter(([type]) => type === "message");
       expect(messageCalls.length).toBe(1);
-   });
-});
-
-// ── Bug C: ngOnDestroy does not remove the message listener → memory leak ─────
-
-describe("PortalAppComponent — Bug C: window 'message' listener leak (app.component.ts:185)", () => {
-
-   // 🐛 single create/destroy: listener must be removed after destroy
-   it.fails("ngOnDestroy must call window.removeEventListener for 'message' (remove .fails after fix)", async () => {
-      const addSpy    = vi.spyOn(window, "addEventListener");
-      const removeSpy = vi.spyOn(window, "removeEventListener");
-
-      const { fixture } = await renderComponent();
-
-      const addCount = addSpy.mock.calls.filter(([type]) => type === "message").length;
-      expect(addCount).toBe(1); // ngOnInit registers exactly 1 listener
-
-      fixture.destroy(); // triggers ngOnDestroy
-
-      const removeCount = removeSpy.mock.calls.filter(([type]) => type === "message").length;
-
-      // Before fix: removeCount = 0 (ngOnDestroy never calls removeEventListener) → expect fails → it.fails ✅
-      // After fix:  removeCount = 1 → expect passes → it.fails ❌ remove it
-      expect(removeCount).toBe(addCount);
-   });
-
-   // 🐛 3 create/destroy cycles: listener count must not grow (simulates repeated navigation)
-   it.fails("repeated create/destroy cycles must not accumulate 'message' listeners (remove .fails after fix)", async () => {
-      const addSpy    = vi.spyOn(window, "addEventListener");
-      const removeSpy = vi.spyOn(window, "removeEventListener");
-
-      for(let i = 0; i < 3; i++) {
-         const { fixture } = await renderComponent();
-         fixture.destroy();
-      }
-
-      const adds    = addSpy.mock.calls.filter(([type]) => type === "message").length;
-      const removes = removeSpy.mock.calls.filter(([type]) => type === "message").length;
-
-      // Before fix: adds = 3, removes = 0 (each navigation leaks one listener) → expect fails → it.fails ✅
-      // After fix:  adds = removes = 3 → expect passes → it.fails ❌ remove it
-      expect(removes).toBe(adds);
-   });
-
-   // ✅ Regression guard: handleMessageEvent silently ignores non-openDialog messages
-   it("handleMessageEvent does not throw on null or unknown data payloads", async () => {
-      const { fixture } = await renderComponent();
-      const comp = fixture.componentInstance;
-
-      expect(() => {
-         comp.handleMessageEvent({ data: null } as any);
-         comp.handleMessageEvent({ data: {} } as any);
-         comp.handleMessageEvent({ data: { event: "unknown" } } as any);
-      }).not.toThrow();
    });
 });
 

--- a/web/projects/portal/src/app/portal/app.component.tl.spec.ts
+++ b/web/projects/portal/src/app/portal/app.component.tl.spec.ts
@@ -177,7 +177,7 @@ describe("PortalAppComponent — ngOnDestroy: 'message' listener cleanup", () =>
 
       const addCount    = addSpy.mock.calls.filter(c => c[0] === "message").length;
       const removeBefore = removeSpy.mock.calls.filter(c => c[0] === "message").length;
-      expect(addCount).toBeGreaterThanOrEqual(1);
+      expect(addCount).toBe(1);
       expect(removeBefore).toBe(0);
 
       fixture.destroy();
@@ -209,6 +209,16 @@ describe("PortalAppComponent — ngOnDestroy: 'message' listener cleanup", () =>
       await renderComponent();
       const removeCount = removeSpy.mock.calls.filter(c => c[0] === "message").length;
       expect(removeCount).toBe(0);
+   });
+
+   it("should not call handleMessageEvent after the component is destroyed", async () => {
+      const { fixture, comp } = await renderComponent();
+      const handlerSpy = vi.spyOn(comp as any, "handleMessageEvent");
+
+      fixture.destroy();
+      window.dispatchEvent(new MessageEvent("message", { data: { event: "openDialog", dialogName: "preferences" } }));
+
+      expect(handlerSpy).not.toHaveBeenCalled();
    });
 });
 

--- a/web/projects/portal/src/app/portal/app.component.ts
+++ b/web/projects/portal/src/app/portal/app.component.ts
@@ -86,6 +86,7 @@ export class PortalAppComponent implements OnInit, OnDestroy {
    private readonly ACCESSIBILITY_CLASS: string = "accessible";
    private destroy$ = new Subject<void>();
    private isGettingStartedShown: boolean = false;
+   private readonly _onMessage = (evt: MessageEvent) => this.handleMessageEvent(evt);
 
    get openComposerEnabled(): boolean {
       return this.model.composerEnabled;
@@ -182,7 +183,7 @@ export class PortalAppComponent implements OnInit, OnDestroy {
       });
 
       this.licenseInfoService.getLicenseInfo().subscribe(info => this.licenseInfo = info);
-      window.addEventListener("message", (evt) => this.handleMessageEvent(evt), false);
+      window.addEventListener("message", this._onMessage, false);
 
       this.firstDayOfWeekService.getFirstDay().subscribe((model) => {
          this.ngbDatepickerConfig.firstDayOfWeek = model.isoFirstDay;
@@ -198,6 +199,8 @@ export class PortalAppComponent implements OnInit, OnDestroy {
    }
 
    ngOnDestroy(): void {
+      window.removeEventListener("message", this._onMessage, false);
+
       if(this.routeSubscription) {
          this.routeSubscription.unsubscribe();
          this.routeSubscription = null;


### PR DESCRIPTION
## Summary

`PortalAppComponent.ngOnDestroy` never removed the `window` `message` event listener registered in `ngOnInit`, causing one additional listener to accumulate each time the component was created. After N navigations, a single `postMessage` call would invoke `handleMessageEvent` N times simultaneously.

## Root Cause

`ngOnInit` registered the listener with an anonymous arrow function:

```ts
window.addEventListener("message", (evt) => this.handleMessageEvent(evt), false);
```

Because the function was anonymous, there was no stored reference to pass to `removeEventListener`, making removal impossible. `ngOnDestroy` never called `removeEventListener` at all.

## Fix

Store the handler as a private `readonly` class field so the same reference can be passed to both `addEventListener` and `removeEventListener`:

```ts
private readonly _onMessage = (evt: MessageEvent) => this.handleMessageEvent(evt);
```

Use `this._onMessage` in `ngOnInit`'s `addEventListener` call and add `window.removeEventListener("message", this._onMessage, false)` as the first statement in `ngOnDestroy`.

A regression test (`app.component.tl.spec.ts`) is included that verifies:
- `removeEventListener` is called for `'message'` on destroy
- The exact same function reference is passed to both `addEventListener` and `removeEventListener`
- `removeEventListener` is not called before the component is destroyed

## Test Plan

- Run `npx ng run portal:test-tl --include "**/portal/app.component.tl.spec.ts"` — all 3 tests pass
- Manually navigate between portal pages multiple times; confirm only one `message` listener exists on `window` (verify via Chrome DevTools → Memory → Heap snapshot, filter EventListener → message type)

Fixes Redmine #75490.