### PR TITLE
fix(wiz): histogram Range@ dimension survives save & reopen

### DIFF
--- a/core/src/main/java/inetsoft/web/vswizard/recommender/WizardRecommenderUtil.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/WizardRecommenderUtil.java
@@ -815,9 +815,41 @@ public final class WizardRecommenderUtil {
          return;
       }
 
+      IntervalData interval = IntervalExecutor.getData(box.get(), tempInfo, dim, tname, XSchema.DOUBLE);
+      buildRangeDimension(dim, rvs, tname, interval);
+   }
+
+   /**
+    * Same as {@link #createRangeDimension(VSDimensionRef, RuntimeViewsheet, String, VSTemporaryInfo)}
+    * but for the non-wizard create/save path, which has no {@link VSTemporaryInfo}: bins are computed
+    * from the chart's {@link SourceInfo} via the source-based {@code IntervalExecutor.getData} overload.
+    * Materializes a histogram's {@code Range@<measure>} dimension into a real range calc field so a
+    * SAVED chart reopens — the {@code Range@} shorthand is only understood by the wizard executor; a
+    * saved viewsheet executes the normal path and would fail with ColumnNotFoundException: Range@&lt;col&gt;.
+    */
+   public static void createRangeDimension(VSDimensionRef dim, RuntimeViewsheet rvs,
+                                           AggregateInfo ainfo, SourceInfo source, String tname)
+      throws Exception
+   {
+      Optional<ViewsheetSandbox> box = rvs.getViewsheetSandbox();
+
+      if(box.isEmpty()) {
+         return;
+      }
+
+      IntervalData interval = IntervalExecutor.getData(box.get(), ainfo, source, dim, tname, XSchema.DOUBLE);
+      buildRangeDimension(dim, rvs, tname, interval);
+   }
+
+   // Build the range calc field (binned expression) for a Range@ dimension from the computed interval,
+   // register it on the viewsheet, and re-point the dimension at it. Shared by both createRangeDimension
+   // overloads (wizard tempInfo path and non-wizard SourceInfo path).
+   private static void buildRangeDimension(VSDimensionRef dim, RuntimeViewsheet rvs, String tname,
+                                           IntervalData interval)
+      throws Exception
+   {
       String refValue = dim.getGroupColumnValue();
       String field = refValue.substring(6); // strip off Range@
-      IntervalData interval = IntervalExecutor.getData(box.get(), tempInfo, dim, tname, XSchema.DOUBLE);
 
       double min = interval != null ? interval.getMin() : 0;
       double max = interval != null ? interval.getMax() : 100;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -178,6 +178,21 @@ public class WizVisualizationService {
       cloned.setPixelOffset(new Point(24, 24));
       newVs.addAssembly(cloned);
 
+      // Carry over the source viewsheet's calc fields for this chart's source (e.g. a histogram's
+      // materialized "Range@<measure>" range field) so the cloned chart's calc-field-backed bindings
+      // still resolve when the saved viz is reopened. Without this the new single-assembly viewsheet
+      // has no such calc field and reopen fails with ColumnNotFoundException: Range@<col>.
+      if(assembly instanceof DataVSAssembly dataAsm && dataAsm.getSourceInfo() != null) {
+         String calcSrc = dataAsm.getSourceInfo().getSource();
+         CalculateRef[] srcCalcs = calcSrc != null ? sourceVs.getCalcFields(calcSrc) : null;
+
+         if(srcCalcs != null) {
+            for(CalculateRef calc : srcCalcs) {
+               newVs.addCalcField(calcSrc, calc);
+            }
+         }
+      }
+
       // ── Step 6: Ensure target ViewSheet folder exists ─────────────────────────
       AssetEntry targetFolder = new AssetEntry(
          AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.REPOSITORY_FOLDER,

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -278,6 +278,33 @@ public class WizVsService {
                hook.apply(rvs, assembly);
             }
 
+            // Materialize any auto-binned "Range@<measure>" histogram dimension into a real range calc
+            // field on the output viewsheet, so a SAVED chart reopens. Range@ is a wizard-only shorthand
+            // (the wizard executor strips it and bins the base column at preview time); a saved viewsheet
+            // executes the normal path and would fail with ColumnNotFoundException: Range@<col>. This is
+            // done here — not in the wizard recommender — because the create/save path rebuilds the chart
+            // on a fresh output viewsheet that has no VSTemporaryInfo, so bins are computed from the
+            // chart's SourceInfo. rvs.getViewsheet() == targetVs here (set above), so the calc field lands
+            // on the viewsheet that save_viewsheet persists. Runs before execution so the chart executes
+            // (and saves) against the materialized binding.
+            if(assembly instanceof ChartVSAssembly rangeChart && rangeChart.getVSChartInfo() != null
+               && rangeChart.getSourceInfo() != null)
+            {
+               SourceInfo rangeSrc = rangeChart.getSourceInfo();
+               ChartRef[] rangeRefs = rangeChart.getVSChartInfo().getBindingRefs(false);
+
+               if(rangeRefs != null) {
+                  for(ChartRef cr : rangeRefs) {
+                     if(cr instanceof VSDimensionRef vdim && vdim.getGroupColumnValue() != null
+                        && vdim.getGroupColumnValue().startsWith("Range@"))
+                     {
+                        WizardRecommenderUtil.createRangeDimension(
+                           vdim, rvs, rangeChart.getVSChartInfo().getAggregateInfo(), rangeSrc, rangeSrc.getSource());
+                     }
+                  }
+               }
+            }
+
             CreateViewsheetResult result;
 
             if(skipExecution) {


### PR DESCRIPTION
## Why

A histogram (a measure bound with no dimension) is auto-bound by the recommender as a `Range@<measure>` dimension — a numeric range grouping. This is a **wizard-only shorthand**: `WizardDataExecutor` strips `Range@` and bins the base column at preview time, so *create* works. But a **saved** visualization executes through the normal viewsheet path, which has no such handling, so on reopen it threw:

```
inetsoft.uql.viewsheet.ColumnNotFoundException: Column not found: Range@amount in Count(amount)
```

The live viewer showed the raw resource key `_#(data.query.columnResultEmpty)`, and `verify_visualization` 500'd.

## What

Materialize the `Range@` dimension into a **real range `CalculateRef`** along the whole create → save → reopen pipeline (the calc field has to survive all three stages):

- **`WizardRecommenderUtil`** — extract `buildRangeDimension()` from the existing `createRangeDimension`; add an overload that computes bins from a `SourceInfo` + `AggregateInfo` (the create/save path has no `VSTemporaryInfo`) via the existing `IntervalExecutor.getData(box, ainfo, source, ref, …)` overload.
- **`WizVsService.createViewsheetInternal`** — after the recommended chart is placed on the output viewsheet (and the base worksheet is loaded), materialize any `Range@` dimension into a calc field, before execution, so the chart executes and saves against the real binding.
- **`WizVisualizationService.saveVisualization`** — copy the source viewsheet's calc fields for the chart's source into the new single-assembly viewsheet, so the cloned chart's calc-field-backed dimension resolves when the saved viz is reopened.

## Testing

Built into a local image and **verified end-to-end** (suitecrm deal-amount histogram): created via the recommender (`x=Range@amount, y=Count`), saved, then `verify_visualization` returns **ok, hasData, 9 rows** — previously it failed with `ColumnNotFoundException`. The interactive-wizard path is unchanged (the original `createRangeDimension` behavior is preserved via the shared `buildRangeDimension`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
