### PR TITLE
fix(core): regenerate an unreadable SSO key pair instead of crash-looping

### DIFF
--- a/core/src/main/java/inetsoft/util/LocalPasswordEncryption.java
+++ b/core/src/main/java/inetsoft/util/LocalPasswordEncryption.java
@@ -265,31 +265,37 @@ abstract class LocalPasswordEncryption extends AbstractPasswordEncryption {
          String privateKeyProperty = SreeEnv.getProperty("sso.rsa.private.key");
          String publicKeyProperty = SreeEnv.getProperty("sso.rsa.public.key");
 
-         if(privateKeyProperty == null || publicKeyProperty == null) {
-            KeyPair keyPair = createSSOKeyPair();
-            byte[] encryptedPrivateKey = encryptSSOPrivateKey(keyPair.getPrivate(), getMasterKey());
-            String encodedPrivateKey = Base64.getEncoder().encodeToString(encryptedPrivateKey);
-            String encodedPublicKey = Base64.getEncoder().encodeToString(
-               keyPair.getPublic().getEncoded());
+         if(privateKeyProperty != null && publicKeyProperty != null) {
+            try {
+               PrivateKey privateKey = decryptSSOPrivateKey(privateKeyProperty, getMasterKey());
+               byte[] publicKeyBytes = Base64.getDecoder().decode(publicKeyProperty);
+               X509EncodedKeySpec pubSpec = new X509EncodedKeySpec(publicKeyBytes);
+               KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+               PublicKey publicKey = keyFactory.generatePublic(pubSpec);
 
-            SreeEnv.setProperty("sso.rsa.private.key", encodedPrivateKey);
-            SreeEnv.setProperty("sso.rsa.public.key", encodedPublicKey);
-            SreeEnv.save();
-
-            return keyPair;
+               return new KeyPair(publicKey, privateKey);
+            }
+            catch(GeneralSecurityException | RuntimeException e) {
+               // A stored SSO key that can't be decoded/decrypted — a corrupted value (e.g. a stray
+               // Base64 character) or the master key changing between restarts — must NOT brick the
+               // server: the SSO auth filter bean fails, Tomcat won't start, and the whole instance
+               // crash-loops. Fall through to regenerate + overwrite the bad value instead. (JWTs
+               // signed by the old key become invalid, so clients simply re-authenticate.)
+               LOG.warn("Stored SSO key pair is unreadable ({}); regenerating.", e.getMessage());
+            }
          }
-         else {
-            PrivateKey privateKey = decryptSSOPrivateKey(privateKeyProperty, getMasterKey());
-            byte[] publicKeyBytes = Base64.getDecoder().decode(publicKeyProperty);
-            X509EncodedKeySpec pubSpec = new X509EncodedKeySpec(publicKeyBytes);
-            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-            PublicKey publicKey = keyFactory.generatePublic(pubSpec);
 
-            return new KeyPair(publicKey, privateKey);
-         }
-      }
-      catch(GeneralSecurityException e) {
-         throw new IOException("Failed to get SSO key pair", e);
+         KeyPair keyPair = createSSOKeyPair();
+         byte[] encryptedPrivateKey = encryptSSOPrivateKey(keyPair.getPrivate(), getMasterKey());
+         String encodedPrivateKey = Base64.getEncoder().encodeToString(encryptedPrivateKey);
+         String encodedPublicKey = Base64.getEncoder().encodeToString(
+            keyPair.getPublic().getEncoded());
+
+         SreeEnv.setProperty("sso.rsa.private.key", encodedPrivateKey);
+         SreeEnv.setProperty("sso.rsa.public.key", encodedPublicKey);
+         SreeEnv.save();
+
+         return keyPair;
       }
       finally {
          lock.unlock();


### PR DESCRIPTION
## Problem

When the stored SSO key properties (`sso.rsa.private.key` / `sso.rsa.public.key`) can't be decoded/decrypted — a corrupted stored value (observed: `Illegal base64 character 5c`) or the master key changing between restarts — `LocalPasswordEncryption.getSSOKeyPair()` threw `IOException`. That fails the SSO authentication filter bean, Tomcat won't start, and the entire instance **crash-loops with no automatic recovery**.

## Fix

Wrap the decode/decrypt of the stored key pair in a `try`/`catch`. On any `GeneralSecurityException` or `RuntimeException`, log a warning and fall through to the **existing** regenerate-and-persist path, which overwrites the bad value with a fresh key pair.

JWTs signed by the old key become invalid, so clients simply re-authenticate — a far better outcome than a server that refuses to boot. The happy path (valid stored keys) and the first-run path (no stored keys) are unchanged.

## Testing

Verified live: an environment that was crash-looping on a corrupt stored `sso.rsa` key booted cleanly after this change (the key was transparently regenerated), and SSO login worked normally afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)