### PR TITLE
Bug #75614, break GraalJS engine-lock deadlock in parallel sub-query execution

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ConcatenatedQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ConcatenatedQuery.java
@@ -33,6 +33,7 @@ import inetsoft.uql.path.XSelection;
 import inetsoft.uql.util.XUtil;
 import inetsoft.util.*;
 import inetsoft.util.log.LogLevel;
+import inetsoft.util.script.JavaScriptEngine;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,7 +113,17 @@ public class ConcatenatedQuery extends AssetQuery {
    protected TableLens getPostBaseTableLens(VariableTable vars)
       throws Exception
    {
-      ThreadPoolExecutor executor =
+      // @by Bug #75614: when this runs inside a script execution (a worksheet
+      // formula/expression column whose script references another table), the
+      // calling thread already holds the per-worksheet GraalJS engine lock.
+      // Fanning the member queries out to a pool would deadlock: each pool thread
+      // blocks on that same engine lock to evaluate its own formula columns while
+      // this thread holds it and waits on their results. In that case run the
+      // members synchronously on the calling thread, which already holds the
+      // (reentrant) lock. Top-level execution is not inside a script, so it is
+      // unaffected and still runs in parallel.
+      final boolean serial = JavaScriptEngine.isScriptThread();
+      ThreadPoolExecutor executor = serial ? null :
          (ThreadPoolExecutor) Executors.newFixedThreadPool(5, new GroupedThreadFactory());
 
       try {
@@ -124,10 +135,16 @@ public class ConcatenatedQuery extends AssetQuery {
 
          for(AssetQuery query : queries) {
             final AssetQuery q = query;
-            results.add(executor.submit(() -> {
+            Callable<TableLens> task = () -> {
                q.setSubQuery(false);
                q.setTimeLimited(isTimeLimited());
                q.setQueryManager(getQueryManager());
+
+               // preserve the caller's sandbox rather than blindly clearing it, so
+               // the synchronous (in-script) path does not wipe the sandbox the
+               // calling thread still needs. On a fresh pool thread prev is null,
+               // so this is equivalent to the previous clear-to-null behavior.
+               final AssetQuerySandbox prevBox = WSExecution.getAssetQuerySandbox();
 
                try {
                   WSExecution.setAssetQuerySandbox(box);
@@ -155,9 +172,20 @@ public class ConcatenatedQuery extends AssetQuery {
                   return AssetQuery.shuckOffFormat(lens);
                }
                finally {
-                  WSExecution.setAssetQuerySandbox(null);
+                  WSExecution.setAssetQuerySandbox(prevBox);
                }
-            }));
+            };
+
+            if(serial) {
+               // run on the calling thread; FutureTask captures any exception so
+               // downstream results.get(i).get() sees identical semantics.
+               FutureTask<TableLens> ftask = new FutureTask<>(task);
+               ftask.run();
+               results.add(ftask);
+            }
+            else {
+               results.add(executor.submit(task));
+            }
          }
 
          TableLens table = results.get(0).get();
@@ -242,7 +270,7 @@ public class ConcatenatedQuery extends AssetQuery {
          return table;
       }
       finally {
-         if(!executor.isShutdown()) {
+         if(executor != null && !executor.isShutdown()) {
             executor.shutdown();
          }
       }

--- a/core/src/main/java/inetsoft/report/composition/execution/ConcatenatedQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ConcatenatedQuery.java
@@ -122,6 +122,10 @@ public class ConcatenatedQuery extends AssetQuery {
       // members synchronously on the calling thread, which already holds the
       // (reentrant) lock. Top-level execution is not inside a script, so it is
       // unaffected and still runs in parallel.
+      // Note: isScriptThread() is true whenever the caller is inside ANY GraalJS
+      // script, not only this worksheet's, so an unrelated in-script caller also
+      // takes the serial path. That is intentional (safe over-conservative): it
+      // never deadlocks, at a small parallelism cost in that uncommon case.
       final boolean serial = JavaScriptEngine.isScriptThread();
       ThreadPoolExecutor executor = serial ? null :
          (ThreadPoolExecutor) Executors.newFixedThreadPool(5, new GroupedThreadFactory());

--- a/core/src/main/java/inetsoft/report/composition/execution/JoinQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/JoinQuery.java
@@ -319,6 +319,10 @@ public class JoinQuery extends AssetQuery {
       // members synchronously on the calling thread, which already holds the
       // (reentrant) lock. Top-level execution is not inside a script, so it is
       // unaffected and still runs in parallel.
+      // Note: isScriptThread() is true whenever the caller is inside ANY GraalJS
+      // script, not only this worksheet's, so an unrelated in-script caller also
+      // takes the serial path. That is intentional (safe over-conservative): it
+      // never deadlocks, at a small parallelism cost in that uncommon case.
       final boolean serial = JavaScriptEngine.isScriptThread();
       ThreadPoolExecutor executor = serial ? null :
          (ThreadPoolExecutor) Executors.newFixedThreadPool(5, new GroupedThreadFactory());

--- a/core/src/main/java/inetsoft/report/composition/execution/JoinQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/JoinQuery.java
@@ -35,6 +35,7 @@ import inetsoft.uql.path.XSelection;
 import inetsoft.uql.util.XUtil;
 import inetsoft.util.*;
 import inetsoft.util.log.LogLevel;
+import inetsoft.util.script.JavaScriptEngine;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -309,7 +310,17 @@ public class JoinQuery extends AssetQuery {
    protected TableLens getPostBaseTableLens0(final VariableTable vars)
       throws Exception
    {
-      ThreadPoolExecutor executor =
+      // @by Bug #75614: when this runs inside a script execution (a worksheet
+      // formula/expression column whose script references another table), the
+      // calling thread already holds the per-worksheet GraalJS engine lock.
+      // Fanning the member queries out to a pool would deadlock: each pool thread
+      // blocks on that same engine lock to evaluate its own formula columns while
+      // this thread holds it and waits on their results. In that case run the
+      // members synchronously on the calling thread, which already holds the
+      // (reentrant) lock. Top-level execution is not inside a script, so it is
+      // unaffected and still runs in parallel.
+      final boolean serial = JavaScriptEngine.isScriptThread();
+      ThreadPoolExecutor executor = serial ? null :
          (ThreadPoolExecutor) Executors.newFixedThreadPool(5, new GroupedThreadFactory());
 
       try {
@@ -320,10 +331,16 @@ public class JoinQuery extends AssetQuery {
 
          for(AssetQuery query : queries) {
             final AssetQuery q = query;
-            results.add(executor.submit(() -> {
+            Callable<TableLens> task = () -> {
                q.setSubQuery(false);
                q.setTimeLimited(isTimeLimited());
                q.setQueryManager(getQueryManager());
+
+               // preserve the caller's sandbox rather than blindly clearing it, so
+               // the synchronous (in-script) path does not wipe the sandbox the
+               // calling thread still needs. On a fresh pool thread prev is null,
+               // so this is equivalent to the previous clear-to-null behavior.
+               final AssetQuerySandbox prevBox = WSExecution.getAssetQuerySandbox();
 
                try {
                   WSExecution.setAssetQuerySandbox(box);
@@ -351,9 +368,20 @@ public class JoinQuery extends AssetQuery {
                   return AssetQuery.shuckOffFormat(lens);
                }
                finally {
-                  WSExecution.setAssetQuerySandbox(null);
+                  WSExecution.setAssetQuerySandbox(prevBox);
                }
-            }));
+            };
+
+            if(serial) {
+               // run on the calling thread; FutureTask captures any exception so
+               // downstream results.get(i).get() sees identical semantics.
+               FutureTask<TableLens> ftask = new FutureTask<>(task);
+               ftask.run();
+               results.add(ftask);
+            }
+            else {
+               results.add(executor.submit(task));
+            }
          }
 
          TableLens table = results.get(0).get();
@@ -562,7 +590,7 @@ public class JoinQuery extends AssetQuery {
       }
       finally {
          // @by stephenwebster, Reclaim resources to prevent thread leak.
-         if(!executor.isShutdown()) {
+         if(executor != null && !executor.isShutdown()) {
             executor.shutdown();
          }
       }


### PR DESCRIPTION
## Summary

A viewsheet containing freehand/calc tables backed by worksheets that mix **expression (formula) columns** with **concatenated/join sub-tables** could hang indefinitely on load (observed: 6+ minutes, never completing). The original Redmine analysis attributed this to `CalcTableVSAQuery`'s per-column crosstab-splitting optimization, but an independent JFR investigation disproved that (0 occurrences of the split path across 7 thread-dump snapshots). The real cause is a **cross-thread deadlock on the per-worksheet GraalJS script-engine lock**.

## Root Cause

There is one `GraalJavaScriptEngine` — one GraalJS `Context` guarded by a single `ReentrantLock` — per worksheet `AssetQuerySandbox` (`getScriptEnv()` caches one instance). A GraalJS `Context` is single-threaded by construction, so the lock is mandatory.

The deadlock (identical in all 7 JFR snapshots, CPU counters frozen):

1. A worksheet formula column's script references another table. Evaluating it enters `GraalJavaScriptEngine.exec` and **holds the engine lock** while inside `context.eval`.
2. The script calls back into Java (`TableArray.getTable` → `AssetQuerySandbox.getTableLens`) and runs a **nested `ConcatenatedQuery`/`JoinQuery`**, which fans its member queries out to a `newFixedThreadPool(5)` and blocks in `FutureTask.get()` — **still holding the engine lock**.
3. The pool worker threads block at `GraalJavaScriptEngine.exec` on `lock.lock()`, needing the **same** lock to evaluate their own formula columns.

Circular wait → permanent hang. (Introduced with the GraalJS migration, which made the per-box engine single-threaded + lock-guarded; the old Rhino engine did not serialize this path.)

## Fix

In `ConcatenatedQuery.getPostBaseTableLens` and `JoinQuery.getPostBaseTableLens0`: when the current thread is already inside a script execution (`JavaScriptEngine.isScriptThread()` — i.e. it already holds the reentrant engine lock), run the member sub-queries **synchronously on the calling thread** (via `FutureTask.run()`) instead of submitting them to a new thread pool. The calling thread already holds the reentrant lock, so re-entering the engine for the members' formula columns is safe and cannot deadlock.

Top-level query execution is **not** inside a script, so `isScriptThread()` is false and it still fans out in parallel — no change to normal calc-table/viewsheet load performance.

Also changed the task's `finally` from `WSExecution.setAssetQuerySandbox(null)` to save/restore the previous sandbox, so the synchronous (in-script) path does not wipe the sandbox the calling thread still needs. On a fresh pool thread the previous value is `null`, so this is equivalent to the prior behavior.

## Test Plan

- Reproduced the hang on the reported asset (`Freehand/Single Plausible Scenario Dashboard`) via JFR; confirmed the deadlock topology across 7 thread dumps.
- After the fix, re-profiled: the viewsheet loads **quickly**, and a fresh JFR shows **zero** occurrences of the deadlock signature (`ConcatenatedQuery/JoinQuery.getPostBaseTableLens`, `FutureTask.get`, `GraalJavaScriptEngine.exec`, engine-lock waits) — the load completes so fast the profiler catches no query-execution frames.
- `core` compiles cleanly; `AssetQueryTest` and `PostProcessorTest` pass (7/7).
- Code-reviewed for serial-path exception semantics (`FutureTask` preserves `ExecutionException` cause), sandbox save/restore correctness on both paths, gate correctness (`isScriptThread()` true only mid-`context.eval`), reentrancy safety, executor null-guarding, and completeness (these are the only two `AssetQuery` subclasses that fan out to a pool).

Fixes Redmine #75614.