### PR TITLE
Bug #75631, scope host-org global-visibility READ bypass to viewsheets

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/AbstractAssetEngine.java
+++ b/core/src/main/java/inetsoft/uql/asset/AbstractAssetEngine.java
@@ -3522,8 +3522,12 @@ public abstract class AbstractAssetEngine implements AssetRepository, AutoClosea
          return true;
       }
 
-      //give permission if default org globally visible
-      if(Tool.equals(permission, ResourceAction.READ) && SUtil.isDefaultVSGloballyVisible(user) &&
+      //give permission if default org globally visible. Scope this bypass to viewsheet-type
+      //entries only (VIEWSHEET/VIEWSHEET_SNAPSHOT): the "expose default org to all" feature shares
+      //host-org viewsheets read-only, and dependent resources (worksheets, libraries, etc.) must
+      //not become independently readable across orgs through this grant.
+      if(Tool.equals(permission, ResourceAction.READ) && entry.isViewsheet() &&
+                           SUtil.isDefaultVSGloballyVisible(user) &&
                            Organization.getDefaultOrganizationID().equals(entry.getOrgID()) &&
                            user != null && !((XPrincipal)user).getOrgId().equals(Organization.getDefaultOrganizationID())) {
          return true;

--- a/core/src/test/java/inetsoft/sree/security/PermissionMatrixSpecialTest.java
+++ b/core/src/test/java/inetsoft/sree/security/PermissionMatrixSpecialTest.java
@@ -115,12 +115,16 @@ package inetsoft.sree.security;
  * SUtil.isMultiTenant() elsewhere in this suite.
  */
 
+import inetsoft.report.LibManagerProvider;
 import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.internal.cluster.Cluster;
 import inetsoft.sree.security.support.*;
 import inetsoft.sree.web.SessionLicenseServiceProvider;
 import inetsoft.test.*;
+import inetsoft.uql.asset.*;
 import inetsoft.uql.util.Identity;
+import inetsoft.util.MessageException;
 import inetsoft.util.ThreadContext;
 import inetsoft.web.security.BasicAuthenticationFilter;
 import org.junit.jupiter.api.*;
@@ -132,7 +136,11 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
@@ -322,6 +330,45 @@ class PermissionMatrixSpecialTest {
       });
    }
 
+   // ── Bug #75631: host-org global-visibility READ bypass is scoped by resource type ──
+
+   @Test
+   void nonHostOrgUser_defaultVisibility_readAllowedForViewsheetButDeniedForWorksheet() throws Exception {
+      // Regression for Bug #75631. AbstractAssetEngine.checkAssetPermission0()'s
+      // "expose default org to all" READ bypass must be scoped to viewsheet-type entries only.
+      // A non-host-org, non-site-admin user under exposeDefaultOrgToAll may READ a host-org
+      // VIEWSHEET (the feature shares viewsheets read-only) but must NOT READ a host-org
+      // WORKSHEET (or any other dependent asset type) directly.
+      ThreadContext.setContextPrincipal(null);
+
+      AbstractAssetEngine engine = new StubAssetEngine();
+      AssetEntry hostOrgViewsheet = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, "bug75631Vs", null, HOST_ORG_ID);
+      AssetEntry hostOrgWorksheet = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, "bug75631Ws", null, HOST_ORG_ID);
+
+      withMultiTenant(true, () -> {
+         SreeEnv.setProperty("security.exposeDefaultOrgToAll", "true");
+
+         try {
+            assertDoesNotThrow(
+               () -> engine.checkAssetPermission(
+                  createdOrgPlainUser, hostOrgViewsheet, ResourceAction.READ, false),
+               "a host-org viewsheet must remain READ-able by a non-host-org user under " +
+               "exposeDefaultOrgToAll (the feature shares viewsheets read-only)");
+
+            assertThrows(MessageException.class,
+               () -> engine.checkAssetPermission(
+                  createdOrgPlainUser, hostOrgWorksheet, ResourceAction.READ, false),
+               "a host-org worksheet must NOT be READ-able by a non-host-org user under " +
+               "exposeDefaultOrgToAll; the bypass is scoped to viewsheet-type entries (Bug #75631)");
+         }
+         finally {
+            SreeEnv.remove("security.exposeDefaultOrgToAll");
+         }
+      });
+   }
+
    // ── Login As: checkLoginAs() permission gate ────────────────────────────────
 
    @Test
@@ -381,5 +428,42 @@ class PermissionMatrixSpecialTest {
 
    private static SecurityEngine engine() {
       return SecurityEngine.getSecurity();
+   }
+
+   /**
+    * Minimal concrete AbstractAssetEngine used only to exercise the resource-type scoping of
+    * checkAssetPermission0()'s host-org global-visibility READ bypass (Bug #75631). The tested
+    * paths (viewsheet -> allow, worksheet -> cross-org deny) return before touching any storage
+    * or asset-model dependency, so no real engine initialization is required.
+    */
+   private static final class StubAssetEngine extends AbstractAssetEngine {
+      StubAssetEngine() {
+         super((LibManagerProvider) null, (Cluster) null);
+      }
+
+      @Override
+      protected boolean checkDataModelFolderPermission(String folder, String source, Principal user) {
+         return false;
+      }
+
+      @Override
+      protected boolean checkQueryFolderPermission(String folder, String source, Principal user) {
+         return false;
+      }
+
+      @Override
+      protected boolean checkQueryPermission(String query, Principal user) {
+         return false;
+      }
+
+      @Override
+      protected boolean checkDataSourcePermission(String dname, Principal user) {
+         return false;
+      }
+
+      @Override
+      protected boolean checkDataSourceFolderPermission(String folder, Principal user) {
+         return false;
+      }
    }
 }


### PR DESCRIPTION
## Summary

When multi-tenancy is enabled and `security.exposeDefaultOrgToAll=true` (or the org-scoped `security.<orgID>.exposeDefaultOrgToAll=true`), the intended behavior is to expose only the default organization's ("host-org") **viewsheets** to users in other organizations, read-only. A non-host-org, non-site-admin user could instead open the host-org's underlying **worksheet** directly via the `/ws/open` STOMP handler, gaining full read access to its table assemblies, column bindings, and SQL/query bindings — beyond the documented "share viewsheets only, read-only" scope.

## Root Cause

`AbstractAssetEngine.checkAssetPermission0()`'s "default org globally visible" READ bypass checked only `entry.getOrgID()` (is it host-org?) but never `entry.getType()`. It therefore granted READ on **any** host-org `AssetEntry` type (WORKSHEET included) to non-host-org, non-site-admin users. Because `/ws/open` (`WorksheetEngine.openSheet` → `getSheet(..., permission=true, ...)`) performs a real READ permission check against a client-supplied asset identifier, the bypass allowed direct cross-org worksheet opens.

## Fix

Add an `entry.isViewsheet()` guard to the bypass condition so it applies only to viewsheet-type entries (`VIEWSHEET` and `VIEWSHEET_SNAPSHOT` — the snapshot type inherits `VIEWSHEET.flags`). All other asset types fall through to the existing cross-org reject and are denied.

## Why this is safe (no regression)

- Shared-viewsheet rendering loads the base worksheet via `Viewsheet.update()`/`repopulateWorksheet()` with `permission=false`, so it never relied on this bypass.
- Repository folder navigation for the feature is gated separately in `RepletEngine.getRepositoryEntries()` (`isDefaultOrgAsset` / `SecurityEngine.checkPermission`), not `checkAssetPermission0`; its viewsheet listing still satisfies `isViewsheet()`.
- Bookmarks read directly from storage; table styles/scripts use a separate `ResourceType`-based check. None are affected.

## Test Plan

- Added regression test `PermissionMatrixSpecialTest.nonHostOrgUser_defaultVisibility_readAllowedForViewsheetButDeniedForWorksheet`: under multi-tenant + `exposeDefaultOrgToAll`, a non-host-org user is allowed READ on a host-org viewsheet but denied (`MessageException`) on a host-org worksheet.
- `mvn test -pl core -Dtest=PermissionMatrixSpecialTest` → 10/10 pass.
- `core` module builds cleanly.
- Manually verified: shared host-org viewsheets still open/view for a non-host-org user; direct `/ws/open` of the host-org's underlying worksheet is now denied.

Fixes Redmine #75631.