### PR TITLE
Bug #75595, resolve CalcRef formula results so they don't leak into calc table cell data

### DIFF
--- a/core/src/main/java/inetsoft/report/lens/CalcTableLens.java
+++ b/core/src/main/java/inetsoft/report/lens/CalcTableLens.java
@@ -27,6 +27,7 @@ import inetsoft.report.internal.Util;
 import inetsoft.report.internal.binding.*;
 import inetsoft.report.internal.table.*;
 import inetsoft.report.script.TableArray;
+import inetsoft.report.script.formula.CalcRef;
 import inetsoft.report.script.formula.CalcTableScope;
 import inetsoft.report.script.viewsheet.VSAScriptable;
 import inetsoft.report.script.viewsheet.ViewsheetScope;
@@ -1112,10 +1113,18 @@ public class CalcTableLens extends DefaultTableLens {
 
          tableScope.setRow(row);
 
-         return ProfileUtils.addExecutionBreakDownRecord(getReportName(),
+         Object result = ProfileUtils.addExecutionBreakDownRecord(getReportName(),
             ExecutionBreakDownRecord.JAVASCRIPT_PROCESSING_CYCLE, args -> {
                return senv.exec(args[0], args[1], null, null);
             }, script, tableScope);
+
+         // A named-cell reference ($name) in the formula result evaluates to the
+         // live CalcRef proxy under GraalJS; resolve it to the referenced value
+         // so a script host object never leaks into the cached cell data (Rhino
+         // coerced a Scriptable result the same way). Runs while the cell location
+         // is still on the FormulaContext stack (popped in the finally block) so
+         // unwrap() resolves correctly. (#75595)
+         return unwrapCalcRefs(result);
 
          //return senv.exec(script, tableScope);
       }
@@ -1139,6 +1148,31 @@ public class CalcTableLens extends DefaultTableLens {
             }
          }
       }
+   }
+
+   /**
+    * Resolve any CalcRef in a formula result to its referenced value, so a live
+    * script host object never leaks into the cached cell data. A bare $name
+    * result is a CalcRef; an array result (e.g. [$a, $b]) can contain CalcRef
+    * elements, since ScriptValueConverter.toHost unwraps each array element back
+    * to its host object. Must be called while the evaluating cell's location is
+    * still on the FormulaContext stack. (#75595)
+    */
+   // package-private for testing
+   static Object unwrapCalcRefs(Object value) {
+      if(value instanceof CalcRef) {
+         return ((CalcRef) value).unwrap();
+      }
+
+      if(value instanceof Object[]) {
+         Object[] arr = (Object[]) value;
+
+         for(int i = 0; i < arr.length; i++) {
+            arr[i] = unwrapCalcRefs(arr[i]);
+         }
+      }
+
+      return value;
    }
 
    /**

--- a/core/src/test/java/inetsoft/report/lens/CalcTableLensTest.java
+++ b/core/src/test/java/inetsoft/report/lens/CalcTableLensTest.java
@@ -18,6 +18,7 @@
 
 package inetsoft.report.lens;
 
+import inetsoft.report.script.formula.CalcRef;
 import inetsoft.test.*;
 import inetsoft.uql.XTable;
 import org.junit.jupiter.api.Assertions;
@@ -27,6 +28,9 @@ import org.junit.jupiter.api.Tag;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
@@ -39,5 +43,65 @@ public class CalcTableLensTest {
       CalcTableLens originalTable = new CalcTableLens(XTableUtil.getDefaultTableLens());
       XTable deserializedTable = TestSerializeUtils.serializeAndDeserialize(originalTable);
       Assertions.assertEquals(CalcTableLens.class, deserializedTable.getClass());
+   }
+
+   /**
+    * Bug #75595: a bare named-cell reference ($name) as a formula result must be
+    * resolved to its referenced value so a live CalcRef never leaks into the
+    * cached cell data (which later crashed JSON serialization of
+    * LoadTableDataCommand and hung the table on "loading").
+    */
+   @Test
+   public void testUnwrapTopLevelCalcRef() {
+      CalcRef ref = mock(CalcRef.class);
+      when(ref.unwrap()).thenReturn("value1");
+
+      Assertions.assertEquals("value1", CalcTableLens.unwrapCalcRefs(ref));
+   }
+
+   /**
+    * Bug #75595: a CalcRef nested inside an array result (e.g. [$a, $b]) must
+    * also be resolved, since ScriptValueConverter.toHost unwraps each array
+    * element back to its raw host object.
+    */
+   @Test
+   public void testUnwrapCalcRefInArray() {
+      CalcRef a = mock(CalcRef.class);
+      CalcRef b = mock(CalcRef.class);
+      when(a.unwrap()).thenReturn(1);
+      when(b.unwrap()).thenReturn(2);
+
+      Object result = CalcTableLens.unwrapCalcRefs(new Object[]{ a, "x", b });
+
+      Assertions.assertArrayEquals(new Object[]{ 1, "x", 2 }, (Object[]) result);
+   }
+
+   /**
+    * Bug #75595: CalcRefs nested in arrays-of-arrays must be resolved too.
+    */
+   @Test
+   public void testUnwrapCalcRefInNestedArray() {
+      CalcRef a = mock(CalcRef.class);
+      when(a.unwrap()).thenReturn(1);
+
+      Object result = CalcTableLens.unwrapCalcRefs(new Object[]{ new Object[]{ a }, "y" });
+
+      Object[] outer = (Object[]) result;
+      Assertions.assertArrayEquals(new Object[]{ 1 }, (Object[]) outer[0]);
+      Assertions.assertEquals("y", outer[1]);
+   }
+
+   /**
+    * Bug #75595: results with no CalcRef must be returned unchanged (no
+    * regression for ordinary numeric/string/array formula results).
+    */
+   @Test
+   public void testNonCalcRefResultUnchanged() {
+      Assertions.assertEquals("plain", CalcTableLens.unwrapCalcRefs("plain"));
+      Assertions.assertEquals(42.0, CalcTableLens.unwrapCalcRefs(42.0));
+      Assertions.assertNull(CalcTableLens.unwrapCalcRefs(null));
+
+      Object[] arr = { 1, "a", null };
+      Assertions.assertArrayEquals(new Object[]{ 1, "a", null }, (Object[]) CalcTableLens.unwrapCalcRefs(arr));
    }
 }


### PR DESCRIPTION
## Summary

After the Rhino→GraalJS migration (#75423), opening/refreshing a Freehand (Calc) Table whose formula cell's top-level result is a bare named-cell reference (`$name`) left the table stuck forever in the "loading" state. The server log filled with:

```
Could not write JSON: Cannot read field "y" because "loc" is null
  (... BaseTableCellModel["cellData"] -> inetsoft.report.script.formula.CalcRef["arraySize"])
Caused by: java.lang.NullPointerException: Cannot read field "y" because "loc" is null
  at inetsoft.report.script.formula.CalcRef.unwrap(CalcRef.java:334)
  at inetsoft.report.script.formula.CalcRef.getArraySize(CalcRef.java:267)
```

## Root Cause

In a runtime freehand table, `CalcTableScope.initRuntimeReferences()` binds each named cell as a `CalcRef` (a `ScriptArrayScope`), so `$name` resolves to a `CalcRef`. When a formula cell's top-level result is a bare `$name`, GraalJS returns it and `ScriptValueConverter.toHost()` unwraps the `ArrayProxy` back to the **raw `CalcRef` host object** — not the value it references (Rhino instead coerced a `Scriptable` result to its scalar default value). `CalcTableLens.evaluate()` then returned that `CalcRef` and `getValue()` cached it as the cell value.

Later, on the WebSocket dispatch thread, Jackson serialized `BaseTableCellModel.cellData` (a `CalcRef`) for `LoadTableDataCommand`. Because `CalcRef` is a plain bean to Jackson, it invoked the `getArraySize()` getter → `unwrap()` → `FormulaContext.getCellLocation()` returns `null` (no formula context on that thread) → NPE. The failed command flush meant the client never received the table data, so it spun on "loading."

## Fix

In `CalcTableLens.evaluate()`, resolve any `CalcRef` in the formula result to its referenced value (via a new `unwrapCalcRefs()` helper) before it is returned/cached — while the evaluating cell's location is still on the `FormulaContext` stack so `unwrap()` resolves correctly. The helper handles both a top-level `CalcRef` and `CalcRef`s nested inside array results (e.g. `[$a, $b]`), since `toHost` unwraps each array element back to its host object.

## Test Plan

- Added regression tests in `CalcTableLensTest` covering: a top-level `CalcRef`, a `CalcRef` inside an array, `CalcRef`s in nested arrays, and non-`CalcRef` results left unchanged.
- Verified `FreeExecution/FormulaScript/FScript1` renders correctly with no `Cannot read field "y" because "loc" is null` errors in the log.
- `CalcTableLensTest`, `RuntimeCalcTableLensTest`, `CalcTableScopeTest`, `CalcRefTest`, `ScriptValueConverterTest`, `CalcTableVSAScriptableTest` all pass.

Fixes Redmine #75595.

🤖 Generated with [Claude Code](https://claude.com/claude-code)