### PR TITLE
feat(wiz): numericBin dimension directive → Range@ bin (faceted histogram support)

### DIFF
--- a/core/src/main/java/inetsoft/web/vswizard/recommender/WizardRecommenderUtil.java
+++ b/core/src/main/java/inetsoft/web/vswizard/recommender/WizardRecommenderUtil.java
@@ -841,6 +841,20 @@ public final class WizardRecommenderUtil {
       buildRangeDimension(dim, rvs, tname, interval);
    }
 
+   /**
+    * Convert a dimension ref into a numeric range-binned dimension using the {@code Range@<field>}
+    * shorthand — the same mechanism the lone-measure histogram uses (see HistogramChartFilter). The
+    * wizard executor auto-bins the numeric column (~8 nice-number bins) and createRangeDimension
+    * materializes it on save. Idempotent; no-op when the ref has no base column.
+    */
+   public static void applyNumericBin(VSDimensionRef ref) {
+      String base = ref.getGroupColumnValue();
+
+      if(base != null && !base.isEmpty() && !base.startsWith("Range@")) {
+         ref.setGroupColumnValue("Range@" + base);
+      }
+   }
+
    // Build the range calc field (binned expression) for a Range@ dimension from the computed interval,
    // register it on the viewsheet, and re-point the dimension at it. Shared by both createRangeDimension
    // overloads (wizard tempInfo path and non-wizard SourceInfo path).

--- a/core/src/main/java/inetsoft/web/wiz/model/DimensionFieldInfo.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/DimensionFieldInfo.java
@@ -55,6 +55,14 @@ public class DimensionFieldInfo extends SimpleFieldInfo {
       this.timeSeries = timeSeries;
    }
 
+   public boolean isNumericBin() {
+      return numericBin;
+   }
+
+   public void setNumericBin(boolean numericBin) {
+      this.numericBin = numericBin;
+   }
+
    public List<String> getManualOrder() {
       return manualOrder;
    }
@@ -67,5 +75,6 @@ public class DimensionFieldInfo extends SimpleFieldInfo {
    private Ranking ranking;
    private String fullName;
    private boolean timeSeries = false;
+   private boolean numericBin = false;
    private List<String> manualOrder;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -688,6 +688,10 @@ public class WizAutoBindingService {
             }
 
             applyDateGroup(dim, dimFc);
+
+            if(dimFc.isNumericBin()) {
+               WizardRecommenderUtil.applyNumericBin(dim);
+            }
          }
 
          if(fc.getOrder() != null) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -2243,6 +2243,14 @@ public class WizVsService {
          ref.setRankingOptionValue(String.valueOf(ranking.getOptionValue()));
       }
 
+      if(dim != null && dim.isNumericBin()) {
+         if(base.getType() != null && !base.getType().isEmpty()) {
+            ref.setDataType(base.getType());
+         }
+
+         WizardRecommenderUtil.applyNumericBin(ref);
+      }
+
       return ref;
    }
 

--- a/core/src/test/java/inetsoft/web/vswizard/recommender/WizardRecommenderUtilTest.java
+++ b/core/src/test/java/inetsoft/web/vswizard/recommender/WizardRecommenderUtilTest.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.vswizard.recommender;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link WizardRecommenderUtil#applyNumericBin(inetsoft.uql.viewsheet.VSDimensionRef)},
+ * the {@code Range@<field>} shorthand helper that lets an explicit {@code apply_binding} request a
+ * numeric range-bin dimension via the same mechanism the lone-measure histogram uses.
+ *
+ * Uses the Spring/@SreeHome harness because constructing a VSChartDimensionRef triggers
+ * GDefaults/SreeEnv init that throws ShutdownException in a plain JVM (see ChartTypeFilterPinsTest).
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizardRecommenderUtilTest {
+   @Test
+   void applyNumericBinPrefixesRangeShorthand() {
+      VSChartDimensionRef ref = new VSChartDimensionRef();
+      ref.setGroupColumnValue("price");
+      WizardRecommenderUtil.applyNumericBin(ref);
+      assertEquals("Range@price", ref.getGroupColumnValue());
+   }
+
+   @Test
+   void applyNumericBinIsIdempotent() {
+      VSChartDimensionRef ref = new VSChartDimensionRef();
+      ref.setGroupColumnValue("Range@price");
+      WizardRecommenderUtil.applyNumericBin(ref);
+      assertEquals("Range@price", ref.getGroupColumnValue());
+   }
+
+   @Test
+   void applyNumericBinNoOpOnBlank() {
+      VSChartDimensionRef ref = new VSChartDimensionRef();
+      WizardRecommenderUtil.applyNumericBin(ref);
+      assertNull(ref.getGroupColumnValue());
+   }
+}


### PR DESCRIPTION
## What

Add a `numericBin` directive to the wiz chart-binding dimension model so an explicit `apply_binding` can request a numeric **range bin** (`Range@<field>`) on a dimension — the same auto-interval mechanism the lone-measure histogram (`HistogramChartFilter`) already uses.

This unblocks a **faceted binned histogram** ("distribution of a numeric measure split by a category") in the wiz-services layer, which previously wasn't expressible: the recommender only synthesizes the `Range@` bin when the measure is bound alone, and silently groups + `Sum`s once a real dimension is added.

## Changes (additive, recommender untouched)

- `DimensionFieldInfo`: new `numericBin` boolean (default false).
- `WizardRecommenderUtil.applyNumericBin(VSDimensionRef)`: static, idempotent — prefixes `groupColumnValue` with `Range@` unless already prefixed; no-op on blank base.
- Wired into both binding paths:
  - explicit `apply_binding` — `WizVsService.createVSChartDimensionRef` (beside the existing `dateGroupLevel`/`ranking` handling; also stamps the ref dataType from the field type).
  - recommender/fieldConfig — `WizAutoBindingService.applyFieldConfig` (right after `applyDateGroup`).
- Unit test `WizardRecommenderUtilTest` (3 cases: prefixes `Range@`; idempotent; no-op on blank).

No new Spring bean; no change to chart-type selection.

## Verification

Built into local image `local-975` and verified end-to-end via the wiz-services faceted-histogram plan-helper: `create_viewsheet(distribution, [price, category])` renders `x=[category, Range@price]`, `y=[Count(price)]`, one mini-histogram per category; saves and reopens cleanly (Range@ materializes on save). `WizardRecommenderUtilTest` 3/3.

Pairs with stylebi-wiz PR #1087 (the wiz-services plan-helper + routing that emits `numericBin`).

> Note: this branch was rebased onto `stylebi-wiz-main-rebase`; the commit was compiled/tested on its original base — worth a CI compile check against current mainline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
