### PR TITLE
feat(wiz): persist viewsheet after removing a visualization

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -2860,9 +2860,9 @@ public class WizVsService {
    }
 
    /**
-    * Removes a single assembly from a live runtime viewsheet. Runtime-only: the
-    * persisted viewsheet asset is left untouched. Idempotent — a missing/expired
-    * runtime or an already-absent assembly is treated as success.
+    * Removes a single assembly from a live runtime viewsheet and persists the change
+    * back to the managed visualization asset so it survives runtime expiry. Idempotent —
+    * a missing/expired runtime or an already-absent assembly is treated as success.
     *
     * @param runtimeId    the runtime viewsheet id (visualizationId on the wiz side)
     * @param assemblyName the assembly to remove
@@ -2906,6 +2906,19 @@ public class WizVsService {
          }
          catch(Exception ignore) {}
       });
+
+      // Persist the removal so it survives runtime expiry. Only write back when the runtime
+      // is backed by a managed visualization entry (mirrors deleteViewsheet's folder guard);
+      // a transient/unsaved runtime has no persistent entry and is left runtime-only.
+      AssetEntry entry = rvs.getEntry();
+      String path = entry != null ? entry.getPath() : null;
+
+      if(path != null &&
+         (path.startsWith(WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/") ||
+          path.startsWith(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/")))
+      {
+         engine.setSheet(entry, vs, user, true);
+      }
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRemoveVisualizationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRemoveVisualizationTest.java
@@ -3,6 +3,7 @@ package inetsoft.web.wiz.service;
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
@@ -25,17 +26,47 @@ class WizVsServiceRemoveVisualizationTest {
       Viewsheet vs = mock(Viewsheet.class);
       ViewsheetSandbox box = mock(ViewsheetSandbox.class);
       VSAssembly assembly = mock(VSAssembly.class);
+      AssetEntry entry = mock(AssetEntry.class);
 
       when(vsService.getViewsheet("rt-1", null)).thenReturn(rvs);
       when(rvs.getViewsheet()).thenReturn(vs);
       when(vs.getAssembly("Chart1")).thenReturn(assembly);
       when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+      when(rvs.getEntry()).thenReturn(entry);
+      when(entry.getPath()).thenReturn(
+         WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/abc");
 
       WizVsService service = new WizVsService(vsService, engine);
       service.removeVisualization("rt-1", "Chart1", null);
 
       verify(vs).removeAssembly("Chart1");
       verify(box).resetDataMap("Chart1");
+      // persists the removal back to the managed visualization entry
+      verify(engine).setSheet(entry, vs, null, true);
+   }
+
+   @Test
+   void doesNotPersistWhenRuntimeNotInManagedFolder() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      ViewsheetSandbox box = mock(ViewsheetSandbox.class);
+      VSAssembly assembly = mock(VSAssembly.class);
+      AssetEntry entry = mock(AssetEntry.class);
+
+      when(vsService.getViewsheet("rt-1", null)).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(vs.getAssembly("Chart1")).thenReturn(assembly);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+      when(rvs.getEntry()).thenReturn(entry);
+      when(entry.getPath()).thenReturn("some/other/folder/abc");
+
+      WizVsService service = new WizVsService(vsService, engine);
+      service.removeVisualization("rt-1", "Chart1", null);
+
+      verify(vs).removeAssembly("Chart1");
+      verify(engine, never()).setSheet(any(), any(), any(), anyBoolean());
    }
 
    @Test


### PR DESCRIPTION
removeVisualization was runtime-only — the assembly was removed from the live RuntimeViewsheet but the change was lost on runtime expiry. Persist the mutated viewsheet back via AssetRepository.setSheet when the runtime is backed by a managed visualization entry (ROOT/COMPONENTS folders), mirroring deleteViewsheet's folder guard. Transient/unsaved runtimes have no persistent entry and remain runtime-only.