### PR TITLE
fixed 75567:Fix privilege escalation where ASSIGN implied full role admin access

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/DefaultCheckPermissionStrategy.java
+++ b/core/src/main/java/inetsoft/sree/security/DefaultCheckPermissionStrategy.java
@@ -232,7 +232,7 @@ public class DefaultCheckPermissionStrategy implements CheckPermissionStrategy {
          //if admin permissions to this resource, return true
          boolean hasResourcePermission = provider.getPermission(type, resource, orgID) != null &&
             provider.getPermission(type, resource, orgID)
-               .getOrgScopedUserGrants(ResourceAction.ASSIGN, OrganizationManager.getInstance().getCurrentOrgID())
+               .getOrgScopedUserGrants(ResourceAction.ADMIN, OrganizationManager.getInstance().getCurrentOrgID())
                .contains(pId);
 
          if(hasResourcePermission) {

--- a/core/src/test/java/inetsoft/sree/security/DefaultCheckPermissionStrategyTest.java
+++ b/core/src/test/java/inetsoft/sree/security/DefaultCheckPermissionStrategyTest.java
@@ -334,6 +334,47 @@ class DefaultCheckPermissionStrategyTest {
       );
    }
 
+   // [Path D] SECURITY_ROLE with only ASSIGN must not imply READ/WRITE/DELETE/ADMIN (#75567).
+   // Regression: hasResourcePermission incorrectly checked ASSIGN grants instead of ADMIN,
+   // granting full access to any action when only ASSIGN was configured.
+   @ParameterizedTest
+   @MethodSource("securityRoleAssignOnlyCases")
+   void securityRoleAssignOnlyDoesNotImplyOtherActions(ResourceAction action, boolean expected) {
+      String roleResource = new IdentityID("targetRole", TEST_ORG).convertToKey();
+      Permission assignOnlyPerm = grantedPermission(TEST_USER, TEST_ORG, ResourceAction.ASSIGN, false);
+
+      try(MockedStatic<SUtil> sutilMock = Mockito.mockStatic(SUtil.class, Mockito.CALLS_REAL_METHODS);
+          MockedStatic<OrganizationManager> omMock =
+             Mockito.mockStatic(OrganizationManager.class, Mockito.CALLS_REAL_METHODS))
+      {
+         sutilMock.when(SUtil::isMultiTenant).thenReturn(false);
+         sutilMock.when(() -> SUtil.isInternalUser(any())).thenReturn(false);
+
+         OrganizationManager mockOM = mock(OrganizationManager.class);
+         omMock.when(OrganizationManager::getInstance).thenReturn(mockOM);
+         omMock.when(OrganizationManager::getCurrentOrgName).thenReturn(TEST_ORG);
+         when(mockOM.getCurrentOrgID()).thenReturn(TEST_ORG);
+         when(mockOM.getCurrentOrgID(any())).thenReturn(TEST_ORG);
+         when(mockOM.isSiteAdmin(any(Principal.class))).thenReturn(false);
+
+         when(mockProvider.getPermission(eq(ResourceType.SECURITY_ROLE), eq(roleResource), eq(TEST_ORG)))
+            .thenReturn(assignOnlyPerm);
+
+         assertEquals(expected,
+            mockStrategy.checkPermission(mockUser, ResourceType.SECURITY_ROLE, roleResource, action));
+      }
+   }
+
+   private static Stream<Arguments> securityRoleAssignOnlyCases() {
+      return Stream.of(
+         Arguments.of(ResourceAction.ASSIGN, true),
+         Arguments.of(ResourceAction.READ, false),
+         Arguments.of(ResourceAction.WRITE, false),
+         Arguments.of(ResourceAction.DELETE, false),
+         Arguments.of(ResourceAction.ADMIN, false)
+      );
+   }
+
    // ─────────────────────────────────────────────────────────────────
    // [Path F] Hierarchical resource traversal falls back to parent — mock-based
    // ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fix ASSIGN grant incorrectly granting full access on security resources

DefaultCheckPermissionStrategy checked ResourceAction.ASSIGN instead of
ADMIN in the early-return block at L232-240, so users with only
"Assign Permissions" on a SECURITY_ROLE were allowed WRITE, DELETE,
and ADMIN. Change the grant lookup to ResourceAction.ADMIN to match
the comment and the rest of the cascade logic.