### PR TITLE
Bug #75497, eliminate per-change-detection cost in tree node menu evaluation

### DIFF
--- a/web/projects/portal/src/app/common/util/gui-tool.ts
+++ b/web/projects/portal/src/app/common/util/gui-tool.ts
@@ -61,6 +61,7 @@ export class GuiTool {
 
    private static scrollbarWidth: number;
    private static scrollIdentifier = 0;
+   private static mobileDevice: boolean;
 
    /**
     * Return the text width in pixels.
@@ -1105,8 +1106,15 @@ export class GuiTool {
     * @returns {boolean} <tt>true</tt> if a mobile device; <tt>false</tt> otherwise.
     */
    static isMobileDevice(): boolean {
-      let a: string = (window.navigator.userAgent || window.navigator.vendor || window["opera"]);
-      return (/(android|bb\d+|meego).+mobile|android|ipad|playbook|silk|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(a) || /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw-(n|u)|c55\/|capi|ccwa|cdm-|cell|chtm|cldc|cmd-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc-s|devi|dica|dmob|do(c|p)o|ds(12|-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(-|_)|g1 u|g560|gene|gf-5|g-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd-(m|p|t)|hei-|hi(pt|ta)|hp( i|ip)|hs-c|ht(c(-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i-(20|go|ma)|i230|iac( |-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|-[a-w])|libw|lynx|m1-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)3-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|-([1-8]|c))|phil|pire|pl(ay|uc)|pn-2|po(ck|rt|se)|prox|psio|pt-g|qa-a|qc(07|12|21|32|60|-[2-7]|i-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h-|oo|p-)|sdk\/|se(c(-|0|1)|47|mc|nd|ri)|sgh-|shar|sie(-|m)|sk-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h-|v-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl-|tdg-|tel(i|m)|tim-|t-mo|to(pl|sh)|ts(70|m-|m3|m5)|tx-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas-|your|zeto|zte-/i.test(a.substr(0, 4)));
+      // The user agent does not change during a page session, so the result is
+      // memoized to avoid re-running these expensive regexes on every call (this
+      // method is invoked from hot template bindings during change detection).
+      if(GuiTool.mobileDevice === undefined) {
+         let a: string = (window.navigator.userAgent || window.navigator.vendor || window["opera"]);
+         GuiTool.mobileDevice = (/(android|bb\d+|meego).+mobile|android|ipad|playbook|silk|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(a) || /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw-(n|u)|c55\/|capi|ccwa|cdm-|cell|chtm|cldc|cmd-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc-s|devi|dica|dmob|do(c|p)o|ds(12|-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(-|_)|g1 u|g560|gene|gf-5|g-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd-(m|p|t)|hei-|hi(pt|ta)|hp( i|ip)|hs-c|ht(c(-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i-(20|go|ma)|i230|iac( |-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|-[a-w])|libw|lynx|m1-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)3-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|-([1-8]|c))|phil|pire|pl(ay|uc)|pn-2|po(ck|rt|se)|prox|psio|pt-g|qa-a|qc(07|12|21|32|60|-[2-7]|i-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h-|oo|p-)|sdk\/|se(c(-|0|1)|47|mc|nd|ri)|sgh-|shar|sie(-|m)|sk-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h-|v-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl-|tdg-|tel(i|m)|tim-|t-mo|to(pl|sh)|ts(70|m-|m3|m5)|tx-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas-|your|zeto|zte-/i.test(a.substr(0, 4)));
+      }
+
+      return GuiTool.mobileDevice;
    }
 
    static getQueryParameters(): Map<string, string[]> {

--- a/web/projects/portal/src/app/widget/tree/tree-node.component.html
+++ b/web/projects/portal/src/app/widget/tree/tree-node.component.html
@@ -86,7 +86,7 @@
           ></span>
         }
       </span>
-      @if (hasMenu()) {
+      @if (hasMenu) {
         <i [attr.data-test]="nodeLabel + ' actions'"
           class="menu-horizontal-icon menu-trigger icon-size-small"
           title="_#(Actions)"

--- a/web/projects/portal/src/app/widget/tree/tree-node.component.ts
+++ b/web/projects/portal/src/app/widget/tree/tree-node.component.ts
@@ -99,6 +99,7 @@ export class TreeNodeComponent implements OnInit, OnDestroy, OnChanges {
    private timeOutEvent: any = 0;
    private subscription = Subscription.EMPTY;
    public inViewport = true;
+   public hasMenu = false;
 
    constructor(private dragService: DragService, private cdRef: ChangeDetectorRef) {
    }
@@ -124,6 +125,10 @@ export class TreeNodeComponent implements OnInit, OnDestroy, OnChanges {
    }
 
    ngOnChanges(changes: SimpleChanges) {
+      if(changes["node"] || changes["tree"] || changes["contextmenu"]) {
+         this.updateHasMenu();
+      }
+
       if(this.node && (changes["node"] || changes["tree"] || changes["dataSource"] ||
          changes["useVirtualScroll"]))
       {
@@ -653,9 +658,18 @@ export class TreeNodeComponent implements OnInit, OnDestroy, OnChanges {
       }
    }
 
-   hasMenu(): boolean {
-      return this.contextmenu && (!this.tree.hasMenuFunction ||
-                                  this.tree.hasMenuFunction(this.node))
-         && !GuiTool.isMobileDevice();
+   // Cached in ngOnChanges instead of being called from the template on every
+   // change-detection cycle, since hasMenuFunction(node) and isMobileDevice() are
+   // relatively expensive. This assumes hasMenuFunction's result for a node only
+   // changes when the node, tree or contextmenu input changes - which holds because
+   // all hasMenuFunction implementations are pure functions of the node, and the
+   // node object reference is replaced when its data changes. Note that [tree] is
+   // bound to the owning TreeComponent's stable "this" reference, so changes["tree"]
+   // only fires on first render; callers whose hasMenuFunction depends on state other
+   // than the node must replace the node object (or call updateHasMenu explicitly).
+   private updateHasMenu(): void {
+      this.hasMenu = !!this.contextmenu && !!this.node &&
+         (!this.tree || !this.tree.hasMenuFunction || this.tree.hasMenuFunction(this.node)) &&
+         !GuiTool.isMobileDevice();
    }
 }

--- a/web/projects/portal/src/app/widget/tree/tree-node.component.ts
+++ b/web/projects/portal/src/app/widget/tree/tree-node.component.ts
@@ -666,7 +666,9 @@ export class TreeNodeComponent implements OnInit, OnDestroy, OnChanges {
    // node object reference is replaced when its data changes. Note that [tree] is
    // bound to the owning TreeComponent's stable "this" reference, so changes["tree"]
    // only fires on first render; callers whose hasMenuFunction depends on state other
-   // than the node must replace the node object (or call updateHasMenu explicitly).
+   // than the node must replace the node object. Note that hasMenuFunction itself
+   // must not change dynamically after the tree is first bound, as changes["tree"]
+   // only fires on first render and the cache would not be refreshed.
    private updateHasMenu(): void {
       this.hasMenu = !!this.contextmenu && !!this.node &&
          (!this.tree || !this.tree.hasMenuFunction || this.tree.hasMenuFunction(this.node)) &&


### PR DESCRIPTION
## Summary

The "Maintenance Dashboard Static" viewsheet took 7s+ to load. CPU profiling of the attached Chrome trace showed the dominant main-thread cost was a single large change-detection pass, and the #1 identifiable component template was `TreeNodeComponent`'s `@if (hasMenu())` block (~1.1s, 12% of load).

## Root Cause

`TreeNodeComponent.hasMenu()` was bound directly in the template (`@if (hasMenu())`), so it re-evaluated on **every change-detection cycle, for every tree node**. Each call ran:
- `GuiTool.isMobileDevice()` — two very large user-agent regexes; the single largest JS leaf in the trace (~370ms).
- `tree.hasMenuFunction(node)` — builds an action list (`createActions`) just to decide whether a menu exists.

On a portal page that renders a large tree (refreshed several times during load), this multiplied into ~1.1s of pure overhead.

## Fix

- **Memoize `GuiTool.isMobileDevice()`**: the user agent is constant for a page session, so the result is cached in a static field instead of re-running the regexes on every call. Benefits all hot callers, not just the tree.
- **Cache `TreeNodeComponent.hasMenu`** as a field recomputed in `ngOnChanges` (on `node`/`tree`/`contextmenu` changes), following the established pattern from Bug #75363, instead of evaluating it from the template on every change-detection cycle.

## Test Plan

Verified with before/after Chrome CPU traces of the same viewsheet load:

| Metric | Before | After |
|---|---|---|
| Main-thread busy CPU | ~6,768 ms | ~2,844 ms (−58%) |
| `isMobileDevice` self-time | 372 ms | 0 ms |
| `@if (hasMenu())` block | 1,098 ms | 9.7 ms |
| `detectChangesInComponent` (incl.) | 3,747 ms | 1,902 ms |

- `ng build portal` (development) succeeds.
- `tree.spec.ts` passes.
- `eslint` clean on changed files.
- Behavior preserved: the menu icon still shows for the same nodes; added `!!node`/`tree` null-guards only harden edge cases.

Fixes Redmine #75497.