### PR TITLE
75592, NPE accessing layout

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutControllerService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutControllerService.java
@@ -119,7 +119,7 @@ public class VSLayoutControllerService {
                rvs.addLayoutCheckPoint(layoutClone);
             }
 
-            vsLayoutService.sendLayout(rvsClone, layoutClone, dispatcher);
+            vsLayoutService.sendLayout(rvsClone, layoutClone, dispatcher, objectModelService);
          });
 
          viewsheetService.flushRuntimeSheet(rvsCloneId);
@@ -159,7 +159,7 @@ public class VSLayoutControllerService {
                null, rvs.getViewsheet().getAssemblies(), new ChangedAssemblyList(), true, true, null);
          }
 
-         vsLayoutService.sendLayout(rvs, layoutClone, dispatcher);
+         vsLayoutService.sendLayout(rvs, layoutClone, dispatcher, objectModelService);
          //update client side layout points
          UpdateLayoutUndoStateCommand command = new UpdateLayoutUndoStateCommand();
          command.setLayoutPoint(parentRvs.getLayoutPoint());
@@ -193,7 +193,7 @@ public class VSLayoutControllerService {
                null, rvs.getViewsheet().getAssemblies(), new ChangedAssemblyList(), true, true, null);
          }
 
-         vsLayoutService.sendLayout(rvs, layoutClone, dispatcher);
+         vsLayoutService.sendLayout(rvs, layoutClone, dispatcher, objectModelService);
          //update client side layout points
          UpdateLayoutUndoStateCommand command = new UpdateLayoutUndoStateCommand();
          command.setLayoutPoint(parentRvs.getLayoutPoint());

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
@@ -37,7 +37,6 @@ import inetsoft.web.viewsheet.command.UpdateLayoutUndoStateCommand;
 import inetsoft.web.viewsheet.command.UpdateUndoStateCommand;
 import inetsoft.web.viewsheet.model.*;
 import inetsoft.web.viewsheet.service.CommandDispatcher;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.awt.*;
@@ -56,11 +55,6 @@ import static inetsoft.uql.viewsheet.internal.CalendarVSAssemblyInfo.DOUBLE_CALE
 @ClusterProxy
 @Service
 public class VSLayoutService {
-   @Autowired
-   public VSLayoutService(VSObjectModelFactoryService objectModelService) {
-      this.objectModelService = objectModelService;
-   }
-
    public boolean isPrintLayout(String layoutName) {
       return Catalog.getCatalog().getString("Print Layout").equals(layoutName);
    }
@@ -1046,7 +1040,6 @@ public class VSLayoutService {
       }
    }
 
-   private final VSObjectModelFactoryService objectModelService;
    private static final int GAP = 20;
    public static final int HEADER = 0;
    public static final int CONTENT = 1;

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
@@ -343,14 +343,15 @@ public class VSLayoutService {
    }
 
    public final void sendLayout(RuntimeViewsheet rvs, AbstractLayout layout,
-                          CommandDispatcher dispatcher)
+                          CommandDispatcher dispatcher,
+                          VSObjectModelFactoryService objectModelService)
    {
       VSLayoutModel model;
 
       if(layout instanceof ViewsheetLayout) {
          model = VSLayoutModel.builder()
             .name(((ViewsheetLayout) layout).getName())
-            .objects(getObjects(layout.getVSAssemblyLayouts(), rvs))
+            .objects(getObjects(layout.getVSAssemblyLayouts(), rvs, objectModelService))
             .runtimeID(rvs.getID())
             .build();
       }
@@ -362,7 +363,7 @@ public class VSLayoutService {
 
          model = VSLayoutModel.builder()
             .name(Catalog.getCatalog().getString("Print Layout"))
-            .objects(getObjects(layout.getVSAssemblyLayouts(), rvs))
+            .objects(getObjects(layout.getVSAssemblyLayouts(), rvs, objectModelService))
             .printLayout(true)
             .unit(info.getUnit())
             .marginTop(margin.top)
@@ -373,8 +374,8 @@ public class VSLayoutService {
             .footerFromEdge(info.getFooterFromEdge())
             .width(size.getWidth())
             .height(size.getHeight())
-            .headerObjects(getObjects(printLayout.getHeaderLayouts(), rvs))
-            .footerObjects(getObjects(printLayout.getFooterLayouts(), rvs))
+            .headerObjects(getObjects(printLayout.getHeaderLayouts(), rvs, objectModelService))
+            .footerObjects(getObjects(printLayout.getFooterLayouts(), rvs, objectModelService))
             .horizontal(printLayout.isHorizontalScreen())
             .runtimeID(rvs.getID())
             .build();
@@ -868,7 +869,8 @@ public class VSLayoutService {
    }
 
    private List<VSLayoutObjectModel> getObjects(List<VSAssemblyLayout> layouts,
-                                                RuntimeViewsheet rvs)
+                                                RuntimeViewsheet rvs,
+                                                VSObjectModelFactoryService objectModelService)
    {
       if(layouts == null) {
          return new ArrayList<>();

--- a/core/src/test/java/inetsoft/test/IntegrationTestConfiguration.java
+++ b/core/src/test/java/inetsoft/test/IntegrationTestConfiguration.java
@@ -169,8 +169,8 @@ public class IntegrationTestConfiguration {
    }
 
    @Bean
-   public VSLayoutService vsLayoutService(VSObjectModelFactoryService objectModelFactoryService) {
-      return new VSLayoutService(objectModelFactoryService);
+   public VSLayoutService vsLayoutService() {
+      return new VSLayoutService();
    }
 
    @Bean

--- a/core/src/test/java/inetsoft/web/composer/vs/controller/VSLayoutServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/controller/VSLayoutServiceTest.java
@@ -43,7 +43,7 @@ class VSLayoutServiceTest {
 
    @BeforeEach
    void setup() {
-      service = new VSLayoutService(objectModelService);
+      service = new VSLayoutService();
    }
 
    @Test


### PR DESCRIPTION
Root Cause:
VSLayoutService.getObjects() was the only place that built layout object models using the class's own instance field (this.objectModelService), whereas every other caller of createObjectModel() (VSLayoutControllerService, VSTextService, PresenterPropertyDialogService, FormatPainterService, ComposerViewsheetService) passes in its own injected VSObjectModelFactoryService.

On the layout-change execution path (changeViewsheetLayout -> sendLayout -> getObjects, which runs through the @ClusterProxy / lazy-initialization machinery), that instance field was null, so getObjects() invoked createModel() on a null service and threw the NullPointerException seen when selecting a device/mobile layout. The calling controller's own injected objectModelService was non-null on the same path (it is used without error elsewhere in the flow), which is why only this one code path failed.

This was a pre-existing (latent) defect, not specific to the Epic #74519 work.

Fix:
Threaded the VSObjectModelFactoryService through as an explicit parameter, matching the convention used by every other createObjectModel caller:
- VSLayoutService.sendLayout(...) and getObjects(...) now accept VSObjectModelFactoryService and pass it down to createObjectModel().
- The three sendLayout() call sites in VSLayoutControllerService (changeViewsheetLayout, layoutUndo, layoutRedo) now pass their injected objectModelService.

getObjects() no longer relies on the (possibly null) instance field, so the layout popup renders correctly.