### PR TITLE
75529, the export funnel chart,the edges have many jagged lines

### DIFF
--- a/core/src/main/java/inetsoft/graph/visual/BarVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/BarVO.java
@@ -275,7 +275,10 @@ public class BarVO extends ElementVO {
       // also if the bar is too narrow, no anti-alias would cause the bars to
       // appear to be different size
       double r = ((IntervalElement) elem).getCornerRadius();
-      if(getOuterArc(path) != null || fraction || (r > 0 && !(this instanceof Bar3DVO))) {
+      // funnel segments are trapezoids with sloped edges; without anti-aliasing the
+      // diagonal sides render as jagged steps in raster exports (e.g. PNG).
+      boolean isFunnel = (elem.getCollisionModifier() & GraphElement.MOVE_MIDDLE) != 0;
+      if(getOuterArc(path) != null || fraction || (r > 0 && !(this instanceof Bar3DVO)) || isFunnel) {
          g.setRenderingHint(GHints.CURVE, "true");
       }
 


### PR DESCRIPTION
Funnel chart segments are rendered as trapezoids (with sloped diagonal sides) through BarVO. In BarVO.paint(), the GHints.CURVE rendering hint — which enables anti-aliasing — was only requested for arcs (pies), fractional bars, and rounded-corner bars, not for funnel segments. On screen the chart is rendered as SVG, where GTool.setRenderingHint() forces anti-aliasing on regardless, so it looked smooth. PNG export, however, uses a raster Graphics2D where anti-aliasing stays OFF unless the CURVE hint is set, so the funnel's diagonal edges rendered as jagged stair-steps.

Fix:
In BarVO.paint(), detect the funnel case using the existing convention (collisionModifier & GraphElement.MOVE_MIDDLE) and include it in the condition that sets the GHints.CURVE hint. This turns on anti-aliasing for funnel segments in the raster/PNG export path, matching the smooth on-screen (SVG) rendering. The change only widens the anti-aliasing condition for funnels and does not affect regular/stacked bars, 3D bars, or the SVG/PDF export paths.