### PR TITLE
Bug #75545, fix 401 instead of 404 when getting a non-existent role

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/DefaultCheckPermissionStrategy.java
+++ b/core/src/main/java/inetsoft/sree/security/DefaultCheckPermissionStrategy.java
@@ -570,8 +570,9 @@ public class DefaultCheckPermissionStrategy implements CheckPermissionStrategy {
 
          Role role = currProvider.getRole(resourceID);
 
+         // role doesn't exist, so just equals org name (see Bug #66393 for SECURITY_USER).
          if(role == null) {
-            return false;
+            return Objects.equals(resourceID.getOrgID(), orgID);
          }
 
          IdentityID[] roles = new IdentityID[]{role.getIdentityID()};

--- a/core/src/test/java/inetsoft/sree/security/DefaultCheckPermissionStrategyTest.java
+++ b/core/src/test/java/inetsoft/sree/security/DefaultCheckPermissionStrategyTest.java
@@ -221,6 +221,44 @@ class DefaultCheckPermissionStrategyTest {
    }
 
    // ─────────────────────────────────────────────────────────────────
+   // [Path C] Org admin checking a role that does not exist
+   // ─────────────────────────────────────────────────────────────────
+
+   // checkOrgAdminPermission's SECURITY_ROLE branch (line 571-575) unconditionally returned
+   // false when the target role did not exist, unlike the analogous SECURITY_USER branch
+   // (line 536-538, "Bug #66393") which falls back to comparing orgIDs. This meant an org
+   // admin looking up a non-existent role in their own org got permission denied (401)
+   // instead of reaching the "not found" (404) check in the calling API layer. (Bug #75545)
+   @Test
+   void orgAdminCanCheckNonExistentRoleInOwnOrg() {
+      String resource = new IdentityID("noExistRole", "org0").convertToKey();
+
+      try(MockedStatic<SUtil> mocked = Mockito.mockStatic(SUtil.class, Mockito.CALLS_REAL_METHODS)) {
+         mocked.when(SUtil::isMultiTenant).thenReturn(true);
+
+         assertTrue(
+            strategy.checkPermission(org_admin, ResourceType.SECURITY_ROLE, resource, ResourceAction.ADMIN),
+            "org admin should have admin permission over a non-existent role in their own org " +
+            "so the caller can surface a 'not found' rather than 'forbidden' result");
+      }
+   }
+
+   // Security boundary: a missing role in a *different* org must still be denied, so this
+   // doesn't leak role existence/permission across organizations.
+   @Test
+   void orgAdminCannotCheckNonExistentRoleInOtherOrg() {
+      String resource = new IdentityID("noExistRole", "otherOrg").convertToKey();
+
+      try(MockedStatic<SUtil> mocked = Mockito.mockStatic(SUtil.class, Mockito.CALLS_REAL_METHODS)) {
+         mocked.when(SUtil::isMultiTenant).thenReturn(true);
+
+         assertFalse(
+            strategy.checkPermission(org_admin, ResourceType.SECURITY_ROLE, resource, ResourceAction.ADMIN),
+            "org admin must not gain permission over a non-existent role outside their own org");
+      }
+   }
+
+   // ─────────────────────────────────────────────────────────────────
    // [Path B] System administrator bypasses all permission checks
    // ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `Get Role` (`/api/public/security/roles/{role}`) returned `401 Permission denied to get user` instead of `404` when queried with a role name that doesn't exist.
- Root cause: `DefaultCheckPermissionStrategy.checkOrgAdminPermission()`'s `SECURITY_ROLE` branch unconditionally returned `false` when the target role wasn't found, so the permission check failed *before* `SecurityApiService.getRole()` ever reached its "not found" check. The analogous `SECURITY_USER` branch already had this fix (Bug #66393) — falling back to an org-ID comparison when the identity doesn't exist — but it was never applied to roles.
- Fix mirrors the existing `SECURITY_USER` handling: when the role doesn't exist, grant permission if the resource's orgID matches the admin's own org (so a missing role in their own org surfaces 404), while still denying non-existent roles in other orgs (no cross-org info leak).

## Test plan
- [x] Added `orgAdminCanCheckNonExistentRoleInOwnOrg` — reproduces the bug (fails before the fix, passes after)
- [x] Added `orgAdminCannotCheckNonExistentRoleInOtherOrg` — confirms the org isolation boundary is preserved
- [x] `./mvnw -pl core test -Dtest=DefaultCheckPermissionStrategyTest` — all 32 tests pass