### PR TITLE
75398, In hyperlink parameter dialog, select boolean type-false, shows warning

### DIFF
--- a/web/projects/portal/src/app/vsobjects/dialog/input-parameter-dialog.component.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/input-parameter-dialog.component.ts
@@ -363,6 +363,8 @@ export class InputParameterDialog implements OnInit {
          case XSchema.TIME_INSTANT:
             return this.form.controls["dateValue"].invalid || this.invalidDate() ||
                this.form.controls["timeValue"].invalid;
+         case XSchema.BOOLEAN:
+            return this.form.controls["alphaNumericValue"].invalid;
          default:
             return this.form.controls["alphaNumericValue"].invalid || !this.model.value;
       }


### PR DESCRIPTION
Root Cause:
In the hyperlink Parameter dialog, isInvalid() in input-parameter-dialog.component.ts validated a Constant value through the switch's default branch, which returned `alphaNumericValue.invalid || !this.model.value`. For a Boolean type, model.value holds the actual boolean, so selecting "False" made `!this.model.value` evaluate to true and the value was wrongly flagged as invalid ("A valid value is required."), disabling OK. "True" passed only because it is truthy.

Fix:
Added a dedicated XSchema.BOOLEAN case to isInvalid() that returns only `this.form.controls["alphaNumericValue"].invalid`. Boolean type registers no validators and the control always holds true/false, so both values are now correctly accepted. Other types are unaffected — they still use the default empty-value check.