### PR TITLE
Window functions Phase 4: RANGE/GROUPS frame modes

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -2957,12 +2957,45 @@ public abstract class AssetQuery extends PreAssetQuery {
     * entity+attribute / header (the codebase convention), not a bare name scan of the selection.
     * <p>
     * Package-private and static so it can be unit-tested directly (see WindowRoutingTest)
-    * without a live query.
+    * without a live query. Builds a spec for EVERY window column in {@code cols}, regardless of
+    * whether its frame is pushable on any particular dialect — use the 3-arg overload to filter
+    * out pushed-down columns for the production in-memory routing path (see
+    * {@link #buildWindowSpecs(XTable, ColumnSelection, SQLHelper)}).
     * @param base the runtime base table the WindowTableLens will wrap and read from.
     * @param cols the column selection to scan for WindowExpressionRef columns.
     * @return the resolved specs, one per window column, in selection order.
     */
    static WindowTableLens.Spec[] buildWindowSpecs(XTable base, ColumnSelection cols) {
+      return buildWindowSpecs(base, cols, null, false);
+   }
+
+   /**
+    * Like {@link #buildWindowSpecs(XTable, ColumnSelection)}, but SKIPS a window column whose
+    * frame is pushable on {@code helper}'s dialect (see
+    * {@link #framePushable(String, SQLHelper)}) — i.e. one already merged into the pushed-down
+    * SQL by {@link #mergeColumn}. Used by the mixed-pushability routing case in
+    * {@link #getWindowTableLens}: when a query is mergeable but not every window column's frame
+    * is pushable (e.g. one ROWS column + one RANGE column on a non-Postgres source), the ROWS
+    * column is already in the generated SQL and must NOT also be recomputed here — building a
+    * spec for it would (1) double-compute it and (2) subject it to
+    * {@link #checkCompatiblePartitionAndOrder} alongside the non-pushed column, which can throw
+    * for two window columns with divergent PARTITION BY that previously worked fine via
+    * independent SQL {@code OVER()} clauses. A pushable column is thus computed exactly once (in
+    * SQL); a non-pushable one exactly once (in memory).
+    * @param base the runtime base table the WindowTableLens will wrap and read from.
+    * @param cols the column selection to scan for WindowExpressionRef columns.
+    * @param helper the source dialect's SQL helper (may be {@code null}).
+    * @return the resolved specs for the NON-pushable window columns only, in selection order.
+    */
+   static WindowTableLens.Spec[] buildWindowSpecs(XTable base, ColumnSelection cols,
+                                                   SQLHelper helper)
+   {
+      return buildWindowSpecs(base, cols, helper, true);
+   }
+
+   private static WindowTableLens.Spec[] buildWindowSpecs(XTable base, ColumnSelection cols,
+                                                           SQLHelper helper, boolean skipPushable)
+   {
       List<WindowTableLens.Spec> specs = new ArrayList<>();
 
       for(int i = 0; i < cols.getAttributeCount(); i++) {
@@ -2979,6 +3012,13 @@ public abstract class AssetQuery extends PreAssetQuery {
          }
 
          WindowExpressionRef w = (WindowExpressionRef) bref;
+
+         if(skipPushable && framePushable(w.getFrameMode(), helper)) {
+            // Already merged into the pushed-down SQL by mergeColumn — do not also compute it
+            // in memory (see javadoc above).
+            continue;
+         }
+
          DataRef argRef = w.getArgRef();
          int arg = argRef == null ? -1 : AssetUtil.findColumn(base, argRef);
          List<DataRef> partRefs = w.getPartitionBy();
@@ -3118,15 +3158,43 @@ public abstract class AssetQuery extends PreAssetQuery {
    }
 
    /**
+    * Like {@link #buildWindowLens(TableLens, ColumnSelection)}, but builds specs ONLY for window
+    * columns that are NOT pushable on {@code helper}'s dialect — see
+    * {@link #buildWindowSpecs(XTable, ColumnSelection, SQLHelper)}. Used for the mixed-pushability
+    * routing case (a mergeable query where some, but not all, window columns' frames are
+    * pushable).
+    * @param base the fully post-processed runtime base table (already includes any pushed-down
+    *             window columns computed in SQL).
+    * @param cols the output column selection (source of the WindowExpressionRef columns).
+    * @param helper the source dialect's SQL helper (may be {@code null}).
+    * @return {@code base} wrapped in a WindowTableLens computing only the non-pushed columns, or
+    *         {@code base} unchanged when there is nothing left to compute in-memory.
+    */
+   static TableLens buildWindowLens(TableLens base, ColumnSelection cols, SQLHelper helper) {
+      WindowTableLens.Spec[] specs = buildWindowSpecs(base, cols, helper);
+
+      if(specs.length == 0) {
+         return base;
+      }
+
+      return new WindowTableLens(base, specs);
+   }
+
+   /**
     * In-memory window computation for non-pushdown sources. No-op when the query pushed the
     * window down (mergeable JDBC) AND every window column's frame is pushable on the source
-    * dialect — the OVER is already in the SELECT. For a tabular / non-mergeable source, OR a
-    * mergeable source where some window column's frame mode (RANGE/GROUPS) is not supported by
-    * the source dialect (see {@link #framePushable(String, SQLHelper)}), wrap the fully
-    * post-processed base in a WindowTableLens. {@link #mergeColumn} refuses to inline a
-    * non-pushable window column into the generated SQL in the first place (see there), so this
-    * method and that gate must agree: a window column is computed exactly once, either in the
-    * pushed-down SQL or here in memory, never both.
+    * dialect — the OVER is already in the SELECT (byte-parity: {@link #buildWindowLens} is not
+    * even reached in this case). For a mergeable source where SOME but not all window columns'
+    * frame modes (RANGE/GROUPS) are pushable on the source dialect (see
+    * {@link #framePushable(String, SQLHelper)}), the pushable ones are already merged into the
+    * SQL by {@link #mergeColumn} — only the non-pushable ones still need computing, so this
+    * routes through the helper-aware {@link #buildWindowLens(TableLens, ColumnSelection, SQLHelper)}
+    * overload, which builds specs ONLY for those (see {@link #buildWindowSpecs(XTable,
+    * ColumnSelection, SQLHelper)}): a pushable column must not also be recomputed in memory
+    * (double-compute) or dragged into {@link #checkCompatiblePartitionAndOrder} alongside an
+    * unrelated non-pushed column. For a tabular / non-mergeable source, NOTHING was pushed down
+    * at all — every window column (any frame mode) must be computed here, so this falls through
+    * to the unfiltered {@link #buildWindowLens(TableLens, ColumnSelection)} overload.
     * @param base the specified base table.
     * @param vars the specified variable table.
     * @return the window table lens, or base unchanged if there is nothing to compute in-memory.
@@ -3134,12 +3202,21 @@ public abstract class AssetQuery extends PreAssetQuery {
    private TableLens getWindowTableLens(TableLens base, VariableTable vars) throws Exception {
       ColumnSelection cols = getTable().getColumnSelection(false);
 
-      // if the query merged (pushed down) and every window frame is pushable on this dialect,
-      // the window is in the SQL SELECT already, nothing to do
-      if(isQueryMergeable(false) && windowFramesAllPushable(cols)) {
-         return base;
+      if(isQueryMergeable(false)) {
+         // if every window frame is pushable on this dialect, the window is in the SQL SELECT
+         // already, nothing to do
+         if(windowFramesAllPushable(cols)) {
+            return base;
+         }
+
+         // mixed pushability: some window columns were merged into the pushed-down SQL, others
+         // were not (mergeColumn refused to inline them) — build in-memory specs ONLY for the
+         // latter so a pushable column is computed exactly once (in SQL).
+         SQLHelper helper = AssetUtil.getSQLHelper(getTable());
+         return buildWindowLens(base, cols, helper);
       }
 
+      // non-mergeable (tabular) source: nothing was pushed down, compute every window column here
       return buildWindowLens(base, cols);
    }
 

--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -37,6 +37,7 @@ import inetsoft.uql.asset.internal.*;
 import inetsoft.uql.erm.*;
 import inetsoft.uql.erm.vpm.VirtualPrivateModel;
 import inetsoft.uql.jdbc.*;
+import inetsoft.uql.path.XSelection;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.schema.XTypeNode;
 import inetsoft.uql.util.*;
@@ -3023,7 +3024,8 @@ public abstract class AssetQuery extends PreAssetQuery {
             specs.add(new WindowTableLens.Spec(
                ref.getName(), w.getFn(), arg, w.getN(), parts, ocols, oasc,
                w.getFrameStartBound(), w.getFrameStartOffset(),
-               w.getFrameEndBound(), w.getFrameEndOffset()));
+               w.getFrameEndBound(), w.getFrameEndOffset(),
+               w.getFrameMode(), w.getFrameOffsetUnit()));
          }
          else {
             specs.add(new WindowTableLens.Spec(
@@ -3117,19 +3119,117 @@ public abstract class AssetQuery extends PreAssetQuery {
 
    /**
     * In-memory window computation for non-pushdown sources. No-op when the query pushed the
-    * window down (mergeable JDBC) — the OVER is already in the SELECT. For a tabular /
-    * non-mergeable source, wrap the fully post-processed base in a WindowTableLens.
+    * window down (mergeable JDBC) AND every window column's frame is pushable on the source
+    * dialect — the OVER is already in the SELECT. For a tabular / non-mergeable source, OR a
+    * mergeable source where some window column's frame mode (RANGE/GROUPS) is not supported by
+    * the source dialect (see {@link #framePushable(String, SQLHelper)}), wrap the fully
+    * post-processed base in a WindowTableLens. {@link #mergeColumn} refuses to inline a
+    * non-pushable window column into the generated SQL in the first place (see there), so this
+    * method and that gate must agree: a window column is computed exactly once, either in the
+    * pushed-down SQL or here in memory, never both.
     * @param base the specified base table.
     * @param vars the specified variable table.
     * @return the window table lens, or base unchanged if there is nothing to compute in-memory.
     */
    private TableLens getWindowTableLens(TableLens base, VariableTable vars) throws Exception {
-      // if the query merged (pushed down), the window is in the SQL SELECT already, nothing to do
-      if(isQueryMergeable(false)) {
+      ColumnSelection cols = getTable().getColumnSelection(false);
+
+      // if the query merged (pushed down) and every window frame is pushable on this dialect,
+      // the window is in the SQL SELECT already, nothing to do
+      if(isQueryMergeable(false) && windowFramesAllPushable(cols)) {
          return base;
       }
 
-      return buildWindowLens(base, getTable().getColumnSelection(false));
+      return buildWindowLens(base, cols);
+   }
+
+   /**
+    * v1 dialect capability map: frame modes {@code postgresql} can push down as SQL (Phase 4).
+    * Every other dialect only pushes {@code ROWS} (Phase 3); {@code RANGE}/{@code GROUPS} fall
+    * back to the in-memory {@link WindowTableLens} engine there.
+    */
+   private static final Set<String> PG_PUSHABLE = Set.of("ROWS", "RANGE", "GROUPS");
+
+   /**
+    * Can {@code mode} be pushed down as SQL on the dialect behind {@code helper}?
+    * {@code ROWS} pushes on every dialect (Phase 3, unchanged). {@code RANGE}/{@code GROUPS}
+    * push only on PostgreSQL (v1 capability map — see {@link #PG_PUSHABLE}); every other
+    * dialect (including a {@code null} helper, e.g. a non-JDBC tabular source) routes them to
+    * the in-memory engine.
+    * <p>
+    * Package-private so {@code WindowRoutingTest} can exercise it directly with lightweight
+    * {@link SQLHelper} instances (no live connection required).
+    * @param mode the frame mode: {@code ROWS}, {@code RANGE}, or {@code GROUPS}.
+    * @param helper the source dialect's SQL helper, or {@code null} if there is none (e.g. a
+    *               tabular/non-JDBC source, which is never frame-pushable beyond ROWS).
+    * @return {@code true} if {@code mode} can be emitted as a pushed-down SQL frame clause.
+    */
+   static boolean framePushable(String mode, SQLHelper helper) {
+      if("ROWS".equals(mode)) {
+         return true;
+      }
+
+      String type = helper == null ? null : helper.getSQLHelperType();
+      return "postgresql".equals(type) && PG_PUSHABLE.contains(mode);
+   }
+
+   /**
+    * Scan {@code cs} for a {@link WindowExpressionRef} column whose frame is not pushable on
+    * this query's source dialect. Used to force the in-memory routing (see
+    * {@link #getWindowTableLens}) and to gate SQL inlining (see {@link #mergeColumn}) for a
+    * dialect that cannot express a RANGE/GROUPS frame natively.
+    * @param cs the column selection to scan.
+    * @return {@code true} if every window column's frame (if any) is pushable on this dialect.
+    */
+   private boolean windowFramesAllPushable(ColumnSelection cs) {
+      SQLHelper helper = AssetUtil.getSQLHelper(getTable());
+
+      for(int i = 0; i < cs.getAttributeCount(); i++) {
+         DataRef ref = cs.getAttribute(i);
+
+         if(!(ref instanceof ColumnRef)) {
+            continue;
+         }
+
+         DataRef bref = ((ColumnRef) ref).getDataRef();
+
+         if(bref instanceof WindowExpressionRef &&
+            !framePushable(((WindowExpressionRef) bref).getFrameMode(), helper))
+         {
+            return false;
+         }
+      }
+
+      return true;
+   }
+
+   /**
+    * Dialect capability gate (Phase 4): refuse to inline a {@link WindowExpressionRef} column
+    * into the pushed-down SQL when its frame mode is not pushable on this query's source
+    * dialect (see {@link #framePushable(String, SQLHelper)}) — e.g. a RANGE/GROUPS frame on a
+    * non-PostgreSQL source. Returning {@code false} here leaves the column out of the SQL
+    * SELECT and {@code column.isProcessed()} false; {@link #getWindowTableLens} then computes
+    * it in memory instead, so it is never both inlined AND lens-computed.
+    * <p>
+    * ROWS frames (and every frame on PostgreSQL) are unaffected — this override delegates to
+    * {@code super.mergeColumn} exactly as before, so pushdown SQL text is byte-for-byte
+    * identical to pre-Phase-4 behavior for those cases (byte-parity requirement).
+    */
+   @Override
+   protected boolean mergeColumn(XSelection nselection, ColumnRef column,
+                                  boolean isAggregateInfoMergeable)
+   {
+      DataRef bref = column.getDataRef();
+
+      if(bref instanceof WindowExpressionRef) {
+         SQLHelper helper = AssetUtil.getSQLHelper(getTable());
+
+         if(!framePushable(((WindowExpressionRef) bref).getFrameMode(), helper)) {
+            return false;
+         }
+      }
+
+      return super.mergeColumn(nselection, column, isAggregateInfoMergeable);
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
+++ b/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
@@ -528,11 +528,17 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
     * 30-peer-group (frame {30,30}, NOT {30,30,10}), even though the row with value 10
     * numerically satisfies "value ≤ 30"; a peer group is a POSITION in the sorted sequence, not
     * a value threshold, and the two only coincide for ASCENDING order.
-    * <p>{@code PRECEDING}/{@code FOLLOWING} WITH an offset are genuine value bounds. Per the SQL
-    * RANGE standard, the offset direction is relative to the ORDER BY SEQUENCE, not raw
-    * arithmetic sign: for an ASCENDING key, {@code n PRECEDING} means "value ≥ current − n"; for
-    * a DESCENDING key it means "value ≤ current + n" (preceding in a descending sequence is a
-    * LARGER value). {@link #rangeStart}/{@link #rangeEnd} apply this directly.
+    * <p>{@code PRECEDING}/{@code FOLLOWING} WITH an offset are genuine value bounds, and either
+    * token is valid on EITHER side (e.g. {@code RANGE BETWEEN 5 PRECEDING AND 2 PRECEDING} or
+    * {@code RANGE BETWEEN 1 FOLLOWING AND 3 FOLLOWING}) — a frame need not straddle the current
+    * row. Per the SQL RANGE standard, the offset direction is relative to the ORDER BY SEQUENCE,
+    * not raw arithmetic sign: for an ASCENDING key, {@code n PRECEDING} means "value = current −
+    * n" and {@code n FOLLOWING} means "value = current + n"; for a DESCENDING key the signs
+    * flip (preceding in a descending sequence is a LARGER value) — see {@link #rangeThreshold}.
+    * Because {@code p} itself need not lie inside a symmetric-offset frame (e.g. both bounds
+    * FOLLOWING excludes the current row entirely), the threshold crossing is found by scanning
+    * the whole (monotonic-by-construction) partition rather than expanding outward from
+    * {@code p} — see {@link #rangeLoScan}/{@link #rangeHiScan}.
     */
    private int[] rangeSlice(Spec spec, Integer[] idx, int start, int end, int p) {
       int size = end - start;
@@ -542,70 +548,101 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
       return new int[]{ lo, hi };
    }
 
-   /** RANGE start-bound resolution (partition-relative). See {@link #rangeSlice}. */
+   /**
+    * RANGE start-bound (LO index) resolution (partition-relative). Accepts all five bound
+    * tokens — see {@link #rangeSlice}.
+    */
    private int rangeStart(Spec spec, Integer[] idx, int start, int size, int p, boolean asc) {
       switch(spec.startBound) {
       case "UNBOUNDED_PRECEDING":
          return 0;
+      case "UNBOUNDED_FOLLOWING":
+         // starts after the last row: always empty once combined with any end bound.
+         return size;
       case "CURRENT_ROW":
          return peerWalkLeft(spec, idx, start, p);
-      case "PRECEDING": {
-         int dataRowP = idx[start + p];
-         int q = p;
-
-         if(asc) {
-            double threshold = offsetOrderValue(spec, dataRowP, -spec.startOffset);
-
-            while(q > 0 && orderValue(spec, idx[start + q - 1]) >= threshold) {
-               q--;
-            }
-         }
-         else {
-            double threshold = offsetOrderValue(spec, dataRowP, spec.startOffset);
-
-            while(q > 0 && orderValue(spec, idx[start + q - 1]) <= threshold) {
-               q--;
-            }
-         }
-
-         return q;
+      case "PRECEDING": case "FOLLOWING": {
+         double threshold =
+            rangeThreshold(spec, idx[start + p], spec.startBound, spec.startOffset, asc);
+         return rangeLoScan(spec, idx, start, size, threshold, asc);
       }
       default:
          throw new RuntimeException("invalid RANGE start bound: " + spec.startBound);
       }
    }
 
-   /** RANGE end-bound resolution (partition-relative). See {@link #rangeSlice}. */
+   /**
+    * RANGE end-bound (HI index) resolution (partition-relative). Accepts all five bound
+    * tokens — see {@link #rangeSlice}.
+    */
    private int rangeEnd(Spec spec, Integer[] idx, int start, int size, int p, boolean asc) {
       switch(spec.endBound) {
       case "UNBOUNDED_FOLLOWING":
          return size - 1;
+      case "UNBOUNDED_PRECEDING":
+         // ends before the first row: always empty once combined with any start bound.
+         return -1;
       case "CURRENT_ROW":
          return peerWalkRight(spec, idx, start, size, p);
-      case "FOLLOWING": {
-         int dataRowP = idx[start + p];
-         int q = p;
-
-         if(asc) {
-            double threshold = offsetOrderValue(spec, dataRowP, spec.endOffset);
-
-            while(q < size - 1 && orderValue(spec, idx[start + q + 1]) <= threshold) {
-               q++;
-            }
-         }
-         else {
-            double threshold = offsetOrderValue(spec, dataRowP, -spec.endOffset);
-
-            while(q < size - 1 && orderValue(spec, idx[start + q + 1]) >= threshold) {
-               q++;
-            }
-         }
-
-         return q;
+      case "PRECEDING": case "FOLLOWING": {
+         double threshold =
+            rangeThreshold(spec, idx[start + p], spec.endBound, spec.endOffset, asc);
+         return rangeHiScan(spec, idx, start, size, threshold, asc);
       }
       default:
          throw new RuntimeException("invalid RANGE end bound: " + spec.endBound);
       }
+   }
+
+   /**
+    * The value threshold for a {@code PRECEDING}/{@code FOLLOWING} RANGE bound at row
+    * {@code dataRowP}, sign-adjusted for the ORDER BY direction (same rule for either side —
+    * see {@link #rangeSlice}): {@code PRECEDING n} → {@code val(p) − n} under ASC,
+    * {@code val(p) + n} under DESC; {@code FOLLOWING n} → {@code val(p) + n} under ASC,
+    * {@code val(p) − n} under DESC.
+    */
+   private double rangeThreshold(Spec spec, int dataRowP, String bound, int offset, boolean asc) {
+      boolean preceding = "PRECEDING".equals(bound);
+      int signedOffset = (preceding == asc) ? -offset : offset;
+      return offsetOrderValue(spec, dataRowP, signedOffset);
+   }
+
+   /**
+    * Leftmost partition-relative index in {@code [0,size)} whose order value is within-range
+    * at/after {@code threshold} (ASC: {@code value ≥ threshold}; DESC: {@code value ≤
+    * threshold}), or {@code size} if no row qualifies (an empty frame once combined with any
+    * HI). Order values are monotonic across the partition by construction (the lens sorted by
+    * this order key), so this condition is a single threshold crossing; scanning the whole
+    * partition (rather than expanding outward from {@code p}) is required because a symmetric
+    * offset frame (e.g. both bounds {@code FOLLOWING}) need not contain {@code p}.
+    */
+   private int rangeLoScan(Spec spec, Integer[] idx, int start, int size, double threshold, boolean asc) {
+      for(int q = 0; q < size; q++) {
+         double v = orderValue(spec, idx[start + q]);
+
+         if(asc ? v >= threshold : v <= threshold) {
+            return q;
+         }
+      }
+
+      return size;
+   }
+
+   /**
+    * Rightmost partition-relative index in {@code [0,size)} whose order value is within-range
+    * at/before {@code threshold} (ASC: {@code value ≤ threshold}; DESC: {@code value ≥
+    * threshold}), or {@code -1} if no row qualifies. See {@link #rangeLoScan}.
+    */
+   private int rangeHiScan(Spec spec, Integer[] idx, int start, int size, double threshold, boolean asc) {
+      for(int q = size - 1; q >= 0; q--) {
+         double v = orderValue(spec, idx[start + q]);
+
+         if(asc ? v <= threshold : v >= threshold) {
+            return q;
+         }
+      }
+
+      return -1;
    }
 
    /** Walk left (decreasing partition-relative index) from {@code p} while tied on order key. */
@@ -653,8 +690,8 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
       int lastGroup = g;
       int pGroup = groupOf[p];
 
-      int startGroup = groupBoundStart(spec.startBound, spec.startOffset, pGroup);
-      int endGroup = groupBoundEnd(spec.endBound, spec.endOffset, pGroup, lastGroup);
+      int startGroup = groupBound(spec.startBound, spec.startOffset, pGroup, lastGroup);
+      int endGroup = groupBound(spec.endBound, spec.endOffset, pGroup, lastGroup);
 
       startGroup = Math.max(0, Math.min(lastGroup, startGroup));
       endGroup = Math.max(0, Math.min(lastGroup, endGroup));
@@ -678,29 +715,37 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
       return new int[]{ lo, hi };
    }
 
-   private int groupBoundStart(String bound, int offset, int pGroup) {
+   /**
+    * GROUPS bound → group index, for EITHER side (start or end): {@code PRECEDING n} = earlier
+    * groups ({@code pGroup − n}), {@code FOLLOWING n} = later groups ({@code pGroup + n}), in
+    * ORDER BY sequence — both tokens are valid on either side (e.g. {@code GROUPS BETWEEN 2
+    * PRECEDING AND 1 PRECEDING}). Accepts all five bound tokens; the caller clamps the result to
+    * {@code [0,lastGroup]}.
+    */
+   private int groupBound(String bound, int offset, int pGroup, int lastGroup) {
       switch(bound) {
       case "UNBOUNDED_PRECEDING": return 0;
-      case "CURRENT_ROW":         return pGroup;
-      case "PRECEDING":           return pGroup - offset;
-      default:
-         throw new RuntimeException("invalid GROUPS start bound: " + bound);
-      }
-   }
-
-   private int groupBoundEnd(String bound, int offset, int pGroup, int lastGroup) {
-      switch(bound) {
       case "UNBOUNDED_FOLLOWING": return lastGroup;
       case "CURRENT_ROW":         return pGroup;
+      case "PRECEDING":           return pGroup - offset;
       case "FOLLOWING":           return pGroup + offset;
       default:
-         throw new RuntimeException("invalid GROUPS end bound: " + bound);
+         throw new RuntimeException("invalid GROUPS bound: " + bound);
       }
    }
 
-   /** value(dataRow) as a double for a numeric order key, or epoch-ms for a date/time key. */
+   /**
+    * value(dataRow) as a double for a numeric order key, or epoch-ms for a date/time key.
+    * NULLS handling is deferred for RANGE value frames (unlike the peer/UNBOUNDED path, which
+    * is null-safe via {@link #orderKeyCompare}/{@link Tool#compare}) — fail loud rather than NPE.
+    */
    private double orderValue(Spec spec, int dataRow) {
       Object v = table.getObject(dataRow + table.getHeaderRowCount(), spec.orderCols[0]);
+
+      if(v == null) {
+         throw new RuntimeException(
+            "RANGE value frame does not support null ORDER BY values (NULLS handling not implemented)");
+      }
 
       if(v instanceof java.util.Date) {
          return ((java.util.Date) v).getTime();
@@ -721,6 +766,11 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
    private double offsetOrderValue(Spec spec, int dataRow, int signedOffset) {
       Object v = table.getObject(dataRow + table.getHeaderRowCount(), spec.orderCols[0]);
 
+      if(v == null) {
+         throw new RuntimeException(
+            "RANGE value frame does not support null ORDER BY values (NULLS handling not implemented)");
+      }
+
       if(v instanceof java.util.Date) {
          return dateOffsetMs((java.util.Date) v, spec.offsetUnit, signedOffset);
       }
@@ -733,6 +783,11 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
          return v.getTime() + signedOffset;   // defensive: no unit given, treat as raw ms
       }
 
+      // Fixed-width units apply a raw millisecond delta. This is exact for a date /
+      // timestamp-without-timezone order key (the common case, no DST shift), but for a
+      // timestamptz key whose offset window crosses a DST boundary, this fixed-width delta can
+      // differ by an hour from Postgres's zone-aware INTERVAL arithmetic (which adds wall-clock
+      // time, not a fixed duration).
       switch(unit.toLowerCase()) {
       case "second": return v.getTime() + signedOffset * 1000L;
       case "minute": return v.getTime() + signedOffset * 60_000L;

--- a/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
+++ b/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
@@ -690,15 +690,22 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
       int lastGroup = g;
       int pGroup = groupOf[p];
 
-      int startGroup = groupBound(spec.startBound, spec.startOffset, pGroup, lastGroup);
-      int endGroup = groupBound(spec.endBound, spec.endOffset, pGroup, lastGroup);
+      int rawStartGroup = groupBound(spec.startBound, spec.startOffset, pGroup, lastGroup);
+      int rawEndGroup = groupBound(spec.endBound, spec.endOffset, pGroup, lastGroup);
 
-      startGroup = Math.max(0, Math.min(lastGroup, startGroup));
-      endGroup = Math.max(0, Math.min(lastGroup, endGroup));
-
-      if(startGroup > endGroup) {
+      // Detect emptiness on the RAW (pre-clamp) group indices, before clamping either bound
+      // into [0,lastGroup]. Clamping first (the pre-fix behavior) silently turned an
+      // out-of-range frame into a real one: e.g. GROUPS BETWEEN 2 PRECEDING AND 1 PRECEDING at
+      // the FIRST group has raw start=-2, end=-1 — both clamp to 0, yielding group 0 instead of
+      // the correct empty frame (Postgres: no rows). Symmetric at the LAST group for
+      // N FOLLOWING .. M FOLLOWING (rawStartGroup > lastGroup). A frame is empty when it lies
+      // entirely before group 0, entirely after the last group, or is inverted.
+      if(rawEndGroup < 0 || rawStartGroup > lastGroup || rawStartGroup > rawEndGroup) {
          return new int[]{ 0, -1 };   // empty frame — clamps to null in frameSlice
       }
+
+      int startGroup = Math.max(0, rawStartGroup);
+      int endGroup = Math.min(lastGroup, rawEndGroup);
 
       int lo = -1, hi = -1;
 
@@ -740,6 +747,15 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
     * is null-safe via {@link #orderKeyCompare}/{@link Tool#compare}) — fail loud rather than NPE.
     */
    private double orderValue(Spec spec, int dataRow) {
+      if(spec.orderCols.length == 0) {
+         // Defense-in-depth: the validated wire path (WorksheetTableService) always requires
+         // exactly one ORDER BY column for a RANGE/GROUPS value-offset frame, so this is
+         // unreachable in practice — fail loud with a named error rather than an
+         // ArrayIndexOutOfBoundsException on orderCols[0] if that invariant is ever violated.
+         throw new RuntimeException(
+            "RANGE/GROUPS value-offset frame requires exactly one ORDER BY column (none present)");
+      }
+
       Object v = table.getObject(dataRow + table.getHeaderRowCount(), spec.orderCols[0]);
 
       if(v == null) {
@@ -764,6 +780,12 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
     * 30-day delta.
     */
    private double offsetOrderValue(Spec spec, int dataRow, int signedOffset) {
+      if(spec.orderCols.length == 0) {
+         // Defense-in-depth — see orderValue.
+         throw new RuntimeException(
+            "RANGE/GROUPS value-offset frame requires exactly one ORDER BY column (none present)");
+      }
+
       Object v = table.getObject(dataRow + table.getHeaderRowCount(), spec.orderCols[0]);
 
       if(v == null) {
@@ -780,7 +802,13 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
 
    private static double dateOffsetMs(java.util.Date v, String unit, int signedOffset) {
       if(unit == null) {
-         return v.getTime() + signedOffset;   // defensive: no unit given, treat as raw ms
+         // Unreachable for a validated frame: WorksheetTableService.applyWindowColumns rejects a
+         // RANGE value-offset whose single ORDER BY key is date/time-typed and offsetUnit is
+         // missing (a numeric offset on a date key is meaningless in SQL — it needs an
+         // INTERVAL). Fail loud rather than silently treating the offset as raw milliseconds,
+         // matching this file's fail-loud style, in case that invariant is ever violated.
+         throw new RuntimeException(
+            "RANGE offset on a date/time order key requires an offsetUnit");
       }
 
       // Fixed-width units apply a raw millisecond delta. This is exact for a date /

--- a/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
+++ b/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
@@ -51,6 +51,11 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
       public final int startOffset;
       public final String endBound;
       public final int endOffset;
+      // Phase 4: frame mode ("ROWS" default | "RANGE" | "GROUPS") and, for a date/time RANGE
+      // value-offset, the interval unit ("year"|"quarter"|"month"|"week"|"day"|"hour"|"minute"|
+      // "second"). null/absent offsetUnit means the RANGE offset is a plain numeric value.
+      public final String mode;
+      public final String offsetUnit;
 
       public Spec(String header, String fn, int argCol, int n,
                   int[] partCols, int[] orderCols, boolean[] orderAsc) {
@@ -60,6 +65,14 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
       public Spec(String header, String fn, int argCol, int n,
                   int[] partCols, int[] orderCols, boolean[] orderAsc,
                   String startBound, int startOffset, String endBound, int endOffset) {
+         this(header, fn, argCol, n, partCols, orderCols, orderAsc,
+              startBound, startOffset, endBound, endOffset, "ROWS", null);
+      }
+
+      public Spec(String header, String fn, int argCol, int n,
+                  int[] partCols, int[] orderCols, boolean[] orderAsc,
+                  String startBound, int startOffset, String endBound, int endOffset,
+                  String mode, String offsetUnit) {
          this.header = header;
          this.fn = fn == null ? "" : fn.toUpperCase();
          this.argCol = argCol;
@@ -71,6 +84,8 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
          this.startOffset = startOffset;
          this.endBound = endBound;
          this.endOffset = endOffset;
+         this.mode = mode == null ? "ROWS" : mode.toUpperCase();
+         this.offsetUnit = offsetUnit;
       }
    }
 
@@ -354,17 +369,17 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
          return table.getObject(idx[start + q] + hrows, spec.argCol);
       }
       case "FIRST_VALUE": {
-         int[] fr = frameSlice(spec, start, end, p);
+         int[] fr = frameSlice(spec, idx, start, end, p);
          int hrows = table.getHeaderRowCount();
          return fr == null ? null : table.getObject(idx[fr[0]] + hrows, spec.argCol);
       }
       case "LAST_VALUE": {
-         int[] fr = frameSlice(spec, start, end, p);
+         int[] fr = frameSlice(spec, idx, start, end, p);
          int hrows = table.getHeaderRowCount();
          return fr == null ? null : table.getObject(idx[fr[1]] + hrows, spec.argCol);
       }
       case "SUM": case "AVG": case "COUNT": case "MIN": case "MAX": {
-         int[] fr = frameSlice(spec, start, end, p);
+         int[] fr = frameSlice(spec, idx, start, end, p);
 
          if(fr == null) {
             // Empty frame: COUNT is 0; every other aggregate is NULL over zero rows
@@ -431,14 +446,20 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
    }
 
    /**
-    * The ROWS frame for {@code spec} at sorted position {@code p} within partition
+    * The frame for {@code spec} at sorted position {@code p} within partition
     * {@code [start,end)}, as absolute indices into {@code idx} (inclusive), or {@code null} if
     * the frame is empty for this row.
     * <p>Frame-less ({@code spec.startBound == null}) reproduces the Phase-1/2 defaults exactly:
     * FIRST_VALUE/LAST_VALUE and an order-less aggregate see the whole partition; an aggregate
-    * with an ORDER BY sees the running frame {@code [0,p]}.
+    * with an ORDER BY sees the running frame {@code [0,p]}. This branch is UNCHANGED from
+    * Phase 3 (byte-parity).
+    * <p>An explicit frame dispatches on {@code spec.mode}: {@code ROWS} (default) keeps the
+    * Phase-3 {@link #boundPos} physical-offset logic unchanged; {@code RANGE}/{@code GROUPS} are
+    * resolved by {@link #rangeSlice}/{@link #groupsSlice}, which return partition-relative
+    * {@code [lo,hi]} (possibly out of {@code [0,size)}) and share the same clamp-to-empty logic
+    * below as ROWS.
     */
-   private static int[] frameSlice(Spec spec, int start, int end, int p) {
+   private int[] frameSlice(Spec spec, Integer[] idx, int start, int end, int p) {
       int size = end - start;
       int lo, hi;
 
@@ -455,8 +476,23 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
          }
       }
       else {
-         lo = boundPos(spec.startBound, spec.startOffset, p, size);
-         hi = boundPos(spec.endBound, spec.endOffset, p, size);
+         switch(spec.mode) {
+         case "RANGE": {
+            int[] fr = rangeSlice(spec, idx, start, end, p);
+            lo = fr[0];
+            hi = fr[1];
+            break;
+         }
+         case "GROUPS": {
+            int[] fr = groupsSlice(spec, idx, start, end, p);
+            lo = fr[0];
+            hi = fr[1];
+            break;
+         }
+         default:
+            lo = boundPos(spec.startBound, spec.startOffset, p, size);   // ROWS
+            hi = boundPos(spec.endBound, spec.endOffset, p, size);
+         }
       }
 
       int loc = Math.max(0, lo);
@@ -478,6 +514,246 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
       case "FOLLOWING":           return p + offset;
       default:
          throw new RuntimeException("invalid window frame bound: " + bound);
+      }
+   }
+
+   /**
+    * RANGE frame resolution for partition-relative position {@code p} within
+    * {@code [start,end)} (given as absolute {@code idx} indices). Returns partition-relative
+    * {@code [lo,hi]} (may be out of {@code [0,size)}; the caller clamps).
+    * <p>{@code CURRENT_ROW} is always resolved as a PEER walk — the contiguous run of rows tied
+    * with {@code p} on the order key (via {@link #orderKeyCompare}) — never as a numeric value
+    * threshold. This matters for a DESCENDING order key: e.g. order key 30,30,10 (desc) with
+    * {@code RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW} must stop at the end of the
+    * 30-peer-group (frame {30,30}, NOT {30,30,10}), even though the row with value 10
+    * numerically satisfies "value ≤ 30"; a peer group is a POSITION in the sorted sequence, not
+    * a value threshold, and the two only coincide for ASCENDING order.
+    * <p>{@code PRECEDING}/{@code FOLLOWING} WITH an offset are genuine value bounds. Per the SQL
+    * RANGE standard, the offset direction is relative to the ORDER BY SEQUENCE, not raw
+    * arithmetic sign: for an ASCENDING key, {@code n PRECEDING} means "value ≥ current − n"; for
+    * a DESCENDING key it means "value ≤ current + n" (preceding in a descending sequence is a
+    * LARGER value). {@link #rangeStart}/{@link #rangeEnd} apply this directly.
+    */
+   private int[] rangeSlice(Spec spec, Integer[] idx, int start, int end, int p) {
+      int size = end - start;
+      boolean asc = spec.orderAsc.length == 0 || spec.orderAsc[0];
+      int lo = rangeStart(spec, idx, start, size, p, asc);
+      int hi = rangeEnd(spec, idx, start, size, p, asc);
+      return new int[]{ lo, hi };
+   }
+
+   /** RANGE start-bound resolution (partition-relative). See {@link #rangeSlice}. */
+   private int rangeStart(Spec spec, Integer[] idx, int start, int size, int p, boolean asc) {
+      switch(spec.startBound) {
+      case "UNBOUNDED_PRECEDING":
+         return 0;
+      case "CURRENT_ROW":
+         return peerWalkLeft(spec, idx, start, p);
+      case "PRECEDING": {
+         int dataRowP = idx[start + p];
+         int q = p;
+
+         if(asc) {
+            double threshold = offsetOrderValue(spec, dataRowP, -spec.startOffset);
+
+            while(q > 0 && orderValue(spec, idx[start + q - 1]) >= threshold) {
+               q--;
+            }
+         }
+         else {
+            double threshold = offsetOrderValue(spec, dataRowP, spec.startOffset);
+
+            while(q > 0 && orderValue(spec, idx[start + q - 1]) <= threshold) {
+               q--;
+            }
+         }
+
+         return q;
+      }
+      default:
+         throw new RuntimeException("invalid RANGE start bound: " + spec.startBound);
+      }
+   }
+
+   /** RANGE end-bound resolution (partition-relative). See {@link #rangeSlice}. */
+   private int rangeEnd(Spec spec, Integer[] idx, int start, int size, int p, boolean asc) {
+      switch(spec.endBound) {
+      case "UNBOUNDED_FOLLOWING":
+         return size - 1;
+      case "CURRENT_ROW":
+         return peerWalkRight(spec, idx, start, size, p);
+      case "FOLLOWING": {
+         int dataRowP = idx[start + p];
+         int q = p;
+
+         if(asc) {
+            double threshold = offsetOrderValue(spec, dataRowP, spec.endOffset);
+
+            while(q < size - 1 && orderValue(spec, idx[start + q + 1]) <= threshold) {
+               q++;
+            }
+         }
+         else {
+            double threshold = offsetOrderValue(spec, dataRowP, -spec.endOffset);
+
+            while(q < size - 1 && orderValue(spec, idx[start + q + 1]) >= threshold) {
+               q++;
+            }
+         }
+
+         return q;
+      }
+      default:
+         throw new RuntimeException("invalid RANGE end bound: " + spec.endBound);
+      }
+   }
+
+   /** Walk left (decreasing partition-relative index) from {@code p} while tied on order key. */
+   private int peerWalkLeft(Spec spec, Integer[] idx, int start, int p) {
+      int q = p;
+
+      while(q > 0 && orderKeyCompare(spec, idx[start + q - 1], idx[start + p]) == 0) {
+         q--;
+      }
+
+      return q;
+   }
+
+   /** Walk right (increasing partition-relative index) from {@code p} while tied on order key. */
+   private int peerWalkRight(Spec spec, Integer[] idx, int start, int size, int p) {
+      int q = p;
+
+      while(q < size - 1 && orderKeyCompare(spec, idx[start + q + 1], idx[start + p]) == 0) {
+         q++;
+      }
+
+      return q;
+   }
+
+   /**
+    * GROUPS frame resolution: offsets count DISTINCT order-key groups (peer groups) rather than
+    * physical rows. Group boundaries are detected the same way as RANK/DENSE_RANK — a break is
+    * where consecutive sorted rows differ on {@link #orderKeyCompare}. Returns
+    * partition-relative {@code [lo,hi]} (may already reflect an empty frame via {@code lo>hi}).
+    */
+   private int[] groupsSlice(Spec spec, Integer[] idx, int start, int end, int p) {
+      int size = end - start;
+      int[] groupOf = new int[size];
+      int g = 0;
+      groupOf[0] = 0;
+
+      for(int q = 1; q < size; q++) {
+         if(orderKeyCompare(spec, idx[start + q - 1], idx[start + q]) != 0) {
+            g++;
+         }
+
+         groupOf[q] = g;
+      }
+
+      int lastGroup = g;
+      int pGroup = groupOf[p];
+
+      int startGroup = groupBoundStart(spec.startBound, spec.startOffset, pGroup);
+      int endGroup = groupBoundEnd(spec.endBound, spec.endOffset, pGroup, lastGroup);
+
+      startGroup = Math.max(0, Math.min(lastGroup, startGroup));
+      endGroup = Math.max(0, Math.min(lastGroup, endGroup));
+
+      if(startGroup > endGroup) {
+         return new int[]{ 0, -1 };   // empty frame — clamps to null in frameSlice
+      }
+
+      int lo = -1, hi = -1;
+
+      for(int q = 0; q < size; q++) {
+         if(groupOf[q] == startGroup && lo == -1) {
+            lo = q;
+         }
+
+         if(groupOf[q] == endGroup) {
+            hi = q;
+         }
+      }
+
+      return new int[]{ lo, hi };
+   }
+
+   private int groupBoundStart(String bound, int offset, int pGroup) {
+      switch(bound) {
+      case "UNBOUNDED_PRECEDING": return 0;
+      case "CURRENT_ROW":         return pGroup;
+      case "PRECEDING":           return pGroup - offset;
+      default:
+         throw new RuntimeException("invalid GROUPS start bound: " + bound);
+      }
+   }
+
+   private int groupBoundEnd(String bound, int offset, int pGroup, int lastGroup) {
+      switch(bound) {
+      case "UNBOUNDED_FOLLOWING": return lastGroup;
+      case "CURRENT_ROW":         return pGroup;
+      case "FOLLOWING":           return pGroup + offset;
+      default:
+         throw new RuntimeException("invalid GROUPS end bound: " + bound);
+      }
+   }
+
+   /** value(dataRow) as a double for a numeric order key, or epoch-ms for a date/time key. */
+   private double orderValue(Spec spec, int dataRow) {
+      Object v = table.getObject(dataRow + table.getHeaderRowCount(), spec.orderCols[0]);
+
+      if(v instanceof java.util.Date) {
+         return ((java.util.Date) v).getTime();
+      }
+
+      return ((Number) v).doubleValue();
+   }
+
+   /**
+    * {@code val(dataRow) + signedOffset} in the order key's units. Numeric keys: the offset is
+    * added directly. Date/time keys: {@code spec.offsetUnit} selects the unit — fixed-width
+    * units ({@code second, minute, hour, day, week}) are applied as a millisecond delta;
+    * calendar units ({@code month, quarter, year}) are applied via per-row {@code java.time}
+    * calendar arithmetic (28-31 day months, etc.) and then compared by epoch-ms — matching
+    * Postgres {@code INTERVAL} semantics, where "1 month" is calendar-relative, not a fixed
+    * 30-day delta.
+    */
+   private double offsetOrderValue(Spec spec, int dataRow, int signedOffset) {
+      Object v = table.getObject(dataRow + table.getHeaderRowCount(), spec.orderCols[0]);
+
+      if(v instanceof java.util.Date) {
+         return dateOffsetMs((java.util.Date) v, spec.offsetUnit, signedOffset);
+      }
+
+      return ((Number) v).doubleValue() + signedOffset;
+   }
+
+   private static double dateOffsetMs(java.util.Date v, String unit, int signedOffset) {
+      if(unit == null) {
+         return v.getTime() + signedOffset;   // defensive: no unit given, treat as raw ms
+      }
+
+      switch(unit.toLowerCase()) {
+      case "second": return v.getTime() + signedOffset * 1000L;
+      case "minute": return v.getTime() + signedOffset * 60_000L;
+      case "hour":   return v.getTime() + signedOffset * 3_600_000L;
+      case "day":    return v.getTime() + signedOffset * 86_400_000L;
+      case "week":   return v.getTime() + signedOffset * 7L * 86_400_000L;
+      case "month": case "quarter": case "year": {
+         java.time.ZoneId zone = java.time.ZoneId.systemDefault();
+         java.time.LocalDateTime ldt =
+            java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(v.getTime()), zone);
+
+         switch(unit.toLowerCase()) {
+         case "month":   ldt = ldt.plusMonths(signedOffset); break;
+         case "quarter": ldt = ldt.plusMonths(signedOffset * 3L); break;
+         default:        ldt = ldt.plusYears(signedOffset); break;
+         }
+
+         return ldt.atZone(zone).toInstant().toEpochMilli();
+      }
+      default:
+         throw new RuntimeException("invalid RANGE offsetUnit: " + unit);
       }
    }
 

--- a/core/src/main/java/inetsoft/uql/asset/WindowExpressionRef.java
+++ b/core/src/main/java/inetsoft/uql/asset/WindowExpressionRef.java
@@ -155,15 +155,16 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
    }
 
    /**
-    * Get the ROWS frame start bound, e.g. {@code "PRECEDING"}, {@code "UNBOUNDED_PRECEDING"},
-    * {@code "CURRENT_ROW"}. {@code null} means no explicit frame was set.
+    * Get the window frame start bound, e.g. {@code "PRECEDING"}, {@code "UNBOUNDED_PRECEDING"},
+    * {@code "CURRENT_ROW"}. {@code null} means no explicit frame was set. Applies to any frame
+    * mode (ROWS, RANGE, or GROUPS) — see {@link #getFrameMode()}.
     */
    public String getFrameStartBound() {
       return frameStartBound;
    }
 
    /**
-    * Get the ROWS frame start offset (meaningful only when {@link #getFrameStartBound()} is
+    * Get the window frame start offset (meaningful only when {@link #getFrameStartBound()} is
     * {@code "PRECEDING"} or {@code "FOLLOWING"}).
     */
    public int getFrameStartOffset() {
@@ -171,15 +172,16 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
    }
 
    /**
-    * Get the ROWS frame end bound, e.g. {@code "FOLLOWING"}, {@code "UNBOUNDED_FOLLOWING"},
-    * {@code "CURRENT_ROW"}. {@code null} means no explicit frame was set.
+    * Get the window frame end bound, e.g. {@code "FOLLOWING"}, {@code "UNBOUNDED_FOLLOWING"},
+    * {@code "CURRENT_ROW"}. {@code null} means no explicit frame was set. Applies to any frame
+    * mode (ROWS, RANGE, or GROUPS) — see {@link #getFrameMode()}.
     */
    public String getFrameEndBound() {
       return frameEndBound;
    }
 
    /**
-    * Get the ROWS frame end offset (meaningful only when {@link #getFrameEndBound()} is
+    * Get the window frame end offset (meaningful only when {@link #getFrameEndBound()} is
     * {@code "PRECEDING"} or {@code "FOLLOWING"}).
     */
    public int getFrameEndOffset() {
@@ -187,7 +189,8 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
    }
 
    /**
-    * Check whether an explicit ROWS frame was set via {@link #setFrame}.
+    * Check whether an explicit window frame (ROWS, RANGE, or GROUPS) was set via
+    * {@link #setFrame}.
     */
    public boolean hasExplicitFrame() {
       return frameStartBound != null;
@@ -244,7 +247,14 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
    {
       requireValidFrameBound(startBound, startOffset);
       requireValidFrameBound(endBound, endOffset);
-      this.frameMode = (mode == null) ? "ROWS" : mode.toUpperCase();
+      String resolved = (mode == null) ? "ROWS" : mode.toUpperCase();
+      requireValidFrameMode(resolved);
+      requireValidFrameOffsetUnit(offsetUnit);
+      // Store null for the default ROWS mode (not the resolved "ROWS" string) so writeAttributes'
+      // `if(frameMode != null)` guard only emits the frameMode attribute for RANGE/GROUPS. This
+      // preserves XML byte-parity with Phase 3 ROWS-frame worksheets, which never wrote this
+      // attribute. getFrameMode() already maps a null field back to "ROWS".
+      this.frameMode = "ROWS".equals(resolved) ? null : resolved;
       this.frameStartBound = startBound;
       this.frameStartOffset = startOffset;
       this.frameEndBound = endBound;
@@ -255,6 +265,13 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
    /** Recognized ROWS frame bound tokens (see {@link #setFrame}). */
    private static final Set<String> VALID_FRAME_BOUNDS = Set.of(
       "UNBOUNDED_PRECEDING", "PRECEDING", "CURRENT_ROW", "FOLLOWING", "UNBOUNDED_FOLLOWING");
+
+   /** Recognized frame mode tokens (see {@link #setFrame}). */
+   private static final Set<String> VALID_FRAME_MODES = Set.of("ROWS", "RANGE", "GROUPS");
+
+   /** Recognized frame offset unit tokens (see {@link #setFrame}). */
+   private static final Set<String> VALID_FRAME_OFFSET_UNITS = Set.of(
+      "year", "quarter", "month", "week", "day", "hour", "minute", "second");
 
    /**
     * Guard against a caller constructing a {@code WindowExpressionRef} frame directly (bypassing
@@ -271,6 +288,28 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
       if(("PRECEDING".equals(bound) || "FOLLOWING".equals(bound)) && offset <= 0) {
          throw new IllegalArgumentException(
             "window frame bound '" + bound + "' requires a positive offset");
+      }
+   }
+
+   /**
+    * Guard against a caller constructing a {@code WindowExpressionRef} frame directly with an
+    * unrecognized mode token, mirroring {@link #requireValidFrameBound}. {@code mode} must
+    * already be uppercased/resolved (i.e. never {@code null}) by the caller.
+    */
+   private static void requireValidFrameMode(String mode) {
+      if(!VALID_FRAME_MODES.contains(mode)) {
+         throw new IllegalArgumentException("invalid window frame mode: " + mode);
+      }
+   }
+
+   /**
+    * Guard against a caller constructing a {@code WindowExpressionRef} frame directly with an
+    * unrecognized offset unit token, mirroring {@link #requireValidFrameBound}. {@code null} is
+    * always valid (a bare-integer offset).
+    */
+   private static void requireValidFrameOffsetUnit(String unit) {
+      if(unit != null && !VALID_FRAME_OFFSET_UNITS.contains(unit)) {
+         throw new IllegalArgumentException("invalid window frame offset unit: " + unit);
       }
    }
 
@@ -419,8 +458,8 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
    }
 
    /**
-    * Get the {@code ROWS BETWEEN ... AND ...} frame fragment, or "" if no frame clause should be
-    * emitted.
+    * Get the {@code ROWS|RANGE|GROUPS BETWEEN ... AND ...} window frame fragment, or "" if no
+    * frame clause should be emitted.
     * <p>
     * Frame-less aggregates and {@code FIRST_VALUE} emit no frame clause (byte-parity with the
     * pre-frame pushdown text — the database's default frame is what today's behavior relies on).

--- a/core/src/main/java/inetsoft/uql/asset/WindowExpressionRef.java
+++ b/core/src/main/java/inetsoft/uql/asset/WindowExpressionRef.java
@@ -194,8 +194,27 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
    }
 
    /**
-    * Set an explicit ROWS frame. Bound values must be one of {@code UNBOUNDED_PRECEDING},
-    * {@code PRECEDING}, {@code CURRENT_ROW}, {@code FOLLOWING}, {@code UNBOUNDED_FOLLOWING}.
+    * Get the frame mode: {@code ROWS}, {@code RANGE}, or {@code GROUPS}. Defaults to
+    * {@code "ROWS"} when no explicit mode was set (Phase 3 frames / frame-less refs).
+    */
+   public String getFrameMode() {
+      return frameMode == null ? "ROWS" : frameMode;
+   }
+
+   /**
+    * Get the frame offset unit (e.g. {@code "day"}), used to render a date-valued {@code RANGE}
+    * frame's {@code PRECEDING}/{@code FOLLOWING} offset as a Postgres {@code INTERVAL} literal
+    * instead of a bare integer. {@code null} for ROWS/GROUPS and numeric RANGE frames.
+    */
+   public String getFrameOffsetUnit() {
+      return frameOffsetUnit;
+   }
+
+   /**
+    * Set an explicit ROWS frame (legacy Phase-3 entry point). Bound values must be one of
+    * {@code UNBOUNDED_PRECEDING}, {@code PRECEDING}, {@code CURRENT_ROW}, {@code FOLLOWING},
+    * {@code UNBOUNDED_FOLLOWING}. Delegates to the 6-arg {@link #setFrame(String, String, int,
+    * String, int, String)} with {@code mode="ROWS"} and no offset unit.
     *
     * @param startBound the frame start bound.
     * @param startOffset the frame start offset (used for PRECEDING/FOLLOWING).
@@ -203,12 +222,34 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
     * @param endOffset the frame end offset (used for PRECEDING/FOLLOWING).
     */
    public void setFrame(String startBound, int startOffset, String endBound, int endOffset) {
+      setFrame("ROWS", startBound, startOffset, endBound, endOffset, null);
+   }
+
+   /**
+    * Set an explicit frame. Bound values must be one of {@code UNBOUNDED_PRECEDING},
+    * {@code PRECEDING}, {@code CURRENT_ROW}, {@code FOLLOWING}, {@code UNBOUNDED_FOLLOWING}.
+    *
+    * @param mode the frame mode: {@code ROWS}, {@code RANGE}, or {@code GROUPS}. {@code null} is
+    *             normalized to {@code "ROWS"}.
+    * @param startBound the frame start bound.
+    * @param startOffset the frame start offset (used for PRECEDING/FOLLOWING).
+    * @param endBound the frame end bound.
+    * @param endOffset the frame end offset (used for PRECEDING/FOLLOWING).
+    * @param offsetUnit the date interval unit (e.g. {@code "day"}) for a date-valued RANGE frame's
+    *                   PRECEDING/FOLLOWING offset; {@code null} for a bare-integer offset (ROWS,
+    *                   GROUPS, and numeric RANGE frames).
+    */
+   public void setFrame(String mode, String startBound, int startOffset, String endBound,
+                         int endOffset, String offsetUnit)
+   {
       requireValidFrameBound(startBound, startOffset);
       requireValidFrameBound(endBound, endOffset);
+      this.frameMode = (mode == null) ? "ROWS" : mode.toUpperCase();
       this.frameStartBound = startBound;
       this.frameStartOffset = startOffset;
       this.frameEndBound = endBound;
       this.frameEndOffset = endOffset;
+      this.frameOffsetUnit = offsetUnit;
    }
 
    /** Recognized ROWS frame bound tokens (see {@link #setFrame}). */
@@ -394,14 +435,15 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
             "ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING" : "";
       }
 
-      return "ROWS BETWEEN " + frameBoundSql(frameStartBound, frameStartOffset)
+      String mode = getFrameMode();   // ROWS | RANGE | GROUPS
+      return mode + " BETWEEN " + frameBoundSql(frameStartBound, frameStartOffset)
          + " AND " + frameBoundSql(frameEndBound, frameEndOffset);
    }
 
    /**
     * Get the SQL text for a single frame bound.
     */
-   private static String frameBoundSql(String bound, int offset) {
+   private String frameBoundSql(String bound, int offset) {
       switch(bound) {
       case "UNBOUNDED_PRECEDING":
          return "UNBOUNDED PRECEDING";
@@ -410,12 +452,25 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
       case "CURRENT_ROW":
          return "CURRENT ROW";
       case "PRECEDING":
-         return offset + " PRECEDING";
+         return frameOffsetSql(offset) + " PRECEDING";
       case "FOLLOWING":
-         return offset + " FOLLOWING";
+         return frameOffsetSql(offset) + " FOLLOWING";
       default:
          throw new RuntimeException("invalid window frame bound: " + bound);
       }
+   }
+
+   /**
+    * Render the PRECEDING/FOLLOWING offset: a bare integer for ROWS/GROUPS/numeric-RANGE frames,
+    * or a Postgres {@code INTERVAL '<n> <unit>'} literal when {@link #frameOffsetUnit} is set
+    * (a date-valued RANGE frame).
+    */
+   private String frameOffsetSql(int offset) {
+      if(frameOffsetUnit != null) {
+         return "INTERVAL '" + offset + " " + frameOffsetUnit + "'";
+      }
+
+      return Integer.toString(offset);
    }
 
    /**
@@ -484,6 +539,14 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
          writer.print(" frameStartOffset=\"" + frameStartOffset + "\"");
          writer.print(" frameEndBound=\"" + Tool.escape(frameEndBound) + "\"");
          writer.print(" frameEndOffset=\"" + frameEndOffset + "\"");
+
+         if(frameMode != null) {
+            writer.print(" frameMode=\"" + Tool.escape(frameMode) + "\"");
+         }
+
+         if(frameOffsetUnit != null) {
+            writer.print(" frameOffsetUnit=\"" + Tool.escape(frameOffsetUnit) + "\"");
+         }
       }
 
       if(getDBType() != null) {
@@ -512,6 +575,8 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
       frameEndBound = Tool.getAttribute(tag, "frameEndBound");
       String endOffsetStr = Tool.getAttribute(tag, "frameEndOffset");
       frameEndOffset = endOffsetStr == null ? 0 : Integer.parseInt(endOffsetStr);
+      frameMode = Tool.getAttribute(tag, "frameMode");
+      frameOffsetUnit = Tool.getAttribute(tag, "frameOffsetUnit");
       setDBType(Tool.getAttribute(tag, "dbType"));
       dbversion = Tool.getAttribute(tag, "dbVersion");
    }
@@ -620,4 +685,6 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
    private int frameStartOffset;
    private String frameEndBound;
    private int frameEndOffset;
+   private String frameMode;         // null = ROWS (default)
+   private String frameOffsetUnit;   // non-null only for date-valued RANGE
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
@@ -233,7 +233,7 @@ public class WorksheetTable {
    }
 
    /**
-    * Structured ROWS frame for a {@link WindowColumnInfo}, e.g.
+    * Structured frame for a {@link WindowColumnInfo}, e.g.
     * {@code {"startBound":"PRECEDING","startOffset":2,"endBound":"CURRENT_ROW"}} for
     * {@code ROWS BETWEEN 2 PRECEDING AND CURRENT ROW}.
     * <p>
@@ -241,6 +241,13 @@ public class WorksheetTable {
     * {@code FOLLOWING} | {@code UNBOUNDED_FOLLOWING}. {@code startOffset}/{@code endOffset} are
     * required (and must be positive) when the corresponding bound is {@code PRECEDING} or
     * {@code FOLLOWING}; ignored otherwise.
+    * <p>
+    * {@code mode}: {@code ROWS} | {@code RANGE} | {@code GROUPS}; {@code null} defaults to
+    * {@code ROWS} (Phase 3 behavior, byte-parity). {@code offsetUnit}: a date interval unit
+    * (e.g. {@code "day"}) for a date-valued {@code RANGE} frame's {@code PRECEDING}/
+    * {@code FOLLOWING} offset; {@code null} for a bare-integer offset (ROWS, GROUPS, and
+    * numeric RANGE frames) — see {@code WorksheetTableService.applyWindowColumns} for the
+    * validation rules.
     */
    @JsonIgnoreProperties(ignoreUnknown = true)
    public static class WindowFrameInfo {
@@ -248,6 +255,8 @@ public class WorksheetTable {
       private Integer startOffset;
       private String endBound;
       private Integer endOffset;
+      private String mode;
+      private String offsetUnit;
 
       public String getStartBound() { return startBound; }
       public void setStartBound(String startBound) { this.startBound = startBound; }
@@ -257,6 +266,10 @@ public class WorksheetTable {
       public void setEndBound(String endBound) { this.endBound = endBound; }
       public Integer getEndOffset() { return endOffset; }
       public void setEndOffset(Integer endOffset) { this.endOffset = endOffset; }
+      public String getMode() { return mode; }
+      public void setMode(String mode) { this.mode = mode; }
+      public String getOffsetUnit() { return offsetUnit; }
+      public void setOffsetUnit(String offsetUnit) { this.offsetUnit = offsetUnit; }
    }
 
    @JsonIgnoreProperties(ignoreUnknown = true)

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1177,7 +1177,54 @@ public class WorksheetTableService {
                   "windowColumns['" + colName + "']: a bounded frame requires orderBy");
             }
 
-            winRef.setFrame(frame.getStartBound(), startOffset, frame.getEndBound(), endOffset);
+            // Phase 4: RANGE/GROUPS frame mode + offsetUnit.
+            String mode = frame.getMode() == null ? "ROWS" : frame.getMode().toUpperCase();
+
+            if(!VALID_FRAME_MODES.contains(mode)) {
+               throw new IllegalArgumentException(
+                  "windowColumns['" + colName + "']: invalid frame mode: " + frame.getMode());
+            }
+
+            // A PRECEDING/FOLLOWING bound carries a real offset (as opposed to a fixed bound
+            // like CURRENT_ROW/UNBOUNDED_*).
+            boolean valueOffset =
+               "PRECEDING".equals(frame.getStartBound()) || "FOLLOWING".equals(frame.getStartBound())
+               || "PRECEDING".equals(frame.getEndBound()) || "FOLLOWING".equals(frame.getEndBound());
+
+            // RANGE value-offset and GROUPS need an ORDER BY; RANGE value-offset needs exactly one.
+            if(("RANGE".equals(mode) && valueOffset) || "GROUPS".equals(mode)) {
+               if(orderRefs.isEmpty()) {
+                  throw new IllegalArgumentException(
+                     "windowColumns['" + colName + "']: a " + mode + " frame requires orderBy");
+               }
+            }
+
+            if("RANGE".equals(mode) && valueOffset && orderRefs.size() != 1) {
+               throw new IllegalArgumentException(
+                  "windowColumns['" + colName +
+                  "']: a RANGE value-offset frame requires exactly one orderBy column");
+            }
+
+            // offsetUnit: only for RANGE, only on a date/time order key.
+            String unit = frame.getOffsetUnit();
+
+            if(unit != null) {
+               if(!"RANGE".equals(mode)) {
+                  throw new IllegalArgumentException(
+                     "windowColumns['" + colName +
+                     "']: frame.offsetUnit is only valid for a RANGE frame");
+               }
+
+               if(!VALID_OFFSET_UNITS.contains(unit)) {
+                  throw new IllegalArgumentException(
+                     "windowColumns['" + colName + "']: invalid frame.offsetUnit: " + unit);
+               }
+
+               requireDateOrderKey(colName, orderRefs);
+            }
+
+            winRef.setFrame(mode, frame.getStartBound(), startOffset, frame.getEndBound(),
+                             endOffset, unit);
          }
 
          ColumnRef colRef = new ColumnRef(winRef);
@@ -1196,6 +1243,30 @@ public class WorksheetTableService {
    /** Window functions a ROWS frame may be attached to (aggregates + FIRST_VALUE/LAST_VALUE). */
    private static final Set<String> FRAMEABLE_FNS =
       Set.of("SUM", "AVG", "COUNT", "MIN", "MAX", "FIRST_VALUE", "LAST_VALUE");
+
+   /** Recognized {@link WorksheetTable.WindowFrameInfo} frame mode tokens (Phase 4). */
+   private static final Set<String> VALID_FRAME_MODES = Set.of("ROWS", "RANGE", "GROUPS");
+
+   /** Recognized {@link WorksheetTable.WindowFrameInfo} offset unit tokens (Phase 4). */
+   private static final Set<String> VALID_OFFSET_UNITS = Set.of(
+      "year", "quarter", "month", "week", "day", "hour", "minute", "second");
+
+   /**
+    * Validate that the (single) orderBy column of a date-valued RANGE frame is actually a
+    * date/time-typed column — {@code offsetUnit} is only meaningful (and only rendered as a
+    * Postgres {@code INTERVAL '<n> <unit>'} literal) when the ORDER BY key it measures the
+    * offset against is itself a date/time value.
+    */
+   private static void requireDateOrderKey(String colName, List<SortRef> orderRefs) {
+      SortRef s = orderRefs.get(0);
+      DataRef ref = s.getDataRef();
+      String dt = ref == null ? null : ref.getDataType();
+
+      if(!XSchema.isDateType(dt)) {
+         throw new IllegalArgumentException(
+            "windowColumns['" + colName + "']: frame.offsetUnit requires a date/time orderBy column");
+      }
+   }
 
    /** Recognized {@link WorksheetTable.WindowFrameInfo} bound tokens. */
    private static final Set<String> VALID_FRAME_BOUNDS = Set.of(

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1205,7 +1205,11 @@ public class WorksheetTableService {
                   "']: a RANGE value-offset frame requires exactly one orderBy column");
             }
 
-            // offsetUnit: only for RANGE, only on a date/time order key.
+            // offsetUnit: only meaningful when the frame has a real value-offset bound (a
+            // PRECEDING/FOLLOWING with an offset) — gate on valueOffset BEFORE consulting
+            // orderRefs, since a whole-partition RANGE/GROUPS frame legitimately carries no
+            // orderBy at all (requireDateOrderKey's orderRefs.get(0) would otherwise throw
+            // IndexOutOfBoundsException instead of a field-named IllegalArgumentException).
             String unit = frame.getOffsetUnit();
 
             if(unit != null) {
@@ -1215,12 +1219,23 @@ public class WorksheetTableService {
                      "']: frame.offsetUnit is only valid for a RANGE frame");
                }
 
-               if(!VALID_OFFSET_UNITS.contains(unit)) {
+               if(!valueOffset) {
+                  throw new IllegalArgumentException(
+                     "windowColumns['" + colName +
+                     "']: frame.offsetUnit requires a PRECEDING/FOLLOWING value-offset bound");
+               }
+
+               String u = unit.toLowerCase();
+
+               if(!VALID_OFFSET_UNITS.contains(u)) {
                   throw new IllegalArgumentException(
                      "windowColumns['" + colName + "']: invalid frame.offsetUnit: " + unit);
                }
 
+               // Safe: a value-offset RANGE frame already requires exactly one orderBy column
+               // (guard above), so orderRefs is never empty here.
                requireDateOrderKey(colName, orderRefs);
+               unit = u;
             }
 
             winRef.setFrame(mode, frame.getStartBound(), startOffset, frame.getEndBound(),

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1191,8 +1191,13 @@ public class WorksheetTableService {
                "PRECEDING".equals(frame.getStartBound()) || "FOLLOWING".equals(frame.getStartBound())
                || "PRECEDING".equals(frame.getEndBound()) || "FOLLOWING".equals(frame.getEndBound());
 
-            // RANGE value-offset and GROUPS need an ORDER BY; RANGE value-offset needs exactly one.
-            if(("RANGE".equals(mode) && valueOffset) || "GROUPS".equals(mode)) {
+            // RANGE value-offset and GROUPS need an ORDER BY; RANGE value-offset needs exactly
+            // one. A whole-partition GROUPS frame (UNBOUNDED_PRECEDING..UNBOUNDED_FOLLOWING) is
+            // exempt, same as the general bounded-frame check above — it needs no peer-group
+            // ordering since it covers every row regardless of order.
+            if(("RANGE".equals(mode) && valueOffset) ||
+               ("GROUPS".equals(mode) && !isWholePartitionFrame(frame)))
+            {
                if(orderRefs.isEmpty()) {
                   throw new IllegalArgumentException(
                      "windowColumns['" + colName + "']: a " + mode + " frame requires orderBy");
@@ -1236,6 +1241,23 @@ public class WorksheetTableService {
                // (guard above), so orderRefs is never empty here.
                requireDateOrderKey(colName, orderRefs);
                unit = u;
+            }
+            else if("RANGE".equals(mode) && valueOffset && orderRefs.size() == 1) {
+               // Converse of requireDateOrderKey above: a RANGE value-offset (PRECEDING/
+               // FOLLOWING n) whose single ORDER BY key is date/time-typed but carries NO
+               // offsetUnit is meaningless in SQL — a bare numeric offset against a date/
+               // timestamp column needs an INTERVAL, not a raw number. Left unguarded, the
+               // in-memory path silently treats the offset as raw milliseconds (dateOffsetMs's
+               // unit==null branch) and a pushdown would emit an invalid date RANGE. Fail loud
+               // here (the authoritative gateway) rather than letting either path mis-render.
+               DataRef oref = orderRefs.get(0).getDataRef();
+               String dt = oref == null ? null : oref.getDataType();
+
+               if(XSchema.isDateType(dt)) {
+                  throw new IllegalArgumentException(
+                     "windowColumns['" + colName + "']: a RANGE value-offset on a date/time " +
+                     "order key requires frame.offsetUnit (e.g. day/month)");
+               }
             }
 
             winRef.setFrame(mode, frame.getStartBound(), startOffset, frame.getEndBound(),

--- a/core/src/test/java/inetsoft/report/composition/execution/WindowRoutingTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/WindowRoutingTest.java
@@ -28,6 +28,8 @@ import inetsoft.uql.asset.SortRef;
 import inetsoft.uql.asset.WindowExpressionRef;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.jdbc.PostgreSQLHelper;
+import inetsoft.uql.jdbc.SQLHelper;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -143,6 +145,49 @@ class WindowRoutingTest {
       assertEquals(2, specs[0].startOffset);
       assertEquals("CURRENT_ROW", specs[0].endBound);
       assertEquals(0, specs[0].endOffset);
+   }
+
+   @Test
+   void buildWindowSpecs_carriesModeAndUnit() {
+      // trailing = SUM(amount) OVER (ORDER BY amount RANGE BETWEEN INTERVAL '7 day' PRECEDING
+      //            AND CURRENT ROW)
+      WindowExpressionRef range = new WindowExpressionRef(
+         "SUM", new ColumnRef(new AttributeRef(null, "amount")), 0,
+         List.of(), List.of(asc(new ColumnRef(new AttributeRef(null, "amount")))));
+      range.setFrame("RANGE", "PRECEDING", 7, "CURRENT_ROW", 0, "day");
+      range.setName("trailing");
+      ColumnRef trailing = new ColumnRef(range);
+      trailing.setSQL(true);
+
+      ColumnSelection cols = new ColumnSelection();
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      cols.addAttribute(trailing);
+
+      WindowTableLens.Spec[] specs = AssetQuery.buildWindowSpecs(stageAmountBase(), cols);
+
+      assertEquals(1, specs.length);
+      assertEquals("RANGE", specs[0].mode);
+      assertEquals("day", specs[0].offsetUnit);
+
+      // a frame-less / ROWS ref resolves mode "ROWS" and a null offsetUnit
+      WindowExpressionRef rowNum = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0,
+         List.of(new ColumnRef(new AttributeRef(null, "stage"))),
+         List.of(desc(new ColumnRef(new AttributeRef(null, "amount")))));
+      rowNum.setName("rn");
+      ColumnRef rn = new ColumnRef(rowNum);
+      rn.setSQL(true);
+
+      ColumnSelection cols2 = new ColumnSelection();
+      cols2.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      cols2.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      cols2.addAttribute(rn);
+
+      WindowTableLens.Spec[] specs2 = AssetQuery.buildWindowSpecs(stageAmountBase(), cols2);
+
+      assertEquals(1, specs2.length);
+      assertEquals("ROWS", specs2[0].mode);
+      assertNull(specs2[0].offsetUnit);
    }
 
    @Test
@@ -351,6 +396,26 @@ class WindowRoutingTest {
          () -> AssetQuery.buildWindowLens(base, cols));
       assertTrue(ex.getMessage().contains("region"));
       assertTrue(ex.getMessage().contains("rn"));
+   }
+
+   /**
+    * Dialect capability gate (Phase 4): PostgreSQL pushes RANGE/GROUPS down as SQL; every other
+    * dialect falls back to the in-memory {@link WindowTableLens} engine for those modes. ROWS
+    * pushes on every dialect, unchanged from Phase 3.
+    */
+   @Test
+   void framePushable_postgresYesOthersNo() {
+      SQLHelper postgresHelper = new PostgreSQLHelper();
+      SQLHelper otherHelper = new SQLHelper();   // getSQLHelperType() == "default"
+
+      assertTrue(AssetQuery.framePushable("RANGE", postgresHelper));
+      assertTrue(AssetQuery.framePushable("GROUPS", postgresHelper));
+      assertFalse(AssetQuery.framePushable("RANGE", otherHelper));
+      assertFalse(AssetQuery.framePushable("GROUPS", otherHelper));
+      assertTrue(AssetQuery.framePushable("ROWS", otherHelper));    // ROWS pushes everywhere
+      assertTrue(AssetQuery.framePushable("ROWS", postgresHelper));
+      assertTrue(AssetQuery.framePushable("ROWS", null));           // no dialect (tabular source)
+      assertFalse(AssetQuery.framePushable("RANGE", null));
    }
 
    private static SortRef desc(DataRef ref) {

--- a/core/src/test/java/inetsoft/report/composition/execution/WindowRoutingTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/WindowRoutingTest.java
@@ -418,6 +418,62 @@ class WindowRoutingTest {
       assertFalse(AssetQuery.framePushable("RANGE", null));
    }
 
+   /**
+    * PR #4235 review Fix B: on the mixed-pushability in-memory route (a mergeable query where
+    * some, but not all, window columns' frames are pushable on the source dialect), the
+    * helper-aware {@link AssetQuery#buildWindowSpecs(inetsoft.uql.XTable, ColumnSelection,
+    * SQLHelper)} overload must build a spec ONLY for the non-pushable column. Building one for
+    * the already-pushed ROWS column too would (1) double-compute it and (2) drag it into
+    * {@link AssetQuery#checkCompatiblePartitionAndOrder} alongside the non-pushed column, which
+    * can throw for two window columns with divergent PARTITION BY that previously worked fine
+    * via independent SQL {@code OVER()} clauses (exercised here: the ROWS column partitions by
+    * "stage", the GROUPS column has no partition at all — divergent presence, which would throw
+    * if both were scanned together, per {@link #divergentPartitionPresenceAcrossSpecsThrows}).
+    */
+   @Test
+   void buildWindowSpecs_helperAware_skipsPushableColumn_onMixedSelection() {
+      SQLHelper otherHelper = new SQLHelper();   // non-Postgres: ROWS pushable, GROUPS/RANGE not
+
+      // rows = ROW_NUMBER() OVER (PARTITION BY stage ORDER BY amount DESC) — pushable everywhere
+      WindowExpressionRef rowsRef = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0,
+         List.of(new ColumnRef(new AttributeRef(null, "stage"))),
+         List.of(desc(new ColumnRef(new AttributeRef(null, "amount")))));
+      rowsRef.setName("rn");
+      ColumnRef rn = new ColumnRef(rowsRef);
+      rn.setSQL(true);
+
+      // grp = SUM(amount) OVER (ORDER BY amount GROUPS BETWEEN 1 PRECEDING AND CURRENT ROW) —
+      // NOT pushable on a non-Postgres dialect; no PARTITION BY (divergent from rn's).
+      WindowExpressionRef groupsRef = new WindowExpressionRef(
+         "SUM", new ColumnRef(new AttributeRef(null, "amount")), 0,
+         List.of(), List.of(asc(new ColumnRef(new AttributeRef(null, "amount")))));
+      groupsRef.setFrame("GROUPS", "PRECEDING", 1, "CURRENT_ROW", 0, null);
+      groupsRef.setName("grp");
+      ColumnRef grp = new ColumnRef(groupsRef);
+      grp.setSQL(true);
+
+      ColumnSelection cols = new ColumnSelection();
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      cols.addAttribute(rn);
+      cols.addAttribute(grp);
+
+      WindowTableLens.Spec[] specs =
+         AssetQuery.buildWindowSpecs(stageAmountBase(), cols, otherHelper);
+
+      assertEquals(1, specs.length, "only the non-pushable (GROUPS) column should get a spec");
+      assertEquals("grp", specs[0].header);
+      assertEquals("GROUPS", specs[0].mode);
+
+      // Sanity / regression demonstration: the unfiltered (helper-less) overload scans BOTH
+      // columns and hits checkCompatiblePartitionAndOrder's divergent-partition-presence guard
+      // — exactly the failure Fix B avoids by filtering out the already-pushed rn column before
+      // the pair is ever compared.
+      assertThrows(RuntimeException.class,
+         () -> AssetQuery.buildWindowSpecs(stageAmountBase(), cols));
+   }
+
    private static SortRef desc(DataRef ref) {
       SortRef s = new SortRef(ref);
       s.setOrder(XConstants.SORT_DESC);

--- a/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
+++ b/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
@@ -388,4 +388,120 @@ class WindowTableLensTest {
       assertEquals(40.0, cell(lens, 2, 1));   // 20 -> {10,10,20}
       assertEquals(50.0, cell(lens, 3, 1));   // 30 -> {20,30}
    }
+
+   // ── Phase 4 review Task 3: symmetric RANGE/GROUPS bounds + null-order-value guard ──────────
+
+   @Test
+   void range_symmetricPreceding() {
+      // amount asc 10,12,14,16,18 (spacing 2), one partition. SUM RANGE BETWEEN 5 PRECEDING AND
+      // 2 PRECEDING -> per row, include rows with amount in [v-5, v-2] (excludes current row,
+      // since v-2 < v). Before the fix, endBound="PRECEDING" hit the `default: throw` in
+      // rangeEnd (only UNBOUNDED_FOLLOWING/CURRENT_ROW/FOLLOWING were accepted) -> RED.
+      Object[][] d = {{"amount"}, {10.0}, {12.0}, {14.0}, {16.0}, {18.0}};
+      DefaultTableLens t = new DefaultTableLens(d); t.setHeaderRowCount(1);
+      WindowTableLens.Spec sum = new WindowTableLens.Spec(
+         "s", "SUM", 0, 0, new int[0], new int[]{0}, new boolean[]{true},
+         "PRECEDING", 5, "PRECEDING", 2, "RANGE", null);
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{sum});
+      assertNull(cell(lens, 0, 1));           // v=10 -> [5,8]   -> {}        = null
+      assertEquals(10.0, cell(lens, 1, 1));   // v=12 -> [7,10]  -> {10}      = 10
+      assertEquals(22.0, cell(lens, 2, 1));   // v=14 -> [9,12]  -> {10,12}   = 22
+      assertEquals(26.0, cell(lens, 3, 1));   // v=16 -> [11,14] -> {12,14}   = 26
+      assertEquals(30.0, cell(lens, 4, 1));   // v=18 -> [13,16] -> {14,16}   = 30
+   }
+
+   @Test
+   void range_symmetricFollowing() {
+      // amount asc 10,11,12,13,14 (spacing 1), one partition. SUM RANGE BETWEEN 1 FOLLOWING AND
+      // 3 FOLLOWING -> per row, include rows with amount in [v+1, v+3]. Before the fix,
+      // startBound="FOLLOWING" hit the `default: throw` in rangeStart -> RED.
+      Object[][] d = {{"amount"}, {10.0}, {11.0}, {12.0}, {13.0}, {14.0}};
+      DefaultTableLens t = new DefaultTableLens(d); t.setHeaderRowCount(1);
+      WindowTableLens.Spec sum = new WindowTableLens.Spec(
+         "s", "SUM", 0, 0, new int[0], new int[]{0}, new boolean[]{true},
+         "FOLLOWING", 1, "FOLLOWING", 3, "RANGE", null);
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{sum});
+      assertEquals(36.0, cell(lens, 0, 1));   // v=10 -> [11,13] -> {11,12,13} = 36
+      assertEquals(39.0, cell(lens, 1, 1));   // v=11 -> [12,14] -> {12,13,14} = 39
+      assertEquals(27.0, cell(lens, 2, 1));   // v=12 -> [13,15] -> {13,14}    = 27
+      assertEquals(14.0, cell(lens, 3, 1));   // v=13 -> [14,16] -> {14}       = 14
+      assertNull(cell(lens, 4, 1));           // v=14 -> [15,17] -> {}        = null
+   }
+
+   @Test
+   void groups_precedingRange() {
+      // amount asc 10,10,20,30,40 -> distinct groups {10,10},{20},{30},{40} (0,1,2,3). SUM
+      // GROUPS BETWEEN 2 PRECEDING AND 1 PRECEDING -> current group's own group is excluded
+      // (end = 1 PRECEDING is strictly before the current group). Before the fix, endBound=
+      // "PRECEDING" hit the `default: throw` in groupBoundEnd -> RED.
+      Object[][] d = {{"amount"}, {10.0}, {10.0}, {20.0}, {30.0}, {40.0}};
+      DefaultTableLens t = new DefaultTableLens(d); t.setHeaderRowCount(1);
+      WindowTableLens.Spec sum = new WindowTableLens.Spec(
+         "s", "SUM", 0, 0, new int[0], new int[]{0}, new boolean[]{true},
+         "PRECEDING", 2, "PRECEDING", 1, "GROUPS", null);
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{sum});
+      assertEquals(20.0, cell(lens, 0, 1));   // group0 (10,10): start&end clamp to group0 -> {10,10}
+      assertEquals(20.0, cell(lens, 1, 1));   // group0 (10,10): same
+      assertEquals(20.0, cell(lens, 2, 1));   // group1 (20): [group(-1)->0, group0] -> {10,10}
+      assertEquals(40.0, cell(lens, 3, 1));   // group2 (30): [group0, group1] -> {10,10,20}
+      assertEquals(50.0, cell(lens, 4, 1));   // group3 (40): [group1, group2] -> {20,30}
+   }
+
+   @Test
+   void range_descValueOffset() {
+      // amount asc in base order 5,10,15,20 but ORDER BY amount DESC -> sorted 20,15,10,5. SUM
+      // RANGE BETWEEN 5 PRECEDING AND CURRENT ROW: for a DESC key, "PRECEDING" is a LARGER
+      // value, so the frame per row v is {rows with value in [v, v+5]}.
+      Object[][] d = {{"amount"}, {5.0}, {10.0}, {15.0}, {20.0}};
+      DefaultTableLens t = new DefaultTableLens(d); t.setHeaderRowCount(1);
+      WindowTableLens.Spec sum = new WindowTableLens.Spec(
+         "s", "SUM", 0, 0, new int[0], new int[]{0}, new boolean[]{false},
+         "PRECEDING", 5, "CURRENT_ROW", 0, "RANGE", null);
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{sum});
+      assertEquals(15.0, cell(lens, 0, 1));   // v=5  -> [5,10]  -> {10,5}     = 15
+      assertEquals(25.0, cell(lens, 1, 1));   // v=10 -> [10,15] -> {15,10}    = 25
+      assertEquals(35.0, cell(lens, 2, 1));   // v=15 -> [15,20] -> {20,15}    = 35
+      assertEquals(20.0, cell(lens, 3, 1));   // v=20 -> [20,25] -> {20}       = 20
+   }
+
+   @Test
+   void range_dateMonth() {
+      // end-of-month dates Jan31/Feb28/Mar31 (2026, not a leap year), asc. SUM RANGE BETWEEN
+      // INTERVAL '1 month' PRECEDING AND CURRENT ROW must use calendar-month arithmetic (Fix 1's
+      // rewritten rangeStart/rangeEnd must still route PRECEDING+CURRENT_ROW through the
+      // existing offsetOrderValue/dateOffsetMs month logic unchanged): Mar31 - 1 month = Feb28
+      // (Mar 31 clamps to the shorter Feb), so Mar31's frame must EXCLUDE Jan31.
+      java.sql.Date jan31 = java.sql.Date.valueOf("2026-01-31");
+      java.sql.Date feb28 = java.sql.Date.valueOf("2026-02-28");
+      java.sql.Date mar31 = java.sql.Date.valueOf("2026-03-31");
+      Object[][] d = {
+         {"date", "amount"},
+         {jan31, 100.0},
+         {feb28, 200.0},
+         {mar31, 300.0},
+      };
+      DefaultTableLens t = new DefaultTableLens(d); t.setHeaderRowCount(1);
+      WindowTableLens.Spec sum = new WindowTableLens.Spec(
+         "s", "SUM", 1, 0, new int[0], new int[]{0}, new boolean[]{true},
+         "PRECEDING", 1, "CURRENT_ROW", 0, "RANGE", "month");
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{sum});
+      assertEquals(100.0, cell(lens, 0, 2));   // Jan31 -> {Jan31}               = 100
+      assertEquals(300.0, cell(lens, 1, 2));   // Feb28 -> {Jan31,Feb28}         = 300
+      assertEquals(500.0, cell(lens, 2, 2));   // Mar31 -> {Feb28,Mar31}, no Jan31 = 500
+   }
+
+   @Test
+   void range_nullOrderValue_failsLoud() {
+      // a null in the numeric ORDER BY column with a RANGE value-threshold frame must fail
+      // loud (NULLS handling is deferred), not NPE inside orderValue/offsetOrderValue.
+      Object[][] d = {{"amount"}, {10.0}, {null}};
+      DefaultTableLens t = new DefaultTableLens(d); t.setHeaderRowCount(1);
+      WindowTableLens.Spec sum = new WindowTableLens.Spec(
+         "s", "SUM", 0, 0, new int[0], new int[]{0}, new boolean[]{true},
+         "PRECEDING", 5, "CURRENT_ROW", 0, "RANGE", null);
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{sum});
+      RuntimeException ex = assertThrows(RuntimeException.class, () -> cell(lens, 0, 1));
+      assertTrue(ex.getMessage().contains("null ORDER BY"),
+                 "error should name the null-order-value cause: " + ex.getMessage());
+   }
 }

--- a/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
+++ b/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
@@ -430,21 +430,55 @@ class WindowTableLensTest {
 
    @Test
    void groups_precedingRange() {
-      // amount asc 10,10,20,30,40 -> distinct groups {10,10},{20},{30},{40} (0,1,2,3). SUM
-      // GROUPS BETWEEN 2 PRECEDING AND 1 PRECEDING -> current group's own group is excluded
-      // (end = 1 PRECEDING is strictly before the current group). Before the fix, endBound=
-      // "PRECEDING" hit the `default: throw` in groupBoundEnd -> RED.
+      // amount asc 10,10,20,30,40 -> distinct groups {10,10}=g0,{20}=g1,{30}=g2,{40}=g3
+      // (lastGroup=3). SUM GROUPS BETWEEN 2 PRECEDING AND 1 PRECEDING -> current group's own
+      // group is excluded (end = 1 PRECEDING is strictly before the current group).
+      //   g0 rows (pGroup=0): raw start=0-2=-2, raw end=0-1=-1 -> rawEnd<0 -> EMPTY (null).
+      //   Per Postgres GROUPS semantics this frame lies entirely before group 0 and returns no
+      //   rows (SUM of no rows is NULL) — NOT clamped to group 0's own {10,10}. Before the fix,
+      //   BOTH raw indices were clamped into [0,lastGroup] before the empty check, so -2/-1 both
+      //   clamped to 0 and wrongly returned group 0 (20.0) instead of null.
+      //   g1 (20, pGroup=1): raw start=1-2=-1, raw end=1-1=0 -> not empty; clamp start to 0,
+      //   end stays 0 -> frame=group0={10,10}=20.0 (unchanged by the fix: this frame is only
+      //   PARTIALLY out of range, which is legitimately clamped, not empty).
+      //   g2 (30, pGroup=2): raw start=0, raw end=1 -> frame=groups0..1={10,10,20}=40.0.
+      //   g3 (40, pGroup=3): raw start=1, raw end=2 -> frame=groups1..2={20,30}=50.0.
       Object[][] d = {{"amount"}, {10.0}, {10.0}, {20.0}, {30.0}, {40.0}};
       DefaultTableLens t = new DefaultTableLens(d); t.setHeaderRowCount(1);
       WindowTableLens.Spec sum = new WindowTableLens.Spec(
          "s", "SUM", 0, 0, new int[0], new int[]{0}, new boolean[]{true},
          "PRECEDING", 2, "PRECEDING", 1, "GROUPS", null);
       WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{sum});
-      assertEquals(20.0, cell(lens, 0, 1));   // group0 (10,10): start&end clamp to group0 -> {10,10}
-      assertEquals(20.0, cell(lens, 1, 1));   // group0 (10,10): same
+      assertNull(cell(lens, 0, 1));           // group0 (10,10): frame entirely before group0 -> empty
+      assertNull(cell(lens, 1, 1));           // group0 (10,10): same
       assertEquals(20.0, cell(lens, 2, 1));   // group1 (20): [group(-1)->0, group0] -> {10,10}
       assertEquals(40.0, cell(lens, 3, 1));   // group2 (30): [group0, group1] -> {10,10,20}
       assertEquals(50.0, cell(lens, 4, 1));   // group3 (40): [group1, group2] -> {20,30}
+   }
+
+   @Test
+   void groups_followingRange_lastGroupEmpty() {
+      // Symmetric to groups_precedingRange: amount asc 10,10,20,30,40 -> groups
+      // {10,10}=g0,{20}=g1,{30}=g2,{40}=g3 (lastGroup=3). SUM GROUPS BETWEEN 1 FOLLOWING AND
+      // 2 FOLLOWING.
+      //   g0 rows (pGroup=0): start=1,end=2 -> frame=groups1..2={20,30}=50.0.
+      //   g1 (20, pGroup=1): start=2,end=3 -> frame=groups2..3={30,40}=70.0.
+      //   g2 (30, pGroup=2): start=3,end=4 -> not empty (rawStart==lastGroup); clamp end to 3
+      //   -> frame=group3={40}=40.0.
+      //   g3 (40, pGroup=3, the LAST group): start=4,end=5 -> rawStart(4) > lastGroup(3) ->
+      //   EMPTY (null). Before the fix, both raw indices would clamp into [0,3] (start=3,
+      //   end=3) and wrongly return group3's own value (40.0) instead of null.
+      Object[][] d = {{"amount"}, {10.0}, {10.0}, {20.0}, {30.0}, {40.0}};
+      DefaultTableLens t = new DefaultTableLens(d); t.setHeaderRowCount(1);
+      WindowTableLens.Spec sum = new WindowTableLens.Spec(
+         "s", "SUM", 0, 0, new int[0], new int[]{0}, new boolean[]{true},
+         "FOLLOWING", 1, "FOLLOWING", 2, "GROUPS", null);
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{sum});
+      assertEquals(50.0, cell(lens, 0, 1));   // group0
+      assertEquals(50.0, cell(lens, 1, 1));   // group0
+      assertEquals(70.0, cell(lens, 2, 1));   // group1
+      assertEquals(40.0, cell(lens, 3, 1));   // group2
+      assertNull(cell(lens, 4, 1));           // group3 (LAST group) -> empty
    }
 
    @Test

--- a/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
+++ b/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
@@ -26,6 +26,8 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.sql.Date;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -287,5 +289,103 @@ class WindowTableLensTest {
       assertEquals(30.0, cell(lens,0,1));    // [10,20]
       assertEquals(60.0, cell(lens,1,1));    // [10,20,30]
       assertEquals(50.0, cell(lens,2,1));    // [20,30]
+   }
+
+   // ── Phase 4: RANGE / GROUPS frame modes ─────────────────────────────────────
+
+   @Test
+   void rows_byteParity_unchanged() {
+      // Same as movingAverage_2precedingToCurrent (Phase 3) — the new ctor overload defaults to
+      // mode="ROWS" via the Phase-3 11-arg ctor, so this must still yield the Phase-3 numbers.
+      Object[][] d = {{"amount"},{10.0},{20.0},{30.0},{40.0}};
+      DefaultTableLens t = new DefaultTableLens(d); t.setHeaderRowCount(1);
+      WindowTableLens.Spec ma = new WindowTableLens.Spec(
+         "ma","AVG",0,0,new int[0],new int[]{0},new boolean[]{true}, "PRECEDING",2,"CURRENT_ROW",0);
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{ma});
+      assertEquals(10.0, cell(lens,0,1));                 // [10]
+      assertEquals(15.0, cell(lens,1,1));                 // [10,20]
+      assertEquals(20.0, cell(lens,2,1));                 // [10,20,30]
+      assertEquals(30.0, cell(lens,3,1));                 // [20,30,40]
+   }
+
+   @Test
+   void range_numeric_valueOffset() {
+      // amount asc 10,20,25,40 in one partition; SUM RANGE BETWEEN 5 PRECEDING AND CURRENT ROW.
+      // Per row, include rows whose amount is within [amt-5, amt]:
+      //   10 -> {10} = 10 ; 20 -> {20} = 20 ; 25 -> {20,25} = 45 ; 40 -> {40} = 40
+      Object[][] d = {{"amount"},{10.0},{20.0},{25.0},{40.0}};
+      DefaultTableLens t = new DefaultTableLens(d); t.setHeaderRowCount(1);
+      WindowTableLens.Spec sum = new WindowTableLens.Spec(
+         "s", "SUM", 0, 0, new int[0], new int[]{0}, new boolean[]{true},
+         "PRECEDING", 5, "CURRENT_ROW", 0, "RANGE", null);
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{sum});
+      assertEquals(10.0, cell(lens, 0, 1));   // amt=10 -> {10}
+      assertEquals(20.0, cell(lens, 1, 1));   // amt=20 -> {20}
+      assertEquals(45.0, cell(lens, 2, 1));   // amt=25 -> {20,25}
+      assertEquals(40.0, cell(lens, 3, 1));   // amt=40 -> {40}
+   }
+
+   @Test
+   void range_date_valueOffset_days() {
+      // dates spaced 0,1,3,10 days apart, ordered asc. SUM RANGE BETWEEN INTERVAL '2 day'
+      // PRECEDING AND CURRENT ROW (offsetUnit=day, offset=2). Row at d0+3 includes rows with
+      // date in [d0+1, d0+3] -> the d0+1 and d0+3 rows: amount 20 + 30 = 50.
+      Date d0 = Date.valueOf("2026-01-01");
+      Date d1 = Date.valueOf("2026-01-02");   // d0+1
+      Date d3 = Date.valueOf("2026-01-04");   // d0+3
+      Date d10 = Date.valueOf("2026-01-11");  // d0+10
+      Object[][] d = {
+         {"date", "amount"},
+         {d0,  10.0},
+         {d1,  20.0},
+         {d3,  30.0},
+         {d10, 40.0},
+      };
+      DefaultTableLens t = new DefaultTableLens(d); t.setHeaderRowCount(1);
+      WindowTableLens.Spec sum = new WindowTableLens.Spec(
+         "s", "SUM", 1, 0, new int[0], new int[]{0}, new boolean[]{true},
+         "PRECEDING", 2, "CURRENT_ROW", 0, "RANGE", "day");
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{sum});
+      assertEquals(10.0, cell(lens, 0, 2));   // d0        -> {d0}                    = 10
+      assertEquals(30.0, cell(lens, 1, 2));   // d0+1      -> {d0,d0+1}                = 10+20
+      assertEquals(50.0, cell(lens, 2, 2));   // d0+3      -> {d0+1,d0+3}              = 20+30
+      assertEquals(40.0, cell(lens, 3, 2));   // d0+10     -> {d0+10}                  = 40
+   }
+
+   @Test
+   void range_peer_currentRowIncludesTies() {
+      // order key desc with a tie: 30,30,10. Running SUM RANGE BETWEEN UNBOUNDED PRECEDING AND
+      // CURRENT ROW -> both 30-rows see the combined peer group (60), the 10-row sees all (70).
+      // This specifically exercises the DESCENDING-order peer-vs-value-threshold distinction:
+      // a naive "value <= current" threshold would wrongly include the 10 for the 30-rows too.
+      Object[][] d = {{"amount"},{30.0},{30.0},{10.0}};
+      DefaultTableLens t = new DefaultTableLens(d); t.setHeaderRowCount(1);
+      WindowTableLens.Spec sum = new WindowTableLens.Spec(
+         "s", "SUM", 0, 0, new int[0], new int[]{0}, new boolean[]{false},
+         "UNBOUNDED_PRECEDING", 0, "CURRENT_ROW", 0, "RANGE", null);
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{sum});
+      assertEquals(60.0, cell(lens, 0, 1));   // 30 (first tie) -> {30,30}
+      assertEquals(60.0, cell(lens, 1, 1));   // 30 (second tie) -> {30,30}
+      assertEquals(70.0, cell(lens, 2, 1));   // 10 -> {30,30,10}
+   }
+
+   @Test
+   void groups_peerGroupCount() {
+      // amount asc with a tied group: 10,10,20,30 -> distinct groups {10},{20},{30} (0,1,2).
+      // SUM GROUPS BETWEEN 1 PRECEDING AND CURRENT ROW: the current group plus the one
+      // preceding distinct-value group.
+      //   group0 (10,10): no preceding group -> just group0 = {10,10} = 20 for both rows
+      //   group1 (20):    group0+group1 = {10,10,20} = 40
+      //   group2 (30):    group1+group2 = {20,30} = 50
+      Object[][] d = {{"amount"},{10.0},{10.0},{20.0},{30.0}};
+      DefaultTableLens t = new DefaultTableLens(d); t.setHeaderRowCount(1);
+      WindowTableLens.Spec sum = new WindowTableLens.Spec(
+         "s", "SUM", 0, 0, new int[0], new int[]{0}, new boolean[]{true},
+         "PRECEDING", 1, "CURRENT_ROW", 0, "GROUPS", null);
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{sum});
+      assertEquals(20.0, cell(lens, 0, 1));   // 10 (first of tied group) -> {10,10}
+      assertEquals(20.0, cell(lens, 1, 1));   // 10 (second of tied group) -> {10,10}
+      assertEquals(40.0, cell(lens, 2, 1));   // 20 -> {10,10,20}
+      assertEquals(50.0, cell(lens, 3, 1));   // 30 -> {20,30}
    }
 }

--- a/core/src/test/java/inetsoft/uql/asset/WindowExpressionRefTest.java
+++ b/core/src/test/java/inetsoft/uql/asset/WindowExpressionRefTest.java
@@ -388,4 +388,52 @@ class WindowExpressionRefTest {
       assertEquals(1, copy.getFrameEndOffset());
       assertEquals(ref.getExpression(), copy.getExpression());
    }
+
+   // ---- RANGE/GROUPS frame (Phase 4 Task 1) ---------------------------------------------------
+
+   @Test
+   void rangeNumericFrame_emitsRangeSql() {
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "SUM", new AttributeRef("amount"), 0, List.of(new AttributeRef("stage")),
+         List.of(sort("amount", XConstants.SORT_ASC)));
+      ref.setFrame("RANGE", "PRECEDING", 1000, "CURRENT_ROW", 0, null);
+      assertTrue(ref.getExpression().contains(
+         "RANGE BETWEEN 1000 PRECEDING AND CURRENT ROW"));
+      assertEquals("RANGE", ref.getFrameMode());
+      assertNull(ref.getFrameOffsetUnit());
+   }
+
+   @Test
+   void rangeDateFrame_emitsIntervalSql() {
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "SUM", new AttributeRef("amt"), 0, List.of(new AttributeRef("stage")),
+         List.of(sort("d", XConstants.SORT_ASC)));
+      ref.setFrame("RANGE", "PRECEDING", 7, "CURRENT_ROW", 0, "day");
+      assertTrue(ref.getExpression().contains(
+         "RANGE BETWEEN INTERVAL '7 day' PRECEDING AND CURRENT ROW"));
+      assertEquals("day", ref.getFrameOffsetUnit());
+   }
+
+   @Test
+   void groupsFrame_emitsGroupsSql() {
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "SUM", new AttributeRef("amt"), 0, List.of(new AttributeRef("stage")),
+         List.of(sort("d", XConstants.SORT_ASC)));
+      ref.setFrame("GROUPS", "PRECEDING", 2, "CURRENT_ROW", 0, null);
+      assertTrue(ref.getExpression().contains(
+         "GROUPS BETWEEN 2 PRECEDING AND CURRENT ROW"));
+      assertEquals("GROUPS", ref.getFrameMode());
+   }
+
+   @Test
+   void rowsFrame_byteParityWithPhase3() {
+      // mode omitted / legacy 4-arg overload -- ROWS output must be byte-identical to Phase 3.
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "SUM", new AttributeRef("amt"), 0, List.of(new AttributeRef("stage")),
+         List.of(sort("d", XConstants.SORT_ASC)));
+      ref.setFrame("PRECEDING", 2, "CURRENT_ROW", 0);
+      assertTrue(ref.getExpression().contains("ROWS BETWEEN 2 PRECEDING AND CURRENT ROW"));
+      assertEquals("ROWS", ref.getFrameMode());
+      assertNull(ref.getFrameOffsetUnit());
+   }
 }

--- a/core/src/test/java/inetsoft/uql/asset/WindowExpressionRefTest.java
+++ b/core/src/test/java/inetsoft/uql/asset/WindowExpressionRefTest.java
@@ -436,4 +436,72 @@ class WindowExpressionRefTest {
       assertEquals("ROWS", ref.getFrameMode());
       assertNull(ref.getFrameOffsetUnit());
    }
+
+   // ---- code-review fixes (Phase 4 Task 1) ----------------------------------------------------
+
+   @Test
+   void rowsFrame_serializesWithoutModeAttribute() throws Exception {
+      // A plain ROWS frame (legacy 4-arg setFrame, or the 6-arg overload with mode="ROWS"/null)
+      // must NOT emit a frameMode attribute -- otherwise an existing Phase-3 ROWS-frame worksheet
+      // gains a new frameMode="ROWS" attribute on save (serialization drift / XML byte-parity).
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "SUM", new AttributeRef("amt"), 0, List.of(new AttributeRef("stage")),
+         List.of(sort("d", XConstants.SORT_ASC)));
+      ref.setFrame("PRECEDING", 2, "CURRENT_ROW", 0);
+
+      StringWriter sw = new StringWriter();
+      PrintWriter writer = new PrintWriter(sw);
+      ref.writeXML(writer);
+      writer.flush();
+      String xml = sw.toString();
+
+      assertFalse(xml.contains("frameMode"),
+                  "a plain ROWS frame must not emit a frameMode attribute: " + xml);
+      assertFalse(xml.contains("frameOffsetUnit"),
+                  "a plain ROWS frame must not emit a frameOffsetUnit attribute: " + xml);
+
+      WindowExpressionRef copy = (WindowExpressionRef) writeAndParse(ref);
+      assertEquals("ROWS", copy.getFrameMode(),
+                   "a missing frameMode attribute must parse back as ROWS");
+   }
+
+   @Test
+   void rangeFrame_serializesModeAttribute() throws Exception {
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "SUM", new AttributeRef("amt"), 0, List.of(new AttributeRef("stage")),
+         List.of(sort("d", XConstants.SORT_ASC)));
+      ref.setFrame("RANGE", "PRECEDING", 1000, "CURRENT_ROW", 0, null);
+
+      StringWriter sw = new StringWriter();
+      PrintWriter writer = new PrintWriter(sw);
+      ref.writeXML(writer);
+      writer.flush();
+      String xml = sw.toString();
+
+      assertTrue(xml.contains("frameMode=\"RANGE\""),
+                 "a RANGE frame must emit a frameMode attribute: " + xml);
+
+      WindowExpressionRef copy = (WindowExpressionRef) writeAndParse(ref);
+      assertEquals("RANGE", copy.getFrameMode());
+   }
+
+   @Test
+   void setFrame_invalidMode_throws() {
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "SUM", new AttributeRef("amount"), 0, List.of(), List.of(sort("t", XConstants.SORT_ASC)));
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> ref.setFrame("BOGUS_MODE", "PRECEDING", 2, "CURRENT_ROW", 0, null));
+      assertTrue(ex.getMessage().contains("BOGUS_MODE"));
+   }
+
+   @Test
+   void setFrame_invalidOffsetUnit_throws() {
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "SUM", new AttributeRef("amount"), 0, List.of(), List.of(sort("t", XConstants.SORT_ASC)));
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> ref.setFrame("RANGE", "PRECEDING", 2, "CURRENT_ROW", 0, "fortnight"));
+      assertTrue(ex.getMessage().contains("fortnight"));
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/model/WorksheetTableRequestTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/WorksheetTableRequestTest.java
@@ -113,5 +113,33 @@ class WorksheetTableRequestTest {
       assertEquals("PRECEDING", f.getStartBound());
       assertEquals(2, f.getStartOffset());
       assertEquals("CURRENT_ROW", f.getEndBound());
+      // Omitted mode/offsetUnit deserialize to null (WorksheetTableService normalizes null → ROWS).
+      assertNull(f.getMode());
+      assertNull(f.getOffsetUnit());
+   }
+
+   @Test
+   void windowColumnFrameModeAndOffsetUnitRoundTrip() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+
+      WorksheetTable t = mapper.readValue(
+         """
+         { "windowColumns": [ { "name":"s","fn":"SUM","column":"amount",
+           "orderBy":[{"field":"d","direction":"ASC"}],
+           "frame":{"mode":"RANGE","startBound":"PRECEDING","startOffset":7,
+                     "endBound":"CURRENT_ROW","offsetUnit":"day"} } ] }
+         """,
+         WorksheetTable.class);
+
+      var f = t.getWindowColumns().get(0).getFrame();
+      assertEquals("RANGE", f.getMode());
+      assertEquals("day", f.getOffsetUnit());
+      assertEquals("PRECEDING", f.getStartBound());
+      assertEquals(7, f.getStartOffset());
+      assertEquals("CURRENT_ROW", f.getEndBound());
+
+      JsonNode output = mapper.valueToTree(t);
+      assertEquals("RANGE", output.at("/windowColumns/0/frame/mode").asText());
+      assertEquals("day", output.at("/windowColumns/0/frame/offsetUnit").asText());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceWindowColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceWindowColumnsTest.java
@@ -490,10 +490,13 @@ class WorksheetTableServiceWindowColumnsTest {
    }
 
    @Test
-   void groupsWholePartition_noOrderBy_throws() throws Exception {
-      // Whole-partition GROUPS frame bypasses the Phase-3 bounded-frame guard, isolating the
-      // Phase-4 GROUPS-requires-orderBy branch (the existing groupsOrRangeValue_withoutOrderBy_throws
-      // test uses a BOUNDED frame, so the Phase-3 guard fires first and this branch is never hit).
+   void groupsWholePartition_noOrderBy_succeeds() throws Exception {
+      // Whole-partition GROUPS frame (UNBOUNDED_PRECEDING..UNBOUNDED_FOLLOWING) needs no
+      // peer-group ordering — it covers every row regardless of order, exactly like a
+      // whole-partition ROWS/RANGE frame. Review fix: the GROUPS-requires-orderBy guard used to
+      // fire unconditionally, rejecting this legitimate whole-partition case too; it is now
+      // gated on !isWholePartitionFrame(frame), consistent with the general bounded-frame
+      // "requires orderBy" guard a few lines above it.
       WorksheetTable req = request("""
          { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount","partitionBy":["stage"],
            "frame":{"mode":"GROUPS","startBound":"UNBOUNDED_PRECEDING",
@@ -507,9 +510,12 @@ class WorksheetTableServiceWindowColumnsTest {
       cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
       table.setColumnSelection(cs);
 
-      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-         () -> service().applyWindowColumns(table, req.getWindowColumns()));
-      assertTrue(ex.getMessage().contains("s"));
+      service().applyWindowColumns(table, req.getWindowColumns());
+
+      ColumnRef added = (ColumnRef) table.getColumnSelection(false).getAttribute("s");
+      String expr = ((WindowExpressionRef) added.getDataRef()).getExpression();
+      assertTrue(expr.contains("GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING"),
+                 "unexpected expression: " + expr);
    }
 
    @Test
@@ -536,5 +542,65 @@ class WorksheetTableServiceWindowColumnsTest {
       ColumnRef added = (ColumnRef) table.getColumnSelection(false).getAttribute("s");
       String expr = ((WindowExpressionRef) added.getDataRef()).getExpression();
       assertTrue(expr.contains("INTERVAL '7 day'"), "unexpected expression: " + expr);
+   }
+
+   // ─── PR #4235 review Fix C: numeric RANGE offset on a date/time order key ────────────────
+
+   @Test
+   void rangeValueOffset_onDateOrderKey_missingOffsetUnit_throws() throws Exception {
+      // Converse of requireDateOrderKey: a RANGE value-offset (PRECEDING/FOLLOWING n) whose
+      // single ORDER BY key ("d") is date/time-typed but carries NO offsetUnit is meaningless —
+      // a bare numeric offset against a date column needs an INTERVAL, not a raw number. Before
+      // the fix this silently passed validation; in memory it would treat the offset as raw
+      // milliseconds (WindowTableLens.dateOffsetMs's unit==null branch) and a pushdown would
+      // emit an invalid date RANGE.
+      WorksheetTable req = request("""
+         { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount","partitionBy":["stage"],
+           "orderBy":[{"field":"d","direction":"ASC"}],
+           "frame":{"mode":"RANGE","startBound":"PRECEDING","startOffset":7,
+                     "endBound":"CURRENT_ROW"}} ] }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      AttributeRef dRef = new AttributeRef(null, "d");
+      dRef.setDataType(inetsoft.uql.schema.XSchema.TIME_INSTANT);
+      cs.addAttribute(new ColumnRef(dRef));
+      table.setColumnSelection(cs);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service().applyWindowColumns(table, req.getWindowColumns()));
+      assertTrue(ex.getMessage().contains("s"));
+      assertTrue(ex.getMessage().contains("offsetUnit"), "unexpected message: " + ex.getMessage());
+   }
+
+   @Test
+   void rangeValueOffset_onNumericOrderKey_missingOffsetUnit_stillSucceeds() throws Exception {
+      // Byte-parity / no-regression check: a RANGE value-offset on a NON-date (numeric) order
+      // key with no offsetUnit is the normal, long-supported case (a plain numeric threshold)
+      // and must still succeed — the new Fix C guard only rejects a date/time order key.
+      WorksheetTable req = request("""
+         { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount","partitionBy":["stage"],
+           "orderBy":[{"field":"amount","direction":"ASC"}],
+           "frame":{"mode":"RANGE","startBound":"PRECEDING","startOffset":5,
+                     "endBound":"CURRENT_ROW"}} ] }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      table.setColumnSelection(cs);
+
+      service().applyWindowColumns(table, req.getWindowColumns());
+
+      ColumnRef added = (ColumnRef) table.getColumnSelection(false).getAttribute("s");
+      String expr = ((WindowExpressionRef) added.getDataRef()).getExpression();
+      assertTrue(expr.contains("RANGE BETWEEN 5 PRECEDING AND CURRENT ROW"),
+                 "unexpected expression: " + expr);
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceWindowColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceWindowColumnsTest.java
@@ -436,4 +436,105 @@ class WorksheetTableServiceWindowColumnsTest {
       assertFalse(expr.contains("RANGE"));
       assertFalse(expr.contains("GROUPS"));
    }
+
+   // ─── Task 2 review fixes ───────────────────────────────────────────────────
+
+   @Test
+   void rangeWholePartition_offsetUnit_noOrderBy_throwsIllegalArgument() throws Exception {
+      // Whole-partition RANGE frame is exempt from the Phase-3 "bounded frame requires orderBy"
+      // guard. Before the fix, offsetUnit validation unconditionally called
+      // requireDateOrderKey(colName, orderRefs) -> orderRefs.get(0) on an EMPTY list, throwing
+      // IndexOutOfBoundsException instead of a field-named IllegalArgumentException.
+      WorksheetTable req = request("""
+         { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount","partitionBy":["stage"],
+           "frame":{"mode":"RANGE","startBound":"UNBOUNDED_PRECEDING",
+                     "endBound":"UNBOUNDED_FOLLOWING","offsetUnit":"day"}} ] }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      table.setColumnSelection(cs);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service().applyWindowColumns(table, req.getWindowColumns()));
+      assertTrue(ex.getMessage().contains("s"));
+   }
+
+   @Test
+   void offsetUnit_withoutValueOffsetBound_throws() throws Exception {
+      // CURRENT_ROW .. CURRENT_ROW carries no PRECEDING/FOLLOWING value-offset bound, so
+      // offsetUnit is meaningless even though orderBy is present and date-typed.
+      WorksheetTable req = request("""
+         { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount","partitionBy":["stage"],
+           "orderBy":[{"field":"d","direction":"ASC"}],
+           "frame":{"mode":"RANGE","startBound":"CURRENT_ROW",
+                     "endBound":"CURRENT_ROW","offsetUnit":"day"}} ] }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      AttributeRef dRef = new AttributeRef(null, "d");
+      dRef.setDataType(inetsoft.uql.schema.XSchema.TIME_INSTANT);
+      cs.addAttribute(new ColumnRef(dRef));
+      table.setColumnSelection(cs);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service().applyWindowColumns(table, req.getWindowColumns()));
+      assertTrue(ex.getMessage().contains("s"));
+   }
+
+   @Test
+   void groupsWholePartition_noOrderBy_throws() throws Exception {
+      // Whole-partition GROUPS frame bypasses the Phase-3 bounded-frame guard, isolating the
+      // Phase-4 GROUPS-requires-orderBy branch (the existing groupsOrRangeValue_withoutOrderBy_throws
+      // test uses a BOUNDED frame, so the Phase-3 guard fires first and this branch is never hit).
+      WorksheetTable req = request("""
+         { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount","partitionBy":["stage"],
+           "frame":{"mode":"GROUPS","startBound":"UNBOUNDED_PRECEDING",
+                     "endBound":"UNBOUNDED_FOLLOWING"}} ] }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      table.setColumnSelection(cs);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service().applyWindowColumns(table, req.getWindowColumns()));
+      assertTrue(ex.getMessage().contains("s"));
+   }
+
+   @Test
+   void offsetUnit_caseInsensitive_accepted() throws Exception {
+      WorksheetTable req = request("""
+         { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount","partitionBy":["stage"],
+           "orderBy":[{"field":"d","direction":"ASC"}],
+           "frame":{"mode":"RANGE","startBound":"PRECEDING","startOffset":7,
+                     "endBound":"CURRENT_ROW","offsetUnit":"Day"}} ] }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      AttributeRef dRef = new AttributeRef(null, "d");
+      dRef.setDataType(inetsoft.uql.schema.XSchema.TIME_INSTANT);
+      cs.addAttribute(new ColumnRef(dRef));
+      table.setColumnSelection(cs);
+
+      service().applyWindowColumns(table, req.getWindowColumns());
+
+      ColumnRef added = (ColumnRef) table.getColumnSelection(false).getAttribute("s");
+      String expr = ((WindowExpressionRef) added.getDataRef()).getExpression();
+      assertTrue(expr.contains("INTERVAL '7 day'"), "unexpected expression: " + expr);
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceWindowColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceWindowColumnsTest.java
@@ -227,4 +227,213 @@ class WorksheetTableServiceWindowColumnsTest {
       assertTrue(ex.getMessage().contains("ma"));
       assertTrue(ex.getMessage().contains("UNBOUNDED_PRECEDING"));
    }
+
+   // ─── Phase 4: RANGE / GROUPS frame mode + offsetUnit ──────────────────────
+
+   @Test
+   void rangeDateFrame_buildsRangeExpressionWithInterval() throws Exception {
+      WorksheetTable req = request("""
+         { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount","partitionBy":["stage"],
+           "orderBy":[{"field":"d","direction":"ASC"}],
+           "frame":{"mode":"RANGE","startBound":"PRECEDING","startOffset":7,
+                     "endBound":"CURRENT_ROW","offsetUnit":"day"}} ] }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      AttributeRef dRef = new AttributeRef(null, "d");
+      dRef.setDataType(inetsoft.uql.schema.XSchema.TIME_INSTANT);
+      cs.addAttribute(new ColumnRef(dRef));
+      table.setColumnSelection(cs);
+
+      service().applyWindowColumns(table, req.getWindowColumns());
+
+      ColumnRef added = (ColumnRef) table.getColumnSelection(false).getAttribute("s");
+      String expr = ((WindowExpressionRef) added.getDataRef()).getExpression();
+      assertTrue(expr.contains("RANGE BETWEEN INTERVAL '7 day' PRECEDING AND CURRENT ROW"),
+                 "unexpected expression: " + expr);
+   }
+
+   @Test
+   void groupsFrame_buildsGroupsExpression() throws Exception {
+      WorksheetTable req = request("""
+         { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount","partitionBy":["stage"],
+           "orderBy":[{"field":"d","direction":"ASC"}],
+           "frame":{"mode":"GROUPS","startBound":"PRECEDING","startOffset":2,
+                     "endBound":"CURRENT_ROW"}} ] }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "d")));
+      table.setColumnSelection(cs);
+
+      service().applyWindowColumns(table, req.getWindowColumns());
+
+      ColumnRef added = (ColumnRef) table.getColumnSelection(false).getAttribute("s");
+      String expr = ((WindowExpressionRef) added.getDataRef()).getExpression();
+      assertTrue(expr.contains("GROUPS BETWEEN 2 PRECEDING AND CURRENT ROW"),
+                 "unexpected expression: " + expr);
+   }
+
+   @Test
+   void rangeValueOffset_requiresSingleOrderKey() throws Exception {
+      WorksheetTable req = request("""
+         { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount","partitionBy":["stage"],
+           "orderBy":[{"field":"d","direction":"ASC"},{"field":"amount","direction":"ASC"}],
+           "frame":{"mode":"RANGE","startBound":"PRECEDING","startOffset":7,
+                     "endBound":"CURRENT_ROW","offsetUnit":"day"}} ] }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      AttributeRef dRef = new AttributeRef(null, "d");
+      dRef.setDataType(inetsoft.uql.schema.XSchema.TIME_INSTANT);
+      cs.addAttribute(new ColumnRef(dRef));
+      table.setColumnSelection(cs);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service().applyWindowColumns(table, req.getWindowColumns()));
+      assertTrue(ex.getMessage().contains("s"));
+   }
+
+   @Test
+   void offsetUnit_onRows_throws() throws Exception {
+      WorksheetTable req = request("""
+         { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount","partitionBy":["stage"],
+           "orderBy":[{"field":"d","direction":"ASC"}],
+           "frame":{"mode":"ROWS","startBound":"PRECEDING","startOffset":7,
+                     "endBound":"CURRENT_ROW","offsetUnit":"day"}} ] }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "d")));
+      table.setColumnSelection(cs);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service().applyWindowColumns(table, req.getWindowColumns()));
+      assertTrue(ex.getMessage().contains("s"));
+   }
+
+   @Test
+   void groupsOrRangeValue_withoutOrderBy_throws() throws Exception {
+      WorksheetTable req = request("""
+         { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount","partitionBy":["stage"],
+           "frame":{"mode":"GROUPS","startBound":"PRECEDING","startOffset":2,
+                     "endBound":"CURRENT_ROW"}} ] }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      table.setColumnSelection(cs);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service().applyWindowColumns(table, req.getWindowColumns()));
+      assertTrue(ex.getMessage().contains("s"));
+   }
+
+   @Test
+   void invalidFrameMode_throws() throws Exception {
+      WorksheetTable req = request("""
+         { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount",
+           "orderBy":[{"field":"amount","direction":"ASC"}],
+           "frame":{"mode":"BOGUS","startBound":"PRECEDING","startOffset":2,
+                     "endBound":"CURRENT_ROW"}} ] }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      table.setColumnSelection(cs);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service().applyWindowColumns(table, req.getWindowColumns()));
+      assertTrue(ex.getMessage().contains("s"));
+   }
+
+   @Test
+   void offsetUnit_onNonDateOrderKey_throws() throws Exception {
+      WorksheetTable req = request("""
+         { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount","partitionBy":["stage"],
+           "orderBy":[{"field":"amount","direction":"ASC"}],
+           "frame":{"mode":"RANGE","startBound":"PRECEDING","startOffset":7,
+                     "endBound":"CURRENT_ROW","offsetUnit":"day"}} ] }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      table.setColumnSelection(cs);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service().applyWindowColumns(table, req.getWindowColumns()));
+      assertTrue(ex.getMessage().contains("s"));
+   }
+
+   @Test
+   void invalidOffsetUnit_throws() throws Exception {
+      WorksheetTable req = request("""
+         { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount","partitionBy":["stage"],
+           "orderBy":[{"field":"d","direction":"ASC"}],
+           "frame":{"mode":"RANGE","startBound":"PRECEDING","startOffset":7,
+                     "endBound":"CURRENT_ROW","offsetUnit":"fortnight"}} ] }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      AttributeRef dRef = new AttributeRef(null, "d");
+      dRef.setDataType(inetsoft.uql.schema.XSchema.TIME_INSTANT);
+      cs.addAttribute(new ColumnRef(dRef));
+      table.setColumnSelection(cs);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service().applyWindowColumns(table, req.getWindowColumns()));
+      assertTrue(ex.getMessage().contains("s"));
+   }
+
+   @Test
+   void rowsFrame_byteParityWithOmittedMode() throws Exception {
+      // A ROWS/omitted-mode frame must produce identical output to Phase 3 (no regression).
+      WorksheetTable req = request("""
+         { "windowColumns":[ {"name":"ma","fn":"AVG","column":"amount",
+           "orderBy":[{"field":"amount","direction":"ASC"}],
+           "frame":{"startBound":"PRECEDING","startOffset":2,"endBound":"CURRENT_ROW"}} ] }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      table.setColumnSelection(cs);
+
+      service().applyWindowColumns(table, req.getWindowColumns());
+
+      ColumnRef added = (ColumnRef) table.getColumnSelection(false).getAttribute("ma");
+      String expr = ((WindowExpressionRef) added.getDataRef()).getExpression();
+      assertTrue(expr.contains("ROWS BETWEEN 2 PRECEDING AND CURRENT ROW"));
+      assertFalse(expr.contains("RANGE"));
+      assertFalse(expr.contains("GROUPS"));
+   }
 }


### PR DESCRIPTION
## Window functions — Phase 4: RANGE / GROUPS frame modes

Adds SQL window **frame modes** `RANGE` and `GROUPS` (Phase 3 shipped `ROWS` only), on both the JDBC pushdown path and the in-memory `WindowTableLens`. A dialect **capability gate** routes non-pushable frames to the in-memory engine, so every mode works on every datasource.

### Frame model
`frame` gains `mode` (`ROWS`|`RANGE`|`GROUPS`, default ROWS) and `offsetUnit` (`year…second`, for date-valued RANGE). `mode` absent ⇒ ROWS, so every Phase-3 caller and stored frame is byte-identical.

### Commits (Tasks 1–4 + review fixes)
- `WindowExpressionRef`: frame `mode`/`offsetUnit`; `getFrameFragment` emits `<MODE> BETWEEN …`; RANGE date → `INTERVAL '<n> <unit>'`; GROUPS → `GROUPS BETWEEN …`. `frameMode` persisted only for RANGE/GROUPS (ROWS stored null → **no XML serialization drift** for Phase-3 assets). mode/offsetUnit token validation.
- `/ws/table` (`WorksheetTable.WindowFrameInfo` + `WorksheetTableService`): accept + validate `mode`/`offsetUnit`, fail-loud (mode enum; RANGE-value/GROUPS require orderBy; RANGE-value requires exactly one orderBy; offsetUnit only for RANGE with a value-offset bound on a date/time key; unit case-normalized). Gated so a no-orderBy whole-partition RANGE never crashes.
- `WindowTableLens`: in-memory RANGE (value + peer, calendar-aware date arithmetic) and GROUPS; symmetric bounds (FOLLOWING-start / PRECEDING-end); null-order-value fail-loud (NULLS deferred). ROWS/frame-less byte-parity preserved.
- `AssetQuery`: `framePushable(mode, helper)` (v1: `postgresql` → ROWS/RANGE/GROUPS; else ROWS only); non-pushable frames excluded from pushed SQL (via the `mergeColumn` choke point) and computed in-memory instead — **no double-compute**, and **Postgres byte-parity byte-identical** (every frame pushable ⇒ gate is a no-op).

### Byte-parity gate
ROWS and frame-less windows produce identical pushdown SQL and identical in-memory values to Phase 3. On Postgres the capability gate never changes routing or SQL.

### Tests
Per-task unit suites green (WindowExpressionRef, WorksheetTableServiceWindowColumns, WindowTableLens incl. DESC-RANGE + calendar-month, WindowRouting). Each task adversarially reviewed; findings fixed (XML byte-parity, no-orderBy crash, symmetric bounds, routing correctness).

### Verification status
Live pushdown + in-memory-fallback verification (`local-992`) and the whole-branch review are in progress; results/any fixes will be pushed here before merge.

Deferred (documented): `EXCLUDE` clause, `NULLS FIRST/LAST`, fractional numeric offsets, non-Postgres dialect *pushdown* (those dialects use the in-memory fallback); and, gated on adding a non-PG dialect, the `mergeGroupBy` bookkeeping follow-up.

Paired with wiz-services PR (frame `mode`/`offsetUnit` wiring + validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
