### PR TITLE
Bug #75516, debounce chart tile HTTP requests and resize-slider server events

### DIFF
--- a/web/projects/portal/src/app/graph/objects/chart-image.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-image.directive.ts
@@ -13,14 +13,14 @@
  */
 
 import { HttpClient } from "@angular/common/http";
-import { Directive, ElementRef, EventEmitter, Input, Output, Renderer2 } from "@angular/core";
+import { Directive, ElementRef, EventEmitter, Input, OnDestroy, Output, Renderer2 } from "@angular/core";
 import { SafeValue } from "@angular/platform-browser";
 
 @Directive({
     selector: "[chartImage]",
     standalone: true
 })
-export class ChartImageDirective {
+export class ChartImageDirective implements OnDestroy {
    @Input()
    get chartImage(): string | SafeValue {
       return this._chartImage;
@@ -29,7 +29,21 @@ export class ChartImageDirective {
    set chartImage(value: string | SafeValue) {
       if(value !== this._chartImage) {
          this._chartImage = value;
-         this.loadImage();
+
+         if(this._loadTimer !== null) {
+            clearTimeout(this._loadTimer);
+            this._loadTimer = null;
+         }
+
+         if(!!value) {
+            this._loadTimer = setTimeout(() => {
+               this._loadTimer = null;
+               this.loadImage();
+            }, 50);
+         }
+         else {
+            this.renderer.removeAttribute(this.element.nativeElement, "src");
+         }
       }
    }
 
@@ -37,8 +51,16 @@ export class ChartImageDirective {
    @Output() onLoaded = new EventEmitter<void>();
    @Output() onError = new EventEmitter<void>();
    private _chartImage: string | SafeValue = null;
+   private _loadTimer: ReturnType<typeof setTimeout> | null = null;
 
    constructor(private element: ElementRef, private http: HttpClient, private renderer: Renderer2) {
+   }
+
+   ngOnDestroy(): void {
+      if(this._loadTimer !== null) {
+         clearTimeout(this._loadTimer);
+         this._loadTimer = null;
+      }
    }
 
    private loadImage(reloading = false): void {

--- a/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
@@ -184,7 +184,6 @@ export class VSChart extends AbstractVSObject<VSChartModel>
    private chartAreasRetryCount: number = 0;
    private readonly MAX_CHART_AREAS_RETRIES = 5;
    private subscriptions = Subscription.EMPTY;
-   private isIE: boolean = GuiTool.isIE();
    private isIFrame: boolean = GuiTool.isIFrame();
    // Stashed by processSetChartAreasCommand so that the model setter can apply fresh
    // chart areas immediately when Angular's CD re-binds the model, instead of issuing
@@ -1340,16 +1339,10 @@ export class VSChart extends AbstractVSObject<VSChartModel>
 
    changeSizeRatio(sizeRatio: number, vertical: boolean): void {
       const chartEvent = new VSChartPlotResizeEvent(this.model, false, sizeRatio, vertical);
-
-      if(this.isIE) {
-         let key = this.getAssemblyName() + (vertical ? "vertical-resize-slider" : "horizontal-resize-slider");
-         this.debounceService.debounce(key, () => {
-            this.viewsheetClient.sendEvent(CHART_PLOT_RESIZE_URL, chartEvent);
-         }, 400, []);
-      }
-      else {
+      const key = this.getAssemblyName() + (vertical ? "vertical-resize-slider" : "horizontal-resize-slider");
+      this.debounceService.debounce(key, () => {
          this.viewsheetClient.sendEvent(CHART_PLOT_RESIZE_URL, chartEvent);
-      }
+      }, 400, []);
    }
 
    public changeTitle(title: string): void {


### PR DESCRIPTION
## Summary

- Added a 50ms debounce in `ChartImageDirective` before firing HTTP GET requests for chart tile images, preventing wasted requests for intermediate states when tile URLs change in rapid succession.
- Removed the IE-only guard in `VSChart.changeSizeRatio()` so the existing 400ms `DebounceService` debounce applies to all browsers, preventing repeated server events when the user holds arrow keys on the plot resize slider.

## Root Cause

When the server sends `RefreshVSObjectCommand` with a new `genTime`, all visible chart tile directives (`ChartImageDirective`) immediately fire independent HTTP GET requests with no coordination. For a typical chart (4 axes + 1 plot + 2 legends), this means 7+ concurrent requests per server update.

Additionally, `changeSizeRatio()` only applied a debounce inside an `if(this.isIE)` branch, which is never true in modern browsers. While mouse-drag `change` events fire only on commit in modern browsers, keyboard arrow-key presses on a focused range input fire `change` on every repeat — causing a server event per keypress without the debounce.

## Fix

- `chart-image.directive.ts`: Debounce each tile's HTTP request by 50ms. If the `chartImage` input changes again within the window, the pending timer is cancelled and rescheduled. Added `ngOnDestroy` to clean up any pending timer on directive teardown.
- `vs-chart.component.ts`: Removed `if(this.isIE)` in `changeSizeRatio` and the now-unused `isIE` field. The `DebounceService` 400ms debounce now always applies.

## Test Plan

- Open a viewsheet with a chart and interact with it (apply filters, drill, sort) — verify chart tiles load correctly and the network tab shows no redundant in-flight requests for superseded tile URLs.
- Focus the plot resize slider and hold an arrow key — verify the server receives only one resize event per 400ms window rather than one per key repeat.
- Verify no visual regressions: chart tiles still load, loading indicators appear, and error handling (onError) still works.

Fixes Redmine #75516.