### PR TITLE
feat(asset): structured WindowExpressionRef window-column node (non-SQL window Phase 1)

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -1554,6 +1554,19 @@ public abstract class AssetQuery extends PreAssetQuery {
       name = name == null ? column.getAttribute() : name;
       DataRef bref = getBaseAttribute(column);
 
+      // Window (analytic) function columns are SQL-pushdown-only (Phase 1 design):
+      // PreAssetQuery.mergeGroupBy always inlines a WindowExpressionRef into the generated SQL
+      // on a mergeable source, so this JS-formula path is only reached when SQL merge did NOT
+      // happen for it (e.g. an unrelated column/condition on the same table made the overall
+      // query non-mergeable). Its emitted text is `fn(...) OVER (...)` SQL, not JS — handing it
+      // to the script engine would produce a cryptic syntax error. Fail loud with a clear
+      // message instead.
+      if(bref instanceof WindowExpressionRef) {
+         throw new RuntimeException("Window function column '" + column.getName() +
+            "' could not be pushed down to SQL; window functions require a fully " +
+            "SQL-mergeable source");
+      }
+
       if(!(bref instanceof ExpressionRef)) {
          return;
       }

--- a/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
@@ -559,10 +559,15 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
       Pattern.compile("\\bOVER\\s*\\(", Pattern.CASE_INSENSITIVE);
 
    /**
-    * True if `column` is an expression column whose SQL text contains a window function
-    * (`... OVER (...)`). Such a column is neither a GROUP BY dimension nor a standard aggregate;
-    * mergeGroupBy emits it into the SELECT list without grouping/aggregating it. Package-private
-    * (static, no instance state) so it can be unit-tested directly.
+    * True if `column` is a window (analytic) function column. Detection is structural first: a
+    * {@link WindowExpressionRef}-wrapped column (the first-class structured node built by
+    * {@code /ws/table}'s {@code windowColumns}) is always a window column, no text inspection
+    * needed. As a fallback — for a hand-authored {@code sql query table} column whose raw SQL
+    * text contains an {@code OVER (...)} call but isn't a {@code WindowExpressionRef} — the
+    * regex is still applied, preserving prior behavior. Such a column is neither a GROUP BY
+    * dimension nor a standard aggregate; mergeGroupBy emits it into the SELECT list without
+    * grouping/aggregating it. Package-private (static, no instance state) so it can be
+    * unit-tested directly.
     */
    static boolean isWindowExpression(ColumnRef column) {
       if(column == null || !column.isExpression()) {
@@ -570,6 +575,10 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
       }
 
       DataRef ref = column.getDataRef();
+
+      if(ref instanceof WindowExpressionRef) {
+         return true;
+      }
 
       if(!(ref instanceof ExpressionRef)) {
          return false;

--- a/core/src/main/java/inetsoft/uql/asset/WindowExpressionRef.java
+++ b/core/src/main/java/inetsoft/uql/asset/WindowExpressionRef.java
@@ -1,0 +1,480 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.asset;
+
+import inetsoft.uql.XConstants;
+import inetsoft.uql.erm.*;
+import inetsoft.util.Tool;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import java.io.*;
+import java.util.*;
+
+/**
+ * WindowExpressionRef represents a structured SQL window (analytic) function column, e.g.
+ * {@code ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)}.
+ * <p>
+ * This is a first-class model of the window column so callers (worksheet table binding, wiz
+ * pushdown) don't need to hand-author an opaque {@code sql:true} expression string. The
+ * synthesized {@link #getExpression()} text is byte-for-byte identical to the text the wiz
+ * {@code expandWindowColumns} helper produces today, so SQL pushdown parity is preserved.
+ * <p>
+ * The column-reference token form emitted is {@code field['<name>']}, exactly like
+ * {@link DateRangeRef}, so {@code PreAssetQuery.getExpressionColumn} rewrites the tokens into
+ * dialect-quoted identifiers. No direct {@code SQLHelper} quoting is performed here.
+ *
+ * @version 14.0
+ * @author InetSoft Technology Corp
+ */
+public final class WindowExpressionRef extends ExpressionRef implements SQLExpressionRef,
+   DataRefWrapper
+{
+   /**
+    * Constructor.
+    */
+   public WindowExpressionRef() {
+      super();
+   }
+
+   /**
+    * Constructor.
+    *
+    * @param fn the window function name, e.g. "ROW_NUMBER", "NTILE", "LAG", "SUM". This is a
+    *           plain string (not an enum) — the set of supported functions is validated by the
+    *           caller (wiz).
+    * @param argRef the column argument ref for functions that take one (LAG/LEAD/SUM/AVG/COUNT/
+    *               MIN/MAX/FIRST_VALUE/LAST_VALUE); {@code null} for ROW_NUMBER/RANK/DENSE_RANK/
+    *               PERCENT_RANK/CUME_DIST/NTILE.
+    * @param n the numeric argument. Used as the tile count for NTILE (required, must be &gt; 0),
+    *          or the optional offset for LAG/LEAD (a value &lt;= 0 means "not specified" and is
+    *          omitted from the emitted call). Ignored by all other functions.
+    * @param partitionBy the PARTITION BY column refs, in order; may be empty.
+    * @param orderBy the ORDER BY sort refs, in order; may be empty.
+    */
+   public WindowExpressionRef(String fn, DataRef argRef, int n, List<DataRef> partitionBy,
+                               List<SortRef> orderBy)
+   {
+      this();
+      this.fn = fn;
+      this.argRef = argRef;
+      this.n = n;
+      this.partitionBy = partitionBy == null ? new ArrayList<>() : partitionBy;
+      this.orderBy = orderBy == null ? new ArrayList<>() : orderBy;
+   }
+
+   /**
+    * Get the window function name.
+    */
+   public String getFn() {
+      return fn;
+   }
+
+   /**
+    * Set the window function name.
+    */
+   public void setFn(String fn) {
+      this.fn = fn;
+   }
+
+   /**
+    * Get the column argument ref.
+    */
+   public DataRef getArgRef() {
+      return argRef;
+   }
+
+   /**
+    * Set the column argument ref.
+    */
+   public void setArgRef(DataRef argRef) {
+      this.argRef = argRef;
+   }
+
+   /**
+    * Get the numeric argument (NTILE tile count, or LAG/LEAD offset).
+    */
+   public int getN() {
+      return n;
+   }
+
+   /**
+    * Set the numeric argument (NTILE tile count, or LAG/LEAD offset).
+    */
+   public void setN(int n) {
+      this.n = n;
+   }
+
+   /**
+    * Get the PARTITION BY column refs.
+    */
+   public List<DataRef> getPartitionBy() {
+      return partitionBy;
+   }
+
+   /**
+    * Set the PARTITION BY column refs.
+    */
+   public void setPartitionBy(List<DataRef> partitionBy) {
+      this.partitionBy = partitionBy == null ? new ArrayList<>() : partitionBy;
+   }
+
+   /**
+    * Get the ORDER BY sort refs.
+    */
+   public List<SortRef> getOrderBy() {
+      return orderBy;
+   }
+
+   /**
+    * Set the ORDER BY sort refs.
+    */
+   public void setOrderBy(List<SortRef> orderBy) {
+      this.orderBy = orderBy == null ? new ArrayList<>() : orderBy;
+   }
+
+   /**
+    * Get the database version.
+    */
+   @Override
+   public String getDBVersion() {
+      return dbversion;
+   }
+
+   /**
+    * Set the database version.
+    */
+   @Override
+   public void setDBVersion(String version) {
+      this.dbversion = version;
+   }
+
+   /**
+    * Get the contained data ref (the column argument ref).
+    */
+   @Override
+   public DataRef getDataRef() {
+      return argRef;
+   }
+
+   /**
+    * Set the contained data ref (the column argument ref).
+    */
+   @Override
+   public void setDataRef(DataRef ref) {
+      this.argRef = ref;
+   }
+
+   /**
+    * Get the SQL expression of this reference: {@code <fn>(<argFrag>) OVER (<partitionFrag>
+    * <orderFrag>)}. This is emitted verbatim regardless of database type — the {@code field['..']}
+    * tokens are rewritten downstream by {@code PreAssetQuery.getExpressionColumn}, mirroring the
+    * wiz {@code expandWindowColumns} text exactly (pushdown parity contract).
+    */
+   @Override
+   public String getExpression() {
+      StringBuilder sb = new StringBuilder();
+      sb.append(getFuncFragment());
+      sb.append(" OVER (");
+      sb.append(getOverBody());
+      sb.append(")");
+
+      return sb.toString();
+   }
+
+   /**
+    * Get the function-call fragment, e.g. {@code ROW_NUMBER()}, {@code NTILE(4)},
+    * {@code LAG(field['amount'], 1)}, {@code SUM(field['amount'])}.
+    */
+   private String getFuncFragment() {
+      switch(fn) {
+      case "ROW_NUMBER":
+      case "RANK":
+      case "DENSE_RANK":
+      case "PERCENT_RANK":
+      case "CUME_DIST":
+         return fn + "()";
+      case "NTILE":
+         return "NTILE(" + n + ")";
+      case "LAG":
+      case "LEAD":
+         return n > 0 ?
+            fn + "(" + fieldToken(argRef) + ", " + n + ")" :
+            fn + "(" + fieldToken(argRef) + ")";
+      default:
+         // SUM/AVG/COUNT/MIN/MAX/FIRST_VALUE/LAST_VALUE and any other single-column-arg function.
+         return fn + "(" + fieldToken(argRef) + ")";
+      }
+   }
+
+   /**
+    * Get the OVER clause body (without the surrounding parens): the space-joined concatenation
+    * of the PARTITION BY and ORDER BY fragments, omitting either when empty.
+    */
+   private String getOverBody() {
+      String partitionFrag = getPartitionFragment();
+      String orderFrag = getOrderFragment();
+
+      if(!partitionFrag.isEmpty() && !orderFrag.isEmpty()) {
+         return partitionFrag + " " + orderFrag;
+      }
+
+      return partitionFrag + orderFrag;
+   }
+
+   /**
+    * Get the {@code PARTITION BY field['p1'], field['p2']} fragment, or "" if there is no
+    * partitioning.
+    */
+   private String getPartitionFragment() {
+      if(partitionBy == null || partitionBy.isEmpty()) {
+         return "";
+      }
+
+      StringBuilder sb = new StringBuilder("PARTITION BY ");
+
+      for(int i = 0; i < partitionBy.size(); i++) {
+         if(i > 0) {
+            sb.append(", ");
+         }
+
+         sb.append(fieldToken(partitionBy.get(i)));
+      }
+
+      return sb.toString();
+   }
+
+   /**
+    * Get the {@code ORDER BY field['o1'] DESC, field['o2'] ASC} fragment, or "" if there is no
+    * ordering.
+    */
+   private String getOrderFragment() {
+      if(orderBy == null || orderBy.isEmpty()) {
+         return "";
+      }
+
+      StringBuilder sb = new StringBuilder("ORDER BY ");
+
+      for(int i = 0; i < orderBy.size(); i++) {
+         if(i > 0) {
+            sb.append(", ");
+         }
+
+         SortRef sort = orderBy.get(i);
+         sb.append(fieldToken(sort.getDataRef()));
+         sb.append(sort.getOrder() == XConstants.SORT_ASC ? " ASC" : " DESC");
+      }
+
+      return sb.toString();
+   }
+
+   /**
+    * Get the {@code field['<name>']} token for a data ref. This matches the token form
+    * {@link DateRangeRef#getExpression()} uses, and the exact form wiz's {@code expandWindowColumns}
+    * emits.
+    */
+   private static String fieldToken(DataRef ref) {
+      return "field['" + ref.getName() + "']";
+   }
+
+   /**
+    * Check if this expression is a sql expression.
+    * @return true if is, false otherwise.
+    */
+   @Override
+   public boolean isSQL() {
+      return true;
+   }
+
+   /**
+    * Check if expression is editable.
+    * @return <tt>true</tt> if editable, <tt>false</tt> otherwise.
+    */
+   @Override
+   public boolean isExpressionEditable() {
+      return false;
+   }
+
+   /**
+    * Check if this window expression ref is mergeable. The emitted text is a plain OVER(...)
+    * expression with {@code field['..']} tokens, which is always rewritable regardless of
+    * database type (the pushdown parity contract), so this is unconditionally mergeable.
+    * @return <tt>true</tt> if mergeable, <tt>false</tt> otherwise.
+    */
+   @Override
+   public boolean isMergeable() {
+      return true;
+   }
+
+   /**
+    * Get a list of all attributes that are referenced by this object.
+    * @return an Enumeration containing DataRef objects.
+    */
+   @Override
+   public Enumeration getAttributes() {
+      Vector list = new Vector();
+
+      if(argRef != null) {
+         list.add(argRef);
+      }
+
+      if(partitionBy != null) {
+         list.addAll(partitionBy);
+      }
+
+      if(orderBy != null) {
+         for(SortRef sort : orderBy) {
+            list.add(sort.getDataRef());
+         }
+      }
+
+      return list.elements();
+   }
+
+   /**
+    * Write the attributes of this object.
+    * @param writer the output stream to which to write the XML data.
+    */
+   @Override
+   protected void writeAttributes(PrintWriter writer) {
+      writer.print(" fn=\"" + Tool.escape(fn) + "\"");
+      writer.print(" n=\"" + n + "\"");
+
+      if(getDBType() != null) {
+         writer.print(" dbType=\"" + Tool.escape(getDBType()) + "\"");
+      }
+
+      if(dbversion != null) {
+         writer.print(" dbVersion=\"" + Tool.escape(dbversion) + "\"");
+      }
+   }
+
+   /**
+    * Read in the attribute of this object from an XML tag.
+    * @param tag the XML element representing this object.
+    */
+   @Override
+   protected void parseAttributes(Element tag) throws Exception {
+      fn = Tool.getAttribute(tag, "fn");
+      String nstr = Tool.getAttribute(tag, "n");
+      n = nstr == null ? 0 : Integer.parseInt(nstr);
+      setDBType(Tool.getAttribute(tag, "dbType"));
+      dbversion = Tool.getAttribute(tag, "dbVersion");
+   }
+
+   /**
+    * Write the contents of this object.
+    * @param writer the output stream to which to write the XML data.
+    */
+   @Override
+   protected void writeContents(PrintWriter writer) {
+      if(argRef != null) {
+         writer.print("<argRef>");
+         argRef.writeXML(writer);
+         writer.println("</argRef>");
+      }
+
+      writer.print("<partitionBy>");
+
+      for(DataRef ref : partitionBy) {
+         ref.writeXML(writer);
+      }
+
+      writer.println("</partitionBy>");
+
+      writer.print("<orderBy>");
+
+      for(SortRef sort : orderBy) {
+         sort.writeXML(writer);
+      }
+
+      writer.println("</orderBy>");
+   }
+
+   /**
+    * Read in the contents of this object from an xml tag.
+    * @param tag the specified xml element.
+    */
+   @Override
+   protected void parseContents(Element tag) throws Exception {
+      Element argNode = Tool.getChildNodeByTagName(tag, "argRef");
+
+      if(argNode != null) {
+         Element dnode = Tool.getChildNodeByTagName(argNode, "dataRef");
+         argRef = dnode == null ? null : createDataRef(dnode);
+      }
+      else {
+         argRef = null;
+      }
+
+      partitionBy = new ArrayList<>();
+      Element partitionNode = Tool.getChildNodeByTagName(tag, "partitionBy");
+
+      if(partitionNode != null) {
+         NodeList nodes = Tool.getChildNodesByTagName(partitionNode, "dataRef");
+
+         for(int i = 0; i < nodes.getLength(); i++) {
+            partitionBy.add(createDataRef((Element) nodes.item(i)));
+         }
+      }
+
+      orderBy = new ArrayList<>();
+      Element orderNode = Tool.getChildNodeByTagName(tag, "orderBy");
+
+      if(orderNode != null) {
+         NodeList nodes = Tool.getChildNodesByTagName(orderNode, "dataRef");
+
+         for(int i = 0; i < nodes.getLength(); i++) {
+            orderBy.add((SortRef) createDataRef((Element) nodes.item(i)));
+         }
+      }
+   }
+
+   /**
+    * Create a copy of this object. Deep-copies the {@code partitionBy}/{@code orderBy} lists and
+    * the {@code argRef} — the inherited {@code AbstractDataRef.clone()} is shallow, which would
+    * otherwise let a clone's mutations leak back into the original's lists.
+    */
+   @Override
+   public Object clone() {
+      WindowExpressionRef ref = (WindowExpressionRef) super.clone();
+
+      ref.argRef = argRef == null ? null : (DataRef) argRef.clone();
+
+      ref.partitionBy = new ArrayList<>();
+
+      for(DataRef p : partitionBy) {
+         ref.partitionBy.add((DataRef) p.clone());
+      }
+
+      ref.orderBy = new ArrayList<>();
+
+      for(SortRef s : orderBy) {
+         ref.orderBy.add((SortRef) s.clone());
+      }
+
+      return ref;
+   }
+
+   private DataRef argRef;
+   private String fn;
+   private int n;
+   private List<DataRef> partitionBy = new ArrayList<>();
+   private List<SortRef> orderBy = new ArrayList<>();
+   private transient String dbversion;
+}

--- a/core/src/main/java/inetsoft/uql/asset/WindowExpressionRef.java
+++ b/core/src/main/java/inetsoft/uql/asset/WindowExpressionRef.java
@@ -42,9 +42,15 @@ import java.util.*;
  * @version 14.0
  * @author InetSoft Technology Corp
  */
-public final class WindowExpressionRef extends ExpressionRef implements SQLExpressionRef,
-   DataRefWrapper
+public final class WindowExpressionRef extends ExpressionRef implements SQLExpressionRef
 {
+   // NOTE: intentionally NOT a DataRefWrapper. A window function references MULTIPLE columns
+   // (arg + partitionBy + orderBy), exposed via getAttributes() — not a single wrapped ref. If it
+   // were a DataRefWrapper, AssetUtil.getBaseAttribute would unwrap a ColumnRef(WindowExpressionRef)
+   // straight past this ref to getDataRef()==argRef, which is null for ROW_NUMBER/RANK/DENSE_RANK/
+   // NTILE/PERCENT_RANK/CUME_DIST — NPE-ing query validation and defeating the AssetQuery window
+   // pushdown guard (which relies on getBaseAttribute returning this ref). Treated as a plain
+   // expression attribute instead, exactly like ExpressionRef / DateRangeRef.
    /**
     * Constructor.
     */
@@ -165,17 +171,16 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
    }
 
    /**
-    * Get the contained data ref (the column argument ref).
+    * Get the contained data ref (the column argument ref). Alias for {@link #getArgRef()};
+    * retained for callers that discover an expression's single wrapped ref generically.
     */
-   @Override
    public DataRef getDataRef() {
       return argRef;
    }
 
    /**
-    * Set the contained data ref (the column argument ref).
+    * Set the contained data ref (the column argument ref). Alias for {@link #setArgRef(DataRef)}.
     */
-   @Override
    public void setDataRef(DataRef ref) {
       this.argRef = ref;
    }
@@ -321,30 +326,13 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
       return true;
    }
 
-   /**
-    * Get a list of all attributes that are referenced by this object.
-    * @return an Enumeration containing DataRef objects.
-    */
-   @Override
-   public Enumeration getAttributes() {
-      Vector list = new Vector();
-
-      if(argRef != null) {
-         list.add(argRef);
-      }
-
-      if(partitionBy != null) {
-         list.addAll(partitionBy);
-      }
-
-      if(orderBy != null) {
-         for(SortRef sort : orderBy) {
-            list.add(sort.getDataRef());
-         }
-      }
-
-      return list.elements();
-   }
+   // getAttributes() is intentionally NOT overridden. The inherited ExpressionRef implementation
+   // parses the field['..'] tokens out of getExpression() and yields AttributeRefs — which is the
+   // contract the query framework relies on (PreAssetQuery.getExprAttributes casts each contained
+   // ref to AttributeRef). Every column this window references (arg + partitionBy + orderBy) is
+   // emitted as a field['..'] token by getExpression(), so token-parsing captures them all. An
+   // override returning the structured ColumnRefs (from the wire's ColumnSelection.getAttribute)
+   // would ClassCastException during column-selection validation.
 
    /**
     * Write the attributes of this object.
@@ -352,6 +340,12 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
     */
    @Override
    protected void writeAttributes(PrintWriter writer) {
+      // Chain to ExpressionRef so the base attributes (name/dataType/refType) are persisted.
+      // Unlike DateRangeRef (which derives getName() from its option+attr and so needs no stored
+      // name), this ref carries a caller-assigned column name/alias — dropping super here would
+      // lose it across the worksheet's XML serialize/reload cycle, and the column would reload
+      // nameless (unbindable by create_viewsheet).
+      super.writeAttributes(writer);
       writer.print(" fn=\"" + Tool.escape(fn) + "\"");
       writer.print(" n=\"" + n + "\"");
 
@@ -370,6 +364,8 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
     */
    @Override
    protected void parseAttributes(Element tag) throws Exception {
+      // Restore the base attributes (name/dataType/refType) written by super.writeAttributes.
+      super.parseAttributes(tag);
       fn = Tool.getAttribute(tag, "fn");
       String nstr = Tool.getAttribute(tag, "n");
       n = nstr == null ? 0 : Integer.parseInt(nstr);

--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
@@ -50,6 +50,8 @@ public class WorksheetTable {
    private List<ColumnInfo> columns;
    /** Expression columns (only valid on non-aggregated mirror tables). */
    private List<ExpressionColumnInfo> expressionColumns;
+   /** Structured window (analytic) function columns, e.g. ROW_NUMBER/RANK/NTILE/LAG/SUM OVER(...). */
+   private List<WindowColumnInfo> windowColumns;
 
    // ─── SQL-query-table field ────────────────────────────────────────────────
 
@@ -104,6 +106,9 @@ public class WorksheetTable {
 
    public List<ExpressionColumnInfo> getExpressionColumns() { return expressionColumns; }
    public void setExpressionColumns(List<ExpressionColumnInfo> expressionColumns) { this.expressionColumns = expressionColumns; }
+
+   public List<WindowColumnInfo> getWindowColumns() { return windowColumns; }
+   public void setWindowColumns(List<WindowColumnInfo> windowColumns) { this.windowColumns = windowColumns; }
 
    public String getSqlExpression() { return sqlExpression; }
    public void setSqlExpression(String sqlExpression) { this.sqlExpression = sqlExpression; }
@@ -181,6 +186,58 @@ public class WorksheetTable {
       public void setExpression(String expression) { this.expression = expression; }
       public boolean isSql() { return sql; }
       public void setSql(boolean sql) { this.sql = sql; }
+   }
+
+   // ─── Nested: window (analytic) function column ───────────────────────────
+
+   /**
+    * Structured window (analytic) function column, e.g.
+    * {@code ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)}. Consumed by
+    * {@code WorksheetTableService.applyWindowColumns}, which builds a
+    * {@link inetsoft.uql.asset.WindowExpressionRef}-backed column — the structured
+    * counterpart of {@link ExpressionColumnInfo}'s free-text {@code sql:true} expression.
+    */
+   @JsonIgnoreProperties(ignoreUnknown = true)
+   public static class WindowColumnInfo {
+      private String name;
+      /** Window function name, e.g. "ROW_NUMBER", "RANK", "NTILE", "LAG", "LEAD", "SUM". */
+      private String fn;
+      /** Column argument for LAG/LEAD/SUM/AVG/COUNT/MIN/MAX/FIRST_VALUE; omit for ROW_NUMBER/RANK/etc. */
+      private String column;
+      /** NTILE bucket count, or LAG/LEAD offset; omit/`<= 0` means unspecified. */
+      private Integer n;
+      /** PARTITION BY column names, in order; may be omitted/empty. */
+      private List<String> partitionBy;
+      /** ORDER BY clauses, in order; may be omitted/empty. */
+      private List<OrderByInfo> orderBy;
+      private String type;
+
+      public String getName() { return name; }
+      public void setName(String name) { this.name = name; }
+      public String getFn() { return fn; }
+      public void setFn(String fn) { this.fn = fn; }
+      public String getColumn() { return column; }
+      public void setColumn(String column) { this.column = column; }
+      public Integer getN() { return n; }
+      public void setN(Integer n) { this.n = n; }
+      public List<String> getPartitionBy() { return partitionBy; }
+      public void setPartitionBy(List<String> partitionBy) { this.partitionBy = partitionBy; }
+      public List<OrderByInfo> getOrderBy() { return orderBy; }
+      public void setOrderBy(List<OrderByInfo> orderBy) { this.orderBy = orderBy; }
+      public String getType() { return type; }
+      public void setType(String type) { this.type = type; }
+   }
+
+   @JsonIgnoreProperties(ignoreUnknown = true)
+   public static class OrderByInfo {
+      private String field;
+      /** "ASC" | "DESC" (default DESC when unrecognized, matching StyleBI's descending-default sort UX). */
+      private String direction;
+
+      public String getField() { return field; }
+      public void setField(String field) { this.field = field; }
+      public String getDirection() { return direction; }
+      public void setDirection(String direction) { this.direction = direction; }
    }
 
    // ─── Nested: join path ────────────────────────────────────────────────────

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -721,6 +721,7 @@ public class WorksheetTableService {
       // Expression columns are only meaningful on non-aggregated mirror tables;
       // log a warning but don't fail if someone passes them here.
       applyExpressionColumns(table, request.getExpressionColumns());
+      applyWindowColumns(table, request.getWindowColumns());
 
       worksheet.addAssembly(table);
       return table;
@@ -896,6 +897,7 @@ public class WorksheetTableService {
 
       if(!hasAggregation) {
          applyExpressionColumns(mirror, request.getExpressionColumns());
+         applyWindowColumns(mirror, request.getWindowColumns());
       }
 
       worksheet.addAssembly(mirror);
@@ -1063,6 +1065,101 @@ public class WorksheetTableService {
          if(Boolean.FALSE.equals(col.getVisible())) {
             colRef.setVisible(false);
          }
+
+         if(!Tool.isEmptyString(col.getType())) {
+            colRef.setDataType(col.getType());
+         }
+
+         cs.addAttribute(colRef);
+      }
+
+      table.setColumnSelection(cs, false);
+   }
+
+   /**
+    * Apply structured window (analytic) function columns — the {@link WindowExpressionRef}-backed
+    * counterpart of {@link #applyExpressionColumns}. Each entry resolves its {@code column},
+    * {@code partitionBy}, and {@code orderBy} field names against the table's own column
+    * selection (same resolution mechanism as {@code cs.getAttribute(name)} used throughout this
+    * class, e.g. {@link #applyAggregateInfo}), builds a {@link WindowExpressionRef}, and adds it
+    * to the selection as a {@code sql:true} {@link ColumnRef} so {@code PreAssetQuery} inlines the
+    * generated {@code OVER(...)} text verbatim.
+    * <p>
+    * Package-private (not private) so {@code WorksheetTableServiceWindowColumnsTest} can invoke it
+    * directly without standing up the full {@code createTable} dependency graph, mirroring how
+    * {@link #buildConditionList} is tested.
+    */
+   void applyWindowColumns(AbstractTableAssembly table,
+                           List<WorksheetTable.WindowColumnInfo> winCols)
+   {
+      if(winCols == null || winCols.isEmpty()) {
+         return;
+      }
+
+      ColumnSelection cs = table.getColumnSelection(false);
+
+      for(WorksheetTable.WindowColumnInfo col : winCols) {
+         String colName = col.getName();
+
+         if(Tool.isEmptyString(colName)) {
+            throw new IllegalArgumentException("windowColumns[].name is required");
+         }
+
+         if(Tool.isEmptyString(col.getFn())) {
+            throw new IllegalArgumentException("windowColumns['" + colName + "'].fn is required");
+         }
+
+         DataRef argRef = null;
+
+         if(!Tool.isEmptyString(col.getColumn())) {
+            argRef = cs.getAttribute(col.getColumn());
+
+            if(argRef == null) {
+               throw new IllegalArgumentException(
+                  "windowColumns['" + colName + "'].column not found: " + col.getColumn());
+            }
+         }
+
+         List<DataRef> partitionRefs = new ArrayList<>();
+
+         if(col.getPartitionBy() != null) {
+            for(String p : col.getPartitionBy()) {
+               DataRef pref = cs.getAttribute(p);
+
+               if(pref == null) {
+                  throw new IllegalArgumentException(
+                     "windowColumns['" + colName + "'].partitionBy column not found: " + p);
+               }
+
+               partitionRefs.add(pref);
+            }
+         }
+
+         List<SortRef> orderRefs = new ArrayList<>();
+
+         if(col.getOrderBy() != null) {
+            for(WorksheetTable.OrderByInfo ob : col.getOrderBy()) {
+               DataRef oref = cs.getAttribute(ob.getField());
+
+               if(oref == null) {
+                  throw new IllegalArgumentException(
+                     "windowColumns['" + colName + "'].orderBy field not found: " + ob.getField());
+               }
+
+               SortRef sort = new SortRef(oref);
+               sort.setOrder("ASC".equalsIgnoreCase(ob.getDirection())
+                                ? XConstants.SORT_ASC : XConstants.SORT_DESC);
+               orderRefs.add(sort);
+            }
+         }
+
+         int n = col.getN() != null ? col.getN() : 0;
+         WindowExpressionRef winRef =
+            new WindowExpressionRef(col.getFn(), argRef, n, partitionRefs, orderRefs);
+         winRef.setName(colName);
+
+         ColumnRef colRef = new ColumnRef(winRef);
+         colRef.setSQL(true);
 
          if(!Tool.isEmptyString(col.getType())) {
             colRef.setDataType(col.getType());

--- a/core/src/test/java/inetsoft/report/composition/execution/WindowExpressionDetectionTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/WindowExpressionDetectionTest.java
@@ -18,7 +18,10 @@
 package inetsoft.report.composition.execution;
 
 import inetsoft.test.*;
+import inetsoft.uql.XConstants;
 import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.SortRef;
+import inetsoft.uql.asset.WindowExpressionRef;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.ExpressionRef;
 import org.junit.jupiter.api.Tag;
@@ -27,6 +30,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -46,6 +51,21 @@ class WindowExpressionDetectionTest {
    @Test
    void rowNumberOverIsWindowExpression() {
       ColumnRef column = expressionColumn("ROW_NUMBER() OVER (ORDER BY field['x'] DESC)");
+      assertTrue(PreAssetQuery.isWindowExpression(column));
+   }
+
+   @Test
+   void windowExpressionRefColumnIsWindowExpressionByType() {
+      AttributeRef orderAttr = new AttributeRef("x");
+      SortRef orderBy = new SortRef(orderAttr);
+      orderBy.setOrder(XConstants.SORT_DESC);
+
+      WindowExpressionRef winRef = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0, Collections.emptyList(), Collections.singletonList(orderBy));
+      winRef.setName("rn");
+      ColumnRef column = new ColumnRef(winRef);
+      column.setSQL(true);
+
       assertTrue(PreAssetQuery.isWindowExpression(column));
    }
 

--- a/core/src/test/java/inetsoft/uql/asset/WindowExpressionRefTest.java
+++ b/core/src/test/java/inetsoft/uql/asset/WindowExpressionRefTest.java
@@ -1,0 +1,221 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.asset;
+
+import inetsoft.test.*;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import java.io.*;
+import java.util.*;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link WindowExpressionRef}. These pin the pushdown-parity contract: the
+ * synthesized {@link WindowExpressionRef#getExpression()} text must be byte-for-byte identical
+ * to what the wiz {@code expandWindowColumns} helper (wiz-services/src/v1/services/windowColumns.ts)
+ * produces today.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WindowExpressionRefTest {
+
+   private static SortRef sort(String attr, int order) {
+      SortRef sortRef = new SortRef(new AttributeRef(attr));
+      sortRef.setOrder(order);
+      return sortRef;
+   }
+
+   // ---- getExpression() parity ------------------------------------------------------------
+
+   @Test
+   void rowNumber_withPartitionAndOrder() {
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0,
+         List.of(new AttributeRef("stage")),
+         List.of(sort("amount", XConstants.SORT_DESC)));
+
+      assertEquals("ROW_NUMBER() OVER (PARTITION BY field['stage'] ORDER BY field['amount'] DESC)",
+                   ref.getExpression());
+   }
+
+   @Test
+   void ntile_withOrderOnly() {
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "NTILE", null, 4,
+         List.of(),
+         List.of(sort("amount", XConstants.SORT_DESC)));
+
+      assertEquals("NTILE(4) OVER (ORDER BY field['amount'] DESC)", ref.getExpression());
+   }
+
+   @Test
+   void lag_withOffsetAndOrder() {
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "LAG", new AttributeRef("amount"), 1,
+         List.of(),
+         List.of(sort("t", XConstants.SORT_ASC)));
+
+      assertEquals("LAG(field['amount'], 1) OVER (ORDER BY field['t'] ASC)", ref.getExpression());
+   }
+
+   @Test
+   void sum_withPartitionOnly_noOrderBy() {
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "SUM", new AttributeRef("amount"), 0,
+         List.of(new AttributeRef("stage")),
+         List.of());
+
+      assertEquals("SUM(field['amount']) OVER (PARTITION BY field['stage'])", ref.getExpression());
+   }
+
+   @Test
+   void neitherPartitionNorOrder_emitsEmptyParens() {
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "SUM", new AttributeRef("amount"), 0, List.of(), List.of());
+
+      assertEquals("SUM(field['amount']) OVER ()", ref.getExpression());
+   }
+
+   @Test
+   void lag_withoutOffset_omitsComma() {
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "LAG", new AttributeRef("amount"), 0,
+         List.of(),
+         List.of(sort("t", XConstants.SORT_ASC)));
+
+      assertEquals("LAG(field['amount']) OVER (ORDER BY field['t'] ASC)", ref.getExpression());
+   }
+
+   // ---- isSQL() ------------------------------------------------------------------------------
+
+   @Test
+   void isSQL_isTrue() {
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0, List.of(), List.of(sort("t", XConstants.SORT_ASC)));
+      assertTrue(ref.isSQL());
+   }
+
+   // ---- XML round-trip -----------------------------------------------------------------------
+
+   @Test
+   void xmlRoundTrip_preservesAllFields() throws Exception {
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0,
+         List.of(new AttributeRef("stage")),
+         List.of(sort("amount", XConstants.SORT_DESC)));
+
+      WindowExpressionRef copy = (WindowExpressionRef) writeAndParse(ref);
+
+      assertEquals(ref.getFn(), copy.getFn());
+      assertEquals(ref.getN(), copy.getN());
+      assertNull(copy.getArgRef());
+      assertEquals(1, copy.getPartitionBy().size());
+      assertEquals("stage", copy.getPartitionBy().get(0).getName());
+      assertEquals(1, copy.getOrderBy().size());
+      assertEquals("amount", copy.getOrderBy().get(0).getName());
+      assertEquals(XConstants.SORT_DESC, copy.getOrderBy().get(0).getOrder());
+      assertEquals(ref.getExpression(), copy.getExpression());
+   }
+
+   @Test
+   void xmlRoundTrip_preservesArgRef() throws Exception {
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "LAG", new AttributeRef("amount"), 1, List.of(), List.of(sort("t", XConstants.SORT_ASC)));
+
+      WindowExpressionRef copy = (WindowExpressionRef) writeAndParse(ref);
+
+      assertNotNull(copy.getArgRef());
+      assertEquals("amount", copy.getArgRef().getName());
+      assertEquals(1, copy.getN());
+      assertEquals(ref.getExpression(), copy.getExpression());
+   }
+
+   private static DataRef writeAndParse(WindowExpressionRef ref) throws Exception {
+      StringWriter sw = new StringWriter();
+      PrintWriter writer = new PrintWriter(sw);
+      ref.writeXML(writer);
+      writer.flush();
+
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      Document doc = factory.newDocumentBuilder().parse(
+         new ByteArrayInputStream(sw.toString().getBytes()));
+      Element elem = doc.getDocumentElement();
+
+      return inetsoft.uql.erm.AbstractDataRef.createDataRef(elem);
+   }
+
+   // ---- clone() deep-copies the lists ---------------------------------------------------------
+
+   @Test
+   void clone_deepCopiesPartitionByList() {
+      List<DataRef> partitionBy = new ArrayList<>(List.of(new AttributeRef("stage")));
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "SUM", new AttributeRef("amount"), 0, partitionBy, new ArrayList<>());
+
+      WindowExpressionRef clone = (WindowExpressionRef) ref.clone();
+      clone.getPartitionBy().add(new AttributeRef("region"));
+
+      assertEquals(1, ref.getPartitionBy().size(), "mutating the clone must not affect the original");
+      assertEquals(2, clone.getPartitionBy().size());
+   }
+
+   @Test
+   void clone_deepCopiesOrderByList() {
+      List<SortRef> orderBy = new ArrayList<>(List.of(sort("amount", XConstants.SORT_DESC)));
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0, new ArrayList<>(), orderBy);
+
+      WindowExpressionRef clone = (WindowExpressionRef) ref.clone();
+      clone.getOrderBy().add(sort("t", XConstants.SORT_ASC));
+
+      assertEquals(1, ref.getOrderBy().size(), "mutating the clone must not affect the original");
+      assertEquals(2, clone.getOrderBy().size());
+   }
+
+   @Test
+   void clone_deepCopiesArgRef() {
+      // ColumnRef.clone() always allocates a new instance (unlike AttributeRef, which returns
+      // `this` as a documented immutability optimization), so it is the right vehicle to prove
+      // WindowExpressionRef.clone() actually calls argRef.clone() rather than sharing the
+      // reference.
+      ColumnRef argRef = new ColumnRef(new AttributeRef("amount"));
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "SUM", argRef, 0, new ArrayList<>(), new ArrayList<>());
+
+      WindowExpressionRef clone = (WindowExpressionRef) ref.clone();
+
+      assertNotSame(ref.getArgRef(), clone.getArgRef(),
+                    "argRef must be deep-copied, not shared by reference");
+      assertEquals(ref.getArgRef().getName(), clone.getArgRef().getName());
+   }
+}

--- a/core/src/test/java/inetsoft/uql/asset/WindowExpressionRefTest.java
+++ b/core/src/test/java/inetsoft/uql/asset/WindowExpressionRefTest.java
@@ -148,6 +148,28 @@ class WindowExpressionRefTest {
    }
 
    @Test
+   void xmlRoundTrip_preservesName() throws Exception {
+      // The column name/alias (e.g. "rnk") is a base-class ExpressionRef attribute set by the
+      // wire (WorksheetTableService.applyWindowColumns -> setName). It MUST survive the
+      // worksheet's XML serialize/reload cycle, otherwise the column reloads nameless and cannot
+      // be bound by create_viewsheet ("Unknown field []").
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0,
+         List.of(new AttributeRef("stage")),
+         List.of(sort("amount", XConstants.SORT_DESC)));
+      ref.setName("rnk");
+      ref.setDataType(inetsoft.uql.schema.XSchema.INTEGER);
+
+      WindowExpressionRef copy = (WindowExpressionRef) writeAndParse(ref);
+
+      assertEquals("rnk", copy.getName(),
+                   "the window column name must survive XML serialization");
+      assertEquals(inetsoft.uql.schema.XSchema.INTEGER, copy.getDataType(),
+                   "the window column data type must survive XML serialization");
+      assertEquals(ref.getExpression(), copy.getExpression());
+   }
+
+   @Test
    void xmlRoundTrip_preservesArgRef() throws Exception {
       WindowExpressionRef ref = new WindowExpressionRef(
          "LAG", new AttributeRef("amount"), 1, List.of(), List.of(sort("t", XConstants.SORT_ASC)));
@@ -172,6 +194,59 @@ class WindowExpressionRefTest {
       Element elem = doc.getDocumentElement();
 
       return inetsoft.uql.erm.AbstractDataRef.createDataRef(elem);
+   }
+
+   // ---- getBaseAttribute must not unwrap past the window ref ---------------------------------
+
+   @Test
+   void getBaseAttribute_stopsAtWindowRef_forNoArgFunction() {
+      // ROW_NUMBER has a null argRef. WindowExpressionRef must NOT be a DataRefWrapper — otherwise
+      // AssetUtil.getBaseAttribute unwraps a ColumnRef(WindowExpressionRef) straight past the window
+      // ref to its null argRef, and query validation NPEs (PreAssetQuery.getContainedAttributes ->
+      // attr.isExpression() on null). It must be treated as a base expression attribute, exactly
+      // like a plain ExpressionRef (and like the AssetQuery window-pushdown guard assumes).
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0,
+         List.of(new AttributeRef("stage")),
+         List.of(sort("amount", XConstants.SORT_DESC)));
+      ColumnRef col = new ColumnRef(ref);
+
+      DataRef base = inetsoft.uql.asset.internal.AssetUtil.getBaseAttribute(col);
+
+      assertNotNull(base, "getBaseAttribute must not unwrap past a no-arg window ref to a null argRef");
+      assertInstanceOf(WindowExpressionRef.class, base,
+                       "getBaseAttribute must return the WindowExpressionRef itself");
+      assertTrue(base.isExpression());
+   }
+
+   // ---- getAttributes() must yield AttributeRefs (framework contract) ------------------------
+
+   @Test
+   void getAttributes_yieldsAttributeRefs_notColumnRefs() {
+      // The wire (WorksheetTableService.applyWindowColumns) passes ColumnRefs for partitionBy/
+      // orderBy (from ColumnSelection.getAttribute). getAttributes() must yield AttributeRefs
+      // parsed from the field['..'] tokens (the ExpressionRef contract) — the query framework
+      // casts each contained ref to AttributeRef (PreAssetQuery.getExprAttributes), so a ColumnRef
+      // there is a ClassCastException during column-selection validation.
+      ColumnRef stage = new ColumnRef(new AttributeRef("sales_stage"));
+      SortRef amountSort = new SortRef(new ColumnRef(new AttributeRef("amount")));
+      amountSort.setOrder(XConstants.SORT_DESC);
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0, List.of(stage), List.of(amountSort));
+
+      List<String> names = new ArrayList<>();
+      Enumeration<?> e = ref.getAttributes();
+
+      while(e.hasMoreElements()) {
+         DataRef r = (DataRef) e.nextElement();
+         assertInstanceOf(AttributeRef.class, r,
+            "contained refs must be AttributeRefs parsed from field[..] tokens, not "
+               + r.getClass().getSimpleName());
+         names.add(r.getName());
+      }
+
+      assertTrue(names.contains("sales_stage"), "partitionBy column must be a contained attribute");
+      assertTrue(names.contains("amount"), "orderBy column must be a contained attribute");
    }
 
    // ---- clone() deep-copies the lists ---------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/wiz/model/WorksheetTableRequestTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/WorksheetTableRequestTest.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("core")
@@ -61,5 +63,37 @@ class WorksheetTableRequestTest {
       assertEquals("w1", req.getWorksheetId());
       assertEquals(1, req.getTables().size());
       assertEquals("A", req.getTables().get(0).getTableName());
+   }
+
+   @Test
+   void windowColumnRoundTrips() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+
+      WorksheetTable table = mapper.readValue(
+         """
+         {
+           "windowColumns": [
+             {
+               "name": "rn",
+               "fn": "ROW_NUMBER",
+               "partitionBy": ["stage"],
+               "orderBy": [ { "field": "amount", "direction": "DESC" } ]
+             }
+           ]
+         }
+         """,
+         WorksheetTable.class);
+
+      assertEquals(1, table.getWindowColumns().size());
+      WorksheetTable.WindowColumnInfo win = table.getWindowColumns().get(0);
+      assertEquals("rn", win.getName());
+      assertEquals("ROW_NUMBER", win.getFn());
+      assertEquals(List.of("stage"), win.getPartitionBy());
+      assertEquals(1, win.getOrderBy().size());
+      assertEquals("amount", win.getOrderBy().get(0).getField());
+      assertEquals("DESC", win.getOrderBy().get(0).getDirection());
+
+      JsonNode output = mapper.valueToTree(table);
+      assertEquals("ROW_NUMBER", output.at("/windowColumns/0/fn").asText());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceWindowColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceWindowColumnsTest.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.PhysicalBoundTableAssembly;
+import inetsoft.uql.asset.WindowExpressionRef;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.web.wiz.model.WorksheetTable;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression/contract test for {@link WorksheetTableService#applyWindowColumns}, the structured
+ * counterpart of {@code applyExpressionColumns}: a {@code windowColumns} entry on the
+ * {@code /ws/table} request must build a {@link ColumnRef} wrapping a {@link WindowExpressionRef}
+ * whose synthesized {@code getExpression()} matches the pushdown-parity text produced by wiz's
+ * {@code expandWindowColumns} helper.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WorksheetTableServiceWindowColumnsTest {
+   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+   private static WorksheetTableService service() {
+      // applyWindowColumns uses only its parameters, never instance state, so null
+      // dependencies are safe here (mirrors WorksheetTableServiceConditionTest).
+      return new WorksheetTableService(null, null, null, null, null, null, null, null, null);
+   }
+
+   private static WorksheetTable request(String json) throws Exception {
+      return MAPPER.readValue(json, WorksheetTable.class);
+   }
+
+   @Test
+   void rowNumberWindowColumnBuildsWindowExpressionRef() throws Exception {
+      WorksheetTable req = request("""
+         {
+           "windowColumns": [
+             {
+               "name": "rn",
+               "fn": "ROW_NUMBER",
+               "partitionBy": ["stage"],
+               "orderBy": [ { "field": "amount", "direction": "DESC" } ]
+             }
+           ]
+         }
+         """);
+
+      Worksheet worksheet = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(worksheet, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      table.setColumnSelection(cs);
+
+      service().applyWindowColumns(table, req.getWindowColumns());
+
+      ColumnSelection result = table.getColumnSelection(false);
+      DataRef added = result.getAttribute("rn");
+
+      assertNotNull(added, "expected a 'rn' column in the private column selection");
+      assertInstanceOf(ColumnRef.class, added);
+      ColumnRef colRef = (ColumnRef) added;
+      assertTrue(colRef.isSQL(), "window column must be marked SQL so PreAssetQuery inlines it");
+      assertInstanceOf(WindowExpressionRef.class, colRef.getDataRef());
+
+      WindowExpressionRef winRef = (WindowExpressionRef) colRef.getDataRef();
+      assertEquals(
+         "ROW_NUMBER() OVER (PARTITION BY field['stage'] ORDER BY field['amount'] DESC)",
+         winRef.getExpression());
+      assertTrue(winRef.isSQL());
+   }
+}


### PR DESCRIPTION
## Summary

StyleBI-core support for **structured, pushed-down window (analytic) columns** — the "non-SQL window" Phase 1. Lets the wiz worksheet layer forward a structured window spec instead of hand-authoring an opaque `sql:true` expression string, and builds the real `fn(...) OVER (PARTITION BY ... ORDER BY ...)` SQL server-side.

Commits (base = `feat/window-fn-phase2b`, the Phase-2b capability-gate + window-over-aggregate tip):

1. **`edcc97dca` — `WindowExpressionRef` node.** A first-class `ExpressionRef` whose expression string is synthesized from structured fields (fn, argRef, n, partitionBy, orderBy). `getExpression()` emits `field['..']` tokens (same form as `DateRangeRef`) so `PreAssetQuery.getExpressionColumn` rewrites them to dialect-quoted identifiers. Byte-parity with the wiz text-hack it replaces.
2. **`03c9ce604` — `/ws/table` wire.** `WorksheetTableService.applyWindowColumns` builds a `WindowExpressionRef` (validating fn/name, resolving arg/partitionBy/orderBy refs) and adds it as a SQL `ColumnRef`, at both the physical- and mirror-table sites.
3. **`35609b39c` — detect-by-type.** `PreAssetQuery.isWindowExpression` is `instanceof WindowExpressionRef` first (regex fallback retained), plus a fail-loud guard in `AssetQuery.addExpression` for the non-mergeable path.
4. **`e42ca5e4e` — ExpressionRef-contract fixes.** Found by the first true end-to-end run through the mirror-query validation path: chain `super` in write/parseAttributes (name/dataType survive XML reload); drop `DataRefWrapper` (else `getBaseAttribute` unwraps to a null `argRef` for no-arg functions → NPE); drop the `getAttributes()` override (else contained refs are `ColumnRef`s the framework casts to `AttributeRef` → CCE). Aligns the node with how `DateRangeRef` behaves.

## Live verification (local StyleBI build, suitecrm / PostgreSQL)

All 15 `windowColumns` functions exercised as real visualizations; values + pushed-down `OVER(...)` SQL confirmed:

- **ROW_NUMBER / RANK / DENSE_RANK** — partitioned + tie behavior (unique / skip-after-tie / dense)
- **NTILE(3)** — 67 / 67 / 66 (remainder front-loaded = true NTILE)
- **PERCENT_RANK / CUME_DIST** — exact `(rank-1)/(n-1)` and `i/n`
- **LAG / LEAD / FIRST_VALUE / running SUM** — over a native SUM…GROUP BY aggregate mirror
- **SUM / AVG / COUNT / MIN / MAX** — per-partition (no ORDER BY)
- **LAST_VALUE** — fails loud (Phase 1 can't emit a frame clause), directs to FIRST_VALUE

Tests: `WindowExpressionRefTest` (getExpression parity + XML round-trip incl. name/dataType + getBaseAttribute stops at the window ref + getAttributes yields AttributeRefs + clone), `WorksheetTableServiceWindowColumnsTest`, `WindowExpressionDetectionTest` — all green.

## Notes

- Pairs with **stylebi-wiz #1189** (retires the client-side text expansion, forwards structured `windowColumns`). Deploy together.
- Base `feat/window-fn-phase2b` and this branch ride the local wiz-feature lineage (`WorksheetTableService`, on `stylebi-wiz-main-rebase`); their own upstreaming to the wiz-feature line is separate from this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
