### PR TITLE
75562, error finding column in tree chart color field

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/RelationVSChartInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/RelationVSChartInfo.java
@@ -461,6 +461,33 @@ public class RelationVSChartInfo extends MergedVSChartInfo implements RelationCh
       }
 
       super.update(vs, columns, sep, pdim, source, dcInfo);
+
+      // Node color/size aesthetic refs are excluded from getAestheticRefs() (bug #75253, to keep
+      // their dimensions out of the GROUP BY), so VSChartInfo.update() does not resolve them.
+      // Resolve them here so their dataRef matches the runtime column selection; otherwise
+      // ChartVSAQuery.createGroupRef() cannot find the column and the node color/size field is
+      // dropped from the query, breaking node color/size rendering. (Bug #75562)
+      updateNodeAestheticRef(nodeColorField, vs, columns);
+      updateNodeAestheticRef(nodeSizeField, vs, columns);
+   }
+
+   /**
+    * Resolve a relation chart node color/size aesthetic ref against the runtime columns.
+    * Only VSDimensionRef-backed fields are handled: those are the ones excluded from
+    * getAestheticRefs() (bug #75253), so VSChartInfo.update() skips them. VSAggregateRef-backed
+    * node fields still flow through getAestheticRefs() and are already resolved by super.update().
+    */
+   private void updateNodeAestheticRef(AestheticRef ref, Viewsheet vs, ColumnSelection columns) {
+      if(ref instanceof VSAestheticRef && ref.getDataRef() instanceof VSDimensionRef) {
+         try {
+            ((VSAestheticRef) ref).update(vs, columns);
+         }
+         catch(ColumnNotFoundException ex) {
+            if(ref.getDataRef() instanceof VSChartRef && ((VSChartRef) ref.getDataRef()).isScript()) {
+               throw ex;
+            }
+         }
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VSUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VSUtil.java
@@ -2194,6 +2194,24 @@ public final class VSUtil {
                   bset.add(obj);
                }
             }
+
+            // Relation (tree/network) chart node color/size dimension fields are intentionally
+            // excluded from getRTFields() (to keep them out of the GROUP BY, see
+            // AbstractChartInfo.getAestheticRefs()) and therefore from getBindingRefs(). For a
+            // logical model source they would otherwise be shrunk away here, leaving ChartVSAQuery
+            // unable to re-add them as MAX aggregates and breaking node color/size. Retain their
+            // columns. (Bug #75562)
+            if(cinfo instanceof RelationChartInfo) {
+               RelationChartInfo rcinfo = (RelationChartInfo) cinfo;
+
+               for(AestheticRef nodeRef :
+                   new AestheticRef[]{ rcinfo.getNodeColorField(), rcinfo.getNodeSizeField() })
+               {
+                  if(nodeRef != null && nodeRef.getDataRef() != null) {
+                     bset.add(nodeRef.getDataRef());
+                  }
+               }
+            }
          }
       }
 


### PR DESCRIPTION
Root Cause:
The tree chart binds a categorical dimension (Customer:State) to Node Color and is bound to a logical model (Order Model). Bug #75253's fix (#3891) intentionally excluded VSDimensionRef node-color/size fields from AbstractChartInfo.getAestheticRefs() (and therefore from getRTFields()) so they no longer enter the GROUP BY, re-adding them as MAX aggregates in ChartVSAQuery.createTableAssembly(). That change had two unintended consequences for the node-color dimension:

1. Because ChartVSAssembly.getBindingRefs() returns getRTFields(), VSUtil.shrinkTable() (which only runs for a logical-model source) no longer saw Customer:State as a used column and trimmed it out of the base table.

2. Because VSChartInfo.update() only resolves aesthetic refs listed in getAestheticRefs(), the node-color dimension's ref was never resolved against the runtime columns. So even after the column was present, ChartVSAQuery's nodeDim.createGroupRef(cols) could not match it and the MAX aggregate was never added.

With the column absent from the query result, the categorical color frame sync (GraphGenerator.initRelationElement -> VSFrameVisitor.syncCategoricalFrame -> VSDimensionRef.createComparator -> AbstractDataSet.getType) threw "Column not found: Customer:State".

Fix:
Two complementary changes, neither of which touches getAestheticRefs()/getRTFields(), so #75253's GROUP-BY fix is preserved:

1. VSUtil.shrinkTable(): retain the relation chart's node color/size dimension columns for a logical-model source (alongside the existing geo-column retention), so the column stays available in the base table.

2. RelationVSChartInfo.update(): after super.update(), resolve the node color/size aesthetic refs (VSDimensionRef-backed) via VSAestheticRef.update(vs, columns) - the same resolution every other aesthetic receives - so createGroupRef() can match the runtime column and the existing MAX-aggregate re-add works.

The node-color/size dimensions still stay out of the GROUP BY; they are only retained and resolved so their column reaches the dataset.