### PR TITLE
Bug #75573, fix chart binding script visual field setters under GraalJS

### DIFF
--- a/core/src/main/java/inetsoft/report/script/AbstractChartBindingScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/AbstractChartBindingScriptable.java
@@ -2353,7 +2353,10 @@ public abstract class AbstractChartBindingScriptable extends PropertyScriptable 
          return;
       }
 
-      boolean aggr = !"undefined".equals(arg3);
+      // GraalJS delivers an omitted/undefined trailing argument as null (Rhino
+      // passed the string "undefined"), so treat null as the 2-arg form and
+      // reserve the aggregate-qualified 3-arg form for a real type value (Bug #75573).
+      boolean aggr = arg3 != null && !"undefined".equals(arg3);
       String arg1 = argObj1 == null ? null : argObj1.toString();
       ChartBindable bindable = ChartProcessor.getChartBindable(info, aggr ? arg1 : null);
 

--- a/core/src/test/java/inetsoft/report/script/viewsheet/VSChartBindingScriptableTest.java
+++ b/core/src/test/java/inetsoft/report/script/viewsheet/VSChartBindingScriptableTest.java
@@ -106,6 +106,24 @@ public class VSChartBindingScriptableTest {
                    vsChartBindingScriptable.getSizeField("order_date").getName());
    }
 
+   // Bug #75573: the 2-arg script form setColorField(field, type) omits the
+   // trailing aggregate argument, which GraalJS delivers as null. The type value
+   // (Chart.STRING == "string") must not be mistaken for the field name.
+   @Test
+   void testSetAestheticFieldByName() {
+      chartVSAssemblyInfo.setChartStyle(GraphTypes.CHART_BAR);
+
+      vsChartBindingScriptable.setColorField("state", ChartConstants.STRING, null);
+      AestheticRef colorField = vsChartBindingScriptable.getColorField("state");
+      assertNotNull(colorField);
+      assertEquals("state", colorField.getName());
+
+      vsChartBindingScriptable.setShapeField("region", ChartConstants.STRING, null);
+      AestheticRef shapeField = vsChartBindingScriptable.getShapeField("region");
+      assertNotNull(shapeField);
+      assertEquals("region", shapeField.getName());
+   }
+
    @Test
    void testSetGetTextField() {
       chartVSAssemblyInfo.setChartStyle(GraphTypes.CHART_LINE);


### PR DESCRIPTION
## Summary

Chart binding scripts that set aesthetic (visual pane) fields by name had no effect. For example, on a chart with the script:

```js
bindingInfo.setColorField("State", Chart.STRING);
bindingInfo.setShapeField("Region", Chart.STRING);
```

the color/shape bindings were silently dropped, and the server log showed `VSDimensionRef: Column not found: string`.

## Root Cause

`AbstractChartBindingScriptable.setAestheticField` (used by `setColorField`/`setShapeField`/`setSizeField`/`setTextField`) supports two script call forms:

- 2-arg: `setColorField(field, type)`
- 3-arg (aggregate-qualified): `setColorField(aggregate, field, type)`

It distinguished them with `boolean aggr = !"undefined".equals(arg3);`. Under the old Rhino engine an omitted trailing argument arrived as the Java string `"undefined"`. Under GraalJS an omitted/undefined argument is converted to Java `null` (see `ScriptFunction`/`ScriptValueConverter.toHost`), so `"undefined".equals(null)` is `false`, making `aggr` incorrectly `true`. The method then read `field = arg2` (the type value `Chart.STRING` == `"string"`) and `type = arg3` (`null`), binding a nonexistent column named `"string"`.

## Fix

Treat a `null` third argument as the 2-arg form:

```java
boolean aggr = arg3 != null && !"undefined".equals(arg3);
```

This restores the pre-GraalJS behavior while leaving the aggregate-qualified 3-arg form (real type string in `arg3`) unchanged. The fix covers all four aesthetic setters, which share `setAestheticField`.

## Test Plan

- Added `VSChartBindingScriptableTest#testSetAestheticFieldByName`, which invokes the 2-arg form with a `null` third argument. Confirmed it fails on the old code (`expected: <state> but was: <string>`) and passes with the fix.
- `./mvnw test -pl core -Dtest=VSChartBindingScriptableTest` — all 27 tests pass.
- Manually verified in Composer: applying the repro script now correctly binds Color=State and Shape=Region, and the `Column not found: string` log warning is gone.

Fixes Redmine #75573.