### PR TITLE
fix(wiz): apply manualOrder on explicit binding + disambiguate non-equi join columns

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -2246,6 +2246,15 @@ public class WizVsService {
          ref.setOrder(base.getOrder());
       }
 
+      // Explicit-binding manual sort order. The auto-binding path applies this via
+      // WizAutoBindingService.applyFieldConfig, but the explicit apply path (used for funnel/pareto/
+      // hierarchy and every other recommender-bypassed chart) never did — so a caller-supplied
+      // manualOrder was silently ignored and the dimension reverted to its default sort. Mirror the
+      // auto path: set the manual order list when present (pair with order == 8 = manual).
+      if(dim != null && dim.getManualOrder() != null && !dim.getManualOrder().isEmpty()) {
+         ref.setManualOrderList(new java.util.ArrayList<>(dim.getManualOrder()));
+      }
+
       if(dim != null && dim.getDateGroupLevel() != null) {
          ref.setDateLevelValue(String.valueOf(getDateGroupLevel(dim.getDateGroupLevel())));
          ref.setTimeSeries(dim.isTimeSeries());

--- a/core/src/main/java/inetsoft/web/wiz/service/WsServiceHelper.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsServiceHelper.java
@@ -252,10 +252,30 @@ final class WsServiceHelper {
             DataRef attr = baseCs.getAttribute(i);
             String alias = attr instanceof ColumnRef cr ? cr.getAlias() : null;
             String colName = alias != null ? alias : attr.getAttribute();
+            boolean visible = needAddColumn(composite, cs, ta.getName(), colName);
             AttributeRef attrRef = new AttributeRef(ta.getName(), colName);
             attrRef.setDataType(attr.getDataType());
             ColumnRef col = new ColumnRef(attrRef);
-            col.setVisible(needAddColumn(composite, cs, ta.getName(), colName));
+
+            // Disambiguate a visible column whose NAME collides with one already added from another
+            // base table. Downstream resolution (ColumnSelection.getAttribute / AssetUtil.findColumn)
+            // matches by attribute NAME, ignoring the entity/table qualifier — so two same-named
+            // columns (e.g. a self-join's "month" exposed by both sides) are indistinguishable, which
+            // makes the join render empty cells and any aggregation over it collapse to zero rows.
+            // Suppressed equi-join keys are invisible (needAddColumn == false) and never reach this
+            // branch; only genuinely-distinct duplicates (non-equi joins) do. Give the duplicate a
+            // unique alias so it resolves, without touching the first (clean-named) occurrence.
+            if(visible && cs.getAttribute(colName) != null) {
+               String uniqueAlias = ta.getName() + "_" + colName;
+
+               for(int suffix = 2; cs.getAttribute(uniqueAlias) != null; suffix++) {
+                  uniqueAlias = ta.getName() + "_" + colName + "_" + suffix;
+               }
+
+               col.setAlias(uniqueAlias);
+            }
+
+            col.setVisible(visible);
             cs.addAttribute(col);
          }
       }


### PR DESCRIPTION
Two small, independent fixes to the wiz worksheet/binding layer, both verified end-to-end against a locally-built image (`local-982` / `local-983`).

## 1. Apply `manualOrder` on the explicit chart-binding path (`WizVsService`)

`WizAutoBindingService.applyFieldConfig` applies a dimension's `order` + `manualOrder` (manual sort) on the **auto-binding** path, but the **explicit** apply path (`WizVsService.applyChartBinding` → `createVSChartDimensionRef`) set `order`/`ranking`/`dateGroupLevel` and **never called `setManualOrderList`**. So a caller-supplied `manualOrder` was honored for recommender-chosen charts (bar/line/…) but **silently ignored** for every recommender-bypassed chart (funnel, pareto, hierarchy, box plot, …), which reverted to the default sort.

Fix: `createVSChartDimensionRef` now applies `setManualOrderList` when the `DimensionFieldInfo` carries a non-empty `manualOrder`.

**Verified:** a funnel with a custom `manualOrder` renders in the caller's order (was alphabetical).

## 2. Disambiguate colliding column names in a non-equi join's output (`WsServiceHelper`)

`initCompositeColumnSelection` added each join output column under its bare source name. For an **equi** join the duplicate key column is suppressed, but a **non-equi** join keeps both sides visible — so a self-join exposed two columns with the same attribute name (e.g. `month_ord` from both sides). Downstream resolution (`ColumnSelection.getAttribute` / `AssetUtil.findColumn`) matches by attribute **name** and ignores the entity qualifier, so those duplicates were indistinguishable: the join rendered **empty cells** and any **aggregation over it silently returned zero rows**.

Fix: when a *visible* column's name collides with one already added from another base table, assign it a unique table-qualified alias (e.g. `WON_MONTHLY_B_month_ord`). The first occurrence keeps its clean name; suppressed equi-join keys are unaffected.

**Verified:** a declarative triangular self-join (`month_a >= month_b`) summed per month — previously **0 rows** — now produces a correct running total (cumulative closed-won ending at the exact stage total). This makes **declarative running totals** possible without a SQL window function.

Both changes are localized (no new beans; AOT-safe) and behavior-preserving for existing equi joins / recommender charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
