### PR TITLE
feat(graph): line/area point-marker control (shape/size + show/hide)

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -3523,6 +3523,25 @@ public abstract class GraphGenerator {
          }
 
          elements.add(area);
+
+         if(desc.getPlotDescriptor().isPointLine()) {
+            PointElement point = new PointElement();
+            String markerShape = desc.getPlotDescriptor().getMarkerShape();
+            int markerSize = desc.getPlotDescriptor().getMarkerSize();
+
+            if(markerShape != null) {
+               point.setShapeFrame(new StaticShapeFrame(mapMarkerShape(markerShape)));
+            }
+
+            if(markerSize > 0) {
+               point.setSizeFrame(new StaticSizeFrame(markerSize));
+            }
+
+            point.setHint("_show_point_", "true");
+            point.setHint(GraphElement.HINT_ALPHA, 1);
+            point.setHint(GraphElement.HINT_SHINE, "false");
+            elements.add(point);
+         }
       }
       else if(GraphTypes.isLine(chartType)) {
          LineElement line = new LineElement();
@@ -3571,7 +3590,7 @@ public abstract class GraphGenerator {
             elements.add(lastp);
          }
 
-         if(desc.getPlotDescriptor().isPointLine() || dateComparison != null) {
+         if((desc.getPlotDescriptor().isPointLine() && dateComparison == null) || dateComparison != null) {
             PointElement point = new PointElement();
             showPoint = true;
 
@@ -3589,7 +3608,10 @@ public abstract class GraphGenerator {
             if(desc.getPlotDescriptor().isPointLine()) {
                String markerShape = desc.getPlotDescriptor().getMarkerShape();
                int markerSize = desc.getPlotDescriptor().getMarkerSize();
-               point.setShapeFrame(new StaticShapeFrame(mapMarkerShape(markerShape)));
+
+               if(markerShape != null) {
+                  point.setShapeFrame(new StaticShapeFrame(mapMarkerShape(markerShape)));
+               }
 
                if(markerSize > 0) {
                   point.setSizeFrame(new StaticSizeFrame(markerSize));

--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -3243,6 +3243,23 @@ public abstract class GraphGenerator {
    }
 
    /**
+    * Maps a marker-shape name (from PlotDescriptor.getMarkerShape()) to the
+    * corresponding GShape constant.  Returns FILLED_CIRCLE for null / unknown names.
+    */
+   private static GShape mapMarkerShape(String name) {
+      switch(name == null ? "" : name.toLowerCase()) {
+      case "square":   return GShape.FILLED_SQUARE;
+      case "diamond":  return GShape.FILLED_DIAMOND;
+      case "triangle": return GShape.FILLED_TRIANGLE;
+      case "cross":    return GShape.CROSS;
+      case "x":        return GShape.XSHAPE;
+      case "star":     return GShape.STAR;
+      case "circle":
+      default:         return GShape.FILLED_CIRCLE;
+      }
+   }
+
+   /**
     * Set hint for data set ranges.
     */
    private void setRangeHint(GraphElement elem, int chartType, boolean all) {
@@ -3450,6 +3467,17 @@ public abstract class GraphGenerator {
                // make sure the point is on top and not seen through to line
                point.setHint(GraphElement.HINT_ALPHA, 1);
                point.setHint(GraphElement.HINT_SHINE, "false");
+
+               String markerShape = desc.getPlotDescriptor().getMarkerShape();
+               int markerSize = desc.getPlotDescriptor().getMarkerSize();
+
+               if(markerShape != null) {
+                  point.setShapeFrame(new StaticShapeFrame(mapMarkerShape(markerShape)));
+               }
+
+               if(markerSize > 0) {
+                  point.setSizeFrame(new StaticSizeFrame(markerSize));
+               }
             }
             // optimization, not need to sort scatter plot.
             // if point on map, more important to make the smaller point on top of larger one
@@ -3558,7 +3586,16 @@ public abstract class GraphGenerator {
                point.setSizeFrame(new StaticSizeFrame(1));
             }
 
-            point.setShapeFrame(new StaticShapeFrame(GShape.FILLED_CIRCLE));
+            if(desc.getPlotDescriptor().isPointLine()) {
+               String markerShape = desc.getPlotDescriptor().getMarkerShape();
+               int markerSize = desc.getPlotDescriptor().getMarkerSize();
+               point.setShapeFrame(new StaticShapeFrame(mapMarkerShape(markerShape)));
+
+               if(markerSize > 0) {
+                  point.setSizeFrame(new StaticSizeFrame(markerSize));
+               }
+            }
+
             point.setHint("_show_point_", "true");
             // make sure the point is on top and not seen through to line
             point.setHint(GraphElement.HINT_ALPHA, 1);
@@ -3630,6 +3667,17 @@ public abstract class GraphGenerator {
 
             if(desc.getPlotDescriptor().isPointLine()) {
                PointElement point = new PointElement();
+               String markerShape = desc.getPlotDescriptor().getMarkerShape();
+               int markerSize = desc.getPlotDescriptor().getMarkerSize();
+
+               if(markerShape != null) {
+                  point.setShapeFrame(new StaticShapeFrame(mapMarkerShape(markerShape)));
+               }
+
+               if(markerSize > 0) {
+                  point.setSizeFrame(new StaticSizeFrame(markerSize));
+               }
+
                point.setHint("_show_point_", "true");
                // make sure the point is on top and not seen through to line
                point.setHint(GraphElement.HINT_ALPHA, 1);

--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/PlotDescriptor.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/PlotDescriptor.java
@@ -749,6 +749,38 @@ public class PlotDescriptor implements AssetObject, ContentObject {
    }
 
    /**
+    * Get the marker shape name for point/line chart markers (e.g. "diamond", "circle").
+    * Returns null to use the StyleBI default shape.
+    */
+   public String getMarkerShape() {
+      return markerShape;
+   }
+
+   /**
+    * Set the marker shape name for point/line chart markers.
+    * Pass null to use the StyleBI default shape.
+    */
+   public void setMarkerShape(String markerShape) {
+      this.markerShape = markerShape;
+   }
+
+   /**
+    * Get the marker size for point/line chart markers.
+    * Returns 0 to use the StyleBI default size.
+    */
+   public int getMarkerSize() {
+      return markerSize;
+   }
+
+   /**
+    * Set the marker size for point/line chart markers.
+    * Pass 0 to use the StyleBI default size.
+    */
+   public void setMarkerSize(int markerSize) {
+      this.markerSize = markerSize;
+   }
+
+   /**
     * Check if a single line should be rendered instead of broken into one line per color/shape.
     */
    public boolean isOneLine() {
@@ -1383,6 +1415,14 @@ public class PlotDescriptor implements AssetObject, ContentObject {
          pointsVisible = "true".equals(val);
       }
 
+      if((val = Tool.getAttribute(node, "markerShape")) != null) {
+         markerShape = val;
+      }
+
+      if((val = Tool.getAttribute(node, "markerSize")) != null) {
+         markerSize = Integer.parseInt(val);
+      }
+
       if((val = Tool.getAttribute(node, "inPlot")) != null) {
          inPlot = "true".equals(val);
       }
@@ -1596,6 +1636,12 @@ public class PlotDescriptor implements AssetObject, ContentObject {
       writer.print(" stackMeasures=\"" + stackMeasures + "\" ");
       writer.print(" webMap=\"" + webMap + "\" ");
       writer.print(" pointsVisible=\"" + pointsVisible + "\" ");
+
+      if(markerShape != null) {
+         writer.print(" markerShape=\"" + markerShape + "\" ");
+      }
+
+      writer.print(" markerSize=\"" + markerSize + "\" ");
       writer.print(" fillGap=\"" + fillGap + "\" ");
       writer.print(" fillZero=\"" + fillZero + "\" ");
       writer.print(" fillGapWithDash=\"" + fillGapWithDash + "\" ");
@@ -1768,7 +1814,9 @@ public class PlotDescriptor implements AssetObject, ContentObject {
          circleFormats.equals(desc.circleFormats) &&
          Tool.equals(errorFormat, desc.errorFormat) &&
          includeParentLabels == desc.includeParentLabels &&
-         oneLine == desc.oneLine;
+         oneLine == desc.oneLine &&
+         Tool.equals(markerShape, desc.markerShape) &&
+         markerSize == desc.markerSize;
    }
 
    public void resetCompositeValues(CompositeValue.Type type) {
@@ -1823,6 +1871,8 @@ public class PlotDescriptor implements AssetObject, ContentObject {
    private boolean rLineVisible = false;
    private boolean valuesVisible = false;
    private boolean pointsVisible = false;
+   private String markerShape = null;   // null = StyleBI default
+   private int markerSize = 0;          // 0 = StyleBI default
    private boolean stackValue = false;
    private boolean inPlot = true;
    private boolean polygonColor = false;

--- a/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
@@ -67,14 +67,17 @@ public class ChartFormatRequest {
    public void setLegendPosition(String legendPosition) { this.legendPosition = legendPosition; }
 
    /** Marker visibility override for point/line charts; null = no change. */
+   @JsonProperty("markerVisible")
    public Boolean getMarkerVisible() { return markerVisible; }
    public void setMarkerVisible(Boolean markerVisible) { this.markerVisible = markerVisible; }
 
    /** Marker shape override (e.g., "CIRCLE", "SQUARE", "TRIANGLE"); null = no change. */
+   @JsonProperty("markerShape")
    public String getMarkerShape() { return markerShape; }
    public void setMarkerShape(String markerShape) { this.markerShape = markerShape; }
 
    /** Marker size override (1–10 recommended); null = no change. */
+   @JsonProperty("markerSize")
    public Integer getMarkerSize() { return markerSize; }
    public void setMarkerSize(Integer markerSize) { this.markerSize = markerSize; }
 

--- a/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
@@ -66,6 +66,18 @@ public class ChartFormatRequest {
    public String getLegendPosition() { return legendPosition; }
    public void setLegendPosition(String legendPosition) { this.legendPosition = legendPosition; }
 
+   /** Marker visibility override for point/line charts; null = no change. */
+   public Boolean getMarkerVisible() { return markerVisible; }
+   public void setMarkerVisible(Boolean markerVisible) { this.markerVisible = markerVisible; }
+
+   /** Marker shape override (e.g., "CIRCLE", "SQUARE", "TRIANGLE"); null = no change. */
+   public String getMarkerShape() { return markerShape; }
+   public void setMarkerShape(String markerShape) { this.markerShape = markerShape; }
+
+   /** Marker size override (1–10 recommended); null = no change. */
+   public Integer getMarkerSize() { return markerSize; }
+   public void setMarkerSize(Integer markerSize) { this.markerSize = markerSize; }
+
    /** The runtime viewsheet that holds the live chart (the plugin's active-chart runtimeId). */
    private String wizRuntimeId;
    /** The chart assembly name within that runtime. */
@@ -80,4 +92,7 @@ public class ChartFormatRequest {
    private Double yAxisIncrement;
    private Boolean yAxisLogarithmic;
    private String legendPosition;
+   private Boolean markerVisible;
+   private String markerShape;
+   private Integer markerSize;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -2056,6 +2056,27 @@ public class WizAutoBindingService {
          }
       }
 
+      // Marker visibility, shape, and size
+      if((request.getMarkerVisible() != null || request.getMarkerShape() != null
+         || request.getMarkerSize() != null) && desc != null)
+      {
+         PlotDescriptor plot = desc.getPlotDescriptor();
+
+         if(plot != null) {
+            if(request.getMarkerVisible() != null) {
+               plot.setPointLine(request.getMarkerVisible());
+            }
+
+            if(request.getMarkerShape() != null) {
+               plot.setMarkerShape(request.getMarkerShape());
+            }
+
+            if(request.getMarkerSize() != null) {
+               plot.setMarkerSize(request.getMarkerSize());
+            }
+         }
+      }
+
       // Invalidate the cached runtime descriptor so the change regenerates on re-execute.
       info.setRTChartDescriptor(null);
 

--- a/core/src/test/java/inetsoft/uql/viewsheet/graph/PlotDescriptorTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/graph/PlotDescriptorTest.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet.graph;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.w3c.dom.Document;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link PlotDescriptor}.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome()
+@Tag("core")
+class PlotDescriptorTest {
+
+   @Test
+   void markerShapeAndSizeSurviveXmlRoundTrip() throws Exception {
+      PlotDescriptor desc = new PlotDescriptor();
+      desc.setPointLine(true);
+      desc.setMarkerShape("diamond");
+      desc.setMarkerSize(12);
+
+      StringWriter sw = new StringWriter();
+      desc.writeXML(new PrintWriter(sw));
+
+      Document doc = parseXmlString(sw.toString());
+      PlotDescriptor parsed = new PlotDescriptor();
+      parsed.parseXML(doc.getDocumentElement());
+
+      assertTrue(parsed.isPointLine());
+      assertEquals("diamond", parsed.getMarkerShape());
+      assertEquals(12, parsed.getMarkerSize());
+      assertTrue(parsed.equalsContent(desc));
+   }
+
+   @Test
+   void markerShapeAndSizeDefaultsAreNullAndZero() {
+      PlotDescriptor desc = new PlotDescriptor();
+      assertNull(desc.getMarkerShape(), "default markerShape should be null");
+      assertEquals(0, desc.getMarkerSize(), "default markerSize should be 0");
+   }
+
+   @Test
+   void markerShapeNullNotWrittenToXml() throws Exception {
+      // When markerShape is null, the attribute should not appear in the XML output
+      PlotDescriptor desc = new PlotDescriptor();
+      desc.setMarkerSize(0); // default
+
+      StringWriter sw = new StringWriter();
+      desc.writeXML(new PrintWriter(sw));
+
+      assertFalse(sw.toString().contains("markerShape="),
+         "null markerShape should not be written to XML");
+   }
+
+   private static Document parseXmlString(String xml) throws Exception {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+      return factory.newDocumentBuilder()
+         .parse(new ByteArrayInputStream(xml.getBytes("UTF-8")));
+   }
+}


### PR DESCRIPTION
## Line/area point markers (StyleBI engine side)

Engine support for the viz-chat **point-marker** feature: show/hide + shape + size markers on line/area charts. Pairs with wiz-services + plugin changes in **inetsoft-technology/stylebi-wiz#947**.

### Changes
- **`PlotDescriptor`** — new `markerShape` (String) + `markerSize` (int); show/hide reuses existing `pointLine`. XML write/parse + `equalsContent`; `markerShape=null`/`markerSize=0` mean "use default". Survives save→reopen (round-trip test included).
- **`ChartFormatRequest`** — `markerVisible`/`markerShape`/`markerSize` (nullable; null = no change), `@JsonProperty`-annotated.
- **`WizAutoBindingService.setChartFormat`** — applies the marker fields to the chart's `PlotDescriptor` (after the legend block, before cache-clear). Reuses the existing `/viewsheet/format` endpoint — no new endpoint.
- **`GraphGenerator`** — when `isPointLine()`, sets `StaticShapeFrame`(mapped `GShape`) + `StaticSizeFrame` on the point element, for **line and area** (and radar, as a harmless consistency extension). Shape allowlist maps circle/square/diamond/triangle→FILLED_*, cross/x→CROSS/XSHAPE, star→STAR; null shape / 0 size leave StyleBI's default untouched. The `dateComparison` path is preserved.

### Tests
`PlotDescriptorTest` covers the XML round-trip, null/zero defaults, and null-not-written. Compiles via the offline Maven build; the rest (rendering) is verified e2e against a local image.

### Base
Targets `stylebi-wiz-main-rebase` (the wiz-integration line) — these changes depend on the wiz-facing `inetsoft/web/wiz/` layer, which is not on community `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
