### PR TITLE
Bug #75593, restore scalar coercion for named calc-table cell references under GraalJS

### DIFF
--- a/core/src/main/java/inetsoft/report/script/formula/CalcRef.java
+++ b/core/src/main/java/inetsoft/report/script/formula/CalcRef.java
@@ -20,6 +20,8 @@ package inetsoft.report.script.formula;
 import inetsoft.report.internal.table.*;
 import inetsoft.util.script.FormulaContext;
 import inetsoft.util.script.graal.ScriptArrayScope;
+import inetsoft.util.script.graal.ScriptValueConverter;
+import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,6 +95,43 @@ public class CalcRef implements ScriptArrayScope {
          // value of the reference is null
          else if(".".equals(id)) {
             return unwrap();
+         }
+         // GraalJS's ToPrimitive coercion (used by ==, string concatenation,
+         // template literals, etc.) probes for callable toString/valueOf
+         // members before falling back to a default conversion. hasMember()
+         // reports true for every id (needed so arbitrary $name@group?cond
+         // specs dispatch here), so without a real implementation the probe
+         // would fall through to getBySpec() below, fail to parse "toString"/
+         // "valueOf" as a CellRange spec, and return non-callable null,
+         // breaking the coercion. Mirrors Rhino's getDefaultValue(Class),
+         // which returned unwrap() directly for the same cases. (#75593)
+         //
+         // unwrap() runs inside the lambda body (invoked later by GraalJS,
+         // after this method's own try/catch has already returned), so it
+         // needs its own try/catch to keep failures degrading to null like
+         // every other accessor in this class instead of propagating as an
+         // uncaught PolyglotException that aborts the whole formula.
+         else if("valueOf".equals(id)) {
+            return (ProxyExecutable) args -> {
+               try {
+                  return ScriptValueConverter.toGuest(unwrap());
+               }
+               catch(Exception ex) {
+                  LOG.warn("Failed to get reference property: " + id, ex);
+                  return null;
+               }
+            };
+         }
+         else if("toString".equals(id)) {
+            return (ProxyExecutable) args -> {
+               try {
+                  return String.valueOf(unwrap());
+               }
+               catch(Exception ex) {
+                  LOG.warn("Failed to get reference property: " + id, ex);
+                  return null;
+               }
+            };
          }
          // check positional reference
          else if(id.length() > 0) {

--- a/core/src/test/java/inetsoft/report/script/formula/CalcRefTest.java
+++ b/core/src/test/java/inetsoft/report/script/formula/CalcRefTest.java
@@ -22,6 +22,7 @@ import inetsoft.report.internal.table.*;
 import inetsoft.report.script.viewsheet.CalcTableVSAScriptable;
 import inetsoft.test.*;
 import inetsoft.util.script.FormulaContext;
+import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -153,6 +154,36 @@ public class CalcRefTest {
 
       Object result2 = calcRef.getMember(".");
       assertArrayEquals(new Object[] {1, null}, (Object[])result2);
+   }
+
+   /**
+    * test get with valueOf (GraalJS ToPrimitive coercion)
+    */
+   @Test
+   void testGetWithValueOf() {
+      FormulaContext.pushCellLocation(point0);
+      when(mockRuntimeCalcTableLens.getCellContext(0, 0)).thenReturn(mockContext);
+      provideMockGroup(mockContext, "cell1", 1, "value1");
+
+      calcRef = new CalcRef(mockRuntimeCalcTableLens, "cell1");
+      Object member = calcRef.getMember("valueOf");
+      assertInstanceOf(ProxyExecutable.class, member);
+      assertEquals("value1", ((ProxyExecutable) member).execute());
+   }
+
+   /**
+    * test get with toString (GraalJS ToPrimitive coercion)
+    */
+   @Test
+   void testGetWithToString() {
+      FormulaContext.pushCellLocation(point0);
+      when(mockRuntimeCalcTableLens.getCellContext(0, 0)).thenReturn(mockContext);
+      provideMockGroup(mockContext, "cell1", 1, "value1");
+
+      calcRef = new CalcRef(mockRuntimeCalcTableLens, "cell1");
+      Object member = calcRef.getMember("toString");
+      assertInstanceOf(ProxyExecutable.class, member);
+      assertEquals("value1", ((ProxyExecutable) member).execute());
    }
 
    /**


### PR DESCRIPTION
## Summary

Importing a freehand table with a date-grouped column (e.g. an hour-level group on a date field) shows blank cells for that group column and its sibling summary cells, with repeated warnings logged for the internal auto-generated named cell reference (e.g. `$ftime_Hour`).

## Root Cause

`CalcRef` (the named `$name` cell-reference scriptable for calc/freehand tables) was ported from Rhino to GraalJS during the JS engine migration (#75423, Feature #75423). Under Rhino, `CalcRef` overrode `getDefaultValue(Class hint)` to return `unwrap()` (the reference's actual scalar value) whenever the reference needed to be coerced to a primitive (`==`/`!=` comparisons, string concatenation, etc.). GraalJS has no equivalent hook — its `ToPrimitive`/`OrdinaryToPrimitive` algorithm instead probes for callable `"toString"`/`"valueOf"` members.

`CalcRef.hasMember(String id)` unconditionally returns `true` for any id (required so arbitrary specs like `$name@group?cond` dispatch to `getMember`). This misleads GraalJS into believing `CalcRef` supplies real `toString`/`valueOf` implementations. `getMember("toString")` isn't one of the special-cased ids, so it falls through to `getBySpec()`, which tries to parse `"toString"` as a `CellRange` spec fragment and fails, returning non-callable `null`. The coercion then breaks, and any calc-table logic depending on it (e.g. Top-N/"Others" grouping comparisons against an auto-generated date-grouped cell name like `$ftime_Hour`) silently fails, leaving the dependent cells blank.

Confirmed via server logs showing the exact failure chain:
```
java.lang.Exception: Group value missing from range: ftime_Hour@toString
	at inetsoft.report.script.formula.CalcRef.getBySpec(CalcRef.java:199)
	at inetsoft.report.script.formula.CalcRef.getMember(CalcRef.java:114)
	at inetsoft.util.script.graal.ArrayProxy.getMember(ArrayProxy.java:75)
	...
	at com.oracle.truffle.js.nodes.cast.OrdinaryToPrimitiveNode.doForeignHintString(...)
	at com.oracle.truffle.js.nodes.binary.JSEqualNodeGen.executeBoolean(...)
```

## Fix

Add explicit `"valueOf"`/`"toString"` handling in `CalcRef.getMember()`, returning real callables backed by `unwrap()` — mirroring Rhino's `getDefaultValue()` exactly. Each callable has its own try/catch so a failure in `unwrap()` degrades to `null` with a logged warning (consistent with every other accessor in this class) instead of propagating an uncaught `PolyglotException` that would abort the whole formula.

Scoped to `CalcRef` only; no other classes touched.

**Note (accepted trade-off):** because `"toString"`/`"valueOf"` are now intercepted before the `getBySpec()` fallback, a calc group named literally `toString` or `valueOf` is no longer reachable via `$name.toString`/`$name.valueOf` dot-access (it remains reachable via `@`/bracket spec forms). This is a vanishingly unlikely name collision and an acceptable trade-off for fixing the far more common coercion failure.

## Test Plan

- [x] `./mvnw -pl core -am compile` — builds cleanly
- [x] `./mvnw -pl core -am -Dtest=CalcRefTest,CalcTableLensTest,RuntimeCalcTableLensTest,CalcTableScopeTest,CalcTableVSAScriptableTest test` — 88/88 tests pass
- [x] Added `testGetWithValueOf`/`testGetWithToString` regression tests covering the two new `getMember` branches
- [x] Reproduced the original bug by importing a freehand table viewsheet with an hour-level date-grouped column; confirmed the group column and dependent summary cells now render correctly and the `CalcRef` toString/join warnings are gone (user-verified)

Fixes Redmine #75593.