### PR TITLE
fix 75504: register crosstab wheel listener outside Angular zone

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-crosstab.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-crosstab.component.html
@@ -111,7 +111,7 @@
         [selectionBoxBannedSelector]="'input, .highlightable'"
         (onSelectionBox)="selectCells($event)"
         (mousedown)="onDown($event)"
-        (wheel)="wheelScrollHandler($event)">
+        outOfZone (onWheel)="wheelScrollHandler($event)">
         <div #leftTopDiv class="left-top-table"
           [style.left.px]="isFullHorizontalWrapper ? -scrollX : null">
           <table>


### PR DESCRIPTION
(wheel)="wheelScrollHandler($event)" used zone-patched addEventListener,
  causing every horizontal scroll event to trigger a global CD cycle.
  Changed to outOfZone (onWheel)="wheelScrollHandler($event)" to match
  the existing pattern used for vertical scroll.