### PR TITLE
Bug #75496, fix intermittent Kryo "unregistered class ID" in swap deserialization

### DIFF
--- a/core/src/main/java/inetsoft/uql/table/XBigObjectColumn.java
+++ b/core/src/main/java/inetsoft/uql/table/XBigObjectColumn.java
@@ -361,6 +361,7 @@ public final class XBigObjectColumn extends XSwappable implements XTableColumn {
 
       File file = getFile(prefix + ".tdat");
       FileOutputStream fout = null;
+      com.esotericsoftware.kryo.kryo5.Kryo kryo = XSwapUtil.getKryo();
 
       try {
          fout = new FileOutputStream(file, true);
@@ -379,7 +380,7 @@ public final class XBigObjectColumn extends XSwappable implements XTableColumn {
             if(parr[i] == -1) {
                parr[i] = len;
                Output oout = new Output(bout);
-               XSwapUtil.getKryo().writeClassAndObject(
+               kryo.writeClassAndObject(
                   oout, image ? new ImageWrapper((Image) arr[i]) : arr[i]);
                oout.flush();
 
@@ -397,6 +398,8 @@ public final class XBigObjectColumn extends XSwappable implements XTableColumn {
          LOG.error("Failed to swap data", ex);
       }
       finally {
+         XSwapUtil.releaseKryo(kryo);
+
          if(fout != null) {
             try {
                fout.close();
@@ -426,6 +429,7 @@ public final class XBigObjectColumn extends XSwappable implements XTableColumn {
       File file = getFile(prefix + ".tdat");
       FileInputStream fin = null;
       Object obj = null;
+      com.esotericsoftware.kryo.kryo5.Kryo kryo = XSwapUtil.getKryo();
 
       try {
          fin = new FileInputStream(file);
@@ -435,7 +439,7 @@ public final class XBigObjectColumn extends XSwappable implements XTableColumn {
 
          Input oin = new Input(in);
          kryoInput = oin;
-         obj = XSwapUtil.getKryo().readClassAndObject(oin);
+         obj = kryo.readClassAndObject(oin);
 
          if(image) {
             obj = ((ImageWrapper) obj).unwrap();
@@ -447,6 +451,8 @@ public final class XBigObjectColumn extends XSwappable implements XTableColumn {
          LOG.error("Failed to read object [" + r + "]", e);
       }
       finally {
+         XSwapUtil.releaseKryo(kryo);
+
          if(fin != null) {
             try {
                fin.close();

--- a/core/src/main/java/inetsoft/uql/table/XObjectColumn.java
+++ b/core/src/main/java/inetsoft/uql/table/XObjectColumn.java
@@ -513,6 +513,9 @@ public final class XObjectColumn extends AbstractTableColumn {
             this.arr = new Object[pos];
          }
       }
+      finally {
+         XSwapUtil.releaseKryo(kryo);
+      }
    }
 
    @Override
@@ -541,6 +544,9 @@ public final class XObjectColumn extends AbstractTableColumn {
       }
       catch(Exception ex) {
          LOG.error("Failed to write data", ex);
+      }
+      finally {
+         XSwapUtil.releaseKryo(kryo);
       }
 
       return null;

--- a/core/src/main/java/inetsoft/uql/viewsheet/SelectionList.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/SelectionList.java
@@ -859,8 +859,9 @@ public class SelectionList extends XSwappable implements AssetObject, DataSerial
       };
 
       // don't reuse swap data. since selection values are mutable, need to write them out.
+      Kryo kryo = XSwapUtil.getKryo();
+
       try(Output objout = new Output(new FileOutputStream(swapFile))) {
-         Kryo kryo = XSwapUtil.getKryo();
          ArrayList<SelectionValue> list2 = new ArrayList<>();
 
          for(int i = 0; i < this.list.size(); i++) {
@@ -881,6 +882,9 @@ public class SelectionList extends XSwappable implements AssetObject, DataSerial
       catch(Exception ex) {
          LOG.warn("Swapping failed for selection list: " + swapFile, ex);
       }
+      finally {
+         XSwapUtil.releaseKryo(kryo);
+      }
 
       return true;
    }
@@ -896,9 +900,9 @@ public class SelectionList extends XSwappable implements AssetObject, DataSerial
                Function<Integer, Format> defFmtMapper = idx -> defFmtDict.get(idx);
                Function<Integer, VSCompositeFormat> fmtMapper = idx -> fmtDict.get(idx);
 
-               try(Input inp = new Input(new FileInputStream(swapFile))) {
-                  Kryo kryo = XSwapUtil.getKryo();
+               Kryo kryo = XSwapUtil.getKryo();
 
+               try(Input inp = new Input(new FileInputStream(swapFile))) {
                   for(int i = 0; i < this.list.size(); i++) {
                      SelectionValue val = this.list.get(i);
 
@@ -917,6 +921,9 @@ public class SelectionList extends XSwappable implements AssetObject, DataSerial
                }
                catch(Exception ex) {
                   LOG.warn("Restore failed for selection list: " + swapFile, ex);
+               }
+               finally {
+                  XSwapUtil.releaseKryo(kryo);
                }
             }
          }

--- a/core/src/main/java/inetsoft/util/swap/XObjectFragment.java
+++ b/core/src/main/java/inetsoft/util/swap/XObjectFragment.java
@@ -549,6 +549,8 @@ public final class XObjectFragment<T> extends XSwappable {
     * @return next position if any, <tt>-1</tt> otherwise.
     */
    private int validate(ByteBuffer buf, ObjectArrayHolder holder) {
+      Kryo kryo = null;
+
       try {
          if(buf.capacity() - buf.position() < HEADER_LENGTH) {
             return spos;
@@ -567,7 +569,7 @@ public final class XObjectFragment<T> extends XSwappable {
          ByteArrayInputStream in = new ByteArrayInputStream(bytes);
 
          Input kin = kryoClass != null ? new Input(in) : null;
-         Kryo kryo = kryoClass != null ? XSwapUtil.getKryo() : null;
+         kryo = kryoClass != null ? XSwapUtil.getKryo() : null;
          ObjectInputStream oin = kryoClass == null ? new ObjectInputStream(in) : null;
 
          if(holder.arr == null) {
@@ -592,6 +594,9 @@ public final class XObjectFragment<T> extends XSwappable {
       }
       catch(Exception ex) {
          LOG.error("Failed to read swap buffer", ex);
+      }
+      finally {
+         XSwapUtil.releaseKryo(kryo);
       }
 
       return -1;
@@ -675,6 +680,8 @@ public final class XObjectFragment<T> extends XSwappable {
                else {
                   oout.close();
                }
+
+               XSwapUtil.releaseKryo(kryo);
             }
 
             writeBlock(bout.size(), pos, (char) (pos - spos), bout.toBytes(),

--- a/core/src/main/java/inetsoft/util/swap/XSwapUtil.java
+++ b/core/src/main/java/inetsoft/util/swap/XSwapUtil.java
@@ -499,7 +499,6 @@ public final class XSwapUtil {
    public static com.esotericsoftware.kryo.kryo5.Kryo getKryo() {
       com.esotericsoftware.kryo.kryo5.Kryo kryo = kryoPool.obtain();
       kryo.setClassLoader(Thread.currentThread().getContextClassLoader());
-      kryo.setRegistrationRequired(false);
       return kryo;
    }
 
@@ -561,10 +560,11 @@ public final class XSwapUtil {
    // Thread-safe pool of Kryo instances. reset() is overridden so an instance
    // freed after a failed (de)serialization is cleaned before it is reused.
    private static final com.esotericsoftware.kryo.kryo5.util.Pool<com.esotericsoftware.kryo.kryo5.Kryo> kryoPool =
-      new com.esotericsoftware.kryo.kryo5.util.Pool<com.esotericsoftware.kryo.kryo5.Kryo>(true, false) {
+      new com.esotericsoftware.kryo.kryo5.util.Pool<com.esotericsoftware.kryo.kryo5.Kryo>(true, false, 16) {
          @Override
          protected com.esotericsoftware.kryo.kryo5.Kryo create() {
-            // class loader and registrationRequired are (re)set on every borrow in getKryo()
+            // class loader is (re)set on every borrow in getKryo(); registrationRequired
+            // is a config flag that reset() does not clear, so set it once here.
             com.esotericsoftware.kryo.kryo5.Kryo kryo = new com.esotericsoftware.kryo.kryo5.Kryo();
             kryo.setRegistrationRequired(false);
             return kryo;

--- a/core/src/main/java/inetsoft/util/swap/XSwapUtil.java
+++ b/core/src/main/java/inetsoft/util/swap/XSwapUtil.java
@@ -484,12 +484,32 @@ public final class XSwapUtil {
    }
 
    /**
-    * Get a shared Kryo object.
+    * Borrow a Kryo object from the pool. The caller <b>must</b> return it with
+    * {@link #releaseKryo} (in a finally block) when finished.
+    * <p>
+    * A pool is used instead of a single shared/thread-local instance because a
+    * Kryo instance carries mutable per-operation state (depth, reference
+    * resolver, and the class-resolver name-id map). If a swap (de)serialization
+    * re-enters another swap operation on the same thread, sharing one instance
+    * corrupts that state and produces a stream with dangling class references
+    * (e.g. "Encountered unregistered class ID"). Each borrow returns an
+    * instance not currently in use, so nested/concurrent operations stay
+    * isolated.
     */
    public static com.esotericsoftware.kryo.kryo5.Kryo getKryo() {
-      com.esotericsoftware.kryo.kryo5.Kryo kryo = kryos.get();
+      com.esotericsoftware.kryo.kryo5.Kryo kryo = kryoPool.obtain();
+      kryo.setClassLoader(Thread.currentThread().getContextClassLoader());
       kryo.setRegistrationRequired(false);
       return kryo;
+   }
+
+   /**
+    * Return a Kryo object previously obtained from {@link #getKryo} to the pool.
+    */
+   public static void releaseKryo(com.esotericsoftware.kryo.kryo5.Kryo kryo) {
+      if(kryo != null) {
+         kryoPool.free(kryo);
+      }
    }
 
    /**
@@ -538,14 +558,23 @@ public final class XSwapUtil {
       parallelGC = cmsGC || args.indexOf("-XX:+ExplicitGCInvokesConcurrent") >= 0;
    }
 
-   private static ThreadLocal<com.esotericsoftware.kryo.kryo5.Kryo> kryos = new ThreadLocal<com.esotericsoftware.kryo.kryo5.Kryo>() {
-      @Override
-      protected com.esotericsoftware.kryo.kryo5.Kryo initialValue() {
-         com.esotericsoftware.kryo.kryo5.Kryo kryo = new com.esotericsoftware.kryo.kryo5.Kryo();
-         kryo.setClassLoader(Thread.currentThread().getContextClassLoader());
-         return kryo;
-      }
-   };
+   // Thread-safe pool of Kryo instances. reset() is overridden so an instance
+   // freed after a failed (de)serialization is cleaned before it is reused.
+   private static final com.esotericsoftware.kryo.kryo5.util.Pool<com.esotericsoftware.kryo.kryo5.Kryo> kryoPool =
+      new com.esotericsoftware.kryo.kryo5.util.Pool<com.esotericsoftware.kryo.kryo5.Kryo>(true, false) {
+         @Override
+         protected com.esotericsoftware.kryo.kryo5.Kryo create() {
+            // class loader and registrationRequired are (re)set on every borrow in getKryo()
+            com.esotericsoftware.kryo.kryo5.Kryo kryo = new com.esotericsoftware.kryo.kryo5.Kryo();
+            kryo.setRegistrationRequired(false);
+            return kryo;
+         }
+
+         @Override
+         protected void reset(com.esotericsoftware.kryo.kryo5.Kryo kryo) {
+            kryo.reset();
+         }
+      };
 
    private static final char MAX_CHAR = '\uffff';
    private static final Logger LOG = LoggerFactory.getLogger(XSwapUtil.class);

--- a/core/src/test/java/inetsoft/util/swap/XSwapUtilTest.java
+++ b/core/src/test/java/inetsoft/util/swap/XSwapUtilTest.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of StyleBI.
- * Copyright (C) 2024  InetSoft Technology
+ * Copyright (C) 2026  InetSoft Technology
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/core/src/test/java/inetsoft/util/swap/XSwapUtilTest.java
+++ b/core/src/test/java/inetsoft/util/swap/XSwapUtilTest.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util.swap;
+
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class XSwapUtilTest {
+   /**
+    * A Kryo instance that is still checked out of the pool must not be handed
+    * to a re-entrant caller, otherwise nested swap (de)serialization on the
+    * same thread corrupts the shared class-resolver/reference state. (Bug 75496)
+    */
+   @Test
+   void reentrantGetKryoReturnsDistinctInstances() {
+      Kryo outer = XSwapUtil.getKryo();
+
+      try {
+         Kryo nested = XSwapUtil.getKryo();
+
+         try {
+            assertNotSame(outer, nested,
+                          "re-entrant getKryo() must not return the in-use instance");
+         }
+         finally {
+            XSwapUtil.releaseKryo(nested);
+         }
+      }
+      finally {
+         XSwapUtil.releaseKryo(outer);
+      }
+   }
+
+   /**
+    * A re-entrant read happening in the middle of an outer write (both via the
+    * pool) must not corrupt the outer stream. Before the fix this produced a
+    * stream with dangling class references that failed on read-back with
+    * "Encountered unregistered class ID". (Bug 75496)
+    */
+   @Test
+   void nestedSerializationDoesNotCorruptOuterStream() throws Exception {
+      // data for a nested (inner) swap operation
+      byte[] nested = write(new ArrayList<>(Arrays.asList(new Date(1), new Date(2), new Date(3))));
+
+      Kryo outerKryo = XSwapUtil.getKryo();
+      byte[] outer;
+
+      try {
+         ByteArrayOutputStream bout = new ByteArrayOutputStream();
+
+         try(Output out = new Output(bout)) {
+            outerKryo.writeClassAndObject(out, "header");
+
+            // re-enter the pool mid-write, as a nested column load would
+            Kryo innerKryo = XSwapUtil.getKryo();
+
+            try(Input in = new Input(new ByteArrayInputStream(nested))) {
+               innerKryo.readClassAndObject(in);
+            }
+            finally {
+               XSwapUtil.releaseKryo(innerKryo);
+            }
+
+            outerKryo.writeClassAndObject(out, new ArrayList<>(Arrays.asList(new Date(4), new Date(5))));
+            outerKryo.writeClassAndObject(out, Integer.valueOf(42));
+         }
+
+         outer = bout.toByteArray();
+      }
+      finally {
+         XSwapUtil.releaseKryo(outerKryo);
+      }
+
+      // the outer stream must read back cleanly with a fresh Kryo
+      Kryo reader = XSwapUtil.getKryo();
+
+      try(Input in = new Input(new ByteArrayInputStream(outer))) {
+         assertEquals("header", reader.readClassAndObject(in));
+         assertEquals(Arrays.asList(new Date(4), new Date(5)), reader.readClassAndObject(in));
+         assertEquals(Integer.valueOf(42), reader.readClassAndObject(in));
+      }
+      finally {
+         XSwapUtil.releaseKryo(reader);
+      }
+   }
+
+   private static byte[] write(Object obj) {
+      Kryo kryo = XSwapUtil.getKryo();
+
+      try {
+         ByteArrayOutputStream bout = new ByteArrayOutputStream();
+
+         try(Output out = new Output(bout)) {
+            kryo.writeClassAndObject(out, obj);
+         }
+
+         return bout.toByteArray();
+      }
+      finally {
+         XSwapUtil.releaseKryo(kryo);
+      }
+   }
+}


### PR DESCRIPTION
## Summary

Accessing a dashboard backed by swappable table data intermittently threw `com.esotericsoftware.kryo.kryo5.KryoException: Encountered unregistered class ID: 54` from `XObjectColumn.copyFromBuffer0()` while deserializing column data that had been paged to disk.

## Root Cause

`XSwapUtil.getKryo()` returned a single shared `ThreadLocal<Kryo>` instance. A Kryo instance carries mutable per-operation state — `depth`, the reference resolver, and the class-resolver `nameId → class` map (used when `registrationRequired=false`, where unregistered classes are written by name and back-referenced by an incrementing id).

When one swap (de)serialization on a thread re-enters another swap operation on the **same thread** (e.g. the swapper serializing a `SelectionList` whose values reference worksheet column data that must be loaded), both operations share the one Kryo instance. The nested operation mutates the shared class-resolver/reference state, so the outer stream is written/read with dangling class references that fail on read-back as "Encountered unregistered class ID". This is intermittent because it depends on a nested swap firing at the exact moment another swap is in flight on the same thread.

The exact symptom was reproduced in isolation: a nested `readClassAndObject` on a shared instance mid-write produces `KryoException: Encountered unregistered class ID`.

## Fix

Replace the shared `ThreadLocal<Kryo>` with a thread-safe `com.esotericsoftware.kryo.kryo5.util.Pool<Kryo>`. `getKryo()` now borrows from the pool; a new `releaseKryo(Kryo)` returns it. Every call site borrows then releases in a `finally` block, so nested/concurrent operations get isolated instances. The pool's `reset(Kryo)` is overridden to call `kryo.reset()` so an instance freed after a failed (de)serialization is cleaned before reuse.

Converted call sites: `XObjectColumn.copyFromBuffer0`/`copyToBuffer`, `XObjectFragment.validate`/`invalidate`, `SelectionList.swap`/`getList`, `XBigObjectColumn.swap` (also hoisted `getKryo()` out of its per-object loop) and `XBigObjectColumn.readObject`.

## Test Plan

- Added `XSwapUtilTest` with two regression tests: nested `getKryo()` returns distinct instances, and a nested read mid-write does not corrupt the outer stream. Both fail against the old `ThreadLocal` implementation and pass with the fix.
- `./mvnw clean install -pl core -am -DskipTests` succeeds.
- Existing swap/selection tests pass (`XSwappableTableTest`, `XSwappableObjectListTest`, `SelectionListVSAScriptableTest`).
- To verify the bug: repeatedly open the affected dashboard under memory pressure (so columns swap to disk and reload); the intermittent "unregistered class ID" error no longer occurs.

Fixes Redmine #75496.