### PR TITLE
feat(wiz): write datasourceVersion to COMMON custom extension in getMetaData

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -129,8 +129,15 @@ public class MetadataApiService {
       dataset.setName(tableName);
       dataset.setSource(source);
       String datasourceType = SQLHelper.getProductName(jdbcDataSource);
-      SQLHelper sqlHelper = SQLHelper.getSQLHelper(jdbcDataSource, null, null);
-      String datasourceVersion = sqlHelper.getProductVersion();
+      String datasourceVersion = null;
+
+      try {
+         datasourceVersion = SQLHelper.getSQLHelper(jdbcDataSource).getProductVersion();
+      }
+      catch(Exception e) {
+         log.debug("Could not retrieve database product version for '{}': {}", dsName, e.getMessage());
+      }
+
       dataset.setCustomExtensions(List.of(buildDatasetExtension(dsName, catalog, schema, source, datasourceType, datasourceVersion)));
 
       Object synonyms = tableData.getAttribute("synonyms");

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -129,7 +129,9 @@ public class MetadataApiService {
       dataset.setName(tableName);
       dataset.setSource(source);
       String datasourceType = SQLHelper.getProductName(jdbcDataSource);
-      dataset.setCustomExtensions(List.of(buildDatasetExtension(dsName, catalog, schema, source, datasourceType)));
+      SQLHelper sqlHelper = SQLHelper.getSQLHelper(jdbcDataSource, null, null);
+      String datasourceVersion = sqlHelper.getProductVersion();
+      dataset.setCustomExtensions(List.of(buildDatasetExtension(dsName, catalog, schema, source, datasourceType, datasourceVersion)));
 
       Object synonyms = tableData.getAttribute("synonyms");
       boolean hasSynonyms = synonyms instanceof String s ? !s.isEmpty()
@@ -215,7 +217,8 @@ public class MetadataApiService {
 
    private OsiCustomExtension buildDatasetExtension(String dsName, String catalog,
                                                      String schema, String path,
-                                                     String datasourceType)
+                                                     String datasourceType,
+                                                     String datasourceVersion)
    {
       try {
          Map<String, Object> extData = new LinkedHashMap<>();
@@ -234,6 +237,10 @@ public class MetadataApiService {
 
          if(!Tool.isEmptyString(datasourceType)) {
             extData.put("datasourceType", datasourceType);
+         }
+
+         if(!Tool.isEmptyString(datasourceVersion)) {
+            extData.put("datasourceVersion", datasourceVersion);
          }
 
          OsiCustomExtension ext = new OsiCustomExtension();


### PR DESCRIPTION


Call SQLHelper.getSQLHelper() after obtaining datasourceType to retrieve the database product version, then pass it to buildDatasetExtension() which writes it as "datasourceVersion" in the COMMON JSON extension.

This allows the wiz-services layer to surface the database version via get_table_details, enabling LLMs to confirm version-specific SQL feature support before writing sqlExpression queries.