### PR TITLE
75624, waterfall graph bridge lines incorrect when used in a facet graph

### DIFF
--- a/core/src/main/java/inetsoft/graph/element/IntervalElement.java
+++ b/core/src/main/java/inetsoft/graph/element/IntervalElement.java
@@ -26,6 +26,7 @@ import inetsoft.graph.data.DataSet;
 import inetsoft.graph.data.SortedDataSet;
 import inetsoft.graph.geometry.IntervalGeometry;
 import inetsoft.graph.geometry.Pie3DGeometry;
+import inetsoft.graph.guide.form.GraphForm;
 import inetsoft.graph.guide.form.LineForm;
 import inetsoft.graph.internal.GDefaults;
 import inetsoft.graph.scale.LinearScale;
@@ -228,8 +229,14 @@ public class IntervalElement extends StackableElement {
                   !Double.isNaN(top) && getDimCount() > 0)
                {
                   String vname0 = getVar(v);
-                  Object xVal = data.getData(getDim(0), i);
-                  Scale xscale = graph.getScale(getDim(0));
+                  // Use the innermost dimension (the bar x axis), not getDim(0): in a facet
+                  // the outer/facet dimension(s) come first, so getDim(0) is the facet
+                  // dimension and would map the total to the wrong x (its facet index),
+                  // yielding a negative step so no bridge is drawn. The last dim is the
+                  // plot x axis, and equals getDim(0) when there is no facet. (75624)
+                  String xdim = getDim(getDimCount() - 1);
+                  Object xVal = data.getData(xdim, i);
+                  Scale xscale = graph.getScale(xdim);
                   Scale yscale = graph.getScale(vname0);
 
                   if(xVal != null && xscale != null && yscale != null && data.getData(vname0, i) == null) {
@@ -241,7 +248,7 @@ public class IntervalElement extends StackableElement {
                      double step = sumX - prevBridgeX[v];
 
                      if(step > 0) {
-                        addBridgeForm(graph, prevBridgeX[v], sumX, bridgeY, step);
+                        addBridgeForm(graph, prevBridgeX[v], sumX, bridgeY);
                      }
                      // NaN suppresses any bridge drawn from the total bar to subsequent bars.
                      prevBridgeX[v] = Double.NaN;
@@ -365,7 +372,7 @@ public class IntervalElement extends StackableElement {
                   double step = vtuple[0] - prevBridgeX[v];
 
                   if(step > 0) {
-                     addBridgeForm(graph, prevBridgeX[v], vtuple[0], vtuple[1], step);
+                     addBridgeForm(graph, prevBridgeX[v], vtuple[0], vtuple[1]);
                   }
                }
 
@@ -803,20 +810,43 @@ public class IntervalElement extends StackableElement {
    }
 
    // halfWidth controls how far from each bar's center the bridge endpoint sits.
-   // Larger halfWidth → shorter bridge. At r=0.3 (default) this equals 0.25*step
-   // (geometric bar edge). Higher radius shrinks halfWidth so the bridge grows
-   // longer to visually cover the rounded corner gap; lower radius extends it
-   // so the bridge doesn't over-run a sharp-cornered bar.
-   private void addBridgeForm(GGraph graph, double fromX, double toX, double bridgeY, double step) {
-      double halfWidth = Math.max(0, step * (0.40 - 0.5 * cornerRadius));
+   // Larger halfWidth → shorter bridge. Adjacent categories are one scaled unit
+   // apart and a bar's width is fixed, so the inset is a fraction of a single
+   // category width and must NOT scale with the distance between the two bars:
+   // when the bridge spans a gap of missing categories (fromX/toX more than one
+   // unit apart) the endpoints must still land just outside each bar rather than
+   // shrinking to a stub in the middle of the gap. Higher corner radius shrinks
+   // halfWidth so the bridge grows longer to visually cover the rounded corner
+   // gap; lower radius extends it so the bridge doesn't over-run a sharp-cornered
+   // bar. (75624)
+   private void addBridgeForm(GGraph graph, double fromX, double toX, double bridgeY) {
+      double halfWidth = Math.max(0, 0.40 - 0.5 * cornerRadius);
+      // In a facet, createGeometry runs once per facet cell and each cell adds its
+      // own bridge forms to the shared EGraph. A form is only scoped to a single
+      // sub-coordinate when its tuple length matches the full scale count; with a
+      // bare [x, y] tuple the facet-matching check is skipped and the bridge is
+      // replicated across every facet cell. Prepend the cell's facet nesting
+      // indices so the bridge is drawn only in its own sub-coordinate. (75624)
+      double[] nest = GraphForm.getNestTuple(graph.getCoordinate());
       LineForm bridge = new LineForm(
-         new double[]{fromX + halfWidth, bridgeY},
-         new double[]{toX - halfWidth, bridgeY});
+         bridgePoint(nest, fromX + halfWidth, bridgeY),
+         bridgePoint(nest, toX - halfWidth, bridgeY));
       bridge.setColor(bridgeLineColor != null ? bridgeLineColor : GDefaults.DEFAULT_LINE_COLOR);
       bridge.setLine(bridgeLineStyle.getStyle());
       bridge.setZIndex(GDefaults.GRIDLINE_Z_INDEX + 1);
       bridge.setInPlot(true);
       graph.getEGraph().addForm(bridge);
+   }
+
+   // Build a bridge endpoint tuple by prepending the facet nesting indices to the
+   // scaled (x, y) position. In a non-faceted chart nest is empty and the tuple is
+   // just {x, y}.
+   private static double[] bridgePoint(double[] nest, double x, double y) {
+      double[] tuple = new double[nest.length + 2];
+      System.arraycopy(nest, 0, tuple, 0, nest.length);
+      tuple[nest.length] = x;
+      tuple[nest.length + 1] = y;
+      return tuple;
    }
 
    private List<String> bases = new Vector<>(); // interval base columns

--- a/core/src/main/java/inetsoft/graph/guide/form/GraphForm.java
+++ b/core/src/main/java/inetsoft/graph/guide/form/GraphForm.java
@@ -339,8 +339,12 @@ public abstract class GraphForm extends Graphable {
 
    /**
     * Get the tuple for the parent coordinates that identify this nested coord.
+    * The returned tuple contains the facet nesting indices (row/column) of the
+    * coordinate within its enclosing facet, in outer-to-inner order. It is empty
+    * for a non-faceted coordinate.
+    * @hidden
     */
-   private double[] getNestTuple(Coordinate coord) {
+   public static double[] getNestTuple(Coordinate coord) {
       List<Double> tuple = new ArrayList<>();
 
       while(coord != null) {

--- a/core/src/main/java/inetsoft/graph/guide/form/LineForm.java
+++ b/core/src/main/java/inetsoft/graph/guide/form/LineForm.java
@@ -96,6 +96,15 @@ public class LineForm extends GeomForm {
    @Override
    public Visualizable createVisual(Coordinate coord) {
       Point2D[] points = getPoints(coord);
+
+      // A form whose tuple doesn't belong to this (sub-)coordinate resolves to no
+      // points (e.g. a waterfall bridge scoped to another facet cell). Skip it so an
+      // empty visual with degenerate origin bounds doesn't perturb in-plot layout.
+      // This mirrors the empty-points handling in the trend-line createVisual. (75624)
+      if(points.length == 0) {
+         return null;
+      }
+
       return createVisual(points);
    }
 


### PR DESCRIPTION
Root Cause:

The waterfall "bridge" connector lines are created in IntervalElement and added to the shared top-level EGraph. In a facet chart, createGeometry() runs once per facet cell, but each bridge's tuple was just [x, y] with no facet dimension. A form is only scoped to a single sub-coordinate when its tuple length matches the full scale count (outer facet dims + inner x/y); with a bare [x, y] tuple the facet-matching check was skipped, so every cell's bridges were drawn in every cell — the doubled lines.

Three related defects surfaced from the same area:
- Empty space: bridges scoped out of a cell resolved to zero points but still produced an empty LineFormVO whose bounds collapse to the origin (0,0); since bridges are inPlot, layout padded the plot to swallow that phantom point.
- Short gap bridges: the endpoint inset (halfWidth) was multiplied by step (the category distance), so a bridge spanning missing categories shrank to a stub in the middle of the gap.
- Missing last->Total connector (facet only): the total bridge computed its x from getDim(0), which in a facet is the outer/facet dimension, mapping the total to the wrong x and yielding a negative step (no bridge). It worked in single-graph charts where getDim(0) is the x axis.

Fix:
- Prefix each bridge tuple with the facet nesting indices (GraphForm.getNestTuple) so a bridge renders only in its own facet cell.
- LineForm.createVisual(Coordinate) returns no visual when a form resolves to zero points (mirrors the existing trend-line handling), removing the phantom origin bounds.
- Compute halfWidth from one category unit instead of step, so gap-spanning bridges reach both bars.
- Compute the total bridge's x from the innermost dimension (getDim(getDimCount()-1)), which equals getDim(0) when there is no facet.