### PR TITLE
75397, calendar display error for date and timeInstant type in auto-drill parameter dialog

### DIFF
--- a/web/projects/portal/src/app/widget/date-type-editor/date-value-editor.component.html
+++ b/web/projects/portal/src/app/widget/date-type-editor/date-value-editor.component.html
@@ -59,12 +59,16 @@
       </div>
     </div>
     <div class="ngb-dp-content ngb-dp-months">
-      <div *ngFor="let month of datepicker.state.months" class="ngb-dp-month">
-        <div *ngIf="datepicker.displayMonths > 1" class="ngb-dp-month-name">
-          {{ datepicker.i18n.getMonthLabel(month) }}
+      @for(month of datepicker.state.months; track month) {
+        <div class="ngb-dp-month">
+          @if(datepicker.displayMonths > 1) {
+            <div class="ngb-dp-month-name">
+              {{ datepicker.i18n.getMonthLabel(month) }}
+            </div>
+          }
+          <ngb-datepicker-month [month]="month"></ngb-datepicker-month>
         </div>
-        <ngb-datepicker-month [month]="month"></ngb-datepicker-month>
-      </div>
+      }
     </div>
   </div>
 </ng-template>

--- a/web/projects/portal/src/app/widget/date-type-editor/date-value-editor.component.ts
+++ b/web/projects/portal/src/app/widget/date-type-editor/date-value-editor.component.ts
@@ -27,7 +27,7 @@ import {
    ViewChild
 } from "@angular/core";
 import { ControlValueAccessor, NG_VALUE_ACCESSOR, FormsModule } from "@angular/forms";
-import { NgbDateParserFormatter, NgbDateStruct, NgbInputDatepicker, NgbDatepicker } from "@ng-bootstrap/ng-bootstrap";
+import { NgbDateParserFormatter, NgbDateStruct, NgbInputDatepicker, NgbDatepicker, NgbDatepickerMonth } from "@ng-bootstrap/ng-bootstrap";
 import { DateTypeFormatter } from "../../../../../shared/util/date-type-formatter";
 import { Tool } from "../../../../../shared/util/tool";
 import { CustomSelectOption, CustomSelectComponent } from "../custom-select/custom-select.component";
@@ -43,7 +43,7 @@ export const DATE_VALUE_ACCESSOR: any = {
     templateUrl: "date-value-editor.component.html",
     styleUrls: ["date-value-editor.component.scss"],
     providers: [DATE_VALUE_ACCESSOR],
-    imports: [NgbInputDatepicker, FormsModule, CustomSelectComponent]
+    imports: [NgbInputDatepicker, NgbDatepickerMonth, FormsModule, CustomSelectComponent]
 })
 export class DateValueEditorComponent implements ControlValueAccessor {
    @ViewChild("datepickerMax") ngbDatepicker;


### PR DESCRIPTION
Root Cause:
DateValueEditorComponent (web/projects/portal/src/app/widget/date-type-editor/date-value-editor.component.ts) was converted to a standalone component during the Angular upgrade (Epic #74519), but its template's calendar body relied on directives and an element that were not listed in the component's standalone `imports`:

  - *ngFor / *ngIf  (NgFor / NgIf)
  - <ngb-datepicker-month>  (NgbDatepickerMonth)

At runtime *ngFor failed to bind, throwing:
  NG0303: Can't bind to 'ngForOf' since it isn't a known property of 'div' (used in the '_DateValueEditorComponent' component template)

Because the *ngFor never instantiated, the day grid was never rendered — the calendar showed only its month/year header. This affected both the "Date" and "timeInstant" constant types (the time-instant editor delegates its date portion to this component), which is why the calendar failed to display in the auto-drill parameter dialog.

Fix:
Provided the missing template dependencies on DateValueEditorComponent:

  - date-value-editor.component.html: converted the calendar-body *ngFor / *ngIf to the new Angular @for / @if control-flow syntax (built into the template compiler, so no module import required), matching the codebase's dominant convention.
  - date-value-editor.component.ts: added NgbDatepickerMonth to the @ng-bootstrap import and to the standalone component's `imports` array (required for the <ngb-datepicker-month> element).

The change is additive and scoped to this one component's metadata/template; it restores the calendar for every consumer of <date-value-editor> (condition, variable, VPM, tabular, schedule, and auto-drill parameter dialogs) with no API or logic change.