### PR TITLE
75550, 'this' keyword no longer scoped to assembly when in assembly script

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -551,28 +551,117 @@ public class GraalJavaScriptEngine implements AutoCloseable {
     * Must be called while holding {@code lock} (result used inline in exec).
     */
    /**
-    * Removes leading ECMAScript Directive Prologue entries for {@code "use strict"} so
-    * that the source can be wrapped in a {@code with(__scope__){...}} block without
-    * triggering a SyntaxError (strict mode forbids {@code with}).
+    * Removes leading ECMAScript Directive Prologue entries for {@code "use strict"}
+    * so the body can be embedded without silently flipping to strict-mode
+    * evaluation (which would forbid {@code with} in the library-function wrapper
+    * and change assignment/scope/`this` semantics in the {@code eval(...)} form
+    * used by {@link #compile}).
+    *
+    * <p>A directive prologue is recognized per the spec: it may be preceded by
+    * whitespace and line/block comments, and the terminating {@code ;} is
+    * optional (ASI). This tolerant scan therefore matches all of
+    * {@code "use strict";}, a bare {@code "use strict"} on its own line, and a
+    * directive preceded by a comment — not just the semicolon-terminated literal.
     */
    private static String stripStrictDirectives(String src) {
       String s = src;
 
       while(true) {
-         String t = s.stripLeading();
+         int i = skipWhitespaceAndComments(s, 0);
+         int end = matchUseStrictDirective(s, i);
 
-         if(t.startsWith("\"use strict\";")) {
-            s = t.substring("\"use strict\";".length());
+         if(end < 0) {
+            break;
          }
-         else if(t.startsWith("'use strict';")) {
-            s = t.substring("'use strict';".length());
+
+         // drop everything up to and including the directive (any skipped
+         // leading comments are inert, so discarding them is harmless).
+         s = s.substring(end);
+      }
+
+      return s;
+   }
+
+   /**
+    * Skip leading whitespace, {@code //} line comments and {@code /* *}{@code /}
+    * block comments starting at {@code from}; return the index of the first
+    * significant character (or {@code s.length()}).
+    */
+   private static int skipWhitespaceAndComments(String s, int from) {
+      int i = from;
+
+      while(i < s.length()) {
+         char c = s.charAt(i);
+
+         if(Character.isWhitespace(c)) {
+            i++;
+         }
+         else if(c == '/' && i + 1 < s.length() && s.charAt(i + 1) == '/') {
+            i += 2;
+
+            while(i < s.length() && s.charAt(i) != '\n' && s.charAt(i) != '\r') {
+               i++;
+            }
+         }
+         else if(c == '/' && i + 1 < s.length() && s.charAt(i + 1) == '*') {
+            i += 2;
+
+            while(i + 1 < s.length() && !(s.charAt(i) == '*' && s.charAt(i + 1) == '/')) {
+               i++;
+            }
+
+            i = Math.min(i + 2, s.length());
          }
          else {
             break;
          }
       }
 
-      return s;
+      return i;
+   }
+
+   /**
+    * If a {@code "use strict"} / {@code 'use strict'} directive begins at
+    * {@code from}, return the index just past it (consuming an optional trailing
+    * {@code ;}, ASI-style); otherwise return -1.
+    *
+    * <p>A directive prologue entry is an ExpressionStatement whose expression is
+    * a lone StringLiteral, so the literal must be terminated by {@code ;}, a line
+    * break (ASI), {@code }} or EOF. When it is instead followed by a continuation
+    * (e.g. {@code "use strict" + x}), the literal is part of a larger expression
+    * and must NOT be treated as a directive — otherwise we would corrupt the
+    * script by stripping the leading token.
+    */
+   private static int matchUseStrictDirective(String s, int from) {
+      for(String lit : new String[] { "\"use strict\"", "'use strict'" }) {
+         if(s.startsWith(lit, from)) {
+            int j = from + lit.length();
+            int k = j;
+
+            // skip spaces/tabs between the literal and its terminator.
+            while(k < s.length() && (s.charAt(k) == ' ' || s.charAt(k) == '\t')) {
+               k++;
+            }
+
+            if(k >= s.length()) {
+               return j;                 // EOF -> ASI terminates the directive
+            }
+
+            char c = s.charAt(k);
+
+            if(c == ';') {
+               return k + 1;             // explicit terminator (consume it)
+            }
+
+            if(c == '\n' || c == '\r' || c == '}') {
+               return j;                 // line break (ASI) or end of block
+            }
+
+            return -1;                   // continuation -> not a directive
+         }
+      }
+
+      return -1;
    }
 
    private int maxErrors() {

--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -371,9 +371,71 @@ public class GraalJavaScriptEngine implements AutoCloseable {
    }
 
    public Object compile(String cmd, boolean fieldOnly) throws Exception {
-      // store raw text; the with-wrap is applied per-exec against the live scope
-      return Source.newBuilder("js", "with(__scope__){\n" + cmd + "\n}", "<cmd>")
+      // Rhino parity: Context.evaluateString(scope, ...) bound the top-level
+      // `this` to the scope object, so dashboard scripts routinely reference
+      // assembly properties as `this.position`, `this.scaledPosition`, etc. A
+      // bare with(__scope__){ ... } wrapper only fixes *unqualified* name
+      // resolution — `this` at the top level of context.eval is globalThis, so
+      // `this.<prop>` would read undefined and throw (Bug #75550).
+      //
+      // Run the body inside a function invoked with __scope__ as its receiver so
+      // `this` === the scope. A plain function body would discard the script's
+      // completion value, which value/expression bindings depend on (e.g. a Text
+      // value binding "=field['Total']"; see ViewsheetSandbox.executeDynamicValue).
+      // A *direct* eval preserves the statement-list completion value while
+      // inheriting both the `this` receiver and the enclosing with(__scope__)
+      // scope chain, so unqualified names still resolve against the live scope.
+      //
+      // Strip any leading "use strict" prologue: under the old top-level
+      // with(__scope__){ ... } wrapper such a directive was an inert string
+      // expression (a directive prologue is only recognized at the very start of
+      // a script/function body, not inside a block), so scripts ran sloppy. As
+      // the first statement of the eval'd body it *would* be recognized and flip
+      // the body to strict eval, changing assignment/scope semantics — so remove
+      // it to preserve the prior behavior.
+      String body = stripStrictDirectives(cmd);
+      return Source.newBuilder("js",
+         "(function(){with(__scope__){return eval(" + toJsStringLiteral(body) +
+            ");}}).call(__scope__)", "<cmd>")
          .buildLiteral();
+   }
+
+   /**
+    * Encode a script body as a JavaScript double-quoted string literal for
+    * embedding in the {@code eval(...)} wrapper built by {@link #compile}.
+    * Escapes the characters that are illegal or ambiguous inside a JS string
+    * (quote, backslash, the C0 control set including the line terminators, and
+    * the U+2028/U+2029 line/paragraph separators).
+    */
+   private static String toJsStringLiteral(String s) {
+      StringBuilder sb = new StringBuilder(s.length() + 16);
+      sb.append('"');
+
+      for(int i = 0; i < s.length(); i++) {
+         char c = s.charAt(i);
+
+         switch(c) {
+         case '"':      sb.append("\\\""); break;
+         case '\\':     sb.append("\\\\"); break;
+         case '\n':     sb.append("\\n"); break;
+         case '\r':     sb.append("\\r"); break;
+         case '\t':     sb.append("\\t"); break;
+         case '\b':     sb.append("\\b"); break;
+         case '\f':     sb.append("\\f"); break;
+         default:
+            // C0 controls plus the U+2028/U+2029 line/paragraph separators
+            // (illegal unescaped inside a JS string literal) -> \\uXXXX.
+            if(c < 0x20 || c == 0x2028 || c == 0x2029) {
+               sb.append(String.format("\\u%04x", (int) c));
+            }
+            else {
+               sb.append(c);
+            }
+         }
+      }
+
+      sb.append('"');
+      return sb.toString();
    }
 
    public void checkFunction(String name, String cmd) throws Exception {

--- a/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineScopeTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineScopeTest.java
@@ -46,6 +46,34 @@ class GraalJavaScriptEngineScopeTest {
       assertEquals("West", engine.exec(src, scope, scope));
    }
 
+   // Bug #75550: `this` must be bound to the executing scope (Rhino parity), so
+   // dashboard scripts that qualify assembly properties as `this.<prop>` resolve
+   // instead of reading undefined off globalThis.
+   @Test void thisResolvesToScope() throws Exception {
+      MapScope scope = new MapScope();
+      scope.putMember("parameter", makeParam("region", "West"));
+      Object src = engine.compile("this.parameter.region");
+      assertEquals("West", engine.exec(src, scope, scope));
+   }
+
+   // The eval-based wrapper must still return the statement-list completion
+   // value, which scripted value/expression bindings depend on.
+   @Test void completionValuePreservedForStatementList() throws Exception {
+      MapScope scope = new MapScope();
+      scope.putMember("x", 10.0);
+      Object src = engine.compile("var y = x + 5;\ny * 2");
+      assertEquals(30.0, ((Number) engine.exec(src, scope, scope)).doubleValue());
+   }
+
+   // Unqualified assignment must still write through to the owning scope.
+   @Test void unqualifiedAssignmentWritesToScope() throws Exception {
+      MapScope scope = new MapScope();
+      scope.putMember("visible", true);
+      Object src = engine.compile("visible = false");
+      engine.exec(src, scope, scope);
+      assertEquals(false, scope.getMember("visible"));
+   }
+
    private static ScriptScope makeParam(String k, String v) {
       MapScope p = new MapScope();
       p.putMember(k, v);

--- a/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineScopeTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineScopeTest.java
@@ -74,6 +74,24 @@ class GraalJavaScriptEngineScopeTest {
       assertEquals(false, scope.getMember("visible"));
    }
 
+   // Characterization test for the JS-string-literal encoding used by compile():
+   // a body containing a double quote, a backslash, and an embedded newline must
+   // survive being embedded in the eval(...) wrapper and evaluate correctly.
+   @Test void bodyWithQuotesBackslashesAndNewlinesRoundTrips() throws Exception {
+      MapScope scope = new MapScope();
+      // script text: var s = "a\"b\\c";<newline>s  -> string value a"b\c
+      Object src = engine.compile("var s = \"a\\\"b\\\\c\";\ns");
+      assertEquals("a\"b\\c", engine.exec(src, scope, scope));
+   }
+
+   // A leading "use strict" that is part of a larger expression (not a standalone
+   // directive) must NOT be stripped — doing so would corrupt the script.
+   @Test void leadingUseStrictInExpressionIsNotStripped() throws Exception {
+      MapScope scope = new MapScope();
+      Object src = engine.compile("\"use strict\" + \" x\"");
+      assertEquals("use strict x", engine.exec(src, scope, scope));
+   }
+
    private static ScriptScope makeParam(String k, String v) {
       MapScope p = new MapScope();
       p.putMember(k, v);


### PR DESCRIPTION
Root Cause:
Regression from the Rhino -> GraalJS migration (Feature #75423). In GraalJavaScriptEngine.compile(), every script was wrapped as with(__scope__){ <script> } and run via context.eval(). The with-block restores resolution of *unqualified* names (value, visible, position), but it does not change the meaning of the `this` keyword. At the top level of a GraalJS context.eval, `this` is the global object (globalThis), which has none of the assembly's properties. So `this.position` and `this.scaledPosition` evaluated to undefined, and reading `.y` off them threw "TypeError: Cannot read property 'y' of undefined".

Under the old Rhino engine, Context.evaluateString(scope, ...) bound the top-level `this` to the scope object, so `this.<property>` worked — an idiom used by many dashboard scripts.

Fix:
Changed the per-script wrapper in GraalJavaScriptEngine.compile() to run the body inside a function invoked with the scope as its receiver, using a direct eval so the script's completion value is preserved:

  (function(){ with(__scope__){ return eval(<script>); } }).call(__scope__)

.call(__scope__) makes `this` refer to the assembly scope; the direct eval inherits that `this` and the with(__scope__) scope chain (so unqualified names still resolve) while returning the statement-list completion value that value/expression bindings rely on. Leading "use strict" directives are stripped to preserve the prior sloppy-mode behavior.

Added regression tests in GraalJavaScriptEngineScopeTest covering this-binding, completion-value preservation, and unqualified assignment.