### PR TITLE
fix(wiz): respect SORT_SPECIFIC (manual order) in funnel chart sort

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
@@ -1946,8 +1946,11 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
                   innerDim.getFullName().equals(refs[j].getFullName())))
                {
                   VSChartDimensionRef dim = (VSChartDimensionRef) refs[j];
-                  dim.setOrder(XConstants.SORT_VALUE_ASC);
-                  dim.setSortByColValue(sortBy);
+                  // respect explicit manual order (SORT_SPECIFIC) set by the caller
+                  if(dim.getOrder() != XConstants.SORT_SPECIFIC) {
+                     dim.setOrder(XConstants.SORT_VALUE_ASC);
+                     dim.setSortByColValue(sortBy);
+                  }
                   innerDim = dim;
                }
                /* sorting on aesthetics doesn't make much sense. the order for each bar

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -428,19 +428,21 @@ public class WizAutoBindingService {
    // ── Apply fieldConfigs to generated ChartRefs ────────────────────────────────
 
    private void applyFieldConfigs(VSChartInfo chartInfo, Map<String, SimpleFieldInfo> configMap) {
+      int chartType = chartInfo.getChartType();
+
       for(ChartRef ref : chartInfo.getXFields()) {
-         applyFieldConfig(ref, configMap);
+         applyFieldConfig(ref, configMap, chartType);
       }
 
       for(ChartRef ref : chartInfo.getYFields()) {
-         applyFieldConfig(ref, configMap);
+         applyFieldConfig(ref, configMap, chartType);
       }
 
       // Aesthetics carry the same per-field config (title/format, ranking/aggregate) as x/y.
-      applyAestheticFieldConfig(chartInfo.getColorField(), configMap);
-      applyAestheticFieldConfig(chartInfo.getShapeField(), configMap);
-      applyAestheticFieldConfig(chartInfo.getSizeField(), configMap);
-      applyAestheticFieldConfig(chartInfo.getTextField(), configMap);
+      applyAestheticFieldConfig(chartInfo.getColorField(), configMap, chartType);
+      applyAestheticFieldConfig(chartInfo.getShapeField(), configMap, chartType);
+      applyAestheticFieldConfig(chartInfo.getSizeField(), configMap, chartType);
+      applyAestheticFieldConfig(chartInfo.getTextField(), configMap, chartType);
    }
 
    /**
@@ -574,10 +576,10 @@ public class WizAutoBindingService {
    }
 
    private void applyAestheticFieldConfig(AestheticRef aestheticRef,
-                                          Map<String, SimpleFieldInfo> configMap)
+                                          Map<String, SimpleFieldInfo> configMap, int chartType)
    {
       if(aestheticRef != null && aestheticRef.getDataRef() instanceof ChartRef ref) {
-         applyFieldConfig(ref, configMap);
+         applyFieldConfig(ref, configMap, chartType);
       }
    }
 
@@ -639,7 +641,8 @@ public class WizAutoBindingService {
       }
    }
 
-   private void applyFieldConfig(ChartRef ref, Map<String, SimpleFieldInfo> configMap) {
+   private void applyFieldConfig(ChartRef ref, Map<String, SimpleFieldInfo> configMap,
+                                  int chartType) {
       String fieldName = WizardRecommenderUtil.getChartRefFieldName(ref);
       SimpleFieldInfo fc = configMap.get(fieldName);
 
@@ -681,7 +684,14 @@ public class WizAutoBindingService {
          if(fc instanceof DimensionFieldInfo dimFc2 && dimFc2.getManualOrder() != null &&
             !dimFc2.getManualOrder().isEmpty())
          {
-            dim.setManualOrderList(new java.util.ArrayList<>(dimFc2.getManualOrder()));
+            java.util.List<String> orderedList =
+               new java.util.ArrayList<>(dimFc2.getManualOrder());
+            // Funnel Y-axis is inverted (index 0 renders at bottom, last at top).
+            // Reverse so the caller's intuitive top→bottom list displays correctly.
+            if(GraphTypes.isFunnel(chartType)) {
+               java.util.Collections.reverse(orderedList);
+            }
+            dim.setManualOrderList(orderedList);
          }
       }
       else if(ref instanceof VSChartAggregateRef agg) {


### PR DESCRIPTION
## Summary

Two-part fix for \`manualOrder\` not being honored on funnel charts:

**1. \`ChartVSAQuery.applyFunnelSort()\`** — unconditionally forced \`SORT_VALUE_ASC\` on all funnel dimensions, silently discarding any user-set sort order including \`SORT_SPECIFIC\` (order=8). Fix: skip the override when the dimension already has \`SORT_SPECIFIC\` set.

**2. \`WizAutoBindingService.applyFieldConfig()\`** — funnel Y-axis is inverted (index 0 renders at bottom, last index at top), so a caller's intuitive top→bottom \`manualOrder\` list displayed reversed. Fix: auto-reverse the list for funnel charts so the user's specified order matches the visual display.

Together these allow \`create_viewsheet\` with \`order=8\` + \`manualOrder\` to render a funnel chart in the exact top-to-bottom stage sequence specified.

## Test plan

- [ ] Create a funnel chart with \`fieldConfigs\` including \`order: 8\` and \`manualOrder: [\"Prospecting\", \"Qualification\", \"Needs Analysis\", ...]\` — verify stages render top-to-bottom in that pipeline order
- [ ] Create a funnel chart without explicit order → verify default value-sort (largest bar at top) still applies (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)