### PR TITLE
Fix unprotected circular imports between standalone components

### DIFF
--- a/web/projects/portal/src/app/composer/dialog/ws/aggregate-dialog.component.ts
+++ b/web/projects/portal/src/app/composer/dialog/ws/aggregate-dialog.component.ts
@@ -17,7 +17,7 @@
  */
 
 import { HttpParams } from "@angular/common/http";
-import { Component, EventEmitter, Inject, Input, OnInit, Output, DOCUMENT } from "@angular/core";
+import { Component, EventEmitter, forwardRef, Inject, Input, OnInit, Output, DOCUMENT } from "@angular/core";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { Tool } from "../../../../../../shared/util/tool";
 import { AggregateInfo } from "../../../binding/data/aggregate-info";
@@ -91,7 +91,7 @@ const CHECK_MODEL_TRAP_REST_URI: string = "../api/composer/worksheet/check-model
     selector: "aggregate-dialog",
     templateUrl: "aggregate-dialog.component.html",
     styleUrls: ["aggregate-dialog.component.scss"],
-    imports: [ModalHeaderComponent, EnterSubmitDirective, AggregatePane, CrosstabPane]
+    imports: [ModalHeaderComponent, EnterSubmitDirective, forwardRef(() => AggregatePane), forwardRef(() => CrosstabPane)]
 })
 export class AggregateDialog implements OnInit {
    @Input() runtimeId: string;

--- a/web/projects/portal/src/app/composer/gui/vs/objects/selection/composer-selection-container-children.component.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/objects/selection/composer-selection-container-children.component.ts
@@ -20,6 +20,7 @@ import {
    ChangeDetectorRef,
    ElementRef,
    EventEmitter,
+   forwardRef,
    HostListener,
    Input,
    NgZone,
@@ -85,7 +86,7 @@ const CHECK_TRAP_URI = "../api/composer/viewsheet/objects/checkSelectionTrap";
     selector: "composer-selection-container-children",
     templateUrl: "composer-selection-container-children.component.html",
     styleUrls: ["composer-selection-container-children.component.scss"],
-    imports: [ActionsContextmenuAnchorDirective, OutOfZoneDirective, CurrentSelection, SelectionContainerActionHandlerDirective, EditableObjectContainer, LayoutOptionDialog]
+    imports: [ActionsContextmenuAnchorDirective, OutOfZoneDirective, CurrentSelection, SelectionContainerActionHandlerDirective, forwardRef(() => EditableObjectContainer), LayoutOptionDialog]
 })
 export class ComposerSelectionContainerChildren extends VSSelectionContainerChildren implements OnInit, OnDestroy, OnChanges {
    @Input() viewsheet: Viewsheet;

--- a/web/projects/portal/src/app/composer/gui/ws/editor/concatenation/ws-concatenation-editor-pane.component.ts
+++ b/web/projects/portal/src/app/composer/gui/ws/editor/concatenation/ws-concatenation-editor-pane.component.ts
@@ -20,6 +20,7 @@ import {
    ChangeDetectionStrategy,
    Component,
    EventEmitter,
+   forwardRef,
    Input,
    OnChanges,
    OnDestroy,
@@ -70,7 +71,7 @@ const REORDER_SUBTABLES_URI = "/events/composer/worksheet/reorder-subtables";
     templateUrl: "ws-concatenation-editor-pane.component.html",
     styleUrls: ["ws-concatenation-editor-pane.component.scss"],
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [ConcatRelationConnectorComponent, ConcatRelationDescriptorComponent, ConcatenatedTableThumbnailComponent, NgClass, ConcatenationPaneDropTargetComponent, AsyncPipe, NumberToArrayPipe]
+    imports: [ConcatRelationConnectorComponent, ConcatRelationDescriptorComponent, ConcatenatedTableThumbnailComponent, NgClass, forwardRef(() => ConcatenationPaneDropTargetComponent), AsyncPipe, NumberToArrayPipe]
 })
 export class WSConcatenationEditorPane implements OnChanges, OnInit, OnDestroy {
    @Input() worksheet: Worksheet;

--- a/web/projects/portal/src/app/embed/chart/embed-chart.routes.ts
+++ b/web/projects/portal/src/app/embed/chart/embed-chart.routes.ts
@@ -47,7 +47,6 @@ import {
 import { SlideOutService } from "../../widget/slide-out/slide-out.service";
 import { AdhocFilterService } from "../../vsobjects/objects/data-tip/adhoc-filter.service";
 import { canDeactivateGuard } from "../../common/services/can-deactivate-guard.service";
-import { EmbedChartComponent } from "./embed-chart.component";
 
 export function EMBED_CHART_URL_MATCHER(url: UrlSegment[]): UrlMatchResult {
    let result: UrlMatchResult = null;
@@ -127,7 +126,7 @@ export function EMBED_CHART_URL_MATCHER(url: UrlSegment[]): UrlMatchResult {
 
 export const embedChartRoutes: Routes = [
    {
-      component: EmbedChartComponent,
+      loadComponent: () => import("./embed-chart.component").then(m => m.EmbedChartComponent),
       canDeactivate: [canDeactivateGuard],
       matcher: EMBED_CHART_URL_MATCHER,
       providers: [

--- a/web/projects/portal/src/app/vsobjects/action/crosstab-actions.ts
+++ b/web/projects/portal/src/app/vsobjects/action/crosstab-actions.ts
@@ -27,10 +27,20 @@ import { BaseTableCellModel } from "../model/base-table-cell-model";
 import { VSCrosstabModel } from "../model/vs-crosstab-model";
 import { DataTipService } from "../objects/data-tip/data-tip.service";
 import { PopComponentService } from "../objects/data-tip/pop-component.service";
-import { VSCrosstab } from "../objects/table/vs-crosstab.component";
 import { ActionStateProvider } from "./action-state-provider";
 import { BaseTableActions } from "./base-table-actions";
 import { MiniToolbarService } from "../objects/mini-toolbar/mini-toolbar.service";
+
+/**
+ * Kept outside VSCrosstab (rather than calling VSCrosstab.getDrillDirection) so that
+ * this module does not import the component module, which owns a large, easily
+ * circular dependency tree.
+ */
+export function getCrosstabDrillDirection(model: VSCrosstabModel, row: number, col: number): string {
+   return row >= model.headerRowCount && col < model.headerColCount
+      ? ChartConstants.DRILL_DIRECTION_Y
+      : ChartConstants.DRILL_DIRECTION_X;
+}
 
 export class CrosstabActions extends BaseTableActions<VSCrosstabModel> {
    constructor(model: VSCrosstabModel, contextProvider: ContextProvider,
@@ -525,7 +535,7 @@ export class CrosstabActions extends BaseTableActions<VSCrosstabModel> {
          }
       }
 
-      const dir = VSCrosstab.getDrillDirection(
+      const dir = getCrosstabDrillDirection(
          this.model, rowIndex, map.get(this.model.firstSelectedRow)[0]);
 
       return (map.size === 1 && dir == ChartConstants.DRILL_DIRECTION_X ||

--- a/web/projects/portal/src/app/vsobjects/objects/calendar/vs-calendar.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/calendar/vs-calendar.component.ts
@@ -22,6 +22,7 @@ import {
    DoCheck,
    ElementRef,
    EventEmitter,
+   forwardRef,
    Input,
    NgZone,
    OnChanges,
@@ -100,8 +101,8 @@ const FORMATE_CALENDAR_TITLE = "../api/calendar/formatTitle";
     TooltipIfDirective,
     FormsModule,
     DefaultFocusDirective,
-    MonthCalendar,
-    YearCalendar
+    forwardRef(() => MonthCalendar),
+    forwardRef(() => YearCalendar)
 ]
 })
 export class VSCalendar extends NavigationComponent<VSCalendarModel>

--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-crosstab.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-crosstab.component.ts
@@ -54,7 +54,7 @@ import { DebounceService } from "../../../widget/services/debounce.service";
 import { ModelService } from "../../../widget/services/model.service";
 import { ScaleService } from "../../../widget/services/scale/scale-service";
 import { DialogService } from "../../../widget/slide-out/dialog-service.service";
-import { CrosstabActions } from "../../action/crosstab-actions";
+import { CrosstabActions, getCrosstabDrillDirection } from "../../action/crosstab-actions";
 import { ClearSelectionCommand } from "../../command/clear-selection-command";
 import { LoadTableDataCommand } from "../../command/load-table-data-command";
 import { ContextProvider } from "../../context-provider.service";
@@ -1414,19 +1414,13 @@ export class VSCrosstab extends BaseTable<VSCrosstabModel> implements OnInit, On
          drillEvent = DrillEvent.builder(model.absoluteName)
             .row(c.row)
             .col(c.col)
-            .direction(VSCrosstab.getDrillDirection(model, c.row, c.col))
+            .direction(getCrosstabDrillDirection(model, c.row, c.col))
             .drillOp(isDrillUp ? ChartConstants.DRILL_UP_OP : ChartConstants.DRILL_DOWN_OP)
             .drillAll(!drillField)
             .field(c.field)
             .build();
          events.push(drillEvent);
       });
-   }
-
-   public static getDrillDirection(model: VSCrosstabModel, row: number, col: number): string {
-      return row >= model.headerRowCount && col < model.headerColCount
-         ? ChartConstants.DRILL_DIRECTION_Y
-         : ChartConstants.DRILL_DIRECTION_X;
    }
 
    private drillAction(isDrillUp: boolean = false): void {

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
@@ -21,6 +21,7 @@ import {
    Component,
    ElementRef,
    EventEmitter,
+   forwardRef,
    Input,
    OnChanges,
    OnDestroy,
@@ -95,7 +96,7 @@ import { VSDataTipDirective } from "./data-tip/vs-data-tip.directive";
     selector: "vs-object-container",
     templateUrl: "vs-object-container.component.html",
     styleUrls: ["vs-object-container.component.scss"],
-    imports: [VSDataTipDirective, VSPopComponentDirective, VSAnnotation, VSCalcTable, VSCalendar, VSChart, VSCheckBox, VSComboBox, VSCrosstab, VSCylinder, VSGauge, VSGroupContainer, VSImage, VSLine, VSOval, VSRadioButton, VSRectangle, VSRangeSlider, VSSelection, VSSelectionContainer, VSSelectionContainerChildren, VSSlider, VSSlidingScale, VSSpinner, VSSubmit, VSTab, VSTable, VSText, VSTextInput, VSThermometer, VSViewsheet, MiniToolbar, PlaceholderDragElement]
+    imports: [VSDataTipDirective, VSPopComponentDirective, VSAnnotation, VSCalcTable, VSCalendar, VSChart, VSCheckBox, VSComboBox, VSCrosstab, VSCylinder, VSGauge, VSGroupContainer, VSImage, VSLine, VSOval, VSRadioButton, VSRectangle, VSRangeSlider, VSSelection, VSSelectionContainer, VSSelectionContainerChildren, VSSlider, VSSlidingScale, VSSpinner, VSSubmit, VSTab, VSTable, VSText, VSTextInput, VSThermometer, forwardRef(() => VSViewsheet), MiniToolbar, PlaceholderDragElement]
 })
 export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
    readonly popUpContentBoostZIndex: number = DateTipHelper.getPopUpContentBoostZIndex();

--- a/web/projects/portal/src/app/widget/dialog/variable-list-dialog/variable-list-dialog.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/variable-list-dialog/variable-list-dialog.component.ts
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { Component, Input, Output, EventEmitter, OnInit } from "@angular/core";
+import { Component, Input, Output, EventEmitter, forwardRef, OnInit } from "@angular/core";
 
 import { XSchema } from "../../../common/data/xschema";
 import { VariableListDialogModel } from "./variable-list-dialog-model";
@@ -28,7 +28,7 @@ import { ModalHeaderComponent } from "../../modal-header/modal-header.component"
     templateUrl: "variable-list-dialog.component.html",
     imports: [
     ModalHeaderComponent,
-    VariableListEditor
+    forwardRef(() => VariableListEditor)
 ]
 })
 export class VariableListDialog implements OnInit {


### PR DESCRIPTION
  Several standalone Angular components reference each other directly in
  their @Component `imports:` array, creating real (non-type-only) circular
  module dependencies. Depending on which file is loaded first, the module
  graph can resolve in an order where one side is still `undefined` when the
  other reads it, crashing with "Class extends value undefined" /
  "Cannot read properties of undefined (reading 'ɵcmp')".

  Wrap the eagerly-referenced side in forwardRef() (already the established
  pattern elsewhere in this codebase) so the reference is resolved lazily
  instead of captured at decorator-evaluation time:

  - vs-object-container.component.ts <-> vs-viewsheet.component.ts
  - composer-selection-container-children.component.ts <-> editable-object-container.component.ts
  - vs-calendar.component.ts <-> month-calendar.component.ts / year-calendar.component.ts
  - aggregate-dialog.component.ts <-> aggregate-pane.component.ts / crosstab-pane.component.ts
  - variable-list-dialog.component.ts <-> variable-list-editor.component.ts
  - ws-concatenation-editor-pane.component.ts <-> concatenation-pane-drop-target.component.ts

  For embed-chart.routes.ts <-> embed-chart.component.ts, convert the static
  `component:` route entry to `loadComponent:` (lazy import) instead, which
  is the idiomatic way to break a route-table/component cycle.

  Also break the one confirmed circular import outside the component-imports
  pattern: crosstab-actions.ts imported vs-crosstab.component.ts only to call
  the pure static method VSCrosstab.getDrillDirection(). Extracted it as a
  standalone function (getCrosstabDrillDirection) in crosstab-actions.ts so
  the action class no longer needs to import its own component.