### PR TITLE
75530, funnel graph selection is incorrect

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/region/VisualObjectArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/VisualObjectArea.java
@@ -279,6 +279,15 @@ public class VisualObjectArea extends InteractiveArea implements MenuArea {
 
          return regions.toArray(new Region[regions.size()]);
       }
+      else if(isFunnelShaped()) {
+         // Funnel bars are trapezoids (BarVO.dodge reshapes them). Keep the
+         // actual polygon outline instead of collapsing to a bounding box so
+         // the selection highlight matches the rendered shape (Bug #75530).
+         Shape tshape = trans.createTransformedShape(shape);
+         tshape = AffineTransform.getTranslateInstance(-p.getX(), -p.getY())
+            .createTransformedShape(tshape);
+         region = new AreaRegion(tshape);
+      }
       else {
          boolean isLine = shape instanceof Line2D;
          Rectangle2D.Double rect =
@@ -321,6 +330,25 @@ public class VisualObjectArea extends InteractiveArea implements MenuArea {
       }
 
       return new Region[] {region};
+   }
+
+   /**
+    * Check if the visual object is a funnel bar, which is reshaped into a
+    * trapezoid by BarVO.dodge(). The MOVE_MIDDLE collision modifier is the
+    * same condition used there to perform the reshaping.
+    */
+   private boolean isFunnelShaped() {
+      if(vobj instanceof ElementVO) {
+         Geometry geo = ((ElementVO) vobj).getGeometry();
+
+         if(geo instanceof ElementGeometry) {
+            GraphElement elem = ((ElementGeometry) geo).getElement();
+            return elem != null &&
+               (elem.getCollisionModifier() & GraphElement.MOVE_MIDDLE) != 0;
+         }
+      }
+
+      return false;
    }
 
    /**

--- a/web/projects/portal/src/app/graph/model/chart-tool.ts
+++ b/web/projects/portal/src/app/graph/model/chart-tool.ts
@@ -982,6 +982,12 @@ export namespace ChartTool {
                            break;
                      }
                   }
+
+                  // close the polygon subpath so stroke() draws the final edge
+                  // back to the start (fill auto-closes, stroke does not). Without
+                  // this the closing edge of polygon shapes (e.g. funnel trapezoid
+                  // selection) is missing. (Bug #75530)
+                  context.closePath();
                }
             }
 


### PR DESCRIPTION
Root Cause:
The funnel reshaping work (Epic #74519) changed BarVO.dodge() to rebuild funnel bars as trapezoidal GeneralPath shapes, but two places still assumed rectangular bars:

1. VisualObjectArea.getRegions() had branches for Arc2D/Area, Ellipse2D, Polygon, Line2D and PolygonVO, but a funnel bar's GeneralPath matched none of them and fell through to the default branch, which collapsed the shape to its bounding box (RectangleRegion). The selection region was therefore a rectangle, not the trapezoid.

2. On the frontend, ChartTool.drawRegions() draws a polygon selection with moveTo + lineTo segments, then fill() + stroke(). fill() auto-closes the path but stroke() does not, so the closing edge of the polygon outline was never drawn.

Fix:
1. (core) VisualObjectArea.getRegions() now detects a funnel bar via the MOVE_MIDDLE collision modifier (the same condition BarVO.dodge() uses to build the trapezoid) and builds an AreaRegion that preserves the actual polygon outline, using the same flip-Y transform and relative-position offset as the existing bounding-box branch.

2. (web) ChartTool.drawRegions() now calls context.closePath() at the end of each polygon subpath so stroke() draws the final closing edge.

The selection highlight now follows the trapezoidal funnel slice exactly. Other chart types are unaffected: only funnel bars carry MOVE_MIDDLE, and the closePath change is a general correctness improvement for any polygon-shaped selection.