### PR TITLE
Window frames: Phase-4 review follow-ups (GROUPS orderBy, numeric-RANGE key, gcolumns gating)

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
@@ -656,8 +656,18 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
          // it OUT of the GROUP BY list (built below from info.getGroups() only). Without this it is
          // silently dropped from the SELECT when the table also carries group/aggregates.
          else if(column.isVisible() && group == null && isWindowExpression(column)) {
-            mergeColumn(nselection, column);
-            gcolumns.addAttribute(column);
+            // Use the 3-arg boolean mergeColumn (not the 2-arg void variant, which always
+            // emits) so a window column that AssetQuery's override refuses to push down (a
+            // non-pushable RANGE/GROUPS frame on a non-Postgres dialect) is kept OUT of
+            // gcolumns when it's absent from the SELECT list — otherwise gcolumns count would
+            // not match the emitted SQL columns on that hybrid grouped-SQL + in-memory-window
+            // path. isAggregateInfoMergeable() is always true here (mergeGroupBy already
+            // returned false above when it isn't), so this is byte-identical to the prior
+            // unconditional mergeColumn(nselection, column) + gcolumns.addAttribute(column) for
+            // every dialect that CAN push the frame down (all-Postgres included).
+            if(mergeColumn(nselection, column, isAggregateInfoMergeable())) {
+               gcolumns.addAttribute(column);
+            }
          }
 
          // if we have no aggs or one agg for a column, increase the count by 1

--- a/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
@@ -661,11 +661,12 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
             // non-pushable RANGE/GROUPS frame on a non-Postgres dialect) is kept OUT of
             // gcolumns when it's absent from the SELECT list — otherwise gcolumns count would
             // not match the emitted SQL columns on that hybrid grouped-SQL + in-memory-window
-            // path. isAggregateInfoMergeable() is always true here (mergeGroupBy already
-            // returned false above when it isn't), so this is byte-identical to the prior
-            // unconditional mergeColumn(nselection, column) + gcolumns.addAttribute(column) for
-            // every dialect that CAN push the frame down (all-Postgres included).
-            if(mergeColumn(nselection, column, isAggregateInfoMergeable())) {
+            // path. The 2-arg mergeColumn this replaces delegates with a hardcoded true, and
+            // mergeGroupBy already returned false above when !isAggregateInfoMergeable(), so
+            // passing true here is byte-identical to the prior unconditional
+            // mergeColumn(nselection, column) + gcolumns.addAttribute(column) for every dialect
+            // that CAN push the frame down (all-Postgres included).
+            if(mergeColumn(nselection, column, true)) {
                gcolumns.addAttribute(column);
             }
          }

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1192,12 +1192,13 @@ public class WorksheetTableService {
                || "PRECEDING".equals(frame.getEndBound()) || "FOLLOWING".equals(frame.getEndBound());
 
             // RANGE value-offset and GROUPS need an ORDER BY; RANGE value-offset needs exactly
-            // one. A whole-partition GROUPS frame (UNBOUNDED_PRECEDING..UNBOUNDED_FOLLOWING) is
-            // exempt, same as the general bounded-frame check above — it needs no peer-group
-            // ordering since it covers every row regardless of order.
-            if(("RANGE".equals(mode) && valueOffset) ||
-               ("GROUPS".equals(mode) && !isWholePartitionFrame(frame)))
-            {
+            // one. Unlike the general bounded-frame check above, GROUPS has NO whole-partition
+            // exemption: Postgres (and ANSI) require an ORDER BY for GROUPS mode regardless of
+            // bounds, since GROUPS defines its peer groups purely from the order-by key — with no
+            // orderBy there is no notion of a "group" to count PRECEDING/FOLLOWING, even when the
+            // frame spans the whole partition. The wiz TS validator rejects ANY GROUPS frame
+            // without orderBy for the same reason; this mirrors it.
+            if(("RANGE".equals(mode) && valueOffset) || "GROUPS".equals(mode)) {
                if(orderRefs.isEmpty()) {
                   throw new IllegalArgumentException(
                      "windowColumns['" + colName + "']: a " + mode + " frame requires orderBy");
@@ -1257,6 +1258,17 @@ public class WorksheetTableService {
                   throw new IllegalArgumentException(
                      "windowColumns['" + colName + "']: a RANGE value-offset on a date/time " +
                      "order key requires frame.offsetUnit (e.g. day/month)");
+               }
+               // Converse case: with no offsetUnit, a RANGE value-offset is a bare numeric
+               // threshold applied against the single order key. A non-numeric, non-date order
+               // key (e.g. string/boolean) makes that threshold meaningless — fail loud instead
+               // of emitting a nonsensical "RANGE BETWEEN n PRECEDING" against e.g. a string
+               // column. Deferred (not thrown) when dt is unresolvable (null), matching the
+               // best-effort pattern used throughout this method.
+               else if(dt != null && !XSchema.isNumericType(dt)) {
+                  throw new IllegalArgumentException(
+                     "windowColumns['" + colName + "']: a numeric RANGE value-offset requires " +
+                     "a numeric order key");
                }
             }
 

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceWindowColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceWindowColumnsTest.java
@@ -490,13 +490,16 @@ class WorksheetTableServiceWindowColumnsTest {
    }
 
    @Test
-   void groupsWholePartition_noOrderBy_succeeds() throws Exception {
-      // Whole-partition GROUPS frame (UNBOUNDED_PRECEDING..UNBOUNDED_FOLLOWING) needs no
-      // peer-group ordering — it covers every row regardless of order, exactly like a
-      // whole-partition ROWS/RANGE frame. Review fix: the GROUPS-requires-orderBy guard used to
-      // fire unconditionally, rejecting this legitimate whole-partition case too; it is now
-      // gated on !isWholePartitionFrame(frame), consistent with the general bounded-frame
-      // "requires orderBy" guard a few lines above it.
+   void groupsWholePartition_noOrderBy_throws() throws Exception {
+      // Review fix (Fix 1): GROUPS mode ALWAYS requires an ORDER BY, even for a whole-partition
+      // frame (UNBOUNDED_PRECEDING..UNBOUNDED_FOLLOWING). Unlike ROWS/RANGE, GROUPS defines its
+      // peer groups purely from the order-by key — with no orderBy there is no notion of a
+      // "group" at all, so a whole-partition exemption (as used for the general bounded-frame
+      // check) is invalid SQL on Postgres/ANSI and diverges from the wiz TS validator, which
+      // rejects ANY GROUPS frame without orderBy. This test used to assert the OPPOSITE
+      // ("...succeeds") — that encoded the bug (a `!isWholePartitionFrame(frame)` exemption on
+      // the GROUPS branch); it is inverted here to lock in the corrected, always-required
+      // behavior.
       WorksheetTable req = request("""
          { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount","partitionBy":["stage"],
            "frame":{"mode":"GROUPS","startBound":"UNBOUNDED_PRECEDING",
@@ -510,12 +513,10 @@ class WorksheetTableServiceWindowColumnsTest {
       cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
       table.setColumnSelection(cs);
 
-      service().applyWindowColumns(table, req.getWindowColumns());
-
-      ColumnRef added = (ColumnRef) table.getColumnSelection(false).getAttribute("s");
-      String expr = ((WindowExpressionRef) added.getDataRef()).getExpression();
-      assertTrue(expr.contains("GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING"),
-                 "unexpected expression: " + expr);
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service().applyWindowColumns(table, req.getWindowColumns()));
+      assertTrue(ex.getMessage().contains("s"));
+      assertTrue(ex.getMessage().contains("GROUPS"), "unexpected message: " + ex.getMessage());
    }
 
    @Test
@@ -581,7 +582,10 @@ class WorksheetTableServiceWindowColumnsTest {
    void rangeValueOffset_onNumericOrderKey_missingOffsetUnit_stillSucceeds() throws Exception {
       // Byte-parity / no-regression check: a RANGE value-offset on a NON-date (numeric) order
       // key with no offsetUnit is the normal, long-supported case (a plain numeric threshold)
-      // and must still succeed — the new Fix C guard only rejects a date/time order key.
+      // and must still succeed — the new Fix 2 guard only rejects a non-numeric, non-date order
+      // key. NOTE: the order key must be explicitly typed numeric here — AttributeRef.getDataType()
+      // defaults an untyped ref to XSchema.STRING, which would otherwise (correctly) trip the
+      // new guard and turn this byte-parity case into a false failure.
       WorksheetTable req = request("""
          { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount","partitionBy":["stage"],
            "orderBy":[{"field":"amount","direction":"ASC"}],
@@ -592,7 +596,9 @@ class WorksheetTableServiceWindowColumnsTest {
       Worksheet ws = new Worksheet();
       PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
       ColumnSelection cs = new ColumnSelection();
-      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      AttributeRef amountRef = new AttributeRef(null, "amount");
+      amountRef.setDataType(inetsoft.uql.schema.XSchema.DOUBLE);
+      cs.addAttribute(new ColumnRef(amountRef));
       cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
       table.setColumnSelection(cs);
 
@@ -602,5 +608,37 @@ class WorksheetTableServiceWindowColumnsTest {
       String expr = ((WindowExpressionRef) added.getDataRef()).getExpression();
       assertTrue(expr.contains("RANGE BETWEEN 5 PRECEDING AND CURRENT ROW"),
                  "unexpected expression: " + expr);
+   }
+
+   @Test
+   void numericRangeValueOffset_stringOrderKey_throws() throws Exception {
+      // Review fix (Fix 2): the converse of rangeValueOffset_onDateOrderKey_missingOffsetUnit_throws
+      // above. A RANGE value-offset (PRECEDING/FOLLOWING n) with no offsetUnit is a bare numeric
+      // threshold; ordering by a non-numeric, non-date key (e.g. a plain string column) makes
+      // that threshold meaningless and must fail loud, matching the wiz TS validator, instead of
+      // silently emitting a nonsensical "RANGE BETWEEN n PRECEDING" against a string column.
+      WorksheetTable req = request("""
+         { "windowColumns":[ {"name":"s","fn":"SUM","column":"amount","partitionBy":["stage"],
+           "orderBy":[{"field":"stage","direction":"ASC"}],
+           "frame":{"mode":"RANGE","startBound":"PRECEDING","startOffset":5,
+                     "endBound":"CURRENT_ROW"}} ] }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      AttributeRef amountRef = new AttributeRef(null, "amount");
+      amountRef.setDataType(inetsoft.uql.schema.XSchema.DOUBLE);
+      cs.addAttribute(new ColumnRef(amountRef));
+      AttributeRef stageRef = new AttributeRef(null, "stage");
+      stageRef.setDataType(inetsoft.uql.schema.XSchema.STRING);
+      cs.addAttribute(new ColumnRef(stageRef));
+      table.setColumnSelection(cs);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service().applyWindowColumns(table, req.getWindowColumns()));
+      assertTrue(ex.getMessage().contains("s"));
+      assertTrue(ex.getMessage().contains("numeric order key"),
+                 "unexpected message: " + ex.getMessage());
    }
 }


### PR DESCRIPTION
## Window frames — Phase-4 review follow-ups (parity + bookkeeping cleanup)

Three small, non-blocking follow-ups deferred from the Phase-4 (RANGE/GROUPS) PR reviews. Guard/validation + bookkeeping only; no new capability. Unit-covered (93/93 across the window suites).

### 1. GROUPS always requires `orderBy` (`WorksheetTableService`)
Drops the whole-partition exemption on the GROUPS-requires-orderBy guard. Postgres/ANSI require an ORDER BY for GROUPS mode regardless of bounds, and the wiz TS validator already rejects any GROUPS without `orderBy` — this restores TS↔Java parity and prevents emitting invalid SQL for a whole-partition GROUPS on the raw `/ws/table` path. Test `groupsWholePartition_noOrderBy_succeeds` inverted → `_throws` (it encoded the old bug).

### 2. Numeric RANGE value-offset requires a numeric order key (`WorksheetTableService`)
Adds the converse of the existing date-key check (which the wiz TS validator already enforces): a numeric RANGE value-offset (no `offsetUnit`) whose single order key resolves to a non-numeric, non-date type now fails loud. Best-effort — defers when the type is unresolvable, matching the existing pattern. New test `numericRangeValueOffset_stringOrderKey_throws`.

### 3. Keep a non-pushed window column out of `gcolumns` (`PreAssetQuery.mergeGroupBy`)
The window-expression special case used the 2-arg `void mergeColumn` (always emits) then unconditionally added the column to `gcolumns`. Switched to the 3-arg boolean `mergeColumn` and gated `gcolumns.addAttribute` on its return, so a window column that `AssetQuery`'s dialect-capability override refuses to push down (a non-pushable RANGE/GROUPS frame on a non-Postgres source) is no longer tracked in `gcolumns` when it's absent from the emitted SELECT — fixing a bookkeeping mismatch on the hybrid grouped-SQL + in-memory-window path.

**Byte-parity (all-Postgres path):** unchanged. `isAggregateInfoMergeable()` is provably `true` at that branch (`mergeGroupBy` returns earlier otherwise), matching the old 2-arg's hardcoded flag; and on Postgres `framePushable` is always true so the override falls through to `super.mergeColumn` and the column is emitted + tracked exactly as before. Verified by reading + the full window suite passing.

Fix 3's non-Postgres bug branch has no dedicated unit seam (would need a non-PG SQLHelper harness — disproportionate; it's unreachable until a non-PG dialect is added); covered by existing `WindowRoutingTest`/`WindowTableLensTest` + code inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
