### PR TITLE
Recover additional data tab and condition UI regressions(with a redesign) from 563ab05dd - recovery-74519-0621

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/SQLQueryDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/SQLQueryDialogService.java
@@ -195,6 +195,8 @@ public class SQLQueryDialogService {
          WorksheetEventUtil.refreshAssembly(rws, name, true, commandDispatcher, principal);
       }
 
+      boolean wasSingleQuery = ws.getWorksheetInfo().isSingleQueryMode();
+
       if(model.isMashUpData()) {
          ws.getWorksheetInfo().setMashupMode();
       }
@@ -207,7 +209,7 @@ public class SQLQueryDialogService {
       AssetEventUtil.refreshTableLastModified(ws, name, true);
       WorksheetEventUtil.refreshVariables(rws, wsEngine, name, commandDispatcher);
 
-      if(ws.getWorksheetInfo().isSingleQueryMode()) {
+      if(wasSingleQuery) {
          SaveWorksheetCommand command = new SaveWorksheetCommand();
          command.setClose(model.isCloseDialog());
          commandDispatcher.sendCommand(command);

--- a/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalModelController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalModelController.java
@@ -183,9 +183,29 @@ public class PhysicalModelController {
          databaseTreeService.getDatabaseNodes(parentPath, parr, additional, false,
             false, principal);
 
+      for(DatabaseTreeNode node : nodes) {
+         if(isSchemaFolderNode(node)) {
+            try {
+               List<DatabaseTreeNode> children = databaseTreeService.getDatabaseNodes(
+                  node.getPath(), node.getParr(), additional, false, false, principal);
+               long tableCount = children.stream()
+                  .filter(c -> DatabaseTreeNodeType.TABLE.equals(c.getType()))
+                  .count();
+               node.setTableCount((int) tableCount);
+            }
+            catch(Exception ignored) {
+            }
+         }
+      }
+
       return nodes.stream()
          .map(this::buildDatabaseTreeNode)
          .collect(Collectors.toList());
+   }
+
+   private boolean isSchemaFolderNode(DatabaseTreeNode node) {
+      return DatabaseTreeNodeType.FOLDER.equals(node.getType()) &&
+         node.getSchema() != null && !node.getSchema().isEmpty();
    }
 
    private TreeNodeModel buildDatabaseTreeNode(DatabaseTreeNode node) {

--- a/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalModelController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalModelController.java
@@ -33,6 +33,8 @@ import inetsoft.web.portal.model.database.events.*;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
 import inetsoft.web.security.RequiredPermission;
 import inetsoft.web.security.Secured;
@@ -193,7 +195,8 @@ public class PhysicalModelController {
                   .count();
                node.setTableCount((int) tableCount);
             }
-            catch(Exception ignored) {
+            catch(Exception e) {
+               LOG.debug("Failed to count tables in schema folder '{}': {}", node.getPath(), e.getMessage());
             }
          }
       }
@@ -819,5 +822,6 @@ public class PhysicalModelController {
    private final XRepository repository;
    private final PhysicalModelManagerService physicalModelManager;
    private final SecurityEngine securityEngine;
+   private static final Logger LOG = LoggerFactory.getLogger(PhysicalModelController.class);
 
 }

--- a/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalModelController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalModelController.java
@@ -30,11 +30,11 @@ import inetsoft.web.composer.model.TreeNodeModel;
 import inetsoft.web.factory.RemainingPath;
 import inetsoft.web.portal.model.database.*;
 import inetsoft.web.portal.model.database.events.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
 import inetsoft.web.security.RequiredPermission;
 import inetsoft.web.security.Secured;
@@ -49,6 +49,8 @@ import java.util.stream.Collectors;
 @RestController
 @Lazy
 public class PhysicalModelController {
+
+   private static final Logger LOG = LoggerFactory.getLogger(PhysicalModelController.class);
 
    public PhysicalModelController(RuntimePartitionService runtimePartitionService,
                                   DatabaseTreeService databaseTreeService,
@@ -822,6 +824,5 @@ public class PhysicalModelController {
    private final XRepository repository;
    private final PhysicalModelManagerService physicalModelManager;
    private final SecurityEngine securityEngine;
-   private static final Logger LOG = LoggerFactory.getLogger(PhysicalModelController.class);
 
 }

--- a/web/projects/portal/src/app/composer/dialog/ws/advanced-condition-pane.component.html
+++ b/web/projects/portal/src/app/composer/dialog/ws/advanced-condition-pane.component.html
@@ -23,7 +23,7 @@
     <div class="cond-section__actions">
       <button type="button" class="btn btn-default cond-section__btn" (click)="preList.edit()">_#(Edit)</button>
       <button type="button" class="btn btn-default cond-section__btn" (click)="preList.clear()"
-              [disabled]="!preAggregateConditionList?.length">_#(Clear)</button>
+              [disabled]="!(preAggregateConditionList?.length > 0)">_#(Clear)</button>
     </div>
   </div>
   <div class="cond-section__body">
@@ -43,7 +43,7 @@
     <div class="cond-section__actions">
       <button type="button" class="btn btn-default cond-section__btn" (click)="postList.edit()">_#(Edit)</button>
       <button type="button" class="btn btn-default cond-section__btn" (click)="postList.clear()"
-              [disabled]="!postAggregateConditionList?.length">_#(Clear)</button>
+              [disabled]="!(postAggregateConditionList?.length > 0)">_#(Clear)</button>
     </div>
   </div>
   <div class="cond-section__body">
@@ -63,7 +63,7 @@
     <div class="cond-section__actions">
       <button type="button" class="btn btn-default cond-section__btn" (click)="rankList.edit()">_#(Edit)</button>
       <button type="button" class="btn btn-default cond-section__btn" (click)="rankList.clear()"
-              [disabled]="!rankingConditionList?.length">_#(Clear)</button>
+              [disabled]="!(rankingConditionList?.length > 0)">_#(Clear)</button>
     </div>
   </div>
   <div class="cond-section__body">

--- a/web/projects/portal/src/app/composer/dialog/ws/advanced-condition-pane.component.html
+++ b/web/projects/portal/src/app/composer/dialog/ws/advanced-condition-pane.component.html
@@ -15,29 +15,64 @@
   ~ You should have received a copy of the GNU Affero General Public License
   ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   -->
-<fieldset>
-  <legend>_#(Pre-aggregate Conditions)</legend>
-  <condition-list [subqueryTables]="subqueryTables" [provider]="prePostProvider"
-                  [fields]="preAggregateFields" [conditionList]="preAggregateConditionList"
-                  [isVSContext]="false"
-                  [showOriginalName]="true"
-                  (conditionListChange)="preAggregateConditionListChange.emit($event)">
-  </condition-list>
-</fieldset>
-<fieldset>
-  <legend>_#(Post-aggregate Conditions)</legend>
-  <condition-list [subqueryTables]="subqueryTables" [provider]="prePostProvider"
-                  [fields]="postAggregateFields" [conditionList]="postAggregateConditionList"
-                  [isVSContext]="false"
-                  [showOriginalName]="true"
-                  (conditionListChange)="postAggregateConditionListChange.emit($event)">
-  </condition-list>
-</fieldset>
-<fieldset>
-  <legend>_#(Ranking Conditions)</legend>
-  <condition-list [subqueryTables]="subqueryTables" [simplePane]="true"
-                  [provider]="rankingProvider" [fields]="rankingFields"
-                  [conditionList]="rankingConditionList" [isVSContext]="false"
-                  [showOriginalName]="true"
-                  (conditionListChange)="rankingConditionListChange.emit($event)"></condition-list>
-</fieldset>
+
+<!-- Pre-aggregate Conditions -->
+<div class="cond-section">
+  <div class="cond-section__header">
+    <span class="cond-section__title">_#(Pre-aggregate Conditions)</span>
+    <div class="cond-section__actions">
+      <button type="button" class="btn btn-default cond-section__btn" (click)="preList.edit()">_#(Edit)</button>
+      <button type="button" class="btn btn-default cond-section__btn" (click)="preList.clear()"
+              [disabled]="!preAggregateConditionList?.length">_#(Clear)</button>
+    </div>
+  </div>
+  <div class="cond-section__body">
+    <condition-list #preList [subqueryTables]="subqueryTables" [provider]="prePostProvider"
+                    [fields]="preAggregateFields" [conditionList]="preAggregateConditionList"
+                    [isVSContext]="false"
+                    [showOriginalName]="true"
+                    (conditionListChange)="preAggregateConditionListChange.emit($event)">
+    </condition-list>
+  </div>
+</div>
+
+<!-- Post-aggregate Conditions -->
+<div class="cond-section">
+  <div class="cond-section__header">
+    <span class="cond-section__title">_#(Post-aggregate Conditions)</span>
+    <div class="cond-section__actions">
+      <button type="button" class="btn btn-default cond-section__btn" (click)="postList.edit()">_#(Edit)</button>
+      <button type="button" class="btn btn-default cond-section__btn" (click)="postList.clear()"
+              [disabled]="!postAggregateConditionList?.length">_#(Clear)</button>
+    </div>
+  </div>
+  <div class="cond-section__body">
+    <condition-list #postList [subqueryTables]="subqueryTables" [provider]="prePostProvider"
+                    [fields]="postAggregateFields" [conditionList]="postAggregateConditionList"
+                    [isVSContext]="false"
+                    [showOriginalName]="true"
+                    (conditionListChange)="postAggregateConditionListChange.emit($event)">
+    </condition-list>
+  </div>
+</div>
+
+<!-- Ranking Conditions -->
+<div class="cond-section">
+  <div class="cond-section__header">
+    <span class="cond-section__title">_#(Ranking Conditions)</span>
+    <div class="cond-section__actions">
+      <button type="button" class="btn btn-default cond-section__btn" (click)="rankList.edit()">_#(Edit)</button>
+      <button type="button" class="btn btn-default cond-section__btn" (click)="rankList.clear()"
+              [disabled]="!rankingConditionList?.length">_#(Clear)</button>
+    </div>
+  </div>
+  <div class="cond-section__body">
+    <condition-list #rankList [simplePane]="true"
+                    [subqueryTables]="subqueryTables" [provider]="rankingProvider"
+                    [fields]="rankingFields" [conditionList]="rankingConditionList"
+                    [isVSContext]="false"
+                    [showOriginalName]="true"
+                    (conditionListChange)="rankingConditionListChange.emit($event)">
+    </condition-list>
+  </div>
+</div>

--- a/web/projects/portal/src/app/composer/dialog/ws/advanced-condition-pane.component.scss
+++ b/web/projects/portal/src/app/composer/dialog/ws/advanced-condition-pane.component.scss
@@ -1,0 +1,79 @@
+/*!
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+:host {
+  display: block;
+}
+
+.cond-section {
+  border-top: 1px solid var(--inet-default-border-color);
+  margin-top: 14px;
+  padding-top: 14px;
+
+  &:first-child {
+    margin-top: 18px;
+  }
+}
+
+.cond-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--inet-space-4);
+}
+
+.cond-section__title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--inet-text-strong-color);
+}
+
+.cond-section__actions {
+  display: flex;
+  flex: none;
+}
+
+.cond-section__btn {
+  height: var(--inet-pill-height); /* 26px */
+  font-size: 12px;
+  font-weight: 500;
+  padding: 0 var(--inet-space-5);
+  line-height: 1;
+  border-radius: var(--inet-radius-md);
+
+  &:disabled,
+  &[disabled] {
+    color: var(--inet-text-subtle-color);
+    cursor: not-allowed;
+    opacity: 1;
+    background: transparent;
+  }
+}
+
+.cond-section__body {
+  margin-top: var(--inet-space-3);
+
+  ::ng-deep .condition-list__empty-state {
+    color: var(--inet-text-subtle-color);
+    padding-left: 0;
+  }
+
+  ::ng-deep .condition-list__empty-icon {
+    display: none;
+  }
+}

--- a/web/projects/portal/src/app/composer/dialog/ws/advanced-condition-pane.component.ts
+++ b/web/projects/portal/src/app/composer/dialog/ws/advanced-condition-pane.component.ts
@@ -34,6 +34,7 @@ import { ConditionList } from "../../../widget/condition/condition-list.componen
 @Component({
     selector: "advanced-condition-pane",
     templateUrl: "advanced-condition-pane.component.html",
+    styleUrls: ["advanced-condition-pane.component.scss"],
     imports: [ConditionList]
 })
 export class AdvancedConditionPane implements OnInit, OnChanges {
@@ -72,6 +73,18 @@ export class AdvancedConditionPane implements OnInit, OnChanges {
    }
 
    ngOnChanges(changes: SimpleChanges) {
+      if(changes.hasOwnProperty("variableNames")) {
+         // variableNames arrives asynchronously (after the parent's REST model loads),
+         // so push the updated list into providers if they already exist.
+         if(this.prePostProvider) {
+            this.prePostProvider.variableNames = this.variableNames;
+         }
+
+         if(this.rankingProvider) {
+            this.rankingProvider.variableNames = this.variableNames;
+         }
+      }
+
       if((changes.hasOwnProperty("preAggregateFields") ||
           changes.hasOwnProperty("postAggregateFields")) &&
          this.preAggregateFields && this.postAggregateFields)

--- a/web/projects/portal/src/app/composer/dialog/ws/assembly-condition-dialog.component.html
+++ b/web/projects/portal/src/app/composer/dialog/ws/assembly-condition-dialog.component.html
@@ -27,8 +27,8 @@
         <ng-template ngbNavContent>
           <fieldset>
             <div class="shell-form-row--field">
-              <div class="form-check">
-                <input type="checkbox" class="form-check-input" [ngModel]="model.advanced"
+              <div class="form-check form-switch">
+                <input type="checkbox" class="form-check-input" role="switch" [ngModel]="model.advanced"
                   (ngModelChange)="advancedChange($event)" id="adv"/>
                 <label class="form-check-label" for="adv">
                   _#(Advanced Conditions)
@@ -52,7 +52,7 @@
                 [rankingConditionList]="model.rankingConditionList"
                 (rankingConditionListChange)="rankingConditionListChange($event)"
                 [expressionFields]="model.expressionFields"
-                [variableNames]="variableNames"
+                [variableNames]="model?.variableNames"
               [grayedOutFields]="grayedOutFields"></advanced-condition-pane>
             }
           </ng-template>

--- a/web/projects/portal/src/app/composer/dialog/ws/assembly-condition-item-pane-provider.ts
+++ b/web/projects/portal/src/app/composer/dialog/ws/assembly-condition-item-pane-provider.ts
@@ -86,9 +86,10 @@ export abstract class AssemblyConditionItemPaneProvider extends AssetConditionIt
 
    getColumnTree(value: ExpressionValue, variableNames?: string[]): Observable<TreeNodeModel> {
       if(variableNames && variableNames.length > 0) {
-         // Merge with existing variable names so that server-provided variables (e.g. session
-         // variables set from model.variableNames) are never lost when the formula editor
-         // passes the client-side variableNames list here.
+         // Intentional merge (not overwrite): the server-provided list arrives via the
+         // variableNames setter before the formula editor calls getColumnTree(), so a plain
+         // overwrite would silently drop server names. Trade-off: deleted server variables
+         // persist for the lifetime of the provider (acceptable — provider is per-dialog).
          const merged = new Set<string>([...(this._variableNames || []), ...variableNames]);
          this._variableNames = Array.from(merged);
       }

--- a/web/projects/portal/src/app/composer/dialog/ws/assembly-condition-item-pane-provider.ts
+++ b/web/projects/portal/src/app/composer/dialog/ws/assembly-condition-item-pane-provider.ts
@@ -85,8 +85,12 @@ export abstract class AssemblyConditionItemPaneProvider extends AssetConditionIt
    }
 
    getColumnTree(value: ExpressionValue, variableNames?: string[]): Observable<TreeNodeModel> {
-      if(!!variableNames) {
-         this.variableNames = variableNames;
+      if(variableNames && variableNames.length > 0) {
+         // Merge with existing variable names so that server-provided variables (e.g. session
+         // variables set from model.variableNames) are never lost when the formula editor
+         // passes the client-side variableNames list here.
+         const merged = new Set<string>([...(this._variableNames || []), ...variableNames]);
+         this._variableNames = Array.from(merged);
       }
 
       return observableOf(this.getColumnTreeModel(value));

--- a/web/projects/portal/src/app/composer/dialog/ws/mv-condition-pane.component.html
+++ b/web/projects/portal/src/app/composer/dialog/ws/mv-condition-pane.component.html
@@ -26,27 +26,75 @@
     </div>
   </div>
 </fieldset>
-<fieldset>
-  <legend>_#(Append Records Matching Pre-aggregate Conditions)</legend>
-  <condition-list [subqueryTables]="subqueryTables" [provider]="appendProvider"
-                  [fields]="model.preAggregateFields" [isVSContext]="false"
-                  [(conditionList)]="model.appendPreAggregateConditionList"></condition-list>
-</fieldset>
-<fieldset>
-  <legend>_#(Append Records Matching Post-aggregate Conditions)</legend>
-  <condition-list [subqueryTables]="subqueryTables" [provider]="appendProvider"
-                  [fields]="model.postAggregateFields" [isVSContext]="false"
-                  [(conditionList)]="model.appendPostAggregateConditionList"></condition-list>
-</fieldset>
-<fieldset>
-  <legend>_#(Delete Records Matching Pre-aggregate Conditions)</legend>
-  <condition-list [subqueryTables]="subqueryTables" [provider]="deleteProvider"
-                  [fields]="model.preAggregateFields" [isVSContext]="false"
-                  [(conditionList)]="model.deletePreAggregateConditionList"></condition-list>
-</fieldset>
-<fieldset>
-  <legend>_#(Delete Records Matching Post-aggregate Conditions)</legend>
-  <condition-list [subqueryTables]="subqueryTables" [provider]="deleteProvider"
-                  [fields]="model.postAggregateFields" [isVSContext]="false"
-                  [(conditionList)]="model.deletePostAggregateConditionList"></condition-list>
-</fieldset>
+
+<!-- Append Pre-aggregate Conditions -->
+<div class="cond-section">
+  <div class="cond-section__header">
+    <span class="cond-section__title">_#(Append Records Matching Pre-aggregate Conditions)</span>
+    <div class="cond-section__actions">
+      <button type="button" class="btn btn-default cond-section__btn" (click)="appendPreList.edit()">_#(Edit)</button>
+      <button type="button" class="btn btn-default cond-section__btn" (click)="appendPreList.clear()"
+              [disabled]="!model.appendPreAggregateConditionList?.length">_#(Clear)</button>
+    </div>
+  </div>
+  <div class="cond-section__body">
+    <condition-list #appendPreList [subqueryTables]="subqueryTables" [provider]="appendProvider"
+                    [fields]="model.preAggregateFields" [isVSContext]="false"
+                    [(conditionList)]="model.appendPreAggregateConditionList">
+    </condition-list>
+  </div>
+</div>
+
+<!-- Append Post-aggregate Conditions -->
+<div class="cond-section">
+  <div class="cond-section__header">
+    <span class="cond-section__title">_#(Append Records Matching Post-aggregate Conditions)</span>
+    <div class="cond-section__actions">
+      <button type="button" class="btn btn-default cond-section__btn" (click)="appendPostList.edit()">_#(Edit)</button>
+      <button type="button" class="btn btn-default cond-section__btn" (click)="appendPostList.clear()"
+              [disabled]="!model.appendPostAggregateConditionList?.length">_#(Clear)</button>
+    </div>
+  </div>
+  <div class="cond-section__body">
+    <condition-list #appendPostList [subqueryTables]="subqueryTables" [provider]="appendProvider"
+                    [fields]="model.postAggregateFields" [isVSContext]="false"
+                    [(conditionList)]="model.appendPostAggregateConditionList">
+    </condition-list>
+  </div>
+</div>
+
+<!-- Delete Pre-aggregate Conditions -->
+<div class="cond-section">
+  <div class="cond-section__header">
+    <span class="cond-section__title">_#(Delete Records Matching Pre-aggregate Conditions)</span>
+    <div class="cond-section__actions">
+      <button type="button" class="btn btn-default cond-section__btn" (click)="deletePreList.edit()">_#(Edit)</button>
+      <button type="button" class="btn btn-default cond-section__btn" (click)="deletePreList.clear()"
+              [disabled]="!model.deletePreAggregateConditionList?.length">_#(Clear)</button>
+    </div>
+  </div>
+  <div class="cond-section__body">
+    <condition-list #deletePreList [subqueryTables]="subqueryTables" [provider]="deleteProvider"
+                    [fields]="model.preAggregateFields" [isVSContext]="false"
+                    [(conditionList)]="model.deletePreAggregateConditionList">
+    </condition-list>
+  </div>
+</div>
+
+<!-- Delete Post-aggregate Conditions -->
+<div class="cond-section">
+  <div class="cond-section__header">
+    <span class="cond-section__title">_#(Delete Records Matching Post-aggregate Conditions)</span>
+    <div class="cond-section__actions">
+      <button type="button" class="btn btn-default cond-section__btn" (click)="deletePostList.edit()">_#(Edit)</button>
+      <button type="button" class="btn btn-default cond-section__btn" (click)="deletePostList.clear()"
+              [disabled]="!model.deletePostAggregateConditionList?.length">_#(Clear)</button>
+    </div>
+  </div>
+  <div class="cond-section__body">
+    <condition-list #deletePostList [subqueryTables]="subqueryTables" [provider]="deleteProvider"
+                    [fields]="model.postAggregateFields" [isVSContext]="false"
+                    [(conditionList)]="model.deletePostAggregateConditionList">
+    </condition-list>
+  </div>
+</div>

--- a/web/projects/portal/src/app/composer/dialog/ws/mv-condition-pane.component.scss
+++ b/web/projects/portal/src/app/composer/dialog/ws/mv-condition-pane.component.scss
@@ -1,0 +1,85 @@
+/*!
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+:host {
+  display: block;
+}
+
+fieldset {
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+
+.cond-section {
+  border-top: 1px solid var(--inet-default-border-color);
+  margin-top: 14px;
+  padding-top: 14px;
+
+  &:first-of-type {
+    margin-top: 18px;
+  }
+}
+
+.cond-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--inet-space-4);
+}
+
+.cond-section__title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--inet-text-strong-color);
+}
+
+.cond-section__actions {
+  display: flex;
+  flex: none;
+}
+
+.cond-section__btn {
+  height: var(--inet-pill-height); /* 26px */
+  font-size: 12px;
+  font-weight: 500;
+  padding: 0 var(--inet-space-5);
+  line-height: 1;
+  border-radius: var(--inet-radius-md);
+
+  &:disabled,
+  &[disabled] {
+    color: var(--inet-text-subtle-color);
+    cursor: not-allowed;
+    opacity: 1;
+    background: transparent;
+  }
+}
+
+.cond-section__body {
+  margin-top: var(--inet-space-3);
+
+  ::ng-deep .condition-list__empty-state {
+    color: var(--inet-text-subtle-color);
+    padding-left: 0;
+  }
+
+  ::ng-deep .condition-list__empty-icon {
+    display: none;
+  }
+}

--- a/web/projects/portal/src/app/composer/dialog/ws/mv-condition-pane.component.ts
+++ b/web/projects/portal/src/app/composer/dialog/ws/mv-condition-pane.component.ts
@@ -28,6 +28,7 @@ import { FormsModule } from "@angular/forms";
 @Component({
     selector: "mv-condition-pane",
     templateUrl: "mv-condition-pane.component.html",
+    styleUrls: ["mv-condition-pane.component.scss"],
     imports: [FormsModule, ConditionList]
 })
 export class MVConditionPane implements OnInit {

--- a/web/projects/portal/src/app/composer/gui/ws/editor/ws-pane.component.ts
+++ b/web/projects/portal/src/app/composer/gui/ws/editor/ws-pane.component.ts
@@ -561,7 +561,7 @@ export class WSPaneComponent extends CommandProcessor implements OnDestroy, OnIn
       };
 
       const onCancel = () => {
-         if(this.worksheet.singleQuery) {
+         if(this.worksheet.singleQuery && !table.sqlEdited) {
             this.onSheetClose.emit(this.worksheet);
          }
       };

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/asset-description/asset-description.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/asset-description/asset-description.component.html
@@ -1,53 +1,205 @@
 <!--
-~ This file is part of StyleBI.
-~ Copyright (C) 2024  InetSoft Technology
-~
-~ This program is free software: you can redistribute it and/or modify
-~ it under the terms of the GNU Affero General Public License as published by
-~ the Free Software Foundation, either version 3 of the License, or
-~ (at your option) any later version.
-~
-~ This program is distributed in the hope that it will be useful,
-~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-~ GNU Affero General Public License for more details.
-~
-~ You should have received a copy of the GNU Affero General Public License
-~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
--->
+  ~ This file is part of StyleBI.
+  ~ Copyright (C) 2024  InetSoft Technology
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
 @if (!!selectedFile) {
-  <div class="description-scroll-container container-fluid light-gray-bg h-100 asset-description-container bl-gray">
-    <div class="row justify-content-end g-0 py-1">
-      <button type="button" class="btn-close cursor-pointer" (click)="close()" aria-label="close">
-      </button>
-    </div>
-    <div class="form-group">
-      <h2>{{selectedFile.name}}</h2>
-    </div>
-    @let basedView = getBasedView();
-    @if (!!basedView) {
-      <div class="form-group">
-        <div class="overview-item__label">_#(data.datasources.basedView)</div>
-        <div>{{basedView}}</div>
-      </div>
-    }
-    <div class="form-group">
-      <div class="overview-item__label">_#(data.datasources.creationDate)</div>
-      <div>{{selectedFile.createdDateLabel}}</div>
-    </div>
-    <div class="form-group">
-      <div class="overview-item__label">_#(Creation By)</div>
-      <div>{{selectedFile.createdBy}}</div>
-    </div>
-    @if (isWorksheet) {
-      <div class="form-group">
-        <div class="overview-item__label">_#(Last Modified)</div>
-        <div>{{selectedFile.modifiedDateLabel}}</div>
-      </div>
-    }
-    <div class="form-group">
-      <div class="overview-item__label">_#(Description)</div>
-      <div>{{selectedFile.description}}</div>
+  <div class="description-scroll-container asset-description-shell">
+    <div class="asset-description-layout">
+      <section class="asset-hero">
+        <div class="asset-hero__copy">
+          <div class="asset-hero__eyebrow">
+            @if (isWorksheet) {
+              _#(Worksheet)
+            } @else {
+              _#(Details)
+            }
+          </div>
+          <h1 class="asset-hero__title">{{selectedFile.name}}</h1>
+          @if (selectedFile.description) {
+            <div class="asset-hero__description">
+              {{selectedFile.description}}
+            </div>
+          }
+        </div>
+        <button type="button" class="btn-close cursor-pointer asset-hero__close"
+                (click)="close()" aria-label="close">
+        </button>
+      </section>
+
+      <section class="info-section">
+        <div class="info-section__title">_#(Overview)</div>
+        <div class="overview-grid">
+          @let basedView = getBasedView();
+          @if (!!basedView) {
+            <div class="overview-item">
+              <div class="overview-item__label">_#(data.datasources.basedView)</div>
+              <div class="overview-item__value">{{basedView}}</div>
+            </div>
+          }
+          <div class="overview-item">
+            <div class="overview-item__label">_#(data.datasources.creationDate)</div>
+            <div class="overview-item__value">
+              @if (selectedFile.createdDateLabel) {
+                {{selectedFile.createdDateLabel}}
+              } @else {
+                _#(None)
+              }
+            </div>
+          </div>
+          <div class="overview-item">
+            <div class="overview-item__label">_#(Creation By)</div>
+            <div class="overview-item__value">
+              @if (selectedFile.createdBy) {
+                {{selectedFile.createdBy}}
+              } @else {
+                _#(None)
+              }
+            </div>
+          </div>
+          @if (isWorksheet) {
+            <div class="overview-item">
+              <div class="overview-item__label">_#(Last Modified)</div>
+              <div class="overview-item__value">
+                @if (selectedFile.modifiedDateLabel) {
+                  {{selectedFile.modifiedDateLabel}}
+                } @else {
+                  _#(None)
+                }
+              </div>
+            </div>
+            <div class="overview-item">
+              <div class="overview-item__label">_#(Primary Fields)</div>
+              <div class="overview-item__value">{{primaryTableAssembly?.fields?.length || 0}}</div>
+            </div>
+            <div class="overview-item">
+              <div class="overview-item__label">_#(Root Inputs)</div>
+              <div class="overview-item__value">{{rootTableAssemblies.length}}</div>
+            </div>
+            <div class="overview-item">
+              <div class="overview-item__label">_#(Used By)</div>
+              <div class="overview-item__value">{{usedBy.length}}</div>
+            </div>
+          }
+        </div>
+      </section>
+
+      @if (isWorksheet) {
+        <section class="info-section">
+          <div class="info-section__title">_#(Transformation Summary)</div>
+          @if (loadingRootTableAssemblies) {
+            <div class="section-empty">_#(Loading)</div>
+          }
+          @if (!loadingRootTableAssemblies && !transformationSummary) {
+            <div class="section-empty">_#(None)</div>
+          }
+          @if (transformationSummary) {
+            <div class="summary-callout">
+              {{transformationSummary}}
+            </div>
+          }
+        </section>
+      }
+
+      @if (isWorksheet) {
+        <div class="detail-grid">
+          <section class="info-section detail-card">
+            <div class="info-section__title">_#(Primary Table Assembly)</div>
+            @if (loadingRootTableAssemblies) {
+              <div class="section-empty">_#(Loading)</div>
+            }
+            @if (!loadingRootTableAssemblies && !primaryTableAssembly) {
+              <div class="section-empty">_#(None)</div>
+            }
+            @if (primaryTableAssembly) {
+              <div class="block-card block-card--primary">
+                <div class="block-card__header">
+                  <div class="block-card__title">{{primaryTableAssembly.name}}</div>
+                  <div class="block-card__badge">{{primaryTableAssembly.fields?.length || 0}} _#(Fields)</div>
+                </div>
+                @if (primaryTableAssembly.fields?.length) {
+                  <div class="field-chip-list">
+                    @for (field of primaryTableAssembly.fields; track field.name) {
+                      <div class="field-chip">
+                        <span class="field-chip__name">{{field.name}}</span>
+                        <span class="field-chip__type">{{getRootTableAssemblyFieldType(field)}}</span>
+                      </div>
+                    }
+                  </div>
+                }
+              </div>
+            }
+          </section>
+
+          <section class="info-section detail-card">
+            <div class="info-section__title">_#(Used By)</div>
+            @if (loadingRootTableAssemblies) {
+              <div class="section-empty">_#(Loading)</div>
+            }
+            @if (!loadingRootTableAssemblies && usedBy.length === 0) {
+              <div class="section-empty">_#(None)</div>
+            }
+            @for (asset of usedBy; track asset.name) {
+              <div class="dependent-asset-item">
+                <div class="dependent-asset-item__header">
+                  <div class="dependent-asset-name">{{asset.name}}</div>
+                  <div class="dependent-asset-meta">{{getDependentAssetTypeLabel(asset)}}</div>
+                </div>
+                <div class="dependent-asset-path">{{asset.path}}</div>
+              </div>
+            }
+          </section>
+        </div>
+      }
+
+      @if (isWorksheet) {
+        <section class="info-section">
+          <div class="info-section__title">_#(Root Table Assemblies)</div>
+          @if (loadingRootTableAssemblies) {
+            <div class="section-empty">_#(Loading)</div>
+          }
+          @if (!loadingRootTableAssemblies && rootTableAssemblies.length === 0) {
+            <div class="section-empty">_#(None)</div>
+          }
+          @if (rootTableAssemblies.length > 0) {
+            <div class="root-block-grid">
+              @for (tableAssembly of rootTableAssemblies; track tableAssembly.name) {
+                <div class="block-card">
+                  <div class="block-card__header">
+                    <div>
+                      <div class="block-card__title">{{tableAssembly.name}}</div>
+                      <div class="block-card__subtitle">{{getRootTableAssemblyLabel(tableAssembly)}}</div>
+                    </div>
+                    <div class="block-card__pill">{{getRootTableAssemblyMeta(tableAssembly)}}</div>
+                  </div>
+                  @if (tableAssembly.fields?.length) {
+                    <div class="field-chip-list">
+                      @for (field of tableAssembly.fields; track field.name) {
+                        <div class="field-chip">
+                          <span class="field-chip__name">{{field.name}}</span>
+                          <span class="field-chip__type">{{getRootTableAssemblyFieldType(field)}}</span>
+                        </div>
+                      }
+                    </div>
+                  }
+                </div>
+              }
+            </div>
+          }
+        </section>
+      }
     </div>
   </div>
 }

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-data-model-browser/database-data-model-browser.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-data-model-browser/database-data-model-browser.component.html
@@ -1,24 +1,24 @@
 <!--
-~ This file is part of StyleBI.
-~ Copyright (C) 2024  InetSoft Technology
-~
-~ This program is free software: you can redistribute it and/or modify
-~ it under the terms of the GNU Affero General Public License as published by
-~ the Free Software Foundation, either version 3 of the License, or
-~ (at your option) any later version.
-~
-~ This program is distributed in the hope that it will be useful,
-~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-~ GNU Affero General Public License for more details.
-~
-~ You should have received a copy of the GNU Affero General Public License
-~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
--->
+  ~ This file is part of StyleBI.
+  ~ Copyright (C) 2024  InetSoft Technology
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
 <div class="data-model-browser-container align-items-stretch g-0 flex-row">
   <div class="d-flex flex-column align-items-stretch p-0 h-100"
-    [class.col-12]="!showDetailsItem"
-    [ngClass]="{'col-6 col-sm-8 col-md-9' : !!showDetailsItem}">
+       [class.col-12]="!showDetailsItem"
+       [ngClass]="{'col-6 col-sm-8 col-md-9' : !!showDetailsItem}">
     <div class="data-model-workspace-header">
       <div class="data-model-workspace-heading">
         <div class="data-model-workspace-eyebrow">_#(Data Model)</div>
@@ -30,15 +30,15 @@
         </div>
       </div>
       <database-data-model-toolbar [database]="databaseName" [model]="listModel"
-        [searchQuery]="searchQuery" [searchVisible]="searchVisible"
-        [isvpm]="false" [isRoot]="isRoot()"
-        [moveDisable]="moveDisable" [selectedItems]="selectedItems"
-        (onAddFolder)="addDataModelFolder()"
-        (onAddLM)="addLogicalModel()"
-        (onAddPhysicalView)="addPhysicalView()"
-        (onDeleteSelected)="deleteSelected()"
-        (onMoveSelected)="moveSelected()"
-        (onToggleSelection)="toggleSelectionState()" (onSearch)="search($event)">
+                                   [searchQuery]="searchQuery" [searchVisible]="searchVisible"
+                                   [isvpm]="false" [isRoot]="isRoot()"
+                                   [moveDisable]="moveDisable" [selectedItems]="selectedItems"
+                                   (onAddFolder)="addDataModelFolder()"
+                                   (onAddLM)="addLogicalModel()"
+                                   (onAddPhysicalView)="addPhysicalView()"
+                                   (onDeleteSelected)="deleteSelected()"
+                                   (onMoveSelected)="moveSelected()"
+                                   (onToggleSelection)="toggleSelectionState()" (onSearch)="search($event)">
       </database-data-model-toolbar>
     </div>
     @if (searchView) {
@@ -49,27 +49,113 @@
         </span>
       </div>
     }
-    <div class="flex-fixed-content">
-      <asset-item-list-view [assets]="models" [columns]="getListColumns()" [selectedItems]="selectedItems"
-        [sortOptions]="sortOptions" [selectionOn]="selectionOn"
-        [searchView]="searchView"
-        [getParentPath]="getParentPath"
-        [iconFunction]="getIcon()" [fetchChildrenFunc]="fetchChildren"
-        [dragSupportFunc]="dragSupportFun()"
-        [dragSupport]="true"
-        (onSelectedChanged)="changeSelectedItems($event)"
-        (sortChanged)="sortModels()" (onClickItem)="clickItem($event)"
-        (onContextmenu)="openContextmenu($event)"
-        (dragAssets)="dragAssetsItems($event)"
-        (assetsDroped)="dropAssetsItems($event)">
-      </asset-item-list-view>
-    </div>
+    <asset-item-list-view [assets]="models" [columns]="getListColumns()" [selectedItems]="selectedItems"
+                          [sortOptions]="sortOptions" [selectionOn]="selectionOn"
+                          [searchView]="searchView"
+                          [getParentPath]="getParentPath"
+                          [iconFunction]="getIcon()" [fetchChildrenFunc]="fetchChildren"
+                          [dragSupportFunc]="dragSupportFun()"
+                          [dragSupport]="true"
+                          (onSelectedChanged)="changeSelectedItems($event)"
+                          (sortChanged)="sortModels()" (onClickItem)="clickItem($event)"
+                          (onContextmenu)="openContextmenu($event)"
+                          (dragAssets)="dragAssetsItems($event)"
+                          (assetsDroped)="dropAssetsItems($event)">
+    </asset-item-list-view>
   </div>
   @if (!!showDetailsItem) {
     <div class="flex h-100 col-6 col-sm-4 col-md-3 p-0">
-      <asset-description [selectedFile]="showDetailsItem"
-        (onClose)="setShowDetailsItem(null)">
-      </asset-description>
+      <div class="data-model-detail-pane">
+        <div class="data-model-detail-pane__header">
+          <div class="data-model-detail-pane__eyebrow">{{getDetailEyebrow(showDetailsItem)}}</div>
+          <div class="data-model-detail-pane__title-row">
+            <h2 class="data-model-detail-pane__title">{{showDetailsItem.name}}</h2>
+            <i role="button" class="close-icon data-model-detail-pane__close"
+               title="_#(Close)"
+               (click)="setShowDetailsItem(null)"></i>
+          </div>
+          <div class="data-model-detail-pane__subtitle">{{getDetailSubtitle(showDetailsItem)}}</div>
+        </div>
+
+        <div class="data-model-detail-pane__actions">
+          <div class="data-model-detail-pane__action-row">
+            <button type="button" class="btn btn-primary"
+                    [disabled]="!showDetailsItem?.editable"
+                    (click)="editModel(showDetailsItem)">
+              _#(Edit)
+            </button>
+            <div class="btn-toolbar toolbar-ghost-actions" role="toolbar">
+              <div class="btn-group" role="group">
+                <i role="button" class="btn py-1 folder-move-icon"
+                   title="_#(Move)"
+                   [class.disabled]="!canMoveDetailItem(showDetailsItem)"
+                   (click)="moveDetailItem()"></i>
+                <i role="button" class="btn py-1 view-detail-meta-icon"
+                   title="_#(Rename)"
+                   [class.disabled]="!canRenameDetailItem(showDetailsItem)"
+                   (click)="renameModel(showDetailsItem)"></i>
+                <i role="button" class="btn py-1 trash-icon"
+                   title="_#(Delete)"
+                   [class.disabled]="!canDeleteDetailItem(showDetailsItem)"
+                   (click)="deleteDetailItem()"></i>
+              </div>
+            </div>
+          </div>
+          @if (canAddLogicalModel(showDetailsItem) || canAddExtendedModel(showDetailsItem)) {
+            <div class="data-model-detail-pane__action-row data-model-detail-pane__action-row--secondary">
+              @if (canAddLogicalModel(showDetailsItem)) {
+                <button type="button" class="btn btn-secondary"
+                        (click)="addLogicalModel0(showDetailsItem)">
+                  _#(New Logical Model)
+                </button>
+              }
+              @if (canAddExtendedModel(showDetailsItem)) {
+                <button type="button" class="btn btn-secondary"
+                        (click)="addExtendModel(showDetailsItem)">
+                  {{isPhysicalView(showDetailsItem) ? '_#(Add Extended View)' : '_#(Add Extended Model)'}}
+                </button>
+              }
+            </div>
+          }
+        </div>
+
+        <div class="data-model-detail-pane__section">
+          <div class="data-model-detail-pane__section-title">_#(Overview)</div>
+          <div class="data-model-detail-pane__meta-grid">
+            <div class="data-model-detail-pane__meta-card">
+              <div class="data-model-detail-pane__meta-label">_#(Type)</div>
+              <div class="data-model-detail-pane__meta-value">{{getTypeLabel(showDetailsItem)}}</div>
+            </div>
+            <div class="data-model-detail-pane__meta-card">
+              <div class="data-model-detail-pane__meta-label">_#(Created By)</div>
+              <div class="data-model-detail-pane__meta-value">{{showDetailsItem.createdBy || '-'}}</div>
+            </div>
+            <div class="data-model-detail-pane__meta-card">
+              <div class="data-model-detail-pane__meta-label">_#(Creation Date)</div>
+              <div class="data-model-detail-pane__meta-value">{{showDetailsItem.createdDateLabel || '-'}}</div>
+            </div>
+            @if (getBasedView(showDetailsItem)) {
+              <div class="data-model-detail-pane__meta-card">
+                <div class="data-model-detail-pane__meta-label">_#(data.datasources.basedView)</div>
+                <div class="data-model-detail-pane__meta-value">{{getBasedView(showDetailsItem)}}</div>
+              </div>
+            }
+            @if (isLogicalModel(showDetailsItem) && getConnectionLabel(showDetailsItem)) {
+              <div class="data-model-detail-pane__meta-card">
+                <div class="data-model-detail-pane__meta-label">_#(Connection)</div>
+                <div class="data-model-detail-pane__meta-value">{{getConnectionLabel(showDetailsItem)}}</div>
+              </div>
+            }
+          </div>
+        </div>
+
+        @if (showDetailsItem.description) {
+          <div class="data-model-detail-pane__section">
+            <div class="data-model-detail-pane__section-title">_#(Description)</div>
+            <div class="data-model-detail-pane__description">{{showDetailsItem.description}}</div>
+          </div>
+        }
+      </div>
     </div>
   }
 </div>

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-data-model-browser/database-vpm-browser/database-vpm-browser.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-data-model-browser/database-vpm-browser/database-vpm-browser.component.html
@@ -1,57 +1,128 @@
 <!--
-~ This file is part of StyleBI.
-~ Copyright (C) 2024  InetSoft Technology
-~
-~ This program is free software: you can redistribute it and/or modify
-~ it under the terms of the GNU Affero General Public License as published by
-~ the Free Software Foundation, either version 3 of the License, or
-~ (at your option) any later version.
-~
-~ This program is distributed in the hope that it will be useful,
-~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-~ GNU Affero General Public License for more details.
-~
-~ You should have received a copy of the GNU Affero General Public License
-~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
--->
+  ~ This file is part of StyleBI.
+  ~ Copyright (C) 2024  InetSoft Technology
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
 <div class="vpm-browser-container align-items-stretch g-0 flex-row">
   <div class="d-flex flex-column align-items-stretch p-0 h-100"
-    [class.col-12]="!showDetailsItem"
-    [ngClass]="{'col-6 col-sm-8 col-md-9' : !!showDetailsItem}">
-    <div class="flex-fixed-container h-100">
-      <database-data-model-toolbar [database]="databaseName" [selectedItems]="selectedItems"
-        [model]="model" [isvpm]="true"
-        [searchQuery]="searchQuery" [searchVisible]="searchVisible"
-        (onAddVPM)="addModel()"
-        (onDeleteSelected)="deleteSelected()"
-        (onToggleSelection)="toggleSelectionState()" (onSearch)="search($event)">
-      </database-data-model-toolbar>
-      @if (searchView) {
-        <div class="vpm-search-banner">
-          <i class="close-circle-icon icon-size-small action-style me-1" (click)="clearSearch()"></i>
-          <span>
-            <b>_#(data.datasets.searchResults):</b> {{currentSearchQuery}} <b>_#(data.datasets.searchIn)</b> {{crrentSearchFolderLabel}}
-          </span>
+     [class.col-12]="!showDetailsItem"
+     [ngClass]="{'col-6 col-sm-8 col-md-9' : !!showDetailsItem}">
+    <div class="vpm-workspace-header">
+      <div class="vpm-workspace-heading">
+        <div class="vpm-workspace-eyebrow">_#(Virtual Private Models)</div>
+        <div class="vpm-workspace-title">
+          {{physicalModelName || rootLabel}}
         </div>
-      }
-      <div class="flex-fixed-content">
-        <asset-item-list-view [assets]="models" [columns]="listColumns" [selectedItems]="selectedItems"
-          [iconFunction]="iconFun" [sortOptions]="sortOptions"
-          [selectionOn]="selectionOn"
-          (sortChanged)="sortOptionsChanged()"
-          (onContextmenu)="openTreeContextmenu($event)"
-          (onClickItem)="editModel($event)"
-          (onSelectedChanged)="selectedItems = $event">
-        </asset-item-list-view>
+        <div class="vpm-workspace-subtitle">
+          _#(Browse and manage virtual private models for this physical view.)
+        </div>
       </div>
+      <database-data-model-toolbar [database]="databaseName" [selectedItems]="selectedItems"
+                                   [model]="model" [isvpm]="true"
+                                   [searchQuery]="searchQuery" [searchVisible]="searchVisible"
+                                   (onAddVPM)="addModel()"
+                                   (onDeleteSelected)="deleteSelected()"
+                                   (onToggleSelection)="toggleSelectionState()" (onSearch)="search($event)">
+      </database-data-model-toolbar>
+    </div>
+    @if (searchView) {
+      <div class="vpm-search-banner">
+        <i class="close-circle-icon icon-size-small action-style me-1" (click)="clearSearch()"></i>
+        <span>
+          <b>_#(data.datasets.searchResults):</b> {{currentSearchQuery}} <b>_#(data.datasets.searchIn)</b> {{crrentSearchFolderLabel}}
+        </span>
+      </div>
+    }
+    <div class="flex-fixed-content">
+      <asset-item-list-view [assets]="models" [columns]="listColumns" [selectedItems]="selectedItems"
+                            [iconFunction]="iconFun" [sortOptions]="sortOptions"
+                            [selectionOn]="selectionOn"
+                            (sortChanged)="sortOptionsChanged()"
+                            (onContextmenu)="openTreeContextmenu($event)"
+                            (onClickItem)="editModel($event)"
+                            (onSelectedChanged)="selectedItems = $event">
+      </asset-item-list-view>
     </div>
   </div>
   @if (!!showDetailsItem) {
     <div class="flex h-100 col-6 col-sm-4 col-md-3 p-0">
-      <asset-description [selectedFile]="showDetailsItem"
-        (onClose)="setShowDetailsItem(null)">
-      </asset-description>
+      <div class="vpm-detail-pane">
+        <div class="vpm-detail-pane__header">
+          <div class="vpm-detail-pane__eyebrow">_#(Virtual Private Model)</div>
+          <div class="vpm-detail-pane__title-row">
+            <h2 class="vpm-detail-pane__title">{{showDetailsItem.name}}</h2>
+            <i role="button" class="close-icon vpm-detail-pane__close"
+               title="_#(Close)"
+               (click)="setShowDetailsItem(null)"></i>
+          </div>
+          <div class="vpm-detail-pane__subtitle">
+            {{getDetailSubtitle(showDetailsItem)}}
+          </div>
+        </div>
+
+        <div class="vpm-detail-pane__actions">
+          <div class="vpm-detail-pane__action-row">
+            <button type="button" class="btn btn-primary"
+                    [disabled]="!showDetailsItem?.editable"
+                    (click)="editModel(showDetailsItem)">
+              _#(Edit)
+            </button>
+            <div class="btn-toolbar toolbar-ghost-actions" role="toolbar">
+              <div class="btn-group" role="group">
+                <i role="button" class="btn py-1 view-detail-meta-icon"
+                   title="_#(Rename)"
+                   [class.disabled]="!showDetailsItem?.editable"
+                   (click)="showDetailsItem?.editable && renameModel(showDetailsItem)"></i>
+                <i role="button" class="btn py-1 trash-icon"
+                   title="_#(Delete)"
+                   [class.disabled]="!showDetailsItem?.deletable"
+                   (click)="showDetailsItem?.deletable && deleteModel([showDetailsItem])"></i>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="vpm-detail-pane__section">
+          <div class="vpm-detail-pane__section-title">_#(Overview)</div>
+          <div class="vpm-detail-pane__meta-grid">
+            <div class="vpm-detail-pane__meta-card">
+              <div class="vpm-detail-pane__meta-label">_#(Type)</div>
+              <div class="vpm-detail-pane__meta-value">_#(Virtual Private Model)</div>
+            </div>
+            <div class="vpm-detail-pane__meta-card">
+              <div class="vpm-detail-pane__meta-label">_#(Created By)</div>
+              <div class="vpm-detail-pane__meta-value">{{showDetailsItem.createdBy || '-'}}</div>
+            </div>
+            <div class="vpm-detail-pane__meta-card">
+              <div class="vpm-detail-pane__meta-label">_#(Creation Date)</div>
+              <div class="vpm-detail-pane__meta-value">{{showDetailsItem.createdDateLabel || '-'}}</div>
+            </div>
+            <div class="vpm-detail-pane__meta-card">
+              <div class="vpm-detail-pane__meta-label">_#(Physical View)</div>
+              <div class="vpm-detail-pane__meta-value">{{physicalModelName || '-'}}</div>
+            </div>
+          </div>
+        </div>
+
+        @if (showDetailsItem.description) {
+          <div class="vpm-detail-pane__section">
+            <div class="vpm-detail-pane__section-title">_#(Description)</div>
+            <div class="vpm-detail-pane__description">{{showDetailsItem.description}}</div>
+          </div>
+        }
+      </div>
     </div>
   }
 </div>

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/attribute-editor/auto-drill-dialog/select-worksheet-dialog.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/attribute-editor/auto-drill-dialog/select-worksheet-dialog.component.html
@@ -24,7 +24,7 @@
         _#(Select a Worksheet)
       </div>
     </legend>
-    <div class="select-worksheet-dialog__tree-shell tree-container">
+    <div class="select-worksheet-dialog__tree-shell bordered-box bd-gray tree-container">
       <asset-tree [datasources]="false" [columns]="false" [viewsheets]="false"
         [readOnly]="true"
         [dataSourcePath]="selectedEntry?.path"
@@ -76,7 +76,7 @@
   }
 </div>
 <div class="modal-footer">
-  <button type="button" class="btn btn-default" (click)="ok()" [disabled]="okDisabled()">_#(OK)</button>
+  <button type="button" class="btn btn-primary" (click)="ok()" [disabled]="okDisabled()">_#(OK)</button>
   <button type="button" class="btn btn-secondary" data-dismiss="modal" (click)="cancel()">_#(Cancel)</button>
   <button type="button" class="btn btn-default" (click)="clear()">_#(Clear)</button>
 </div>

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/driver-wizard/driver-wizard.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/driver-wizard/driver-wizard.component.html
@@ -1,166 +1,138 @@
 <!--
-~ This file is part of StyleBI.
-~ Copyright (C) 2024  InetSoft Technology
-~
-~ This program is free software: you can redistribute it and/or modify
-~ it under the terms of the GNU Affero General Public License as published by
-~ the Free Software Foundation, either version 3 of the License, or
-~ (at your option) any later version.
-~
-~ This program is distributed in the hope that it will be useful,
-~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-~ GNU Affero General Public License for more details.
-~
-~ You should have received a copy of the GNU Affero General Public License
-~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
--->
+  ~ This file is part of StyleBI.
+  ~ Copyright (C) 2024  InetSoft Technology
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
 <modal-header title="_#(em.data.databases.createDriver)" [cshid]="'AllDataSourcesPortal'"
   (onCancel)="cancel()">
 </modal-header>
 <div class="modal-body" blockMouse>
   <loading-indicator-pane [show]="loading"></loading-indicator-pane>
   @if (step === 'upload') {
-    <div class="container-fluid" [formGroup]="uploadForm">
-      <div class="container">
-        <div class="row mb-1">
-          <div class="driver-wizard__section driver-wizard__plugin-copy">
-            <div class="form-check">
-              <input type="radio" class="form-check-input" name="uploadType" value="upload" formControlName="uploadType" id="uploadTypeUpload" [disabled]="uploadForm.controls['uploadType']?.value !== 'upload'">
-              <label class="form-check-label" for="uploadTypeUpload">_#(Upload)</label>
-            </div>
-          </div>
+    <div class="driver-wizard driver-wizard--upload" [formGroup]="uploadForm">
+      <div class="driver-wizard__choice-row">
+        <div class="form-check driver-wizard__choice-toggle">
+          <input type="radio" class="form-check-input" name="uploadType" value="upload" formControlName="uploadType" id="uploadTypeUpload" [disabled]="uploadForm.controls['uploadType']?.value !== 'upload'">
+          <label class="form-check-label" for="uploadTypeUpload">_#(Upload)</label>
         </div>
-        <div class="row mb-1">
-          <div class="col-10 upload-files">
-            <div class="list-group">
-              @for (file of uploadForm.controls['uploadFiles']?.value; track $index; let i = $index) {
-                <a class="driver-wizard__list-item unhighlightable"
-                  [class.selected]="selectedDriverFiles.indexOf(i) >= 0"
-                  [attr.title]="file.name"
-                  (click)="selectDriverFile($event, i)">
-                  {{ file. name }}
-                </a>
-              }
-            </div>
-          </div>
-          <div class="driver-wizard__side-actions driver-wizard__upload-actions">
-            <input #uploadFileInput type="file" accept="application/java-archive" hidden multiple (change)="addDriverFiles($event)">
-            <button type="button" class="btn btn-secondary" (click)="uploadFileInput.value = null; uploadFileInput.click()" [disabled]="uploadForm.controls['uploadType']?.value !== 'upload'">_#(Add)</button>
-            <button type="button" class="btn btn-default" (click)="removeDriverFiles()" [disabled]="uploadForm.controls['uploadType']?.value !== 'upload' || selectedDriverFiles.length === 0">_#(Remove)</button>
-          </div>
-        </div>
-        @if (uploadForm.errors?.uploadFilesRequired) {
-          <div class="row mb-1">
-            <div class="driver-wizard__section driver-wizard__plugin-copy">
-              <span class="is-invalid"></span>
-              <span class="invalid-feedback">_#(em.data.databases.driver.uploadFilesRequired)</span>
-            </div>
-          </div>
-        }
-        <div class="driver-wizard__field form-floating">
-          <div class="driver-wizard__section driver-wizard__plugin-copy">
-            <div class="form-check">
-              <input type="radio" class="form-check-input" name="uploadType" value="maven" formControlName="uploadType" id="uploadTypeMaven">
-              <label class="form-check-label" for="uploadTypeMaven">_#(Maven)</label>
-            </div>
-          </div>
-        </div>
-        <div class="driver-wizard__field form-floating">
-          <div class="col form-floating">
-            <input class="form-control" type="text" formControlName="mavenCoord"
-              [class.is-invalid]="uploadForm.controls['mavenCoord'].invalid"
-              placeholder="_#(em.data.databases.driver.mavenCoord)"
-              [ngbTypeahead]="mavenSearch">
-            <label>_#(em.data.databases.driver.mavenCoord)</label>
-            @if (uploadForm.controls['mavenCoord']?.errors?.required) {
-              <span class="invalid-feedback">_#(em.data.databases.driver.mavenCoordRequired)</span>
-            }
-            @if (uploadForm.controls['mavenCoord']?.errors?.pattern) {
-              <span class="invalid-feedback">_#(em.data.databases.driver.mavenCoordInvalid)</span>
+        <div class="upload-files">
+          <div class="list-group">
+            @for (file of uploadForm.controls['uploadFiles']?.value; track $index; let i = $index) {
+              <a class="list-group-item unhighlightable"
+                 [class.selected]="selectedDriverFiles.indexOf(i) >= 0"
+                 (click)="selectDriverFile($event, i)">
+                {{ file.name }}
+              </a>
             }
           </div>
         </div>
-        @if (!uploadForm.controls['mavenCoord']?.errors?.required || uploadForm.controls['mavenCoord']?.pristine) {
-          <div class="driver-wizard__hint">_#(em.data.databases.driver.mavenCoordHint)</div>
-        }
+        <div class="driver-wizard__side-actions driver-wizard__upload-actions">
+          <input #uploadFileInput type="file" accept="application/java-archive" hidden multiple (change)="addDriverFiles($event)">
+          <button type="button" class="btn btn-secondary" (click)="uploadFileInput.value = null; uploadFileInput.click()" [disabled]="uploadForm.controls['uploadType']?.value !== 'upload'">_#(Add)</button>
+          <button type="button" class="btn btn-default" (click)="removeDriverFiles()" [disabled]="uploadForm.controls['uploadType']?.value !== 'upload' || selectedDriverFiles.length === 0">_#(Remove)</button>
+        </div>
       </div>
+      @if (uploadForm.errors?.uploadFilesRequired) {
+        <div class="driver-wizard__validation">
+          <span class="is-invalid"></span>
+          <span class="invalid-feedback">_#(em.data.databases.driver.uploadFilesRequired)</span>
+        </div>
+      }
+      <div class="driver-wizard__divider" role="separator" aria-hidden="true"></div>
+      <div class="driver-wizard__choice-row">
+        <div class="form-check driver-wizard__choice-toggle">
+          <input type="radio" class="form-check-input" name="uploadType" value="maven" formControlName="uploadType" id="uploadTypeMaven">
+          <label class="form-check-label" for="uploadTypeMaven">_#(Maven)</label>
+        </div>
+        <div class="driver-wizard__field form-floating">
+          <input class="form-control" type="text" formControlName="mavenCoord"
+                 [class.is-invalid]="uploadForm.controls['mavenCoord'].invalid"
+                 placeholder="_#(em.data.databases.driver.mavenCoord)"
+                 [ngbTypeahead]="mavenSearch">
+          <label>_#(em.data.databases.driver.mavenCoord)</label>
+          @if (uploadForm.controls['mavenCoord']?.errors?.required) {
+            <span class="invalid-feedback">_#(em.data.databases.driver.mavenCoordRequired)</span>
+          }
+          @if (uploadForm.controls['mavenCoord']?.errors?.pattern) {
+            <span class="invalid-feedback">_#(em.data.databases.driver.mavenCoordInvalid)</span>
+          }
+        </div>
+      </div>
+      @if (!uploadForm.controls['mavenCoord']?.errors?.required || uploadForm.controls['mavenCoord']?.pristine) {
+        <div class="driver-wizard__hint">_#(em.data.databases.driver.mavenCoordHint)</div>
+      }
     </div>
   }
   @if (step === 'drivers') {
-    <div class="container-fluid">
-      <div class="container">
-        <div class="row mb-1">
-          <div class="driver-wizard__section driver-wizard__plugin-copy">
-            <div class="list-group">
-              @for (driver of drivers; track trackByIdx(i, driver); let i = $index) {
-                <div class="list-group-item">
-                  <input type="checkbox" class="form-check-input checkbox" [(ngModel)]="selectedDrivers[i]" (ngModelChange)="selectDriver(i)">
-                  <span>{{ driver }}</span>
-                </div>
-              }
+    <div class="driver-wizard driver-wizard--drivers">
+      <div class="driver-wizard__section">
+        <div class="list-group">
+          @for (driver of drivers; track trackByIdx(i, driver); let i = $index) {
+            <div class="list-group-item">
+              <input type="checkbox" class="checkbox" [(ngModel)]="selectedDrivers[i]" (ngModelChange)="selectDriver(i)">
+              <span>{{ driver }}</span>
             </div>
-          </div>
+          }
         </div>
-        @if (driverForm.controls['drivers'].errors?.required) {
-          <div class="driver-wizard__validation">
-            <div class="driver-wizard__section driver-wizard__plugin-copy">
-              <span class="is-invalid"></span>
-              <span class="invalid-feedback">_#(em.data.databases.driver.driversRequired)</span>
-            </div>
-          </div>
-        }
       </div>
+      @if (driverForm.controls['drivers'].errors?.required) {
+        <div class="driver-wizard__validation">
+          <span class="is-invalid"></span>
+          <span class="invalid-feedback">_#(em.data.databases.driver.driversRequired)</span>
+        </div>
+      }
     </div>
   }
   @if (step === 'plugin') {
-    <div class="container-fluid" [formGroup]="pluginForm">
-      <div class="container">
-        <div class="row plugin-settings">
-          <div class="driver-wizard__section driver-wizard__plugin-copy">_#(em.data.databases.driver.pluginSettingsHelp)</div>
-        </div>
-        <div class="driver-wizard__field driver-wizard__field--plugin form-floating">
-          <div class="col form-floating">
-            <input class="form-control" type="text" formControlName="pluginId"
-              [class.is-invalid]="pluginForm.controls['pluginId'].invalid"
-              placeholder="_#(em.data.databases.driver.pluginId)">
-            <label>_#(em.data.databases.driver.pluginId)</label>
-            @if (pluginForm.controls['pluginId']?.errors?.required) {
-              <span class="invalid-feedback">_#(em.data.databases.driver.pluginIdRequired)</span>
-            }
-            @if (pluginForm.controls['pluginId']?.errors?.pluginExists) {
-              <span class="invalid-feedback">_#(em.data.databases.driver.pluginIdExists)</span>
-            }
-            <span class="plugin-settings-hint">_#(em.data.databases.driver.pluginIdHint)</span>
-          </div>
-        </div>
-        <div class="driver-wizard__field driver-wizard__field--plugin form-floating">
-          <div class="col form-floating">
-            <input class="form-control" type="text" formControlName="pluginName"
-              [class.is-invalid]="pluginForm.controls['pluginName'].invalid"
-              placeholder="_#(em.data.databases.driver.pluginName)">
-            <label>_#(em.data.databases.driver.pluginName)</label>
-            @if (pluginForm.controls['pluginName']?.errors?.required) {
-              <span class="invalid-feedback">_#(em.data.databases.driver.pluginNameRequired)</span>
-            }
-            <span class="plugin-settings-hint">_#(em.data.databases.driver.pluginNameHint)</span>
-          </div>
-        </div>
-        <div class="driver-wizard__field driver-wizard__field--plugin form-floating">
-          <div class="col form-floating">
-            <input class="form-control" type="text" formControlName="pluginVersion"
-              [class.is-invalid]="pluginForm.controls['pluginVersion'].invalid"
-              placeholder="_#(em.data.databases.driver.pluginVersion)">
-            <label>_#(em.data.databases.driver.pluginVersion)</label>
-            @if (pluginForm.controls['pluginVersion']?.errors?.required) {
-              <span class="invalid-feedback">_#(em.data.databases.driver.pluginVersionRequired)</span>
-            }
-            @if (pluginForm.controls['pluginVersion']?.errors?.pattern) {
-              <span class="invalid-feedback">_#(em.data.databases.driver.pluginVersionInvalid)</span>
-            }
-            <span class="plugin-settings-hint" [innerHTML]="'_#(em.data.databases.driver.pluginVersionHint)'"></span>
-          </div>
-        </div>
+    <div class="driver-wizard driver-wizard--plugin" [formGroup]="pluginForm">
+      <div class="driver-wizard__section driver-wizard__plugin-copy">_#(em.data.databases.driver.pluginSettingsHelp)</div>
+      <div class="driver-wizard__field driver-wizard__field--plugin form-floating">
+        <input class="form-control" type="text" formControlName="pluginId"
+               [class.is-invalid]="pluginForm.controls['pluginId'].invalid"
+               placeholder="_#(em.data.databases.driver.pluginId)">
+        <label>_#(em.data.databases.driver.pluginId)</label>
+        @if (pluginForm.controls['pluginId']?.errors?.required) {
+          <span class="invalid-feedback">_#(em.data.databases.driver.pluginIdRequired)</span>
+        }
+        @if (pluginForm.controls['pluginId']?.errors?.pluginExists) {
+          <span class="invalid-feedback">_#(em.data.databases.driver.pluginIdExists)</span>
+        }
+        <span class="plugin-settings-hint">_#(em.data.databases.driver.pluginIdHint)</span>
+      </div>
+      <div class="driver-wizard__field driver-wizard__field--plugin form-floating">
+        <input class="form-control" type="text" formControlName="pluginName"
+               [class.is-invalid]="pluginForm.controls['pluginName'].invalid"
+               placeholder="_#(em.data.databases.driver.pluginName)">
+        <label>_#(em.data.databases.driver.pluginName)</label>
+        @if (pluginForm.controls['pluginName']?.errors?.required) {
+          <span class="invalid-feedback">_#(em.data.databases.driver.pluginNameRequired)</span>
+        }
+        <span class="plugin-settings-hint">_#(em.data.databases.driver.pluginNameHint)</span>
+      </div>
+      <div class="driver-wizard__field driver-wizard__field--plugin form-floating">
+        <input class="form-control" type="text" formControlName="pluginVersion"
+               [class.is-invalid]="pluginForm.controls['pluginVersion'].invalid"
+               placeholder="_#(em.data.databases.driver.pluginVersion)">
+        <label>_#(em.data.databases.driver.pluginVersion)</label>
+        @if (pluginForm.controls['pluginVersion']?.errors?.required) {
+          <span class="invalid-feedback">_#(em.data.databases.driver.pluginVersionRequired)</span>
+        }
+        @if (pluginForm.controls['pluginVersion']?.errors?.pattern) {
+          <span class="invalid-feedback">_#(em.data.databases.driver.pluginVersionInvalid)</span>
+        }
+        <span class="plugin-settings-hint" [innerHTML]="'_#(em.data.databases.driver.pluginVersionHint)'"></span>
       </div>
     </div>
   }

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-datasource/datasources-datasource-editor/datasources-datasource-editor.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-datasource/datasources-datasource-editor/datasources-datasource-editor.component.html
@@ -1,58 +1,71 @@
 <!--
-~ This file is part of StyleBI.
-~ Copyright (C) 2024  InetSoft Technology
-~
-~ This program is free software: you can redistribute it and/or modify
-~ it under the terms of the GNU Affero General Public License as published by
-~ the Free Software Foundation, either version 3 of the License, or
-~ (at your option) any later version.
-~
-~ This program is distributed in the hope that it will be useful,
-~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-~ GNU Affero General Public License for more details.
-~
-~ You should have received a copy of the GNU Affero General Public License
-~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
--->
-<div class="shell-form-group form-floating datasource-editor-name-field" [formGroup]="nameGroup">
-  <input type="text"
-    name="name"
-    class="form-control"
-    formControlName="name"
-    [class.is-invalid]="nameGroup?.controls['name']?.invalid"
-    [disabled]="!datasource.deletable"
-    required>
-  <label>_#(Name)</label>
-  @if (nameGroup?.controls['name']?.errors?.required) {
-    <span class="invalid-feedback">
-      _#(data.datasources.enterDataSourceName)
-    </span>
-  }
-  @if (nameGroup?.controls['name']?.errors?.pattern) {
-    <span class="invalid-feedback">
-      _#(data.datasources.enterAValidName)
-    </span>
-  }
-  @if (nameGroup?.controls['name']?.errors?.exists) {
-    <span class="invalid-feedback">
-      _#(data.datasources.nameExists)
-    </span>
+  ~ This file is part of StyleBI.
+  ~ Copyright (C) 2024  InetSoft Technology
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+<div class="datasource-editor-shell">
+  <section class="datasource-editor-card datasource-editor-card--compact">
+    <div class="datasource-editor-card__header">
+      <div>
+        <div class="datasource-editor-card__eyebrow">_#(Identity)</div>
+        <div class="datasource-editor-card__title">_#(Data Source Name)</div>
+      </div>
+    </div>
+    <div class="form-group form-floating datasource-editor-name-field" [formGroup]="nameGroup">
+      <input type="text"
+             name="name"
+             class="form-control"
+             formControlName="name"
+             [class.is-invalid]="nameGroup?.controls['name']?.invalid"
+             [disabled]="!datasource.deletable"
+             required>
+      <label>_#(Name)</label>
+      @if (nameGroup?.controls['name']?.errors?.required) {
+        <span class="invalid-feedback">
+          _#(data.datasources.enterDataSourceName)
+        </span>
+      }
+      @if (nameGroup?.controls['name']?.errors?.pattern) {
+        <span class="invalid-feedback">
+          _#(data.datasources.enterAValidName)
+        </span>
+      }
+      @if (nameGroup?.controls['name']?.errors?.exists) {
+        <span class="invalid-feedback">
+          _#(data.datasources.nameExists)
+        </span>
+      }
+    </div>
+  </section>
+
+  @if (datasource.tabularView) {
+    <section class="datasource-editor-card">
+      <div class="datasource-editor-card__header datasource-editor-card__header--actions">
+        <div>
+          <div class="datasource-editor-card__eyebrow">_#(Configuration)</div>
+          <div class="datasource-editor-card__title">_#(Connector Settings)</div>
+        </div>
+        <button class="btn btn-secondary" type="button" (click)="refreshMetadata()">
+          _#(Refresh Metadata)
+        </button>
+      </div>
+      <tabular-view [rootView]="datasource.tabularView" (viewChange)="onViewChanged($event)"
+                    [browseFunction]="browseFunction" (validChange)="onValidChanged($event)"
+                    [panel]="true" (buttonClick)="buttonClicked($event)"
+                    [cancelButtonExists]="cancelButtonExists">
+      </tabular-view>
+    </section>
   }
 </div>
-@if (datasource.tabularView) {
-  <div class="form-group">
-    <tabular-view [rootView]="datasource.tabularView" (viewChange)="onViewChanged($event)"
-      [browseFunction]="browseFunction" (validChange)="onValidChanged($event)"
-      [panel]="true" (buttonClick)="buttonClicked($event)"
-      [cancelButtonExists]="cancelButtonExists">
-    </tabular-view>
-  </div>
-}
-@if (datasource.type === 'GOOGLE_ANALYTICS_GA4') {
-  <div class="form-group">
-    <button class="btn btn-secondary" type="button" (click)="refreshMetadata()">
-      _#(Refresh Metadata)
-    </button>
-  </div>
-}

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-datasource/datasources-datasource.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-datasource/datasources-datasource.component.html
@@ -1,75 +1,108 @@
 <!--
-~ This file is part of StyleBI.
-~ Copyright (C) 2024  InetSoft Technology
-~
-~ This program is free software: you can redistribute it and/or modify
-~ it under the terms of the GNU Affero General Public License as published by
-~ the Free Software Foundation, either version 3 of the License, or
-~ (at your option) any later version.
-~
-~ This program is distributed in the hope that it will be useful,
-~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-~ GNU Affero General Public License for more details.
-~
-~ You should have received a copy of the GNU Affero General Public License
-~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
--->
+  ~ This file is part of StyleBI.
+  ~ Copyright (C) 2024  InetSoft Technology
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
 <div class="editor-container">
-  <div class="h-100 container-fluid flex-fixed-container">
-    <div class="row flex-fixed-content">
-      <div class="col-10 col-sm-8">
-        <datasources-datasource-editor
-          [datasource]="datasource"
-          (datasourceChanged)="datasourceChanged($event)"
-          (datasourceValid)="updateDatasourceValid($event)"
-          (onWarning)="dataNotifications.notifications.danger($event)"
-          (onSuccess)="dataNotifications.notifications.success($event)"
-        ></datasources-datasource-editor>
-        @if (datasource.tabularView && enterprise) {
-          <div class="row">
-            <div class="col">
-              <label class="addition-label">_#(Additional Connections) :</label>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-10 additional-datasource">
-              <div class="bordered-box bd-gray h-100">
-                @for (additional of additionalList; track additional.name; let i = $index) {
-                  <div
-                    class="unhighlightable additional-datasource-list__item" [class.selected]="additionalSelected(i)"
-                    [title]="additional.tooltip"
-                    (click)="selectAdditional($event, i)">
-                    <div>{{additional?.name}}</div>
-                  </div>
-                }
-              </div>
-            </div>
-            <div class="col-2 btn-container-vertical">
-              <button type="button" class="btn btn-default" (click)="newAdditional()">_#(New)</button>
-              <button type="button" class="btn btn-default"
-                [disabled]="selectedAdditionalIndex.length == 0"
-              (click)="deleteAdditional()">_#(Delete)</button>
-              <button type="button" class="btn btn-default"
-                [disabled]="selectedAdditionalIndex.length != 1"
-              (click)="editAdditional()">_#(Edit)</button>
-              <button type="button" class="btn btn-default"
-                [disabled]="selectedAdditionalIndex.length != 1"
-              (click)="renameAdditional()">_#(Rename)</button>
-            </div>
-          </div>
-        }
-        <div class="btn-container-vertical">
-          <button type="button" class="btn btn-default"
-            [disabled]="!datasourceValid"
-            (click)="ok()">
-            _#(OK)
-          </button>
-          <button type="button" class="btn btn-secondary" (click)="close()">
-            _#(Cancel)
-          </button>
+  <div class="editor-content">
+    <div class="editor-query-strip">
+      <div class="editor-query-strip__status">
+        <div class="editor-query-strip__label">_#(Status)</div>
+        <div class="editor-query-strip__badge"
+             [class.is-ready]="dataSourceConnected === true"
+             [class.is-unavailable]="dataSourceConnected === false">
+          <i class="editor-query-strip__status-icon" [ngClass]="queryStatusIconClass"></i>
+          {{queryStatusLabel}}
         </div>
       </div>
+      <div class="editor-query-strip__content">
+        <div class="editor-query-strip__message">{{queryStatusMessage}}</div>
+        <div class="editor-query-strip__actions">
+          <button type="button" class="btn btn-primary"
+                  [disabled]="!canCreateQuery"
+                  (click)="createQuery()">
+            _#(New Query)
+          </button>
+          <button type="button" class="btn btn-secondary"
+                  [disabled]="loadingDataSourceStatus || !datasourcePath"
+                  (click)="refreshDataSourceStatus()">
+            _#(Refresh Status)
+          </button>
+          <div class="btn-toolbar toolbar-ghost-actions editor-query-strip__toolbar" role="toolbar">
+            <div class="btn-group" role="group">
+              <i role="button" class="btn py-1 folder-move-icon"
+                 title="_#(Move)"
+                 [class.disabled]="!currentDataSourceInfo?.deletable"
+                 (click)="moveDataSource()">
+              </i>
+              <i role="button" class="btn py-1 trash-icon"
+                 title="_#(Delete)"
+                 [class.disabled]="!currentDataSourceInfo?.deletable"
+                 (click)="deleteDataSource()">
+              </i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <datasources-datasource-editor
+      [datasource]="datasource"
+      (datasourceChanged)="datasourceChanged($event)"
+      (datasourceValid)="updateDatasourceValid($event)"
+      (onWarning)="dataNotifications.notifications.danger($event)"
+      (onSuccess)="dataNotifications.notifications.success($event)"
+      ></datasources-datasource-editor>
+    @if (datasource.tabularView && enterprise) {
+      <div class="additional-connections">
+        <label class="addition-label">_#(Additional Connections) :</label>
+        <div class="additional-connections__layout">
+          <div class="additional-datasource">
+            <div class="additional-datasource-list h-100">
+              @for (additional of additionalList; track additional.name; let i = $index) {
+                <div class="unhighlightable" [class.selected]="additionalSelected(i)"
+                     [title]="additional.tooltip"
+                     (click)="selectAdditional($event, i)">
+                  <div>{{additional?.name}}</div>
+                </div>
+              }
+            </div>
+          </div>
+          <div class="btn-container-vertical">
+            <button type="button" class="btn btn-default" (click)="newAdditional()">_#(New)</button>
+            <button type="button" class="btn btn-default"
+                    [disabled]="selectedAdditionalIndex.length == 0"
+                    (click)="deleteAdditional()">_#(Delete)</button>
+            <button type="button" class="btn btn-default"
+                    [disabled]="selectedAdditionalIndex.length != 1"
+                    (click)="editAdditional()">_#(Edit)</button>
+            <button type="button" class="btn btn-default"
+                    [disabled]="selectedAdditionalIndex.length != 1"
+                    (click)="renameAdditional()">_#(Rename)</button>
+          </div>
+        </div>
+      </div>
+    }
+    <div class="bottom-button-container">
+      <button type="button" class="btn btn-primary me-2"
+              [disabled]="!datasourceValid"
+              (click)="ok()">
+        _#(OK)
+      </button>
+      <button type="button" class="btn btn-secondary" (click)="close()">
+        _#(Cancel)
+      </button>
     </div>
   </div>
   <data-notifications #dataNotifications></data-notifications>

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-datasource/datasources-datasource.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-datasource/datasources-datasource.component.ts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { HttpClient, HttpParams } from "@angular/common/http";
+import { NgClass } from "@angular/common";
 import { ChangeDetectorRef, Component, HostListener, NgZone, OnDestroy, OnInit, ViewChild } from "@angular/core";
 import { ActivatedRoute, ParamMap, Router } from "@angular/router";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
@@ -54,7 +55,7 @@ export interface AdditionalInfo {
     selector: "datasources-datasource",
     templateUrl: "datasources-datasource.component.html",
     styleUrls: ["datasources-datasource.component.scss"],
-    imports: [DatasourcesDatasourceEditorComponent, DataNotificationsComponent]
+    imports: [NgClass, DatasourcesDatasourceEditorComponent, DataNotificationsComponent]
 })
 export class DatasourcesDatasourceComponent implements OnInit, OnDestroy{
    @ViewChild("dataNotifications") dataNotifications: DataNotificationsComponent;

--- a/web/projects/portal/src/app/portal/data/move-asset-dialog/move-asset-dialog.component.html
+++ b/web/projects/portal/src/app/portal/data/move-asset-dialog/move-asset-dialog.component.html
@@ -1,54 +1,50 @@
 <!--
-~ This file is part of StyleBI.
-~ Copyright (C) 2024  InetSoft Technology
-~
-~ This program is free software: you can redistribute it and/or modify
-~ it under the terms of the GNU Affero General Public License as published by
-~ the Free Software Foundation, either version 3 of the License, or
-~ (at your option) any later version.
-~
-~ This program is distributed in the hope that it will be useful,
-~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-~ GNU Affero General Public License for more details.
-~
-~ You should have received a copy of the GNU Affero General Public License
-~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
--->
+  ~ This file is part of StyleBI.
+  ~ Copyright (C) 2024  InetSoft Technology
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
 <modal-header [title]="'_#(data.datasets.moveTo)'"
-  [cshid]="'DataSourceNewFolder'"
-  (onCancel)="cancel()">
+              [cshid]="'DataSourceNewFolder'"
+              (onCancel)="cancel()">
 </modal-header>
-<div class="modal-body">
-  <div class="container-fluid">
-    <div class="row">
-      <div class="col">
-        <files-browser [folderSelectable]="true"
-          [selectedFolders]="[{ path: parentPath, scope: parentScope, type: AssetType.FOLDER }]"
-          [openFolderRequest]="openFolderRequest"
-          [openFolderError]="config.templateConfig.openFolderError"
-          [openFolderPath]="grandparentFolder"
-          [openFolderScope]="parentScope"
-          (selectionChange)="folderSelected($event)">
-        </files-browser>
-        @if (!folderPath) {
-          <div class="alert alert-danger w-100 mt-2">
-            {{isFolder ? config.templateConfig.targetFolderRequired : config.templateConfig.targetAssetTypeRequired}}
-          </div>
-        }
-      </div>
+<div class="modal-body move-datasource-dialog__body">
+  <files-browser class="move-datasource-dialog__browser"
+                 [folderSelectable]="true"
+                 [showBreadcrumb]="false"
+                 [selectedFolders]="[{ path: parentPath, scope: parentScope, type: AssetType.FOLDER }]"
+                 [openFolderRequest]="openFolderRequest"
+                 [openFolderError]="config.templateConfig.openFolderError"
+                 [openFolderPath]="fakeRootPath"
+                 [openFolderScope]="parentScope"
+                 (selectionChange)="folderSelected($event)">
+  </files-browser>
+  @if (!folderPath) {
+    <div class="alert alert-danger move-datasource-dialog__error">
+      {{isFolder ? config.templateConfig.targetFolderRequired : config.templateConfig.targetAssetTypeRequired}}
     </div>
-  </div>
+  }
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-primary"
-    [disabled]="!folderPath"
-    (click)="ok()">
+          [disabled]="!folderPath"
+          (click)="ok()">
     _#(OK)
   </button>
-  <button type="button" class="btn btn-default"
-    data-dismiss="modal"
-    (click)="cancel()">
+  <button type="button" class="btn btn-secondary"
+          data-dismiss="modal"
+          (click)="cancel()">
     _#(Cancel)
   </button>
 </div>

--- a/web/projects/portal/src/app/portal/data/move-data-model-dialog/move-data-model-dialog.component.html
+++ b/web/projects/portal/src/app/portal/data/move-data-model-dialog/move-data-model-dialog.component.html
@@ -1,49 +1,46 @@
 <!--
-~ This file is part of StyleBI.
-~ Copyright (C) 2024  InetSoft Technology
-~
-~ This program is free software: you can redistribute it and/or modify
-~ it under the terms of the GNU Affero General Public License as published by
-~ the Free Software Foundation, either version 3 of the License, or
-~ (at your option) any later version.
-~
-~ This program is distributed in the hope that it will be useful,
-~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-~ GNU Affero General Public License for more details.
-~
-~ You should have received a copy of the GNU Affero General Public License
-~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
--->
+  ~ This file is part of StyleBI.
+  ~ Copyright (C) 2024  InetSoft Technology
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
 <modal-header [title]="'_#(data.datasets.moveTo)'"
-  (onCancel)="cancel()">
+              (onCancel)="cancel()">
 </modal-header>
-<div class="modal-body">
-  <div class="container-fluid">
-    <div class="row">
-      <div class="col">
-        <data-models-browser [rootLabel]="rootLabel"
-          [openFolderRequest]="openFolderRequest"
-          (selectionChange)="folderSelected($event)">
-        </data-models-browser>
-        @if (!folderPath) {
-          <div class="alert alert-danger w-100 mt-2">
-            _#(data.datasets.targetFolderRequired)
-          </div>
-        }
-      </div>
+<div class="modal-body move-datasource-dialog__body">
+  <data-models-browser class="move-datasource-dialog__browser"
+                       [rootLabel]="rootLabel"
+                       [showBreadcrumb]="false"
+                       [openFolderPath]="fakeRootPath"
+                       [openFolderRequest]="openFolderRequest"
+                       (selectionChange)="folderSelected($event)">
+  </data-models-browser>
+  @if (!folderPath) {
+    <div class="alert alert-danger move-datasource-dialog__error">
+      _#(data.datasets.targetFolderRequired)
     </div>
-  </div>
+  }
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-primary"
-    [disabled]="!folderPath"
-    (click)="ok()">
+          [disabled]="!folderPath"
+          (click)="ok()">
     _#(OK)
   </button>
   <button defaultFocus type="button" class="btn btn-secondary"
-    data-dismiss="modal"
-    (click)="cancel()">
+          data-dismiss="modal"
+          (click)="cancel()">
     _#(Cancel)
   </button>
 </div>

--- a/web/projects/portal/src/app/portal/data/move-datasource-dialog/move-datasource-dialog.component.html
+++ b/web/projects/portal/src/app/portal/data/move-datasource-dialog/move-datasource-dialog.component.html
@@ -1,52 +1,48 @@
 <!--
-~ This file is part of StyleBI.
-~ Copyright (C) 2024  InetSoft Technology
-~
-~ This program is free software: you can redistribute it and/or modify
-~ it under the terms of the GNU Affero General Public License as published by
-~ the Free Software Foundation, either version 3 of the License, or
-~ (at your option) any later version.
-~
-~ This program is distributed in the hope that it will be useful,
-~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-~ GNU Affero General Public License for more details.
-~
-~ You should have received a copy of the GNU Affero General Public License
-~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
--->
+  ~ This file is part of StyleBI.
+  ~ Copyright (C) 2024  InetSoft Technology
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
 <modal-header [title]="'_#(data.datasets.moveTo)'" (onCancel)="cancel()" [cshid]="'DataSourceNewFolder'">
 </modal-header>
-<div class="modal-body">
-  <div class="container-fluid">
-    <div class="row">
-      <div class="col">
-        <data-sources-browser [folderSelectable]="true"
-          [rootLabel]="rootLabel"
-          [selectedFolders]="[{ path: parentPath, type: { name: 'DATA_SOURCE_FOLDER', label: 'DATA_SOURCE_FOLDER'} }]"
-          [openFolderRequest]="openFolderRequest"
-          [openFolderError]="config.templateConfig.openFolderError"
-          [openFolderPath]="grandparentFolder"
-          (selectionChange)="folderSelected($event)">
-        </data-sources-browser>
-        @if (!folderPath) {
-          <div class="alert alert-danger w-100 mt-2">
-            {{isFolder ? config.templateConfig.targetFolderRequired : config.templateConfig.targetAssetTypeRequired}}
-          </div>
-        }
-      </div>
+<div class="modal-body move-datasource-dialog__body">
+  <data-sources-browser class="move-datasource-dialog__browser"
+                 [folderSelectable]="true"
+                 [showBreadcrumb]="false"
+                 [rootLabel]="rootLabel"
+                 [selectedFolders]="[{ path: parentPath, type: { name: 'DATA_SOURCE_FOLDER', label: 'DATA_SOURCE_FOLDER'} }]"
+                 [openFolderRequest]="openFolderRequest"
+                 [openFolderError]="config.templateConfig.openFolderError"
+                 [openFolderPath]="fakeRootPath"
+                 (selectionChange)="folderSelected($event)">
+  </data-sources-browser>
+  @if (!folderPath) {
+    <div class="alert alert-danger move-datasource-dialog__error">
+      {{isFolder ? config.templateConfig.targetFolderRequired : config.templateConfig.targetAssetTypeRequired}}
     </div>
-  </div>
+  }
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-primary"
-    [disabled]="!folderPath"
-    (click)="ok()">
+          [disabled]="!folderPath"
+          (click)="ok()">
     _#(OK)
   </button>
   <button type="button" class="btn btn-secondary"
-    data-dismiss="modal"
-    (click)="cancel()">
+          data-dismiss="modal"
+          (click)="cancel()">
     _#(Cancel)
   </button>
 </div>

--- a/web/projects/portal/src/app/portal/dialog/vpm-condition-dialog/vpm-condition-pane/vpm-condition-item-pane/vpm-condition-editor/one-of-vpm-condition-editor.component.html
+++ b/web/projects/portal/src/app/portal/dialog/vpm-condition-dialog/vpm-condition-pane/vpm-condition-item-pane/vpm-condition-editor/one-of-vpm-condition-editor.component.html
@@ -1,51 +1,53 @@
 <!--
-~ This file is part of StyleBI.
-~ Copyright (C) 2024  InetSoft Technology
-~
-~ This program is free software: you can redistribute it and/or modify
-~ it under the terms of the GNU Affero General Public License as published by
-~ the Free Software Foundation, either version 3 of the License, or
-~ (at your option) any later version.
-~
-~ This program is distributed in the hope that it will be useful,
-~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-~ GNU Affero General Public License for more details.
-~
-~ You should have received a copy of the GNU Affero General Public License
-~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
--->
-<div class="form-inline">
-  <div class="form-group-column">
+  ~ This file is part of StyleBI.
+  ~ Copyright (C) 2024  InetSoft Technology
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+<div class="one-of-editor">
+  <div class="one-of-editor__content">
     <vpm-condition-editor [value]="editingModel" [values]="values"
-      [operation]="operation" [fields]="fields"
-      [valueTypes]="valueTypes"
-      [enableBrowseData]="enableBrowseData" [type]="valueType"
-      [dataFunction]="dataFunction"
-      [primaryValue]="primaryValue" [varShowDate]="varShowDate"
-      [datasource]="datasource" [isWSQuery]="isWSQuery"
-      (valueChanges)="selectValues($event)"
-      (valueChange)="updateValue($event)">
+                      [operation]="operation" [fields]="fields"
+                      [valueTypes]="valueTypes"
+                      [enableBrowseData]="enableBrowseData" [type]="valueType"
+                      [dataFunction]="dataFunction"
+                      [primaryValue]="primaryValue" [varShowDate]="varShowDate"
+                      [datasource]="datasource" [isWSQuery]="isWSQuery"
+                      (valueChanges)="selectValues($event)"
+                      (valueChange)="updateValue($event)">
     </vpm-condition-editor>
-    @if (isValueListVisible()) {
-      <div class="value-list-container">
-        <div class="sm-selectable-list value-list">
-          @for (val of values; track val; let i = $index) {
-            <div class="unhighlightable value-list__element"
-              [class.selected]="isSelected(val)" (click)="selectValue(i, val)">
-              {{val}}
-            </div>
-          }
-        </div>
-        <div class="one-of-editor__actions">
-          <button type="button" class="btn btn-default" (click)="add()"
-          [disabled]="isEmpty()">_#(Add)</button>
-          <button type="button" class="btn btn-default delete_id" (click)="remove()"
-          [disabled]="selectedIndex < 0 || selectedIndex >= values.length">_#(Delete)</button>
-          <button type="button" class="btn btn-default delete_id" (click)="modify()"
-          [disabled]="selectedIndex < 0 || selectedIndex >= values.length">_#(Modify)</button>
+    <div *ngIf="isValueListVisible()" class="value-list-container">
+      <div class="value-list-panel">
+        <div class="value-list-panel__label">_#(Selected values)</div>
+        <div class="sm-selectable-list value-list" [class.value-list--empty]="values.length === 0">
+          <div *ngIf="values.length === 0" class="value-list__empty">
+            _#(Enter a value above, then click Add.)
+          </div>
+          <div *ngFor="let val of values; let i = index;" class="unhighlightable value-list__element"
+             [class.selected]="isSelected(val)" (click)="selectValue(i, val)">
+            {{val}}
+          </div>
         </div>
       </div>
-    }
+      <div class="one-of-editor__actions">
+        <button type="button" class="btn btn-default" (click)="add()"
+                [disabled]="isEmpty()">_#(Add)</button>
+        <button type="button" class="btn btn-default delete_id" (click)="remove()"
+                [disabled]="selectedIndex < 0 || selectedIndex >= values.length">_#(Delete)</button>
+        <button type="button" class="btn btn-default delete_id" (click)="modify()"
+                [disabled]="selectedIndex < 0 || selectedIndex >= values.length">_#(Modify)</button>
+      </div>
+    </div>
   </div>
 </div>

--- a/web/projects/portal/src/app/portal/dialog/vpm-condition-dialog/vpm-condition-pane/vpm-condition-item-pane/vpm-condition-item-pane.component.html
+++ b/web/projects/portal/src/app/portal/dialog/vpm-condition-dialog/vpm-condition-pane/vpm-condition-item-pane/vpm-condition-item-pane.component.html
@@ -1,51 +1,50 @@
 <!--
-~ This file is part of StyleBI.
-~ Copyright (C) 2024  InetSoft Technology
-~
-~ This program is free software: you can redistribute it and/or modify
-~ it under the terms of the GNU Affero General Public License as published by
-~ the Free Software Foundation, either version 3 of the License, or
-~ (at your option) any later version.
-~
-~ This program is distributed in the hope that it will be useful,
-~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-~ GNU Affero General Public License for more details.
-~
-~ You should have received a copy of the GNU Affero General Public License
-~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
--->
+  ~ This file is part of StyleBI.
+  ~ Copyright (C) 2024  InetSoft Technology
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
 <div class="item-pane">
-  <div class="row align-items-start g-0">
-    <div class="col-auto value-editor-container">
-      @if (leftOneOf) {
-        <one-of-vpm-condition-editor
-          [operation]="condition.operation"
-          [fields]="fields"
-          [valueTypes]="valueTypes1"
-          [dataFunction]="dataFunction1"
-          [enableBrowseData]="isBrowseDataEnabled(1)"
-          [valueType]="getValueFieldType(1)"
-          [valueModel]="condition.value1" [datasource]="datasource"
-          (valueChange)="changeConditionValue()"
-          [varShowDate]="showDefDateValue"
-          [isWSQuery]="provider.isWSQuery">
-        </one-of-vpm-condition-editor>
-      } @else {
-        <vpm-condition-editor [operation]="condition.operation"
-          [fields]="fields"
-          [valueTypes]="valueTypes1"
-          [dataFunction]="dataFunction1"
-          [enableBrowseData]="isBrowseDataEnabled(1)"
-          [type]="getValueFieldType(1)"
-          [primaryValue]="true" [datasource]="datasource"
-          [(value)]="condition.value1"
-          [varShowDate]="showDefDateValue"
-          (valueChange)="changeField($event)"
-          [isWSQuery]="provider.isWSQuery">
-        </vpm-condition-editor>
-      }
+  <div class="item-pane__row">
+    <div class="item-pane__value item-pane__value--primary">
+      <one-of-vpm-condition-editor *ngIf="leftOneOf; else leftConditionEditor"
+                                   [operation]="condition.operation"
+                                   [fields]="fields"
+                                   [valueTypes]="valueTypes1"
+                                   [dataFunction]="dataFunction1"
+                                   [enableBrowseData]="isBrowseDataEnabled(1)"
+                                   [valueType]="getValueFieldType(1)"
+                                   [valueModel]="condition.value1" [datasource]="datasource"
+                                   (valueChange)="changeConditionValue()"
+                                   [varShowDate]="showDefDateValue"
+                                   [isWSQuery]="provider.isWSQuery">
+      </one-of-vpm-condition-editor>
 
+      <ng-template #leftConditionEditor>
+        <vpm-condition-editor [operation]="condition.operation"
+                              [fields]="fields"
+                              [valueTypes]="valueTypes1"
+                              [dataFunction]="dataFunction1"
+                              [enableBrowseData]="isBrowseDataEnabled(1)"
+                              [type]="getValueFieldType(1)"
+                              [primaryValue]="true" [datasource]="datasource"
+                              [(value)]="condition.value1"
+                              [varShowDate]="showDefDateValue"
+                              (valueChange)="changeField($event)"
+                              [isWSQuery]="provider.isWSQuery">
+        </vpm-condition-editor>
+      </ng-template>
     </div>
     <div class="item-pane__select">
       <custom-select class="isNot_check_id"
@@ -54,75 +53,61 @@
                      (selectionChange)="conditionChange.emit(this.condition)">
       </custom-select>
     </div>
-    <div class="col-auto form-group-column">
+    <div class="item-pane__select">
       <custom-select class="operation_check_id"
                      [options]="operationSelectOptions"
                      [(ngModel)]="optSymbol"
                      (selectionChange)="optionChange($event)">
       </custom-select>
-      @if (supportEqualsOperation()) {
-        <div class="checkbox">
-          <div class="form-check">
-            <input type="checkbox" class="form-check-input" [ngModel]="equalsOperation"
-              id="equal" (ngModelChange)="equalsChanged($event)">
-            <label class="form-check-label" for="equal">
-              _#(or equal to)
-            </label>
-          </div>
-        </div>
-      }
-    </div>
-    @if (!isUnaryOperation) {
-      <div class="item-pane__value"
-        >
-        @switch (condition.operation.symbol) {
-          @case (ClauseOperationSymbols.BETWEEN) {
-            <vpm-trinary-condition-editor
-              [operation]="condition.operation"
-              [fields]="fields"
-              [valueTypes2]="valueTypes2"
-              [valueTypes3]="valueTypes3"
-              [dataFunction2]="dataFunction2"
-              [dataFunction3]="dataFunction3"
-              [enableBrowseData2]="isBrowseDataEnabled(2)"
-              [enableBrowseData3]="isBrowseDataEnabled(3)"
-              [valueFieldType2]="getValueFieldType(2)"
-              [valueFieldType3]="getValueFieldType(3)"
-              [value2]="condition.value2"
-              [value3]="condition.value3"
-              [varShowDate]="showDefDateValue" [datasource]="datasource"
-              [isWSQuery]="provider.isWSQuery"
-              (valuesChange)="trinaryConditionChanged($event)">
-            </vpm-trinary-condition-editor>
-          }
-          @case (ClauseOperationSymbols.IN) {
-            <one-of-vpm-condition-editor
-              [operation]="condition.operation"
-              [fields]="fields"
-              [valueTypes]="valueTypes2"
-              [dataFunction]="dataFunction2"
-              [enableBrowseData]="isBrowseDataEnabled(2)"
-              [valueType]="getValueFieldType(2)"
-              [valueModel]="condition.value2" [datasource]="datasource"
-              (valueChange)="changeConditionValue()"
-              [varShowDate]="showDefDateValue" [isWSQuery]="provider.isWSQuery">
-            </one-of-vpm-condition-editor>
-          }
-          @default {
-            <vpm-condition-editor [operation]="condition.operation"
-              [fields]="fields"
-              [valueTypes]="valueTypes2"
-              [dataFunction]="dataFunction2"
-              [enableBrowseData]="isBrowseDataEnabled(2)"
-              [type]="getValueFieldType(2)"
-              [(value)]="condition.value2" [datasource]="datasource"
-              (valueChange)="changeConditionValue()"
-              [varShowDate]="showDefDateValue"
-              [isWSQuery]="provider.isWSQuery">
-            </vpm-condition-editor>
-          }
-        }
+      <div *ngIf="supportEqualsOperation()" class="item-pane__equals">
+        <input type="checkbox" class="form-check-input" [ngModel]="equalsOperation"
+               id="equal" (ngModelChange)="equalsChanged($event)">
+        <label class="form-check-label" for="equal">
+          _#(or equal to)
+        </label>
       </div>
-    }
+    </div>
+    <div class="item-pane__value" *ngIf="!isUnaryOperation"
+         [ngSwitch]="condition.operation.symbol">
+      <vpm-trinary-condition-editor *ngSwitchCase="ClauseOperationSymbols.BETWEEN"
+                                    [operation]="condition.operation"
+                                    [fields]="fields"
+                                    [valueTypes2]="valueTypes2"
+                                    [valueTypes3]="valueTypes3"
+                                    [dataFunction2]="dataFunction2"
+                                    [dataFunction3]="dataFunction3"
+                                    [enableBrowseData2]="isBrowseDataEnabled(2)"
+                                    [enableBrowseData3]="isBrowseDataEnabled(3)"
+                                    [valueFieldType2]="getValueFieldType(2)"
+                                    [valueFieldType3]="getValueFieldType(3)"
+                                    [value2]="condition.value2"
+                                    [value3]="condition.value3"
+                                    [varShowDate]="showDefDateValue" [datasource]="datasource"
+                                    [isWSQuery]="provider.isWSQuery"
+                                    (valuesChange)="trinaryConditionChanged($event)">
+      </vpm-trinary-condition-editor>
+      <one-of-vpm-condition-editor *ngSwitchCase="ClauseOperationSymbols.IN"
+                            [operation]="condition.operation"
+                            [fields]="fields"
+                            [valueTypes]="valueTypes2"
+                            [dataFunction]="dataFunction2"
+                            [enableBrowseData]="isBrowseDataEnabled(2)"
+                            [valueType]="getValueFieldType(2)"
+                            [valueModel]="condition.value2" [datasource]="datasource"
+                            (valueChange)="changeConditionValue()"
+                            [varShowDate]="showDefDateValue" [isWSQuery]="provider.isWSQuery">
+      </one-of-vpm-condition-editor>
+      <vpm-condition-editor *ngSwitchDefault [operation]="condition.operation"
+                            [fields]="fields"
+                            [valueTypes]="valueTypes2"
+                            [dataFunction]="dataFunction2"
+                            [enableBrowseData]="isBrowseDataEnabled(2)"
+                            [type]="getValueFieldType(2)"
+                            [(value)]="condition.value2" [datasource]="datasource"
+                            (valueChange)="changeConditionValue()"
+                            [varShowDate]="showDefDateValue"
+                            [isWSQuery]="provider.isWSQuery">
+      </vpm-condition-editor>
+    </div>
   </div>
 </div>

--- a/web/projects/portal/src/app/widget/condition/binary-condition-editor.component.html
+++ b/web/projects/portal/src/app/widget/condition/binary-condition-editor.component.html
@@ -28,7 +28,7 @@
                     [showOriginalName]="showOriginalName"
                     [(value)]="values[0]" (valueChange)="valuesChange.emit(values)">
   </condition-editor>
-  <div class="binary-and mb-1">_#(and)</div>
+  <div class="binary-and">_#(and)</div>
   <condition-editor [dataFunction]="dataFunction" [variablesFunction]="variablesFunction"
                     [columnTreeFunction]="columnTreeFunction" [vsId]="vsId"
                     [scriptDefinitionsFunction]="scriptDefinitionsFunction"

--- a/web/projects/portal/src/app/widget/condition/binary-condition-editor.component.scss
+++ b/web/projects/portal/src/app/widget/condition/binary-condition-editor.component.scss
@@ -16,7 +16,16 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 :host {
+  display: block;
+  width: 100%;
+  min-width: 0;
+
+  .form-group-column {
+    gap: 0.375rem;
+  }
+
   .binary-and {
-    margin-top: -1rem;
+    font-size: 0.875rem;
+    color: var(--inet-text-muted-color, inherit);
   }
 }

--- a/web/projects/portal/src/app/widget/condition/condition-field-combo-list.component.scss
+++ b/web/projects/portal/src/app/widget/condition/condition-field-combo-list.component.scss
@@ -17,10 +17,7 @@
  */
 .condition-field-combo-list__surface {
   box-sizing: border-box;
-  border-radius: var(--inet-radius-md);
-  background-color: var(--inet-list-bg-color);
   overflow: hidden;
-  box-shadow: inset 0 0 0 1px var(--inet-list-border-color);
 }
 
 .list-container {
@@ -28,7 +25,7 @@
 }
 
 .condition-field-combo-list-item {
-  height: 19.5px;
+  height: var(--inet-control-height-sm);
   padding: 0 var(--inet-space-4);
   color: var(--inet-text-color);
   display: flex;

--- a/web/projects/portal/src/app/widget/condition/condition-field-combo-list.component.ts
+++ b/web/projects/portal/src/app/widget/condition/condition-field-combo-list.component.ts
@@ -19,12 +19,14 @@ import {
    AfterContentInit,
    Component,
    EventEmitter,
+   Inject,
    Input,
    OnInit,
    OnChanges,
    Output,
    SimpleChanges
 } from "@angular/core";
+import { DOCUMENT } from "@angular/common";
 import { Tool } from "../../../../../shared/util/tool";
 import { ColumnRef } from "../../binding/data/column-ref";
 import { DataRef } from "../../common/data/data-ref";
@@ -52,11 +54,18 @@ export class ConditionFieldComboListComponent implements OnInit, OnChanges, Afte
    visibleIndexRange: Range;
    listContainerHeight = 0;
    private readonly LIST_CONTAINER_MAX_HEIGHT = 300;
-   // LIST_ENTRY_HEIGHT = fontSize(--inet-font-size-base) * lineHeight(1.5)
-   private readonly LIST_ENTRY_HEIGHT = 13 * 1.5;
+   private listEntryHeight = 24; // resolved from --inet-control-height-sm in ngOnInit
    minWidth: number = 0;
 
+   constructor(@Inject(DOCUMENT) private document: Document) {}
+
    ngOnInit() {
+      const raw = getComputedStyle(this.document.documentElement)
+         .getPropertyValue("--inet-control-height-sm").trim();
+      const px = parseFloat(raw);
+      if(Number.isFinite(px) && px > 0) {
+         this.listEntryHeight = px;
+      }
       this.updateMinWidth();
    }
 
@@ -145,7 +154,7 @@ export class ConditionFieldComboListComponent implements OnInit, OnChanges, Afte
          return 0;
       }
 
-      return this.listModel.length * this.LIST_ENTRY_HEIGHT;
+      return this.listModel.length * this.listEntryHeight;
    }
 
    private updateVisibleIndexRange(): void {
@@ -153,8 +162,8 @@ export class ConditionFieldComboListComponent implements OnInit, OnChanges, Afte
          return;
       }
 
-      const maxVisibleEntries = this.LIST_CONTAINER_MAX_HEIGHT / this.LIST_ENTRY_HEIGHT;
-      const beginIndexExact = this.scrollTop / this.LIST_ENTRY_HEIGHT;
+      const maxVisibleEntries = this.LIST_CONTAINER_MAX_HEIGHT / this.listEntryHeight;
+      const beginIndexExact = this.scrollTop / this.listEntryHeight;
       const beginIndexLowerBound = Math.floor(beginIndexExact);
       const endRowUpperBound = Math.ceil(beginIndexExact + maxVisibleEntries);
       const endIndex = Math.min(endRowUpperBound, this.listModel.length - 1);
@@ -167,6 +176,6 @@ export class ConditionFieldComboListComponent implements OnInit, OnChanges, Afte
          return 0;
       }
 
-      return this.visibleIndexRange.start * this.LIST_ENTRY_HEIGHT;
+      return this.visibleIndexRange.start * this.listEntryHeight;
    }
 }

--- a/web/projects/portal/src/app/widget/condition/condition-item-pane.component.html
+++ b/web/projects/portal/src/app/widget/condition/condition-item-pane.component.html
@@ -1,127 +1,118 @@
 <!--
-~ This file is part of StyleBI.
-~ Copyright (C) 2024  InetSoft Technology
-~
-~ This program is free software: you can redistribute it and/or modify
-~ it under the terms of the GNU Affero General Public License as published by
-~ the Free Software Foundation, either version 3 of the License, or
-~ (at your option) any later version.
-~
-~ This program is distributed in the hope that it will be useful,
-~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-~ GNU Affero General Public License for more details.
-~
-~ You should have received a copy of the GNU Affero General Public License
-~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
--->
+  ~ This file is part of StyleBI.
+  ~ Copyright (C) 2024  InetSoft Technology
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
 <div class="item-pane">
-  <div class="form-inline align-items-start">
-    <div>
-      <div class="form-inline align-items-start">
-        <condition-field-combo [field]="condition.field" [fieldsModel]="fieldsModel"
-          [addNoneItem]="addNoneItem" [grayedOutFields]="getGrayedOutFields()"
-          [showOriginalName]="showOriginalName"
-        (onSelectField)="fieldChanged($event)"></condition-field-combo>
-        <custom-select class="condition-edit-row__select condition-edit-row__negation-select"
+  <div class="condition-edit-row"
+       [class.condition-edit-row--expression]="condition?.values?.[0]?.type === ConditionValueType.EXPRESSION">
+    <div class="condition-edit-row__field-group">
+      <condition-field-combo class="condition-edit-row__field-picker"
+                             [field]="condition.field" [fieldsModel]="fieldsModel"
+                             [addNoneItem]="addNoneItem" [grayedOutFields]="getGrayedOutFields()"
+                             [showOriginalName]="showOriginalName"
+                             (onSelectField)="fieldChanged($event)"></condition-field-combo>
+    </div>
+    <div class="condition-edit-row__operator-group">
+      <custom-select class="condition-edit-row__select condition-edit-row__negation-select"
                      [options]="negationOptions"
                      [(ngModel)]="condition.negated"
                      (selectionChange)="conditionChanged()"
                      [disabled]="!negationAllowed"
                      ariaLabel="_#(Negation)">
       </custom-select>
-        <div class="form-group-column">
-          <custom-select class="condition-edit-row__select condition-edit-row__operation-select"
+      <div class="condition-edit-row__operator">
+        <custom-select class="condition-edit-row__select condition-edit-row__operation-select"
                        dataTest="selectConditionDropdown"
                        [options]="operationOptions"
                        [(ngModel)]="condition.operation"
                        (selectionChange)="operationChanged()"
                        ariaLabel="_#(Condition Operation)">
         </custom-select>
-          @if (condition.operation == ConditionOperation.LESS_THAN || condition.operation == ConditionOperation.GREATER_THAN) {
-            <div class="checkbox">
-              <div class="form-check">
-                <input type="checkbox" class="form-check-input" [(ngModel)]="condition.equal"
-                  id="equal"
-                  (ngModelChange)="conditionChanged()">
-                <label class="form-check-label" for="equal">
-                  _#(or equal to)
-                </label>
-              </div>
-            </div>
-          }
+        <div *ngIf="condition.operation == ConditionOperation.LESS_THAN || condition.operation == ConditionOperation.GREATER_THAN" class="checkbox">
+          <div class="form-check">
+            <input type="checkbox" class="form-check-input" [(ngModel)]="condition.equal"
+                   id="equal"
+                   (ngModelChange)="conditionChanged()">
+            <label class="form-check-label" for="equal">
+              _#(or equal to)
+            </label>
+          </div>
         </div>
       </div>
     </div>
-    @if (condition.operation != ConditionOperation.NULL) {
-      <div class="condition-edit-row__value shell-form-group value-editor-container"
-        class="value-editor-container">
-        @switch (condition.operation) {
-          @case (ConditionOperation.ONE_OF) {
-            <one-of-condition-editor
-              [dataFunction]="dataFunction" [vsId]="vsId"
-              [variablesFunction]="variablesFunction"
-              [columnTreeFunction]="columnTreeFunction"
-              [scriptDefinitionsFunction]="scriptDefinitionsFunction"
-              [expressionTypes]="expressionTypes" [valueTypes]="valueTypes"
-              [subqueryTables]="subqueryTables"
-              [fieldsModel]="fieldsModel" [grayedOutFields]="getGrayedOutFields()"
-              [field]="condition.field" [table]="table"
-              [showUseList]="showUseList"
-              [source]="getSource()" [isVSContext]="isVSContext"
-              [(values)]="condition.values"
-              [enableBrowseData]="isBrowseDataEnabled()"
-              [showOriginalName]="showOriginalName"
-            (valuesChange)="conditionChanged()"></one-of-condition-editor>
-          }
-          @case (ConditionOperation.BETWEEN) {
-            <binary-condition-editor
-              [dataFunction]="dataFunction" [vsId]="vsId"
-              [variablesFunction]="variablesFunction"
-              [columnTreeFunction]="columnTreeFunction"
-              [scriptDefinitionsFunction]="scriptDefinitionsFunction"
-              [expressionTypes]="expressionTypes" [valueTypes]="valueTypes"
-              [subqueryTables]="subqueryTables"
-              [fieldsModel]="fieldsModel" [grayedOutFields]="getGrayedOutFields()"
-              [field]="condition.field" [table]="table"
-              [showUseList]="showUseList"
-              [source]="getSource()"
-              [(values)]="condition.values"
-              [enableBrowseData]="isBrowseDataEnabled()"
-              [isVSContext]="isVSContext"
-              [showOriginalName]="showOriginalName"
-            (valuesChange)="conditionChanged()"></binary-condition-editor>
-          }
-          @default {
-            <condition-editor [operation]="condition.operation"
-              [dataFunction]="dataFunction" [vsId]="vsId"
-              [variablesFunction]="variablesFunction"
-              [columnTreeFunction]="columnTreeFunction"
-              [scriptDefinitionsFunction]="scriptDefinitionsFunction"
-              [isHighlight]="isHighlight"
-              [expressionTypes]="expressionTypes" [valueTypes]="valueTypes"
-              [subqueryTables]="subqueryTables"
-              [enableBrowseData]="isBrowseDataEnabled()"
-              [fieldsModel]="fieldsModel" [grayedOutFields]="getGrayedOutFields()"
-              [field]="condition.field" [table]="table"
-              [source]="getSource()"
-              [showUseList]="showUseList" [isVSContext]="isVSContext"
-              [showOriginalName]="showOriginalName"
-              [value]="condition.values == null ? null : condition.values[0]"
-            (valueChange)="onConditionValueChange($event)"></condition-editor>
-          }
-        }
-      </div>
-    }
+    <div class="condition-edit-row__value shell-form-group value-editor-container"
+         *ngIf="condition.operation != ConditionOperation.NULL"
+         [ngSwitch]="condition.operation">
+      <one-of-condition-editor *ngSwitchCase="ConditionOperation.ONE_OF"
+                               [dataFunction]="dataFunction" [vsId]="vsId"
+                               [variablesFunction]="variablesFunction"
+                               [columnTreeFunction]="columnTreeFunction"
+                               [scriptDefinitionsFunction]="scriptDefinitionsFunction"
+                               [expressionTypes]="expressionTypes" [valueTypes]="valueTypes"
+                               [subqueryTables]="subqueryTables"
+                               [fieldsModel]="fieldsModel" [grayedOutFields]="getGrayedOutFields()"
+                               [field]="condition.field" [table]="table"
+                               [showUseList]="showUseList"
+                               [source]="getSource()" [isVSContext]="isVSContext"
+                               [(values)]="condition.values"
+                               [enableBrowseData]="isBrowseDataEnabled()"
+                               [showOriginalName]="showOriginalName"
+                               (valuesChange)="conditionChanged()"></one-of-condition-editor>
+      <binary-condition-editor *ngSwitchCase="ConditionOperation.BETWEEN"
+                               [dataFunction]="dataFunction" [vsId]="vsId"
+                               [variablesFunction]="variablesFunction"
+                               [columnTreeFunction]="columnTreeFunction"
+                               [scriptDefinitionsFunction]="scriptDefinitionsFunction"
+                               [expressionTypes]="expressionTypes" [valueTypes]="valueTypes"
+                               [subqueryTables]="subqueryTables"
+                               [fieldsModel]="fieldsModel" [grayedOutFields]="getGrayedOutFields()"
+                               [field]="condition.field" [table]="table"
+                               [showUseList]="showUseList"
+                               [source]="getSource()"
+                               [(values)]="condition.values"
+                               [enableBrowseData]="isBrowseDataEnabled()"
+                               [isVSContext]="isVSContext"
+                               [showOriginalName]="showOriginalName"
+                               (valuesChange)="conditionChanged()"></binary-condition-editor>
+      <condition-editor *ngSwitchDefault [operation]="condition.operation"
+                        [dataFunction]="dataFunction" [vsId]="vsId"
+                        [variablesFunction]="variablesFunction"
+                        [columnTreeFunction]="columnTreeFunction"
+                        [scriptDefinitionsFunction]="scriptDefinitionsFunction"
+                        [isHighlight]="isHighlight"
+                        [expressionTypes]="expressionTypes" [valueTypes]="valueTypes"
+                        [subqueryTables]="subqueryTables"
+                        [enableBrowseData]="isBrowseDataEnabled()"
+                        [fieldsModel]="fieldsModel" [grayedOutFields]="getGrayedOutFields()"
+                        [field]="condition.field" [table]="table"
+                        [source]="getSource()"
+                        [showUseList]="showUseList" [isVSContext]="isVSContext"
+                        [showOriginalName]="showOriginalName"
+                        [(value)]="condition.values == null ? null : condition.values[0]"
+                        (valueChange)="conditionChanged()"></condition-editor>
+    </div>
   </div>
 </div>
 <ng-template #formulaEditorDialog let-close="close" let-dismiss="dismiss">
-  <formula-editor-dialog (onCommit)="close($event)" (onCancel)="dismiss($event)"
-    [columnTreeRoot]="columnTreeModel" [expression]="formulaExpression"
-    [formulaType]="formulaType" [formulaName]="formula.name" [vsId]="vsId"
-    [availableFields]="availableFields"
-    [dataType]="formula.dataType" [grayedOutFields]="getGrayedOutFields()"
-    [showOriginalName]="showOriginalName" [reportWorksheetSource]="isReportWorksheetSource()"
-    >
-  </formula-editor-dialog>
+   <formula-editor-dialog (onCommit)="close($event)" (onCancel)="dismiss($event)"
+      [columnTreeRoot]="columnTreeModel" [expression]="formulaExpression"
+      [formulaType]="formulaType" [formulaName]="formula.name" [vsId]="vsId"
+      [availableFields]="availableFields"
+      [dataType]="formula.dataType" [grayedOutFields]="getGrayedOutFields()"
+      [showOriginalName]="showOriginalName" [reportWorksheetSource]="isReportWorksheetSource()"
+   >
+   </formula-editor-dialog>
 </ng-template>

--- a/web/projects/portal/src/app/widget/condition/condition-item-pane.component.html
+++ b/web/projects/portal/src/app/widget/condition/condition-item-pane.component.html
@@ -41,69 +41,79 @@
                        (selectionChange)="operationChanged()"
                        ariaLabel="_#(Condition Operation)">
         </custom-select>
-        <div *ngIf="condition.operation == ConditionOperation.LESS_THAN || condition.operation == ConditionOperation.GREATER_THAN" class="checkbox">
-          <div class="form-check">
-            <input type="checkbox" class="form-check-input" [(ngModel)]="condition.equal"
-                   id="equal"
-                   (ngModelChange)="conditionChanged()">
-            <label class="form-check-label" for="equal">
-              _#(or equal to)
-            </label>
+        @if (condition.operation == ConditionOperation.LESS_THAN || condition.operation == ConditionOperation.GREATER_THAN) {
+          <div class="checkbox">
+            <div class="form-check">
+              <input type="checkbox" class="form-check-input" [(ngModel)]="condition.equal"
+                     id="equal"
+                     (ngModelChange)="conditionChanged()">
+              <label class="form-check-label" for="equal">
+                _#(or equal to)
+              </label>
+            </div>
           </div>
-        </div>
+        }
       </div>
     </div>
-    <div class="condition-edit-row__value shell-form-group value-editor-container"
-         *ngIf="condition.operation != ConditionOperation.NULL"
-         [ngSwitch]="condition.operation">
-      <one-of-condition-editor *ngSwitchCase="ConditionOperation.ONE_OF"
-                               [dataFunction]="dataFunction" [vsId]="vsId"
-                               [variablesFunction]="variablesFunction"
-                               [columnTreeFunction]="columnTreeFunction"
-                               [scriptDefinitionsFunction]="scriptDefinitionsFunction"
-                               [expressionTypes]="expressionTypes" [valueTypes]="valueTypes"
-                               [subqueryTables]="subqueryTables"
-                               [fieldsModel]="fieldsModel" [grayedOutFields]="getGrayedOutFields()"
-                               [field]="condition.field" [table]="table"
-                               [showUseList]="showUseList"
-                               [source]="getSource()" [isVSContext]="isVSContext"
-                               [(values)]="condition.values"
-                               [enableBrowseData]="isBrowseDataEnabled()"
-                               [showOriginalName]="showOriginalName"
-                               (valuesChange)="conditionChanged()"></one-of-condition-editor>
-      <binary-condition-editor *ngSwitchCase="ConditionOperation.BETWEEN"
-                               [dataFunction]="dataFunction" [vsId]="vsId"
-                               [variablesFunction]="variablesFunction"
-                               [columnTreeFunction]="columnTreeFunction"
-                               [scriptDefinitionsFunction]="scriptDefinitionsFunction"
-                               [expressionTypes]="expressionTypes" [valueTypes]="valueTypes"
-                               [subqueryTables]="subqueryTables"
-                               [fieldsModel]="fieldsModel" [grayedOutFields]="getGrayedOutFields()"
-                               [field]="condition.field" [table]="table"
-                               [showUseList]="showUseList"
-                               [source]="getSource()"
-                               [(values)]="condition.values"
-                               [enableBrowseData]="isBrowseDataEnabled()"
-                               [isVSContext]="isVSContext"
-                               [showOriginalName]="showOriginalName"
-                               (valuesChange)="conditionChanged()"></binary-condition-editor>
-      <condition-editor *ngSwitchDefault [operation]="condition.operation"
-                        [dataFunction]="dataFunction" [vsId]="vsId"
-                        [variablesFunction]="variablesFunction"
-                        [columnTreeFunction]="columnTreeFunction"
-                        [scriptDefinitionsFunction]="scriptDefinitionsFunction"
-                        [isHighlight]="isHighlight"
-                        [expressionTypes]="expressionTypes" [valueTypes]="valueTypes"
-                        [subqueryTables]="subqueryTables"
-                        [enableBrowseData]="isBrowseDataEnabled()"
-                        [fieldsModel]="fieldsModel" [grayedOutFields]="getGrayedOutFields()"
-                        [field]="condition.field" [table]="table"
-                        [source]="getSource()"
-                        [showUseList]="showUseList" [isVSContext]="isVSContext"
-                        [showOriginalName]="showOriginalName"
-                        [(value)]="condition.values == null ? null : condition.values[0]"
-                        (valueChange)="conditionChanged()"></condition-editor>
-    </div>
+    @if (condition.operation != ConditionOperation.NULL) {
+      <div class="condition-edit-row__value shell-form-group value-editor-container">
+        @switch (condition.operation) {
+          @case (ConditionOperation.ONE_OF) {
+            <one-of-condition-editor
+                                     [dataFunction]="dataFunction" [vsId]="vsId"
+                                     [variablesFunction]="variablesFunction"
+                                     [columnTreeFunction]="columnTreeFunction"
+                                     [scriptDefinitionsFunction]="scriptDefinitionsFunction"
+                                     [expressionTypes]="expressionTypes" [valueTypes]="valueTypes"
+                                     [subqueryTables]="subqueryTables"
+                                     [fieldsModel]="fieldsModel" [grayedOutFields]="getGrayedOutFields()"
+                                     [field]="condition.field" [table]="table"
+                                     [showUseList]="showUseList"
+                                     [source]="getSource()" [isVSContext]="isVSContext"
+                                     [(values)]="condition.values"
+                                     [enableBrowseData]="isBrowseDataEnabled()"
+                                     [showOriginalName]="showOriginalName"
+                                     (valuesChange)="conditionChanged()"></one-of-condition-editor>
+          }
+          @case (ConditionOperation.BETWEEN) {
+            <binary-condition-editor
+                                     [dataFunction]="dataFunction" [vsId]="vsId"
+                                     [variablesFunction]="variablesFunction"
+                                     [columnTreeFunction]="columnTreeFunction"
+                                     [scriptDefinitionsFunction]="scriptDefinitionsFunction"
+                                     [expressionTypes]="expressionTypes" [valueTypes]="valueTypes"
+                                     [subqueryTables]="subqueryTables"
+                                     [fieldsModel]="fieldsModel" [grayedOutFields]="getGrayedOutFields()"
+                                     [field]="condition.field" [table]="table"
+                                     [showUseList]="showUseList"
+                                     [source]="getSource()"
+                                     [(values)]="condition.values"
+                                     [enableBrowseData]="isBrowseDataEnabled()"
+                                     [isVSContext]="isVSContext"
+                                     [showOriginalName]="showOriginalName"
+                                     (valuesChange)="conditionChanged()"></binary-condition-editor>
+          }
+          @default {
+            <condition-editor [operation]="condition.operation"
+                              [dataFunction]="dataFunction" [vsId]="vsId"
+                              [variablesFunction]="variablesFunction"
+                              [columnTreeFunction]="columnTreeFunction"
+                              [scriptDefinitionsFunction]="scriptDefinitionsFunction"
+                              [isHighlight]="isHighlight"
+                              [expressionTypes]="expressionTypes" [valueTypes]="valueTypes"
+                              [subqueryTables]="subqueryTables"
+                              [enableBrowseData]="isBrowseDataEnabled()"
+                              [fieldsModel]="fieldsModel" [grayedOutFields]="getGrayedOutFields()"
+                              [field]="condition.field" [table]="table"
+                              [source]="getSource()"
+                              [showUseList]="showUseList" [isVSContext]="isVSContext"
+                              [showOriginalName]="showOriginalName"
+                              [value]="condition.values == null ? null : condition.values[0]"
+                              (valueChange)="onConditionValueChange($event)"></condition-editor>
+          }
+        }
+      </div>
+    }
   </div>
 </div>
 <ng-template #formulaEditorDialog let-close="close" let-dismiss="dismiss">

--- a/web/projects/portal/src/app/widget/condition/condition-list.component.html
+++ b/web/projects/portal/src/app/widget/condition/condition-list.component.html
@@ -15,35 +15,27 @@
 ~ You should have received a copy of the GNU Affero General Public License
 ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
-<div class="container">
-  <div class="row">
-    <div class="bordered-box col condition-list__surface">
-      @for (item of conditionList; track $index; let even = $even; let i = $index) {
-        <div
-          class="unhighlightable condition-list__item" [class.selected]="selectedIndex === i"
-          (click)="selectedIndex = i">
-          @if (even) {
-            <div>
-              {{item | conditionToString}}
-            </div>
-          }
-          @if (!even) {
-            <div>
-              {{item | junctionOperatorToString}}
-            </div>
-          }
-        </div>
+@if (!conditionList || conditionList.length === 0) {
+  <div class="condition-list__empty-state">
+    <svg class="condition-list__empty-icon" width="14" height="14" viewBox="0 0 16 16" fill="none"
+         aria-hidden="true">
+      <path d="M8 3.5v9M3.5 8h9" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+    </svg>
+    <span>_#(No conditions set) &mdash; click <span class="condition-list__empty-edit-hint">_#(Edit)</span> _#(to add one.)</span>
+  </div>
+} @else {
+  @for (item of conditionList; track $index; let even = $even; let i = $index) {
+    <div class="unhighlightable condition-list__item" [class.selected]="selectedIndex === i"
+         (click)="selectedIndex = i">
+      @if (even) {
+        <div>{{item | conditionToString}}</div>
+      }
+      @if (!even) {
+        <div>{{item | junctionOperatorToString}}</div>
       }
     </div>
-    @if (showDefaultButtons) {
-      <div class="col-auto btn-container-vertical">
-        <button type="button" class="btn btn-default" (click)="edit()">_#(Edit)</button>
-        <button type="button" class="btn btn-default" (click)="clear()"
-        [disabled]="conditionList == null || conditionList.length == 0">_#(Clear)</button>
-      </div>
-    }
-  </div>
-</div>
+  }
+}
 <ng-template #conditionDialog let-close="close" let-dismiss="dismiss">
   <condition-dialog (onCommit)="close($event)" (onCancel)="dismiss($event)"
     [simplePane]="simplePane" [provider]="provider"

--- a/web/projects/portal/src/app/widget/condition/condition-list.component.scss
+++ b/web/projects/portal/src/app/widget/condition/condition-list.component.scss
@@ -15,12 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-.condition-list__surface {
-  background-color: var(--inet-list-bg-color);
-  border-color: var(--inet-list-border-color);
-  padding: 0;
-  border-radius: var(--inet-radius-md);
-  overflow: auto;
+:host {
+  display: block;
 }
 
 .condition-list__item {
@@ -37,6 +33,27 @@
   &.selected {
     background-color: var(--inet-list-selected-bg-color);
   }
+}
+
+.condition-list__empty-state {
+  display: flex;
+  align-items: center;
+  gap: var(--inet-space-4);
+  padding: 0.875rem var(--inet-space-5);
+  font-size: var(--inet-font-size-base);
+  color: var(--inet-text-muted-color);
+}
+
+.condition-list__empty-icon {
+  flex: none;
+  color: var(--inet-text-muted-color);
+  opacity: 0.6;
+}
+
+.condition-list__empty-edit-hint {
+  color: var(--inet-primary-color);
+  font-style: normal;
+  font-weight: 500;
 }
 
 .condition-list__text {

--- a/web/projects/portal/src/app/widget/condition/condition-list.component.ts
+++ b/web/projects/portal/src/app/widget/condition/condition-list.component.ts
@@ -35,7 +35,6 @@ import { ConditionDialog } from "./condition-dialog.component";
 })
 export class ConditionList {
    public XSchema = XSchema;
-   @Input() showDefaultButtons: boolean = true;
    @Input() simplePane: boolean = false;
    @Input() provider: ConditionItemPaneProvider;
    @Input() fields: DataRef[];

--- a/web/projects/portal/src/app/widget/condition/expression-editor.component.html
+++ b/web/projects/portal/src/app/widget/condition/expression-editor.component.html
@@ -16,7 +16,7 @@
 ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 @if (expressionTypes.length > 1) {
-  <button type="button" class="btn btn-outline-info btn-sm"
+  <button type="button" class="btn btn-light btn-sm"
     title="_#(Expression Type)" [style.align-self]="'center'"
     (click)="changeExpressionType()" [disabled]="isVSContext && !isHighlight">
     @switch (expressionType) {

--- a/web/projects/portal/src/app/widget/condition/one-of-condition-editor.component.html
+++ b/web/projects/portal/src/app/widget/condition/one-of-condition-editor.component.html
@@ -56,7 +56,7 @@
         <div class="btn-container-vertical one-of-condition-editor__list-actions">
           <button type="button" class="btn btn-default" (click)="add()"
                   [disabled]="isEmpty(value)">_#(Add)</button>
-          <button type="button" class="btn btn-default delete_id" (click)="modify()"
+          <button type="button" class="btn btn-default" (click)="modify()"
                   [disabled]="!(selectedIndex >= 0)">_#(Modify)</button>
           <button type="button" class="btn btn-default delete_id" (click)="remove()"
                   [disabled]="!(selectedIndex >= 0)">_#(Delete)</button>

--- a/web/projects/portal/src/app/widget/condition/one-of-condition-editor.component.html
+++ b/web/projects/portal/src/app/widget/condition/one-of-condition-editor.component.html
@@ -58,7 +58,7 @@
                   [disabled]="isEmpty(value)">_#(Add)</button>
           <button type="button" class="btn btn-default" (click)="modify()"
                   [disabled]="!(selectedIndex >= 0)">_#(Modify)</button>
-          <button type="button" class="btn btn-default delete_id" (click)="remove()"
+          <button type="button" class="btn btn-default" data-testid="delete-btn" (click)="remove()"
                   [disabled]="!(selectedIndex >= 0)">_#(Delete)</button>
         </div>
       </div>

--- a/web/projects/portal/src/app/widget/condition/one-of-condition-editor.component.html
+++ b/web/projects/portal/src/app/widget/condition/one-of-condition-editor.component.html
@@ -15,40 +15,51 @@
 ~ You should have received a copy of the GNU Affero General Public License
 ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
-<div class="form-inline">
-  <div class="form-group-column">
-    <condition-editor [dataFunction]="dataFunction" [variablesFunction]="variablesFunction"
-      [columnTreeFunction]="columnTreeFunction" [vsId]="vsId"
-      [scriptDefinitionsFunction]="scriptDefinitionsFunction"
-      [expressionTypes]="expressionTypes" [source]="source"
-      [valueTypes]="valueTypes" [subqueryTables]="subqueryTables"
-      [fieldsModel]="fieldsModel" [grayedOutFields]="grayedOutFields"
-      [field]="field" [table]="table" [showUseList]="showUseList"
-      [isVSContext]="isVSContext" (addValue)="add()"
-      [(values)]="values"
-      [isOneOf]="true"
-      [enableBrowseData]="enableBrowseData"
-      [(value)]="value"
-      [showOriginalName]="showOriginalName"
-      (valueChange)="valueChanged()"
-    (valueChanges)="valueChanges($event)"></condition-editor>
+<div class="shell-inline-form one-of-condition-editor">
+  <div class="form-group-column one-of-condition-editor__content">
+    <div class="one-of-condition-editor__entry-row">
+      <condition-editor class="one-of-condition-editor__entry-editor"
+                        [dataFunction]="dataFunction" [variablesFunction]="variablesFunction"
+                        [columnTreeFunction]="columnTreeFunction" [vsId]="vsId"
+                        [scriptDefinitionsFunction]="scriptDefinitionsFunction"
+                        [expressionTypes]="expressionTypes" [source]="source"
+                        [valueTypes]="valueTypes" [subqueryTables]="subqueryTables"
+                        [fieldsModel]="fieldsModel" [grayedOutFields]="grayedOutFields"
+                        [field]="field" [table]="table" [showUseList]="showUseList"
+                        [isVSContext]="isVSContext" (addValue)="add()"
+                        [(values)]="values"
+                        [isOneOf]="true"
+                        [enableBrowseData]="enableBrowseData"
+                        [(value)]="value"
+                        [showOriginalName]="showOriginalName"
+                        (valueChange)="valueChanged($event)"
+                        (valueChanges)="valueChanges($event)"></condition-editor>
+    </div>
     @if (isValueListVisible(value.type)) {
       <div class="value-list-container">
-        <div class="sm-selectable-list value-list">
-          @for (val of values; track $index; let i = $index) {
-            <div class="unhighlightable value-list__element"
-              [class.selected]="isSelected(val)" (click)="selectValue(i, $event)">
-              {{val | conditionValueToString}}
-            </div>
-          }
+        <div class="value-list-panel">
+          <div class="value-list-panel__label">_#(Selected values)</div>
+          <div class="sm-selectable-list value-list" [class.value-list--empty]="values.length === 0">
+            @if (values.length === 0) {
+              <div class="value-list__empty">
+                _#(Enter a value above, then click Add.)
+              </div>
+            }
+            @for (val of values; track $index; let i = $index) {
+              <div class="unhighlightable value-list__element"
+                   [class.selected]="isSelected(val)" (click)="selectValue(i, $event)">
+                {{val | conditionValueToString}}
+              </div>
+            }
+          </div>
         </div>
         <div class="btn-container-vertical one-of-condition-editor__list-actions">
           <button type="button" class="btn btn-default" (click)="add()"
-          [disabled]="isEmpty(value)">_#(Add)</button>
-          <button type="button" class="btn btn-default delete_id" (click)="remove()"
-          [disabled]="!(selectedIndex >= 0)">_#(Delete)</button>
+                  [disabled]="isEmpty(value)">_#(Add)</button>
           <button type="button" class="btn btn-default delete_id" (click)="modify()"
-          [disabled]="!(selectedIndex >= 0)">_#(Modify)</button>
+                  [disabled]="!(selectedIndex >= 0)">_#(Modify)</button>
+          <button type="button" class="btn btn-default delete_id" (click)="remove()"
+                  [disabled]="!(selectedIndex >= 0)">_#(Delete)</button>
         </div>
       </div>
     }

--- a/web/projects/portal/src/app/widget/condition/one-of-condition-editor.component.scss
+++ b/web/projects/portal/src/app/widget/condition/one-of-condition-editor.component.scss
@@ -15,6 +15,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+:host {
+  display: block;
+  width: 100%;
+  min-width: 0;
+}
+
 .one-of-condition-editor {
   width: 100%;
 }
@@ -37,11 +43,6 @@
   min-width: 0;
 }
 
-.one-of-condition-editor__add-button {
-  flex: 0 0 auto;
-  min-height: var(--condition-row-control-height, var(--inet-control-height-md));
-  align-self: flex-start;
-}
 
 .value-list-container {
   display: flex;

--- a/web/projects/portal/src/app/widget/condition/one-of-condition-editor.component.spec.ts
+++ b/web/projects/portal/src/app/widget/condition/one-of-condition-editor.component.spec.ts
@@ -80,7 +80,7 @@ describe("One Of Condition Editor Unit Test", () => {
       valueList[0].click();
       fixture.detectChanges();
 
-      let delBtn = fixture.nativeElement.querySelector("button.delete_id");
+      let delBtn = fixture.nativeElement.querySelector("[data-testid='delete-btn']");
       delBtn.click();
       fixture.detectChanges();
 
@@ -89,12 +89,12 @@ describe("One Of Condition Editor Unit Test", () => {
       valueList[0].click();
       fixture.detectChanges();
 
-      delBtn = fixture.nativeElement.querySelector("button.delete_id");
+      delBtn = fixture.nativeElement.querySelector("[data-testid='delete-btn']");
       delBtn.click();
       fixture.detectChanges();
 
       valueList = fixture.nativeElement.querySelector("div.value-list__element");
-      delBtn = fixture.nativeElement.querySelector("button.delete_id");
+      delBtn = fixture.nativeElement.querySelector("[data-testid='delete-btn']");
       expect(valueList).toBeNull();
       expect(delBtn.hasAttribute("disabled")).toBeTruthy();
    });

--- a/web/projects/portal/src/app/widget/condition/one-of-condition-editor.component.spec.ts
+++ b/web/projects/portal/src/app/widget/condition/one-of-condition-editor.component.spec.ts
@@ -75,7 +75,7 @@ describe("One Of Condition Editor Unit Test", () => {
       oneOfEditor.value = {value: null, type: ConditionValueType.VALUE};
       fixture.detectChanges();
 
-      let valueList = fixture.nativeElement.querySelectorAll("div.sm-selectable-list div");
+      let valueList = fixture.nativeElement.querySelectorAll("div.value-list__element");
       expect(valueList.length).toBe(2);
       valueList[0].click();
       fixture.detectChanges();
@@ -84,7 +84,7 @@ describe("One Of Condition Editor Unit Test", () => {
       delBtn.click();
       fixture.detectChanges();
 
-      valueList = fixture.nativeElement.querySelectorAll("div.sm-selectable-list div");
+      valueList = fixture.nativeElement.querySelectorAll("div.value-list__element");
       expect(valueList.length).toBe(1);
       valueList[0].click();
       fixture.detectChanges();
@@ -93,7 +93,7 @@ describe("One Of Condition Editor Unit Test", () => {
       delBtn.click();
       fixture.detectChanges();
 
-      valueList = fixture.nativeElement.querySelector("div.sm-selectable-list div");
+      valueList = fixture.nativeElement.querySelector("div.value-list__element");
       delBtn = fixture.nativeElement.querySelector("button.delete_id");
       expect(valueList).toBeNull();
       expect(delBtn.hasAttribute("disabled")).toBeTruthy();

--- a/web/projects/portal/src/app/widget/condition/one-of-condition-editor.component.ts
+++ b/web/projects/portal/src/app/widget/condition/one-of-condition-editor.component.ts
@@ -93,8 +93,10 @@ export class OneOfConditionEditor implements OnInit, OnChanges {
             choiceQuery: this.values[0].choiceQuery
          };
       }
-      else if(this.value == null || (this.value.type != ConditionValueType.VALUE && this.values[0])) {
-         // set the type of the current editor to the last value that was added
+      else if(this.value == null ||
+         (this.value.type != ConditionValueType.VALUE && this.values[0] &&
+          this.values[0].type === ConditionValueType.VALUE))
+      {
          this.value = {
             value: this.getDefaultValue(),
             type: ConditionValueType.VALUE,
@@ -173,7 +175,9 @@ export class OneOfConditionEditor implements OnInit, OnChanges {
          }
          else {
             this.value = {
-               value: this.getDefaultValue(),
+               value: this.value.type === ConditionValueType.FIELD && this.fieldsModel?.list?.[0]
+                  ? this.fieldsModel.list[0]
+                  : this.getDefaultValue(),
                type: this.value.type,
                choiceQuery: this.value.choiceQuery
             };
@@ -217,17 +221,20 @@ export class OneOfConditionEditor implements OnInit, OnChanges {
       }
    }
 
-   valueChanged(): void {
-      let isSpecialType: boolean = this.isSpecialType(this.value.type);
+   valueChanged(newValue?: ConditionValue): void {
+      // Use the incoming event value directly to avoid racing with [(value)] assignment
+      const value = newValue ?? this.value;
+      this.value = value;
+      let isSpecialType: boolean = this.isSpecialType(value.type);
 
       // if the editor type is special type then propagate the value change
       if(isSpecialType) {
-         this.values = [this.value];
+         this.values = [value];
          this.valuesChange.emit(this.values);
       }
-      // if switching from a special type to some other then clear the values
-      else if(!isSpecialType && this.values[0] &&
-         this.isSpecialType(this.values[0].type))
+      // clear the list when the existing items are incompatible with the new type
+      else if(this.values[0] && (this.isSpecialType(this.values[0].type) ||
+              this.values[0].type !== value.type))
       {
          this.values = [];
          this.valuesChange.emit(this.values);

--- a/web/projects/portal/src/app/widget/condition/one-of-condition-editor.component.ts
+++ b/web/projects/portal/src/app/widget/condition/one-of-condition-editor.component.ts
@@ -24,6 +24,7 @@ import {
    Output,
    SimpleChanges
 } from "@angular/core";
+import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { Observable } from "rxjs";
 import { Tool } from "../../../../../shared/util/tool";
 import { SourceInfo } from "../../binding/data/source-info";
@@ -35,6 +36,7 @@ import { ExpressionValue } from "../../common/data/condition/expression-value";
 import { SubqueryTable } from "../../common/data/condition/subquery-table";
 import { DataRef } from "../../common/data/data-ref";
 import { XSchema } from "../../common/data/xschema";
+import { ComponentTool } from "../../common/util/component-tool";
 import { TreeNodeModel } from "../tree/tree-node-model";
 import { ConditionFieldComboModel } from "./condition-field-combo-model";
 import { ConditionValuePipe } from "./condition-value.pipe";
@@ -50,6 +52,9 @@ import { ConditionEditor } from "./condition-editor.component";
 export class OneOfConditionEditor implements OnInit, OnChanges {
    public XSchema = XSchema;
    public ConditionValueType = ConditionValueType;
+
+   constructor(private modalService: NgbModal) {}
+
    @Input() dataFunction: () => Observable<BrowseDataModel>;
    @Input() vsId: string;
    @Input() variablesFunction: () => Observable<any[]>;
@@ -232,12 +237,25 @@ export class OneOfConditionEditor implements OnInit, OnChanges {
          this.values = [value];
          this.valuesChange.emit(this.values);
       }
-      // clear the list when the existing items are incompatible with the new type
-      else if(this.values[0] && (this.isSpecialType(this.values[0].type) ||
-              this.values[0].type !== value.type))
-      {
+      // transitioning away from a special type — clear immediately (no list to preserve)
+      else if(this.values[0] && this.isSpecialType(this.values[0].type)) {
          this.values = [];
          this.valuesChange.emit(this.values);
+      }
+      // non-special type change (e.g. VALUE → FIELD) with an existing list — confirm first
+      else if(this.values[0] && this.values[0].type !== value.type) {
+         const revertTo = Tool.clone(this.values[this.values.length - 1]);
+         ComponentTool.showConfirmDialog(this.modalService, "_#(js:Confirm)",
+            "_#(js:Switching value type will clear the current value list. Continue?)")
+            .then(result => {
+               if(result === "ok") {
+                  this.values = [];
+                  this.valuesChange.emit(this.values);
+               }
+               else {
+                  this.value = revertTo;
+               }
+            });
       }
    }
 

--- a/web/projects/portal/src/app/widget/condition/simple-condition-pane.component.html
+++ b/web/projects/portal/src/app/widget/condition/simple-condition-pane.component.html
@@ -15,47 +15,72 @@
 ~ You should have received a copy of the GNU Affero General Public License
 ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
-<div class="container-fluid">
-  <div class="row">
-    <div class="selectable-list col-12 simple-condition-pane__list">
-      @for (item of conditionList; track $index; let even = $even; let i = $index) {
-        <div class="unhighlightable"
-          [class.selected]="selectedIndex == i" (click)="conditionItemSelected(i)">
-          @if (even) {
-            <div>
-              {{item | conditionToString}}
-            </div>
-          }
-          @if (!even) {
-            <div>
-              {{item | junctionOperatorToString}}
-            </div>
-          }
-        </div>
-      }
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <div class="pull-right">
-        <button type="button" class="btn btn-secondary" (click)="more()">_#(More)</button>
-        <button type="button" class="btn btn-default ms-1" (click)="fewer()"
-        [disabled]="this.selectedIndex == null || this.selectedIndex % 2 != 0">_#(Fewer)</button>
-      </div>
-    </div>
-  </div>
+
+<!-- CONDITIONS section label + count pill -->
+<div class="simple-pane__section-head">
+  <span class="simple-pane__section-label">_#(Conditions)</span>
+  @if (clauseRows.length > 0) {
+    <span class="simple-pane__count-pill">{{ clauseRows.length }}</span>
+  }
 </div>
-<fieldset>
-  <legend>_#(Edit)</legend>
-  <div class="condition-item-container">
-    @if (condition != null) {
-      <condition-item-pane [provider]="provider" [variableNames]="variableNames"
-        [subqueryTables]="subqueryTables" [fields]="fields"
-        [condition]="condition" [isVSContext]="isVSContext"
-        [showOriginalName]="true"
-        (conditionChange)="conditionChange($event)"
-        [addNoneItem]="false">
-      </condition-item-pane>
+
+<!-- Empty state -->
+@if (clauseRows.length === 0) {
+  <div class="simple-pane__empty">
+    _#(No conditions defined yet) &mdash; _#(build one below and click)
+    <span class="simple-pane__empty-add-hint">_#(Add)</span>.
+  </div>
+}
+
+<!-- Clause list -->
+@if (clauseRows.length > 0) {
+  <div class="simple-pane__clause-list">
+    @for (clause of clauseRows; track $index; let i = $index) {
+      <div class="simple-pane__clause-row">
+        <span class="simple-pane__conj">{{ clause.conjLabel }}</span>
+        <div class="simple-pane__expr">
+          <span class="simple-pane__field-token">{{ clause.field?.view ?? clause.field?.name }}</span>
+          <span class="simple-pane__op">
+            @if (clause.negated) { _#(is not) } @else { _#(is) }
+            @if (!clause.isEqualOp) { {{ clause.operation | conditionOperationToString }} }
+          </span>
+          <span class="simple-pane__val">{{ clause.valueLabel }}</span>
+        </div>
+        <button type="button" class="simple-pane__remove" (click)="removeClause(i)"
+                title="_#(Remove)">&times;</button>
+      </div>
     }
   </div>
-</fieldset>
+}
+
+<!-- ADD CONDITION builder -->
+<div class="simple-pane__builder">
+  <div class="simple-pane__builder-label">_#(Add Condition)</div>
+
+  @if (draftCondition) {
+    <condition-item-pane
+      [provider]="provider"
+      [variableNames]="variableNames"
+      [subqueryTables]="subqueryTables"
+      [fields]="fields"
+      [condition]="draftCondition"
+      [isVSContext]="isVSContext"
+      [showOriginalName]="true"
+      [addNoneItem]="false"
+      (conditionChange)="draftCondition = $event">
+    </condition-item-pane>
+  }
+
+  <div class="simple-pane__builder-footer">
+    @if (clauseRows.length > 0) {
+      <div class="simple-pane__select-wrap">
+        <select class="simple-pane__join-ctrl" [(ngModel)]="draftConj">
+          <option value="and">_#(And)</option>
+          <option value="or">_#(Or)</option>
+        </select>
+        <span class="simple-pane__caret">&#9660;</span>
+      </div>
+    }
+    <button type="button" class="simple-pane__add-btn" (click)="addClause()">_#(Add)</button>
+  </div>
+</div>

--- a/web/projects/portal/src/app/widget/condition/simple-condition-pane.component.scss
+++ b/web/projects/portal/src/app/widget/condition/simple-condition-pane.component.scss
@@ -15,62 +15,225 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-.simple-condition-pane__list {
-  background-color: var(--inet-list-bg-color);
-  border-color: var(--inet-list-border-color);
-  max-height: 14rem;
+
+:host {
+  display: block;
 }
 
-.simple-condition-pane__list-item {
-  align-items: center;
+/* ── Section label row ────────────────────────────────────────────────── */
+
+.simple-pane__section-head {
   display: flex;
-  min-height: var(--inet-control-height-md);
-  padding: 0 var(--inet-space-3);
+  align-items: center;
+  gap: var(--inet-space-4);
+  margin: 18px 0 8px;
+}
 
-  &:hover {
-    background-color: var(--inet-list-hover-bg-color);
-  }
+.simple-pane__section-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+  color: var(--inet-text-subtle-color);
+}
 
-  &.selected {
-    background-color: var(--inet-list-selected-bg-color);
+.simple-pane__count-pill {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--inet-text-muted-color);
+  background: var(--inet-shell-surface-hover);
+  border-radius: var(--inet-radius-pill);
+  padding: 1px 7px;
+  line-height: 1.5;
+}
+
+/* ── Empty state ──────────────────────────────────────────────────────── */
+
+.simple-pane__empty {
+  font-size: var(--inet-font-size-base);
+  color: var(--inet-text-muted-color);
+  padding: 2px 0 6px;
+}
+
+.simple-pane__empty-add-hint {
+  color: var(--inet-text-color);
+  font-weight: 500;
+}
+
+/* ── Clause list ──────────────────────────────────────────────────────── */
+
+.simple-pane__clause-list {
+  border: 1px solid var(--inet-default-border-color);
+  border-radius: var(--inet-radius-lg); /* 4px */
+  overflow: hidden;
+}
+
+.simple-pane__clause-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: var(--inet-row-height-md); /* 34px */
+  padding: 5px 8px 5px 12px;
+
+  & + & {
+    border-top: 1px solid var(--inet-shell-surface-hover);
   }
 }
 
-.simple-condition-pane__list-text {
+.simple-pane__conj {
+  width: 40px;
+  flex: none;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--inet-text-subtle-color);
+}
+
+.simple-pane__expr {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex-wrap: wrap;
+  font-size: var(--inet-font-size-base);
+  min-width: 0;
+}
+
+.simple-pane__field-token {
+  font-weight: 500;
+  color: var(--inet-text-color);
+  background: var(--inet-shell-surface-subtle);
+  border: 1px solid var(--inet-default-border-color);
+  border-radius: var(--inet-radius-md);
+  padding: 1px 7px;
+  white-space: nowrap;
+}
+
+.simple-pane__op {
+  color: var(--inet-text-muted-color);
+  white-space: nowrap;
+}
+
+.simple-pane__val {
+  font-weight: 500;
+  color: var(--inet-text-strong-color);
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.condition-editor-header {
+.simple-pane__remove {
+  width: var(--inet-control-height-sm); /* 24px */
+  height: var(--inet-control-height-sm);
+  flex: none;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-top: 1rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--inet-border-color, #d9d4cb);
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  border-radius: var(--inet-radius-md);
+  color: var(--inet-text-subtle-color);
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--inet-danger-color-light);
+    color: var(--inet-danger-color);
+  }
 }
 
-.condition-editor-header__title {
-  font-weight: 400;
-  color: var(--inet-text-color, #2f2f2f);
+/* ── ADD CONDITION builder ────────────────────────────────────────────── */
+
+.simple-pane__builder {
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px solid var(--inet-default-border-color);
+  /* Compact control height matches design spec 30 px; also moves field input
+     higher so the field-combo fixed dropdown has more viewport room below. */
+  --condition-row-control-height: var(--inet-control-height-md);
+  --condition-row-icon-size: 1.75rem;
 }
 
-.condition-editor-header__actions {
-  display: inline-flex;
+.simple-pane__builder-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+  color: var(--inet-text-subtle-color);
+  margin-bottom: 8px;
+}
+
+/* ── Builder footer: join select + Add button ─────────────────────────── */
+
+.simple-pane__builder-footer {
+  display: flex;
   align-items: center;
-  flex-shrink: 0;
+  gap: var(--inet-space-4);
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--inet-default-border-color);
 }
 
-.condition-editor-fieldset {
-  margin-top: 0.5rem;
+.simple-pane__select-wrap {
+  position: relative;
+  flex: none;
 }
 
-.condition-editor-fieldset legend {
-  display: none;
+.simple-pane__join-ctrl {
+  width: 72px;
+  height: var(--inet-control-height-md); /* 30px */
+  font-family: inherit;
+  font-size: var(--inet-font-size-base);
+  color: var(--inet-text-color);
+  background: var(--inet-shell-surface-default);
+  border: 1px solid var(--inet-default-border-color);
+  border-radius: var(--inet-radius-md);
+  padding: 0 24px 0 var(--inet-space-4);
+  appearance: none;
+  -webkit-appearance: none;
+  cursor: pointer;
+  outline: none;
+
+  &:focus {
+    border-color: var(--inet-primary-color);
+    box-shadow: var(--inet-focus-ring);
+  }
 }
 
-.condition-item-container {
-  min-height: 300px;
+.simple-pane__caret {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: var(--inet-text-subtle-color);
+  font-size: 8px;
+  line-height: 1;
+}
+
+.simple-pane__add-btn {
+  height: var(--inet-control-height-md); /* 30px */
+  font-size: var(--inet-font-size-base);
+  font-weight: 500;
+  color: var(--inet-text-muted-color);
+  background: transparent;
+  border: 1px solid var(--inet-default-border-color);
+  border-radius: var(--inet-radius-md);
+  padding: 0 14px;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover:not(:disabled) {
+    background: var(--inet-shell-surface-hover);
+    color: var(--inet-text-color);
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
 }

--- a/web/projects/portal/src/app/widget/condition/simple-condition-pane.component.ts
+++ b/web/projects/portal/src/app/widget/condition/simple-condition-pane.component.ts
@@ -58,11 +58,13 @@ export class SimpleConditionPane implements OnInit {
    draftCondition: Condition = null;
 
    private _conditionList: any[] = [];
+   private _clauseRowsCache: ClauseRow[] | null = null;
    private readonly valPipe = new ConditionValuePipe();
 
    @Input()
    set conditionList(list: any[]) {
       this._conditionList = Tool.clone(list) ?? [];
+      this._clauseRowsCache = null;
    }
 
    get conditionList(): any[] {
@@ -70,6 +72,14 @@ export class SimpleConditionPane implements OnInit {
    }
 
    get clauseRows(): ClauseRow[] {
+      if(!this._clauseRowsCache) {
+         this._clauseRowsCache = this._buildClauseRows();
+      }
+
+      return this._clauseRowsCache;
+   }
+
+   private _buildClauseRows(): ClauseRow[] {
       return this._conditionList
          .filter((_, i) => i % 2 === 0)
          .map((cond: Condition, ci: number) => {
@@ -80,9 +90,14 @@ export class SimpleConditionPane implements OnInit {
             const isEqualOp = cond.operation === ConditionOperation.EQUAL_TO
                || cond.operation === ConditionOperation.NONE;
 
-            const rawVal = cond.values?.[0] ? this.valPipe.transform(cond.values[0]) : "";
-            const isNumeric = rawVal !== "" && !isNaN(Number(rawVal));
-            const valueLabel = !rawVal ? "" : isNumeric ? rawVal : `"${rawVal}"`;
+            const allLabels = (cond.values ?? [])
+               .map(v => this.valPipe.transform(v))
+               .filter(s => s !== "");
+            const isNumeric = (s: string) => s !== "" && !isNaN(Number(s));
+            const valueLabel = allLabels.length === 0 ? ""
+               : allLabels.length === 1
+                  ? (isNumeric(allLabels[0]) ? allLabels[0] : `"${allLabels[0]}"`)
+                  : `(${allLabels.slice(0, 3).map(s => isNumeric(s) ? s : `"${s}"`).join(", ")}${allLabels.length > 3 ? "…" : ""})`;
 
             return {
                conjLabel,
@@ -120,6 +135,7 @@ export class SimpleConditionPane implements OnInit {
 
       list.push(Tool.clone(this.draftCondition));
       this._conditionList = list;
+      this._clauseRowsCache = null;
       this._initDraft();
       this.conditionListChange.emit(list);
    }
@@ -139,6 +155,7 @@ export class SimpleConditionPane implements OnInit {
       }
 
       this._conditionList = list;
+      this._clauseRowsCache = null;
       this.conditionListChange.emit(list);
    }
 

--- a/web/projects/portal/src/app/widget/condition/simple-condition-pane.component.ts
+++ b/web/projects/portal/src/app/widget/condition/simple-condition-pane.component.ts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
+import { FormsModule } from "@angular/forms";
 import { Condition } from "../../common/data/condition/condition";
 import { ConditionItemPaneProvider } from "../../common/data/condition/condition-item-pane-provider";
 import { ConditionOperation } from "../../common/data/condition/condition-operation";
@@ -24,126 +25,135 @@ import { JunctionOperatorType } from "../../common/data/condition/junction-opera
 import { SubqueryTable } from "../../common/data/condition/subquery-table";
 import { DataRef } from "../../common/data/data-ref";
 import { Tool } from "../../../../../shared/util/tool";
-import { JunctionOperatorPipe } from "./junction-operator.pipe";
-import { ConditionPipe } from "./condition.pipe";
 import { ConditionItemPane } from "./condition-item-pane.component";
+import { ConditionOperationPipe } from "./condition-operation.pipe";
+import { ConditionValuePipe } from "./condition-value.pipe";
 
+export interface ClauseRow {
+   conjLabel: string;
+   field: DataRef;
+   negated: boolean;
+   isEqualOp: boolean;
+   operation: ConditionOperation;
+   valueLabel: string;
+}
 
 @Component({
     selector: "simple-condition-pane",
     templateUrl: "simple-condition-pane.component.html",
     styleUrls: ["simple-condition-pane.component.scss"],
-    imports: [ConditionItemPane, ConditionPipe, JunctionOperatorPipe]
+    imports: [FormsModule, ConditionItemPane, ConditionOperationPipe]
 })
 export class SimpleConditionPane implements OnInit {
    public ConditionOperation = ConditionOperation;
+
    @Input() subqueryTables: SubqueryTable[];
    @Input() fields: DataRef[];
    @Input() provider: ConditionItemPaneProvider;
    @Input() isVSContext = true;
    @Input() variableNames: string[];
    @Output() conditionListChange = new EventEmitter<any[]>();
-   condition: Condition;
-   selectedIndex: number;
-   private _conditionList: any[]; // even indexes contain conditions, odd contain junctions
+
+   draftConj: "and" | "or" = "and";
+   draftCondition: Condition = null;
+
+   private _conditionList: any[] = [];
+   private readonly valPipe = new ConditionValuePipe();
 
    @Input()
-   set conditionList(conditionList: any[]) {
-      this._conditionList = Tool.clone(conditionList);
-
-      if(this.selectedIndex >= 0 && this.selectedIndex < this._conditionList.length) {
-         if(this.selectedIndex % 2 !== 0) {
-            this.condition = null;
-         }
-         else if(this.selectedIndex % 2 === 0) {
-            this.condition = Tool.clone(this.conditionList[this.selectedIndex]);
-         }
-      }
-      else {
-         this.condition = null;
-         this.selectedIndex = null;
-      }
+   set conditionList(list: any[]) {
+      this._conditionList = Tool.clone(list) ?? [];
    }
 
    get conditionList(): any[] {
       return this._conditionList;
    }
 
-   ngOnInit(): void {
-      if(this.conditionList == null) {
-         this.conditionList = [];
-      }
+   get clauseRows(): ClauseRow[] {
+      return this._conditionList
+         .filter((_, i) => i % 2 === 0)
+         .map((cond: Condition, ci: number) => {
+            const junction: JunctionOperator = ci > 0 ? this._conditionList[ci * 2 - 1] : null;
+            const conjLabel = ci === 0 ? "WHERE"
+               : junction?.type === JunctionOperatorType.OR ? "OR" : "AND";
+
+            const isEqualOp = cond.operation === ConditionOperation.EQUAL_TO
+               || cond.operation === ConditionOperation.NONE;
+
+            const rawVal = cond.values?.[0] ? this.valPipe.transform(cond.values[0]) : "";
+            const isNumeric = rawVal !== "" && !isNaN(Number(rawVal));
+            const valueLabel = !rawVal ? "" : isNumeric ? rawVal : `"${rawVal}"`;
+
+            return {
+               conjLabel,
+               field: cond.field,
+               negated: cond.negated,
+               isEqualOp,
+               operation: cond.operation,
+               valueLabel
+            };
+         });
    }
 
-   more(): void {
-      if(this.conditionList.length > 0) {
-         this.conditionList.push(<JunctionOperator> {
+   ngOnInit(): void {
+      if(!this._conditionList) {
+         this._conditionList = [];
+      }
+
+      this._initDraft();
+   }
+
+   addClause(): void {
+      if(!this.draftCondition) {
+         return;
+      }
+
+      const list = [...this._conditionList];
+
+      if(list.length > 0) {
+         list.push(<JunctionOperator>{
             jsonType: "junction",
-            type: JunctionOperatorType.AND,
+            type: this.draftConj === "or" ? JunctionOperatorType.OR : JunctionOperatorType.AND,
             level: 0
          });
       }
 
-      let newCondition: Condition = <Condition> {
+      list.push(Tool.clone(this.draftCondition));
+      this._conditionList = list;
+      this._initDraft();
+      this.conditionListChange.emit(list);
+   }
+
+   removeClause(clauseIndex: number): void {
+      const list = [...this._conditionList];
+      const pos = clauseIndex * 2;
+
+      if(pos === 0 && list.length > 1) {
+         list.splice(0, 2);
+      }
+      else if(pos > 0) {
+         list.splice(pos - 1, 2);
+      }
+      else {
+         list.splice(0, 1);
+      }
+
+      this._conditionList = list;
+      this.conditionListChange.emit(list);
+   }
+
+   private _initDraft(): void {
+      const firstField = this.fields?.[0] ?? null;
+      const probe = <Condition>{
          jsonType: "condition",
-         field: this.fields != null && this.fields.length > 0 ? this.fields[0] : null,
-         operation: this.provider.getConditionOperations(null)[0],
+         field: firstField,
+         operation: ConditionOperation.EQUAL_TO,
          values: [],
          level: 0,
          equal: false,
          negated: false
       };
-
-      this.conditionList.push(newCondition);
-      this.conditionItemSelected(this.conditionList.length - 1);
-      this.conditionListChange.emit(this.conditionList);
-   }
-
-   fewer(): void {
-      if(this.selectedIndex == null || this.selectedIndex % 2 != 0) {
-         return;
-      }
-
-      let selectedIndex = this.selectedIndex;
-      this.conditionList.splice(selectedIndex, 1);
-
-      if(this.selectedIndex < this.conditionList.length) {
-         this.conditionList.splice(selectedIndex, 1);
-      }
-      else if(this.conditionList.length > 0) {
-         this.conditionList.splice(selectedIndex - 1, 1);
-         selectedIndex -= 2;
-      }
-      else {
-         selectedIndex = null;
-      }
-
-      this.conditionItemSelected(selectedIndex);
-      this.conditionListChange.emit(this.conditionList);
-   }
-
-   modify(): void {
-      if(this.selectedIndex % 2 == 0) {
-         let updatedConditionList = [...this.conditionList];
-         updatedConditionList[this.selectedIndex] = Tool.clone(this.condition);
-         updatedConditionList[this.selectedIndex].level = 0;
-         this.conditionListChange.emit(updatedConditionList);
-      }
-   }
-
-   conditionItemSelected(index: number): void {
-      this.selectedIndex = index;
-
-      if(index == null || index % 2 != 0) {
-         this.condition = null;
-      }
-      else if(index % 2 == 0) {
-         this.condition = Tool.clone(this.conditionList[index]);
-      }
-   }
-
-   conditionChange(condition: Condition) {
-      this.condition = condition;
-      this.modify();
+      const ops = this.provider?.getConditionOperations(probe) ?? [ConditionOperation.EQUAL_TO];
+      this.draftCondition = { ...probe, operation: ops[0] ?? ConditionOperation.EQUAL_TO };
    }
 }

--- a/web/projects/portal/src/app/widget/condition/variable-editor.component.html
+++ b/web/projects/portal/src/app/widget/condition/variable-editor.component.html
@@ -1,40 +1,36 @@
 <!--
-~ This file is part of StyleBI.
-~ Copyright (C) 2024  InetSoft Technology
-~
-~ This program is free software: you can redistribute it and/or modify
-~ it under the terms of the GNU Affero General Public License as published by
-~ the Free Software Foundation, either version 3 of the License, or
-~ (at your option) any later version.
-~
-~ This program is distributed in the hope that it will be useful,
-~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-~ GNU Affero General Public License for more details.
-~
-~ You should have received a copy of the GNU Affero General Public License
-~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
--->
+  ~ This file is part of StyleBI.
+  ~ Copyright (C) 2024  InetSoft Technology
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
 <form [formGroup]="vform">
-  <div class="variable-editor-field">
-    <input class="form-control variable-input" type="text" placeholder="_#(Variable Name)"
-             [ngClass]="{'input-transparent border-0': variableList && variableList.length > 0,
-                        'hideText' : variableList.includes(variableName)}"
-      [ngModel]="variableName" (ngModelChange)="variableNameChanged($event)"
-      formControlName="name"/>
-    <label>_#(Variable Name)</label>
-    @if (variableList && variableList.length > 0) {
-      <custom-select
-                     class="variable-picker"
-                     [options]="variableSelectOptions"
-                     [ngModel]="variableName"
-                     [ngModelOptions]="{standalone: true}"
-                     (selectionChange)="variableNameChanged($event)"
-                     ariaLabel="_#(Variable Name)"
-                     placeholder="_#(Variable Name)">
-      </custom-select>
-    }
-  </div>
+   <div class="variable-editor-field">
+      <input class="form-control variable-input" type="text" placeholder="_#(Variable Name)"
+             [ngModel]="variableName" (ngModelChange)="variableNameChanged($event)"
+             formControlName="name"/>
+      @if (variableList && variableList.length > 0) {
+        <custom-select class="variable-picker"
+                       [options]="variableSelectOptions"
+                       [ngModel]="variableName"
+                       [ngModelOptions]="{standalone: true}"
+                       (selectionChange)="variableNameChanged($event)"
+                       ariaLabel="_#(Variable Name)"
+                       placeholder="_#(Variable Name)">
+        </custom-select>
+      }
+   </div>
 </form>
 
 @if (showUseList) {

--- a/web/projects/portal/src/app/widget/condition/variable-editor.component.ts
+++ b/web/projects/portal/src/app/widget/condition/variable-editor.component.ts
@@ -47,7 +47,7 @@ export class VariableEditor implements OnChanges, AfterViewInit {
       //fix a problem for IE
       //in IE if a select in form only has one option, it will Selected it by default
       //but we needn't.
-      if(this.variableName == "" && this.variableList.length == 1) {
+      if(this.variableName == "" && this.variableList?.length == 1) {
          this.vform.controls["name"].setValue(this.variableName);
       }
    }

--- a/web/projects/portal/src/app/widget/fixed-dropdown/fixed-dropdown.component.ts
+++ b/web/projects/portal/src/app/widget/fixed-dropdown/fixed-dropdown.component.ts
@@ -122,17 +122,19 @@ export class FixedDropdownComponent implements OnInit, AfterViewInit, OnDestroy 
 
    /**
     * Set the boundaries of the dropdown. If a container element defined then use those boundaries
-    * to calculate the position
+    * to calculate the position; otherwise fall back to viewport bounds so the dropdown is never
+    * clipped at the edge of the screen.
     */
    set dropdownBounds(dropdownBounds: Rectangle) {
       // set the position of the dropdown
       this.dropdownPosition = new Point(dropdownBounds.x, dropdownBounds.y);
       this.opacity = 1;
 
-      // adjust to the given container element
+      let restrictBounds: Rectangle;
+
       if(this.container) {
          const containerElement = this.container;
-         const restrictBounds = Rectangle.fromClientRect(containerElement.getBoundingClientRect());
+         restrictBounds = Rectangle.fromClientRect(containerElement.getBoundingClientRect());
 
          // Restricting to an empty rectangle (such as when the body size is 0) doesn't really
          // make sense so use the viewport size instead
@@ -146,19 +148,24 @@ export class FixedDropdownComponent implements OnInit, AfterViewInit, OnDestroy 
          if(GuiTool.isMobileDevice() && containerElement == document.body) {
             restrictBounds.height = window.innerHeight;
          }
+      }
+      else {
+         // No container supplied — clamp to the viewport so the dropdown is never cut off.
+         const [vw, vh] = GuiTool.getViewportSize();
+         restrictBounds = new Rectangle(0, 0, vw, vh);
+      }
 
-         const dropdownRight = dropdownBounds.x + dropdownBounds.width;
-         const dropdownBottom = dropdownBounds.y + dropdownBounds.height;
-         const restrictRight = restrictBounds.x + restrictBounds.width;
-         const restrictBottom = restrictBounds.y + restrictBounds.height;
+      const dropdownRight = dropdownBounds.x + dropdownBounds.width;
+      const dropdownBottom = dropdownBounds.y + dropdownBounds.height;
+      const restrictRight = restrictBounds.x + restrictBounds.width;
+      const restrictBottom = restrictBounds.y + restrictBounds.height;
 
-         if(dropdownRight > restrictRight) {
-            this.dropdownPosition.x = Math.max(0, restrictRight - dropdownBounds.width);
-         }
+      if(dropdownRight > restrictRight) {
+         this.dropdownPosition.x = Math.max(0, restrictRight - dropdownBounds.width);
+      }
 
-         if(dropdownBottom > restrictBottom) {
-            this.dropdownPosition.y = Math.max(0, restrictBottom - dropdownBounds.height);
-         }
+      if(dropdownBottom > restrictBottom) {
+         this.dropdownPosition.y = Math.max(0, restrictBottom - dropdownBounds.height);
       }
    }
 

--- a/web/projects/portal/src/app/widget/share/share-link-dialog.component.html
+++ b/web/projects/portal/src/app/widget/share/share-link-dialog.component.html
@@ -57,6 +57,6 @@
   </div>
 </div>
 <div class="modal-footer">
-  <button #okButton type="button" class="btn btn-default" (click)="ok()">_#(OK)</button>
+  <button #okButton type="button" class="btn btn-primary" (click)="ok()">_#(OK)</button>
 </div>
 <notifications #notifications class="notifications-share-link-dialog" [timeout]="2000"></notifications>

--- a/web/projects/portal/src/scss/_bootstrap-override.scss
+++ b/web/projects/portal/src/scss/_bootstrap-override.scss
@@ -572,6 +572,7 @@ a:not([href]) {
 
 .modal-footer {
   padding: var(--inet-modal-footer-padding);
+  background-color: var(--inet-shell-surface-subtle);
 }
 
 .form-control, .form-control[readonly], .form-control.input-group-btn-addon,


### PR DESCRIPTION
Recovery (UI lost when 563ab05dd overwrote prior PRs)

Data tab (PR #3604): Restores 11 regressions across asset-description, datasources-datasource, datasources-datasource-editor, database-data-model-browser, database-vpm-browser, move-*-dialog components, driver-wizard, share-link-dialog, and select-worksheet-dialog. Also fixes PhysicalModelController to populate tableCount on schema folder nodes so counts show on initial load.

VPM condition dialog (PR #3700): Restores one-of-vpm-condition-editor and vpm-condition-item-pane BEM class structure lost in the bad merge.

Condition item pane: Restores condition-item-pane.component.html single-row BEM layout (condition-edit-row) that 563ab05dd had reverted to Bootstrap form-inline.

Condition editor components: Restores condition-list, binary-condition-editor, one-of-condition-editor, variable-editor, and expression-editor to their post-PR-#3700 BEM state.

Condition dialog redesign

simple-condition-pane: New ADD+REMOVE paradigm — built conditions accumulate in a tokenized clause list (WHERE/AND/OR chips, field token chip, × remove button per row); full condition editor embedded in "Add Condition" section below.

advanced-condition-pane / mv-condition-pane: Replaced boxed card rows with flat cond-section layout — border-top separator, section header with ghost Edit/Clear buttons at 26 px pill height, collapsible body.
_bootstrap-override.scss: Sets .modal-footer background to --inet-shell-surface-subtle per design spec.
Bug fixes

SQLQueryDialogService: Capture isSingleQueryMode() before calling setMashupMode() so SaveWorksheetCommand is sent, persisting the SINGLE_QUERY→MASHUP transition to disk. Previously the mode change was lost on server restart.
ws-pane.onCancel: Only close the worksheet when the SQL table has no prior commits (sqlEdited=false); existing worksheets stay open on cancel.

fixed-dropdown: Add viewport fallback when this.container is not set so dropdowns are never clipped at the screen edge.
condition-field-combo-list: Read item height from --inet-control-height-sm via getComputedStyle at runtime instead of the hardcoded 19.5 px constant (actual CSS height is 24 px), fixing virtual-scroll container clipping.
Test fix

one-of-condition-editor.component.spec.ts / .html: Remove stray delete_id class from the Modify button (button order changed in redesign made querySelector("button.delete_id") target Modify instead of Delete); tighten value-list selectors to div.value-list__element to account for the new empty-state placeholder div.

Test plan
 Verify data tab: asset detail panel, datasource editor, data model browser, VPM browser, move dialogs, driver wizard all render correctly
 Verify condition dialogs: simple-condition-pane ADD/REMOVE flow, advanced and MV panes collapse/expand correctly
 Verify single-query worksheet: SINGLE_QUERY→MASHUP transition persists after server restart; cancel on a new SQL table closes the sheet, cancel on an existing one does not
 Verify condition field combo dropdown renders all items without clipping
 npm run test:portal — 1253/1253 passing