### PR TITLE
Bug #75569, fix dataConditions script returning undefined attr/value under GraalJS

### DIFF
--- a/core/src/main/java/inetsoft/report/script/viewsheet/VSAScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/viewsheet/VSAScriptable.java
@@ -28,6 +28,7 @@ import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.ContainerVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
 import inetsoft.util.script.*;
+import inetsoft.util.script.graal.ScriptArrayScope;
 import inetsoft.util.script.graal.ScriptFunction;
 import inetsoft.util.script.graal.ScriptScope;
 import inetsoft.web.vswizard.recommender.WizardRecommenderUtil;
@@ -36,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import java.awt.*;
 import java.util.*;
+import java.util.List;
 import java.util.stream.Collectors;
 
 /**
@@ -949,7 +951,7 @@ public class VSAScriptable
    /**
     * Get tipped assembly's tip condition.
     */
-   protected ScriptScope[] getTipConditions() {
+   protected ScriptArrayScope getTipConditions() {
       ConditionListWrapper wrapper = getVSAssembly().getTipConditionList();
 
       if(wrapper == null || wrapper.isEmpty()) {
@@ -957,7 +959,7 @@ public class VSAScriptable
       }
 
       int size = wrapper.getConditionSize();
-      ArrayList<ScriptScope> items = new ArrayList<>();
+      List<ScriptScope> items = new ArrayList<>();
       ConditionItem item;
       Condition cond;
 
@@ -974,7 +976,7 @@ public class VSAScriptable
          items.add(new TipDataCondition(attr, value));
       }
 
-      return items.toArray(new ScriptScope[0]);
+      return new TipDataConditionArray(items);
    }
 
    protected Map<String, Object> getVarMap() {
@@ -1021,6 +1023,51 @@ public class VSAScriptable
 
       private final String attr;
       private final Object value;
+   }
+
+   /**
+    * Array-shaped scope wrapping the tip/data conditions so that indexed access
+    * (conds[i]) routes each element through ScriptValueConverter.toGuest and is
+    * exposed to scripts as a ScopeProxy. A plain ScriptScope[] would be handed
+    * to GraalJS as a raw host array whose elements bypass the converter, leaving
+    * conds[i].attr / conds[i].value undefined. (#75569)
+    */
+   private static class TipDataConditionArray implements ScriptArrayScope {
+      TipDataConditionArray(List<ScriptScope> items) {
+         this.items = items;
+      }
+
+      @Override
+      public long getArraySize() {
+         return items.size();
+      }
+
+      @Override
+      public Object getArrayElement(long index) {
+         return index >= 0 && index < items.size() ? items.get((int) index) : null;
+      }
+
+      @Override
+      public Object getMember(String id) {
+         return "length".equals(id) ? items.size() : null;
+      }
+
+      @Override
+      public boolean hasMember(String id) {
+         return "length".equals(id);
+      }
+
+      @Override
+      public void putMember(String id, Object value) {
+         // read-only
+      }
+
+      @Override
+      public Object[] getMemberKeys() {
+         return new Object[] {"length"};
+      }
+
+      private final List<ScriptScope> items;
    }
 
    @Override


### PR DESCRIPTION
## Summary

A viewsheet table script that reads `Query1.dataConditions` and builds the title from each condition's `attr`/`value` rendered `Filter: undefined = undefined` after the Rhino→GraalJS migration (Feature #75423), instead of showing the selected VO's label.

## Root Cause

`VSAScriptable.getTipConditions()` returned a plain Java `ScriptScope[]` array of `TipDataCondition` elements. `ScriptValueConverter.toGuest()` only bridges `ScriptArrayScope` (→ `ArrayProxy`) and `ScriptScope` (→ `ScopeProxy`); a raw `ScriptScope[]` array falls through and GraalJS auto-wraps it. Auto-wrap supports `.length` and indexing (so the loop ran without error), but indexing returns the **raw host** `TipDataCondition` — bypassing `toGuest`. Its `attr`/`value` are private fields with no getters (accessible only via `getMember`), so `conds[i].attr` / `conds[i].value` read as `undefined`.

Under Rhino this worked because Rhino auto-wrapped each `Scriptable` array element via the `Scriptable` interface. `getTipConditions()` was the only remaining method returning a raw `ScriptScope[]`.

## Fix

`getTipConditions()` now returns a `ScriptArrayScope` (new inner class `TipDataConditionArray` wrapping a `List<ScriptScope>`). `toGuest` bridges it to the existing, unit-tested `ArrayProxy`, whose `get(index)` runs each element through `toGuest` (→ `ScopeProxy`), so `.attr`/`.value` resolve. `.length` is provided via `ProxyArray.getSize()`. The empty-conditions `null` return is preserved. Also added an explicit `import java.util.List;` to disambiguate from `java.awt.List` (both wildcard-imported).

All three call sites (`TableDataVSAScriptable`, `ChartVSAScriptable`, `OutputVSAScriptable`) share `getTipConditions()` and are fixed by this change; each just returns it from an `Object`-typed `getMember`, so the return-type change is transparent.

## Test Plan

- Import `datacondition.vso`, open on portal, select a VO on the chart → the table title now shows the selected VO's label (e.g. `Filter: <attr> = <value>`) instead of `undefined=undefined`. (Verified.)
- `./mvnw -o compile -pl core` succeeds.
- GraalJS script test suite (`inetsoft.util.script.graal.*Test`) passes: 81 tests, 0 failures.

Fixes Redmine #75569.