### PR TITLE
Feature to not animate graphs except in runtime mode.

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/VGraphPair.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/VGraphPair.java
@@ -2018,11 +2018,20 @@ public class VGraphPair {
     * Get the image for plot.
     */
    public Graphics2D getPlotGraphic(int row, int col) {
+      return getPlotGraphic(row, col, true);
+   }
+
+   /**
+    * Get the image for plot.
+    * @param animate when false, no entrance-animation hint is applied to the SVG. Used to
+    * suppress animation in design-time surfaces (composer canvas, binding editor, wizard editing).
+    */
+   public Graphics2D getPlotGraphic(int row, int col, boolean animate) {
       final VGraph vgraph = getExpandedVGraph();
       final GraphBounds gbounds = new GraphBounds(vgraph, getRealSizeVGraph(), cinfo);
       // Radar charts render PolarAxis (spokes/rings) inside the plot tile, so paintAxes must
       // be true for them. All other types suppress axes to prevent label bleed into plot tiles.
-      return getFlipYSubGraphic(vgraph, gbounds.getPlotBounds(), row, col, true, getEVGraphContext(hasRadarCoord(vgraph), true), true);
+      return getFlipYSubGraphic(vgraph, gbounds.getPlotBounds(), row, col, true, getEVGraphContext(hasRadarCoord(vgraph), true), animate);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/AssemblyImageService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/AssemblyImageService.java
@@ -108,7 +108,7 @@ public class AssemblyImageService {
       throws Exception
    {
       return processGetAssemblyImage(vid, aid, width, height, maxWidth, maxHeight, null,
-                              0, 0, 0, principal, svg, true);
+                              0, 0, 0, principal, svg, true, false);
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
@@ -118,18 +118,19 @@ public class AssemblyImageService {
                                                                double maxHeight, String aname,
                                                                int index, int row, int col,
                                                                Principal principal, boolean svg,
-                                                               boolean export) throws Exception
+                                                               boolean export, boolean noAnimation)
+      throws Exception
    {
       return VSUtil.globalShareVsRunInHostScope(vid, principal, () -> processGetAssemblyImage(
          vid, aid, width, height, maxWidth, maxHeight, aname, index, row, col, principal, svg,
-         export));
+         export, noAnimation));
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public ImageRenderResult processGetAssemblyImage(@ClusterProxyKey String vid, String aid, double width, double height,
                                        double maxWidth, double maxHeight, String aname,
                                        int index, int row, int col, Principal principal,
-                                       boolean svg, boolean export)
+                                       boolean svg, boolean export, boolean noAnimation)
       throws Exception
    {
       RuntimeViewsheet rvs = viewsheetService.getViewsheet(vid, principal);
@@ -148,7 +149,7 @@ public class AssemblyImageService {
          ProfileUtils.addExecutionBreakDownRecord(box.map(ViewsheetSandbox::getID).orElse(vid),
              ExecutionBreakDownRecord.UI_PROCESSING_CYCLE, args -> {
                ImageRenderResult result = processGetAssemblyImage1(vid, aid, width, height, maxWidth, maxHeight, aname, index,
-                                        row, col, principal, svg, export);
+                                        row, col, principal, svg, export, noAnimation);
               imageResultsRef.set(result);
          });
       }
@@ -571,7 +572,7 @@ public class AssemblyImageService {
    private ImageRenderResult processGetAssemblyImage1(String vid, String aid, double width, double height,
                                          double maxWidth, double maxHeight, String aname,
                                          int index, int row, int col, Principal principal,
-                                         boolean svg, boolean export)
+                                         boolean svg, boolean export, boolean noAnimation)
       throws Exception
    {
       RuntimeViewsheet rvs = viewsheetService.getViewsheet(vid, principal);
@@ -651,7 +652,8 @@ public class AssemblyImageService {
                   }
 
                   if(svg) {
-                     svgGraphics = getChartSVG(aname, row, col, index, pair, box.get(), name, height);
+                     svgGraphics = getChartSVG(aname, row, col, index, pair, box.get(), name, height,
+                                               noAnimation);
 
                      if(svgGraphics == null) {
                         image = getChartImage(aname, row, col, index, pair, box.get(), name, dpi * scale);
@@ -668,7 +670,7 @@ public class AssemblyImageService {
 
                   box.get().clearGraph(name);
                   return processGetAssemblyImage1(vid, aid, width, height, maxWidth, maxHeight, aname,
-                                           index, row, col, principal, svg, export);
+                                           index, row, col, principal, svg, export, noAnimation);
                }
                finally {
                   box.get().unlockRead();
@@ -778,7 +780,8 @@ public class AssemblyImageService {
     * Get chart image.
     */
    private Graphics2D getChartSVG(String aname, int row, int col, int index, VGraphPair pair,
-                                     ViewsheetSandbox box, String name, double tileHeight)
+                                     ViewsheetSandbox box, String name, double tileHeight,
+                                     boolean noAnimation)
    {
       Graphics2D image = null;
 
@@ -820,7 +823,7 @@ public class AssemblyImageService {
          // svg is more expensive than java graphics. very large svg can also crash the
          // browser, so only only use svg when the number of points is not excessive
          if(rcnt < 10000) {
-            image = pair.getPlotGraphic(row, col);
+            image = pair.getPlotGraphic(row, col, !noAnimation);
          }
       }
       else if("x_title".equals(aname)) {

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/GetImageController.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/GetImageController.java
@@ -42,6 +42,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -131,7 +132,7 @@ public class GetImageController {
    {
       vid = Tool.byteDecode(vid);
       AssemblyImageService.ImageRenderResult result = imageServiceProxy.processGetAssemblyImage(
-         vid, aid, width, height, 0, 0, null, 0, 0, 0, principal, true, false);
+         vid, aid, width, height, 0, 0, null, 0, 0, 0, principal, true, false, false);
       imageService.processImageRenderResult(result, request, response);
    }
 
@@ -184,6 +185,7 @@ public class GetImageController {
       @PathVariable("col") int col,
       @PathVariable("genTime") String genTime,
       @PathVariable("svg") boolean svg,
+      @RequestParam(value = "noanim", required = false, defaultValue = "false") boolean noAnimation,
       Principal principal,
       HttpServletRequest request,
       HttpServletResponse response) throws Exception
@@ -192,7 +194,7 @@ public class GetImageController {
             imageServiceProxy.processGetAssemblyImageInHostScope(Tool.byteDecode(vid), aid, width,
                                                                  height, maxWidth, maxHeight, aname,
                                                                  index, row, col, principal, svg,
-                                                                 false);
+                                                                 false, noAnimation);
          imageService.processImageRenderResult(result, request, response);
    }
 

--- a/web/projects/portal/src/app/graph/objects/chart-area.component.html
+++ b/web/projects/portal/src/app/graph/objects/chart-area.component.html
@@ -202,6 +202,7 @@
               [flyOnClick]="model.flyOnClick"
               [dataTipOnClick]="model.dataTipOnClick"
               [urlPrefix]="urlPrefix"
+              [suppressAnimation]="suppressAnimation"
               [scrollbarWidth]="scrollbarWidth"
               [plotScaleInfo]="plotScaleInfo"
               [selectionBoxWithTouch]="vsChartModel.multiSelect"

--- a/web/projects/portal/src/app/graph/objects/chart-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-area.component.ts
@@ -106,6 +106,7 @@ export class ChartArea implements OnInit, OnChanges, OnDestroy {
    @Input() emptyChart = false;
    @Input() backgroundColor: string;
    @Input() urlPrefix: string;
+   @Input() suppressAnimation: boolean = false;
    @Input() format: BaseFormatModel;
    @Input() titleFormat: BaseFormatModel;
    @Input() hideSortIcon: boolean;

--- a/web/projects/portal/src/app/graph/objects/chart-object-area-base.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-object-area-base.ts
@@ -44,6 +44,7 @@ export abstract class ChartObjectAreaBase<T extends ChartObject>
    @Input() maxMode: boolean;
    @Input() genTime: number;
    @Input() urlPrefix: string;
+   @Input() suppressAnimation: boolean = false;
    @Input() objectIndex = 0;
    @Input() links: string[];
    @Input() isDataTip: boolean = false;
@@ -226,7 +227,8 @@ export abstract class ChartObjectAreaBase<T extends ChartObject>
          "/" + col +
          "/" + this.genTime +
          "/" + true +
-         "?" + NetTool.xsrfToken();
+         "?" + NetTool.xsrfToken() +
+         (this.suppressAnimation ? "&noanim=true" : "");
    }
 
    isTileVisible(tile: ChartTile): boolean {

--- a/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.html
@@ -91,6 +91,7 @@
         [viewerMode]="contextProvider.viewer"
         [isBinding]="contextProvider.binding"
         [previewMode]="contextProvider.preview"
+        [suppressAnimation]="suppressChartAnimation"
         [supportHyperlink]="viewer"
         [class.resizer-open]="model.showPlotResizers"
         [urlPrefix]="getImageUrlPrefix()"

--- a/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
@@ -1045,6 +1045,14 @@ export class VSChart extends AbstractVSObject<VSChartModel>
          "/" + Tool.byteEncode(this.getAssemblyName()) : null;
    }
 
+   // Entrance animation should only play in runtime-facing surfaces. Suppress it in the
+   // composer editing canvas, the chart binding editor, and the wizard (editing and its
+   // preview) — but not the composer Preview, which is a runtime simulation (preview, not
+   // composer). See getSrc() in chart-object-area-base.
+   get suppressChartAnimation(): boolean {
+      return this.contextProvider.composer || this.contextProvider.binding;
+   }
+
    saveImageAs(): void {
       let dialog: ImageFormatSelectComponent = ComponentTool.showDialog(this.ngbModalService, ImageFormatSelectComponent, (isSvg: boolean) => {
             if(this.vsInfo && this.vsInfo.linkUri) {

--- a/web/projects/portal/src/app/vsview/edit/vs-binding-pane.component.ts
+++ b/web/projects/portal/src/app/vsview/edit/vs-binding-pane.component.ts
@@ -1013,7 +1013,8 @@ export class VSBindingPane extends CommandProcessor implements OnInit, OnDestroy
    }
 
    private isExpressionAes(ref: AestheticInfo) {
-      return ref.dataInfo.columnValue.startsWith("=");
+      return !!ref && !!ref.dataInfo && !!ref.dataInfo.columnValue &&
+         ref.dataInfo.columnValue.startsWith("=");
    }
 
    private isCrosstab(): boolean {


### PR DESCRIPTION
  Chart entrance animations are injected into the plot SVG server-side and
  replay on every regeneration, so editing in the Visual Composer, chart
  binding editor, or wizard re-triggers them repeatedly. Animation should
  only play in runtime-facing surfaces.

  The design-time vs runtime distinction lives on the client (ContextProvider),
  so the client now signals it via a "noanim" query param on the plot image
  request and the server skips the animation hint when set. A non-animated SVG
  carries no data-animated attribute; the inline-svg directive already adds
  .ready immediately in that case, so hover still works.

  Suppressed in: composer canvas, wizard editing, wizard preview, binding
  editor (contextProvider.composer || contextProvider.binding).
  Still animates in: composer Preview, real viewer, embedded.

  Also fixes a pre-existing NPE that crashed the chart binding pane on open and prevented testing:
  VSBindingPane.isExpressionAes dereferenced ref.dataInfo.columnValue when
  colorField/shapeField/sizeField were null (no aesthetic bound).