### PR TITLE
feat(sql): SQLHelper window-function capability + emit window columns over GROUP BY

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
@@ -554,6 +554,31 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
     * Merge group by clause.
     * @return <tt>true</tt> if fully merged, <tt>false</tt> otherwise.
     */
+   /** Matches a SQL window-function call: the OVER keyword followed by '(' (case-insensitive). */
+   private static final Pattern WINDOW_FN_PATTERN =
+      Pattern.compile("\\bOVER\\s*\\(", Pattern.CASE_INSENSITIVE);
+
+   /**
+    * True if `column` is an expression column whose SQL text contains a window function
+    * (`... OVER (...)`). Such a column is neither a GROUP BY dimension nor a standard aggregate;
+    * mergeGroupBy emits it into the SELECT list without grouping/aggregating it. Package-private
+    * (static, no instance state) so it can be unit-tested directly.
+    */
+   static boolean isWindowExpression(ColumnRef column) {
+      if(column == null || !column.isExpression()) {
+         return false;
+      }
+
+      DataRef ref = column.getDataRef();
+
+      if(!(ref instanceof ExpressionRef)) {
+         return false;
+      }
+
+      String expr = ((ExpressionRef) ref).getExpression();
+      return expr != null && WINDOW_FN_PATTERN.matcher(expr).find();
+   }
+
    protected boolean mergeGroupBy() throws Exception {
       AggregateInfo info = getAggregateInfo();
       GroupRef[] groups = info.getGroups();
@@ -614,6 +639,15 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
 
          if(column.isVisible() && aggs.length > 0) {
             mergeAggregates(nselection, aggs);
+            gcolumns.addAttribute(column);
+         }
+         // A window expression column (e.g. RANK() OVER (ORDER BY SUM(x))) is neither a GROUP BY
+         // dimension nor a standard aggregate. Emit it into the SELECT list as a plain expression
+         // (via mergeColumn, NOT mergeAggregates — so it is not flagged as an aggregate) and leave
+         // it OUT of the GROUP BY list (built below from info.getGroups() only). Without this it is
+         // silently dropped from the SELECT when the table also carries group/aggregates.
+         else if(column.isVisible() && group == null && isWindowExpression(column)) {
+            mergeColumn(nselection, column);
             gcolumns.addAttribute(column);
          }
 

--- a/core/src/main/java/inetsoft/uql/jdbc/AccessSQLHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/AccessSQLHelper.java
@@ -39,6 +39,15 @@ public class AccessSQLHelper extends SQLHelper {
       return "access";
    }
 
+   @Override
+   public boolean supportsOperation(String op) {
+      if(WINDOW_FUNCTION.equals(op)) {
+         return false;
+      }
+
+      return super.supportsOperation(op);
+   }
+
    /**
     * Get the order by column of a field.
     */

--- a/core/src/main/java/inetsoft/uql/jdbc/DerbyHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/DerbyHelper.java
@@ -128,6 +128,10 @@ public class DerbyHelper extends SQLHelper {
     */
    @Override
    public boolean supportsOperation(String op) {
+      if(WINDOW_FUNCTION.equals(op)) {
+         return false;
+      }
+
       if(expgrp && EXPRESSION_GROUPBY.equals(op)) {
          return true;
       }

--- a/core/src/main/java/inetsoft/uql/jdbc/MongoHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/MongoHelper.java
@@ -47,6 +47,10 @@ public class MongoHelper extends SQLHelper {
 
    @Override
    public boolean supportsOperation(String op, String info) {
+      if(WINDOW_FUNCTION.equals(op)) {
+         return false;
+      }
+
       // nested queries with unity driver is very problematic. just do post processing for now.
       // (56329, 56311, 56313)
       if(MIRROR_TABLE.equals(op)) {

--- a/core/src/main/java/inetsoft/uql/jdbc/MySQLHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/MySQLHelper.java
@@ -76,6 +76,28 @@ public class MySQLHelper extends SQLHelper {
     */
    @Override
    public boolean supportsOperation(String op, String info) {
+      if(WINDOW_FUNCTION.equals(op)) {
+         JDBCDataSource wdx = uniformSql == null ? null : uniformSql.getDataSource();
+         String wver = wdx == null ? null : wdx.getProductVersion();
+
+         if(wver == null) {
+            return super.supportsOperation(op, info);   // can't prove too old -> permissive
+         }
+
+         // MariaDB reports via the MySQL protocol as "5.5.5-10.x.y-MariaDB"; strip the fake
+         // 5.5.5- prefix so we read the real major (10), not 5.
+         String v = wver.startsWith("5.5.5-") ? wver.substring(6) : wver;
+
+         try {
+            int major = Integer.parseInt(v.split("\\.")[0]);
+            // MySQL >= 8 and MariaDB >= 10 support window functions.
+            return major >= 8;
+         }
+         catch(Exception ex) {
+            return super.supportsOperation(op, info);   // unparseable -> permissive
+         }
+      }
+
       if(MAXROWS.equals(op) && WHERE_SUBQUERY.equals(info)) {
          return false;
       }

--- a/core/src/main/java/inetsoft/uql/jdbc/SQLHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/SQLHelper.java
@@ -128,6 +128,12 @@ public class SQLHelper implements KeywordProvider {
    public static final String GROUP_ORDERED = "group_ordered";
 
    /**
+    * SQL window function (OVER clause). Default = supported (ANSI SQL:2003); dialects without
+    * window functions override supportsOperation to gate it off, and MySQL version-gates it.
+    */
+   public static final String WINDOW_FUNCTION = "window_function";
+
+   /**
     * Year date function.
     */
    public static final String YEAR_FUNCTION = "year";

--- a/core/src/test/java/inetsoft/report/composition/execution/WindowExpressionDetectionTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/WindowExpressionDetectionTest.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.composition.execution;
+
+import inetsoft.test.*;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.ExpressionRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WindowExpressionDetectionTest {
+
+   private ColumnRef expressionColumn(String expr) {
+      ExpressionRef ref = new ExpressionRef(null, "name");
+      ref.setExpression(expr);
+      return new ColumnRef(ref);
+   }
+
+   @Test
+   void rowNumberOverIsWindowExpression() {
+      ColumnRef column = expressionColumn("ROW_NUMBER() OVER (ORDER BY field['x'] DESC)");
+      assertTrue(PreAssetQuery.isWindowExpression(column));
+   }
+
+   @Test
+   void plainAggregateExpressionIsNotWindowExpression() {
+      ColumnRef column = expressionColumn("SUM(field['x'])");
+      assertFalse(PreAssetQuery.isWindowExpression(column));
+   }
+
+   @Test
+   void nonExpressionColumnIsNotWindowExpression() {
+      ColumnRef column = new ColumnRef(new AttributeRef("x"));
+      assertFalse(PreAssetQuery.isWindowExpression(column));
+   }
+
+   @Test
+   void identifierContainingOverWithoutParenIsNotWindowExpression() {
+      ColumnRef column = expressionColumn("field['takeover']");
+      assertFalse(PreAssetQuery.isWindowExpression(column));
+   }
+
+   @Test
+   void nullColumnIsNotWindowExpression() {
+      assertFalse(PreAssetQuery.isWindowExpression(null));
+   }
+}

--- a/core/src/test/java/inetsoft/uql/jdbc/WindowFunctionCapabilityTest.java
+++ b/core/src/test/java/inetsoft/uql/jdbc/WindowFunctionCapabilityTest.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.jdbc;
+
+import inetsoft.test.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WindowFunctionCapabilityTest {
+
+   // ── ANSI-compliant dialects support it by default ──────────────────────
+
+   @Test
+   void postgreSQLSupportsWindowFunction() {
+      assertTrue(new PostgreSQLHelper().supportsOperation(SQLHelper.WINDOW_FUNCTION));
+   }
+
+   @Test
+   void oracleSupportsWindowFunction() {
+      assertTrue(new OracleSQLHelper().supportsOperation(SQLHelper.WINDOW_FUNCTION));
+   }
+
+   @Test
+   void db2SupportsWindowFunction() {
+      assertTrue(new DB2SQLHelper().supportsOperation(SQLHelper.WINDOW_FUNCTION));
+   }
+
+   // ── Dialects with no window function support gate it off ──────────────
+
+   @Test
+   void derbyDoesNotSupportWindowFunction() {
+      assertFalse(new DerbyHelper().supportsOperation(SQLHelper.WINDOW_FUNCTION));
+   }
+
+   @Test
+   void accessDoesNotSupportWindowFunction() {
+      assertFalse(new AccessSQLHelper().supportsOperation(SQLHelper.WINDOW_FUNCTION));
+   }
+
+   @Test
+   void mongoDoesNotSupportWindowFunction() {
+      assertFalse(new MongoHelper().supportsOperation(SQLHelper.WINDOW_FUNCTION));
+   }
+
+   // ── MySQL version gate ──────────────────────────────────────────────────
+   // NOTE: exercising the >= 8 / MariaDB >= 10 version gate requires a
+   // UniformSQL wired to a JDBCDataSource with a mocked getProductVersion().
+   // Per task brief, that mock is skipped here (kept minimal) — this is
+   // covered by the live check in a follow-on task instead. With no
+   // UniformSQL attached, uniformSql is null, so the helper falls back to
+   // the permissive super.supportsOperation(...) result (denylist default
+   // = supported).
+   @Test
+   void mySQLWithNoDataSourceFallsBackToPermissiveDefault() {
+      assertTrue(new MySQLHelper().supportsOperation(SQLHelper.WINDOW_FUNCTION));
+   }
+}


### PR DESCRIPTION
## Summary

StyleBI-core foundations for pushed-down window (analytic) functions. Two commits (base `stylebi-wiz-main-rebase`):

1. **`SQLHelper.WINDOW_FUNCTION` capability** — a per-dialect, version-gated capability flag so callers can ask whether a datasource supports window functions before emitting them (PostgreSQL/etc. yes; Derby and older MySQL/MariaDB gated by version). Includes `WindowFunctionCapabilityTest`.
2. **Emit window expression columns in SELECT over GROUP BY aggregates** — `PreAssetQuery` detects a window expression column and emits it in the SELECT alongside grouped aggregates (rather than trying to fold it into the GROUP BY). Includes `WindowExpressionDetectionTest`.

## Verification

Cherry-picked cleanly onto the current `stylebi-wiz-main-rebase` tip; `inetsoft-core` compiles and both tests pass (`WindowFunctionCapabilityTest` 7/7, `WindowExpressionDetectionTest` 5/5).

## Notes

This is the capability/query-gen layer the structured window node builds on. The structured `WindowExpressionRef` node (stylebi #4229) and the wiz forwarding (stylebi-wiz #1189) sit **on top** of this — recommended merge order: this → #4229 → #1189, all deploying together. #4229 was opened against a staging base branch (`feat/window-fn-phase2b`) that carries these same two commits; once this lands on `rebase`, #4229 can be retargeted onto `rebase`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
