### PR TITLE
75533, faceted funnel graph renders improperly

### DIFF
--- a/core/src/main/java/inetsoft/graph/visual/BarVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/BarVO.java
@@ -782,11 +782,25 @@ public class BarVO extends ElementVO {
          // dodge(). Subsequent bars must return immediately — if they run the centering step below,
          // their shape is already a trapezoid whose bounding-box
          // height differs from the original rectangle height, causing a wrong extra shift.
-         if(elem.getHint("_funnel_shaped_") != null) {
-            return;
+         //
+         // The guard must be scoped per-coordinate, not per-element: in a faceted
+         // (multi-dimension) chart each facet is rendered as a separate sub-graph with its
+         // own dodge() pass, but they all share this single GraphElement instance. An
+         // element-wide flag would let the first facet set it and suppress funnel shaping in
+         // every other facet, leaving those bars as plain rectangles. The coord passed to
+         // dodge() is the facet's own inner coordinate, so it uniquely identifies the pass.
+         @SuppressWarnings("unchecked")
+         Set<Coordinate> shaped = (Set<Coordinate>) elem.getHint("_funnel_shaped_");
+
+         if(shaped == null) {
+            shaped = Collections.newSetFromMap(new IdentityHashMap<>());
+            elem.setHint("_funnel_shaped_", shaped);
          }
 
-         elem.setHint("_funnel_shaped_", Boolean.TRUE);
+         // already shaped this facet's bars in this pass
+         if(!shaped.add(coord)) {
+            return;
+         }
 
          // Collect all funnel bars for this element from the full collision map.
          List<BarVO> allBars = new ArrayList<>();

--- a/core/src/main/java/inetsoft/graph/visual/BarVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/BarVO.java
@@ -789,16 +789,7 @@ public class BarVO extends ElementVO {
          // element-wide flag would let the first facet set it and suppress funnel shaping in
          // every other facet, leaving those bars as plain rectangles. The coord passed to
          // dodge() is the facet's own inner coordinate, so it uniquely identifies the pass.
-         @SuppressWarnings("unchecked")
-         Set<Coordinate> shaped = (Set<Coordinate>) elem.getHint("_funnel_shaped_");
-
-         if(shaped == null) {
-            shaped = Collections.newSetFromMap(new IdentityHashMap<>());
-            elem.setHint("_funnel_shaped_", shaped);
-         }
-
-         // already shaped this facet's bars in this pass
-         if(!shaped.add(coord)) {
+         if(!markFunnelShaped(elem, coord)) {
             return;
          }
 
@@ -1514,6 +1505,31 @@ public class BarVO extends ElementVO {
       }
 
       return result;
+   }
+
+   /**
+    * Mark a funnel facet as shaped, scoping the guard per-coordinate rather than per-element.
+    *
+    * In a faceted (multi-dimension) funnel chart, every facet shares the same GraphElement
+    * instance but is laid out in its own sub-graph with its own dodge() pass and its own
+    * coordinate. The "_funnel_shaped_" hint therefore holds a set of the coordinates already
+    * shaped (identity-based, since each facet has a distinct Coordinate instance) instead of a
+    * single boolean. The first bar of a facet records its coordinate and proceeds with the
+    * reshaping; later bars in the same facet pass the same coordinate and are de-duplicated.
+    *
+    * @return true if this coordinate had not been shaped yet (caller should proceed),
+    *         false if it was already shaped (caller should return early).
+    */
+   static boolean markFunnelShaped(GraphElement elem, Coordinate coord) {
+      @SuppressWarnings("unchecked")
+      Set<Coordinate> shaped = (Set<Coordinate>) elem.getHint("_funnel_shaped_");
+
+      if(shaped == null) {
+         shaped = Collections.newSetFromMap(new IdentityHashMap<>());
+         elem.setHint("_funnel_shaped_", shaped);
+      }
+
+      return shaped.add(coord);
    }
 
    /**

--- a/core/src/test/java/inetsoft/graph/visual/BarVOStackRoundingTest.java
+++ b/core/src/test/java/inetsoft/graph/visual/BarVOStackRoundingTest.java
@@ -17,6 +17,9 @@
  */
 package inetsoft.graph.visual;
 
+import inetsoft.graph.coord.Coordinate;
+import inetsoft.graph.element.GraphElement;
+import inetsoft.graph.element.IntervalElement;
 import inetsoft.graph.geometry.IntervalGeometry;
 import org.junit.jupiter.api.Test;
 
@@ -152,5 +155,36 @@ class BarVOStackRoundingTest {
       assertEquals(posZones.arc(), negZones.arc(), 1e-9);
       assertEquals(posZones.inOuterArcZone(), negZones.inOuterArcZone());
       assertEquals(posZones.inInnerArcZone(), negZones.inInnerArcZone());
+   }
+
+   // -----------------------------------------------------------------------
+   // Funnel per-facet shaping guard (Bug #75533).
+   // A faceted (multi-dimension) funnel chart lays out each facet in its own
+   // sub-graph/dodge() pass but they share one IntervalElement instance. The
+   // shaping guard must be scoped per coordinate so every facet is shaped, not
+   // just the first one — while still de-duplicating repeated calls from the
+   // multiple bars within a single facet's pass.
+   // -----------------------------------------------------------------------
+
+   @Test
+   void markFunnelShaped_scopedPerFacetCoordinate() {
+      GraphElement elem = new IntervalElement("value");
+      Coordinate facetA = mock(Coordinate.class);
+      Coordinate facetB = mock(Coordinate.class);
+
+      // First bar of facet A: not yet shaped -> caller proceeds with reshaping.
+      assertTrue(BarVO.markFunnelShaped(elem, facetA),
+                 "first bar of facet A should trigger funnel shaping");
+      // Another bar of facet A in the same pass: already shaped -> caller returns early.
+      assertFalse(BarVO.markFunnelShaped(elem, facetA),
+                  "later bars of facet A must be de-duplicated");
+
+      // Facet B shares the same element but is a distinct coordinate: it must still
+      // be shaped. Before the fix an element-level flag suppressed every facet after
+      // the first, which is exactly the regression this guards against.
+      assertTrue(BarVO.markFunnelShaped(elem, facetB),
+                 "facet B must be shaped even though it shares the element with facet A");
+      assertFalse(BarVO.markFunnelShaped(elem, facetB),
+                  "later bars of facet B must be de-duplicated");
    }
 }


### PR DESCRIPTION
Root Cause:
Funnel shaping is done in BarVO.dodge(). When a chart binds multiple dimensions on the category axis it becomes a faceted chart, and each value of the outer dimension is rendered as a separate sub-graph (GraphVO creates a new VGraph per inner coordinate, each running its own dodge() pass with its own collision map). The funnel block guarded against re-processing using an element-level hint "_funnel_shaped_" set on the IntervalElement instance. Because that element instance is shared across all facets, the first facet's dodge() set the flag and every subsequent facet returned immediately — so only the first group was centered/reshaped into a funnel while the remaining group(s) stayed as plain left-aligned bars.

Fix:
Scoped the guard per facet coordinate instead of per shared element. The hint now holds an IdentityHashMap-backed Set<Coordinate> of already-shaped facets, keyed by the coordinate passed into dodge() (the facet's own inner coordinate). The first bar of each facet records its coordinate and shapes that facet's bars; remaining bars in the same facet return early; each additional facet is keyed by a distinct coordinate and gets shaped independently. As a result every group now renders as its own centered funnel. The change is isolated to the funnel (MOVE_MIDDLE) branch, so single-dimension funnels and all non-funnel charts are unaffected.