### PR TITLE
Bug #75571, fix event.source.title returning undefined in viewsheet event scripts

### DIFF
--- a/core/src/main/java/inetsoft/analytic/composition/event/InputScriptEvent.java
+++ b/core/src/main/java/inetsoft/analytic/composition/event/InputScriptEvent.java
@@ -21,6 +21,7 @@ package inetsoft.analytic.composition.event;
 import inetsoft.report.script.viewsheet.ScriptEvent;
 import inetsoft.report.script.viewsheet.VSAScriptable;
 import inetsoft.uql.viewsheet.*;
+import inetsoft.util.script.graal.ScriptScope;
 
 /**
  * Event for viewsheet script, it keeps event source, assembly and other
@@ -29,7 +30,7 @@ import inetsoft.uql.viewsheet.*;
  * @version 14.0
  * @author InetSoft Technology Corp
  */
-public class InputScriptEvent implements ScriptEvent {
+public class InputScriptEvent implements ScriptEvent, ScriptScope {
    /**
     * Constructor.
     */
@@ -76,6 +77,40 @@ public class InputScriptEvent implements ScriptEvent {
    @Override
    public void setSource(VSAScriptable source) {
       this.source = source;
+   }
+
+   /**
+    * Get a named member. Exposing the event properties through the scope
+    * interface ensures the source scriptable is wrapped as a ScopeProxy, so
+    * nested access such as event.source.title resolves correctly.
+    */
+   @Override
+   public Object getMember(String id) {
+      switch(id) {
+      case "name":
+         return name;
+      case "type":
+         return type;
+      case "source":
+         return source;
+      default:
+         return null;
+      }
+   }
+
+   @Override
+   public boolean hasMember(String id) {
+      return "name".equals(id) || "type".equals(id) || "source".equals(id);
+   }
+
+   @Override
+   public void putMember(String id, Object value) {
+      // the event object is read-only from scripts
+   }
+
+   @Override
+   public Object[] getMemberKeys() {
+      return new String[]{ "name", "type", "source" };
    }
 
    public VSAScriptable source;     // source scriptable object

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/table/VSFormTableService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/table/VSFormTableService.java
@@ -26,6 +26,7 @@ import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.report.internal.Util;
 import inetsoft.report.script.viewsheet.ScriptEvent;
 import inetsoft.report.script.viewsheet.VSAScriptable;
+import inetsoft.util.script.graal.ScriptScope;
 import inetsoft.uql.ColumnSelection;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.schema.XSchema;
@@ -343,7 +344,7 @@ public class VSFormTableService {
     * Event for viewsheet script, it keeps event source, assembly and other
     * properties.
     */
-   public static final class TableScriptEvent implements ScriptEvent {
+   public static final class TableScriptEvent implements ScriptEvent, ScriptScope {
       /**
        * Constructure.
        */
@@ -367,6 +368,45 @@ public class VSFormTableService {
       @Override
       public void setSource(VSAScriptable source) {
          this.source = source;
+      }
+
+      /**
+       * Get a named member. Exposing the event properties through the scope
+       * interface ensures the source scriptable is wrapped as a ScopeProxy, so
+       * nested access such as event.source.title resolves correctly.
+       */
+      @Override
+      public Object getMember(String id) {
+         switch(id) {
+         case "name":
+            return name;
+         case "type":
+            return type;
+         case "source":
+            return source;
+         case "row":
+            return row;
+         case "column":
+            return column;
+         default:
+            return null;
+         }
+      }
+
+      @Override
+      public boolean hasMember(String id) {
+         return "name".equals(id) || "type".equals(id) || "source".equals(id) ||
+            "row".equals(id) || "column".equals(id);
+      }
+
+      @Override
+      public void putMember(String id, Object value) {
+         // the event object is read-only from scripts
+      }
+
+      @Override
+      public Object[] getMemberKeys() {
+         return new String[]{ "name", "type", "source", "row", "column" };
       }
 
       public VSAScriptable source;     // source scriptable object


### PR DESCRIPTION
## Summary

After the Rhino→GraalJS migration (#75423), viewsheet event-handler scripts saw `event.source.title` (and any nested scriptable access off `event.source`) return `undefined`. Reproduced with `sEvent.vso`: selecting a value on a selection list ran a script whose output showed `undefined` where the source assembly's title should appear.

## Root Cause

The `event` object handed to scripts is a plain Java object — `InputScriptEvent` (input/selection assemblies) or `TableScriptEvent` (form tables). Neither implemented `ScriptScope`, so `ViewsheetScope.getMember("event")` returned it raw and `ScriptValueConverter.toGuest()` (which only wraps `ScriptScope` instances in a `ScopeProxy`) exposed it as a raw GraalJS host object.

Reading `event.source` then returned the `VSAScriptable` as a raw host object as well. `VSAScriptable`'s `title` is registered dynamically via `addProperty(...)` and only resolves through its `getMember()` — reachable only when the object is wrapped in a `ScopeProxy`. As a raw host object it has no public `title` member, so `event.source.title` read as `undefined`. Under Rhino the returned `Scriptable` was used directly, so `.title` worked.

## Fix

Make both `ScriptEvent` implementations also implement `ScriptScope`, exposing their properties via `getMember`/`hasMember`/`getMemberKeys` (read-only `putMember`):

- `InputScriptEvent` — `name`, `type`, `source`
- `VSFormTableService.TableScriptEvent` — `name`, `type`, `source`, `row`, `column`

Now `getMember("event")` returns a `ScriptScope`, which `toGuest` wraps in a `ScopeProxy`; its `getMember("source")` returns the `VSAScriptable`, which `toGuest` re-wraps in a `ScopeProxy`, so `event.source.title` resolves through `VSAScriptable.getMember("title")`. Public fields are unchanged, so existing Java callers (`getName()`/`setSource()`/field reads) are unaffected.

## Test Plan

- Import `sEvent.vso`, open in the portal, select a value on the selection list (or trigger an action on another assembly). The event script's text now shows the source assembly title instead of `undefined` (e.g. `SelectionList1, selectionlist, undefined, undefined, state`). `row`/`column` remain `undefined` for a selection list, which is correct (no cell coordinates).
- `./mvnw -pl core -am compile` succeeds.
- GraalJS engine scope tests pass: `ScopeProxyTest`, `ScriptValueConverterTest`, `BindingRootProxyTest`, `ArrayProxyTest`, `GraalJavaScriptEngineScopeTest` (31 tests, 0 failures).

Fixes Redmine #75571.