### PR TITLE
Add transparent runtime restore for wiz modify operations

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/WizUtil.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizUtil.java
@@ -18,12 +18,20 @@
 
 package inetsoft.web.wiz;
 
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.ExpiredSheetException;
+import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.*;
+import inetsoft.util.Tool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.awt.*;
 import java.nio.charset.StandardCharsets;
+import java.security.Principal;
 import java.util.Base64;
 
 public class WizUtil {
@@ -43,6 +51,51 @@ public class WizUtil {
       }
 
       return decodedId;
+   }
+
+   /**
+    * Resolve the runtime viewsheet for a wiz modify operation, transparently restoring it when the
+    * runtime has been reaped (TTL expiry / server restart).
+    *
+    * The runtime viewsheet is transient, but the viewsheet asset that {@code viewsheetIdentifier}
+    * points to is durable (every wiz create/modify rewrites it via persistViewsheet), so a reaped
+    * runtime can be reopened from the identifier into a fresh runtime carrying the same state. Callers
+    * MUST read {@link RuntimeViewsheet#getID()} off the returned value to pick up the (possibly new)
+    * runtimeId and echo it back to the client, so subsequent edits target the live runtime instead of
+    * the reaped one.
+    *
+    * @param viewsheetService    the runtime registry (resolve + reopen).
+    * @param runtimeId           the runtime id the client believes is active (may be reaped).
+    * @param viewsheetIdentifier the durable asset identifier to restore from; may be null/empty.
+    * @param user                the requesting principal.
+    * @return the live RuntimeViewsheet (the existing one, or a freshly reopened one).
+    * @throws ExpiredSheetException if the runtime is gone AND no identifier is available to restore from.
+    */
+   public static RuntimeViewsheet getViewsheetOrRestore(ViewsheetService viewsheetService,
+                                                        String runtimeId, String viewsheetIdentifier,
+                                                        Principal user)
+      throws Exception
+   {
+      try {
+         return viewsheetService.getViewsheet(runtimeId, user);
+      }
+      catch(ExpiredSheetException ex) {
+         if(Tool.isEmptyString(viewsheetIdentifier)) {
+            // Nothing durable to restore from (e.g. the asset was explicitly removed) — surface expiry.
+            throw ex;
+         }
+
+         AssetEntry entry = AssetEntry.createAssetEntry(viewsheetIdentifier);
+
+         if(entry == null) {
+            throw ex;
+         }
+
+         String restoredId = viewsheetService.openViewsheet(entry, user, false);
+         LOG.debug("Restored reaped runtime [{}] from identifier [{}] as [{}]",
+                   runtimeId, viewsheetIdentifier, restoredId);
+         return viewsheetService.getViewsheet(restoredId, user);
+      }
    }
 
    /**
@@ -104,4 +157,6 @@ public class WizUtil {
    }
 
    public static final String ANNOTATION_RAW_DATA_MAX_ROW = "annotation.rawdata.maxrow";
+
+   private static final Logger LOG = LoggerFactory.getLogger(WizUtil.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizBrowseDataController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizBrowseDataController.java
@@ -18,7 +18,7 @@
 package inetsoft.web.wiz.controller;
 
 import inetsoft.web.binding.drm.DataRefModel;
-import inetsoft.web.composer.model.BrowseDataModel;
+import inetsoft.web.wiz.model.WizBrowseDataResponse;
 import inetsoft.web.wiz.service.WizBrowseDataService;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -36,19 +36,21 @@ public class WizBrowseDataController {
     * Browse distinct values for a worksheet column, using a VS runtimeId to locate
     * the underlying worksheet.
     *
-    * @param runtimeId    VS runtime ID (vsId)
-    * @param assemblyName worksheet table/assembly name that owns the column
-    * @param dataRefModel column descriptor (classType, name, attribute, …)
-    * @param principal    current user
+    * @param runtimeId           VS runtime ID (vsId)
+    * @param assemblyName        worksheet table/assembly name that owns the column
+    * @param viewsheetIdentifier durable asset id, used to restore a reaped runtime (optional)
+    * @param dataRefModel        column descriptor (classType, name, attribute, …)
+    * @param principal           current user
     */
    @PostMapping(value = "/vs/condition/browse-data", produces = MediaType.APPLICATION_JSON_VALUE)
-   public BrowseDataModel browseData(
+   public WizBrowseDataResponse browseData(
       @RequestParam("runtimeId") String runtimeId,
       @RequestParam("assemblyName") String assemblyName,
+      @RequestParam(value = "viewsheetIdentifier", required = false) String viewsheetIdentifier,
       @RequestBody DataRefModel dataRefModel,
       Principal principal) throws Exception
    {
-      return wizBrowseDataService.browseData(runtimeId, assemblyName, dataRefModel, principal);
+      return wizBrowseDataService.browseData(runtimeId, assemblyName, viewsheetIdentifier, dataRefModel, principal);
    }
 
    private final WizBrowseDataService wizBrowseDataService;

--- a/core/src/main/java/inetsoft/web/wiz/model/GeoDetectResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/GeoDetectResponse.java
@@ -71,10 +71,23 @@ public class GeoDetectResponse {
       this.candidateFeatures = candidateFeatures;
    }
 
+   /**
+    * The live runtimeId, echoed only when a reaped runtime was transparently restored during detect
+    * (its id changed). Null on the normal path; the client keeps its existing id when this is absent.
+    */
+   public String getRuntimeId() {
+      return runtimeId;
+   }
+
+   public void setRuntimeId(String runtimeId) {
+      this.runtimeId = runtimeId;
+   }
+
    private String geoType;
    private int layer;
    private String layerName;
    private int matchedCount;
    private List<String> unmatched;
    private List<String> candidateFeatures;
+   private String runtimeId;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizBrowseDataResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizBrowseDataResponse.java
@@ -17,36 +17,23 @@
  */
 package inetsoft.web.wiz.model;
 
-import java.util.List;
+import java.io.Serializable;
 
 /**
- * Response for {@code POST /api/wiz/viewsheet/geo/apply}.
- * {@code status} is "complete" when no originally-unmatched values remain, else "partial".
+ * Response for {@code POST /api/wiz/vs/condition/browse-data}: the distinct column values, plus the
+ * live {@code runtimeId} echoed only when a reaped runtime was transparently restored during the
+ * browse (its id changed). The client adopts the echoed id so the next edit targets the live runtime
+ * instead of triggering a second restore.
  */
-public class GeoApplyResponse {
-   public static final String STATUS_COMPLETE = "complete";
-   public static final String STATUS_PARTIAL  = "partial";
-
-   public String getStatus() {
-      return status;
+public class WizBrowseDataResponse implements Serializable {
+   public Object[] getValues() {
+      return values;
    }
 
-   public void setStatus(String status) {
-      this.status = status;
+   public void setValues(Object[] values) {
+      this.values = values;
    }
 
-   public List<String> getStillUnmatched() {
-      return stillUnmatched;
-   }
-
-   public void setStillUnmatched(List<String> stillUnmatched) {
-      this.stillUnmatched = stillUnmatched;
-   }
-
-   /**
-    * The live runtimeId, echoed only when a reaped runtime was transparently restored (its id
-    * changed). Null on the normal path; the client keeps its existing id when this is absent.
-    */
    public String getRuntimeId() {
       return runtimeId;
    }
@@ -55,7 +42,8 @@ public class GeoApplyResponse {
       this.runtimeId = runtimeId;
    }
 
-   private String status;
-   private List<String> stillUnmatched;
+   private Object[] values;
    private String runtimeId;
+
+   private static final long serialVersionUID = 1L;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.service;
 
 import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.ExpiredSheetException;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.internal.graph.ChangeChartTypeProcessor;
 import inetsoft.uql.*;
@@ -44,6 +45,7 @@ import inetsoft.web.viewsheet.service.CommandDispatcher;
 import inetsoft.web.vswizard.service.VSWizardTemporaryInfoService;
 import inetsoft.uql.viewsheet.graph.Calculator;
 import inetsoft.web.binding.model.graph.CalculateInfo;
+import inetsoft.web.wiz.WizUtil;
 import inetsoft.web.wiz.model.*;
 import inetsoft.web.wiz.model.BindingInfo;
 import org.slf4j.Logger;
@@ -81,6 +83,21 @@ public class WizAutoBindingService {
       return autoBindingInternal(request, user, false);
    }
 
+   /**
+    * Whether a cached recommendation (auto-binding) runtime can still be reused. The recommendation
+    * runtime is a transient temp viewsheet with no durable asset, so a reaped one cannot be restored
+    * and must be replaced; returns false for a gone/expired id so the caller mints a fresh one.
+    */
+   public boolean isRecommendationRuntimeReusable(String autoBindingRuntimeId, Principal user) throws Exception {
+      try {
+         return viewsheetService.getViewsheet(autoBindingRuntimeId, user) != null;
+      }
+      catch(ExpiredSheetException ex) {
+         LOG.debug("Recommendation runtime [{}] expired; will mint a fresh one", autoBindingRuntimeId);
+         return false;
+      }
+   }
+
    private AutoBindingResponse autoBindingInternal(AutoBindingRequest request, Principal user,
                                                    boolean skipExecution)
       throws Exception
@@ -92,6 +109,16 @@ public class WizAutoBindingService {
       // Phase 1: resolve or create the recommendation RVS.
       String autoBindingRuntimeId = request.getAutoBindingRuntimeId();
       boolean createdAutoBindingRvs = false;
+
+      // A cached recommendation runtime that has been reaped (TTL/restart) cannot be reused, and unlike
+      // the chart's viewsheet it has no durable asset to restore from — so treat an expired id as
+      // absent and mint a fresh one below (mirrors changeType's fallback). Without this, a later
+      // update_binding on an expired recommendation runtime would fail outright.
+      if(!Tool.isEmptyString(autoBindingRuntimeId)
+         && !isRecommendationRuntimeReusable(autoBindingRuntimeId, user))
+      {
+         autoBindingRuntimeId = null;
+      }
 
       if(Tool.isEmptyString(autoBindingRuntimeId)) {
          Viewsheet.WizInfo wizInfo = new Viewsheet.WizInfo(true, null, null);
@@ -2018,11 +2045,14 @@ public class WizAutoBindingService {
    public CreateViewsheetResult setChartFormat(ChartFormatRequest request, Principal user)
       throws Exception
    {
-      RuntimeViewsheet rvs = viewsheetService.getViewsheet(request.getWizRuntimeId(), user);
+      RuntimeViewsheet rvs = WizUtil.getViewsheetOrRestore(
+         viewsheetService, request.getWizRuntimeId(), request.getViewsheetIdentifier(), user);
 
       if(rvs == null || rvs.getViewsheet() == null) {
          throw new Exception("Chart runtime not found: " + request.getWizRuntimeId());
       }
+
+      String effRuntimeId = rvs.getID();
 
       VSAssembly assembly = rvs.getViewsheet().getAssembly(request.getAssemblyName());
 
@@ -2164,13 +2194,13 @@ public class WizAutoBindingService {
       }
 
       CreateViewsheetResult result =
-         wizVsService.fetchAssemblyData(request.getWizRuntimeId(), request.getAssemblyName(), user);
+         wizVsService.fetchAssemblyData(effRuntimeId, request.getAssemblyName(), user);
 
       if(result == null) {
          result = new CreateViewsheetResult();
       }
 
-      result.setRuntimeId(request.getWizRuntimeId());
+      result.setRuntimeId(effRuntimeId);
       result.setAssemblyName(request.getAssemblyName());
 
       if(request.getViewsheetIdentifier() != null) {
@@ -2209,11 +2239,14 @@ public class WizAutoBindingService {
    public CreateViewsheetResult setChartColors(ChartColorsRequest request, Principal user)
       throws Exception
    {
-      RuntimeViewsheet rvs = viewsheetService.getViewsheet(request.getWizRuntimeId(), user);
+      RuntimeViewsheet rvs = WizUtil.getViewsheetOrRestore(
+         viewsheetService, request.getWizRuntimeId(), request.getViewsheetIdentifier(), user);
 
       if(rvs == null || rvs.getViewsheet() == null) {
          throw new Exception("Chart runtime not found: " + request.getWizRuntimeId());
       }
+
+      String effRuntimeId = rvs.getID();
 
       VSAssembly assembly = rvs.getViewsheet().getAssembly(request.getAssemblyName());
 
@@ -2267,13 +2300,13 @@ public class WizAutoBindingService {
       }
 
       CreateViewsheetResult result =
-         wizVsService.fetchAssemblyData(request.getWizRuntimeId(), request.getAssemblyName(), user);
+         wizVsService.fetchAssemblyData(effRuntimeId, request.getAssemblyName(), user);
 
       if(result == null) {
          result = new CreateViewsheetResult();
       }
 
-      result.setRuntimeId(request.getWizRuntimeId());
+      result.setRuntimeId(effRuntimeId);
       result.setAssemblyName(request.getAssemblyName());
 
       if(request.getViewsheetIdentifier() != null) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizBrowseDataService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizBrowseDataService.java
@@ -25,6 +25,8 @@ import inetsoft.uql.erm.DataRef;
 import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.composer.BrowseDataController;
 import inetsoft.web.composer.model.BrowseDataModel;
+import inetsoft.web.wiz.WizUtil;
+import inetsoft.web.wiz.model.WizBrowseDataResponse;
 import org.springframework.stereotype.Service;
 
 import java.security.Principal;
@@ -39,17 +41,20 @@ public class WizBrowseDataService {
    /**
     * Browse distinct values for a worksheet table column, accessed via a VS runtimeId.
     *
-    * @param runtimeId    the VS runtime ID (vsId)
-    * @param assemblyName the worksheet table/assembly name that owns the column
-    * @param dataRefModel the column ref describing which column to browse
-    * @param principal    the current user
+    * @param runtimeId           the VS runtime ID (vsId)
+    * @param assemblyName        the worksheet table/assembly name that owns the column
+    * @param viewsheetIdentifier the durable asset id, used to restore a reaped runtime; may be null
+    * @param dataRefModel        the column ref describing which column to browse
+    * @param principal           the current user
     */
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
-   public BrowseDataModel browseData(@ClusterProxyKey String runtimeId, String assemblyName,
-                                     DataRefModel dataRefModel, Principal principal)
+   public WizBrowseDataResponse browseData(@ClusterProxyKey String runtimeId, String assemblyName,
+                                           String viewsheetIdentifier, DataRefModel dataRefModel,
+                                           Principal principal)
       throws Exception
    {
-      RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
+      RuntimeViewsheet rvs =
+         WizUtil.getViewsheetOrRestore(viewsheetService, runtimeId, viewsheetIdentifier, principal);
 
       if(rvs == null) {
          throw new IllegalArgumentException("No viewsheet found for runtimeId=" + runtimeId);
@@ -75,7 +80,18 @@ public class WizBrowseDataService {
       browseDataController.setColumn((ColumnRef) dataRef);
       browseDataController.setName(assemblyName);
 
-      return browseDataController.process(rws.getAssetQuerySandbox());
+      BrowseDataModel model = browseDataController.process(rws.getAssetQuerySandbox());
+
+      WizBrowseDataResponse response = new WizBrowseDataResponse();
+      response.setValues(model != null ? model.values() : null);
+
+      // Echo the runtimeId only when a reaped runtime was restored (id changed) so the client adopts
+      // the live runtime for its next edit instead of triggering a second restore.
+      if(!runtimeId.equals(rvs.getID())) {
+         response.setRuntimeId(rvs.getID());
+      }
+
+      return response;
    }
 
    private final ViewsheetService viewsheetService;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
@@ -183,6 +183,12 @@ public class WizGeoService {
       response.setUnmatched(new ArrayList<>(unmatched));
       response.setCandidateFeatures(candidateFeatures(layer));
 
+      // If the runtime was reaped, getRuntimeViewsheet reopened it under a new id; echo it so the
+      // client adopts the live runtime for the following geo_apply (mirrors apply()).
+      if(!request.getRuntimeId().equals(rvs.getID())) {
+         response.setRuntimeId(rvs.getID());
+      }
+
       // Persist the converted map back to the session asset so save_viewsheet (which reads from
       // storage, not the live runtime) captures the map type + geo binding.
       persistViewsheet(vs, request.getViewsheetIdentifier(), user);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
@@ -48,6 +48,7 @@ import inetsoft.uql.viewsheet.graph.VSMapInfo;
 import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
 import inetsoft.util.Tool;
 import inetsoft.web.binding.handler.VSChartHandler;
+import inetsoft.web.wiz.WizUtil;
 import inetsoft.web.wiz.model.GeoApplyRequest;
 import inetsoft.web.wiz.model.GeoApplyResponse;
 import inetsoft.web.wiz.model.GeoDetectRequest;
@@ -83,7 +84,8 @@ public class WizGeoService {
     * Marks {@code column} geographic on the chart and auto-detects its geo type/layer + matching.
     */
    public GeoDetectResponse detect(GeoDetectRequest request, Principal user) throws Exception {
-      RuntimeViewsheet rvs = getRuntimeViewsheet(request.getRuntimeId(), user);
+      RuntimeViewsheet rvs =
+         getRuntimeViewsheet(request.getRuntimeId(), request.getViewsheetIdentifier(), user);
       Viewsheet vs = rvs.getViewsheet();
       ChartVSAssembly chart = getChart(vs, request.getAssemblyName());
       ViewsheetSandbox box = getSandbox(rvs);
@@ -192,7 +194,8 @@ public class WizGeoService {
     * unmatched values.
     */
    public GeoApplyResponse apply(GeoApplyRequest request, Principal user) throws Exception {
-      RuntimeViewsheet rvs = getRuntimeViewsheet(request.getRuntimeId(), user);
+      RuntimeViewsheet rvs =
+         getRuntimeViewsheet(request.getRuntimeId(), request.getViewsheetIdentifier(), user);
       Viewsheet vs = rvs.getViewsheet();
       ChartVSAssembly chart = getChart(vs, request.getAssemblyName());
       ViewsheetSandbox box = getSandbox(rvs);
@@ -262,6 +265,12 @@ public class WizGeoService {
       GeoApplyResponse response = new GeoApplyResponse();
       response.setStatus(stillUnmatched.isEmpty() ? GeoApplyResponse.STATUS_COMPLETE : GeoApplyResponse.STATUS_PARTIAL);
       response.setStillUnmatched(new ArrayList<>(stillUnmatched));
+
+      // If the runtime was reaped, getRuntimeViewsheet reopened it under a new id; echo it so the
+      // client adopts the live runtime for its next edit (mirrors the create/modify path).
+      if(!request.getRuntimeId().equals(rvs.getID())) {
+         response.setRuntimeId(rvs.getID());
+      }
 
       // Persist the resolved feature mappings to the session asset so a saved map keeps them.
       persistViewsheet(vs, request.getViewsheetIdentifier(), user);
@@ -443,12 +452,17 @@ public class WizGeoService {
       return null;
    }
 
-   private RuntimeViewsheet getRuntimeViewsheet(String runtimeId, Principal user) throws Exception {
+   private RuntimeViewsheet getRuntimeViewsheet(String runtimeId, String viewsheetIdentifier,
+                                                Principal user)
+      throws Exception
+   {
       if(Tool.isEmptyString(runtimeId)) {
          throw new IllegalArgumentException("runtimeId is required");
       }
 
-      RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, user);
+      // Transparently restore a reaped runtime from its durable asset identifier.
+      RuntimeViewsheet rvs =
+         WizUtil.getViewsheetOrRestore(viewsheetService, runtimeId, viewsheetIdentifier, user);
 
       if(rvs == null || rvs.getViewsheet() == null) {
          throw new IllegalStateException("Runtime viewsheet not found: " + runtimeId);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -44,6 +44,7 @@ import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.VSUtil;
 import inetsoft.util.Tool;
 import inetsoft.web.vswizard.recommender.WizardRecommenderUtil;
+import inetsoft.web.wiz.WizUtil;
 import inetsoft.web.wiz.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,7 +108,10 @@ public class WizVsService {
       }
 
       try {
-         RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, user);
+         RuntimeViewsheet rvs = WizUtil.getViewsheetOrRestore(
+            viewsheetService, runtimeId, model.getViewsheetIdentifier(), user);
+         boolean restored = !runtimeId.equals(rvs.getID());
+         runtimeId = rvs.getID();
          Viewsheet vs = getValidatedViewsheet(rvs);
 
          final Viewsheet targetVs;
@@ -410,7 +414,7 @@ public class WizVsService {
             result.setBinding(binding);
             result.setAssemblyName(assembly.getName());
 
-            if(createdRuntimeId) {
+            if(createdRuntimeId || restored) {
                result.setRuntimeId(runtimeId);
             }
 

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartColorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartColorsTest.java
@@ -104,6 +104,7 @@ class WizAutoBindingServiceSetChartColorsTest {
       RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
       when(rvs.getViewsheet()).thenReturn(vs);
       when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+      when(rvs.getID()).thenReturn("rt-1");
       when(viewsheetService.getViewsheet(anyString(), any())).thenReturn(rvs);
       when(wizVsService.fetchAssemblyData(anyString(), anyString(), any(Principal.class)))
          .thenReturn(new CreateViewsheetResult());

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
@@ -18,8 +18,10 @@
 package inetsoft.web.wiz.service;
 
 import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.ExpiredSheetException;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
@@ -32,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.security.Principal;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -52,6 +55,7 @@ import static org.mockito.Mockito.when;
 @Tag("core")
 class WizAutoBindingServiceSetChartFormatTest {
    private WizAutoBindingService service;
+   private ViewsheetService viewsheetService;
    private WizVsService wizVsService;
    private Viewsheet vs;
    private ChartVSAssemblyInfo info;
@@ -59,7 +63,7 @@ class WizAutoBindingServiceSetChartFormatTest {
 
    @BeforeEach
    void setUp() throws Exception {
-      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      viewsheetService = mock(ViewsheetService.class);
       wizVsService = mock(WizVsService.class);
       // collaborators not used by setChartFormat; their classes can't be initialized in a plain
       // unit-test environment (no Spring context), so pass null instead of mocks.
@@ -84,6 +88,7 @@ class WizAutoBindingServiceSetChartFormatTest {
       RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
       when(rvs.getViewsheet()).thenReturn(vs);
       when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+      when(rvs.getID()).thenReturn("rt-1");
       when(viewsheetService.getViewsheet(anyString(), any())).thenReturn(rvs);
       when(wizVsService.fetchAssemblyData(anyString(), anyString(), any()))
          .thenReturn(new CreateViewsheetResult());
@@ -104,6 +109,29 @@ class WizAutoBindingServiceSetChartFormatTest {
 
       verify(info).setTitleValue("Contacts per Account");
       verify(info).setTitleVisible(true);
+   }
+
+   // When the runtime was reaped, WizUtil.getViewsheetOrRestore reopens it from the durable identifier
+   // under a NEW id; setChartFormat must echo that live id in the result so the client adopts it next.
+   @Test
+   void echoesTheRestoredRuntimeIdWhenTheRuntimeWasReopened() throws Exception {
+      // rt-1 was reaped: getViewsheet throws; the identifier is reopened as rt-restored.
+      RuntimeViewsheet restored = mock(RuntimeViewsheet.class);
+      when(restored.getViewsheet()).thenReturn(vs);
+      when(restored.getViewsheetSandbox()).thenReturn(Optional.of(box));
+      when(restored.getID()).thenReturn("rt-restored");
+      when(viewsheetService.getViewsheet(eq("rt-1"), any()))
+         .thenThrow(new ExpiredSheetException("rt-1", null));
+      when(viewsheetService.openViewsheet(any(AssetEntry.class), any(), eq(false)))
+         .thenReturn("rt-restored");
+      when(viewsheetService.getViewsheet(eq("rt-restored"), any())).thenReturn(restored);
+      when(wizVsService.fetchAssemblyData(eq("rt-restored"), anyString(), any()))
+         .thenReturn(new CreateViewsheetResult());
+
+      CreateViewsheetResult result =
+         service.setChartFormat(titleRequest("1^128^__NULL__^visualizations-abc/chart1^host-org"), null);
+
+      assertEquals("rt-restored", result.getRuntimeId());
    }
 
    @Test


### PR DESCRIPTION
When a RuntimeViewsheet is reaped (TTL/restart), wiz modify operations that reference its runtimeId failed. Reopen the viewsheet from its durable asset identifier and echo the new runtimeId so the client adopts it.

- WizUtil.getViewsheetOrRestore: getViewsheet, and on ExpiredSheetException reopen from viewsheetIdentifier into a fresh runtime (falls back to the expiry when no identifier is available).
- Applied at create/filter/binding (WizVsService.createViewsheetInternal), format/colors/markers (WizAutoBindingService), geo detect/apply (WizGeoService), and column-values browse (WizBrowseDataService, whose controller gains an optional viewsheetIdentifier param).
- Echo the restored runtimeId in the create/format/colors/geo-apply and browse-data responses so wiz-services and the plugin adopt the live runtime for the next edit (browse returns a new WizBrowseDataResponse carrying it).
- update_binding: treat a reaped recommendation (auto-binding) runtime as absent and mint a fresh one; it has no durable asset to restore from.