### PR TITLE
feat(wiz): expose line time-gap fill on /viewsheet/format

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
@@ -86,6 +86,23 @@ public class ChartFormatRequest {
    public Integer getMarkerSize() { return markerSize; }
    public void setMarkerSize(Integer markerSize) { this.markerSize = markerSize; }
 
+   /** Line/area time-gap fill: complete missing date periods so the line reflects no-data months
+    *  (requires the date dimension's timeSeries to be on); null = no change. */
+   @JsonProperty("fillTimeGap")
+   public Boolean getFillTimeGap() { return fillTimeGap; }
+   public void setFillTimeGap(Boolean fillTimeGap) { this.fillTimeGap = fillTimeGap; }
+
+   /** When filling time gaps, fill with 0 (true) instead of null (false). Null fill leaves the line
+    *  broken/dashed at the gap; 0 fill drops it to the axis. Null = no change. */
+   @JsonProperty("fillZero")
+   public Boolean getFillZero() { return fillZero; }
+   public void setFillZero(Boolean fillZero) { this.fillZero = fillZero; }
+
+   /** Draw a dashed connector across a null-filled gap (true) vs a hard line break (false); null = no change. */
+   @JsonProperty("fillGapWithDash")
+   public Boolean getFillGapWithDash() { return fillGapWithDash; }
+   public void setFillGapWithDash(Boolean fillGapWithDash) { this.fillGapWithDash = fillGapWithDash; }
+
    /** The runtime viewsheet that holds the live chart (the plugin's active-chart runtimeId). */
    private String wizRuntimeId;
    /** The chart assembly name within that runtime. */
@@ -104,4 +121,7 @@ public class ChartFormatRequest {
    private Boolean markerVisible;
    private String markerShape;
    private Integer markerSize;
+   private Boolean fillTimeGap;
+   private Boolean fillZero;
+   private Boolean fillGapWithDash;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -2123,6 +2123,29 @@ public class WizAutoBindingService {
          }
       }
 
+      // Time-gap fill for line/area charts. fillTimeGap completes missing date periods (paired with
+      // the date dimension's timeSeries); fillZero=false fills with null (vs 0); fillGapWithDash
+      // chooses a dashed connector (true) vs a hard line break (false) across the null gap.
+      if((request.getFillTimeGap() != null || request.getFillZero() != null
+         || request.getFillGapWithDash() != null) && desc != null)
+      {
+         PlotDescriptor plot = desc.getPlotDescriptor();
+
+         if(plot != null) {
+            if(request.getFillTimeGap() != null) {
+               plot.setFillTimeGap(request.getFillTimeGap());
+            }
+
+            if(request.getFillZero() != null) {
+               plot.setFillZero(request.getFillZero());
+            }
+
+            if(request.getFillGapWithDash() != null) {
+               plot.setFillGapWithDash(request.getFillGapWithDash());
+            }
+         }
+      }
+
       // Invalidate the cached runtime descriptor so the change regenerates on re-execute.
       info.setRTChartDescriptor(null);
 


### PR DESCRIPTION
## Why

A date line/area chart with missing periods interpolated a misleading slope across the empty months. StyleBI's engine already supports null-filling those gaps so the line breaks (`GraphGenerator`: `missval = fillTimeGap && fillZero ? 0 : null`, gated on `(fillTimeGap || hasPreColCalc) && dim.isTimeSeries()`), but the wiz `/viewsheet/format` API didn't expose the `PlotDescriptor` flags, so the plugin couldn't reach it.

## What

Add three nullable Boolean fields to `ChartFormatRequest` and apply them to the chart's `PlotDescriptor` in `WizAutoBindingService.setChartFormat` (mirroring the existing marker block, which already holds the `PlotDescriptor`):

- `fillTimeGap` → `plot.setFillTimeGap(...)` — complete missing date periods (pairs with the date dim's `timeSeries`).
- `fillZero` → `plot.setFillZero(...)` — fill with 0 (true) vs null (false).
- `fillGapWithDash` → `plot.setFillGapWithDash(...)` — dashed connector (true) vs hard line break (false).

Only non-null fields are applied (no-op otherwise), consistent with the rest of the request.

## Testing

Built into a local image (`local-956`) and **verified live end-to-end** via the wiz `/viewsheet/format` endpoint on a suitecrm closed-won-by-month line chart with `timeSeries:true`: posting `fillTimeGap:true, fillZero:false, fillGapWithDash:false` made the chart return **11 rows instead of 8** — the three empty months appear with `null` revenue, so the line breaks at them. Paired plugin/wiz-services change: stylebi-wiz#1010.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
