### PR TITLE
Bug #75574: org-scoped role admin permission leaks onto global roles

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/DefaultCheckPermissionStrategy.java
+++ b/core/src/main/java/inetsoft/sree/security/DefaultCheckPermissionStrategy.java
@@ -610,7 +610,7 @@ public class DefaultCheckPermissionStrategy implements CheckPermissionStrategy {
 
          // org admin permission never extends to global (org-less) roles — e.g. the built-in
          // Administrator and Organization Administrator roles — only to roles owned by this org
-         return !isSiteAdmin && Tool.equals(orgID, currProvider.getRole(resourceID).getOrganizationID());
+         return !isSiteAdmin && Tool.equals(orgID, role.getOrganizationID());
       case SECURITY_ORGANIZATION:
          if(resource.equals("*")) {
             return false;
@@ -764,11 +764,16 @@ public class DefaultCheckPermissionStrategy implements CheckPermissionStrategy {
             // the dedicated root-check block above, lines ~135-154)
             Role currentRole = provider.getRole(IdentityID.getIdentityIDFromKey(currentResource));
 
-            if(currentRole != null && currentRole.getOrganizationID() != null) {
+            if(currentRole != null && currentRole.getOrganizationID() != null &&
+               Tool.equals(currentRole.getOrganizationID(), OrganizationManager.getInstance().getCurrentOrgID()))
+            {
                perm = provider.getPermission(currentType, new IdentityID("Organization Roles", OrganizationManager.getInstance().getCurrentOrgID()));
             }
-            else {
+            else if(currentRole == null || currentRole.getOrganizationID() == null) {
                perm = provider.getPermission(currentType, new IdentityID("Roles", OrganizationManager.getInstance().getCurrentOrgID()));
+            }
+            else {
+               perm = null; // role belongs to a different org — no cumulative admin merge applies
             }
 
             if(perm != null) {

--- a/core/src/main/java/inetsoft/sree/security/DefaultCheckPermissionStrategy.java
+++ b/core/src/main/java/inetsoft/sree/security/DefaultCheckPermissionStrategy.java
@@ -329,10 +329,20 @@ public class DefaultCheckPermissionStrategy implements CheckPermissionStrategy {
       }
 
       if(type == ResourceType.SECURITY_ROLE) {
-         Permission rolePerm = provider.getPermission(type, new IdentityID("Organization Roles", organization), orgID);
+         // "Organization Roles" admin delegation only covers roles actually scoped to this
+         // org — never org-less/global roles like Administrator or Organization Administrator
+         Role orgRolesTarget = provider.getRole(IdentityID.getIdentityIDFromKey(resource));
+         boolean targetInOrgRoleScope = orgRolesTarget != null &&
+            Tool.equals(orgRolesTarget.getOrganizationID(), organization) &&
+            Arrays.stream(provider.getAllRoles(new IdentityID[]{ orgRolesTarget.getIdentityID() }))
+               .noneMatch(provider::isSystemAdministratorRole);
 
-         if(rolePerm != null && checker.checkPermission(identity, rolePerm, action, true)) {
-            return true;
+         if(targetInOrgRoleScope) {
+            Permission rolePerm = provider.getPermission(type, new IdentityID("Organization Roles", organization), orgID);
+
+            if(rolePerm != null && checker.checkPermission(identity, rolePerm, action, true)) {
+               return true;
+            }
          }
       }
 
@@ -380,10 +390,30 @@ public class DefaultCheckPermissionStrategy implements CheckPermissionStrategy {
             type == ResourceType.SECURITY_ROLE)
          {
             if((perm == null) || !perm.hasOrgEditedGrantAll(orgID) || type == ResourceType.SECURITY_ROLE) {
-               Permission orgPerm = provider.getPermission(ResourceType.SECURITY_ORGANIZATION, new IdentityID(organization, organization), orgID);
+               // org admin permission never extends to global (org-less) roles — e.g. the
+               // built-in Administrator and Organization Administrator roles — only to
+               // roles actually owned by this org
+               boolean roleOutOfOrgAdminScope = false;
 
-               if(orgPerm != null && checker.checkPermission(identity, orgPerm, ResourceAction.ADMIN, true)) {
-                  return true;
+               if(type == ResourceType.SECURITY_ROLE) {
+                  Role targetRole = provider.getRole(IdentityID.getIdentityIDFromKey(resource));
+
+                  if(targetRole == null || !Tool.equals(targetRole.getOrganizationID(), organization)) {
+                     roleOutOfOrgAdminScope = true;
+                  }
+                  else {
+                     roleOutOfOrgAdminScope = Arrays.stream(
+                        provider.getAllRoles(new IdentityID[]{ targetRole.getIdentityID() }))
+                        .anyMatch(provider::isSystemAdministratorRole);
+                  }
+               }
+
+               if(!roleOutOfOrgAdminScope) {
+                  Permission orgPerm = provider.getPermission(ResourceType.SECURITY_ORGANIZATION, new IdentityID(organization, organization), orgID);
+
+                  if(orgPerm != null && checker.checkPermission(identity, orgPerm, ResourceAction.ADMIN, true)) {
+                     return true;
+                  }
                }
             }
          }
@@ -578,8 +608,9 @@ public class DefaultCheckPermissionStrategy implements CheckPermissionStrategy {
          isSiteAdmin = Arrays.stream(currProvider.getAllRoles(roles))
             .anyMatch(currProvider::isSystemAdministratorRole);
 
-         return !isSiteAdmin && (currProvider.getRole(resourceID).getOrganizationID() == null ||
-                 orgID.equals(currProvider.getRole(resourceID).getOrganizationID()));
+         // org admin permission never extends to global (org-less) roles — e.g. the built-in
+         // Administrator and Organization Administrator roles — only to roles owned by this org
+         return !isSiteAdmin && Tool.equals(orgID, currProvider.getRole(resourceID).getOrganizationID());
       case SECURITY_ORGANIZATION:
          if(resource.equals("*")) {
             return false;
@@ -728,17 +759,17 @@ public class DefaultCheckPermissionStrategy implements CheckPermissionStrategy {
             }
          }
          else if(currentType == ResourceType.SECURITY_ROLE) {
+            // "Organization Roles" and "Roles" (global) are independent permission roots —
+            // only merge the one that actually owns the checked role (mirrors the guard at
+            // the dedicated root-check block above, lines ~135-154)
+            Role currentRole = provider.getRole(IdentityID.getIdentityIDFromKey(currentResource));
 
-            perm = provider.getPermission(currentType, new IdentityID("Organization Roles", OrganizationManager.getInstance().getCurrentOrgID()));
-
-            if(perm != null) {
-               users.addAll(perm.getOrgScopedUserGrants(action, orgId));
-               roles.addAll(perm.getOrgScopedRoleGrants(action, orgId));
-               groups.addAll(perm.getOrgScopedGroupGrants(action, orgId));
-               organizations.addAll(perm.getOrgScopedOrganizationGrants(action, orgId));
+            if(currentRole != null && currentRole.getOrganizationID() != null) {
+               perm = provider.getPermission(currentType, new IdentityID("Organization Roles", OrganizationManager.getInstance().getCurrentOrgID()));
             }
-
-            perm = provider.getPermission(currentType, new IdentityID("Roles", OrganizationManager.getInstance().getCurrentOrgID()));
+            else {
+               perm = provider.getPermission(currentType, new IdentityID("Roles", OrganizationManager.getInstance().getCurrentOrgID()));
+            }
 
             if(perm != null) {
                users.addAll(perm.getOrgScopedUserGrants(action, orgId));

--- a/core/src/test/java/inetsoft/sree/security/DefaultCheckPermissionStrategyTest.java
+++ b/core/src/test/java/inetsoft/sree/security/DefaultCheckPermissionStrategyTest.java
@@ -375,6 +375,191 @@ class DefaultCheckPermissionStrategyTest {
       );
    }
 
+   // Bug #75574: an org administrator (SECURITY_ORGANIZATION ADMIN on their own org) must not
+   // be granted SECURITY_ROLE ADMIN on the global system administrator role via the org-admin
+   // fallback (line ~382). That fallback previously granted access to ANY role once the caller
+   // had org-admin permission on their own org, without checking the target role's org or
+   // whether it is the system administrator role.
+   @Test
+   void orgAdminCannotAccessGlobalSystemAdministratorRole() {
+      IdentityID sysAdminRoleId = new IdentityID("Administrator", null);
+      String sysAdminRoleResource = sysAdminRoleId.convertToKey();
+      IdentityID orgIdentityID = new IdentityID(TEST_ORG, TEST_ORG);
+
+      Role sysAdminRole = mock(Role.class);
+      when(sysAdminRole.getIdentityID()).thenReturn(sysAdminRoleId);
+      when(sysAdminRole.getOrganizationID()).thenReturn(null);
+
+      Permission orgAdminPermission = grantedPermission(TEST_USER, TEST_ORG, ResourceAction.ADMIN, false);
+
+      try(MockedStatic<SUtil> sutilMock = Mockito.mockStatic(SUtil.class, Mockito.CALLS_REAL_METHODS);
+          MockedStatic<OrganizationManager> omMock =
+             Mockito.mockStatic(OrganizationManager.class, Mockito.CALLS_REAL_METHODS))
+      {
+         sutilMock.when(SUtil::isMultiTenant).thenReturn(false);
+         sutilMock.when(() -> SUtil.isInternalUser(any())).thenReturn(false);
+
+         OrganizationManager mockOM = mock(OrganizationManager.class);
+         omMock.when(OrganizationManager::getInstance).thenReturn(mockOM);
+         omMock.when(OrganizationManager::getCurrentOrgName).thenReturn(TEST_ORG);
+         when(mockOM.getCurrentOrgID()).thenReturn(TEST_ORG);
+         when(mockOM.getCurrentOrgID(any())).thenReturn(TEST_ORG);
+         when(mockOM.isSiteAdmin(any(Principal.class))).thenReturn(false);
+
+         when(mockProvider.getRole(eq(sysAdminRoleId))).thenReturn(sysAdminRole);
+         when(mockProvider.isSystemAdministratorRole(eq(sysAdminRoleId))).thenReturn(true);
+         when(mockProvider.isOrgAdministratorRole(eq(new IdentityID(TEST_ROLE, TEST_ORG)))).thenReturn(true);
+         when(mockProvider.getPermission(eq(ResourceType.SECURITY_ORGANIZATION), eq(orgIdentityID)))
+            .thenReturn(orgAdminPermission);
+         when(mockProvider.getPermission(eq(ResourceType.SECURITY_ORGANIZATION), eq(orgIdentityID), eq(TEST_ORG)))
+            .thenReturn(orgAdminPermission);
+
+         assertFalse(
+            mockStrategy.checkPermission(mockUser, ResourceType.SECURITY_ROLE, sysAdminRoleResource,
+                                         ResourceAction.ADMIN),
+            "org administrator must not gain ADMIN over the global system administrator role");
+      }
+   }
+
+   // Bug #75574 (follow-up): a plain user granted ADMIN specifically on the "Organization Roles"
+   // node of their own org (a standard delegation action, not requiring the org-admin role or
+   // SECURITY_ORGANIZATION permission) must not be able to manage global/org-less roles such as
+   // "Administrator" or "Organization Administrator" through that grant.
+   @Test
+   void organizationRolesDelegationCannotAccessGlobalRole() {
+      IdentityID sysAdminRoleId = new IdentityID("Administrator", null);
+      String sysAdminRoleResource = sysAdminRoleId.convertToKey();
+      IdentityID orgRolesNodeId = new IdentityID("Organization Roles", TEST_ORG);
+
+      Role sysAdminRole = mock(Role.class);
+      when(sysAdminRole.getIdentityID()).thenReturn(sysAdminRoleId);
+      when(sysAdminRole.getOrganizationID()).thenReturn(null);
+
+      Permission orgRolesPermission = grantedPermission(TEST_USER, TEST_ORG, ResourceAction.ADMIN, false);
+
+      try(MockedStatic<SUtil> sutilMock = Mockito.mockStatic(SUtil.class, Mockito.CALLS_REAL_METHODS);
+          MockedStatic<OrganizationManager> omMock =
+             Mockito.mockStatic(OrganizationManager.class, Mockito.CALLS_REAL_METHODS))
+      {
+         sutilMock.when(SUtil::isMultiTenant).thenReturn(false);
+         sutilMock.when(() -> SUtil.isInternalUser(any())).thenReturn(false);
+
+         OrganizationManager mockOM = mock(OrganizationManager.class);
+         omMock.when(OrganizationManager::getInstance).thenReturn(mockOM);
+         omMock.when(OrganizationManager::getCurrentOrgName).thenReturn(TEST_ORG);
+         when(mockOM.getCurrentOrgID()).thenReturn(TEST_ORG);
+         when(mockOM.getCurrentOrgID(any())).thenReturn(TEST_ORG);
+         when(mockOM.isSiteAdmin(any(Principal.class))).thenReturn(false);
+
+         // mockUser is NOT an org admin — access comes only from the direct "Organization
+         // Roles" node grant, not from any org-admin role or SECURITY_ORGANIZATION permission.
+         when(mockProvider.getRole(eq(sysAdminRoleId))).thenReturn(sysAdminRole);
+         when(mockProvider.isSystemAdministratorRole(eq(sysAdminRoleId))).thenReturn(true);
+         when(mockProvider.getPermission(eq(ResourceType.SECURITY_ROLE), eq(orgRolesNodeId), eq(TEST_ORG)))
+            .thenReturn(orgRolesPermission);
+
+         assertFalse(
+            mockStrategy.checkPermission(mockUser, ResourceType.SECURITY_ROLE, sysAdminRoleResource,
+                                         ResourceAction.ADMIN),
+            "\"Organization Roles\" delegation must not extend to global/org-less roles");
+      }
+   }
+
+   // Bug #75574 follow-up [tester-reported Bug 1]: checkOrgAdminPermission()'s SECURITY_ROLE
+   // case previously allowed ANY org-less role through via a "getOrganizationID() == null"
+   // disjunct, gated only by isSiteAdmin (which checks isSystemAdministratorRole). The built-in
+   // "Organization Administrator" role is global (org-less) but is NOT itself flagged as the
+   // system administrator role, so it slipped past that guard — letting any org-admin-permission
+   // holder manage the very role that grants org-admin privilege in the first place.
+   @Test
+   void orgAdminCannotAccessGlobalOrganizationAdministratorRole() {
+      IdentityID orgAdminRoleId = new IdentityID("Organization Administrator", null);
+      String orgAdminRoleResource = orgAdminRoleId.convertToKey();
+      IdentityID orgIdentityID = new IdentityID(TEST_ORG, TEST_ORG);
+
+      Role orgAdminRole = mock(Role.class);
+      when(orgAdminRole.getIdentityID()).thenReturn(orgAdminRoleId);
+      when(orgAdminRole.getOrganizationID()).thenReturn(null);
+
+      Permission orgAdminPermission = grantedPermission(TEST_USER, TEST_ORG, ResourceAction.ADMIN, false);
+
+      try(MockedStatic<SUtil> sutilMock = Mockito.mockStatic(SUtil.class, Mockito.CALLS_REAL_METHODS);
+          MockedStatic<OrganizationManager> omMock =
+             Mockito.mockStatic(OrganizationManager.class, Mockito.CALLS_REAL_METHODS))
+      {
+         sutilMock.when(SUtil::isMultiTenant).thenReturn(false);
+         sutilMock.when(() -> SUtil.isInternalUser(any())).thenReturn(false);
+
+         OrganizationManager mockOM = mock(OrganizationManager.class);
+         omMock.when(OrganizationManager::getInstance).thenReturn(mockOM);
+         omMock.when(OrganizationManager::getCurrentOrgName).thenReturn(TEST_ORG);
+         when(mockOM.getCurrentOrgID()).thenReturn(TEST_ORG);
+         when(mockOM.getCurrentOrgID(any())).thenReturn(TEST_ORG);
+         when(mockOM.isSiteAdmin(any(Principal.class))).thenReturn(false);
+
+         when(mockProvider.getRole(eq(orgAdminRoleId))).thenReturn(orgAdminRole);
+         // NOT flagged as system administrator — that's exactly the gap: isSiteAdmin checked
+         // isSystemAdministratorRole only, never isOrgAdministratorRole or org-less-ness alone.
+         when(mockProvider.isSystemAdministratorRole(eq(orgAdminRoleId))).thenReturn(false);
+         when(mockProvider.isOrgAdministratorRole(eq(new IdentityID(TEST_ROLE, TEST_ORG)))).thenReturn(true);
+         when(mockProvider.getPermission(eq(ResourceType.SECURITY_ORGANIZATION), eq(orgIdentityID)))
+            .thenReturn(orgAdminPermission);
+         when(mockProvider.getPermission(eq(ResourceType.SECURITY_ORGANIZATION), eq(orgIdentityID), eq(TEST_ORG)))
+            .thenReturn(orgAdminPermission);
+
+         assertFalse(
+            mockStrategy.checkPermission(mockUser, ResourceType.SECURITY_ROLE, orgAdminRoleResource,
+                                         ResourceAction.ADMIN),
+            "org administrator must not gain ADMIN over the global Organization Administrator role");
+      }
+   }
+
+   // Bug #75574 follow-up [tester-reported Bug 2 / S2-GLOBAL-ROLE-ROOT]: the private ADMIN-
+   // cumulative getPermission() helper unconditionally merged grants from BOTH the
+   // "Organization Roles" and "Roles" (global) permission roots into one synthetic Permission
+   // for any SECURITY_ROLE ADMIN check, regardless of which root the checked role actually
+   // belongs to. An ADMIN grant on an org's "Organization Roles" root must not leak onto a
+   // global (org-less) role, and vice versa.
+   @Test
+   void organizationRolesRootGrantDoesNotLeakOntoGlobalRoleViaAdminCumulativeHelper() {
+      IdentityID globalRoleId = new IdentityID("Designer", null);
+      String globalRoleResource = globalRoleId.convertToKey();
+      IdentityID orgRolesNodeId = new IdentityID("Organization Roles", TEST_ORG);
+
+      Role globalRole = mock(Role.class);
+      when(globalRole.getIdentityID()).thenReturn(globalRoleId);
+      when(globalRole.getOrganizationID()).thenReturn(null);
+
+      Permission orgRolesRootPermission = grantedPermission(TEST_USER, TEST_ORG, ResourceAction.ADMIN, false);
+
+      try(MockedStatic<SUtil> sutilMock = Mockito.mockStatic(SUtil.class, Mockito.CALLS_REAL_METHODS);
+          MockedStatic<OrganizationManager> omMock =
+             Mockito.mockStatic(OrganizationManager.class, Mockito.CALLS_REAL_METHODS))
+      {
+         sutilMock.when(SUtil::isMultiTenant).thenReturn(false);
+         sutilMock.when(() -> SUtil.isInternalUser(any())).thenReturn(false);
+
+         OrganizationManager mockOM = mock(OrganizationManager.class);
+         omMock.when(OrganizationManager::getInstance).thenReturn(mockOM);
+         omMock.when(OrganizationManager::getCurrentOrgName).thenReturn(TEST_ORG);
+         when(mockOM.getCurrentOrgID()).thenReturn(TEST_ORG);
+         when(mockOM.getCurrentOrgID(any())).thenReturn(TEST_ORG);
+         when(mockOM.isSiteAdmin(any(Principal.class))).thenReturn(false);
+
+         when(mockProvider.getRole(eq(globalRoleId))).thenReturn(globalRole);
+         // grant only exists on the "Organization Roles" root (2-arg lookup, exactly as used
+         // by the ADMIN-cumulative helper) — never on the "Roles" (global) root, and never as
+         // a SECURITY_ORGANIZATION or org-admin-role grant, to isolate this code path.
+         when(mockProvider.getPermission(eq(ResourceType.SECURITY_ROLE), eq(orgRolesNodeId)))
+            .thenReturn(orgRolesRootPermission);
+
+         assertFalse(
+            mockStrategy.checkPermission(mockUser, ResourceType.SECURITY_ROLE, globalRoleResource,
+                                         ResourceAction.ADMIN),
+            "ADMIN on the org's \"Organization Roles\" root must not leak onto a global role");
+      }
+   }
+
    // ─────────────────────────────────────────────────────────────────
    // [Path F] Hierarchical resource traversal falls back to parent — mock-based
    // ─────────────────────────────────────────────────────────────────

--- a/core/src/test/java/inetsoft/sree/security/DefaultCheckPermissionStrategyTest.java
+++ b/core/src/test/java/inetsoft/sree/security/DefaultCheckPermissionStrategyTest.java
@@ -560,6 +560,52 @@ class DefaultCheckPermissionStrategyTest {
       }
    }
 
+   // PR #4187 review follow-up: the ADMIN-cumulative helper's SECURITY_ROLE branch checked only
+   // "does the target role have SOME org" (getOrganizationID() != null), not "does that org match
+   // the current org context" — so an ADMIN grant on org A's "Organization Roles" node leaked
+   // onto a specific role belonging to a completely different org B, a cross-tenant escalation
+   // distinct from the org-less/global-role leak covered above.
+   @Test
+   void organizationRolesRootGrantDoesNotLeakOntoDifferentOrgsRole() {
+      String otherOrg = "otherOrg";
+      IdentityID otherOrgRoleId = new IdentityID("otherOrgRole", otherOrg);
+      String otherOrgRoleResource = otherOrgRoleId.convertToKey();
+      IdentityID orgRolesNodeId = new IdentityID("Organization Roles", TEST_ORG);
+
+      Role otherOrgRole = mock(Role.class);
+      when(otherOrgRole.getIdentityID()).thenReturn(otherOrgRoleId);
+      when(otherOrgRole.getOrganizationID()).thenReturn(otherOrg);
+
+      Permission orgRolesRootPermission = grantedPermission(TEST_USER, TEST_ORG, ResourceAction.ADMIN, false);
+
+      try(MockedStatic<SUtil> sutilMock = Mockito.mockStatic(SUtil.class, Mockito.CALLS_REAL_METHODS);
+          MockedStatic<OrganizationManager> omMock =
+             Mockito.mockStatic(OrganizationManager.class, Mockito.CALLS_REAL_METHODS))
+      {
+         sutilMock.when(SUtil::isMultiTenant).thenReturn(false);
+         sutilMock.when(() -> SUtil.isInternalUser(any())).thenReturn(false);
+
+         OrganizationManager mockOM = mock(OrganizationManager.class);
+         omMock.when(OrganizationManager::getInstance).thenReturn(mockOM);
+         omMock.when(OrganizationManager::getCurrentOrgName).thenReturn(TEST_ORG);
+         when(mockOM.getCurrentOrgID()).thenReturn(TEST_ORG);
+         when(mockOM.getCurrentOrgID(any())).thenReturn(TEST_ORG);
+         when(mockOM.isSiteAdmin(any(Principal.class))).thenReturn(false);
+
+         when(mockProvider.getRole(eq(otherOrgRoleId))).thenReturn(otherOrgRole);
+         // grant only exists on the caller's own org's "Organization Roles" root — never on the
+         // target role's own org, and never as a SECURITY_ORGANIZATION or org-admin-role grant,
+         // to isolate this code path.
+         when(mockProvider.getPermission(eq(ResourceType.SECURITY_ROLE), eq(orgRolesNodeId)))
+            .thenReturn(orgRolesRootPermission);
+
+         assertFalse(
+            mockStrategy.checkPermission(mockUser, ResourceType.SECURITY_ROLE, otherOrgRoleResource,
+                                         ResourceAction.ADMIN),
+            "ADMIN on org A's \"Organization Roles\" root must not leak onto org B's role");
+      }
+   }
+
    // ─────────────────────────────────────────────────────────────────
    // [Path F] Hierarchical resource traversal falls back to parent — mock-based
    // ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
An org-scoped SECURITY_ROLE admin delegation (via org-admin role, `SECURITY_ORGANIZATION` admin permission, or a direct grant on the "Organization Roles" node in Security > Users) was not scoped to the granting org, letting an org's delegate manage global/org-less roles such as the built-in `Administrator` and `Organization Administrator` roles — including reading full role details (e.g. `isSysAdmin: true`) via a direct REST call to `/api/em/security/providers/{provider}/roles/{role}/`, even though the EM UI correctly hides these roles from that user.

Four independent paths in `DefaultCheckPermissionStrategy.checkPermission()` had this gap:
- The "Organization Roles" node direct-grant fallback didn't check that the target role actually belongs to the granting org.
- The org-admin `SECURITY_ORGANIZATION`-permission fallback had the same gap, and additionally allowed *any* org-less role through unconditionally.
- `checkOrgAdminPermission()`'s `SECURITY_ROLE` case explicitly allowed org-less roles through via a `role.getOrganizationID() == null` disjunct, gated only by `isSystemAdministratorRole` — so an org-admin-flagged-but-not-sysadmin-flagged role (`Organization Administrator`) slipped past.
- The private ADMIN-cumulative `getPermission()` helper unconditionally merged grants from *both* the `"Organization Roles"` and `"Roles"` (global) permission roots into one synthetic permission, regardless of which root the checked role actually belongs to.

Each path now requires the checked role's own organization to match the granting org (or excludes org-less roles from cross-root merges entirely), mirroring the guard already used correctly elsewhere in the same file (lines ~135-154).

## Test plan
- [x] Added 4 regression tests to `DefaultCheckPermissionStrategyTest`, one per fixed path — each verified to fail against the pre-fix code and pass after the fix (confirmed by temporarily reverting each fix independently).
- [x] Full `inetsoft.sree.security.**` + `inetsoft.web.admin.security.**` test packages: 2622 tests, 0 failures, 0 errors.