### PR TITLE
feat(ws): worksheet-structure introspection model + GET /ws/structure endpoint

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
@@ -97,6 +97,14 @@ public class DatasourceMetaApiController {
       return metadataService.getWorksheetMetaData(WizUtil.decodeId(worksheetId), (XPrincipal) principal);
    }
 
+   @GetMapping("/ws/structure/{id}")
+   public WorksheetStructure getWorksheetStructure(
+      @PathVariable("id") String worksheetId,
+      Principal principal) throws Exception
+   {
+      return metadataService.getWorksheetStructure(WizUtil.decodeId(worksheetId), (XPrincipal) principal);
+   }
+
    /**
     * Gets all tables and FK relationships for the specified datasource.
     *

--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetStructure.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetStructure.java
@@ -1,0 +1,126 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WorksheetStructure {
+   private String path;
+   private String name;
+   private String primaryTable;
+   private List<StructureTable> tables = new ArrayList<>();
+
+   public String getPath() { return path; }
+   public void setPath(String path) { this.path = path; }
+   public String getName() { return name; }
+   public void setName(String name) { this.name = name; }
+   public String getPrimaryTable() { return primaryTable; }
+   public void setPrimaryTable(String primaryTable) { this.primaryTable = primaryTable; }
+   public List<StructureTable> getTables() { return tables; }
+   public void setTables(List<StructureTable> tables) { this.tables = tables; }
+
+   public static class StructureTable {
+      private String name;
+      private String tableType;
+      private List<Column> columns = new ArrayList<>();
+      private SourceRef source;               // null unless a bound/sql table
+      private List<String> baseTables = new ArrayList<>();
+      private List<JoinEdge> joins = new ArrayList<>();
+      private List<ConditionLeaf> conditions = new ArrayList<>();
+      private AggregateSummary aggregate;     // null unless grouped/aggregated
+
+      public String getName() { return name; }
+      public void setName(String name) { this.name = name; }
+      public String getTableType() { return tableType; }
+      public void setTableType(String tableType) { this.tableType = tableType; }
+      public List<Column> getColumns() { return columns; }
+      public void setColumns(List<Column> columns) { this.columns = columns; }
+      public SourceRef getSource() { return source; }
+      public void setSource(SourceRef source) { this.source = source; }
+      public List<String> getBaseTables() { return baseTables; }
+      public void setBaseTables(List<String> baseTables) { this.baseTables = baseTables; }
+      public List<JoinEdge> getJoins() { return joins; }
+      public void setJoins(List<JoinEdge> joins) { this.joins = joins; }
+      public List<ConditionLeaf> getConditions() { return conditions; }
+      public void setConditions(List<ConditionLeaf> conditions) { this.conditions = conditions; }
+      public AggregateSummary getAggregate() { return aggregate; }
+      public void setAggregate(AggregateSummary aggregate) { this.aggregate = aggregate; }
+   }
+
+   public static class Column {
+      private String name; private String alias; private String type;
+      private String expression; private int refType;
+      public String getName() { return name; } public void setName(String v) { this.name = v; }
+      public String getAlias() { return alias; } public void setAlias(String v) { this.alias = v; }
+      public String getType() { return type; } public void setType(String v) { this.type = v; }
+      public String getExpression() { return expression; } public void setExpression(String v) { this.expression = v; }
+      public int getRefType() { return refType; } public void setRefType(int v) { this.refType = v; }
+   }
+
+   public static class SourceRef {
+      private String datasource; private String table; private String sqlText; private int sourceType;
+      public String getDatasource() { return datasource; } public void setDatasource(String v) { this.datasource = v; }
+      public String getTable() { return table; } public void setTable(String v) { this.table = v; }
+      public String getSqlText() { return sqlText; } public void setSqlText(String v) { this.sqlText = v; }
+      public int getSourceType() { return sourceType; } public void setSourceType(int v) { this.sourceType = v; }
+   }
+
+   public static class JoinEdge {
+      private String leftTable; private String rightTable;
+      private String leftColumn; private String rightColumn; private String joinType;
+      public String getLeftTable() { return leftTable; } public void setLeftTable(String v) { this.leftTable = v; }
+      public String getRightTable() { return rightTable; } public void setRightTable(String v) { this.rightTable = v; }
+      public String getLeftColumn() { return leftColumn; } public void setLeftColumn(String v) { this.leftColumn = v; }
+      public String getRightColumn() { return rightColumn; } public void setRightColumn(String v) { this.rightColumn = v; }
+      public String getJoinType() { return joinType; } public void setJoinType(String v) { this.joinType = v; }
+   }
+
+   public static class ConditionLeaf {
+      private String field; private String operation; private List<String> values = new ArrayList<>();
+      private boolean negated; private String junction; private String phase; // pre|post|preRuntime|ranking
+      public String getField() { return field; } public void setField(String v) { this.field = v; }
+      public String getOperation() { return operation; } public void setOperation(String v) { this.operation = v; }
+      public List<String> getValues() { return values; } public void setValues(List<String> v) { this.values = v; }
+      public boolean isNegated() { return negated; } public void setNegated(boolean v) { this.negated = v; }
+      public String getJunction() { return junction; } public void setJunction(String v) { this.junction = v; }
+      public String getPhase() { return phase; } public void setPhase(String v) { this.phase = v; }
+   }
+
+   public static class AggregateSummary {
+      private List<AggGroupBy> groupBy = new ArrayList<>();
+      private List<AggMeasure> aggregates = new ArrayList<>();
+      public List<AggGroupBy> getGroupBy() { return groupBy; } public void setGroupBy(List<AggGroupBy> v) { this.groupBy = v; }
+      public List<AggMeasure> getAggregates() { return aggregates; } public void setAggregates(List<AggMeasure> v) { this.aggregates = v; }
+   }
+
+   public static class AggGroupBy {
+      private String field; private String dateLevel;
+      public String getField() { return field; } public void setField(String v) { this.field = v; }
+      public String getDateLevel() { return dateLevel; } public void setDateLevel(String v) { this.dateLevel = v; }
+   }
+
+   public static class AggMeasure {
+      private String field; private String formula; private String secondaryField; private String n;
+      public String getField() { return field; } public void setField(String v) { this.field = v; }
+      public String getFormula() { return formula; } public void setFormula(String v) { this.formula = v; }
+      public String getSecondaryField() { return secondaryField; } public void setSecondaryField(String v) { this.secondaryField = v; }
+      public String getN() { return n; } public void setN(String v) { this.n = v; }
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -27,6 +27,7 @@ import inetsoft.web.wiz.request.GetDatabaseTableMetaRequest;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.erm.*;
+import inetsoft.uql.asset.internal.SQLBoundTableAssemblyInfo;
 import inetsoft.uql.jdbc.util.JDBCUtil;
 import inetsoft.uql.jdbc.util.SQLTypes;
 import inetsoft.uql.schema.XSchema;
@@ -551,6 +552,360 @@ public class MetadataApiService {
       }
 
       return joinInfo;
+   }
+
+   /**
+    * Walks a worksheet's table assemblies into a full structural description — columns,
+    * source, base tables, joins, conditions, and aggregate — for the wiz worksheet-structure
+    * introspection endpoint. Mirrors {@link #getWorksheetMetaData} but captures per-table
+    * provenance detail rather than just names/columns.
+    */
+   public WorksheetStructure getWorksheetStructure(String wsId, XPrincipal principal)
+      throws Exception
+   {
+      if(wsId == null || Tool.isEmptyString(wsId)) {
+         throw new Exception("Invalid request.");
+      }
+
+      AssetEntry entry = AssetEntry.createAssetEntry(wsId);
+      AbstractSheet sheet = assetRepository.getSheet(entry, principal, true, AssetContent.ALL);
+
+      if(!(sheet instanceof Worksheet worksheet)) {
+         throw new Exception("Worksheet " + wsId + " not found.");
+      }
+
+      List<WorksheetStructure.StructureTable> tables = new ArrayList<>();
+
+      for(Assembly assembly : sheet.getAssemblies()) {
+         if(!(assembly instanceof TableAssembly tableAssembly)) {
+            continue;
+         }
+
+         try {
+            tables.add(buildStructureTable(tableAssembly));
+         }
+         catch(Exception ex) {
+            // Best-effort: one malformed/unexpected assembly shouldn't fail the whole call.
+            WorksheetStructure.StructureTable partial = new WorksheetStructure.StructureTable();
+            partial.setName(tableAssembly.getName());
+            tables.add(partial);
+            log.debug("Failed to fully map worksheet assembly '{}'", tableAssembly.getName(), ex);
+         }
+      }
+
+      WorksheetStructure structure = new WorksheetStructure();
+      structure.setPath(entry.getPath());
+      structure.setName(entry.getName());
+      structure.setTables(tables);
+
+      WSAssembly primaryAssembly = worksheet.getPrimaryAssembly();
+
+      if(primaryAssembly != null) {
+         structure.setPrimaryTable(primaryAssembly.getName());
+      }
+
+      return structure;
+   }
+
+   private WorksheetStructure.StructureTable buildStructureTable(TableAssembly tableAssembly) {
+      WorksheetStructure.StructureTable table = new WorksheetStructure.StructureTable();
+      table.setName(tableAssembly.getName());
+      table.setTableType(structureTableType(tableAssembly));
+      table.setColumns(extractStructureColumns(tableAssembly));
+      table.setSource(extractStructureSource(tableAssembly));
+      table.setBaseTables(extractStructureBaseTables(tableAssembly));
+      table.setJoins(extractStructureJoins(tableAssembly));
+      table.setConditions(extractStructureConditions(tableAssembly));
+      table.setAggregate(extractStructureAggregate(tableAssembly.getAggregateInfo()));
+      return table;
+   }
+
+   /**
+    * Mirrors {@link WorksheetTableService}'s private {@code getTableType} strings exactly, so
+    * the construction and introspection endpoints speak the same vocabulary.
+    */
+   static String structureTableType(TableAssembly tableAssembly) {
+      if(tableAssembly instanceof PhysicalBoundTableAssembly) {
+         return "physical table";
+      }
+      else if(tableAssembly instanceof MirrorTableAssembly) {
+         return "mirror table";
+      }
+      else if(tableAssembly instanceof RelationalJoinTableAssembly) {
+         return "relational join table";
+      }
+      else if(tableAssembly instanceof SQLBoundTableAssembly) {
+         return "sql query table";
+      }
+
+      return tableAssembly.getClass().getSimpleName();
+   }
+
+   static List<WorksheetStructure.Column> extractStructureColumns(TableAssembly tableAssembly) {
+      List<WorksheetStructure.Column> columns = new ArrayList<>();
+      ColumnSelection selection = tableAssembly.getColumnSelection(true);
+
+      if(selection == null) {
+         return columns;
+      }
+
+      for(int i = 0; i < selection.getAttributeCount(); i++) {
+         DataRef ref = selection.getAttribute(i);
+
+         if(ref instanceof ColumnRef columnRef) {
+            columns.add(createStructureColumn(columnRef));
+         }
+      }
+
+      return columns;
+   }
+
+   private static WorksheetStructure.Column createStructureColumn(ColumnRef columnRef) {
+      WorksheetStructure.Column column = new WorksheetStructure.Column();
+      column.setName(columnRef.getAttribute());
+      column.setAlias(columnRef.getAlias());
+      column.setRefType(columnRef.getRefType());
+
+      if(columnRef.getTypeNode() != null) {
+         column.setType(columnRef.getTypeNode().getType());
+      }
+
+      if(columnRef.isExpression() && columnRef.getDataRef() instanceof ExpressionRef expressionRef) {
+         column.setExpression(expressionRef.getExpression());
+      }
+
+      return column;
+   }
+
+   /**
+    * Source of a bound/sql table. Returns {@code null} for tables with no direct physical
+    * source (mirror/join/rotated/unpivot/embedded), matching {@code StructureTable.source}'s
+    * documented "null unless a bound/sql table" contract.
+    */
+   static WorksheetStructure.SourceRef extractStructureSource(TableAssembly tableAssembly) {
+      if(!(tableAssembly instanceof BoundTableAssembly boundTable) ||
+         boundTable.getSourceInfo() == null)
+      {
+         return null;
+      }
+
+      SourceInfo sourceInfo = boundTable.getSourceInfo();
+      WorksheetStructure.SourceRef source = new WorksheetStructure.SourceRef();
+      source.setDatasource(sourceInfo.getPrefix());
+      source.setTable(sourceInfo.getSource());
+      source.setSourceType(sourceInfo.getType());
+
+      if(tableAssembly instanceof SQLBoundTableAssembly &&
+         tableAssembly.getInfo() instanceof SQLBoundTableAssemblyInfo sqlInfo &&
+         sqlInfo.getQuery() != null && sqlInfo.getQuery().getSQLDefinition() != null)
+      {
+         source.setSqlText(sqlInfo.getQuery().getSQLDefinition().getSQLString());
+      }
+
+      return source;
+   }
+
+   /**
+    * Names of the tables a composed assembly (mirror/join/rotated/unpivot) is built from.
+    * Reuses the same {@code ComposedTableAssembly.getTableNames()} accessor as
+    * {@code WorksheetTableService#getBaseTables}.
+    */
+   static List<String> extractStructureBaseTables(TableAssembly tableAssembly) {
+      if(!(tableAssembly instanceof ComposedTableAssembly composed)) {
+         return new ArrayList<>();
+      }
+
+      String[] names = composed.getTableNames();
+      return names == null ? new ArrayList<>() : new ArrayList<>(Arrays.asList(names));
+   }
+
+   static List<WorksheetStructure.JoinEdge> extractStructureJoins(TableAssembly tableAssembly) {
+      List<WorksheetStructure.JoinEdge> joins = new ArrayList<>();
+
+      if(!(tableAssembly instanceof AbstractJoinTableAssembly joinTable)) {
+         return joins;
+      }
+
+      Enumeration<TableAssemblyOperator> operators = joinTable.getOperators();
+
+      if(operators == null) {
+         return joins;
+      }
+
+      while(operators.hasMoreElements()) {
+         TableAssemblyOperator operator = operators.nextElement();
+
+         if(operator == null) {
+            continue;
+         }
+
+         for(TableAssemblyOperator.Operator operatorOperator : operator.getOperators()) {
+            if(operatorOperator == null || operatorOperator.getLeftTable() == null ||
+               operatorOperator.getRightTable() == null)
+            {
+               continue;
+            }
+
+            WorksheetStructure.JoinEdge join = new WorksheetStructure.JoinEdge();
+            join.setLeftTable(operatorOperator.getLeftTable());
+            join.setRightTable(operatorOperator.getRightTable());
+
+            if(operatorOperator.getLeftAttribute() != null) {
+               join.setLeftColumn(operatorOperator.getLeftAttribute().getAttribute());
+            }
+
+            if(operatorOperator.getRightAttribute() != null) {
+               join.setRightColumn(operatorOperator.getRightAttribute().getAttribute());
+            }
+
+            // Same accessor createJoinInfo() uses for its JoinInfo.joinType (operator display
+            // name, e.g. "Inner Join"/"Left Outer Join").
+            join.setJoinType(operatorOperator.getName());
+            joins.add(join);
+         }
+      }
+
+      return joins;
+   }
+
+   static List<WorksheetStructure.ConditionLeaf> extractStructureConditions(
+      TableAssembly tableAssembly)
+   {
+      List<WorksheetStructure.ConditionLeaf> conditions = new ArrayList<>();
+      collectStructureConditions(tableAssembly.getPreConditionList(), "pre", conditions);
+      collectStructureConditions(
+         tableAssembly.getPreRuntimeConditionList(), "preRuntime", conditions);
+      collectStructureConditions(tableAssembly.getPostConditionList(), "post", conditions);
+      collectStructureConditions(tableAssembly.getRankingConditionList(), "ranking", conditions);
+      return conditions;
+   }
+
+   /**
+    * Walks one {@link ConditionListWrapper}'s alternating ConditionItem/JunctionOperator list.
+    * Non-{@link Condition} {@link XCondition} implementations (e.g. correlated/asset conditions)
+    * still yield a leaf with field/operation/negated/phase — just no values, since
+    * {@code getValueCount()}/{@code getValue(int)} aren't declared on the {@code XCondition}
+    * interface itself.
+    */
+   static void collectStructureConditions(ConditionListWrapper wrapper, String phase,
+                                          List<WorksheetStructure.ConditionLeaf> out)
+   {
+      if(wrapper == null || wrapper.getConditionList() == null) {
+         return;
+      }
+
+      ConditionList list = wrapper.getConditionList();
+
+      for(int i = 0; i < list.getSize(); i++) {
+         if(!list.isConditionItem(i)) {
+            continue;
+         }
+
+         ConditionItem item = list.getConditionItem(i);
+         XCondition xCondition = item.getXCondition();
+
+         if(xCondition == null) {
+            continue;
+         }
+
+         WorksheetStructure.ConditionLeaf leaf = new WorksheetStructure.ConditionLeaf();
+         leaf.setField(item.getAttribute() != null ? item.getAttribute().getAttribute() : null);
+         leaf.setOperation(structureOperationName(xCondition.getOperation()));
+         leaf.setNegated(xCondition.isNegated());
+         leaf.setPhase(phase);
+
+         // The junction PRECEDING this item (joining it to the previous leaf) sits at i - 1;
+         // the first leaf in a phase has none.
+         if(i > 0 && list.isJunctionOperator(i - 1)) {
+            leaf.setJunction(list.getJunction(i - 1) == JunctionOperator.OR ? "OR" : "AND");
+         }
+
+         if(xCondition instanceof Condition condition) {
+            List<String> values = new ArrayList<>();
+
+            for(int v = 0; v < condition.getValueCount(); v++) {
+               Object value = condition.getValue(v);
+
+               // Only stringify plain scalar values; skip parameter/session/sub-query objects
+               // (e.g. UserVariable, DataRef) rather than dumping an opaque toString().
+               if(value instanceof String || value instanceof Number ||
+                  value instanceof Boolean || value instanceof java.util.Date)
+               {
+                  values.add(String.valueOf(value));
+               }
+            }
+
+            leaf.setValues(values);
+         }
+
+         out.add(leaf);
+      }
+   }
+
+   /**
+    * No StyleBI helper converts an {@link XCondition} operation int to a name (confirmed: no
+    * {@code getOperationName} exists anywhere in this codebase; {@link Condition#toString()}
+    * inlines a private, localized switch). Uses the {@link XCondition} constant names
+    * themselves so the vocabulary is stable and self-documenting for API consumers.
+    */
+   private static String structureOperationName(int operation) {
+      return switch(operation) {
+         case XCondition.EQUAL_TO -> "EQUAL_TO";
+         case XCondition.ONE_OF -> "ONE_OF";
+         case XCondition.LESS_THAN -> "LESS_THAN";
+         case XCondition.GREATER_THAN -> "GREATER_THAN";
+         case XCondition.BETWEEN -> "BETWEEN";
+         case XCondition.STARTING_WITH -> "STARTING_WITH";
+         case XCondition.CONTAINS -> "CONTAINS";
+         case XCondition.NULL -> "NULL";
+         case XCondition.TOP_N -> "TOP_N";
+         case XCondition.BOTTOM_N -> "BOTTOM_N";
+         case XCondition.DATE_IN -> "DATE_IN";
+         case XCondition.PSEUDO -> "PSEUDO";
+         case XCondition.LIKE -> "LIKE";
+         default -> "UNKNOWN(" + operation + ")";
+      };
+   }
+
+   /**
+    * Uses {@link WizDateLevelUtil#getDateGroupLevelName(int)} (package-private in this same
+    * package) for date-level names, so the introspection endpoint reports the same vocabulary
+    * as the rest of the wiz service layer.
+    */
+   static WorksheetStructure.AggregateSummary extractStructureAggregate(
+      AggregateInfo aggregateInfo)
+   {
+      if(aggregateInfo == null || aggregateInfo.isEmpty()) {
+         return null;
+      }
+
+      WorksheetStructure.AggregateSummary summary = new WorksheetStructure.AggregateSummary();
+
+      for(GroupRef groupRef : aggregateInfo.getGroups()) {
+         WorksheetStructure.AggGroupBy groupBy = new WorksheetStructure.AggGroupBy();
+         groupBy.setField(groupRef.getName());
+         groupBy.setDateLevel(WizDateLevelUtil.getDateGroupLevelName(groupRef.getDateGroup()));
+         summary.getGroupBy().add(groupBy);
+      }
+
+      for(AggregateRef aggregateRef : aggregateInfo.getAggregates()) {
+         WorksheetStructure.AggMeasure measure = new WorksheetStructure.AggMeasure();
+         measure.setField(aggregateRef.getName());
+         measure.setFormula(
+            aggregateRef.getFormula() != null ? aggregateRef.getFormula().getName() : null);
+
+         if(aggregateRef.getSecondaryColumn() != null) {
+            measure.setSecondaryField(aggregateRef.getSecondaryColumn().getName());
+         }
+
+         if(aggregateRef.getN() > 0) {
+            measure.setN(String.valueOf(aggregateRef.getN()));
+         }
+
+         summary.getAggregates().add(measure);
+      }
+
+      return summary;
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceStructureTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceStructureTest.java
@@ -1,0 +1,318 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.*;
+import inetsoft.uql.asset.*;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.jdbc.JDBCQuery;
+import inetsoft.uql.jdbc.UniformSQL;
+import inetsoft.uql.util.XSourceInfo;
+import inetsoft.web.wiz.model.WorksheetStructure;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the {@code getWorksheetStructure} extraction helpers on
+ * {@link MetadataApiService}.
+ *
+ * <p>{@code getWorksheetStructure} itself is a thin wrapper — resolve the {@link AssetEntry},
+ * fetch the {@link Worksheet} via {@code assetRepository.getSheet}, loop assemblies, catch
+ * per-assembly — that mirrors the already-covered {@code getWorksheetMetaData} shape 1:1. All of
+ * the new logic lives in the package-private static extraction helpers below, so (per the task
+ * brief's guidance) this suite drives those helpers directly with hand-built
+ * {@code ConditionList}/{@code AggregateInfo}/{@code SourceInfo}/table-assembly objects rather
+ * than standing up a full {@code AssetRepository}-backed round trip.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class MetadataApiServiceStructureTest {
+
+   /**
+    * Builds a {@link PhysicalBoundTableAssembly} with a private {@link ColumnSelection} holding
+    * a {@link ColumnRef} per name. Deliberately avoids {@code EmbeddedTableAssembly} /
+    * {@code TestWorksheets.tableWithColumns}: constructing an embedded table eagerly creates an
+    * {@code XEmbeddedTable} backed by {@code XSwappableTable}, which needs an {@code XSwapper}
+    * Spring bean this lightweight test context doesn't provide. A physical bound table needs no
+    * such runtime machinery and is a more representative "real" worksheet table besides.
+    */
+   private static PhysicalBoundTableAssembly physicalTable(Worksheet ws, String name, String... cols) {
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, name);
+      ColumnSelection cs = new ColumnSelection();
+
+      for(String col : cols) {
+         cs.addAttribute(new ColumnRef(new AttributeRef(null, col)));
+      }
+
+      table.setColumnSelection(cs, false);
+      return table;
+   }
+
+   // ---- structureTableType ----
+
+   @Test
+   void classifiesPhysicalBoundTable() {
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly t = new PhysicalBoundTableAssembly(ws, "accounts");
+      assertEquals("physical table", MetadataApiService.structureTableType(t));
+   }
+
+   @Test
+   void classifiesSqlBoundTable() {
+      Worksheet ws = new Worksheet();
+      SQLBoundTableAssembly t = new SQLBoundTableAssembly(ws, "sqlTable");
+      assertEquals("sql query table", MetadataApiService.structureTableType(t));
+   }
+
+   @Test
+   void classifiesRelationalJoinTable() {
+      Worksheet ws = new Worksheet();
+      TableAssembly left = physicalTable(ws, "t1", "id");
+      TableAssembly right = physicalTable(ws, "t2", "id");
+      RelationalJoinTableAssembly join = new RelationalJoinTableAssembly(
+         ws, "joined", new TableAssembly[] { left, right }, new TableAssemblyOperator[0]);
+      assertEquals("relational join table", MetadataApiService.structureTableType(join));
+   }
+
+   @Test
+   void classifiesMirrorTable() {
+      Worksheet ws = new Worksheet();
+      TableAssembly base = physicalTable(ws, "base", "id");
+      ws.addAssembly(base);
+      MirrorTableAssembly mirror = new MirrorTableAssembly(ws, "mirrored", base);
+      assertEquals("mirror table", MetadataApiService.structureTableType(mirror));
+   }
+
+   @Test
+   void fallsBackToSimpleClassNameForUnrecognizedType() {
+      // UnpivotTableAssembly isn't one of the four classified types, so it exercises the
+      // getClass().getSimpleName() fallback branch.
+      Worksheet ws = new Worksheet();
+      TableAssembly base = physicalTable(ws, "base", "id", "h1", "h2");
+      ws.addAssembly(base);
+      UnpivotTableAssembly t = new UnpivotTableAssembly(ws, "unpivoted", base);
+      assertEquals("UnpivotTableAssembly", MetadataApiService.structureTableType(t));
+   }
+
+   // ---- extractStructureColumns ----
+
+   @Test
+   void extractsColumnsFromColumnSelection() {
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly t = physicalTable(ws, "accounts", "industry", "annual_revenue");
+
+      var columns = MetadataApiService.extractStructureColumns(t);
+
+      assertEquals(2, columns.size());
+      assertEquals("industry", columns.get(0).getName());
+      assertEquals("annual_revenue", columns.get(1).getName());
+   }
+
+   // ---- extractStructureSource ----
+
+   @Test
+   void extractsSourceFromBoundTable() {
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly t = new PhysicalBoundTableAssembly(ws, "accounts");
+      t.setSourceInfo(new SourceInfo(XSourceInfo.PHYSICAL_TABLE, "suitecrm", "accounts"));
+
+      WorksheetStructure.SourceRef source = MetadataApiService.extractStructureSource(t);
+
+      assertNotNull(source);
+      assertEquals("suitecrm", source.getDatasource());
+      assertEquals("accounts", source.getTable());
+      assertEquals(XSourceInfo.PHYSICAL_TABLE, source.getSourceType());
+      assertNull(source.getSqlText(), "non-SQL bound table should not carry SQL text");
+   }
+
+   @Test
+   void extractsSqlTextFromSqlBoundTable() {
+      Worksheet ws = new Worksheet();
+      SQLBoundTableAssembly t = new SQLBoundTableAssembly(ws, "sqlTable");
+      t.setSourceInfo(new SourceInfo(XSourceInfo.PHYSICAL_TABLE, "suitecrm", "suitecrm"));
+
+      UniformSQL sql = new UniformSQL();
+      sql.setParseSQL(false);
+      sql.setSQLString("SELECT * FROM accounts", false);
+
+      JDBCQuery query = new JDBCQuery();
+      query.setSQLDefinition(sql);
+
+      inetsoft.uql.asset.internal.SQLBoundTableAssemblyInfo info =
+         (inetsoft.uql.asset.internal.SQLBoundTableAssemblyInfo) t.getInfo();
+      info.setQuery(query);
+
+      WorksheetStructure.SourceRef source = MetadataApiService.extractStructureSource(t);
+
+      assertNotNull(source);
+      assertEquals("SELECT * FROM accounts", source.getSqlText());
+   }
+
+   @Test
+   void returnsNullSourceForComposedTable() {
+      Worksheet ws = new Worksheet();
+      TableAssembly base = physicalTable(ws, "base", "id");
+      ws.addAssembly(base);
+      MirrorTableAssembly mirror = new MirrorTableAssembly(ws, "mirrored", base);
+
+      assertNull(MetadataApiService.extractStructureSource(mirror));
+   }
+
+   // ---- extractStructureBaseTables / extractStructureJoins ----
+
+   @Test
+   void extractsBaseTablesAndJoinEdgeFromJoinTable() {
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly left = physicalTable(ws, "t1", "id", "name");
+      PhysicalBoundTableAssembly right = physicalTable(ws, "t2", "id", "value");
+
+      TableAssemblyOperator.Operator op = new TableAssemblyOperator.Operator();
+      op.setLeftTable("t1");
+      op.setRightTable("t2");
+      op.setLeftAttribute(new AttributeRef(null, "id"));
+      op.setRightAttribute(new AttributeRef(null, "id"));
+      op.setOperation(TableAssemblyOperator.INNER_JOIN);
+
+      TableAssemblyOperator top = new TableAssemblyOperator();
+      top.addOperator(op);
+
+      RelationalJoinTableAssembly join = new RelationalJoinTableAssembly(
+         ws, "joined", new TableAssembly[] { left, right }, new TableAssemblyOperator[] { top });
+
+      var baseTables = MetadataApiService.extractStructureBaseTables(join);
+      assertTrue(baseTables.contains("t1"));
+      assertTrue(baseTables.contains("t2"));
+
+      var joins = MetadataApiService.extractStructureJoins(join);
+      assertEquals(1, joins.size());
+      WorksheetStructure.JoinEdge edge = joins.get(0);
+      assertEquals("t1", edge.getLeftTable());
+      assertEquals("t2", edge.getRightTable());
+      assertEquals("id", edge.getLeftColumn());
+      assertEquals("id", edge.getRightColumn());
+      assertEquals("INNER_JOIN", edge.getJoinType());
+   }
+
+   @Test
+   void baseTablesAndJoinsAreEmptyForNonComposedTable() {
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly t = new PhysicalBoundTableAssembly(ws, "accounts");
+
+      assertTrue(MetadataApiService.extractStructureBaseTables(t).isEmpty());
+      assertTrue(MetadataApiService.extractStructureJoins(t).isEmpty());
+   }
+
+   // ---- collectStructureConditions ----
+
+   @Test
+   void collectsSingleConditionLeaf() {
+      ConditionList list = new ConditionList();
+      Condition cond = new Condition();
+      cond.setOperation(XCondition.EQUAL_TO);
+      cond.addValue(0);
+      list.append(new ConditionItem(new AttributeRef(null, "deleted"), cond, 0));
+
+      var out = new java.util.ArrayList<WorksheetStructure.ConditionLeaf>();
+      MetadataApiService.collectStructureConditions(list, "pre", out);
+
+      assertEquals(1, out.size());
+      WorksheetStructure.ConditionLeaf leaf = out.get(0);
+      assertEquals("deleted", leaf.getField());
+      assertEquals("EQUAL_TO", leaf.getOperation());
+      assertEquals("pre", leaf.getPhase());
+      assertFalse(leaf.isNegated());
+      assertEquals("0", leaf.getValues().get(0));
+      assertNull(leaf.getJunction(), "first leaf in a phase has no preceding junction");
+   }
+
+   @Test
+   void collectsSecondLeafJunctionAndNegation() {
+      ConditionList list = new ConditionList();
+
+      Condition c1 = new Condition();
+      c1.setOperation(XCondition.EQUAL_TO);
+      c1.addValue(0);
+      list.append(new ConditionItem(new AttributeRef(null, "deleted"), c1, 0));
+
+      list.append(new JunctionOperator(JunctionOperator.AND, 0));
+
+      Condition c2 = new Condition();
+      c2.setOperation(XCondition.ONE_OF);
+      c2.setNegated(true);
+      c2.addValue("Closed Lost");
+      list.append(new ConditionItem(new AttributeRef(null, "sales_stage"), c2, 0));
+
+      var out = new java.util.ArrayList<WorksheetStructure.ConditionLeaf>();
+      MetadataApiService.collectStructureConditions(list, "pre", out);
+
+      assertEquals(2, out.size());
+      WorksheetStructure.ConditionLeaf second = out.get(1);
+      assertEquals("sales_stage", second.getField());
+      assertEquals("ONE_OF", second.getOperation());
+      assertEquals("AND", second.getJunction());
+      assertTrue(second.isNegated());
+      assertEquals("Closed Lost", second.getValues().get(0));
+   }
+
+   @Test
+   void collectStructureConditionsNoOpsOnNullOrEmptyWrapper() {
+      var out = new java.util.ArrayList<WorksheetStructure.ConditionLeaf>();
+      MetadataApiService.collectStructureConditions(null, "pre", out);
+      MetadataApiService.collectStructureConditions(new ConditionList(), "pre", out);
+      assertTrue(out.isEmpty());
+   }
+
+   // ---- extractStructureAggregate ----
+
+   @Test
+   void extractsGroupByAndAggregate() {
+      ColumnRef groupCol = new ColumnRef(new AttributeRef(null, "industry"));
+      ColumnRef sumCol = new ColumnRef(new AttributeRef(null, "annual_revenue"));
+
+      AggregateInfo info = new AggregateInfo();
+      info.addGroup(new GroupRef(groupCol));
+      info.addAggregate(new AggregateRef(sumCol, AggregateFormula.SUM));
+
+      WorksheetStructure.AggregateSummary summary = MetadataApiService.extractStructureAggregate(info);
+
+      assertNotNull(summary);
+      assertEquals(1, summary.getGroupBy().size());
+      assertEquals("industry", summary.getGroupBy().get(0).getField());
+      assertEquals(1, summary.getAggregates().size());
+      assertEquals("annual_revenue", summary.getAggregates().get(0).getField());
+      assertTrue("SUM".equalsIgnoreCase(summary.getAggregates().get(0).getFormula()));
+   }
+
+   @Test
+   void returnsNullForEmptyOrNullAggregateInfo() {
+      assertNull(MetadataApiService.extractStructureAggregate(null));
+      assertNull(MetadataApiService.extractStructureAggregate(new AggregateInfo()));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceStructureTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceStructureTest.java
@@ -23,8 +23,11 @@ import inetsoft.test.SreeHome;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.jdbc.JDBCQuery;
 import inetsoft.uql.jdbc.UniformSQL;
+import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.util.XSourceInfo;
 import inetsoft.web.wiz.model.WorksheetStructure;
 import org.junit.jupiter.api.Tag;
@@ -133,6 +136,45 @@ class MetadataApiServiceStructureTest {
       assertEquals(2, columns.size());
       assertEquals("industry", columns.get(0).getName());
       assertEquals("annual_revenue", columns.get(1).getName());
+   }
+
+   @Test
+   void mapsAliasTypeRefTypeAndExpressionForColumns() {
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly t = new PhysicalBoundTableAssembly(ws, "accounts");
+      ColumnSelection cs = new ColumnSelection();
+
+      // Plain column: attribute-backed ColumnRef with an alias, explicit data type, and a
+      // non-default ref type (MEASURE).
+      AttributeRef attr = new AttributeRef(null, "annual_revenue");
+      attr.setRefType(DataRef.MEASURE);
+      ColumnRef plainColumn = new ColumnRef(attr);
+      plainColumn.setAlias("Annual Revenue");
+      plainColumn.setDataType(XSchema.DOUBLE);
+      cs.addAttribute(plainColumn);
+
+      // Expression column: ColumnRef wrapping an ExpressionRef, per the isExpression() &&
+      // getDataRef() instanceof ExpressionRef branch in createStructureColumn.
+      ExpressionRef expressionRef = new ExpressionRef(null, "revenue_plus_tax");
+      expressionRef.setExpression("field['a'] + field['b']");
+      ColumnRef expressionColumn = new ColumnRef(expressionRef);
+      cs.addAttribute(expressionColumn);
+
+      t.setColumnSelection(cs, false);
+
+      var columns = MetadataApiService.extractStructureColumns(t);
+
+      assertEquals(2, columns.size());
+
+      WorksheetStructure.Column plain = columns.get(0);
+      assertEquals("annual_revenue", plain.getName());
+      assertEquals("Annual Revenue", plain.getAlias());
+      assertEquals(XSchema.DOUBLE, plain.getType());
+      assertEquals(DataRef.MEASURE, plain.getRefType());
+      assertNull(plain.getExpression(), "non-expression column should not carry an expression");
+
+      WorksheetStructure.Column expression = columns.get(1);
+      assertEquals("field['a'] + field['b']", expression.getExpression());
    }
 
    // ---- extractStructureSource ----


### PR DESCRIPTION
## Summary

Read-only worksheet introspection for the wiz worksheet layer: a `WorksheetStructure` model plus a `getWorksheetStructure` walk and a `GET /ws/structure/{id}` endpoint. This backs the `get_worksheet_structure` MCP tool (per-table source, joins, conditions, group-by/aggregates, and columns incl. expressions), which the plugin uses to confirm what a worksheet actually built — including verifying that structured `windowColumns` materialized correctly.

Commits (base `stylebi-wiz-main-rebase`):

1. **`WorksheetStructure` model** — DTO for worksheet introspection (tables, source, joins, conditions, aggregate, columns).
2. **`getWorksheetStructure`** — walks the worksheet's assemblies into a `WorksheetStructure`.
3. **test** — covers expression/alias column mapping in the walk.
4. **`GET /ws/structure/{id}`** — REST endpoint exposing it.

## Verification

Cherry-picked cleanly onto the current `stylebi-wiz-main-rebase` tip; `inetsoft-core` compiles and `MetadataApiServiceStructureTest` passes (17/17).

## Notes

Extracted from a local wiz-feature lineage that had drifted off `rebase`; the already-merged parts of that lineage (crosstab binding-echo #4162/#4163, manualOrder + non-equi-join #4206) are excluded here. Independent of the window-function work; pairs conceptually with the worksheet-agent tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
