### PR TITLE
75528, funnel graph layout incorrect with text binding

### DIFF
--- a/core/src/main/java/inetsoft/graph/visual/BarVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/BarVO.java
@@ -796,56 +796,98 @@ public class BarVO extends ElementVO {
             return;
          }
 
-         // Collect all funnel bars for this element from the full collision map.
-         List<BarVO> allBars = new ArrayList<>();
+         // Collect every funnel segment for this element. The collision map only keys the
+         // bottom segment of each stacked column; when a text/color aesthetic adds a peer
+         // group dimension, the remaining stacked segments are stored in the overlapped
+         // value lists (the dodge driver marks them "moved" so they never become keys).
+         // Gather keys and values so every segment is reshaped, not just the bottom one,
+         // otherwise the upper segments keep their stacked rectangles and the funnel
+         // renders disordered. (Bug #75528)
+         Set<BarVO> barSet = new LinkedHashSet<>();
 
-         for(ElementVO key : comap.keySet()) {
-            if(!(key instanceof BarVO)) {
-               continue;
-            }
+         for(Map.Entry<ElementVO, List<ElementVO>> e : comap.entrySet()) {
+            collectFunnelBar(barSet, e.getKey(), elem);
 
-            GraphElement ke = ((ElementGeometry) key.getGeometry()).getElement();
-
-            if((ke.getCollisionModifier() & GraphElement.MOVE_MIDDLE) != 0 && ke == elem) {
-               allBars.add((BarVO) key);
+            for(ElementVO ov : e.getValue()) {
+               collectFunnelBar(barSet, ov, elem);
             }
          }
 
-         // Center every bar vertically (heights are still original rectangles here).
-         for(BarVO bar : allBars) {
-            double h = bar.shape.getBounds2D().getHeight();
-            bar.shape = GTool.move(bar.shape, 0, (GHEIGHT - h) / 2);
-            bar.cachedShape.clear();
+         // Group segments into funnel levels by x position (one column per inner-dimension
+         // value). Stacked segments within a level share the same x/width and differ in y.
+         Map<Long, List<BarVO>> levelMap = new LinkedHashMap<>();
+
+         for(BarVO bar : barSet) {
+            long key = Math.round(bar.shape.getBounds2D().getX());
+            levelMap.computeIfAbsent(key, k -> new ArrayList<>()).add(bar);
          }
 
-         // Sort left to right by x position.
-         allBars.sort(Comparator.comparingDouble(b -> b.shape.getBounds2D().getX()));
+         // Sort levels left to right by x position.
+         List<List<BarVO>> levels = new ArrayList<>(levelMap.values());
+         levels.sort(Comparator.comparingDouble(lvl -> lvl.get(0).shape.getBounds2D().getX()));
+
+         // Each level's funnel height is the total of its stacked segment heights.
+         double[] levelH = new double[levels.size()];
+
+         for(int i = 0; i < levels.size(); i++) {
+            double sum = 0;
+
+            for(BarVO bar : levels.get(i)) {
+               sum += bar.shape.getBounds2D().getHeight();
+            }
+
+            levelH[i] = sum;
+         }
 
          double cy = GHEIGHT / 2.0;
 
-         // Reshape each bar into a parallelogram whose right edge height equals the
-         // left edge height of the next bar, so adjacent sections connect seamlessly.
-         for(int i = 0; i < allBars.size(); i++) {
-            BarVO bar = allBars.get(i);
-            Rectangle2D bounds = bar.shape.getBounds2D();
+         // Reshape each level so its outer silhouette forms the funnel: the bottom-most
+         // segment's bottom edge and the top-most segment's top edge follow the taper
+         // (this level's height on the left, the next level's height on the right), while
+         // the dividers between stacked segments stay straight (horizontal). Inner segments
+         // are therefore rectangles and only the top/bottom segments are trapezoids. With a
+         // single segment per level this reduces to a plain left-to-right trapezoid.
+         for(int i = 0; i < levels.size(); i++) {
+            List<BarVO> level = levels.get(i);
+            // Stack segments bottom-to-top.
+            level.sort(Comparator.comparingDouble(b -> b.shape.getBounds2D().getY()));
+
+            double leftH  = levelH[i];
+            // Right edge = next level's height; last level is a flat trapezoid end.
+            double rightH = (i + 1 < levels.size()) ? levelH[i + 1] : leftH;
+
+            Rectangle2D bounds = level.get(0).shape.getBounds2D();
             double x = bounds.getX();
             double w = bounds.getWidth();
-            double leftH  = bounds.getHeight();
-            // Right edge = next bar's height; last bar is a flat rectangle end.
-            double rightH = (i + 1 < allBars.size())
-               ? allBars.get(i + 1).shape.getBounds2D().getHeight()
-               : leftH;
+            double cum = 0;        // height consumed from the bottom of this level
+            int n = level.size();
 
-            GeneralPath path = new GeneralPath();
-            path.moveTo((float) x,       (float)(cy + leftH  / 2)); // top-left
-            path.lineTo((float)(x + w),  (float)(cy + rightH / 2)); // top-right
-            path.lineTo((float)(x + w),  (float)(cy - rightH / 2)); // bottom-right
-            path.lineTo((float) x,       (float)(cy - leftH  / 2)); // bottom-left
-            path.closePath();
+            for(int s = 0; s < n; s++) {
+               BarVO bar = level.get(s);
+               double segH = bar.shape.getBounds2D().getHeight();
+               double divLow  = cy - leftH / 2 + cum;          // straight divider below
+               double divHigh = cy - leftH / 2 + cum + segH;   // straight divider above
+               cum += segH;
 
-            bar.shape = path;
-            bar.geomShape = path;
-            bar.cachedShape.clear();
+               boolean isBottom = s == 0;
+               boolean isTop = s == n - 1;
+               // Only the outer edges follow the taper; inner dividers stay horizontal.
+               double bL = isBottom ? cy - leftH  / 2 : divLow;
+               double bR = isBottom ? cy - rightH / 2 : divLow;
+               double tL = isTop    ? cy + leftH  / 2 : divHigh;
+               double tR = isTop    ? cy + rightH / 2 : divHigh;
+
+               GeneralPath path = new GeneralPath();
+               path.moveTo((float) x,       (float) tL); // top-left
+               path.lineTo((float)(x + w),  (float) tR); // top-right
+               path.lineTo((float)(x + w),  (float) bR); // bottom-right
+               path.lineTo((float) x,       (float) bL); // bottom-left
+               path.closePath();
+
+               bar.shape = path;
+               bar.geomShape = path;
+               bar.cachedShape.clear();
+            }
          }
 
          return;
@@ -931,6 +973,19 @@ public class BarVO extends ElementVO {
                BarVO bar = (BarVO) stack.get(j);
                bar.setShape(GTool.move(bar.shape, offset, 0));
             }
+         }
+      }
+   }
+
+   /**
+    * Add vo to the set if it is a funnel (MOVE_MIDDLE) bar belonging to elem.
+    */
+   private static void collectFunnelBar(Set<BarVO> set, ElementVO vo, GraphElement elem) {
+      if(vo instanceof BarVO) {
+         GraphElement ke = ((ElementGeometry) vo.getGeometry()).getElement();
+
+         if((ke.getCollisionModifier() & GraphElement.MOVE_MIDDLE) != 0 && ke == elem) {
+            set.add((BarVO) vo);
          }
       }
    }

--- a/core/src/main/java/inetsoft/graph/visual/BarVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/BarVO.java
@@ -796,100 +796,7 @@ public class BarVO extends ElementVO {
             return;
          }
 
-         // Collect every funnel segment for this element. The collision map only keys the
-         // bottom segment of each stacked column; when a text/color aesthetic adds a peer
-         // group dimension, the remaining stacked segments are stored in the overlapped
-         // value lists (the dodge driver marks them "moved" so they never become keys).
-         // Gather keys and values so every segment is reshaped, not just the bottom one,
-         // otherwise the upper segments keep their stacked rectangles and the funnel
-         // renders disordered. (Bug #75528)
-         Set<BarVO> barSet = new LinkedHashSet<>();
-
-         for(Map.Entry<ElementVO, List<ElementVO>> e : comap.entrySet()) {
-            collectFunnelBar(barSet, e.getKey(), elem);
-
-            for(ElementVO ov : e.getValue()) {
-               collectFunnelBar(barSet, ov, elem);
-            }
-         }
-
-         // Group segments into funnel levels by x position (one column per inner-dimension
-         // value). Stacked segments within a level share the same x/width and differ in y.
-         Map<Long, List<BarVO>> levelMap = new LinkedHashMap<>();
-
-         for(BarVO bar : barSet) {
-            long key = Math.round(bar.shape.getBounds2D().getX());
-            levelMap.computeIfAbsent(key, k -> new ArrayList<>()).add(bar);
-         }
-
-         // Sort levels left to right by x position.
-         List<List<BarVO>> levels = new ArrayList<>(levelMap.values());
-         levels.sort(Comparator.comparingDouble(lvl -> lvl.get(0).shape.getBounds2D().getX()));
-
-         // Each level's funnel height is the total of its stacked segment heights.
-         double[] levelH = new double[levels.size()];
-
-         for(int i = 0; i < levels.size(); i++) {
-            double sum = 0;
-
-            for(BarVO bar : levels.get(i)) {
-               sum += bar.shape.getBounds2D().getHeight();
-            }
-
-            levelH[i] = sum;
-         }
-
-         double cy = GHEIGHT / 2.0;
-
-         // Reshape each level so its outer silhouette forms the funnel: the bottom-most
-         // segment's bottom edge and the top-most segment's top edge follow the taper
-         // (this level's height on the left, the next level's height on the right), while
-         // the dividers between stacked segments stay straight (horizontal). Inner segments
-         // are therefore rectangles and only the top/bottom segments are trapezoids. With a
-         // single segment per level this reduces to a plain left-to-right trapezoid.
-         for(int i = 0; i < levels.size(); i++) {
-            List<BarVO> level = levels.get(i);
-            // Stack segments bottom-to-top.
-            level.sort(Comparator.comparingDouble(b -> b.shape.getBounds2D().getY()));
-
-            double leftH  = levelH[i];
-            // Right edge = next level's height; last level is a flat trapezoid end.
-            double rightH = (i + 1 < levels.size()) ? levelH[i + 1] : leftH;
-
-            Rectangle2D bounds = level.get(0).shape.getBounds2D();
-            double x = bounds.getX();
-            double w = bounds.getWidth();
-            double cum = 0;        // height consumed from the bottom of this level
-            int n = level.size();
-
-            for(int s = 0; s < n; s++) {
-               BarVO bar = level.get(s);
-               double segH = bar.shape.getBounds2D().getHeight();
-               double divLow  = cy - leftH / 2 + cum;          // straight divider below
-               double divHigh = cy - leftH / 2 + cum + segH;   // straight divider above
-               cum += segH;
-
-               boolean isBottom = s == 0;
-               boolean isTop = s == n - 1;
-               // Only the outer edges follow the taper; inner dividers stay horizontal.
-               double bL = isBottom ? cy - leftH  / 2 : divLow;
-               double bR = isBottom ? cy - rightH / 2 : divLow;
-               double tL = isTop    ? cy + leftH  / 2 : divHigh;
-               double tR = isTop    ? cy + rightH / 2 : divHigh;
-
-               GeneralPath path = new GeneralPath();
-               path.moveTo((float) x,       (float) tL); // top-left
-               path.lineTo((float)(x + w),  (float) tR); // top-right
-               path.lineTo((float)(x + w),  (float) bR); // bottom-right
-               path.lineTo((float) x,       (float) bL); // bottom-left
-               path.closePath();
-
-               bar.shape = path;
-               bar.geomShape = path;
-               bar.cachedShape.clear();
-            }
-         }
-
+         reshapeFunnel(comap, elem);
          return;
       }
 
@@ -973,6 +880,110 @@ public class BarVO extends ElementVO {
                BarVO bar = (BarVO) stack.get(j);
                bar.setShape(GTool.move(bar.shape, offset, 0));
             }
+         }
+      }
+   }
+
+   /**
+    * Reshape every funnel segment of a MOVE_MIDDLE element into the connected trapezoid
+    * "funnel" silhouette. Extracted from dodge() so the funnel geometry is independently
+    * readable and unit-testable; it reads only comap/elem and computes everything locally.
+    *
+    * @param comap collision map, from the first visual object to its overlapping objects.
+    * @param elem  the funnel (MOVE_MIDDLE) element whose segments are reshaped.
+    */
+   static void reshapeFunnel(Map<ElementVO,List<ElementVO>> comap, GraphElement elem) {
+      // Collect every funnel segment for this element. The collision map only keys the
+      // bottom segment of each stacked column; when a text/color aesthetic adds a peer
+      // group dimension, the remaining stacked segments are stored in the overlapped
+      // value lists (the dodge driver marks them "moved" so they never become keys).
+      // Gather keys and values so every segment is reshaped, not just the bottom one,
+      // otherwise the upper segments keep their stacked rectangles and the funnel
+      // renders disordered. (Bug #75528)
+      Set<BarVO> barSet = new LinkedHashSet<>();
+
+      for(Map.Entry<ElementVO, List<ElementVO>> e : comap.entrySet()) {
+         collectFunnelBar(barSet, e.getKey(), elem);
+
+         for(ElementVO ov : e.getValue()) {
+            collectFunnelBar(barSet, ov, elem);
+         }
+      }
+
+      // Group segments into funnel levels by x position (one column per inner-dimension
+      // value). Stacked segments within a level share the same x/width and differ in y.
+      Map<Long, List<BarVO>> levelMap = new LinkedHashMap<>();
+
+      for(BarVO bar : barSet) {
+         long key = Math.round(bar.shape.getBounds2D().getX());
+         levelMap.computeIfAbsent(key, k -> new ArrayList<>()).add(bar);
+      }
+
+      // Sort levels left to right by x position.
+      List<List<BarVO>> levels = new ArrayList<>(levelMap.values());
+      levels.sort(Comparator.comparingDouble(lvl -> lvl.get(0).shape.getBounds2D().getX()));
+
+      // Each level's funnel height is the total of its stacked segment heights.
+      double[] levelH = new double[levels.size()];
+
+      for(int i = 0; i < levels.size(); i++) {
+         double sum = 0;
+
+         for(BarVO bar : levels.get(i)) {
+            sum += bar.shape.getBounds2D().getHeight();
+         }
+
+         levelH[i] = sum;
+      }
+
+      double cy = GHEIGHT / 2.0;
+
+      // Reshape each level so its outer silhouette forms the funnel: the bottom-most
+      // segment's bottom edge and the top-most segment's top edge follow the taper
+      // (this level's height on the left, the next level's height on the right), while
+      // the dividers between stacked segments stay straight (horizontal). Inner segments
+      // are therefore rectangles and only the top/bottom segments are trapezoids. With a
+      // single segment per level this reduces to a plain left-to-right trapezoid.
+      for(int i = 0; i < levels.size(); i++) {
+         List<BarVO> level = levels.get(i);
+         // Stack segments bottom-to-top.
+         level.sort(Comparator.comparingDouble(b -> b.shape.getBounds2D().getY()));
+
+         double leftH  = levelH[i];
+         // Right edge = next level's height; last level is a flat trapezoid end.
+         double rightH = (i + 1 < levels.size()) ? levelH[i + 1] : leftH;
+
+         Rectangle2D bounds = level.get(0).shape.getBounds2D();
+         double x = bounds.getX();
+         double w = bounds.getWidth();
+         double cum = 0;        // height consumed from the bottom of this level
+         int n = level.size();
+
+         for(int s = 0; s < n; s++) {
+            BarVO bar = level.get(s);
+            double segH = bar.shape.getBounds2D().getHeight();
+            double divLow  = cy - leftH / 2 + cum;          // straight divider below
+            double divHigh = cy - leftH / 2 + cum + segH;   // straight divider above
+            cum += segH;
+
+            boolean isBottom = s == 0;
+            boolean isTop = s == n - 1;
+            // Only the outer edges follow the taper; inner dividers stay horizontal.
+            double bL = isBottom ? cy - leftH  / 2 : divLow;
+            double bR = isBottom ? cy - rightH / 2 : divLow;
+            double tL = isTop    ? cy + leftH  / 2 : divHigh;
+            double tR = isTop    ? cy + rightH / 2 : divHigh;
+
+            GeneralPath path = new GeneralPath();
+            path.moveTo((float) x,       (float) tL); // top-left
+            path.lineTo((float)(x + w),  (float) tR); // top-right
+            path.lineTo((float)(x + w),  (float) bR); // bottom-right
+            path.lineTo((float) x,       (float) bL); // bottom-left
+            path.closePath();
+
+            bar.shape = path;
+            bar.geomShape = path;
+            bar.cachedShape.clear();
          }
       }
    }

--- a/core/src/test/java/inetsoft/graph/visual/BarVOStackRoundingTest.java
+++ b/core/src/test/java/inetsoft/graph/visual/BarVOStackRoundingTest.java
@@ -19,19 +19,32 @@ package inetsoft.graph.visual;
 
 import inetsoft.graph.coord.Coordinate;
 import inetsoft.graph.element.GraphElement;
-import inetsoft.graph.element.IntervalElement;
+import inetsoft.graph.geometry.ElementGeometry;
 import inetsoft.graph.geometry.IntervalGeometry;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.awt.geom.PathIterator;
 import java.awt.geom.Rectangle2D;
+import java.lang.ref.SoftReference;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for BarVO stack rounding geometry helpers.
  */
+@Tag("core")
 class BarVOStackRoundingTest {
 
    // -----------------------------------------------------------------------
@@ -168,7 +181,10 @@ class BarVOStackRoundingTest {
 
    @Test
    void markFunnelShaped_scopedPerFacetCoordinate() {
-      GraphElement elem = new IntervalElement("value");
+      // Mock the element with a real hint map rather than constructing a concrete
+      // GraphElement: GraphElement.<init> pulls in GDefaults, which reads SreeEnv and
+      // requires a running Spring context. markFunnelShaped only get/setHint on elem.
+      GraphElement elem = mockElementWithHints();
       Coordinate facetA = mock(Coordinate.class);
       Coordinate facetB = mock(Coordinate.class);
 
@@ -186,5 +202,154 @@ class BarVOStackRoundingTest {
                  "facet B must be shaped even though it shares the element with facet A");
       assertFalse(BarVO.markFunnelShaped(elem, facetB),
                   "later bars of facet B must be de-duplicated");
+   }
+
+   // -----------------------------------------------------------------------
+   // Funnel level grouping / reshaping (Bug #75528).
+   // When a text/color aesthetic is bound to a funnel, the aesthetic field
+   // becomes a grouping dimension so each category renders as a stacked column
+   // of segments. reshapeFunnel must collect every segment (from both the
+   // collision-map keys AND their overlapped value lists, since only the bottom
+   // segment of a column is a key), group them into levels by x, and reshape
+   // each level so only its outer silhouette tapers while inner stacked dividers
+   // stay horizontal. cy = GHEIGHT/2 = 500 throughout.
+   // -----------------------------------------------------------------------
+
+   @Test
+   void reshapeFunnel_singleSegmentLevels_reduceToTaperedTrapezoids() {
+      GraphElement elem = mock(GraphElement.class);
+      when(elem.getCollisionModifier()).thenReturn(GraphElement.MOVE_MIDDLE);
+
+      // Two single-segment levels: left total height 200, right total height 100.
+      BarVO left  = funnelBar(elem, 100, 400, 50, 200);
+      BarVO right = funnelBar(elem, 300, 450, 50, 100);
+
+      Map<ElementVO, List<ElementVO>> comap = new LinkedHashMap<>();
+      comap.put(left, new ArrayList<>());
+      comap.put(right, new ArrayList<>());
+
+      BarVO.reshapeFunnel(comap, elem);
+
+      // Left edge = own height (200 -> cy±100 = 400..600), right edge = the next
+      // level's height (100 -> cy±50 = 450..550): a left-to-right tapered trapezoid.
+      assertCorners(left, new double[][] {
+         {100, 600}, {150, 550}, {150, 450}, {100, 400}
+      });
+      // Last level has no successor, so both edges use its own height (flat end).
+      assertCorners(right, new double[][] {
+         {300, 550}, {350, 550}, {350, 450}, {300, 450}
+      });
+   }
+
+   @Test
+   void reshapeFunnel_stackedLevel_keepsInnerDividerHorizontalAndSilhouetteSeamless() {
+      GraphElement elem = mock(GraphElement.class);
+      when(elem.getCollisionModifier()).thenReturn(GraphElement.MOVE_MIDDLE);
+
+      // Left level: single segment, total height 200.
+      BarVO left = funnelBar(elem, 100, 400, 50, 200);
+      // Right level: two stacked segments (as a text/color binding produces),
+      // total height 100. Only the bottom segment is a collision-map key; the top
+      // segment lives in the key's overlapped value list — this is exactly what the
+      // fix for #75528 must pick up.
+      BarVO rightBottom = funnelBar(elem, 300, 450, 50, 60);
+      BarVO rightTop    = funnelBar(elem, 300, 510, 50, 40);
+
+      Map<ElementVO, List<ElementVO>> comap = new LinkedHashMap<>();
+      comap.put(left, new ArrayList<>());
+      List<ElementVO> overlapped = new ArrayList<>();
+      overlapped.add(rightTop);
+      comap.put(rightBottom, overlapped);
+
+      BarVO.reshapeFunnel(comap, elem);
+
+      // Left tapers from its own height (200) to the right level's total (100).
+      assertCorners(left, new double[][] {
+         {100, 600}, {150, 550}, {150, 450}, {100, 400}
+      });
+      // The stacked right level (total 100, last level so no taper) occupies
+      // cy±50 = 450..550. Both segments are plain rectangles separated by a single
+      // straight horizontal divider at y = 510 — the upper segment is no longer
+      // left as a stray stacked rectangle (the #75528 regression).
+      assertBounds(rightBottom, 300, 450, 50, 60);
+      assertBounds(rightTop,    300, 510, 50, 40);
+      // Divider is shared exactly: bottom segment's top == top segment's bottom.
+      assertEquals(510.0, rightBottom.shape.getBounds2D().getMaxY(), 1e-6);
+      assertEquals(510.0, rightTop.shape.getBounds2D().getMinY(), 1e-6);
+   }
+
+   /**
+    * Build a mocked funnel BarVO whose geometry belongs to elem and whose initial
+    * shape is the given rectangle. Mockito/Objenesis bypasses the constructor (and
+    * its field initializers), so the private cachedShape SoftReference is null on a
+    * mock; reshapeFunnel calls cachedShape.clear(), so seed it with a real reference.
+    */
+   private static BarVO funnelBar(GraphElement elem, double x, double y, double w, double h) {
+      BarVO bar = mock(BarVO.class);
+      ElementGeometry geom = mock(ElementGeometry.class);
+      when(geom.getElement()).thenReturn(elem);
+      when(bar.getGeometry()).thenReturn(geom);
+      bar.shape = new Rectangle2D.Double(x, y, w, h);
+
+      try {
+         Field f = BarVO.class.getDeclaredField("cachedShape");
+         f.setAccessible(true);
+         f.set(bar, new SoftReference<>(null));
+      }
+      catch(ReflectiveOperationException ex) {
+         throw new IllegalStateException("failed to seed cachedShape", ex);
+      }
+
+      return bar;
+   }
+
+   /**
+    * Assert the reshaped path's four corners (moveTo + 3 lineTo) match, in order.
+    */
+   private static void assertCorners(BarVO bar, double[][] expected) {
+      double[] coords = new double[6];
+      List<double[]> pts = new ArrayList<>();
+      PathIterator it = bar.shape.getPathIterator(null);
+
+      while(!it.isDone()) {
+         int type = it.currentSegment(coords);
+
+         if(type == PathIterator.SEG_MOVETO || type == PathIterator.SEG_LINETO) {
+            pts.add(new double[] { coords[0], coords[1] });
+         }
+
+         it.next();
+      }
+
+      assertEquals(expected.length, pts.size(), "corner count");
+
+      for(int i = 0; i < expected.length; i++) {
+         assertEquals(expected[i][0], pts.get(i)[0], 1e-6, "corner " + i + " x");
+         assertEquals(expected[i][1], pts.get(i)[1], 1e-6, "corner " + i + " y");
+      }
+   }
+
+   /**
+    * A mocked GraphElement whose getHint/setHint are backed by a real map, so
+    * markFunnelShaped's hint state persists across calls without constructing a
+    * concrete element (which would require the Spring/SreeEnv context).
+    */
+   private static GraphElement mockElementWithHints() {
+      GraphElement elem = mock(GraphElement.class);
+      Map<String, Object> hints = new HashMap<>();
+      when(elem.getHint(anyString())).thenAnswer(inv -> hints.get(inv.<String>getArgument(0)));
+      doAnswer(inv -> {
+         hints.put(inv.getArgument(0), inv.getArgument(1));
+         return null;
+      }).when(elem).setHint(anyString(), any());
+      return elem;
+   }
+
+   private static void assertBounds(BarVO bar, double x, double y, double w, double h) {
+      Rectangle2D b = bar.shape.getBounds2D();
+      assertEquals(x, b.getX(), 1e-6, "x");
+      assertEquals(y, b.getY(), 1e-6, "y");
+      assertEquals(w, b.getWidth(), 1e-6, "width");
+      assertEquals(h, b.getHeight(), 1e-6, "height");
    }
 }


### PR DESCRIPTION
Root Cause:
When a Text (or Color) field is bound to a funnel chart, that field becomes a grouping dimension, so the dataset has multiple rows per category and each category is rendered as a stacked column of segments.

The funnel layout in BarVO.dodge() reshapes the bars into the connected trapezoid "funnel" silhouette, but it collected the bars to reshape from the collision map's key set only. The collision map keys only the bottom segment of each stacked column — the remaining stacked segments are stored in the keys' overlapped value lists (marked already-moved, so they never become keys). As a result the reshaping saw just one segment per column and shaped each column from that single segment's height, leaving the other stacked segments as their original rectangles. The drawn heights no longer matched the data, producing the disordered funnel. Funnels without a text/color aesthetic were unaffected because each category then has exactly one bar.

Fix:
In BarVO.dodge() (funnel / MOVE_MIDDLE branch):
- Collect all funnel segments for the element — from both the collision-map keys and their overlapped value lists (deduplicated) — instead of the keys alone.
- Group the segments into funnel levels by column (x position) and sort the levels left to right.
- Reshape each level as a single trapezoid whose outer silhouette tapers from the level's own stacked total to the next level's total. Stacked segments within a level are drawn with straight horizontal dividers (inner segments are rectangles; only the top/bottom segments carry the tapered edges).

The change is confined to the funnel branch; non-funnel bar rendering is unchanged, and a single-segment funnel reduces to exactly the previous trapezoid.

(Re-applies the previously-approved fix from PR #4140, which had been closed after developing merge conflicts with the faceted-funnel PRs #4145/#4146/#4147. Adapted to retain the current per-coordinate markFunnelShaped() guard.)