### PR TITLE
75549, Cannot read property 'setActionVisible' of undefined

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -122,7 +122,7 @@ public class GraalJavaScriptEngine implements AutoCloseable {
          Value bindings = context.getBindings("js");
 
          for(Map.Entry<String, Object> e : vars.entrySet()) {
-            bindings.putMember(e.getKey(), e.getValue());
+            bindings.putMember(e.getKey(), ScriptValueConverter.toGuest(e.getValue()));
          }
       }
 
@@ -730,7 +730,7 @@ public class GraalJavaScriptEngine implements AutoCloseable {
 
       try {
          if(context != null) {
-            context.getBindings("js").putMember(name, value);
+            context.getBindings("js").putMember(name, ScriptValueConverter.toGuest(value));
          }
       }
       finally {

--- a/core/src/main/java/inetsoft/util/script/graal/ScriptValueConverter.java
+++ b/core/src/main/java/inetsoft/util/script/graal/ScriptValueConverter.java
@@ -123,18 +123,16 @@ public final class ScriptValueConverter {
 
       // proxy/host wrappers and plain objects: hand back the raw value's
       // host object if present, else the Value itself for member access.
-      // Unwrap our own scope adapters back to the underlying ScriptScope so
-      // toHost is symmetric with toGuest (e.g. env.get("viewsheet") returns the
-      // real ViewsheetScope, not the ScopeProxy bridge).
+      // Unwrap a ScopeProxy back to the underlying ScriptScope so toHost is
+      // symmetric with toGuest (e.g. env.get("viewsheet") returns the real
+      // ViewsheetScope, not the ScopeProxy bridge). An ArrayProxy needs no case
+      // here: it is a ProxyArray, so it is handled by the hasArrayElements()
+      // branch above.
       if(v.isProxyObject()) {
          Object proxy = v.asProxyObject();
 
-         if(proxy instanceof ScopeProxy) {
-            return ((ScopeProxy) proxy).getScope();
-         }
-
-         if(proxy instanceof ArrayProxy) {
-            return ((ArrayProxy) proxy).getScope();
+         if(proxy instanceof ScopeProxy scopeProxy) {
+            return scopeProxy.getScope();
          }
 
          return proxy;

--- a/core/src/main/java/inetsoft/util/script/graal/ScriptValueConverter.java
+++ b/core/src/main/java/inetsoft/util/script/graal/ScriptValueConverter.java
@@ -87,24 +87,6 @@ public final class ScriptValueConverter {
          return new Date(inst.toEpochMilli());
       }
 
-      // Our own adapters first (the inverse of toGuest): ArrayProxy implements
-      // both ProxyArray and ProxyObject, so it also satisfies hasArrayElements()
-      // below — it must be unwrapped back to its ScriptArrayScope here, before
-      // the generic array branch flattens it into a plain Object[] copy.
-      if(v.isProxyObject()) {
-         Object proxy = v.asProxyObject();
-
-         if(proxy instanceof ScopeProxy) {
-            return ((ScopeProxy) proxy).getScope();
-         }
-
-         if(proxy instanceof ArrayProxy) {
-            return ((ArrayProxy) proxy).getScope();
-         }
-
-         return proxy;
-      }
-
       if(v.hasArrayElements()) {
          long n = v.getArraySize();
 

--- a/core/src/main/java/inetsoft/util/script/graal/ScriptValueConverter.java
+++ b/core/src/main/java/inetsoft/util/script/graal/ScriptValueConverter.java
@@ -121,6 +121,25 @@ public final class ScriptValueConverter {
          return arr;
       }
 
+      // proxy/host wrappers and plain objects: hand back the raw value's
+      // host object if present, else the Value itself for member access.
+      // Unwrap our own scope adapters back to the underlying ScriptScope so
+      // toHost is symmetric with toGuest (e.g. env.get("viewsheet") returns the
+      // real ViewsheetScope, not the ScopeProxy bridge).
+      if(v.isProxyObject()) {
+         Object proxy = v.asProxyObject();
+
+         if(proxy instanceof ScopeProxy) {
+            return ((ScopeProxy) proxy).getScope();
+         }
+
+         if(proxy instanceof ArrayProxy) {
+            return ((ArrayProxy) proxy).getScope();
+         }
+
+         return proxy;
+      }
+
       return v;
    }
 }

--- a/core/src/main/java/inetsoft/util/script/graal/ScriptValueConverter.java
+++ b/core/src/main/java/inetsoft/util/script/graal/ScriptValueConverter.java
@@ -87,6 +87,27 @@ public final class ScriptValueConverter {
          return new Date(inst.toEpochMilli());
       }
 
+      // Our own adapters first (the inverse of toGuest): ArrayProxy implements
+      // both ProxyArray and ProxyObject, so it also satisfies hasArrayElements()
+      // below — it must be unwrapped back to its ScriptArrayScope here, before
+      // the generic array branch would flatten it into a plain Object[] copy.
+      // Keeps toHost symmetric with toGuest so a published scope global reads
+      // back as the real ScriptScope/ScriptArrayScope (e.g. senv.get("viewsheet")
+      // returns the real ViewsheetScope in CalcTableLens, not the proxy bridge).
+      if(v.isProxyObject()) {
+         Object proxy = v.asProxyObject();
+
+         if(proxy instanceof ScopeProxy scopeProxy) {
+            return scopeProxy.getScope();
+         }
+
+         if(proxy instanceof ArrayProxy arrayProxy) {
+            return arrayProxy.getScope();
+         }
+
+         return proxy;
+      }
+
       if(v.hasArrayElements()) {
          long n = v.getArraySize();
 
@@ -101,23 +122,6 @@ public final class ScriptValueConverter {
          }
 
          return arr;
-      }
-
-      // proxy/host wrappers and plain objects: hand back the raw value's
-      // host object if present, else the Value itself for member access.
-      // Unwrap a ScopeProxy back to the underlying ScriptScope so toHost is
-      // symmetric with toGuest (e.g. env.get("viewsheet") returns the real
-      // ViewsheetScope, not the ScopeProxy bridge). An ArrayProxy needs no case
-      // here: it is a ProxyArray, so it is handled by the hasArrayElements()
-      // branch above.
-      if(v.isProxyObject()) {
-         Object proxy = v.asProxyObject();
-
-         if(proxy instanceof ScopeProxy scopeProxy) {
-            return scopeProxy.getScope();
-         }
-
-         return proxy;
       }
 
       return v;

--- a/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineScopeTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineScopeTest.java
@@ -92,6 +92,29 @@ class GraalJavaScriptEngineScopeTest {
       assertEquals("use strict x", engine.exec(src, scope, scope));
    }
 
+   // Regression test for Bug #75549: a ScriptScope published as a global (e.g.
+   // "viewsheet") must be wrapped as a ScopeProxy so member access such as
+   // viewsheet['Chart1'] routes through ScriptScope.getMember() rather than
+   // GraalJS's Java host-member reflection, which returned undefined and made
+   // viewsheet['Chart1'].someMethod() throw "Cannot read property ... of undefined".
+   @Test void publishedScopeGlobalResolvesBracketAndDotAccess() throws Exception {
+      MapScope viewsheet = new MapScope();
+      MapScope chart = new MapScope();
+      chart.putMember("name", "Chart1");
+      viewsheet.putMember("Chart1", chart);
+      engine.put("viewsheet", viewsheet);
+
+      // bracket access (the exact form reported in #75549) resolves the assembly
+      assertEquals("Chart1",
+         engine.exec(engine.compile("viewsheet['Chart1'].name"), null, null));
+      // dot access resolves equivalently
+      assertEquals("Chart1",
+         engine.exec(engine.compile("viewsheet.Chart1.name"), null, null));
+      // the member itself must be defined, not undefined
+      assertEquals(Boolean.FALSE,
+         engine.exec(engine.compile("typeof viewsheet['Chart1'] === 'undefined'"), null, null));
+   }
+
    private static ScriptScope makeParam(String k, String v) {
       MapScope p = new MapScope();
       p.putMember(k, v);

--- a/core/src/test/java/inetsoft/util/script/graal/ScriptValueConverterTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/ScriptValueConverterTest.java
@@ -95,8 +95,29 @@ class ScriptValueConverterTest {
       assertSame(scope, v);
    }
 
+   // Bug #75549: symmetry must also hold for array-shaped scopes. An
+   // ArrayProxy-wrapped ScriptArrayScope round-trips back to the underlying
+   // scope, not a flattened Object[] copy — ArrayProxy is a ProxyArray, so
+   // toHost must unwrap it (via isProxyObject) before the generic array branch.
+   @Test void arrayScopeProxyUnwrapsToUnderlyingScope() {
+      ScriptArrayScope scope = new SimpleArrayScope();
+      ctx.getBindings("js").putMember("a", ScriptValueConverter.toGuest(scope));
+      Object v = ScriptValueConverter.toHost(ctx.getBindings("js").getMember("a"));
+      assertSame(scope, v);
+   }
+
    /** Minimal ScriptScope so toGuest produces a ScopeProxy. */
    private static class SimpleScope implements ScriptScope {
+      public Object getMember(String name) { return null; }
+      public boolean hasMember(String name) { return false; }
+      public void putMember(String name, Object value) { }
+      public Object[] getMemberKeys() { return new Object[0]; }
+   }
+
+   /** Minimal ScriptArrayScope so toGuest produces an ArrayProxy. */
+   private static class SimpleArrayScope implements ScriptArrayScope {
+      public long getArraySize() { return 0; }
+      public Object getArrayElement(long index) { return null; }
       public Object getMember(String name) { return null; }
       public boolean hasMember(String name) { return false; }
       public void putMember(String name, Object value) { }

--- a/core/src/test/java/inetsoft/util/script/graal/ScriptValueConverterTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/ScriptValueConverterTest.java
@@ -83,4 +83,23 @@ class ScriptValueConverterTest {
       Object v = ScriptValueConverter.toHost(ctx.getBindings("js").getMember("d"));
       assertSame(d, v);
    }
+
+   // Bug #75549: toHost must be symmetric with toGuest — a ScopeProxy-wrapped
+   // ScriptScope round-trips back to the underlying scope, so Java callers that
+   // read a published scope global back (e.g. senv.get("viewsheet") in
+   // CalcTableLens) still receive the real ScriptScope, not the proxy bridge.
+   @Test void scopeProxyUnwrapsToUnderlyingScope() {
+      ScriptScope scope = new SimpleScope();
+      ctx.getBindings("js").putMember("s", ScriptValueConverter.toGuest(scope));
+      Object v = ScriptValueConverter.toHost(ctx.getBindings("js").getMember("s"));
+      assertSame(scope, v);
+   }
+
+   /** Minimal ScriptScope so toGuest produces a ScopeProxy. */
+   private static class SimpleScope implements ScriptScope {
+      public Object getMember(String name) { return null; }
+      public boolean hasMember(String name) { return false; }
+      public void putMember(String name, Object value) { }
+      public Object[] getMemberKeys() { return new Object[0]; }
+   }
 }


### PR DESCRIPTION
Root Cause:
This was a regression from the Rhino → GraalJS scripting engine migration. The "viewsheet" object exposed to scripts is a ViewsheetScope, which resolves assembly references (e.g. Chart1) through its getMember() method. Under Rhino, "viewsheet" was a Scriptable, so viewsheet['Chart1'] routed through get(String) and returned the assembly scriptable.

Under GraalJS, the ViewsheetScope global was published to the script bindings as a raw host object (bypassing the ScopeProxy adapter). As a result, GraalJS resolved viewsheet['Chart1'] via Java HostAccess reflection — looking for a Java member literally named "Chart1", which does not exist — so it returned undefined. Calling .setActionVisible('Brush', false) on undefined then threw the TypeError. (Unqualified access such as Chart1.setActionVisible(...) still worked because it resolves through the scope chain rather than the "viewsheet" global, which is why only the viewsheet[...] / viewsheet.<name> form was broken.)

Fix:
Route script globals through the central ScriptValueConverter.toGuest() adapter when publishing them to the GraalJS bindings (in GraalJavaScriptEngine.put() and the initScope() vars loop), so a ScriptScope such as ViewsheetScope is wrapped as a ScopeProxy and member/bracket access is bridged to getMember()/hasMember() — restoring the original Rhino behavior. Made the conversion symmetric by unwrapping ScopeProxy/ArrayProxy back to the underlying scope in ScriptValueConverter.toHost(), so Java-side callers reading the global back (e.g. ViewsheetScope in CalcTableLens) continue to receive the real scope object. This also fixes the same latent issue for the other scope globals (worksheet, pviewsheet, etc.).