### PR TITLE
feat(wiz): support manualOrder in DimensionFieldInfo for SORT_SPECIFIC ordering

### DIFF
--- a/core/src/main/java/inetsoft/web/vswizard/recommender/chart/TreemapChartFilter.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/chart/TreemapChartFilter.java
@@ -72,7 +72,6 @@ public class TreemapChartFilter extends ChartTypeFilter {
       addTField(info, comb, refs);
       addColor(info, comb);
       addInsideField(info, comb, refs);
-
       return getClassyInfo(info);
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/model/DimensionFieldInfo.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/DimensionFieldInfo.java
@@ -19,6 +19,8 @@ package inetsoft.web.wiz.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import java.util.List;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DimensionFieldInfo extends SimpleFieldInfo {
    public String getDateGroupLevel() {
@@ -53,8 +55,17 @@ public class DimensionFieldInfo extends SimpleFieldInfo {
       this.timeSeries = timeSeries;
    }
 
+   public List<String> getManualOrder() {
+      return manualOrder;
+   }
+
+   public void setManualOrder(List<String> manualOrder) {
+      this.manualOrder = manualOrder;
+   }
+
    private String dateGroupLevel;
    private Ranking ranking;
    private String fullName;
    private boolean timeSeries = false;
+   private List<String> manualOrder;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -677,6 +677,12 @@ public class WizAutoBindingService {
          if(fc.getOrder() != null) {
             dim.setOrder(fc.getOrder());
          }
+
+         if(fc instanceof DimensionFieldInfo dimFc2 && dimFc2.getManualOrder() != null &&
+            !dimFc2.getManualOrder().isEmpty())
+         {
+            dim.setManualOrderList(new java.util.ArrayList<>(dimFc2.getManualOrder()));
+         }
       }
       else if(ref instanceof VSChartAggregateRef agg) {
          if(fc instanceof MeasureFieldInfo meaFc) {


### PR DESCRIPTION
## Summary

- Add `private List<String> manualOrder` (+ getter/setter) to `DimensionFieldInfo` so Jackson deserializes the field from the `/viewsheet/autoBinding` request body instead of silently dropping it (`@JsonIgnoreProperties(ignoreUnknown=true)` was swallowing it before).
- Wire `dim.setManualOrderList()` in `WizAutoBindingService` after `dim.setOrder()` — when `order=8` (SORT_SPECIFIC) and `manualOrder` is non-empty, the list is passed to `VSChartDimensionRef`, activating `ManualOrderComparer` for the funnel/bar/other chart.

## Test plan

- [ ] Create a funnel chart via the viz-chat plugin with `fieldConfigs: [{ fieldType: "dimension", field: "sales_stage", order: 8, manualOrder: ["Prospecting","Qualification","Needs Analysis",...,"Closed Won","Closed Lost"] }]`
- [ ] Verify chart stages render in the specified pipeline order, not alphabetically
- [ ] Verify no regression on charts without `manualOrder` (order=null or order=2 still sort normally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)