### PR TITLE
Bug #75609, fix freehand table toList NPE when options argument is omitted

### DIFF
--- a/core/src/main/java/inetsoft/report/script/formula/FormulaFunctions.java
+++ b/core/src/main/java/inetsoft/report/script/formula/FormulaFunctions.java
@@ -1835,6 +1835,13 @@ public class FormulaFunctions {
     */
    private static class Options implements Serializable {
       public Options(String str) {
+         // a script may omit the trailing options argument (e.g. toList(arr)),
+         // which reaches here as null under GraalJS; treat it as no options.
+         // (Rhino coerced the missing arg to the string "undefined".) (#75609)
+         if(str == null) {
+            str = "";
+         }
+
          // options name=value
          List<String> opts = new ArrayList<>();
          int start = 0;

--- a/core/src/test/java/inetsoft/report/script/formula/FormulaFunctionsTest.java
+++ b/core/src/test/java/inetsoft/report/script/formula/FormulaFunctionsTest.java
@@ -223,6 +223,18 @@ public class FormulaFunctionsTest {
    }
 
    /**
+    * test toList with omitted (null) options argument (#75609). A calc-table
+    * cell script may call toList(arr) with no options; under GraalJS the missing
+    * String argument reaches toList as null, which must be treated as no options
+    * rather than throwing a NullPointerException.
+    */
+   @Test
+   void testToListWithNullOptions() {
+      Object res = FormulaFunctions.toList(new Object[]{"c", "a", "b", "a"}, null);
+      assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) res);
+   }
+
+   /**
     * test union with array
     */
    @ParameterizedTest


### PR DESCRIPTION
## Summary

A freehand/calc table cell script calling `toList(q2['col@...'])` — i.e. `toList` with a single argument, omitting the optional trailing `options` string — failed at runtime with *"JavaScript error: Failed to invoke script function: toList"*. This is a regression from the Rhino→GraalJS migration (Feature #75423); it worked in v13.8.

## Root Cause

`FormulaFunctions.toList(Object arrObj, String options)`. Under GraalJS, when a script omits a trailing argument, `ScriptFunction.execute` passes `null` for the missing parameter and `coerce(null, String.class)` returns `null` (it only substitutes defaults for primitive types). `toList` then calls `new Options(null)`, and the `Options(String str)` constructor immediately calls `str.replace(...)` on the null string, throwing `NullPointerException`, which is surfaced as the cell error.

Rhino previously coerced the omitted `String` argument to the literal string `"undefined"`, so `new Options("undefined")` produced an empty option map — no crash.

The same `new Options(options)` pattern is used by `toList`, `mapList`, `rowList`, and the union/intersect `processTable`, so all short-arg calls that omit options were affected.

## Fix

Add a null guard at the top of the `Options(String)` constructor, treating a `null` option string as no options (`""`). This reproduces the pre-migration empty-option-map behavior exactly (`"".indexOf('=')` and `"undefined".indexOf('=')` both yield `-1`, so neither adds any option), and fixes the whole `toList`/`mapList`/`rowList`/union/intersect family at once. `WrapperOptions` calls `super("")` (non-null) and is unaffected.

## Test Plan

- Added `FormulaFunctionsTest.testToListWithNullOptions`, which calls `toList(arr, null)` and asserts the correct distinct/sorted result (previously threw NPE).
- `FormulaFunctionsTest` passes (28/28).
- Manual: import `FScript2 (1).vso`, open the viewsheet on the portal, and confirm the freehand table cells show correct values instead of the `toList` script error.

Fixes Redmine #75609.