### PR TITLE
Fixed: Old assembly now always removed on chart replacement, regardless of skipExecution

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -418,9 +418,12 @@ public class WizVsService {
                result.setRuntimeId(runtimeId);
             }
 
-            // For skipExecution (changeType): remove the displaced primary before persisting
-            // so the stored viewsheet contains only the new assembly.
-            if(skipExecution && previousPrimaryAssembly != null && !createdRuntimeId) {
+            // Remove the displaced primary before persisting so the stored viewsheet contains only
+            // the new assembly. Previously this ran only for skipExecution (changeType), so the
+            // standard autoBinding path (create_viewsheet / update_binding) left the old assembly
+            // behind — merely demoted to non-primary — and it got persisted alongside the new one,
+            // accumulating an extra chart in the viewsheet on every re-bind of an existing runtime.
+            if(previousPrimaryAssembly != null && !createdRuntimeId) {
                targetVs.removeAssembly(previousPrimaryAssembly.getName());
                removedPreviousPrimary = true;
             }


### PR DESCRIPTION
StyleBI, when performing in-place chart modification (update_binding), cannot directly reuse the new chart configuration because it comes from another temporary recommendation viewsheet. Therefore, it must create a new assembly object to replace the old one. However, the code only sets the old assembly's primary flag to false without actually removing it from the viewsheet, causing both the old and new assemblies to be saved together — this is why two charts appear in a single viewsheet. The only line of code responsible for deleting the old assembly was mistakenly placed under the condition `skipExecution &&`. But `skipExecution` is merely a performance switch for "whether to execute the query and fetch data" (used for quick chart type changes via changeType, skipping the query and supplementing data later), and has nothing to do with "whether the old chart should be cleaned up." It just so happens that historically, only changeType required deleting the old chart, so the deletion logic was hard-wired to this switch, causing the normal path of create_viewsheet/update_binding — where skipExecution is always false — to never delete the old chart. Therefore, I removed the `skipExecution &&` restriction, keeping only the truly relevant condition (reusing the existing runtime and indeed replacing the old chart), so that the old chart can be correctly deleted in all paths.