### PR TITLE
Bug #75630, fix missing crosstab-optimized freehand table columns/aggregates

### DIFF
--- a/core/src/main/java/inetsoft/report/script/TableArray.java
+++ b/core/src/main/java/inetsoft/report/script/TableArray.java
@@ -18,6 +18,7 @@
 package inetsoft.report.script;
 
 import inetsoft.report.*;
+import inetsoft.report.filter.CrossFilter;
 import inetsoft.report.internal.*;
 import inetsoft.report.lens.AttributeTableLens;
 import inetsoft.report.lens.SubTableLens;
@@ -98,6 +99,15 @@ public class TableArray implements ArrayObject, ScriptArrayScope {
       if(id.indexOf('@') >= 0 || id.indexOf('?') >= 0 || id.indexOf(':') >= 0 ||
          id.indexOf("^_^") >= 0 || id.startsWith("*"))
       {
+         return true;
+      }
+
+      // A crosstab flattens its own row/col dimension values into headers, so a bare
+      // reference to the dimension's name (e.g. data['city']) never appears as literal
+      // column/header text and Util.findColumn below can't find it -- only the
+      // dimension's values (e.g. "Aachen") do. Defer to getMember, which resolves
+      // dimension names directly against the crosstab (see NamedCellRange).
+      if(lens instanceof CrossFilter) {
          return true;
       }
 

--- a/core/src/main/java/inetsoft/report/script/TableArray.java
+++ b/core/src/main/java/inetsoft/report/script/TableArray.java
@@ -106,12 +106,33 @@ public class TableArray implements ArrayObject, ScriptArrayScope {
       // reference to the dimension's name (e.g. data['city']) never appears as literal
       // column/header text and Util.findColumn below can't find it -- only the
       // dimension's values (e.g. "Aachen") do. Defer to getMember, which resolves
-      // dimension names directly against the crosstab (see NamedCellRange).
-      if(lens instanceof CrossFilter) {
+      // dimension names directly against the crosstab (see NamedCellRange), but only
+      // for ids that actually name a row/col dimension -- a genuinely nonexistent
+      // property should still report absent, not be over-claimed as present.
+      if(lens instanceof CrossFilter && isCrosstabDimension((CrossFilter) lens, id)) {
          return true;
       }
 
       return Util.findColumn(lens, id) >= 0;
+   }
+
+   /**
+    * Check if id names one of the crosstab's own row or column dimensions.
+    */
+   private static boolean isCrosstabDimension(CrossFilter table, String id) {
+      for(int i = 0; i < table.getRowHeaderCount(); i++) {
+         if(Tool.equals(table.getRowHeader(i), id)) {
+            return true;
+         }
+      }
+
+      for(int i = 0; i < table.getColHeaderCount(); i++) {
+         if(Tool.equals(table.getColHeader(i), id)) {
+            return true;
+         }
+      }
+
+      return false;
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/script/formula/NamedCellRange.java
+++ b/core/src/main/java/inetsoft/report/script/formula/NamedCellRange.java
@@ -384,6 +384,19 @@ public class NamedCellRange extends CellRange {
          throw new RuntimeException("Expression reference not supported in crosstab: " + range);
       }
 
+      // A bare (unqualified) reference to one of the crosstab's own row/col dimension
+      // names, e.g. data['city'] where city is the crosstab's column dimension, has no
+      // matching data cell -- the crosstab flattens dimension values into column/row
+      // headers, so no cell's path ever literally equals the dimension name itself.
+      // Resolve it directly to the dimension's distinct values instead. (#75423 follow-up)
+      if(!position && groupspecs.isEmpty() && condition == null) {
+         java.util.List<Object> dimValues = getCrosstabDimensionValues(table, colexpr);
+
+         if(dimValues != null) {
+            return dimValues;
+         }
+      }
+
       Vector cells = new Vector();
       Map<String, GroupSpec> specs = getRuntimeGroups();
       RangeSelector selector = CrosstabGroupSelector.getSelector(
@@ -393,6 +406,64 @@ public class NamedCellRange extends CellRange {
       proc.selectCells(cells, selector, condition, position);
 
       return cells;
+   }
+
+   /**
+    * Get the distinct values of a crosstab's own row or column dimension.
+    * @return the ordered, deduplicated values, or null if {@code name} does not
+    * match a row or column dimension of the crosstab (e.g. it is a measure name).
+    */
+   private java.util.List<Object> getCrosstabDimensionValues(CrossFilter table, String name) {
+      int rowDimIdx = -1;
+      int colDimIdx = -1;
+
+      for(int i = 0; i < table.getRowHeaderCount(); i++) {
+         if(Tool.equals(table.getRowHeader(i), name)) {
+            rowDimIdx = i;
+            break;
+         }
+      }
+
+      if(rowDimIdx < 0) {
+         for(int i = 0; i < table.getColHeaderCount(); i++) {
+            if(Tool.equals(table.getColHeader(i), name)) {
+               colDimIdx = i;
+               break;
+            }
+         }
+      }
+
+      if(rowDimIdx < 0 && colDimIdx < 0) {
+         return null;
+      }
+
+      LinkedHashSet<Object> values = new LinkedHashSet<>();
+      table.moreRows(Integer.MAX_VALUE);
+
+      if(rowDimIdx >= 0) {
+         for(int r = table.getHeaderRowCount(); r < table.getRowCount(); r++) {
+            Object[] row = table.getRowTuple(r).getRow();
+
+            // subtotal/grand-total tuples leave the outer grouping position(s)
+            // unset (null) -- only collect positions populated by real data.
+            if(rowDimIdx < row.length && row[rowDimIdx] != null) {
+               values.add(row[rowDimIdx]);
+            }
+         }
+      }
+      else {
+         for(int c = table.getHeaderColCount(); c < table.getColCount(); c++) {
+            Object[] row = table.getColTuple(c).getRow();
+
+            // subtotal/grand-total tuples leave the outer grouping position(s)
+            // unset (null) -- only collect positions populated by real data.
+            if(colDimIdx < row.length && row[colDimIdx] != null) {
+               values.add(row[colDimIdx]);
+            }
+         }
+      }
+
+      return new ArrayList<>(values);
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/script/formula/NamedCellRange.java
+++ b/core/src/main/java/inetsoft/report/script/formula/NamedCellRange.java
@@ -442,22 +442,24 @@ public class NamedCellRange extends CellRange {
 
       if(rowDimIdx >= 0) {
          for(int r = table.getHeaderRowCount(); r < table.getRowCount(); r++) {
-            Object[] row = table.getRowTuple(r).getRow();
+            CrossFilter.Tuple tuple = table.getRowTuple(r);
+            Object[] row = tuple == null ? null : tuple.getRow();
 
             // subtotal/grand-total tuples leave the outer grouping position(s)
             // unset (null) -- only collect positions populated by real data.
-            if(rowDimIdx < row.length && row[rowDimIdx] != null) {
+            if(row != null && rowDimIdx < row.length && row[rowDimIdx] != null) {
                values.add(row[rowDimIdx]);
             }
          }
       }
       else {
          for(int c = table.getHeaderColCount(); c < table.getColCount(); c++) {
-            Object[] row = table.getColTuple(c).getRow();
+            CrossFilter.Tuple tuple = table.getColTuple(c);
+            Object[] row = tuple == null ? null : tuple.getRow();
 
             // subtotal/grand-total tuples leave the outer grouping position(s)
             // unset (null) -- only collect positions populated by real data.
-            if(colDimIdx < row.length && row[colDimIdx] != null) {
+            if(row != null && colDimIdx < row.length && row[colDimIdx] != null) {
                values.add(row[colDimIdx]);
             }
          }


### PR DESCRIPTION
## Summary

- A freehand table combining a Top-N/"Others" ranked row group with a plain expand-horizontal column group (e.g. state rows x city columns, sum(price)) collapsed to a single column with missing/wrong aggregate values.
- Root cause: such tables qualify for the crosstab-optimization shortcut in `CalcTableVSAQuery`. The hidden crosstab computes the correct aggregation, but re-expanding it into the freehand grid evaluates generated formulas like `toList(data['city'])` against the crosstab result. `TableArray.hasMember()` gated bare column references on `Util.findColumn`, which matches literal header-row *text* — but a crosstab flattens dimension *values* into headers, never the dimension *name* itself, so `hasMember("city")` returned `false`, GraalJS never called `getMember`, and `data['city']` resolved to `undefined`. The row dimension only happened to work by coincidence (its name is literally the crosstab's corner-cell text).
- Fix: `TableArray.hasMember()` now defers bare-name lookups to `getMember` for `CrossFilter`-backed tables; `NamedCellRange.getCrosstabCells()` resolves a bare name matching a crosstab's own row/col dimension to that dimension's distinct values (skipping raw-null subtotal/grand-total placeholder tuples so multi-level grouped crosstabs don't get spurious blank columns/rows).

## Test plan

- [x] Reproduced the bug in a freehand table (state rows, Top-N + Others; city columns, expand-horizontal; sum(price)) — collapsed to one column with missing sums.
- [x] Applied fix, rebuilt `core`, confirmed live in the portal viewer: all city columns render with correct per-state price sums, including the "Others" bucket.
- [x] `mvn compile` passes on `core`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>