### PR TITLE
Bug #75576, formula can't work on freehand table (GraalJS TableArray unwrap)

### DIFF
--- a/core/src/main/java/inetsoft/util/script/ScriptUtil.java
+++ b/core/src/main/java/inetsoft/util/script/ScriptUtil.java
@@ -41,6 +41,16 @@ public class ScriptUtil {
          return ((inetsoft.uql.script.XTableArray) obj).unwrap();
       }
 
+      // Likewise for a TableArray (the calc/report script table wrapper,
+      // e.g. the value returned by a calc cell's data['*@...'] subtable
+      // reference). It was also a Rhino Wrapper; unwrap it to its underlying
+      // XTable so host code (toList/mapList/etc.) can detect and process it as
+      // a table instead of leaving the non-serializable wrapper in a cell
+      // value. (#75576 / #75423)
+      if(obj instanceof inetsoft.report.script.TableArray) {
+         return ((inetsoft.report.script.TableArray) obj).unwrap();
+      }
+
       // @by larryl, if a calculation generates an invalid result, show null
       // instead of NaN of Infinity. This can be caused by performing a time
       // series comparison and the result fo the first or last item would

--- a/core/src/test/java/inetsoft/report/script/TableArrayTest.java
+++ b/core/src/test/java/inetsoft/report/script/TableArrayTest.java
@@ -20,6 +20,7 @@ package inetsoft.report.script;
 import inetsoft.report.lens.DefaultTableLens;
 import inetsoft.test.*;
 import inetsoft.uql.XTable;
+import inetsoft.util.script.ScriptUtil;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.annotation.DirtiesContext;
@@ -79,5 +80,17 @@ class TableArrayTest {
       assertFalse(arr.hasMember("nonexistent"));
       assertFalse(arr.hasMember("toString"));
       assertFalse(arr.hasMember("then"));
+   }
+
+   @Test
+   void unwrapReturnsUnderlyingXTable() {
+      // #75576: ScriptUtil.unwrap must unwrap a TableArray to its XTable so host
+      // code (toList/mapList/etc.) can process a data['*@...'] subtable reference
+      // instead of leaving the non-serializable wrapper in a cell value.
+      XTable xtable = table();
+      Object unwrapped = ScriptUtil.unwrap(new TableArray(xtable));
+
+      assertInstanceOf(XTable.class, unwrapped);
+      assertSame(xtable, unwrapped);
    }
 }


### PR DESCRIPTION
## Summary

A viewsheet containing a formula on a freehand (calc) table hangs forever in the "loading" state when opened on the portal. This is a regression from the Rhino → GraalJS JavaScript engine migration (feature #75423).

## Root Cause

A calc-table group cell formula such as:

```js
toList(data['*@=toList(rowValue["orderdate"], "rounddate=year,interval=1.0"):$orderdate_Year'],
       'remainder=Others ,sort=desc,field=state,sorton=sum(customer_id),maxrows=3')
```

`data['*@...']` (a subtable reference — any key starting with `*`) returns a new `inetsoft.report.script.TableArray` wrapping a subtable. `FormulaFunctions.toList` calls `JavaScriptEngine.unwrap()` → `ScriptUtil.unwrap()` and relies on it converting the `TableArray` to its underlying `XTable` so the `instanceof XTable` branch (using `field=state`) runs.

Pre-migration, Rhino's `ScriptUtil.unwrap` unwrapped **any** `org.mozilla.javascript.Wrapper` via `.unwrap()`, and `TableArray` was `implements ArrayObject, Wrapper`. The GraalJS migration replaced that generic check with a special case for `inetsoft.uql.script.XTableArray` **only**, silently dropping `TableArray`.

As a result `toList` returns the raw `TableArray` as the cell value. Serializing `LoadTableDataCommand` to JSON then throws `NullPointerException` (`DFWrapper.getHeaders()` is null) in `CommandDispatcher`, so the command is never sent to the client and the viewsheet stays in the loading state.

## Fix

In `ScriptUtil.unwrap`, add a case for `inetsoft.report.script.TableArray` that unwraps it to its underlying `XTable`, mirroring the existing `XTableArray` handling. This restores the exact pre-migration Rhino unwrap semantics at the single shared unwrap chokepoint.

## Test Plan

- Import `free.vso` and open it on the portal — the freehand table now loads instead of hanging; no script-related errors in the log.
- `./mvnw clean install -pl core -am -DskipTests` → BUILD SUCCESS.
- `./mvnw test -pl core -Dtest=TableArrayTest,XTableArrayTest,FormulaFunctionsTest,FormulaFunctions2Test` → 58 tests pass.

Fixes Redmine #75576.