### PR TITLE
Bug #75494 - Drive snap-tooltip series highlight on line and stacked charts

### DIFF
--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
@@ -280,6 +280,77 @@ describe("ChartInlineSvgDirective cross-tile dim", () => {
       });
    });
 
+   describe("highlightSnapSeries (line chart snap dim)", () => {
+      // Stacked line chart: one measure (data-series 2) split into two color groups, each with a
+      // line and a point marker. Points carry row+col+color; the snapped point resolves to a color.
+      const html = `
+         <div class="inetsoft-line" data-color="1,1,1"></div>
+         <div class="inetsoft-line" data-color="2,2,2"></div>
+         <div class="inetsoft-point" data-row="0" data-col="2" data-color="1,1,1"></div>
+         <div class="inetsoft-point" data-row="1" data-col="2" data-color="2,2,2"></div>`;
+      const sel = ".inetsoft-line,.inetsoft-point";
+
+      // Configure the directive as a loaded line tile. afterSvgInjected wires the abort-signal
+      // hover listeners, which jsdom can't attach, so set the state it would have produced: the
+      // line-hover flag plus the point-marker color maps (built from the .inetsoft-point markers).
+      function makeLineTile(): { dir: ChartInlineSvgDirective, host: HTMLElement } {
+         const { dir, host } = makeDirective(html);
+         (dir as any).isLineSeriesHover = true;
+         (dir as any).seriesColorByKey = new Map([["0-2", "1,1,1"], ["1-2", "2,2,2"]]);
+         (dir as any).seriesColorByCol = new Map([["2", "1,1,1"]]);
+         return { dir, host };
+      }
+
+      it("undims only the snapped point's series, dimming the others", () => {
+         const { dir, host } = makeLineTile();
+         dir.highlightSnapSeries([{ row: 1, col: 2 }]);
+         // Series 2,2,2 (line + its point) stays full; series 1,1,1 dims.
+         expect(opacities(host, sel)).toEqual(["0.2", "", "0.2", ""]);
+      });
+
+      it("re-targets the undimmed series as the snap moves between series", () => {
+         const { dir, host } = makeLineTile();
+         dir.highlightSnapSeries([{ row: 1, col: 2 }]);
+         dir.highlightSnapSeries([{ row: 0, col: 2 }]);
+         expect(opacities(host, sel)).toEqual(["", "0.2", "", "0.2"]);
+      });
+
+      it("clears the dim when the snap ends (empty pairs)", () => {
+         vi.useFakeTimers();
+         try {
+            const { dir, host } = makeLineTile();
+            dir.highlightSnapSeries([{ row: 1, col: 2 }]);
+            dir.highlightSnapSeries([]);
+            vi.advanceTimersByTime(ChartInlineSvgDirective["CLEAR_DELAY_MS"]);
+            expect(opacities(host, sel)).toEqual(["", "", "", ""]);
+         }
+         finally {
+            vi.useRealTimers();
+         }
+      });
+
+      it("uses the col fallback only when cols distinguish series (multi-measure)", () => {
+         const { dir, host } = makeLineTile();
+         // Single-measure stack: one col, so the col map can't tell series apart — no fallback so
+         // an unknown row-col leaves everything undimmed rather than dimming to an arbitrary color.
+         dir.highlightSnapSeries([{ row: 9, col: 2 }]);
+         expect(opacities(host, sel)).toEqual(["", "", "", ""]);
+
+         // Multi-measure: distinct cols map to distinct colors, so an unknown row-col falls back
+         // by col (col 3 → 2,2,2), dimming the other series.
+         (dir as any).seriesColorByCol = new Map([["2", "1,1,1"], ["3", "2,2,2"]]);
+         dir.highlightSnapSeries([{ row: 9, col: 3 }]);
+         expect(opacities(host, sel)).toEqual(["0.2", "", "0.2", ""]);
+      });
+
+      it("is a no-op on a non-line tile (area keeps its own cursor-band hover)", () => {
+         const { dir, host } = makeLineTile();
+         (dir as any).isLineSeriesHover = false;
+         dir.highlightSnapSeries([{ row: 1, col: 2 }]);
+         expect(opacities(host, sel)).toEqual(["", "", "", ""]);
+      });
+   });
+
    describe("getRelationEdges + emitRelationHover dedup", () => {
       it("returns this tile's edges as source/target pairs", () => {
          const { dir } = makeDirective("");

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
@@ -349,6 +349,30 @@ describe("ChartInlineSvgDirective cross-tile dim", () => {
          dir.highlightSnapSeries([{ row: 1, col: 2 }]);
          expect(opacities(host, sel)).toEqual(["", "", "", ""]);
       });
+
+      it("emits seriesDimChange in cross-tile mode instead of dimming locally", () => {
+         vi.useFakeTimers();
+         try {
+            const { dir, host } = makeLineTile();
+            (dir as any).crossTile = true;
+            const emitted: (string | null)[] = [];
+            dir.seriesDimChange.subscribe(v => emitted.push(v));
+
+            // The parent applies the dim across tiles, so this tile emits the color and leaves its
+            // own opacity untouched.
+            dir.highlightSnapSeries([{ row: 1, col: 2 }]);
+            expect(emitted).toEqual(["2,2,2"]);
+            expect(opacities(host, sel)).toEqual(["", "", "", ""]);
+
+            // Clearing emits null once the debounce elapses.
+            dir.highlightSnapSeries([]);
+            vi.advanceTimersByTime(ChartInlineSvgDirective["CLEAR_DELAY_MS"]);
+            expect(emitted).toEqual(["2,2,2", null]);
+         }
+         finally {
+            vi.useRealTimers();
+         }
+      });
    });
 
    describe("getRelationEdges + emitRelationHover dedup", () => {

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
@@ -373,6 +373,32 @@ describe("ChartInlineSvgDirective cross-tile dim", () => {
             vi.useRealTimers();
          }
       });
+
+      it("resolves the snap color from .inetsoft-line when the chart has no point markers", () => {
+         // Multi-measure line chart with no point markers. afterSvgInjected scrapes data-series
+         // (the colIdx) and data-color off the lines into seriesColorByCol, since seriesColorByKey
+         // stays empty without points. A snapped row-col with no exact match then resolves by col.
+         const lineHtml = `
+            <svg>
+               <g class="inetsoft-line" data-series="0" data-color="1,1,1"></g>
+               <g class="inetsoft-line" data-series="1" data-color="2,2,2"></g>
+            </svg>`;
+         const { dir, host } = makeDirective(lineHtml);
+         // setupLineSeriesHover wires abort-signal listeners jsdom can't attach; stub it to just
+         // set the flag. The .inetsoft-line scraping loop under test runs earlier in afterSvgInjected.
+         vi.spyOn(dir as any, "setupLineSeriesHover").mockImplementation(() => {
+            (dir as any).isLineSeriesHover = true;
+         });
+         (dir as any).afterSvgInjected();
+
+         expect((dir as any).isLineSeriesHover).toBe(true);
+         expect(Array.from((dir as any).seriesColorByCol.entries()))
+            .toEqual([["0", "1,1,1"], ["1", "2,2,2"]]);
+
+         dir.highlightSnapSeries([{ row: 9, col: 1 }]);
+         // Col 1 → series 2,2,2 stays full; the col-0 line dims.
+         expect(opacities(host, ".inetsoft-line")).toEqual(["0.2", ""]);
+      });
    });
 
    describe("getRelationEdges + emitRelationHover dedup", () => {

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
@@ -63,6 +63,10 @@ export class ChartInlineSvgDirective implements OnDestroy {
     *  setExternalSeriesDim so every tile dims consistently (geometry-based local dim can't reach
     *  sibling SVGs). */
    @Input() crossTile = false;
+   /** Snap-to-nearest tooltip active. On line charts the snapped series drives the dim via
+    *  highlightSnapSeries, so setupLineSeriesHover's enter/leave suppress their own dim to avoid
+    *  fighting it. Area charts ignore it — their cursor-band hover already resolves a series. */
+   @Input() snapTooltip = false;
    private _url: string = null;
    /** Last color emitted via seriesDimChange, to suppress duplicate emits. */
    private _emittedSeriesColor: string | null = null;
@@ -121,6 +125,18 @@ export class ChartInlineSvgDirective implements OnDestroy {
    private lineSeriesAbortController: AbortController | null = null;
    /** Debounce timer for clearing line-series dim, so moving between elements of one series is flicker-free. */
    private lineSeriesClearTimer: ReturnType<typeof setTimeout> | null = null;
+   /** True for pure line charts (setupLineSeriesHover ran). Gates the snap-driven series dim so it
+    *  applies only to line charts; area/radar tiles keep their own hover mechanism. */
+   private isLineSeriesHover = false;
+   /** Maps "rowIdx-colIdx" → data-color for point markers, so a snapped data point resolves to its
+    *  series color for the snap-driven dim. Line groups carry data-color but not row/col. */
+   private seriesColorByKey = new Map<string, string>();
+   /** Maps colIdx → data-color, a fallback for a snapped point with no exact row-col match. */
+   private seriesColorByCol = new Map<string, string>();
+   /** data-color of the series currently undimmed by snap; suppresses redundant re-dims. */
+   private _snapSeriesColor: string | null = null;
+   /** Debounce timer for clearing the snap-driven series dim. */
+   private snapClearTimer: ReturnType<typeof setTimeout> | null = null;
    private static readonly CLEAR_DELAY_MS = 120;
    /** Milliseconds after SVG load before the .ready class is added (gates A1 hover CSS). */
    private static readonly READY_MS = 900;
@@ -146,6 +162,11 @@ export class ChartInlineSvgDirective implements OnDestroy {
       if(this.readyHandle !== null) {
          clearTimeout(this.readyHandle);
          this.readyHandle = null;
+      }
+
+      if(this.snapClearTimer !== null) {
+         clearTimeout(this.snapClearTimer);
+         this.snapClearTimer = null;
       }
 
       this.teardownAreaHover();
@@ -242,6 +263,81 @@ export class ChartInlineSvgDirective implements OnDestroy {
             }, ChartInlineSvgDirective.CLEAR_DELAY_MS);
          }
       }
+   }
+
+   /**
+    * Drive the per-series dim from a snapped data point so the hovered series stays undimmed
+    * regardless of cursor Y. Line charts only: geometry hover fires only when the cursor is exactly
+    * on a thin line/point, which rarely lines up with the snap guideline. No-op on area (keeps its
+    * cursor-band hover) and bar/radar (don't dim by series color). Cross-tile mode emits the color
+    * so the parent mirrors the dim onto sibling tiles holding the rest of the series. Pass an empty
+    * array to clear; clearing is debounced so moving between snap columns of one series doesn't flash.
+    */
+   highlightSnapSeries(pairs: { row: number, col: number }[]): void {
+      if(!this.isLineSeriesHover) {
+         return;
+      }
+
+      if(pairs.length === 0) {
+         if(this._snapSeriesColor !== null && this.snapClearTimer === null) {
+            this.snapClearTimer = setTimeout(() => {
+               this.snapClearTimer = null;
+               this._snapSeriesColor = null;
+
+               if(this.crossTile) {
+                  this.emitSeriesDim(null);
+               }
+               else {
+                  this.setExternalSeriesDim(null);
+               }
+            }, ChartInlineSvgDirective.CLEAR_DELAY_MS);
+         }
+
+         return;
+      }
+
+      if(this.snapClearTimer !== null) {
+         clearTimeout(this.snapClearTimer);
+         this.snapClearTimer = null;
+      }
+
+      const color = this.resolveSnapSeriesColor(pairs);
+
+      // Only the tile holding the snapped point resolves a color; a tile that can't leaves its dim
+      // untouched rather than clearing it, which would fight the resolving tile.
+      if(color == null || color === this._snapSeriesColor) {
+         return;
+      }
+
+      this._snapSeriesColor = color;
+
+      if(this.crossTile) {
+         this.emitSeriesDim(color);
+      }
+      else {
+         this.setExternalSeriesDim(color);
+      }
+   }
+
+   /**
+    * Resolve a snapped point to its series data-color: exact row-col first, then col. The col
+    * fallback is gated on map size > 1 (multi-measure); in a single-measure stacked chart every
+    * point shares one col, so it can't distinguish series and would dim to an arbitrary color.
+    */
+   private resolveSnapSeriesColor(pairs: { row: number, col: number }[]): string | null {
+      for(const p of pairs) {
+         const c = this.seriesColorByKey.get(`${p.row}-${p.col}`);
+         if(c != null) return c;
+      }
+
+      if(this.seriesColorByCol.size > 1) {
+         for(const p of pairs) {
+            const c = this.seriesColorByCol.get(String(p.col));
+            if(c != null) return c;
+         }
+      }
+
+      return null;
    }
 
    /** True when keys match the current active set, order-independent. */
@@ -406,11 +502,20 @@ export class ChartInlineSvgDirective implements OnDestroy {
       this.areaSeries = [];
       this.activeSeriesIdx = -1;
       this.usesSeriesColorDim = false;
+      this.isLineSeriesHover = false;
       this.dimKeyAttr = "data-color";
       this.dimTargetSelector = ".inetsoft-area,.inetsoft-line,.inetsoft-point";
       this._emittedSeriesColor = null;
       this.isRelationChart = false;
       this._emittedRelationId = null;
+      this.seriesColorByKey.clear();
+      this.seriesColorByCol.clear();
+      this._snapSeriesColor = null;
+
+      if(this.snapClearTimer !== null) {
+         clearTimeout(this.snapClearTimer);
+         this.snapClearTimer = null;
+      }
 
       this.elementGroupMap.clear();
       this.labelGroupMap.clear();
@@ -434,6 +539,30 @@ export class ChartInlineSvgDirective implements OnDestroy {
             if(row != null && col != null) {
                this.elementGroupMap.set(`${row}-${col}`, el);
             }
+         }
+      }
+
+      // Map each point marker's row/col → data-color for snap resolution. Built from .inetsoft-point,
+      // the only annotation carrying row, col and color together (line/area groups omit row/col).
+      const pointColorEls = Array.from(
+         this.element.nativeElement.querySelectorAll(".inetsoft-point") as NodeListOf<Element>);
+
+      for(const p of pointColorEls) {
+         const color = p.getAttribute("data-color");
+
+         if(color == null) {
+            continue;
+         }
+
+         const row = p.getAttribute("data-row");
+         const col = p.getAttribute("data-col");
+
+         if(row != null && col != null) {
+            this.seriesColorByKey.set(`${row}-${col}`, color);
+         }
+
+         if(col != null && !this.seriesColorByCol.has(col)) {
+            this.seriesColorByCol.set(col, color);
          }
       }
 
@@ -716,6 +845,7 @@ export class ChartInlineSvgDirective implements OnDestroy {
       if(seriesMap.size === 0) return;
 
       this.usesSeriesColorDim = true;
+      this.isLineSeriesHover = true;
 
       // allElems intentionally spans the entire SVG (all panels). Hovering a series dims
       // every element outside that series, including sibling panels in a faceted chart.
@@ -748,6 +878,10 @@ export class ChartInlineSvgDirective implements OnDestroy {
             .map(e => e.getAttribute("data-color")).find(c => c) ?? null;
 
          const enterHandler = () => {
+            // Under snap, highlightSnapSeries drives the dim; this geometry hover would fight it.
+            if(this.snapTooltip) {
+               return;
+            }
             if(this.lineSeriesClearTimer !== null) {
                clearTimeout(this.lineSeriesClearTimer);
                this.lineSeriesClearTimer = null;
@@ -769,6 +903,9 @@ export class ChartInlineSvgDirective implements OnDestroy {
          };
 
          const leaveHandler = () => {
+            if(this.snapTooltip) {
+               return;
+            }
             if(this.lineSeriesClearTimer !== null) {
                clearTimeout(this.lineSeriesClearTimer);
             }

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
@@ -566,6 +566,21 @@ export class ChartInlineSvgDirective implements OnDestroy {
          }
       }
 
+      // Lines carry data-series (the colIdx) and data-color but no row/col, so they fill the col
+      // fallback for line charts drawn without point markers, where the loop above leaves both maps
+      // empty and the snap dim would otherwise find no color.
+      const lineColorEls = Array.from(
+         this.element.nativeElement.querySelectorAll(".inetsoft-line") as NodeListOf<Element>);
+
+      for(const l of lineColorEls) {
+         const color = l.getAttribute("data-color");
+         const col = l.getAttribute("data-series");
+
+         if(color != null && col != null && !this.seriesColorByCol.has(col)) {
+            this.seriesColorByCol.set(col, color);
+         }
+      }
+
       // Radar hover is driven entirely by CSS :hover on polygon groups (hit paths injected
       // server-side have pointer-events:all so the filled interior is reactive). Vertex points
       // intentionally produce no dim effect — no JS activation and no inetsoft-active toggling.

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
@@ -304,7 +304,10 @@ export class ChartInlineSvgDirective implements OnDestroy {
       const color = this.resolveSnapSeriesColor(pairs);
 
       // Only the tile holding the snapped point resolves a color; a tile that can't leaves its dim
-      // untouched rather than clearing it, which would fight the resolving tile.
+      // untouched rather than clearing it, which would fight the resolving tile in cross-tile mode.
+      // Not stranding a dim on a single tile: one that dims at all resolves every column (markers
+      // fill seriesColorByKey, or multi-measure lines fill seriesColorByCol), and a marker-less
+      // single-measure chart resolves to null on every column, so it never sets a color to begin with.
       if(color == null || color === this._snapSeriesColor) {
          return;
       }

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.html
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.html
@@ -63,6 +63,7 @@
             <div class="chart-plot-area__inline-svg"
               [chartInlineSvg]="getSrc(tile, container)"
               [crossTile]="chartObject.tiles.length > 1"
+              [snapTooltip]="!!(model && model.snapTooltip)"
               (seriesDimChange)="onSeriesDimChange($event, tile)"
               (relationHover)="onRelationHover($event, tile)"
               (onLoading)="loading(tile)"

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.spec.ts
@@ -32,6 +32,7 @@ import { ScaleService } from "../../widget/services/scale/scale-service";
 import { ChartObject } from "../model/chart-object";
 import { Plot } from "../model/plot";
 import { ChartTool } from "../model/chart-tool";
+import { GraphTypes } from "../../common/graph-types";
 import { ChartService } from "../services/chart.service";
 import { ChartConfigService } from "../services/chart-config.service";
 import { ChartPlotArea } from "./chart-plot-area.component";
@@ -483,6 +484,102 @@ describe("ChartPlotArea Integration Tests", () => {
          noselect: false, grouped: false, boundaryIdx: -1 };
       expect((component as any).isBarLikeRegion(point)).toBe(false);
       expect((component as any).collectColumnRegions(point)).toEqual([point]);
+   });
+
+   // Two stacked-series points at one X (centerX 237): top at y~62, bottom at y~202. Distinct
+   // rowIdx (long format), so they land in separate snap buckets — snapSeriesByX re-unites them by
+   // X. centroid is null (as on real markers), so the choice must come from pts, not centroid.
+   const stackedTopPoint: any = { segTypes: [[9]], pts: [[[[235, 60], [4, 4]]]], centroid: null,
+      index: 70, tipIdx: 40, metaIdx: 0, rowIdx: 5, valIdx: -1, hyperlinks: [],
+      noselect: false, grouped: false, boundaryIdx: -1 };
+   const stackedBottomPoint: any = { segTypes: [[9]], pts: [[[[235, 200], [4, 4]]]], centroid: null,
+      index: 71, tipIdx: 41, metaIdx: 1, rowIdx: 6, valIdx: -1, hyperlinks: [],
+      noselect: false, grouped: false, boundaryIdx: -1 };
+
+   it("picks the stacked series whose point is vertically nearest the cursor", () => {
+      const fixture = TestBed.createComponent(TestApp);
+      const debugEl = fixture.debugElement.query(By.css("chart-plot-area"));
+      const component: ChartPlotArea = debugEl.componentInstance;
+      vi.spyOn(component, "getSrc").mockImplementation(() => "");
+      fixture.detectChanges();
+      (component as any).model = { regionMetaDictionary: [{ colIdx: 0 }, { colIdx: 1 }] };
+      (component as any).snapSeriesByX = new Map([[237, [stackedTopPoint, stackedBottomPoint]]]);
+
+      // Cursor near the top point → the top series; near the bottom → the bottom series.
+      expect((component as any).nearestSnapRegion(237, 64)).toBe(stackedTopPoint);
+      expect((component as any).nearestSnapRegion(237, 198)).toBe(stackedBottomPoint);
+   });
+
+   it("focuses the bar segment the cursor is inside, not the nearer-center neighbour", () => {
+      const fixture = TestBed.createComponent(TestApp);
+      const debugEl = fixture.debugElement.query(By.css("chart-plot-area"));
+      const component: ChartPlotArea = debugEl.componentInstance;
+      vi.spyOn(component, "getSrc").mockImplementation(() => "");
+      fixture.detectChanges();
+      (component as any).model = { regionMetaDictionary: [{ colIdx: 0 }, { colIdx: 1 }] };
+
+      // A tall segment [300,470] (center 385) and a short one below it [470,490] (center 480),
+      // both RECT (seg 8) at centerX 241. The cursor sits inside the tall segment near its lower
+      // edge, where the short segment's center is actually closer — containment must still win so
+      // focus does not flip to the neighbour before the cursor crosses the boundary.
+      const tall: any = { segTypes: [[8]], pts: [[[[235, 300], [12, 170]]]], centroid: null,
+         index: 80, tipIdx: 50, metaIdx: 0, rowIdx: 3, valIdx: -1, hyperlinks: [],
+         noselect: false, grouped: false, boundaryIdx: -1 };
+      const short: any = { segTypes: [[8]], pts: [[[[235, 470], [12, 20]]]], centroid: null,
+         index: 81, tipIdx: 51, metaIdx: 1, rowIdx: 4, valIdx: -1, hyperlinks: [],
+         noselect: false, grouped: false, boundaryIdx: -1 };
+      (component as any).snapSeriesByX = new Map([[241, [tall, short]]]);
+
+      expect((component as any).nearestSnapRegion(241, 460)).toBe(tall);
+   });
+
+   it("focuses the stacked-area band whose top boundary is just above the cursor", () => {
+      const fixture = TestBed.createComponent(TestApp);
+      const debugEl = fixture.debugElement.query(By.css("chart-plot-area"));
+      const component: ChartPlotArea = debugEl.componentInstance;
+      vi.spyOn(component, "getSrc").mockImplementation(() => "");
+      fixture.detectChanges();
+      (component as any).model = { chartType: GraphTypes.CHART_AREA_STACK,
+         regionMetaDictionary: [{ colIdx: 0 }, { colIdx: 1 }, { colIdx: 2 }] };
+
+      // Cumulative-top boundary points (screen Y): top series 100, middle 300, bottom 500 — the
+      // band polygons span every X so only these per-X boundary points are in snapSeriesByX. Bands:
+      // top [100,300], middle [300,500], bottom below 500. centroid null, as on real markers.
+      const topPt: any = { segTypes: [[9]], pts: [[[[235, 98], [4, 4]]]], centroid: null,
+         index: 90, tipIdx: 60, metaIdx: 0, rowIdx: 1, valIdx: -1, hyperlinks: [],
+         noselect: false, grouped: false, boundaryIdx: -1 };
+      const midPt: any = { segTypes: [[9]], pts: [[[[235, 298], [4, 4]]]], centroid: null,
+         index: 91, tipIdx: 61, metaIdx: 1, rowIdx: 2, valIdx: -1, hyperlinks: [],
+         noselect: false, grouped: false, boundaryIdx: -1 };
+      const botPt: any = { segTypes: [[9]], pts: [[[[235, 498], [4, 4]]]], centroid: null,
+         index: 92, tipIdx: 62, metaIdx: 2, rowIdx: 3, valIdx: -1, hyperlinks: [],
+         noselect: false, grouped: false, boundaryIdx: -1 };
+      (component as any).snapSeriesByX = new Map([[237, [topPt, midPt, botPt]]]);
+
+      // Cursor in the middle band → the middle series (its top boundary is the one just above 400).
+      expect((component as any).nearestSnapRegion(237, 400)).toBe(midPt);
+      // Cursor above the whole stack → nearest point, the topmost series.
+      expect((component as any).nearestSnapRegion(237, 50)).toBe(topPt);
+   });
+
+   it("groups every series' point region by rounded X in snapSeriesByX", () => {
+      const fixture = TestBed.createComponent(TestApp);
+      const debugEl = fixture.debugElement.query(By.css("chart-plot-area"));
+      const component: ChartPlotArea = debugEl.componentInstance;
+      vi.spyOn(component, "getSrc").mockImplementation(() => "");
+      fixture.detectChanges();
+      (component as any).model = { regionMetaDictionary: [{ colIdx: 0 }, { colIdx: 1 }] };
+
+      const otherX: any = { segTypes: [[9]], pts: [[[[400, 100], [4, 4]]]], centroid: null,
+         index: 72, tipIdx: 42, metaIdx: 0, rowIdx: 7, valIdx: -1, hyperlinks: [],
+         noselect: false, grouped: false, boundaryIdx: -1 };
+      component.chartObject.regions = [stackedTopPoint, stackedBottomPoint, otherX] as any;
+      (component as any).rebuildSnapIndex();
+
+      const map: Map<number, any[]> = (component as any).snapSeriesByX;
+      // Both series at X 237 group together (their separate rowIdx buckets re-united); X 402 alone.
+      expect(map.get(237)?.length).toBe(2);
+      expect(map.get(402)?.length).toBe(1);
    });
 
    it("skips wide area polygons when snapping to the nearest point", () => {

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
@@ -502,7 +502,7 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
    //  2. Stacked area — per-X regions are cumulative-top boundary points; the band is owned by the
    //     series whose boundary is immediately above the cursor.
    //  3. Nearest center — line points, or the cursor above the area stack.
-   private nearestSnapRegion(snapColumnX: number, eventY: number): ChartRegion {
+   private nearestSnapRegion(snapColumnX: number | null, eventY: number): ChartRegion {
       if(snapColumnX == null) {
          return null;
       }
@@ -547,7 +547,9 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
          return container.region;
       }
 
-      // Area band: its top edge is the lowest boundary still at or above the cursor.
+      // Area band: owned by the series whose boundary marker is the lowest still at or above the
+      // cursor. The marker center (its data point, the band's cumulative top) is the boundary; the
+      // tier filter has already dropped wide area-fill polygons whose center isn't a boundary.
       if(this.model && GraphTypes.isArea(this.model.chartType)) {
          let band: { region: ChartRegion, minY: number, maxY: number } = null;
          let bandY = -Infinity;

--- a/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-plot-area.component.ts
@@ -36,6 +36,7 @@ import {
 import { SafeStyle } from "@angular/platform-browser";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { ComponentTool } from "../../common/util/component-tool";
+import { GraphTypes } from "../../common/graph-types";
 import { GuiTool } from "../../common/util/gui-tool";
 import { ContextProvider } from "../../vsobjects/context-provider.service";
 import { SelectionBoxEvent, SelectionBoxDirective } from "../../widget/directive/selection-box.directive";
@@ -157,6 +158,9 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
    // Snap: cached column key (rounded left/right X edge) → bar regions sharing that column.
    // Rebuilt alongside snapXTicks so collectColumnRegions is an O(1) lookup, not a full scan.
    private snapColumnMap = new Map<string, ChartRegion[]>();
+   // Snap: rounded centerX → every series' region at that X. Stacked series sit in separate rowIdx
+   // buckets, so this regroups them by X for nearestSnapRegion to choose among all series.
+   private snapSeriesByX = new Map<number, ChartRegion[]>();
 
    @HostBinding("style.cursor") hostCursor: string = "inherit";
    private cursorStyle: string = "inherit";
@@ -241,6 +245,7 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
    private rebuildSnapIndex(): void {
       this.snapXTicks = [];
       this.snapColumnMap = new Map();
+      this.snapSeriesByX = new Map();
       this.snapXTicksFor = this.chartObject;
 
       if(!this.chartObject || !this.chartObject.regions) {
@@ -283,6 +288,24 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
       this.snapXTicks = Array.from(buckets.values())
          .map(b => ({ pixelX: Math.round(b.bestX), regionIndices: b.regionIndices }))
          .sort((a, b) => a.pixelX - b.pixelX);
+
+      // Regroup every series' region by rounded centerX (stacked series sit in separate rowIdx
+      // buckets sharing one X). Keyed by the same regionBoundsX centerX as snapXTicks.pixelX so the
+      // snapped-X lookup matches.
+      for(const r of this.chartObject.regions) {
+         if(!r || r.tipIdx < 0 || r.rowIdx < 0 || ChartTool.colIdx(this.model, r) < 0) {
+            continue;
+         }
+
+         const bounds = this.regionBoundsX(r);
+
+         if(bounds) {
+            const key = Math.round(bounds.centerX);
+            const arr = this.snapSeriesByX.get(key);
+            if(arr) arr.push(r);
+            else this.snapSeriesByX.set(key, [r]);
+         }
+      }
 
       // Group bar regions by column key so a stacked column can be resolved with one lookup.
       // Same filter as collectColumnRegions (bar-like, valid row/col); keyed by ptsBoundsX so
@@ -472,6 +495,138 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
       return this.snapColumnMap.get(this.columnKey(base)) ?? [region];
    }
 
+   // The region at the snapped X the cursor is on — drives the tooltip header, guideline and
+   // highlight. Uses snapSeriesByX so it sees all stacked series (which sit in separate rowIdx
+   // buckets); narrowest tier only, so wide line-path regions don't skew it. Three cases, in order:
+   //  1. Containment — the shortest region whose extent encloses the cursor (a bar segment).
+   //  2. Stacked area — per-X regions are cumulative-top boundary points; the band is owned by the
+   //     series whose boundary is immediately above the cursor.
+   //  3. Nearest center — line points, or the cursor above the area stack.
+   private nearestSnapRegion(snapColumnX: number, eventY: number): ChartRegion {
+      if(snapColumnX == null) {
+         return null;
+      }
+
+      // Tolerate ±1px rounding between the snapped X and a series' centerX key.
+      const series = this.snapSeriesByX.get(snapColumnX) ??
+         this.snapSeriesByX.get(snapColumnX - 1) ?? this.snapSeriesByX.get(snapColumnX + 1);
+
+      if(!series || series.length === 0) {
+         return null;
+      }
+
+      const candidates: { region: ChartRegion, width: number, minY: number, maxY: number }[] = [];
+      let minWidth = Infinity;
+
+      for(const region of series) {
+         const bounds = this.ptsBoundsX(region);
+         const yb = this.regionYBounds(region);
+
+         if(ChartTool.colIdx(this.model, region) < 0 || !bounds || !yb) {
+            continue;
+         }
+
+         candidates.push({ region, width: bounds.width, minY: yb.minY, maxY: yb.maxY });
+         minWidth = Math.min(minWidth, bounds.width);
+      }
+
+      const tier = candidates.filter(c => c.width <= minWidth + 1);
+
+      // Shortest enclosing region wins, so a tall segment never shadows a thin one the cursor is in.
+      let container: { region: ChartRegion, minY: number, maxY: number } = null;
+
+      for(const c of tier) {
+         if(eventY >= c.minY && eventY <= c.maxY &&
+            (!container || (c.maxY - c.minY) < (container.maxY - container.minY)))
+         {
+            container = c;
+         }
+      }
+
+      if(container) {
+         return container.region;
+      }
+
+      // Area band: its top edge is the lowest boundary still at or above the cursor.
+      if(this.model && GraphTypes.isArea(this.model.chartType)) {
+         let band: { region: ChartRegion, minY: number, maxY: number } = null;
+         let bandY = -Infinity;
+
+         for(const c of tier) {
+            const boundaryY = (c.minY + c.maxY) / 2;
+
+            if(boundaryY <= eventY && boundaryY > bandY) {
+               bandY = boundaryY;
+               band = c;
+            }
+         }
+
+         if(band) {
+            return band.region;
+         }
+      }
+
+      // Fallback: nearest center (line points, or the cursor above the area stack).
+      let best: ChartRegion = null;
+      let bestDy = Infinity;
+
+      for(const c of tier) {
+         const dy = Math.abs((c.minY + c.maxY) / 2 - eventY);
+
+         if(dy < bestDy) {
+            bestDy = dy;
+            best = c.region;
+         }
+      }
+
+      return best;
+   }
+
+   // Vertical extent of a region from its marker geometry. Prefers pts over centroid, which is
+   // absent on the point markers snap uses. RECT(8)/ELLIPSE(9) store pts as [[x,y],[w,h]]; others
+   // use the bbox.
+   private regionYBounds(region: ChartRegion): { minY: number, maxY: number } | null {
+      const pts = region.pts;
+
+      if(!pts || pts.length === 0) {
+         return region.centroid ? { minY: region.centroid.y, maxY: region.centroid.y } : null;
+      }
+
+      const seg = region.segTypes && region.segTypes[0] ? region.segTypes[0][0] : -1;
+
+      if((seg === 8 || seg === 9) && pts[0] && pts[0][0] && pts[0][0].length === 2) {
+         const origin = pts[0][0][0];
+         const size = pts[0][0][1];
+
+         if(origin && size) {
+            return { minY: origin[1], maxY: origin[1] + size[1] };
+         }
+      }
+
+      let minY = Infinity;
+      let maxY = -Infinity;
+
+      for(const polygon of pts) {
+         for(const sub of polygon) {
+            for(const pt of sub) {
+               if(pt[1] < minY) {
+                  minY = pt[1];
+               }
+
+               if(pt[1] > maxY) {
+                  maxY = pt[1];
+               }
+            }
+         }
+      }
+
+      if(minY === Infinity) {
+         return region.centroid ? { minY: region.centroid.y, maxY: region.centroid.y } : null;
+      }
+
+      return { minY, maxY };
+   }
+
    private drawSnapGuideline(pixelX: number): void {
       if(!this.referenceLineCanvas) {
          return;
@@ -577,8 +732,12 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
             if(snap) {
                regions = snap.regionIndices.map(i => this.chartObject.regions[i]);
                const primary = this.findPrimarySnapRegion(snap.regionIndices, eventX, eventY);
-               snapPrimary = primary ? primary.region : null;
-               this.drawSnapGuideline(primary ? Math.round(primary.centerX) : snap.pixelX);
+               // X (rounded) of the snapped column, shared by every series there.
+               const snapColumnX = primary ? Math.round(primary.centerX) : snap.pixelX;
+               // The series under the cursor across all of them; the snap bucket holds only one.
+               const nearest = this.nearestSnapRegion(snapColumnX, eventY);
+               snapPrimary = nearest ?? (primary ? primary.region : null);
+               this.drawSnapGuideline(snapColumnX);
             }
             else {
                this.clearSnapGuideline();
@@ -672,6 +831,14 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
                const rowIdx = voRegion != null ? voRegion.rowIdx : null;
                const colIdx = voRegion != null ? ChartTool.colIdx(this.model, voRegion) : null;
                this.inlineSvgTiles?.forEach(d => d.highlightElement(rowIdx, colIdx));
+
+               // Line tiles dim by series color (highlightElement is a no-op there); voRegion
+               // (snapPrimary) is the series under the cursor. No-op on area/bar tiles.
+               if(this.model && this.model.snapTooltip) {
+                  const pairs = (voRegion != null && colIdx >= 0)
+                     ? [{ row: rowIdx, col: colIdx }] : [];
+                  this.inlineSvgTiles?.forEach(d => d.highlightSnapSeries(pairs));
+               }
             }
          }
       }
@@ -865,7 +1032,10 @@ export class ChartPlotArea extends ChartObjectAreaBase<Plot> implements OnChange
       }
 
       if(this.inlineSvg) {
-         this.inlineSvgTiles?.forEach(d => d.highlightElement(null, null));
+         this.inlineSvgTiles?.forEach(d => {
+            d.highlightElement(null, null);
+            d.highlightSnapSeries([]);
+         });
       }
    }
 


### PR DESCRIPTION
### Problem
With the snap-to-nearest tooltip active, the series highlight on line charts was flaky. The highlight was driven by the SVG geometry hover, which only triggers when the cursor sits exactly on a thin line or point. That position rarely coincides with the snap guideline, so the hovered series often stayed dimmed or the wrong series was emphasized.

On stacked bar and stacked area columns the tooltip header resolved the snap region by nearest X with a centroid Y tiebreak, so it reflected the column rather than the specific segment or band the cursor was inside.

### Fix
Resolve the snapped region by the cursor's vertical position across all series at the column, then use it to drive the header, guideline, and per-series highlight consistently.

chart-plot-area.component.ts
- snapSeriesByX: a rounded-centerX index of every series' region at a column. Stacked series live in separate rowIdx buckets, so they are regrouped by X here.
- nearestSnapRegion(snapColumnX, eventY): selects the region under the cursor in three ordered cases — containment (shortest enclosing bar segment), stacked-area band (series whose cumulative-top boundary is immediately above the cursor), and nearest center (line points or the cursor above the stack). Limited to the narrowest width tier so wide line-path regions don't skew the result.
- regionYBounds(region): vertical extent from marker geometry, preferring pts over centroid (absent on the point markers snap uses).
- The mousemove handler uses nearest ?? primary, preserving prior behavior whenever the new resolution returns nothing.

chart-inline-svg.directive.ts
- snapTooltip input plus highlightSnapSeries(pairs): drives the per-series dim from the snapped point's data-color (resolved via seriesColorByKey / seriesColorByCol), so the hovered line series stays undimmed regardless of cursor Y. In cross-tile mode it emits the color so the parent mirrors the dim onto sibling tiles holding the rest of the series.
- The line geometry hover (setupLineSeriesHover) is suppressed while snap is active so it doesn't fight the snap-driven dim.
- No-op on area (keeps its cursor-band hover), bar and radar tiles.
- Timer and map state cleaned up on destroy and reset.

### Compatibility
The snapTooltip input defaults to false; all new behavior is gated on it, so charts without the snap tooltip are unchanged.

### Testing
Added 5 directive specs (snapped-series dim, re-targeting, debounced clear, col-fallback gating, non-line no-op) and 4 component specs (stacked point nearest, bar containment vs nearer center, area band selection, X grouping). Full file suite: 44/44 passing.