### PR TITLE
fix(core): clean-alias quoted subquery/window passthrough columns in SQL query tables

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/util/JDBCUtil.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/util/JDBCUtil.java
@@ -356,6 +356,23 @@ public class JDBCUtil {
       for(int i = 0; i < xselect.getColumnCount(); i++) {
          String path = xselect.getColumn(i);
          String alias = xselect.getAlias(i);
+
+         // A bare select-list identifier the parser could not resolve to a known table — e.g. a
+         // column passed through from a subquery in the FROM clause, or a window-function column —
+         // is captured wrapped in double-quotes (e.g. "role"). That quoted form becomes the column's
+         // identifier in the result lens, but the worksheet/viewsheet binding layer refers to it
+         // unquoted (role) and then cannot resolve it, so a chart bound to such a column silently
+         // renders no rows (and the column can't be renamed). Give it a clean alias — the unquoted
+         // name — which is exactly what an explicit AS alias does (those bind correctly), while
+         // leaving the quoted source path untouched for SQL generation.
+         if((alias == null || alias.isEmpty()) && path != null && path.length() >= 3 &&
+            path.charAt(0) == '"' && path.charAt(path.length() - 1) == '"' &&
+            path.indexOf('.') < 0 && path.indexOf('"', 1) == path.length() - 1)
+         {
+            alias = path.substring(1, path.length() - 1);
+            xselect.setAlias(i, alias);
+         }
+
          String fp = getFullPathOf(sql, path);
 
          if(fp != null) {


### PR DESCRIPTION
## Problem

A SQL query table whose outer SELECT passes through a **bare identifier the parser can't resolve to a known table** — a column from a **subquery in `FROM`**, or a **window-function** column — silently renders **0 rows** when bound to a chart, and the column can't be renamed in the Composer.

Root cause: the SQL parser captures such an identifier wrapped in double-quotes (e.g. `"role"`). That quoted form becomes the result lens's column **identifier**, but the worksheet/viewsheet binding layer refers to it **unquoted** (`role`) and can't resolve it → the bound column reads nothing. Columns with an explicit `AS alias` are unaffected (they come back clean), which is why a flat `UNION ALL` of aliased SELECTs works but `SELECT role, status, ... FROM (subquery) t GROUP BY ...` does not.

This reproduces in the **native Composer** (no plugin): the worksheet preview shows `"role"` quoted, renaming reverts, and a chart bound to it errors "column not found".

## Fix

In `JDBCUtil.fixSelectionInfo(UniformSQL)` — the shared post-parse step both the Composer (`SQLQueryDialogService`) and the wiz `/ws/table` builder run — give a fully double-quoted, single-part, **unaliased** select column an alias equal to its unquoted name. The lens column identifier then uses the clean alias (exactly what an explicit `AS` does, which already binds correctly), while the quoted source path is left untouched for SQL generation. Narrow guard (`"..."`, no `.`, no embedded quote, no existing alias) so ordinary columns are untouched.

## Verification (inventree, local build)

| Case | Before | After |
|---|---|---|
| `SELECT role,status,COUNT(*) cnt FROM (UNION ALL subquery) t GROUP BY ...` | 0 rows | 2 rows ✓ |
| `ROW_NUMBER() OVER(...)` per-group top-N | 0 rows | 5 rows ✓ |
| Flat `UNION ALL` of aliased SELECTs (regression) | works | works ✓ |

Lens column identifiers are now clean (`role`) instead of quoted (`"role"`). One fix closes both the subquery-empty bug and the window-function / per-group-top-N "renders null" gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)