### PR TITLE
Bug #75512, skip ngDoCheck reflow when data tip position is unchanged

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/data-tip/vs-data-tip.directive.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/data-tip/vs-data-tip.directive.ts
@@ -35,6 +35,11 @@ export class VSDataTipDirective implements DoCheck {
    private leaveListener: () => any;
    private inElement: Element = null;
    private mobileDevice = GuiTool.isMobileDevice();
+   private lastRenderedTipX: number | undefined;
+   private lastRenderedTipY: number | undefined;
+   private lastRenderedTipName: string | undefined;
+   private lastRenderedTipAlpha: number | undefined;
+   private lastRenderedPopShowing: boolean | undefined;
 
    constructor(private popService: PopComponentService,
                private dataTipService: DataTipService,
@@ -75,6 +80,26 @@ export class VSDataTipDirective implements DoCheck {
          {
             // cancel existing hide events
             this.debounceService.cancel(DataTipService.DEBOUNCE_KEY);
+
+            const tipX = this.dataTipService.dataTipX;
+            const tipY = this.dataTipService.dataTipY;
+            const tipName = this.dataTipService.dataTipName;
+            const tipAlpha = this.dataTipService.dataTipAlpha;
+            const popShowing = this.popService.hasPopUpComponentShowing();
+
+            // Skip expensive DOM reads and style writes when all inputs are unchanged.
+            if(tipX === this.lastRenderedTipX && tipY === this.lastRenderedTipY &&
+               tipName === this.lastRenderedTipName && tipAlpha === this.lastRenderedTipAlpha &&
+               popShowing === this.lastRenderedPopShowing) {
+               return;
+            }
+
+            this.lastRenderedTipX = tipX;
+            this.lastRenderedTipY = tipY;
+            this.lastRenderedTipName = tipName;
+            this.lastRenderedTipAlpha = tipAlpha;
+            this.lastRenderedPopShowing = popShowing;
+
             const popInfo = this.popService.getPopInfo(this.dataTipName);
             const containerInfo = this.popService.getPopInfo(this.popContainerName);
             const nativeElement = !this.miniToolbar
@@ -84,9 +109,8 @@ export class VSDataTipDirective implements DoCheck {
             const mainComponent = !this.miniToolbar ? nativeElement :
                document.getElementById(this.dataTipService.getVSObjectId(this.dataTipName));
 
-            let top = this.dataTipService.dataTipY;
-            let left = this.dataTipService.dataTipX;
-            const alpha = this.dataTipService.dataTipAlpha;
+            let top = tipY;
+            let left = tipX;
             let parentElem: any = nativeElement;
             let reducedEmbeddedVsTop = 0;
             let reducedEmbeddedVsLeft = 0;
@@ -183,8 +207,8 @@ export class VSDataTipDirective implements DoCheck {
             if(!this.miniToolbar) {
                this.renderer.setStyle(nativeElement, "display", "block");
 
-               if(alpha != null && alpha != 1) {
-                  this.renderer.setStyle(nativeElement, "opacity", alpha / 100);
+               if(tipAlpha != null && tipAlpha != 1) {
+                  this.renderer.setStyle(nativeElement, "opacity", tipAlpha / 100);
                }
             }
             else {
@@ -193,12 +217,16 @@ export class VSDataTipDirective implements DoCheck {
             }
             // background set on the server so alpha can be applied to all backgrounds
             //this.renderer.setStyle(nativeElement, "background", "rgba(245,245,245,1.0)");
-            let showingComponent = this.popService.hasPopUpComponentShowing();
             this.renderer.setStyle(nativeElement, "z-index",
-               this.popZIndex + 99999 + (showingComponent ? 1000 : 0));
+               this.popZIndex + 99999 + (popShowing ? 1000 : 0));
             this.createOutsideClickListener();
          }
          else {
+            this.lastRenderedTipX = undefined;
+            this.lastRenderedTipY = undefined;
+            this.lastRenderedTipName = undefined;
+            this.lastRenderedTipAlpha = undefined;
+            this.lastRenderedPopShowing = undefined;
             this.renderer.setStyle(this.elementRef.nativeElement, "display", "none");
             this.removeOutsideClickListener();
          }


### PR DESCRIPTION
## Summary

`VSDataTipDirective.ngDoCheck()` was unconditionally reading `clientWidth`/`clientHeight` (forcing synchronous browser layout reflows) and calling `renderer.setStyle()` multiple times on every Angular change detection cycle while a data tip was visible, causing noticeable mousemove lag on dashboards.

## Root Cause

`VSDataTipDirective` implements `DoCheck`, so `ngDoCheck()` runs on every Angular CD cycle. The CD trigger is `DataTipService.showDataTip()` → `showHideDataTip.next()` → `VSObjectContainer.detectChanges()`, which fires approximately every 100 ms while the mouse moves over a chart. On each cycle, every `VSDataTipDirective` instance on the dashboard performed expensive DOM reads (`mainComponent.clientWidth`, `mainComponent.clientHeight`) and multiple `renderer.setStyle()` calls — even when the data tip position, name, alpha, and pop state were all unchanged.

## Fix

Added a 5-field position cache (`lastRenderedTipX`, `lastRenderedTipY`, `lastRenderedTipName`, `lastRenderedTipAlpha`, `lastRenderedPopShowing`) to `VSDataTipDirective`. At the start of the visible branch in `ngDoCheck()`, all five inputs are read from their services (lightweight property reads, no DOM access), and if none have changed since the last render, the method returns immediately — skipping all DOM reads and style writes. The cache is reset to `undefined` when the data tip hides so the next show always renders fresh.

Also eliminated a duplicate `hasPopUpComponentShowing()` call inside the render path by reusing the pre-read `popShowing` variable.

## Test Plan

- Open a dashboard with a chart that has a data tip configured
- Move the mouse over the chart and verify there is no mousemove lag
- Verify the data tip still appears, positions correctly, and hides correctly
- Verify alpha/opacity is applied correctly when configured
- Verify z-index adjusts correctly when a pop-up component is showing

Fixes Redmine #75512.