### PR TITLE
Bug #75577, restore JavaBeans property access for graph objects in chart scripts

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/HostBeanProxy.java
+++ b/core/src/main/java/inetsoft/util/script/graal/HostBeanProxy.java
@@ -61,6 +61,13 @@ import java.util.concurrent.ConcurrentHashMap;
  * evaluates to {@code false} for a wrapped object. The {@code ProxyObject} SPI has
  * no hook to answer host {@code instanceof}. Scripts should branch on behavior
  * (method/property presence) rather than Java type.
+ *
+ * <p><b>Known limitation:</b> argument unwrapping only inspects the top-level
+ * argument {@code Value}. A wrapper nested inside an array/{@code List}/varargs
+ * argument would reach the host call still wrapped. This is not exercised by the
+ * current API surface (no {@code EGraph}/{@code GraphElement} method takes a
+ * collection of graph elements), but a future method that does would need to
+ * unwrap collection elements as well.
  */
 public final class HostBeanProxy implements ProxyObject {
    // Intern wrappers per underlying object so that repeated access to the same
@@ -162,7 +169,8 @@ public final class HostBeanProxy implements ProxyObject {
          return wrapResult(host.invokeMember(getter));
       }
 
-      // Native public field.
+      // Native public field. Reached only when no bean getter matched above, so a
+      // same-named bean accessor deliberately takes precedence over a native field.
       if(host.hasMember(key)) {
          return wrapResult(host.getMember(key));
       }
@@ -181,7 +189,8 @@ public final class HostBeanProxy implements ProxyObject {
          return;
       }
 
-      // Native writable field.
+      // Native writable field. Reached only when no bean setter matched above, so a
+      // same-named bean accessor deliberately takes precedence over a native field.
       Value host = hostValue();
 
       if(host.hasMember(key)) {

--- a/core/src/main/java/inetsoft/util/script/graal/HostBeanProxy.java
+++ b/core/src/main/java/inetsoft/util/script/graal/HostBeanProxy.java
@@ -1,0 +1,288 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util.script.graal;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import inetsoft.graph.EGraph;
+import inetsoft.graph.element.GraphElement;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import org.graalvm.polyglot.proxy.ProxyExecutable;
+import org.graalvm.polyglot.proxy.ProxyObject;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Restores Rhino-style JavaBeans property access for the graph host objects that
+ * chart binding scripts manipulate directly ({@link EGraph} and its
+ * {@link GraphElement}s).
+ *
+ * <p>Rhino's {@code NativeJavaObject} automatically mapped bean syntax
+ * ({@code element.endArrow = true} to {@code setEndArrow(true)},
+ * {@code element.endArrow} to {@code isEndArrow()}). GraalJS's {@code HostAccess}
+ * exposes only the raw accessor methods ({@code isEndArrow}/{@code setEndArrow}) and
+ * does <em>not</em> synthesize a {@code endArrow} property, so a Rhino-era script
+ * that assigns {@code element.endArrow = true} silently no-ops. This proxy re-adds
+ * the getter/setter&harr;property mapping <em>on top of</em> GraalJS's native host
+ * member handling. (#75577)
+ *
+ * <p>Method calls, overload resolution, and argument coercion are delegated to
+ * GraalJS (via {@link Value#invokeMember}) so behavior matches a bare host object;
+ * this proxy only adds bean-property get/set. Return values that are themselves
+ * wrappable graph objects (e.g. {@code graph.getElement(i)}) are wrapped again so
+ * bean access is available on them too, and wrapped arguments passed back into a
+ * host method (e.g. {@code graph.addElement(graph.getElement(0))}) are unwrapped
+ * to their target first. Wrappers are interned per target (identity cache) so
+ * repeated access to the same graph object yields the same proxy, preserving JS
+ * reference equality ({@code ===}).
+ *
+ * <p><b>Known limitation:</b> because the object is presented to the script as a
+ * {@code ProxyObject} rather than a raw host object, a Java {@code instanceof}
+ * check ({@code elem instanceof Java.type('inetsoft.graph.element.LineElement')})
+ * evaluates to {@code false} for a wrapped object. The {@code ProxyObject} SPI has
+ * no hook to answer host {@code instanceof}. Scripts should branch on behavior
+ * (method/property presence) rather than Java type.
+ */
+public final class HostBeanProxy implements ProxyObject {
+   // Intern wrappers per underlying object so that repeated access to the same
+   // graph object returns the same proxy (JS === / identity). Weak keys (identity
+   // comparison) and weak values let transient per-render graph objects and their
+   // wrappers be collected once no script/host reference remains.
+   private static final Cache<Object, HostBeanProxy> WRAPPERS =
+      Caffeine.newBuilder().weakKeys().weakValues().build();
+
+   private final Object target;
+
+   private HostBeanProxy(Object target) {
+      this.target = Objects.requireNonNull(target);
+   }
+
+   /**
+    * Wrap a graph host object, reusing an existing wrapper for the same target so
+    * script-level reference equality is preserved.
+    */
+   public static HostBeanProxy wrap(Object target) {
+      return WRAPPERS.get(target, HostBeanProxy::new);
+   }
+
+   /** The wrapped host object. */
+   public Object getTarget() {
+      return target;
+   }
+
+   /**
+    * Whether a host value is a graph object whose bean properties scripts expect
+    * to read/write directly. Kept narrow on purpose: only the objects chart
+    * scripts build and mutate ({@link EGraph}, {@link GraphElement}).
+    */
+   public static boolean shouldWrap(Object value) {
+      return value instanceof EGraph || value instanceof GraphElement;
+   }
+
+   /** Wrap a host value if it is a graph object; otherwise return it unchanged. */
+   private static Object wrapResult(Value result) {
+      if(result != null && result.isHostObject()) {
+         Object host = result.asHostObject();
+
+         if(shouldWrap(host)) {
+            return wrap(host);
+         }
+      }
+
+      return result;
+   }
+
+   /** Unwrap a HostBeanProxy argument back to its target before a host call. */
+   private static Object unwrapArg(Value arg) {
+      if(arg != null && arg.isProxyObject()) {
+         Object proxy = arg.asProxyObject();
+
+         if(proxy instanceof HostBeanProxy) {
+            return ((HostBeanProxy) proxy).getTarget();
+         }
+      }
+
+      return arg;
+   }
+
+   /** GraalJS-native view of the target, for delegating methods/fields. */
+   private Value hostValue() {
+      return Context.getCurrent().asValue(target);
+   }
+
+   @Override
+   public boolean hasMember(String key) {
+      Beans beans = Beans.of(target.getClass());
+      return hostValue().hasMember(key) || beans.getters.containsKey(key) ||
+         beans.setters.containsKey(key);
+   }
+
+   @Override
+   public Object getMember(String key) {
+      Value host = hostValue();
+
+      // A native member that is a method: return an executable that delegates to
+      // the host method (preserving overload resolution + coercion) and wraps the
+      // result. Reads unwrap any proxied arguments first.
+      if(host.hasMember(key) && host.getMember(key).canExecute()) {
+         return (ProxyExecutable) args -> {
+            Object[] hostArgs = new Object[args.length];
+
+            for(int i = 0; i < args.length; i++) {
+               hostArgs[i] = unwrapArg(args[i]);
+            }
+
+            return wrapResult(host.invokeMember(key, hostArgs));
+         };
+      }
+
+      // Bean read: element.endArrow -> isEndArrow()/getEndArrow().
+      String getter = Beans.of(target.getClass()).getters.get(key);
+
+      if(getter != null) {
+         return wrapResult(host.invokeMember(getter));
+      }
+
+      // Native public field.
+      if(host.hasMember(key)) {
+         return wrapResult(host.getMember(key));
+      }
+
+      return null;
+   }
+
+   @Override
+   public void putMember(String key, Value value) {
+      // Bean write: element.endArrow = true -> setEndArrow(true). Delegated by name
+      // so GraalJS resolves the setter overload and coerces the argument.
+      String setter = Beans.of(target.getClass()).setters.get(key);
+
+      if(setter != null) {
+         hostValue().invokeMember(setter, unwrapArg(value));
+         return;
+      }
+
+      // Native writable field.
+      Value host = hostValue();
+
+      if(host.hasMember(key)) {
+         host.putMember(key, value);
+      }
+   }
+
+   @Override
+   public Object getMemberKeys() {
+      Set<String> keys = new LinkedHashSet<>();
+      Set<String> nativeKeys = hostValue().getMemberKeys();
+
+      if(nativeKeys != null) {
+         keys.addAll(nativeKeys);
+      }
+
+      Beans beans = Beans.of(target.getClass());
+      keys.addAll(beans.getters.keySet());
+      keys.addAll(beans.setters.keySet());
+
+      return keys.toArray(new String[0]);
+   }
+
+   @Override
+   public boolean removeMember(String key) {
+      // host object members cannot be removed
+      return false;
+   }
+
+   /**
+    * Per-class cache of JavaBeans getter/setter accessor names, keyed by property
+    * name. Only accessor <em>names</em> are stored; the actual invocation goes
+    * through {@link Value#invokeMember}, which resolves overloads from the real
+    * argument types.
+    */
+   private static final class Beans {
+      final Map<String, String> getters;
+      final Map<String, String> setters;
+
+      private Beans(Map<String, String> getters, Map<String, String> setters) {
+         this.getters = getters;
+         this.setters = setters;
+      }
+
+      static Beans of(Class<?> cls) {
+         return CACHE.computeIfAbsent(cls, Beans::introspect);
+      }
+
+      private static Beans introspect(Class<?> cls) {
+         Map<String, String> getters = new HashMap<>();
+         Map<String, String> setters = new HashMap<>();
+
+         for(Method m : cls.getMethods()) {
+            int mod = m.getModifiers();
+
+            if(!Modifier.isPublic(mod) || Modifier.isStatic(mod)) {
+               continue;
+            }
+
+            // Skip methods declared on Object (notably getClass(), which would
+            // otherwise register a "class" bean property; invoking it is blocked
+            // by the HostAccess policy and would surface as an error during
+            // generic member enumeration, e.g. JSON.stringify). (#75577)
+            if(m.getDeclaringClass() == Object.class) {
+               continue;
+            }
+
+            String name = m.getName();
+
+            if(m.getParameterCount() == 0 && m.getReturnType() != void.class) {
+               if(name.length() > 3 && name.startsWith("get")) {
+                  getters.putIfAbsent(decapitalize(name.substring(3)), name);
+               }
+               else if(name.length() > 2 && name.startsWith("is") &&
+                  (m.getReturnType() == boolean.class || m.getReturnType() == Boolean.class))
+               {
+                  getters.putIfAbsent(decapitalize(name.substring(2)), name);
+               }
+            }
+            else if(m.getParameterCount() == 1 && name.length() > 3 && name.startsWith("set")) {
+               setters.putIfAbsent(decapitalize(name.substring(3)), name);
+            }
+         }
+
+         return new Beans(getters, setters);
+      }
+
+      // JavaBeans decapitalization: leading upper-case run of length >= 2 (an
+      // acronym) is left as-is; otherwise the first char is lower-cased.
+      private static String decapitalize(String name) {
+         if(name.isEmpty() || (name.length() > 1 && Character.isUpperCase(name.charAt(1)) &&
+            Character.isUpperCase(name.charAt(0))))
+         {
+            return name;
+         }
+
+         char[] chars = name.toCharArray();
+         chars[0] = Character.toLowerCase(chars[0]);
+         return new String(chars);
+      }
+
+      private static final Map<Class<?>, Beans> CACHE = new ConcurrentHashMap<>();
+   }
+}

--- a/core/src/main/java/inetsoft/util/script/graal/ScriptValueConverter.java
+++ b/core/src/main/java/inetsoft/util/script/graal/ScriptValueConverter.java
@@ -55,6 +55,13 @@ public final class ScriptValueConverter {
          return new ScopeProxy((ScriptScope) value);
       }
 
+      // Restore Rhino-style bean-property access for graph objects that chart
+      // scripts manipulate directly (EGraph/GraphElement); GraalJS's HostAccess
+      // exposes only the raw getX/isX/setX accessor methods. (#75577)
+      if(HostBeanProxy.shouldWrap(value)) {
+         return HostBeanProxy.wrap(value);
+      }
+
       return value;
    }
 
@@ -100,6 +107,11 @@ public final class ScriptValueConverter {
 
          if(proxy instanceof ArrayProxy) {
             return ((ArrayProxy) proxy).getScope();
+         }
+
+         // unwrap the graph bean proxy back to its host object (#75577)
+         if(proxy instanceof HostBeanProxy) {
+            return ((HostBeanProxy) proxy).getTarget();
          }
 
          return proxy;

--- a/core/src/test/java/inetsoft/util/script/graal/HostBeanProxyTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/HostBeanProxyTest.java
@@ -1,0 +1,161 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util.script.graal;
+
+import inetsoft.graph.EGraph;
+import inetsoft.graph.element.LineElement;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.EnvironmentAccess;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies that {@link HostBeanProxy} restores Rhino-style JavaBeans property
+ * access for the graph objects chart scripts manipulate directly, so that
+ * {@code element.endArrow = true} reaches {@code LineElement.setEndArrow(true)}
+ * under GraalJS. (#75577)
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class HostBeanProxyTest {
+   private Context ctx;
+
+   @BeforeEach
+   void setup() {
+      // mirror the engine's Context configuration so the test exercises the real
+      // HostAccess policy (public access on, bean properties NOT auto-exposed).
+      ctx = Context.newBuilder("js")
+         .allowHostAccess(ScriptHostAccess.hostAccess())
+         .allowHostClassLookup(ScriptHostAccess.classFilter())
+         .allowIO(false)
+         .allowCreateThread(false)
+         .allowNativeAccess(false)
+         .allowCreateProcess(false)
+         .allowEnvironmentAccess(EnvironmentAccess.NONE)
+         .build();
+   }
+
+   @AfterEach
+   void teardown() {
+      ctx.close();
+   }
+
+   @Test
+   void shouldWrapOnlyGraphObjects() {
+      assertTrue(HostBeanProxy.shouldWrap(new EGraph()));
+      assertTrue(HostBeanProxy.shouldWrap(new LineElement("d", "m")));
+      assertFalse(HostBeanProxy.shouldWrap("not a graph object"));
+      assertFalse(HostBeanProxy.shouldWrap(new Object()));
+   }
+
+   @Test
+   void beanWriteReachesSetter() {
+      EGraph graph = new EGraph();
+      graph.addElement(new LineElement("State", "Total 1"));
+      graph.addElement(new LineElement("State", "Total 2"));
+      ctx.getBindings("js").putMember("graph", HostBeanProxy.wrap(graph));
+
+      // the exact pattern from the reported chart binding script
+      ctx.eval("js",
+               "for(var i = 0; i < graph.getElementCount(); i++) {" +
+               "   graph.getElement(i).endArrow = true;" +
+               "}");
+
+      assertTrue(((LineElement) graph.getElement(0)).isEndArrow());
+      assertTrue(((LineElement) graph.getElement(1)).isEndArrow());
+   }
+
+   @Test
+   void beanWriteSilentlyNoOpsWithoutProxy() {
+      // documents the underlying GraalJS behavior the proxy compensates for:
+      // a bare host object does not expose the 'endArrow' bean property.
+      EGraph graph = new EGraph();
+      graph.addElement(new LineElement("State", "Total 1"));
+      ctx.getBindings("js").putMember("graph", graph);
+
+      ctx.eval("js", "graph.getElement(0).endArrow = true;");
+
+      assertFalse(((LineElement) graph.getElement(0)).isEndArrow());
+   }
+
+   @Test
+   void beanReadReflectsGetter() {
+      EGraph graph = new EGraph();
+      LineElement line = new LineElement("State", "Total 1");
+      line.setEndArrow(true);
+      graph.addElement(line);
+      ctx.getBindings("js").putMember("graph", HostBeanProxy.wrap(graph));
+
+      assertTrue(ctx.eval("js", "graph.getElement(0).endArrow").asBoolean());
+      assertFalse(ctx.eval("js", "graph.getElement(0).startArrow").asBoolean());
+   }
+
+   @Test
+   void objectMethodsAreNotExposedAsBeanProperties() {
+      // getClass() must not surface as a "class" property; invoking it is blocked
+      // by the HostAccess policy, and generic enumeration (JSON.stringify) must not
+      // crash on it. (regression guard, #75577)
+      EGraph graph = new EGraph();
+      graph.addElement(new LineElement("State", "Total 1"));
+      ctx.getBindings("js").putMember("graph", HostBeanProxy.wrap(graph));
+
+      assertTrue(ctx.eval("js", "typeof graph.class === 'undefined'").asBoolean());
+      // enumerate + read every advertised member without throwing
+      assertDoesNotThrow(() -> ctx.eval(
+         "js", "Object.keys(graph).forEach(function(k){ var v = graph[k]; });"));
+   }
+
+   @Test
+   void wrapperIdentityIsPreservedAcrossAccesses() {
+      // repeated access to the same underlying element yields the same proxy so
+      // JS reference equality holds. (regression guard, #75577)
+      EGraph graph = new EGraph();
+      graph.addElement(new LineElement("State", "Total 1"));
+      ctx.getBindings("js").putMember("graph", HostBeanProxy.wrap(graph));
+
+      assertTrue(ctx.eval("js", "graph.getElement(0) === graph.getElement(0)").asBoolean());
+   }
+
+   @Test
+   void methodDelegationAndProxyArgUnwrapping() {
+      EGraph graph = new EGraph();
+      graph.addElement(new LineElement("State", "Total 1"));
+      graph.addElement(new LineElement("State", "Total 2"));
+      ctx.getBindings("js").putMember("graph", HostBeanProxy.wrap(graph));
+
+      // addElement receives a wrapped element (from getElement) and must still
+      // resolve against the host GraphElement param (proxy arg unwrapped), not
+      // fail with the proxy as an incompatible argument.
+      ctx.eval("js", "graph.addElement(graph.getElement(0));");
+
+      assertEquals(3, graph.getElementCount());
+      assertSame(graph.getElement(0), graph.getElement(2));
+   }
+}


### PR DESCRIPTION
## Summary

Chart binding scripts set bean properties directly on script-created graph objects, e.g.:

```js
graph = new EGraph();
graph.addElement(new LineElement("State","Total 1"));
for (var i = 0; i < graph.getElementCount(); i++) { graph.getElement(i).endArrow = true; }
```

Under the old Rhino engine, `element.endArrow = true` mapped to `LineElement.setEndArrow(true)`. After the Rhino→GraalJS migration (feature #75423) the assignment silently no-ops, so line arrowheads never render.

## Root Cause

GraalVM's `HostAccess` exposes only the raw accessor methods (`isEndArrow`/`setEndArrow`) on a host object and does **not** synthesize a `endArrow` JavaBeans property (verified against GraalVM 24.1.2 — the only bean-property support is bundled in the broad, experimental `js.nashorn-compat` mode). So `element.endArrow = true` writes nothing and reads return `undefined`.

## Fix

Add `HostBeanProxy`, a `ProxyObject` that re-adds getter/setter↔property mapping **on top of** GraalJS's native host member handling, applied only to `EGraph`/`GraphElement` via `ScriptValueConverter.toGuest` (and unwrapped in `toHost`):

- Method calls are delegated to GraalJS (`Value.invokeMember`) so overload resolution and argument coercion are preserved.
- Method return values that are themselves graph objects (e.g. `graph.getElement(i)`) are re-wrapped so bean access works on them too; wrapped arguments passed back into a host method are unwrapped first.
- Wrappers are interned per target (Caffeine `weakKeys().weakValues()`) so JS reference equality (`===`) is preserved.
- `Object`-declared methods (notably `getClass()`) are excluded from bean introspection so generic enumeration/serialization doesn't hit the HostAccess-denied `getClass()`.

**Known limitation:** because the object is presented as a `ProxyObject`, a Java `instanceof Java.type('inetsoft.graph...')` check on a wrapped graph object evaluates to `false` (the `ProxyObject` SPI has no hook to answer host `instanceof`). Documented in the class Javadoc.

## Test Plan

- New `HostBeanProxyTest` (7 tests): reproduces the reported script pattern and asserts `setEndArrow` is reached; bean read; the silent-no-op baseline without the proxy; method delegation + proxy-arg unwrapping; `getClass()`/`"class"` is not exposed and generic enumeration doesn't throw; `===` identity across accesses.
- Full `inetsoft.util.script.graal.**` suite (86 tests) passes, plus `ChartVSAScriptableTest` and `ChartHighlightedArrayTest`.
- Manually verified in the composer: the `EGraph1` viewsheet chart now renders end arrows.

Fixes Redmine #75577.