### PR TITLE
fix NPEs in viewsheet binding pane and object view

### DIFF
--- a/web/projects/portal/src/app/vsview/edit/vs-binding-pane.component.ts
+++ b/web/projects/portal/src/app/vsview/edit/vs-binding-pane.component.ts
@@ -1013,7 +1013,7 @@ export class VSBindingPane extends CommandProcessor implements OnInit, OnDestroy
    }
 
    private isExpressionAes(ref: AestheticInfo) {
-      return ref.dataInfo.columnValue.startsWith("=");
+      return !!ref && !!ref.dataInfo && ref.dataInfo.columnValue.startsWith("=");
    }
 
    private isCrosstab(): boolean {

--- a/web/projects/portal/src/app/vsview/view/vs-object-view.component.ts
+++ b/web/projects/portal/src/app/vsview/view/vs-object-view.component.ts
@@ -160,6 +160,10 @@ export class VSObjectView extends CommandProcessor implements OnDestroy, OnInit,
 
    //only resize vstable and vscrosstable
    public resizeModelView(): void {
+      if(!this.model) {
+         return;
+      }
+
       if(this.model.objectType == "VSTable" || this.model.objectType == "VSCrosstab" ||
          this.model.objectType == "VSCalcTable")
       {


### PR DESCRIPTION
  Two frontend NullPointerExceptions were flooding the console during
  viewsheet binding:

  - VSBindingPane.isExpressionAes dereferenced ref.dataInfo without a null check. The goToWizardVisible getter runs on every change-detection cycle and passes the chart's colorField/shapeField/sizeField, which are null when no aesthetic is bound. Added null guards for ref and dataInfo.
  - VSObjectView.resizeModelView dereferenced this.model.objectType, but the method is invoked from a resize host listener (and ngAfterViewInit) that can fire before the model input is bound. Added an early return when model is unset, matching the existing guard in onResize.

  Both paths now safely no-op when the data is not yet present; no
  behavioral change.