### PR TITLE
Proxy Scope message not supported

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -273,12 +273,19 @@ public class GraalJavaScriptEngine implements AutoCloseable {
       };
 
       putConstantScope(bindings, "Chart", chartcls);
-      putConstantScope(bindings, "GLine", inetsoft.graph.aesthetic.GLine.class);
-      putConstantScope(bindings, "GTexture", inetsoft.graph.aesthetic.GTexture.class);
-      // GShape upgraded to JavaClassProxy so GShape.ImageShape (a public static
-      // nested class) is accessible in chart scripts alongside the static constants.
+      // GLine/GTexture/GShape/SVGShape are Java classes with both public
+      // constructors and public static final constants. Rhino exposed them as a
+      // NativeJavaClass, so scripts both construct them (new GLine(3), used by
+      // elem.setLineFrame(new StaticLineFrame(new GLine(3)))) and read their
+      // constants (GLine.THIN_LINE). A ConstantScope only surfaces the constants
+      // and is not instantiable ("instantiate on ScopeProxy ... Message not
+      // supported"), so register them as JavaClassProxy, which allowPublicAccess
+      // makes serve both the static constants and `new`.
+      putClassProxy(bindings, "GLine", "inetsoft.graph.aesthetic.GLine");
+      putClassProxy(bindings, "GTexture", "inetsoft.graph.aesthetic.GTexture");
+      // GShape also exposes GShape.ImageShape (a public static nested class).
       putClassProxy(bindings, "GShape", "inetsoft.graph.aesthetic.GShape");
-      putConstantScope(bindings, "SVGShape", inetsoft.graph.aesthetic.SVGShape.class);
+      putClassProxy(bindings, "SVGShape", "inetsoft.graph.aesthetic.SVGShape");
 
       installChartClasses(bindings);
 

--- a/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineGlobalsTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineGlobalsTest.java
@@ -85,4 +85,32 @@ class GraalJavaScriptEngineGlobalsTest {
       assertInstanceOf(Double.class, result);
       assertEquals(1.0, result);
    }
+
+   // Bug: chart scripts construct these aesthetic classes, e.g.
+   // elem.setLineFrame(new StaticLineFrame(new GLine(3))). GLine/GTexture/SVGShape
+   // are Java classes with both public constructors and public static final
+   // constants; Rhino exposed them as NativeJavaClass (both new and constants).
+   @Test
+   void gLineIsConstructable() throws Exception {
+      Object result = eval("new GLine(3)");
+      assertInstanceOf(inetsoft.graph.aesthetic.GLine.class, result);
+   }
+
+   @Test
+   void gLineConstantStillResolves() throws Exception {
+      Object result = eval("GLine.THIN_LINE");
+      assertInstanceOf(inetsoft.graph.aesthetic.GLine.class, result);
+   }
+
+   @Test
+   void gTextureIsConstructable() throws Exception {
+      Object result = eval("new GTexture()");
+      assertInstanceOf(inetsoft.graph.aesthetic.GTexture.class, result);
+   }
+
+   @Test
+   void svgShapeIsConstructable() throws Exception {
+      Object result = eval("new SVGShape()");
+      assertInstanceOf(inetsoft.graph.aesthetic.SVGShape.class, result);
+   }
 }


### PR DESCRIPTION
Root cause found and fixed

  The bug: The failing line 4 is new StaticLineFrame(new GLine(3)) — specifically the inner new GLine(3). In the Rhino→GraalJS migration (#75423), chart script globals were registered two
  different ways in GraalJavaScriptEngine:

  - putClassProxy → JavaClassProxy, which implements ProxyInstantiable (supports new) and exposes static members.

  instantiate on ...ScopeProxy... Message not supported. In Rhino these were NativeJavaClass objects that supported both construction and constants. GShape had already been upgraded to
  putClassProxy for a related reason; these three were left behind.
  The fix (core/.../graal/GraalJavaScriptEngine.java): register GLine, GTexture, SVGShape via putClassProxy like GShape. Since ScriptHostAccess sets allowPublicAccess(true) and inetsoft.graph.*
  is allow-listed, a JavaClassProxy serves both new GLine(3) and GLine.THIN_LINE.