### PR TITLE
Bug #75517, optimize hide axis action to avoid unnecessary data re-execution

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartAxesVisibilityService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartAxesVisibilityService.java
@@ -23,11 +23,10 @@ import inetsoft.cluster.*;
 import inetsoft.graph.data.PairsDataSet;
 import inetsoft.report.composition.WorksheetEngine;
 import inetsoft.report.composition.graph.GraphTypeUtil;
+import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.VSDimensionRef;
 import inetsoft.uql.viewsheet.graph.*;
 import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
-import inetsoft.util.Tool;
-import inetsoft.web.composer.vs.objects.controller.VSObjectPropertyService;
 import inetsoft.web.viewsheet.event.chart.VSChartAxesVisibilityEvent;
 import inetsoft.web.viewsheet.service.CommandDispatcher;
 import inetsoft.web.viewsheet.service.CoreLifecycleService;
@@ -42,43 +41,36 @@ import java.util.stream.Stream;
 public class VSChartAxesVisibilityService extends VSChartControllerService<VSChartAxesVisibilityEvent> {
    public VSChartAxesVisibilityService(CoreLifecycleService coreLifecycleService,
                                           ViewsheetService viewsheetService,
-                                          VSChartAreasServiceProxy vsChartAreasService,
-                                          VSObjectPropertyService vsObjectPropertyService) {
+                                          VSChartAreasServiceProxy vsChartAreasService) {
       super(coreLifecycleService, viewsheetService, vsChartAreasService);
-      this.vsObjectPropertyService = vsObjectPropertyService;
    }
 
    @Override
    @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void eventHandler(@ClusterProxyKey String runtimeId,
-                            VSChartAxesVisibilityEvent event, 
-                            String linkUri, Principal principal, 
-                            CommandDispatcher dispatcher) throws Exception 
+                            VSChartAxesVisibilityEvent event,
+                            String linkUri, Principal principal,
+                            CommandDispatcher dispatcher) throws Exception
    {
-      this.processEvent(runtimeId, event, principal, chartState -> {
+      this.processEvent(runtimeId, event, principal, linkUri, dispatcher, chartState -> {
          if(event.isHide()) {
-            hideAxis(event, chartState, linkUri, principal, dispatcher);
+            return hideAxis(event, chartState);
          }
          else {
-            showAllAxes(chartState, linkUri, principal, dispatcher);
+            return showAllAxes(chartState);
          }
       });
 
       return null;
    }
 
-   private void hideAxis(VSChartAxesVisibilityEvent event, VSChartStateInfo chartState,
-                         String linkUri, Principal principal, CommandDispatcher dispatcher)
+   private int hideAxis(VSChartAxesVisibilityEvent event, VSChartStateInfo chartState)
    {
-      ChartVSAssemblyInfo info = (ChartVSAssemblyInfo) Tool.clone(chartState.getChartAssemblyInfo());
-      VSChartInfo chartInfo = info.getVSChartInfo();
+      ChartVSAssemblyInfo info = chartState.getChartAssemblyInfo();
+      VSChartInfo chartInfo = chartState.getChartInfo();
       String columnName = event.getColumnName();
-      ChartRef chartRef = null;
-
-      if(chartState.getChartAssemblyInfo() != null) {
-         chartRef = (ChartRef) info.getDCBIndingRef(columnName);
-      }
+      ChartRef chartRef = (ChartRef) info.getDCBIndingRef(columnName);
 
       if(chartRef == null) {
          chartRef = getAxixRef(chartInfo, columnName);
@@ -154,16 +146,8 @@ public class VSChartAxesVisibilityService extends VSChartControllerService<VSCha
          setVisible(axisDescriptor, false, false);
       }
 
-      try {
-         info.resetRuntimeValues();
-         chartInfo.clearRuntime();
-         vsObjectPropertyService.editObjectProperty(
-            chartState.getRuntimeViewsheet(), info, info.getAbsoluteName(), info.getAbsoluteName(),
-            linkUri, principal, dispatcher);
-      }
-      catch(Exception ex) {
-         throw new RuntimeException(ex);
-      }
+      chartInfo.clearRuntime();
+      return VSAssembly.VIEW_CHANGED;
    }
 
    // find ref in axes.
@@ -174,18 +158,14 @@ public class VSChartAxesVisibilityService extends VSChartControllerService<VSCha
          .findFirst().orElse(null);
    }
 
-   private void showAllAxes(VSChartStateInfo chartState,
-                            String linkUri,
-                            Principal principal,
-                            CommandDispatcher dispatcher)
+   private int showAllAxes(VSChartStateInfo chartState)
    {
-      ChartVSAssemblyInfo info = (ChartVSAssemblyInfo)
-         Tool.clone(chartState.getChartAssemblyInfo());
-      VSChartInfo chartInfo = info.getVSChartInfo();
+      ChartVSAssemblyInfo info = chartState.getChartAssemblyInfo();
+      VSChartInfo chartInfo = chartState.getChartInfo();
       ChartDescriptor chartDescriptor = info.getChartDescriptor();
 
       if(chartInfo == null || chartDescriptor == null) {
-         return;
+         return VSAssembly.VIEW_CHANGED;
       }
 
       boolean maxMode = info.getMaxSize() != null;
@@ -198,15 +178,8 @@ public class VSChartAxesVisibilityService extends VSChartControllerService<VSCha
          showAllAxes(chartInfo, false);
       }
 
-      try {
-         info.resetRuntimeValues();
-         vsObjectPropertyService.editObjectProperty(
-            chartState.getRuntimeViewsheet(), info, info.getAbsoluteName(), info.getAbsoluteName(),
-            linkUri, principal, dispatcher);
-      }
-      catch(Exception ex) {
-         throw new RuntimeException(ex);
-      }
+      chartInfo.clearRuntime();
+      return VSAssembly.VIEW_CHANGED;
    }
 
    private void showAllAxes(VSChartInfo chartInfo, boolean maxMode) {
@@ -248,5 +221,4 @@ public class VSChartAxesVisibilityService extends VSChartControllerService<VSCha
       }
    }
 
-   private final VSObjectPropertyService vsObjectPropertyService;
 }


### PR DESCRIPTION
## Summary

Hiding a chart axis on a viewsheet with multiple charts was taking ~8 seconds instead of being nearly instant.

## Root Cause

`VSChartAxesVisibilityService` was calling `editObjectProperty()` with a cloned `ChartVSAssemblyInfo`. Because `AxisDescriptor` objects live inside `VSChartInfo` (the `cinfo` field of `ChartVSAssemblyInfo`), the clone-and-set path triggered `copyInputDataInfo()`, which detected a `cinfo` change and returned `INPUT_DATA_CHANGED | BINDING_CHANGED`. This caused a full data re-execution (with sandbox write lock acquisition) for each chart on the viewsheet. With N charts, N serialized re-executions produced the observed delay.

## Fix

Replaced the heavy `editObjectProperty()` path with the same lightweight pattern used by `VSChartAxisResizeService`: modify the live assembly info directly (no clone), call `chartInfo.clearRuntime()`, and return `VSAssembly.VIEW_CHANGED` via the `processEvent(ToIntFunction)` overload. This triggers only a visual refresh without data re-execution, regardless of how many charts are on the viewsheet.

## Test Plan

- Open a viewsheet with multiple charts (5+)
- Right-click a chart axis and select Hide — should be nearly instant
- Verify the axis is hidden and other charts are unaffected
- Right-click and Show All Axes — should also be instant
- Verify undo/redo restores axis visibility correctly

Fixes Redmine #75517.