### PR TITLE
Bug #75611, coerce numeric-string script args to numeric parameters

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/ScriptFunction.java
+++ b/core/src/main/java/inetsoft/util/script/graal/ScriptFunction.java
@@ -197,12 +197,15 @@ public class ScriptFunction implements ProxyExecutable {
     * semantics (mirroring Rhino's {@code ScriptRuntime.toNumber}): a boolean maps
     * to 1/0; a string is parsed ("" → 0, unparseable → NaN). Any other type
     * returns {@code null} so the caller passes the value through unchanged.
+    *
+    * <p>String parsing uses {@link Double#parseDouble} and therefore diverges
+    * slightly from JS {@code ToNumber} at the edges: hex-integer strings like
+    * {@code "0x1A"} coerce to {@code NaN} here (JS yields {@code 26}), and
+    * Java-only numeric suffixes like {@code "3.0d"} are accepted here (JS yields
+    * {@code NaN}). These cases do not occur in practice for CALC formula arguments.
     */
    private static Number toNumber(Object value) {
-      if(value instanceof Number) {
-         return (Number) value;
-      }
-      else if(value instanceof Boolean) {
+      if(value instanceof Boolean) {
          return ((Boolean) value) ? 1 : 0;
       }
       else if(value instanceof CharSequence) {

--- a/core/src/main/java/inetsoft/util/script/graal/ScriptFunction.java
+++ b/core/src/main/java/inetsoft/util/script/graal/ScriptFunction.java
@@ -142,9 +142,16 @@ public class ScriptFunction implements ProxyExecutable {
          return null;
       }
 
-      if(value instanceof Number) {
-         Number n = (Number) value;
+      // A numeric parameter may receive a value that is not already a Number,
+      // e.g. the numeric string "3" from CALC.edate(date, '3'). Rhino's
+      // FunctionObject coerced such arguments via ScriptRuntime.toNumber; without
+      // this, reflective invocation fails with an argument-type mismatch
+      // ("Failed to invoke script function"). Only convert when the declared
+      // parameter is numeric so string/Object parameters keep their value.
+      Number n = (value instanceof Number) ? (Number) value
+         : (isNumericType(ptype) ? toNumber(value) : null);
 
+      if(n != null) {
          if(ptype == int.class || ptype == Integer.class) {
             return n.intValue();
          }
@@ -169,6 +176,51 @@ public class ScriptFunction implements ProxyExecutable {
       }
 
       return value;
+   }
+
+   /**
+    * Whether the given parameter type is a numeric primitive or wrapper that a
+    * script number (or numeric string/boolean) should be coerced to.
+    */
+   private static boolean isNumericType(Class<?> ptype) {
+      return ptype == int.class || ptype == Integer.class ||
+         ptype == long.class || ptype == Long.class ||
+         ptype == double.class || ptype == Double.class ||
+         ptype == float.class || ptype == Float.class ||
+         ptype == short.class || ptype == Short.class ||
+         ptype == byte.class || ptype == Byte.class ||
+         ptype == char.class || ptype == Character.class;
+   }
+
+   /**
+    * Convert a non-Number host value to a Number using JavaScript {@code toNumber}
+    * semantics (mirroring Rhino's {@code ScriptRuntime.toNumber}): a boolean maps
+    * to 1/0; a string is parsed ("" → 0, unparseable → NaN). Any other type
+    * returns {@code null} so the caller passes the value through unchanged.
+    */
+   private static Number toNumber(Object value) {
+      if(value instanceof Number) {
+         return (Number) value;
+      }
+      else if(value instanceof Boolean) {
+         return ((Boolean) value) ? 1 : 0;
+      }
+      else if(value instanceof CharSequence) {
+         String s = value.toString().trim();
+
+         if(s.isEmpty()) {
+            return 0;
+         }
+
+         try {
+            return Double.parseDouble(s);
+         }
+         catch(NumberFormatException ex) {
+            return Double.NaN;
+         }
+      }
+
+      return null;
    }
 
    private final Object target;

--- a/core/src/test/java/inetsoft/util/script/graal/ScriptFunctionTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/ScriptFunctionTest.java
@@ -114,6 +114,48 @@ class ScriptFunctionTest {
    }
 
    @Test
+   void numericStringArgIsCoerced() {
+      // Bug #75611: a numeric string (e.g. CALC.edate(date, '3')) passed to an
+      // int parameter must be coerced to a number, matching Rhino's argument
+      // conversion, rather than failing the reflective invocation.
+      Target t = new Target();
+      ctx.getBindings("js").putMember(
+         "setCount", new ScriptFunction(t, Target.class, "setCount", int.class));
+
+      ctx.eval("js", "setCount('3')");
+
+      assertTrue(t.called);
+      assertEquals(3, t.count, "numeric string argument should be coerced to int");
+   }
+
+   @Test
+   void unparseableNumericStringArgBecomesZero() {
+      // Bug #75611: an unparseable string to a numeric parameter degrades to
+      // NaN -> 0 (Rhino ScriptRuntime.toNumber parity), not an invocation error.
+      Target t = new Target();
+      ctx.getBindings("js").putMember(
+         "setCount", new ScriptFunction(t, Target.class, "setCount", int.class));
+
+      ctx.eval("js", "setCount('abc')");
+
+      assertTrue(t.called);
+      assertEquals(0, t.count, "unparseable numeric string should coerce to 0");
+   }
+
+   @Test
+   void numericStringArgIsCoercedToDouble() {
+      // Bug #75611: numeric string coercion also applies to double parameters.
+      Target t = new Target();
+      ctx.getBindings("js").putMember(
+         "setRatio", new ScriptFunction(t, Target.class, "setRatio", double.class));
+
+      ctx.eval("js", "setRatio('2.5')");
+
+      assertTrue(t.called);
+      assertEquals(2.5, t.ratio, 0.0, "numeric string argument should be coerced to double");
+   }
+
+   @Test
    void omittedDoubleArgDefaultsToZero() {
       Target t = new Target();
       ctx.getBindings("js").putMember(

--- a/core/src/test/java/inetsoft/util/script/graal/ScriptFunctionTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/ScriptFunctionTest.java
@@ -156,6 +156,25 @@ class ScriptFunctionTest {
    }
 
    @Test
+   void booleanArgIsCoercedToNumber() {
+      // Bug #75611 side effect: a JS boolean passed to a numeric parameter
+      // coerces to 1/0 (JS ToNumber / Rhino parity), rather than failing the
+      // reflective invocation. Lock in this widened behavior.
+      Target t1 = new Target();
+      ctx.getBindings("js").putMember(
+         "setCount", new ScriptFunction(t1, Target.class, "setCount", int.class));
+      ctx.eval("js", "setCount(true)");
+      assertTrue(t1.called);
+      assertEquals(1, t1.count, "boolean true should coerce to 1");
+
+      Target t2 = new Target();
+      ctx.getBindings("js").putMember(
+         "setCount", new ScriptFunction(t2, Target.class, "setCount", int.class));
+      ctx.eval("js", "setCount(false)");
+      assertEquals(0, t2.count, "boolean false should coerce to 0");
+   }
+
+   @Test
    void omittedDoubleArgDefaultsToZero() {
       Target t = new Target();
       ctx.getBindings("js").putMember(


### PR DESCRIPTION
## Summary

Opening the attached `topN (1).vso` viewsheet on the portal failed with `JavaScript error: Failed to invoke script function: edate`. The freehand-table formula `CALC.edate(field['Order:Date'], '3')` could not be evaluated. This is a regression from the Rhino→GraalJS migration (feature #75423).

## Root Cause

`CALC.edate` maps to `CalcDateTime.edate(Object date, int months)`, invoked reflectively via `ScriptFunction`. The JS argument `'3'` arrives as a Java `String`. `ScriptFunction.coerce()` only converted `Number` values to the target numeric primitive; a `String` fell through unchanged, so `Method.invoke([Date, "3"])` threw `IllegalArgumentException: argument type mismatch`, which was wrapped as "Failed to invoke script function".

Under Rhino, `FunctionObject` coerced arguments via `ScriptRuntime.toNumber`, so `'3'` became `3` and the call succeeded. The GraalJS `coerce()` never reproduced that string→number conversion, affecting every CALC/global function that receives a numeric string for a numeric parameter.

## Fix

Extend `ScriptFunction.coerce()` so that when the declared parameter type is numeric and the value is not already a `Number`, it is converted with JS-`toNumber` semantics (boolean → 1/0; string parsed, `""` → 0, unparseable → `NaN`) before narrowing. Non-numeric parameter types are untouched, so string/Object parameters keep their value. This restores pre-migration behavior rather than changing it.

## Test Plan

- Added regression tests in `ScriptFunctionTest`: numeric string → `int`, unparseable string → 0, numeric string → `double`.
- `ScriptFunctionTest` 9/9, `CalcDateTimeTest` 38/38, `GraalJavaScriptEngineGlobalsTest` 6/6 pass.
- Verified in-app: importing and opening `topN (1).vso` on the portal no longer produces the `edate` error.

Fixes Redmine #75611.