### PR TITLE
Docker container not starting

### DIFF
--- a/core/src/main/java/inetsoft/setup/StorageInitializer.java
+++ b/core/src/main/java/inetsoft/setup/StorageInitializer.java
@@ -35,7 +35,6 @@ import inetsoft.util.log.logback.AuditLogFilter;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.annotation.*;
-import org.springframework.context.support.AbstractApplicationContext;
 import picocli.CommandLine;
 
 import java.io.*;
@@ -400,8 +399,15 @@ public class StorageInitializer implements Callable<Integer> {
          try {
             InetsoftConfig.bootstrap();
 
-            try(AbstractApplicationContext applicationContext = new AnnotationConfigApplicationContext(ClusterConfig.class)) {
+            try(AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext()) {
+               // Register the config and publish the context to ConfigurationContext BEFORE
+               // refreshing. refresh() eagerly instantiates singletons (including the cluster
+               // bean, whose IgniteCluster constructor resolves PasswordEncryption via
+               // ConfigurationContext.getSpringBean). If the context isn't published first,
+               // that lookup sees a null applicationContext and throws ShutdownException.
+               applicationContext.register(ClusterConfig.class);
                configContext.setApplicationContext(applicationContext);
+               applicationContext.refresh();
                Cluster.getInstance().submit("plugins", new LoadKeyValueTask<>("plugins", true));
                context.attributes().put("pluginsInstalled", false);
             }


### PR DESCRIPTION
Root cause: In StorageInitializer.reloadClusterPlugins(), the Spring AnnotationConfigApplicationContext(ClusterConfig.class) constructor eagerly instantiates the cluster bean before the
  context was published to ConfigurationContext. IgniteCluster's constructor resolves PasswordEncryption via ConfigurationContext.getSpringBean(...), which throws ShutdownException because
  applicationContext was still null at that moment. The configContext.setApplicationContext(...) call happened one line too late (after the constructor returned). This aborts storage init, which
  is why the server and scheduler containers then refuse to start.

  Commit #4098 (proxyBeanMethods = false) had fixed an earlier BeanDefinitionStoreException that used to abort refresh before any bean was built — which is why this latent ordering bug only
  surfaced now.

  Fix (core/src/main/java/inetsoft/setup/StorageInitializer.java): switched to the no-arg AnnotationConfigApplicationContext, then register() → setApplicationContext() → refresh() in that order.
  Now when refresh() eagerly builds the cluster bean and it looks up PasswordEncryption, ConfigurationContext already holds the (registered, not-yet-refreshed) context, so getSpringBean
  resolves the passwordEncryption bean on demand instead of throwing. Also removed the now-unused AbstractApplicationContext import.