### PR TITLE
Bug #75511, move chart resize listeners outside Angular Zone

### DIFF
--- a/web/projects/portal/src/app/graph/objects/chart-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-area.component.ts
@@ -21,6 +21,7 @@ import {
    ElementRef,
    EventEmitter,
    Input,
+   NgZone,
    OnChanges,
    OnDestroy, OnInit,
    Output,
@@ -325,7 +326,8 @@ export class ChartArea implements OnInit, OnChanges, OnDestroy {
                private scaleService: ScaleService,
                private changeDetectorRef: ChangeDetectorRef,
                private pagingControlService: PagingControlService,
-               protected renderer: Renderer2)
+               protected renderer: Renderer2,
+               private ngZone: NgZone)
    {
    }
 
@@ -349,10 +351,12 @@ export class ChartArea implements OnInit, OnChanges, OnDestroy {
    }
 
    ngOnInit() {
-      window.addEventListener("resize", this.onResize);
+      this.ngZone.runOutsideAngular(() => {
+         window.addEventListener("resize", this.onResize);
 
-      this.devicePixelRatioMedia = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
-      this.devicePixelRatioMedia.addEventListener("change", this.onDevicePixelRatioChange);
+         this.devicePixelRatioMedia = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+         this.devicePixelRatioMedia.addEventListener("change", this.onDevicePixelRatioChange);
+      });
    }
 
    private onResize = (): void => {

--- a/web/projects/portal/src/app/graph/objects/chart-object-area-base.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-object-area-base.ts
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { AfterViewInit, ElementRef, HostBinding, Input, OnDestroy, ViewChild, Directive } from "@angular/core";
+import { AfterViewInit, Directive, ElementRef, HostBinding, inject, Input, NgZone, OnDestroy, ViewChild } from "@angular/core";
 import { SafeStyle } from "@angular/platform-browser";
 import { fromEvent, Subscription } from "rxjs";
 import { GuiTool } from "../../common/util/gui-tool";
@@ -125,10 +125,11 @@ export abstract class ChartObjectAreaBase<T extends ChartObject>
          scaleService.getScale().subscribe((scale) => this.viewsheetScale = scale)
       );
 
-      this.addSubscription(fromEvent(window, "resize")
-         .subscribe((event) => this.drawSelectedRegions())
-
-      );
+      inject(NgZone).runOutsideAngular(() => {
+         this.addSubscription(fromEvent(window, "resize")
+            .subscribe(() => this.drawSelectedRegions())
+         );
+      });
    }
 
    ngAfterViewInit() {


### PR DESCRIPTION
## Summary

- `ChartObjectAreaBase`: wraps `fromEvent(window, "resize")` subscription in `NgZone.runOutsideAngular()` using the `inject(NgZone)` API, eliminating per-instance in-zone resize callbacks that each triggered a global change-detection cycle. Uses `inject()` in the constructor body to avoid modifying any of the 5 subclass constructor signatures.
- `ChartArea`: wraps both `window.addEventListener("resize", ...)` and `devicePixelRatioMedia.addEventListener("change", ...)` registrations in `this.ngZone.runOutsideAngular()`. The handlers already call `changeDetectorRef.detectChanges()` explicitly, so component updates are unaffected.

With a complex chart (≈14 `ChartObjectAreaBase` instances) and 10 charts on a dashboard, the previous code fired ≈140 in-zone callbacks per resize event, each independently scheduling a global CD pass. The fix reduces this to zero Zone-triggered CD passes on resize.

## Test plan

- [ ] Build passes: `npm run build` in `web/` with no TypeScript errors
- [ ] Open a dashboard with multiple charts; apply a selection on one chart; resize the browser window — selection overlays remain correctly positioned after resize
- [ ] Scrollbar width recalculates correctly on resize (chart plot area scrollbar renders at correct width)
- [ ] No `ExpressionChangedAfterItHasBeenCheckedError` in the browser console after resize
- [ ] Chrome DevTools Performance trace: resize events produce no `ApplicationRef.tick` spikes attributable to these listeners

🤖 Generated with [Claude Code](https://claude.com/claude-code)