### PR TITLE
fix(wiz): surface JDBC root cause in sql query table column resolution error

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/JDBCQuery.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/JDBCQuery.java
@@ -256,6 +256,7 @@ public class JDBCQuery extends XQuery {
       }
       catch(Exception ex) {
          LOG.debug("Failed to get meta-data from prepared statement", ex);
+         lastQueryError = ex;
       }
 
       // when failed, try overhead way second: executing sql and getting
@@ -281,9 +282,11 @@ public class JDBCQuery extends XQuery {
          }
 
          result.close();
+         lastQueryError = null;
       }
       catch(Exception ex) {
          LOG.debug("Failed to get output meta-data", ex);
+         lastQueryError = ex;
       }
 
       return output;
@@ -904,10 +907,15 @@ public class JDBCQuery extends XQuery {
       defmap.put(UniformSQL.XML_TAG, "inetsoft.uql.jdbc.UniformSQL");
    }
 
+   /** Last exception caught by {@link #getOutputTypeForNonParseableSQL}; null on success. */
+   public Exception getLastQueryError() { return lastQueryError; }
+   public void setLastQueryError(Exception e) { lastQueryError = e; }
+
    private SQLDefinition sql;
    private boolean venabled;
    // this is set when query is generated at runtime so it's not persistent
    private boolean userQuery;
+   private Exception lastQueryError;
 
    private static final Logger LOG =
       LoggerFactory.getLogger(JDBCQuery.class);

--- a/core/src/main/java/inetsoft/uql/jdbc/JDBCQuery.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/JDBCQuery.java
@@ -908,14 +908,20 @@ public class JDBCQuery extends XQuery {
    }
 
    /** Last exception caught by {@link #getOutputTypeForNonParseableSQL}; null on success. */
-   public Exception getLastQueryError() { return lastQueryError; }
-   public void setLastQueryError(Exception e) { lastQueryError = e; }
+   public Exception getLastQueryError() {
+      return lastQueryError;
+   }
+
+   public void setLastQueryError(Exception e) {
+      lastQueryError = e;
+   }
 
    private SQLDefinition sql;
    private boolean venabled;
    // this is set when query is generated at runtime so it's not persistent
    private boolean userQuery;
-   private Exception lastQueryError;
+   // transient: Exception may hold non-serializable thread-local state
+   private transient Exception lastQueryError;
 
    private static final Logger LOG =
       LoggerFactory.getLogger(JDBCQuery.class);

--- a/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
@@ -1950,6 +1950,8 @@ public class QueryManagerService {
          cinfo.setMaxOccurs(XTypeNode.STAR);
          JDBCQuery clone = query.clone();
          cinfo = clone.getOutputTypeForNonParseableSQL(cinfo, vars, session);
+         // Propagate any JDBC failure from the clone so callers can surface the root cause.
+         query.setLastQueryError(clone.getLastQueryError());
 
          for(int i = 0; i < cinfo.getChildCount(); i++) {
             XTypeNode node = (XTypeNode) cinfo.getChild(i);

--- a/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/QueryManagerService.java
@@ -1949,6 +1949,7 @@ public class QueryManagerService {
          cinfo.setMinOccurs(0);
          cinfo.setMaxOccurs(XTypeNode.STAR);
          JDBCQuery clone = query.clone();
+         clone.setLastQueryError(null);
          cinfo = clone.getOutputTypeForNonParseableSQL(cinfo, vars, session);
          // Propagate any JDBC failure from the clone so callers can surface the root cause.
          query.setLastQueryError(clone.getLastQueryError());

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -502,9 +502,13 @@ public class WorksheetTableService {
          queryManagerService.getColumnSelection(query, new VariableTable(), table, session, null);
 
       if(columns == null || columns.getAttributeCount() == 0) {
+         Exception cause = query.getLastQueryError();
+         String detail = cause != null
+            ? " Database reported: " + rootMessage(cause)
+            : "";
          throw new IllegalArgumentException(
             "Could not resolve any columns from sqlExpression — check the SQL is a valid SELECT for datasource '" +
-            dsName + "'.");
+            dsName + "'." + detail, cause);
       }
 
       // The parsed UniformSQL selection only carries types for base table columns it can resolve
@@ -1243,6 +1247,14 @@ public class WorksheetTableService {
    private final QueryManagerService queryManagerService;
    private final XRepository xrepository;
    private final ObjectMapper objectMapper;
+
+   private static String rootMessage(Throwable t) {
+      Throwable root = t;
+      while(root.getCause() != null) {
+         root = root.getCause();
+      }
+      return root.getMessage() != null ? root.getMessage() : root.getClass().getSimpleName();
+   }
 
    private static final Logger LOG = LoggerFactory.getLogger(WorksheetTableService.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1253,7 +1253,9 @@ public class WorksheetTableService {
       while(root.getCause() != null) {
          root = root.getCause();
       }
-      return root.getMessage() != null ? root.getMessage() : root.getClass().getSimpleName();
+      String msg = root.getMessage() != null ? root.getMessage() : root.getClass().getSimpleName();
+      int nl = msg.indexOf('\n');
+      return nl > 0 ? msg.substring(0, nl) : msg;
    }
 
    private static final Logger LOG = LoggerFactory.getLogger(WorksheetTableService.class);


### PR DESCRIPTION
getOutputTypeForNonParseableSQL() swallowed all JDBC exceptions with LOG.debug, returning an empty XTypeNode with no indication of why. buildSqlTable() then threw a generic "Could not resolve any columns" message with no cause chain — making it impossible to distinguish "Derby doesn't support window functions" from "table name typo".

- JDBCQuery: save last caught exception in lastQueryError field
- QueryManagerService: propagate clone's lastQueryError back to the original query after getOutputTypeForNonParseableSQL()
- WorksheetTableService: chain lastQueryError as the cause when throwing IllegalArgumentException; append rootMessage() to the error text so the DB error (e.g. "ERROR 42X01: Encountered OVER") reaches the caller