### PR TITLE
fix(wiz): fail loud on unresolvable condition field (no orphaned junction → no ClassCastException)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1046,10 +1046,11 @@ public class WorksheetTableService {
     * @param isHaving  true when building a HAVING (post-aggregate) condition list;
     *                  fields with {@code aggregateFormula} are wrapped in {@link AggregateRef}
     */
-   private ConditionList buildConditionList(ColumnSelection columns,
-                                            List<WorksheetTableRequest.ConditionItem> items,
-                                            Worksheet worksheet,
-                                            boolean isHaving)
+   // Package-private for unit testing (WorksheetTableServiceConditionTest).
+   ConditionList buildConditionList(ColumnSelection columns,
+                                    List<WorksheetTableRequest.ConditionItem> items,
+                                    Worksheet worksheet,
+                                    boolean isHaving)
    {
       ConditionList list = new ConditionList();
 
@@ -1130,15 +1131,26 @@ public class WorksheetTableService {
                                     Worksheet worksheet,
                                     boolean isHaving)
    {
+      // Fail loud rather than silently skipping. A skipped item leaves a dangling JunctionOperator
+      // in the ConditionList (the operator for this item was already appended by buildConditionList),
+      // which breaks the list's required item/operator alternation and later throws an opaque
+      // "JunctionOperator cannot be cast to ConditionItem". With a single condition the silent skip
+      // instead dropped the filter outright (wrong results, no error). Either way the caller's intent
+      // was lost without a signal — so reject the bad condition with a clear, actionable message.
       if(item.getField() == null || item.getOperation() == null) {
-         return;
+         throw new IllegalArgumentException(
+            "Condition is missing a field or operation (field=" + item.getField() +
+            ", operation=" + item.getOperation() + ").");
       }
 
       // Resolve the column reference.
       DataRef ref = columns.getAttribute(item.getField());
 
       if(ref == null) {
-         return;
+         throw new IllegalArgumentException(
+            "Condition references column \"" + item.getField() + "\" which is not in the table's " +
+            "column selection. Add it to the table's columns (or omit columns to select all), " +
+            "and reference it exactly as it appears in the selection.");
       }
 
       // For HAVING conditions, wrap the column in an AggregateRef when a formula is present.

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceConditionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceConditionTest.java
@@ -1,0 +1,144 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.web.wiz.model.WorksheetTableRequest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for {@link WorksheetTableService#buildConditionList}.
+ *
+ * <p>The bug: a {@code preAggregateCondition} that references a column NOT in the table's
+ * {@link ColumnSelection} caused {@code appendConditionItem} to return early (the field resolved to
+ * {@code null}) WITHOUT appending a {@code ConditionItem} — but the {@link inetsoft.uql.JunctionOperator}
+ * for that item had already been appended by {@code buildConditionList}. The resulting
+ * {@link ConditionList} violated its required item/operator alternation (a junction landed at an even
+ * index), surfacing downstream as
+ * {@code "class inetsoft.uql.JunctionOperator cannot be cast to class inetsoft.uql.ConditionItem"}.
+ * With a single condition the same early-return silently DROPPED the filter (no error, wrong results).
+ *
+ * <p>The fix makes an unresolvable condition field fail loud with a clear, field-named error, so a
+ * malformed {@code ConditionList} can never be built and a dropped filter is never silent.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WorksheetTableServiceConditionTest {
+   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+   private static WorksheetTableService service() {
+      // buildConditionList and its callees use only their parameters, never instance state,
+      // so null dependencies are safe here.
+      return new WorksheetTableService(null, null, null, null, null, null, null);
+   }
+
+   private static ColumnSelection columns(String... names) {
+      ColumnSelection cs = new ColumnSelection();
+
+      for(String n : names) {
+         cs.addAttribute(new ColumnRef(new AttributeRef(null, n)));
+      }
+
+      return cs;
+   }
+
+   private static WorksheetTableRequest request(String json) throws Exception {
+      return MAPPER.readValue(json, WorksheetTableRequest.class);
+   }
+
+   @Test
+   void compoundConditionWithUnresolvedFieldFailsLoud() throws Exception {
+      // Two leaves joined by "and"; the FIRST references a column not in the selection.
+      WorksheetTableRequest req = request("""
+         {
+           "preAggregateCondition": [
+             { "field": "deleted", "operation": "EQUAL_TO", "values": [{ "type": "VALUE", "value": 0 }] },
+             { "field": "sales_stage", "operation": "EQUAL_TO", "junction": "and",
+               "values": [{ "type": "VALUE", "value": "Closed Won" }] }
+           ]
+         }
+         """);
+
+      // 'deleted' is intentionally NOT selected; 'sales_stage' is.
+      ColumnSelection cs = columns("sales_stage");
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+         service().buildConditionList(cs, req.getPreAggregateCondition(), new Worksheet(), false));
+      assertTrue(ex.getMessage().contains("deleted"),
+                 "error should name the unresolved column, got: " + ex.getMessage());
+   }
+
+   @Test
+   void singleConditionWithUnresolvedFieldFailsLoud() throws Exception {
+      // Previously silently dropped (no error, filter ignored) — must now fail loud.
+      WorksheetTableRequest req = request("""
+         {
+           "preAggregateCondition": [
+             { "field": "deleted", "operation": "EQUAL_TO", "values": [{ "type": "VALUE", "value": 0 }] }
+           ]
+         }
+         """);
+
+      ColumnSelection cs = columns("sales_stage");
+
+      assertThrows(IllegalArgumentException.class, () ->
+         service().buildConditionList(cs, req.getPreAggregateCondition(), new Worksheet(), false));
+   }
+
+   @Test
+   void compoundConditionWithResolvedFieldsBuildsAlternatingList() throws Exception {
+      // Both columns selected → a well-formed alternating list: Condition, Junction, Condition.
+      WorksheetTableRequest req = request("""
+         {
+           "preAggregateCondition": [
+             { "field": "deleted", "operation": "EQUAL_TO", "values": [{ "type": "VALUE", "value": 0 }] },
+             { "field": "sales_stage", "operation": "EQUAL_TO", "junction": "and",
+               "values": [{ "type": "VALUE", "value": "Closed Won" }] }
+           ]
+         }
+         """);
+
+      ColumnSelection cs = columns("deleted", "sales_stage");
+
+      ConditionList list = service().buildConditionList(
+         cs, req.getPreAggregateCondition(), new Worksheet(), false);
+
+      assertEquals(3, list.getSize(), "two leaves joined by a junction => 3 list elements");
+      assertTrue(list.isConditionItem(0), "index 0 must be a ConditionItem");
+      assertTrue(list.isJunctionOperator(1), "index 1 must be a JunctionOperator");
+      assertTrue(list.isConditionItem(2), "index 2 must be a ConditionItem");
+   }
+}


### PR DESCRIPTION
## Problem

A worksheet table's `preAggregateCondition` / `postAggregateCondition` that references a column **not in the table's `ColumnSelection`** corrupted the `ConditionList`:

- `appendConditionItem` resolved the field to `null` and **returned early without appending a `ConditionItem`** — but `buildConditionList` had already appended that item's `JunctionOperator`.
- The list then violated its required item/operator alternation (a junction at an even index), surfacing downstream as the opaque:
  ```
  class inetsoft.uql.JunctionOperator cannot be cast to class inetsoft.uql.ConditionItem
  ```
- With a **single** condition the same early-return instead **silently dropped the filter** (wrong results, no error).

### Repro (via the wiz plugin)
A physical table projected to a column subset, filtered on a column not in that subset:
```
columns: [lead_source, sales_stage]
preAggregateCondition: deleted = 0  AND  sales_stage = 'Closed Won'
```
Two leaves joined by a junction → `ClassCastException`. One leaf → filter silently ignored. (`deleted` isn't in the projected columns.)

## Root cause

`buildConditionList` appends a `JunctionOperator` for each non-first item **before** `appendConditionItem` runs. When `appendConditionItem` short-circuits (unresolvable field, or null field/operation) it appends no `ConditionItem`, orphaning the junction and breaking parity. `mapOperation` already throws on unknown operations, so the *only* skip paths were the silent early-returns.

## Fix

Make `appendConditionItem` **fail loud** — an unresolvable condition field (or a missing field/operation) now throws a clear, actionable `IllegalArgumentException` naming the column, instead of silently skipping. Because no item can be skipped anymore, a `JunctionOperator` can never be orphaned: the malformed-list class of bug is eliminated, and dropped filters are no longer silent.

`buildConditionList` is made package-private for unit testing.

## Tests

`WorksheetTableServiceConditionTest` (3 cases, all passing):
- compound condition with an unresolved field → fails loud, error names the column (the regression);
- single condition with an unresolved field → fails loud (was a silent drop);
- fully-resolved compound condition → still builds a well-formed `Condition / Junction / Condition` list.

165/166 wiz-package tests pass (the 1 failure is the pre-existing, unrelated `SheetJoinServiceTest.viewsheetCodeGrantsViewsheetSession`).

## Verification

- Unit: `mvn -pl core test -Dtest=WorksheetTableServiceConditionTest` → 3/3.
- Live (image `local-953`): the exact repro now returns the clear error instead of the cast crash; and the same compound filter with the column selected applies correctly (`deleted=0 AND sales_stage='Closed Won'` → 10 Closed Won rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)