### PR TITLE
fixed bug 75606,

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
@@ -240,12 +240,10 @@ public class ScheduleTaskService {
          return false;
       }
 
-      OrganizationManager organizationManager = OrganizationManager.getInstance();
-
-      if(organizationManager.isSiteAdmin(principal) || organizationManager.isOrgAdmin(principal)) {
-         return true;
-      }
-
+      // Site admins are granted directly by checkPermission(). Org admins must go through
+      // checkPermission() as well so that ActionPermissionService.orgAdminActionExclusions
+      // (e.g. the internal asset file backup/balance tasks/update assets dependencies tasks)
+      // is consulted instead of being bypassed.
       return engine.checkPermission(principal, ResourceType.SCHEDULE_TASK,
          task.getName(), ResourceAction.WRITE);
    }

--- a/core/src/test/java/inetsoft/web/admin/schedule/ScheduleTaskServiceSanitizeTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/ScheduleTaskServiceSanitizeTest.java
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package inetsoft.web.admin.schedule;
+import inetsoft.sree.AnalyticRepository;
+import inetsoft.sree.RepletEngine;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.schedule.*;
 import inetsoft.sree.security.OrganizationManager;
@@ -40,6 +42,10 @@ import static org.mockito.Mockito.*;
 class ScheduleTaskServiceSanitizeTest {
 
    @Mock
+   private AnalyticRepository analyticRepository;
+   @Mock
+   private RepletEngine repletEngine;
+   @Mock
    private ScheduleService scheduleService;
    @Mock
    private Principal principal;
@@ -48,7 +54,7 @@ class ScheduleTaskServiceSanitizeTest {
 
    @BeforeEach
    void setUp() {
-      service = new ScheduleTaskService(null, null, scheduleService, null, null, null, null);
+      service = new ScheduleTaskService(analyticRepository, null, scheduleService, null, null, null, null);
    }
 
    /**
@@ -510,6 +516,69 @@ class ScheduleTaskServiceSanitizeTest {
       assertEquals(0, action.getSaveFormats().length);
       assertFalse(action.isSaveToServerMatch());
       assertFalse(action.isSaveToServerExpandSelections());
+   }
+
+   // ── canDeleteInternalTask ────────────────────────────────────────────────
+   //
+   // Regression coverage: canDeleteInternalTask() must always defer to
+   // RepletEngine.checkPermission() for SCHEDULE_TASK WRITE rather than granting any
+   // Organization Administrator unconditional access. Bypassing checkPermission() let an org
+   // admin save changes to the three internal system tasks
+   // (__asset file backup__/__balance tasks__/__update assets dependencies__) that
+   // ActionPermissionService.orgAdminActionExclusions specifically excludes them from.
+
+   @Test
+   void canDeleteInternalTask_nullTask_returnsFalse() {
+      assertFalse(service.canDeleteInternalTask(null, principal));
+      verifyNoInteractions(repletEngine);
+   }
+
+   @Test
+   void canDeleteInternalTask_nullPrincipal_returnsFalse() {
+      assertFalse(service.canDeleteInternalTask(internalTask("__asset file backup__"), null));
+      verifyNoInteractions(repletEngine);
+   }
+
+   @Test
+   void canDeleteInternalTask_noRepletEngine_returnsFalse() {
+      when(analyticRepository.isWrapperFor(RepletEngine.class)).thenReturn(false);
+
+      assertFalse(service.canDeleteInternalTask(internalTask("__asset file backup__"), principal));
+   }
+
+   @Test
+   void canDeleteInternalTask_engineDenies_returnsFalseRegardlessOfRole() {
+      wireRepletEngine();
+      ScheduleTask task = internalTask("__asset file backup__");
+      when(repletEngine.checkPermission(principal, ResourceType.SCHEDULE_TASK,
+         "__asset file backup__", ResourceAction.WRITE)).thenReturn(false);
+
+      assertFalse(service.canDeleteInternalTask(task, principal),
+         "must defer to checkPermission() instead of granting access by role");
+
+      verify(repletEngine).checkPermission(principal, ResourceType.SCHEDULE_TASK,
+         "__asset file backup__", ResourceAction.WRITE);
+   }
+
+   @Test
+   void canDeleteInternalTask_engineGrants_returnsTrue() {
+      wireRepletEngine();
+      ScheduleTask task = internalTask("some other internal task");
+      when(repletEngine.checkPermission(principal, ResourceType.SCHEDULE_TASK,
+         "some other internal task", ResourceAction.WRITE)).thenReturn(true);
+
+      assertTrue(service.canDeleteInternalTask(task, principal));
+   }
+
+   private void wireRepletEngine() {
+      when(analyticRepository.isWrapperFor(RepletEngine.class)).thenReturn(true);
+      when(analyticRepository.unwrap(RepletEngine.class)).thenReturn(repletEngine);
+   }
+
+   private ScheduleTask internalTask(String name) {
+      ScheduleTask task = new ScheduleTask();
+      task.setName(name);
+      return task;
    }
 
    // ── helpers ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
Bug Summary:
ActionPermissionService.orgAdminActionExclusions specifically excludes the three built-in internal scheduled tasks (asset file backup, balance tasks, update assets dependencies) from org-admin access, so SecurityEngine.checkPermission(orgAdmin, ResourceType.SCHEDULE_TASK, "__asset file backup__", ...) correctly returns false. However, the only authorization check actually applied when saving an internal task, ScheduleTaskService.canDeleteInternalTask(), grants access to any Organization Administrator by role, without ever consulting checkPermission() for SCHEDULE_TASK. An org admin can therefore modify the schedule (time conditions) of these protected internal system tasks via the task-save endpoint, despite the exclusion list saying they should not be able to.


Fix (community/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java): removed the isSiteAdmin/isOrgAdmin shortcut from canDeleteInternalTask() so it always delegates to engine.checkPermission(). Site admins are still granted (that check lives inside checkPermission() itself at DefaultCheckPermissionStrategy.java:209), and org admins now correctly get denied for the three excluded internal tasks.