### PR TITLE
feat(query): in-memory WindowTableLens for non-SQL window functions (Phase 2)

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -973,6 +973,9 @@ public abstract class AssetQuery extends PreAssetQuery {
          base = getRankingTableLens(base, vars);
       }
 
+      // compute window functions in-memory for non-pushdown sources (no-op when merged)
+      base = getWindowTableLens(base, vars);
+
       // get visible table lens
       base = getVisibleTableLens(base, vars);
 
@@ -1403,6 +1406,14 @@ public abstract class AssetQuery extends PreAssetQuery {
 
       for(int i = 0; i < columns.getAttributeCount(); i++) {
          ColumnRef column = (ColumnRef) columns.getAttribute(i);
+
+         // window-function columns are computed by getWindowTableLens (in-memory) or pushed
+         // down as SQL; never evaluate them as JS formula columns (addExpression fails loud
+         // on a WindowExpressionRef, since its emitted text is SQL, not JS).
+         if(column.getDataRef() instanceof WindowExpressionRef) {
+            continue;
+         }
+
          boolean groupedExpression = isGroupedExpression(column);
          columns0.addAttribute(column);
 
@@ -2929,6 +2940,136 @@ public abstract class AssetQuery extends PreAssetQuery {
       rtable.setTopRanking(condition.getOperation() == XCondition.TOP_N);
 
       return rtable;
+   }
+
+   /**
+    * Build WindowTableLens specs from the window-expression columns in a column selection,
+    * resolving each partitionBy/orderBy/arg ref to its index in that same selection. Returns an
+    * empty array if there are no window columns.
+    * <p>
+    * Package-private and static so it can be unit-tested directly (see WindowRoutingTest)
+    * without a live query.
+    * @param cols the column selection to scan for WindowExpressionRef columns.
+    * @return the resolved specs, one per window column, in selection order.
+    */
+   static WindowTableLens.Spec[] buildWindowSpecs(ColumnSelection cols) {
+      List<WindowTableLens.Spec> specs = new ArrayList<>();
+
+      for(int i = 0; i < cols.getAttributeCount(); i++) {
+         DataRef ref = cols.getAttribute(i);
+
+         if(!(ref instanceof ColumnRef)) {
+            continue;
+         }
+
+         DataRef base = ((ColumnRef) ref).getDataRef();
+
+         if(!(base instanceof WindowExpressionRef)) {
+            continue;
+         }
+
+         WindowExpressionRef w = (WindowExpressionRef) base;
+         int arg = w.getArgRef() == null ? -1 : indexOf(cols, w.getArgRef());
+         int[] parts = w.getPartitionBy().stream().mapToInt(p -> indexOf(cols, p)).toArray();
+         List<SortRef> obs = w.getOrderBy();
+         int[] ocols = new int[obs.size()];
+         boolean[] oasc = new boolean[obs.size()];
+
+         for(int k = 0; k < obs.size(); k++) {
+            ocols[k] = indexOf(cols, obs.get(k).getDataRef());
+            oasc[k] = obs.get(k).getOrder() == XConstants.SORT_ASC;
+         }
+
+         specs.add(new WindowTableLens.Spec(
+            ref.getName(), w.getFn(), arg, w.getN(), parts, ocols, oasc));
+      }
+
+      checkCompatiblePartitionAndOrder(specs);
+      return specs.toArray(new WindowTableLens.Spec[0]);
+   }
+
+   /**
+    * Fail loud if the collected specs declare mutually-incompatible non-empty PARTITION BY or
+    * ORDER BY grammars. WindowTableLens sorts its rows once, by the first spec that declares a
+    * partition/order (see WindowTableLens.partCols()/orderCols()) — two window columns on the
+    * same table with divergent (both non-empty but unequal) partitioning or ordering would
+    * silently mis-sort whichever one loses. Specs that all share the same partition/order, or
+    * where only one declares order (e.g. one running aggregate plus one partition-total
+    * aggregate), are the common case and remain allowed.
+    */
+   private static void checkCompatiblePartitionAndOrder(List<WindowTableLens.Spec> specs) {
+      int[] partition = null;
+      int[] orderCols = null;
+      boolean[] orderAsc = null;
+
+      for(WindowTableLens.Spec s : specs) {
+         if(s.partCols.length > 0) {
+            if(partition == null) {
+               partition = s.partCols;
+            }
+            else if(!Arrays.equals(partition, s.partCols)) {
+               throw new RuntimeException("In-memory window computation supports one " +
+                  "PARTITION BY/ORDER BY grammar per table (Phase 2); found divergent " +
+                  "PARTITION BY clauses among window columns on the same table.");
+            }
+         }
+
+         if(s.orderCols.length > 0) {
+            if(orderCols == null) {
+               orderCols = s.orderCols;
+               orderAsc = s.orderAsc;
+            }
+            else if(!Arrays.equals(orderCols, s.orderCols) || !Arrays.equals(orderAsc, s.orderAsc)) {
+               throw new RuntimeException("In-memory window computation supports one " +
+                  "PARTITION BY/ORDER BY grammar per table (Phase 2); found divergent " +
+                  "ORDER BY clauses among window columns on the same table.");
+            }
+         }
+      }
+   }
+
+   /** Index of the column in the selection matching ref by attribute (name), or -1. */
+   private static int indexOf(ColumnSelection cols, DataRef ref) {
+      String name = ref.getName();
+
+      for(int i = 0; i < cols.getAttributeCount(); i++) {
+         if(name != null && name.equals(cols.getAttribute(i).getName())) {
+            return i;
+         }
+      }
+
+      return -1;
+   }
+
+   /**
+    * In-memory window computation for non-pushdown sources. No-op when the query pushed the
+    * window down (mergeable JDBC) — the OVER is already in the SELECT. For a tabular /
+    * non-mergeable source, wrap the fully post-processed base in a WindowTableLens.
+    * @param base the specified base table.
+    * @param vars the specified variable table.
+    * @return the window table lens, or base unchanged if there is nothing to compute in-memory.
+    */
+   private TableLens getWindowTableLens(TableLens base, VariableTable vars) throws Exception {
+      // if the query merged (pushed down), the window is in the SQL SELECT already, nothing to do
+      if(isQueryMergeable(false)) {
+         return base;
+      }
+
+      ColumnSelection cols = getTable().getColumnSelection(false);
+      WindowTableLens.Spec[] specs = buildWindowSpecs(cols);
+
+      if(specs.length == 0) {
+         return base;
+      }
+
+      // guard: every referenced index must resolve in the post-processed base
+      for(WindowTableLens.Spec s : specs) {
+         if(s.argCol >= base.getColCount()) {
+            return base;
+         }
+      }
+
+      return new WindowTableLens(base, specs);
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -2969,8 +2969,10 @@ public abstract class AssetQuery extends PreAssetQuery {
          }
 
          WindowExpressionRef w = (WindowExpressionRef) base;
-         int arg = w.getArgRef() == null ? -1 : indexOf(cols, w.getArgRef());
-         int[] parts = w.getPartitionBy().stream().mapToInt(p -> indexOf(cols, p)).toArray();
+         DataRef argRef = w.getArgRef();
+         int arg = argRef == null ? -1 : indexOf(cols, argRef);
+         List<DataRef> partRefs = w.getPartitionBy();
+         int[] parts = partRefs.stream().mapToInt(p -> indexOf(cols, p)).toArray();
          List<SortRef> obs = w.getOrderBy();
          int[] ocols = new int[obs.size()];
          boolean[] oasc = new boolean[obs.size()];
@@ -2978,6 +2980,33 @@ public abstract class AssetQuery extends PreAssetQuery {
          for(int k = 0; k < obs.size(); k++) {
             ocols[k] = indexOf(cols, obs.get(k).getDataRef());
             oasc[k] = obs.get(k).getOrder() == XConstants.SORT_ASC;
+         }
+
+         // fail loud: an unresolved (-1) partitionBy/orderBy/argument ref must not silently
+         // flow into WindowTableLens, where it surfaces as a cryptic
+         // ArrayIndexOutOfBoundsException from table.getObject(row, -1). argCol == -1 is only
+         // an error when an argument was actually expected (argRef != null) — ROW_NUMBER/RANK
+         // legitimately have no argument and use -1 as the "no argument" sentinel.
+         if(argRef != null && arg < 0) {
+            throw new RuntimeException("Window column '" + ref.getName() +
+               "': could not resolve argument column '" + argRef.getName() +
+               "' in the query output");
+         }
+
+         for(int k = 0; k < parts.length; k++) {
+            if(parts[k] < 0) {
+               throw new RuntimeException("Window column '" + ref.getName() +
+                  "': could not resolve partitionBy column '" + partRefs.get(k).getName() +
+                  "' in the query output");
+            }
+         }
+
+         for(int k = 0; k < ocols.length; k++) {
+            if(ocols[k] < 0) {
+               throw new RuntimeException("Window column '" + ref.getName() +
+                  "': could not resolve orderBy column '" + obs.get(k).getDataRef().getName() +
+                  "' in the query output");
+            }
          }
 
          specs.add(new WindowTableLens.Spec(
@@ -3062,10 +3091,16 @@ public abstract class AssetQuery extends PreAssetQuery {
          return base;
       }
 
-      // guard: every referenced index must resolve in the post-processed base
+      // guard: every referenced index must resolve in the post-processed base. This is not a
+      // genuine no-op — it means a window column's argument couldn't be located in the base
+      // table actually produced for this query, so silently returning base would silently drop
+      // the window column instead of computing it. Fail loud instead.
       for(WindowTableLens.Spec s : specs) {
          if(s.argCol >= base.getColCount()) {
-            return base;
+            throw new RuntimeException("Window column '" + s.header +
+               "': argument column index " + s.argCol +
+               " is out of bounds for the post-processed base table (" +
+               base.getColCount() + " columns)");
          }
       }
 

--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -3018,21 +3018,28 @@ public abstract class AssetQuery extends PreAssetQuery {
    }
 
    /**
-    * Fail loud if the collected specs declare mutually-incompatible non-empty PARTITION BY or
-    * ORDER BY grammars. WindowTableLens sorts its rows once, by the first spec that declares a
+    * Fail loud if the collected specs declare mutually-incompatible PARTITION BY or ORDER BY
+    * grammars. WindowTableLens sorts its rows once, by the first spec that declares a
     * partition/order (see WindowTableLens.partCols()/orderCols()) — two window columns on the
-    * same table with divergent (both non-empty but unequal) partitioning or ordering would
-    * silently mis-sort whichever one loses. Specs that all share the same partition/order, or
-    * where only one declares order (e.g. one running aggregate plus one partition-total
-    * aggregate), are the common case and remain allowed.
+    * same table with divergent (both non-empty but unequal) partitioning would silently
+    * mis-sort whichever one loses, and non-uniform partition PRESENCE (some specs empty,
+    * others not) would silently apply the partitioned spec's grammar to the un-partitioned
+    * one (WindowTableLens.partCols() always returns the first non-empty partCols found).
+    * Non-uniform ORDER presence, by contrast, is the common and correct case (e.g. one
+    * running aggregate plus one partition-total aggregate) and remains allowed — only
+    * both-non-empty-and-unequal ORDER BY grammars throw.
     */
    private static void checkCompatiblePartitionAndOrder(List<WindowTableLens.Spec> specs) {
       int[] partition = null;
       int[] orderCols = null;
       boolean[] orderAsc = null;
+      boolean sawEmptyPartition = false;
+      boolean sawNonEmptyPartition = false;
 
       for(WindowTableLens.Spec s : specs) {
          if(s.partCols.length > 0) {
+            sawNonEmptyPartition = true;
+
             if(partition == null) {
                partition = s.partCols;
             }
@@ -3041,6 +3048,15 @@ public abstract class AssetQuery extends PreAssetQuery {
                   "PARTITION BY/ORDER BY grammar per table (Phase 2); found divergent " +
                   "PARTITION BY clauses among window columns on the same table.");
             }
+         }
+         else {
+            sawEmptyPartition = true;
+         }
+
+         if(sawEmptyPartition && sawNonEmptyPartition) {
+            throw new RuntimeException("in-memory window computation requires all window " +
+               "columns on a table to share the same PARTITION BY (mixing a global/" +
+               "un-partitioned window with a partitioned one is not supported in Phase 2)");
          }
 
          if(s.orderCols.length > 0) {

--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -2944,15 +2944,24 @@ public abstract class AssetQuery extends PreAssetQuery {
 
    /**
     * Build WindowTableLens specs from the window-expression columns in a column selection,
-    * resolving each partitionBy/orderBy/arg ref to its index in that same selection. Returns an
-    * empty array if there are no window columns.
+    * resolving each partitionBy/orderBy/arg ref to its index IN {@code base} — the runtime
+    * table the window lens will actually read. Returns an empty array if there are no window
+    * columns.
+    * <p>
+    * The column selection and {@code base} are DIFFERENT coordinate spaces: getFormulaTableLens
+    * skips WindowExpressionRef columns, so {@code base} does not contain the window columns at
+    * all, and a name-only index into the selection would silently point at the wrong base column
+    * (or out of bounds). We therefore resolve every ref against {@code base} with
+    * {@link AssetUtil#findColumn(XTable, DataRef)}, which matches by full identifier /
+    * entity+attribute / header (the codebase convention), not a bare name scan of the selection.
     * <p>
     * Package-private and static so it can be unit-tested directly (see WindowRoutingTest)
     * without a live query.
+    * @param base the runtime base table the WindowTableLens will wrap and read from.
     * @param cols the column selection to scan for WindowExpressionRef columns.
     * @return the resolved specs, one per window column, in selection order.
     */
-   static WindowTableLens.Spec[] buildWindowSpecs(ColumnSelection cols) {
+   static WindowTableLens.Spec[] buildWindowSpecs(XTable base, ColumnSelection cols) {
       List<WindowTableLens.Spec> specs = new ArrayList<>();
 
       for(int i = 0; i < cols.getAttributeCount(); i++) {
@@ -2962,31 +2971,32 @@ public abstract class AssetQuery extends PreAssetQuery {
             continue;
          }
 
-         DataRef base = ((ColumnRef) ref).getDataRef();
+         DataRef bref = ((ColumnRef) ref).getDataRef();
 
-         if(!(base instanceof WindowExpressionRef)) {
+         if(!(bref instanceof WindowExpressionRef)) {
             continue;
          }
 
-         WindowExpressionRef w = (WindowExpressionRef) base;
+         WindowExpressionRef w = (WindowExpressionRef) bref;
          DataRef argRef = w.getArgRef();
-         int arg = argRef == null ? -1 : indexOf(cols, argRef);
+         int arg = argRef == null ? -1 : AssetUtil.findColumn(base, argRef);
          List<DataRef> partRefs = w.getPartitionBy();
-         int[] parts = partRefs.stream().mapToInt(p -> indexOf(cols, p)).toArray();
+         int[] parts = partRefs.stream().mapToInt(p -> AssetUtil.findColumn(base, p)).toArray();
          List<SortRef> obs = w.getOrderBy();
          int[] ocols = new int[obs.size()];
          boolean[] oasc = new boolean[obs.size()];
 
          for(int k = 0; k < obs.size(); k++) {
-            ocols[k] = indexOf(cols, obs.get(k).getDataRef());
+            ocols[k] = AssetUtil.findColumn(base, obs.get(k).getDataRef());
             oasc[k] = obs.get(k).getOrder() == XConstants.SORT_ASC;
          }
 
-         // fail loud: an unresolved (-1) partitionBy/orderBy/argument ref must not silently
-         // flow into WindowTableLens, where it surfaces as a cryptic
-         // ArrayIndexOutOfBoundsException from table.getObject(row, -1). argCol == -1 is only
-         // an error when an argument was actually expected (argRef != null) — ROW_NUMBER/RANK
-         // legitimately have no argument and use -1 as the "no argument" sentinel.
+         // fail loud: a ref that does not resolve in `base` (findColumn returns -1) must not
+         // silently flow into WindowTableLens, where it surfaces as a cryptic
+         // ArrayIndexOutOfBoundsException from table.getObject(row, -1) — or, worse, an in-range
+         // but WRONG index that reads a different column silently. argCol == -1 is only an error
+         // when an argument was actually expected (argRef != null) — ROW_NUMBER/RANK legitimately
+         // have no argument and use -1 as the "no argument" sentinel.
          if(argRef != null && arg < 0) {
             throw new RuntimeException("Window column '" + ref.getName() +
                "': could not resolve argument column '" + argRef.getName() +
@@ -3073,17 +3083,28 @@ public abstract class AssetQuery extends PreAssetQuery {
       }
    }
 
-   /** Index of the column in the selection matching ref by attribute (name), or -1. */
-   private static int indexOf(ColumnSelection cols, DataRef ref) {
-      String name = ref.getName();
+   /**
+    * Resolve the window columns in {@code cols} against {@code base} and, if any exist, wrap
+    * {@code base} in a WindowTableLens that computes them in memory. All partitionBy/orderBy/arg
+    * indices are resolved against {@code base} (see {@link #buildWindowSpecs(XTable, ColumnSelection)})
+    * and validated there (unresolved refs throw a named RuntimeException), so a spec reaching the
+    * lens is guaranteed to reference only valid base columns — no cryptic downstream AIOOBE.
+    * <p>
+    * Package-private and static so it can be exercised as an integration seam (base coordinate
+    * space + value computation) without a live query — see WindowRoutingTest.
+    * @param base the fully post-processed runtime base table.
+    * @param cols the output column selection (source of the WindowExpressionRef columns).
+    * @return {@code base} wrapped in a WindowTableLens, or {@code base} unchanged when there are
+    *         no window columns to compute.
+    */
+   static TableLens buildWindowLens(TableLens base, ColumnSelection cols) {
+      WindowTableLens.Spec[] specs = buildWindowSpecs(base, cols);
 
-      for(int i = 0; i < cols.getAttributeCount(); i++) {
-         if(name != null && name.equals(cols.getAttribute(i).getName())) {
-            return i;
-         }
+      if(specs.length == 0) {
+         return base;
       }
 
-      return -1;
+      return new WindowTableLens(base, specs);
    }
 
    /**
@@ -3100,27 +3121,7 @@ public abstract class AssetQuery extends PreAssetQuery {
          return base;
       }
 
-      ColumnSelection cols = getTable().getColumnSelection(false);
-      WindowTableLens.Spec[] specs = buildWindowSpecs(cols);
-
-      if(specs.length == 0) {
-         return base;
-      }
-
-      // guard: every referenced index must resolve in the post-processed base. This is not a
-      // genuine no-op — it means a window column's argument couldn't be located in the base
-      // table actually produced for this query, so silently returning base would silently drop
-      // the window column instead of computing it. Fail loud instead.
-      for(WindowTableLens.Spec s : specs) {
-         if(s.argCol >= base.getColCount()) {
-            throw new RuntimeException("Window column '" + s.header +
-               "': argument column index " + s.argCol +
-               " is out of bounds for the post-processed base table (" +
-               base.getColCount() + " columns)");
-         }
-      }
-
-      return new WindowTableLens(base, specs);
+      return buildWindowLens(base, getTable().getColumnSelection(false));
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
+++ b/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
@@ -289,7 +289,7 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
          // rank of a tie = position of the first row sharing its order key
          int first = p;
 
-         while(first > 0 && orderKeyCompare(idx[start + first - 1], idx[start + p]) == 0) {
+         while(first > 0 && orderKeyCompare(spec, idx[start + first - 1], idx[start + p]) == 0) {
             first--;
          }
 
@@ -299,7 +299,7 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
          int dr = 1;
 
          for(int q = 1; q <= p; q++) {
-            if(orderKeyCompare(idx[start + q - 1], idx[start + q]) != 0) {
+            if(orderKeyCompare(spec, idx[start + q - 1], idx[start + q]) != 0) {
                dr++;
             }
          }
@@ -375,7 +375,7 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
          int sz = end - start;
          int first = p;
 
-         while(first > 0 && orderKeyCompare(idx[start + first - 1], idx[start + p]) == 0) {
+         while(first > 0 && orderKeyCompare(spec, idx[start + first - 1], idx[start + p]) == 0) {
             first--;
          }
 
@@ -385,7 +385,7 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
          int sz = end - start;
          int last = p;   // number of rows with order key <= current, minus 1
 
-         while(last + 1 < sz && orderKeyCompare(idx[start + last + 1], idx[start + p]) == 0) {
+         while(last + 1 < sz && orderKeyCompare(spec, idx[start + last + 1], idx[start + p]) == 0) {
             last++;
          }
 
@@ -396,11 +396,19 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
       }
    }
 
-   /** Compare two data rows (0-based) by the order-by key only (0 = same order key = tie). */
-   private int orderKeyCompare(int a, int b) {
+   /**
+    * Compare two data rows (0-based) by the ORDER BY key of a SPECIFIC spec (0 = same order key
+    * = tie). Rank/dist kernels must tie on their OWN order, not the table-shared order: a
+    * RANK/DENSE_RANK/PERCENT_RANK/CUME_DIST window with NO ORDER BY ties the whole partition
+    * (spec.orderCols is empty → the loop below never runs → always 0), even when it shares the
+    * lens with an ordered running aggregate. When the spec's own order is non-empty it equals
+    * the table-shared order (divergent non-empty orders are rejected upstream in
+    * AssetQuery.checkCompatiblePartitionAndOrder), so no behavior changes for ordered specs.
+    */
+   private int orderKeyCompare(Spec spec, int a, int b) {
       int hrows = table.getHeaderRowCount();
-      int[] ocols = orderCols();
-      boolean[] oasc = orderAsc();
+      int[] ocols = spec.orderCols;
+      boolean[] oasc = spec.orderAsc;
 
       for(int i = 0; i < ocols.length; i++) {
          int r = Tool.compare(table.getObject(a + hrows, ocols[i]), table.getObject(b + hrows, ocols[i]), true, true);

--- a/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
+++ b/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
@@ -318,8 +318,23 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
 
          return bucket;
       }
+      case "LAG": case "LEAD": {
+         int off = spec.n > 0 ? spec.n : 1;
+         int q = spec.fn.equals("LAG") ? p - off : p + off;
+
+         if(q < 0 || q >= (end - start)) {
+            return null;
+         }
+
+         int hrows = table.getHeaderRowCount();
+         return table.getObject(idx[start + q] + hrows, spec.argCol);
+      }
+      case "FIRST_VALUE": {
+         int hrows = table.getHeaderRowCount();
+         return table.getObject(idx[start] + hrows, spec.argCol);
+      }
       default:
-         return null;   // other kernels added in Tasks 2-4
+         return null;   // other kernels added in Task 4
       }
    }
 

--- a/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
+++ b/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
@@ -126,9 +126,12 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
       switch(fn) {
       case "ROW_NUMBER": case "RANK": case "DENSE_RANK": case "NTILE": case "COUNT":
          return Integer.class;
-      case "PERCENT_RANK": case "CUME_DIST": case "AVG":
+      case "PERCENT_RANK": case "CUME_DIST": case "AVG": case "SUM": case "MIN": case "MAX":
+         // the kernels for these always return boxed Double (see kernel()), regardless of the
+         // argument column's declared type — reporting the true runtime type here avoids a
+         // downstream ClassCastException from a consumer that casts on the declared col type.
          return Double.class;
-      default: // LAG/LEAD/FIRST_VALUE/SUM/MIN/MAX → follow the argument column type
+      default: // LAG/LEAD/FIRST_VALUE → return the original object, so its type is correct
          int a = specs[col - ncols].argCol;
          return a >= 0 ? table.getColType(a) : Double.class;
       }
@@ -146,7 +149,10 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
          return specs[col - ncols].header;   // header cell
       }
 
-      validate();
+      if(!validated) {
+         validate();
+      }
+
       return computed[col - ncols][row - hrows];
    }
 

--- a/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
+++ b/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
@@ -1,0 +1,292 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.lens;
+
+import inetsoft.report.TableFilter;
+import inetsoft.report.TableLens;
+import inetsoft.util.Tool;
+
+import java.util.Arrays;
+
+/**
+ * In-memory SQL-window-function engine. Given a base {@link TableLens} and a set of
+ * {@link Spec} window columns (resolved to base column indices), appends one computed column
+ * per window function, computed over the rows sorted by (partitionBy…, orderBy…) and reset at
+ * each partition boundary. Base columns are presented unchanged in base row order.
+ *
+ * Used only on the non-pushdown (tabular / non-mergeable) path — see
+ * AssetQuery.getWindowTableLens. For a mergeable JDBC source the OVER is pushed down and this
+ * lens is never constructed.
+ */
+public class WindowTableLens extends AbstractTableLens implements TableFilter {
+   /** One window column: {@code fn(argCol) OVER (PARTITION BY partCols ORDER BY orderCols)}. */
+   public static final class Spec {
+      public final String header;
+      public final String fn;        // ROW_NUMBER … MAX (upper-case)
+      public final int argCol;       // base col index of the argument, or -1
+      public final int n;            // NTILE bucket count / LAG-LEAD offset; 0 = unset
+      public final int[] partCols;   // PARTITION BY base col indices (may be empty)
+      public final int[] orderCols;  // ORDER BY base col indices (may be empty)
+      public final boolean[] orderAsc;
+
+      public Spec(String header, String fn, int argCol, int n,
+                  int[] partCols, int[] orderCols, boolean[] orderAsc) {
+         this.header = header;
+         this.fn = fn == null ? "" : fn.toUpperCase();
+         this.argCol = argCol;
+         this.n = n;
+         this.partCols = partCols == null ? new int[0] : partCols;
+         this.orderCols = orderCols == null ? new int[0] : orderCols;
+         this.orderAsc = orderAsc == null ? new boolean[0] : orderAsc;
+      }
+   }
+
+   public WindowTableLens(TableLens table, Spec[] specs) {
+      super();
+      this.table = table;
+      this.specs = specs == null ? new Spec[0] : specs;
+      this.ncols = table.getColCount();
+   }
+
+   @Override
+   public TableLens getTable() {
+      return table;
+   }
+
+   @Override
+   public void setTable(TableLens table) {
+      this.table = table;
+      invalidate();
+   }
+
+   @Override
+   public synchronized void invalidate() {
+      validated = false;
+      computed = null;
+   }
+
+   @Override
+   public int getBaseRowIndex(int row) {
+      return row;   // base order preserved
+   }
+
+   @Override
+   public int getBaseColIndex(int col) {
+      return col < ncols ? col : -1;
+   }
+
+   @Override
+   public int getColCount() {
+      return ncols + specs.length;
+   }
+
+   @Override
+   public int getRowCount() {
+      return table.getRowCount();
+   }
+
+   @Override
+   public boolean moreRows(int row) {
+      return table.moreRows(row);
+   }
+
+   @Override
+   public int getHeaderRowCount() {
+      return table.getHeaderRowCount();
+   }
+
+   @Override
+   public int getHeaderColCount() {
+      return table.getHeaderColCount();
+   }
+
+   @Override
+   public Class<?> getColType(int col) {
+      if(col < ncols) {
+         return table.getColType(col);
+      }
+
+      String fn = specs[col - ncols].fn;
+
+      switch(fn) {
+      case "ROW_NUMBER": case "RANK": case "DENSE_RANK": case "NTILE": case "COUNT":
+         return Integer.class;
+      case "PERCENT_RANK": case "CUME_DIST": case "AVG":
+         return Double.class;
+      default: // LAG/LEAD/FIRST_VALUE/SUM/MIN/MAX → follow the argument column type
+         int a = specs[col - ncols].argCol;
+         return a >= 0 ? table.getColType(a) : Double.class;
+      }
+   }
+
+   @Override
+   public Object getObject(int row, int col) {
+      int hrows = table.getHeaderRowCount();
+
+      if(col < ncols) {
+         return table.getObject(row, col);
+      }
+
+      if(row < hrows) {
+         return specs[col - ncols].header;   // header cell
+      }
+
+      validate();
+      return computed[col - ncols][row - hrows];
+   }
+
+   // ── materialization ───────────────────────────────────────────────────────
+   private synchronized void validate() {
+      if(validated) {
+         return;
+      }
+
+      table.moreRows(TableLens.EOT);
+      final int hrows = table.getHeaderRowCount();
+      final int nrows = Math.max(0, table.getRowCount() - hrows);   // data rows
+
+      // sorted index of data rows: partition keys first (asc), then order keys (per dir)
+      Integer[] idx = new Integer[nrows];
+
+      for(int i = 0; i < nrows; i++) {
+         idx[i] = i;
+      }
+
+      Arrays.sort(idx, this::compareRows);
+
+      computed = new Object[specs.length][nrows];
+
+      // walk partitions (a run of equal partition-key in sorted order)
+      int start = 0;
+
+      while(start < nrows) {
+         int end = start + 1;
+
+         while(end < nrows && samePartition(idx[start], idx[end])) {
+            end++;
+         }
+
+         computePartition(idx, start, end);   // [start,end) is one partition, in order
+         start = end;
+      }
+
+      validated = true;
+   }
+
+   private int compareRows(int a, int b) {
+      int hrows = table.getHeaderRowCount();
+
+      for(int c : partCols()) {           // partition cols always ascending
+         int r = Tool.compare(table.getObject(a + hrows, c), table.getObject(b + hrows, c), true, true);
+
+         if(r != 0) {
+            return r;
+         }
+      }
+
+      // order cols: any spec's orderBy — Phase-2 assumption: all window specs on a table
+      // share compatible partition/order OR we sort per the FIRST spec that defines order.
+      // Kernels that need a different order recompute their own key (see RANK/running).
+      int[] ocols = orderCols();
+      boolean[] oasc = orderAsc();
+
+      for(int i = 0; i < ocols.length; i++) {
+         int r = Tool.compare(table.getObject(a + hrows, ocols[i]), table.getObject(b + hrows, ocols[i]), true, true);
+
+         if(r != 0) {
+            return oasc[i] ? r : -r;
+         }
+      }
+
+      return Integer.compare(a, b);       // stable
+   }
+
+   private boolean samePartition(int a, int b) {
+      int hrows = table.getHeaderRowCount();
+
+      for(int c : partCols()) {
+         if(Tool.compare(table.getObject(a + hrows, c), table.getObject(b + hrows, c), true, true) != 0) {
+            return false;
+         }
+      }
+
+      return true;
+   }
+
+   // partition/order columns are shared across specs in Phase 2 (single window grammar per table);
+   // use the first spec that declares them.
+   private int[] partCols() {
+      for(Spec s : specs) {
+         if(s.partCols.length > 0) {
+            return s.partCols;
+         }
+      }
+
+      return new int[0];
+   }
+
+   private int[] orderCols() {
+      for(Spec s : specs) {
+         if(s.orderCols.length > 0) {
+            return s.orderCols;
+         }
+      }
+
+      return new int[0];
+   }
+
+   private boolean[] orderAsc() {
+      for(Spec s : specs) {
+         if(s.orderCols.length > 0) {
+            return s.orderAsc;
+         }
+      }
+
+      return new boolean[0];
+   }
+
+   /** Compute every spec for one partition given as sorted data-row indices idx[start..end). */
+   private void computePartition(Integer[] idx, int start, int end) {
+      int size = end - start;
+
+      for(int s = 0; s < specs.length; s++) {
+         Spec spec = specs[s];
+
+         for(int p = 0; p < size; p++) {
+            int baseRow = idx[start + p];               // 0-based data row
+            computed[s][baseRow] = kernel(spec, idx, start, end, p);
+         }
+      }
+   }
+
+   /** Per-fn value for the row at sorted position {@code p} within partition [start,end). */
+   private Object kernel(Spec spec, Integer[] idx, int start, int end, int p) {
+      switch(spec.fn) {
+      case "ROW_NUMBER":
+         return p + 1;
+      default:
+         return null;   // other kernels added in Tasks 2-4
+      }
+   }
+
+   private TableLens table;
+   private final Spec[] specs;
+   private final int ncols;
+   private volatile boolean validated;
+   private Object[][] computed;   // [specIndex][dataRow]
+}

--- a/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
+++ b/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
@@ -392,7 +392,12 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
          return ((double) (last + 1)) / sz;
       }
       default:
-         return null;
+         // Fail loud rather than silently returning null for every row. Every window function this
+         // lens supports has an explicit case above; anything else (e.g. LAST_VALUE, which the SQL
+         // path emits but the in-memory path cannot without a frame clause, or an unknown fn) must
+         // not be silently mis-computed on the in-memory path.
+         throw new RuntimeException(
+            "window function '" + spec.fn + "' is not supported for in-memory computation");
       }
    }
 

--- a/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
+++ b/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
@@ -333,8 +333,60 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
          int hrows = table.getHeaderRowCount();
          return table.getObject(idx[start] + hrows, spec.argCol);
       }
+      case "SUM": case "AVG": case "COUNT": case "MIN": case "MAX": {
+         // running vs. whole-partition is per-spec (this spec's own ORDER BY presence),
+         // not the table-wide sort order — a table may mix an ordered running aggregate
+         // with an order-less partition-total aggregate (see WindowTableLensTest).
+         boolean running = spec.orderCols.length > 0;
+         int from = start, to = running ? (start + p + 1) : end;   // running → up to current row
+         int hrows = table.getHeaderRowCount();
+         double sum = 0, min = Double.POSITIVE_INFINITY, max = Double.NEGATIVE_INFINITY;
+         int cnt = 0;
+
+         for(int q = from; q < to; q++) {
+            Object v = table.getObject(idx[q] + hrows, spec.argCol);
+
+            if(v == null) {
+               continue;
+            }
+
+            double d = ((Number) v).doubleValue();
+            sum += d;
+            cnt++;
+            min = Math.min(min, d);
+            max = Math.max(max, d);
+         }
+
+         switch(spec.fn) {
+         case "COUNT": return cnt;
+         case "SUM":   return sum;
+         case "AVG":   return cnt == 0 ? null : sum / cnt;
+         case "MIN":   return cnt == 0 ? null : min;
+         default:      return cnt == 0 ? null : max;   // MAX
+         }
+      }
+      case "PERCENT_RANK": {
+         int sz = end - start;
+         int first = p;
+
+         while(first > 0 && orderKeyCompare(idx[start + first - 1], idx[start + p]) == 0) {
+            first--;
+         }
+
+         return sz <= 1 ? 0.0 : ((double) first) / (sz - 1);   // (rank-1)/(n-1)
+      }
+      case "CUME_DIST": {
+         int sz = end - start;
+         int last = p;   // number of rows with order key <= current, minus 1
+
+         while(last + 1 < sz && orderKeyCompare(idx[start + last + 1], idx[start + p]) == 0) {
+            last++;
+         }
+
+         return ((double) (last + 1)) / sz;
+      }
       default:
-         return null;   // other kernels added in Task 4
+         return null;
       }
    }
 

--- a/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
+++ b/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
@@ -279,9 +279,65 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
       switch(spec.fn) {
       case "ROW_NUMBER":
          return p + 1;
+      case "RANK": {
+         // rank of a tie = position of the first row sharing its order key
+         int first = p;
+
+         while(first > 0 && orderKeyCompare(idx[start + first - 1], idx[start + p]) == 0) {
+            first--;
+         }
+
+         return first + 1;
+      }
+      case "DENSE_RANK": {
+         int dr = 1;
+
+         for(int q = 1; q <= p; q++) {
+            if(orderKeyCompare(idx[start + q - 1], idx[start + q]) != 0) {
+               dr++;
+            }
+         }
+
+         return dr;
+      }
+      case "NTILE": {
+         int size = end - start;
+         int k = Math.max(1, spec.n);
+         int base = size / k, rem = size % k;   // first `rem` buckets get one extra (front-loaded)
+         int bucket, cum = 0;
+
+         for(bucket = 1; bucket <= k; bucket++) {
+            int bsize = base + (bucket <= rem ? 1 : 0);
+
+            if(p < cum + bsize) {
+               break;
+            }
+
+            cum += bsize;
+         }
+
+         return bucket;
+      }
       default:
          return null;   // other kernels added in Tasks 2-4
       }
+   }
+
+   /** Compare two data rows (0-based) by the order-by key only (0 = same order key = tie). */
+   private int orderKeyCompare(int a, int b) {
+      int hrows = table.getHeaderRowCount();
+      int[] ocols = orderCols();
+      boolean[] oasc = orderAsc();
+
+      for(int i = 0; i < ocols.length; i++) {
+         int r = Tool.compare(table.getObject(a + hrows, ocols[i]), table.getObject(b + hrows, ocols[i]), true, true);
+
+         if(r != 0) {
+            return oasc[i] ? r : -r;
+         }
+      }
+
+      return 0;
    }
 
    private TableLens table;

--- a/core/src/test/java/inetsoft/report/composition/execution/WindowRoutingTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/WindowRoutingTest.java
@@ -1,0 +1,136 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.composition.execution;
+
+import inetsoft.report.lens.WindowTableLens;
+import inetsoft.test.*;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.SortRef;
+import inetsoft.uql.asset.WindowExpressionRef;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link AssetQuery#buildWindowSpecs(ColumnSelection)} — the resolver that
+ * translates {@link WindowExpressionRef} columns in a column selection into
+ * {@link WindowTableLens.Spec} instances (base-column indices) for the in-memory window
+ * routing stage ({@code AssetQuery.getWindowTableLens}).
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WindowRoutingTest {
+   @Test
+   void buildsSpecsFromWindowColumnsResolvingIndices() {
+      // output columns: [stage(0), amount(1), rn(2 = ROW_NUMBER OVER(PARTITION BY stage ORDER BY amount DESC))]
+      ColumnRef stage = new ColumnRef(new AttributeRef(null, "stage"));
+      ColumnRef amount = new ColumnRef(new AttributeRef(null, "amount"));
+      WindowExpressionRef win = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0,
+         List.of(new ColumnRef(new AttributeRef(null, "stage"))),
+         List.of(desc(new ColumnRef(new AttributeRef(null, "amount")))));
+      win.setName("rn");
+      ColumnRef rn = new ColumnRef(win);
+      rn.setSQL(true);
+
+      ColumnSelection cols = new ColumnSelection();
+      cols.addAttribute(stage);
+      cols.addAttribute(amount);
+      cols.addAttribute(rn);
+
+      WindowTableLens.Spec[] specs = AssetQuery.buildWindowSpecs(cols);
+
+      assertEquals(1, specs.length);
+      assertEquals("rn", specs[0].header);
+      assertEquals("ROW_NUMBER", specs[0].fn);
+      assertArrayEquals(new int[]{0}, specs[0].partCols);   // stage -> col 0
+      assertArrayEquals(new int[]{1}, specs[0].orderCols);  // amount -> col 1
+      assertArrayEquals(new boolean[]{false}, specs[0].orderAsc);
+      assertEquals(-1, specs[0].argCol);                    // ROW_NUMBER has none
+   }
+
+   @Test
+   void noWindowColumnsYieldsEmptySpecs() {
+      ColumnSelection cols = new ColumnSelection();
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+
+      WindowTableLens.Spec[] specs = AssetQuery.buildWindowSpecs(cols);
+
+      assertEquals(0, specs.length);
+   }
+
+   @Test
+   void divergentOrderByAcrossSpecsThrows() {
+      // Two window columns on the same table with different, non-empty ORDER BY grammars —
+      // WindowTableLens shares a single partition/order across all specs in a table (Phase 2),
+      // so this must fail loud rather than silently mis-sort the second column.
+      ColumnRef stage = new ColumnRef(new AttributeRef(null, "stage"));
+      ColumnRef amount = new ColumnRef(new AttributeRef(null, "amount"));
+      ColumnRef qty = new ColumnRef(new AttributeRef(null, "qty"));
+
+      WindowExpressionRef win1 = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0, List.of(),
+         List.of(desc(new ColumnRef(new AttributeRef(null, "amount")))));
+      win1.setName("rn1");
+      ColumnRef rn1 = new ColumnRef(win1);
+      rn1.setSQL(true);
+
+      WindowExpressionRef win2 = new WindowExpressionRef(
+         "RANK", null, 0, List.of(),
+         List.of(asc(new ColumnRef(new AttributeRef(null, "qty")))));
+      win2.setName("rn2");
+      ColumnRef rn2 = new ColumnRef(win2);
+      rn2.setSQL(true);
+
+      ColumnSelection cols = new ColumnSelection();
+      cols.addAttribute(stage);
+      cols.addAttribute(amount);
+      cols.addAttribute(qty);
+      cols.addAttribute(rn1);
+      cols.addAttribute(rn2);
+
+      assertThrows(RuntimeException.class, () -> AssetQuery.buildWindowSpecs(cols));
+   }
+
+   private static SortRef desc(DataRef ref) {
+      SortRef s = new SortRef(ref);
+      s.setOrder(XConstants.SORT_DESC);
+      return s;
+   }
+
+   private static SortRef asc(DataRef ref) {
+      SortRef s = new SortRef(ref);
+      s.setOrder(XConstants.SORT_ASC);
+      return s;
+   }
+}

--- a/core/src/test/java/inetsoft/report/composition/execution/WindowRoutingTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/WindowRoutingTest.java
@@ -122,6 +122,56 @@ class WindowRoutingTest {
       assertThrows(RuntimeException.class, () -> AssetQuery.buildWindowSpecs(cols));
    }
 
+   @Test
+   void unresolvedPartitionByColumnThrows() {
+      // partitionBy references "missing", which is not in the column selection — buildWindowSpecs
+      // must fail loud with a named error instead of letting a -1 index flow into
+      // WindowTableLens and surface as a cryptic ArrayIndexOutOfBoundsException later.
+      ColumnRef stage = new ColumnRef(new AttributeRef(null, "stage"));
+      ColumnRef amount = new ColumnRef(new AttributeRef(null, "amount"));
+      WindowExpressionRef win = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0,
+         List.of(new ColumnRef(new AttributeRef(null, "missing"))),
+         List.of(desc(new ColumnRef(new AttributeRef(null, "amount")))));
+      win.setName("rn");
+      ColumnRef rn = new ColumnRef(win);
+      rn.setSQL(true);
+
+      ColumnSelection cols = new ColumnSelection();
+      cols.addAttribute(stage);
+      cols.addAttribute(amount);
+      cols.addAttribute(rn);
+
+      RuntimeException ex = assertThrows(RuntimeException.class,
+         () -> AssetQuery.buildWindowSpecs(cols));
+      assertTrue(ex.getMessage().contains("missing"));
+      assertTrue(ex.getMessage().contains("rn"));
+   }
+
+   @Test
+   void unresolvedOrderByColumnThrows() {
+      // orderBy references "missing", which is not in the column selection.
+      ColumnRef stage = new ColumnRef(new AttributeRef(null, "stage"));
+      ColumnRef amount = new ColumnRef(new AttributeRef(null, "amount"));
+      WindowExpressionRef win = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0,
+         List.of(new ColumnRef(new AttributeRef(null, "stage"))),
+         List.of(desc(new ColumnRef(new AttributeRef(null, "missing")))));
+      win.setName("rn");
+      ColumnRef rn = new ColumnRef(win);
+      rn.setSQL(true);
+
+      ColumnSelection cols = new ColumnSelection();
+      cols.addAttribute(stage);
+      cols.addAttribute(amount);
+      cols.addAttribute(rn);
+
+      RuntimeException ex = assertThrows(RuntimeException.class,
+         () -> AssetQuery.buildWindowSpecs(cols));
+      assertTrue(ex.getMessage().contains("missing"));
+      assertTrue(ex.getMessage().contains("rn"));
+   }
+
    private static SortRef desc(DataRef ref) {
       SortRef s = new SortRef(ref);
       s.setOrder(XConstants.SORT_DESC);

--- a/core/src/test/java/inetsoft/report/composition/execution/WindowRoutingTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/WindowRoutingTest.java
@@ -17,6 +17,8 @@
  */
 package inetsoft.report.composition.execution;
 
+import inetsoft.report.TableLens;
+import inetsoft.report.lens.DefaultTableLens;
 import inetsoft.report.lens.WindowTableLens;
 import inetsoft.test.*;
 import inetsoft.uql.ColumnSelection;
@@ -38,10 +40,16 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Unit tests for {@link AssetQuery#buildWindowSpecs(ColumnSelection)} — the resolver that
- * translates {@link WindowExpressionRef} columns in a column selection into
- * {@link WindowTableLens.Spec} instances (base-column indices) for the in-memory window
- * routing stage ({@code AssetQuery.getWindowTableLens}).
+ * Unit tests for the in-memory window routing stage in {@link AssetQuery}:
+ * {@link AssetQuery#buildWindowSpecs(inetsoft.uql.XTable, ColumnSelection)} — the resolver that
+ * translates {@link WindowExpressionRef} columns into {@link WindowTableLens.Spec} instances
+ * (base-column indices) — and {@link AssetQuery#buildWindowLens(TableLens, ColumnSelection)},
+ * the seam that resolves-against-base + wraps the base in a {@link WindowTableLens}.
+ * <p>
+ * The critical invariant under test: partitionBy/orderBy/arg indices are resolved against the
+ * runtime {@code base} table (which does NOT contain the window columns), NOT against the output
+ * column selection (which does). The two are different coordinate spaces; resolving against the
+ * selection reads the wrong base column or runs off the end.
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
@@ -49,11 +57,46 @@ import static org.junit.jupiter.api.Assertions.*;
 @SreeHome
 @Tag("core")
 class WindowRoutingTest {
+   /** Base table [stage(0,String), amount(1,Double)] — does NOT contain any window column. */
+   private static DefaultTableLens stageAmountBase() {
+      Object[][] data = {
+         {"stage", "amount"},
+         {"A", 30.0},
+         {"A", 10.0},
+         {"A", 20.0},
+         {"B", 5.0},
+      };
+      DefaultTableLens t = new DefaultTableLens(data);
+      t.setHeaderRowCount(1);
+      t.setColumnIdentifier(0, "stage");
+      t.setColumnIdentifier(1, "amount");
+      return t;
+   }
+
+   /** Base table [stage(0), amount(1), qty(2)]. */
+   private static DefaultTableLens stageAmountQtyBase() {
+      Object[][] data = {
+         {"stage", "amount", "qty"},
+         {"A", 30.0, 1.0},
+         {"B", 5.0, 2.0},
+      };
+      DefaultTableLens t = new DefaultTableLens(data);
+      t.setHeaderRowCount(1);
+      t.setColumnIdentifier(0, "stage");
+      t.setColumnIdentifier(1, "amount");
+      t.setColumnIdentifier(2, "qty");
+      return t;
+   }
+
+   private static Object cell(TableLens t, int dataRow, int col) {
+      return t.getObject(dataRow + t.getHeaderRowCount(), col);
+   }
+
    @Test
-   void buildsSpecsFromWindowColumnsResolvingIndices() {
-      // output columns: [stage(0), amount(1), rn(2 = ROW_NUMBER OVER(PARTITION BY stage ORDER BY amount DESC))]
-      ColumnRef stage = new ColumnRef(new AttributeRef(null, "stage"));
-      ColumnRef amount = new ColumnRef(new AttributeRef(null, "amount"));
+   void buildsSpecsFromWindowColumnsResolvingIndicesAgainstBase() {
+      // base: [stage(0), amount(1)]; output selection additionally carries
+      // rn = ROW_NUMBER OVER(PARTITION BY stage ORDER BY amount DESC).
+      DefaultTableLens base = stageAmountBase();
       WindowExpressionRef win = new WindowExpressionRef(
          "ROW_NUMBER", null, 0,
          List.of(new ColumnRef(new AttributeRef(null, "stage"))),
@@ -63,17 +106,17 @@ class WindowRoutingTest {
       rn.setSQL(true);
 
       ColumnSelection cols = new ColumnSelection();
-      cols.addAttribute(stage);
-      cols.addAttribute(amount);
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
       cols.addAttribute(rn);
 
-      WindowTableLens.Spec[] specs = AssetQuery.buildWindowSpecs(cols);
+      WindowTableLens.Spec[] specs = AssetQuery.buildWindowSpecs(base, cols);
 
       assertEquals(1, specs.length);
       assertEquals("rn", specs[0].header);
       assertEquals("ROW_NUMBER", specs[0].fn);
-      assertArrayEquals(new int[]{0}, specs[0].partCols);   // stage -> col 0
-      assertArrayEquals(new int[]{1}, specs[0].orderCols);  // amount -> col 1
+      assertArrayEquals(new int[]{0}, specs[0].partCols);   // stage -> base col 0
+      assertArrayEquals(new int[]{1}, specs[0].orderCols);  // amount -> base col 1
       assertArrayEquals(new boolean[]{false}, specs[0].orderAsc);
       assertEquals(-1, specs[0].argCol);                    // ROW_NUMBER has none
    }
@@ -84,9 +127,50 @@ class WindowRoutingTest {
       cols.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
       cols.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
 
-      WindowTableLens.Spec[] specs = AssetQuery.buildWindowSpecs(cols);
+      WindowTableLens.Spec[] specs = AssetQuery.buildWindowSpecs(stageAmountBase(), cols);
 
       assertEquals(0, specs.length);
+   }
+
+   /**
+    * SEAM TEST (integration-style, no live query): resolve-against-base + value computation.
+    * The window column is placed FIRST in the selection (index 0), while the columns it
+    * references live at base indices 0 (stage) and 1 (amount). With the OLD selection-index
+    * resolution, partitionBy stage would resolve to selection index 1 (= base "amount") and
+    * orderBy amount to selection index 2 (OUT OF BOUNDS for the 2-column base → AIOOBE). With
+    * findColumn-against-base the values come out correct. This test FAILS on the old code and
+    * PASSES on the fix.
+    */
+   @Test
+   void buildWindowLens_resolvesAgainstBase_withNonTrailingWindowColumn() {
+      DefaultTableLens base = stageAmountBase();   // [stage(0), amount(1)]
+
+      // rn = ROW_NUMBER() OVER (PARTITION BY stage ORDER BY amount DESC)
+      WindowExpressionRef win = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0,
+         List.of(new ColumnRef(new AttributeRef(null, "stage"))),
+         List.of(desc(new ColumnRef(new AttributeRef(null, "amount")))));
+      win.setName("rn");
+      ColumnRef rn = new ColumnRef(win);
+      rn.setSQL(true);
+
+      // window column FIRST (non-trailing) in the selection — different coordinate space
+      ColumnSelection cols = new ColumnSelection();
+      cols.addAttribute(rn);
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+
+      TableLens lens = AssetQuery.buildWindowLens(base, cols);
+
+      // base columns preserved (2), window column appended at index 2
+      assertEquals(3, lens.getColCount());
+      assertEquals("rn", lens.getObject(0, 2));   // header
+      // base data (original order): A/30, A/10, A/20, B/5
+      // ROW_NUMBER PARTITION BY stage ORDER BY amount DESC → A:30=1,10=3,20=2 ; B:5=1
+      assertEquals("A", cell(lens, 0, 0)); assertEquals(1, cell(lens, 0, 2)); // A/30 → 1
+      assertEquals("A", cell(lens, 1, 0)); assertEquals(3, cell(lens, 1, 2)); // A/10 → 3
+      assertEquals("A", cell(lens, 2, 0)); assertEquals(2, cell(lens, 2, 2)); // A/20 → 2
+      assertEquals("B", cell(lens, 3, 0)); assertEquals(1, cell(lens, 3, 2)); // B/5  → 1
    }
 
    @Test
@@ -94,10 +178,6 @@ class WindowRoutingTest {
       // Two window columns on the same table with different, non-empty ORDER BY grammars —
       // WindowTableLens shares a single partition/order across all specs in a table (Phase 2),
       // so this must fail loud rather than silently mis-sort the second column.
-      ColumnRef stage = new ColumnRef(new AttributeRef(null, "stage"));
-      ColumnRef amount = new ColumnRef(new AttributeRef(null, "amount"));
-      ColumnRef qty = new ColumnRef(new AttributeRef(null, "qty"));
-
       WindowExpressionRef win1 = new WindowExpressionRef(
          "ROW_NUMBER", null, 0, List.of(),
          List.of(desc(new ColumnRef(new AttributeRef(null, "amount")))));
@@ -113,13 +193,14 @@ class WindowRoutingTest {
       rn2.setSQL(true);
 
       ColumnSelection cols = new ColumnSelection();
-      cols.addAttribute(stage);
-      cols.addAttribute(amount);
-      cols.addAttribute(qty);
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "qty")));
       cols.addAttribute(rn1);
       cols.addAttribute(rn2);
 
-      assertThrows(RuntimeException.class, () -> AssetQuery.buildWindowSpecs(cols));
+      assertThrows(RuntimeException.class,
+         () -> AssetQuery.buildWindowSpecs(stageAmountQtyBase(), cols));
    }
 
    @Test
@@ -127,11 +208,7 @@ class WindowRoutingTest {
       // One window column with no PARTITION BY (global) and another with a non-empty
       // PARTITION BY on the same table — WindowTableLens.partCols() applies the first
       // non-empty partition grammar found to EVERY spec, so the un-partitioned spec would
-      // silently be partitioned too (e.g. ROW_NUMBER() OVER (ORDER BY amount DESC) wrongly
-      // resetting per stage instead of numbering globally). Must fail loud instead.
-      ColumnRef stage = new ColumnRef(new AttributeRef(null, "stage"));
-      ColumnRef amount = new ColumnRef(new AttributeRef(null, "amount"));
-
+      // silently be partitioned too. Must fail loud instead.
       WindowExpressionRef win1 = new WindowExpressionRef(
          "ROW_NUMBER", null, 0, List.of(),
          List.of(desc(new ColumnRef(new AttributeRef(null, "amount")))));
@@ -148,23 +225,21 @@ class WindowRoutingTest {
       rn2.setSQL(true);
 
       ColumnSelection cols = new ColumnSelection();
-      cols.addAttribute(stage);
-      cols.addAttribute(amount);
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
       cols.addAttribute(rn1);
       cols.addAttribute(rn2);
 
       RuntimeException ex = assertThrows(RuntimeException.class,
-         () -> AssetQuery.buildWindowSpecs(cols));
+         () -> AssetQuery.buildWindowSpecs(stageAmountBase(), cols));
       assertTrue(ex.getMessage().contains("PARTITION BY"));
    }
 
    @Test
    void unresolvedPartitionByColumnThrows() {
-      // partitionBy references "missing", which is not in the column selection — buildWindowSpecs
+      // partitionBy references "missing", which is not in the BASE table — buildWindowSpecs
       // must fail loud with a named error instead of letting a -1 index flow into
       // WindowTableLens and surface as a cryptic ArrayIndexOutOfBoundsException later.
-      ColumnRef stage = new ColumnRef(new AttributeRef(null, "stage"));
-      ColumnRef amount = new ColumnRef(new AttributeRef(null, "amount"));
       WindowExpressionRef win = new WindowExpressionRef(
          "ROW_NUMBER", null, 0,
          List.of(new ColumnRef(new AttributeRef(null, "missing"))),
@@ -174,21 +249,19 @@ class WindowRoutingTest {
       rn.setSQL(true);
 
       ColumnSelection cols = new ColumnSelection();
-      cols.addAttribute(stage);
-      cols.addAttribute(amount);
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
       cols.addAttribute(rn);
 
       RuntimeException ex = assertThrows(RuntimeException.class,
-         () -> AssetQuery.buildWindowSpecs(cols));
+         () -> AssetQuery.buildWindowSpecs(stageAmountBase(), cols));
       assertTrue(ex.getMessage().contains("missing"));
       assertTrue(ex.getMessage().contains("rn"));
    }
 
    @Test
    void unresolvedOrderByColumnThrows() {
-      // orderBy references "missing", which is not in the column selection.
-      ColumnRef stage = new ColumnRef(new AttributeRef(null, "stage"));
-      ColumnRef amount = new ColumnRef(new AttributeRef(null, "amount"));
+      // orderBy references "missing", which is not in the BASE table.
       WindowExpressionRef win = new WindowExpressionRef(
          "ROW_NUMBER", null, 0,
          List.of(new ColumnRef(new AttributeRef(null, "stage"))),
@@ -198,13 +271,37 @@ class WindowRoutingTest {
       rn.setSQL(true);
 
       ColumnSelection cols = new ColumnSelection();
-      cols.addAttribute(stage);
-      cols.addAttribute(amount);
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
       cols.addAttribute(rn);
 
       RuntimeException ex = assertThrows(RuntimeException.class,
-         () -> AssetQuery.buildWindowSpecs(cols));
+         () -> AssetQuery.buildWindowSpecs(stageAmountBase(), cols));
       assertTrue(ex.getMessage().contains("missing"));
+      assertTrue(ex.getMessage().contains("rn"));
+   }
+
+   @Test
+   void buildWindowLens_failsLoudWhenPartitionRefUnresolvedInBase() {
+      // Fail-loud through the wrap seam: a partitionBy ref that is not present in `base` must
+      // throw a named RuntimeException, not build a lens with a -1 index that later AIOOBEs.
+      DefaultTableLens base = stageAmountBase();   // [stage(0), amount(1)] — no "region" column
+      WindowExpressionRef win = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0,
+         List.of(new ColumnRef(new AttributeRef(null, "region"))),   // absent from base
+         List.of(desc(new ColumnRef(new AttributeRef(null, "amount")))));
+      win.setName("rn");
+      ColumnRef rn = new ColumnRef(win);
+      rn.setSQL(true);
+
+      ColumnSelection cols = new ColumnSelection();
+      cols.addAttribute(rn);
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+
+      RuntimeException ex = assertThrows(RuntimeException.class,
+         () -> AssetQuery.buildWindowLens(base, cols));
+      assertTrue(ex.getMessage().contains("region"));
       assertTrue(ex.getMessage().contains("rn"));
    }
 

--- a/core/src/test/java/inetsoft/report/composition/execution/WindowRoutingTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/WindowRoutingTest.java
@@ -123,6 +123,42 @@ class WindowRoutingTest {
    }
 
    @Test
+   void divergentPartitionPresenceAcrossSpecsThrows() {
+      // One window column with no PARTITION BY (global) and another with a non-empty
+      // PARTITION BY on the same table — WindowTableLens.partCols() applies the first
+      // non-empty partition grammar found to EVERY spec, so the un-partitioned spec would
+      // silently be partitioned too (e.g. ROW_NUMBER() OVER (ORDER BY amount DESC) wrongly
+      // resetting per stage instead of numbering globally). Must fail loud instead.
+      ColumnRef stage = new ColumnRef(new AttributeRef(null, "stage"));
+      ColumnRef amount = new ColumnRef(new AttributeRef(null, "amount"));
+
+      WindowExpressionRef win1 = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0, List.of(),
+         List.of(desc(new ColumnRef(new AttributeRef(null, "amount")))));
+      win1.setName("rn1");
+      ColumnRef rn1 = new ColumnRef(win1);
+      rn1.setSQL(true);
+
+      WindowExpressionRef win2 = new WindowExpressionRef(
+         "SUM", new ColumnRef(new AttributeRef(null, "amount")), 0,
+         List.of(new ColumnRef(new AttributeRef(null, "stage"))),
+         List.of());
+      win2.setName("rn2");
+      ColumnRef rn2 = new ColumnRef(win2);
+      rn2.setSQL(true);
+
+      ColumnSelection cols = new ColumnSelection();
+      cols.addAttribute(stage);
+      cols.addAttribute(amount);
+      cols.addAttribute(rn1);
+      cols.addAttribute(rn2);
+
+      RuntimeException ex = assertThrows(RuntimeException.class,
+         () -> AssetQuery.buildWindowSpecs(cols));
+      assertTrue(ex.getMessage().contains("PARTITION BY"));
+   }
+
+   @Test
    void unresolvedPartitionByColumnThrows() {
       // partitionBy references "missing", which is not in the column selection — buildWindowSpecs
       // must fail loud with a named error instead of letting a -1 index flow into

--- a/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
+++ b/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
@@ -133,4 +133,35 @@ class WindowTableLensTest {
       assertNull(cell(lens, 2, 2));                  // LEAD(30) → none after
       assertEquals(10.0, cell(lens, 2, 3));          // FIRST_VALUE → 10
    }
+
+   @Test
+   void windowedSum_runningWhenOrdered_partitionTotalWhenNot() {
+      Object[][] data = {{"stage","amount"},{"A",10.0},{"A",20.0},{"A",30.0}};
+      DefaultTableLens t = new DefaultTableLens(data); t.setHeaderRowCount(1);
+      // running SUM ordered asc: 10,30,60
+      WindowTableLens.Spec run = new WindowTableLens.Spec("rt","SUM",1,0,new int[]{0}, new int[]{1}, new boolean[]{true});
+      // partition-total SUM (no order): 60,60,60
+      WindowTableLens.Spec tot = new WindowTableLens.Spec("pt","SUM",1,0,new int[]{0}, new int[0], new boolean[0]);
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{run, tot});
+      assertEquals(10.0, cell(lens,0,2)); assertEquals(60.0, cell(lens,0,3));
+      assertEquals(30.0, cell(lens,1,2)); assertEquals(60.0, cell(lens,1,3));
+      assertEquals(60.0, cell(lens,2,2)); assertEquals(60.0, cell(lens,2,3));
+   }
+
+   @Test
+   void countAvgMinMax_partitionWide() {
+      Object[][] data = {{"stage","amount"},{"A",10.0},{"A",30.0}};
+      DefaultTableLens t = new DefaultTableLens(data); t.setHeaderRowCount(1);
+      WindowTableLens.Spec[] s = {
+         new WindowTableLens.Spec("c","COUNT",1,0,new int[]{0},new int[0],new boolean[0]),
+         new WindowTableLens.Spec("a","AVG",1,0,new int[]{0},new int[0],new boolean[0]),
+         new WindowTableLens.Spec("mn","MIN",1,0,new int[]{0},new int[0],new boolean[0]),
+         new WindowTableLens.Spec("mx","MAX",1,0,new int[]{0},new int[0],new boolean[0]),
+      };
+      WindowTableLens lens = new WindowTableLens(t, s);
+      assertEquals(2, cell(lens,0,2));      // COUNT
+      assertEquals(20.0, cell(lens,0,3));   // AVG
+      assertEquals(10.0, cell(lens,0,4));   // MIN
+      assertEquals(30.0, cell(lens,0,5));   // MAX
+   }
 }

--- a/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
+++ b/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
@@ -28,6 +28,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
@@ -217,5 +219,17 @@ class WindowTableLensTest {
       assertEquals(20.0, cell(lens,0,3));   // AVG
       assertEquals(10.0, cell(lens,0,4));   // MIN
       assertEquals(30.0, cell(lens,0,5));   // MAX
+   }
+
+   @Test
+   void unsupportedFunction_failsLoud_notSilentNull() {
+      // LAST_VALUE (and any fn the in-memory kernel does not implement) must throw, not silently
+      // return null for every row — the SQL path emits it, so a silent null would diverge.
+      WindowTableLens.Spec last = new WindowTableLens.Spec(
+         "lv", "LAST_VALUE", 1, 0, new int[0], new int[]{1}, new boolean[]{true});
+      WindowTableLens lens = new WindowTableLens(base(), new WindowTableLens.Spec[]{last});
+      RuntimeException ex = assertThrows(RuntimeException.class, () -> cell(lens, 0, 2));
+      assertTrue(ex.getMessage().contains("LAST_VALUE"),
+                 "error should name the unsupported function: " + ex.getMessage());
    }
 }

--- a/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
+++ b/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
@@ -27,6 +27,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
@@ -110,5 +111,26 @@ class WindowTableLensTest {
       assertEquals(1, cell(lens, 1, 1)); // 30
       assertEquals(2, cell(lens, 2, 1)); // 20
       assertEquals(3, cell(lens, 3, 1)); // 10
+   }
+
+   @Test
+   void lag_lead_firstValue_withEdgeNulls() {
+      // one partition, ordered by amount ASC: 10,20,30
+      Object[][] data = {{"amount"},{10.0},{20.0},{30.0}};
+      DefaultTableLens t = new DefaultTableLens(data); t.setHeaderRowCount(1);
+      WindowTableLens.Spec lag  = new WindowTableLens.Spec("lg","LAG", 0, 1, new int[0], new int[]{0}, new boolean[]{true});
+      WindowTableLens.Spec lead = new WindowTableLens.Spec("ld","LEAD",0, 1, new int[0], new int[]{0}, new boolean[]{true});
+      WindowTableLens.Spec fv   = new WindowTableLens.Spec("fv","FIRST_VALUE",0,0,new int[0], new int[]{0}, new boolean[]{true});
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{lag, lead, fv});
+      // rows in base order == asc order here: 10,20,30
+      assertNull(cell(lens, 0, 1));                  // LAG(10) → none before
+      assertEquals(20.0, cell(lens, 0, 2));          // LEAD(10) → 20
+      assertEquals(10.0, cell(lens, 0, 3));          // FIRST_VALUE → 10
+      assertEquals(10.0, cell(lens, 1, 1));          // LAG(20) → 10
+      assertEquals(30.0, cell(lens, 1, 2));          // LEAD(20) → 30
+      assertEquals(10.0, cell(lens, 1, 3));          // FIRST_VALUE → 10
+      assertEquals(20.0, cell(lens, 2, 1));          // LAG(30) → 20
+      assertNull(cell(lens, 2, 2));                  // LEAD(30) → none after
+      assertEquals(10.0, cell(lens, 2, 3));          // FIRST_VALUE → 10
    }
 }

--- a/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
+++ b/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
@@ -149,6 +149,32 @@ class WindowTableLensTest {
    }
 
    @Test
+   void percentRank_tiesShareFirstPosition() {
+      // A desc, tied: 30,30,10 → rank(first-tied-position) 1,1,3 over n=3
+      // PERCENT_RANK = (rank-1)/(n-1): (1-1)/2=0.0, (1-1)/2=0.0, (3-1)/2=1.0
+      WindowTableLens.Spec pr = new WindowTableLens.Spec(
+         "pr", "PERCENT_RANK", -1, 0, new int[]{0}, new int[]{1}, new boolean[]{false});
+      WindowTableLens lens = new WindowTableLens(tiedBase(), new WindowTableLens.Spec[]{pr});
+      assertEquals(0.0, cell(lens, 0, 2)); // A/30
+      assertEquals(0.0, cell(lens, 1, 2)); // A/30 tie
+      assertEquals(1.0, cell(lens, 2, 2)); // A/10
+      assertEquals(0.0, cell(lens, 3, 2)); // B/7 — sole row in its partition, size<=1 → 0.0
+   }
+
+   @Test
+   void cumeDist_tiesShareUpperBound() {
+      // A desc, tied: 30,30,10 → rows with order key <= current (in desc direction):
+      // 30 → {30,30} = 2/3 ; 30 → 2/3 ; 10 → {30,30,10} = 3/3 = 1.0
+      WindowTableLens.Spec cd = new WindowTableLens.Spec(
+         "cd", "CUME_DIST", -1, 0, new int[]{0}, new int[]{1}, new boolean[]{false});
+      WindowTableLens lens = new WindowTableLens(tiedBase(), new WindowTableLens.Spec[]{cd});
+      assertEquals(2.0 / 3, cell(lens, 0, 2)); // A/30
+      assertEquals(2.0 / 3, cell(lens, 1, 2)); // A/30 tie
+      assertEquals(1.0, cell(lens, 2, 2));     // A/10
+      assertEquals(1.0, cell(lens, 3, 2));     // B/7 — sole row in its partition
+   }
+
+   @Test
    void countAvgMinMax_partitionWide() {
       Object[][] data = {{"stage","amount"},{"A",10.0},{"A",30.0}};
       DefaultTableLens t = new DefaultTableLens(data); t.setHeaderRowCount(1);

--- a/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
+++ b/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.lens;
+
+import inetsoft.report.TableLens;
+import inetsoft.test.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WindowTableLensTest {
+   /** Base: header row + data. cols: stage(0,String), amount(1,Double). */
+   private static DefaultTableLens base() {
+      Object[][] data = {
+         {"stage", "amount"},
+         {"A", 30.0},
+         {"A", 10.0},
+         {"A", 20.0},
+         {"B", 5.0},
+      };
+      DefaultTableLens t = new DefaultTableLens(data);
+      t.setHeaderRowCount(1);
+      return t;
+   }
+
+   private static Object cell(TableLens t, int dataRow, int col) {
+      return t.getObject(dataRow + t.getHeaderRowCount(), col);
+   }
+
+   @Test
+   void rowNumber_perPartition_orderedDesc() {
+      // ROW_NUMBER() OVER (PARTITION BY stage ORDER BY amount DESC) as "rn"
+      WindowTableLens.Spec spec = new WindowTableLens.Spec(
+         "rn", "ROW_NUMBER", -1, 0, new int[]{0}, new int[]{1}, new boolean[]{false});
+      WindowTableLens lens = new WindowTableLens(base(), new WindowTableLens.Spec[]{spec});
+
+      assertEquals(3, lens.getColCount());                 // 2 base + 1 window
+      assertEquals("rn", lens.getObject(0, 2));            // header
+      // base rows preserved in ORIGINAL order; rn computed over sorted partition
+      // original data: A/30, A/10, A/20, B/5  →  A desc: 30=1,20=2,10=3 ; B: 5=1
+      assertEquals("A", cell(lens, 0, 0)); assertEquals(1, cell(lens, 0, 2)); // A/30 → 1
+      assertEquals("A", cell(lens, 1, 0)); assertEquals(3, cell(lens, 1, 2)); // A/10 → 3
+      assertEquals("A", cell(lens, 2, 0)); assertEquals(2, cell(lens, 2, 2)); // A/20 → 2
+      assertEquals("B", cell(lens, 3, 0)); assertEquals(1, cell(lens, 3, 2)); // B/5  → 1
+   }
+}

--- a/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
+++ b/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
@@ -175,6 +175,34 @@ class WindowTableLensTest {
    }
 
    @Test
+   void rankWithNoOrder_tiesWholePartition_evenWhenSharingLensWithOrderedAggregate() {
+      // A RANK() OVER (PARTITION BY stage) with NO ORDER BY, sharing the lens with a running
+      // SUM that DOES declare ORDER BY amount. The lens sorts rows once by the shared order
+      // (amount); the rank kernel must key off ITS OWN (empty) order — so the whole partition
+      // ties (RANK = 1 for every row), NOT rank by the SUM's amount order (which would give
+      // 1,2,3 within partition A). This test FAILS if the rank kernel uses the shared order.
+      Object[][] data = {{"stage","amount"},{"A",10.0},{"A",20.0},{"A",30.0},{"B",5.0}};
+      DefaultTableLens t = new DefaultTableLens(data); t.setHeaderRowCount(1);
+      // running SUM ordered asc by amount (partition by stage)
+      WindowTableLens.Spec run = new WindowTableLens.Spec(
+         "rt", "SUM", 1, 0, new int[]{0}, new int[]{1}, new boolean[]{true});
+      // RANK partitioned by stage with NO order → whole partition ties at 1
+      WindowTableLens.Spec rk = new WindowTableLens.Spec(
+         "rk", "RANK", -1, 0, new int[]{0}, new int[0], new boolean[0]);
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{run, rk});
+      // running SUM (col 2): A → 10,30,60 ; B → 5
+      assertEquals(10.0, cell(lens, 0, 2));
+      assertEquals(30.0, cell(lens, 1, 2));
+      assertEquals(60.0, cell(lens, 2, 2));
+      assertEquals(5.0,  cell(lens, 3, 2));
+      // RANK (col 3): every row ties within its partition → all 1
+      assertEquals(1, cell(lens, 0, 3));
+      assertEquals(1, cell(lens, 1, 3));
+      assertEquals(1, cell(lens, 2, 3));
+      assertEquals(1, cell(lens, 3, 3));
+   }
+
+   @Test
    void countAvgMinMax_partitionWide() {
       Object[][] data = {{"stage","amount"},{"A",10.0},{"A",30.0}};
       DefaultTableLens t = new DefaultTableLens(data); t.setHeaderRowCount(1);

--- a/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
+++ b/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
@@ -68,4 +68,47 @@ class WindowTableLensTest {
       assertEquals("A", cell(lens, 2, 0)); assertEquals(2, cell(lens, 2, 2)); // A/20 → 2
       assertEquals("B", cell(lens, 3, 0)); assertEquals(1, cell(lens, 3, 2)); // B/5  → 1
    }
+
+   /** Base with an intentional tie in the order key. cols: stage(0), amount(1). */
+   private static DefaultTableLens tiedBase() {
+      Object[][] data = {
+         {"stage", "amount"},
+         {"A", 30.0},
+         {"A", 30.0},   // tie with row above on amount
+         {"A", 10.0},
+         {"B", 7.0},
+      };
+      DefaultTableLens t = new DefaultTableLens(data);
+      t.setHeaderRowCount(1);
+      return t;
+   }
+
+   @Test
+   void rank_and_denseRank_shareTiesButDifferOnGaps() {
+      WindowTableLens.Spec rank = new WindowTableLens.Spec(
+         "rk", "RANK", -1, 0, new int[]{0}, new int[]{1}, new boolean[]{false});
+      WindowTableLens.Spec dense = new WindowTableLens.Spec(
+         "dr", "DENSE_RANK", -1, 0, new int[]{0}, new int[]{1}, new boolean[]{false});
+      WindowTableLens lens = new WindowTableLens(tiedBase(), new WindowTableLens.Spec[]{rank, dense});
+      // A desc: 30(tie),30(tie),10 → RANK 1,1,3 ; DENSE_RANK 1,1,2. B: 7 → 1,1
+      assertEquals(1, cell(lens, 0, 2)); assertEquals(1, cell(lens, 0, 3)); // A/30
+      assertEquals(1, cell(lens, 1, 2)); assertEquals(1, cell(lens, 1, 3)); // A/30 tie
+      assertEquals(3, cell(lens, 2, 2)); assertEquals(2, cell(lens, 2, 3)); // A/10 (RANK skips 2)
+      assertEquals(1, cell(lens, 3, 2)); assertEquals(1, cell(lens, 3, 3)); // B/7
+   }
+
+   @Test
+   void ntile_frontLoadsRemainder() {
+      // 4 rows / 3 buckets → sizes 2,1,1 (front-loaded). Global window (no partition).
+      Object[][] data = {{"amount"},{40.0},{30.0},{20.0},{10.0}};
+      DefaultTableLens t = new DefaultTableLens(data); t.setHeaderRowCount(1);
+      WindowTableLens.Spec ntile = new WindowTableLens.Spec(
+         "b", "NTILE", -1, 3, new int[0], new int[]{0}, new boolean[]{false});
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{ntile});
+      // desc: 40,30,20,10 → buckets 1,1,2,3
+      assertEquals(1, cell(lens, 0, 1)); // 40
+      assertEquals(1, cell(lens, 1, 1)); // 30
+      assertEquals(2, cell(lens, 2, 1)); // 20
+      assertEquals(3, cell(lens, 3, 1)); // 10
+   }
 }


### PR DESCRIPTION
## Summary

Phase 2 of window functions on non-SQL sources: compute window functions **in StyleBI's in-memory engine** for non-pushdown (tabular / non-mergeable) sources, while SQL/JDBC sources keep pushing the identical `OVER(...)` down, unchanged.

Phase 1 (merged) made the window column a structured `WindowExpressionRef` that renders `OVER(...)` for pushdown. Phase 2 adds the in-memory path so the same declarative `windowColumns` also work where there is no SQL to push into. Spec: `docs/superpowers/specs/2026-07-10-nonsql-window-support-design.md`.

## What's in it (7 commits)

- **`report/lens/WindowTableLens.java` (new)** — a `TableFilter` that presents base rows in base order and appends one computed column per window function. It sorts an internal row-index by `(partitionBy…, orderBy…)`, walks each partition, and writes each window value back to its originating base row. Kernels:
  - `ROW_NUMBER`, `RANK` (ties share first position, then gap), `DENSE_RANK`, `NTILE(k)` (front-loaded remainder), `PERCENT_RANK` = (rank-1)/(n-1), `CUME_DIST`;
  - `LAG`/`LEAD(col, n)` (null past the partition edge), `FIRST_VALUE(col)`;
  - windowed `SUM/AVG/COUNT/MIN/MAX` — **per-spec** frame: running (`UNBOUNDED PRECEDING → CURRENT ROW`) when the spec has `orderBy`, else whole-partition.
- **`report/composition/execution/AssetQuery.java`** — routing:
  - `getWindowTableLens(base, vars)` inserted between the ranking and visible lens stages. **No-op when `isQueryMergeable(false)` is true** (a mergeable JDBC query already has the `OVER` in its SELECT), so SQL pushdown is untouched; wraps `base` in `WindowTableLens` only for the non-mergeable/tabular path.
  - `buildWindowSpecs(ColumnSelection)` resolves each `WindowExpressionRef` column's arg/partitionBy/orderBy refs to base-column indices, **failing loud** (named error) on an unresolved ref rather than letting a `-1` index reach the lens.
  - `getFormulaTableLens` skips `WindowExpressionRef` columns so, on the non-mergeable path, a window column routes to the new stage instead of hitting the Phase-1 pushdown-only fail-loud throw in `addExpression`.
  - Fail-loud guard when window columns on one table declare a **mixed/divergent PARTITION BY grammar** (the lens uses one shared sort per table — Phase 2 single-window-grammar scope).

## Testing

- **Unit (JUnit, no image):** `WindowTableLensTest` (8) — every kernel, partition resets, tie behavior, NTILE remainder, edge nulls, running-vs-partition-total frame; `WindowRoutingTest` (6) — spec resolution, empty case, divergent-order / mixed-partition / unresolved-ref throws.
- **Live SQL-pushdown regression (Postgres, image built from this branch):** re-ran the Phase-1 charts — partitioned `ROW_NUMBER` and two-table `RANK` over `SUM(amount)` — and confirmed the emitted `OVER(...)` SQL and the result values are **byte-identical to Phase 1** (routing stage is a verified no-op for JDBC).
- **Non-SQL in-memory path:** covered by the unit-lens tests; the live REST/tabular-source stand-up (the known-hard prerequisite) is deferred per the spec.

## Notes

- No behavior change for SQL sources — reviewed and live-verified.
- Stacked on the merged Phase-1 window work (structured node + `/ws/table` wire + Phase-2b capability). Pairs with the merged wiz forwarding (stylebi-wiz #1189).
- Phase 3 (frames / `LAST_VALUE` / NULLS ordering) remains out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
