### PR TITLE
feat(worksheet-plugin): logical model support, tool description fixes, concatenation validation

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/AssetTreeController.java
+++ b/core/src/main/java/inetsoft/web/composer/AssetTreeController.java
@@ -87,12 +87,13 @@ public class AssetTreeController {
       @RequestParam(value = "reportRepositoryEnabled", required = false) boolean reportRepositoryEnabled,
       @RequestParam(value = "readOnly", required = false, defaultValue = "false") boolean readOnly,
       @RequestParam(value = "physical", required = false, defaultValue = "true") boolean physical,
+      @RequestParam(value = "includeModel", required = false, defaultValue = "false") boolean includeModel,
       @RequestBody LoadAssetTreeNodesEvent event, Principal principal)
       throws Exception
    {
       return assetTreeService.getNodes(includeDatasources, includeColumns, includeWorksheets, includeViewsheets,
-                                       includeTableStyles, includeScripts, includeLibrary, reportRepositoryEnabled, readOnly,
-                                       physical, event, principal);
+                                       includeTableStyles, includeScripts, includeLibrary, includeModel,
+                                       reportRepositoryEnabled, readOnly, physical, event, principal);
    }
 
    @PostMapping("/api/composer/asset_tree/set-connection-variables")

--- a/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
@@ -20,6 +20,7 @@ package inetsoft.web.wiz.controller;
 
 import inetsoft.sree.security.*;
 import inetsoft.uql.*;
+import inetsoft.uql.asset.*;
 import inetsoft.uql.erm.*;
 import inetsoft.web.composer.model.*;
 import inetsoft.web.portal.controller.database.DataSourceService;
@@ -37,7 +38,6 @@ import org.springframework.web.bind.annotation.*;
 import java.rmi.RemoteException;
 import java.security.Principal;
 import java.util.*;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/wiz")
@@ -52,27 +52,32 @@ public class DatasourceMetaApiController {
    }
 
    /**
-    * Lists all data sources available in the repository.
+    * Lists all data sources available in the repository that the user has READ permission for.
     * Used by the MCP plugin's list_datasources tool.
     */
    @GetMapping(value = "/v1/datasources", produces = MediaType.APPLICATION_JSON_VALUE)
-   public List<Map<String, String>> listDatasources() throws RemoteException {
+   public List<Map<String, String>> listDatasources(Principal principal) throws Exception {
       String[] names = xrepository.getDataSourceFullNames();
-      return Arrays.stream(names)
-         .sorted()
-         .map(name -> {
+      List<Map<String, String>> result = new ArrayList<>();
+
+      for(String name : Arrays.stream(names).sorted().toArray(String[]::new)) {
+         try {
+            if(!dataSourceService.checkPermission(name, ResourceAction.READ, principal)) {
+               continue;
+            }
+
+            XDataSource ds = xrepository.getDataSource(name);
             Map<String, String> entry = new LinkedHashMap<>();
             entry.put("name", name);
-            try {
-               XDataSource ds = xrepository.getDataSource(name);
-               entry.put("type", ds != null ? ds.getType() : "unknown");
-            }
-            catch(Exception e) {
-               entry.put("type", "unknown");
-            }
-            return entry;
-         })
-         .collect(Collectors.toList());
+            entry.put("type", ds != null ? ds.getType() : "unknown");
+            result.add(entry);
+         }
+         catch(Exception e) {
+            LOG.debug("Skipping datasource {} due to error: {}", name, e.getMessage());
+         }
+      }
+
+      return result;
    }
 
    @PostMapping("/datasource/table/meta")
@@ -166,17 +171,24 @@ public class DatasourceMetaApiController {
    }
 
    /**
-    * Lists all logical models and their entities/attributes for a given datasource.
+    * Lists logical models (with entities/attributes) for a given datasource that the user has
+    * READ permission for. Checks both datasource-level and per-model permissions.
     * Used by the MCP plugin's list_logical_models tool.
     *
     * @param datasource the datasource name (e.g. "Examples/Orders")
+    * @param principal  the current user
     * @return list of logical models, each with entity names and attribute metadata
     */
    @GetMapping(value = "/v1/logical-models", produces = MediaType.APPLICATION_JSON_VALUE)
    public List<Map<String, Object>> listLogicalModels(
-      @RequestParam("datasource") String datasource)
+      @RequestParam("datasource") String datasource,
+      Principal principal)
       throws Exception
    {
+      if(!dataSourceService.checkPermission(datasource, ResourceAction.READ, principal)) {
+         return Collections.emptyList();
+      }
+
       XDataModel dataModel = dataSourceService.getDataModel(datasource);
 
       if(dataModel == null) {
@@ -189,6 +201,16 @@ public class DatasourceMetaApiController {
          XLogicalModel lm = dataModel.getLogicalModel(modelName);
 
          if(lm == null) {
+            continue;
+         }
+
+         AssetEntry entry = new AssetEntry(AssetRepository.QUERY_SCOPE,
+            AssetEntry.Type.LOGIC_MODEL, datasource + "/" + modelName, null);
+         entry = dataSourceService.getModelAssetEntry(entry);
+
+         if(entry == null ||
+            !dataSourceService.checkPermission(entry, ResourceAction.READ, principal))
+         {
             continue;
          }
 
@@ -214,9 +236,34 @@ public class DatasourceMetaApiController {
             entities.add(entityMap);
          }
 
+         // Include physical view join relationships so agents know how entities relate.
+         List<Map<String, String>> joins = new ArrayList<>();
+         String partitionName = lm.getPartition();
+
+         if(partitionName != null) {
+            XPartition partition = dataModel.getPartition(partitionName);
+
+            if(partition != null) {
+               Enumeration<XRelationship> relEnum = partition.getRelationships();
+
+               while(relEnum.hasMoreElements()) {
+                  XRelationship rel = relEnum.nextElement();
+                  Map<String, String> joinMap = new LinkedHashMap<>();
+                  joinMap.put("table", rel.getDependentTable());
+                  joinMap.put("column", rel.getDependentColumn());
+                  joinMap.put("foreignTable", rel.getIndependentTable());
+                  joinMap.put("foreignColumn", rel.getIndependentColumn());
+                  joinMap.put("joinType", rel.getJoinType());
+                  joins.add(joinMap);
+               }
+            }
+         }
+
          Map<String, Object> modelMap = new LinkedHashMap<>();
          modelMap.put("name", modelName);
+         modelMap.put("physicalView", partitionName);
          modelMap.put("entities", entities);
+         modelMap.put("joins", joins);
          result.add(modelMap);
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
@@ -20,7 +20,9 @@ package inetsoft.web.wiz.controller;
 
 import inetsoft.sree.security.*;
 import inetsoft.uql.*;
+import inetsoft.uql.erm.*;
 import inetsoft.web.composer.model.*;
+import inetsoft.web.portal.controller.database.DataSourceService;
 import inetsoft.web.wiz.WizUtil;
 import inetsoft.web.wiz.model.*;
 import inetsoft.web.wiz.model.osi.OsiDataset;
@@ -40,9 +42,13 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping("/api/wiz")
 public class DatasourceMetaApiController {
-   public DatasourceMetaApiController(MetadataApiService metadataService, XRepository xrepository) {
+   public DatasourceMetaApiController(MetadataApiService metadataService,
+                                      XRepository xrepository,
+                                      DataSourceService dataSourceService)
+   {
       this.metadataService = metadataService;
       this.xrepository = xrepository;
+      this.dataSourceService = dataSourceService;
    }
 
    /**
@@ -159,6 +165,64 @@ public class DatasourceMetaApiController {
       return metadataService.searchSchema(request, principal);
    }
 
+   /**
+    * Lists all logical models and their entities/attributes for a given datasource.
+    * Used by the MCP plugin's list_logical_models tool.
+    *
+    * @param datasource the datasource name (e.g. "Examples/Orders")
+    * @return list of logical models, each with entity names and attribute metadata
+    */
+   @GetMapping(value = "/v1/logical-models", produces = MediaType.APPLICATION_JSON_VALUE)
+   public List<Map<String, Object>> listLogicalModels(
+      @RequestParam("datasource") String datasource)
+      throws Exception
+   {
+      XDataModel dataModel = dataSourceService.getDataModel(datasource);
+
+      if(dataModel == null) {
+         return Collections.emptyList();
+      }
+
+      List<Map<String, Object>> result = new ArrayList<>();
+
+      for(String modelName : dataModel.getLogicalModelNames()) {
+         XLogicalModel lm = dataModel.getLogicalModel(modelName);
+
+         if(lm == null) {
+            continue;
+         }
+
+         List<Map<String, Object>> entities = new ArrayList<>();
+         Enumeration<XEntity> entityEnum = lm.getEntities();
+
+         while(entityEnum.hasMoreElements()) {
+            XEntity entity = entityEnum.nextElement();
+            List<Map<String, String>> attributes = new ArrayList<>();
+            Enumeration<XAttribute> attrEnum = entity.getAttributes();
+
+            while(attrEnum.hasMoreElements()) {
+               XAttribute attr = attrEnum.nextElement();
+               Map<String, String> attrMap = new LinkedHashMap<>();
+               attrMap.put("name", attr.getName());
+               attrMap.put("type", attr.getDataType());
+               attributes.add(attrMap);
+            }
+
+            Map<String, Object> entityMap = new LinkedHashMap<>();
+            entityMap.put("name", entity.getName());
+            entityMap.put("attributes", attributes);
+            entities.add(entityMap);
+         }
+
+         Map<String, Object> modelMap = new LinkedHashMap<>();
+         modelMap.put("name", modelName);
+         modelMap.put("entities", entities);
+         result.add(modelMap);
+      }
+
+      return result;
+   }
+
    @ExceptionHandler(Exception.class)
    @ResponseStatus(org.springframework.http.HttpStatus.BAD_REQUEST)
    @ResponseBody
@@ -171,4 +235,5 @@ public class DatasourceMetaApiController {
 
    private final MetadataApiService metadataService;
    private final XRepository xrepository;
+   private final DataSourceService dataSourceService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -39,7 +39,7 @@ import java.util.Map;
  *   <li>{@code set_sort} — {@code table}, {@code field}, {@code direction} ("ASC" | "DESC")</li>
  *   <li>{@code add_join} — {@code name}, {@code leftTable}, {@code leftKey}, {@code rightTable}, {@code rightKey}, {@code joinType}; for multi-key joins use {@code leftKeys}/{@code rightKeys} instead of single key fields</li>
  *   <li>{@code remove_join} — {@code name}</li>
- *   <li>{@code add_table} — {@code table}, optional {@code datasource} (when provided, creates a bound table from the named datasource)</li>
+ *   <li>{@code add_table} — {@code table}, optional {@code datasource} (when provided, creates a bound table from the named datasource); optional {@code logicalModel} (when provided alongside datasource, {@code table} is an entity name within that logical model)</li>
  *   <li>{@code edit_condition} — {@code table}, {@code field}, {@code operation}, {@code values}</li>
  *   <li>{@code edit_expression} — {@code table}, {@code name}, {@code expression}, {@code type}, {@code sql}</li>
  *   <li>{@code edit_join} — {@code name}, {@code leftKey}, {@code rightKey}, {@code joinType}; for multi-key joins use {@code leftKeys}/{@code rightKeys}</li>
@@ -148,6 +148,8 @@ public record EditRequest(
    String schema,
    /** Catalog name for add_table. */
    String catalog,
+   /** Logical model name for add_table (when provided alongside datasource, creates a BoundTableAssembly from the logical model entity). */
+   String logicalModel,
    /** Multi-key join: left column names for add_join / edit_join. */
    List<String> leftKeys,
    /** Multi-key join: right column names for add_join / edit_join. */

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -22,6 +22,7 @@ import inetsoft.report.composition.WorksheetService;
 import inetsoft.report.composition.event.AssetEventUtil;
 import inetsoft.report.composition.execution.AssetQuerySandbox;
 import inetsoft.sree.security.IdentityID;
+import inetsoft.sree.security.ResourceAction;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.AssetUtil;
@@ -341,6 +342,12 @@ public class WorksheetAgentController {
          throw new PairingException("table (entity name) is required for add_table with a logical model.");
       }
 
+      // Verify READ permission on the datasource and logical model,
+      // mirroring the checks in DatasourceMetaApiController.listLogicalModels().
+      if(!dataSourceService.checkPermission(datasourceName, ResourceAction.READ, user)) {
+         throw new PairingException("Access denied: no READ permission on datasource " + datasourceName);
+      }
+
       XDataModel dataModel = dataSourceService.getDataModel(datasourceName);
 
       if(dataModel == null) {
@@ -352,6 +359,17 @@ public class WorksheetAgentController {
       if(lm == null) {
          throw new PairingException("Logical model not found: " + logicalModelName
             + " (datasource=" + datasourceName + ")");
+      }
+
+      AssetEntry modelEntry = new AssetEntry(AssetRepository.QUERY_SCOPE,
+         AssetEntry.Type.LOGIC_MODEL, datasourceName + "/" + logicalModelName, null);
+      modelEntry = dataSourceService.getModelAssetEntry(modelEntry);
+
+      if(modelEntry == null ||
+         !dataSourceService.checkPermission(modelEntry, ResourceAction.READ, user))
+      {
+         throw new PairingException("Access denied: no READ permission on logical model "
+            + logicalModelName + " (datasource=" + datasourceName + ")");
       }
 
       XEntity entity = lm.getEntity(entityName);

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -206,6 +206,12 @@ public class WorksheetAgentController {
          return;
       }
 
+      // add_variable needs RuntimeWorksheet to add the assembly.
+      if("add_variable".equals(req.op())) {
+         addVariableFromEdit(sessionToken, req, user);
+         return;
+      }
+
       editService.apply(sessionToken, user, editor -> dispatch(editor, req));
    }
 
@@ -1268,6 +1274,79 @@ public class WorksheetAgentController {
    }
 
    // ---------------------------------------------------------------------------
+   // Add variable from edit endpoint
+   // ---------------------------------------------------------------------------
+
+   /**
+    * Handles {@code add_variable} dispatched through the edit endpoint.
+    */
+   private void addVariableFromEdit(String sessionToken, EditRequest req, Principal user)
+      throws Exception
+   {
+      String varName = req.name();
+
+      if(varName == null || varName.isBlank()) {
+         throw new PairingException("name is required for add_variable.");
+      }
+
+      editService.applyOnRuntime(sessionToken, user, rws -> {
+         Worksheet ws = rws.getWorksheet();
+         createVariable(ws, varName, req.type(), req.label(), req.defaultValue());
+         return null;
+      });
+   }
+
+   /**
+    * Shared helper that creates a {@link DefaultVariableAssembly} with the given
+    * name, type, label, and default value.
+    */
+   private void createVariable(Worksheet ws, String name, String type,
+                               String label, String defaultValue)
+   {
+      AssetVariable var = new AssetVariable(name);
+
+      if(label != null) {
+         var.setAlias(label);
+      }
+
+      if(type != null) {
+         var.setTypeNode(XSchema.createPrimitiveType(type));
+      }
+
+      if(defaultValue != null) {
+         // Determine the effective type for the value node.  When a type is specified,
+         // use the typed factory so the value node matches the variable type (e.g.
+         // IntegerValue for "integer") and the value is parsed correctly through
+         // XValueNode.parse0().  Without this, createValueNode(Object, String) always
+         // creates a StringValue regardless of the variable type, and the stored
+         // default value can be silently lost on serialization round-trips.
+         String effectiveType = type != null
+            ? type : (var.getTypeNode() != null ? var.getTypeNode().getType() : null);
+         inetsoft.uql.schema.XValueNode valueNode =
+            inetsoft.uql.schema.XValueNode.createValueNode(name, effectiveType);
+
+         if(valueNode != null) {
+            try {
+               valueNode.parse0(defaultValue);
+            }
+            catch(Exception e) {
+               // Fall back to storing the raw string value if parsing fails
+               // (e.g. non-numeric string for an integer variable).
+               valueNode.setValue(defaultValue);
+            }
+
+            var.setValueNode(valueNode);
+         }
+      }
+
+      DefaultVariableAssembly assembly = new DefaultVariableAssembly(ws, name);
+      assembly.setVariable(var);
+      assembly.setPixelOffset(new Point(25, 25));
+      AssetEventUtil.adjustAssemblyPosition(assembly, ws);
+      ws.addAssembly(assembly);
+   }
+
+   // ---------------------------------------------------------------------------
    // Query execution plan (read-only)
    // ---------------------------------------------------------------------------
 
@@ -1359,28 +1438,7 @@ public class WorksheetAgentController {
 
       editService.applyOnRuntime(sessionToken, user, rws -> {
          Worksheet ws = rws.getWorksheet();
-         AssetVariable var = new AssetVariable(body.name());
-
-         if(body.label() != null) {
-            var.setAlias(body.label());
-         }
-
-         if(body.type() != null) {
-            var.setTypeNode(XSchema.createPrimitiveType(body.type()));
-         }
-
-         if(body.defaultValue() != null) {
-            var.setValueNode(
-               inetsoft.uql.schema.XValueNode.createValueNode(
-                  body.defaultValue(), body.name()));
-         }
-
-         DefaultVariableAssembly assembly =
-            new DefaultVariableAssembly(ws, body.name());
-         assembly.setVariable(var);
-         assembly.setPixelOffset(new Point(25, 25));
-         AssetEventUtil.adjustAssemblyPosition(assembly, ws);
-         ws.addAssembly(assembly);
+         createVariable(ws, body.name(), body.type(), body.label(), body.defaultValue());
          return null;
       });
    }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -152,6 +152,15 @@ public class WorksheetAgentController {
    {
       requireEnabled();
 
+      // add_table with logicalModel requires datasource.
+      if("add_table".equals(req.op()) && req.logicalModel() != null
+         && !req.logicalModel().isBlank()
+         && (req.datasource() == null || req.datasource().isBlank()))
+      {
+         throw new PairingException(
+            "datasource is required when logicalModel is specified.");
+      }
+
       // add_table with a datasource needs RuntimeWorksheet for initColumnSelection.
       if("add_table".equals(req.op()) && req.datasource() != null
          && !req.datasource().isBlank())

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -25,8 +25,8 @@ import inetsoft.sree.security.IdentityID;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.AssetUtil;
-import inetsoft.uql.erm.AttributeRef;
-import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.erm.*;
+import inetsoft.web.portal.controller.database.DataSourceService;
 import inetsoft.uql.asset.internal.*;
 import inetsoft.uql.jdbc.*;
 import inetsoft.uql.jdbc.util.JDBCUtil;
@@ -75,7 +75,8 @@ public class WorksheetAgentController {
                                    AssetRepository assetRepository,
                                    inetsoft.web.wiz.service.MetadataApiService metadataApiService,
                                    QueryManagerService queryManagerService,
-                                   LayoutGraphService layoutGraphService)
+                                   LayoutGraphService layoutGraphService,
+                                   DataSourceService dataSourceService)
    {
       this.feature = feature;
       this.joinService = joinService;
@@ -90,6 +91,7 @@ public class WorksheetAgentController {
       this.metadataApiService = metadataApiService;
       this.queryManagerService = queryManagerService;
       this.layoutGraphService = layoutGraphService;
+      this.dataSourceService = dataSourceService;
    }
 
    // ---------------------------------------------------------------------------
@@ -154,7 +156,12 @@ public class WorksheetAgentController {
       if("add_table".equals(req.op()) && req.datasource() != null
          && !req.datasource().isBlank())
       {
-         addBoundTable(sessionToken, req, user);
+         if(req.logicalModel() != null && !req.logicalModel().isBlank()) {
+            addLogicalModelTable(sessionToken, req, user);
+         }
+         else {
+            addBoundTable(sessionToken, req, user);
+         }
          return;
       }
 
@@ -285,6 +292,93 @@ public class WorksheetAgentController {
          assembly.setColumnSelection(columns);
 
          // Position below existing assemblies.
+         int maxY = 0;
+
+         for(Assembly a : ws.getAssemblies()) {
+            if(!(a instanceof AbstractWSAssembly wa)) {
+               continue;
+            }
+
+            Point p = wa.getPixelOffset();
+            Dimension d = wa.getPixelSize();
+
+            if(p != null && d != null) {
+               maxY = Math.max(maxY, p.y + d.height);
+            }
+         }
+
+         assembly.setPixelOffset(new Point(25, maxY + 40));
+         ws.addAssembly(assembly);
+         return null;
+      });
+   }
+
+   /**
+    * Create a {@link BoundTableAssembly} from a logical model entity.
+    *
+    * <p>{@code req.datasource()} is the datasource name, {@code req.logicalModel()} is the
+    * logical model name, and {@code req.table()} is the entity name within that model.
+    * A {@link SourceInfo} of type {@link SourceInfo#MODEL} is created and the column
+    * selection is populated from the entity's attributes.</p>
+    */
+   private void addLogicalModelTable(String sessionToken, EditRequest req, Principal user)
+      throws Exception
+   {
+      String datasourceName = req.datasource();
+      String logicalModelName = req.logicalModel();
+      String entityName = req.table();
+
+      if(entityName == null || entityName.isBlank()) {
+         throw new PairingException("table (entity name) is required for add_table with a logical model.");
+      }
+
+      XDataModel dataModel = dataSourceService.getDataModel(datasourceName);
+
+      if(dataModel == null) {
+         throw new PairingException("No data model found for datasource: " + datasourceName);
+      }
+
+      XLogicalModel lm = dataModel.getLogicalModel(logicalModelName);
+
+      if(lm == null) {
+         throw new PairingException("Logical model not found: " + logicalModelName
+            + " (datasource=" + datasourceName + ")");
+      }
+
+      XEntity entity = lm.getEntity(entityName);
+
+      if(entity == null) {
+         throw new PairingException("Entity not found: " + entityName
+            + " (logicalModel=" + logicalModelName + ", datasource=" + datasourceName + ")");
+      }
+
+      ColumnSelection columns = new ColumnSelection();
+      Enumeration<XAttribute> attrEnum = entity.getAttributes();
+
+      while(attrEnum.hasMoreElements()) {
+         XAttribute attr = attrEnum.nextElement();
+         AttributeRef attributeRef = new AttributeRef(entityName, attr.getName());
+         ColumnRef ref = new ColumnRef(attributeRef);
+
+         if(attr.getDataType() != null) {
+            ref.setDataType(attr.getDataType());
+         }
+
+         columns.addAttribute(ref);
+      }
+
+      editService.applyOnRuntime(sessionToken, user, rws -> {
+         Worksheet ws = rws.getWorksheet();
+         String assemblyName = AssetUtil.normalizeTable(entityName);
+         assemblyName = AssetUtil.getNextName(ws, assemblyName);
+
+         BoundTableAssembly assembly = new BoundTableAssembly(ws, assemblyName);
+
+         SourceInfo sinfo = new SourceInfo(
+            SourceInfo.MODEL, datasourceName, logicalModelName);
+         assembly.setSourceInfo(sinfo);
+         assembly.setColumnSelection(columns);
+
          int maxY = 0;
 
          for(Assembly a : ws.getAssemblies()) {
@@ -1651,4 +1745,5 @@ public class WorksheetAgentController {
    private final inetsoft.web.wiz.service.MetadataApiService metadataApiService;
    private final QueryManagerService queryManagerService;
    private final LayoutGraphService layoutGraphService;
+   private final DataSourceService dataSourceService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -211,9 +211,15 @@ public class WorksheetEditService {
       for(Assembly a : ws.getAssemblies()) {
          if(a instanceof TableAssembly ta) {
             String name = ta.getName();
-            WorksheetEventUtil.refreshColumnSelection(rws, name, true);
-            WorksheetEventUtil.loadTableData(rws, name, true, true);
-            WorksheetEventUtil.fixAssemblyInfo(rws, ta);
+
+            try {
+               WorksheetEventUtil.refreshColumnSelection(rws, name, true);
+               WorksheetEventUtil.loadTableData(rws, name, true, true);
+               WorksheetEventUtil.fixAssemblyInfo(rws, ta);
+            }
+            catch(Exception ex) {
+               LOG.warn("Failed to refresh assembly: " + name, ex);
+            }
          }
       }
    }
@@ -599,6 +605,10 @@ public class WorksheetEditService {
        * Creates a {@link RotatedTableAssembly} (transpose) from an existing table.
        */
       public void addRotate(String name, String source) throws PairingException {
+         if(name == null || name.isBlank()) {
+            name = AssetUtil.getNextName(ws, AbstractSheet.TABLE_ASSET);
+         }
+
          TableAssembly src = requireTable(source);
          RotatedTableAssembly table = new RotatedTableAssembly(ws, name, src);
          table.setLiveData(true);
@@ -615,6 +625,10 @@ public class WorksheetEditService {
       public void addUnpivot(String name, String source, int headerColumns)
          throws PairingException
       {
+         if(name == null || name.isBlank()) {
+            name = AssetUtil.getNextName(ws, AbstractSheet.TABLE_ASSET);
+         }
+
          TableAssembly src = requireTable(source);
          int colCount = src.getColumnSelection(false).getAttributeCount();
 
@@ -751,6 +765,10 @@ public class WorksheetEditService {
       public void addConcatenation(String name, List<String> tables, String opType)
          throws PairingException
       {
+         if(name == null || name.isBlank()) {
+            name = AssetUtil.getNextName(ws, AbstractSheet.TABLE_ASSET);
+         }
+
          if(tables == null || tables.size() < 2) {
             throw new PairingException("Concatenation requires at least two tables.");
          }
@@ -787,6 +805,10 @@ public class WorksheetEditService {
        * @throws PairingException if the source assembly is not found
        */
       public void addMirror(String name, String source) throws PairingException {
+         if(name == null || name.isBlank()) {
+            name = AssetUtil.getNextName(ws, AbstractSheet.TABLE_ASSET);
+         }
+
          Assembly a = ws.getAssembly(source);
 
          if(!(a instanceof WSAssembly wsa)) {
@@ -877,7 +899,7 @@ public class WorksheetEditService {
        * @throws PairingException if the table or column is not found
        */
       public void changeColumnType(String table, String col, String type)
-         throws PairingException
+         throws Exception
       {
          if(!XSchema.isPrimitiveType(type)) {
             throw new PairingException(
@@ -887,14 +909,48 @@ public class WorksheetEditService {
          }
 
          TableAssembly t = requireTable(table);
-         ColumnSelection cs = t.getColumnSelection(false);
+
+         // Use the public column selection (matching the UI's ColumnTypeDialogService
+         // approach) so that AssetUtil.findColumn can match against the embedded data.
+         ColumnSelection cs = t.getColumnSelection();
          DataRef ref = cs.getAttribute(col);
+
+         if(ref == null) {
+            // Fall back to private column selection.
+            cs = t.getColumnSelection(false);
+            ref = cs.getAttribute(col);
+         }
 
          if(!(ref instanceof ColumnRef cr)) {
             throw new PairingException("Column not found: " + col);
          }
 
-         cr.setDataType(type);
+         // Also update the matching ref from findAttribute (same approach as
+         // ColumnTypeDialogService) to ensure the canonical ref is updated.
+         ColumnRef cr2 = (ColumnRef) cs.findAttribute(cr);
+
+         if(cr2 != null) {
+            cr2.setDataType(type);
+         }
+         else {
+            cr.setDataType(type);
+         }
+
+         // For embedded tables, also update the underlying XEmbeddedTable data type.
+         // Without this, refreshColumnSelection rebuilds the column selection from
+         // the data and resets the type back to the original.
+         if(t instanceof EmbeddedTableAssembly embedded) {
+            XEmbeddedTable data = embedded.getEmbeddedData();
+
+            if(data != null) {
+               int index = AssetUtil.findColumn(data, cr2 != null ? cr2 : cr);
+
+               if(index >= 0) {
+                  data.setDataType(index, type, null, null, true);
+                  embedded.setEmbeddedData(data);
+               }
+            }
+         }
       }
 
       // -----------------------------------------------------------------------
@@ -1398,6 +1454,7 @@ public class WorksheetEditService {
          DefaultNamedGroupAssembly assembly = new DefaultNamedGroupAssembly(ws, name);
          assembly.setNamedGroupInfo(ngi);
          assembly.setAttachedType(AttachedAssembly.COLUMN_ATTACHED);
+         assembly.setAttachedSource(new SourceInfo(SourceInfo.ASSET, null, table));
          assembly.setAttachedAttribute(ref);
 
          placeAssembly(assembly);
@@ -1577,8 +1634,24 @@ public class WorksheetEditService {
          }
 
          if(defaultValue != null) {
-            var.setValueNode(
-               inetsoft.uql.schema.XValueNode.createValueNode(defaultValue, name));
+            // Use the variable's type to create the correct value node subclass
+            // (e.g. IntegerValue for "integer") so the default value survives
+            // serialization round-trips.
+            String effectiveType = type != null
+               ? type : (var.getTypeNode() != null ? var.getTypeNode().getType() : null);
+            inetsoft.uql.schema.XValueNode valueNode =
+               inetsoft.uql.schema.XValueNode.createValueNode(name, effectiveType);
+
+            if(valueNode != null) {
+               try {
+                  valueNode.parse0(defaultValue);
+               }
+               catch(Exception e) {
+                  valueNode.setValue(defaultValue);
+               }
+
+               var.setValueNode(valueNode);
+            }
          }
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -98,7 +98,7 @@ public class WorksheetEditService {
             throw me;
          }
 
-         LOG.warn("Auto-confirmed cross join in agent edit: {}", me.getMessage());
+         LOG.info("Auto-confirmed cross join in agent edit: {}", me.getMessage());
       }
 
       // Checkpoint saved after the mutation so redo restores the post-edit state,

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -25,6 +25,7 @@ import inetsoft.uql.ColumnSelection;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.uql.asset.internal.TableAssemblyInfo;
+import inetsoft.util.MessageException;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.schema.XSchema;
@@ -85,7 +86,21 @@ public class WorksheetEditService {
       applySocketSession(rws, session);
 
       Editor editor = new Editor(rws.getWorksheet());
-      mutation.accept(editor);
+
+      try {
+         mutation.accept(editor);
+      }
+      catch(MessageException me) {
+         // Auto-confirm cross-join: the column selection change has already been applied
+         // in memory before AbstractJoinTableAssembly.setColumnSelection throws.  In the
+         // browser UI this would surface as a confirmation dialog — here we just accept it.
+         if(!(me.getCause() instanceof CrossJoinException)) {
+            throw me;
+         }
+
+         LOG.debug("Auto-confirmed cross join in agent edit: {}", me.getMessage());
+      }
+
       // Checkpoint saved after the mutation so redo restores the post-edit state,
       // matching the @Undoable / makeUndoable pattern used by the standard WS controllers.
       rws.addCheckpoint(rws.getWorksheet().prepareCheckpoint());
@@ -780,6 +795,20 @@ public class WorksheetEditService {
             sources[i] = requireTable(tables.get(i));
          }
 
+         // Validate that all tables have the same number of columns.
+         int colCount = sources[0].getColumnSelection(true).getAttributeCount();
+
+         for(int i = 1; i < sources.length; i++) {
+            int otherCount = sources[i].getColumnSelection(true).getAttributeCount();
+
+            if(otherCount != colCount) {
+               throw new PairingException(
+                  "Data blocks that do not have the same number of columns cannot be " +
+                  "concatenated. \"" + sources[0].getName() + "\" has " + colCount +
+                  " columns but \"" + sources[i].getName() + "\" has " + otherCount + ".");
+            }
+         }
+
          // Build one operator per adjacent pair.
          TableAssemblyOperator[] operators = new TableAssemblyOperator[sources.length - 1];
 
@@ -1057,7 +1086,7 @@ public class WorksheetEditService {
                newTop.addOperator(newOp);
             }
          }
-         else {
+         else if(leftKey != null && rightKey != null) {
             TableAssemblyOperator.Operator newOp = new TableAssemblyOperator.Operator();
             newOp.setLeftTable(leftTable);
             newOp.setRightTable(rightTable);
@@ -1065,6 +1094,19 @@ public class WorksheetEditService {
             newOp.setRightAttribute(new AttributeRef(null, rightKey));
             newOp.setOperation(operation);
             newTop.addOperator(newOp);
+         }
+         else {
+            // No new keys provided — preserve existing key pairs, only update join type.
+            for(int i = 0; i < top.getOperatorCount(); i++) {
+               TableAssemblyOperator.Operator orig = top.getOperator(i);
+               TableAssemblyOperator.Operator newOp = new TableAssemblyOperator.Operator();
+               newOp.setLeftTable(orig.getLeftTable());
+               newOp.setRightTable(orig.getRightTable());
+               newOp.setLeftAttribute(orig.getLeftAttribute());
+               newOp.setRightAttribute(orig.getRightAttribute());
+               newOp.setOperation(operation);
+               newTop.addOperator(newOp);
+            }
          }
 
          join.setOperator(leftTable, rightTable, newTop);
@@ -1358,6 +1400,18 @@ public class WorksheetEditService {
 
          TableAssembly newTable = requireTable(tableName);
          TableAssembly[] existing = ctbl.getTableAssemblies();
+
+         // Validate column count matches existing subtables.
+         int colCount = existing[0].getColumnSelection(true).getAttributeCount();
+         int newCount = newTable.getColumnSelection(true).getAttributeCount();
+
+         if(newCount != colCount) {
+            throw new PairingException(
+               "Data blocks that do not have the same number of columns cannot be " +
+               "concatenated. Existing subtables have " + colCount +
+               " columns but \"" + tableName + "\" has " + newCount + ".");
+         }
+
          TableAssembly[] updated = new TableAssembly[existing.length + 1];
          System.arraycopy(existing, 0, updated, 0, existing.length);
          updated[existing.length] = newTable;
@@ -1366,7 +1420,7 @@ public class WorksheetEditService {
          // Copy the last-pair operator (between existing[n-2] and existing[n-1]) so that
          // the new table inherits the same UNION/INTERSECT/MINUS as the most recent pair
          // rather than always defaulting to whatever operator 0 happens to be.
-         TableAssemblyOperator op = ctbl.getOperator(existing.length - 1);
+         TableAssemblyOperator op = ctbl.getOperator(existing.length - 2);
          ctbl.setTableAssemblies(updated);
 
          // Set operator between last existing and new table

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -98,7 +98,7 @@ public class WorksheetEditService {
             throw me;
          }
 
-         LOG.debug("Auto-confirmed cross join in agent edit: {}", me.getMessage());
+         LOG.warn("Auto-confirmed cross join in agent edit: {}", me.getMessage());
       }
 
       // Checkpoint saved after the mutation so redo restores the post-edit state,
@@ -233,7 +233,7 @@ public class WorksheetEditService {
                WorksheetEventUtil.fixAssemblyInfo(rws, ta);
             }
             catch(Exception ex) {
-               LOG.warn("Failed to refresh assembly: " + name, ex);
+               LOG.warn("Failed to refresh assembly: {}", name, ex);
             }
          }
       }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -87,18 +87,10 @@ public final class WorksheetMutationSupport {
    {
       boolean negate = isNegatedOperation(operation);
       int op = parseOperation(operation);
-      AttributeRef ref = new AttributeRef(null, field);
-      // Infer type from the column selection so numeric comparisons work correctly.
-      String dtype = XSchema.STRING;
-      ColumnSelection cs = t.getColumnSelection(false);
-
-      if(cs != null) {
-         DataRef col = cs.getAttribute(field);
-
-         if(col != null && col.getDataType() != null && !col.getDataType().isBlank()) {
-            dtype = col.getDataType();
-         }
-      }
+      DataRef ref = resolveField(t, field);
+      // Infer type from the resolved column so numeric comparisons work correctly.
+      String dtype = ref.getDataType() != null && !ref.getDataType().isBlank()
+         ? ref.getDataType() : XSchema.STRING;
 
       Condition c = new Condition(dtype);
       c.setOperation(op);
@@ -232,13 +224,39 @@ public final class WorksheetMutationSupport {
       }
 
       AggregateInfo ainfo = new AggregateInfo();
+      ColumnSelection cs = t.getColumnSelection(false);
 
-      for(String group : groups) {
-         GroupRef gr = new GroupRef(new ColumnRef(new AttributeRef(null, group)));
-         ainfo.addGroup(gr);
+      // Build a lookup map of available columns keyed by both raw name and alias,
+      // matching the pattern used by AggregateDialogService.getAggregateInfo().
+      Map<String, ColumnRef> availableColumns = new LinkedHashMap<>();
+
+      if(cs != null) {
+         for(int i = 0; i < cs.getAttributeCount(); i++) {
+            DataRef ref = cs.getAttribute(i);
+
+            if(ref instanceof ColumnRef cr) {
+               availableColumns.put(cr.getName(), cr);
+
+               if(cr.getAlias() != null && !cr.getAlias().isEmpty()) {
+                  availableColumns.putIfAbsent(cr.getAlias(), cr);
+               }
+
+               // Also index by raw attribute name (without entity prefix)
+               availableColumns.putIfAbsent(cr.getAttribute(), cr);
+            }
+         }
       }
 
-      ColumnSelection cs = t.getColumnSelection(false);
+      for(String group : groups) {
+         ColumnRef resolved = availableColumns.get(group);
+
+         if(resolved == null) {
+            resolved = new ColumnRef(new AttributeRef(null, group));
+         }
+
+         GroupRef gr = new GroupRef(resolved);
+         ainfo.addGroup(gr);
+      }
 
       for(AggregateSpec spec : aggregates) {
          AggregateFormula formula = AggregateFormula.getFormula(spec.formula());
@@ -247,28 +265,18 @@ public final class WorksheetMutationSupport {
             formula = AggregateFormula.SUM;
          }
 
-         ColumnRef colRef = new ColumnRef(new AttributeRef(null, spec.field()));
+         ColumnRef colRef = availableColumns.get(spec.field());
+
+         if(colRef == null) {
+            colRef = new ColumnRef(new AttributeRef(null, spec.field()));
+         }
+
          AggregateRef ar = new AggregateRef(colRef, formula);
 
          if(spec.alias() != null) {
             colRef.setAlias(spec.alias());
-
-            // Set the alias on the matching column in the table's column
-            // selection so that AssetUtil.applyAlias() renames the output header.
-            if(cs != null) {
-               DataRef csCol = cs.getAttribute(spec.field());
-
-               if(csCol instanceof ColumnRef csCr) {
-                  csCr.setAlias(spec.alias());
-               }
-            }
          }
 
-         // If the aggregate info already contains an aggregate for this column
-         // (same column, different formula), add it as a secondary aggregate.
-         // This matches the standard UI pattern (AggregateDialogService) where
-         // the first aggregate goes into the primary list and subsequent ones
-         // for the same column go into the secondary list.
          if(ainfo.containsAggregate(ar)) {
             ainfo.addSecondaryAggregate(ar);
          }
@@ -427,7 +435,7 @@ public final class WorksheetMutationSupport {
          }
       }
 
-      AttributeRef ref = new AttributeRef(null, field);
+      DataRef ref = resolveField(t, field);
       SortRef sr = new SortRef(ref);
       sr.setOrder("DESC".equalsIgnoreCase(direction) ? XConstants.SORT_DESC : XConstants.SORT_ASC);
       si.addSort(sr);
@@ -510,7 +518,7 @@ public final class WorksheetMutationSupport {
             boolean negate = spec.negated() || isNegatedOperation(spec.operation());
             String dtype = spec.type() != null ? spec.type() : inferColumnType(t, spec.field());
 
-            AttributeRef ref = new AttributeRef(null, spec.field());
+            DataRef ref = resolveField(t, spec.field());
             Condition c = new Condition(dtype);
             c.setOperation(op);
 
@@ -575,7 +583,7 @@ public final class WorksheetMutationSupport {
       int op = "BOTTOM_N".equalsIgnoreCase(spec.operation())
          ? XCondition.BOTTOM_N : XCondition.TOP_N;
 
-      AttributeRef ref = new AttributeRef(null, spec.field());
+      DataRef ref = resolveField(t, spec.field());
       inetsoft.uql.asset.RankingCondition rc = new inetsoft.uql.asset.RankingCondition();
       rc.setOperation(op);
       rc.setN(spec.n());
@@ -591,18 +599,47 @@ public final class WorksheetMutationSupport {
    // =========================================================================
 
    /**
+    * Resolves a field name (which may be a column name or alias) against the table's
+    * column selection.  Returns the matching {@link DataRef} from the selection, or
+    * a new {@link AttributeRef} as fallback.  This mirrors the lookup pattern used by
+    * {@code AggregateDialogService.getAggregateInfo()} so that conditions, ranking,
+    * and aggregates reference the real column objects.
+    */
+   static DataRef resolveField(TableAssembly t, String field) {
+      ColumnSelection cs = t.getColumnSelection(false);
+
+      if(cs != null && field != null) {
+         // Try direct lookup first (handles both raw name and alias via ColumnSelection).
+         DataRef col = cs.getAttribute(field);
+
+         if(col != null) {
+            return col;
+         }
+
+         // Fallback: scan for alias match (getAttribute may not check aliases on all paths).
+         for(int i = 0; i < cs.getAttributeCount(); i++) {
+            DataRef ref = cs.getAttribute(i);
+
+            if(ref instanceof ColumnRef cr &&
+               field.equals(cr.getAlias()))
+            {
+               return cr;
+            }
+         }
+      }
+
+      return new AttributeRef(null, field);
+   }
+
+   /**
     * Looks up the XSchema data type for {@code field} in the table's column selection.
     * Falls back to {@link XSchema#STRING} when the column is not found or has no type.
     */
    private static String inferColumnType(TableAssembly t, String field) {
-      ColumnSelection cs = t.getColumnSelection(false);
+      DataRef col = resolveField(t, field);
 
-      if(cs != null && field != null) {
-         DataRef col = cs.getAttribute(field);
-
-         if(col != null && col.getDataType() != null && !col.getDataType().isBlank()) {
-            return col.getDataType();
-         }
+      if(col.getDataType() != null && !col.getDataType().isBlank()) {
+         return col.getDataType();
       }
 
       return XSchema.STRING;

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -26,7 +26,7 @@ import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.schema.UserVariable;
 import inetsoft.uql.schema.XSchema;
 
-import java.util.List;
+import java.util.*;
 
 /**
  * Static helpers that implement the low-level structural mutations used by
@@ -238,6 +238,8 @@ public final class WorksheetMutationSupport {
          ainfo.addGroup(gr);
       }
 
+      ColumnSelection cs = t.getColumnSelection(false);
+
       for(AggregateSpec spec : aggregates) {
          AggregateFormula formula = AggregateFormula.getFormula(spec.formula());
 
@@ -250,9 +252,75 @@ public final class WorksheetMutationSupport {
 
          if(spec.alias() != null) {
             colRef.setAlias(spec.alias());
+
+            // Set the alias on the matching column in the table's column
+            // selection so that AssetUtil.applyAlias() renames the output header.
+            if(cs != null) {
+               DataRef csCol = cs.getAttribute(spec.field());
+
+               if(csCol instanceof ColumnRef csCr) {
+                  csCr.setAlias(spec.alias());
+               }
+            }
          }
 
-         ainfo.addAggregate(ar);
+         // If the aggregate info already contains an aggregate for this column
+         // (same column, different formula), add it as a secondary aggregate.
+         // This matches the standard UI pattern (AggregateDialogService) where
+         // the first aggregate goes into the primary list and subsequent ones
+         // for the same column go into the secondary list.
+         if(ainfo.containsAggregate(ar)) {
+            ainfo.addSecondaryAggregate(ar);
+         }
+         else {
+            ainfo.addAggregate(ar, false);
+         }
+      }
+
+      // Convert secondary aggregates into expression columns + primary aggregates.
+      // This matches the standard UI pattern (AggregateDialogService.updateAggregateInfo):
+      // each secondary aggregate gets a new expression column (field['Amount']) added to
+      // the column selection with a unique name, then a new primary aggregate is created
+      // on that expression column so the query engine produces a separate output column.
+      AggregateRef[] secondaryAggs = ainfo.getSecondaryAggregates();
+
+      if(secondaryAggs.length > 0) {
+         ColumnSelection cs2 = t.getColumnSelection();
+
+         for(AggregateRef sref : secondaryAggs) {
+            ColumnRef cref = (ColumnRef) sref.getDataRef();
+            String base = cref.getAttribute();
+
+            // Generate a unique column name (e.g. Amount_1, Amount_2).
+            int suffix = 1;
+            String exprName = base + "_1";
+
+            while(cs2.getAttribute(exprName) != null) {
+               exprName = base + "_" + (++suffix);
+            }
+
+            // Create an expression column that references the original column.
+            ExpressionRef exp = new ExpressionRef(null, exprName);
+            String fieldRef = cref.isEntityBlank() ? cref.getAttribute()
+               : cref.getEntity() + "." + cref.getAttribute();
+            exp.setExpression("field['" + fieldRef + "']");
+            ColumnRef exprCol = new ColumnRef(exp);
+            exprCol.setDataType(cref.getDataType());
+
+            // Carry over the alias from the secondary aggregate.
+            if(cref.getAlias() != null) {
+               exprCol.setAlias(cref.getAlias());
+            }
+
+            cs2.addAttribute(exprCol);
+
+            // Create a new primary aggregate on the expression column.
+            AggregateRef newAgg = new AggregateRef(exprCol, sref.getFormula());
+            ainfo.addAggregate(newAgg, false);
+         }
+
+         ainfo.removeSecondaryAggregates();
+         t.setColumnSelection(cs2);
       }
 
       t.setAggregateInfo(ainfo);

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -54,6 +54,7 @@ public class WorksheetReadService {
 
       List<WorksheetModel.TableModel> tables = new ArrayList<>();
       List<WorksheetModel.VariableModel> variables = new ArrayList<>();
+      List<WorksheetModel.NamedGroupModel> namedGroups = new ArrayList<>();
 
       for(Assembly assembly : assemblies) {
          if(assembly instanceof TableAssembly t) {
@@ -63,9 +64,12 @@ public class WorksheetReadService {
          else if(assembly instanceof DefaultVariableAssembly dva) {
             variables.add(readVariable(dva));
          }
+         else if(assembly instanceof DefaultNamedGroupAssembly nga) {
+            namedGroups.add(readNamedGroup(nga));
+         }
       }
 
-      return new WorksheetModel(tables, variables);
+      return new WorksheetModel(tables, variables, namedGroups);
    }
 
    // -------------------------------------------------------------------------
@@ -178,6 +182,62 @@ public class WorksheetReadService {
          ? valueNode.getValue().toString() : null : null;
 
       return new WorksheetModel.VariableModel(var.getName(), label, type, defaultValue);
+   }
+
+   // -------------------------------------------------------------------------
+   // Named groups
+   // -------------------------------------------------------------------------
+
+   private WorksheetModel.NamedGroupModel readNamedGroup(DefaultNamedGroupAssembly nga) {
+      String name = nga.getName();
+
+      DataRef attachedAttr = nga.getAttachedAttribute();
+      SourceInfo attachedSource = nga.getAttachedSource();
+      String table = attachedSource != null ? attachedSource.getSource() : null;
+      String column = attachedAttr != null ? attachedAttr.getAttribute() : null;
+
+      NamedGroupInfo ngi = nga.getNamedGroupInfo();
+      boolean groupOthers = ngi != null && ngi.getOthers() == XConstants.GROUP_OTHERS;
+
+      List<WorksheetModel.GroupMappingModel> mappings = new ArrayList<>();
+
+      if(ngi != null) {
+         String[] groups = ngi.getGroups(false);
+
+         for(String group : groups) {
+            ConditionList conds = ngi.getGroupCondition(group);
+            List<String> values = new ArrayList<>();
+
+            if(conds != null) {
+               int size = conds.getConditionSize();
+
+               for(int i = 0; i < size; i++) {
+                  if(!conds.isConditionItem(i)) {
+                     continue;
+                  }
+
+                  ConditionItem item = conds.getConditionItem(i);
+
+                  if(item == null) {
+                     continue;
+                  }
+
+                  XCondition xc = item.getXCondition();
+
+                  if(xc instanceof Condition c) {
+                     for(int v = 0; v < c.getValueCount(); v++) {
+                        Object val = c.getValue(v);
+                        values.add(val != null ? val.toString() : null);
+                     }
+                  }
+               }
+            }
+
+            mappings.add(new WorksheetModel.GroupMappingModel(group, values));
+         }
+      }
+
+      return new WorksheetModel.NamedGroupModel(name, table, column, mappings, groupOthers);
    }
 
    // -------------------------------------------------------------------------
@@ -327,19 +387,34 @@ public class WorksheetReadService {
          groups.add(gr.getName());
       }
 
-      // Aggregates
+      // Aggregates (primary + secondary)
       AggregateRef[] aggRefs = info.getAggregates();
+      AggregateRef[] secondaryRefs = info.getSecondaryAggregates();
       List<WorksheetModel.AggregateModel.AggregateRefModel> aggregates =
-         new ArrayList<>(aggRefs.length);
+         new ArrayList<>(aggRefs.length + secondaryRefs.length);
 
       for(AggregateRef ar : aggRefs) {
-         String column = ar.getAttribute();
-         AggregateFormula formula = ar.getFormula();
-         String formulaName = formula != null ? formula.getName() : null;
-         aggregates.add(new WorksheetModel.AggregateModel.AggregateRefModel(column, formulaName));
+         aggregates.add(readAggregateRef(ar));
+      }
+
+      for(AggregateRef ar : secondaryRefs) {
+         aggregates.add(readAggregateRef(ar));
       }
 
       return new WorksheetModel.AggregateModel(groups, aggregates);
+   }
+
+   private WorksheetModel.AggregateModel.AggregateRefModel readAggregateRef(AggregateRef ar) {
+      String column = ar.getAttribute();
+      AggregateFormula formula = ar.getFormula();
+      String formulaName = formula != null ? formula.getName() : null;
+      String alias = null;
+
+      if(ar.getDataRef() instanceof ColumnRef cr) {
+         alias = cr.getAlias();
+      }
+
+      return new WorksheetModel.AggregateModel.AggregateRefModel(column, formulaName, alias);
    }
 
    // -------------------------------------------------------------------------

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
@@ -26,7 +26,8 @@ import java.util.List;
  * class can be constructed anywhere (tests, service, controller) without a
  * container.</p>
  */
-public record WorksheetModel(List<TableModel> tables, List<VariableModel> variables) {
+public record WorksheetModel(List<TableModel> tables, List<VariableModel> variables,
+                             List<NamedGroupModel> namedGroups) {
 
    /**
     * A single table assembly inside the worksheet.
@@ -122,8 +123,9 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
        *
        * @param column  source column name
        * @param formula formula name (e.g. {@code "Sum"}, {@code "Count"})
+       * @param alias   output alias; may be {@code null}
        */
-      public record AggregateRefModel(String column, String formula) {}
+      public record AggregateRefModel(String column, String formula, String alias) {}
    }
 
    /**
@@ -143,4 +145,29 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     * @param defaultValue stringified default value; may be {@code null}
     */
    public record VariableModel(String name, String label, String type, String defaultValue) {}
+
+   /**
+    * A named group assembly in the worksheet.
+    *
+    * @param name          assembly name
+    * @param table         the source table the grouping is attached to
+    * @param column        the column the grouping is attached to
+    * @param groupMappings list of group name to values mappings
+    * @param groupOthers   {@code true} if unmapped values are grouped as "Others"
+    */
+   public record NamedGroupModel(
+      String name,
+      String table,
+      String column,
+      List<GroupMappingModel> groupMappings,
+      boolean groupOthers
+   ) {}
+
+   /**
+    * A single group mapping inside a named group.
+    *
+    * @param groupName the name of the group
+    * @param values    the values assigned to this group
+    */
+   public record GroupMappingModel(String groupName, List<String> values) {}
 }

--- a/web/projects/portal/src/app/composer/dialog/vs/select-data-source-dialog.component.html
+++ b/web/projects/portal/src/app/composer/dialog/vs/select-data-source-dialog.component.html
@@ -24,6 +24,7 @@
     <legend>_#(Select a Worksheet) (<i class="worksheet-icon icon-size-small"></i>) _#(or Data Table) (<i class="db-table-icon icon-size-small"></i>)</legend>
     <div class="bordered-box bd-gray bordered-box-lg">
       <asset-tree [datasources]="true" [columns]="false" [viewsheets]="false"
+                  [includeModel]="true"
                   [dataSourcePath]="model.dataSource?.path"
                   [dataSourceScope]="model.dataSource?.scope"
                   [readOnly]="true"

--- a/web/projects/portal/src/app/composer/gui/asset-pane/asset-tree-pane.component.html
+++ b/web/projects/portal/src/app/composer/gui/asset-pane/asset-tree-pane.component.html
@@ -18,6 +18,7 @@
 <asset-tree tabindex="0" class="h-100"
             [datasources]="!wizComposer && focusedSheet?.type === 'worksheet'"
             [columns]="!wizComposer && focusedSheet?.type === 'worksheet'"
+            [includeModel]="!wizComposer && focusedSheet?.type === 'worksheet'"
             [viewsheets]="true" [worksheets]="!wizComposer && !deployed"
             [scripts]="!wizComposer" [tableStyles]="!wizComposer"
             [library]="!wizComposer"

--- a/web/projects/portal/src/app/vs-wizard/gui/new-viewsheet-dialog.component.html
+++ b/web/projects/portal/src/app/vs-wizard/gui/new-viewsheet-dialog.component.html
@@ -28,6 +28,7 @@
      </legend>
       <div class="bordered-box bd-gray tree-container">
          <asset-tree [datasources]="true"  [columns]="false"  [viewsheets]="false"
+                     [includeModel]="true"
                      [readOnly]="true"  [dataSourcePath]="null"
                      [searchEnabled]="true" [stickySearch]="true"
                      (nodeSelected)="changeSource($event)"

--- a/web/projects/portal/src/app/widget/asset-tree/asset-tree.component.ts
+++ b/web/projects/portal/src/app/widget/asset-tree/asset-tree.component.ts
@@ -79,6 +79,7 @@ export class AssetTreeComponent implements OnInit, OnDestroy, OnChanges {
    @Input() library: boolean = false;
    @Input() draggable: boolean = false;
    @Input() physical: boolean = true;
+   @Input() includeModel: boolean = false;
    @Input() multiSelect: boolean = false;
    @Input() showContextmenu: boolean = false;
    @Input() hasMenuFunction: (node: TreeNodeModel) => boolean;
@@ -176,7 +177,7 @@ export class AssetTreeComponent implements OnInit, OnDestroy, OnChanges {
                                              this.columns, this.worksheets, this.viewsheets,
                                              this.tableStyles, this.scripts, this.library,
                                              this.reportRepositoryEnabled,
-                                             this.readOnly, this.physical)
+                                             this.readOnly, this.physical, this.includeModel)
          .subscribe((res) => {
             this.root = res.treeNodeModel;
             this.activeRoot = this.root;
@@ -269,7 +270,7 @@ export class AssetTreeComponent implements OnInit, OnDestroy, OnChanges {
       this.setLoadingIndicator(this.root, true);
       const obs = this.assetTreeService.getAssetTreeNode(rootEvent, this.datasources,
          this.columns, this.worksheets, this.viewsheets, this.tableStyles, this.scripts, this.library, false,
-         this.readOnly, this.physical);
+         this.readOnly, this.physical, this.includeModel);
 
       obs.subscribe(
          (res) => {
@@ -408,7 +409,7 @@ export class AssetTreeComponent implements OnInit, OnDestroy, OnChanges {
                                                          this.columns, this.worksheets, this.viewsheets,
                                                          this.tableStyles, this.scripts, this.library,
                                                          this.reportRepositoryEnabled,
-                                                         this.readOnly, this.physical);
+                                                         this.readOnly, this.physical, this.includeModel);
 
       obs.pipe(
          catchError((error) => {

--- a/web/projects/portal/src/app/widget/asset-tree/asset-tree.service.ts
+++ b/web/projects/portal/src/app/widget/asset-tree/asset-tree.service.ts
@@ -58,7 +58,8 @@ export class AssetTreeService {
                            columns: boolean, worksheets: boolean, viewsheets: boolean,
                            tableStyles: boolean, scripts: boolean, library: boolean,
                            reportRepositoryEnabled: boolean = false,
-                           readOnly: boolean = false, physical: boolean = true): Observable<LoadAssetTreeNodesValidator>
+                           readOnly: boolean = false, physical: boolean = true,
+                           includeModel: boolean = false): Observable<LoadAssetTreeNodesValidator>
    {
       if(!event) {
          event = new LoadAssetTreeNodesEvent();
@@ -74,7 +75,8 @@ export class AssetTreeService {
          .set("includeLibrary", library + "")
          .set("reportRepositoryEnabled", reportRepositoryEnabled + "")
          .set("readOnly", readOnly + "")
-         .set("physical", physical + "");
+         .set("physical", physical + "")
+         .set("includeModel", includeModel + "");
 
       const options = {headers: this.headers, params: params};
 


### PR DESCRIPTION
 Summary

  - Add list_logical_models tool and logicalModel parameter to add_table — enables agents to discover and
  load business-friendly logical model entities instead of raw database tables
  - Improve tool descriptions across all worksheet tools for better agent comprehension (identity
  formatting, cross-join safety notes, aggregation guidance)
  - Update add_concatenation and add_concat_subtable descriptions to document column count validation
  requirement (server-side validation added in companion community PR)
  - Add Batch 6 logical model test cases (78-82) to the worksheet plugin test plan
  - Add analytics & business scenarios test plan (50 cases covering CSV, database-backed, and logical
  model scenarios)

  Test plan

  - All 82 worksheet plugin test cases pass (Cases 1-77 tool-level + Cases 78-82 logical model)
  - All 50 analytics scenario test cases pass (natural language prompt tests across CSV imports,
  Examples/Orders DB, and Order Model logical model)
  - Logical model permission filtering verified (admin sees all models, restricted user sees only
  permitted models)
  - Concatenation with mismatched column counts rejected with descriptive error