### PR TITLE
Bug #75513, add ChangeDetectionStrategy.OnPush to VSChart and fix showHints detectChanges

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
@@ -17,6 +17,7 @@
  */
 import { HttpParams } from "@angular/common/http";
 import {
+   ChangeDetectionStrategy,
    ChangeDetectorRef,
    Component,
    ElementRef,
@@ -127,6 +128,7 @@ const CHART_WIZARD_CHANGE_TITLE_URL = "/events/vswizard/preview/changeDescriptio
     selector: "vs-chart",
     templateUrl: "vs-chart.component.html",
     styleUrls: ["vs-chart.component.scss"],
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [VSDataTipDirective, VSPopComponentDirective, TooltipDirective, VSTitle, ChartArea, OutOfZoneDirective, VSHiddenAnnotation, VSPreviewTable, VSAnnotation, VSLoadingDisplay]
 })
 export class VSChart extends AbstractVSObject<VSChartModel>
@@ -1277,7 +1279,11 @@ export class VSChart extends AbstractVSObject<VSChartModel>
 
       if(this.mobileDevice) {
          this.showHints = true;
-         setTimeout(() => this.showHints = false, 1000);
+         this.detectChanges();
+         setTimeout(() => {
+            this.showHints = false;
+            this.detectChanges();
+         }, 1000);
       }
    }
 

--- a/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
@@ -196,6 +196,7 @@ export class VSChart extends AbstractVSObject<VSChartModel>
    // Fallback timeout handle: clears loading state if chart-area's onLoad never fires
    // (e.g. during rapid max-mode transitions). (Bug #74278)
    private chartLoadingTimeout: ReturnType<typeof setTimeout> | null = null;
+   private showHintsTimer: ReturnType<typeof setTimeout> | null = null;
    // DOM clone of chart-area shown while tiles reload, so the old chart stays visible. (Bug #74260)
    private chartSnapshot: HTMLElement | null = null;
 
@@ -988,6 +989,11 @@ export class VSChart extends AbstractVSObject<VSChartModel>
          this.chartAreasRetryTimer = null;
       }
 
+      if(this.showHintsTimer) {
+         clearTimeout(this.showHintsTimer);
+         this.showHintsTimer = null;
+      }
+
       this.subscriptions.unsubscribe();
 
       if(this.actionSubscription) {
@@ -1278,9 +1284,14 @@ export class VSChart extends AbstractVSObject<VSChartModel>
       }
 
       if(this.mobileDevice) {
+         if(this.showHintsTimer) {
+            clearTimeout(this.showHintsTimer);
+         }
+
          this.showHints = true;
          this.detectChanges();
-         setTimeout(() => {
+         this.showHintsTimer = setTimeout(() => {
+            this.showHintsTimer = null;
             this.showHints = false;
             this.detectChanges();
          }, 1000);


### PR DESCRIPTION
## Summary

`VSChart` (`vs-chart.component.ts`) was using Angular's default change detection strategy, causing the component to re-render on every change detection cycle regardless of whether its inputs had changed. This caused excessive change detection and redundant server round-trips on every chart interaction.

## Root Cause

`VSChart` used the default `ChangeDetectionStrategy.Default`, so Angular re-ran change detection on this component during every application-level tick — including those triggered by unrelated events elsewhere in the view. In addition, the `showHints` state mutations inside `processSetChartAreasCommand()` were placed outside the final `detectChanges()` call, meaning they would never render under `OnPush`.

## Fix

- Added `ChangeDetectionStrategy.OnPush` to the `@Component` decorator on `VSChart`
- Added explicit `this.detectChanges()` calls immediately after the `showHints = true` assignment and inside the `setTimeout` callback that resets `showHints = false`, so those state changes propagate correctly under `OnPush`

All other state mutations in the component already call `detectChanges()` explicitly, so no further changes were needed.

## Test Plan

- Open a viewsheet containing a chart
- Interact with the chart (brush, zoom, drill, axis resize, legend move) and verify rendering is correct
- Verify no regressions in chart selection, flyover, annotations, or loading indicator behavior
- On a mobile device (or browser mobile emulation), verify the swipe hints appear briefly after chart areas load and then disappear

Fixes Redmine #75513.