### PR TITLE
Bug #75585, reuse a warm per-thread ScriptEnv in FormulaEvaluator

### DIFF
--- a/core/src/main/java/inetsoft/report/internal/ReportJavaScriptEnv.java
+++ b/core/src/main/java/inetsoft/report/internal/ReportJavaScriptEnv.java
@@ -147,6 +147,13 @@ public class ReportJavaScriptEnv extends GraalJavaScriptEnv
          catch(Exception e) {
             LOG.error("Failed to initialize script engine when " +
                "initializing environment", e);
+            // init(vars) may close/replace the Context; a failure here leaves
+            // rengine referencing a broken/closed Context that this method (a
+            // no-op while rengine != null) would never rebuild. Drop it so the
+            // next init()/exec() rebuilds from scratch rather than poisoning
+            // this (now long-lived, per-thread) env. Mirrors the reset() fix.
+            rengine = null;
+            engine = null;
          }
       }
    }

--- a/core/src/main/java/inetsoft/report/internal/ReportJavaScriptEnv.java
+++ b/core/src/main/java/inetsoft/report/internal/ReportJavaScriptEnv.java
@@ -56,6 +56,14 @@ public class ReportJavaScriptEnv extends GraalJavaScriptEnv
          catch(Exception ex) {
             LOG.error("Failed to initialize script engine when " +
                "resetting environment", ex);
+            // init(vars) closes the old Context before building the replacement,
+            // so a failure here leaves rengine referencing a closed Context that
+            // init() (a no-op while rengine != null) would never rebuild. Drop
+            // the engine so the next init()/exec() rebuilds it from scratch
+            // rather than poisoning a long-lived env. (mirrors the base
+            // GraalJavaScriptEnv.reset() fix)
+            rengine = null;
+            engine = null;
          }
       }
    }

--- a/core/src/main/java/inetsoft/report/script/formula/FormulaEvaluator.java
+++ b/core/src/main/java/inetsoft/report/script/formula/FormulaEvaluator.java
@@ -19,12 +19,14 @@ package inetsoft.report.script.formula;
 
 import inetsoft.report.script.TableRow;
 import inetsoft.report.script.TableRowScope;
+import inetsoft.sree.security.OrganizationManager;
 import inetsoft.util.script.*;
 import inetsoft.util.script.graal.ScriptScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Hashtable;
+import java.util.Objects;
 
 /**
  * Provide interface for executing formula scripts.
@@ -97,7 +99,44 @@ public class FormulaEvaluator {
       }
 
       try {
-         ScriptEnv senv = ScriptEnvRepository.getScriptEnv();
+         // Reuse a warm, per-thread ScriptEnv instead of creating a fresh one
+         // on every call. Under GraalJS an uninitialized env builds a complete
+         // Context on first exec (Truffle language init, reflected globals,
+         // library-function parsing), so newing one per calc-formula evaluation
+         // dominated calc-table/chart render time. GraalJavaScriptEnv holds one
+         // Context guarded by a ReentrantLock, so a per-thread env avoids the
+         // rebuild without serializing evaluations across threads; exec() swaps
+         // the global scope per call, so reuse across different scopes is safe.
+         ScriptEnv senv = ENV.get();
+
+         // A reused env keeps its GraalJS Context across evaluations, so any
+         // top-level var/function a formula declares hoists onto the shared
+         // globalThis (#75596) and library functions are installed per the
+         // org that first initialized it (LibManagerProvider.getManager(orgID)).
+         // Reset the env when the executing organization changes so neither
+         // declared globals nor org-scoped library functions leak across
+         // tenants on a pooled thread. reset() is a no-op on a not-yet-inited
+         // env, and only rebuilds on an actual tenant handoff (rare), not per
+         // evaluation.
+         //
+         // Only reconcile at the outermost exec on this thread (depth == 0).
+         // exec() is reentrant — a formula/condition can trigger a nested
+         // FormulaEvaluator.exec (e.g. NamedCellRange resolving a "="-prefixed
+         // reference) while the outer call is still inside context.eval on this
+         // same thread. Resetting there would close the Context the outer eval
+         // is running in and rebuild the engine's scopeProxy/context, which the
+         // outer call restores in its finally. The org cannot change between an
+         // outer and nested call on one thread during normal rendering, so
+         // deferring the check to the outermost frame loses nothing.
+         if(senv != null && DEPTH.get() == 0) {
+            String org = currentOrgID();
+
+            if(!Objects.equals(org, ENV_ORG.get())) {
+               senv.reset();
+               ENV_ORG.set(org);
+            }
+         }
+
          Object script = scriptcache.get(expr);
 
          if(script == null) {
@@ -109,8 +148,15 @@ public class FormulaEvaluator {
             scriptcache.put(expr, script);
          }
 
-         Object rc = senv.exec(script, scope, scope, null);
-         return JavaScriptEngine.unwrap(rc);
+         DEPTH.set(DEPTH.get() + 1);
+
+         try {
+            Object rc = senv.exec(script, scope, scope, null);
+            return JavaScriptEngine.unwrap(rc);
+         }
+         finally {
+            DEPTH.set(DEPTH.get() - 1);
+         }
       }
       catch(Exception ex) {
          LOG.error("Failed to execute formula script: " + expr, ex);
@@ -119,7 +165,29 @@ public class FormulaEvaluator {
       return null;
    }
 
+   /**
+    * The current organization id, or null if it can't be determined (e.g. a
+    * thread with no associated principal). Used only as a change key to decide
+    * when the per-thread env must be reset, so a null is a safe sentinel.
+    */
+   private static String currentOrgID() {
+      try {
+         return OrganizationManager.getInstance().getCurrentOrgID();
+      }
+      catch(Throwable ex) {
+         return null;
+      }
+   }
+
    private static Hashtable scriptcache = new Hashtable(); // expr -> script
+   // one warm ScriptEnv per thread, reused across evaluations
+   private static final ThreadLocal<ScriptEnv> ENV =
+      ThreadLocal.withInitial(ScriptEnvRepository::getScriptEnv);
+   // org id the per-thread env was last initialized for (reset on change)
+   private static final ThreadLocal<String> ENV_ORG = new ThreadLocal<>();
+   // reentrancy depth of exec() on the current thread; the env is only
+   // reconciled/reset at the outermost frame (depth 0)
+   private static final ThreadLocal<Integer> DEPTH = ThreadLocal.withInitial(() -> 0);
    private static final Logger LOG =
       LoggerFactory.getLogger(FormulaEvaluator.class);
 }

--- a/core/src/main/java/inetsoft/report/script/formula/FormulaEvaluator.java
+++ b/core/src/main/java/inetsoft/report/script/formula/FormulaEvaluator.java
@@ -119,6 +119,15 @@ public class FormulaEvaluator {
          // env, and only rebuilds on an actual tenant handoff (rare), not per
          // evaluation.
          //
+         // Note the reset key is the org, not the individual render: within one
+         // org the Context (and its globalThis) is intentionally shared across
+         // every viewsheet/report/calc-table render on this thread for the life
+         // of the thread. A formula's top-level var/function bleeding into an
+         // unrelated later same-org render is the accepted tradeoff of #75596-
+         // style Context reuse (org-scoped library functions are already shared
+         // the same way); scoping narrower would reintroduce the per-call
+         // rebuild this change exists to avoid.
+         //
          // Only reconcile at the outermost exec on this thread (depth == 0).
          // exec() is reentrant — a formula/condition can trigger a nested
          // FormulaEvaluator.exec (e.g. NamedCellRange resolving a "="-prefixed
@@ -174,7 +183,7 @@ public class FormulaEvaluator {
       try {
          return OrganizationManager.getInstance().getCurrentOrgID();
       }
-      catch(Throwable ex) {
+      catch(Exception ex) {
          return null;
       }
    }

--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEnv.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEnv.java
@@ -319,6 +319,12 @@ public class GraalJavaScriptEnv implements ScriptEnv {
          }
          catch(Exception e) {
             LOG.error("Failed to init GraalJavaScriptEngine", e);
+            // init(vars) may close/replace the Context; a failure here leaves
+            // engine referencing a broken/closed Context that this method (a
+            // no-op while engine != null) would never rebuild. Drop it so the
+            // next compile()/exec() rebuilds from scratch rather than poisoning
+            // this (now long-lived, per-thread) env. Mirrors the reset() fix.
+            engine = null;
          }
       }
    }

--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEnv.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEnv.java
@@ -54,6 +54,12 @@ public class GraalJavaScriptEnv implements ScriptEnv {
          }
          catch(Exception ex) {
             LOG.error("Failed to reset GraalJavaScriptEngine", ex);
+            // init(vars) closes the old Context before building the replacement,
+            // so a failure here leaves engine referencing a closed Context that
+            // init() (a no-op while engine != null) would never rebuild. Drop
+            // the engine so the next compile()/exec() rebuilds it from scratch
+            // rather than poisoning this (now long-lived, per-thread) env.
+            engine = null;
          }
       }
    }


### PR DESCRIPTION
## Summary

Chart / calc-table rendering became very slow after the Rhino→GraalJS migration (Feature #75423). Server-side profiling showed the render was dominated by repeated GraalJS `Context` construction, not the client. This fix makes `FormulaEvaluator` reuse a warm script environment instead of building a throwaway one per formula evaluation.

## Root Cause

`FormulaEvaluator.exec(String, ScriptScope)` called `ScriptEnvRepository.getScriptEnv()` on **every** invocation, which returns a fresh, uninitialized `GraalJavaScriptEnv`. Under GraalJS the first `exec` on a fresh env builds a complete `Context` — Truffle JS language init, reflecting all global functions, installing the global scope (CALC/Chart/etc.), and parsing every user library function. Calc-table cell-range and calc-field formulas route through `FormulaEvaluator.exec` (`TableArray.getMember` → `CellRange.getCells` → `NamedCellRange.getTableCells` → `FormulaEvaluator.exec`) many times per render, so a full throwaway `Context` was built per evaluation.

JFR method sampling of a slow render of the reporter's `vs_calc` viewsheet showed **~85% of server render CPU inside `GraalJavaScriptEngine.init`**, reached via `FormulaEvaluator` (55% in `init` alone, 53% of stacks passing through `CellRange`/`NamedCellRange`). The remaining GraalJS samples were parser/AST-construction frames — i.e. the cost of building the Context and parsing its globals, not of running the actual formulas.

Note: the `CalcRef.hasMember`/`getMember` coercion-probe path proposed in the issue was **not** the cause (0 samples); the earlier #75593 fix already handled that, and it applies to calc tables rather than the chart path.

## Fix

Reuse one warm `ScriptEnv` per thread (`ThreadLocal`) instead of creating a fresh one per call:

- `GraalJavaScriptEnv` holds a single `Context` guarded by a `ReentrantLock`, so a **per-thread** env (not a shared static) avoids the rebuild without serializing evaluations across threads.
- **Cross-tenant safety:** a reused env keeps its `Context` across evaluations, so top-level `var`/`function` declarations hoist onto the shared `globalThis` (#75596) and library functions are installed for the org that first initialized it. The env is `reset()` when the executing organization changes, giving a fresh `globalThis` and org-correct library functions.
- **Reentrancy safety:** `exec` is reentrant (a formula/condition can trigger a nested `FormulaEvaluator.exec` via e.g. `NamedCellRange` resolving a `"="`-prefixed reference). The org reconcile/reset runs only at the outermost `exec` on the thread (reentrancy-depth guard), so a nested call can never close the `Context` the outer eval is running inside.

This mirrors how other `getScriptEnv()` callers (`AssetQuerySandbox`, `ViewsheetScope`, `ScheduleParameterScope`) already cache and reuse a warm env.

## Test Plan

- `./mvnw -pl core compile` — clean.
- `./mvnw -pl core test` for the calc-formula path: `CalcRefTest`, `NamedCellRangeTest`, `CalcTableScopeTest`, `CalcGroupSelectorTest`, `CrosstabGroupSelectorTest`, `GroupRowSelectorTest`, `TableValueListTest`, `TableAssemblyScriptableTest`, `FormulaFunctionsTest`, `FormulaFunctions2Test` — **159 tests, 0 failures**.
- Manual: import `vs_calc.zip`, open the "calc field1" viewsheet — charts render substantially faster.
- JFR before/after on the same render: `GraalJavaScriptEngine.init` dropped from **55% → 1%** of CPU samples; `FormulaEvaluator` from 54% → 0%; the `reset()` path shows 0 samples (no reset thrash within a single-org render).

Fixes Redmine #75585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)