### PR TITLE
Bug #75580, fix script-created dataset dropped for EGraph charts under GraalJS

### DIFF
--- a/core/src/main/java/inetsoft/report/script/viewsheet/ChartVSAScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/viewsheet/ChartVSAScriptable.java
@@ -187,7 +187,12 @@ public class ChartVSAScriptable extends VSAScriptable implements CommonChartScri
             data.table = new DataSetTable(nset);
          }
       }
-      else if(name.equals("dataset") && !(value instanceof DataSet)) {
+      else if(name.equals("dataset")) {
+         // under GraalJS a script-created DataSet arrives unwrapped, so it is
+         // already 'instanceof DataSet' here; createDataSet() returns it as-is,
+         // while non-DataSet values (arrays/tables) are converted. Either way
+         // the result must be set on the creator so the script dataset reaches
+         // the graph. (Bug #75580)
          value = JavaScriptEngine.unwrap(value);
          DataSet nset = PropertyDescriptor.createDataSet(value);
 

--- a/core/src/test/java/inetsoft/report/script/viewsheet/ChartVSAScriptableTest.java
+++ b/core/src/test/java/inetsoft/report/script/viewsheet/ChartVSAScriptableTest.java
@@ -155,6 +155,14 @@ public class ChartVSAScriptableTest {
       chartVSAScriptable.putMember("dataset", data2);
       assert chartVSAScriptable.getMember("dataset") instanceof DefaultDataSet;
 
+      //put dataset as a DataSet instance. Under GraalJS a script-created DataSet
+      //(dataset = new DefaultDataSet(...)) arrives here unwrapped, so it must
+      //still be routed to the creator rather than dropped. (Bug #75580)
+      DefaultDataSet dataSet2 = new DefaultDataSet(
+         new Object[][]{{"State", "Quantity"}, {"NJ", 200}, {"NY", 300}});
+      chartVSAScriptable.putMember("dataset", dataSet2);
+      assertSame(dataSet2, chartVSAScriptable.getMember("dataset"));
+
       //put query
       chartVSAScriptable.putMember("query", "q1");
       assertEquals("q1", chartVSAScriptable.getMember("query"));


### PR DESCRIPTION
## Summary

A script-defined EGraph chart (e.g. the `ParallelCoord` chart in the `EGraph1_G` viewsheet) rendered empty after the Rhino→GraalJS script-engine migration — "No data is available!" (or axes at a default 0–1 range with no data lines). The chart's script assigns its own dataset via `dataset = new DefaultDataSet(arr)`.

## Root Cause

`ChartVSAScriptable.putMember` guarded the `"dataset"` branch with `else if(name.equals("dataset") && !(value instanceof DataSet))`. The `!(value instanceof DataSet)` guard assumed Rhino, which wrapped Java objects handed into a script scope in a `NativeJavaObject` — so a script-created `DataSet` was **not** directly `instanceof DataSet`, the guard passed, and the branch ran `JavaScriptEngine.unwrap(value)` + `PropertyDescriptor.createDataSet(value)` + `creator.setDataSet(nset)`, connecting the dataset to the graph.

Under GraalJS, host objects arrive **unwrapped** — `ScopeProxy.putMember` / `BindingRootProxy.putMember` both call `ScriptValueConverter.toHost(value)` before delegating — so `value` **is** a real `DataSet`. The guard becomes false, the branch is skipped, and `creator.setDataSet` is never called. In `VGraphPair`, `creator.getDataSet()` is then null, so the graph is rendered against the empty binding dataset.

## Fix

Remove the `&& !(value instanceof DataSet)` guard. `PropertyDescriptor.createDataSet` already returns a `DataSet` as-is and converts arrays/tables otherwise, so both cases now correctly reach `creator.setDataSet(nset)`. The non-DataSet path is unchanged (it already entered this branch and returned before the fall-through), and the skipped fall-through `super.putMember("dataset", value)` was dead — `getMember("dataset")` returns `creator.getDataSet()`, never the propmap.

## Test Plan

- Added a regression assertion to `ChartVSAScriptableTest.testPutProperties`: assigning a `DefaultDataSet` instance to `"dataset"` now round-trips via `getMember` (fails before the fix, passes after).
- `./mvnw test -pl core -Dtest=ChartVSAScriptableTest` — all 8 tests pass.
- Manually verified: opening `EGraph1_G` now renders the `ParallelCoord` chart with correct axis ranges (Quantity 0–200, Total 0–1000, Returns 0–20) and the data polylines.

Fixes Redmine #75580.