### PR TITLE
75510, docker container not starting

### DIFF
--- a/core/src/main/java/inetsoft/setup/StorageInitializer.java
+++ b/core/src/main/java/inetsoft/setup/StorageInitializer.java
@@ -413,7 +413,7 @@ public class StorageInitializer implements Callable<Integer> {
       }
    }
 
-   @Configuration
+   @Configuration(proxyBeanMethods = false)
    private static class ClusterConfig {
       @Bean
       public InetsoftConfig inetsoftConfig() {


### PR DESCRIPTION
 What was happening: Spring's ConfigurationClassPostProcessor enhances every @Configuration class with a CGLIB subclass (so @Bean methods can be intercepted for singleton caching when one bean
  method calls another). CGLIB subclassing requires a non-private constructor. ClusterConfig is private static, so its compiler-generated default constructor inherits private access → No visible
  constructors → BeanDefinitionStoreException.

  Why proxyBeanMethods = false is the right fix here: CGLIB enhancement only buys you anything when a @Bean method calls another @Bean method directly (so the call returns the cached singleton
  instead of a fresh instance). None of these four methods do that — each takes its dependency (InetsoftConfig, SecretsConfig) as a parameter, which Spring injects. So disabling proxying changes
  no behavior and sidesteps CGLIB entirely. It's also exactly what the error message recommends.

  The alternative — bumping ClusterConfig to package-private/public to expose a visible constructor — would also work, but it's an unnecessary visibility leak when the class genuinely doesn't
  need bean-method proxying.