### PR TITLE
Bug #75503, override trackByIdx in VSSelection to use stable value key

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.spec.ts
@@ -18,10 +18,13 @@
 import { VSSelection } from "./vs-selection.component";
 
 // trackByIdx is a pure method — test it directly on the prototype.
+// NOTE: This assumes trackByIdx does not access `this`. If that ever changes,
+// migrate these tests to a TestBed fixture (otherwise they pass against a
+// broken implementation because `this` is bound to {}).
 const trackByIdx = VSSelection.prototype.trackByIdx.bind({});
 
 describe("VSSelection.trackByIdx", () => {
-   describe("performance - CD count", () => {
+   describe("stable tracking keys", () => {
       it("should return a stable value key for a SelectionValueModel item", () => {
          const item = { value: "California", label: "California", state: 1 };
          expect(trackByIdx(0, item)).toBe("California");
@@ -58,6 +61,10 @@ describe("VSSelection.trackByIdx", () => {
 
       it("should fall back to index for array row whose first element is null", () => {
          expect(trackByIdx(3, [null])).toBe(3);
+      });
+
+      it("should fall back to index for array row whose first element has null value property", () => {
+         expect(trackByIdx(5, [{ value: null, label: "Something" }])).toBe(5);
       });
 
       it("should fall back to index for item with null value property", () => {

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.spec.ts
@@ -1,0 +1,77 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program, if not, see <https://www.gnu.org/licenses/>.
+ */
+import { VSSelection } from "./vs-selection.component";
+
+// trackByIdx is a pure method — test it directly on the prototype.
+const trackByIdx = VSSelection.prototype.trackByIdx.bind({});
+
+describe("VSSelection.trackByIdx", () => {
+   describe("performance - CD count", () => {
+      it("should return a stable value key for a SelectionValueModel item", () => {
+         const item = { value: "California", label: "California", state: 1 };
+         expect(trackByIdx(0, item)).toBe("California");
+         expect(trackByIdx(3, item)).toBe("California");
+      });
+
+      it("should return the same key regardless of position index", () => {
+         const item = { value: "East", label: "East", state: 2 };
+         const key0 = trackByIdx(0, item);
+         const key7 = trackByIdx(7, item);
+         expect(key0).toBe(key7);
+      });
+
+      it("should use item[0].value for an array row (outer loop)", () => {
+         const row = [
+            { value: "North", label: "North", state: 0 },
+            { value: "South", label: "South", state: 0 },
+         ];
+         expect(trackByIdx(0, row)).toBe("North");
+         expect(trackByIdx(5, row)).toBe("North");
+      });
+
+      it("should fall back to index for null item", () => {
+         expect(trackByIdx(4, null)).toBe(4);
+      });
+
+      it("should fall back to index for undefined item", () => {
+         expect(trackByIdx(2, undefined)).toBe(2);
+      });
+
+      it("should fall back to index for item with no value property", () => {
+         expect(trackByIdx(1, {})).toBe(1);
+      });
+
+      it("should fall back to index for array row whose first element is null", () => {
+         expect(trackByIdx(3, [null])).toBe(3);
+      });
+
+      it("should fall back to index for item with null value property", () => {
+         expect(trackByIdx(2, { value: null, label: "Something" })).toBe(2);
+      });
+
+      it("should return empty string as the key when value is empty string", () => {
+         expect(trackByIdx(0, { value: "", label: "Blank" })).toBe("");
+      });
+
+      it("should return different keys for items with different values", () => {
+         const itemA = { value: "Alpha", label: "Alpha", state: 0 };
+         const itemB = { value: "Beta", label: "Beta", state: 0 };
+         expect(trackByIdx(0, itemA)).not.toBe(trackByIdx(0, itemB));
+      });
+   });
+});

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
@@ -1586,6 +1586,14 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
       this.updateSelectionValues();
    }
 
+   public override trackByIdx(index: number, item: any): any {
+      if(Array.isArray(item)) {
+         return item[0]?.value ?? index;
+      }
+
+      return item?.value ?? index;
+   }
+
    // force selected status to be updated in cells
    private selectedCellsChanged() {
       this.selectedCells = Tool.clone(this.selectedCells);

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
@@ -1586,6 +1586,10 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
       this.updateSelectionValues();
    }
 
+   // Returns a stable key per row/item so Angular's @for reconciler avoids
+   // re-rendering unchanged cells. For array rows the first item's value is the
+   // key; this assumes selectionValues has no duplicate value strings (true for
+   // well-formed dimension data). Falls back to index when value is null/undefined.
    public override trackByIdx(index: number, item: any): any {
       if(Array.isArray(item)) {
          return item[0]?.value ?? index;


### PR DESCRIPTION
## Summary

\`AbstractVSObject.trackByIdx\` always returns the position index. \`VSSelection\` uses it as the track expression for its nested \`@for\` loops that render \`SelectionListCell\` components. Because the track key is just a position, Angular cannot distinguish a reordered item from a new item — it discards and rebuilds all DOM nodes on every sort or association-filter reorder, re-delivering \`[selectionValue]\` inputs to all visible cells (up to 500) even when the underlying data has not changed.

## Root Cause

\`AbstractVSObject.trackByIdx\` (\`abstract-vsobject.component.ts:189\`) unconditionally returns \`index\`. The two \`@for\` loops in \`vs-selection.component.html\` (one over \`SelectionValueModel[][]\` rows, one over \`SelectionValueModel\` cells within each row) both use this as their track expression. Angular's identity-by-position strategy forces O(N) \`@Input\` re-delivery and \`ngOnChanges\` invocations on every reorder. Since \`SelectionListCell\` has no \`OnPush\`, each delivery triggers a full subtree check.

## Fix

Override \`trackByIdx\` in \`VSSelection\` to return \`SelectionValueModel.value\` (the unique data value string) for leaf items and \`row[0].value\` for multi-column row arrays. Falls back to \`index\` when the value is absent or null (e.g. trailing partial rows in multi-column layout, or server-serialized \`null\` values). With a stable key, Angular moves existing DOM nodes to their new positions instead of rebuilding them, reducing \`@Input\` re-delivery from O(N) to O(changed_count).

A new spec file (\`vs-selection.component.spec.ts\`) covers 10 cases: stable key return, position-independence, array-row branch, null/undefined/no-value fallbacks, null-value-property fallback, empty-string key, and key distinctness.

## Test Plan

- All 1129 portal unit tests pass including the 10 new \`trackByIdx\` cases
- Frontend lint passes clean
- Reproduce the bug by opening a viewsheet with a selection list, making a selection (which reorders values by association state), and observing — before the fix — that all cells re-render; after the fix, only changed cells re-render

Fixes Redmine #75503.