### PR TITLE
Bug #75596, persist top-level var/function declarations across scripts

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -432,6 +432,14 @@ public class GraalJavaScriptEngine implements AutoCloseable {
       // semantics. Names that were not actually declared at the eval's top level
       // (e.g. inside a nested function, or block-scoped let/const confined to the
       // eval) are guarded by `typeof` and simply skipped.
+      //
+      // A top-level `return` in the script body is not a case this needs to
+      // handle: GraalJS rejects it with a SyntaxError ("Invalid return
+      // statement") at eval time, unlike V8/SpiderMonkey/Rhino which permit
+      // `return` inside a direct eval nested in a function. So the hoist can
+      // never be skipped by an early return here — the eval throws before the
+      // hoist statement would matter either way, and that throw is pre-existing
+      // behavior unrelated to this fix.
       String hoist = buildDeclarationHoist(body);
       return Source.newBuilder("js",
          "(function(){with(__scope__){var " + RESULT_VAR + "=eval(" + toJsStringLiteral(body) +
@@ -719,6 +727,14 @@ public class GraalJavaScriptEngine implements AutoCloseable {
     * not to be reachable at the eval's top level are skipped) and wrapped in a
     * {@code try/catch} so it can never disrupt the user's script. Returns an
     * empty string when the body declares nothing.
+    * <p>
+    * The copy unconditionally overwrites {@code globalThis[name]}, including any
+    * built-in function/constant of the same name (e.g. a script-local
+    * {@code var trim = ...;} permanently clobbers the built-in {@code trim} for
+    * every later script on this engine/context). This matches the pre-#75550
+    * Rhino behavior being restored here and is not a new regression, but the
+    * blast radius is wider than the transient-wrapper-frame behavior #75550
+    * introduced.
     */
    private static String buildDeclarationHoist(String body) {
       Set<String> names = collectTopLevelDeclarations(body);
@@ -798,6 +814,13 @@ public class GraalJavaScriptEngine implements AutoCloseable {
     * {@code i} (just past the {@code var} keyword). Handles simple and
     * comma-separated declarators (e.g. {@code var a, b = 1, c}); stops at the end
     * of the statement. Returns the index at which scanning should resume.
+    * <p>
+    * Known limitation: a line break falling immediately after a bare declarator
+    * name and before its own {@code =} or the following {@code ,} (e.g.
+    * {@code var a\n = 1, b = 2;}) is treated as end-of-statement, so later
+    * declarators in that statement are missed. This is safe — a missed name is
+    * simply not hoisted, since the emitted copy is {@code typeof}-guarded — and
+    * the pattern is not expected in practice.
     */
    private static int collectVarNames(String src, int i, Set<String> names) {
       int n = src.length();

--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
@@ -66,6 +67,31 @@ public class GraalJavaScriptEngine implements AutoCloseable {
       new SreeEnv.Value("script.execution.timeout", 10000);
    private static final SreeEnv.Value MAX_ERRORS_PROP =
       new SreeEnv.Value("script.max.errors", 10000);
+
+   // Names used by the compile() wrapper to (a) hold the script completion value
+   // and (b) name the catch binding of the per-declaration hoist guard. Chosen to
+   // be unlikely to collide with any user-declared identifier. (#75596)
+   private static final String RESULT_VAR = "__inetsoft_script_result__";
+   private static final String HOIST_ERR_VAR = "__inetsoft_hoist_err__";
+
+   // JS reserved words that must never be emitted as an unguarded identifier in
+   // the generated hoist statements (typeof <keyword> is a SyntaxError, which
+   // would break compilation of the whole script). A declared name can never be
+   // one of these in valid source, but the lightweight scanner is defensive.
+   private static final Set<String> RESERVED_WORDS = Set.of(
+      "break", "case", "catch", "class", "const", "continue", "debugger",
+      "default", "delete", "do", "else", "enum", "export", "extends", "false",
+      "finally", "for", "function", "if", "import", "in", "instanceof", "new",
+      "null", "return", "super", "switch", "this", "throw", "true", "try",
+      "typeof", "var", "void", "while", "with", "yield", "let", "static",
+      "await", "async", "implements", "interface", "package", "private",
+      "protected", "public");
+
+   // Keywords after which a `/` begins a regular-expression literal rather than a
+   // division operator (used by the declaration scanner to skip regex bodies).
+   private static final Set<String> REGEX_PRECEDING_KEYWORDS = Set.of(
+      "return", "typeof", "instanceof", "in", "of", "new", "delete", "void",
+      "do", "else", "case", "yield", "await", "throw");
 
    /**
     * Per-Source error counts. Keyed by compiled Source identity; WeakHashMap
@@ -394,9 +420,22 @@ public class GraalJavaScriptEngine implements AutoCloseable {
       // the body to strict eval, changing assignment/scope semantics — so remove
       // it to preserve the prior behavior.
       String body = stripStrictDirectives(cmd);
+
+      // Bug #75596: top-level `var`/`function` declarations must persist across
+      // executions on the same engine so a later script (e.g. an assembly script
+      // referencing a variable/function declared in the viewsheet onInit/onLoad
+      // script) can see them. Under the direct-eval-in-a-function wrapper, such
+      // declarations hoist into the transient wrapper-function frame and are lost
+      // when it returns. After the eval, copy each top-level declared name out to
+      // the context global so it survives — restoring the pre-#75550 (and Rhino)
+      // behavior while keeping the #75550 `this`-binding and completion-value
+      // semantics. Names that were not actually declared at the eval's top level
+      // (e.g. inside a nested function, or block-scoped let/const confined to the
+      // eval) are guarded by `typeof` and simply skipped.
+      String hoist = buildDeclarationHoist(body);
       return Source.newBuilder("js",
-         "(function(){with(__scope__){return eval(" + toJsStringLiteral(body) +
-            ");}}).call(__scope__)", "<cmd>")
+         "(function(){with(__scope__){var " + RESULT_VAR + "=eval(" + toJsStringLiteral(body) +
+            ");" + hoist + "return " + RESULT_VAR + ";}}).call(__scope__)", "<cmd>")
          .buildLiteral();
    }
 
@@ -667,6 +706,475 @@ public class GraalJavaScriptEngine implements AutoCloseable {
 
             return -1;                   // continuation -> not a directive
          }
+      }
+
+      return -1;
+   }
+
+   /**
+    * Build the JS snippet, appended inside the compile() wrapper after the eval,
+    * that copies each top-level {@code var}/{@code function} declaration in
+    * {@code body} out to the context global so it persists for later scripts
+    * (#75596). Each copy is guarded by {@code typeof} (so names that turned out
+    * not to be reachable at the eval's top level are skipped) and wrapped in a
+    * {@code try/catch} so it can never disrupt the user's script. Returns an
+    * empty string when the body declares nothing.
+    */
+   private static String buildDeclarationHoist(String body) {
+      Set<String> names = collectTopLevelDeclarations(body);
+
+      if(names.isEmpty()) {
+         return "";
+      }
+
+      StringBuilder sb = new StringBuilder();
+
+      for(String name : names) {
+         sb.append("try{if(typeof ").append(name).append("!==\"undefined\"){globalThis[")
+            .append(toJsStringLiteral(name)).append("]=").append(name)
+            .append(";}}catch(").append(HOIST_ERR_VAR).append("){}");
+      }
+
+      return sb.toString();
+   }
+
+   /**
+    * Scan {@code body} for identifiers introduced by {@code var} and
+    * {@code function} declarations. This is a deliberately lightweight lexical
+    * scan (not a full parser): it strips strings/comments first, then collects
+    * names following {@code var}/{@code function} tokens. It may over-collect
+    * (e.g. names declared inside a nested function) — those are harmless because
+    * the emitted copy is {@code typeof}-guarded — and it does not attempt to
+    * handle destructuring patterns. Only {@code var}/{@code function} are
+    * considered, because {@code let}/{@code const} at an eval's top level are
+    * confined to the eval and never persist anyway.
+    */
+   private static Set<String> collectTopLevelDeclarations(String body) {
+      String src = stripStringsAndComments(body);
+      Set<String> names = new LinkedHashSet<>();
+      int n = src.length();
+      int i = 0;
+      char prev = 0;
+
+      while(i < n) {
+         char c = src.charAt(i);
+
+         if(isIdentStart(c)) {
+            int start = i;
+            i++;
+
+            while(i < n && isIdentPart(src.charAt(i))) {
+               i++;
+            }
+
+            String word = src.substring(start, i);
+
+            // ignore keywords used as member names (obj.var / obj.function)
+            if(prev != '.') {
+               if(word.equals("var")) {
+                  i = collectVarNames(src, i, names);
+               }
+               else if(word.equals("function")) {
+                  i = collectFunctionName(src, i, names);
+               }
+            }
+
+            prev = src.charAt(i - 1);
+            continue;
+         }
+
+         if(!Character.isWhitespace(c)) {
+            prev = c;
+         }
+
+         i++;
+      }
+
+      return names;
+   }
+
+   /**
+    * Collect the identifier(s) in a {@code var} declarator list starting at
+    * {@code i} (just past the {@code var} keyword). Handles simple and
+    * comma-separated declarators (e.g. {@code var a, b = 1, c}); stops at the end
+    * of the statement. Returns the index at which scanning should resume.
+    */
+   private static int collectVarNames(String src, int i, Set<String> names) {
+      int n = src.length();
+      int depth = 0;
+      boolean expectName = true;
+
+      while(i < n) {
+         char c = src.charAt(i);
+
+         if(expectName && depth == 0) {
+            if(Character.isWhitespace(c)) {
+               i++;
+               continue;
+            }
+
+            if(isIdentStart(c)) {
+               int s = i;
+               i++;
+
+               while(i < n && isIdentPart(src.charAt(i))) {
+                  i++;
+               }
+
+               addName(names, src.substring(s, i));
+               expectName = false;
+               continue;
+            }
+
+            // not a plain identifier (e.g. a destructuring pattern) — stop
+            // collecting names but keep scanning to the end of the statement.
+            expectName = false;
+         }
+
+         if(c == '(' || c == '[' || c == '{') {
+            depth++;
+         }
+         else if(c == ')' || c == ']' || c == '}') {
+            if(depth == 0) {
+               return i;
+            }
+
+            depth--;
+         }
+         else if(depth == 0) {
+            if(c == ';') {
+               return i + 1;
+            }
+
+            if(c == ',') {
+               expectName = true;
+               i++;
+               continue;
+            }
+
+            if(c == '\n' || c == '\r') {
+               return i + 1;
+            }
+         }
+
+         i++;
+      }
+
+      return i;
+   }
+
+   /**
+    * Collect the name of a {@code function} declaration starting at {@code i}
+    * (just past the {@code function} keyword). Skips an optional generator
+    * {@code *}; adds nothing for an anonymous function expression. Returns the
+    * index at which scanning should resume.
+    */
+   private static int collectFunctionName(String src, int i, Set<String> names) {
+      int n = src.length();
+
+      while(i < n && (Character.isWhitespace(src.charAt(i)) || src.charAt(i) == '*')) {
+         i++;
+      }
+
+      if(i < n && isIdentStart(src.charAt(i))) {
+         int s = i;
+         i++;
+
+         while(i < n && isIdentPart(src.charAt(i))) {
+            i++;
+         }
+
+         addName(names, src.substring(s, i));
+      }
+
+      return i;
+   }
+
+   private static void addName(Set<String> names, String name) {
+      // reserved words can never be declared names in valid source; excluding
+      // them keeps the generated `typeof <name>` from being a SyntaxError.
+      if(!name.isEmpty() && !RESERVED_WORDS.contains(name) &&
+         !name.equals(RESULT_VAR) && !name.equals(HOIST_ERR_VAR))
+      {
+         names.add(name);
+      }
+   }
+
+   private static boolean isIdentStart(char c) {
+      return Character.isLetter(c) || c == '_' || c == '$';
+   }
+
+   private static boolean isIdentPart(char c) {
+      return Character.isLetterOrDigit(c) || c == '_' || c == '$';
+   }
+
+   /**
+    * Replace the contents of string/template literals, comments and
+    * regular-expression literals with spaces (line breaks preserved) so a
+    * subsequent declaration scan cannot match keywords inside them. Character
+    * offsets and overall structure are preserved.
+    *
+    * <p>This is a small lexer rather than a naive replace: it recognizes
+    * template-literal {@code `${ ... }`} substitution nesting (so a backtick
+    * inside a substitution does not falsely close the template) and regular
+    * expression literals (so slashes inside a regex are not misread as a
+    * {@code //} comment). Regex-vs-division is disambiguated by the preceding
+    * significant token; when genuinely ambiguous the text is left as code, which
+    * at worst over-collects a declaration name (harmless — the emitted copy is
+    * typeof-guarded) rather than dropping one.
+    */
+   private static String stripStringsAndComments(String s) {
+      int n = s.length();
+      StringBuilder sb = new StringBuilder(n);
+      // Code-brace depth at which each open template substitution (`${`) began;
+      // the matching `}` at that depth resumes template scanning.
+      java.util.Deque<Integer> templateStack = new java.util.ArrayDeque<>();
+      int braceDepth = 0;
+      char prevSig = 0;   // previous significant code char (regex/division hint)
+      int i = 0;
+
+      while(i < n) {
+         char c = s.charAt(i);
+
+         // line comment
+         if(c == '/' && i + 1 < n && s.charAt(i + 1) == '/') {
+            sb.append("  ");
+            i += 2;
+
+            while(i < n && !isLineBreak(s.charAt(i))) {
+               sb.append(' ');
+               i++;
+            }
+
+            continue;
+         }
+
+         // block comment
+         if(c == '/' && i + 1 < n && s.charAt(i + 1) == '*') {
+            sb.append("  ");
+            i += 2;
+
+            while(i < n && !(i + 1 < n && s.charAt(i) == '*' && s.charAt(i + 1) == '/')) {
+               sb.append(isLineBreak(s.charAt(i)) ? s.charAt(i) : ' ');
+               i++;
+            }
+
+            if(i + 1 < n) {
+               sb.append("  ");
+               i += 2;
+            }
+            else {
+               while(i < n) {
+                  sb.append(' ');
+                  i++;
+               }
+            }
+
+            continue;
+         }
+
+         // regular-expression literal (only where '/' cannot be division)
+         if(c == '/' && regexAllowed(s, i, prevSig)) {
+            int end = scanRegexEnd(s, i);
+
+            if(end > 0) {
+               for(int k = i; k < end; k++) {
+                  sb.append(isLineBreak(s.charAt(k)) ? s.charAt(k) : ' ');
+               }
+
+               i = end;
+               prevSig = ')';   // a regex literal ends an expression (division next)
+               continue;
+            }
+         }
+
+         // single/double-quoted string
+         if(c == '"' || c == '\'') {
+            char quote = c;
+            sb.append(' ');
+            i++;
+
+            while(i < n) {
+               char d = s.charAt(i);
+
+               if(d == '\\') {
+                  sb.append("  ");
+                  i += 2;
+                  continue;
+               }
+
+               if(d == quote) {
+                  sb.append(' ');
+                  i++;
+                  break;
+               }
+
+               sb.append(isLineBreak(d) ? d : ' ');
+               i++;
+            }
+
+            prevSig = ')';   // a string ends an expression
+            continue;
+         }
+
+         // template-literal start
+         if(c == '`') {
+            sb.append(' ');
+            i = scanTemplateBody(s, i + 1, sb, braceDepth, templateStack);
+            prevSig = ')';
+            continue;
+         }
+
+         // '}' that closes an open template substitution -> resume the template
+         if(c == '}' && !templateStack.isEmpty() && braceDepth == templateStack.peek()) {
+            templateStack.pop();
+            sb.append(' ');
+            i = scanTemplateBody(s, i + 1, sb, braceDepth, templateStack);
+            prevSig = ')';
+            continue;
+         }
+
+         if(c == '{') {
+            braceDepth++;
+         }
+         else if(c == '}' && braceDepth > 0) {
+            braceDepth--;
+         }
+
+         sb.append(c);
+
+         if(!Character.isWhitespace(c)) {
+            prevSig = c;
+         }
+
+         i++;
+      }
+
+      return sb.toString();
+   }
+
+   private static boolean isLineBreak(char c) {
+      return c == '\n' || c == '\r';
+   }
+
+   /**
+    * Scan a template-literal body starting at {@code i} (just past a backtick or
+    * the {@code }} that closed a substitution), blanking each character. Returns
+    * the index just past the closing backtick, or — when a {@code ${} is reached
+    * — the index just past {@code ${} after recording the current code-brace
+    * depth on {@code templateStack}, so the caller resumes scanning the
+    * substitution as code.
+    */
+   private static int scanTemplateBody(String s, int i, StringBuilder sb,
+                                       int braceDepth, java.util.Deque<Integer> templateStack)
+   {
+      int n = s.length();
+
+      while(i < n) {
+         char d = s.charAt(i);
+
+         if(d == '\\') {
+            sb.append("  ");
+            i += 2;
+            continue;
+         }
+
+         if(d == '`') {
+            sb.append(' ');
+            return i + 1;
+         }
+
+         if(d == '$' && i + 1 < n && s.charAt(i + 1) == '{') {
+            sb.append("  ");
+            templateStack.push(braceDepth);
+            return i + 2;
+         }
+
+         sb.append(isLineBreak(d) ? d : ' ');
+         i++;
+      }
+
+      return i;
+   }
+
+   /**
+    * Decide whether a {@code /} at {@code slashIndex} begins a regular-expression
+    * literal (rather than a division operator), based on the previous significant
+    * token. Conservative: only returns true in positions where a regex is
+    * unambiguous or a division would be invalid.
+    */
+   private static boolean regexAllowed(String s, int slashIndex, char prevSig) {
+      if(prevSig == 0) {
+         return true;   // start of input
+      }
+
+      if(isIdentPart(prevSig)) {
+         // end of an identifier/number: a regex only follows a keyword
+         return REGEX_PRECEDING_KEYWORDS.contains(precedingWord(s, slashIndex));
+      }
+
+      // a value-ender (), ], and — via prevSig=')' — a prior string/regex/template)
+      // means the '/' is division; anything else is a regex position.
+      return prevSig != ')' && prevSig != ']';
+   }
+
+   /** The identifier/keyword ending just before {@code end} (skipping whitespace). */
+   private static String precedingWord(String s, int end) {
+      int j = end - 1;
+
+      while(j >= 0 && Character.isWhitespace(s.charAt(j))) {
+         j--;
+      }
+
+      int wordEnd = j + 1;
+
+      while(j >= 0 && isIdentPart(s.charAt(j))) {
+         j--;
+      }
+
+      return s.substring(j + 1, wordEnd);
+   }
+
+   /**
+    * If a regular-expression literal begins at {@code start} (an opening
+    * {@code /}), return the index just past its closing {@code /} and flags;
+    * otherwise return -1 (unterminated, or spanning a line break — neither is a
+    * valid regex literal).
+    */
+   private static int scanRegexEnd(String s, int start) {
+      int n = s.length();
+      int j = start + 1;
+      boolean inClass = false;
+
+      while(j < n) {
+         char c = s.charAt(j);
+
+         if(isLineBreak(c)) {
+            return -1;
+         }
+
+         if(c == '\\') {
+            j += 2;
+            continue;
+         }
+
+         if(c == '[') {
+            inClass = true;
+         }
+         else if(c == ']') {
+            inClass = false;
+         }
+         else if(c == '/' && !inClass) {
+            j++;
+
+            while(j < n && isIdentPart(s.charAt(j))) {
+               j++;   // regex flags
+            }
+
+            return j;
+         }
+
+         j++;
       }
 
       return -1;

--- a/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineScopeTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineScopeTest.java
@@ -115,6 +115,83 @@ class GraalJavaScriptEngineScopeTest {
          engine.exec(engine.compile("typeof viewsheet['Chart1'] === 'undefined'"), null, null));
    }
 
+   // Bug #75596: a top-level `var` declared in one script (e.g. a viewsheet
+   // onInit script) must persist so a later script executed on the same engine
+   // (e.g. an assembly script) can resolve it. Regression from Bug #75550, whose
+   // direct-eval-in-a-function wrapper hoisted such declarations into the
+   // transient wrapper frame where they were discarded.
+   @Test void topLevelVarPersistsAcrossExecutions() throws Exception {
+      MapScope init = new MapScope();
+      engine.exec(engine.compile("var color = [1, 2, 3]"), init, init);
+
+      MapScope assembly = new MapScope();
+      Object result = engine.exec(engine.compile("color"), assembly, assembly);
+      assertNotNull(result, "variable declared in a prior script must be visible");
+      assertEquals(3, ((Object[]) result).length);
+   }
+
+   // Bug #75596: a top-level `function` declared in one script (e.g. a viewsheet
+   // onLoad script) must likewise persist for later scripts to call.
+   @Test void topLevelFunctionPersistsAcrossExecutions() throws Exception {
+      MapScope load = new MapScope();
+      engine.exec(engine.compile("function dbl(v){ return v * 2; }"), load, load);
+
+      MapScope assembly = new MapScope();
+      Object result = engine.exec(engine.compile("dbl(21)"), assembly, assembly);
+      assertEquals(42.0, ((Number) result).doubleValue());
+   }
+
+   // Comma-separated declarators in a single `var` statement must all persist.
+   @Test void multipleVarDeclaratorsPersist() throws Exception {
+      MapScope init = new MapScope();
+      engine.exec(engine.compile("var a = 1, b = 2, c = 3"), init, init);
+
+      MapScope assembly = new MapScope();
+      assertEquals(6.0,
+         ((Number) engine.exec(engine.compile("a + b + c"), assembly, assembly)).doubleValue());
+   }
+
+   // The declaration-hoist must not disturb a script that also uses `this`: the
+   // #75550 this-binding and completion value must both still hold, and a
+   // variable declared in a prior script must remain readable from it.
+   @Test void hoistCoexistsWithThisBindingAndPriorDeclarations() throws Exception {
+      MapScope init = new MapScope();
+      engine.exec(engine.compile("var factor = 10"), init, init);
+
+      MapScope scope = new MapScope();
+      scope.putMember("parameter", makeParam("region", "West"));
+      Object result = engine.exec(
+         engine.compile("this.parameter.region + factor"), scope, scope);
+      assertEquals("West10", result);
+   }
+
+   // The declaration scanner must not mistake the slashes inside a regex literal
+   // for a `//` comment (which would blank the rest of the line and drop a
+   // following declaration). Here the regex contains an escaped slash, so its
+   // last two characters are adjacent slashes.
+   @Test void varAfterRegexWithSlashesOnSameLinePersists() throws Exception {
+      MapScope init = new MapScope();
+      engine.exec(engine.compile("var re = /\\//; var color = [1, 2, 3]"), init, init);
+
+      MapScope assembly = new MapScope();
+      Object result = engine.exec(engine.compile("color"), assembly, assembly);
+      assertNotNull(result, "declaration after a regex literal must still be hoisted");
+      assertEquals(3, ((Object[]) result).length);
+   }
+
+   // The scanner must handle nested template literals (a backtick inside a
+   // `${ ... }` substitution) so a declaration following the template is not
+   // dropped from collection.
+   @Test void varAfterNestedTemplateLiteralPersists() throws Exception {
+      MapScope init = new MapScope();
+      engine.exec(
+         engine.compile("var t = `a ${true ? `b` : `c`} d`; var color = 7"), init, init);
+
+      MapScope assembly = new MapScope();
+      assertEquals(7.0,
+         ((Number) engine.exec(engine.compile("color"), assembly, assembly)).doubleValue());
+   }
+
    private static ScriptScope makeParam(String k, String v) {
       MapScope p = new MapScope();
       p.putMember(k, v);


### PR DESCRIPTION
## Summary

Fixes a regression from the Rhino→GraalJS migration (Feature #75423) surfaced by follow-up Bug #75550: a viewsheet-scope script (onInit/onLoad) that declares a top-level `var` or `function` no longer made those declarations visible to a later assembly script, producing `ReferenceError: X is not defined`. Reproduced by `scope4.vso` (onInit `var color=[…]`, onLoad `function fun(){…}`, TableView1 script `background = color; title = fun(TextInput1.value)`).

## Root Cause

Bug #75550 changed `GraalJavaScriptEngine.compile()` to wrap every script as:

```js
(function(){ with(__scope__){ return eval(<body>); } }).call(__scope__)
```

so top-level `this` resolves to the executing scope. In a sloppy-mode **direct eval**, top-level `var`/`function` declarations hoist into the enclosing function's variable environment — i.e. the transient wrapper-function frame — which is discarded when the IIFE returns. So a variable/function declared in the viewsheet onInit/onLoad script did not persist, and a later assembly script on the same GraalJS `Context` could not resolve it. Under Rhino (and the pre-#75550 top-level `with` wrapper) these declarations persisted and were visible to later scripts.

## Fix

After the eval, `compile()` now copies each top-level `var`/`function` declaration out to the context global (`globalThis`) so it persists for later scripts — restoring the pre-#75550 / Rhino behavior while keeping the #75550 `this`-binding and completion-value semantics. Each copy is `typeof`-guarded and wrapped in try/catch, so it can never disturb the user's script. Declared names are found by a small lexical scanner that is regex- and template-literal-aware (so slashes inside a regex aren't misread as a `//` comment and nested template `${}` substitutions don't confuse string boundaries); reserved words are excluded so the generated `typeof <name>` can never be a `SyntaxError`.

Reading a persisted variable already works from any wrapper (globals resolve via normal scope-chain fall-through), so consumer scripts that use `this` **and** read such a variable are also covered.

## Test Plan

- New regression tests in `GraalJavaScriptEngineScopeTest`:
  - top-level `var` persists across executions (the `scope4.vso` scenario)
  - top-level `function` persists across executions
  - comma-separated declarators persist
  - hoist coexists with `this`-binding and prior declarations
  - declaration after a regex literal with escaped slashes on the same line still persists
  - declaration after a nested template literal still persists
- All 13 `GraalJavaScriptEngineScopeTest` tests pass, including the 7 pre-existing #75550/#75549 tests (this-binding, completion value, unqualified assignment, published-scope access) — confirming no regression.
- Full `inetsoft.util.script.**` suite passes (508 tests, 0 failures).
- Manual: import `scope4.vso`, open on the portal — the `ReferenceError: color is not defined` no longer appears and TableView1 renders.

Fixes Redmine #75596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)