### PR TITLE
Bug #75515, fix memory leak in ChartImageDirective

### DIFF
--- a/web/projects/portal/src/app/graph/objects/chart-image.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-image.directive.ts
@@ -55,11 +55,17 @@ export class ChartImageDirective implements OnDestroy {
    private _loadTimer: ReturnType<typeof setTimeout> | null = null;
    private currentBlobUrl: string = null;
    private loadSubscription: Subscription = null;
+   private retryTimer: ReturnType<typeof setTimeout> | null = null;
 
    constructor(private element: ElementRef, private http: HttpClient, private renderer: Renderer2) {
    }
 
    ngOnDestroy(): void {
+      if(this.retryTimer != null) {
+         clearTimeout(this.retryTimer);
+         this.retryTimer = null;
+      }
+
       this.loadSubscription?.unsubscribe();
       this.loadSubscription = null;
 
@@ -75,6 +81,11 @@ export class ChartImageDirective implements OnDestroy {
    }
 
    private loadImage(reloading = false): void {
+      if(this.retryTimer != null) {
+         clearTimeout(this.retryTimer);
+         this.retryTimer = null;
+      }
+
       this.loadSubscription?.unsubscribe();
       this.loadSubscription = null;
 
@@ -89,7 +100,10 @@ export class ChartImageDirective implements OnDestroy {
             response => {
                if(response.headers?.has("Retry-After")) {
                   const interval = parseInt(response.headers.get("Retry-After"), 10) * 1000;
-                  setTimeout(() => this.loadImage(true), interval);
+                  this.retryTimer = setTimeout(() => {
+                     this.retryTimer = null;
+                     this.loadImage(true);
+                  }, interval);
                }
                else if(requestedImage == this.chartImage) {
                   // Do not set if image address changed before the request returned

--- a/web/projects/portal/src/app/graph/objects/chart-image.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-image.directive.ts
@@ -15,6 +15,7 @@
 import { HttpClient } from "@angular/common/http";
 import { Directive, ElementRef, EventEmitter, Input, OnDestroy, Output, Renderer2 } from "@angular/core";
 import { SafeValue } from "@angular/platform-browser";
+import { Subscription } from "rxjs";
 
 @Directive({
     selector: "[chartImage]",
@@ -52,11 +53,21 @@ export class ChartImageDirective implements OnDestroy {
    @Output() onError = new EventEmitter<void>();
    private _chartImage: string | SafeValue = null;
    private _loadTimer: ReturnType<typeof setTimeout> | null = null;
+   private currentBlobUrl: string = null;
+   private loadSubscription: Subscription = null;
 
    constructor(private element: ElementRef, private http: HttpClient, private renderer: Renderer2) {
    }
 
    ngOnDestroy(): void {
+      this.loadSubscription?.unsubscribe();
+      this.loadSubscription = null;
+
+      if(this.currentBlobUrl) {
+         URL.revokeObjectURL(this.currentBlobUrl);
+         this.currentBlobUrl = null;
+      }
+
       if(this._loadTimer !== null) {
          clearTimeout(this._loadTimer);
          this._loadTimer = null;
@@ -64,6 +75,9 @@ export class ChartImageDirective implements OnDestroy {
    }
 
    private loadImage(reloading = false): void {
+      this.loadSubscription?.unsubscribe();
+      this.loadSubscription = null;
+
       if(!!this.chartImage) {
          if(!reloading) {
             this.onLoading.emit();
@@ -71,7 +85,7 @@ export class ChartImageDirective implements OnDestroy {
 
          const requestedImage = this._chartImage;
 
-         this.http.get(this.chartImage as string, { observe: "response", responseType: "blob" }).subscribe(
+         this.loadSubscription = this.http.get(this.chartImage as string, { observe: "response", responseType: "blob" }).subscribe(
             response => {
                if(response.headers?.has("Retry-After")) {
                   const interval = parseInt(response.headers.get("Retry-After"), 10) * 1000;
@@ -79,7 +93,12 @@ export class ChartImageDirective implements OnDestroy {
                }
                else if(requestedImage == this.chartImage) {
                   // Do not set if image address changed before the request returned
-                  this.renderer.setAttribute(this.element.nativeElement, "src", URL.createObjectURL(response.body));
+                  if(this.currentBlobUrl) {
+                     URL.revokeObjectURL(this.currentBlobUrl);
+                  }
+
+                  this.currentBlobUrl = URL.createObjectURL(response.body);
+                  this.renderer.setAttribute(this.element.nativeElement, "src", this.currentBlobUrl);
                   this.onLoaded.emit();
                }
             },


### PR DESCRIPTION
## Summary

- Every chart tile image load called `URL.createObjectURL()` but never `URL.revokeObjectURL()`, causing blob data to accumulate in memory across tab switches.
- HTTP subscriptions were never cancelled, leaving in-flight requests holding references to detached DOM nodes when tile counts changed or the directive was destroyed.

## Root Cause

`ChartImageDirective` had two leaks:

1. **Blob URL leak**: `URL.createObjectObject()` was called on every successful image response with no matching `revokeObjectURL()`. Each chart refresh (triggered by tab switching → `SetChartAreasCommand`) added new unreleased blobs, explaining the `system/ExternalStringData: +12.4 MB` growth seen in heap snapshots.

2. **Subscription/detached DOM node leak**: The `Subscription` returned by `http.get(...).subscribe(...)` was never stored or cancelled. When `chartImage` changed while a request was in-flight, or when the directive was destroyed (e.g., tile count changed and Angular removed `<img>` elements from the `@for` loop), the subscription closure kept the detached `<img>` element alive indefinitely.

## Fix

In `ChartImageDirective`:
- Added `ngOnDestroy` to unsubscribe the pending HTTP request and revoke the current blob URL on teardown.
- At the start of each `loadImage()` call, cancel any in-flight subscription before issuing a new request.
- Track `currentBlobUrl` and revoke it before assigning the next blob URL.

## Test Plan

- [ ] Open a viewsheet with chart assemblies inside VSTab containers
- [ ] Switch between tabs repeatedly while monitoring memory in Chrome DevTools (heap snapshots)
- [ ] Confirm blob count and detached node count no longer grow with each tab switch
- [ ] Confirm charts still load correctly on each tab activation
- [ ] Confirm `Retry-After` retry behavior still works (charts with server-side throttling)

Fixes Redmine #75515.