### PR TITLE
Bug #75491, enable virtual scroll after folder expansion regardless of search-mode state

### DIFF
--- a/web/projects/portal/src/app/widget/asset-tree/asset-tree.component.ts
+++ b/web/projects/portal/src/app/widget/asset-tree/asset-tree.component.ts
@@ -750,7 +750,7 @@ export class AssetTreeComponent implements OnInit, OnDestroy, OnChanges {
    private updateUseVirtualScroll(): void {
       this.useVirtualScroll = false;
 
-      if(this.manyNodesUseVirtualScroll && this.hasLoadedAllNode()) {
+      if(this.manyNodesUseVirtualScroll) {
          this.useVirtualScroll = TreeTool.needUseVirtualScroll(this.activeRoot);
       }
    }


### PR DESCRIPTION
## Summary

- The asset tree in the Composer suffered severe performance degradation when expanding a folder with a large number of children (600+), causing a multi-second UI freeze.
- The same freeze recurred after renaming any asset, because the rename event triggered a tree refresh that also bypassed virtual scrolling.

## Root Cause

`updateUseVirtualScroll()` in `asset-tree.component.ts` gated the virtual scroll threshold check on `hasLoadedAllNode()`, which returns `true` only when `vSAdnWsLoadedAll` is set — and that flag is only ever set during search mode's "load all" pass. During normal folder expansion, the flag is always `false`, so `useVirtualScroll` was always reset to `false` after each `refreshNodeChildren()` call, forcing Angular to create all 600+ `tree-node` DOM elements simultaneously.

This was inconsistent with `loadAssetTree()`, which called `TreeTool.needUseVirtualScroll` directly without any such guard.

## Fix

Removed the `hasLoadedAllNode()` guard from `updateUseVirtualScroll()` so that virtual scrolling activates whenever `manyNodesUseVirtualScroll` is true and the loaded node count exceeds 500, regardless of whether the tree is in search mode.

## Test Plan

- [ ] Expand a folder containing 600+ children — tree should render immediately with virtual scrolling (no freeze)
- [ ] Rename an asset in a folder with 600+ siblings — tree refresh after the rename should also use virtual scrolling
- [ ] Verify search mode still works correctly: virtual scroll activates after all nodes are loaded
- [ ] Run frontend test suite: `npm run test`
- [ ] Run linter: `npm run lint`

Fixes Redmine #75491.