### PR TITLE
Bug #75605, fix org admin cluster monitoring bypass

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/cluster/ClusterController.java
+++ b/core/src/main/java/inetsoft/web/admin/cluster/ClusterController.java
@@ -80,7 +80,7 @@ public class ClusterController {
       throws SecurityException
    {
       if(!securityEngine.getSecurityProvider().checkPermission(
-         principal, ResourceType.EM_COMPONENT, "monitoring/cluster/reportCluster", ResourceAction.ACCESS))
+         principal, ResourceType.EM_COMPONENT, "monitoring/cluster", ResourceAction.ACCESS))
       {
          throw new SecurityException("Unauthorized access to cluster monitoring by user " + principal.getName());
       }
@@ -92,7 +92,7 @@ public class ClusterController {
    @Secured(
       @RequiredPermission(
          resourceType = ResourceType.EM_COMPONENT,
-         resource = "monitoring/cluster/reportCluster",
+         resource = "monitoring/cluster",
          actions = ResourceAction.ACCESS
       )
    )
@@ -104,7 +104,7 @@ public class ClusterController {
    @Secured(
       @RequiredPermission(
          resourceType = ResourceType.EM_COMPONENT,
-         resource = "monitoring/cluster/reportCluster",
+         resource = "monitoring/cluster",
          actions = ResourceAction.ACCESS
       )
    )
@@ -116,7 +116,7 @@ public class ClusterController {
    @Secured(
       @RequiredPermission(
          resourceType = ResourceType.EM_COMPONENT,
-         resource = "monitoring/cluster/reportCluster",
+         resource = "monitoring/cluster",
          actions = ResourceAction.ACCESS
       )
    )
@@ -128,7 +128,7 @@ public class ClusterController {
    @Secured(
       @RequiredPermission(
          resourceType = ResourceType.EM_COMPONENT,
-         resource = "monitoring/cluster/reportCluster",
+         resource = "monitoring/cluster",
          actions = ResourceAction.ACCESS
       )
    )

--- a/core/src/test/java/inetsoft/web/admin/cluster/ClusterControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/cluster/ClusterControllerTest.java
@@ -143,7 +143,7 @@ class ClusterControllerTest {
       when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
       when(securityProvider.checkPermission(
             eq(principal), eq(ResourceType.EM_COMPONENT),
-            eq("monitoring/cluster/reportCluster"), eq(ResourceAction.ACCESS)))
+            eq("monitoring/cluster"), eq(ResourceAction.ACCESS)))
          .thenReturn(false);
 
       assertThrows(SecurityException.class,


### PR DESCRIPTION
## Summary
- `ClusterController`'s `@Secured` endpoints (`getClusterStatus`, `getClusterEnabled`, `pauseServer`, `resumeServer`) and the `subscribeClusterStatus` STOMP handler checked resource `"monitoring/cluster/reportCluster"`.
- `ActionPermissionService.orgAdminActionExclusions` excludes org admins from `"monitoring/cluster"` via exact string matching, so the mismatched resource string meant the exclusion never applied.
- In multi-tenant mode, this let an Organization Administrator pause/resume cluster servers via the REST API even though Monitoring > Cluster is hidden from them in the EM UI.
- Fix aligns the resource strings to `"monitoring/cluster"`, matching the existing convention in `LogMonitoringController` (`"monitoring/log"`) and `ServerMonitoringController` (`"monitoring/summary"`).

## Test plan
- [x] Updated `ClusterControllerTest` to assert the corrected resource string.
- [x] `./mvnw test -pl core -Dtest=ClusterControllerTest,DefaultCheckPermissionStrategyTest` — 43/43 passing.