### PR TITLE
bug-75564: fix toHost to match with toGuest

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/ScriptValueConverter.java
+++ b/core/src/main/java/inetsoft/util/script/graal/ScriptValueConverter.java
@@ -87,6 +87,24 @@ public final class ScriptValueConverter {
          return new Date(inst.toEpochMilli());
       }
 
+      // Our own adapters first (the inverse of toGuest): ArrayProxy implements
+      // both ProxyArray and ProxyObject, so it also satisfies hasArrayElements()
+      // below — it must be unwrapped back to its ScriptArrayScope here, before
+      // the generic array branch flattens it into a plain Object[] copy.
+      if(v.isProxyObject()) {
+         Object proxy = v.asProxyObject();
+
+         if(proxy instanceof ScopeProxy) {
+            return ((ScopeProxy) proxy).getScope();
+         }
+
+         if(proxy instanceof ArrayProxy) {
+            return ((ArrayProxy) proxy).getScope();
+         }
+
+         return proxy;
+      }
+
       if(v.hasArrayElements()) {
          long n = v.getArraySize();
 
@@ -101,23 +119,6 @@ public final class ScriptValueConverter {
          }
 
          return arr;
-      }
-
-      // proxy/host wrappers and plain objects: unwrap our own adapters back
-      // to the ScriptScope/ScriptArrayScope they wrap (the inverse of
-      // toGuest), else hand back the raw proxy/Value for member access.
-      if(v.isProxyObject()) {
-         Object proxy = v.asProxyObject();
-
-         if(proxy instanceof ScopeProxy) {
-            return ((ScopeProxy) proxy).getScope();
-         }
-
-         if(proxy instanceof ArrayProxy) {
-            return ((ArrayProxy) proxy).getScope();
-         }
-
-         return proxy;
       }
 
       return v;

--- a/core/src/main/java/inetsoft/util/script/graal/ScriptValueConverter.java
+++ b/core/src/main/java/inetsoft/util/script/graal/ScriptValueConverter.java
@@ -103,10 +103,21 @@ public final class ScriptValueConverter {
          return arr;
       }
 
-      // proxy/host wrappers and plain objects: hand back the raw value's
-      // host object if present, else the Value itself for member access.
+      // proxy/host wrappers and plain objects: unwrap our own adapters back
+      // to the ScriptScope/ScriptArrayScope they wrap (the inverse of
+      // toGuest), else hand back the raw proxy/Value for member access.
       if(v.isProxyObject()) {
-         return v.asProxyObject();
+         Object proxy = v.asProxyObject();
+
+         if(proxy instanceof ScopeProxy) {
+            return ((ScopeProxy) proxy).getScope();
+         }
+
+         if(proxy instanceof ArrayProxy) {
+            return ((ArrayProxy) proxy).getScope();
+         }
+
+         return proxy;
       }
 
       return v;


### PR DESCRIPTION
toGuest() and toHost() are theoretically a pair of inverse operations:

toGuest: ScriptScope → wraps it into a ScopeProxy for GraalJS
toHost: should do the opposite, unpacking the ScopeProxy and restoring it back to a ScriptScope