### PR TITLE
Bug #75541, generate 512-bit FIPS JWT signing key for HS512

### DIFF
--- a/core/src/main/java/inetsoft/util/FipsPasswordEncryption.java
+++ b/core/src/main/java/inetsoft/util/FipsPasswordEncryption.java
@@ -114,7 +114,9 @@ class FipsPasswordEncryption extends LocalPasswordEncryption {
    private SecretKey createHmacKey() {
       try {
          KeyGenerator keyGenerator = KeyGenerator.getInstance("HmacSHA512", "BCFIPS");
-         keyGenerator.init(128, random);
+         // HS512 (used to sign JWT tokens) requires a key of at least 256 bits; use 512 bits
+         // to match JcePasswordEncryption and provide the full security strength of SHA-512.
+         keyGenerator.init(512, random);
          return keyGenerator.generateKey();
       }
       catch(Exception e) {

--- a/core/src/main/java/inetsoft/util/LocalPasswordEncryption.java
+++ b/core/src/main/java/inetsoft/util/LocalPasswordEncryption.java
@@ -240,16 +240,31 @@ abstract class LocalPasswordEncryption extends AbstractPasswordEncryption {
       String property = SreeEnv.getProperty("jwt.signing.key");
 
       if(property == null) {
-         signingKey = createJwtSigningKey();
-         byte[] encryptedKey = encryptJwtSigningKey(signingKey, getMasterKey());
-         String encoded = Base64.getEncoder().encodeToString(encryptedKey);
-         SreeEnv.setProperty("jwt.signing.key", encoded);
-         SreeEnv.save();
+         signingKey = createAndStoreJwtSigningKey();
       }
       else {
          signingKey = decryptJwtSigningKey(property, getMasterKey());
+
+         // Bug #75541: earlier FIPS builds persisted an undersized (128-bit) HmacSHA512
+         // signing key, which HS512 sign/verify rejects (>= 256 bits required). Regenerate
+         // it so upgraded deployments recover. JWTs are short-lived and do not survive a
+         // restart, so replacing the key has no impact.
+         byte[] encoded = signingKey == null ? null : signingKey.getEncoded();
+
+         if(encoded == null || encoded.length < JWT_SIGNING_KEY_MIN_BYTES) {
+            signingKey = createAndStoreJwtSigningKey();
+         }
       }
 
+      return signingKey;
+   }
+
+   private SecretKey createAndStoreJwtSigningKey() throws IOException {
+      SecretKey signingKey = createJwtSigningKey();
+      byte[] encryptedKey = encryptJwtSigningKey(signingKey, getMasterKey());
+      String encoded = Base64.getEncoder().encodeToString(encryptedKey);
+      SreeEnv.setProperty("jwt.signing.key", encoded);
+      SreeEnv.save();
       return signingKey;
    }
 
@@ -519,6 +534,8 @@ abstract class LocalPasswordEncryption extends AbstractPasswordEncryption {
    }
 
    private final boolean throwExceptions;
+   // Minimum JWT signing key size in bytes (256 bits) required by the HS512 algorithm.
+   private static final int JWT_SIGNING_KEY_MIN_BYTES = 32;
    private static final String LOCK_NAME = LocalPasswordEncryption.class.getName() + ".lock";
 
    private static final Logger LOG = LoggerFactory.getLogger(LocalPasswordEncryption.class);

--- a/core/src/main/java/inetsoft/util/LocalPasswordEncryption.java
+++ b/core/src/main/java/inetsoft/util/LocalPasswordEncryption.java
@@ -236,27 +236,41 @@ abstract class LocalPasswordEncryption extends AbstractPasswordEncryption {
 
    @Override
    public final SecretKey getJwtSigningKey() throws IOException {
-      SecretKey signingKey;
-      String property = SreeEnv.getProperty("jwt.signing.key");
+      // Guard the read-check-regenerate sequence with the cluster lock, matching
+      // getSSOKeyPair(). Without it, an upgraded clustered FIPS deployment could have every
+      // node independently regenerate and persist a different key at once (the self-heal
+      // branch below), causing transient cross-node JWT verification failures. Reading the
+      // property inside the lock also double-checks: once one node re-persists a valid key,
+      // the next node reads it and skips a redundant regeneration.
+      Lock lock = Cluster.getInstance().getLock(LOCK_NAME);
+      lock.lock();
 
-      if(property == null) {
-         signingKey = createAndStoreJwtSigningKey();
-      }
-      else {
-         signingKey = decryptJwtSigningKey(property, getMasterKey());
+      try {
+         SecretKey signingKey;
+         String property = SreeEnv.getProperty("jwt.signing.key");
 
-         // Bug #75541: earlier FIPS builds persisted an undersized (128-bit) HmacSHA512
-         // signing key, which HS512 sign/verify rejects (>= 256 bits required). Regenerate
-         // it so upgraded deployments recover. JWTs are short-lived and do not survive a
-         // restart, so replacing the key has no impact.
-         byte[] encoded = signingKey == null ? null : signingKey.getEncoded();
-
-         if(encoded == null || encoded.length < JWT_SIGNING_KEY_MIN_BYTES) {
+         if(property == null) {
             signingKey = createAndStoreJwtSigningKey();
          }
-      }
+         else {
+            signingKey = decryptJwtSigningKey(property, getMasterKey());
 
-      return signingKey;
+            // Bug #75541: earlier FIPS builds persisted an undersized (128-bit) HmacSHA512
+            // signing key, which HS512 sign/verify rejects (>= 256 bits required). Regenerate
+            // it so upgraded deployments recover. JWTs are short-lived and do not survive a
+            // restart, so replacing the key has no impact.
+            byte[] encoded = signingKey == null ? null : signingKey.getEncoded();
+
+            if(encoded == null || encoded.length < JWT_SIGNING_KEY_MIN_BYTES) {
+               signingKey = createAndStoreJwtSigningKey();
+            }
+         }
+
+         return signingKey;
+      }
+      finally {
+         lock.unlock();
+      }
    }
 
    private SecretKey createAndStoreJwtSigningKey() throws IOException {

--- a/core/src/test/java/inetsoft/util/FipsPasswordEncryptionTest.java
+++ b/core/src/test/java/inetsoft/util/FipsPasswordEncryptionTest.java
@@ -45,11 +45,15 @@ package inetsoft.util;
  * Cases deferred - require integration context:
  *
  * updateMasterPassword() — reads/writes SreeEnv password.hash.key; needs mockStatic or full context
- * getJwtSigningKey() / getSSOKeyPair() — Cluster distributed lock + SreeEnv persistence
+ * getSSOKeyPair() — Cluster distributed lock + SreeEnv persistence
  * encryptPassword() / decryptPassword() — getSecretKey() lifecycle + SreeEnv round-trip
+ *
+ * getJwtSigningKey() self-heal path (Bug #75541) is covered by
+ * getJwtSigningKey_undersizedLegacyKey_regeneratesAndPersists.
  */
 
 import com.nimbusds.jose.*;
+import inetsoft.sree.SreeEnv;
 import inetsoft.test.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,6 +65,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.util.Arrays;
@@ -231,6 +236,29 @@ class FipsPasswordEncryptionTest {
          JWSObject jws = new JWSObject(new JWSHeader(JWSAlgorithm.HS512), new Payload("payload"));
          jws.sign(encryption.createJwsSigner(key));
          assertTrue(jws.verify(encryption.createJwsVerifier(key)));
+      }
+
+      // Bug #75541: self-heal path — an upgraded FIPS deployment with a persisted 128-bit
+      // key must have getJwtSigningKey() regenerate and re-persist a 512-bit (64-byte) key.
+      @Test
+      void getJwtSigningKey_undersizedLegacyKey_regeneratesAndPersists() throws Exception {
+         SecretKey legacyKey = new SecretKeySpec(new byte[16], "HmacSHA512");
+         byte[] encrypted = encryption.encryptJwtSigningKey(legacyKey, encryption.getMasterKey());
+         SreeEnv.setProperty("jwt.signing.key", Base64.getEncoder().encodeToString(encrypted));
+
+         try {
+            SecretKey healed = encryption.getJwtSigningKey();
+            assertEquals(64, healed.getEncoded().length,
+               "Bug #75541: undersized key must be regenerated at 512 bits");
+
+            // the regenerated key must be re-persisted, not just returned in-memory
+            String persisted = SreeEnv.getProperty("jwt.signing.key");
+            SecretKey reloaded = encryption.decryptJwtSigningKey(persisted, encryption.getMasterKey());
+            assertEquals(64, reloaded.getEncoded().length);
+         }
+         finally {
+            SreeEnv.remove("jwt.signing.key");
+         }
       }
 
       @Test

--- a/core/src/test/java/inetsoft/util/FipsPasswordEncryptionTest.java
+++ b/core/src/test/java/inetsoft/util/FipsPasswordEncryptionTest.java
@@ -32,14 +32,13 @@ package inetsoft.util;
  *            with a WARN log so legacy passwords remain valid during migration.
  *            Verified by checkHashedPassword_noneAlgorithm.
  *
- * Known bug (production — see Redmine/GitHub issue)
+ * Fixed bug (see Redmine #75541)
  *
- * [Bug #75541] FipsPasswordEncryption.createHmacKey() generates a 128-bit HmacSHA512 key
- *       (FipsPasswordEncryption.java:117), but JoseJwtService signs tokens with HS512
- *       (JoseJwtService.java:137), and Nimbus MACSigner/MACVerifier require >= 256 bits.
- *       Non-FIPS JcePasswordEncryption uses 512-bit keys (JcePasswordEncryption.java:72).
- *       Impact: JWT/API token sign/verify fails when secrets.fipsComplianceMode=true.
- *       Guard: jwsHs512SignVerify_roundTrip (@Disabled until fixed).
+ * [Bug #75541] FipsPasswordEncryption.createHmacKey() previously generated a 128-bit
+ *       HmacSHA512 key, but JoseJwtService signs tokens with HS512 (JoseJwtService.java:137),
+ *       and Nimbus MACSigner/MACVerifier require >= 256 bits. The key is now generated at
+ *       512 bits, matching non-FIPS JcePasswordEncryption.
+ *       Guard: jwsHs512SignVerify_roundTrip.
  */
 
 /*
@@ -143,7 +142,7 @@ class FipsPasswordEncryptionTest {
    class KeyGeneration {
 
       // Documents current key material (algorithm + length), not HS512 correctness.
-      // Companion: jwsHs512SignVerify_roundTrip (@Disabled) is the real HS512 guard.
+      // Companion: jwsHs512SignVerify_roundTrip is the real HS512 guard.
       @Test
       void createJwtSigningKey_producesHmacSha512Key() {
          SecretKey key = encryption.createJwtSigningKey();
@@ -151,10 +150,9 @@ class FipsPasswordEncryptionTest {
             () -> assertNotNull(key),
             () -> assertEquals("HmacSHA512", key.getAlgorithm()),
             () -> assertNotNull(key.getEncoded()),
-            // Bug #75541: key is only 128 bits; HS512 requires >= 256 bits.
-            // Change to assertEquals(32, ...) once createHmacKey() is fixed.
-            () -> assertEquals(16, key.getEncoded().length,
-               "Bug #75541: currently 128-bit, needs 256-bit for HS512")
+            // Bug #75541: key must be 512 bits (64 bytes); HS512 requires >= 256 bits.
+            () -> assertEquals(64, key.getEncoded().length,
+               "Bug #75541: key must be 512-bit to satisfy HS512")
          );
       }
 
@@ -224,9 +222,9 @@ class FipsPasswordEncryptionTest {
          assertEquals("HmacSHA512", restored.getAlgorithm());
       }
 
-      // Companion: createJwtSigningKey_producesHmacSha512Key documents the 128-bit key length.
+      // Companion: createJwtSigningKey_producesHmacSha512Key documents the 512-bit key length.
       // via: createJwsSigner() / createJwsVerifier() — same path as JoseJwtService HS512 tokens
-      @Disabled("Bug #75541: KeyLength >= 256 bits required for HS512 - FipsPasswordEncryption:117; Fix: keyGenerator.init(256, random)")
+      // Bug #75541: HS512 requires a key of >= 256 bits; guards the 512-bit key fix.
       @Test
       void jwsHs512SignVerify_roundTrip() throws Exception {
          SecretKey key = encryption.createJwtSigningKey();


### PR DESCRIPTION
## Summary

In FIPS compliance mode (`secrets.fipsComplianceMode: true`), JWT authorization tokens for the Public API (`/api/public/**`) and embed API failed to sign/verify, breaking token-based auth. This PR fixes the underlying key-size mismatch and adds self-healing for already-deployed FIPS installs.

## Root Cause

`FipsPasswordEncryption.createHmacKey()` generated a **128-bit** HmacSHA512 key, but `JoseJwtService` signs tokens with **HS512**. Nimbus JOSE `MACSigner`/`MACVerifier` require a key of at least **256 bits** for HS512 and throw `KeyLengthException: The secret length must be at least 256 bits`. Non-FIPS `JcePasswordEncryption` already uses 512-bit keys, so only FIPS mode was affected.

## Fix

- `FipsPasswordEncryption.createHmacKey()` now generates a **512-bit** HmacSHA512 key (FIPS 140-3 approved; matches `JcePasswordEncryption` and provides SHA-512's full security strength). The HS512 algorithm is unchanged.
- `LocalPasswordEncryption.getJwtSigningKey()` now detects a previously stored, undersized (< 256-bit) signing key and regenerates + re-persists it, so upgraded FIPS deployments recover automatically. JWTs are short-lived and do not survive a restart, so replacing the key has no impact. This is a safe no-op on the non-FIPS path (keys are already 512-bit).
- The shared `createHmacKey()` also feeds the password hash key, but the fix does **not** regenerate `password.hash.key`; existing 128-bit password hash keys continue to work, so no user password hashes are invalidated.

## Test Plan

- Enabled the previously `@Disabled` `FipsPasswordEncryptionTest.jwsHs512SignVerify_roundTrip` (real HS512 sign/verify guard) and updated the key-length assertion to 64 bytes — `FipsPasswordEncryptionTest`: 13 tests pass, 0 skipped.
- Enterprise `JoseJwtServiceTest`: 14 tests pass (no regression in the JWT consumer).
- `core` module builds successfully.
- Verified end-to-end with `fipsComplianceMode: true`: JWT issuance no longer throws `KeyLengthException`.

Fixes Redmine #75541.