### PR TITLE
Bug #75521 - Make XUtil partition cache lazy so the class loads without a Spring context

### DIFF
--- a/core/src/main/java/inetsoft/uql/util/XUtil.java
+++ b/core/src/main/java/inetsoft/uql/util/XUtil.java
@@ -336,11 +336,11 @@ public final class XUtil {
       String partitionName = (partition.getBasePartition() != null ?
          partition.getBasePartition().getName() + "^^" + partition.getName() :
          partition.getName());
-      XPartition tempPartition = partitionDataCache.get(partitionName);
+      XPartition tempPartition = partitionDataCache().get(partitionName);
 
       if(tempPartition == null ) {
          tempPartition = partition.applyAutoAliases();
-         partitionDataCache.put(partitionName, tempPartition);
+         partitionDataCache().put(partitionName, tempPartition);
       }
 
       partition = tempPartition;
@@ -3426,11 +3426,11 @@ public final class XUtil {
       String partitionName = partition.getBasePartition() != null ?
          partition.getBasePartition().getName() + "^^" + partition.getName() :
          partition.getName();
-      XPartition tempPartition = partitionDataCache.get(partitionName);
+      XPartition tempPartition = partitionDataCache().get(partitionName);
 
       if(tempPartition == null) {
          tempPartition = partition.applyAutoAliases();
-         partitionDataCache.put(partitionName, tempPartition);
+         partitionDataCache().put(partitionName, tempPartition);
       }
 
       partition = tempPartition;
@@ -4878,7 +4878,14 @@ public final class XUtil {
    // @by stephenwebster, For bug1416867569612, add short term cache for getting
    // the applyAutoAliases result. This saves significant time when in a tight
    // loop, such as repeated calls to getAttributes
-   private static DataCache<String, XPartition> partitionDataCache = new DataCache<>(5, 1000);
+   // Created lazily (holder idiom) so loading XUtil does not require a live Spring context.
+   private static DataCache<String, XPartition> partitionDataCache() {
+      return PartitionCacheHolder.CACHE;
+   }
+
+   private static final class PartitionCacheHolder {
+      static final DataCache<String, XPartition> CACHE = new DataCache<>(5, 1000);
+   }
 
    @FunctionalInterface
    public interface PermissionUpdater {

--- a/core/src/test/java/inetsoft/uql/util/XUtilClassLoadTest.java
+++ b/core/src/test/java/inetsoft/uql/util/XUtilClassLoadTest.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.util;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Guards against reintroducing a Spring-dependent static initializer in {@link XUtil}.
+ * The database key-value engine bootstrap loads XUtil (via DBConnectionPool.applyProperties)
+ * before any Spring context exists, so XUtil's class initializer must not require a live
+ * context. Loading the class in an isolated, context-free classloader reproduces that path.
+ */
+@Tag("core")
+public class XUtilClassLoadTest {
+   @Test
+   void initializesWithoutSpringContext() throws Exception {
+      List<URL> urls = new ArrayList<>();
+
+      for(String entry : System.getProperty("java.class.path").split(File.pathSeparator)) {
+         urls.add(new File(entry).toURI().toURL());
+      }
+
+      // Child-first for inetsoft.* so XUtil and ConfigurationContext initialize fresh with
+      // no application context, mirroring the offline storage bootstrap.
+      try(URLClassLoader loader = new IsolatedLoader(urls.toArray(new URL[0]),
+                                                     getClass().getClassLoader()))
+      {
+         assertDoesNotThrow(() -> Class.forName("inetsoft.uql.util.XUtil", true, loader));
+      }
+   }
+
+   private static final class IsolatedLoader extends URLClassLoader {
+      IsolatedLoader(URL[] urls, ClassLoader parent) {
+         super(urls, parent);
+      }
+
+      @Override
+      protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+         synchronized(getClassLoadingLock(name)) {
+            Class<?> c = findLoadedClass(name);
+
+            if(c == null && name.startsWith("inetsoft.")) {
+               c = findClass(name);
+            }
+
+            if(c == null) {
+               return super.loadClass(name, resolve);
+            }
+
+            if(resolve) {
+               resolveClass(c);
+            }
+
+            return c;
+         }
+      }
+   }
+}


### PR DESCRIPTION
## Problem

On a database key-value + S3 blob backend, the offline shell restore commands
cannot bootstrap the database key-value engine. Building the engine loads XUtil,
whose static initializer eagerly creates a Spring-managed DataCache:

    private static DataCache<String, XPartition> partitionDataCache = new DataCache<>(5, 1000);

DataCache's constructor calls DataCacheSweeper.getInstance(), which resolves a
Spring bean. The database engine path forces XUtil to load during engine creation
(DBConnectionPool.createStandalonePool -> XUtil.applyProperties), before any
context is available, failing two ways:

- :setup restore (no context): ExceptionInInitializerError caused by
  ShutdownException "Spring application context is not available".
- local :connect (context mid-refresh): a circular bean dependency
  keyValueEngine -> XUtil -> dataCacheSweeper -> propertiesEngine, yielding
  BeanCurrentlyInCreationException.

The default mapdb engine never calls DBConnectionPool/XUtil.applyProperties, so
the issue is specific to the database key-value engine and went unnoticed.

## Fix

Defer the partition DataCache creation out of the static initializer using the
initialization-on-demand holder idiom, so loading XUtil no longer requires a live
Spring context. The cache is built on first call to getTables/getColumns, both of
which run only at runtime when the context is up. Cache semantics (size, timeout,
get/put) are unchanged.

## Testing

Added XUtilClassLoadTest, which loads XUtil through an isolated child-first
classloader with no application context and asserts the class initializer does
not throw. Verified the test fails (ExceptionInInitializerError / ShutdownException)
when an eager Spring-touching static field is reintroduced, and passes with the
holder fix. core module compiles cleanly.

This is one of two independent defects that block storage restore on the
database/S3 backend; it addresses the offline shell path. The live REST/EM restore
path is a separate enterprise-side issue.