### PR TITLE
fix(wiz): honor explicit dateGroupLevel:"none" in chart binding

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -660,22 +660,7 @@ public class WizAutoBindingService {
                dim.setRankingColValue(r.getRankingCol());
             }
 
-            if(dimFc.getDateGroupLevel() != null) {
-               try {
-                  int level =
-                     WizDateLevelUtil.getDateGroupLevel(dimFc.getDateGroupLevel());
-
-                  if(level != XConstants.NONE_DATE_GROUP) {
-                     dim.setDateLevelValue(String.valueOf(level));
-                  }
-
-                  dim.setTimeSeries(dimFc.isTimeSeries());
-               }
-               catch(IllegalArgumentException e) {
-                  LOG.warn("Ignoring unsupported dateGroupLevel '{}' for field '{}'",
-                           dimFc.getDateGroupLevel(), dimFc.getField());
-               }
-            }
+            applyDateGroup(dim, dimFc);
          }
 
          if(fc.getOrder() != null) {
@@ -714,6 +699,40 @@ public class WizAutoBindingService {
       // Common to dimensions and measures: a display title (axis/legend/series label) and a
       // number/date display format. Applies to whichever ref kind matched above.
       applyTitleAndFormat(ref, fc);
+   }
+
+   /**
+    * Apply a dimension fieldConfig's requested date-group level to the dimension.
+    *
+    * <p>The caller's level is authoritative and ALWAYS overrides whatever level the recommender
+    * picked (it defaults a date-typed dimension to YEAR). In particular an explicit {@code "none"}
+    * must reset the dimension to {@link XConstants#NONE_DATE_GROUP}. Previously a {@code "none"} was
+    * silently ignored — the guard only applied non-NONE levels — so a column that the worksheet had
+    * already bucketed (e.g. {@code Month(date_entered)}) was re-grouped by year at the chart layer,
+    * collapsing the intended monthly series. The caller's intent was dropped with no error.
+    *
+    * <p>No-ops when the fieldConfig requests no level ({@code getDateGroupLevel() == null}). An
+    * unsupported level string is logged and ignored rather than thrown, preserving the previous
+    * lenient behavior.
+    *
+    * <p>Package-private and static so it can be unit-tested directly with a mocked dimension ref.
+    */
+   static void applyDateGroup(VSDimensionRef dim, DimensionFieldInfo dimFc) {
+      if(dimFc.getDateGroupLevel() == null) {
+         return;
+      }
+
+      try {
+         int level = WizDateLevelUtil.getDateGroupLevel(dimFc.getDateGroupLevel());
+         // Always apply — an explicit "none" (NONE_DATE_GROUP) must override the recommender's
+         // default level, not be silently skipped.
+         dim.setDateLevelValue(String.valueOf(level));
+         dim.setTimeSeries(dimFc.isTimeSeries());
+      }
+      catch(IllegalArgumentException e) {
+         LOG.warn("Ignoring unsupported dateGroupLevel '{}' for field '{}'",
+                  dimFc.getDateGroupLevel(), dimFc.getField());
+      }
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceDateGroupTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceDateGroupTest.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.viewsheet.VSDimensionRef;
+import inetsoft.web.wiz.model.DimensionFieldInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Regression tests for {@link WizAutoBindingService#applyDateGroup}.
+ *
+ * <p>The bug: an explicit {@code dateGroupLevel:"none"} on a date dimension was silently dropped —
+ * the old guard only applied non-NONE levels, so the recommender's default (YEAR) survived and a
+ * worksheet column already bucketed to month (e.g. {@code Month(date_entered)}) got re-grouped by
+ * year, collapsing a 13-month series into 2 yearly points. The fix makes the caller's level
+ * authoritative, including "none".
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizAutoBindingServiceDateGroupTest {
+   private static DimensionFieldInfo dimFc(String dateGroupLevel, boolean timeSeries) {
+      DimensionFieldInfo fc = new DimensionFieldInfo();
+      fc.setField("Month(date_entered)");
+      fc.setDateGroupLevel(dateGroupLevel);
+      fc.setTimeSeries(timeSeries);
+      return fc;
+   }
+
+   @Test
+   void explicitNoneOverridesRecommenderDefault() {
+      VSDimensionRef dim = mock(VSDimensionRef.class);
+
+      // The caller asks for no grouping on an already-month-bucketed column.
+      WizAutoBindingService.applyDateGroup(dim, dimFc("none", true));
+
+      // NONE_DATE_GROUP must be pushed onto the dimension so it overrides the recommender's
+      // default YEAR level — previously this call never happened and the bug surfaced.
+      verify(dim).setDateLevelValue(String.valueOf(XConstants.NONE_DATE_GROUP));
+      verify(dim).setTimeSeries(true);
+   }
+
+   @Test
+   void explicitMonthIsApplied() {
+      VSDimensionRef dim = mock(VSDimensionRef.class);
+      int month = WizDateLevelUtil.getDateGroupLevel("month");
+
+      WizAutoBindingService.applyDateGroup(dim, dimFc("month", true));
+
+      verify(dim).setDateLevelValue(String.valueOf(month));
+      verify(dim).setTimeSeries(true);
+   }
+
+   @Test
+   void timeSeriesFlagIsForwarded() {
+      VSDimensionRef dim = mock(VSDimensionRef.class);
+
+      WizAutoBindingService.applyDateGroup(dim, dimFc("year", false));
+
+      verify(dim).setTimeSeries(false);
+   }
+
+   @Test
+   void nullLevelIsANoOp() {
+      VSDimensionRef dim = mock(VSDimensionRef.class);
+
+      WizAutoBindingService.applyDateGroup(dim, dimFc(null, true));
+
+      verify(dim, never()).setDateLevelValue(anyString());
+      verify(dim, never()).setTimeSeries(anyBoolean());
+   }
+
+   @Test
+   void unsupportedLevelIsIgnoredWithoutThrowing() {
+      VSDimensionRef dim = mock(VSDimensionRef.class);
+
+      // Must not propagate the IllegalArgumentException from WizDateLevelUtil; lenient by design.
+      WizAutoBindingService.applyDateGroup(dim, dimFc("fortnight", true));
+
+      verify(dim, never()).setDateLevelValue(anyString());
+      verify(dim, never()).setTimeSeries(anyBoolean());
+   }
+}


### PR DESCRIPTION
## Problem

`WizAutoBindingService.applyFieldConfig` only applied a fieldConfig's `dateGroupLevel` when it resolved to a **non-NONE** level:

```java
if(level != XConstants.NONE_DATE_GROUP) {
   dim.setDateLevelValue(String.valueOf(level));
}
```

So an explicit `dateGroupLevel:"none"` became a **silent no-op** — the recommender's default (YEAR for a date-typed dimension) survived. A worksheet column the user had already bucketed (e.g. `Month(date_entered)`) was therefore re-grouped by year at the chart layer, collapsing an intended 13-month line into 2 yearly points, with no error. This is the silent-degradation pattern: the caller's intent is dropped and a plausible-but-wrong chart is rendered.

## Fix

Extract the date-group logic into a package-private static `applyDateGroup(VSDimensionRef, DimensionFieldInfo)` and **always** push the caller's resolved level onto the dimension — including `NONE_DATE_GROUP` — so an explicit `"none"` overrides the recommender default. Unsupported level strings remain lenient (logged, ignored), as before.

## Tests

Adds `WizAutoBindingServiceDateGroupTest` (5 cases, all passing):
- `"none"` overrides the recommender default (the regression)
- an explicit interval (`month`) is applied
- the `timeSeries` flag is forwarded
- a `null` level is a no-op
- an unsupported level neither throws nor mutates the dimension

## Verification

- Unit: `mvn -pl core test -Dtest=WizAutoBindingServiceDateGroupTest` → 5/5 pass.
- Live (image `local-952` = `local-951` tree + this fix): the same `create_viewsheet` call with `dateGroupLevel:"none"` now renders **13 monthly points** (`None(Month(date_entered))`), where before it collapsed to **2 yearly points** (`Year(Month(date_entered))`, 151/49). Binding echo confirms `dateGroupLevel: null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)