### PR TITLE
fix(wiz): crosstab binding-echo carries level-qualified date name

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.service;
 
 import inetsoft.uql.XCondition;
 import inetsoft.uql.XConstants;
+import inetsoft.uql.asset.DateRangeRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.viewsheet.VSAggregateRef;
 import inetsoft.uql.viewsheet.VSDimensionRef;
@@ -42,9 +43,28 @@ final class WizFieldInfoFactory {
    static DimensionFieldInfo createCrosstabDimensionFieldInfo(VSDimensionRef dim) {
       DimensionFieldInfo info = baseDimensionFieldInfo(dim);
       info.setType(dim.getDataType());
+      info.setFullName(crosstabDimFullName(dim));
       applyDateGroup(info, dim);
       applyRanking(info, dim);
       return info;
+   }
+
+   /**
+    * A crosstab design ref built from an explicit binding has no backing ColumnRef, so getVSName()
+    * is empty and getFullName() short-circuits to "" before the date-qualifying branch. Derive the
+    * level-qualified name (e.g. "DayOfWeek(date_start)") directly from the group column + date level.
+    */
+   static String crosstabDimFullName(VSDimensionRef dim) {
+      String fullName = dim.getFullName();
+
+      if((fullName == null || fullName.isEmpty() || fullName.equals(dim.getGroupColumnValue()))
+         && dim.getDateLevel() != XConstants.NONE_DATE_GROUP
+         && dim.getGroupColumnValue() != null && !dim.getGroupColumnValue().isEmpty())
+      {
+         return DateRangeRef.getName(dim.getGroupColumnValue(), dim.getDateLevel());
+      }
+
+      return fullName;
    }
 
    static DimensionFieldInfo createChartDimensionFieldInfo(VSDimensionRef dim) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1295,8 +1295,23 @@ public class WizVsService {
    }
 
    private static String slotName(DataRef ref) {
-      return ref instanceof VSAggregateRef agg ? agg.getFullName()
-         : WizardRecommenderUtil.getChartRefFieldName(ref);
+      if(ref instanceof VSAggregateRef agg) {
+         return agg.getFullName();
+      }
+
+      String name = WizardRecommenderUtil.getChartRefFieldName(ref);
+
+      // A crosstab design ref built from an explicit binding is a plain VSDimensionRef
+      // (not VSChartDimensionRef), so getChartRefFieldName() falls through to
+      // getAttribute() == "". Fall back to the level-qualified name so date-level
+      // crosstab dims (e.g. "DayOfWeek(date_start)") still echo a usable slot name.
+      // Chart dims are VSChartDimensionRef, whose groupColumnValue is non-empty, so
+      // this branch is crosstab-only and leaves chart slot names unaffected.
+      if((name == null || name.isEmpty()) && ref instanceof VSDimensionRef dim) {
+         return WizFieldInfoFactory.crosstabDimFullName(dim);
+      }
+
+      return name;
    }
 
    private static String aestheticSlotName(AestheticRef aref) {
@@ -1340,7 +1355,7 @@ public class WizVsService {
 
       for(DataRef ref : refs) {
          if(ref instanceof VSDimensionRef dim) {
-            dimensions.add(WizFieldInfoFactory.createDimensionFieldInfo(dim));
+            dimensions.add(WizFieldInfoFactory.createCrosstabDimensionFieldInfo(dim));
          }
       }
    }
@@ -2257,6 +2272,10 @@ public class WizVsService {
    private VSDimensionRef createVSDimensionRef(DimensionFieldInfo field) {
       VSDimensionRef ref = new VSDimensionRef();
       ref.setGroupColumnValue(field.getField());
+
+      if(field.getType() != null && !field.getType().isEmpty()) {
+         ref.setDataType(field.getType());
+      }
 
       if(field.getOrder() != null) {
          ref.setOrder(field.getOrder());

--- a/core/src/test/java/inetsoft/web/wiz/service/BindingSlotsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/BindingSlotsTest.java
@@ -20,8 +20,12 @@ package inetsoft.web.wiz.service;
 import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.asset.DateRangeRef;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.viewsheet.CrosstabVSAssembly;
 import inetsoft.uql.viewsheet.VSAggregateRef;
 import inetsoft.uql.viewsheet.VSCrosstabInfo;
 import inetsoft.uql.viewsheet.VSDimensionRef;
@@ -30,6 +34,8 @@ import inetsoft.uql.viewsheet.graph.VSAestheticRef;
 import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
 import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.web.wiz.model.CreateViewsheetResult;
+import inetsoft.web.wiz.model.DimensionFieldInfo;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -107,6 +113,45 @@ class BindingSlotsTest {
       // aggregate name to line up with the measures list / rankingCol convention.
       assertEquals(List.of("Sum(amount)"), slots.get("aggregates"),
          "crosstab aggregate reported as full aggregate name, not the bare column");
+   }
+
+   @Test
+   void crosstabDateLevelDimensionSlotUsesLevelQualifiedName() {
+      // A crosstab design ref built from an explicit binding is a plain VSDimensionRef
+      // with no backing ColumnRef (no setDataRef), so getAttribute() == "". Before the
+      // fix, both the dimensions echo (createDimensionFieldInfo) and the rows slot name
+      // (getChartRefFieldName) collapsed to "" for a date-level dim like this one.
+      VSDimensionRef dim = new VSDimensionRef();
+      dim.setGroupColumnValue("date_start");
+      dim.setDataType(XSchema.TIME_INSTANT);
+      dim.setDateLevelValue(String.valueOf(XConstants.DAY_OF_WEEK_DATE_GROUP));
+
+      VSCrosstabInfo cinfo = new VSCrosstabInfo();
+      cinfo.setDesignRowHeaders(new DataRef[]{ dim });
+      cinfo.setDesignAggregates(new DataRef[]{ crosstabAggregate("amount", "Sum") });
+
+      String expectedFullName =
+         DateRangeRef.getName("date_start", XConstants.DAY_OF_WEEK_DATE_GROUP);
+
+      // Fix 2: slots.rows must report the level-qualified name, not "".
+      Map<String, Object> slots = WizVsService.collectCrosstabSlots(cinfo);
+      assertEquals(List.of(expectedFullName), slots.get("rows"),
+         "date-level crosstab row dimension slot falls back to the level-qualified name");
+
+      // Fix 1: the dimensions echo (reached via the public collectFlatBinding entry
+      // point, same as the create_viewsheet/apply_binding response path) must route
+      // through createCrosstabDimensionFieldInfo, not the chart variant.
+      CrosstabVSAssembly assembly = new CrosstabVSAssembly();
+      assembly.setVSCrosstabInfo(cinfo);
+
+      WizVsService service = new WizVsService(null, null);
+      CreateViewsheetResult.FlatBinding binding = service.collectFlatBinding(assembly);
+
+      assertEquals(1, binding.getDimensions().size());
+      DimensionFieldInfo info = binding.getDimensions().get(0);
+      assertEquals("date_start", info.getField());
+      assertEquals(expectedFullName, info.getFullName(),
+         "crosstab dimensions echo carries the level-qualified fullName");
    }
 
    private static VSDimensionRef crosstabDimension(String field) {

--- a/core/src/test/java/inetsoft/web/wiz/service/WizFieldInfoFactoryTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizFieldInfoFactoryTest.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.asset.DateRangeRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
+import inetsoft.web.wiz.model.DimensionFieldInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression test for the crosstab dimension echo: a date-grouped dimension must carry the
+ * level-qualified {@code fullName} (parity with the chart variants) so the downstream facts pack
+ * can key dimensions distinctly instead of collapsing to a false "single value" caveat.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizFieldInfoFactoryTest {
+   @Test
+   void crosstabDimEchoCarriesLevelQualifiedFullName() {
+      VSChartDimensionRef dim = new VSChartDimensionRef();
+      dim.setGroupColumnValue("date_start");
+      dim.setDataType(XSchema.TIME_INSTANT);
+      dim.setDateLevelValue(String.valueOf(XConstants.DAY_OF_WEEK_DATE_GROUP));
+
+      DimensionFieldInfo info = WizFieldInfoFactory.createCrosstabDimensionFieldInfo(dim);
+
+      String expectedFullName =
+         DateRangeRef.getName("date_start", XConstants.DAY_OF_WEEK_DATE_GROUP);
+
+      assertEquals("date_start", info.getField());
+      assertFalse(info.getFullName() == null || info.getFullName().isEmpty()); // NOT empty
+      assertEquals(expectedFullName, info.getFullName());   // level-qualified, e.g. "DayOfWeek(date_start)"
+      assertNotNull(info.getDateGroupLevel());              // level echoed
+   }
+}


### PR DESCRIPTION
## Bug

A crosstab built through the explicit `apply_binding` path — one date column grouped at two levels (e.g. `date_start` as day-of-week on rows, hour-of-day on cols) — echoed its date dimensions back with **blank `fullName` and null `dateGroupLevel`**, and `slots.rows`/`cols` came back `[""]`.

Root cause: the crosstab design `VSDimensionRef` (built from the binding, no backing `ColumnRef`) has an empty `getVSName()`, so `VSDimensionRef.getFullName()` short-circuits to `""` before its date-qualifying branch. The wiz binding-echo (`collectDimensionFieldInfos` → `createDimensionFieldInfo`) copied that empty name. Downstream the facts pack keys dimensions by `fullName`, so it mis-read both dims and emitted a false "single value" caveat.

## Fix (recommender untouched)

- `WizFieldInfoFactory.createCrosstabDimensionFieldInfo`: derive the level-qualified name (`DayOfWeek(date_start)`) via `DateRangeRef.getName(groupColumnValue, dateLevel)` when `getFullName()` is empty/unqualified and `dateLevel != NONE`; also set the ref `dataType`.
- `WizVsService.collectDimensionFieldInfos` (crosstab-only echo): route through `createCrosstabDimensionFieldInfo` instead of the chart variant.
- `WizVsService.slotName`: fall back to the same helper for a plain `VSDimensionRef` when the primary lookup is empty (chart slots — `VSChartDimensionRef` with non-empty group value — are unaffected).

## Tests
`WizFieldInfoFactoryTest` + `BindingSlotsTest` (5 tests) — each fix independently RED-confirmed; the level-qualified name and populated crosstab slots are asserted. Non-date crosstab dims and chart slots are unchanged.

## Verification
Built into local image `local-979` and verified end-to-end via the wiz-services multi-date-level plan-helper: `create_viewsheet` binding `date_start` at two levels renders the weekday×hour crosstab with `binding.dimensions[].fullName` = `DayOfWeek(date_start)`/`HourOfDay(date_start)`, populated `slots`, and a correct facts pack.

Pairs with stylebi-wiz PR #1089 (the plan-helper that emits this crosstab binding).

> Rebased/based on `stylebi-wiz-main-rebase`; squashed from 3 dev commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
