### PR TITLE
Bug #75501, restore thread interrupted flag in ScheduleStatusDao

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleStatusDao.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleStatusDao.java
@@ -100,6 +100,10 @@ public class ScheduleStatusDao implements AutoCloseable {
       try {
          storage.put(encodedTaskName, newStatus).get(10L, TimeUnit.SECONDS);
       }
+      catch(InterruptedException ex) {
+         Thread.currentThread().interrupt();
+         LOG.error("Failed to put schedule status {} for {}", status, taskName);
+      }
       catch(Exception ex) {
          LOG.error("Failed to put schedule status {} for {}", status, taskName);
       }
@@ -119,7 +123,11 @@ public class ScheduleStatusDao implements AutoCloseable {
       try {
          storage.remove(encodedTaskName).get(10L, TimeUnit.SECONDS);
       }
-      catch(InterruptedException | ExecutionException | TimeoutException e) {
+      catch(InterruptedException e) {
+         Thread.currentThread().interrupt();
+         LOG.error("Failed to clear status for task: {}", taskName, e);
+      }
+      catch(ExecutionException | TimeoutException e) {
          LOG.error("Failed to clear status for task: {}", taskName, e);
       }
    }

--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleStatusDao.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleStatusDao.java
@@ -102,7 +102,7 @@ public class ScheduleStatusDao implements AutoCloseable {
       }
       catch(InterruptedException ex) {
          Thread.currentThread().interrupt();
-         LOG.error("Failed to put schedule status {} for {}", status, taskName);
+         LOG.error("Failed to put schedule status {} for {}", status, taskName, ex);
       }
       catch(Exception ex) {
          LOG.error("Failed to put schedule status {} for {}", status, taskName);


### PR DESCRIPTION
## Summary

`ScheduleStatusDao` was silently swallowing `InterruptedException` in two methods without restoring the thread's interrupted flag, violating the Java interrupt protocol.

## Root Cause

When `Future.get(timeout, unit)` throws `InterruptedException`, the JVM clears the calling thread's interrupted flag as part of throwing the exception. Both affected methods caught the exception but never called `Thread.currentThread().interrupt()` to restore it:

- **`setStatus()`**: Used a broad `catch(Exception ex)` that silently consumed `InterruptedException` with no flag restoration.
- **`clearStatus()`**: Explicitly named `InterruptedException` in a multi-catch but still omitted the flag restoration.

This matters on Quartz worker threads, which can be interrupted by Quartz's thread pool during scheduler shutdown. Losing the interrupted flag prevents upstream shutdown machinery from detecting that the thread was interrupted, potentially delaying graceful shutdown.

## Fix

In `setStatus()`, added a dedicated `catch(InterruptedException)` block before the broad `catch(Exception)` that calls `Thread.currentThread().interrupt()` before logging.

In `clearStatus()`, extracted `InterruptedException` from the multi-catch into its own block with the same flag restoration. `ExecutionException | TimeoutException` remain combined with identical logging behavior.

## Test Plan

- Build `inetsoft-core` module: passes
- Run `inetsoft-core` test suite (2547 tests): passes

Fixes Redmine #75501.