### PR TITLE
fix(wiz): don't date-name a non-date crosstab dimension in the binding echo

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
@@ -52,16 +52,26 @@ final class WizFieldInfoFactory {
    /**
     * A crosstab design ref built from an explicit binding has no backing ColumnRef, so getVSName()
     * is empty and getFullName() short-circuits to "" before the date-qualifying branch. Derive the
-    * level-qualified name (e.g. "DayOfWeek(date_start)") directly from the group column + date level.
+    * name directly from the group column: a level-qualified name (e.g. "DayOfWeek(date_start)") for a
+    * DATE-typed dimension that carries a real date level, else the plain column name.
+    *
+    * The date-type guard matters: a non-date crosstab dimension (a string/numeric column) can carry a
+    * spurious default YEAR date level, and date-naming it would echo a bogus "Year(status)" fullName
+    * that pollutes the downstream facts pack. We only date-qualify genuine date dimensions, and always
+    * fall back to the group column (never an empty string) for everything else.
     */
    static String crosstabDimFullName(VSDimensionRef dim) {
       String fullName = dim.getFullName();
+      String groupColumn = dim.getGroupColumnValue();
 
-      if((fullName == null || fullName.isEmpty() || fullName.equals(dim.getGroupColumnValue()))
-         && dim.getDateLevel() != XConstants.NONE_DATE_GROUP
-         && dim.getGroupColumnValue() != null && !dim.getGroupColumnValue().isEmpty())
+      if((fullName == null || fullName.isEmpty() || fullName.equals(groupColumn))
+         && groupColumn != null && !groupColumn.isEmpty())
       {
-         return DateRangeRef.getName(dim.getGroupColumnValue(), dim.getDateLevel());
+         if(dim.isDateTime() && dim.getDateLevel() != XConstants.NONE_DATE_GROUP) {
+            return DateRangeRef.getName(groupColumn, dim.getDateLevel());
+         }
+
+         return groupColumn;
       }
 
       return fullName;

--- a/core/src/test/java/inetsoft/web/wiz/service/WizFieldInfoFactoryTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizFieldInfoFactoryTest.java
@@ -62,4 +62,24 @@ class WizFieldInfoFactoryTest {
       assertEquals(expectedFullName, info.getFullName());   // level-qualified, e.g. "DayOfWeek(date_start)"
       assertNotNull(info.getDateGroupLevel());              // level echoed
    }
+
+   /**
+    * A NON-date crosstab dimension (e.g. a string column) can carry a spurious default YEAR date
+    * level. Its echoed {@code fullName} must be the plain column name, NOT a date-range name like
+    * "Year(status)" — otherwise the downstream facts pack keys the grid by a bogus dimension name.
+    * Regression for the multi-dim string-crosstab facts-pack pollution.
+    */
+   @Test
+   void crosstabDimEchoDoesNotDateNameANonDateDimension() {
+      VSChartDimensionRef dim = new VSChartDimensionRef();
+      dim.setGroupColumnValue("status");
+      dim.setDataType(XSchema.STRING);
+      dim.setDateLevelValue(String.valueOf(XConstants.YEAR_DATE_GROUP)); // spurious default level
+
+      DimensionFieldInfo info = WizFieldInfoFactory.createCrosstabDimensionFieldInfo(dim);
+
+      assertEquals("status", info.getField());
+      assertEquals("status", info.getFullName());            // NOT "Year(status)"
+      assertFalse(info.getFullName().startsWith("Year("));   // explicit guard against the regression
+   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #4162 (multi-date-level crosstab echo). `crosstabDimFullName` — added there to give date-grouped crosstab dimensions a level-qualified `fullName` — applied `DateRangeRef.getName(groupColumn, dateLevel)` whenever `dateLevel != NONE_DATE_GROUP`, **without checking the dimension is a date type**.

A **non-date** crosstab dimension (a string/numeric column) can carry a spurious default `YEAR` date level, so it was echoed as e.g. `Year(status)`. The chart itself renders correctly (grouping ignores the level for non-dates), but the bogus `fullName` propagates into the wiz facts pack, which keys its grid by dimension name → a degenerate summary (`by Year(status): — 70`).

## Fix

Gate the date-qualified name on `dim.isDateTime()` (DATE / TIME_INSTANT / TIME), and always fall back to the group column (never an empty string) for non-date dimensions. Genuine date dimensions are unaffected.

- Date dim + real level → `DayOfWeek(date_start)` (unchanged; existing test still green).
- String dim (+ spurious YEAR level) → `status` (was `Year(status)`).

## Tests

`WizFieldInfoFactoryTest`:
- existing `crosstabDimEchoCarriesLevelQualifiedFullName` (TIME_INSTANT → `DayOfWeek(date_start)`) — still passes.
- new `crosstabDimEchoDoesNotDateNameANonDateDimension` (STRING + YEAR level → `status`) — fails before this change (`expected: <status> but was: <Year(status)>`), passes after.

Built as local image `local-980` and verified end-to-end via the wiz plugin: a suitecrm bugs `status × resolution` crosstab now echoes `fullName` `status`/`resolution` and the facts grid keys by the real dimensions (`by status: Pending 19, Assigned 14…`) instead of `by Year(status): —70`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)