### PR TITLE
fix(wiz): set_chart_format chart title + persist format/color edits on save

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
@@ -38,6 +38,11 @@ public class ChartFormatRequest {
    public String getViewsheetIdentifier() { return viewsheetIdentifier; }
    public void setViewsheetIdentifier(String viewsheetIdentifier) { this.viewsheetIdentifier = viewsheetIdentifier; }
 
+   /** The chart's overall (assembly-level) title — the heading shown above the plot; null = no change. */
+   @JsonProperty("chartTitle")
+   public String getChartTitle() { return chartTitle; }
+   public void setChartTitle(String chartTitle) { this.chartTitle = chartTitle; }
+
    @JsonProperty("xAxisTitle")
    public String getXAxisTitle() { return xAxisTitle; }
    public void setXAxisTitle(String xAxisTitle) { this.xAxisTitle = xAxisTitle; }
@@ -88,6 +93,7 @@ public class ChartFormatRequest {
    /** Optional — carried back on the result so a subsequent save keeps the same identifier. */
    private String viewsheetIdentifier;
 
+   private String chartTitle;
    private String xAxisTitle;
    private String yAxisTitle;
    private Double yAxisMin;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -25,6 +25,7 @@ import inetsoft.uql.asset.*;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
 import inetsoft.uql.viewsheet.graph.*;
 import inetsoft.graph.aesthetic.*;
 import inetsoft.uql.viewsheet.graph.aesthetic.ColorPalettes;
@@ -2014,6 +2015,16 @@ public class WizAutoBindingService {
       ChartDescriptor desc = info.getChartDescriptor();
       VSChartInfo vsChartInfo = info.getVSChartInfo();
 
+      // Chart (assembly-level) title — the heading shown above the plot. Setting a value also makes
+      // the title visible, so a chart that defaulted to the generic "Chart" heading shows the
+      // caller's text instead.
+      if(request.getChartTitle() != null &&
+         chart.getVSAssemblyInfo() instanceof ChartVSAssemblyInfo cinfo)
+      {
+         cinfo.setTitleValue(request.getChartTitle());
+         cinfo.setTitleVisible(true);
+      }
+
       // Axis titles
       if(desc != null && desc.getTitlesDescriptor() != null) {
          TitlesDescriptor titles = desc.getTitlesDescriptor();
@@ -2101,6 +2112,14 @@ public class WizAutoBindingService {
       // above. Clear the cached graph explicitly — mirroring VSChartDataHandler — or every
       // subsequent render (including brand-new embed connections) serves the stale graph.
       rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(request.getAssemblyName()));
+
+      // Commit the in-place mutation to the backing asset. save_viewsheet clones the assembly from
+      // the PERSISTED viewsheet (not this live runtime), so a format/color change left only on the
+      // runtime — the chart title above the plot in particular — is silently dropped on save.
+      // Mirrors how create/changeType call persistViewsheet so their changes survive a save.
+      if(request.getViewsheetIdentifier() != null) {
+         wizVsService.persistViewsheet(rvs.getViewsheet(), request.getViewsheetIdentifier(), user);
+      }
 
       CreateViewsheetResult result =
          wizVsService.fetchAssemblyData(request.getWizRuntimeId(), request.getAssemblyName(), user);
@@ -2196,6 +2215,14 @@ public class WizAutoBindingService {
       // above. Clear the cached graph explicitly — mirroring VSChartDataHandler — or every
       // subsequent render (including brand-new embed connections) serves the stale graph.
       rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(request.getAssemblyName()));
+
+      // Commit the in-place mutation to the backing asset. save_viewsheet clones the assembly from
+      // the PERSISTED viewsheet (not this live runtime), so a format/color change left only on the
+      // runtime — the chart title above the plot in particular — is silently dropped on save.
+      // Mirrors how create/changeType call persistViewsheet so their changes survive a save.
+      if(request.getViewsheetIdentifier() != null) {
+         wizVsService.persistViewsheet(rvs.getViewsheet(), request.getViewsheetIdentifier(), user);
+      }
 
       CreateViewsheetResult result =
          wizVsService.fetchAssemblyData(request.getWizRuntimeId(), request.getAssemblyName(), user);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1343,8 +1343,13 @@ public class WizVsService {
     * @return the {@link AssetEntry#toIdentifier() identifier} of the saved entry
     *
     * @throws Exception if the entry identifier is invalid or the repository save fails
+    *
+    * <p>Public so the in-place chart edits in {@link WizAutoBindingService} (set chart format /
+    * colors) can commit their runtime mutation to the backing asset — {@code save_viewsheet}
+    * reads the PERSISTED viewsheet, so an unpersisted runtime change (e.g. the chart title) is
+    * otherwise silently dropped on save.
     */
-   private String persistViewsheet(Viewsheet vs, String existingIdentifier, Principal user)
+   public String persistViewsheet(Viewsheet vs, String existingIdentifier, Principal user)
       throws Exception
    {
       final AssetEntry entry;

--- a/core/src/test/java/inetsoft/web/wiz/model/ChartFormatRequestTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/ChartFormatRequestTest.java
@@ -41,13 +41,14 @@ class ChartFormatRequestTest {
       ChartFormatRequest req = mapper.readValue(
          """
          { "wizRuntimeId": "rt-1", "assemblyName": "Chart1",
-           "xAxisTitle": "Gross", "yAxisTitle": "Actor",
+           "chartTitle": "Contacts per Account", "xAxisTitle": "Gross", "yAxisTitle": "Actor",
            "yAxisMin": 0.5, "yAxisMax": 100.0, "yAxisIncrement": 10.0,
            "yAxisLogarithmic": true, "legendPosition": "top" }
          """,
          ChartFormatRequest.class);
 
       assertEquals("rt-1", req.getWizRuntimeId());
+      assertEquals("Contacts per Account", req.getChartTitle());
       assertEquals("Gross", req.getXAxisTitle());
       assertEquals("Actor", req.getYAxisTitle());
       assertEquals(0.5, req.getYAxisMin());

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.web.wiz.model.ChartFormatRequest;
+import inetsoft.web.wiz.model.CreateViewsheetResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * setChartFormat mutates the live runtime chart in place. save_viewsheet clones the assembly from
+ * the PERSISTED viewsheet (assetRepository.getSheet), NOT this runtime — so a format change left
+ * only on the runtime (the chart title above the plot in particular) is silently dropped on save.
+ * The service MUST commit the mutation back to the backing asset via persistViewsheet.
+ * Regression test for the live "title still shows 'Chart' after set + save" bug (2026-06-25).
+ */
+@Tag("core")
+class WizAutoBindingServiceSetChartFormatTest {
+   private WizAutoBindingService service;
+   private WizVsService wizVsService;
+   private Viewsheet vs;
+   private ChartVSAssemblyInfo info;
+   private ViewsheetSandbox box;
+
+   @BeforeEach
+   void setUp() throws Exception {
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      wizVsService = mock(WizVsService.class);
+      // collaborators not used by setChartFormat; their classes can't be initialized in a plain
+      // unit-test environment (no Spring context), so pass null instead of mocks.
+      service = new WizAutoBindingService(
+         viewsheetService, null, null, null, null, wizVsService);
+
+      // getChartInfo() and getVSAssemblyInfo() both return the ChartVSAssemblyInfo for a chart;
+      // one mock backs both. A title-only request leaves the descriptor null, so every axis/
+      // scale/legend/marker block is guarded out.
+      info = mock(ChartVSAssemblyInfo.class);
+      when(info.getChartDescriptor()).thenReturn(null);
+      when(info.getVSChartInfo()).thenReturn(null);
+
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getChartInfo()).thenReturn(info);
+      when(chart.getVSAssemblyInfo()).thenReturn(info);
+
+      vs = mock(Viewsheet.class);
+      when(vs.getAssembly("vs_1")).thenReturn(chart);
+
+      box = mock(ViewsheetSandbox.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+      when(viewsheetService.getViewsheet(anyString(), any())).thenReturn(rvs);
+      when(wizVsService.fetchAssemblyData(anyString(), anyString(), any()))
+         .thenReturn(new CreateViewsheetResult());
+   }
+
+   private static ChartFormatRequest titleRequest(String identifier) {
+      ChartFormatRequest request = new ChartFormatRequest();
+      request.setWizRuntimeId("rt-1");
+      request.setAssemblyName("vs_1");
+      request.setChartTitle("Contacts per Account");
+      request.setViewsheetIdentifier(identifier);
+      return request;
+   }
+
+   @Test
+   void chartTitleIsAppliedAndMadeVisible() throws Exception {
+      service.setChartFormat(titleRequest("visualizations-xyz"), null);
+
+      verify(info).setTitleValue("Contacts per Account");
+      verify(info).setTitleVisible(true);
+   }
+
+   @Test
+   void chartTitleIsPersistedToTheBackingAssetSoSaveKeepsIt() throws Exception {
+      // The crux: without this persist, save_viewsheet reads the stored asset (title "Chart") and
+      // the runtime title is lost. Must write the runtime viewsheet back to its identifier.
+      service.setChartFormat(titleRequest("visualizations-xyz"), null);
+
+      verify(wizVsService).persistViewsheet(same(vs), eq("visualizations-xyz"), isNull());
+   }
+
+   @Test
+   void noPersistWhenThereIsNoBackingIdentifier() throws Exception {
+      // With no identifier there is no managed asset to update; persisting would mint a stray new
+      // asset. The title still applies to the runtime; we just must not persist blindly.
+      service.setChartFormat(titleRequest(null), null);
+
+      verify(info).setTitleValue("Contacts per Account");
+      verify(wizVsService, never()).persistViewsheet(any(), any(), any());
+   }
+}


### PR DESCRIPTION
## Problem
Setting a chart title via `set_chart_format` had no effect after save: the live viewer kept showing the default **"Chart"** heading.

Two layers were missing in core:
1. The `/api/wiz/viewsheet/format` endpoint had no way to set the assembly-level chart title (the heading above the plot).
2. More importantly, **`set_chart_format`/`set_chart_colors` mutate only the in-memory runtime** and never persist. `save_viewsheet` clones the assembly from the **persisted** viewsheet (`assetRepository.getSheet`), so any format/color edit was silently dropped on save — the saved (and reopened) chart reverted to defaults.

## Fix
- **`ChartFormatRequest`**: add `chartTitle` (with `@JsonProperty` so it binds).
- **`WizAutoBindingService.setChartFormat`**: apply `chartTitle` via `ChartVSAssemblyInfo.setTitleValue` + `setTitleVisible(true)`.
- **Persist**: `setChartFormat` and `setChartColors` now call `wizVsService.persistViewsheet(rvs.getViewsheet(), request.getViewsheetIdentifier(), user)` after the in-place mutation (guarded on a non-null identifier) — mirroring how `create`/`changeType` persist so their changes survive a save. `persistViewsheet` made public for this.

## Tests
- **`WizAutoBindingServiceSetChartFormatTest`** (new): title is applied + made visible; `persistViewsheet` is invoked with the runtime viewsheet + identifier; and is **not** invoked when there is no backing identifier.
- **`ChartFormatRequestTest`**: lock `chartTitle` into the wire-contract deserialization case.

## Verification
Verified end-to-end on a local build: after `set_chart_format` the backing asset's `titleInfo` shows the real title, and after `save_viewsheet` the saved asset carries `titleValue="<title>"` / `titleVisible=true` (previously stuck at `Chart`). 3/3 new unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)