### PR TITLE
Bug #75632, disable Save when schedule task Options tab has invalid values

### DIFF
--- a/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.ts
+++ b/web/projects/em/src/app/settings/schedule/task-options-pane/task-options-pane.component.ts
@@ -231,17 +231,23 @@ export class TaskOptionsPane {
    }
 
    /**
-    * ignore the owner because the sso user do not in the provider.
+    * ignore the owner only when sso is enabled, because the sso user do not in the provider.
     */
    private formValidIgnoreOwner(): boolean {
       if(this.optionsForm.valid) {
          return true;
       }
 
+      // honor group-level errors (e.g. dateGreaterThan from the dateSmallerThan validator),
+      // which are not attached to any individual control
+      if(this.optionsForm.errors) {
+         return false;
+      }
+
       for(let controlsKey in this.optionsForm.controls) {
          let control = this.optionsForm.controls[controlsKey];
 
-         if(!control || "owner" == controlsKey) {
+         if(!control || ("owner" == controlsKey && this.ssoEnable)) {
             continue;
          }
 


### PR DESCRIPTION
## Summary

In Enterprise Manager, when creating/editing a schedule task and switching to the **Options** tab, entering an invalid value (a Stop date earlier than the Start date, or a non-existent user in Owner/Execute As) displayed a validation error but left the **Save** button enabled. It should be disabled while any invalid value exists.

## Root Cause

The Save button is disabled via `[applyDisabled]="!(valid && taskChanged)"`. The parent editor's `valid` getter depends on `optionsValid`, which is set from the Options pane's emitted `TaskOptionChanges.valid`. That boolean was computed in `TaskOptionsPane.formValidIgnoreOwner()` rather than from `optionsForm.valid`, and it had two gaps:

1. It only inspected per-**control** `.invalid`, so it missed the **FormGroup-level** `dateGreaterThan` error set by `FormValidators.dateSmallerThan("startDate", "endDate")` — the Stop-before-Start case slipped through as valid.
2. It **always** skipped the `owner` control (a workaround for SSO users who are not in the local provider list), so a genuinely invalid owner was ignored even when SSO is disabled and the owners list is authoritative.

## Fix

`formValidIgnoreOwner()` now:
- Returns `false` when the FormGroup itself has errors (`this.optionsForm.errors`), covering the date-range validator and any future group-level validators.
- Skips the `owner` control **only when SSO is enabled**, preserving the SSO workaround while enforcing owner validity when SSO is off.

## Test Plan

1. Create a task → Options tab → set **Stop On** earlier than **Start From** → the validation error shows and **Save is now disabled**.
2. (SSO off) Set **Owner/Execute As** to a non-existent user → **Save is disabled**.
3. A valid Options configuration still leaves **Save enabled** after a change.
4. `ng build em`, `ng lint em`, and `npm run test:em` (304 tests) all pass.

Fixes Redmine #75632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)