### PR TITLE
Fix UnfinishedStubbingException in TextFormatArrayTest causing 800+ cascading failures

### DIFF
--- a/core/src/test/java/inetsoft/report/script/TextFormatArrayTest.java
+++ b/core/src/test/java/inetsoft/report/script/TextFormatArrayTest.java
@@ -87,7 +87,8 @@ public class TextFormatArrayTest {
       when(mockChartInfo.isMultiAesthetic()).thenReturn(false);
 
       ChartRef mockChartRef = mock(ChartRef.class);
-      when(mockChartRef.getTextFormat()).thenReturn(new CompositeTextFormat());
+      CompositeTextFormat dimTextFormat = new CompositeTextFormat();
+      when(mockChartRef.getTextFormat()).thenReturn(dimTextFormat);
 
       AestheticRef mockAestheticRef = mock(AestheticRef.class);
       when(mockAestheticRef.getDataRef()).thenReturn(mockChartRef);
@@ -105,7 +106,8 @@ public class TextFormatArrayTest {
       when(mockChartInfo.getRTFieldByFullName("sum(id)")).thenReturn(mockChartAggRef);
       when(mockChartInfo.isMultiAesthetic()).thenReturn(true);
 
-      when(mockChartAggRef.getTextFormat()).thenReturn(new CompositeTextFormat());
+      CompositeTextFormat aggTextFormat = new CompositeTextFormat();
+      when(mockChartAggRef.getTextFormat()).thenReturn(aggTextFormat);
 
       textFormatArray = new TextFormatArray(mockChartInfo, mockPlotDescriptor);
       assertInstanceOf(TextFormatScriptable.class, textFormatArray.get("sum(id)", null));


### PR DESCRIPTION
## Summary

- `TextFormatArrayTest` called `new CompositeTextFormat()` inside `thenReturn()`, which evaluated the constructor argument before Mockito's `when()` state was closed
- `CompositeTextFormat`'s constructor triggered `VSUtil.<clinit>` → `DataCache.<init>` → `DataCacheSweeper.getInstance().addCache(this)`, where `DataCacheSweeper` is a Mockito mock bean (from `BaseTestConfiguration`)
- Calling a method on a mock while a `when()` is still open throws `UnfinishedStubbingException`, which permanently fails `VSUtil`'s JVM-level class initialization, cascading into 800+ `NoClassDefFoundError` failures across the entire test suite

## Fix

Extract `new CompositeTextFormat()` into a local variable before the `when()` call in both affected test methods (`testGetWithNotAggregateRef` and `testGetWithAggregateRef`), so `VSUtil` initializes cleanly before any Mockito stubbing state is entered.

## Test plan

- [ ] Run `./mvnw test -pl core -Dtest=TextFormatArrayTest` — all 3 tests should pass
- [ ] Run `./mvnw test -pl core` — the 800+ cascade failures should be gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)