### PR TITLE
Bug #75555, make script runtime error serializable across cluster

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -517,7 +517,15 @@ public class GraalJavaScriptEngine implements AutoCloseable {
                loc = " (line " + ex.getSourceLocation().getStartLine() + ")";
             }
 
-            throw new ScriptException(ex.getMessage() + loc, ex);
+            // Do not retain the PolyglotException as the cause: it is not
+            // serializable (PolyglotException.writeObject throws), which would
+            // mask the real script error when this exception is marshalled
+            // across the cluster (e.g. an Ignite affinity-call response). The
+            // message already carries the JS error text and line; copy the
+            // merged host/guest stack trace so nothing useful is lost. (#75555)
+            ScriptException se = new ScriptException(ex.getMessage() + loc);
+            se.setStackTrace(ex.getStackTrace());
+            throw se;
          }
          finally {
             // clear the script-execution flag for this thread (balanced with the

--- a/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineErrorTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineErrorTest.java
@@ -19,6 +19,8 @@ package inetsoft.util.script.graal;
 
 import inetsoft.util.script.ScriptException;
 import org.junit.jupiter.api.*;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
@@ -39,6 +41,28 @@ class GraalJavaScriptEngineErrorTest {
       ScriptException ex = assertThrows(ScriptException.class,
          () -> engine.exec(src, null, null));
       assertTrue(ex.getMessage().contains("boom"));
+   }
+
+   /**
+    * Bug #75555: the ScriptException thrown for a runtime script error must be
+    * fully serializable. Previously it retained the non-serializable GraalJS
+    * PolyglotException as its cause, so marshalling it across the cluster (Ignite
+    * affinity-call response) failed with "PolyglotException serialization is not
+    * supported", masking the real script error.
+    */
+   @Test void runtimeErrorScriptExceptionIsSerializable() throws Exception {
+      Object src = engine.compile("var o; o.y");
+      ScriptException ex = assertThrows(ScriptException.class,
+         () -> engine.exec(src, null, null));
+
+      // must round-trip through Java serialization without throwing
+      try(ObjectOutputStream oos = new ObjectOutputStream(new ByteArrayOutputStream())) {
+         assertDoesNotThrow(() -> oos.writeObject(ex),
+            "runtime-error ScriptException must be serializable (#75555)");
+      }
+
+      // the real script error is preserved in the message
+      assertNotNull(ex.getMessage());
    }
 
    /**


### PR DESCRIPTION
## Summary

In a clustered environment, running a viewsheet with a failing JS script produced a misleading error — `NotSerializableException: PolyglotException serialization is not supported` — instead of the real script error (e.g. `TypeError: Cannot read property 'y' of undefined (line 2)`).

## Root Cause

`GraalJavaScriptEngine.exec()` caught the GraalJS `PolyglotException` and rethrew it as a `ScriptException` **retaining the PolyglotException as the cause**. That exception propagates up (re-wrapped by `ViewsheetScope.execute()`, still carrying the polyglot cause) and becomes the `error` field of an Ignite `AffinityCallResponse`. When Ignite marshals the response, `PolyglotException.writeObject()` throws `NotSerializableException`, masking the real script error. This is a Rhino→GraalJS migration regression — Rhino exceptions were serializable.

## Fix

In `GraalJavaScriptEngine.exec()`, stop retaining the non-serializable `PolyglotException` as the cause. Throw a `ScriptException` with the same message (already includes the JS error text and `(line N)`) and copy the merged host/guest stack trace via `setStackTrace(ex.getStackTrace())` (`StackTraceElement[]` is serializable). Nothing is lost from the user's perspective, and the exception chain is now fully serializable.

The other two `catch(PolyglotException)` sites are intentionally left unchanged:
- `installLibraryFunctions()` only logs and never rethrows.
- `checkFunction()` feeds `OpenScriptController.checkScript`, a synchronous same-node REST handler that walks the cause chain to recover the `PolyglotException` source location — it must keep the cause and is never marshalled across the cluster.

## Test Plan

- Added `GraalJavaScriptEngineErrorTest.runtimeErrorScriptExceptionIsSerializable`, which round-trips the thrown exception through `ObjectOutputStream` (fails on old code, passes now).
- GraalJS engine test package passes (7/7); `core` module builds successfully.
- Verified in a clustered environment: the failing-script viewsheet now logs the real `TypeError` instead of `PolyglotException serialization is not supported`.

Fixes Redmine #75555.