### PR TITLE
fixed 75603 and 75604, update test case.

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/vslayout/DeviceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/vslayout/DeviceRegistry.java
@@ -129,7 +129,8 @@ public final class DeviceRegistry {
    public static boolean isOrgAllowedToEditDevices(Principal principal) {
       return !LicenseManager.isEnterprise() ||
          OrganizationManager.getInstance().isSiteAdmin(principal) ||
-         OrganizationManager.getInstance().getCurrentOrgID().equals(Organization.getDefaultOrganizationID());
+         OrganizationManager.getInstance().getCurrentOrgID(principal).toLowerCase()
+            .equals(Organization.getDefaultOrganizationID());
    }
 
    private final KeyValueStorage<DeviceInfo> storage;

--- a/core/src/main/java/inetsoft/uql/viewsheet/vslayout/DeviceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/vslayout/DeviceRegistry.java
@@ -17,6 +17,9 @@
  */
 package inetsoft.uql.viewsheet.vslayout;
 
+import inetsoft.report.internal.license.LicenseManager;
+import inetsoft.sree.security.Organization;
+import inetsoft.sree.security.OrganizationManager;
 import inetsoft.storage.*;
 import inetsoft.util.ConfigurationContext;
 import inetsoft.util.Tool;
@@ -25,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.*;
 
 import java.io.InputStream;
+import java.security.Principal;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -109,6 +113,23 @@ public final class DeviceRegistry {
     */
    public synchronized DeviceInfo getDevice(String id) {
       return storage.get(id);
+   }
+
+   /**
+    * Determines whether the organization associated with the given principal is allowed to
+    * manage device profiles. Device profiles are stored globally rather than per-organization,
+    * so in multi-org enterprise deployments only site admins or users in the default
+    * organization are allowed to edit them -- otherwise an org admin could modify device
+    * profiles used by other organizations.
+    *
+    * @param principal the user attempting to manage device profiles.
+    *
+    * @return <tt>true</tt> if the principal's organization is allowed to manage device profiles.
+    */
+   public static boolean isOrgAllowedToEditDevices(Principal principal) {
+      return !LicenseManager.isEnterprise() ||
+         OrganizationManager.getInstance().isSiteAdmin(principal) ||
+         OrganizationManager.getInstance().getCurrentOrgID().equals(Organization.getDefaultOrganizationID());
    }
 
    private final KeyValueStorage<DeviceInfo> storage;

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
@@ -655,8 +655,13 @@ public class ScheduleTaskService {
    {
       boolean canSetStartTime = scheduleService.checkPermission(
          principal, ResourceType.SCHEDULE_OPTION, "startTime");
+      IdentityID pId = IdentityID.getIdentityIDFromKey(principal.getName());
+      boolean multitenant = SUtil.isMultiTenant();
+      boolean timeRangeAllowedForOrg = !multitenant ||
+         OrganizationManager.getInstance().isSiteAdmin(principal) &&
+         Tool.equals(OrganizationManager.getInstance().getCurrentOrgID(principal), pId.orgID);
       boolean canUseTimeRange = scheduleService.checkPermission(
-         principal, ResourceType.SCHEDULE_OPTION, "timeRange");
+         principal, ResourceType.SCHEDULE_OPTION, "timeRange") && timeRangeAllowedForOrg;
 
       if(canSetStartTime && canUseTimeRange) {
          return;

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogService.java
@@ -28,7 +28,6 @@ import inetsoft.report.*;
 import inetsoft.report.composition.*;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.report.internal.PaperSize;
-import inetsoft.report.internal.license.LicenseManager;
 import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.security.*;
@@ -170,11 +169,9 @@ public class ViewsheetPropertyDialogService {
       screensPane.setBalancePadding(info.isBalancePadding());
 
       AssetRepository assetRepository = viewsheetService.getAssetRepository();
-      boolean enterprise = LicenseManager.isEnterprise();
-      screensPane.setEditDevicesAllowed((!enterprise || OrganizationManager.getInstance().isSiteAdmin(principal) ||
-         OrganizationManager.getInstance().getCurrentOrgID().equals(Organization.getDefaultOrganizationID()))
-                                           && assetRepository.checkPermission(
-         principal, ResourceType.DEVICE, "*", EnumSet.of(ResourceAction.ACCESS)));
+      screensPane.setEditDevicesAllowed(DeviceRegistry.isOrgAllowedToEditDevices(principal) &&
+         assetRepository.checkPermission(
+            principal, ResourceType.DEVICE, "*", EnumSet.of(ResourceAction.ACCESS)));
 
       List<DeviceInfo> devices = Arrays.asList(deviceRegistry.getDevices());
 

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/DeviceController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/DeviceController.java
@@ -50,6 +50,7 @@ public class DeviceController {
    @PostMapping("/api/composer/device/new")
    @ResponseBody
    public void newDevice(@RequestBody ScreenSizeDialogModel device, Principal principal) {
+      checkOrgAllowedToEditDevices(principal);
       String userName = SUtil.getUserName(principal);
       Timestamp actionTimestamp = new Timestamp(System.currentTimeMillis());
       ActionRecord actionRecord = new ActionRecord(userName, ActionRecord.ACTION_NAME_CREATE,
@@ -77,6 +78,7 @@ public class DeviceController {
    @PostMapping("/api/composer/device/edit")
    @ResponseBody
    public void editDevice(@RequestBody ScreenSizeDialogModel device, Principal principal) {
+      checkOrgAllowedToEditDevices(principal);
       String userName = SUtil.getUserName(principal);
       Timestamp actionTimestamp = new Timestamp(System.currentTimeMillis());
       ActionRecord actionRecord = new ActionRecord(userName, ActionRecord.ACTION_NAME_EDIT,
@@ -104,6 +106,7 @@ public class DeviceController {
    @PostMapping("/api/composer/device/delete")
    @ResponseBody
    public void deleteDevice(@RequestBody ScreenSizeDialogModel device, Principal principal) {
+      checkOrgAllowedToEditDevices(principal);
       String userName = SUtil.getUserName(principal);
       Timestamp actionTimestamp = new Timestamp(System.currentTimeMillis());
       ActionRecord actionRecord = new ActionRecord(userName, ActionRecord.ACTION_NAME_DELETE,
@@ -116,6 +119,20 @@ public class DeviceController {
                                         AssetEntry.Type.DEVICE, device.getId(), null);
       dependencyHandler.deleteDependenciesKey(entry);
       Audit.getInstance().auditAction(actionRecord, principal);
+   }
+
+   /**
+    * Device profiles are stored globally rather than per-organization, so in multi-org
+    * enterprise deployments the DEVICE:*:ACCESS permission alone is not sufficient -- an org
+    * admin granted that permission within their own org's security config could otherwise
+    * modify device profiles used by every other organization. This mirrors the additional
+    * gate applied to the UI control in ViewsheetPropertyDialogService.
+    */
+   private void checkOrgAllowedToEditDevices(Principal principal) {
+      if(!DeviceRegistry.isOrgAllowedToEditDevices(principal)) {
+         throw new SecurityException(
+            "Unauthorized access to device profile management by user " + principal.getName());
+      }
    }
 
    private final DeviceRegistry deviceRegistry;

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/DeviceController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/DeviceController.java
@@ -19,6 +19,8 @@
 package inetsoft.web.composer.vs.objects.controller;
 
 import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.DependencyHandler;
 import inetsoft.uql.viewsheet.vslayout.DeviceInfo;
@@ -26,6 +28,8 @@ import inetsoft.uql.viewsheet.vslayout.DeviceRegistry;
 import inetsoft.util.audit.ActionRecord;
 import inetsoft.util.audit.Audit;
 import inetsoft.web.composer.model.vs.ScreenSizeDialogModel;
+import inetsoft.web.security.RequiredPermission;
+import inetsoft.web.security.Secured;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
@@ -38,6 +42,11 @@ public class DeviceController {
       this.dependencyHandler = dependencyHandler;
    }
 
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.DEVICE,
+      resource = "*",
+      actions = ResourceAction.ACCESS
+   ))
    @PostMapping("/api/composer/device/new")
    @ResponseBody
    public void newDevice(@RequestBody ScreenSizeDialogModel device, Principal principal) {
@@ -60,6 +69,11 @@ public class DeviceController {
       Audit.getInstance().auditAction(actionRecord, principal);
    }
 
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.DEVICE,
+      resource = "*",
+      actions = ResourceAction.ACCESS
+   ))
    @PostMapping("/api/composer/device/edit")
    @ResponseBody
    public void editDevice(@RequestBody ScreenSizeDialogModel device, Principal principal) {
@@ -82,6 +96,11 @@ public class DeviceController {
       Audit.getInstance().auditAction(actionRecord, principal);
    }
 
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.DEVICE,
+      resource = "*",
+      actions = ResourceAction.ACCESS
+   ))
    @PostMapping("/api/composer/device/delete")
    @ResponseBody
    public void deleteDevice(@RequestBody ScreenSizeDialogModel device, Principal principal) {

--- a/core/src/test/java/inetsoft/uql/viewsheet/vslayout/DeviceRegistryTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/vslayout/DeviceRegistryTest.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet.vslayout;
+
+import inetsoft.report.internal.license.LicenseManager;
+import inetsoft.sree.security.Organization;
+import inetsoft.sree.security.OrganizationManager;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/*
+ * Device profiles are stored in a single global DeviceRegistry, not per-organization (see
+ * Bug #75603 follow-up). isOrgAllowedToEditDevices() mirrors the (!enterprise || isSiteAdmin ||
+ * currentOrg == defaultOrg) gate already applied to the "Edit Mobile Devices" UI control in
+ * ViewsheetPropertyDialogService, so that DeviceController can enforce the same restriction
+ * server-side instead of only checking the DEVICE:*:ACCESS permission.
+ */
+@ExtendWith(MockitoExtension.class)
+@Tag("core")
+class DeviceRegistryTest {
+
+   @Mock
+   private Principal principal;
+
+   @Test
+   void isOrgAllowedToEditDevices_notEnterprise_allowedRegardlessOfOrg() {
+      try(MockedStatic<LicenseManager> license = mockStatic(LicenseManager.class)) {
+         license.when(LicenseManager::isEnterprise).thenReturn(false);
+
+         assertTrue(DeviceRegistry.isOrgAllowedToEditDevices(principal));
+      }
+   }
+
+   @Test
+   void isOrgAllowedToEditDevices_enterpriseSiteAdmin_allowed() {
+      try(MockedStatic<LicenseManager> license = mockStatic(LicenseManager.class);
+          MockedStatic<OrganizationManager> orgManagerStatic = mockStatic(OrganizationManager.class))
+      {
+         license.when(LicenseManager::isEnterprise).thenReturn(true);
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+         when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+
+         assertTrue(DeviceRegistry.isOrgAllowedToEditDevices(principal));
+      }
+   }
+
+   @Test
+   void isOrgAllowedToEditDevices_enterpriseNonSiteAdminInDefaultOrg_allowed() {
+      try(MockedStatic<LicenseManager> license = mockStatic(LicenseManager.class);
+          MockedStatic<OrganizationManager> orgManagerStatic = mockStatic(OrganizationManager.class))
+      {
+         license.when(LicenseManager::isEnterprise).thenReturn(true);
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+         when(orgManager.isSiteAdmin(principal)).thenReturn(false);
+         when(orgManager.getCurrentOrgID()).thenReturn(Organization.getDefaultOrganizationID());
+
+         assertTrue(DeviceRegistry.isOrgAllowedToEditDevices(principal));
+      }
+   }
+
+   @Test
+   void isOrgAllowedToEditDevices_enterpriseOrgAdminInNonDefaultOrg_denied() {
+      try(MockedStatic<LicenseManager> license = mockStatic(LicenseManager.class);
+          MockedStatic<OrganizationManager> orgManagerStatic = mockStatic(OrganizationManager.class))
+      {
+         license.when(LicenseManager::isEnterprise).thenReturn(true);
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+         when(orgManager.isSiteAdmin(principal)).thenReturn(false);
+         when(orgManager.getCurrentOrgID()).thenReturn("orgB");
+
+         assertFalse(DeviceRegistry.isOrgAllowedToEditDevices(principal));
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/uql/viewsheet/vslayout/DeviceRegistryTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/vslayout/DeviceRegistryTest.java
@@ -81,7 +81,10 @@ class DeviceRegistryTest {
          OrganizationManager orgManager = mock(OrganizationManager.class);
          orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
          when(orgManager.isSiteAdmin(principal)).thenReturn(false);
-         when(orgManager.getCurrentOrgID()).thenReturn(Organization.getDefaultOrganizationID());
+         // mixed case on purpose: getCurrentOrgID(principal) is not lower-cased by the provider
+         // itself (unlike the no-arg overload), so the comparison must normalize case itself
+         when(orgManager.getCurrentOrgID(principal))
+            .thenReturn(Organization.getDefaultOrganizationID().toUpperCase());
 
          assertTrue(DeviceRegistry.isOrgAllowedToEditDevices(principal));
       }
@@ -96,7 +99,7 @@ class DeviceRegistryTest {
          OrganizationManager orgManager = mock(OrganizationManager.class);
          orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
          when(orgManager.isSiteAdmin(principal)).thenReturn(false);
-         when(orgManager.getCurrentOrgID()).thenReturn("orgB");
+         when(orgManager.getCurrentOrgID(principal)).thenReturn("orgB");
 
          assertFalse(DeviceRegistry.isOrgAllowedToEditDevices(principal));
       }

--- a/core/src/test/java/inetsoft/web/admin/schedule/ScheduleTaskServiceSanitizeTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/ScheduleTaskServiceSanitizeTest.java
@@ -16,14 +16,16 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package inetsoft.web.admin.schedule;
-
+import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.schedule.*;
+import inetsoft.sree.security.OrganizationManager;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.uql.viewsheet.FileFormatInfo;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.security.Principal;
@@ -34,6 +36,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@Tag("core")
 class ScheduleTaskServiceSanitizeTest {
 
    @Mock
@@ -48,6 +51,19 @@ class ScheduleTaskServiceSanitizeTest {
       service = new ScheduleTaskService(null, null, scheduleService, null, null, null, null);
    }
 
+   /**
+    * sanitizeConditions() now consults SUtil.isMultiTenant() unconditionally to gate time
+    * ranges for non-site-admins in multi-tenant mode. Tests exercising the single-tenant
+    * default (the common case) stub it here rather than each hitting the real, Spring-context-
+    * dependent implementation.
+    */
+   private void invokeSanitizeConditions(ScheduleTask task, ScheduleTask original) {
+      try(MockedStatic<SUtil> sutil = mockStatic(SUtil.class)) {
+         sutil.when(SUtil::isMultiTenant).thenReturn(false);
+         service.sanitizeConditions(task, original, principal);
+      }
+   }
+
    // ── sanitizeConditions ────────────────────────────────────────────────────
 
    @Test
@@ -58,7 +74,7 @@ class ScheduleTaskServiceSanitizeTest {
       ScheduleTask task = taskWithEveryDay(10, 0, 0);
       ScheduleTask original = taskWithEveryDay(9, 30, 0);
 
-      service.sanitizeConditions(task, original, principal);
+      invokeSanitizeConditions(task, original);
 
       TimeCondition tc = (TimeCondition) task.getCondition(0);
       assertEquals(10, tc.getHour());
@@ -72,7 +88,7 @@ class ScheduleTaskServiceSanitizeTest {
       ScheduleTask task = taskWithEveryDay(10, 0, 0);
       ScheduleTask original = taskWithEveryDay(9, 30, 0);
 
-      service.sanitizeConditions(task, original, principal);
+      invokeSanitizeConditions(task, original);
 
       assertEquals(1, task.getConditionCount());
       TimeCondition tc = (TimeCondition) task.getCondition(0);
@@ -90,7 +106,7 @@ class ScheduleTaskServiceSanitizeTest {
       ScheduleTask task = taskWithEveryDay(10, 15, 0);
       ScheduleTask original = new ScheduleTask();   // no conditions
 
-      service.sanitizeConditions(task, original, principal);
+      invokeSanitizeConditions(task, original);
 
       assertEquals(1, task.getConditionCount());
       TimeCondition tc = (TimeCondition) task.getCondition(0);
@@ -114,7 +130,7 @@ class ScheduleTaskServiceSanitizeTest {
       origTc.setMinute(0);
       original.addCondition(origTc);
 
-      service.sanitizeConditions(task, original, principal);
+      invokeSanitizeConditions(task, original);
 
       // EVERY_DAY condition is kept (not removed), but time is defaulted
       assertEquals(1, task.getConditionCount());
@@ -137,7 +153,7 @@ class ScheduleTaskServiceSanitizeTest {
       ScheduleTask original = taskWithAt(date);
       TimeCondition origTc = (TimeCondition) original.getCondition(0);
 
-      service.sanitizeConditions(task, original, principal);
+      invokeSanitizeConditions(task, original);
 
       assertEquals(1, task.getConditionCount());
       assertSame(origTc, task.getCondition(0));
@@ -152,7 +168,7 @@ class ScheduleTaskServiceSanitizeTest {
       ScheduleTask task = taskWithAt(new Date());
       ScheduleTask original = taskWithEveryDay(9, 0, 0);
 
-      service.sanitizeConditions(task, original, principal);
+      invokeSanitizeConditions(task, original);
 
       assertEquals(0, task.getConditionCount());
    }
@@ -166,7 +182,7 @@ class ScheduleTaskServiceSanitizeTest {
       ScheduleTask original = taskWithEveryHour(9, 15);
       TimeCondition origTc = (TimeCondition) original.getCondition(0);
 
-      service.sanitizeConditions(task, original, principal);
+      invokeSanitizeConditions(task, original);
 
       assertEquals(1, task.getConditionCount());
       assertSame(origTc, task.getCondition(0));
@@ -180,7 +196,7 @@ class ScheduleTaskServiceSanitizeTest {
       ScheduleTask task = taskWithEveryHour(10, 0);
       ScheduleTask original = taskWithEveryDay(9, 0, 0);
 
-      service.sanitizeConditions(task, original, principal);
+      invokeSanitizeConditions(task, original);
 
       assertEquals(0, task.getConditionCount());
    }
@@ -193,7 +209,7 @@ class ScheduleTaskServiceSanitizeTest {
       ScheduleTask task = taskWithAt(new Date());
       ScheduleTask original = new ScheduleTask();   // empty
 
-      service.sanitizeConditions(task, original, principal);
+      invokeSanitizeConditions(task, original);
 
       assertEquals(0, task.getConditionCount());
    }
@@ -211,7 +227,7 @@ class ScheduleTaskServiceSanitizeTest {
       TimeRange origRange = new TimeRange("server-range", "10:00", "11:00", true);
       ((TimeCondition) original.getCondition(0)).setTimeRange(origRange);
 
-      service.sanitizeConditions(task, original, principal);
+      invokeSanitizeConditions(task, original);
 
       assertEquals(1, task.getConditionCount());
       TimeCondition result = (TimeCondition) task.getCondition(0);
@@ -234,13 +250,42 @@ class ScheduleTaskServiceSanitizeTest {
       origTc.setType(TimeCondition.EVERY_WEEK);
       original.addCondition(origTc);
 
-      service.sanitizeConditions(task, original, principal);
+      invokeSanitizeConditions(task, original);
 
       // EVERY_DAY condition is kept (not removed), but time range is cleared
       assertEquals(1, task.getConditionCount());
       TimeCondition result = (TimeCondition) task.getCondition(0);
       assertEquals(TimeCondition.EVERY_DAY, result.getType());
       assertNull(result.getTimeRange());
+   }
+
+   @Test
+   void sanitizeConditions_orgAdminMultiTenant_stripsTimeRangeDespiteDefaultAllow() {
+      allowStartTime();
+      allowTimeRange();   // SCHEDULE_OPTION defaults to allow when unconfigured -- true even
+                           // for an org admin who was never explicitly granted this action
+
+      try(MockedStatic<SUtil> sutil = mockStatic(SUtil.class);
+          MockedStatic<OrganizationManager> orgManagerStatic = mockStatic(OrganizationManager.class))
+      {
+         sutil.when(SUtil::isMultiTenant).thenReturn(true);
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+         when(orgManager.isSiteAdmin(principal)).thenReturn(false);   // org admin, not site admin
+
+         ScheduleTask task = taskWithEveryDay(9, 0, 0);
+         ((TimeCondition) task.getCondition(0))
+            .setTimeRange(new TimeRange("client-range", "08:00", "09:00", false));
+
+         ScheduleTask original = taskWithEveryDay(9, 0, 0);   // server had no time range
+
+         service.sanitizeConditions(task, original, principal);
+
+         TimeCondition result = (TimeCondition) task.getCondition(0);
+         assertNull(result.getTimeRange(),
+            "org admin in multi-tenant mode must not be able to smuggle a time range onto a " +
+            "task even though SCHEDULE_OPTION:timeRange defaults to allow when unconfigured");
+      }
    }
 
    // ── sanitizeAction ────────────────────────────────────────────────────────

--- a/core/src/test/java/inetsoft/web/composer/vs/objects/controller/DeviceControllerTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/objects/controller/DeviceControllerTest.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.vs.objects.controller;
+
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.uql.asset.DependencyHandler;
+import inetsoft.uql.viewsheet.vslayout.DeviceRegistry;
+import inetsoft.web.composer.model.vs.ScreenSizeDialogModel;
+import inetsoft.web.security.RequiredPermission;
+import inetsoft.web.security.Secured;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Method;
+import java.security.Principal;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ * DeviceController has no test class predating this one -- see permission-matrix-actions.md's
+ * "Edit Mobile Devices" writeup (Bug #75603) for the full analysis. The three endpoints write
+ * device profiles with no @Secured/@RequiredPermission annotation and no checkPermission() call
+ * anywhere in the class; ViewsheetPropertyDialogService computes the DEVICE ACCESS check but only
+ * feeds it into a UI-display boolean (editDevicesAllowed), never into an actual authorization gate.
+ *
+ * This is asserted via reflection on the annotation rather than by invoking the controller and
+ * checking a rejection, because there is currently nothing in the method to reject a call with --
+ * the fix is expected to add @Secured, matching the RequiredPermission shape already computed (for
+ * display only) in ViewsheetPropertyDialogService.
+ */
+@ExtendWith(MockitoExtension.class)
+@Tag("core")
+class DeviceControllerTest {
+
+   @Mock
+   private DeviceRegistry deviceRegistry;
+   @Mock
+   private DependencyHandler dependencyHandler;
+
+   private DeviceController controller;
+
+   @BeforeEach
+   void setUp() {
+      controller = new DeviceController(deviceRegistry, dependencyHandler);
+   }
+
+   @Test
+   void newEditDeleteDevice_requireDeviceAccessPermission() throws NoSuchMethodException {
+      for(String methodName : new String[] {"newDevice", "editDevice", "deleteDevice"}) {
+         Method method = DeviceController.class.getMethod(
+            methodName, ScreenSizeDialogModel.class, Principal.class);
+         Secured secured = method.getAnnotation(Secured.class);
+         assertNotNull(secured, methodName + "() must be gated by @Secured");
+
+         boolean requiresDeviceAccess = Arrays.stream(secured.value())
+            .anyMatch(rp -> rp.resourceType() == ResourceType.DEVICE &&
+               "*".equals(rp.resource()) &&
+               Arrays.asList(rp.actions()).contains(ResourceAction.ACCESS));
+         assertTrue(requiresDeviceAccess,
+            methodName + "() must require DEVICE ACCESS on resource \"*\", matching the " +
+            "\"Edit Mobile Devices\" Security Action check already computed (for UI display " +
+            "only) in ViewsheetPropertyDialogService: checkPermission(principal, " +
+            "ResourceType.DEVICE, \"*\", ResourceAction.ACCESS)");
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/composer/vs/objects/controller/DeviceControllerTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/objects/controller/DeviceControllerTest.java
@@ -27,6 +27,7 @@ import inetsoft.web.security.Secured;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Method;
@@ -34,6 +35,8 @@ import java.security.Principal;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 /*
  * DeviceController has no test class predating this one -- see permission-matrix-actions.md's
@@ -55,6 +58,8 @@ class DeviceControllerTest {
    private DeviceRegistry deviceRegistry;
    @Mock
    private DependencyHandler dependencyHandler;
+   @Mock
+   private Principal principal;
 
    private DeviceController controller;
 
@@ -80,6 +85,33 @@ class DeviceControllerTest {
             "\"Edit Mobile Devices\" Security Action check already computed (for UI display " +
             "only) in ViewsheetPropertyDialogService: checkPermission(principal, " +
             "ResourceType.DEVICE, \"*\", ResourceAction.ACCESS)");
+      }
+   }
+
+   /*
+    * Device profiles are stored in a single global DeviceRegistry, not per-organization.
+    * DEVICE:*:ACCESS alone is therefore not sufficient in multi-org enterprise deployments --
+    * an org admin granted that permission within their own org could otherwise modify device
+    * profiles used by every other org. DeviceRegistry.isOrgAllowedToEditDevices() mirrors the
+    * additional (!enterprise || isSiteAdmin || currentOrg == defaultOrg) gate already applied to
+    * the UI control in ViewsheetPropertyDialogService.
+    */
+   @Test
+   void newEditDeleteDevice_orgNotAllowed_rejectsAndDoesNotWrite() {
+      try(MockedStatic<DeviceRegistry> registryStatic = mockStatic(DeviceRegistry.class)) {
+         registryStatic.when(() -> DeviceRegistry.isOrgAllowedToEditDevices(principal))
+            .thenReturn(false);
+
+         ScreenSizeDialogModel device = new ScreenSizeDialogModel();
+         device.setId("d1");
+         device.setLabel("Device 1");
+
+         assertThrows(SecurityException.class, () -> controller.newDevice(device, principal));
+         assertThrows(SecurityException.class, () -> controller.editDevice(device, principal));
+         assertThrows(SecurityException.class, () -> controller.deleteDevice(device, principal));
+
+         verify(deviceRegistry, never()).setDevice(any());
+         verify(deviceRegistry, never()).deleteDevice(any());
       }
    }
 }


### PR DESCRIPTION
fixed below two issue:
**Bug #75603**

The REST endpoints that create, edit, and delete device profiles (used for responsive/mobile viewsheet layouts) perform no server-side authorization check at all. Any authenticated user — including users with no administrative privileges — can create, modify, or delete device profiles by calling these endpoints directly, regardless of the Edit Mobile Devices (ResourceType.DEVICE) permission configured in Security Actions.

**Bug #75604**
In multi-tenant mode, the "Time Range" option on a schedule task's time condition is hidden from Organization Administrators in the UI, but the server-side save path does not independently enforce this restriction. An org admin can attach a time-range condition to a schedule task by sending a crafted save request directly, bypassing the UI restriction entirely.

Note: this is distinct from — and should not be confused with — the EM "Schedule → Settings" page that defines named time ranges (start/end times). That page is correctly protected (EM_COMPONENT:settings/schedule/settings, hiddenForMultiTenancy: true, requires site admin) and is not affected by this issue. This bug is about using an existing named time range as a condition on a schedule task.