### PR TITLE
Bug #75526, restore worksheet table name resolution in viewsheet scripts under GraalJS

### DIFF
--- a/core/src/main/java/inetsoft/report/script/formula/AssetQueryScope.java
+++ b/core/src/main/java/inetsoft/report/script/formula/AssetQueryScope.java
@@ -24,6 +24,7 @@ import inetsoft.uql.asset.TableAssembly;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.script.VariableScriptable;
 import inetsoft.util.script.DynamicScope;
+import inetsoft.util.script.graal.ScriptScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -163,6 +164,16 @@ public class AssetQueryScope implements DynamicScope, Cloneable {
       return members.keySet().toArray(new Object[0]);
    }
 
+   @Override
+   public ScriptScope getParentScope() {
+      return parentScope;
+   }
+
+   @Override
+   public void setParentScope(ScriptScope parent) {
+      this.parentScope = parent;
+   }
+
    /**
     * Get the name of this scriptable.
     */
@@ -191,6 +202,7 @@ public class AssetQueryScope implements DynamicScope, Cloneable {
    private AssetQuerySandbox box;
    private Map tablemap = new HashMap();
    private final Map<String, Object> members = new LinkedHashMap<>();
+   private ScriptScope parentScope;
 
    private static final Logger LOG =
       LoggerFactory.getLogger(AssetQueryScope.class);

--- a/core/src/main/java/inetsoft/report/script/formula/AssetQueryScope.java
+++ b/core/src/main/java/inetsoft/report/script/formula/AssetQueryScope.java
@@ -202,7 +202,8 @@ public class AssetQueryScope implements DynamicScope, Cloneable {
    private AssetQuerySandbox box;
    private Map tablemap = new HashMap();
    private final Map<String, Object> members = new LinkedHashMap<>();
-   private ScriptScope parentScope;
+   // volatile for safe publication (see ViewsheetScope.parentScope)
+   private volatile ScriptScope parentScope;
 
    private static final Logger LOG =
       LoggerFactory.getLogger(AssetQueryScope.class);

--- a/core/src/main/java/inetsoft/report/script/viewsheet/ViewsheetScope.java
+++ b/core/src/main/java/inetsoft/report/script/viewsheet/ViewsheetScope.java
@@ -401,6 +401,16 @@ public class ViewsheetScope implements Cloneable, DynamicScope {
       propmap.put(name, value);
    }
 
+   @Override
+   public ScriptScope getParentScope() {
+      return parentScope;
+   }
+
+   @Override
+   public void setParentScope(ScriptScope parent) {
+      this.parentScope = parent;
+   }
+
    /**
     * Add a variable.
     */
@@ -1044,6 +1054,7 @@ public class ViewsheetScope implements Cloneable, DynamicScope {
    private Map<String, Object> propmap = Collections.synchronizedMap(new HashMap<>());
    private final Map<String, Object> members = new LinkedHashMap<>();
    private Vector<String> oldAssemblies = new Vector<>();
+   private ScriptScope parentScope;
    private DBScriptable db;
    private long executeStart = System.currentTimeMillis();
 

--- a/core/src/main/java/inetsoft/report/script/viewsheet/ViewsheetScope.java
+++ b/core/src/main/java/inetsoft/report/script/viewsheet/ViewsheetScope.java
@@ -1054,7 +1054,9 @@ public class ViewsheetScope implements Cloneable, DynamicScope {
    private Map<String, Object> propmap = Collections.synchronizedMap(new HashMap<>());
    private final Map<String, Object> members = new LinkedHashMap<>();
    private Vector<String> oldAssemblies = new Vector<>();
-   private ScriptScope parentScope;
+   // volatile for safe publication: ViewsheetSandbox.getScope() has an
+   // unsynchronized fast-path read of the published scope
+   private volatile ScriptScope parentScope;
    private DBScriptable db;
    private long executeStart = System.currentTimeMillis();
 

--- a/core/src/main/java/inetsoft/util/script/DynamicScope.java
+++ b/core/src/main/java/inetsoft/util/script/DynamicScope.java
@@ -27,8 +27,13 @@ public interface DynamicScope extends ScriptScope {
     * Set the next scope in the lookup chain. Used by
     * {@link inetsoft.util.script.JavaScriptEngine#addToPrototype} to chain
     * cooperating dynamic scopes (e.g. a viewsheet scope to its worksheet
-    * scope). The default is a no-op; implementations that participate in
-    * scope chaining override this together with {@link #getParentScope()}.
+    * scope). The default is a no-op.
+    *
+    * <p>Implementations that participate in scope chaining must override
+    * <b>both</b> this method and {@link #getParentScope()} as a pair: the
+    * inherited {@link ScriptScope#getParentScope()} default returns
+    * {@code null}, so overriding only {@code setParentScope} would store a
+    * parent that no caller can ever read, silently breaking name resolution.
     */
    default void setParentScope(ScriptScope parent) {
    }

--- a/core/src/main/java/inetsoft/util/script/DynamicScope.java
+++ b/core/src/main/java/inetsoft/util/script/DynamicScope.java
@@ -23,4 +23,13 @@ import inetsoft.util.script.graal.ScriptScope;
  * Mark a scriptable that should be treated as dynamic scope for script function.
  */
 public interface DynamicScope extends ScriptScope {
+   /**
+    * Set the next scope in the lookup chain. Used by
+    * {@link inetsoft.util.script.JavaScriptEngine#addToPrototype} to chain
+    * cooperating dynamic scopes (e.g. a viewsheet scope to its worksheet
+    * scope). The default is a no-op; implementations that participate in
+    * scope chaining override this together with {@link #getParentScope()}.
+    */
+   default void setParentScope(ScriptScope parent) {
+   }
 }

--- a/core/src/main/java/inetsoft/util/script/JavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/JavaScriptEngine.java
@@ -884,15 +884,52 @@ public class JavaScriptEngine {
    }
 
    /**
-    * Add a JS object to a scope's prototype chain.
+    * Add a JS object to the end of a scope's lookup chain.
     *
-    * <p>TODO(cutover): Rhino prototype-chain injection is obsolete under
-    * GraalJS, which resolves names through the FormulaContext scope chain
-    * (see BindingRootProxy). This is now a no-op; the dynamic-library and
-    * worksheet scope members are exposed through the scope objects directly.
+    * <p>Under GraalJS, unqualified name resolution walks the
+    * {@link ScriptScope#getParentScope()} chain (see BindingRootProxy), which
+    * replaces the Rhino prototype chain. This appends {@code jsobj} at the end
+    * of {@code scope}'s parent chain so the two cooperating scopes (e.g. a
+    * viewsheet scope and its worksheet {@code AssetQueryScope}) resolve each
+    * other's members. The terminal scope must be a {@link DynamicScope}
+    * (the only scopes chained this way); otherwise this is a no-op. A
+    * duplicate/cycle guard prevents re-adding {@code jsobj} or forming a loop.
     */
    public static void addToPrototype(Object scope, Object jsobj) {
-      // no-op (see javadoc)
+      if(!(scope instanceof ScriptScope) || !(jsobj instanceof ScriptScope)) {
+         return;
+      }
+
+      ScriptScope start = (ScriptScope) scope;
+      ScriptScope obj = (ScriptScope) jsobj;
+
+      if(start == obj) {
+         return;
+      }
+
+      // if jsobj's own chain already leads back to scope, appending scope -> jsobj
+      // would close a loop; bail out
+      for(ScriptScope s = obj; s != null; s = s.getParentScope()) {
+         if(s == start) {
+            return;
+         }
+      }
+
+      // walk to the end of the parent chain, bailing out if jsobj is already
+      // present (already added, or would create a cycle)
+      ScriptScope target = start;
+
+      while(target.getParentScope() != null) {
+         if(target.getParentScope() == obj) {
+            return;
+         }
+
+         target = target.getParentScope();
+      }
+
+      if(target instanceof DynamicScope) {
+         ((DynamicScope) target).setParentScope(obj);
+      }
    }
 
    public static void setOnClickScript(boolean value) {

--- a/core/src/test/java/inetsoft/util/script/AddToPrototypeTest.java
+++ b/core/src/test/java/inetsoft/util/script/AddToPrototypeTest.java
@@ -42,6 +42,14 @@ class AddToPrototypeTest {
       public void setParentScope(ScriptScope p) { this.parent = p; }
    }
 
+   /** A plain ScriptScope that is NOT a DynamicScope (no settable parent). */
+   static class LeafScope implements ScriptScope {
+      public Object getMember(String n) { return null; }
+      public boolean hasMember(String n) { return false; }
+      public void putMember(String n, Object v) { }
+      public Object[] getMemberKeys() { return new Object[0]; }
+   }
+
    @Test void appendsParentWhenChainEmpty() {
       ChainScope a = new ChainScope();
       ChainScope b = new ChainScope();
@@ -73,6 +81,33 @@ class AddToPrototypeTest {
 
       assertSame(b, a.getParentScope());
       assertNull(b.getParentScope());
+   }
+
+   @Test void doesNothingWhenAlreadyPresentDeeper() {
+      ChainScope a = new ChainScope();
+      ChainScope b = new ChainScope();
+      ChainScope c = new ChainScope();
+      a.setParentScope(b);
+      b.setParentScope(c);
+
+      // c already sits two hops away; the walk must detect it at depth > 1
+      JavaScriptEngine.addToPrototype(a, c);
+
+      assertSame(b, a.getParentScope());
+      assertSame(c, b.getParentScope());
+      assertNull(c.getParentScope());
+   }
+
+   @Test void doesNothingWhenTerminalIsNotDynamicScope() {
+      ChainScope a = new ChainScope();
+      LeafScope b = new LeafScope();   // not a DynamicScope -> no settable parent
+      ChainScope c = new ChainScope();
+      a.setParentScope(b);
+
+      // the chain tail (b) cannot accept a parent; append is silently skipped
+      JavaScriptEngine.addToPrototype(a, c);
+
+      assertSame(b, a.getParentScope());
    }
 
    @Test void doesNothingWhenScopeEqualsObject() {

--- a/core/src/test/java/inetsoft/util/script/AddToPrototypeTest.java
+++ b/core/src/test/java/inetsoft/util/script/AddToPrototypeTest.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util.script;
+
+import inetsoft.util.script.graal.ScriptScope;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression guard for {@link JavaScriptEngine#addToPrototype}. This is the
+ * method that chains a viewsheet scope to its worksheet {@code AssetQueryScope}
+ * (and vice versa) so that worksheet table names resolve in viewsheet scripts.
+ * It was reduced to a no-op during the GraalJS migration, breaking that
+ * resolution (Bug #75526).
+ */
+@Tag("core")
+class AddToPrototypeTest {
+   /** Minimal dynamic scope with a settable parent link. */
+   static class ChainScope implements DynamicScope {
+      private ScriptScope parent;
+      public Object getMember(String n) { return null; }
+      public boolean hasMember(String n) { return false; }
+      public void putMember(String n, Object v) { }
+      public Object[] getMemberKeys() { return new Object[0]; }
+      public ScriptScope getParentScope() { return parent; }
+      public void setParentScope(ScriptScope p) { this.parent = p; }
+   }
+
+   @Test void appendsParentWhenChainEmpty() {
+      ChainScope a = new ChainScope();
+      ChainScope b = new ChainScope();
+
+      JavaScriptEngine.addToPrototype(a, b);
+
+      assertSame(b, a.getParentScope());
+   }
+
+   @Test void appendsAtEndOfExistingChain() {
+      ChainScope a = new ChainScope();
+      ChainScope b = new ChainScope();
+      ChainScope c = new ChainScope();
+      a.setParentScope(b);
+
+      JavaScriptEngine.addToPrototype(a, c);
+
+      // c is appended at the end of the chain, not in front of b
+      assertSame(b, a.getParentScope());
+      assertSame(c, b.getParentScope());
+   }
+
+   @Test void doesNothingWhenAlreadyPresent() {
+      ChainScope a = new ChainScope();
+      ChainScope b = new ChainScope();
+      a.setParentScope(b);
+
+      JavaScriptEngine.addToPrototype(a, b);
+
+      assertSame(b, a.getParentScope());
+      assertNull(b.getParentScope());
+   }
+
+   @Test void doesNothingWhenScopeEqualsObject() {
+      ChainScope a = new ChainScope();
+
+      JavaScriptEngine.addToPrototype(a, a);
+
+      assertNull(a.getParentScope());
+   }
+
+   @Test void doesNotFormCycle() {
+      ChainScope a = new ChainScope();
+      ChainScope b = new ChainScope();
+      // b already leads back to a; appending a -> b would close a loop
+      b.setParentScope(a);
+
+      JavaScriptEngine.addToPrototype(a, b);
+
+      assertNull(a.getParentScope());
+      assertSame(a, b.getParentScope());
+   }
+
+   @Test void ignoresNonScriptScopeArguments() {
+      ChainScope a = new ChainScope();
+
+      assertDoesNotThrow(() -> JavaScriptEngine.addToPrototype("not a scope", a));
+      assertDoesNotThrow(() -> JavaScriptEngine.addToPrototype(a, "not a scope"));
+      assertNull(a.getParentScope());
+   }
+}


### PR DESCRIPTION
## Summary

Referencing a base-worksheet table by name in a viewsheet script (e.g. `Orders['City']`, inserted from the script dialog's **Data** tree node) threw `ReferenceError: Orders is not defined`. This is a regression from the Rhino → GraalJS migration (Feature #75423).

## Root Cause

`JavaScriptEngine.addToPrototype(scope, jsobj)` was reduced to a no-op during the migration. Under Rhino it appended `jsobj` to the end of the scope's prototype chain; two call sites depend on it:

- `ViewsheetSandbox.getScope()` chains the worksheet `AssetQueryScope` onto the `ViewsheetScope` so worksheet tables resolve in viewsheet scripts.
- `AssetQuerySandbox.createAssetQueryScope()` chains a `ViewsheetScope` onto the worksheet scope so viewsheet assemblies resolve in worksheet scripts.

Under GraalJS, unqualified name resolution is done by `BindingRootProxy.findInChain()`, which walks the `ScriptScope.getParentScope()` chain. With `addToPrototype` a no-op, `ViewsheetScope.getParentScope()` returned the interface default (`null`), so the `AssetQueryScope` — whose `getMember`/`hasMember` resolve worksheet `TableAssembly` names to a `TableAssemblyScriptable` (`TableArray`) — was never reached.

## Fix

- Reimplement `JavaScriptEngine.addToPrototype` to append `jsobj` at the end of `scope`'s `getParentScope()` chain (the GraalJS equivalent of the old prototype chain), with a duplicate/cycle guard.
- Add a no-op `default void setParentScope(ScriptScope)` on the `DynamicScope` interface.
- Give `ViewsheetScope` and `AssetQueryScope` a settable parent scope (field + `getParentScope`/`setParentScope` overrides).

No change to `BindingRootProxy`, `getMember`, or `hasMember` — those were already correct; only the parent link was missing. The fix also restores the reverse direction (viewsheet assemblies visible in worksheet scripts).

## Test Plan

- Added `AddToPrototypeTest` (6 cases): empty-chain append, append at end of an existing chain, no-op when already present, self no-op, cycle prevention, and non-`ScriptScope` argument handling.
- Existing GraalJS engine/scope suites pass (`BindingRootProxyTest`, `GraalJavaScriptEngineScopeTest`, `GraalJavaScriptEngineTest`, `GraalJavaScriptEnvTest`, `JavaScriptEngineTest`, `ScopeProxyTest`).
- Manual: viewsheet bound to a worksheet with a `TableAssembly` "Orders"; a Text assembly with script `text = Orders['City']` now populates instead of throwing `ReferenceError`. Verified by reporter.

Fixes Redmine #75526.