### PR TITLE
75474, format not unique when adding multiple data fields to text layout designer

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/controller/FormatPainterService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/FormatPainterService.java
@@ -2225,14 +2225,19 @@ public class FormatPainterService {
    // is stable: textLayoutFields are rebuilt in model order and removals compact indices in lockstep.
    private static final String LAYOUT_FIELD_PREFIX = "_layoutfield:";
 
-   private static boolean isLayoutFieldKey(String columnName) {
+   // Package-private for direct unit testing (FormatPainterServiceLayoutFieldTest).
+   static boolean isLayoutFieldKey(String columnName) {
       return columnName != null && columnName.startsWith(LAYOUT_FIELD_PREFIX);
    }
 
    // Resolve the ChartRef for an index key against the chart-level textLayoutFields, or against the
    // named aggregate's list when an aggregate full name is appended (multi-style). Returns null when
    // the key is malformed, the aggregate is not found, or the index is out of range.
-   private ChartRef resolveLayoutFieldByIndex(VSChartInfo chartInfo, String columnName) {
+   // static (no instance state) and package-private for direct unit testing
+   // (FormatPainterServiceLayoutFieldTest).
+   static ChartRef resolveLayoutFieldByIndex(VSChartInfo chartInfo, String columnName) {
+      // Re-check the prefix so this method is safe to call standalone (callers also guard); the
+      // duplicated check keeps it self-contained for tests that invoke it directly.
       if(!isLayoutFieldKey(columnName)) {
          return null;
       }

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/FormatPainterService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/FormatPainterService.java
@@ -1638,6 +1638,27 @@ public class FormatPainterService {
                format = staticItems.isEmpty() ? new CompositeTextFormat()
                                               : buildFormatFromStaticItem(staticItems.get(0));
             }
+            else if(isLayoutFieldKey(columnName)) {
+               // Index-based layout-field key (Redmine #75474): read the field's format from the
+               // resolved layout ref, creating an empty one on first open so panel edits attach to
+               // the same ref the SET path (writeToTextLayoutStubs) writes. Never fall through to the
+               // scalar path, which would read a different place than the panel writes.
+               ChartRef layoutRef = resolveLayoutFieldByIndex(chartInfo, columnName);
+
+               if(layoutRef != null) {
+                  CompositeTextFormat layoutFmt = layoutRef.getTextFormat();
+
+                  if(layoutFmt == null) {
+                     layoutFmt = new CompositeTextFormat();
+                     layoutRef.setTextFormat(layoutFmt);
+                  }
+
+                  format = layoutFmt;
+               }
+               else {
+                  format = new CompositeTextFormat();
+               }
+            }
             else {
                // Multi-field text layout: read the field's format from its layout-field ref
                // (symmetric with writeToTextLayoutStubs and with the render path), so the panel
@@ -2142,6 +2163,19 @@ public class FormatPainterService {
    private boolean writeToTextLayoutStubs(VSChartInfo chartInfo, String columnName,
                                           CompositeTextFormat format)
    {
+      // An index-based key ("_layoutfield:<i>[:<aggrName>]") addresses a designer field whose
+      // aggregated full name is not yet known on the client (Redmine #75474). Resolve by index and
+      // claim the key unconditionally so it never leaks to the scalar-textField fallback below.
+      if(isLayoutFieldKey(columnName)) {
+         ChartRef ref = resolveLayoutFieldByIndex(chartInfo, columnName);
+
+         if(ref != null) {
+            ref.setTextFormat(format);
+         }
+
+         return true;
+      }
+
       boolean found = false;
 
       for(AestheticRef aref : chartInfo.getTextLayoutFields()) {
@@ -2182,6 +2216,61 @@ public class FormatPainterService {
       }
 
       return null;
+   }
+
+   // ── Index-based text-layout field key ("_layoutfield:<i>[:<aggrFullName>]") ──────────
+   // A field added in the Layout Designer is built client-side; its aggregated full name (e.g.
+   // "Sum(Sales)") is assigned by the backend only on the next model round-trip, so the Format panel
+   // cannot key by name on first open (Redmine #75474). Instead it keys by the field's index, which
+   // is stable: textLayoutFields are rebuilt in model order and removals compact indices in lockstep.
+   private static final String LAYOUT_FIELD_PREFIX = "_layoutfield:";
+
+   private static boolean isLayoutFieldKey(String columnName) {
+      return columnName != null && columnName.startsWith(LAYOUT_FIELD_PREFIX);
+   }
+
+   // Resolve the ChartRef for an index key against the chart-level textLayoutFields, or against the
+   // named aggregate's list when an aggregate full name is appended (multi-style). Returns null when
+   // the key is malformed, the aggregate is not found, or the index is out of range.
+   private ChartRef resolveLayoutFieldByIndex(VSChartInfo chartInfo, String columnName) {
+      if(!isLayoutFieldKey(columnName)) {
+         return null;
+      }
+
+      String rest = columnName.substring(LAYOUT_FIELD_PREFIX.length());
+      int sep = rest.indexOf(':');
+      String idxStr = sep < 0 ? rest : rest.substring(0, sep);
+      String aggrName = sep < 0 ? null : rest.substring(sep + 1);
+      int index;
+
+      try {
+         index = Integer.parseInt(idxStr);
+      }
+      catch(NumberFormatException ex) {
+         return null;
+      }
+
+      List<AestheticRef> fields = null;
+
+      if(aggrName == null || aggrName.isEmpty()) {
+         fields = chartInfo.getTextLayoutFields();
+      }
+      else {
+         for(ChartAggregateRef aggr : AllChartAggregateRef.getXYAggregateRefs(chartInfo, false)) {
+            if(Tool.equals(aggr.getFullName(), aggrName)) {
+               fields = aggr.getTextLayoutFields();
+               break;
+            }
+         }
+      }
+
+      if(fields == null || index < 0 || index >= fields.size()) {
+         return null;
+      }
+
+      AestheticRef aref = fields.get(index);
+      return aref != null && aref.getDataRef() instanceof ChartRef
+         ? (ChartRef) aref.getDataRef() : null;
    }
 
    // ── Static text-item formatting bridge (issue 1) ─────────────────────────────────────

--- a/core/src/test/java/inetsoft/web/composer/vs/controller/FormatPainterServiceLayoutFieldTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/controller/FormatPainterServiceLayoutFieldTest.java
@@ -1,0 +1,123 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.vs.controller;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.viewsheet.graph.ChartRef;
+import inetsoft.uql.viewsheet.graph.DefaultVSChartInfo;
+import inetsoft.uql.viewsheet.graph.VSAestheticRef;
+import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the index-based text-layout field key path (Redmine #75474): the Format panel addresses a
+ * Layout Designer field by its INDEX ("_layoutfield:&lt;i&gt;[:&lt;aggrName&gt;]") rather than its
+ * aggregated name, which the client cannot know on first open. Covers key recognition and
+ * FormatPainterService.resolveLayoutFieldByIndex for valid, out-of-bounds, malformed, and
+ * missing-aggregate keys.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class FormatPainterServiceLayoutFieldTest {
+   private static VSChartInfo infoWithTextLayoutFields(String... names) {
+      VSChartInfo info = new DefaultVSChartInfo();
+
+      for(String name : names) {
+         VSAestheticRef ref = new VSAestheticRef();
+         ref.setDataRef(new VSChartDimensionRef(new AttributeRef(null, name)));
+         info.addTextLayoutField(ref);
+      }
+
+      return info;
+   }
+
+   @Test
+   void isLayoutFieldKeyRecognizesPrefix() {
+      assertTrue(FormatPainterService.isLayoutFieldKey("_layoutfield:0"));
+      assertTrue(FormatPainterService.isLayoutFieldKey("_layoutfield:2:Sum(Sales)"));
+      assertFalse(FormatPainterService.isLayoutFieldKey("_static:Total:"));
+      assertFalse(FormatPainterService.isLayoutFieldKey("Sum(Sales)"));
+      assertFalse(FormatPainterService.isLayoutFieldKey(null));
+   }
+
+   @Test
+   void resolvesEachFieldByItsOwnIndex() {
+      VSChartInfo info = infoWithTextLayoutFields("state", "city", "zip");
+
+      ChartRef r0 = FormatPainterService.resolveLayoutFieldByIndex(info, "_layoutfield:0");
+      ChartRef r1 = FormatPainterService.resolveLayoutFieldByIndex(info, "_layoutfield:1");
+      ChartRef r2 = FormatPainterService.resolveLayoutFieldByIndex(info, "_layoutfield:2");
+
+      assertNotNull(r0);
+      assertNotNull(r1);
+      assertNotNull(r2);
+      // Each index must resolve to a DISTINCT ref — this is the crux of #75474 (every field gets its
+      // own unique format target, not all collapsing onto the first).
+      assertNotSame(r0, r1);
+      assertNotSame(r1, r2);
+      assertSame(info.getTextLayoutFields().get(1).getDataRef(), r1);
+   }
+
+   @Test
+   void returnsNullForOutOfRangeIndex() {
+      VSChartInfo info = infoWithTextLayoutFields("state");
+
+      assertNull(FormatPainterService.resolveLayoutFieldByIndex(info, "_layoutfield:1"));
+      assertNull(FormatPainterService.resolveLayoutFieldByIndex(info, "_layoutfield:-1"));
+   }
+
+   @Test
+   void returnsNullForMalformedIndex() {
+      VSChartInfo info = infoWithTextLayoutFields("state");
+
+      assertNull(FormatPainterService.resolveLayoutFieldByIndex(info, "_layoutfield:abc"));
+      assertNull(FormatPainterService.resolveLayoutFieldByIndex(info, "_layoutfield:"));
+   }
+
+   @Test
+   void returnsNullForNonLayoutFieldKey() {
+      VSChartInfo info = infoWithTextLayoutFields("state");
+
+      assertNull(FormatPainterService.resolveLayoutFieldByIndex(info, "Sum(Sales)"));
+      assertNull(FormatPainterService.resolveLayoutFieldByIndex(info, "_static:Total:"));
+   }
+
+   @Test
+   void returnsNullWhenAggregateNotFound() {
+      VSChartInfo info = infoWithTextLayoutFields("state");
+
+      // A key naming an aggregate that does not exist resolves against that aggregate's (absent)
+      // textLayoutFields, not the chart-level list, so it must return null rather than mis-resolving
+      // to the chart-level field at the same index.
+      assertNull(FormatPainterService.resolveLayoutFieldByIndex(info, "_layoutfield:0:NoSuchAggr"));
+   }
+}

--- a/web/projects/portal/src/app/binding/editor/binding-editor.component.ts
+++ b/web/projects/portal/src/app/binding/editor/binding-editor.component.ts
@@ -391,6 +391,12 @@ export class BindingEditor implements OnInit, AfterViewInit, OnDestroy {
 
          if(target) {
             target.textLayout = layout;
+            // Apply the designer's WORKING field list too (same as commit). Without this, fields
+            // added on a first, not-yet-committed open never reach the backend, so the round-trip
+            // rebuilds an empty textLayoutFields and the per-field Format panel has no ref to write
+            // to — the color reverts immediately (Redmine #75474). Indices stay aligned: the backend
+            // rebuilds textLayoutFields in this list's order, which is what the index key resolves.
+            target.textFields = this.layoutDesignerTextFields.slice();
          }
       }
 
@@ -399,8 +405,15 @@ export class BindingEditor implements OnInit, AfterViewInit, OnDestroy {
       this.chartEditorService.changeChartAesthetic("text");
    }
 
-   onLayoutFieldFormat(fullName: string): void {
-      this.chartEditorService.measureName = fullName;
+   onLayoutFieldFormat(key: string): void {
+      // For an index-based layout-field key, append the multi-style aggregate context so the backend
+      // resolves the field against the correct per-aggregate textLayoutFields list. Chart-level
+      // (no aggregate) and static (_static:) keys pass through unchanged.
+      if(key && key.startsWith("_layoutfield:") && this.layoutDesignerAggregateName) {
+         key = key + ":" + this.layoutDesignerAggregateName;
+      }
+
+      this.chartEditorService.measureName = key;
       this.hideFormatPane = false;
       this.updateData("showTextFormat");
    }

--- a/web/projects/portal/src/app/binding/editor/binding-editor.component.ts
+++ b/web/projects/portal/src/app/binding/editor/binding-editor.component.ts
@@ -37,7 +37,7 @@ import { Tool } from "../../../../../shared/util/tool";
 import { GraphUtil } from "../util/graph-util";
 import { AestheticInfo } from "../data/chart/aesthetic-info";
 import { TextLayoutModel } from "../../common/data/visual-frame-model";
-import { TextLayoutDesignerComponent } from "./chart/aesthetic/text-layout-designer.component";
+import { TextLayoutDesignerComponent, LAYOUT_FIELD_PREFIX } from "./chart/aesthetic/text-layout-designer.component";
 import { ChartEditorService } from "../services/chart/chart-editor.service";
 import { ModelService } from "../../widget/services/model.service";
 import { StatusBar } from "../../status-bar/status-bar.component";
@@ -409,7 +409,7 @@ export class BindingEditor implements OnInit, AfterViewInit, OnDestroy {
       // For an index-based layout-field key, append the multi-style aggregate context so the backend
       // resolves the field against the correct per-aggregate textLayoutFields list. Chart-level
       // (no aggregate) and static (_static:) keys pass through unchanged.
-      if(key && key.startsWith("_layoutfield:") && this.layoutDesignerAggregateName) {
+      if(key && key.startsWith(LAYOUT_FIELD_PREFIX) && this.layoutDesignerAggregateName) {
          key = key + ":" + this.layoutDesignerAggregateName;
       }
 

--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.ts
@@ -38,6 +38,11 @@ import { DragDropModule } from "@angular/cdk/drag-drop";
 import { ChartAestheticMc } from "./chart-aesthetic-mc.component";
 import { BlockMouseDirective } from "../../../../widget/mouse-event/block-mouse.directive";
 
+// Prefix for the index-based Format-panel key ("_layoutfield:<index>"). Keying by index (not the
+// client-side, not-yet-aggregated field name) is what fixes the "format reverts on first open" bug
+// (#75474). Must match LAYOUT_FIELD_PREFIX on the Java side (FormatPainterService).
+export const LAYOUT_FIELD_PREFIX = "_layoutfield:";
+
 @Component({
    selector: "text-layout-designer",
    templateUrl: "./text-layout-designer.component.html",
@@ -575,18 +580,14 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
    }
 
    openFieldFormat(item: TextLayoutItemModel): void {
-      // Key the Format panel by the field's INDEX, not its name. A field added in the designer is
-      // built client-side and its aggregated full name (e.g. "Sum(Sales)") is only assigned by the
-      // backend on the next round-trip — so a name key would not match the layout-field ref until a
-      // close/reopen, which is exactly the "format reverts on first open" bug (#75474). The index is
-      // stable end-to-end: the backend rebuilds textLayoutFields in model order and removals compact
-      // fieldIndex in lockstep. The host appends the multi-style aggregate context when present.
+      // Key the Format panel by field INDEX, not name — a designer-added field's aggregated name
+      // isn't known client-side until a round-trip, so a name key fails on first open (#75474).
       if(item?.fieldIndex == null) {
          return;
       }
 
       this.onPreSaveLayout.emit({ rows: this.workingRows });
-      this.onFormatField.emit("_layoutfield:" + item.fieldIndex);
+      this.onFormatField.emit(LAYOUT_FIELD_PREFIX + item.fieldIndex);
    }
 
    /**

--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/text-layout-designer.component.ts
@@ -49,7 +49,7 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
    @Input() textFields: AestheticInfo[] = []; // the real binding list FIELD items index into
    @Output() onCommit = new EventEmitter<TextLayoutModel>();
    @Output() onCancel = new EventEmitter<void>();
-   @Output() onFormatField = new EventEmitter<string>(); // emits stub key (fullName or "_static:text")
+   @Output() onFormatField = new EventEmitter<string>(); // emits format key ("_layoutfield:<index>" or "_static:text")
    @Output() onPreSaveLayout = new EventEmitter<TextLayoutModel>(); // pre-save to create stubs before Format panel
    @Output() onAddField = new EventEmitter<{ field: AestheticInfo; insertRow: number; insertIndex: number }>();
    // Emitted when a FIELD chip is removed and its binding is no longer referenced, so the host can
@@ -575,12 +575,18 @@ export class TextLayoutDesignerComponent implements OnInit, AfterViewInit, OnDes
    }
 
    openFieldFormat(item: TextLayoutItemModel): void {
-      const fullName = (this.getFieldRef(item)?.dataInfo as any)?.fullName;
-
-      if(fullName) {
-         this.onPreSaveLayout.emit({ rows: this.workingRows });
-         this.onFormatField.emit(fullName);
+      // Key the Format panel by the field's INDEX, not its name. A field added in the designer is
+      // built client-side and its aggregated full name (e.g. "Sum(Sales)") is only assigned by the
+      // backend on the next round-trip — so a name key would not match the layout-field ref until a
+      // close/reopen, which is exactly the "format reverts on first open" bug (#75474). The index is
+      // stable end-to-end: the backend rebuilds textLayoutFields in model order and removals compact
+      // fieldIndex in lockstep. The host appends the multi-style aggregate context when present.
+      if(item?.fieldIndex == null) {
+         return;
       }
+
+      this.onPreSaveLayout.emit({ rows: this.workingRows });
+      this.onFormatField.emit("_layoutfield:" + item.fieldIndex);
    }
 
    /**


### PR DESCRIPTION
Root Cause:
Two defects in the Text Layout Designer's per-field formatting, both only visible on the first (not-yet-committed) open of the designer:

1. Format key mismatch. The per-field Format panel matched a layout field to its backend ref by aggregated full name (e.g. "Sum(Sales)"). But a field added in the designer is built client-side with fullName = the bare column caption ("Sales"), not "Sum(Sales)" — the aggregated name is only assigned by the backend on a later model round-trip. So the format SET/GET could not match the newly added fields until a commit+reopen. (The first field appeared to work only because it was seeded from the existing scalar Text binding, which already carried the correct backend name and was served by the legacy scalar-text-field path.)

2. Pre-save dropped the added fields. onLayoutDesignerPreSave (which fires when the Format panel is opened) applied only target.textLayout, not target.textFields. So fields added on a fresh open lived only in the designer's working copy; the round-trip rebuilt an empty textLayoutFields on the backend, leaving no ref for the per-field format to write to — the color reverted immediately. Reopening worked only because OK had already pushed the fields into target.textFields.

Fix:
1. Key the designer's Format panel by the field INDEX instead of its (client-side, not-yet-aggregated) name: the designer emits "_layoutfield:<index>" and the host appends the multi-style aggregate name when applicable. FormatPainterService resolves the layout-field ref by index (chart-level textLayoutFields, or the named aggregate's list) in both the SET (writeToTextLayoutStubs) and GET (getChartRegionFormat) paths, claiming the key so it never leaks to the scalar fallback. Name-based matching is retained for the chart-region-click path. The index is stable end-to-end (textLayoutFields are rebuilt in model order; removals compact indices in lockstep).
2. onLayoutDesignerPreSave now also applies target.textFields = layoutDesignerTextFields (same as commit), so the backend builds textLayoutFields aligned with the designer's field indices and the per-field format SET/GET lands on real refs.