### PR TITLE
fix(wiz): run sql query table verbatim (don't parse) so GROUP BY/ORDER BY survive

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -559,14 +559,16 @@ public class WorksheetTableService {
       UniformSQL sql = new UniformSQL();
       sql.setDataSource(ds);
 
-      // Block until the SQL string is parsed; SQLProcessor calls notifyAll() in its parse finally
-      // block. Bounded wait so a parse that never notifies can't hang the request thread — the
-      // column resolution below falls back to executing the query for output metadata.
-      synchronized(sql) {
-         sql.setParseSQL(true);
-         sql.setSQLString(sqlString, true);
-         sql.wait(30000);
-      }
+      // Do NOT parse: the sqlExpression is authored to run verbatim. StyleBI's SQL parser builds a
+      // structured representation and REGENERATES the query at execution, which silently drops
+      // clauses it can't round-trip — notably a GROUP BY / ORDER BY whose expression isn't identical
+      // to a SELECT column (e.g. GROUP BY DATE_TRUNC('month', d) under SELECT TO_CHAR(DATE_TRUNC(...))),
+      // producing an aggregate-without-GROUP-BY error against the database. With parsing off the raw
+      // string is sent to the database unchanged (honoring GROUP BY/ORDER BY/HAVING/CTEs/window
+      // functions), and column metadata is resolved from the result set (the non-parsed branch of
+      // QueryManagerService.getColumnSelection → JDBCQuery.getOutputTypeForNonParseableSQL).
+      sql.setParseSQL(false);
+      sql.setSQLString(sqlString, false);
 
       JDBCQuery query = new JDBCQuery();
       query.setUserQuery(true);


### PR DESCRIPTION
## Problem
A `sql query table` is documented to run its `sqlExpression` **verbatim**, but `WorksheetTableService.buildSqlTable` set `UniformSQL.setParseSQL(true)`. StyleBI then parses the SQL and **regenerates** it at execution, silently dropping clauses it can't round-trip — notably a `GROUP BY`/`ORDER BY` whose expression isn't identical to a SELECT column.

### Reproduction (captured from the Postgres statement log)
Authored SQL:
```sql
SELECT TO_CHAR(DATE_TRUNC('month', date_entered),'YYYY-MM') AS month, COUNT(*) AS leads
FROM leads WHERE deleted=0 AND date_entered IS NOT NULL
GROUP BY DATE_TRUNC('month', date_entered) ORDER BY 1
```
What StyleBI actually sent to the database:
```sql
select COUNT(*) as "leads", TO_CHAR(DATE_TRUNC('month',"date_entered"),'YYYY-MM') as "month"
from "leads" where "deleted"=0 and "date_entered" is not null
-- GROUP BY and ORDER BY are gone
```
→ `ERROR: column "leads.date_entered" must appear in the GROUP BY clause`. The identical SQL runs fine directly against Postgres, confirming the loss is in StyleBI's parse→regenerate, not the SQL.

## Fix
`setParseSQL(false)` + `setSQLString(sql, false)` in `buildSqlTable`. With parsing off:
- The raw string is sent to the DB **unchanged** — `GROUP BY`/`ORDER BY`/`HAVING`/CTEs/window functions all work (the feature's documented intent).
- Column metadata is resolved from the **result set**: `QueryManagerService.getColumnSelection` already has a non-parsed branch → `JDBCQuery.getOutputTypeForNonParseableSQL` (prepared-statement / `maxRows=1` `ResultSetMetaData`).
- `JDBCUtil.fixUniformSQLInfo` early-returns on non-parsed SQL (`getTableCount()<=0`), so it's a safe no-op here.
- Result column names come clean from the DB, obviating the quoted-alias workaround that existed for parsed selections.

One localized change; `applySqlResultTypes` (type overlay from `ResultSetMetaData`) continues to apply.

## Verification status — please note
- ✅ **Root cause proven** via the Postgres statement log (above) and by confirming the SQL is valid directly against the DB.
- ✅ **Fix path code-traced** (non-parsed column resolution + safe `fixUniformSQLInfo` early-return).
- ⚠️ **Not yet live-verified in the dev env.** Verifying required an image built from current `stylebi-wiz-main-rebase` source, which crash-loops in our local env on an **unrelated** pre-existing issue — `WizServiceAuthenticationFilter` fails to decrypt the stored SSO key (`Illegal base64 character 5c`). That blocks booting any current-source build locally; it is not caused by this change. Requesting CI / a clean env to run the end-to-end check (the `DATE_TRUNC` query above should render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)