### PR TITLE
Bug #75568, register "table" chart script variable so GraalJS can resolve it

### DIFF
--- a/core/src/main/java/inetsoft/report/script/viewsheet/ChartVSAScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/viewsheet/ChartVSAScriptable.java
@@ -349,6 +349,9 @@ public class ChartVSAScriptable extends VSAScriptable implements CommonChartScri
 
       addProperty("bindingInfo", bindingInfo = new VSChartBindingScriptable(this));
       addProperty("data", data);
+      // "table" is an alias for "data" resolved in getPropertyValue; it must be
+      // registered so hasMember("table") is true (GraalJS gates getMember on hasMember).
+      addProperty("table", data);
       addProperty("dataset", null);
       addProperty("graph", null);
       addProperty("query", null);

--- a/core/src/test/java/inetsoft/report/script/viewsheet/ChartVSAScriptableTest.java
+++ b/core/src/test/java/inetsoft/report/script/viewsheet/ChartVSAScriptableTest.java
@@ -222,7 +222,7 @@ public class ChartVSAScriptableTest {
       chartVSAScriptable.setTipView("this is a tip view");
       assertEquals("this is a tip view", chartVSAScriptable.getTipView());
 
-      assertEquals(145, chartVSAScriptable.getMemberKeys().length);
+      assertEquals(146, chartVSAScriptable.getMemberKeys().length);
    }
 
    /**
@@ -242,6 +242,10 @@ public class ChartVSAScriptableTest {
       assertEquals("Median Income", chartVSAScriptable1.getMember("sizeField"));
       assertEquals("Property Value", chartVSAScriptable1.getMember("textField"));
       assertNotNull(chartVSAScriptable1.getMember("data"));
+      // Bug #75568: "table" is an alias of "data" and must be resolvable. Under GraalJS,
+      // hasMember gates getMember, so "table" must be registered as a member.
+      assertTrue(chartVSAScriptable1.hasMember("table"));
+      assertNotNull(chartVSAScriptable1.getMember("table"));
       assertEquals("Data", chartVSAScriptable1.getMember("query"));
 
       //check getSuffix


### PR DESCRIPTION
## Summary

After the Rhino→GraalJS script engine migration (feature #75423), the `table` variable — automatically available to viewsheet chart scripts under Rhino — could no longer be resolved. Scripts referencing `table` failed with `ReferenceError: table is not defined`.

## Root Cause

Under GraalJS, `hasMember` gates `getMember`: `ScopeProxy.getMember(name)` is only called when `hasMember(name)` first returns `true` (Rhino called `get()` unconditionally).

In `ChartVSAScriptable`, `getMember`/`getPropertyValue` already handles `"table"` as an alias of `"data"`, but `"table"` was never registered via `addProperty(...)`, so it wasn't in `propmap`. `VSAScriptable.hasMember` therefore returned `false` for `"table"`, and GraalJS never invoked `getMember("table")`. `"data"` worked because it is registered; the sibling `TableDataVSAScriptable` registers `"table"`, so the bug was chart-specific.

## Fix

Register `"table"` alongside `"data"` in `ChartVSAScriptable.addProperties()` so `hasMember("table")` returns `true` and the read reaches `getPropertyValue`, which returns the live chart data. One-line change; read/write/enumeration semantics are unchanged.

## Test Plan

- Added a regression assertion in `ChartVSAScriptableTest.testGetBindingField` verifying `hasMember("table")` is true and `getMember("table")` is non-null.
- Updated the member-key count assertion in `testCommonFunctions` (145 → 146) to reflect the newly registered member.
- `ChartVSAScriptableTest`: 8/8 pass. `core` module builds cleanly.
- Manual: import `AccessChartData.zip`, open the `AccessChartData` viewsheet in composer, confirm the `Chart1` script using `table` no longer errors.

Fixes Redmine #75568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)