### PR TITLE
Bug #75520 - Select storage transfer by backend type via shared factory

### DIFF
--- a/core/src/main/java/inetsoft/storage/StorageTransfer.java
+++ b/core/src/main/java/inetsoft/storage/StorageTransfer.java
@@ -17,6 +17,8 @@
  */
 package inetsoft.storage;
 
+import inetsoft.util.config.InetsoftConfig;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Path;
@@ -26,6 +28,24 @@ import java.nio.file.Path;
  * and blob stores.
  */
 public interface StorageTransfer {
+   /**
+    * Creates a {@code StorageTransfer} appropriate for the configured key-value engine. The mapdb
+    * engine is node-local, so its contents are transferred through the cluster; every other engine
+    * is shared and is read from and written to directly. Going through the cluster on a non-mapdb
+    * backend would fire the live storage change-listeners during a bulk import and fail on
+    * not-yet-imported parent folders.
+    *
+    * @param keyValueEngine the key-value storage engine.
+    * @param blobEngine     the blob storage engine.
+    *
+    * @return the storage transfer implementation to use.
+    */
+   static StorageTransfer create(KeyValueEngine keyValueEngine, BlobEngine blobEngine) {
+      boolean mapdb = "mapdb".equals(InetsoftConfig.getInstance().getKeyValue().getType());
+      return mapdb ? new ClusterStorageTransfer()
+         : new DirectStorageTransfer(keyValueEngine, blobEngine);
+   }
+
    /**
     * Exports the contents of the key-value and blob stores.
     *

--- a/core/src/main/java/inetsoft/storage/StorageTransfer.java
+++ b/core/src/main/java/inetsoft/storage/StorageTransfer.java
@@ -35,6 +35,9 @@ public interface StorageTransfer {
     * backend would fire the live storage change-listeners during a bulk import and fail on
     * not-yet-imported parent folders.
     *
+    * <p>For the mapdb backend the provided engines are not used; {@code ClusterStorageTransfer}
+    * routes all I/O through the cluster singletons.</p>
+    *
     * @param keyValueEngine the key-value storage engine.
     * @param blobEngine     the blob storage engine.
     *

--- a/core/src/main/java/inetsoft/web/admin/general/DataSpaceSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/general/DataSpaceSettingsService.java
@@ -102,12 +102,9 @@ public class DataSpaceSettingsService extends BackupSupport {
          // For the same backup, use the same timestamp
          String stamp = createBackupTimestamp();
          file = this.fileSystemService.getCacheTempFile("backup", ".zip");
-         boolean mapdbStorage = "mapdb".equals(InetsoftConfig.getInstance().getKeyValue().getType());
 
          try(OutputStream output = new FileOutputStream(file)) {
-            StorageTransfer storageTransfer = mapdbStorage ? new ClusterStorageTransfer() :
-               new DirectStorageTransfer(this.keyValueEngine, this.blobEngine);
-            storageTransfer.exportContents(output);
+            StorageTransfer.create(this.keyValueEngine, this.blobEngine).exportContents(output);
          }
 
          String path = getBackFile(model != null ? model.dataspace() : null, stamp);

--- a/core/src/test/java/inetsoft/storage/DirectStorageTransferRoundTripTest.java
+++ b/core/src/test/java/inetsoft/storage/DirectStorageTransferRoundTripTest.java
@@ -60,6 +60,10 @@ class DirectStorageTransferRoundTripTest {
       assertEquals("valueA", tgtKv.get("sreeProperties", "a.prop"));
       assertEquals("valueB", tgtKv.get("sreeProperties", "b.prop"));
       assertEquals("1", tgtKv.get("otherStore", "x"));
+
+      // no spurious entries beyond what was exported
+      assertEquals(2, tgtKv.size("sreeProperties"));
+      assertEquals(1, tgtKv.size("otherStore"));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/storage/DirectStorageTransferRoundTripTest.java
+++ b/core/src/test/java/inetsoft/storage/DirectStorageTransferRoundTripTest.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.storage;
+
+import inetsoft.storage.fs.FilesystemBlobEngine;
+import inetsoft.test.TestKeyValueEngine;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Round-trips a backup through {@link DirectStorageTransfer} (export then import into fresh engines)
+ * to verify the non-mapdb restore path used by {@code StorageTransfer.create}. Unlike
+ * {@code ClusterStorageTransfer}, the direct path writes straight to the engines and never fires the
+ * live change-listeners, so the import cannot NPE on a not-yet-imported parent folder.
+ */
+@Tag("core")
+class DirectStorageTransferRoundTripTest {
+   @TempDir
+   Path tempDir;
+
+   @Test
+   void keyValueRoundTrip() throws Exception {
+      KeyValueEngine srcKv = new TestKeyValueEngine();
+      BlobEngine srcBlob = new FilesystemBlobEngine(tempDir.resolve("src-blob"));
+      srcKv.put("sreeProperties", "a.prop", "valueA");
+      srcKv.put("sreeProperties", "b.prop", "valueB");
+      srcKv.put("otherStore", "x", "1");
+
+      Path zip = exportTo("kv.zip", srcKv, srcBlob);
+
+      KeyValueEngine tgtKv = new TestKeyValueEngine();
+      BlobEngine tgtBlob = new FilesystemBlobEngine(tempDir.resolve("tgt-blob"));
+      new DirectStorageTransfer(tgtKv, tgtBlob).importContents(zip);
+
+      assertEquals("valueA", tgtKv.get("sreeProperties", "a.prop"));
+      assertEquals("valueB", tgtKv.get("sreeProperties", "b.prop"));
+      assertEquals("1", tgtKv.get("otherStore", "x"));
+   }
+
+   @Test
+   void blobRoundTrip() throws Exception {
+      KeyValueEngine srcKv = new TestKeyValueEngine();
+      BlobEngine srcBlob = new FilesystemBlobEngine(tempDir.resolve("src-blob"));
+      byte[] content = "blob-bytes-1234567890".getBytes(StandardCharsets.UTF_8);
+      Path srcFile = tempDir.resolve("content.dat");
+      Files.write(srcFile, content);
+      String digest = DigestUtils.md5Hex(content);
+      String storeId = "blobStore";
+      srcBlob.write(storeId, digest, srcFile);
+      Blob<Serializable> blob =
+         new Blob<>("path/to/file", digest, content.length, Instant.now(), null);
+      srcKv.put(storeId, "the-key", blob);
+
+      Path zip = exportTo("blob.zip", srcKv, srcBlob);
+
+      KeyValueEngine tgtKv = new TestKeyValueEngine();
+      BlobEngine tgtBlob = new FilesystemBlobEngine(tempDir.resolve("tgt-blob"));
+      new DirectStorageTransfer(tgtKv, tgtBlob).importContents(zip);
+
+      Blob<?> imported = tgtKv.get(storeId, "the-key");
+      assertNotNull(imported, "blob entry should be imported into the key-value store");
+      assertEquals(digest, imported.getDigest());
+      assertTrue(tgtBlob.exists(storeId, digest), "blob bytes should be written to the blob engine");
+
+      Path readBack = tempDir.resolve("readback.dat");
+      tgtBlob.read(storeId, digest, readBack);
+      assertArrayEquals(content, Files.readAllBytes(readBack));
+   }
+
+   private Path exportTo(String name, KeyValueEngine kv, BlobEngine blob) throws Exception {
+      Path zip = tempDir.resolve(name);
+
+      try(OutputStream out = Files.newOutputStream(zip)) {
+         new DirectStorageTransfer(kv, blob).exportContents(out);
+      }
+
+      return zip;
+   }
+}

--- a/core/src/test/java/inetsoft/storage/StorageTransferTest.java
+++ b/core/src/test/java/inetsoft/storage/StorageTransferTest.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.storage;
+
+import inetsoft.util.config.InetsoftConfig;
+import inetsoft.util.config.KeyValueConfig;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class StorageTransferTest {
+   @Test
+   void createReturnsClusterTransferForMapdb() {
+      assertTransferType("mapdb", ClusterStorageTransfer.class);
+   }
+
+   @ParameterizedTest
+   @ValueSource(strings = {"database", "s3"})
+   void createReturnsDirectTransferForSharedBackends(String keyValueType) {
+      assertTransferType(keyValueType, DirectStorageTransfer.class);
+   }
+
+   private void assertTransferType(String keyValueType,
+                                   Class<? extends StorageTransfer> expected)
+   {
+      KeyValueEngine keyValueEngine = mock(KeyValueEngine.class);
+      BlobEngine blobEngine = mock(BlobEngine.class);
+
+      KeyValueConfig keyValueConfig = new KeyValueConfig();
+      keyValueConfig.setType(keyValueType);
+      InetsoftConfig config = new InetsoftConfig();
+      config.setKeyValue(keyValueConfig);
+
+      try(MockedStatic<InetsoftConfig> mocked = mockStatic(InetsoftConfig.class)) {
+         mocked.when(InetsoftConfig::getInstance).thenReturn(config);
+         StorageTransfer transfer = StorageTransfer.create(keyValueEngine, blobEngine);
+         assertInstanceOf(expected, transfer);
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/storage/StorageTransferTest.java
+++ b/core/src/test/java/inetsoft/storage/StorageTransferTest.java
@@ -41,16 +41,22 @@ class StorageTransferTest {
       assertTransferType(keyValueType, DirectStorageTransfer.class);
    }
 
+   @Test
+   void createReturnsDirectTransferForNullType() {
+      // unconfigured type falls through to the shared backend via "mapdb".equals(null) == false
+      assertTransferType(null, DirectStorageTransfer.class);
+   }
+
    private void assertTransferType(String keyValueType,
                                    Class<? extends StorageTransfer> expected)
    {
       KeyValueEngine keyValueEngine = mock(KeyValueEngine.class);
       BlobEngine blobEngine = mock(BlobEngine.class);
 
-      KeyValueConfig keyValueConfig = new KeyValueConfig();
-      keyValueConfig.setType(keyValueType);
-      InetsoftConfig config = new InetsoftConfig();
-      config.setKeyValue(keyValueConfig);
+      KeyValueConfig keyValueConfig = mock(KeyValueConfig.class);
+      when(keyValueConfig.getType()).thenReturn(keyValueType);
+      InetsoftConfig config = mock(InetsoftConfig.class);
+      when(config.getKeyValue()).thenReturn(keyValueConfig);
 
       try(MockedStatic<InetsoftConfig> mocked = mockStatic(InetsoftConfig.class)) {
          mocked.when(InetsoftConfig::getInstance).thenReturn(config);


### PR DESCRIPTION
## Summary

Storage restore fails with a NullPointerException on a non-mapdb backend (database
key-value + S3 blob). The selection of which StorageTransfer implementation to use
was inlined only on the backup side, so the rule could not be reused on the restore
side. This PR extracts that rule into a shared factory so both backup and restore
select consistently.

mapdb is a node-local engine, so its contents are transferred through the cluster
(ClusterStorageTransfer). Every other engine is shared and is read from and written
to directly (DirectStorageTransfer). The cluster path fires the live storage
change-listeners during a bulk import; a listener resolves a parent AssetFolder that
has not been imported yet, gets null, and calls getEntries() on it. The direct path
writes straight to the engines and never fires those listeners, so it cannot hit
that NPE.

## Changes

- StorageTransfer — new static create(KeyValueEngine, BlobEngine) factory holding
the single source of truth for the mapdb-vs-shared selection.
- DataSpaceSettingsService.doBackup — now delegates to StorageTransfer.create(...)
instead of an inline ternary.

## Tests

- StorageTransferTest — asserts ClusterStorageTransfer for mapdb and
DirectStorageTransfer for database/s3.
- DirectStorageTransferRoundTripTest — exports key-value and blob content to a ZIP
and re-imports it into fresh engines, verifying values, blob digest, and exact byte
content survive the round trip.

Existing GeneralSettingsPageControllerTest continues to pass.