### PR TITLE
fix(wiz): give plugin-created charts a meaningful title (not "Chart")

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -2079,8 +2079,19 @@ public class WizVsService {
 
    /** Set a derived display title on a titled assembly (crosstab/table); no-op on blank input. */
    private void applyGridTitle(VSAssembly assembly, String title) {
-      if(title != null && !title.isEmpty()
-         && assembly.getVSAssemblyInfo() instanceof inetsoft.uql.viewsheet.internal.TitledVSAssemblyInfo ti)
+      if(title == null || title.isEmpty()
+         || !(assembly.getVSAssemblyInfo() instanceof inetsoft.uql.viewsheet.internal.TitledVSAssemblyInfo ti))
+      {
+         return;
+      }
+
+      // Only fill in StyleBI's bland placeholder titles ("Chart"/"Table") or a blank — never
+      // override a title that was already set to something meaningful (e.g. a chart the recommender
+      // titled). This keeps the fix to genuinely-untitled assemblies (treemap, crosstab, table).
+      String current = ti.getTitleValue();
+
+      if(current == null || current.isEmpty()
+         || "Chart".equals(current) || "Table".equals(current))
       {
          ti.setTitleValue(title);
       }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -348,6 +348,52 @@ public class WizVsService {
 
                applyGridTitle(tblAssembly, buildGridTitle(null, null, detailRefs));
             }
+            else if(assembly instanceof ChartVSAssembly titleChart
+               && titleChart.getVSChartInfo() != null)
+            {
+               // Charts default to the generic "Chart" title (ChartVSAssemblyInfo's
+               // new TitleInfo("Chart")); replace it with a binding-derived one, e.g.
+               // "Sum(amount) by sales_stage". applyGridTitle only sets the value (not visibility),
+               // so a chart whose title isn't shown is unaffected. Gather refs the same way
+               // collectChartFlatBinding does — x/y/group PLUS aesthetics — because for some types
+               // (e.g. treemap) the measure lives on the size aesthetic, not in getBindingRefs.
+               VSChartInfo titleInfo = titleChart.getVSChartInfo();
+               List<DataRef> titleCandidates = new ArrayList<>();
+               ChartRef[] titleRefs = titleInfo.getBindingRefs(false);
+
+               if(titleRefs != null) {
+                  Collections.addAll(titleCandidates, titleRefs);
+               }
+
+               for(AestheticRef aref : new AestheticRef[]{
+                  titleInfo.getColorField(), titleInfo.getShapeField(),
+                  titleInfo.getSizeField(), titleInfo.getTextField()
+               }) {
+                  if(aref != null && aref.getDataRef() != null) {
+                     titleCandidates.add(aref.getDataRef());
+                  }
+               }
+
+               List<DataRef> chartMeasures = new ArrayList<>();
+               List<DataRef> chartDims = new ArrayList<>();
+               Set<String> titleSeen = new HashSet<>();
+
+               for(DataRef cr : titleCandidates) {
+                  if(cr == null) {
+                     continue;
+                  }
+
+                  if(cr instanceof VSAggregateRef && titleSeen.add("m:" + cr.getName())) {
+                     chartMeasures.add(cr);
+                  }
+                  else if(cr instanceof VSDimensionRef && titleSeen.add("d:" + cr.getName())) {
+                     chartDims.add(cr);
+                  }
+               }
+
+               applyGridTitle(titleChart, buildGridTitle(
+                  chartMeasures.toArray(new DataRef[0]), null, chartDims.toArray(new DataRef[0])));
+            }
 
             CreateViewsheetResult result;
 


### PR DESCRIPTION
## Problem

Follow-up to #4138 (crosstab/table titles). Plugin-created **charts** defaulted to the generic **"Chart"** heading (`ChartVSAssemblyInfo`'s `new TitleInfo("Chart")`) — visible on e.g. a treemap.

## Fix

Derive the same `"<measures> by <dimensions>"` title for chart assemblies in `createViewsheetInternal`, set via `applyGridTitle` (sets the value only, not visibility — so a chart that doesn't render a title row is unaffected).

Gather refs the way `collectChartFlatBinding` does — `getBindingRefs(false)` (x/y/group) **plus the aesthetic fields** (color/shape/size/text) — because for some chart types (treemap, …) the measure lives on the **size aesthetic**, not in `getBindingRefs`. Classify by the base `VSDimensionRef` / `VSAggregateRef` types and de-dupe.

## Testing

Verified live (image `local-972`): an industry × account-type treemap now titles itself **"Sum(COUNT_accounts) by account_type, industry"** instead of "Chart". (A first attempt read only `getBindingRefs` and produced "account_type, industry" — missing the size measure — which is what motivated also collecting the aesthetic refs.)

With this + #4138, charts, crosstabs, and tables all derive a meaningful title uniformly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)