### PR TITLE
74993, The tree chart refreshes slowly when changes are made.

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/AnimationConstants.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/AnimationConstants.java
@@ -120,6 +120,28 @@ public final class AnimationConstants {
    public static final double PIE_TEXT_DURATION = 0.4;
 
    // -------------------------------------------------------------------------
+   // Relation / tree / network chart animation constants
+   // -------------------------------------------------------------------------
+
+   /**
+    * Fade duration for relation/tree/network nodes, edges, and labels (seconds).  Matches the
+    * global {@link #DURATION}; the smooth root→leaf reveal comes from the per-node stagger
+    * ({@link #relationDelay}), not from shortening the fade.
+    */
+   public static final double RELATION_FADE_DURATION = 0.8;
+
+   /** Additional delay applied per tree depth level for the relation stagger (seconds). */
+   public static final double RELATION_LEVEL_STEP = 0.32;
+
+   /**
+    * Maximum relation stagger delay (seconds).  Caps the depth-based <em>base</em> delay so the
+    * entrance time stays bounded and independent of node count even for very deep graphs.  The
+    * intra-level spread (up to one {@link #RELATION_LEVEL_STEP}) is added after this cap, so the
+    * effective last-node delay can exceed the cap by at most one step.
+    */
+   public static final double RELATION_MAX_STAGGER = 2.4;
+
+   // -------------------------------------------------------------------------
    // Sunburst label glyph-matching constants
    // -------------------------------------------------------------------------
 
@@ -162,5 +184,34 @@ public final class AnimationConstants {
       }
 
       return index * (STAGGER_WINDOW / (count - 1));
+   }
+
+   /**
+    * Compute the entrance delay for a relation node at tree {@code depth} (0 = root), spreading
+    * the {@code countInLevel} nodes that share that depth smoothly across one
+    * {@link #RELATION_LEVEL_STEP} by their {@code indexInLevel}.
+    *
+    * <p>The delay has two parts:
+    * <ul>
+    *   <li><b>Base</b> — {@code depth * RELATION_LEVEL_STEP}, capped at {@link #RELATION_MAX_STAGGER},
+    *       giving the root→leaf cascade (root at 0, each level one step later, bounded for deep
+    *       graphs).
+    *   <li><b>Intra-level spread</b> — {@code (indexInLevel / countInLevel) * RELATION_LEVEL_STEP},
+    *       so a level's nodes trickle in individually rather than all firing at the same instant.
+    *       Dividing by {@code countInLevel} (not {@code countInLevel - 1}) makes the last node of a
+    *       level land just before the next level's first node, producing one continuous, evenly
+    *       paced ramp across the whole graph — the smooth, fine-grained reveal users expect.
+    * </ul>
+    *
+    * @param depth        0-based depth of the node (root = 0)
+    * @param indexInLevel 0-based position of this node among nodes at the same depth
+    * @param countInLevel total number of nodes at this depth
+    * @return delay in seconds (≥ 0)
+    */
+   public static double relationDelay(int depth, int indexInLevel, int countInLevel) {
+      double base = Math.min(Math.max(depth, 0) * RELATION_LEVEL_STEP, RELATION_MAX_STAGGER);
+      double intra = countInLevel <= 1
+         ? 0 : ((double) indexInLevel / countInLevel) * RELATION_LEVEL_STEP;
+      return base + intra;
    }
 }

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/AnimationConstants.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/AnimationConstants.java
@@ -138,6 +138,11 @@ public final class AnimationConstants {
     * entrance time stays bounded and independent of node count even for very deep graphs.  The
     * intra-level spread (up to one {@link #RELATION_LEVEL_STEP}) is added after this cap, so the
     * effective last-node delay can exceed the cap by at most one step.
+    *
+    * <p>Typical charts (a handful of depth levels) finish their entrance in roughly 2s.  The worst
+    * case is bounded, not fixed: a very deep graph reaches {@code RELATION_MAX_STAGGER +
+    * RELATION_LEVEL_STEP} before its last fade begins (≈2.7s here), completing about one
+    * {@link #RELATION_FADE_DURATION} later.
     */
    public static final double RELATION_MAX_STAGGER = 2.4;
 

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -2069,16 +2069,20 @@ public class SVGAnimationDOMInjector {
    // -------------------------------------------------------------------------
 
    /**
-    * Inject fade-in animation for relation/tree charts, ordered root-first (top-to-bottom).
+    * Inject fade-in animation for relation/tree/network charts, ordered root-first.
     *
     * <p>Each {@code inetsoft-relation} annotation group (one per tree node) fades in using
     * the A2 pattern — animation is applied to inner child elements so the group's own opacity
     * is never animated and hover dimming works without a {@code .ready} gate.
     *
-    * <p>Nodes are sorted by their SVG Y-centre (ascending = topmost = root level first) and
-    * clustered into discrete depth bands: consecutive nodes whose Y-centres differ by more than
-    * half the average node height begin a new level.  All nodes in the same band receive the
-    * same stagger delay, so siblings at the same depth appear together.
+    * <p>Node depth (0 = root) is derived from the edge source→target topology via
+    * {@link #computeTopologicalDepth}, which is orientation-independent — root-first ordering is
+    * therefore correct for every tree direction (top-to-bottom, bottom-to-top, left-to-right,
+    * right-to-left, radial).  Only when no usable topology exists (no edges, or a fully cyclic
+    * network graph with no root) does it fall back to clustering by SVG Y-centre.  Delay grows a
+    * fixed, capped amount per depth level ({@link AnimationConstants#relationDelay}), so the total
+    * entrance time is bounded and independent of node count — large graphs no longer trail in over
+    * a long stagger window.  Siblings at the same depth share a delay, so they appear together.
     */
    private static void injectRelationAnimation(Element svgRoot, Document doc) {
       appendStyle(svgRoot, doc,
@@ -2114,85 +2118,105 @@ public class SVGAnimationDOMInjector {
          }
       }
 
-      // Sort node indices by Y-centre ascending (root = topmost = smallest Y in SVG coords).
-      // NOTE: this assumes a vertical (top-to-bottom) tree layout. For horizontal COMPACT_TREE
-      // layouts the level ordering will be approximate (nodes sorted by the width axis instead of
-      // the depth axis), but the animation will still complete correctly — it just won't follow
-      // root-first order on horizontal trees. For force-directed network graph layouts there is
-      // no inherent ordering at all; nodes will stagger in approximate top-to-bottom order.
-      List<Integer> order = new ArrayList<>();
+      // Edges carry the source→target topology, so collect them up front: depth is derived from
+      // the graph structure (orientation-independent) rather than screen geometry.
+      List<Element> edgeGroups = collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_RELATION_EDGE);
 
-      for(int i = 0; i < nodes.size(); i++) {
-         order.add(i);
-      }
-
-      order.sort(Comparator.comparingDouble(nodeCY::get));
-
-      // Cluster into level bands: a gap larger than 50% of the average node height signals
-      // a new level.  Clamp threshold to at least 5px for degenerate single-pixel nodes.
-      double avgHeight = bounds.stream().mapToDouble(b -> b[3] - b[1]).average().orElse(20.0);
-      double threshold = Math.max(avgHeight * 0.5, 5.0);
-      int[] levelOf = new int[nodes.size()];
-      int numLevels = 0;
-      double prevLevelY = Double.NEGATIVE_INFINITY;
-
-      for(int idx : order) {
-         double cy = nodeCY.get(idx);
-
-         if(numLevels == 0 || cy - prevLevelY > threshold) {
-            prevLevelY = cy;
-            numLevels++;
-         }
-
-         levelOf[idx] = numLevels - 1;
-      }
-
-      // A2 fade staggered by level — root (level 0) appears first, leaves last.
-      for(int i = 0; i < nodes.size(); i++) {
-         double delay = AnimationConstants.staggerDelay(levelOf[i], numLevels);
-         applyAnimStyleToChildren(nodes.get(i), String.format(java.util.Locale.US,
-            "animation:inetsoft-relation-fade %.2fs %s %.2fs both",
-            AnimationConstants.DURATION, AnimationConstants.EASING, delay));
-      }
-
-      // Build node-ID → level map so edges can be assigned the same level as their target node.
-      Map<String, Integer> levelByNodeId = new HashMap<>();
+      // Map node id → node index so both the depth computation and the edge/label passes can
+      // resolve a node from its stamped data-node-id.
+      Map<String, Integer> nodeIndexById = new HashMap<>();
 
       for(int i = 0; i < nodes.size(); i++) {
          String id = nodes.get(i).getAttribute("data-" + SVGSupport.ATTR_NODE_ID);
 
          if(!id.isEmpty()) {
-            levelByNodeId.put(id, levelOf[i]);
+            nodeIndexById.put(id, i);
+         }
+      }
+
+      // Prefer topological depth (root = 0); fall back to Y-centre clustering only when there is
+      // no usable topology (no edges, no node ids, or a fully cyclic graph with no root).
+      int[] levelOf = computeTopologicalDepth(nodes, edgeGroups, nodeIndexById);
+
+      if(levelOf == null) {
+         levelOf = new int[nodes.size()];
+
+         // Sort node indices by Y-centre ascending (root = topmost = smallest Y in SVG coords)
+         // and cluster into level bands: a gap larger than 50% of the average node height signals
+         // a new level.  Clamp threshold to at least 5px for degenerate single-pixel nodes.  This
+         // approximates root-first order for top-to-bottom layouts only.
+         List<Integer> order = new ArrayList<>();
+
+         for(int i = 0; i < nodes.size(); i++) {
+            order.add(i);
+         }
+
+         order.sort(Comparator.comparingDouble(nodeCY::get));
+
+         double avgHeight = bounds.stream().mapToDouble(b -> b[3] - b[1]).average().orElse(20.0);
+         double threshold = Math.max(avgHeight * 0.5, 5.0);
+         int numLevels = 0;
+         double prevLevelY = Double.NEGATIVE_INFINITY;
+
+         for(int idx : order) {
+            double cy = nodeCY.get(idx);
+
+            if(numLevels == 0 || cy - prevLevelY > threshold) {
+               prevLevelY = cy;
+               numLevels++;
+            }
+
+            levelOf[idx] = numLevels - 1;
+         }
+      }
+
+      // Give each node a precise delay: a per-depth base (root→leaf cascade) plus an intra-level
+      // spread by DOM order, so the nodes of one depth trickle in individually across a step
+      // instead of all popping at the same instant.  This restores the smooth, fine-grained
+      // reveal of the legacy geometry-based stagger while keeping correct root→leaf ordering.
+      double[] delayOf = computeRelationDelays(levelOf);
+
+      for(int i = 0; i < nodes.size(); i++) {
+         applyAnimStyleToChildren(nodes.get(i), String.format(java.util.Locale.US,
+            "animation:inetsoft-relation-fade %.2fs %s %.2fs both",
+            AnimationConstants.RELATION_FADE_DURATION, AnimationConstants.EASING, delayOf[i]));
+      }
+
+      // Build node-ID → delay map so edges/labels inherit their node's exact delay and fade in
+      // together with it (not merely at the same depth band).
+      Map<String, Double> delayByNodeId = new HashMap<>();
+
+      for(int i = 0; i < nodes.size(); i++) {
+         String id = nodes.get(i).getAttribute("data-" + SVGSupport.ATTR_NODE_ID);
+
+         if(!id.isEmpty()) {
+            delayByNodeId.put(id, delayOf[i]);
          }
       }
 
       // Edge animation: each edge fades in with its target (child) node so the edge and
-      // its destination appear together. Falls back to the source node's level, then level 0.
-      List<Element> edgeGroups = collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_RELATION_EDGE);
-
+      // its destination appear together. Falls back to the source node's delay, then 0.
       for(Element edgeG : edgeGroups) {
          String targetId = edgeG.getAttribute("data-" + SVGSupport.ATTR_TARGET);
          String sourceId = edgeG.getAttribute("data-" + SVGSupport.ATTR_SOURCE);
-         Integer level = levelByNodeId.get(targetId);
+         Double delay = delayByNodeId.get(targetId);
 
-         if(level == null) {
-            level = levelByNodeId.get(sourceId);
+         if(delay == null) {
+            delay = delayByNodeId.get(sourceId);
          }
 
-         if(level == null) {
-            level = 0;
+         if(delay == null) {
+            delay = 0.0;
          }
 
-         double delay = AnimationConstants.staggerDelay(level, numLevels);
          applyAnimStyleToChildren(edgeG, String.format(java.util.Locale.US,
             "animation:inetsoft-relation-fade %.2fs %s %.2fs both",
-            AnimationConstants.DURATION, AnimationConstants.EASING, delay));
+            AnimationConstants.RELATION_FADE_DURATION, AnimationConstants.EASING, delay));
       }
 
       // Label animation: labels are stamped with class="inetsoft-relation-label" and
       // data-row/data-col directly by RelationVO during rendering, so no geometric matching
-      // is needed — just look them up by data-row and apply the same stagger delay as the
-      // matched node.
+      // is needed — just look them up by data-row and apply the same delay as the matched node.
       Map<String, Integer> nodeIndexByRow = new HashMap<>();
       for(int i = 0; i < nodes.size(); i++) {
          String row = nodes.get(i).getAttribute("data-" + SVGSupport.ATTR_ROW);
@@ -2206,14 +2230,145 @@ public class SVGAnimationDOMInjector {
          String row = labelG.getAttribute("data-" + SVGSupport.ATTR_ROW);
          Integer idx = nodeIndexByRow.get(row);
          if(idx != null) {
-            double delay = AnimationConstants.staggerDelay(levelOf[idx], numLevels);
             // Use A2 pattern (apply to children) for consistency with nodes/edges, so the
             // group's own opacity is never set and hover dim CSS can override without conflict.
             applyAnimStyleToChildren(labelG, String.format(java.util.Locale.US,
                "animation:inetsoft-relation-fade %.2fs %s %.2fs both",
-               AnimationConstants.DURATION, AnimationConstants.EASING, delay));
+               AnimationConstants.RELATION_FADE_DURATION, AnimationConstants.EASING, delayOf[idx]));
          }
       }
+   }
+
+   /**
+    * Compute a per-node entrance delay from each node's depth plus its position within that depth.
+    *
+    * <p>Nodes are walked in DOM order; the k-th node encountered at a given depth becomes that
+    * depth's k-th element.  {@link AnimationConstants#relationDelay(int, int, int)} then adds an
+    * intra-level spread so a depth's nodes fade in one after another instead of simultaneously,
+    * yielding one continuous root→leaf ramp rather than a few large synchronized batches.
+    *
+    * @param levelOf per-node depth array (0 = root), aligned to the node list
+    * @return per-node delay in seconds, aligned to the node list
+    */
+   private static double[] computeRelationDelays(int[] levelOf) {
+      int maxDepth = 0;
+
+      for(int d : levelOf) {
+         maxDepth = Math.max(maxDepth, d);
+      }
+
+      int[] countAtDepth = new int[maxDepth + 1];
+
+      for(int d : levelOf) {
+         countAtDepth[d]++;
+      }
+
+      int[] seenAtDepth = new int[maxDepth + 1];
+      double[] delay = new double[levelOf.length];
+
+      for(int i = 0; i < levelOf.length; i++) {
+         int d = levelOf[i];
+         delay[i] = AnimationConstants.relationDelay(d, seenAtDepth[d]++, countAtDepth[d]);
+      }
+
+      return delay;
+   }
+
+   /**
+    * Compute each relation node's tree depth (0 = root) from the edge source→target topology.
+    *
+    * <p>Depth comes from the graph structure, not screen geometry, so root-first ordering is
+    * correct regardless of tree direction (top-to-bottom, bottom-to-top, left-to-right,
+    * right-to-left, radial).  Roots are nodes with no incoming edge; depth is assigned by a
+    * breadth-first traversal from all roots.  A node is assigned a depth only the first time it
+    * is reached (shortest path from a root), which also guarantees termination on cyclic network
+    * graphs.  Nodes not reachable from any root default to depth 0.
+    *
+    * @param nodes          relation node annotation groups, in DOM order
+    * @param edgeGroups     relation edge annotation groups carrying data-source / data-target
+    * @param nodeIndexById  map of stamped node id → index into {@code nodes}
+    * @return a per-node depth array aligned to {@code nodes}, or {@code null} when no usable
+    *         topology is available (no edges, no node ids, or no roots) so the caller can fall
+    *         back to geometry-based ordering
+    */
+   private static int[] computeTopologicalDepth(List<Element> nodes, List<Element> edgeGroups,
+                                                Map<String, Integer> nodeIndexById)
+   {
+      if(edgeGroups.isEmpty() || nodeIndexById.isEmpty()) {
+         return null;
+      }
+
+      // adjacency: source id → target ids; hasIncoming: ids that are some edge's target.
+      Map<String, List<String>> adjacency = new HashMap<>();
+      Set<String> hasIncoming = new HashSet<>();
+
+      for(Element edgeG : edgeGroups) {
+         String source = edgeG.getAttribute("data-" + SVGSupport.ATTR_SOURCE);
+         String target = edgeG.getAttribute("data-" + SVGSupport.ATTR_TARGET);
+
+         if(source.isEmpty() || target.isEmpty()) {
+            continue;
+         }
+
+         // Root nodes are stamped with a sentinel parent ("null") or a source that is not a real
+         // node.  Such an edge must NOT mark its target as having an incoming edge, otherwise the
+         // real root is excluded from the root set and the whole traversal collapses to depth 0.
+         if(!nodeIndexById.containsKey(source)) {
+            continue;
+         }
+
+         adjacency.computeIfAbsent(source, k -> new ArrayList<>()).add(target);
+         hasIncoming.add(target);
+      }
+
+      if(hasIncoming.isEmpty()) {
+         return null;
+      }
+
+      // Roots = known nodes that are never an edge target.
+      Deque<String> queue = new ArrayDeque<>();
+      Map<String, Integer> depthById = new HashMap<>();
+
+      for(String id : nodeIndexById.keySet()) {
+         if(!hasIncoming.contains(id)) {
+            depthById.put(id, 0);
+            queue.add(id);
+         }
+      }
+
+      if(queue.isEmpty()) {
+         // Fully cyclic — no root to start from; let the caller fall back to geometry.
+         return null;
+      }
+
+      while(!queue.isEmpty()) {
+         String id = queue.poll();
+         int depth = depthById.get(id);
+         List<String> targets = adjacency.get(id);
+
+         if(targets == null) {
+            continue;
+         }
+
+         for(String target : targets) {
+            // Assign a depth only once (shortest path from a root); the containsKey check also
+            // guarantees termination on cyclic graphs.
+            if(!depthById.containsKey(target)) {
+               depthById.put(target, depth + 1);
+               queue.add(target);
+            }
+         }
+      }
+
+      int[] levelOf = new int[nodes.size()];
+
+      for(int i = 0; i < nodes.size(); i++) {
+         String id = nodes.get(i).getAttribute("data-" + SVGSupport.ATTR_NODE_ID);
+         Integer d = id.isEmpty() ? null : depthById.get(id);
+         levelOf[i] = d != null ? d : 0;
+      }
+
+      return levelOf;
    }
 
    // -------------------------------------------------------------------------

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -2094,30 +2094,6 @@ public class SVGAnimationDOMInjector {
          return;
       }
 
-      List<double[]> bounds = nodes.stream()
-         .map(SVGAnimationDOMInjector::annotGroupBounds)
-         .collect(Collectors.toList());
-
-      // Prefer data-y stamped by RelationVO (shape-agnostic screen Y center) over the
-      // bounds-derived center, which fails for non-rect node shapes such as circles.
-      List<Double> nodeCY = new ArrayList<>();
-
-      for(int i = 0; i < nodes.size(); i++) {
-         String yAttr = nodes.get(i).getAttribute("data-" + SVGSupport.ATTR_Y);
-
-         if(!yAttr.isEmpty()) {
-            try {
-               nodeCY.add(Double.parseDouble(yAttr));
-            }
-            catch(NumberFormatException ignored) {
-               nodeCY.add((bounds.get(i)[1] + bounds.get(i)[3]) / 2.0);
-            }
-         }
-         else {
-            nodeCY.add((bounds.get(i)[1] + bounds.get(i)[3]) / 2.0);
-         }
-      }
-
       // Edges carry the source→target topology, so collect them up front: depth is derived from
       // the graph structure (orientation-independent) rather than screen geometry.
       List<Element> edgeGroups = collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_RELATION_EDGE);
@@ -2140,6 +2116,32 @@ public class SVGAnimationDOMInjector {
 
       if(levelOf == null) {
          levelOf = new int[nodes.size()];
+
+         // Geometry is only needed for this fallback, so compute it lazily here rather than on
+         // every render (the topological path above is the common case and never reads it).
+         List<double[]> bounds = nodes.stream()
+            .map(SVGAnimationDOMInjector::annotGroupBounds)
+            .collect(Collectors.toList());
+
+         // Prefer data-y stamped by RelationVO (shape-agnostic screen Y center) over the
+         // bounds-derived center, which fails for non-rect node shapes such as circles.
+         List<Double> nodeCY = new ArrayList<>();
+
+         for(int i = 0; i < nodes.size(); i++) {
+            String yAttr = nodes.get(i).getAttribute("data-" + SVGSupport.ATTR_Y);
+
+            if(!yAttr.isEmpty()) {
+               try {
+                  nodeCY.add(Double.parseDouble(yAttr));
+               }
+               catch(NumberFormatException ignored) {
+                  nodeCY.add((bounds.get(i)[1] + bounds.get(i)[3]) / 2.0);
+               }
+            }
+            else {
+               nodeCY.add((bounds.get(i)[1] + bounds.get(i)[3]) / 2.0);
+            }
+         }
 
          // Sort node indices by Y-centre ascending (root = topmost = smallest Y in SVG coords)
          // and cluster into level bands: a gap larger than 50% of the average node height signals
@@ -2310,10 +2312,12 @@ public class SVGAnimationDOMInjector {
             continue;
          }
 
-         // Root nodes are stamped with a sentinel parent ("null") or a source that is not a real
-         // node.  Such an edge must NOT mark its target as having an incoming edge, otherwise the
-         // real root is excluded from the root set and the whole traversal collapses to depth 0.
-         if(!nodeIndexById.containsKey(source)) {
+         // A root's parent is stamped with the literal sentinel id "null" (RelationElement.getId
+         // returns "null" for a null "from" value; that sentinel may itself be rendered as a node).
+         // An edge from that sentinel — or from any source dropped upstream (e.g. maxNodes
+         // truncation) and thus unknown here — must NOT mark its target as having a real incoming
+         // edge, so the actual root is detected as depth 0 rather than a child of the sentinel.
+         if("null".equals(source) || !nodeIndexById.containsKey(source)) {
             continue;
          }
 
@@ -2365,6 +2369,10 @@ public class SVGAnimationDOMInjector {
       for(int i = 0; i < nodes.size(); i++) {
          String id = nodes.get(i).getAttribute("data-" + SVGSupport.ATTR_NODE_ID);
          Integer d = id.isEmpty() ? null : depthById.get(id);
+         // Nodes never reached by BFS — an isolated all-cyclic component while the rest of the
+         // graph has a real root — intentionally default to depth 0 and fade in with the roots.
+         // This is an accepted trade-off: the whole-graph cyclic case is already handled by the
+         // geometry fallback, and a per-node geometry fallback isn't worth the complexity here.
          levelOf[i] = d != null ? d : 0;
       }
 

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -1777,4 +1777,157 @@ class SVGAnimationDOMInjectorTest {
                     "every 3D pie face must receive an animation, including depth quads");
       }
    }
+
+   // -------------------------------------------------------------------------
+   // Relation / tree / network chart tests
+   // -------------------------------------------------------------------------
+
+   /** Adds a relation node annotation group with a stamped id and screen-Y. */
+   private static Element relNode(Document doc, String id, double y) {
+      Map<String, String> attrs = new LinkedHashMap<>();
+      attrs.put(SVGSupport.ATTR_NODE_ID, id);
+      attrs.put(SVGSupport.ATTR_Y, String.valueOf(y));
+      return addAnnotGroup(doc, SVGSupport.ANNOTATION_RELATION, attrs, 0, y, 20, 16);
+   }
+
+   /** Adds a relation edge annotation group linking source→target node ids. */
+   private static Element relEdge(Document doc, String source, String target) {
+      Map<String, String> attrs = new LinkedHashMap<>();
+      attrs.put(SVGSupport.ATTR_SOURCE, source);
+      attrs.put(SVGSupport.ATTR_TARGET, target);
+      return addAnnotGroup(doc, SVGSupport.ANNOTATION_RELATION_EDGE, attrs, 0, 0, 20, 2);
+   }
+
+   /**
+    * A linear tree (root → child → grandchild, one node per depth) staggers strictly root-first:
+    * delay grows by exactly {@link AnimationConstants#RELATION_LEVEL_STEP} per depth level.
+    */
+   @Test
+   void relationTopologyStaggersRootBeforeLeaf() throws Exception {
+      Document doc = newDocument();
+      Element root = relNode(doc, "R", 100);
+      Element child = relNode(doc, "A", 200);
+      Element leaf = relNode(doc, "C", 300);
+      relEdge(doc, "R", "A");
+      relEdge(doc, "A", "C");
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_RELATION);
+
+      double step = AnimationConstants.RELATION_LEVEL_STEP;
+      assertEquals(0.0, parseDelay(firstChildStyle(root)), 0.001, "root → depth 0");
+      assertEquals(step, parseDelay(firstChildStyle(child)), 0.001, "child → depth 1");
+      assertEquals(2 * step, parseDelay(firstChildStyle(leaf)), 0.001, "grandchild → depth 2");
+   }
+
+   /**
+    * Reveal order comes from the edge topology, not screen geometry: a root placed at the BOTTOM
+    * of the chart (largest Y) still reveals first, where the legacy Y-clustering would reveal it
+    * last.  Proves orientation-independence (bottom-up / left-right / radial trees).
+    */
+   @Test
+   void relationDepthIsTopologyNotGeometry() throws Exception {
+      Document doc = newDocument();
+      Element root = relNode(doc, "R", 500);   // bottom of the chart
+      Element child = relNode(doc, "A", 100);  // top of the chart
+      relEdge(doc, "R", "A");
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_RELATION);
+
+      assertEquals(0.0, parseDelay(firstChildStyle(root)), 0.001,
+                   "topological root reveals first even though its Y is largest");
+      assertTrue(parseDelay(firstChildStyle(child)) > parseDelay(firstChildStyle(root)),
+                 "child reveals after its root regardless of geometry");
+   }
+
+   /**
+    * Regression for the null-parent sentinel (Redmine #74993): a root whose parent is stamped with
+    * the literal id {@code "null"} (RelationElement.getId's sentinel for a null "from" value) must
+    * still be detected as a depth-0 root — the sentinel edge must not push it to depth 1.  A
+    * depth-0 node's total delay is always below one {@link AnimationConstants#RELATION_LEVEL_STEP}
+    * (base 0 + intra-level spread &lt; step), whereas a depth-1 node is at or above one step.
+    */
+   @Test
+   void relationNullParentSentinelDetectsRealRoot() throws Exception {
+      Document doc = newDocument();
+      relNode(doc, "null", 50);                // sentinel node getId(...) == "null"
+      Element root = relNode(doc, "R", 100);
+      Element child = relNode(doc, "A", 200);
+      relEdge(doc, "null", "R");               // root's parent is the null sentinel
+      relEdge(doc, "R", "A");                  // a real edge keeps the topology path active
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_RELATION);
+
+      double step = AnimationConstants.RELATION_LEVEL_STEP;
+      assertTrue(parseDelay(firstChildStyle(root)) < step,
+                 "real root stays depth 0 (delay < one step) despite the null-parent sentinel edge");
+      assertEquals(step, parseDelay(firstChildStyle(child)), 0.001,
+                   "child of the real root is depth 1");
+   }
+
+   /**
+    * Siblings at the same depth do not all fire at once: the intra-level spread gives each its own
+    * moment (in DOM order), while keeping them all within one step of the depth base.
+    */
+   @Test
+   void relationIntraLevelSpreadTricklesSiblings() throws Exception {
+      Document doc = newDocument();
+      relNode(doc, "R", 50);
+      Element a = relNode(doc, "A", 100);
+      Element b = relNode(doc, "B", 110);
+      Element c = relNode(doc, "C", 120);
+      relEdge(doc, "R", "A");
+      relEdge(doc, "R", "B");
+      relEdge(doc, "R", "C");
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_RELATION);
+
+      double da = parseDelay(firstChildStyle(a));
+      double db = parseDelay(firstChildStyle(b));
+      double dc = parseDelay(firstChildStyle(c));
+      double step = AnimationConstants.RELATION_LEVEL_STEP;
+
+      assertTrue(da < db && db < dc,
+                 "same-depth siblings stagger individually: " + da + " < " + db + " < " + dc);
+      assertTrue(da >= step - 0.001 && dc < 2 * step,
+                 "sibling delays lie within [depth-1 base, base + one step)");
+   }
+
+   /**
+    * A fully cyclic graph has no root, so depth cannot be derived — the injector falls back to the
+    * geometry (Y-centre) ordering.  It must not throw, every node must still animate, and the
+    * higher (smaller-Y) node must reveal no later than the lower one.
+    */
+   @Test
+   void relationCyclicGraphFallsBackToGeometry() throws Exception {
+      Document doc = newDocument();
+      Element top = relNode(doc, "A", 100);
+      Element bottom = relNode(doc, "B", 300);
+      relEdge(doc, "A", "B");
+      relEdge(doc, "B", "A");   // cycle → no root → geometry fallback
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_RELATION);
+
+      assertTrue(firstChildStyle(top).contains("inetsoft-relation-fade"),
+                 "cyclic-graph nodes still animate via the geometry fallback");
+      assertTrue(firstChildStyle(bottom).contains("inetsoft-relation-fade"), "both nodes animate");
+      assertTrue(parseDelay(firstChildStyle(top)) <= parseDelay(firstChildStyle(bottom)),
+                 "top (smaller Y) reveals before bottom in the geometry fallback");
+   }
+
+   /**
+    * Edges inherit their target (child) node's exact delay so an edge fades in together with the
+    * node it points to, not merely at the same depth band.
+    */
+   @Test
+   void relationEdgeInheritsTargetNodeDelay() throws Exception {
+      Document doc = newDocument();
+      relNode(doc, "R", 100);
+      Element child = relNode(doc, "A", 200);
+      Element edge = relEdge(doc, "R", "A");
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_RELATION);
+
+      assertEquals(parseDelay(firstChildStyle(child)), parseDelay(firstChildStyle(edge)), 0.001,
+                   "edge fades in with its target node (same delay)");
+   }
 }


### PR DESCRIPTION
Root Cause:

The tree/network (relation) chart entrance animation had two problems that made it feel slow and abrupt with many nodes:

1. Coarse, geometry-based ordering. Node reveal order was derived from each node's screen Y-position, then clustered into depth "bands." This only approximated root-to-leaf order for top-to-bottom trees; for other orientations (bottom-up, left-right, radial/circular network) the ordering was wrong or arbitrary.

2. Broken depth on network/circular layouts (everything appeared at once). Relation charts stamp the root node's parent as data-source="null" (a sentinel, not a real node). The depth logic counted that sentinel edge as a real incoming edge, so the true root was excluded from the root set and the breadth-first traversal reached nothing - every node collapsed to depth 0 and faded in simultaneously. On dense graphs this read as an abrupt, "slow" bulk render rather than a progressive reveal.

Fix:

- Reveal order is now derived from the actual graph topology (edge source > target links) via a breadth-first traversal from the roots, making the root-to-leaf cascade correct for every orientation (top-down, bottom-up, left-right, right-left, radial). Falls back to the legacy geometry ordering only when no topology is available (e.g. a fully cyclic graph). Edges from a sentinel/unknown parent (data-source="null") are no longer treated as incoming edges, so the real root is detected and the cascade actually runs on network/circular charts.
- Each node's delay is a per-depth base plus an intra-level spread, so nodes at the same depth trickle in individually instead of popping all at once - restoring a smooth, fine-grained reveal while keeping correct ordering. Edges and labels inherit their node's exact delay so they appear together with it.
- Timing is bounded and independent of node count (deep graphs stay capped), and tuned to a snappier ~2s entrance for typical graphs (bounded, not unbounded, for very deep ones).

Changes are confined to SVGAnimationDOMInjector.injectRelationAnimation and timing constants in AnimationConstants - no rendering, controller, or frontend changes.