### PR TITLE
Update ai assistant package version to most recent build

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/router": "^21.2.15",
         "@ckeditor/ckeditor5-angular": "^9.1.0",
         "@ctrl/tinycolor": "^3.4.1",
-        "@inetsoft-technology/ai-assistant": "^0.0.20260622175658",
+        "@inetsoft-technology/ai-assistant": "^0.0.20260708200331",
         "@ng-bootstrap/ng-bootstrap": "^20.0.0",
         "@popperjs/core": "^2.11.8",
         "@thebespokepixel/es-tinycolor": "^2.1.1",
@@ -5030,9 +5030,9 @@
       }
     },
     "node_modules/@inetsoft-technology/ai-assistant": {
-      "version": "0.0.20260622175658",
-      "resolved": "https://npm.pkg.github.com/download/@inetsoft-technology/ai-assistant/0.0.20260622175658/91ce5308264a2ae3f0bab44d4b9db033e94516a2",
-      "integrity": "sha512-iZ/1jqfag7aCot+JOzhUTPqnV5Z3Gq6C5wSOAtb1nAAcpgzDaWqiV9y89ScXHC7xxCmAT1CHTOWeZ/fpGPPjvw=="
+      "version": "0.0.20260708200331",
+      "resolved": "https://npm.pkg.github.com/download/@inetsoft-technology/ai-assistant/0.0.20260708200331/4114422e1258d862e8232d49024f86905bb992a5",
+      "integrity": "sha512-C7Iwk2malAj4aeIY+OQzfSNtyZIwZYFW95PT4JL8dyMwO7AMtC5IunfJ5NP2IZcM/2jdtCo5Fn5ssfIOIhR9tA=="
     },
     "node_modules/@inquirer/ansi": {
       "version": "2.0.5",

--- a/web/package.json
+++ b/web/package.json
@@ -35,7 +35,7 @@
     "@angular/router": "^21.2.15",
     "@ckeditor/ckeditor5-angular": "^9.1.0",
     "@ctrl/tinycolor": "^3.4.1",
-    "@inetsoft-technology/ai-assistant": "^0.0.20260622175658",
+    "@inetsoft-technology/ai-assistant": "^0.0.20260708200331",
     "@ng-bootstrap/ng-bootstrap": "^20.0.0",
     "@popperjs/core": "^2.11.8",
     "@thebespokepixel/es-tinycolor": "^2.1.1",


### PR DESCRIPTION
## Summary
- Bump `@inetsoft-technology/ai-assistant` from `0.0.20260622175658` to `0.0.20260708200331` in `web/package.json` and `web/package-lock.json`, matching the newly published build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)