### PR TITLE
fix(wiz): render histograms as full-width, square, borderless bars

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/aesthetic/SizeFrameWrapper.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/aesthetic/SizeFrameWrapper.java
@@ -88,6 +88,10 @@ public abstract class SizeFrameWrapper extends VisualFrameWrapper {
 
       writer.print(" largestSize=\"" + frame.getLargest() + "\"");
       writer.print(" smallestSize=\"" + frame.getSmallest() + "\"");
+      // max is the denominator in BarVO.getBarSize (width = minwidth + w*size/max); without
+      // persisting it, a non-default max (e.g. set for full-width histogram bars) reverts to the
+      // default 30 on save/reopen and the bar width is wrong.
+      writer.print(" maxSize=\"" + frame.getMax() + "\"");
    }
 
    /**
@@ -106,6 +110,10 @@ public abstract class SizeFrameWrapper extends VisualFrameWrapper {
 
       if((val = Tool.getAttribute(tag, "smallestSize")) != null) {
          frame.setSmallest(Double.parseDouble(val));
+      }
+
+      if((val = Tool.getAttribute(tag, "maxSize")) != null) {
+         frame.setMax(Double.parseDouble(val));
       }
    }
 }

--- a/core/src/main/java/inetsoft/web/vswizard/recommender/chart/HistogramChartFilter.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/chart/HistogramChartFilter.java
@@ -22,6 +22,7 @@ import inetsoft.uql.CompositeValue;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.schema.XSchema;
+import inetsoft.graph.aesthetic.StaticSizeFrame;
 import inetsoft.uql.viewsheet.graph.*;
 import inetsoft.uql.viewsheet.graph.aesthetic.StaticSizeFrameWrapper;
 
@@ -72,7 +73,20 @@ public class HistogramChartFilter extends ChartTypeFilter {
       info.setClearedFormula(clearedFormula);
       yref.setFormulaValue("Count");
       StaticSizeFrameWrapper size = new StaticSizeFrameWrapper();
-      size.setSize(30, CompositeValue.Type.DEFAULT);
+      // Render the binned bars at FULL band width (contiguous) so the chart reads as a histogram
+      // rather than a gapped category bar chart. Per BarVO.getBarSize, a static-sized bar fills the
+      // band (width == maxbar) only when BOTH: (1) size == max, and (2) largest != smallest — when
+      // largest == smallest (the default) it short-circuits to maxbar/2, i.e. the half-width gap that
+      // made the histogram look like a normal bar chart. So set distinct largest/smallest and pin
+      // size to max. (max is persisted via SizeFrameWrapper so this survives save/reopen.)
+      StaticSizeFrame frame = (StaticSizeFrame) size.getVisualFrame();
+      // BarVO.getBarSize: width = maxbar * size/max (with smallest=0). The rendered geometry size is
+      // a fixed 15 here, so width == maxbar (full band, contiguous histogram) exactly when max == 15.
+      // largest must differ from smallest, else getBarSize short-circuits to maxbar/2 (the gap).
+      frame.setSmallest(0);
+      frame.setLargest(15);
+      frame.setMax(15);
+      size.setSize(15, CompositeValue.Type.DEFAULT);
       yref.setSizeFrameWrapper(size);
 
       VSChartDimensionRef range = new VSChartDimensionRef();

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -300,6 +300,19 @@ public class WizVsService {
                      {
                         WizardRecommenderUtil.createRangeDimension(
                            vdim, rvs, rangeChart.getVSChartInfo().getAggregateInfo(), rangeSrc, rangeSrc.getSource());
+
+                        // A Range@ binding is a histogram: the binned bars represent a continuous
+                        // distribution, so they must read as one contiguous band, not discrete
+                        // category bars. The full-band width is set on the size frame in
+                        // HistogramChartFilter; here we also drop the rounded corners (default 0.3)
+                        // and the bar border so adjacent bins butt cleanly together.
+                        ChartDescriptor cdesc = rangeChart.getChartDescriptor();
+
+                        if(cdesc != null && cdesc.getPlotDescriptor() != null) {
+                           PlotDescriptor plot = cdesc.getPlotDescriptor();
+                           plot.setBarCornerRadius(0);
+                           plot.setBorderColor(null);
+                        }
                      }
                   }
                }


### PR DESCRIPTION
## Problem

A histogram — a measure auto-bound to a `Range@<measure>` numeric-range dimension — rendered as gapped, rounded, bordered category bars. A distribution therefore looked like an ordinary bar chart instead of a continuous histogram.

## Root cause & fix

`BarVO.getBarSize` computes `width = maxbar * geom.getSize(0) / max` (with `smallest=0`), and short-circuits to `maxbar/2` (the gap) when `largest == smallest`. The rendered geometry size is a fixed 15, so a bar fills the band (`width == maxbar`) only when `max == 15` **and** `largest != smallest`.

- **`SizeFrameWrapper`** — persist the size frame's `max`. It was never serialized, so a non-default `max` reverted to the default 30 on save/reopen and the bar width came out wrong.
- **`HistogramChartFilter`** — bind the measure with a `StaticSizeFrame` (`smallest=0`, distinct `largest`, `max=15`) so the bars fill the band edge-to-edge.
- **`WizVsService`** — when materializing the `Range@` dimension on the placed chart, also set `barCornerRadius=0` and clear the bar border (default corner radius is `0.3`) so adjacent bins butt together cleanly. Done on the placed chart so it survives save/reopen.

## Testing

Verified live (image `local-966`): a histogram of opportunity deal amounts now renders as contiguous, square-cornered, borderless bars across the 9 `$50K` bins, and the appearance is preserved through save/reopen (builds on the Range@ materialization from #4129).

🤖 Generated with [Claude Code](https://claude.com/claude-code)