### PR TITLE
Bug #75514, debounce wizard binding tree column selection to prevent server event storms

### DIFF
--- a/web/projects/portal/src/app/vs-wizard/gui/object-wizard/wizard-binding-tree.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/vs-wizard/gui/object-wizard/wizard-binding-tree.component.interaction.tl.spec.ts
@@ -71,6 +71,7 @@ import { ViewsheetClientService } from "../../../common/viewsheet-client";
 import { FixedDropdownService } from "../../../widget/fixed-dropdown/fixed-dropdown.service";
 import { BindingTreeService } from "../../../binding/widget/binding-tree/binding-tree.service";
 import { ModelService } from "../../../widget/services/model.service";
+import { DebounceService } from "../../../widget/services/debounce.service";
 import { ComponentTool } from "../../../common/util/component-tool";
 import { MessageDialog } from "../../../widget/dialog/message-dialog/message-dialog.component";
 import { TreeNodeModel } from "../../../widget/tree/tree-node-model";
@@ -130,6 +131,11 @@ const MODAL_MOCK = {
    })),
 };
 
+const DEBOUNCE_SERVICE_MOCK = {
+   debounce: vi.fn().mockImplementation((_key: string, fn: () => void) => fn()),
+   cancel: vi.fn(),
+};
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -153,6 +159,7 @@ async function renderComponent(opts: RenderOpts = {}) {
          { provide: BindingTreeService, useValue: TREE_SERVICE_MOCK },
          { provide: ModelService, useValue: {} },
          { provide: NgbModal, useValue: MODAL_MOCK },
+         { provide: DebounceService, useValue: DEBOUNCE_SERVICE_MOCK },
       ],
       schemas: [NO_ERRORS_SCHEMA],
    });
@@ -187,6 +194,8 @@ beforeEach(() => {
       close: vi.fn(),
       dismiss: vi.fn(),
    }));
+   DEBOUNCE_SERVICE_MOCK.debounce.mockClear().mockImplementation((_key: string, fn: () => void) => fn());
+   DEBOUNCE_SERVICE_MOCK.cancel.mockClear();
 
    MessageDialog.lastMessage = null;
    (MessageDialog as any).lastMessageTS = 0;

--- a/web/projects/portal/src/app/vs-wizard/gui/object-wizard/wizard-binding-tree.component.ts
+++ b/web/projects/portal/src/app/vs-wizard/gui/object-wizard/wizard-binding-tree.component.ts
@@ -19,6 +19,7 @@ import { Component, Input, NgZone, OnDestroy, OnInit, Optional, ViewChild } from
 import { Subscription } from "rxjs";
 import { TreeNodeModel } from "../../../widget/tree/tree-node-model";
 import { NotificationsComponent } from "../../../widget/notifications/notifications.component";
+import { DebounceService } from "../../../widget/services/debounce.service";
 import { Tool } from "../../../../../../shared/util/tool";
 import {
    CommandProcessor,
@@ -89,7 +90,8 @@ export class WizardBindingTree extends CommandProcessor implements OnInit, OnDes
                private treeService: BindingTreeService,
                private modelService: ModelService,
                private dialogService: NgbModal,
-               protected zone: NgZone)
+               protected zone: NgZone,
+               private debounceService: DebounceService)
    {
       super(viewsheetClient, zone, true);
    }
@@ -118,6 +120,7 @@ export class WizardBindingTree extends CommandProcessor implements OnInit, OnDes
          this.bindingTreeSubscription.unsubscribe();
       }
 
+      this.debounceService.cancel("wizard-recommender-" + this.runtimeId);
       this.cleanup();
    }
 
@@ -291,7 +294,10 @@ export class WizardBindingTree extends CommandProcessor implements OnInit, OnDes
          }
       }
 
-      this.recommender(tableName);
+      this.debounceService.debounce(
+         "wizard-recommender-" + this.runtimeId,
+         () => this.recommender(tableName),
+         200);
    }
 
    public recommender(tableName?: string, reload?: boolean): void {

--- a/web/projects/portal/src/app/vs-wizard/gui/object-wizard/wizard-binding-tree.component.ts
+++ b/web/projects/portal/src/app/vs-wizard/gui/object-wizard/wizard-binding-tree.component.ts
@@ -74,6 +74,8 @@ const OBJECT_WIZARD_REFRESH = "/events/vswizard/object-wizard/refresh";
     imports: [TreeComponent, NotificationsComponent]
 })
 export class WizardBindingTree extends CommandProcessor implements OnInit, OnDestroy {
+   private static readonly RECOMMENDER_DEBOUNCE_MS = 200;
+
    @Input() runtimeId: string;
    @Input() temporarySheet: boolean;
    @Input() originalMode: VsWizardEditModes;
@@ -297,7 +299,7 @@ export class WizardBindingTree extends CommandProcessor implements OnInit, OnDes
       this.debounceService.debounce(
          "wizard-recommender-" + this.runtimeId,
          () => this.recommender(tableName),
-         200);
+         WizardBindingTree.RECOMMENDER_DEBOUNCE_MS);
    }
 
    public recommender(tableName?: string, reload?: boolean): void {


### PR DESCRIPTION
## Summary

Every column checkbox click in the Composer Wizard binding tree immediately triggered a server round-trip chain with no debounce: `selectNodes()` → `recommender()` → `REFRESH_BINDING_NODES_CHANGED_URI` → server responds with `FireRecommandCommand` → `sendRefreshWizardBindingEvent()` → `REFRESH_WIZARD_BINDING_INFO`. Rapid selection of N columns produced 2N server events, most superseded before the server could respond.

## Root Cause

`WizardBindingTree.selectNodes()` called `this.recommender(tableName)` synchronously on every click with no debounce. No coalescing mechanism existed to suppress intermediate selections.

## Fix

Injected `DebounceService` into `WizardBindingTree` and wrapped the `recommender()` call in `selectNodes()` with a 200ms debounce keyed on `"wizard-recommender-" + runtimeId`. The debounce is applied only at `selectNodes()` — not inside `recommender()` itself — so the other callers of `recommender()` via the `recommenderSubject` path (`reloadSelectedBinding`, `unSelectNode`, MV progress close) continue to fire immediately as discrete operations. A matching `debounceService.cancel()` call was added to `ngOnDestroy` to clear any pending timer when the component is destroyed.

## Test Plan

- Open the Composer Wizard and select multiple columns rapidly by clicking checkboxes in quick succession — confirm only one server round-trip fires per debounce window rather than one per click.
- Select a single column normally — confirm the binding recommendation still updates correctly after the 200ms delay.
- Open the wizard, click a column, then immediately close the wizard — confirm no errors and no stale server events are sent.
- Run the existing portal test suite: `npm run test:portal` — all tests pass.

Fixes Redmine #75514.