### PR TITLE
Bug #75495, defer loading of binding editor to prevent main thread freeze

### DIFF
--- a/web/projects/portal/src/app/composer/gui/composer-main.component.html
+++ b/web/projects/portal/src/app/composer/gui/composer-main.component.html
@@ -269,7 +269,7 @@
        </split-pane>
      </div>
    </div>
-   @defer (on immediate; prefetch on idle) {
+   @defer (when focusedViewsheet?.bindingEditMode && !wizardEditMode; prefetch on idle) {
       @if (focusedViewsheet?.bindingEditMode && !wizardEditMode) {
          <vs-binding-pane
             [runtimeId]="bindingPaneModel.runtimeId"

--- a/web/projects/portal/src/app/composer/gui/composer-main.component.html
+++ b/web/projects/portal/src/app/composer/gui/composer-main.component.html
@@ -269,8 +269,8 @@
        </split-pane>
      </div>
    </div>
-   @if (focusedViewsheet?.bindingEditMode && !wizardEditMode) {
-      @defer (prefetch on idle) {
+   @defer (on immediate; prefetch on idle) {
+      @if (focusedViewsheet?.bindingEditMode && !wizardEditMode) {
          <vs-binding-pane
             [runtimeId]="bindingPaneModel.runtimeId"
             [assemblyName]="bindingPaneModel.absoluteName"
@@ -287,13 +287,11 @@
             (onAssemblyChanged)="refreshChangedAssembly($event)"
             (onRenamed)="changeBindingAssemblyName($event)">
          </vs-binding-pane>
-      } @loading {
-         <div class="loading-container">
-            <div class="loading-content">
-               <i class="loading-icon--spin loading-icon fa-spin icon-4x fa-fw" aria-hidden="true"></i>
-            </div>
-         </div>
       }
+   } @error {
+      <div class="loading-container">
+         <span>_#(js:Failed to load the binding editor)</span>
+      </div>
    }
    <vs-wizard *ngIf="wizardEditMode"
       [model]="wizardModel"

--- a/web/projects/portal/src/app/composer/gui/composer-main.component.html
+++ b/web/projects/portal/src/app/composer/gui/composer-main.component.html
@@ -269,22 +269,32 @@
        </split-pane>
      </div>
    </div>
-   <vs-binding-pane *ngIf="focusedViewsheet?.bindingEditMode && !wizardEditMode"
-      [runtimeId]="bindingPaneModel.runtimeId"
-      [assemblyName]="bindingPaneModel.absoluteName"
-      [temporarySheet]="focusedSheet.newSheet"
-      [objectType]="bindingPaneModel.objectType"
-      [wizardOriginalInfo]="bindingPaneModel.wizardOriginalInfo"
-      [variableValues]="getVariables(bindingPaneModel.absoluteName, bindingPaneModel.objectType)"
-      [linkUri]="focusedViewsheet?.linkUri"
-      [assetId]="focusedViewsheet.id"
-      [isCube]="!!!focusedViewsheet?.baseEntry"
-      [aiAssistantPermission]="aiAssistantPermission"
-      (onOpenWizardPane)="switchBindingToWizard($event)"
-      (onCloseBindingPane)="closeBindingPane()"
-      (onAssemblyChanged)="refreshChangedAssembly($event)"
-      (onRenamed)="changeBindingAssemblyName($event)">
-   </vs-binding-pane>
+   @if (focusedViewsheet?.bindingEditMode && !wizardEditMode) {
+      @defer (prefetch on idle) {
+         <vs-binding-pane
+            [runtimeId]="bindingPaneModel.runtimeId"
+            [assemblyName]="bindingPaneModel.absoluteName"
+            [temporarySheet]="focusedSheet.newSheet"
+            [objectType]="bindingPaneModel.objectType"
+            [wizardOriginalInfo]="bindingPaneModel.wizardOriginalInfo"
+            [variableValues]="getVariables(bindingPaneModel.absoluteName, bindingPaneModel.objectType)"
+            [linkUri]="focusedViewsheet?.linkUri"
+            [assetId]="focusedViewsheet.id"
+            [isCube]="!!!focusedViewsheet?.baseEntry"
+            [aiAssistantPermission]="aiAssistantPermission"
+            (onOpenWizardPane)="switchBindingToWizard($event)"
+            (onCloseBindingPane)="closeBindingPane()"
+            (onAssemblyChanged)="refreshChangedAssembly($event)"
+            (onRenamed)="changeBindingAssemblyName($event)">
+         </vs-binding-pane>
+      } @loading {
+         <div class="loading-container">
+            <div class="loading-content">
+               <i class="loading-icon--spin loading-icon fa-spin icon-4x fa-fw" aria-hidden="true"></i>
+            </div>
+         </div>
+      }
+   }
    <vs-wizard *ngIf="wizardEditMode"
       [model]="wizardModel"
       [aiAssistantPermission]="aiAssistantPermission"


### PR DESCRIPTION
Use Angular @defer to lazy-load vs-binding-pane and its dependency tree (70+ components) asynchronously when opening the Full Editor, eliminating the ~882ms long task that blocked the browser main thread.