### PR TITLE
fix(embed): non-chart embed types render in the live viewer (*ngIf → @if)

### DIFF
--- a/web/projects/portal/src/app/embed/crosstab/embed-crosstab.component.html
+++ b/web/projects/portal/src/app/embed/crosstab/embed-crosstab.component.html
@@ -22,32 +22,40 @@
      [attr.runtime-id]="runtimeId"
      (mouseenter)="onMouseEnter($event)"
      (resized)="onResize()">
-  <vs-crosstab *ngIf="vsObject && runtimeId && !timeoutError"
+  @if (vsObject && runtimeId && !timeoutError) {
+    <vs-crosstab
                [vsInfo]="vsInfo" [model]="vsObject" [actions]="vsObjectActions"
                [appSize]="appSize"
                [container]="viewerRoot"
                [variableValues]="variableValuesFunction"
                (contextmenu)="onOpenContextMenu($event)">
-  </vs-crosstab>
-  <div *ngIf="showError" class="error-crosstab txt-danger">
-    <span class="error-label">
-      _#(Failed to generate crosstab)
-    </span>
-  </div>
-  <div *ngIf="!showError && timeoutError" class="error-crosstab txt-danger">
-    <span class="error-label">
-      _#(vs.viewsheet.crosstab.timeout)
-    </span>
-  </div>
+    </vs-crosstab>
+  }
+  @if (showError) {
+    <div class="error-crosstab txt-danger">
+      <span class="error-label">
+        _#(Failed to generate crosstab)
+      </span>
+    </div>
+  }
+  @if (!showError && timeoutError) {
+    <div class="error-crosstab txt-danger">
+      <span class="error-label">
+        _#(vs.viewsheet.crosstab.timeout)
+      </span>
+    </div>
+  }
 
-  <mini-toolbar *ngIf="isMiniToolbarVisible()"
+  @if (isMiniToolbarVisible()) {
+    <mini-toolbar
                 [actions]="vsObjectActions"
                 [top]="getToolbarTop(vsObject)"
                 [left]="getToolbarLeft(vsObject)"
                 [width]="getToolbarWidth(vsObject)"
                 [assembly]="vsObject.absoluteName"
                 [forceHide]="!showMiniToolbar()">
-  </mini-toolbar>
+    </mini-toolbar>
+  }
 </div>
 
 <dl-download-target

--- a/web/projects/portal/src/app/embed/crosstab/embed-crosstab.component.ts
+++ b/web/projects/portal/src/app/embed/crosstab/embed-crosstab.component.ts
@@ -185,7 +185,6 @@ export class EmbedCrosstabComponent extends CommandProcessor implements OnInit, 
          this.assemblyName = result.posParams?.assemblyName?.path;
          this.inputRuntimeId = result.posParams?.runtimeId?.path;
          this.queryParams = tree.queryParams;
-
          this.subscriptions.add(
             (window.inetsoftConnected as BehaviorSubject<boolean>).subscribe((connected) => {
                if(!this.connected && connected) {
@@ -317,6 +316,8 @@ export class EmbedCrosstabComponent extends CommandProcessor implements OnInit, 
 
       this.vsObjectActions = new EmbedCrosstabActions(this.vsObject, this.contextProvider,
          false, null, null, null, this.miniToolbarService);
+      // Force change detection: as an Angular Elements custom element, this view is not refreshed by the zone tick that wraps websocket command processing, so the embedded object would otherwise never render on open.
+      this.cdRef.detectChanges();
    }
 
    // noinspection JSUnusedGlobalSymbols
@@ -335,6 +336,8 @@ export class EmbedCrosstabComponent extends CommandProcessor implements OnInit, 
       this.vsObject.active = true;
       this.vsObjectActions = new EmbedCrosstabActions(this.vsObject, this.contextProvider,
          false, null, null, null, this.miniToolbarService);
+      // Force change detection: as an Angular Elements custom element, this view is not refreshed by the zone tick that wraps websocket command processing, so the embedded object would otherwise never render on open.
+      this.cdRef.detectChanges();
    }
 
    // noinspection JSUnusedGlobalSymbols

--- a/web/projects/portal/src/app/embed/gauge/embed-gauge.component.html
+++ b/web/projects/portal/src/app/embed/gauge/embed-gauge.component.html
@@ -22,28 +22,36 @@
      [attr.runtime-id]="runtimeId"
      (mouseenter)="onMouseEnter($event)"
      (resized)="onResize()">
-  <vs-gauge *ngIf="vsObject && runtimeId && !timeoutError"
+  @if (vsObject && runtimeId && !timeoutError) {
+    <vs-gauge
             [vsInfo]="vsInfo" [model]="vsObject" [actions]="vsObjectActions"
             [container]="viewerRoot"
             (contextmenu)="onOpenContextMenu($event)">
-  </vs-gauge>
-  <div *ngIf="showError" class="error-gauge txt-danger">
-    <span class="error-label">
-      _#(Failed to generate gauge)
-    </span>
-  </div>
-  <div *ngIf="!showError && timeoutError" class="error-gauge txt-danger">
-    <span class="error-label">
-      _#(vs.viewsheet.timeout)
-    </span>
-  </div>
+    </vs-gauge>
+  }
+  @if (showError) {
+    <div class="error-gauge txt-danger">
+      <span class="error-label">
+        _#(Failed to generate gauge)
+      </span>
+    </div>
+  }
+  @if (!showError && timeoutError) {
+    <div class="error-gauge txt-danger">
+      <span class="error-label">
+        _#(vs.viewsheet.timeout)
+      </span>
+    </div>
+  }
 
-  <mini-toolbar *ngIf="isMiniToolbarVisible()"
+  @if (isMiniToolbarVisible()) {
+    <mini-toolbar
                 [actions]="vsObjectActions"
                 [top]="getToolbarTop(vsObject)"
                 [left]="getToolbarLeft(vsObject)"
                 [width]="getToolbarWidth(vsObject)"
                 [assembly]="vsObject.absoluteName"
                 [forceHide]="!showMiniToolbar()">
-  </mini-toolbar>
+    </mini-toolbar>
+  }
 </div>

--- a/web/projects/portal/src/app/embed/gauge/embed-gauge.component.ts
+++ b/web/projects/portal/src/app/embed/gauge/embed-gauge.component.ts
@@ -289,6 +289,8 @@ export class EmbedGaugeComponent extends CommandProcessor implements OnInit, OnD
 
       this.vsObjectActions = new EmbedGaugeActions(this.vsObject, this.contextProvider,
          false, null, null, null, this.miniToolbarService);
+      // Force change detection: as an Angular Elements custom element, this view is not refreshed by the zone tick that wraps websocket command processing, so the embedded object would otherwise never render on open.
+      this.cdRef.detectChanges();
    }
 
    processRefreshVSObjectCommand(command: RefreshVSObjectCommand): void {
@@ -306,6 +308,8 @@ export class EmbedGaugeComponent extends CommandProcessor implements OnInit, OnD
       this.vsObject.active = true;
       this.vsObjectActions = new EmbedGaugeActions(this.vsObject, this.contextProvider,
          false, null, null, null, this.miniToolbarService);
+      // Force change detection: as an Angular Elements custom element, this view is not refreshed by the zone tick that wraps websocket command processing, so the embedded object would otherwise never render on open.
+      this.cdRef.detectChanges();
    }
 
    processCollectParametersCommand(command: CollectParametersCommand): void {

--- a/web/projects/portal/src/app/embed/image/embed-image.component.html
+++ b/web/projects/portal/src/app/embed/image/embed-image.component.html
@@ -22,28 +22,36 @@
      [attr.runtime-id]="runtimeId"
      (mouseenter)="onMouseEnter($event)"
      (resized)="onResize()">
-  <vs-image *ngIf="vsObject && runtimeId && !timeoutError"
+  @if (vsObject && runtimeId && !timeoutError) {
+    <vs-image
             [vsInfo]="vsInfo" [model]="vsObject" [actions]="vsObjectActions"
             [container]="viewerRoot"
             (contextmenu)="onOpenContextMenu($event)">
-  </vs-image>
-  <div *ngIf="showError" class="error-image txt-danger">
-    <span class="error-label">
-      _#(Failed to generate image)
-    </span>
-  </div>
-  <div *ngIf="!showError && timeoutError" class="error-image txt-danger">
-    <span class="error-label">
-      _#(vs.viewsheet.timeout)
-    </span>
-  </div>
+    </vs-image>
+  }
+  @if (showError) {
+    <div class="error-image txt-danger">
+      <span class="error-label">
+        _#(Failed to generate image)
+      </span>
+    </div>
+  }
+  @if (!showError && timeoutError) {
+    <div class="error-image txt-danger">
+      <span class="error-label">
+        _#(vs.viewsheet.timeout)
+      </span>
+    </div>
+  }
 
-  <mini-toolbar *ngIf="isMiniToolbarVisible()"
+  @if (isMiniToolbarVisible()) {
+    <mini-toolbar
                 [actions]="vsObjectActions"
                 [top]="getToolbarTop(vsObject)"
                 [left]="getToolbarLeft(vsObject)"
                 [width]="getToolbarWidth(vsObject)"
                 [assembly]="vsObject.absoluteName"
                 [forceHide]="!showMiniToolbar()">
-  </mini-toolbar>
+    </mini-toolbar>
+  }
 </div>

--- a/web/projects/portal/src/app/embed/image/embed-image.component.ts
+++ b/web/projects/portal/src/app/embed/image/embed-image.component.ts
@@ -289,6 +289,8 @@ export class EmbedImageComponent extends CommandProcessor implements OnInit, OnD
 
       this.vsObjectActions = new EmbedImageActions(this.vsObject,
          this.contextProvider, false, null, null, null, this.miniToolbarService);
+      // Force change detection: as an Angular Elements custom element, this view is not refreshed by the zone tick that wraps websocket command processing, so the embedded object would otherwise never render on open.
+      this.cdRef.detectChanges();
    }
 
    processRefreshVSObjectCommand(command: RefreshVSObjectCommand): void {
@@ -306,6 +308,8 @@ export class EmbedImageComponent extends CommandProcessor implements OnInit, OnD
       this.vsObject.active = true;
       this.vsObjectActions = new EmbedImageActions(this.vsObject,
          this.contextProvider, false, null, null, null, this.miniToolbarService);
+      // Force change detection: as an Angular Elements custom element, this view is not refreshed by the zone tick that wraps websocket command processing, so the embedded object would otherwise never render on open.
+      this.cdRef.detectChanges();
    }
 
    processCollectParametersCommand(command: CollectParametersCommand): void {

--- a/web/projects/portal/src/app/embed/table/embed-table.component.html
+++ b/web/projects/portal/src/app/embed/table/embed-table.component.html
@@ -22,32 +22,40 @@
      [attr.runtime-id]="runtimeId"
      (mouseenter)="onMouseEnter($event)"
      (resized)="onResize()">
-  <vs-table *ngIf="vsObject && runtimeId && !timeoutError"
+  @if (vsObject && runtimeId && !timeoutError) {
+    <vs-table
             [vsInfo]="vsInfo" [model]="vsObject" [actions]="vsObjectActions"
             [appSize]="appSize"
             [container]="viewerRoot"
             [variableValues]="variableValuesFunction"
             (contextmenu)="onOpenContextMenu($event)">
-  </vs-table>
-  <div *ngIf="showError" class="error-table txt-danger">
-    <span class="error-label">
-      _#(Failed to generate table)
-    </span>
-  </div>
-  <div *ngIf="!showError && timeoutError" class="error-table txt-danger">
-    <span class="error-label">
-      _#(vs.viewsheet.table.timeout)
-    </span>
-  </div>
+    </vs-table>
+  }
+  @if (showError) {
+    <div class="error-table txt-danger">
+      <span class="error-label">
+        _#(Failed to generate table)
+      </span>
+    </div>
+  }
+  @if (!showError && timeoutError) {
+    <div class="error-table txt-danger">
+      <span class="error-label">
+        _#(vs.viewsheet.table.timeout)
+      </span>
+    </div>
+  }
 
-  <mini-toolbar *ngIf="isMiniToolbarVisible()"
+  @if (isMiniToolbarVisible()) {
+    <mini-toolbar
                 [actions]="vsObjectActions"
                 [top]="getToolbarTop(vsObject)"
                 [left]="getToolbarLeft(vsObject)"
                 [width]="getToolbarWidth(vsObject)"
                 [assembly]="vsObject.absoluteName"
                 [forceHide]="!showMiniToolbar()">
-  </mini-toolbar>
+    </mini-toolbar>
+  }
 </div>
 
 <dl-download-target

--- a/web/projects/portal/src/app/embed/table/embed-table.component.ts
+++ b/web/projects/portal/src/app/embed/table/embed-table.component.ts
@@ -317,6 +317,8 @@ export class EmbedTableComponent extends CommandProcessor implements OnInit, OnD
 
       this.vsObjectActions = new EmbedTableActions(this.vsObject, this.contextProvider,
          false, null, null, null, this.miniToolbarService);
+      // Force change detection: as an Angular Elements custom element, this view is not refreshed by the zone tick that wraps websocket command processing, so the embedded object would otherwise never render on open.
+      this.cdRef.detectChanges();
    }
 
    // noinspection JSUnusedGlobalSymbols
@@ -335,6 +337,8 @@ export class EmbedTableComponent extends CommandProcessor implements OnInit, OnD
       this.vsObject.active = true;
       this.vsObjectActions = new EmbedTableActions(this.vsObject, this.contextProvider,
          false, null, null, null, this.miniToolbarService);
+      // Force change detection: as an Angular Elements custom element, this view is not refreshed by the zone tick that wraps websocket command processing, so the embedded object would otherwise never render on open.
+      this.cdRef.detectChanges();
    }
 
    // noinspection JSUnusedGlobalSymbols

--- a/web/projects/portal/src/app/embed/text/embed-text.component.html
+++ b/web/projects/portal/src/app/embed/text/embed-text.component.html
@@ -22,28 +22,36 @@
      [attr.runtime-id]="runtimeId"
      (mouseenter)="onMouseEnter($event)"
      (resized)="onResize()">
-  <vs-text *ngIf="vsObject && runtimeId && !timeoutError"
+  @if (vsObject && runtimeId && !timeoutError) {
+    <vs-text
            [vsInfo]="vsInfo" [model]="vsObject" [actions]="vsObjectActions"
            [container]="viewerRoot"
            (contextmenu)="onOpenContextMenu($event)">
-  </vs-text>
-  <div *ngIf="showError" class="error-text txt-danger">
-    <span class="error-label">
-      _#(Failed to generate text)
-    </span>
-  </div>
-  <div *ngIf="!showError && timeoutError" class="error-text txt-danger">
-    <span class="error-label">
-      _#(vs.viewsheet.timeout)
-    </span>
-  </div>
+    </vs-text>
+  }
+  @if (showError) {
+    <div class="error-text txt-danger">
+      <span class="error-label">
+        _#(Failed to generate text)
+      </span>
+    </div>
+  }
+  @if (!showError && timeoutError) {
+    <div class="error-text txt-danger">
+      <span class="error-label">
+        _#(vs.viewsheet.timeout)
+      </span>
+    </div>
+  }
 
-  <mini-toolbar *ngIf="isMiniToolbarVisible()"
+  @if (isMiniToolbarVisible()) {
+    <mini-toolbar
                 [actions]="vsObjectActions"
                 [top]="getToolbarTop(vsObject)"
                 [left]="getToolbarLeft(vsObject)"
                 [width]="getToolbarWidth(vsObject)"
                 [assembly]="vsObject.absoluteName"
                 [forceHide]="!showMiniToolbar()">
-  </mini-toolbar>
+    </mini-toolbar>
+  }
 </div>

--- a/web/projects/portal/src/app/embed/text/embed-text.component.ts
+++ b/web/projects/portal/src/app/embed/text/embed-text.component.ts
@@ -289,6 +289,8 @@ export class EmbedTextComponent extends CommandProcessor implements OnInit, OnDe
 
       this.vsObjectActions = new EmbedTextActions(this.vsObject,
          this.contextProvider, false, null, null, null, this.miniToolbarService);
+      // Force change detection: as an Angular Elements custom element, this view is not refreshed by the zone tick that wraps websocket command processing, so the embedded object would otherwise never render on open.
+      this.cdRef.detectChanges();
    }
 
    processRefreshVSObjectCommand(command: RefreshVSObjectCommand): void {
@@ -306,6 +308,8 @@ export class EmbedTextComponent extends CommandProcessor implements OnInit, OnDe
       this.vsObject.active = true;
       this.vsObjectActions = new EmbedTextActions(this.vsObject,
          this.contextProvider, false, null, null, null, this.miniToolbarService);
+      // Force change detection: as an Angular Elements custom element, this view is not refreshed by the zone tick that wraps websocket command processing, so the embedded object would otherwise never render on open.
+      this.cdRef.detectChanges();
    }
 
    processCollectParametersCommand(command: CollectParametersCommand): void {


### PR DESCRIPTION
## Problem
In the companion live viewer, **crosstab, table, gauge, text, and image** assemblies render as an **empty bordered container** — only **chart** works.

## Root cause
The five non-chart embed components (`embed-crosstab/table/gauge/text/image.component`) are **standalone** but their templates use the legacy **`*ngIf`** structural directive *without importing `NgIf`/`CommonModule`*. With no matching directive, `*ngIf` is inert and the gated elements (`<vs-crosstab>`/`<vs-table>`/…, plus the error and mini-toolbar blocks) are **never instantiated** — so nothing paints, even though the server sends the object model (`AddVSObjectCommand`) and the cell data (`LoadTableDataCommand`).

The chart embed works only because it was already migrated to Angular's built-in **`@if`** control flow (which requires no import).

Diagnosis was confirmed end-to-end with runtime logging: `processAddVSObjectCommand` runs fully (`assemblyName === command.name`, `runtimeId` set, no early return) and sets `vsObject`, yet the `*ngIf`-gated `<vs-crosstab>` was absent from the DOM.

## Fix — bring the 5 non-chart embeds to parity with the working chart embed
- Convert every `*ngIf="cond"` → `@if (cond) { … }` in all five templates (mirrors `embed-chart.component.html`; no `NgIf` import needed).
- Add `cdRef.detectChanges()` to `processAddVSObjectCommand` / `processRefreshVSObjectCommand` in all five components, mirroring the chart fix — as Angular Elements custom elements their views aren't refreshed by the zone tick around websocket command processing, so an in-place update would otherwise not repaint.

## Verification
Rebuilt the embed elements bundle and verified live: the Status × Lead Source **crosstab now renders the full grid** in the companion viewer (previously blank). 10 files: 5 templates (`*ngIf`→`@if`) + 5 components (`detectChanges`).

## Note
`@if` is the proven fix (chart already uses it). The `detectChanges` additions are the consistency/safety half of "make these five behave like chart" — they cover the in-place-update repaint case the open-render test didn't exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)