### PR TITLE
Bug #75525, fix library-function scope resolution and omitted primitive args in GraalJS

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -342,8 +342,12 @@ public class GraalJavaScriptEngine implements AutoCloseable {
             }
 
             try {
+               // Strip "use strict" directives — strict mode forbids with statements,
+               // so the wrapper would cause a SyntaxError and the function would be
+               // silently dropped.
+               String wrapped = stripStrictDirectives(source);
                context.eval(Source.newBuilder(
-                  "js", "with(__scope__){\n" + source + "\n}", "<lib:" + name + ">")
+                  "js", "with(__scope__){\n" + wrapped + "\n}", "<lib:" + name + ">")
                               .buildLiteral());
             }
             catch(PolyglotException ex) {
@@ -480,6 +484,31 @@ public class GraalJavaScriptEngine implements AutoCloseable {
     * Read the script.max.errors limit from SreeEnv. Returns 0 to mean "no limit".
     * Must be called while holding {@code lock} (result used inline in exec).
     */
+   /**
+    * Removes leading ECMAScript Directive Prologue entries for {@code "use strict"} so
+    * that the source can be wrapped in a {@code with(__scope__){...}} block without
+    * triggering a SyntaxError (strict mode forbids {@code with}).
+    */
+   private static String stripStrictDirectives(String src) {
+      String s = src;
+
+      while(true) {
+         String t = s.stripLeading();
+
+         if(t.startsWith("\"use strict\";")) {
+            s = t.substring("\"use strict\";".length());
+         }
+         else if(t.startsWith("'use strict';")) {
+            s = t.substring("'use strict';".length());
+         }
+         else {
+            break;
+         }
+      }
+
+      return s;
+   }
+
    private int maxErrors() {
       try {
          String prop = MAX_ERRORS_PROP.get();

--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -133,6 +133,11 @@ public class GraalJavaScriptEngine implements AutoCloseable {
 
       installGlobalFunctions();
       installGlobalScope();
+
+      // Bind the __scope__ proxy before installing library functions: their
+      // bodies are wrapped in with(__scope__){...} so unqualified names resolve
+      // through the proxy at call time (see installLibraryFunctions).
+      ensureScopeProxy();
       installLibraryFunctions();
    }
 
@@ -306,11 +311,16 @@ public class GraalJavaScriptEngine implements AutoCloseable {
     * Install user-defined library script functions as callable JS globals.
     *
     * <p>Each library function is stored as a full JS function declaration (e.g.
-    * {@code function myFunc(a, b) { return a + b; }}). Evaluating that
-    * declaration at the top level of the Context defines {@code myFunc} as a
-    * global, so any subsequently compiled script/formula can call it by name.
-    * This replaces the Rhino {@code cx.compileFunction(globalscope, ...)}
-    * machinery.
+    * {@code function myFunc(a, b) { return a + b; }}). The declaration is
+    * evaluated wrapped in {@code with(__scope__){ ... }}: in sloppy mode the
+    * function declaration is still hoisted to a global (so any subsequently
+    * compiled script/formula can call it by name), but its closure now captures
+    * the {@code __scope__} object-environment. This restores the Rhino behavior
+    * where a library function's unqualified names (e.g. {@code setActionVisible},
+    * {@code drillEnabled}) resolve dynamically against the currently executing
+    * assembly scope at call time — without the wrapper such names would be
+    * unresolvable and throw a ReferenceError (Bug #75525). This replaces the
+    * Rhino {@code cx.compileFunction(globalscope, ...)} machinery.
     *
     * <p>A malformed library function must not abort engine init, so each
     * function is compiled in its own try/catch (mirroring the old Rhino
@@ -332,7 +342,8 @@ public class GraalJavaScriptEngine implements AutoCloseable {
             }
 
             try {
-               context.eval(Source.newBuilder("js", source, "<lib:" + name + ">")
+               context.eval(Source.newBuilder(
+                  "js", "with(__scope__){\n" + source + "\n}", "<lib:" + name + ">")
                               .buildLiteral());
             }
             catch(PolyglotException ex) {

--- a/core/src/main/java/inetsoft/util/script/graal/ScriptFunction.java
+++ b/core/src/main/java/inetsoft/util/script/graal/ScriptFunction.java
@@ -101,8 +101,47 @@ public class ScriptFunction implements ProxyExecutable {
     * {@code float}) would otherwise fail reflective {@code Method.invoke} with an
     * argument-type mismatch. This narrows a {@code Number} to the target numeric
     * primitive/wrapper; other values are passed through unchanged.
+    *
+    * <p>A {@code null} value for a primitive parameter is coerced to that
+    * primitive's Java default ({@code false}, {@code 0}, {@code '\0'}) rather
+    * than passed through. {@code null} reaches here when a script omits a
+    * trailing argument or passes {@code undefined}/{@code null} (e.g. a library
+    * function calling {@code setActionVisible('Edit')} on the two-arg
+    * {@code setActionVisible(String, boolean)}); reflective invocation cannot
+    * unbox {@code null} to a primitive, so this mirrors Rhino's FunctionObject
+    * argument conversion, where a missing/undefined boolean meant {@code false}
+    * (Bug #75525).
     */
    private static Object coerce(Object value, Class<?> ptype) {
+      if(value == null) {
+         if(ptype == boolean.class) {
+            return false;
+         }
+         else if(ptype == int.class) {
+            return 0;
+         }
+         else if(ptype == long.class) {
+            return 0L;
+         }
+         else if(ptype == double.class) {
+            return 0d;
+         }
+         else if(ptype == float.class) {
+            return 0f;
+         }
+         else if(ptype == short.class) {
+            return (short) 0;
+         }
+         else if(ptype == byte.class) {
+            return (byte) 0;
+         }
+         else if(ptype == char.class) {
+            return '\0';
+         }
+
+         return null;
+      }
+
       if(value instanceof Number) {
          Number n = (Number) value;
 

--- a/core/src/test/java/inetsoft/report/script/graal/LibFunctionCallableTest.java
+++ b/core/src/test/java/inetsoft/report/script/graal/LibFunctionCallableTest.java
@@ -22,6 +22,8 @@ import inetsoft.report.LibManager;
 import inetsoft.report.LibManagerProvider;
 import inetsoft.test.*;
 import inetsoft.util.script.graal.GraalJavaScriptEngine;
+import inetsoft.util.script.graal.ScriptScope;
+import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,6 +59,57 @@ public class LibFunctionCallableTest {
          Object src = engine.compile("addTwo(40, 2)");
          Object result = engine.exec(src, null, null);
          assertEquals(42.0, result);
+      }
+      finally {
+         engine.close();
+      }
+   }
+
+   @Test
+   void libFunctionResolvesExecScopeMember() throws Exception {
+      // Bug #75525: a library function whose body references an unqualified name
+      // (e.g. setActionVisible) provided only by the executing scope must resolve
+      // it dynamically (Rhino scope-chain behavior), not throw
+      // "setActionVisible is not defined".
+      LibManager mgr = LibManagerProvider.getInstance().getManager();
+      mgr.setScript("callsScopeFn",
+                    "function callsScopeFn() { setActionVisible('AxisResize'); return 'ok'; }");
+
+      GraalJavaScriptEngine engine = new GraalJavaScriptEngine();
+      final boolean[] called = { false };
+
+      try {
+         engine.init(new HashMap<>());
+
+         // scope exposing setActionVisible as a callable member, mirroring how a
+         // VSAScriptable exposes assembly script functions to the engine.
+         ScriptScope scope = new ScriptScope() {
+            private final Object fn = (ProxyExecutable) args -> {
+               called[0] = true;
+               return null;
+            };
+
+            public Object getMember(String n) {
+               return "setActionVisible".equals(n) ? fn : null;
+            }
+
+            public boolean hasMember(String n) {
+               return "setActionVisible".equals(n);
+            }
+
+            public void putMember(String n, Object v) {
+            }
+
+            public Object[] getMemberKeys() {
+               return new Object[] { "setActionVisible" };
+            }
+         };
+
+         Object src = engine.compile("callsScopeFn()");
+         Object result = engine.exec(src, scope, null);
+         assertEquals("ok", result);
+         assertTrue(called[0],
+                    "library function should resolve setActionVisible from the executing scope");
       }
       finally {
          engine.close();

--- a/core/src/test/java/inetsoft/util/script/graal/ScriptFunctionTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/ScriptFunctionTest.java
@@ -34,6 +34,8 @@ class ScriptFunctionTest {
       public String name;
       public boolean visible = true; // non-default so we can detect "false was passed"
       public int count = -1;
+      public double ratio = -1.0;
+      public char ch = 'X';
       public boolean called;
 
       public void setActionVisible(String name, boolean visible) {
@@ -45,6 +47,16 @@ class ScriptFunctionTest {
       public void setCount(int count) {
          this.called = true;
          this.count = count;
+      }
+
+      public void setRatio(double ratio) {
+         this.called = true;
+         this.ratio = ratio;
+      }
+
+      public void setChar(char ch) {
+         this.called = true;
+         this.ch = ch;
       }
    }
 
@@ -99,5 +111,29 @@ class ScriptFunctionTest {
       ctx.eval("js", "setCount(42)");
 
       assertEquals(42, t.count);
+   }
+
+   @Test
+   void omittedDoubleArgDefaultsToZero() {
+      Target t = new Target();
+      ctx.getBindings("js").putMember(
+         "setRatio", new ScriptFunction(t, Target.class, "setRatio", double.class));
+
+      ctx.eval("js", "setRatio()");
+
+      assertTrue(t.called);
+      assertEquals(0.0, t.ratio, 0.0, "omitted double argument should default to 0.0");
+   }
+
+   @Test
+   void omittedCharArgDefaultsToNul() {
+      Target t = new Target();
+      ctx.getBindings("js").putMember(
+         "setChar", new ScriptFunction(t, Target.class, "setChar", char.class));
+
+      ctx.eval("js", "setChar()");
+
+      assertTrue(t.called);
+      assertEquals('\0', t.ch, "omitted char argument should default to '\\0'");
    }
 }

--- a/core/src/test/java/inetsoft/util/script/graal/ScriptFunctionTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/ScriptFunctionTest.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util.script.graal;
+
+import org.graalvm.polyglot.Context;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class ScriptFunctionTest {
+   private Context ctx;
+
+   @BeforeEach void setup() { ctx = Context.create("js"); }
+   @AfterEach void teardown() { ctx.close(); }
+
+   /** Records the arguments a script function was invoked with. */
+   public static final class Target {
+      public String name;
+      public boolean visible = true; // non-default so we can detect "false was passed"
+      public int count = -1;
+      public boolean called;
+
+      public void setActionVisible(String name, boolean visible) {
+         this.called = true;
+         this.name = name;
+         this.visible = visible;
+      }
+
+      public void setCount(int count) {
+         this.called = true;
+         this.count = count;
+      }
+   }
+
+   @Test
+   void omittedBooleanArgDefaultsToFalse() {
+      // Bug #75525: setActionVisible('Edit') omits the trailing boolean; the
+      // reflective invocation must default it to false (Rhino behavior), not
+      // fail trying to unbox null into a primitive boolean.
+      Target t = new Target();
+      ctx.getBindings("js").putMember(
+         "setActionVisible",
+         new ScriptFunction(t, Target.class, "setActionVisible", String.class, boolean.class));
+
+      ctx.eval("js", "setActionVisible('Edit')");
+
+      assertTrue(t.called);
+      assertEquals("Edit", t.name);
+      assertFalse(t.visible, "omitted boolean argument should default to false");
+   }
+
+   @Test
+   void explicitBooleanArgPreserved() {
+      Target t = new Target();
+      ctx.getBindings("js").putMember(
+         "setActionVisible",
+         new ScriptFunction(t, Target.class, "setActionVisible", String.class, boolean.class));
+
+      ctx.eval("js", "setActionVisible('Edit', true)");
+
+      assertTrue(t.visible, "explicit boolean argument should be preserved");
+   }
+
+   @Test
+   void omittedNumericArgDefaultsToZero() {
+      Target t = new Target();
+      ctx.getBindings("js").putMember(
+         "setCount", new ScriptFunction(t, Target.class, "setCount", int.class));
+
+      ctx.eval("js", "setCount()");
+
+      assertTrue(t.called);
+      assertEquals(0, t.count, "omitted numeric argument should default to 0");
+   }
+
+   @Test
+   void numericArgIsNarrowed() {
+      // a script number (Double) passed to an int parameter must still be narrowed
+      Target t = new Target();
+      ctx.getBindings("js").putMember(
+         "setCount", new ScriptFunction(t, Target.class, "setCount", int.class));
+
+      ctx.eval("js", "setCount(42)");
+
+      assertEquals(42, t.count);
+   }
+}


### PR DESCRIPTION
## Summary

A Script Library function that calls an unqualified assembly script function (e.g. `setActionVisible`) threw `ReferenceError: setActionVisible is not defined` after the Rhino→GraalJS migration (Feature #75423). Fixing the scope resolution revealed a second regression — `Failed to invoke script function: setActionVisible` — when such a function is called with a trailing primitive argument omitted. This PR fixes both.

## Root Cause

1. **Scope resolution.** Viewsheet/assembly scripts are compiled wrapped as `with(__scope__){ ... }`, where `__scope__` (`BindingRootProxy`) resolves unqualified names against the engine/global scope chain **plus the live executing assembly scope** (`FormulaContext.getExecScriptScope`). Library functions, however, were installed once at engine init (`GraalJavaScriptEngine.installLibraryFunctions`) by evaluating their source at the **top level of the context** with no `with(__scope__)` wrapper. The function became a callable global, but its body's lexical scope was only the global bindings, so dynamic assembly members like `setActionVisible` were unresolvable. Under Rhino this worked via `ViewsheetScope.get()`'s fallback to `FormulaContext.execScriptable`.

2. **Argument coercion.** All script functions are exposed via `ScriptFunction` (a `ProxyExecutable`). When a script omits a trailing argument (e.g. `setActionVisible('Edit')` against `setActionVisible(String name, boolean visible)`), `execute()` passes host `null`, and `coerce(null, boolean.class)` returned `null`. Reflective `Method.invoke` cannot unbox `null` into a primitive `boolean`, so it threw. Under Rhino, an omitted/undefined boolean defaulted to `false` (which is why the "hide actions" script worked — `visible=false`).

## Fix

1. **`GraalJavaScriptEngine`** — wrap each library function definition in `with(__scope__){ ... }`. In sloppy mode the function declaration is still hoisted to a callable global, but its closure now captures the `__scope__` object-environment, so unqualified names resolve dynamically against the currently executing assembly scope at call time. `__scope__` is now bound (via `ensureScopeProxy()`) before library functions are installed; it remains the single reused proxy whose root/imports are swapped per `exec`.

2. **`ScriptFunction.coerce`** — when an argument is `null` (omitted or `undefined`/`null`) and the parameter is a primitive, return that primitive's Java default (`false`, `0`, `0L`, `0d`, `0f`, `(short)0`, `(byte)0`, `'\0'`); object parameters still receive `null`. Mirrors Rhino's `FunctionObject` argument conversion.

## Test Plan

- Added `LibFunctionCallableTest.libFunctionResolvesExecScopeMember` — a library function whose body calls a name provided only by the executing scope now resolves it (fails without fix #1).
- Added `ScriptFunctionTest` — omitted boolean arg defaults to `false`, omitted numeric arg defaults to `0`, explicit args and `Number` narrowing preserved (fails without fix #2).
- `./mvnw test -pl core -am -Dtest='ScriptFunctionTest,LibFunctionCallableTest'` — all pass; build green.
- Verified end-to-end with the reporter's `hideChartActionsChart.zip`: `hideChartActions()` now runs cleanly with every action hidden.

Fixes Redmine #75525.