### PR TITLE
75379, Edit Join dialog layout isn't good

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-edit-table/physical-table-joins/edit-join-dialog/edit-join-dialog.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-edit-table/physical-table-joins/edit-join-dialog/edit-join-dialog.component.html
@@ -29,7 +29,6 @@
     </div>
     <div class="join-properties__content">
       @if (!!joinModel) {
-        <div class="mt-3 col-12">
           <div class="form-floating">
             <input type="text" name="joinPreview" class="form-control"
               [ngModel]="joinPreview"
@@ -78,8 +77,6 @@
                     [(ngModel)]="joinModel.mergingRule">
                   _#(And)
                 </label>
-              </div>
-              <div class="join-properties__choice-row">
                 <label class="join-properties__choice-label">
                   <input class="form-check-input align-middle" type="radio"
                     name="mergingRadio"
@@ -99,8 +96,6 @@
                     [(ngModel)]="joinModel.cardinality">
                   _#(One to one)
                 </label>
-              </div>
-              <div class="join-properties__choice-row">
                 <label class="join-properties__choice-label">
                   <input class="form-check-input align-middle" type="radio"
                     name="cardinalityRadio"
@@ -108,8 +103,6 @@
                     [(ngModel)]="joinModel.cardinality">
                   _#(One to many)
                 </label>
-              </div>
-              <div class="join-properties__choice-row">
                 <label class="join-properties__choice-label">
                   <input class="form-check-input align-middle" type="radio"
                     name="cardinalityRadio"
@@ -117,8 +110,6 @@
                     [(ngModel)]="joinModel.cardinality">
                   _#(Many to one)
                 </label>
-              </div>
-              <div class="join-properties__choice-row">
                 <label class="join-properties__choice-label">
                   <input class="form-check-input align-middle" type="radio"
                     name="cardinalityRadio"
@@ -136,7 +127,6 @@
               </label>
             </div>
           }
-        </div>
       }
     </div>
   </div>

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-edit-table/physical-table-joins/edit-join-dialog/edit-join-dialog.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-edit-table/physical-table-joins/edit-join-dialog/edit-join-dialog.component.html
@@ -29,104 +29,104 @@
     </div>
     <div class="join-properties__content">
       @if (!!joinModel) {
-          <div class="form-floating">
-            <input type="text" name="joinPreview" class="form-control"
-              [ngModel]="joinPreview"
-              disabled/>
-            <label>_#(Join)</label>
-          </div>
-          <div class="shell-form-group form-floating">
-            <custom-select [options]="joinTypeSelectOptions"
-                           [(ngModel)]="joinModel.type">
-            </custom-select>
-            <label>_#(Join Type)</label>
-          </div>
-          @if (dataType == 'physical') {
-            <div class="shell-form-group">
-              <div class="form-floating">
-                <number-stepper #orderPriorityCtrl="ngModel"
-                              name="orderPriority"
-                              [(ngModel)]="selectedJoinOrderPriority"
-                              (valueChange)="validateOrderPriority($event >= 1)"
-                              [min]="1"
-                              [invalid]="orderPriorityCtrl.dirty && orderPriorityCtrl.invalid">
-              </number-stepper>
-                <label>_#(Order Priority)</label>
-                @if (orderPriorityCtrl.hasError('required')) {
-                  <span class="invalid-feedback">
-                    _#(data.physicalmodel.joinOrderPriorityRequired)
-                  </span>
-                }
-                @if (orderPriorityCtrl.hasError('min')) {
-                  <span class="invalid-feedback">
-                    _#(data.physicalmodel.joinOrderPriorityMin)
-                  </span>
-                }
-                @if (orderPriorityCtrl.hasError('max')) {
-                  <span class="invalid-feedback">
-                    _#(data.physicalmodel.joinOrderPriorityMax)
-                  </span>
-                }
-              </div>
-              <div class="mt-1 font-weight-bold">_#(Merging Rule):</div>
-              <div class="join-properties__choice-row">
-                <label class="join-properties__choice-label">
-                  <input class="form-check-input align-middle" type="radio"
-                    name="mergingRadio"
-                    [value]="MergingRule.AND"
-                    [(ngModel)]="joinModel.mergingRule">
-                  _#(And)
-                </label>
-                <label class="join-properties__choice-label">
-                  <input class="form-check-input align-middle" type="radio"
-                    name="mergingRadio"
-                    [value]="MergingRule.OR"
-                    [(ngModel)]="joinModel.mergingRule">
-                  _#(Or)
-                </label>
-              </div>
+        <div class="form-floating">
+          <input type="text" name="joinPreview" class="form-control"
+            [ngModel]="joinPreview"
+            disabled/>
+          <label>_#(Join)</label>
+        </div>
+        <div class="shell-form-group form-floating">
+          <custom-select [options]="joinTypeSelectOptions"
+                         [(ngModel)]="joinModel.type">
+          </custom-select>
+          <label>_#(Join Type)</label>
+        </div>
+        @if (dataType == 'physical') {
+          <div class="shell-form-group">
+            <div class="form-floating">
+              <number-stepper #orderPriorityCtrl="ngModel"
+                            name="orderPriority"
+                            [(ngModel)]="selectedJoinOrderPriority"
+                            (valueChange)="validateOrderPriority($event >= 1)"
+                            [min]="1"
+                            [invalid]="orderPriorityCtrl.dirty && orderPriorityCtrl.invalid">
+            </number-stepper>
+              <label>_#(Order Priority)</label>
+              @if (orderPriorityCtrl.hasError('required')) {
+                <span class="invalid-feedback">
+                  _#(data.physicalmodel.joinOrderPriorityRequired)
+                </span>
+              }
+              @if (orderPriorityCtrl.hasError('min')) {
+                <span class="invalid-feedback">
+                  _#(data.physicalmodel.joinOrderPriorityMin)
+                </span>
+              }
+              @if (orderPriorityCtrl.hasError('max')) {
+                <span class="invalid-feedback">
+                  _#(data.physicalmodel.joinOrderPriorityMax)
+                </span>
+              }
             </div>
-            <div class="shell-form-group">
-              <div class="font-weight-bold">_#(Cardinality):</div>
-              <div class="join-properties__choice-row">
-                <label class="join-properties__choice-label">
-                  <input class="form-check-input align-middle" type="radio"
-                    name="cardinalityRadio"
-                    [value]="Cardinality.ONE_TO_ONE"
-                    [(ngModel)]="joinModel.cardinality">
-                  _#(One to one)
-                </label>
-                <label class="join-properties__choice-label">
-                  <input class="form-check-input align-middle" type="radio"
-                    name="cardinalityRadio"
-                    [value]="Cardinality.ONE_TO_MANY"
-                    [(ngModel)]="joinModel.cardinality">
-                  _#(One to many)
-                </label>
-                <label class="join-properties__choice-label">
-                  <input class="form-check-input align-middle" type="radio"
-                    name="cardinalityRadio"
-                    [value]="Cardinality.MANY_TO_ONE"
-                    [(ngModel)]="joinModel.cardinality">
-                  _#(Many to one)
-                </label>
-                <label class="join-properties__choice-label">
-                  <input class="form-check-input align-middle" type="radio"
-                    name="cardinalityRadio"
-                    [value]="Cardinality.MANY_TO_MANY"
-                    [(ngModel)]="joinModel.cardinality">
-                  _#(Many to many)
-                </label>
-              </div>
-            </div>
-            <div class="shell-form-group">
+            <div class="mt-1 font-weight-bold">_#(Merging Rule):</div>
+            <div class="join-properties__choice-row">
               <label class="join-properties__choice-label">
-                <input class="form-check-input align-middle" type="checkbox"
-                  [(ngModel)]="joinModel.weak">
-                _#(Weak join)
+                <input class="form-check-input align-middle" type="radio"
+                  name="mergingRadio"
+                  [value]="MergingRule.AND"
+                  [(ngModel)]="joinModel.mergingRule">
+                _#(And)
+              </label>
+              <label class="join-properties__choice-label">
+                <input class="form-check-input align-middle" type="radio"
+                  name="mergingRadio"
+                  [value]="MergingRule.OR"
+                  [(ngModel)]="joinModel.mergingRule">
+                _#(Or)
               </label>
             </div>
-          }
+          </div>
+          <div class="shell-form-group">
+            <div class="font-weight-bold">_#(Cardinality):</div>
+            <div class="join-properties__choice-row">
+              <label class="join-properties__choice-label">
+                <input class="form-check-input align-middle" type="radio"
+                  name="cardinalityRadio"
+                  [value]="Cardinality.ONE_TO_ONE"
+                  [(ngModel)]="joinModel.cardinality">
+                _#(One to one)
+              </label>
+              <label class="join-properties__choice-label">
+                <input class="form-check-input align-middle" type="radio"
+                  name="cardinalityRadio"
+                  [value]="Cardinality.ONE_TO_MANY"
+                  [(ngModel)]="joinModel.cardinality">
+                _#(One to many)
+              </label>
+              <label class="join-properties__choice-label">
+                <input class="form-check-input align-middle" type="radio"
+                  name="cardinalityRadio"
+                  [value]="Cardinality.MANY_TO_ONE"
+                  [(ngModel)]="joinModel.cardinality">
+                _#(Many to one)
+              </label>
+              <label class="join-properties__choice-label">
+                <input class="form-check-input align-middle" type="radio"
+                  name="cardinalityRadio"
+                  [value]="Cardinality.MANY_TO_MANY"
+                  [(ngModel)]="joinModel.cardinality">
+                _#(Many to many)
+              </label>
+            </div>
+          </div>
+          <div class="shell-form-group">
+            <label class="join-properties__choice-label">
+              <input class="form-check-input align-middle" type="checkbox"
+                [(ngModel)]="joinModel.weak">
+              _#(Weak join)
+            </label>
+          </div>
+        }
       }
     </div>
   </div>

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-edit-table/physical-table-joins/edit-join-dialog/edit-join-dialog.component.scss
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-edit-table/physical-table-joins/edit-join-dialog/edit-join-dialog.component.scss
@@ -41,6 +41,7 @@
 .join-properties__content {
    display: grid;
    gap: 12px;
+   padding-top: var(--inet-space-5);
 }
 
 .join-properties__content > .form-floating:first-child {


### PR DESCRIPTION
Root Cause:

The Edit Join dialog's theming (added in PR #3811) relies on a specific DOM structure:

- The Merging Rule and Cardinality radio groups use .join-properties__choice-row / .join-properties__choice-grid, which are flex containers (display:flex; flex-wrap:wrap) meant to hold all options in a group so they flow horizontally.
- The field container .join-properties__content is a CSS grid (gap: 12px) with direct-child reset rules (> .form-floating:first-child, > .shell-form-group) so the grid gap is the single, uniform spacer for every field.

The Angular-21 recovery PR (#3880) regenerated this template with two structural mistakes:

1. It wrapped each individual radio in its own .join-properties__choice-row, so each flex container held a single item and the radios stacked vertically instead of laying out horizontally.
2. It wrapped all the fields in an extra <div class="mt-3 col-12">. This made the fields grandchildren of .join-properties__content, so the grid gap applied to nothing (a single child) and the > child-combinator margin resets no longer matched. Spacing fell back to each field's own margin -- .form-floating (the Join field) has no bottom margin, so it appeared squished against Join Type, while the .shell-form-group fields kept their 12px margin, producing uneven spacing.

Both were markup oversights in the recovery; the theme CSS itself was correct.

Fix:

In edit-join-dialog.component.html:
- Grouped both Merging Rule radios into a single .join-properties__choice-row, and all four Cardinality radios into a single .join-properties__choice-row, so they render horizontally as designed.
- Removed the intermediate <div class="mt-3 col-12"> wrapper so the form fields are again direct children of .join-properties__content, restoring the uniform 12px grid spacing and the margin-reset rules.

In edit-join-dialog.component.scss:
- Added padding-top: var(--inet-space-5) (12px) to .join-properties__content to preserve the gap below the "Join Properties:" heading that the removed mt-3 wrapper previously provided, keeping the spacing rhythm uniform.

No TypeScript, binding, or component-logic changes.