### PR TITLE
fix(wiz): geo conversion produces one choropleth, not a map per region

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
@@ -40,6 +40,7 @@ import inetsoft.uql.viewsheet.graph.GeoRef;
 import inetsoft.uql.viewsheet.graph.GeographicOption;
 import inetsoft.uql.viewsheet.graph.GraphTypes;
 import inetsoft.uql.viewsheet.graph.VSAestheticRef;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
 import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
 import inetsoft.uql.viewsheet.graph.VSChartGeoRef;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
@@ -340,6 +341,20 @@ public class WizGeoService {
          mapInfo.setColorField(color);
       }
 
+      // No category dimension to color by → shade the choropleth by the MEASURE instead (mirrors
+      // MapChartFilter.putInside: on a polygon map the aggregate drives the fill color). Move the
+      // first aggregate left on an axis onto color so the regions reflect the value (e.g. account
+      // count per state) instead of rendering a single flat shade.
+      if(mapInfo.getColorField() == null && !hasPointField(mapInfo)) {
+         VSChartAggregateRef measure = takeFirstAxisAggregate(mapInfo);
+
+         if(measure != null) {
+            VSAestheticRef color = new VSAestheticRef();
+            color.setDataRef(measure);
+            mapInfo.setColorField(color);
+         }
+      }
+
       // Render filled polygons (a choropleth) rather than point markers: with no point-layer geo
       // field and no size field, set a NIL static shape frame so the regions fill instead of
       // drawing a shape at each centroid. Mirrors MapChartFilter.createChartInfo.
@@ -385,8 +400,12 @@ public class WizGeoService {
       for(int i = fields.length - 1; i >= 0; i--) {
          ChartRef ref = fields[i];
 
-         if(ref instanceof XDimensionRef && !geoColumn.equals(ref.getName())) {
-            if(category == null) {
+         if(ref instanceof XDimensionRef) {
+            // A non-geo dimension becomes the fill-color category. The geo column itself must ALSO be
+            // removed from the axis — otherwise it both draws the polygons (as the geo field) and
+            // facets the map into one panel per value (the small-multiples bug). Only the
+            // category-assignment is guarded by name; the axis removal applies to both.
+            if(!geoColumn.equals(ref.getName()) && category == null) {
                category = ref;
             }
 
@@ -399,6 +418,29 @@ public class WizGeoService {
       }
 
       return category;
+   }
+
+   /** Removes and returns the first aggregate (measure) found on the X or Y axis, or null. */
+   private VSChartAggregateRef takeFirstAxisAggregate(VSMapInfo mapInfo) {
+      ChartRef[] xfields = mapInfo.getXFields();
+
+      for(int i = xfields.length - 1; i >= 0; i--) {
+         if(xfields[i] instanceof VSChartAggregateRef agg) {
+            mapInfo.removeXField(i);
+            return agg;
+         }
+      }
+
+      ChartRef[] yfields = mapInfo.getYFields();
+
+      for(int i = yfields.length - 1; i >= 0; i--) {
+         if(yfields[i] instanceof VSChartAggregateRef agg) {
+            mapInfo.removeYField(i);
+            return agg;
+         }
+      }
+
+      return null;
    }
 
    private RuntimeViewsheet getRuntimeViewsheet(String runtimeId, Principal user) throws Exception {


### PR DESCRIPTION
## Summary

`WizGeoService.fixMapBinding` (the create_viewsheet → geo_detect map conversion) had two defects that turned an "accounts by US state" request into **49 small-multiple maps, one per state**, instead of one choropleth.

### 1. Faceting (the visible bug)
`stripNonGeoDims` removed axis dimensions but guarded with `&& !geoColumn.equals(ref.getName())`, which **skipped removing the geo column itself**. So when the geo column sat on an axis (e.g. `billing_address_state` on Y after the bar fallback), it stayed on Y *and* `addGeoField()` added it as the geo shape → the column both drew the polygons and faceted the chart into one panel per value.

**Fix:** always strip the geo column from x/y/group; keep the name guard only on the *color-category* assignment.

### 2. No shading
The measure was never moved to color, so a measure choropleth (count per state) rendered with a flat fill.

**Fix:** new `takeFirstAxisAggregate()` + a measure→color fallback mirroring `MapChartFilter.putInside` (on a polygon map the aggregate drives the fill), applied when there's no category dimension and no point field.

## Verification

Built image local946; live on suitecrm `accounts.billing_address_state`: **one US choropleth, 43 states shaded by account count** (6 territories dropped) — previously 49 facet panels.

## Notes

`fixMapBinding` is private and exercises the full VSMapInfo/ChangeChartTypeProcessor pipeline, so it isn't unit-testable without SreeHome; verified via the live create→geo_detect→geo_apply workflow. Compiles clean (`mvn -pl community/core compile`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)