### PR TITLE
ci: allow a GH_PACKAGES_TOKEN for cross-repo GitHub Packages in the PR build

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -46,8 +46,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-
 
+      # The workflow's repo-scoped GITHUB_TOKEN can only read GitHub Packages owned by / granted to
+      # this repo. The wiz-feature frontend (web/package.json) also depends on packages published by
+      # other repos — @inetsoft-technology/stylebi-wiz-ai-chat and stylebi-wiz-portal — which
+      # GITHUB_TOKEN cannot read, so `npm ci` fails (main is green because it doesn't need them).
+      #
+      # Fix requires ONE org/admin action, then this workflow uses it automatically:
+      #   Option A (no secret): grant this repo *Actions access* to those two packages
+      #     (each package -> Settings -> Manage Actions access -> add inetsoft-technology/stylebi).
+      #     GITHUB_TOKEN then reads them and the fallback below is sufficient.
+      #   Option B: add a secret GH_PACKAGES_TOKEN = a PAT (or app token) with read:packages for the
+      #     @inetsoft-technology scope. It is preferred here when present.
+      # Regression-safe: with neither in place this is identical to the previous GITHUB_TOKEN auth.
       - name: Authenticate with GitHub Packages
-        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
+        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}" >> ~/.npmrc
 
       - name: Build with Maven
         run: ./mvnw --batch-mode clean install


### PR DESCRIPTION
## Problem
The **Validation Build** fails at `npm ci` (frontend `web/`) for wiz-feature-line PRs (e.g. the window stack #4229/#4230/#4231). `web/package.json` on this line depends on two GitHub-Packages-scoped packages `main` does not have:

- `@inetsoft-technology/stylebi-wiz-ai-chat@^0.1.5`
- `@inetsoft-technology/stylebi-wiz-portal@^0.1.3`

npm auth uses the repo-scoped `secrets.GITHUB_TOKEN`, which can only read packages owned by / granted to this repo. It reads `@inetsoft-technology/ai-assistant` (why `main` is green) but **cannot read the two wiz packages** (published by other repos) → `npm ci` exits 1. Verified: `npm ci --prefer-offline` **succeeds locally** (2306 packages) with a PAT that has `read:packages`, so the lockfile/versions are valid — only the CI token's reach is the gap.

## This PR (regression-safe)
Prefer a `GH_PACKAGES_TOKEN` secret for the npm registry auth, falling back to `GITHUB_TOKEN` when absent — so it is a **no-op until an admin acts** (no build regression).

## ⚠️ Needs ONE admin action to actually turn CI green (either works)
- **Option A — no secret:** grant this repo *Actions access* to the two packages (each package → Settings → *Manage Actions access* → add `inetsoft-technology/stylebi`). Then `GITHUB_TOKEN` reads them and the fallback here suffices — this PR is then optional.
- **Option B — secret:** add `GH_PACKAGES_TOKEN` = a PAT (or app token) with `read:packages` for the `@inetsoft-technology` scope. This PR then uses it automatically.

Until one of those is done, this PR's own build still fails at `npm ci` (fallback = today's behavior).

_Note: I first tried minting a token from the existing release GitHub App (`actions/create-github-app-token` with `RELEASE_APP_ID`), but it returned **"Integration not found"**, so that lever isn't usable here._

🤖 Generated with [Claude Code](https://claude.com/claude-code)