### PR TITLE
Bug #75594, harden wiz agent authorization and input validation

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/AppDomainUtils.java
+++ b/core/src/main/java/inetsoft/web/wiz/AppDomainUtils.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz;
 
 import inetsoft.sree.SreeEnv;
+import inetsoft.sree.security.OrganizationManager;
 import inetsoft.uql.XPrincipal;
 import inetsoft.util.Tool;
 
@@ -37,6 +38,12 @@ public final class AppDomainUtils {
    }
 
    public static void setAppDomains(OrganizationDomains appDomains, Principal user) {
+      OrganizationManager orgManager = OrganizationManager.getInstance();
+
+      if(!orgManager.isSiteAdmin(user) && !orgManager.isOrgAdmin(user)) {
+         throw new SecurityException("Access denied to app domains configuration.");
+      }
+
       SreeEnv.setProperty(getOrgAppDomainPropKey(user), appDomains.toString(), true);
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz;
+
+import inetsoft.util.Catalog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Maps authorization denials from the wiz (AI composer agent) controllers to HTTP 403, mirroring
+ * {@code ComposerControllerErrorHandler} for the standard composer. Without this the
+ * {@code SecurityException}s thrown by the wiz permission gates would fall through unhandled to
+ * {@code GlobalExceptionHandler} — which does not handle {@code SecurityException} — and surface as
+ * a generic 500 instead of a 403.
+ *
+ * <p>Scoped to {@code inetsoft.web.wiz} so it covers every wiz controller. The two controllers in
+ * this package that carry their own catch-all {@code @ExceptionHandler(Exception.class)}
+ * ({@code WorksheetTableController}, {@code DatasourceMetaApiController}) each declare a more
+ * specific local {@code SecurityException} handler, since a local handler takes precedence over a
+ * {@code @ControllerAdvice} and their catch-all would otherwise intercept the denial first (as 400).
+ */
+@ControllerAdvice(basePackages = "inetsoft.web.wiz")
+public class WizControllerErrorHandler {
+   @ExceptionHandler({ inetsoft.sree.security.SecurityException.class, java.lang.SecurityException.class })
+   public ResponseEntity<Map<String, String>> handleSecurityException(Exception e) {
+      LOG.warn("Unauthorized wiz access: {}", e.getMessage());
+
+      Map<String, String> payload = new HashMap<>();
+      payload.put("error", "Forbidden");
+      payload.put("message", Catalog.getCatalog().getString("http.error.unauthorized"));
+      return new ResponseEntity<>(payload, null, HttpStatus.FORBIDDEN);
+   }
+
+   private static final Logger LOG = LoggerFactory.getLogger(WizControllerErrorHandler.class);
+}

--- a/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
@@ -271,6 +271,18 @@ public class DatasourceMetaApiController {
       return result;
    }
 
+   // A permission denial must surface as 403, not be swallowed to 400 by the catch-all below.
+   // More specific than the Exception handler, so it wins for SecurityException within this
+   // controller (a local handler also takes precedence over WizControllerErrorHandler).
+   @ExceptionHandler({ inetsoft.sree.security.SecurityException.class, java.lang.SecurityException.class })
+   @ResponseStatus(org.springframework.http.HttpStatus.FORBIDDEN)
+   @ResponseBody
+   public Map<String, String> handleSecurityException(Exception e) {
+      LOG.warn("Unauthorized datasource metadata access: {}", e.getMessage());
+      return Map.of("error", "Forbidden",
+                    "message", e.getMessage() != null ? e.getMessage() : "Forbidden");
+   }
+
    @ExceptionHandler(Exception.class)
    @ResponseStatus(org.springframework.http.HttpStatus.BAD_REQUEST)
    @ResponseBody

--- a/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
@@ -82,10 +82,11 @@ public class DatasourceMetaApiController {
 
    @PostMapping("/datasource/table/meta")
    public OsiDataset getDatabaseTableMeta(
-      @RequestBody GetDatabaseTableMetaRequest data)
+      @RequestBody GetDatabaseTableMetaRequest data,
+      Principal principal)
       throws Exception
    {
-      return metadataService.getMetaData(data);
+      return metadataService.getMetaData(data, principal);
    }
 
    @GetMapping("/ws/meta/{id}")

--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -20,11 +20,16 @@ package inetsoft.web.wiz.controller;
 
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
 import inetsoft.web.wiz.model.CloseViewsheetRequest;
 import inetsoft.web.wiz.model.OpenViewsheetResult;
@@ -46,10 +51,12 @@ import java.security.Principal;
 public class ViewsheetRuntimeController {
 
    public ViewsheetRuntimeController(ViewsheetService viewsheetService,
-                                     WizVsService wizVsService)
+                                     WizVsService wizVsService,
+                                     SecurityEngine securityEngine)
    {
       this.viewsheetService = viewsheetService;
       this.wizVsService = wizVsService;
+      this.securityEngine = securityEngine;
    }
 
    /**
@@ -87,6 +94,16 @@ public class ViewsheetRuntimeController {
       {
          throw new IllegalArgumentException(
             "Viewsheet is not in the managed visualizations folder: " + path);
+      }
+
+      // Action-level gate ("Visual Composer -> Data Viewsheet"): the managed-folder path check
+      // above is an asset-path scoping restriction, not the action permission itself. Enforced
+      // here for consistency/defense-in-depth with the other viewsheet-opening entry points
+      // (ComposerViewsheetController, OpenViewsheetController, VSWizardDialogController), even
+      // though in practice this endpoint only reopens entries wiz itself already created.
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
       }
 
       String runtimeId = viewsheetService.openViewsheet(entry, user, true);
@@ -190,6 +207,14 @@ public class ViewsheetRuntimeController {
       {
          throw new IllegalArgumentException(
             "Viewsheet is not in the managed visualizations folder: " + path);
+      }
+
+      // Action-level gate ("Visual Composer -> Data Viewsheet"), mirroring openViewsheet.
+      // verify is the more sensitive sibling — it opens the runtime AND executes the chart's
+      // query, returning hasData/rowCount — so it must not be more permissive than open.
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
       }
 
       VerifyViewsheetResult result = new VerifyViewsheetResult();
@@ -301,5 +326,6 @@ public class ViewsheetRuntimeController {
 
    private final ViewsheetService viewsheetService;
    private final WizVsService wizVsService;
+   private final SecurityEngine securityEngine;
    private static final Logger log = LoggerFactory.getLogger(ViewsheetRuntimeController.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizAuthCallbackController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizAuthCallbackController.java
@@ -101,7 +101,7 @@ public class WizAuthCallbackController {
     */
    @GetMapping(value = "/v1/auth/pickup", produces = MediaType.APPLICATION_JSON_VALUE)
    public ResponseEntity<Map<String, Object>> pickup(@RequestParam("nonce") String nonce) {
-      if(nonce.isBlank()) {
+      if(nonce.isBlank() || !isWellFormedNonce(nonce)) {
          return ResponseEntity.badRequest().build();
       }
 
@@ -132,6 +132,23 @@ public class WizAuthCallbackController {
    // -------------------------------------------------------------------------
    // Helpers
    // -------------------------------------------------------------------------
+
+   /**
+    * Minimum acceptable length for a pickup nonce. The nonce itself is generated outside this
+    * codebase (by the MCP plugin / login_start flow), so the exact length/format is not
+    * documented here. This is a conservative floor to reject obviously-too-short guesses in
+    * addition to the {@code isBlank()} check, mirroring the length/charset validation style used
+    * for pairing codes (see {@link inetsoft.web.wiz.pairing.SheetPairingService#ALPHABET}).
+    */
+   private static final int MIN_NONCE_LENGTH = 16;
+
+   /** Nonces are expected to be URL-safe tokens (letters, digits, {@code -}, {@code _}). */
+   private static final java.util.regex.Pattern NONCE_PATTERN =
+      java.util.regex.Pattern.compile("^[A-Za-z0-9_-]+$");
+
+   private static boolean isWellFormedNonce(String nonce) {
+      return nonce.length() >= MIN_NONCE_LENGTH && NONCE_PATTERN.matcher(nonce).matches();
+   }
 
    private static void writeHtml(HttpServletResponse response, String html) throws IOException {
       response.setContentType("text/html;charset=UTF-8");

--- a/core/src/main/java/inetsoft/web/wiz/controller/WorksheetTableController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WorksheetTableController.java
@@ -22,10 +22,12 @@ import inetsoft.web.wiz.model.*;
 import inetsoft.web.wiz.service.WorksheetTableService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
+import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -116,6 +118,20 @@ public class WorksheetTableController {
       throws Exception
    {
       return worksheetTableService.getWorksheetModel(wsIdentifier, user);
+   }
+
+   /**
+    * getWorksheetModel is a pure read that does not catch its own exceptions the way
+    * createTable/deleteTables do (they report failure in a 200 response body instead), so a
+    * permission-denied (or any other) failure from the service would otherwise fall through to
+    * an unhandled 500. Mirrors DatasourceMetaApiController's catch-all handler.
+    */
+   @ExceptionHandler(Exception.class)
+   @ResponseStatus(HttpStatus.BAD_REQUEST)
+   @ResponseBody
+   public Map<String, String> handleException(Exception e) {
+      LOG.warn("Worksheet table API error: {}", e.getMessage(), e);
+      return Map.of("error", e.getMessage() != null ? e.getMessage() : e.getClass().getName());
    }
 
    private final WorksheetTableService worksheetTableService;

--- a/core/src/main/java/inetsoft/web/wiz/controller/WorksheetTableController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WorksheetTableController.java
@@ -126,6 +126,18 @@ public class WorksheetTableController {
     * permission-denied (or any other) failure from the service would otherwise fall through to
     * an unhandled 500. Mirrors DatasourceMetaApiController's catch-all handler.
     */
+   // A permission denial must surface as 403, not be swallowed to 400 by the catch-all below.
+   // More specific than the Exception handler, so it wins for SecurityException within this
+   // controller (a local handler also takes precedence over WizControllerErrorHandler).
+   @ExceptionHandler({ inetsoft.sree.security.SecurityException.class, java.lang.SecurityException.class })
+   @ResponseStatus(HttpStatus.FORBIDDEN)
+   @ResponseBody
+   public Map<String, String> handleSecurityException(Exception e) {
+      LOG.warn("Unauthorized worksheet table access: {}", e.getMessage());
+      return Map.of("error", "Forbidden",
+                    "message", e.getMessage() != null ? e.getMessage() : "Forbidden");
+   }
+
    @ExceptionHandler(Exception.class)
    @ResponseStatus(HttpStatus.BAD_REQUEST)
    @ResponseBody

--- a/core/src/main/java/inetsoft/web/wiz/pairing/PairingException.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/PairingException.java
@@ -35,6 +35,7 @@ public class PairingException extends Exception {
     *   <li>{@link #SESSION_EXPIRED}  — session or runtime not found / expired → HTTP 404</li>
     *   <li>{@link #USER_MISMATCH}    — pairing code belongs to a different user → HTTP 403</li>
     *   <li>{@link #FEATURE_DISABLED} — feature flag off → HTTP 403</li>
+    *   <li>{@link #RATE_LIMITED}     — too many failed join attempts → HTTP 429</li>
     *   <li>{@link #INTERNAL}         — unexpected server error → HTTP 500</li>
     * </ul>
     */
@@ -47,6 +48,8 @@ public class PairingException extends Exception {
       USER_MISMATCH,
       /** Feature is administratively disabled. Maps to HTTP 403. */
       FEATURE_DISABLED,
+      /** Too many failed join attempts from the same caller in a short window. Maps to HTTP 429. */
+      RATE_LIMITED,
       /** Unexpected internal error. Maps to HTTP 500. */
       INTERNAL
    }

--- a/core/src/main/java/inetsoft/web/wiz/pairing/PairingUtil.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/PairingUtil.java
@@ -35,4 +35,28 @@ public final class PairingUtil {
       IdentityID agentId = IdentityID.getIdentityIDFromKey(p.getName());
       return ownerIdentity.equals(agentId == null ? p.getName() : agentId.convertToKey());
    }
+
+   /**
+    * Returns true iff two principals resolve to the same logical identity (IdentityID = name+org).
+    *
+    * <p>Compares logical identity rather than {@code Principal.equals}, because the two principals
+    * legitimately differ as objects: the runtime owner is the browser-session {@code SRPrincipal},
+    * while the agent principal is rebuilt from the JWT by {@code WizServiceAuthenticationFilter}
+    * (different {@code ClientInfo}/secureId). {@code SRPrincipal.equals} would therefore reject the
+    * real owner; the name+org comparison is what tolerates that.
+    */
+   public static boolean sameLogicalUser(Principal owner, Principal agentUser) {
+      String ownerKey = identityKey(owner);
+      return ownerKey != null && sameLogicalUser(ownerKey, agentUser);
+   }
+
+   /** The IdentityID key (name+org) for a principal, or null if it cannot be determined. */
+   public static String identityKey(Principal user) {
+      if (!(user instanceof XPrincipal p)) {
+         return user == null ? null : user.getName();
+      }
+
+      IdentityID id = IdentityID.getIdentityIDFromKey(p.getName());
+      return id == null ? p.getName() : id.convertToKey();
+   }
 }

--- a/core/src/main/java/inetsoft/web/wiz/pairing/PairingUtil.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/PairingUtil.java
@@ -31,6 +31,10 @@ public final class PairingUtil {
     * matches the ownerIdentity string (IdentityID key format: "name~;~org").
     */
    public static boolean sameLogicalUser(String ownerIdentity, Principal agentUser) {
+      // Fail closed: a non-XPrincipal agent carries no IdentityID key to compare (its plain name
+      // lacks the "name~;~org" form ownerIdentity uses), so we cannot prove a match and must reject
+      // rather than risk a false positive. Not reachable in practice — the join flow's agent is
+      // always the XPrincipal rebuilt from the JWT by WizServiceAuthenticationFilter.
       if (!(agentUser instanceof XPrincipal p)) return false;
       IdentityID agentId = IdentityID.getIdentityIDFromKey(p.getName());
       return ownerIdentity.equals(agentId == null ? p.getName() : agentId.convertToKey());

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetJoinService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetJoinService.java
@@ -187,12 +187,19 @@ public class SheetJoinService {
    }
 
    /**
-    * Best-effort caller key for attempt throttling: the client IP when an HTTP request is bound
-    * to the current thread (the normal case for this REST-backed join flow), falling back to the
-    * authenticated agent identity when no request context is available (e.g. direct/unit-test
-    * invocation), and finally to a constant key if neither is available.
+    * Caller key for attempt throttling. Prefers the authenticated agent identity: {@code join} is
+    * only reached with a JWT-validated principal (rebuilt by {@code WizServiceAuthenticationFilter}),
+    * so the identity cannot be forged to reset the attempt window. The client IP is used only as a
+    * fallback when there is no authenticated identity (e.g. direct/unit-test invocation), and is
+    * deliberately NOT preferred: {@code Tool.getRemoteAddr} honors the client-supplied
+    * {@code remote_ip} header, which an attacker could vary per request to defeat the lockout when
+    * the deployment's edge does not strip it. Falls back to a constant key if neither is available.
     */
    private static String throttleKey(Principal agentUser) {
+      if(agentUser != null && agentUser.getName() != null) {
+         return "user:" + agentUser.getName();
+      }
+
       try {
          ServletRequestAttributes attrs =
             (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
@@ -204,10 +211,10 @@ public class SheetJoinService {
          }
       }
       catch(IllegalStateException e) {
-         // No servlet request bound to this thread — fall back to caller identity below.
+         // No servlet request bound to this thread and no authenticated identity.
       }
 
-      return "user:" + (agentUser == null ? "anonymous" : agentUser.getName());
+      return "user:anonymous";
    }
 
    private final SheetPairingService pairing;

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetJoinService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetJoinService.java
@@ -17,11 +17,18 @@
  */
 package inetsoft.web.wiz.pairing;
 
+import inetsoft.util.Tool;
+import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
 import java.security.Principal;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Pairing-authorized join. Validates the feature flag, consumes the single-use pairing code,
@@ -32,18 +39,31 @@ import java.security.Principal;
  * - Code is single-use (consumed by SheetPairingService.consume).
  * - Same-logical-user enforced via PairingUtil.sameLogicalUser (IdentityID name+org match).
  * - Every join attempt (success + failure) is audit-logged.
+ * - Failed lookups (invalid/expired code or user mismatch) are throttled per caller: after
+ *   {@link #MAX_FAILED_ATTEMPTS} failures within {@link SheetPairingService#TTL_MILLIS}, the
+ *   caller is locked out for {@link #LOCKOUT_MILLIS} to blunt a guessing-driven load pattern
+ *   against the pairing grant map. This is an in-memory, best-effort throttle — not a substitute
+ *   for the code's own entropy, which already makes brute force impractical.
  */
 @Service
 public class SheetJoinService {
    private static final Logger LOG = LoggerFactory.getLogger(SheetJoinService.class);
 
+   /** Failed lookups allowed within the attempt window before a caller is locked out. */
+   private static final int MAX_FAILED_ATTEMPTS = 8;
+
+   /** How long a caller is locked out once {@link #MAX_FAILED_ATTEMPTS} is exceeded. */
+   private static final long LOCKOUT_MILLIS = 60_000L;
+
    @Autowired
    public SheetJoinService(SheetPairingService pairing,
                            SheetSessionService sessions,
-                           SheetAgentFeature feature) {
+                           SheetAgentFeature feature,
+                           SheetRuntimeAccess runtimeAccess) {
       this.pairing = pairing;
       this.sessions = sessions;
       this.feature = feature;
+      this.runtimeAccess = runtimeAccess;
    }
 
    /**
@@ -54,6 +74,10 @@ public class SheetJoinService {
     * @throws PairingException if the flag is off, code is invalid/expired, or user doesn't match
     */
    public JoinSession join(String code, Principal agentUser) throws PairingException {
+      String throttleKey = throttleKey(agentUser);
+      long now = System.currentTimeMillis();
+      assertNotLockedOut(throttleKey, now);
+
       // 1. Gate FIRST: do NOT consume the code when the capability is disabled.
       if(!feature.isEnabled()) {
          LOG.warn("Sheet agent pairing join rejected: feature disabled (agent={})",
@@ -66,6 +90,7 @@ public class SheetJoinService {
       // with a clean 4xx rather than a 500 from SheetAgentBroadcastService later.
       PairingGrant grant = pairing.consume(code);
       if(grant == null) {
+         recordFailedAttempt(throttleKey, now);
          LOG.warn("Sheet agent pairing join rejected: invalid/expired code (agent={})",
                   agentUser == null ? "?" : agentUser.getName());
          throw new PairingException(PairingException.Kind.SESSION_EXPIRED, "Invalid or expired pairing code");
@@ -79,23 +104,115 @@ public class SheetJoinService {
             "Viewsheet agent pairing is not yet supported — use a worksheet pairing code.");
       }
 
-      // 4. Same-logical-user check.
+      // 4. Same-logical-user check: the agent must be the identity recorded at mint time.
       if(!PairingUtil.sameLogicalUser(grant.ownerIdentity(), agentUser)) {
+         recordFailedAttempt(throttleKey, now);
          LOG.warn("Sheet agent pairing join rejected: user mismatch (owner={}, agent={})",
                   grant.ownerIdentity(), agentUser == null ? "?" : agentUser.getName());
          throw new PairingException(PairingException.Kind.USER_MISMATCH, "Pairing code does not belong to this user");
+      }
+
+      // 4b. Runtime-ownership check. Step 4 only proves agent == the identity recorded at mint;
+      // that identity is the CALLER's, taken from the mint request, NOT from the runtime. So a
+      // user could mint a code naming another user's runtimeId and pass step 4 (attacker ==
+      // attacker). The pairing access path (SheetRuntimeAccess.getSheetForPairing) deliberately
+      // bypasses the per-session matches() check, so this is the one place that binds the grant
+      // to the runtime's real owner. Compare logical identity (name+org) against the runtime's
+      // owner; a mismatch means the caller is trying to pair into a runtime they do not own.
+      //
+      // A null owner (runtime not in this node's cache / no user) is not treated as a mismatch:
+      // getSheetDirect is node-local, so the runtime — and thus any data access — only exists on
+      // its hosting node, where this lookup returns the real owner and the check bites.
+      Principal runtimeOwner = runtimeAccess.getRuntimeOwner(grant.sheetType(), grant.runtimeId());
+
+      if(runtimeOwner != null && !PairingUtil.sameLogicalUser(runtimeOwner, agentUser)) {
+         recordFailedAttempt(throttleKey, now);
+         LOG.warn("Sheet agent pairing join rejected: runtime not owned by agent " +
+                  "(runtimeId={}, agent={})",
+                  grant.runtimeId(), agentUser == null ? "?" : agentUser.getName());
+         throw new PairingException(PairingException.Kind.USER_MISMATCH,
+                                    "Pairing code does not belong to this user");
       }
 
       // 5. Open a reusable session, carrying the browser's socket session ID for broadcast.
       JoinSession session = sessions.open(grant.runtimeId(), grant.ownerIdentity(),
                                           grant.sheetType(), grant.socketSessionId(),
                                           grant.socketUserName());
+      failedAttempts.remove(throttleKey);
       LOG.info("Sheet agent pairing join granted (runtimeId={}, sheetType={}, agent={})",
                grant.runtimeId(), grant.sheetType(), agentUser.getName());
       return session;
    }
 
+   // -------------------------------------------------------------------------
+   // Failed-attempt throttling
+   // -------------------------------------------------------------------------
+
+   /**
+    * Tracks failed join lookups for a caller within a sliding window.
+    *
+    * @param failures    number of failed attempts recorded in the current window
+    * @param windowStart when the current window started
+    * @param lockedUntil non-zero once {@link #MAX_FAILED_ATTEMPTS} is reached; the caller is
+    *                    rejected until this timestamp
+    */
+   private record AttemptWindow(int failures, long windowStart, long lockedUntil) {}
+
+   private void assertNotLockedOut(String key, long now) throws PairingException {
+      AttemptWindow window = failedAttempts.get(key);
+
+      if(window != null && window.lockedUntil() != 0 && now < window.lockedUntil()) {
+         LOG.warn("Sheet agent pairing join rejected: too many failed attempts (caller={})", key);
+         throw new PairingException(PairingException.Kind.RATE_LIMITED,
+            "Too many failed pairing attempts; try again shortly");
+      }
+   }
+
+   private void recordFailedAttempt(String key, long now) {
+      failedAttempts.compute(key, (k, prev) -> {
+         boolean freshWindow = prev == null || now - prev.windowStart() > SheetPairingService.TTL_MILLIS;
+         long windowStart = freshWindow ? now : prev.windowStart();
+         int failures = freshWindow ? 1 : prev.failures() + 1;
+         long lockedUntil = failures >= MAX_FAILED_ATTEMPTS ? now + LOCKOUT_MILLIS : 0L;
+         return new AttemptWindow(failures, windowStart, lockedUntil);
+      });
+   }
+
+   /** Removes attempt-tracking entries that are no longer relevant to any lockout decision. */
+   @Scheduled(fixedDelay = 10 * 60_000)
+   void evictStaleAttempts() {
+      long now = System.currentTimeMillis();
+      failedAttempts.values().removeIf(w ->
+         now - w.windowStart() > SheetPairingService.TTL_MILLIS && now >= w.lockedUntil());
+   }
+
+   /**
+    * Best-effort caller key for attempt throttling: the client IP when an HTTP request is bound
+    * to the current thread (the normal case for this REST-backed join flow), falling back to the
+    * authenticated agent identity when no request context is available (e.g. direct/unit-test
+    * invocation), and finally to a constant key if neither is available.
+    */
+   private static String throttleKey(Principal agentUser) {
+      try {
+         ServletRequestAttributes attrs =
+            (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+         HttpServletRequest request = attrs.getRequest();
+         String addr = Tool.getRemoteAddr(request);
+
+         if(addr != null && !addr.isBlank()) {
+            return "ip:" + addr;
+         }
+      }
+      catch(IllegalStateException e) {
+         // No servlet request bound to this thread — fall back to caller identity below.
+      }
+
+      return "user:" + (agentUser == null ? "anonymous" : agentUser.getName());
+   }
+
    private final SheetPairingService pairing;
    private final SheetSessionService sessions;
    private final SheetAgentFeature feature;
+   private final SheetRuntimeAccess runtimeAccess;
+   private final ConcurrentHashMap<String, AttemptWindow> failedAttempts = new ConcurrentHashMap<>();
 }

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetRuntimeAccess.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetRuntimeAccess.java
@@ -93,6 +93,24 @@ public class SheetRuntimeAccess {
       };
    }
 
+   /**
+    * Return the owner principal of the runtime with the given id on this node, or null if the
+    * runtime is not in this node's cache (expired / never opened / hosted on another node) or
+    * has no associated user. Side-effect free: does not touch or audit the runtime.
+    *
+    * <p>Used by SheetJoinService to verify, at join time, that the joining agent is the same
+    * logical user as the runtime's owner — the pairing path otherwise bypasses the per-session
+    * matches() check (see {@link #getSheetForPairing}).
+    */
+   public Principal getRuntimeOwner(SheetType sheetType, String runtimeId) {
+      RuntimeSheet rs = switch (sheetType) {
+         case WORKSHEET -> worksheetAccessor.getSheetDirect(runtimeId);
+         case VIEWSHEET -> viewsheetAccessor.getSheetDirect(runtimeId);
+      };
+
+      return rs == null ? null : rs.getUser();
+   }
+
    private RuntimeWorksheet getWorksheetForPairing(String runtimeId, Principal agentUser)
       throws PairingException
    {

--- a/core/src/main/java/inetsoft/web/wiz/service/AddVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/AddVisualizationService.java
@@ -21,9 +21,14 @@ import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.cluster.*;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.WorksheetEngine;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.*;
+import inetsoft.util.Catalog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -46,11 +51,13 @@ public class AddVisualizationService {
 
    public AddVisualizationService(ViewsheetService viewsheetService,
                                   AssetRepository assetRepository,
-                                  WsMergeService wsMergeService)
+                                  WsMergeService wsMergeService,
+                                  SecurityEngine securityEngine)
    {
       this.viewsheetService = viewsheetService;
       this.assetRepository = assetRepository;
       this.wsMergeService = wsMergeService;
+      this.securityEngine = securityEngine;
    }
 
    /**
@@ -81,6 +88,18 @@ public class AddVisualizationService {
                                    Principal principal)
       throws Exception
    {
+      // Action-level gate ("Visual Composer -> Data Worksheet"): the wiz dashboard runtime
+      // referenced by runtimeId may not yet have a backing worksheet (dashVS.getBaseEntry()
+      // == null on the first visualization added to a freshly created dashboard), in which
+      // case this method creates a brand-new Worksheet() below. That runtime can be reached
+      // via WizVsService.createViewsheet without ever passing through a WORKSHEET-gated
+      // open/create flow, so the check must be enforced here rather than relying on the
+      // caller having already been gated.
+      if(!securityEngine.checkPermission(principal, ResourceType.WORKSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
+
       RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
 
       if(rvs == null) {
@@ -98,9 +117,14 @@ public class AddVisualizationService {
          throw new IllegalStateException("Viewsheet is not a wiz dashboard (isWizSheet=false): " + runtimeId);
       }
 
-      // Load visualization VS
+      // Load visualization VS.
+      // permission=true is required: vizEntry comes straight from the client event
+      // (WizComposerController -> AddVisualizationEvent.getEntry()), so the READ ACL must
+      // actually run — otherwise a caller could merge any viewsheet they cannot read
+      // (another user's private viewsheet) into their own dashboard and exfiltrate its data.
+      // Mirrors WizVisualizationService.saveVisualization's permission=true load.
       Viewsheet vizVS = (Viewsheet) assetRepository.getSheet(
-         vizEntry, principal, false, AssetContent.ALL);
+         vizEntry, principal, true, AssetContent.ALL);
 
       if(vizVS == null) {
          throw new Exception("Visualization viewsheet not found: " + vizEntry);
@@ -114,9 +138,12 @@ public class AddVisualizationService {
             "Visualization must be bound to a worksheet datasource: " + vizEntry);
       }
 
-      // Load visualization WS
+      // Load visualization WS.
+      // permission=true for the same reason as the vizVS load above: baseEntry is derived from
+      // the client-supplied vizEntry, so its READ ACL must run to prevent reading the source
+      // tables of a worksheet the caller is not authorized for.
       Worksheet vizWS = (Worksheet) assetRepository.getSheet(
-         baseEntry, principal, false, AssetContent.ALL);
+         baseEntry, principal, true, AssetContent.ALL);
 
       if(vizWS == null) {
          throw new Exception("Could not load worksheet for visualization: " + vizEntry);
@@ -445,6 +472,7 @@ public class AddVisualizationService {
    private final ViewsheetService viewsheetService;
    private final AssetRepository assetRepository;
    private final WsMergeService wsMergeService;
+   private final SecurityEngine securityEngine;
 
    private static final int GRID_COLS = 3;
    private static final int VIZ_GAP = 50;

--- a/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/GenerateWsService.java
@@ -21,6 +21,10 @@ package inetsoft.web.wiz.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.sree.security.IdentityID;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.AssetUtil;
@@ -29,10 +33,12 @@ import inetsoft.uql.jdbc.JDBCDataSource;
 import inetsoft.uql.jdbc.util.SQLTypes;
 import inetsoft.uql.XCondition;
 import inetsoft.uql.schema.XSchema;
+import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
 import inetsoft.web.composer.ws.LayoutGraphService;
 import inetsoft.web.composer.ws.event.WSLayoutGraphEvent;
 import inetsoft.web.composer.ws.joins.InnerJoinService;
+import inetsoft.web.portal.controller.database.DataSourceService;
 import inetsoft.web.wiz.model.*;
 import inetsoft.web.wiz.model.osi.*;
 import inetsoft.web.wiz.request.GetDatabaseTableMetaRequest;
@@ -49,7 +55,9 @@ public class GenerateWsService {
                             InnerJoinService innerJoinService,
                             LayoutGraphService layoutGraphService,
                             WsMergeService wsMergeService,
-                            ObjectMapper objectMapper)
+                            ObjectMapper objectMapper,
+                            DataSourceService dataSourceService,
+                            SecurityEngine securityEngine)
    {
       this.viewsheetService = viewsheetService;
       this.metadataApiService = metadataApiService;
@@ -57,6 +65,8 @@ public class GenerateWsService {
       this.layoutGraphService = layoutGraphService;
       this.wsMergeService = wsMergeService;
       this.objectMapper = objectMapper;
+      this.dataSourceService = dataSourceService;
+      this.securityEngine = securityEngine;
    }
 
    private Worksheet getWorksheet(WorksheetConstructionModel model, Principal user) throws Exception {
@@ -103,6 +113,13 @@ public class GenerateWsService {
    public GenerateWsResponse generateWs(WorksheetConstructionModel model, Principal user)
       throws Exception
    {
+      // Action-level gate ("Visual Composer -> Data Worksheet"): checked first, before any
+      // worksheet is created or loaded/merged — mirrors OpenWorksheetController's ordering.
+      if(!securityEngine.checkPermission(user, ResourceType.WORKSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
+
       WorksheetBuildResult buildResult = buildFreshWorksheet(model, user);
       Worksheet worksheet = buildResult.worksheet();
       AbstractTableAssembly table = buildResult.primaryTable();
@@ -120,7 +137,7 @@ public class GenerateWsService {
          }
 
          AbstractSheet sheet = viewsheetService.getAssetRepository()
-            .getSheet(existingEntry, user, false, AssetContent.ALL);
+            .getSheet(existingEntry, user, true, AssetContent.ALL);
 
          if(!(sheet instanceof Worksheet dashWS)) {
             throw new IllegalArgumentException(
@@ -186,7 +203,7 @@ public class GenerateWsService {
          }
          else {
             table = new PhysicalBoundTableAssembly(worksheet, model.getName());
-            applyColumnSelection(table, fields);
+            applyColumnSelection(table, fields, user);
          }
 
          worksheet.addAssembly(table);
@@ -206,7 +223,7 @@ public class GenerateWsService {
             Map<String, String> tableMapping = new HashMap<>();
 
             for(WorksheetConstructionModel.JoinPath joinPath : joinPaths) {
-               AbstractTableAssembly joinTable = createJoinTable(worksheet, joinPath, fields, tableMapping);
+               AbstractTableAssembly joinTable = createJoinTable(worksheet, joinPath, fields, tableMapping, user);
                worksheet.addAssembly(joinTable);
 
                if(joinPath == joinPaths.getLast()) {
@@ -223,7 +240,7 @@ public class GenerateWsService {
             final Set<TableAssembly> tableAssemblies = new LinkedHashSet<>();
 
             for(WorksheetConstructionModel.JoinPath joinPath : joinPaths) {
-               noperator.addOperator(createJoinOperator(worksheet, joinPath, fields));
+               noperator.addOperator(createJoinOperator(worksheet, joinPath, fields, user));
                tableAssemblies.add((TableAssembly) worksheet.getAssembly(joinPath.getLeftTable().getName()));
                tableAssemblies.add((TableAssembly) worksheet.getAssembly(joinPath.getRightTable().getName()));
             }
@@ -243,7 +260,7 @@ public class GenerateWsService {
          Map<String, String> tableMapping = new HashMap<>();
 
          for(WorksheetConstructionModel.TableSetOperation tableSetOperation : tableSetOperations) {
-            AbstractTableAssembly concatenatedTable = createConcatenatedTable(worksheet, tableSetOperation, fields, tableMapping);
+            AbstractTableAssembly concatenatedTable = createConcatenatedTable(worksheet, tableSetOperation, fields, tableMapping, user);
 
             worksheet.addAssembly(concatenatedTable);
             tableMapping.put(getTableInfoKey(tableSetOperation.getLeftTable()), concatenatedTable.getName());
@@ -482,10 +499,11 @@ public class GenerateWsService {
    }
 
    private TableAssemblyOperator.Operator createJoinOperator(Worksheet worksheet, WorksheetConstructionModel.JoinPath joinPath,
-                                                             List<WorksheetConstructionModel.QueryField> allFields) throws Exception
+                                                             List<WorksheetConstructionModel.QueryField> allFields,
+                                                             Principal user) throws Exception
    {
-      AbstractTableAssembly leftTable = createJoinBaseTable(worksheet, allFields, joinPath.getLeftTable(), joinPath.getLeftKey(), new HashMap<>());
-      AbstractTableAssembly rightTable = createJoinBaseTable(worksheet, allFields, joinPath.getRightTable(), joinPath.getRightKey(), new HashMap<>());
+      AbstractTableAssembly leftTable = createJoinBaseTable(worksheet, allFields, joinPath.getLeftTable(), joinPath.getLeftKey(), new HashMap<>(), user);
+      AbstractTableAssembly rightTable = createJoinBaseTable(worksheet, allFields, joinPath.getRightTable(), joinPath.getRightKey(), new HashMap<>(), user);
       DataRef leftAttr = resolveJoinKeyAttribute(leftTable, joinPath.getLeftKey());
       DataRef rightAttr = resolveJoinKeyAttribute(rightTable, joinPath.getRightKey());
 
@@ -518,10 +536,11 @@ public class GenerateWsService {
    }
 
    private AbstractTableAssembly createConcatenatedTable(Worksheet worksheet, WorksheetConstructionModel.TableSetOperation tableSetOperation,
-                                                         List<WorksheetConstructionModel.QueryField> allFields, Map<String, String> tableMapping) throws Exception
+                                                         List<WorksheetConstructionModel.QueryField> allFields, Map<String, String> tableMapping,
+                                                         Principal user) throws Exception
    {
-      AbstractTableAssembly leftTable = createConcatenatedBaseTable(worksheet, allFields, tableSetOperation.getLeftTable(), tableMapping);
-      AbstractTableAssembly rightTable = createConcatenatedBaseTable(worksheet, allFields, tableSetOperation.getRightTable(), tableMapping);
+      AbstractTableAssembly leftTable = createConcatenatedBaseTable(worksheet, allFields, tableSetOperation.getLeftTable(), tableMapping, user);
+      AbstractTableAssembly rightTable = createConcatenatedBaseTable(worksheet, allFields, tableSetOperation.getRightTable(), tableMapping, user);
       TableAssemblyOperator.Operator operator = new TableAssemblyOperator.Operator();
       operator.setOperation(getConcatenatedOperationType(tableSetOperation.getOperation()));
       TableAssemblyOperator tableAssemblyOperator = new TableAssemblyOperator();
@@ -539,10 +558,11 @@ public class GenerateWsService {
    }
 
    private AbstractTableAssembly createJoinTable(Worksheet worksheet, WorksheetConstructionModel.JoinPath joinPath,
-                                                 List<WorksheetConstructionModel.QueryField> allFields, Map<String, String> tableMapping) throws Exception
+                                                 List<WorksheetConstructionModel.QueryField> allFields, Map<String, String> tableMapping,
+                                                 Principal user) throws Exception
    {
-      AbstractTableAssembly leftTable = createJoinBaseTable(worksheet, allFields, joinPath.getLeftTable(), joinPath.getLeftKey(), tableMapping);
-      AbstractTableAssembly rightTable = createJoinBaseTable(worksheet, allFields, joinPath.getRightTable(), joinPath.getRightKey(), tableMapping);
+      AbstractTableAssembly leftTable = createJoinBaseTable(worksheet, allFields, joinPath.getLeftTable(), joinPath.getLeftKey(), tableMapping, user);
+      AbstractTableAssembly rightTable = createJoinBaseTable(worksheet, allFields, joinPath.getRightTable(), joinPath.getRightKey(), tableMapping, user);
       DataRef leftAttr = resolveJoinKeyAttribute(leftTable, joinPath.getLeftKey());
       DataRef rightAttr = resolveJoinKeyAttribute(rightTable, joinPath.getRightKey());
 
@@ -649,7 +669,8 @@ public class GenerateWsService {
    private AbstractTableAssembly createJoinBaseTable(Worksheet worksheet,
                                                      List<WorksheetConstructionModel.QueryField> allFields,
                                                      WorksheetConstructionModel.TableInfo tableInfo,
-                                                     String joinKey, Map<String, String> tableMapping) throws Exception
+                                                     String joinKey, Map<String, String> tableMapping,
+                                                     Principal user) throws Exception
    {
       String joinLeafTableName = getBaseTableName(tableInfo, tableMapping);
 
@@ -664,15 +685,15 @@ public class GenerateWsService {
          request.setCatalog(tableInfo.getSource().getCatalog());
          request.setSchema(tableInfo.getSource().getSchema());
          request.setTableName(tableInfo.getName());
-         OsiDataset metaData = metadataApiService.getMetaData(request);
+         OsiDataset metaData = metadataApiService.getMetaData(request, user);
 
          table = new PhysicalBoundTableAssembly(worksheet, tableInfo.getName());
-         applySourceInfo(table, tableInfo);
+         applySourceInfo(table, tableInfo, user);
          Set<WorksheetConstructionModel.QueryField> tableFields = getTableFields(allFields, tableInfo);
 
          addJoinKeyField(tableFields, tableInfo, joinKey);
 
-         applyColumnSelection(table, tableFields.stream().toList(), metaData);
+         applyColumnSelection(table, tableFields.stream().toList(), metaData, user);
          worksheet.addAssembly(table);
 
          return table;
@@ -685,7 +706,8 @@ public class GenerateWsService {
    private AbstractTableAssembly createConcatenatedBaseTable(Worksheet worksheet,
                                                              List<WorksheetConstructionModel.QueryField> allFields,
                                                              WorksheetConstructionModel.TableInfo tableInfo,
-                                                             Map<String, String> tableMapping) throws Exception
+                                                             Map<String, String> tableMapping,
+                                                             Principal user) throws Exception
    {
       String joinLeafTableName = getBaseTableName(tableInfo, tableMapping);
 
@@ -695,9 +717,9 @@ public class GenerateWsService {
          }
 
          AbstractTableAssembly table = new PhysicalBoundTableAssembly(worksheet, tableInfo.getName());
-         applySourceInfo(table, tableInfo);
+         applySourceInfo(table, tableInfo, user);
          Set<WorksheetConstructionModel.QueryField> tableFields = getTableFields(allFields, tableInfo);
-         applyColumnSelection(table, tableFields.stream().toList());
+         applyColumnSelection(table, tableFields.stream().toList(), user);
          worksheet.addAssembly(table);
 
          return table;
@@ -744,14 +766,16 @@ public class GenerateWsService {
    }
 
    private void applyColumnSelection(AbstractTableAssembly table,
-                                     List<WorksheetConstructionModel.QueryField> fields) throws Exception
+                                     List<WorksheetConstructionModel.QueryField> fields,
+                                     Principal user) throws Exception
    {
-      applyColumnSelection(table, fields, null);
+      applyColumnSelection(table, fields, null, user);
    }
 
    private void applyColumnSelection(AbstractTableAssembly table,
                                      List<WorksheetConstructionModel.QueryField> fields,
-                                     OsiDataset metaData)
+                                     OsiDataset metaData,
+                                     Principal user)
       throws Exception
    {
       WorksheetConstructionModel.TableInfo selectTable = null;
@@ -772,7 +796,7 @@ public class GenerateWsService {
       table.setColumnSelection(columns);
 
       if(selectTable != null && table instanceof PhysicalBoundTableAssembly) {
-         applySourceInfo(table, selectTable);
+         applySourceInfo(table, selectTable, user);
       }
    }
 
@@ -848,13 +872,22 @@ public class GenerateWsService {
    }
 
    private void applySourceInfo(AbstractTableAssembly table,
-                                WorksheetConstructionModel.TableInfo selectTable) throws Exception
+                                WorksheetConstructionModel.TableInfo selectTable,
+                                Principal user) throws Exception
    {
       if(selectTable == null) {
          return;
       }
 
       WorksheetConstructionModel.SourceInfo source = selectTable.getSource();
+
+      // Verify READ permission on the datasource before resolving/querying its metadata.
+      // Mirrors WorksheetAgentController.addLogicalModelTable's usage of DataSourceService.
+      if(!dataSourceService.checkPermission(source.getPath(), ResourceAction.READ, user)) {
+         throw new IllegalArgumentException(
+            "Access denied: no READ permission on datasource " + source.getPath());
+      }
+
       JDBCDataSource jdbcDatasource = metadataApiService.getJDBCDatasource(source.getPath());
       XNode tableMetaData = metadataApiService.getTableMetaData(jdbcDatasource, source.getCatalog(), source.getSchema(), selectTable.getName());
 
@@ -1323,7 +1356,9 @@ public class GenerateWsService {
    private final InnerJoinService innerJoinService;
    private final LayoutGraphService layoutGraphService;
    private final WsMergeService wsMergeService;
+   private final DataSourceService dataSourceService;
    private final ObjectMapper objectMapper;
+   private final SecurityEngine securityEngine;
 
    // UUID suffix prevents name collision with user-created folders.
    public static final String WORKSHEET_ROOT_FOLDER_PATH =

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -88,8 +88,13 @@ public class MetadataApiService {
          .build();
    }
 
-   public OsiDataset getMetaData(GetDatabaseTableMetaRequest data) throws Exception {
+   public OsiDataset getMetaData(GetDatabaseTableMetaRequest data, Principal principal) throws Exception {
       String dsName = data.getDsName();
+
+      if(!dataSourceService.checkPermission(dsName, ResourceAction.READ, principal)) {
+         throw new SecurityException("Access denied to data source: " + dsName);
+      }
+
       JDBCDataSource jdbcDataSource = getJDBCDatasource(dsName);
       DefaultMetaDataProvider metaDataProvider = getMetaDataProvider(dsName);
 

--- a/core/src/main/java/inetsoft/web/wiz/service/RawDataService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/RawDataService.java
@@ -33,6 +33,7 @@ import inetsoft.uql.jdbc.*;
 import inetsoft.uql.jdbc.util.JDBCUtil;
 import inetsoft.uql.util.XSourceInfo;
 import inetsoft.util.Tool;
+import inetsoft.web.portal.controller.database.DataSourceService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -44,9 +45,12 @@ import java.nio.charset.StandardCharsets;
 
 @Service
 public class RawDataService {
-   public RawDataService(XRepository xrepository, AssetRepository assetRepository) {
+   public RawDataService(XRepository xrepository, AssetRepository assetRepository,
+                         DataSourceService dataSourceService)
+   {
       this.xrepository = xrepository;
       this.assetRepository = assetRepository;
+      this.dataSourceService = dataSourceService;
    }
 
    public void writeWorksheetTableCsvStream(String wsId, String tableName, XPrincipal principal,
@@ -93,6 +97,14 @@ public class RawDataService {
    {
       String datasourcePath = requestData.getDatasourcePath();
       AssetEntry tableEntry = requestData.getTable();
+
+      // Deny before any datasource lookup or query execution; ResponseStatusException (like the
+      // 400 guard below) so the denial surfaces as a clean 403 — RawDataController has no
+      // @ExceptionHandler and a bare SecurityException would become an opaque 500.
+      if(!dataSourceService.checkPermission(datasourcePath, ResourceAction.READ, principal)) {
+         throw new ResponseStatusException(
+            HttpStatus.FORBIDDEN, "Access denied to data source: " + datasourcePath);
+      }
 
       // Fail fast with a diagnosable 400 when the request carries no table asset entry.
       // Callers (e.g. the WIZ annotation profiler) may omit it; without this guard setupTable
@@ -250,6 +262,7 @@ public class RawDataService {
 
    private final XRepository xrepository;
    private final AssetRepository assetRepository;
+   private final DataSourceService dataSourceService;
    private static final int RAW_DATA_MAX_ROW = 10000;
    private static final Logger LOG = LoggerFactory.getLogger(RawDataService.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -31,6 +31,11 @@ import inetsoft.uql.viewsheet.graph.*;
 import inetsoft.graph.aesthetic.*;
 import inetsoft.uql.viewsheet.graph.aesthetic.ColorPalettes;
 import java.awt.Color;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
 import inetsoft.web.vswizard.handler.VSWizardBindingHandler;
 import inetsoft.web.vswizard.model.VSWizardData;
@@ -67,7 +72,8 @@ public class WizAutoBindingService {
                                 VSWizardTemporaryInfoService temporaryInfoService,
                                 VSWizardBindingHandler bindingHandler,
                                 VSDefaultRecommendationFactory defaultRecommendationFactory,
-                                WizVsService wizVsService)
+                                WizVsService wizVsService,
+                                SecurityEngine securityEngine)
    {
       this.viewsheetService = viewsheetService;
       this.engine = engine;
@@ -75,6 +81,7 @@ public class WizAutoBindingService {
       this.bindingHandler = bindingHandler;
       this.defaultRecommendationFactory = defaultRecommendationFactory;
       this.wizVsService = wizVsService;
+      this.securityEngine = securityEngine;
    }
 
    public AutoBindingResponse autoBinding(AutoBindingRequest request, Principal user)
@@ -102,6 +109,16 @@ public class WizAutoBindingService {
                                                    boolean skipExecution)
       throws Exception
    {
+      // Action-level gate ("Visual Composer -> Data Viewsheet"): this method may open a brand-new
+      // temporary viewsheet via viewsheetService.openTemporaryViewsheet below. It is reachable from
+      // two public entry points — autoBinding() directly, and changeType()'s fallback when its
+      // cached recommendation runtime is missing/expired — so the check is enforced here, at the
+      // single choke point both paths share, rather than duplicated in each caller.
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
+
       List<SimpleFieldInfo> fieldConfigs = request.getFieldConfigs() != null
          ? request.getFieldConfigs() : Collections.emptyList();
       String worksheetId = request.getWorksheetId();
@@ -2049,6 +2066,13 @@ public class WizAutoBindingService {
    public CreateViewsheetResult setChartFormat(ChartFormatRequest request, Principal user)
       throws Exception
    {
+      // Action-level gate ("Visual Composer -> Data Viewsheet"): mutates and (below) persists a
+      // viewsheet, so require the composer action right before touching the runtime. Mirrors autoBinding.
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
+
       RuntimeViewsheet rvs = WizUtil.getViewsheetOrRestore(
          viewsheetService, request.getWizRuntimeId(), request.getViewsheetIdentifier(), user);
 
@@ -2243,6 +2267,13 @@ public class WizAutoBindingService {
    public CreateViewsheetResult setChartColors(ChartColorsRequest request, Principal user)
       throws Exception
    {
+      // Action-level gate ("Visual Composer -> Data Viewsheet"): mutates and (below) persists a
+      // viewsheet, so require the composer action right before touching the runtime. Mirrors autoBinding.
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
+
       RuntimeViewsheet rvs = WizUtil.getViewsheetOrRestore(
          viewsheetService, request.getWizRuntimeId(), request.getViewsheetIdentifier(), user);
 
@@ -2499,4 +2530,5 @@ public class WizAutoBindingService {
    private final VSWizardBindingHandler bindingHandler;
    private final VSDefaultRecommendationFactory defaultRecommendationFactory;
    private final WizVsService wizVsService;
+   private final SecurityEngine securityEngine;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizGeoService.java
@@ -28,6 +28,10 @@ import inetsoft.report.composition.graph.GraphUtil;
 import inetsoft.report.internal.graph.ChangeChartTypeProcessor;
 import inetsoft.report.internal.graph.MapData;
 import inetsoft.report.internal.graph.MapHelper;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.erm.DataRef;
@@ -46,6 +50,7 @@ import inetsoft.uql.viewsheet.graph.VSChartGeoRef;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.uql.viewsheet.graph.VSMapInfo;
 import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
 import inetsoft.web.binding.handler.VSChartHandler;
 import inetsoft.web.wiz.WizUtil;
@@ -75,15 +80,26 @@ import java.util.*;
  */
 @Service
 public class WizGeoService {
-   public WizGeoService(ViewsheetService viewsheetService, VSChartHandler chartHandler) {
+   public WizGeoService(ViewsheetService viewsheetService, VSChartHandler chartHandler,
+                        SecurityEngine securityEngine)
+   {
       this.viewsheetService = viewsheetService;
       this.chartHandler = chartHandler;
+      this.securityEngine = securityEngine;
    }
 
    /**
     * Marks {@code column} geographic on the chart and auto-detects its geo type/layer + matching.
     */
    public GeoDetectResponse detect(GeoDetectRequest request, Principal user) throws Exception {
+      // Action-level gate ("Visual Composer -> Data Viewsheet"): opens/mutates a viewsheet runtime
+      // and (in apply) persists it, so require the composer action right. Mirrors the other wiz
+      // viewsheet operations.
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
+
       RuntimeViewsheet rvs =
          getRuntimeViewsheet(request.getRuntimeId(), request.getViewsheetIdentifier(), user);
       Viewsheet vs = rvs.getViewsheet();
@@ -200,6 +216,13 @@ public class WizGeoService {
     * unmatched values.
     */
    public GeoApplyResponse apply(GeoApplyRequest request, Principal user) throws Exception {
+      // Action-level gate ("Visual Composer -> Data Viewsheet"): mutates and persists a viewsheet,
+      // so require the composer action right before touching the runtime.
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
+
       RuntimeViewsheet rvs =
          getRuntimeViewsheet(request.getRuntimeId(), request.getViewsheetIdentifier(), user);
       Viewsheet vs = rvs.getViewsheet();
@@ -300,6 +323,20 @@ public class WizGeoService {
          AssetEntry entry = AssetEntry.createAssetEntry(viewsheetIdentifier);
 
          if(entry != null) {
+            // Restrict writes to the managed wiz folders, mirroring WizVsService.persistViewsheet:
+            // ROOT holds session viewsheets, COMPONENTS holds saved visualizations. Prevents the
+            // mutated (map-converted) viewsheet being written to an arbitrary caller-supplied
+            // identifier outside the wiz-managed area.
+            String path = entry.getPath();
+
+            if(path == null ||
+               !(path.startsWith(WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/") ||
+                 path.startsWith(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/")))
+            {
+               throw new IllegalArgumentException(
+                  "viewsheetIdentifier points outside the managed visualizations folder: " + path);
+            }
+
             viewsheetService.setViewsheet(vs, entry, user, true, true);
          }
       }
@@ -570,6 +607,7 @@ public class WizGeoService {
 
    private final ViewsheetService viewsheetService;
    private final VSChartHandler chartHandler;
+   private final SecurityEngine securityEngine;
 
    private static final Logger LOG = LoggerFactory.getLogger(WizGeoService.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -120,8 +120,25 @@ public class WizVisualizationService {
             "Cannot parse sourceViewsheetIdentifier: " + event.getSourceViewsheetIdentifier());
       }
 
+      String sourceVsPath = sourceVsEntry.getPath();
+
+      // Restrict to the managed wiz folders, mirroring ViewsheetRuntimeController#openViewsheet /
+      // #verifyViewsheet: VISUALIZATION_ROOT_FOLDER_PATH holds wiz session viewsheets (the
+      // "chat's shared ViewSheet" this method is documented to read from), and
+      // VISUALIZATION_COMPONENTS_FOLDER_PATH holds previously-saved visualizations.
+      if(sourceVsPath == null ||
+         !(sourceVsPath.startsWith(VISUALIZATION_ROOT_FOLDER_PATH + "/") ||
+           sourceVsPath.startsWith(VISUALIZATION_COMPONENTS_FOLDER_PATH + "/")))
+      {
+         throw new IllegalArgumentException(
+            "Source viewsheet is not in the managed visualizations folder: " + sourceVsPath);
+      }
+
+      // permission=true is required here: sourceVsEntry is built directly from an
+      // attacker-controlled request field, so the READ permission check must actually run
+      // (see checkAssetPermission) instead of being silently skipped.
       Viewsheet sourceVs = (Viewsheet) assetRepository.getSheet(
-         sourceVsEntry, principal, false, AssetContent.ALL);
+         sourceVsEntry, principal, true, AssetContent.ALL);
 
       if(sourceVs == null) {
          throw new IllegalStateException(

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -33,6 +33,10 @@ import inetsoft.report.composition.graph.VGraphPair;
 import inetsoft.report.composition.graph.VSDataSet;
 import inetsoft.report.internal.graph.MapData;
 import inetsoft.sree.security.IdentityID;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.erm.AttributeRef;
@@ -42,6 +46,7 @@ import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.graph.*;
 import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.VSUtil;
+import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
 import inetsoft.web.vswizard.recommender.WizardRecommenderUtil;
 import inetsoft.web.wiz.WizUtil;
@@ -57,9 +62,12 @@ import java.util.stream.Collectors;
 
 @Service
 public class WizVsService {
-   public WizVsService(ViewsheetService viewsheetService, AssetRepository engine) {
+   public WizVsService(ViewsheetService viewsheetService, AssetRepository engine,
+                       SecurityEngine securityEngine)
+   {
       this.viewsheetService = viewsheetService;
       this.engine = engine;
+      this.securityEngine = securityEngine;
    }
 
    @FunctionalInterface
@@ -98,6 +106,16 @@ public class WizVsService {
                                                          boolean skipExecution,
                                                          PostAssemblyHook hook) throws Exception
    {
+      // Action-level gate ("Visual Composer -> Data Viewsheet"): this path may create a brand-new
+      // temporary viewsheet via viewsheetService.openTemporaryViewsheet below, mirroring the
+      // ComposerViewsheetController.newViewsheet VIEWSHEET/ACCESS check for the UI-driven flow.
+      // Checked unconditionally at the top since this method is reachable from multiple wiz
+      // entry points regardless of whether a new runtime is actually created.
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
+
       String runtimeId = model.getRuntimeId();
       boolean createdRuntimeId = false;
 
@@ -499,6 +517,13 @@ public class WizVsService {
     * @param user  the current user
     */
    public void validateBinding(CreateVisualizationModel model, Principal user) throws Exception {
+      // Action-level gate ("Visual Composer -> Data Viewsheet"): opens and executes a temporary
+      // viewsheet, so require the composer action right before doing any work. Mirrors createViewsheet.
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
+
       String runtimeId = buildAndExecuteFresh(model, user);
 
       try {
@@ -1506,6 +1531,16 @@ public class WizVsService {
    public String persistViewsheet(Viewsheet vs, String existingIdentifier, Principal user)
       throws Exception
    {
+      // Action-level gate ("Visual Composer -> Data Viewsheet"): this is the shared save choke
+      // point for every wiz viewsheet write (createViewsheet, setChartFormat/Colors, and any other
+      // caller). setViewsheet below enforces the per-asset WRITE ACL, but NOT the composer action
+      // right — without this a user denied viewsheet-composer access could still mutate and save a
+      // viewsheet. Mirrors the createViewsheet gate.
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
+
       final AssetEntry entry;
 
       if(!Tool.isEmptyString(existingIdentifier)) {
@@ -3065,6 +3100,14 @@ public class WizVsService {
     * @throws Exception if the repository removal fails
     */
    public void deleteViewsheet(String identifier, Principal user) throws Exception {
+      // Action-level gate ("Visual Composer -> Data Viewsheet"): removeSheet enforces the per-asset
+      // DELETE ACL, but require the composer action right too, consistent with the other wiz
+      // viewsheet operations.
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
+
       AssetEntry entry = AssetEntry.createAssetEntry(identifier);
 
       if(entry == null) {
@@ -3127,6 +3170,13 @@ public class WizVsService {
    public void removeVisualization(String runtimeId, String assemblyName, Principal user)
       throws Exception
    {
+      // Action-level gate ("Visual Composer -> Data Viewsheet"): mutates and persists a viewsheet,
+      // so require the composer action right. The setSheet write below still enforces the WRITE ACL.
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
+
       if(runtimeId == null || runtimeId.isEmpty() || assemblyName == null || assemblyName.isEmpty()) {
          throw new IllegalArgumentException("runtimeId and assemblyName are required");
       }
@@ -3192,6 +3242,7 @@ public class WizVsService {
 
    private final ViewsheetService viewsheetService;
    private final AssetRepository engine;
+   private final SecurityEngine securityEngine;
 
    private static final Logger LOG = LoggerFactory.getLogger(WizVsService.class);
    private static final Map<Class<?>, BiFunction<Viewsheet, String, VSAssembly>> ASSEMBLY_FACTORIES = Map.of(

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -634,7 +634,7 @@ public class WorksheetTableService {
       // sql query table both bind to one via physicalSource; mirror/join tables only reference
       // already-in-worksheet assemblies, so there is no new datasource to check for them).
       // Mirrors WorksheetAgentController.addLogicalModelTable's usage of DataSourceService.
-      WorksheetTableRequest.PhysicalSource src = request.getPhysicalSource();
+      WorksheetTable.PhysicalSource src = request.getPhysicalSource();
 
       if(src != null && src.getDatasourcePath() != null &&
          !dataSourceService.checkPermission(src.getDatasourcePath(), ResourceAction.READ, user))

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -22,6 +22,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.report.TableLens;
 import inetsoft.report.composition.execution.AssetQuerySandbox;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.AssetUtil;
@@ -37,9 +41,11 @@ import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.schema.XTypeNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
 import inetsoft.web.composer.ws.LayoutGraphService;
 import inetsoft.web.composer.ws.joins.InnerJoinService;
+import inetsoft.web.portal.controller.database.DataSourceService;
 import inetsoft.web.portal.controller.database.QueryManagerService;
 import inetsoft.web.wiz.model.*;
 import inetsoft.web.wiz.model.osi.*;
@@ -74,7 +80,9 @@ public class WorksheetTableService {
                                 LayoutGraphService layoutGraphService,
                                 QueryManagerService queryManagerService,
                                 XRepository xrepository,
-                                ObjectMapper objectMapper)
+                                ObjectMapper objectMapper,
+                                DataSourceService dataSourceService,
+                                SecurityEngine securityEngine)
    {
       this.viewsheetService = viewsheetService;
       this.metadataApiService = metadataApiService;
@@ -83,6 +91,21 @@ public class WorksheetTableService {
       this.queryManagerService = queryManagerService;
       this.xrepository = xrepository;
       this.objectMapper = objectMapper;
+      this.dataSourceService = dataSourceService;
+      this.securityEngine = securityEngine;
+   }
+
+   /**
+    * Verifies the "Visual Composer -> Data Worksheet" action permission (EM Security -> Actions).
+    * This is the same action-level gate that {@code OpenWorksheetController}/
+    * {@code SaveWorksheetController} apply to every worksheet open/create/save entry point;
+    * it is independent of (and checked before) any asset- or datasource-level permission.
+    */
+   private void checkWorksheetActionPermission(Principal user) throws Exception {
+      if(!securityEngine.checkPermission(user, ResourceType.WORKSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
    }
 
    // ─── Public entry point ───────────────────────────────────────────────────
@@ -90,6 +113,10 @@ public class WorksheetTableService {
    public WorksheetTablesResponse createTables(WorksheetTableRequest request, Principal user)
       throws Exception
    {
+      // Action-level gate ("Visual Composer -> Data Worksheet"): checked first, before any
+      // asset- or datasource-level permission and before any worksheet construction/mutation.
+      checkWorksheetActionPermission(user);
+
       // 1. Load or create the worksheet — once for the whole batch.
       Worksheet worksheet;
       AssetEntry worksheetEntry;
@@ -97,7 +124,7 @@ public class WorksheetTableService {
       if(request.getWorksheetId() != null) {
          worksheetEntry = AssetEntry.createAssetEntry(request.getWorksheetId());
          AbstractSheet sheet = viewsheetService.getAssetRepository()
-            .getSheet(worksheetEntry, user, false, AssetContent.ALL);
+            .getSheet(worksheetEntry, user, true, AssetContent.ALL);
 
          if(!(sheet instanceof Worksheet ws)) {
             throw new IllegalArgumentException(
@@ -324,6 +351,8 @@ public class WorksheetTableService {
    public WorksheetModel getWorksheetModel(String wsIdentifier, Principal user)
       throws Exception
    {
+      checkWorksheetActionPermission(user);
+
       if(Tool.isEmptyString(wsIdentifier)) {
          throw new IllegalArgumentException("wsIdentifier is required");
       }
@@ -407,6 +436,8 @@ public class WorksheetTableService {
                                                      Principal user)
       throws Exception
    {
+      checkWorksheetActionPermission(user);
+
       if(request.getWorksheetId() == null) {
          throw new IllegalArgumentException("worksheetId is required");
       }
@@ -417,7 +448,7 @@ public class WorksheetTableService {
 
       AssetEntry worksheetEntry = AssetEntry.createAssetEntry(request.getWorksheetId());
       AbstractSheet sheet = viewsheetService.getAssetRepository()
-         .getSheet(worksheetEntry, user, false, AssetContent.ALL);
+         .getSheet(worksheetEntry, user, true, AssetContent.ALL);
 
       if(!(sheet instanceof Worksheet worksheet)) {
          throw new IllegalArgumentException("worksheetId does not reference a worksheet: "
@@ -599,6 +630,31 @@ public class WorksheetTableService {
          throw new IllegalArgumentException("tableType is required");
       }
 
+      // Verify READ permission on the datasource before resolving/using it (physical table and
+      // sql query table both bind to one via physicalSource; mirror/join tables only reference
+      // already-in-worksheet assemblies, so there is no new datasource to check for them).
+      // Mirrors WorksheetAgentController.addLogicalModelTable's usage of DataSourceService.
+      WorksheetTableRequest.PhysicalSource src = request.getPhysicalSource();
+
+      if(src != null && src.getDatasourcePath() != null &&
+         !dataSourceService.checkPermission(src.getDatasourcePath(), ResourceAction.READ, user))
+      {
+         throw new IllegalArgumentException(
+            "Access denied: no READ permission on datasource " + src.getDatasourcePath());
+      }
+
+      // Free-Form SQL action gate ("Visual Composer -> Free Form SQL"): a raw sql query table
+      // executes caller-authored SQL verbatim against the datasource (parsing disabled), so it
+      // must be gated exactly like the SQL query dialog and WorksheetAgentController.addSqlQuery/
+      // editSqlQuery. WORKSHEET/ACCESS + datasource READ (checked above) are not sufficient — a
+      // user allowed to pick tables but denied free-form SQL must not reach this path.
+      if("sql query table".equals(tableType) &&
+         !securityEngine.checkPermission(user, ResourceType.FREE_FORM_SQL, "*", ResourceAction.ACCESS))
+      {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
+
       AbstractTableAssembly table = switch(tableType) {
          case "physical table"        -> buildPhysicalTable(worksheet, request, user);
          case "mirror table"          -> buildMirrorTable(worksheet, request);
@@ -657,7 +713,7 @@ public class WorksheetTableService {
          metaReq.setCatalog(src.getCatalog());
          metaReq.setSchema(src.getSchema());
          metaReq.setTableName(src.getTableName());
-         OsiDataset metaData = metadataApiService.getMetaData(metaReq);
+         OsiDataset metaData = metadataApiService.getMetaData(metaReq, user);
          ColumnSelection cs = buildColumnSelectionFromMeta(metaData);
          table.setColumnSelection(cs);
       }
@@ -1941,7 +1997,7 @@ public class WorksheetTableService {
    {
       AssetEntry worksheetEntry = AssetEntry.createAssetEntry(wsIdentifier);
       AbstractSheet sheet = viewsheetService.getAssetRepository()
-         .getSheet(worksheetEntry, user, false, AssetContent.ALL);
+         .getSheet(worksheetEntry, user, true, AssetContent.ALL);
 
       if(!(sheet instanceof Worksheet worksheet)) {
          throw new IllegalArgumentException(
@@ -2021,6 +2077,8 @@ public class WorksheetTableService {
    private final QueryManagerService queryManagerService;
    private final XRepository xrepository;
    private final ObjectMapper objectMapper;
+   private final DataSourceService dataSourceService;
+   private final SecurityEngine securityEngine;
 
    private static String rootMessage(Throwable t) {
       Throwable root = t;

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -23,6 +23,9 @@ import inetsoft.report.composition.event.AssetEventUtil;
 import inetsoft.report.composition.execution.AssetQuerySandbox;
 import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.AssetUtil;
@@ -34,6 +37,7 @@ import inetsoft.uql.jdbc.util.JDBCUtil;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.util.DefaultMetaDataProvider;
 import inetsoft.uql.util.XEmbeddedTable;
+import inetsoft.util.Catalog;
 import inetsoft.web.composer.ws.LayoutGraphService;
 import inetsoft.web.composer.ws.assembly.WorksheetEventUtil;
 import inetsoft.web.composer.ws.event.WSLayoutGraphEvent;
@@ -77,7 +81,8 @@ public class WorksheetAgentController {
                                    inetsoft.web.wiz.service.MetadataApiService metadataApiService,
                                    QueryManagerService queryManagerService,
                                    LayoutGraphService layoutGraphService,
-                                   DataSourceService dataSourceService)
+                                   DataSourceService dataSourceService,
+                                   SecurityEngine securityEngine)
    {
       this.feature = feature;
       this.joinService = joinService;
@@ -93,6 +98,7 @@ public class WorksheetAgentController {
       this.queryManagerService = queryManagerService;
       this.layoutGraphService = layoutGraphService;
       this.dataSourceService = dataSourceService;
+      this.securityEngine = securityEngine;
    }
 
    // ---------------------------------------------------------------------------
@@ -249,6 +255,25 @@ public class WorksheetAgentController {
 
       if(tablePath == null || tablePath.isBlank()) {
          throw new PairingException("table is required for add_table.");
+      }
+
+      // Verify ACCESS permission on physical-table binding ("Visual Composer -> Physical
+      // Table"), mirroring the checks in OpenWorksheetController.checkPermission() and
+      // TableAssemblyModelFactory.createModelFrom().
+      if(!securityEngine.checkPermission(user, ResourceType.PHYSICAL_TABLE, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(
+            Catalog.getCatalog().getString("composer.ws.boundPhysicalTableForbidden"));
+      }
+
+      // Verify READ on the datasource BEFORE any JDBC metadata probe. getJDBCDatasource/
+      // getTableMetaData do no permission check of their own, so without this an unauthorized
+      // datasource would still be probed (getTableDetails below only checks READ afterwards).
+      // Mirrors addLogicalModelTable / addSqlQuery.
+      if(datasourceName != null &&
+         !dataSourceService.checkPermission(datasourceName, ResourceAction.READ, user))
+      {
+         throw new PairingException(
+            "Access denied: no READ permission on datasource " + datasourceName);
       }
 
       // Get the qualified table name via metadata lookup.
@@ -959,6 +984,14 @@ public class WorksheetAgentController {
    private void editSqlQuery(String sessionToken, EditRequest req, Principal user)
       throws Exception
    {
+      // Verify ACCESS permission on freeform SQL ("Visual Composer -> Free Form SQL"),
+      // mirroring the check performed for the SQL query dialog (SQLQueryDialogController /
+      // SQLQueryDialogService).
+      if(!securityEngine.checkPermission(user, ResourceType.FREE_FORM_SQL, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(
+            Catalog.getCatalog().getString("composer.authorization.permissionDenied"));
+      }
+
       if(req.table() == null || req.table().isBlank()) {
          throw new PairingException("table is required for edit_sql_query.");
       }
@@ -980,6 +1013,20 @@ public class WorksheetAgentController {
 
          if(info.getQuery() == null) {
             throw new PairingException("Table has no query: " + req.table());
+         }
+
+         // Verify READ permission on the datasource this SQL executes against, mirroring
+         // addSqlQuery (which checks the datasource named in the request). Here the datasource
+         // is the one already bound to the assembly; re-checking it ensures a caller cannot run
+         // arbitrary SQL against a datasource they lack READ on (e.g. via a paired-in runtime).
+         XDataSource boundDs = info.getQuery().getDataSource();
+         String dsName = boundDs != null ? boundDs.getFullName() : null;
+
+         if(dsName != null &&
+            !dataSourceService.checkPermission(dsName, ResourceAction.READ, user))
+         {
+            throw new PairingException(
+               "Access denied: no READ permission on datasource " + dsName);
          }
 
          UniformSQL sql = (UniformSQL) info.getQuery().getSQLDefinition();
@@ -1613,6 +1660,21 @@ public class WorksheetAgentController {
          throw new PairingException("sql is required.");
       }
 
+      // Verify ACCESS permission on freeform SQL ("Visual Composer -> Free Form SQL"),
+      // mirroring the check performed for the SQL query dialog (SQLQueryDialogController /
+      // SQLQueryDialogService).
+      if(!securityEngine.checkPermission(user, ResourceType.FREE_FORM_SQL, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(
+            Catalog.getCatalog().getString("composer.authorization.permissionDenied"));
+      }
+
+      // Verify READ permission on the datasource before resolving/querying it,
+      // mirroring the check in addLogicalModelTable().
+      if(!dataSourceService.checkPermission(body.datasource(), ResourceAction.READ, user)) {
+         throw new PairingException(
+            "Access denied: no READ permission on datasource " + body.datasource());
+      }
+
       XDataSource xds;
 
       try {
@@ -1746,6 +1808,7 @@ public class WorksheetAgentController {
          case SESSION_EXPIRED  -> HttpStatus.NOT_FOUND;
          case USER_MISMATCH,
               FEATURE_DISABLED -> HttpStatus.FORBIDDEN;
+         case RATE_LIMITED     -> HttpStatus.TOO_MANY_REQUESTS;
          case INTERNAL        -> HttpStatus.INTERNAL_SERVER_ERROR;
          default              -> HttpStatus.BAD_REQUEST;
       };
@@ -1773,4 +1836,5 @@ public class WorksheetAgentController {
    private final QueryManagerService queryManagerService;
    private final LayoutGraphService layoutGraphService;
    private final DataSourceService dataSourceService;
+   private final SecurityEngine securityEngine;
 }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -20,11 +20,16 @@ package inetsoft.web.wiz.worksheet;
 import inetsoft.report.composition.RuntimeWorksheet;
 import inetsoft.report.composition.event.AssetEventUtil;
 import inetsoft.sree.security.IdentityID;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.*;
 import inetsoft.uql.ColumnSelection;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.uql.asset.internal.TableAssemblyInfo;
+import inetsoft.util.Catalog;
 import inetsoft.util.MessageException;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.DataRef;
@@ -55,11 +60,13 @@ public class WorksheetEditService {
    @Autowired
    public WorksheetEditService(SheetSessionService sessions,
                                SheetRuntimeAccess runtimeAccess,
-                               SheetAgentBroadcastService broadcast)
+                               SheetAgentBroadcastService broadcast,
+                               SecurityEngine securityEngine)
    {
       this.sessions = sessions;
       this.runtimeAccess = runtimeAccess;
       this.broadcast = broadcast;
+      this.securityEngine = securityEngine;
    }
 
    /**
@@ -85,7 +92,7 @@ public class WorksheetEditService {
          SheetType.WORKSHEET, session.runtimeId(), agent);
       applySocketSession(rws, session);
 
-      Editor editor = new Editor(rws.getWorksheet());
+      Editor editor = new Editor(rws.getWorksheet(), agent, securityEngine);
 
       try {
          mutation.accept(editor);
@@ -265,6 +272,7 @@ public class WorksheetEditService {
    private final SheetSessionService sessions;
    private final SheetRuntimeAccess runtimeAccess;
    private final SheetAgentBroadcastService broadcast;
+   private final SecurityEngine securityEngine;
    private static final Logger LOG = LoggerFactory.getLogger(WorksheetEditService.class);
 
    // =========================================================================
@@ -279,8 +287,10 @@ public class WorksheetEditService {
     */
    public static final class Editor {
 
-      Editor(Worksheet ws) {
+      Editor(Worksheet ws, Principal agent, SecurityEngine securityEngine) {
          this.ws = ws;
+         this.agent = agent;
+         this.securityEngine = securityEngine;
       }
 
       /**
@@ -432,8 +442,10 @@ public class WorksheetEditService {
        * @throws PairingException if no {@link TableAssembly} with {@code table} exists
        */
       public void addExpressionColumn(String table, String name, String expression,
-                                      String type, boolean sql) throws PairingException
+                                      String type, boolean sql)
+         throws PairingException, SecurityException
       {
+         requirePermission(ResourceType.WORKSHEET_EXPRESSION_COLUMN);
          WorksheetMutationSupport.addExpressionColumn(requireTable(table), name,
                                                       expression, type, sql);
       }
@@ -484,7 +496,7 @@ public class WorksheetEditService {
                           String rightTable, String rightKey,
                           String joinType,
                           List<String> leftKeys, List<String> rightKeys)
-         throws PairingException
+         throws PairingException, SecurityException
       {
          if("CROSS".equalsIgnoreCase(joinType)) {
             addCrossJoin(name, leftTable, rightTable);
@@ -1020,8 +1032,9 @@ public class WorksheetEditService {
        */
       public void editExpression(String table, String name, String expression,
                                  String type, boolean sql)
-         throws PairingException
+         throws PairingException, SecurityException
       {
+         requirePermission(ResourceType.WORKSHEET_EXPRESSION_COLUMN);
          WorksheetMutationSupport.editExpression(requireTable(table), name, expression, type, sql);
       }
 
@@ -1037,12 +1050,16 @@ public class WorksheetEditService {
        * @param leftKey   the new left-side key column (single-key fallback)
        * @param rightKey  the new right-side key column (single-key fallback)
        * @param joinType  new join type — {@code "INNER"}, {@code "LEFT"}, {@code "RIGHT"},
-       *                  {@code "FULL"} (case-insensitive; defaults to {@code "INNER"})
+       *                  {@code "FULL"}, {@code "CROSS"} (case-insensitive; defaults to
+       *                  {@code "INNER"}). {@code "CROSS"} requires the same CROSS_JOIN
+       *                  permission as {@link #addCrossJoin}.
        * @throws PairingException if the assembly is not found or has no operators
+       * @throws SecurityException if changing to a cross join and the caller lacks
+       *                           CROSS_JOIN permission
        */
       public void editJoin(String name, String leftKey, String rightKey, String joinType,
                            List<String> leftKeys, List<String> rightKeys)
-         throws PairingException
+         throws PairingException, SecurityException
       {
          Assembly a = ws.getAssembly(name);
 
@@ -1069,6 +1086,13 @@ public class WorksheetEditService {
          String leftTable  = existing.getLeftTable();
          String rightTable = existing.getRightTable();
          int operation = parseJoinType(joinType);
+
+         // Changing an existing join into a cross join is as sensitive as creating
+         // one, so it must clear the same permission gate as addCrossJoin(); otherwise
+         // a caller denied CROSS_JOIN could add an INNER join and then edit it to CROSS.
+         if(operation == TableAssemblyOperator.CROSS_JOIN) {
+            requirePermission(ResourceType.CROSS_JOIN);
+         }
 
          // Build a replacement operator with updated keys and join type.
          TableAssemblyOperator newTop = new TableAssemblyOperator();
@@ -1276,8 +1300,9 @@ public class WorksheetEditService {
        * @throws PairingException if either source assembly is not found
        */
       public void addCrossJoin(String name, String leftTable, String rightTable)
-         throws PairingException
+         throws PairingException, SecurityException
       {
+         requirePermission(ResourceType.CROSS_JOIN);
          TableAssembly left  = requireTable(leftTable);
          TableAssembly right = requireTable(rightTable);
 
@@ -1903,6 +1928,15 @@ public class WorksheetEditService {
          }
       }
 
+      private void requirePermission(ResourceType type) throws SecurityException {
+         if(!securityEngine.checkPermission(agent, type, "*", ResourceAction.ACCESS)) {
+            throw new SecurityException(Catalog.getCatalog().getString(
+               "composer.authorization.permissionDenied"));
+         }
+      }
+
       private final Worksheet ws;
+      private final Principal agent;
+      private final SecurityEngine securityEngine;
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/AppDomainUtilsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/AppDomainUtilsTest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz;
 
 import inetsoft.sree.SreeEnv;
+import inetsoft.sree.security.OrganizationManager;
 import inetsoft.uql.XPrincipal;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -97,10 +98,62 @@ class AppDomainUtilsTest {
       OrganizationDomains domains = new OrganizationDomains();
       domains.setId("global.example");
 
-      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class);
+          MockedStatic<OrganizationManager> orgManagerStatic = mockStatic(OrganizationManager.class))
+      {
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+         when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+
          AppDomainUtils.setAppDomains(domains, principal);
 
          sreeEnv.verify(() -> SreeEnv.setProperty("app.domains", "global.example", true));
+      }
+   }
+
+   @Test
+   void setAppDomainsThrowsForNonAdminUser() {
+      XPrincipal principal = mock(XPrincipal.class);
+      when(principal.getOrgId()).thenReturn("customerOrg");
+
+      OrganizationDomains domains = new OrganizationDomains();
+      domains.setId("attacker.example");
+
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class);
+          MockedStatic<OrganizationManager> orgManagerStatic = mockStatic(OrganizationManager.class))
+      {
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+         when(orgManager.isSiteAdmin(principal)).thenReturn(false);
+         when(orgManager.isOrgAdmin(principal)).thenReturn(false);
+
+         assertThrows(SecurityException.class,
+                      () -> AppDomainUtils.setAppDomains(domains, principal));
+
+         sreeEnv.verifyNoInteractions();
+      }
+   }
+
+   @Test
+   void setAppDomainsAllowsOrgAdminEvenWhenNotSiteAdmin() {
+      XPrincipal principal = mock(XPrincipal.class);
+      when(principal.getOrgId()).thenReturn("customerOrg");
+
+      OrganizationDomains domains = new OrganizationDomains();
+      domains.setId("customer.example");
+
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class);
+          MockedStatic<OrganizationManager> orgManagerStatic = mockStatic(OrganizationManager.class))
+      {
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+         when(orgManager.isSiteAdmin(principal)).thenReturn(false);
+         when(orgManager.isOrgAdmin(principal)).thenReturn(true);
+
+         AppDomainUtils.setAppDomains(domains, principal);
+
+         sreeEnv.verify(() -> SreeEnv.setProperty(
+            "app.domains.customerOrg", "customer.example", true));
       }
    }
 
@@ -141,7 +194,13 @@ class AppDomainUtilsTest {
       domains.setId("customer.example");
       domains.setSubDomainIds(List.of("sub.customer.example"));
 
-      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class);
+          MockedStatic<OrganizationManager> orgManagerStatic = mockStatic(OrganizationManager.class))
+      {
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+         when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+
          AppDomainUtils.setAppDomains(domains, principal);
 
          sreeEnv.verify(() -> SreeEnv.setProperty(

--- a/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+/**
+ * Verifies that {@link WizControllerErrorHandler} maps a permission-denial {@code SecurityException}
+ * thrown from a wiz controller to HTTP 403 — rather than the generic 500 it would produce without a
+ * package-scoped advice (no other {@code @ControllerAdvice} covers {@code inetsoft.web.wiz}, and
+ * {@code GlobalExceptionHandler} does not handle {@code SecurityException}).
+ */
+@Tag("core")
+class WizControllerErrorHandlerTest {
+   private MockMvc mvc;
+
+   @BeforeEach
+   void setUp() {
+      mvc = standaloneSetup(new ThrowingController())
+         .setControllerAdvice(new WizControllerErrorHandler())
+         .build();
+   }
+
+   @Test
+   void sreeSecurityExceptionMapsToForbidden() throws Exception {
+      mvc.perform(get("/wiz-test/throw").param("type", "sree"))
+         .andExpect(status().isForbidden())
+         .andExpect(content().string(containsString("Forbidden")));
+   }
+
+   @Test
+   void javaLangSecurityExceptionMapsToForbidden() throws Exception {
+      mvc.perform(get("/wiz-test/throw").param("type", "lang"))
+         .andExpect(status().isForbidden())
+         .andExpect(content().string(containsString("Forbidden")));
+   }
+
+   @RestController
+   private static class ThrowingController {
+      @GetMapping("/wiz-test/throw")
+      public String throwIt(@RequestParam("type") String type) throws Exception {
+         if("sree".equals(type)) {
+            throw new inetsoft.sree.security.SecurityException("denied");
+         }
+
+         throw new java.lang.SecurityException("denied");
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/DatasourceMetaApiControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/DatasourceMetaApiControllerTest.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.uql.XRepository;
+import inetsoft.web.portal.controller.database.DataSourceService;
+import inetsoft.web.wiz.model.osi.OsiDataset;
+import inetsoft.web.wiz.request.GetDatabaseTableMetaRequest;
+import inetsoft.web.wiz.service.MetadataApiService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that {@link DatasourceMetaApiController#getDatabaseTableMeta} passes the resolved
+ * {@link Principal} through to {@link MetadataApiService#getMetaData} unchanged, so the
+ * READ-permission check added there actually receives the requesting user.
+ */
+@Tag("core")
+class DatasourceMetaApiControllerTest {
+
+   @Test
+   void getDatabaseTableMeta_passesRequestAndPrincipalThroughUnchanged() throws Exception {
+      MetadataApiService metadataService = mock(MetadataApiService.class);
+      XRepository xrepository = mock(XRepository.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      DatasourceMetaApiController controller =
+         new DatasourceMetaApiController(metadataService, xrepository, dataSourceService);
+
+      GetDatabaseTableMetaRequest request = new GetDatabaseTableMetaRequest();
+      request.setDsName("Examples/Orders");
+      request.setTableName("CUSTOMERS");
+      Principal principal = mock(Principal.class);
+
+      OsiDataset expected = new OsiDataset();
+      when(metadataService.getMetaData(request, principal)).thenReturn(expected);
+
+      OsiDataset result = controller.getDatabaseTableMeta(request, principal);
+
+      assertSame(expected, result);
+      verify(metadataService).getMetaData(request, principal);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/ViewsheetRuntimeControllerSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/ViewsheetRuntimeControllerSecurityTest.java
@@ -1,0 +1,171 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.web.wiz.service.WizVisualizationService;
+import inetsoft.web.wiz.service.WizVsService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the VIEWSHEET/ACCESS authorization gate in {@code ViewsheetRuntimeController#openViewsheet}
+ * and {@code #verifyViewsheet}, enforced right after the existing managed-folder path-scoping check
+ * and before {@code viewsheetService.openViewsheet(...)} is called.
+ */
+@Tag("core")
+class ViewsheetRuntimeControllerSecurityTest {
+
+   /** A valid identifier whose path lives under the managed wiz visualization root folder,
+    *  so the pre-existing path-scoping check passes and the new security gate is reached. */
+   private static String managedIdentifier() {
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/abc", null);
+      return entry.toIdentifier();
+   }
+
+   @Test
+   void openViewsheet_throwsSecurityExceptionAndSkipsOpenWhenPermissionDenied() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      WizVsService wizVsService = mock(WizVsService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      ViewsheetRuntimeController controller =
+         new ViewsheetRuntimeController(vsService, wizVsService, securityEngine);
+
+      SecurityException ex = assertThrows(SecurityException.class,
+         () -> controller.openViewsheet(managedIdentifier(), null, principal));
+
+      assertNotNull(ex.getMessage(), "SecurityException should carry a localized denial message");
+
+      // Denied before the downstream open call.
+      verify(vsService, never())
+         .openViewsheet(any(AssetEntry.class), any(), anyBoolean());
+   }
+
+   @Test
+   void openViewsheet_proceedsPastPermissionCheckWhenGranted() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      WizVsService wizVsService = mock(WizVsService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      // A distinctive marker exception from the very next collaborator call
+      // (viewsheetService.openViewsheet) proves execution reached past the security gate.
+      RuntimeException marker = new RuntimeException("marker-past-gate");
+      when(vsService.openViewsheet(any(AssetEntry.class), eq(principal), eq(true)))
+         .thenThrow(marker);
+
+      ViewsheetRuntimeController controller =
+         new ViewsheetRuntimeController(vsService, wizVsService, securityEngine);
+
+      RuntimeException thrown = assertThrows(RuntimeException.class,
+         () -> controller.openViewsheet(managedIdentifier(), null, principal));
+
+      assertEquals("marker-past-gate", thrown.getMessage(),
+         "should fail past the gate on the marker, not be denied by SecurityException");
+
+      verify(securityEngine).checkPermission(
+         principal, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS);
+      verify(vsService).openViewsheet(any(AssetEntry.class), eq(principal), eq(true));
+   }
+
+   @Test
+   void verifyViewsheet_throwsSecurityExceptionAndSkipsOpenWhenPermissionDenied() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      WizVsService wizVsService = mock(WizVsService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      ViewsheetRuntimeController controller =
+         new ViewsheetRuntimeController(vsService, wizVsService, securityEngine);
+
+      SecurityException ex = assertThrows(SecurityException.class,
+         () -> controller.verifyViewsheet(managedIdentifier(), null, principal));
+
+      assertNotNull(ex.getMessage(), "SecurityException should carry a localized denial message");
+
+      // Denied before the runtime is opened — no query is executed for an unauthorized caller.
+      verify(vsService, never())
+         .openViewsheet(any(AssetEntry.class), any(), anyBoolean());
+   }
+
+   @Test
+   void verifyViewsheet_proceedsPastPermissionCheckWhenGranted() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      WizVsService wizVsService = mock(WizVsService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      // A distinctive marker exception from the very next collaborator call
+      // (viewsheetService.openViewsheet) proves execution reached past the security gate.
+      RuntimeException marker = new RuntimeException("marker-past-gate");
+      when(vsService.openViewsheet(any(AssetEntry.class), eq(principal), eq(true)))
+         .thenThrow(marker);
+
+      ViewsheetRuntimeController controller =
+         new ViewsheetRuntimeController(vsService, wizVsService, securityEngine);
+
+      RuntimeException thrown = assertThrows(RuntimeException.class,
+         () -> controller.verifyViewsheet(managedIdentifier(), null, principal));
+
+      assertEquals("marker-past-gate", thrown.getMessage(),
+         "should fail past the gate on the marker, not be denied by SecurityException");
+
+      verify(securityEngine).checkPermission(
+         principal, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS);
+      verify(vsService).openViewsheet(any(AssetEntry.class), eq(principal), eq(true));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizAuthCallbackControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizAuthCallbackControllerTest.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link WizAuthCallbackController#pickup(String)}.
+ *
+ * <p>The controller has no external dependencies (the pending-token store is an in-memory
+ * map owned by the instance), so it can be exercised directly without mocks or a Spring
+ * context.
+ *
+ * [blankNonce]           blank nonce -> badRequest()
+ * [tooShortNonce]        non-blank, valid charset, < 16 chars -> badRequest()
+ * [invalidCharsSpace]    >= 16 chars but contains a space -> badRequest()
+ * [invalidCharsScript]   >= 16 chars but contains "<script>"-style characters -> badRequest()
+ * [wellFormedUnknown]    well-formed (>= 16 chars, valid charset) but unknown nonce ->
+ *                        notFound(), proving the format check does not overreject
+ */
+@Tag("core")
+class WizAuthCallbackControllerTest {
+
+   private final WizAuthCallbackController controller = new WizAuthCallbackController();
+
+   @Test
+   void blankNonceIsRejected() {
+      ResponseEntity<Map<String, Object>> response = controller.pickup("   ");
+
+      assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+   }
+
+   @Test
+   void emptyNonceIsRejected() {
+      ResponseEntity<Map<String, Object>> response = controller.pickup("");
+
+      assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+   }
+
+   @Test
+   void tooShortNonceIsRejected() {
+      // 15 chars, valid charset (< MIN_NONCE_LENGTH of 16).
+      ResponseEntity<Map<String, Object>> response = controller.pickup("Abc123_-Xyz9876");
+
+      assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+   }
+
+   @Test
+   void nonceWithSpaceIsRejected() {
+      // >= 16 chars but contains a space, which is outside [A-Za-z0-9_-].
+      String nonce = "Abc123 456789012";
+      assertEquals(16, nonce.length());
+
+      ResponseEntity<Map<String, Object>> response = controller.pickup(nonce);
+
+      assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+   }
+
+   @Test
+   void nonceWithScriptTagCharsIsRejected() {
+      // >= 16 chars, contains characters outside the allowed nonce charset.
+      String nonce = "<script>alert(1)</script>";
+
+      ResponseEntity<Map<String, Object>> response = controller.pickup(nonce);
+
+      assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+   }
+
+   @Test
+   void wellFormedButUnknownNonceIsNotFoundRatherThanBadRequest() {
+      // 32 chars, valid charset, but no pending token was ever stored for it. This proves the
+      // well-formed check passes and the request fails for a *different* reason (unknown/expired
+      // token), not because the format check is overly strict.
+      String nonce = "Abcdefgh12345678_-ABCDEFGH123456";
+      assertEquals(32, nonce.length());
+
+      ResponseEntity<Map<String, Object>> response = controller.pickup(nonce);
+
+      assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetJoinServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetJoinServiceTest.java
@@ -39,6 +39,10 @@ import static org.mockito.Mockito.when;
  * [codeConsumed]    second join with same code -> PairingException
  * [featureOff]      feature off -> PairingException; code not consumed
  * [viewsheet]       viewsheet code -> PairingException (not yet supported)
+ * [lockout]         8 failed lookups from the same caller -> 9th call (even with a valid code)
+ *                   throws PairingException with Kind.RATE_LIMITED
+ * [differentKeys]   lockout of one caller does not affect a different caller
+ * [resetOnSuccess]  a successful join resets the failure counter for that caller
  */
 @Tag("core")
 @ExtendWith(MockitoExtension.class)
@@ -51,6 +55,9 @@ class SheetJoinServiceTest {
    @Mock
    private SheetAgentFeature feature;
 
+   @Mock
+   private SheetRuntimeAccess runtimeAccess;
+
    private SheetPairingService pairing;
    private SheetSessionService sessions;
    private SheetJoinService svc;
@@ -59,7 +66,7 @@ class SheetJoinServiceTest {
    void setUp() {
       pairing  = new SheetPairingService(() -> FIXED_NOW);
       sessions = new SheetSessionService(() -> FIXED_NOW);
-      svc      = new SheetJoinService(pairing, sessions, feature);
+      svc      = new SheetJoinService(pairing, sessions, feature, runtimeAccess);
    }
 
    // ---------------------------------------------------------------------------
@@ -141,5 +148,134 @@ class SheetJoinServiceTest {
       Principal alice = TestPrincipals.user("alice", "host-org");
 
       assertThrows(PairingException.class, () -> svc.join(code, alice));
+   }
+
+   // ---------------------------------------------------------------------------
+   // 7. lockoutAfterThresholdBlocksSubsequentValidJoin
+   // ---------------------------------------------------------------------------
+   @Test
+   void lockoutAfterThresholdBlocksSubsequentValidJoin() {
+      when(feature.isEnabled()).thenReturn(true);
+      Principal alice = TestPrincipals.user("alice", "host-org");
+
+      // 8 failed lookups (invalid code) from the same caller trip the lockout.
+      for(int i = 0; i < 8; i++) {
+         assertThrows(PairingException.class, () -> svc.join("NOPE", alice));
+      }
+
+      // The 9th call is rejected as rate-limited even though the code is valid — the lockout
+      // blocks all attempts, not just repeats of the same failure.
+      String code = pairing.mint("Worksheet/lockout-1", ALICE_KEY, "sock-lockout-1", null,
+                                  SheetType.WORKSHEET);
+
+      PairingException ex = assertThrows(PairingException.class, () -> svc.join(code, alice));
+      assertEquals(PairingException.Kind.RATE_LIMITED, ex.getKind());
+   }
+
+   // ---------------------------------------------------------------------------
+   // 8. differentThrottleKeysDoNotInterfere
+   // ---------------------------------------------------------------------------
+   @Test
+   void differentThrottleKeysDoNotInterfere() throws PairingException {
+      when(feature.isEnabled()).thenReturn(true);
+      Principal alice = TestPrincipals.user("alice", "host-org");
+      Principal bob = TestPrincipals.user("bob", "host-org");
+
+      // Lock out alice.
+      for(int i = 0; i < 8; i++) {
+         assertThrows(PairingException.class, () -> svc.join("NOPE", alice));
+      }
+
+      String aliceCode = pairing.mint("Worksheet/lockout-2a", ALICE_KEY, "sock-lockout-2a", null,
+                                       SheetType.WORKSHEET);
+      PairingException ex = assertThrows(PairingException.class, () -> svc.join(aliceCode, alice));
+      assertEquals(PairingException.Kind.RATE_LIMITED, ex.getKind());
+
+      // bob is a different throttle key (no HTTP request bound in this unit test, so the key
+      // falls back to "user:" + agent name) and must be unaffected by alice's lockout.
+      String bobCode = pairing.mint("Worksheet/lockout-2b", BOB_KEY, "sock-lockout-2b", null,
+                                     SheetType.WORKSHEET);
+      JoinSession session = svc.join(bobCode, bob);
+
+      assertNotNull(session);
+   }
+
+   // ---------------------------------------------------------------------------
+   // 9. successfulJoinResetsFailureCounter
+   // ---------------------------------------------------------------------------
+   @Test
+   void successfulJoinResetsFailureCounter() throws PairingException {
+      when(feature.isEnabled()).thenReturn(true);
+      Principal alice = TestPrincipals.user("alice", "host-org");
+
+      // 5 failures — below the lockout threshold of 8.
+      for(int i = 0; i < 5; i++) {
+         assertThrows(PairingException.class, () -> svc.join("NOPE", alice));
+      }
+
+      String code = pairing.mint("Worksheet/reset-1", ALICE_KEY, "sock-reset-1", null,
+                                  SheetType.WORKSHEET);
+      JoinSession session = svc.join(code, alice);
+      assertNotNull(session);
+
+      // 5 more failures post-success. If the earlier 5 failures had carried over instead of
+      // being reset, this would total 10 cumulative failures and alice would already be locked
+      // out by now.
+      for(int i = 0; i < 5; i++) {
+         assertThrows(PairingException.class, () -> svc.join("NOPE", alice));
+      }
+
+      String code2 = pairing.mint("Worksheet/reset-2", ALICE_KEY, "sock-reset-2", null,
+                                   SheetType.WORKSHEET);
+      JoinSession session2 = svc.join(code2, alice);
+
+      assertNotNull(session2);
+   }
+
+   // ---------------------------------------------------------------------------
+   // 10. runtimeOwnedByAnotherUserIsRejected
+   //
+   // The core IDOR guard: a caller mints a code naming a runtime they do NOT own (the grant's
+   // ownerIdentity is stamped with the CALLER's identity, so the same-logical-user check in
+   // step 4 passes — attacker == attacker). Step 4b must still reject the join because the
+   // runtime's real owner is a different logical user.
+   // ---------------------------------------------------------------------------
+   @Test
+   void runtimeOwnedByAnotherUserIsRejected() {
+      when(feature.isEnabled()).thenReturn(true);
+      // Attacker (alice) mints a code for carol's runtime — grant.ownerIdentity == ALICE_KEY.
+      String code = pairing.mint("Worksheet/victim-1", ALICE_KEY, "sock-idor", null,
+                                 SheetType.WORKSHEET);
+      when(runtimeAccess.getRuntimeOwner(SheetType.WORKSHEET, "Worksheet/victim-1"))
+         .thenReturn(TestPrincipals.user("carol", "host-org"));
+      Principal alice = TestPrincipals.user("alice", "host-org");
+
+      PairingException ex = assertThrows(PairingException.class, () -> svc.join(code, alice));
+      assertEquals(PairingException.Kind.USER_MISMATCH, ex.getKind());
+
+      // The code was still consumed (single-use), so a retry also fails.
+      assertNull(pairing.peek(code));
+   }
+
+   // ---------------------------------------------------------------------------
+   // 11. runtimeOwnedBySameUserIsAllowed
+   //
+   // The legitimate case: the runtime's real owner is the same logical user as the agent, even
+   // though they are different Principal objects (browser session vs JWT-rebuilt agent).
+   // ---------------------------------------------------------------------------
+   @Test
+   void runtimeOwnedBySameUserIsAllowed() throws PairingException {
+      when(feature.isEnabled()).thenReturn(true);
+      String code = pairing.mint("Worksheet/mine-1", ALICE_KEY, "sock-mine", null,
+                                 SheetType.WORKSHEET);
+      // A distinct Principal object with the same logical identity (name+org) as the agent.
+      when(runtimeAccess.getRuntimeOwner(SheetType.WORKSHEET, "Worksheet/mine-1"))
+         .thenReturn(TestPrincipals.user("alice", "host-org"));
+      Principal alice = TestPrincipals.user("alice", "host-org");
+
+      JoinSession session = svc.join(code, alice);
+
+      assertNotNull(session);
+      assertEquals("Worksheet/mine-1", session.runtimeId());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/AddVisualizationServiceSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/AddVisualizationServiceSecurityTest.java
@@ -1,0 +1,158 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.uql.asset.AssetContent;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.Viewsheet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the authorization gate at the top of {@code AddVisualizationService#doAddVisualization}
+ * (reached via the public {@code addVisualization} entry point): unlike the other three wiz
+ * security gates, this one checks {@link ResourceType#WORKSHEET}/{@link ResourceAction#ACCESS} —
+ * not VIEWSHEET — because this method may create a brand-new backing {@code Worksheet()} for the
+ * wiz dashboard (see the code comment on doAddVisualization). The check must run before any
+ * runtime viewsheet lookup, and must deny with a {@link SecurityException} when refused.
+ */
+@Tag("core")
+class AddVisualizationServiceSecurityTest {
+
+   @Test
+   void addVisualization_throwsSecurityExceptionAndSkipsLookupWhenPermissionDenied() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WsMergeService wsMergeService = mock(WsMergeService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      AssetEntry vizEntry = mock(AssetEntry.class);
+
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.WORKSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      AddVisualizationService service =
+         new AddVisualizationService(vsService, assetRepository, wsMergeService, securityEngine);
+
+      SecurityException ex = assertThrows(SecurityException.class,
+         () -> service.addVisualization("rt-1", vizEntry, 0, 0, 1.0f, principal));
+
+      assertNotNull(ex.getMessage(), "SecurityException should carry a localized denial message");
+
+      // Denied before any runtime viewsheet lookup or asset access.
+      verifyNoInteractions(vsService);
+      verifyNoInteractions(assetRepository);
+      verifyNoInteractions(wsMergeService);
+   }
+
+   @Test
+   void addVisualization_proceedsPastPermissionCheckWhenGranted() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WsMergeService wsMergeService = mock(WsMergeService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      AssetEntry vizEntry = mock(AssetEntry.class);
+
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.WORKSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      // A distinctive marker exception thrown by the very next collaborator call
+      // (viewsheetService.getViewsheet) proves execution reached past the security gate.
+      RuntimeException marker = new RuntimeException("marker-past-gate");
+      when(vsService.getViewsheet(eq("rt-1"), eq(principal))).thenThrow(marker);
+
+      AddVisualizationService service =
+         new AddVisualizationService(vsService, assetRepository, wsMergeService, securityEngine);
+
+      RuntimeException thrown = assertThrows(RuntimeException.class,
+         () -> service.addVisualization("rt-1", vizEntry, 0, 0, 1.0f, principal));
+
+      assertEquals("marker-past-gate", thrown.getMessage(),
+         "should fail past the gate on the marker, not be denied by SecurityException");
+
+      verify(securityEngine).checkPermission(
+         principal, ResourceType.WORKSHEET, "*", ResourceAction.ACCESS);
+      verify(vsService).getViewsheet("rt-1", principal);
+   }
+
+   /**
+    * IDOR regression guard: the client-supplied {@code vizEntry} must be loaded with
+    * permission=true so the READ ACL actually runs. If it were loaded with permission=false
+    * (the original bug), a caller could merge any viewsheet they cannot read into their own
+    * dashboard and exfiltrate its data. This test drives execution to the vizEntry load and
+    * asserts the permission flag is true.
+    */
+   @Test
+   void addVisualization_loadsVizEntryWithPermissionCheckEnabled() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WsMergeService wsMergeService = mock(WsMergeService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      AssetEntry vizEntry = mock(AssetEntry.class);
+
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.WORKSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      // A valid wiz dashboard runtime so execution reaches the vizEntry load.
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet dashVS = mock(Viewsheet.class);
+      Viewsheet.WizInfo wizInfo = mock(Viewsheet.WizInfo.class);
+      when(vsService.getViewsheet(eq("rt-1"), eq(principal))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(dashVS);
+      when(dashVS.getWizInfo()).thenReturn(wizInfo);
+      when(wizInfo.isWizSheet()).thenReturn(true);
+
+      // The vizEntry load returns null, so the method throws right after — but only after the
+      // (permission=true) getSheet call we are asserting on has been made.
+      when(assetRepository.getSheet(eq(vizEntry), eq(principal), eq(true), any(AssetContent.class)))
+         .thenReturn(null);
+
+      AddVisualizationService service =
+         new AddVisualizationService(vsService, assetRepository, wsMergeService, securityEngine);
+
+      assertThrows(Exception.class,
+         () -> service.addVisualization("rt-1", vizEntry, 0, 0, 1.0f, principal));
+
+      // The attacker-controlled vizEntry must be loaded with the READ permission check ENABLED.
+      verify(assetRepository).getSheet(eq(vizEntry), eq(principal), eq(true), any(AssetContent.class));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/BindingSlotsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/BindingSlotsTest.java
@@ -144,7 +144,7 @@ class BindingSlotsTest {
       CrosstabVSAssembly assembly = new CrosstabVSAssembly();
       assembly.setVSCrosstabInfo(cinfo);
 
-      WizVsService service = new WizVsService(null, null);
+      WizVsService service = new WizVsService(null, null, null);
       CreateViewsheetResult.FlatBinding binding = service.collectFlatBinding(assembly);
 
       assertEquals(1, binding.getDimensions().size());

--- a/core/src/test/java/inetsoft/web/wiz/service/GenerateWsServicePermissionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/GenerateWsServicePermissionTest.java
@@ -1,0 +1,193 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.web.composer.ws.LayoutGraphService;
+import inetsoft.web.composer.ws.joins.InnerJoinService;
+import inetsoft.web.portal.controller.database.DataSourceService;
+import inetsoft.web.wiz.model.WorksheetConstructionModel;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Coverage for the authorization gates added to {@link GenerateWsService}:
+ * <ul>
+ *   <li>the "Visual Composer -> Data Worksheet" action-level gate checked at the top of
+ *       {@code generateWs}</li>
+ *   <li>the datasource READ check inside {@code applySourceInfo}, reached while building the
+ *       primary physical table for a new (non-worksheet-origin, non-join) query</li>
+ * </ul>
+ *
+ * <p>These tests only assert on the gate itself: denial short-circuits before any worksheet
+ * load/mutation or datasource metadata lookup, and grant lets execution proceed past the check
+ * (verified by the mock interaction actually happening), regardless of what unrelated exception
+ * the deliberately-minimal downstream mocking then produces.
+ *
+ * <p>Needs the full Sree bootstrap because {@code new Worksheet()} (constructed by
+ * {@code buildFreshWorksheet} once the field-selection check passes) reads {@code SreeEnv} in its
+ * constructor.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class GenerateWsServicePermissionTest {
+   private static class Deps {
+      final ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      final MetadataApiService metadataApiService = mock(MetadataApiService.class);
+      final InnerJoinService innerJoinService = mock(InnerJoinService.class);
+      final LayoutGraphService layoutGraphService = mock(LayoutGraphService.class);
+      final WsMergeService wsMergeService = mock(WsMergeService.class);
+      final ObjectMapper objectMapper = new ObjectMapper();
+      final DataSourceService dataSourceService = mock(DataSourceService.class);
+      final SecurityEngine securityEngine = mock(SecurityEngine.class);
+
+      GenerateWsService service() {
+         return new GenerateWsService(viewsheetService, metadataApiService, innerJoinService,
+                                      layoutGraphService, wsMergeService, objectMapper,
+                                      dataSourceService, securityEngine);
+      }
+   }
+
+   private static final Principal USER = mock(Principal.class);
+
+   /** A single-field, single-table (DATABASE, not WORKSHEET), no-join construction model. */
+   private static WorksheetConstructionModel physicalFieldModel(String datasourcePath) {
+      WorksheetConstructionModel.SourceInfo source = new WorksheetConstructionModel.SourceInfo();
+      source.setType("DATABASE");
+      source.setPath(datasourcePath);
+      source.setSchema("public");
+
+      WorksheetConstructionModel.TableInfo table = new WorksheetConstructionModel.TableInfo();
+      table.setName("customers");
+      table.setSource(source);
+
+      WorksheetConstructionModel.QueryField field =
+         new WorksheetConstructionModel.QueryField(table, "id");
+      field.setVisible(true);
+
+      WorksheetConstructionModel model = new WorksheetConstructionModel();
+      model.setName("newTable");
+      model.setFields(List.of(field));
+      return model;
+   }
+
+   // ─── generateWs: WORKSHEET/ACCESS gate ─────────────────────────────────────
+
+   @Test
+   void generateWsThrowsWhenWorksheetAccessDenied() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      // Content doesn't matter: denial must short-circuit before the model is even inspected.
+      WorksheetConstructionModel model = new WorksheetConstructionModel();
+
+      assertThrows(SecurityException.class, () -> deps.service().generateWs(model, USER));
+
+      verifyNoInteractions(deps.viewsheetService);
+      verifyNoInteractions(deps.metadataApiService);
+      verifyNoInteractions(deps.dataSourceService);
+   }
+
+   @Test
+   void generateWsProceedsWhenWorksheetAccessGranted() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      // No fields => fails for an unrelated reason once past the gate.
+      WorksheetConstructionModel model = new WorksheetConstructionModel();
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> deps.service().generateWs(model, USER));
+      assertTrue(ex.getMessage().contains("field"),
+                 "expected the 'at least one field' error, got: " + ex.getMessage());
+
+      verify(deps.securityEngine).checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                                   eq(ResourceAction.ACCESS));
+   }
+
+   // ─── generateWs -> applySourceInfo: datasource READ gate ───────────────────
+
+   @Test
+   void generateWsThrowsWhenDatasourceReadDenied() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(deps.dataSourceService.checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(false);
+
+      WorksheetConstructionModel model = physicalFieldModel("myds");
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> deps.service().generateWs(model, USER));
+      assertTrue(ex.getMessage().contains("myds"),
+                 "error should name the denied datasource, got: " + ex.getMessage());
+
+      verifyNoInteractions(deps.metadataApiService);
+   }
+
+   @Test
+   void generateWsProceedsWhenDatasourceReadGranted() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(deps.dataSourceService.checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(true);
+
+      WorksheetConstructionModel model = physicalFieldModel("myds");
+
+      // metadataApiService is an unstubbed mock: getJDBCDatasource/getTableMetaData both return
+      // null, so this fails downstream with "Table does not exist" — proof execution proceeded
+      // past the datasource gate all the way into applySourceInfo's metadata lookup.
+      assertThrows(IllegalArgumentException.class, () -> deps.service().generateWs(model, USER));
+
+      verify(deps.metadataApiService).getJDBCDatasource(eq("myds"));
+      verify(deps.dataSourceService).checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceGetMetaDataTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceGetMetaDataTest.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.web.composer.AssetTreeService;
+import inetsoft.web.portal.controller.database.DataSourceService;
+import inetsoft.web.wiz.request.GetDatabaseTableMetaRequest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the authorization gate added to {@link MetadataApiService#getMetaData}: a
+ * {@code READ} permission check on the requested data source must run before any
+ * metadata/schema lookup, and must deny access with a {@link SecurityException} when the
+ * check fails.
+ */
+@Tag("core")
+class MetadataApiServiceGetMetaDataTest {
+
+   private MetadataApiService createService(DataSourceService dataSourceService,
+                                             XRepository xrepository)
+   {
+      return new MetadataApiService(
+         xrepository, dataSourceService, mock(AssetRepository.class),
+         mock(AssetTreeService.class), new ObjectMapper());
+   }
+
+   @Test
+   void getMetaData_throwsSecurityExceptionAndSkipsLookupWhenPermissionDenied() throws Exception {
+      XRepository xrepository = mock(XRepository.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      Principal principal = mock(Principal.class);
+
+      GetDatabaseTableMetaRequest request = new GetDatabaseTableMetaRequest();
+      request.setDsName("Examples/Orders");
+      request.setTableName("CUSTOMERS");
+
+      when(dataSourceService.checkPermission(
+         eq("Examples/Orders"), eq(ResourceAction.READ), eq(principal)))
+         .thenReturn(false);
+
+      MetadataApiService service = createService(dataSourceService, xrepository);
+
+      SecurityException ex = assertThrows(SecurityException.class,
+         () -> service.getMetaData(request, principal));
+
+      assertTrue(ex.getMessage().contains("Examples/Orders"),
+         "exception message should reference the denied data source name");
+
+      // No metadata/schema lookup should have happened past the permission gate.
+      verifyNoInteractions(xrepository);
+      verify(dataSourceService, never()).getDataSource(anyString());
+   }
+
+   @Test
+   void getMetaData_proceedsPastPermissionCheckWhenGranted() throws Exception {
+      XRepository xrepository = mock(XRepository.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      Principal principal = mock(Principal.class);
+
+      GetDatabaseTableMetaRequest request = new GetDatabaseTableMetaRequest();
+      request.setDsName("Examples/Orders");
+      request.setTableName("CUSTOMERS");
+
+      when(dataSourceService.checkPermission(
+         eq("Examples/Orders"), eq(ResourceAction.READ), eq(principal)))
+         .thenReturn(true);
+      // No data source registered: getJDBCDatasource() will fail past the permission
+      // gate with a plain Exception (not SecurityException), proving the gate was cleared.
+      when(xrepository.getDataSource("Examples/Orders")).thenReturn(null);
+
+      MetadataApiService service = createService(dataSourceService, xrepository);
+
+      Exception ex = assertThrows(Exception.class,
+         () -> service.getMetaData(request, principal));
+
+      assertFalse(ex instanceof SecurityException,
+         "should have advanced past the permission gate rather than being denied");
+
+      verify(dataSourceService).checkPermission(
+         eq("Examples/Orders"), eq(ResourceAction.READ), eq(principal));
+      verify(xrepository).getDataSource("Examples/Orders");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/RawDataServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/RawDataServiceTest.java
@@ -17,8 +17,11 @@
  */
 package inetsoft.web.wiz.service;
 
+import inetsoft.sree.security.ResourceAction;
 import inetsoft.uql.XRepository;
+import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
+import inetsoft.web.portal.controller.database.DataSourceService;
 import inetsoft.web.wiz.request.ExportDatabaseTableToCsvRequest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -31,16 +34,30 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @Tag("core")
 class RawDataServiceTest {
+   private static class Deps {
+      final XRepository xrepository = mock(XRepository.class);
+      final AssetRepository assetRepository = mock(AssetRepository.class);
+      final DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      RawDataService service() {
+         return new RawDataService(xrepository, assetRepository, dataSourceService);
+      }
+   }
+
    @Test
    void rejectsRequestWithNullTableEntryWithClearMessageAndWithoutTouchingRepository() throws Exception {
-      XRepository xrepository = mock(XRepository.class);
-      AssetRepository assetRepository = mock(AssetRepository.class);
-      RawDataService service = new RawDataService(xrepository, assetRepository);
+      Deps deps = new Deps();
+      when(deps.dataSourceService.checkPermission(eq("inventree"), eq(ResourceAction.READ), any()))
+         .thenReturn(true);
 
       ExportDatabaseTableToCsvRequest request = new ExportDatabaseTableToCsvRequest();
       request.setDatasourcePath("inventree");
@@ -48,7 +65,7 @@ class RawDataServiceTest {
 
       ResponseStatusException ex = assertThrows(
          ResponseStatusException.class,
-         () -> service.writeDataSourceTableCsvStream(request, null, new ByteArrayOutputStream()));
+         () -> deps.service().writeDataSourceTableCsvStream(request, null, new ByteArrayOutputStream()));
 
       // A missing table asset entry must surface as a clean 400 Bad Request (not an opaque 500 NPE).
       assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
@@ -58,6 +75,55 @@ class RawDataServiceTest {
                  "exception reason should name the data source: " + ex.getReason());
 
       // The guard must run before any repository lookup.
-      verifyNoInteractions(xrepository);
+      verifyNoInteractions(deps.xrepository);
+   }
+
+   @Test
+   void exportThrowsWhenDatasourceReadDenied() throws Exception {
+      Deps deps = new Deps();
+      when(deps.dataSourceService.checkPermission(eq("secretds"), eq(ResourceAction.READ), any()))
+         .thenReturn(false);
+
+      ExportDatabaseTableToCsvRequest request = new ExportDatabaseTableToCsvRequest();
+      request.setDatasourcePath("secretds");
+      request.setTable(new AssetEntry(AssetRepository.QUERY_SCOPE, AssetEntry.Type.PHYSICAL_TABLE,
+                                      "secretds/customers", null));
+
+      ResponseStatusException ex = assertThrows(
+         ResponseStatusException.class,
+         () -> deps.service().writeDataSourceTableCsvStream(request, null, new ByteArrayOutputStream()));
+
+      assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+      assertNotNull(ex.getReason());
+      assertTrue(ex.getReason().contains("secretds"),
+                 "error should name the denied datasource, got: " + ex.getReason());
+
+      // Denial must short-circuit before any datasource lookup or query execution.
+      verifyNoInteractions(deps.xrepository);
+   }
+
+   @Test
+   void exportProceedsWhenDatasourceReadGranted() throws Exception {
+      Deps deps = new Deps();
+      when(deps.dataSourceService.checkPermission(eq("myds"), eq(ResourceAction.READ), any()))
+         .thenReturn(true);
+
+      ExportDatabaseTableToCsvRequest request = new ExportDatabaseTableToCsvRequest();
+      request.setDatasourcePath("myds");
+      request.setTable(new AssetEntry(AssetRepository.QUERY_SCOPE, AssetEntry.Type.PHYSICAL_TABLE,
+                                      "myds/customers", null));
+
+      // xrepository is an unstubbed mock: getDataSource returns null, so execution fails
+      // downstream with "not found" — proof it proceeded past the permission gate into the
+      // datasource lookup.
+      Exception ex = assertThrows(
+         Exception.class,
+         () -> deps.service().writeDataSourceTableCsvStream(request, null, new ByteArrayOutputStream()));
+
+      assertTrue(ex.getMessage().contains("myds"),
+                 "expected the 'data source not found' error, got: " + ex.getMessage());
+
+      verify(deps.dataSourceService).checkPermission(eq("myds"), eq(ResourceAction.READ), any());
+      verify(deps.xrepository).getDataSource(eq("myds"));
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceAutoBindingSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceAutoBindingSecurityTest.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.web.wiz.model.AutoBindingRequest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the VIEWSHEET/ACCESS authorization gate at the top of
+ * {@code WizAutoBindingService#autoBindingInternal} — the single choke point shared by both
+ * the public {@code autoBinding()} entry point and {@code changeType()}'s fallback path. The
+ * check must run before any temporary recommendation viewsheet is opened, and must deny with a
+ * {@link SecurityException} when the permission is refused.
+ */
+@Tag("core")
+class WizAutoBindingServiceAutoBindingSecurityTest {
+
+   private static WizAutoBindingService createService(ViewsheetService viewsheetService,
+                                                       SecurityEngine securityEngine)
+   {
+      // Collaborators other than viewsheetService/securityEngine are not reached before (denied
+      // case) or immediately after (granted case, via the openTemporaryViewsheet marker) the
+      // permission gate. Some of them (e.g. VSWizardBindingHandler) have static initializers
+      // that reach into SreeEnv/Spring and cannot even be mocked in a plain unit-test
+      // environment (no Spring context) — mirroring the WizAutoBindingServiceSetChartColorsTest /
+      // WizAutoBindingServiceSetChartFormatTest pattern in this package, pass null instead.
+      return new WizAutoBindingService(
+         viewsheetService, null, null, null, null, mock(WizVsService.class), securityEngine);
+   }
+
+   @Test
+   void autoBinding_throwsSecurityExceptionAndSkipsOpenWhenPermissionDenied() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      WizAutoBindingService service = createService(vsService, securityEngine);
+      AutoBindingRequest request = new AutoBindingRequest();
+
+      SecurityException ex = assertThrows(SecurityException.class,
+         () -> service.autoBinding(request, principal));
+
+      assertNotNull(ex.getMessage(), "SecurityException should carry a localized denial message");
+
+      // Nothing past the gate should have been touched: no temp viewsheet opened.
+      verifyNoInteractions(vsService);
+   }
+
+   @Test
+   void autoBinding_proceedsPastPermissionCheckWhenGranted() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      // A distinctive marker exception thrown by the very next collaborator call
+      // (openTemporaryViewsheet, since request.getAutoBindingRuntimeId() is empty) proves
+      // execution reached past the security gate.
+      RuntimeException marker = new RuntimeException("marker-past-gate");
+      when(vsService.openTemporaryViewsheet(any(), any(), eq(principal), any()))
+         .thenThrow(marker);
+
+      WizAutoBindingService service = createService(vsService, securityEngine);
+      AutoBindingRequest request = new AutoBindingRequest();
+
+      RuntimeException thrown = assertThrows(RuntimeException.class,
+         () -> service.autoBinding(request, principal));
+
+      assertEquals("marker-past-gate", thrown.getMessage(),
+         "should fail past the gate on the marker, not be denied by SecurityException");
+
+      verify(securityEngine).checkPermission(
+         principal, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS);
+      verify(vsService).openTemporaryViewsheet(any(), any(), eq(principal), any());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartColorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartColorsTest.java
@@ -22,6 +22,8 @@ import inetsoft.graph.aesthetic.ColorFrame;
 import inetsoft.graph.aesthetic.StaticColorFrame;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.graph.ChartRef;
@@ -48,9 +50,11 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -70,15 +74,19 @@ class WizAutoBindingServiceSetChartColorsTest {
    private ViewsheetSandbox box;
    private VSChartAggregateRef yAgg;
    private VSChartAggregateRef rtYAgg;
+   private SecurityEngine securityEngine;
+   private ViewsheetService viewsheetService;
 
    @BeforeEach
    void setUp() throws Exception {
-      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      viewsheetService = mock(ViewsheetService.class);
       WizVsService wizVsService = mock(WizVsService.class);
       // collaborators not used by setChartColors; their classes can't be initialized in
       // a plain unit-test environment (no Spring context), so pass null instead of mocks.
+      securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
       service = new WizAutoBindingService(
-         viewsheetService, null, null, null, null, wizVsService);
+         viewsheetService, null, null, null, null, wizVsService, securityEngine);
 
       // Real Viewsheet/assembly/info objects need SreeEnv (Spring context), so mock the
       // whole chain and hand the service a mock measure ref to capture the applied frame.
@@ -148,5 +156,19 @@ class WizAutoBindingServiceSetChartColorsTest {
       service.setChartColors(staticRed(), null);
 
       verify(box).clearGraph("vs_1");
+   }
+
+   @Test
+   void deniedPermissionThrowsAndSkipsRuntimeLookupAndMutation() throws Exception {
+      // The action gate is the first statement in setChartColors, before the runtime is even
+      // resolved. A denied caller must throw and touch nothing.
+      when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(false);
+
+      assertThrows(SecurityException.class, () -> service.setChartColors(staticRed(), null));
+
+      verify(viewsheetService, never()).getViewsheet(anyString(), any());
+      verify(yAgg, never()).setColorFrame(any());
+      verify(rtYAgg, never()).setColorFrame(any());
+      verify(box, never()).clearGraph(anyString());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
@@ -19,6 +19,8 @@ package inetsoft.web.wiz.service;
 
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.report.composition.ExpiredSheetException;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.uql.asset.AssetEntry;
@@ -35,6 +37,7 @@ import java.security.Principal;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -60,6 +63,7 @@ class WizAutoBindingServiceSetChartFormatTest {
    private Viewsheet vs;
    private ChartVSAssemblyInfo info;
    private ViewsheetSandbox box;
+   private SecurityEngine securityEngine;
 
    @BeforeEach
    void setUp() throws Exception {
@@ -67,8 +71,10 @@ class WizAutoBindingServiceSetChartFormatTest {
       wizVsService = mock(WizVsService.class);
       // collaborators not used by setChartFormat; their classes can't be initialized in a plain
       // unit-test environment (no Spring context), so pass null instead of mocks.
+      securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
       service = new WizAutoBindingService(
-         viewsheetService, null, null, null, null, wizVsService);
+         viewsheetService, null, null, null, null, wizVsService, securityEngine);
 
       // getChartInfo() and getVSAssemblyInfo() both return the ChartVSAssemblyInfo for a chart;
       // one mock backs both. A title-only request leaves the descriptor null, so every axis/
@@ -150,6 +156,20 @@ class WizAutoBindingServiceSetChartFormatTest {
       service.setChartFormat(titleRequest(null), null);
 
       verify(info).setTitleValue("Contacts per Account");
+      verify(wizVsService, never()).persistViewsheet(any(), any(), any());
+   }
+
+   @Test
+   void deniedPermissionThrowsAndSkipsRuntimeLookupAndMutation() throws Exception {
+      // The action gate is the first statement in setChartFormat, before the runtime is even
+      // resolved. A denied caller must throw and touch nothing.
+      when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(false);
+
+      assertThrows(SecurityException.class,
+         () -> service.setChartFormat(titleRequest("visualizations-xyz"), null));
+
+      verify(viewsheetService, never()).getViewsheet(anyString(), any());
+      verify(info, never()).setTitleValue(any());
       verify(wizVsService, never()).persistViewsheet(any(), any(), any());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizGeoServiceSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizGeoServiceSecurityTest.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.web.binding.handler.VSChartHandler;
+import inetsoft.web.wiz.model.GeoApplyRequest;
+import inetsoft.web.wiz.model.GeoDetectRequest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the VIEWSHEET/ACCESS action gates added to {@link WizGeoService#detect} and
+ * {@link WizGeoService#apply}: both mutate (and apply persists) a viewsheet, so the composer
+ * action right must be checked before any runtime lookup. Denial short-circuits before the
+ * viewsheet service is touched.
+ */
+@Tag("core")
+class WizGeoServiceSecurityTest {
+
+   @Test
+   void detect_throwsSecurityExceptionAndSkipsRuntimeLookupWhenDenied() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      VSChartHandler chartHandler = mock(VSChartHandler.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      WizGeoService service = new WizGeoService(vsService, chartHandler, securityEngine);
+
+      assertThrows(SecurityException.class,
+         () -> service.detect(new GeoDetectRequest(), principal));
+
+      verifyNoInteractions(vsService);
+   }
+
+   @Test
+   void apply_throwsSecurityExceptionAndSkipsRuntimeLookupWhenDenied() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      VSChartHandler chartHandler = mock(VSChartHandler.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      WizGeoService service = new WizGeoService(vsService, chartHandler, securityEngine);
+
+      assertThrows(SecurityException.class,
+         () -> service.apply(new GeoApplyRequest(), principal));
+
+      verifyNoInteractions(vsService);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVisualizationServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVisualizationServiceTest.java
@@ -1,0 +1,170 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.security.IdentityID;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.AssetContent;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.TextVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.util.MessageException;
+import inetsoft.web.service.BinaryTransferService;
+import inetsoft.web.viewsheet.controller.AssemblyImageService;
+import inetsoft.web.viewsheet.service.VSExportService;
+import inetsoft.web.wiz.model.WizVisualizationSaveEvent;
+import inetsoft.web.wiz.model.WizVisualizationSaveResult;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Regression coverage for the security fix applied to
+ * {@link WizVisualizationService#saveVisualization}:
+ * <ol>
+ *   <li>{@code sourceVsEntry.getPath()} must be restricted to the managed wiz folders
+ *       ({@link WizVisualizationService#VISUALIZATION_ROOT_FOLDER_PATH} or
+ *       {@link WizVisualizationService#VISUALIZATION_COMPONENTS_FOLDER_PATH}) before any asset
+ *       is loaded.</li>
+ *   <li>{@code assetRepository.getSheet(..., permission=true, ...)} must actually run the
+ *       {@code checkAssetPermission} check (instead of {@code permission=false}, which silently
+ *       skips it) and any resulting exception must propagate, not be swallowed.</li>
+ * </ol>
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizVisualizationServiceTest {
+   @Test
+   void rejectsSourcePathOutsideManagedFolders() {
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WizVisualizationService service = createService(viewsheetService, assetRepository);
+
+      AssetEntry outsideEntry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         "some/unmanaged/folder/vs1", null);
+
+      WizVisualizationSaveEvent event = new WizVisualizationSaveEvent();
+      event.setSourceViewsheetIdentifier(outsideEntry.toIdentifier());
+      event.setAssemblyName("Chart1");
+
+      Principal principal = mock(Principal.class);
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> service.saveVisualization(event, principal));
+
+      // The folder-scope check must happen before any asset is loaded, so the asset
+      // repository (and therefore checkAssetPermission) is never touched.
+      verifyNoInteractions(assetRepository);
+   }
+
+   @Test
+   void propagatesPermissionDenialFromGetSheet() throws Exception {
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WizVisualizationService service = createService(viewsheetService, assetRepository);
+
+      AssetEntry insideEntry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/vs1", null);
+
+      WizVisualizationSaveEvent event = new WizVisualizationSaveEvent();
+      event.setSourceViewsheetIdentifier(insideEntry.toIdentifier());
+      event.setAssemblyName("Chart1");
+
+      Principal principal = mock(Principal.class);
+
+      when(assetRepository.getSheet(
+         any(AssetEntry.class), eq(principal), eq(true), any(AssetContent.class)))
+         .thenThrow(new MessageException("Permission denied"));
+
+      // The exception raised by checkAssetPermission (via getSheet) must propagate out of
+      // saveVisualization rather than being swallowed.
+      assertThrows(MessageException.class,
+                   () -> service.saveVisualization(event, principal));
+
+      verify(assetRepository).getSheet(
+         any(AssetEntry.class), eq(principal), eq(true), any(AssetContent.class));
+   }
+
+   @Test
+   void savesVisualizationWhenSourceInManagedFolderAndPermissionGranted() throws Exception {
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WizVisualizationService service = createService(viewsheetService, assetRepository);
+
+      AssetEntry insideEntry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/vs1", null);
+
+      // Real (not mocked) source viewsheet + assembly so the full method body can execute:
+      // getBaseEntry() is null, so saveWorksheet() short-circuits before needing a worksheet.
+      Viewsheet sourceVs = new Viewsheet();
+      TextVSAssembly assembly = new TextVSAssembly(sourceVs, "Text1");
+      sourceVs.addAssembly(assembly);
+
+      WizVisualizationSaveEvent event = new WizVisualizationSaveEvent();
+      event.setSourceViewsheetIdentifier(insideEntry.toIdentifier());
+      event.setAssemblyName("Text1");
+
+      Principal principal = mock(Principal.class);
+      when(principal.getName()).thenReturn("admin" + IdentityID.KEY_DELIMITER + "host-org");
+
+      when(assetRepository.getSheet(
+         any(AssetEntry.class), eq(principal), eq(true), any(AssetContent.class)))
+         .thenReturn(sourceVs);
+
+      WizVisualizationSaveResult result = service.saveVisualization(event, principal);
+
+      assertNotNull(result);
+      assertNotNull(result.getSavedViewsheetIdentifier());
+
+      // permission=true is required so checkAssetPermission actually runs instead of being
+      // silently skipped.
+      verify(assetRepository).getSheet(
+         any(AssetEntry.class), eq(principal), eq(true), any(AssetContent.class));
+      verify(viewsheetService).setViewsheet(
+         any(Viewsheet.class), any(AssetEntry.class), eq(principal), eq(true), eq(true));
+   }
+
+   private static WizVisualizationService createService(ViewsheetService viewsheetService,
+                                                          AssetRepository assetRepository)
+   {
+      return new WizVisualizationService(
+         viewsheetService, assetRepository,
+         mock(AssemblyImageService.class),
+         mock(BinaryTransferService.class),
+         mock(VSExportService.class));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceCreateViewsheetSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceCreateViewsheetSecurityTest.java
@@ -1,0 +1,174 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.model.CreateVisualizationModel;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the VIEWSHEET/ACCESS authorization gate at the top of
+ * {@code WizVsService#createViewsheetInternal} (reached via the public
+ * {@code createViewsheet} entry point): the check must run before any temporary viewsheet
+ * is opened, and must deny with a {@link SecurityException} when the permission is refused.
+ */
+@Tag("core")
+class WizVsServiceCreateViewsheetSecurityTest {
+
+   @Test
+   void createViewsheet_throwsSecurityExceptionAndSkipsOpenWhenPermissionDenied() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      WizVsService service = new WizVsService(vsService, engine, securityEngine);
+      CreateVisualizationModel model = new CreateVisualizationModel();
+
+      SecurityException ex = assertThrows(SecurityException.class,
+         () -> service.createViewsheet(model, principal));
+
+      assertNotNull(ex.getMessage(), "SecurityException should carry a localized denial message");
+
+      // Nothing past the gate should have been touched: no temp viewsheet opened, no
+      // sheet lookups performed.
+      verifyNoInteractions(vsService);
+      verifyNoInteractions(engine);
+   }
+
+   @Test
+   void createViewsheet_proceedsPastPermissionCheckWhenGranted() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      // A distinctive marker exception thrown by the very next collaborator call
+      // (openTemporaryViewsheet) proves execution reached past the security gate,
+      // regardless of how the rest of the (unmocked) flow would behave.
+      RuntimeException marker = new RuntimeException("marker-past-gate");
+      when(vsService.openTemporaryViewsheet(any(), any(), eq(principal), any()))
+         .thenThrow(marker);
+
+      WizVsService service = new WizVsService(vsService, engine, securityEngine);
+      CreateVisualizationModel model = new CreateVisualizationModel();
+
+      RuntimeException thrown = assertThrows(RuntimeException.class,
+         () -> service.createViewsheet(model, principal));
+
+      assertEquals("marker-past-gate", thrown.getMessage(),
+         "should fail past the gate on the marker, not be denied by SecurityException");
+
+      verify(securityEngine).checkPermission(
+         principal, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS);
+      verify(vsService).openTemporaryViewsheet(any(), any(), eq(principal), any());
+   }
+
+   /**
+    * The save choke point: persistViewsheet must refuse (and not call setViewsheet) when the caller
+    * lacks the VIEWSHEET/ACCESS composer action right — a user without viewsheet-composer access
+    * must not be able to save a mutated viewsheet even though the asset WRITE ACL might allow it.
+    */
+   @Test
+   void persistViewsheet_throwsSecurityExceptionAndSkipsSaveWhenPermissionDenied() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      Viewsheet vs = mock(Viewsheet.class);
+
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      WizVsService service = new WizVsService(vsService, engine, securityEngine);
+
+      assertThrows(SecurityException.class,
+         () -> service.persistViewsheet(vs, "1^128^__NULL__^visualizations/abc^host-org", principal));
+
+      // No save must occur when the composer action right is denied.
+      verifyNoInteractions(vsService);
+      verifyNoInteractions(engine);
+   }
+
+   @Test
+   void validateBinding_throwsSecurityExceptionAndSkipsOpenWhenPermissionDenied() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      WizVsService service = new WizVsService(vsService, engine, securityEngine);
+
+      assertThrows(SecurityException.class,
+         () -> service.validateBinding(new CreateVisualizationModel(), principal));
+
+      verifyNoInteractions(vsService);
+   }
+
+   @Test
+   void deleteViewsheet_throwsSecurityExceptionAndSkipsRemovalWhenPermissionDenied() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      WizVsService service = new WizVsService(vsService, engine, securityEngine);
+
+      assertThrows(SecurityException.class,
+         () -> service.deleteViewsheet("1^128^__NULL__^visualizations/abc^host-org", principal));
+
+      // No asset removal when the composer action right is denied.
+      verifyNoInteractions(engine);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRemoveVisualizationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRemoveVisualizationTest.java
@@ -3,6 +3,8 @@ package inetsoft.web.wiz.service;
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.viewsheet.VSAssembly;
@@ -18,6 +20,13 @@ import static org.mockito.Mockito.*;
 
 @Tag("core")
 class WizVsServiceRemoveVisualizationTest {
+   /** A SecurityEngine that grants VIEWSHEET/ACCESS so the removeVisualization action gate passes. */
+   private static SecurityEngine grantedSecurity() throws Exception {
+      SecurityEngine sec = mock(SecurityEngine.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+      return sec;
+   }
+
    @Test
    void removesAssemblyAndResetsSandboxWhenPresent() throws Exception {
       ViewsheetService vsService = mock(ViewsheetService.class);
@@ -36,7 +45,7 @@ class WizVsServiceRemoveVisualizationTest {
       when(entry.getPath()).thenReturn(
          WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/abc");
 
-      WizVsService service = new WizVsService(vsService, engine);
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity());
       service.removeVisualization("rt-1", "Chart1", null);
 
       verify(vs).removeAssembly("Chart1");
@@ -62,7 +71,7 @@ class WizVsServiceRemoveVisualizationTest {
       when(rvs.getEntry()).thenReturn(entry);
       when(entry.getPath()).thenReturn("some/other/folder/abc");
 
-      WizVsService service = new WizVsService(vsService, engine);
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity());
       service.removeVisualization("rt-1", "Chart1", null);
 
       verify(vs).removeAssembly("Chart1");
@@ -80,7 +89,7 @@ class WizVsServiceRemoveVisualizationTest {
       when(rvs.getViewsheet()).thenReturn(vs);
       when(vs.getAssembly("Chart1")).thenReturn(null);
 
-      WizVsService service = new WizVsService(vsService, engine);
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity());
       service.removeVisualization("rt-1", "Chart1", null);
 
       verify(vs, never()).removeAssembly(anyString());
@@ -93,15 +102,15 @@ class WizVsServiceRemoveVisualizationTest {
 
       when(vsService.getViewsheet("rt-1", null)).thenThrow(new RuntimeException("expired"));
 
-      WizVsService service = new WizVsService(vsService, engine);
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity());
       assertDoesNotThrow(() -> service.removeVisualization("rt-1", "Chart1", null));
    }
 
    @Test
-   void throwsWhenArgsBlank() {
+   void throwsWhenArgsBlank() throws Exception {
       ViewsheetService vsService = mock(ViewsheetService.class);
       AssetRepository engine = mock(AssetRepository.class);
-      WizVsService service = new WizVsService(vsService, engine);
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity());
 
       assertThrows(IllegalArgumentException.class,
                    () -> service.removeVisualization("", "Chart1", null));
@@ -111,5 +120,21 @@ class WizVsServiceRemoveVisualizationTest {
                    () -> service.removeVisualization(null, "Chart1", null));
       assertThrows(IllegalArgumentException.class,
                    () -> service.removeVisualization("rt-1", null, null));
+   }
+
+   @Test
+   void throwsSecurityExceptionWhenViewsheetAccessDenied() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(false);
+
+      WizVsService service = new WizVsService(vsService, engine, sec);
+
+      assertThrows(SecurityException.class,
+                   () -> service.removeVisualization("rt-1", "Chart1", null));
+
+      // Denied before any runtime lookup or mutation.
+      verifyNoInteractions(vsService);
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceBatchTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceBatchTest.java
@@ -55,7 +55,7 @@ class WorksheetTableServiceBatchTest {
    private static WorksheetTableService service() {
       // firstMissingDependency uses only its parameters, never instance state, so null
       // dependencies are safe here.
-      return new WorksheetTableService(null, null, null, null, null, null, null);
+      return new WorksheetTableService(null, null, null, null, null, null, null, null, null);
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceConditionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceConditionTest.java
@@ -62,7 +62,7 @@ class WorksheetTableServiceConditionTest {
    private static WorksheetTableService service() {
       // buildConditionList and its callees use only their parameters, never instance state,
       // so null dependencies are safe here.
-      return new WorksheetTableService(null, null, null, null, null, null, null);
+      return new WorksheetTableService(null, null, null, null, null, null, null, null, null);
    }
 
    private static ColumnSelection columns(String... names) {

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServicePermissionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServicePermissionTest.java
@@ -1,0 +1,319 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.XRepository;
+import inetsoft.web.composer.ws.LayoutGraphService;
+import inetsoft.web.composer.ws.joins.InnerJoinService;
+import inetsoft.web.portal.controller.database.DataSourceService;
+import inetsoft.web.portal.controller.database.QueryManagerService;
+import inetsoft.web.wiz.model.DeleteWorksheetTablesRequest;
+import inetsoft.web.wiz.model.WorksheetTableRequest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Coverage for the authorization gates added to {@link WorksheetTableService}:
+ * <ul>
+ *   <li>{@code checkWorksheetActionPermission} — the "Visual Composer -> Data Worksheet" action-level
+ *       gate checked at the top of {@code createTable}, {@code getWorksheetModel} and
+ *       {@code deleteTables}.</li>
+ *   <li>The datasource READ check inside {@code createTable}'s {@code buildTable} step, gating
+ *       physical/sql-query tables bound to a {@code physicalSource.datasourcePath}.</li>
+ * </ul>
+ *
+ * <p>These tests only assert on the gate itself — denial short-circuits before any worksheet
+ * load/mutation or datasource metadata lookup, and grant lets execution proceed past the check
+ * (verified by the mock interaction actually happening), regardless of what unrelated exception
+ * the deliberately-minimal downstream mocking then produces.
+ *
+ * <p>Needs the full Sree bootstrap because {@code new Worksheet()} (constructed unconditionally by
+ * {@code createTable} before {@code buildTable} runs) reads {@code SreeEnv} in its constructor.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WorksheetTableServicePermissionTest {
+   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+   private static class Deps {
+      final ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      final MetadataApiService metadataApiService = mock(MetadataApiService.class);
+      final InnerJoinService innerJoinService = mock(InnerJoinService.class);
+      final LayoutGraphService layoutGraphService = mock(LayoutGraphService.class);
+      final QueryManagerService queryManagerService = mock(QueryManagerService.class);
+      final XRepository xrepository = mock(XRepository.class);
+      final ObjectMapper objectMapper = new ObjectMapper();
+      final DataSourceService dataSourceService = mock(DataSourceService.class);
+      final SecurityEngine securityEngine = mock(SecurityEngine.class);
+
+      WorksheetTableService service() {
+         return new WorksheetTableService(viewsheetService, metadataApiService, innerJoinService,
+                                          layoutGraphService, queryManagerService, xrepository,
+                                          objectMapper, dataSourceService, securityEngine);
+      }
+   }
+
+   private static WorksheetTableRequest tableRequest(String json) throws Exception {
+      return MAPPER.readValue(json, WorksheetTableRequest.class);
+   }
+
+   private static final Principal USER = mock(Principal.class);
+
+   // ─── createTable: WORKSHEET/ACCESS gate ────────────────────────────────────
+
+   @Test
+   void createTableThrowsWhenWorksheetAccessDenied() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      WorksheetTableRequest request = tableRequest("{ \"tableType\": \"physical table\" }");
+
+      assertThrows(SecurityException.class, () -> deps.service().createTable(request, USER));
+
+      verifyNoInteractions(deps.viewsheetService);
+      verifyNoInteractions(deps.metadataApiService);
+   }
+
+   @Test
+   void createTableProceedsWhenWorksheetAccessGranted() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      // No tableType => buildTable fails for an unrelated reason once past the gate.
+      WorksheetTableRequest request = tableRequest("{}");
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> deps.service().createTable(request, USER));
+      assertTrue(ex.getMessage().contains("tableType"));
+
+      verify(deps.securityEngine).checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                                   eq(ResourceAction.ACCESS));
+   }
+
+   // ─── getWorksheetModel: WORKSHEET/ACCESS gate ──────────────────────────────
+
+   @Test
+   void getWorksheetModelThrowsWhenWorksheetAccessDenied() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      assertThrows(SecurityException.class,
+         () -> deps.service().getWorksheetModel("1^128^__NULL__^ws1", USER));
+
+      verifyNoInteractions(deps.viewsheetService);
+   }
+
+   @Test
+   void getWorksheetModelProceedsWhenWorksheetAccessGranted() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      // Empty identifier => fails for an unrelated reason once past the gate, before touching
+      // the asset repository.
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> deps.service().getWorksheetModel("", USER));
+      assertTrue(ex.getMessage().contains("wsIdentifier"));
+
+      verify(deps.securityEngine).checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                                   eq(ResourceAction.ACCESS));
+   }
+
+   // ─── deleteTables: WORKSHEET/ACCESS gate ───────────────────────────────────
+
+   @Test
+   void deleteTablesThrowsWhenWorksheetAccessDenied() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      DeleteWorksheetTablesRequest request = new DeleteWorksheetTablesRequest();
+      request.setWorksheetId("1^128^__NULL__^ws1");
+
+      assertThrows(SecurityException.class, () -> deps.service().deleteTables(request, USER));
+
+      verifyNoInteractions(deps.viewsheetService);
+   }
+
+   @Test
+   void deleteTablesProceedsWhenWorksheetAccessGranted() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      // No worksheetId => fails for an unrelated reason once past the gate.
+      DeleteWorksheetTablesRequest request = new DeleteWorksheetTablesRequest();
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> deps.service().deleteTables(request, USER));
+      assertTrue(ex.getMessage().contains("worksheetId"));
+
+      verify(deps.securityEngine).checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                                   eq(ResourceAction.ACCESS));
+   }
+
+   // ─── createTable -> buildTable: datasource READ gate ───────────────────────
+
+   @Test
+   void createTablePhysicalTableThrowsWhenDatasourceReadDenied() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(deps.dataSourceService.checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(false);
+
+      WorksheetTableRequest request = tableRequest("""
+         {
+           "tableName": "t1",
+           "tableType": "physical table",
+           "physicalSource": { "datasourcePath": "myds", "tableName": "CUSTOMERS" }
+         }
+         """);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> deps.service().createTable(request, USER));
+      assertTrue(ex.getMessage().contains("myds"),
+                 "error should name the denied datasource, got: " + ex.getMessage());
+
+      verifyNoInteractions(deps.metadataApiService);
+   }
+
+   @Test
+   void createTablePhysicalTableProceedsWhenDatasourceReadGranted() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(deps.dataSourceService.checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(true);
+
+      WorksheetTableRequest request = tableRequest("""
+         {
+           "tableName": "t1",
+           "tableType": "physical table",
+           "physicalSource": { "datasourcePath": "myds", "tableName": "CUSTOMERS" }
+         }
+         """);
+
+      // metadataApiService is an unstubbed mock: getJDBCDatasource/getTableMetaData both return
+      // null, so this fails downstream with "Table not found" — proof execution proceeded past
+      // the datasource gate all the way into buildPhysicalTable.
+      assertThrows(IllegalArgumentException.class, () -> deps.service().createTable(request, USER));
+
+      verify(deps.metadataApiService).getJDBCDatasource(eq("myds"));
+      verify(deps.dataSourceService).checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER));
+   }
+
+   // ─── createTable -> buildTable: sql query table FREE_FORM_SQL gate ─────────
+
+   @Test
+   void createTableSqlQueryThrowsWhenFreeFormSqlDenied() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(deps.dataSourceService.checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(true);
+      // Free-Form SQL right is denied — even though worksheet access and datasource READ are granted.
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.FREE_FORM_SQL), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      WorksheetTableRequest request = tableRequest("""
+         {
+           "tableName": "t1",
+           "tableType": "sql query table",
+           "sqlExpression": "SELECT 1",
+           "physicalSource": { "datasourcePath": "myds" }
+         }
+         """);
+
+      assertThrows(SecurityException.class, () -> deps.service().createTable(request, USER));
+
+      // Denial must short-circuit before buildSqlTable resolves/executes anything.
+      verifyNoInteractions(deps.metadataApiService);
+   }
+
+   @Test
+   void createTableSqlQueryProceedsWhenFreeFormSqlGranted() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(deps.dataSourceService.checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(true);
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.FREE_FORM_SQL), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      WorksheetTableRequest request = tableRequest("""
+         {
+           "tableName": "t1",
+           "tableType": "sql query table",
+           "sqlExpression": "SELECT 1",
+           "physicalSource": { "datasourcePath": "myds" }
+         }
+         """);
+
+      // All three gates pass, so execution proceeds into buildSqlTable, which then fails on the
+      // deliberately-minimal downstream mocks (getJDBCDatasource returns null). The failure type
+      // is irrelevant — what matters is that the FREE_FORM_SQL gate was passed and buildSqlTable
+      // was entered.
+      assertThrows(Exception.class, () -> deps.service().createTable(request, USER));
+
+      verify(deps.securityEngine).checkPermission(eq(USER), eq(ResourceType.FREE_FORM_SQL), eq("*"),
+                                                  eq(ResourceAction.ACCESS));
+      verify(deps.metadataApiService).getJDBCDatasource(eq("myds"));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServicePermissionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServicePermissionTest.java
@@ -33,6 +33,8 @@ import inetsoft.web.portal.controller.database.DataSourceService;
 import inetsoft.web.portal.controller.database.QueryManagerService;
 import inetsoft.web.wiz.model.DeleteWorksheetTablesRequest;
 import inetsoft.web.wiz.model.WorksheetTableRequest;
+import inetsoft.web.wiz.model.WorksheetTableResponse;
+import inetsoft.web.wiz.model.WorksheetTablesResponse;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,6 +44,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.security.Principal;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
@@ -54,19 +58,22 @@ import static org.mockito.Mockito.when;
  * Coverage for the authorization gates added to {@link WorksheetTableService}:
  * <ul>
  *   <li>{@code checkWorksheetActionPermission} — the "Visual Composer -> Data Worksheet" action-level
- *       gate checked at the top of {@code createTable}, {@code getWorksheetModel} and
+ *       gate checked at the top of {@code createTables}, {@code getWorksheetModel} and
  *       {@code deleteTables}.</li>
- *   <li>The datasource READ check inside {@code createTable}'s {@code buildTable} step, gating
+ *   <li>The datasource READ check inside {@code createTables}'s {@code buildTable} step, gating
  *       physical/sql-query tables bound to a {@code physicalSource.datasourcePath}.</li>
  * </ul>
  *
- * <p>These tests only assert on the gate itself — denial short-circuits before any worksheet
- * load/mutation or datasource metadata lookup, and grant lets execution proceed past the check
- * (verified by the mock interaction actually happening), regardless of what unrelated exception
- * the deliberately-minimal downstream mocking then produces.
+ * <p>These tests only assert on the gate itself. The action-level WORKSHEET/ACCESS gate is checked
+ * before the batch loop, so its denial throws. The per-table datasource-READ and FREE_FORM_SQL
+ * gates live inside {@code buildTable}; {@code createTables} catches a failed table and records it
+ * as {@code success=false} with an {@code errorMessage} rather than throwing — so the per-table
+ * cases assert on that response entry (the table was not built) plus the mock interactions that
+ * prove where execution stopped, regardless of what unrelated failure the deliberately-minimal
+ * downstream mocking then produces.
  *
  * <p>Needs the full Sree bootstrap because {@code new Worksheet()} (constructed unconditionally by
- * {@code createTable} before {@code buildTable} runs) reads {@code SreeEnv} in its constructor.
+ * {@code createTables} before {@code buildTable} runs) reads {@code SreeEnv} in its constructor.
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
@@ -98,6 +105,17 @@ class WorksheetTableServicePermissionTest {
       return MAPPER.readValue(json, WorksheetTableRequest.class);
    }
 
+   /** Wraps a single WorksheetTable JSON object into a one-table batch request. */
+   private static WorksheetTableRequest batchOf(String tableJson) throws Exception {
+      return MAPPER.readValue("{ \"tables\": [ " + tableJson + " ] }", WorksheetTableRequest.class);
+   }
+
+   /** Asserts the batch produced exactly one table result and returns it. */
+   private static WorksheetTableResponse only(WorksheetTablesResponse response) {
+      assertEquals(1, response.getTables().size(), "expected exactly one table result");
+      return response.getTables().get(0);
+   }
+
    private static final Principal USER = mock(Principal.class);
 
    // ─── createTable: WORKSHEET/ACCESS gate ────────────────────────────────────
@@ -111,7 +129,7 @@ class WorksheetTableServicePermissionTest {
 
       WorksheetTableRequest request = tableRequest("{ \"tableType\": \"physical table\" }");
 
-      assertThrows(SecurityException.class, () -> deps.service().createTable(request, USER));
+      assertThrows(SecurityException.class, () -> deps.service().createTables(request, USER));
 
       verifyNoInteractions(deps.viewsheetService);
       verifyNoInteractions(deps.metadataApiService);
@@ -124,12 +142,13 @@ class WorksheetTableServicePermissionTest {
                                                eq(ResourceAction.ACCESS)))
          .thenReturn(true);
 
-      // No tableType => buildTable fails for an unrelated reason once past the gate.
-      WorksheetTableRequest request = tableRequest("{}");
+      // One table with no tableType => past the action gate, the per-table build fails and the
+      // batch records it as a failure (rather than throwing) with the tableType reason.
+      WorksheetTableRequest request = batchOf("{}");
 
-      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-         () -> deps.service().createTable(request, USER));
-      assertTrue(ex.getMessage().contains("tableType"));
+      WorksheetTableResponse table = only(deps.service().createTables(request, USER));
+      assertFalse(table.isSuccess());
+      assertTrue(table.getErrorMessage().contains("tableType"));
 
       verify(deps.securityEngine).checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
                                                    eq(ResourceAction.ACCESS));
@@ -205,7 +224,7 @@ class WorksheetTableServicePermissionTest {
    // ─── createTable -> buildTable: datasource READ gate ───────────────────────
 
    @Test
-   void createTablePhysicalTableThrowsWhenDatasourceReadDenied() throws Exception {
+   void createTablePhysicalTableFailsWhenDatasourceReadDenied() throws Exception {
       Deps deps = new Deps();
       when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
                                                eq(ResourceAction.ACCESS)))
@@ -213,7 +232,7 @@ class WorksheetTableServicePermissionTest {
       when(deps.dataSourceService.checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER)))
          .thenReturn(false);
 
-      WorksheetTableRequest request = tableRequest("""
+      WorksheetTableRequest request = batchOf("""
          {
            "tableName": "t1",
            "tableType": "physical table",
@@ -221,11 +240,12 @@ class WorksheetTableServicePermissionTest {
          }
          """);
 
-      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-         () -> deps.service().createTable(request, USER));
-      assertTrue(ex.getMessage().contains("myds"),
-                 "error should name the denied datasource, got: " + ex.getMessage());
+      WorksheetTableResponse table = only(deps.service().createTables(request, USER));
+      assertFalse(table.isSuccess());
+      assertTrue(table.getErrorMessage().contains("myds"),
+                 "error should name the denied datasource, got: " + table.getErrorMessage());
 
+      // Denial short-circuits before any datasource metadata lookup.
       verifyNoInteractions(deps.metadataApiService);
    }
 
@@ -238,7 +258,7 @@ class WorksheetTableServicePermissionTest {
       when(deps.dataSourceService.checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER)))
          .thenReturn(true);
 
-      WorksheetTableRequest request = tableRequest("""
+      WorksheetTableRequest request = batchOf("""
          {
            "tableName": "t1",
            "tableType": "physical table",
@@ -247,9 +267,11 @@ class WorksheetTableServicePermissionTest {
          """);
 
       // metadataApiService is an unstubbed mock: getJDBCDatasource/getTableMetaData both return
-      // null, so this fails downstream with "Table not found" — proof execution proceeded past
-      // the datasource gate all the way into buildPhysicalTable.
-      assertThrows(IllegalArgumentException.class, () -> deps.service().createTable(request, USER));
+      // null, so the table fails downstream with "Table not found" — proof execution proceeded
+      // past the datasource gate all the way into buildPhysicalTable. The batch records the
+      // failure rather than throwing.
+      WorksheetTableResponse table = only(deps.service().createTables(request, USER));
+      assertFalse(table.isSuccess());
 
       verify(deps.metadataApiService).getJDBCDatasource(eq("myds"));
       verify(deps.dataSourceService).checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER));
@@ -258,7 +280,7 @@ class WorksheetTableServicePermissionTest {
    // ─── createTable -> buildTable: sql query table FREE_FORM_SQL gate ─────────
 
    @Test
-   void createTableSqlQueryThrowsWhenFreeFormSqlDenied() throws Exception {
+   void createTableSqlQueryFailsWhenFreeFormSqlDenied() throws Exception {
       Deps deps = new Deps();
       when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
                                                eq(ResourceAction.ACCESS)))
@@ -270,7 +292,7 @@ class WorksheetTableServicePermissionTest {
                                                eq(ResourceAction.ACCESS)))
          .thenReturn(false);
 
-      WorksheetTableRequest request = tableRequest("""
+      WorksheetTableRequest request = batchOf("""
          {
            "tableName": "t1",
            "tableType": "sql query table",
@@ -279,7 +301,10 @@ class WorksheetTableServicePermissionTest {
          }
          """);
 
-      assertThrows(SecurityException.class, () -> deps.service().createTable(request, USER));
+      // The Free-Form SQL denial (a SecurityException in buildTable) is caught by the batch and
+      // recorded as a failed table — the table must not be built.
+      WorksheetTableResponse table = only(deps.service().createTables(request, USER));
+      assertFalse(table.isSuccess());
 
       // Denial must short-circuit before buildSqlTable resolves/executes anything.
       verifyNoInteractions(deps.metadataApiService);
@@ -297,7 +322,7 @@ class WorksheetTableServicePermissionTest {
                                                eq(ResourceAction.ACCESS)))
          .thenReturn(true);
 
-      WorksheetTableRequest request = tableRequest("""
+      WorksheetTableRequest request = batchOf("""
          {
            "tableName": "t1",
            "tableType": "sql query table",
@@ -307,10 +332,11 @@ class WorksheetTableServicePermissionTest {
          """);
 
       // All three gates pass, so execution proceeds into buildSqlTable, which then fails on the
-      // deliberately-minimal downstream mocks (getJDBCDatasource returns null). The failure type
-      // is irrelevant — what matters is that the FREE_FORM_SQL gate was passed and buildSqlTable
-      // was entered.
-      assertThrows(Exception.class, () -> deps.service().createTable(request, USER));
+      // deliberately-minimal downstream mocks (getJDBCDatasource returns null). What matters is
+      // that the FREE_FORM_SQL gate was passed and buildSqlTable was entered; the batch records
+      // the downstream failure rather than throwing.
+      WorksheetTableResponse table = only(deps.service().createTables(request, USER));
+      assertFalse(table.isSuccess());
 
       verify(deps.securityEngine).checkPermission(eq(USER), eq(ResourceType.FREE_FORM_SQL), eq("*"),
                                                   eq(ResourceAction.ACCESS));

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -19,8 +19,20 @@ package inetsoft.web.wiz.worksheet;
 
 import inetsoft.report.composition.RuntimeWorksheet;
 import inetsoft.report.composition.WorksheetService;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.uql.XRepository;
 import inetsoft.uql.asset.*;
+import inetsoft.uql.asset.internal.SQLBoundTableAssemblyInfo;
+import inetsoft.uql.jdbc.JDBCDataSource;
+import inetsoft.uql.jdbc.JDBCQuery;
+import inetsoft.web.composer.ws.LayoutGraphService;
+import inetsoft.web.portal.controller.database.DataSourceService;
+import inetsoft.web.portal.controller.database.QueryManagerService;
 import inetsoft.web.wiz.pairing.*;
+import inetsoft.web.wiz.service.MetadataApiService;
 import inetsoft.web.wiz.worksheet.model.WorksheetModel;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -62,7 +74,8 @@ class WorksheetAgentControllerTest {
                                           mock(inetsoft.web.wiz.service.MetadataApiService.class),
                                           mock(inetsoft.web.portal.controller.database.QueryManagerService.class),
                                           mock(inetsoft.web.composer.ws.LayoutGraphService.class),
-                                          mock(inetsoft.web.portal.controller.database.DataSourceService.class));
+                                          mock(inetsoft.web.portal.controller.database.DataSourceService.class),
+                                          mock(inetsoft.sree.security.SecurityEngine.class));
    }
 
    private static SheetAgentFeature featureOn() {
@@ -75,6 +88,49 @@ class WorksheetAgentControllerTest {
       SheetAgentFeature f = mock(SheetAgentFeature.class);
       when(f.isEnabled()).thenReturn(false);
       return f;
+   }
+
+   /**
+    * Builds a controller (feature flag ON) exposing the specific collaborators a permission
+    * test needs to stub/verify; every other dependency is a fresh mock.
+    */
+   private static WorksheetAgentController securityController(
+      WorksheetEditService edit,
+      DataSourceService dataSourceService,
+      SecurityEngine securityEngine,
+      MetadataApiService metadataApiService,
+      XRepository xrepository,
+      QueryManagerService queryManagerService)
+   {
+      return new WorksheetAgentController(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), edit, mock(WorksheetService.class),
+         mock(WorksheetPreviewService.class), mock(SheetAgentBroadcastService.class),
+         xrepository, mock(AssetRepository.class), metadataApiService,
+         queryManagerService, mock(LayoutGraphService.class),
+         dataSourceService, securityEngine);
+   }
+
+   /** Builds an {@code add_table} EditRequest that routes to addBoundTable() (no logicalModel). */
+   private static EditRequest addBoundTableRequest(String table, String datasource) {
+      return new EditRequest(
+         "add_table", table, null, null, null, null, null, null, null, null,
+         null, null, null, false, null, null, null, null, null, null, null, null, null, null,
+         null, null, null, null, datasource, null, null, null, null, null, null, null, null,
+         null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null
+      );
+   }
+
+   /** Builds an {@code edit_sql_query} EditRequest that routes to editSqlQuery(). */
+   private static EditRequest editSqlQueryRequest(String table, String expression) {
+      return new EditRequest(
+         "edit_sql_query", table, null, null, null, null, null, null, null, null,
+         null, null, expression, false, null, null, null, null, null, null, null, null, null, null,
+         null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null
+      );
    }
 
    // ---------------------------------------------------------------------------
@@ -165,7 +221,7 @@ class WorksheetAgentControllerTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
 
       EditRequest req = new EditRequest("remove_column", "T", "x",
          null, null, null, null, null, null, null, null, null, null, false,
@@ -209,5 +265,300 @@ class WorksheetAgentControllerTest {
       ctrl.detach("TOK-D", agent);
 
       verify(sessions).close("TOK-D");
+   }
+
+   // ---------------------------------------------------------------------------
+   // addBoundTable — PHYSICAL_TABLE / ACCESS permission gate
+   // ---------------------------------------------------------------------------
+
+   @Test
+   void addBoundTableDeniedThrowsSecurityException() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      MetadataApiService metadataApiService = mock(MetadataApiService.class);
+
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.PHYSICAL_TABLE),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         mock(DataSourceService.class), securityEngine, metadataApiService,
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = addBoundTableRequest("dbo.orders", "MyDatasource");
+
+      assertThrows(SecurityException.class, () -> ctrl.edit("TOK-BT", req, agent));
+
+      verify(securityEngine).checkPermission(eq(agent), eq(ResourceType.PHYSICAL_TABLE),
+                                             eq("*"), eq(ResourceAction.ACCESS));
+      verifyNoInteractions(metadataApiService);
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addBoundTableGrantedPassesPermissionGate() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      MetadataApiService metadataApiService = mock(MetadataApiService.class);
+
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.PHYSICAL_TABLE),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      // Datasource READ is now checked before the JDBC metadata probe; grant it so execution
+      // reaches getJDBCDatasource.
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, securityEngine, metadataApiService,
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = addBoundTableRequest("dbo.orders", "MyDatasource");
+
+      // Gets past the security gate; fails further downstream because metadataApiService is
+      // an unstubbed mock (getJDBCDatasource/getTableMetaData return null), which is expected —
+      // we only assert that the PHYSICAL_TABLE check let execution proceed.
+      Exception ex = assertThrows(Exception.class, () -> ctrl.edit("TOK-BT2", req, agent));
+      assertFalse(ex instanceof SecurityException,
+                   "should not fail on the permission check when granted");
+
+      verify(securityEngine).checkPermission(eq(agent), eq(ResourceType.PHYSICAL_TABLE),
+                                             eq("*"), eq(ResourceAction.ACCESS));
+      verify(metadataApiService).getJDBCDatasource("MyDatasource");
+   }
+
+   @Test
+   void addBoundTableDeniedByDatasourceReadThrowsPairingExceptionBeforeProbe() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      MetadataApiService metadataApiService = mock(MetadataApiService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      // Physical-table action granted, but datasource READ denied.
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.PHYSICAL_TABLE),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(false);
+
+      WorksheetAgentController ctrl = securityController(mock(WorksheetEditService.class),
+         dataSourceService, securityEngine, metadataApiService,
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = addBoundTableRequest("dbo.orders", "MyDatasource");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-BT3", req, agent));
+      assertTrue(ex.getMessage().contains("READ permission"));
+
+      // The READ denial must short-circuit before any JDBC metadata probe.
+      verifyNoInteractions(metadataApiService);
+   }
+
+   // ---------------------------------------------------------------------------
+   // editSqlQuery — FREE_FORM_SQL / ACCESS permission gate
+   // ---------------------------------------------------------------------------
+
+   @Test
+   void editSqlQueryDeniedThrowsSecurityException() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         mock(DataSourceService.class), securityEngine, mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = editSqlQueryRequest("SqlTable1", "SELECT * FROM foo");
+
+      assertThrows(SecurityException.class, () -> ctrl.edit("TOK-ES", req, agent));
+
+      verify(securityEngine).checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                             eq("*"), eq(ResourceAction.ACCESS));
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void editSqlQueryGrantedPassesPermissionGate() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         mock(DataSourceService.class), securityEngine, mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = editSqlQueryRequest("SqlTable1", "SELECT * FROM foo");
+
+      // editSvc is a plain mock: applyOnRuntime() is never actually executed, so the call
+      // completes without exception — proving the permission check did not block it.
+      ctrl.edit("TOK-ES2", req, agent);
+
+      verify(securityEngine).checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                             eq("*"), eq(ResourceAction.ACCESS));
+      verify(editSvc).applyOnRuntime(eq("TOK-ES2"), eq(agent), any());
+   }
+
+   @Test
+   void editSqlQueryDeniedByDatasourceReadThrowsPairingException() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      // Real runtime worksheet holding a SQL-bound table whose query is bound to datasource "myds".
+      // The datasource/query are mocked: constructing a real JDBCDataSource pulls a
+      // CredentialService bean the lightweight test context does not provide, and the READ-denial
+      // path throws before the query's SQL definition is ever touched.
+      Worksheet ws = new Worksheet();
+      SQLBoundTableAssembly sqlt = new SQLBoundTableAssembly(ws, "SqlTable1");
+      JDBCDataSource ds = mock(JDBCDataSource.class);
+      when(ds.getFullName()).thenReturn("myds");
+      JDBCQuery q = mock(JDBCQuery.class);
+      when(q.getDataSource()).thenReturn(ds);
+      ((SQLBoundTableAssemblyInfo) sqlt.getInfo()).setQuery(q);
+      ws.addAssembly(sqlt);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-ES3"), any())).thenReturn(session("TOK-ES3"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      // Free-Form SQL right is granted, so we get past the action gate and into the lambda.
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      // ...but READ on the assembly's bound datasource is denied.
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      when(dataSourceService.checkPermission(eq("myds"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(false);
+
+      WorksheetAgentController ctrl = securityController(editSvc, dataSourceService, securityEngine,
+         mock(MetadataApiService.class), mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = editSqlQueryRequest("SqlTable1", "SELECT * FROM foo");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-ES3", req, agent));
+      assertTrue(ex.getMessage().contains("READ permission"),
+                 "error should name the denied datasource READ, got: " + ex.getMessage());
+
+      verify(dataSourceService).checkPermission(eq("myds"), eq(ResourceAction.READ), eq(agent));
+   }
+
+   // ---------------------------------------------------------------------------
+   // addSqlQuery — FREE_FORM_SQL / ACCESS + datasource READ permission gates
+   // ---------------------------------------------------------------------------
+
+   @Test
+   void addSqlQueryDeniedByFreeFormSqlThrowsSecurityException() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      WorksheetAgentController ctrl = securityController(mock(WorksheetEditService.class),
+         dataSourceService, securityEngine, mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      WorksheetAgentController.SqlQueryRequest body =
+         new WorksheetAgentController.SqlQueryRequest("MyDatasource", "SELECT 1", null);
+
+      assertThrows(SecurityException.class, () -> ctrl.addSqlQuery("TOK-SQ", body, agent));
+
+      verify(securityEngine).checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                             eq("*"), eq(ResourceAction.ACCESS));
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(xrepository);
+   }
+
+   @Test
+   void addSqlQueryDeniedByDatasourceReadThrowsPairingException() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(false);
+
+      WorksheetAgentController ctrl = securityController(mock(WorksheetEditService.class),
+         dataSourceService, securityEngine, mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      WorksheetAgentController.SqlQueryRequest body =
+         new WorksheetAgentController.SqlQueryRequest("MyDatasource", "SELECT 1", null);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.addSqlQuery("TOK-SQ2", body, agent));
+      assertTrue(ex.getMessage().contains("READ permission"));
+
+      verify(securityEngine).checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                             eq("*"), eq(ResourceAction.ACCESS));
+      verify(dataSourceService).checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent));
+      verifyNoInteractions(xrepository);
+   }
+
+   @Test
+   void addSqlQueryGrantedPassesBothPermissionGates() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      WorksheetAgentController ctrl = securityController(mock(WorksheetEditService.class),
+         dataSourceService, securityEngine, mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      WorksheetAgentController.SqlQueryRequest body =
+         new WorksheetAgentController.SqlQueryRequest("MyDatasource", "SELECT 1", null);
+
+      // Both gates pass; fails further downstream because xrepository (unstubbed mock)
+      // returns null for getDataSource(), which is expected — we only assert that both
+      // permission checks let execution proceed past them.
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.addSqlQuery("TOK-SQ3", body, agent));
+      assertTrue(ex.getMessage().contains("Datasource not found"));
+
+      verify(securityEngine).checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                             eq("*"), eq(ResourceAction.ACCESS));
+      verify(dataSourceService).checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent));
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -18,6 +18,10 @@
 package inetsoft.web.wiz.worksheet;
 
 import inetsoft.report.composition.RuntimeWorksheet;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.ColumnSelection;
 import inetsoft.uql.XConstants;
 import inetsoft.uql.asset.*;
@@ -26,6 +30,7 @@ import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.web.wiz.pairing.*;
 import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
 
 import java.security.Principal;
 import java.util.List;
@@ -43,7 +48,26 @@ class WorksheetEditServiceMutatorsTest {
    // =========================================================================
 
    private WorksheetEditService service(RuntimeWorksheet rws, String runtimeId,
-                                        Principal agent, String token) throws PairingException
+                                        Principal agent, String token)
+      throws PairingException, inetsoft.sree.security.SecurityException
+   {
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(
+         any(), any(ResourceType.class), any(String.class), any(ResourceAction.class)))
+         .thenReturn(true);
+
+      return service(rws, runtimeId, agent, token, securityEngine);
+   }
+
+   /**
+    * Same as {@link #service(RuntimeWorksheet, String, Principal, String)} but lets the caller
+    * supply an already-stubbed {@link SecurityEngine} mock, so permission checks can be denied
+    * (or captured) for specific {@link ResourceType}s.
+    */
+   private WorksheetEditService service(RuntimeWorksheet rws, String runtimeId,
+                                        Principal agent, String token,
+                                        SecurityEngine securityEngine)
+      throws PairingException, inetsoft.sree.security.SecurityException
    {
       SheetSessionService sessions       = mock(SheetSessionService.class);
       SheetRuntimeAccess  runtimeAccess  = mock(SheetRuntimeAccess.class);
@@ -56,7 +80,7 @@ class WorksheetEditServiceMutatorsTest {
       when(runtimeAccess.getSheetForPairing(eq(SheetType.WORKSHEET), eq(runtimeId), eq(agent)))
          .thenReturn(rws);
 
-      return new WorksheetEditService(sessions, runtimeAccess, broadcast);
+      return new WorksheetEditService(sessions, runtimeAccess, broadcast, securityEngine);
    }
 
    private RuntimeWorksheet rws(Worksheet ws) {
@@ -494,5 +518,279 @@ class WorksheetEditServiceMutatorsTest {
       EmbeddedTableAssembly t = (EmbeddedTableAssembly) a;
       assertNotNull(t.getColumnSelection(false).getAttribute("col1"));
       assertNotNull(t.getColumnSelection(false).getAttribute("col2"));
+   }
+
+   // =========================================================================
+   // Permission gate tests — addCrossJoin / addExpressionColumn / editExpression
+   // =========================================================================
+   //
+   // Each gated op calls requirePermission(ResourceType), which is backed by
+   // securityEngine.checkPermission(agent, <type>, "*", ResourceAction.ACCESS). These tests
+   // pin down two things per op: (1) denial throws SecurityException *and* the underlying
+   // mutation never happens, and (2) the EXACT ResourceType checked is the one documented for
+   // that op — guarding against a copy-paste mix-up between CROSS_JOIN and
+   // WORKSHEET_EXPRESSION_COLUMN across the three call sites added together.
+
+   /** Builds a securityEngine mock granting every permission except the one given. */
+   private SecurityEngine securityEngineDenying(Principal agent, ResourceType deniedType)
+      throws SecurityException
+   {
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(
+         any(), any(ResourceType.class), any(String.class), any(ResourceAction.class)))
+         .thenReturn(true);
+      when(securityEngine.checkPermission(
+         eq(agent), eq(deniedType), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+      return securityEngine;
+   }
+
+   /** Builds a securityEngine mock granting every permission — used for ResourceType capture. */
+   private SecurityEngine securityEngineGrantingAll() throws SecurityException {
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(
+         any(), any(ResourceType.class), any(String.class), any(ResourceAction.class)))
+         .thenReturn(true);
+      return securityEngine;
+   }
+
+   // --- addCrossJoin -------------------------------------------------------
+
+   @Test
+   void addCrossJoinDeniedThrowsAndDoesNotAddAssembly() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly left  = TestWorksheets.tableWithColumns(ws, "L", "id");
+      EmbeddedTableAssembly right = TestWorksheets.tableWithColumns(ws, "R", "id");
+      ws.addAssembly(left);
+      ws.addAssembly(right);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      SecurityEngine securityEngine = securityEngineDenying(agent, ResourceType.CROSS_JOIN);
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK", securityEngine);
+
+      assertThrows(SecurityException.class, () ->
+         svc.apply("TOK", agent, ed -> ed.addCrossJoin("J", "L", "R")));
+
+      assertNull(ws.getAssembly("J"),
+         "cross join assembly must not be created when CROSS_JOIN permission is denied");
+   }
+
+   @Test
+   void addCrossJoinChecksCrossJoinResourceTypeExactly() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly left  = TestWorksheets.tableWithColumns(ws, "L", "id");
+      EmbeddedTableAssembly right = TestWorksheets.tableWithColumns(ws, "R", "id");
+      ws.addAssembly(left);
+      ws.addAssembly(right);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      SecurityEngine securityEngine = securityEngineGrantingAll();
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK", securityEngine);
+
+      svc.apply("TOK", agent, ed -> ed.addCrossJoin("J", "L", "R"));
+
+      ArgumentCaptor<ResourceType> typeCaptor = ArgumentCaptor.forClass(ResourceType.class);
+      verify(securityEngine).checkPermission(
+         eq(agent), typeCaptor.capture(), eq("*"), eq(ResourceAction.ACCESS));
+      assertEquals(ResourceType.CROSS_JOIN, typeCaptor.getValue(),
+         "addCrossJoin must check ResourceType.CROSS_JOIN, not e.g. WORKSHEET_EXPRESSION_COLUMN");
+
+      assertNotNull(ws.getAssembly("J"),
+         "cross join assembly should be created when permission is granted");
+   }
+
+   // --- addExpressionColumn -------------------------------------------------
+
+   @Test
+   void addExpressionColumnDeniedThrowsAndDoesNotAddColumn() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      SecurityEngine securityEngine =
+         securityEngineDenying(agent, ResourceType.WORKSHEET_EXPRESSION_COLUMN);
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK", securityEngine);
+
+      assertThrows(SecurityException.class, () ->
+         svc.apply("TOK", agent,
+            ed -> ed.addExpressionColumn("T", "computed", "field['a'] * 2", "integer", false)));
+
+      assertNull(t.getColumnSelection(false).getAttribute("computed"),
+         "expression column must not be added when WORKSHEET_EXPRESSION_COLUMN permission is denied");
+   }
+
+   @Test
+   void addExpressionColumnChecksExpressionColumnResourceTypeExactly() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      SecurityEngine securityEngine = securityEngineGrantingAll();
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK", securityEngine);
+
+      svc.apply("TOK", agent,
+         ed -> ed.addExpressionColumn("T", "computed", "field['a'] * 2", "integer", false));
+
+      ArgumentCaptor<ResourceType> typeCaptor = ArgumentCaptor.forClass(ResourceType.class);
+      verify(securityEngine).checkPermission(
+         eq(agent), typeCaptor.capture(), eq("*"), eq(ResourceAction.ACCESS));
+      assertEquals(ResourceType.WORKSHEET_EXPRESSION_COLUMN, typeCaptor.getValue(),
+         "addExpressionColumn must check ResourceType.WORKSHEET_EXPRESSION_COLUMN, not e.g. CROSS_JOIN");
+
+      assertNotNull(t.getColumnSelection(false).getAttribute("computed"),
+         "expression column should be added when permission is granted");
+   }
+
+   // --- editExpression -------------------------------------------------------
+
+   @Test
+   void editExpressionDeniedThrowsAndDoesNotChangeColumn() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      // Seed the existing expression column directly via WorksheetMutationSupport, bypassing
+      // the Editor entirely, so setup does not itself consult securityEngine.
+      WorksheetMutationSupport.addExpressionColumn(t, "calc", "field['a'] * 1", "integer", false);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      SecurityEngine securityEngine =
+         securityEngineDenying(agent, ResourceType.WORKSHEET_EXPRESSION_COLUMN);
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK", securityEngine);
+
+      assertThrows(SecurityException.class, () ->
+         svc.apply("TOK", agent,
+            ed -> ed.editExpression("T", "calc", "field['a'] * 2", "integer", false)));
+
+      ColumnRef col = (ColumnRef) t.getColumnSelection(false).getAttribute("calc");
+      assertNotNull(col, "'calc' column should still be present");
+      assertEquals("field['a'] * 1", ((ExpressionRef) col.getDataRef()).getExpression(),
+         "expression must be unchanged when WORKSHEET_EXPRESSION_COLUMN permission is denied");
+   }
+
+   @Test
+   void editExpressionChecksExpressionColumnResourceTypeExactly() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      WorksheetMutationSupport.addExpressionColumn(t, "calc", "field['a'] * 1", "integer", false);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      SecurityEngine securityEngine = securityEngineGrantingAll();
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK", securityEngine);
+
+      svc.apply("TOK", agent,
+         ed -> ed.editExpression("T", "calc", "field['a'] * 2", "integer", false));
+
+      ArgumentCaptor<ResourceType> typeCaptor = ArgumentCaptor.forClass(ResourceType.class);
+      verify(securityEngine).checkPermission(
+         eq(agent), typeCaptor.capture(), eq("*"), eq(ResourceAction.ACCESS));
+      assertEquals(ResourceType.WORKSHEET_EXPRESSION_COLUMN, typeCaptor.getValue(),
+         "editExpression must check ResourceType.WORKSHEET_EXPRESSION_COLUMN, not e.g. CROSS_JOIN");
+
+      ColumnRef col = (ColumnRef) t.getColumnSelection(false).getAttribute("calc");
+      assertEquals("field['a'] * 2", ((ExpressionRef) col.getDataRef()).getExpression(),
+         "expression should be updated when permission is granted");
+   }
+
+   // --- addJoin("CROSS", ...) delegation to the CROSS_JOIN gate --------------
+
+   @Test
+   void addJoinCrossTypeDeniedThrowsAndDoesNotAddAssembly() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly left  = TestWorksheets.tableWithColumns(ws, "L", "id");
+      EmbeddedTableAssembly right = TestWorksheets.tableWithColumns(ws, "R", "id");
+      ws.addAssembly(left);
+      ws.addAssembly(right);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      SecurityEngine securityEngine = securityEngineDenying(agent, ResourceType.CROSS_JOIN);
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK", securityEngine);
+
+      assertThrows(SecurityException.class, () ->
+         svc.apply("TOK", agent,
+            ed -> ed.addJoin("J", "L", "id", "R", "id", "CROSS", null, null)));
+
+      assertNull(ws.getAssembly("J"),
+         "addJoin(\"CROSS\",...) must go through the same CROSS_JOIN gate as addCrossJoin " +
+         "and must not create the assembly when denied");
+   }
+
+   @Test
+   void addJoinNonCrossTypeDoesNotRequireCrossJoinPermission() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly left  = TestWorksheets.tableWithColumns(ws, "L", "id");
+      EmbeddedTableAssembly right = TestWorksheets.tableWithColumns(ws, "R", "id");
+      ws.addAssembly(left);
+      ws.addAssembly(right);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      // CROSS_JOIN denied — an INNER join must succeed anyway, proving the gate is scoped to
+      // cross joins only.
+      SecurityEngine securityEngine = securityEngineDenying(agent, ResourceType.CROSS_JOIN);
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK", securityEngine);
+
+      svc.apply("TOK", agent, ed -> ed.addJoin("J", "L", "id", "R", "id", "INNER", null, null));
+
+      assertNotNull(ws.getAssembly("J"),
+         "INNER join must succeed even though CROSS_JOIN permission is denied");
+      verify(securityEngine, never()).checkPermission(
+         eq(agent), eq(ResourceType.CROSS_JOIN), anyString(), any(ResourceAction.class));
+   }
+
+   // --- editJoin("CROSS", ...) must clear the same CROSS_JOIN gate -----------
+
+   @Test
+   void editJoinToCrossTypeDeniedThrowsAndDoesNotChangeOperator() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly left  = TestWorksheets.tableWithColumns(ws, "L", "id");
+      EmbeddedTableAssembly right = TestWorksheets.tableWithColumns(ws, "R", "id");
+      ws.addAssembly(left);
+      ws.addAssembly(right);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      // CROSS_JOIN denied. An INNER join is allowed (gate is scoped to cross joins),
+      // so the attacker first creates one, then tries to rewrite it into a cross join
+      // via editJoin — which must hit the same gate and be rejected.
+      SecurityEngine securityEngine = securityEngineDenying(agent, ResourceType.CROSS_JOIN);
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK", securityEngine);
+
+      svc.apply("TOK", agent, ed -> ed.addJoin("J", "L", "id", "R", "id", "INNER", null, null));
+
+      assertThrows(SecurityException.class, () ->
+         svc.apply("TOK", agent, ed -> ed.editJoin("J", "id", "id", "CROSS", null, null)));
+
+      // The operator must remain the original INNER join — the mutation must not have
+      // happened before the permission check threw.
+      RelationalJoinTableAssembly join = (RelationalJoinTableAssembly) ws.getAssembly("J");
+      assertNotNull(join, "join assembly should still exist");
+      @SuppressWarnings("unchecked")
+      java.util.Enumeration<TableAssemblyOperator> iter =
+         (java.util.Enumeration<TableAssemblyOperator>) join.getOperators();
+      assertTrue(iter.hasMoreElements());
+      TableAssemblyOperator top = iter.nextElement();
+      assertEquals(TableAssemblyOperator.INNER_JOIN, top.getOperator(0).getOperation(),
+         "editJoin(\"CROSS\",...) must not downgrade the join to a cross join when " +
+         "CROSS_JOIN permission is denied");
+   }
+
+   @Test
+   void editJoinNonCrossTypeDoesNotRequireCrossJoinPermission() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly left  = TestWorksheets.tableWithColumns(ws, "L", "id");
+      EmbeddedTableAssembly right = TestWorksheets.tableWithColumns(ws, "R", "id");
+      ws.addAssembly(left);
+      ws.addAssembly(right);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      // CROSS_JOIN denied — editing to a LEFT join must still succeed, proving the gate
+      // is scoped to cross joins only.
+      SecurityEngine securityEngine = securityEngineDenying(agent, ResourceType.CROSS_JOIN);
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK", securityEngine);
+
+      svc.apply("TOK", agent, ed -> ed.addJoin("J", "L", "id", "R", "id", "INNER", null, null));
+      svc.apply("TOK", agent, ed -> ed.editJoin("J", "id", "id", "LEFT", null, null));
+
+      RelationalJoinTableAssembly join = (RelationalJoinTableAssembly) ws.getAssembly("J");
+      @SuppressWarnings("unchecked")
+      java.util.Enumeration<TableAssemblyOperator> iter =
+         (java.util.Enumeration<TableAssemblyOperator>) join.getOperators();
+      assertTrue(iter.hasMoreElements());
+      TableAssemblyOperator top = iter.nextElement();
+      assertEquals(TableAssemblyOperator.LEFT_JOIN, top.getOperator(0).getOperation(),
+         "editing to a LEFT join must succeed even though CROSS_JOIN permission is denied");
+      verify(securityEngine, never()).checkPermission(
+         eq(agent), eq(ResourceType.CROSS_JOIN), anyString(), any(ResourceAction.class));
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.worksheet;
 
 import inetsoft.report.composition.RuntimeWorksheet;
+import inetsoft.sree.security.SecurityEngine;
 import inetsoft.uql.ColumnSelection;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.erm.DataRef;
@@ -58,7 +59,8 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(eq(SheetType.WORKSHEET), eq("Worksheet/foo-7"), eq(agent)))
          .thenReturn(rws);
 
-      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess, broadcast);
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess, broadcast,
+         mock(SecurityEngine.class));
       svc.apply("TOK", agent, ed -> ed.removeColumn("T", "a"));
 
       assertNull(t.getColumnSelection(false).getAttribute("a"));
@@ -70,7 +72,8 @@ class WorksheetEditServiceTest {
       SheetSessionService sessions = mock(SheetSessionService.class);
       when(sessions.resolve(any(), any())).thenReturn(null);
       WorksheetEditService svc = new WorksheetEditService(sessions,
-         mock(SheetRuntimeAccess.class), mock(SheetAgentBroadcastService.class));
+         mock(SheetRuntimeAccess.class), mock(SheetAgentBroadcastService.class),
+         mock(SecurityEngine.class));
       assertThrows(PairingException.class,
          () -> svc.apply("BAD", TestPrincipals.user("alice", "host-org"), ed -> {}));
    }
@@ -93,7 +96,7 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
       svc.apply("TOK", agent, ed -> ed.addColumn("T", "c", "string"));
 
       assertNotNull(t.getColumnSelection(false).getAttribute("c"));
@@ -117,7 +120,7 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
       svc.apply("TOK", agent, ed -> ed.renameColumn("T", "a", "alpha"));
 
       ColumnSelection cs = t.getColumnSelection(false);


### PR DESCRIPTION
## Bug #75594 — Harden wiz (AI composer) agent authorization and input validation

Adds the missing permission and validation guards across the `web/wiz` subsystem — the endpoints/services the AI worksheet & viewsheet agent drives — plus covering tests. Community-only change.

### Guards added

- **Action-level `VIEWSHEET/ACCESS` gates** on the viewsheet-opening entry points (`ViewsheetRuntimeController.openViewsheet` and `verifyViewsheet`) and the chart format/color mutators (`WizAutoBindingService.setChartFormat` / `setChartColors`), mirroring the standard composer's open/save gates. `verifyViewsheet` is the more sensitive of the pair (it executes the chart query and returns `hasData`/`rowCount`), so it must not be more permissive than open.
- **Asset/datasource `READ` enforcement** (`permission=true` on `getSheet`, `DataSourceService.checkPermission`) on the metadata, raw-data CSV export, worksheet-table, and visualization-source loads — closing paths where an attacker-controlled asset/datasource identifier previously skipped the ACL check.
- **`CROSS_JOIN` permission gate** on **both** the add- and edit-join paths (`WorksheetEditService.addCrossJoin` / `addJoin("CROSS")` / `editJoin(...,"CROSS")`) — previously `editJoin` could rewrite an existing join to a cross join with no check, bypassing the gate.
- **Pairing-join hardening** (`SheetJoinService`): per-caller rate limiting on failed join attempts, a runtime-ownership (IDOR) check so a caller can't mint a code naming a runtime they don't own, plus `PairingUtil` logical-user helpers.
- **Nonce validation** on the unauthenticated `WizAuthCallbackController` auth-pickup endpoint (length + URL-safe charset), consistent with the hex nonce the wiz plugin generates.
- **Managed-folder path scoping** for viewsheet read/write entry points (accept only the wiz session/components folders).
- **App-domain setter** restricted to site/org admins (was previously unauthenticated-writable).

### Tests

New and expanded unit tests cover each guard on **both** the denial and authorized paths (`ViewsheetRuntimeControllerSecurityTest`, `WizVsServiceCreateViewsheetSecurityTest`, `WizGeoServiceSecurityTest`, `AddVisualizationServiceSecurityTest`, `GenerateWsServicePermissionTest`, `WorksheetTableServicePermissionTest`, `WizAutoBindingServiceAutoBindingSecurityTest`, the CROSS_JOIN cases in `WorksheetEditServiceMutatorsTest`, the pairing cases in `SheetJoinServiceTest`, etc.).

### Notes

- Second commit adapts `WorksheetTableServicePermissionTest` and `WorksheetTableServiceBatchTest` to main's batch `createTables` API (constructor arity + single-throw → batch-collect-in-response). The permission gates themselves are unchanged and still enforced in `buildTable`; only their surfacing changed, and the tests assert on the per-table response entry accordingly.
- Full `web.wiz` unit suite passes (257 tests, 0 failures/errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
