### PR TITLE
fix(wiz): accept prefixed field names for sql query table columns in fieldConfigs

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -757,6 +757,12 @@ public class WizAutoBindingService {
     * column (e.g. {@code growth_pct}) while its alias carries the output name (e.g.
     * {@code growth_rate}); matching on the attribute alone would reject the alias the caller
     * (correctly) supplies in fieldConfigs.
+    *
+    * <p>Prefix normalisation: physical-table columns are exposed as "Table.Column" but
+    * sql-query-table columns are bare "Column" names (no entity prefix). When a caller
+    * passes "GapQuery.COMPANY_NAME" and the worksheet only has bare "COMPANY_NAME", the
+    * prefix is stripped and the key in {@code configMap} is updated in-place so all
+    * downstream lookups (buildEntryFromColumn, applyFieldConfigs) see the correct key.
     */
    static List<ColumnRef> selectBindColumns(List<ColumnRef> worksheetColumns,
                                             Map<String, SimpleFieldInfo> configMap)
@@ -765,15 +771,43 @@ public class WizAutoBindingService {
          Set<String> available = worksheetColumns.stream()
             .map(ColumnRef::getDisplayName)
             .collect(Collectors.toCollection(LinkedHashSet::new));
-         List<String> missing = configMap.keySet().stream()
-            .filter(k -> !available.contains(k))
-            .sorted()
-            .collect(Collectors.toList());
+
+         // Index bare (no-dot) display names for sql query table columns.
+         // Physical-table columns contain a dot so they are excluded here.
+         Set<String> bareAvailable = available.stream()
+            .filter(n -> !n.contains("."))
+            .collect(Collectors.toSet());
+
+         List<String> toNormalize = new ArrayList<>();
+         List<String> missing     = new ArrayList<>();
+
+         for(String key : configMap.keySet()) {
+            if(available.contains(key)) {
+               continue; // exact match
+            }
+            int dot = key.lastIndexOf('.');
+            String bare = dot >= 0 ? key.substring(dot + 1) : null;
+            if(bare != null && bareAvailable.contains(bare)) {
+               toNormalize.add(key); // "GapQuery.COMPANY_NAME" → "COMPANY_NAME"
+            }
+            else {
+               missing.add(key);
+            }
+         }
 
          if(!missing.isEmpty()) {
             throw new IllegalArgumentException(
-               "Unknown field(s) in fieldConfigs: " + missing +
+               "Unknown field(s) in fieldConfigs: " + missing.stream().sorted().collect(Collectors.toList()) +
                ". Available worksheet columns: " + available);
+         }
+
+         // Rename prefixed keys to bare names in-place so buildEntryFromColumn /
+         // applyFieldConfigs see the same key form as getDisplayName() returns.
+         for(String prefixed : toNormalize) {
+            int dot = prefixed.lastIndexOf('.');
+            String bare = prefixed.substring(dot + 1);
+            SimpleFieldInfo fi = configMap.remove(prefixed);
+            configMap.put(bare, fi);
          }
 
          return worksheetColumns.stream()

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -817,7 +817,9 @@ public class WizAutoBindingService {
                configMap.remove(prefixed);
             }
             else {
-               configMap.put(bare, configMap.remove(prefixed));
+               SimpleFieldInfo fi = configMap.remove(prefixed);
+               fi.setField(bare); // keep fi.getField() consistent with the map key so log messages show the bare name
+               configMap.put(bare, fi);
             }
          });
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -763,6 +763,9 @@ public class WizAutoBindingService {
     * passes "GapQuery.COMPANY_NAME" and the worksheet only has bare "COMPANY_NAME", the
     * prefix is stripped and the key in {@code configMap} is updated in-place so all
     * downstream lookups (buildEntryFromColumn, applyFieldConfigs) see the correct key.
+    *
+    * @param configMap mutable map of field name → config; keys may be rewritten in-place
+    *                  during prefix normalisation — must not be an unmodifiable map.
     */
    static List<ColumnRef> selectBindColumns(List<ColumnRef> worksheetColumns,
                                             Map<String, SimpleFieldInfo> configMap)
@@ -778,8 +781,9 @@ public class WizAutoBindingService {
             .filter(n -> !n.contains("."))
             .collect(Collectors.toSet());
 
-         List<String> toNormalize = new ArrayList<>();
-         List<String> missing     = new ArrayList<>();
+         // prefixed → bare: computed once, reused during the rename step (avoids re-scanning).
+         Map<String, String> toNormalize = new LinkedHashMap<>();
+         List<String> missing = new ArrayList<>();
 
          for(String key : configMap.keySet()) {
             if(available.contains(key)) {
@@ -788,7 +792,7 @@ public class WizAutoBindingService {
             int dot = key.lastIndexOf('.');
             String bare = dot >= 0 ? key.substring(dot + 1) : null;
             if(bare != null && bareAvailable.contains(bare)) {
-               toNormalize.add(key); // "GapQuery.COMPANY_NAME" → "COMPANY_NAME"
+               toNormalize.put(key, bare); // "GapQuery.COMPANY_NAME" → "COMPANY_NAME"
             }
             else {
                missing.add(key);
@@ -803,12 +807,19 @@ public class WizAutoBindingService {
 
          // Rename prefixed keys to bare names in-place so buildEntryFromColumn /
          // applyFieldConfigs see the same key form as getDisplayName() returns.
-         for(String prefixed : toNormalize) {
-            int dot = prefixed.lastIndexOf('.');
-            String bare = prefixed.substring(dot + 1);
-            SimpleFieldInfo fi = configMap.remove(prefixed);
-            configMap.put(bare, fi);
-         }
+         // If two prefixed keys strip to the same bare name (caller error), the first
+         // entry wins and a warning is logged rather than silently overwriting it.
+         toNormalize.forEach((prefixed, bare) -> {
+            if(configMap.containsKey(bare)) {
+               LOG.warn("fieldConfigs prefix normalisation collision: '{}' strips to '{}' which " +
+                        "is already present. The existing entry wins; '{}' is ignored.",
+                        prefixed, bare, prefixed);
+               configMap.remove(prefixed);
+            }
+            else {
+               configMap.put(bare, configMap.remove(prefixed));
+            }
+         });
 
          return worksheetColumns.stream()
             .filter(c -> configMap.containsKey(c.getDisplayName()))

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSelectBindColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSelectBindColumnsTest.java
@@ -23,10 +23,12 @@ import inetsoft.web.wiz.model.SimpleFieldInfo;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -110,6 +112,43 @@ class WizAutoBindingServiceSelectBindColumnsTest {
          WizAutoBindingService.selectBindColumns(columns, Map.of());
 
       assertEquals(2, result.size());
+   }
+
+   @Test
+   void prefixedFieldConfigNormalisedForSqlQueryTable() {
+      // sql-query-table columns are bare; caller passes prefixed form "GapQuery.COMPANY_NAME"
+      List<ColumnRef> columns = List.of(col("COMPANY_NAME"), col("REVENUE"));
+
+      Map<String, SimpleFieldInfo> configMap = new HashMap<>();
+      configMap.put("GapQuery.COMPANY_NAME", config("GapQuery.COMPANY_NAME"));
+      configMap.put("GapQuery.REVENUE",      config("GapQuery.REVENUE"));
+
+      List<ColumnRef> result = WizAutoBindingService.selectBindColumns(columns, configMap);
+
+      assertEquals(2, result.size());
+      // after normalisation, configMap keys must be bare names so downstream lookups resolve
+      assertTrue(configMap.containsKey("COMPANY_NAME"));
+      assertTrue(configMap.containsKey("REVENUE"));
+      assertFalse(configMap.containsKey("GapQuery.COMPANY_NAME"));
+      assertFalse(configMap.containsKey("GapQuery.REVENUE"));
+   }
+
+   @Test
+   void prefixNormalisationCollisionFirstEntryWins() {
+      // Two prefixed keys strip to the same bare name — first entry wins, second is dropped.
+      List<ColumnRef> columns = List.of(col("FOO"));
+
+      Map<String, SimpleFieldInfo> configMap = new HashMap<>();
+      SimpleFieldInfo first  = config("TableA.FOO");
+      SimpleFieldInfo second = config("TableB.FOO");
+      configMap.put("TableA.FOO", first);
+      configMap.put("TableB.FOO", second);
+
+      List<ColumnRef> result = WizAutoBindingService.selectBindColumns(columns, configMap);
+
+      assertEquals(1, result.size());
+      assertTrue(configMap.containsKey("FOO"));
+      assertEquals(1, configMap.size()); // exactly one entry survived
    }
 
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSelectBindColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSelectBindColumnsTest.java
@@ -126,11 +126,14 @@ class WizAutoBindingServiceSelectBindColumnsTest {
       List<ColumnRef> result = WizAutoBindingService.selectBindColumns(columns, configMap);
 
       assertEquals(2, result.size());
-      // after normalisation, configMap keys must be bare names so downstream lookups resolve
+      // after normalisation, map keys must be bare names so downstream lookups resolve
       assertTrue(configMap.containsKey("COMPANY_NAME"));
       assertTrue(configMap.containsKey("REVENUE"));
       assertFalse(configMap.containsKey("GapQuery.COMPANY_NAME"));
       assertFalse(configMap.containsKey("GapQuery.REVENUE"));
+      // fi.getField() must also be updated so log messages show the bare name
+      assertEquals("COMPANY_NAME", configMap.get("COMPANY_NAME").getField());
+      assertEquals("REVENUE",      configMap.get("REVENUE").getField());
    }
 
    @Test


### PR DESCRIPTION


Physical-table columns have Table.Column display names; sql query table columns are bare Column names. When a caller passes GapQuery.COMPANY_NAME but the worksheet only exposes COMPANY_NAME, selectBindColumns now strips the table prefix and normalizes the configMap key in-place so all downstream lookups (buildEntryFromColumn, applyFieldConfigs) resolve correctly.