### PR TITLE
Bug #75502, preserve vault secretId/useCredential when saving schedule task server paths

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/ServerPathInfo.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ServerPathInfo.java
@@ -77,6 +77,7 @@ public class ServerPathInfo implements Cloneable, Serializable, HttpXMLSerializa
 
    public void setUseCredential(boolean useCredential) {
       this.useCredential = useCredential;
+      checkFTP();
    }
 
    public String getSecretId() {
@@ -85,6 +86,7 @@ public class ServerPathInfo implements Cloneable, Serializable, HttpXMLSerializa
 
    public void setSecretId(String secretId) {
       this.secretId = secretId;
+      checkFTP();
    }
 
    public String getUsername() {

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
@@ -1286,7 +1286,12 @@ public class ScheduleService {
                   }
 
                   if(pModel.ftp()) {
-                     info = new ServerPathInfo(pModel.path(), pModel.username(), password);
+                     if(pModel.useCredential()) {
+                        info = new ServerPathInfo(pModel);
+                     }
+                     else {
+                        info = new ServerPathInfo(pModel.path(), pModel.username(), password);
+                     }
                   }
                   else {
                      info = new ServerPathInfo(pModel.path(), null, null);


### PR DESCRIPTION
## Summary

- `ScheduleService` was reconstructing `ServerPathInfo` from `ServerPathInfoModel` using only `path`, `username`, and `password`, silently discarding `useCredential` and `secretId` for FTP vault-credential paths.
- `ServerPathInfo.setUseCredential()` and `setSecretId()` did not call `checkFTP()`, leaving `isFTP()` returning `false` when credentials were set via setters after construction.

## Root Cause

In `ScheduleService.getViewsheetActionModel`, the FTP branch always used `new ServerPathInfo(path, username, password)` regardless of whether the path used vault credentials (`useCredential=true`). The `ServerPathInfoModel` constructor that correctly copies `useCredential` and `secretId` was not used.

Additionally, `setSecretId()` and `setUseCredential()` in `ServerPathInfo` did not call `checkFTP()`, inconsistent with every other field-mutating setter in the class (`setPath`, `setUsername`, `setPassword` all call `checkFTP()`).

## Fix

- `ScheduleService`: check `pModel.useCredential()` and use `new ServerPathInfo(pModel)` for vault paths; non-vault FTP and non-FTP paths are unchanged.
- `ServerPathInfo`: `setUseCredential()` and `setSecretId()` now call `checkFTP()`, consistent with all other setters.

## Test Plan

- [ ] Create a schedule task with a Viewsheet action, Save to Server enabled, FTP path, and Use Secret ID set with a valid Secret ID.
- [ ] Save the task and re-open it — verify Secret ID and FTP configuration are preserved.
- [ ] Run the task — verify the file is uploaded via FTP using the vault credential.
- [ ] Verify non-vault FTP paths (username/password) still work correctly after save/reload.
- [ ] Verify non-FTP server paths still work correctly.

Fixes Redmine #75502.