### PR TITLE
fix(wiz): use RSA verifier for SSO callback JWT signature check

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizAuthCallbackController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizAuthCallbackController.java
@@ -31,6 +31,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.security.KeyPair;
+import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.util.*;
 import java.util.concurrent.*;
@@ -138,21 +140,28 @@ public class WizAuthCallbackController {
    }
 
    /**
-    * Verifies the JWT signature using the same shared signing key that
-    * {@code SSOTokenService} uses to mint tokens.
+    * Verifies the JWT signature using the RSA public key from the SSO key pair.
+    * The {@code /sso/authorize} page signs tokens with RS256; this method validates
+    * the signature using the same key pair that {@link
+    * inetsoft.web.wiz.security.WizServiceAuthenticationFilter} uses.
     *
     * @return {@code true} if the signature is valid, {@code false} otherwise
     */
    private static boolean verifySignature(String token) {
       try {
-         java.security.KeyPair kp = PasswordEncryption.newInstance().getSSOKeyPair();
+         KeyPair kp = PasswordEncryption.newInstance().getSSOKeyPair();
 
          if(kp == null) {
             LOG.warn("SSO key pair not available — cannot verify callback token signature");
             return false;
          }
 
-         RSASSAVerifier verifier = new RSASSAVerifier((java.security.interfaces.RSAPublicKey) kp.getPublic());
+         if(!(kp.getPublic() instanceof RSAPublicKey rsaPub)) {
+            LOG.warn("SSO public key is not RSA — cannot verify callback token signature");
+            return false;
+         }
+
+         RSASSAVerifier verifier = new RSASSAVerifier(rsaPub);
          SignedJWT jws = SignedJWT.parse(token);
          return jws.verify(verifier);
       }

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizAuthCallbackController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizAuthCallbackController.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.controller;
 
 import com.nimbusds.jose.*;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import inetsoft.util.PasswordEncryption;
@@ -29,7 +30,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.*;
 
-import javax.crypto.SecretKey;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.*;
@@ -145,9 +145,14 @@ public class WizAuthCallbackController {
     */
    private static boolean verifySignature(String token) {
       try {
-         PasswordEncryption enc = PasswordEncryption.newInstance();
-         SecretKey signingKey = enc.getJwtSigningKey();
-         JWSVerifier verifier = enc.createJwsVerifier(signingKey);
+         java.security.KeyPair kp = PasswordEncryption.newInstance().getSSOKeyPair();
+
+         if(kp == null) {
+            LOG.warn("SSO key pair not available — cannot verify callback token signature");
+            return false;
+         }
+
+         RSASSAVerifier verifier = new RSASSAVerifier((java.security.interfaces.RSAPublicKey) kp.getPublic());
          SignedJWT jws = SignedJWT.parse(token);
          return jws.verify(verifier);
       }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -195,6 +195,9 @@ class WorksheetAgentControllerTest {
    @Test
    void detachClosesSession() {
       SheetSessionService sessions = mock(SheetSessionService.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      // resolve must return a non-null session so the ownership check passes
+      when(sessions.resolve(eq("TOK-D"), any())).thenReturn(session("TOK-D"));
 
       // feature is OFF — detach must still work
       WorksheetAgentController ctrl = controller(featureOff(),
@@ -202,7 +205,7 @@ class WorksheetAgentControllerTest {
          mock(WorksheetReadService.class), mock(WorksheetEditService.class),
          mock(WorksheetService.class));
 
-      ctrl.detach("TOK-D");
+      ctrl.detach("TOK-D", agent);
 
       verify(sessions).close("TOK-D");
    }


### PR DESCRIPTION
The /sso/authorize page signs tokens with RS256 (RSA), but WizAuthCallbackController.verifySignature() was using the HMAC shared key (HS256) via getJwtSigningKey(). This caused every callback POST to fail with "Unsupported JWS algorithm RS256, must be HS256, HS384 or HS512", returning 401 and blocking the MCP plugin login flow.

Switch to getSSOKeyPair() + RSASSAVerifier to match the algorithm used by WizServiceAuthenticationFilter. Also fix the detachClosesSession test to pass the now-required Principal parameter.