### PR TITLE
Window functions Phase 5: dialect-aware frame pushdown (all SQLHelper dialects)

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -2972,8 +2972,8 @@ public abstract class AssetQuery extends PreAssetQuery {
    /**
     * Like {@link #buildWindowSpecs(XTable, ColumnSelection)}, but SKIPS a window column whose
     * frame is pushable on {@code helper}'s dialect (see
-    * {@link #framePushable(String, SQLHelper)}) — i.e. one already merged into the pushed-down
-    * SQL by {@link #mergeColumn}. Used by the mixed-pushability routing case in
+    * {@link #framePushable(WindowExpressionRef, SQLHelper)}) — i.e. one already merged into the
+    * pushed-down SQL by {@link #mergeColumn}. Used by the mixed-pushability routing case in
     * {@link #getWindowTableLens}: when a query is mergeable but not every window column's frame
     * is pushable (e.g. one ROWS column + one RANGE column on a non-Postgres source), the ROWS
     * column is already in the generated SQL and must NOT also be recomputed here — building a
@@ -3013,7 +3013,7 @@ public abstract class AssetQuery extends PreAssetQuery {
 
          WindowExpressionRef w = (WindowExpressionRef) bref;
 
-         if(skipPushable && framePushable(w.getFrameMode(), helper)) {
+         if(skipPushable && framePushable(w, helper)) {
             // Already merged into the pushed-down SQL by mergeColumn — do not also compute it
             // in memory (see javadoc above).
             continue;
@@ -3186,8 +3186,9 @@ public abstract class AssetQuery extends PreAssetQuery {
     * dialect — the OVER is already in the SELECT (byte-parity: {@link #buildWindowLens} is not
     * even reached in this case). For a mergeable source where SOME but not all window columns'
     * frame modes (RANGE/GROUPS) are pushable on the source dialect (see
-    * {@link #framePushable(String, SQLHelper)}), the pushable ones are already merged into the
-    * SQL by {@link #mergeColumn} — only the non-pushable ones still need computing, so this
+    * {@link #framePushable(WindowExpressionRef, SQLHelper)}), the pushable ones are already
+    * merged into the SQL by {@link #mergeColumn} — only the non-pushable ones still need
+    * computing, so this
     * routes through the helper-aware {@link #buildWindowLens(TableLens, ColumnSelection, SQLHelper)}
     * overload, which builds specs ONLY for those (see {@link #buildWindowSpecs(XTable,
     * ColumnSelection, SQLHelper)}): a pushable column must not also be recomputed in memory
@@ -3221,33 +3222,33 @@ public abstract class AssetQuery extends PreAssetQuery {
    }
 
    /**
-    * v1 dialect capability map: frame modes {@code postgresql} can push down as SQL (Phase 4).
-    * Every other dialect only pushes {@code ROWS} (Phase 3); {@code RANGE}/{@code GROUPS} fall
-    * back to the in-memory {@link WindowTableLens} engine there.
-    */
-   private static final Set<String> PG_PUSHABLE = Set.of("ROWS", "RANGE", "GROUPS");
-
-   /**
-    * Can {@code mode} be pushed down as SQL on the dialect behind {@code helper}?
-    * {@code ROWS} pushes on every dialect (Phase 3, unchanged). {@code RANGE}/{@code GROUPS}
-    * push only on PostgreSQL (v1 capability map — see {@link #PG_PUSHABLE}); every other
-    * dialect (including a {@code null} helper, e.g. a non-JDBC tabular source) routes them to
-    * the in-memory engine.
+    * Can {@code w}'s frame be pushed down as SQL on the dialect behind {@code helper}? Derives
+    * the frame's shape (mode, whether a real value offset is present, whether it is a date
+    * INTERVAL) from the ref and delegates the dialect decision to
+    * {@link SQLHelper#supportsWindowFrame}. A frame-less ref (no explicit frame — e.g. a bare
+    * ROW_NUMBER/RANK, or the Phase-3 default) is always "pushable": it emits no dialect-specific
+    * frame syntax at all, so there is nothing for the dialect to refuse.
     * <p>
     * Package-private so {@code WindowRoutingTest} can exercise it directly with lightweight
     * {@link SQLHelper} instances (no live connection required).
-    * @param mode the frame mode: {@code ROWS}, {@code RANGE}, or {@code GROUPS}.
+    * @param w the window column whose frame is being routed.
     * @param helper the source dialect's SQL helper, or {@code null} if there is none (e.g. a
-    *               tabular/non-JDBC source, which is never frame-pushable beyond ROWS).
-    * @return {@code true} if {@code mode} can be emitted as a pushed-down SQL frame clause.
+    *               tabular/non-JDBC source, which is never frame-pushable beyond a frame-less
+    *               ref or ROWS).
+    * @return {@code true} if {@code w}'s frame can be emitted as a pushed-down SQL frame clause.
     */
-   static boolean framePushable(String mode, SQLHelper helper) {
-      if("ROWS".equals(mode)) {
-         return true;
+   static boolean framePushable(WindowExpressionRef w, SQLHelper helper) {
+      if(!w.hasExplicitFrame()) {
+         return true;   // frame-less / LAST_VALUE default — no dialect-specific frame syntax
       }
 
-      String type = helper == null ? null : helper.getSQLHelperType();
-      return "postgresql".equals(type) && PG_PUSHABLE.contains(mode);
+      String mode = w.getFrameMode();
+      boolean hasValueOffset =
+         "PRECEDING".equals(w.getFrameStartBound()) || "FOLLOWING".equals(w.getFrameStartBound())
+         || "PRECEDING".equals(w.getFrameEndBound()) || "FOLLOWING".equals(w.getFrameEndBound());
+      boolean dateOffset = w.getFrameOffsetUnit() != null;
+
+      return helper != null && helper.supportsWindowFrame(mode, hasValueOffset, dateOffset);
    }
 
    /**
@@ -3271,7 +3272,7 @@ public abstract class AssetQuery extends PreAssetQuery {
          DataRef bref = ((ColumnRef) ref).getDataRef();
 
          if(bref instanceof WindowExpressionRef &&
-            !framePushable(((WindowExpressionRef) bref).getFrameMode(), helper))
+            !framePushable((WindowExpressionRef) bref, helper))
          {
             return false;
          }
@@ -3281,16 +3282,16 @@ public abstract class AssetQuery extends PreAssetQuery {
    }
 
    /**
-    * Dialect capability gate (Phase 4): refuse to inline a {@link WindowExpressionRef} column
-    * into the pushed-down SQL when its frame mode is not pushable on this query's source
-    * dialect (see {@link #framePushable(String, SQLHelper)}) — e.g. a RANGE/GROUPS frame on a
-    * non-PostgreSQL source. Returning {@code false} here leaves the column out of the SQL
-    * SELECT and {@code column.isProcessed()} false; {@link #getWindowTableLens} then computes
-    * it in memory instead, so it is never both inlined AND lens-computed.
+    * Dialect capability gate (Phase 4/5): refuse to inline a {@link WindowExpressionRef} column
+    * into the pushed-down SQL when its frame is not pushable on this query's source dialect
+    * (see {@link #framePushable(WindowExpressionRef, SQLHelper)}) — e.g. a RANGE/GROUPS frame on
+    * a dialect that doesn't support it. Returning {@code false} here leaves the column out of
+    * the SQL SELECT and {@code column.isProcessed()} false; {@link #getWindowTableLens} then
+    * computes it in memory instead, so it is never both inlined AND lens-computed.
     * <p>
-    * ROWS frames (and every frame on PostgreSQL) are unaffected — this override delegates to
-    * {@code super.mergeColumn} exactly as before, so pushdown SQL text is byte-for-byte
-    * identical to pre-Phase-4 behavior for those cases (byte-parity requirement).
+    * ROWS frames (and every frame the dialect opts into) are unaffected — this override
+    * delegates to {@code super.mergeColumn} exactly as before, so pushdown SQL text is
+    * byte-for-byte identical to pre-Phase-4 behavior for those cases (byte-parity requirement).
     */
    @Override
    protected boolean mergeColumn(XSelection nselection, ColumnRef column,
@@ -3301,7 +3302,7 @@ public abstract class AssetQuery extends PreAssetQuery {
       if(bref instanceof WindowExpressionRef) {
          SQLHelper helper = AssetUtil.getSQLHelper(getTable());
 
-         if(!framePushable(((WindowExpressionRef) bref).getFrameMode(), helper)) {
+         if(!framePushable((WindowExpressionRef) bref, helper)) {
             return false;
          }
       }

--- a/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
@@ -2597,7 +2597,67 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
       }
 
       expstr.append(exp);
-      return expstr.toString();
+      return expandWindowFrameTokens(expstr.toString(), helper);
+   }
+
+   /**
+    * Prefix of the canonical window-frame date-interval token emitted by
+    * {@code WindowExpressionRef.frameOffsetSql} for a date-valued RANGE frame offset, e.g.
+    * {@code WINFRAME_INTERVAL(7,day)}. Mirrors the {@code field['} token convention: a
+    * database-agnostic placeholder embedded in the expression text that this rewrite pass expands
+    * into the dialect's real SQL syntax.
+    */
+   private static final String WINFRAME_INTERVAL_TOKEN = "WINFRAME_INTERVAL(";
+
+   /**
+    * Expand every {@code WINFRAME_INTERVAL(<n>,<unit>)} token in {@code exp} into the given
+    * dialect's {@code INTERVAL} literal via {@link SQLHelper#formatWindowFrameInterval}. Mirrors
+    * the {@code field['..']} rewrite loop above: a simple, well-bounded left-to-right scan that
+    * leaves everything else in the expression untouched.
+    * <p>
+    * {@code helper} may be {@code null} (no resolvable dialect, e.g. no backing SQL) — the base
+    * {@link SQLHelper} (ANSI/Postgres-literal default) is used in that case, matching the fallback
+    * already used elsewhere in this class when no dialect-specific helper is available.
+    *
+    * @param exp the expression text, possibly containing zero or more window-frame interval tokens.
+    * @param helper the dialect's {@code SQLHelper}, or {@code null} to use the ANSI default.
+    * @return {@code exp} with every token replaced by its dialect-rendered literal; unchanged
+    *         (same content) if no token is present.
+    */
+   static String expandWindowFrameTokens(String exp, SQLHelper helper) {
+      if(exp == null || !exp.contains(WINFRAME_INTERVAL_TOKEN)) {
+         return exp;
+      }
+
+      SQLHelper dialect = helper == null ? new SQLHelper() : helper;
+      StringBuilder result = new StringBuilder();
+      int start;
+
+      while((start = exp.indexOf(WINFRAME_INTERVAL_TOKEN)) != -1) {
+         int end = exp.indexOf(")", start + WINFRAME_INTERVAL_TOKEN.length());
+
+         if(end == -1) {
+            break;
+         }
+
+         String args = exp.substring(start + WINFRAME_INTERVAL_TOKEN.length(), end);
+         int comma = args.indexOf(',');
+
+         if(comma == -1) {
+            break;
+         }
+
+         result.append(exp, 0, start);
+
+         int offset = Integer.parseInt(args.substring(0, comma).trim());
+         String unit = args.substring(comma + 1).trim();
+         result.append(dialect.formatWindowFrameInterval(offset, unit));
+
+         exp = exp.substring(end + 1);
+      }
+
+      result.append(exp);
+      return result.toString();
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/asset/WindowExpressionRef.java
+++ b/core/src/main/java/inetsoft/uql/asset/WindowExpressionRef.java
@@ -206,8 +206,10 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
 
    /**
     * Get the frame offset unit (e.g. {@code "day"}), used to render a date-valued {@code RANGE}
-    * frame's {@code PRECEDING}/{@code FOLLOWING} offset as a Postgres {@code INTERVAL} literal
-    * instead of a bare integer. {@code null} for ROWS/GROUPS and numeric RANGE frames.
+    * frame's {@code PRECEDING}/{@code FOLLOWING} offset as a dialect-specific {@code INTERVAL}
+    * literal (via the {@code WINFRAME_INTERVAL(..)} token, expanded downstream by
+    * {@code SQLHelper.formatWindowFrameInterval}) instead of a bare integer. {@code null} for
+    * ROWS/GROUPS and numeric RANGE frames.
     */
    public String getFrameOffsetUnit() {
       return frameOffsetUnit;
@@ -501,15 +503,21 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
 
    /**
     * Render the PRECEDING/FOLLOWING offset: a bare integer for ROWS/GROUPS/numeric-RANGE frames,
-    * or a Postgres {@code INTERVAL '<n> <unit>'} literal when {@link #frameOffsetUnit} is set
-    * (a date-valued RANGE frame).
+    * or -- when {@link #frameOffsetUnit} is set (a date-valued RANGE frame) -- a canonical
+    * {@code WINFRAME_INTERVAL(<n>,<unit>)} token. This is deliberately NOT a rendered SQL literal:
+    * the dialect-appropriate {@code INTERVAL} syntax varies (Postgres: {@code INTERVAL '<n> <unit>'};
+    * other dialects differ), so this ref stays database-agnostic and defers to the dialect-rewrite
+    * pass ({@code PreAssetQuery.getExpressionColumn}, via {@code SQLHelper.formatWindowFrameInterval})
+    * that already rewrites this expression's {@code field['..']} tokens per dialect. Kept
+    * token-shaped (parenthesized call syntax, like a function) so it survives that rewrite intact
+    * and is unambiguous to scan for.
     */
    private String frameOffsetSql(int offset) {
       if(frameOffsetUnit != null) {
-         return "INTERVAL '" + offset + " " + frameOffsetUnit + "'";
+         return "WINFRAME_INTERVAL(" + offset + "," + frameOffsetUnit + ")";
       }
 
-      return Integer.toString(offset);
+      return Integer.toString(offset);   // numeric offset — ANSI-standard, no rewrite needed
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/jdbc/DB2SQLHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/DB2SQLHelper.java
@@ -98,6 +98,35 @@ class DB2SQLHelper extends SQLHelper {
       return true;
    }
 
+   /**
+    * DB2 (LUW) supports RANGE frames with a numeric or date/time (labeled duration) value
+    * offset, e.g. {@code RANGE BETWEEN 7 DAYS PRECEDING AND CURRENT ROW}. GROUPS frames are
+    * not part of DB2's documented window-frame grammar; left denied here (falls back to the
+    * correct in-memory engine).
+    */
+   @Override
+   public boolean supportsWindowFrame(String mode, boolean hasValueOffset, boolean dateOffset) {
+      if(!supportsOperation(WINDOW_FUNCTION)) {
+         return false;
+      }
+
+      if("RANGE".equals(mode)) {
+         return true;   // peer, numeric value, and date (labeled duration) offsets all supported
+      }
+
+      return super.supportsWindowFrame(mode, hasValueOffset, dateOffset);   // ROWS true, GROUPS false
+   }
+
+   /**
+    * DB2 has no ISO INTERVAL literal type; date/time offsets are expressed as a labeled
+    * duration (the same mechanism used for date arithmetic elsewhere in DB2), e.g.
+    * {@code 7 DAYS} -- no {@code INTERVAL} keyword, plural unit.
+    */
+   @Override
+   public String formatWindowFrameInterval(int offset, String unit) {
+      return offset + " " + unit.toUpperCase() + "S";
+   }
+
    private static Set keywords = new HashSet(); // keywords
 
    static {

--- a/core/src/main/java/inetsoft/uql/jdbc/DB2SQLHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/DB2SQLHelper.java
@@ -99,10 +99,13 @@ class DB2SQLHelper extends SQLHelper {
    }
 
    /**
-    * DB2 (LUW) supports RANGE frames with a numeric or date/time (labeled duration) value
-    * offset, e.g. {@code RANGE BETWEEN 7 DAYS PRECEDING AND CURRENT ROW}. GROUPS frames are
-    * not part of DB2's documented window-frame grammar; left denied here (falls back to the
-    * correct in-memory engine).
+    * DB2 (LUW) supports RANGE frames with a numeric value offset (ANSI-standard
+    * {@code RANGE BETWEEN n PRECEDING AND CURRENT ROW}). A date/time (labeled duration) value
+    * offset, e.g. {@code RANGE BETWEEN 7 DAYS PRECEDING AND CURRENT ROW}, is NOT confirmed by
+    * any first-party IBM example and is denied here (fail-safe default-deny: falls back to the
+    * in-memory WindowTableLens for DB2 date-windowed queries). GROUPS frames are not part of
+    * DB2's documented window-frame grammar; left denied here (falls back to the correct
+    * in-memory engine).
     */
    @Override
    public boolean supportsWindowFrame(String mode, boolean hasValueOffset, boolean dateOffset) {
@@ -110,21 +113,11 @@ class DB2SQLHelper extends SQLHelper {
          return false;
       }
 
-      if("RANGE".equals(mode)) {
-         return true;   // peer, numeric value, and date (labeled duration) offsets all supported
+      if("RANGE".equals(mode) && hasValueOffset) {
+         return !dateOffset;   // numeric value offset supported; date offset unverified, deny
       }
 
-      return super.supportsWindowFrame(mode, hasValueOffset, dateOffset);   // ROWS true, GROUPS false
-   }
-
-   /**
-    * DB2 has no ISO INTERVAL literal type; date/time offsets are expressed as a labeled
-    * duration (the same mechanism used for date arithmetic elsewhere in DB2), e.g.
-    * {@code 7 DAYS} -- no {@code INTERVAL} keyword, plural unit.
-    */
-   @Override
-   public String formatWindowFrameInterval(int offset, String unit) {
-      return offset + " " + unit.toUpperCase() + "S";
+      return super.supportsWindowFrame(mode, hasValueOffset, dateOffset);   // ROWS/RANGE-peer true, GROUPS false
    }
 
    private static Set keywords = new HashSet(); // keywords

--- a/core/src/main/java/inetsoft/uql/jdbc/DatabricksHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/DatabricksHelper.java
@@ -116,4 +116,32 @@ public class DatabricksHelper extends SQLHelper {
    protected boolean supportsMapKeySubqueryAliasing() {
       return true;
    }
+
+   /**
+    * Databricks/Spark SQL supports RANGE frames with a numeric or date/time (INTERVAL) value
+    * offset, e.g. {@code RANGE BETWEEN INTERVAL 7 DAYS PRECEDING AND CURRENT ROW}. GROUPS
+    * frames are not part of Spark's window-frame grammar; left denied here (falls back to
+    * the correct in-memory engine).
+    */
+   @Override
+   public boolean supportsWindowFrame(String mode, boolean hasValueOffset, boolean dateOffset) {
+      if(!supportsOperation(WINDOW_FUNCTION)) {
+         return false;
+      }
+
+      if("RANGE".equals(mode)) {
+         return true;   // peer, numeric value, and date INTERVAL offsets all supported
+      }
+
+      return super.supportsWindowFrame(mode, hasValueOffset, dateOffset);   // ROWS true, GROUPS false
+   }
+
+   /**
+    * Spark SQL's multi-unit interval literal is unquoted with a plural unit keyword, e.g.
+    * {@code INTERVAL 7 DAYS}.
+    */
+   @Override
+   public String formatWindowFrameInterval(int offset, String unit) {
+      return "INTERVAL " + offset + " " + unit.toUpperCase() + "S";
+   }
 }

--- a/core/src/main/java/inetsoft/uql/jdbc/DatabricksHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/DatabricksHelper.java
@@ -138,10 +138,12 @@ public class DatabricksHelper extends SQLHelper {
 
    /**
     * Spark SQL's multi-unit interval literal is unquoted with a plural unit keyword, e.g.
-    * {@code INTERVAL 7 DAYS}.
+    * {@code INTERVAL 7 DAYS}. Spark's INTERVAL literal doesn't accept QUARTER (or WEEK), so
+    * quarter/week are normalized first (see {@link SQLHelper#normalizeFrameInterval}).
     */
    @Override
    public String formatWindowFrameInterval(int offset, String unit) {
-      return "INTERVAL " + offset + " " + unit.toUpperCase() + "S";
+      Object[] normalized = normalizeFrameInterval(offset, unit);
+      return "INTERVAL " + normalized[0] + " " + ((String) normalized[1]).toUpperCase() + "S";
    }
 }

--- a/core/src/main/java/inetsoft/uql/jdbc/GoogleBigQueryHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/GoogleBigQueryHelper.java
@@ -82,5 +82,24 @@ public class GoogleBigQueryHelper extends SQLHelper {
       return alias == null || super.isValidAlias(alias) && !containsSpecialChar(alias);
    }
 
+   /**
+    * BigQuery's RANGE frame only supports a single numeric (INT64) ORDER BY expression and
+    * offset -- date/timestamp ORDER BY expressions are not permitted in a RANGE frame at all,
+    * so a date offset is always denied. GROUPS frames are not part of BigQuery's window-frame
+    * grammar; left denied here (falls back to the correct in-memory engine).
+    */
+   @Override
+   public boolean supportsWindowFrame(String mode, boolean hasValueOffset, boolean dateOffset) {
+      if(!supportsOperation(WINDOW_FUNCTION)) {
+         return false;
+      }
+
+      if("RANGE".equals(mode)) {
+         return !dateOffset;   // peer + numeric value offsets supported; no date INTERVAL frame
+      }
+
+      return super.supportsWindowFrame(mode, hasValueOffset, dateOffset);   // ROWS true, GROUPS false
+   }
+
    private Pattern special;
 }

--- a/core/src/main/java/inetsoft/uql/jdbc/InformixSQLHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/InformixSQLHelper.java
@@ -45,6 +45,31 @@ public class InformixSQLHelper extends DB2SQLHelper {
    }
 
    /**
+    * Informix extends {@link DB2SQLHelper} only for SQL-generation quirks unrelated to window
+    * frames (MAXROWS-clause suppression, alias-length limiting, keyword list). IBM Informix is a
+    * distinct product from DB2 (LUW), and its window-frame RANGE-value-offset support has not
+    * been independently verified against Informix's own SQL reference, so this class must NOT
+    * silently inherit {@code DB2SQLHelper}'s RANGE-value opt-in (added for Task 4). Fail-safe
+    * default-deny: reproduce the conservative {@link SQLHelper} base behavior directly (ROWS and
+    * RANGE-peer allowed; RANGE-value/date and GROUPS denied -> in-memory {@code WindowTableLens}).
+    */
+   @Override
+   public boolean supportsWindowFrame(String mode, boolean hasValueOffset, boolean dateOffset) {
+      if(!supportsOperation(WINDOW_FUNCTION)) {
+         return false;
+      }
+
+      switch(mode) {
+      case "ROWS":
+         return true;
+      case "RANGE":
+         return !hasValueOffset;
+      default:
+         return false;
+      }
+   }
+
+   /**
     * Generate condition string for XBinaryCondition.
     * @param condition
     * @return condition string

--- a/core/src/main/java/inetsoft/uql/jdbc/MySQLHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/MySQLHelper.java
@@ -126,6 +126,34 @@ public class MySQLHelper extends SQLHelper {
    }
 
    /**
+    * MySQL >= 8 (and MariaDB >= 10, via the version gate on {@link #WINDOW_FUNCTION} above)
+    * supports RANGE frames with a numeric or date/time (INTERVAL) value offset, e.g.
+    * {@code RANGE BETWEEN INTERVAL 7 DAY PRECEDING AND CURRENT ROW}. The GROUPS frame unit is
+    * parsed but not implemented by MySQL; left denied here (falls back to the correct
+    * in-memory engine).
+    */
+   @Override
+   public boolean supportsWindowFrame(String mode, boolean hasValueOffset, boolean dateOffset) {
+      if(!supportsOperation(WINDOW_FUNCTION)) {
+         return false;
+      }
+
+      if("RANGE".equals(mode)) {
+         return true;   // peer, numeric value, and date INTERVAL offsets all supported
+      }
+
+      return super.supportsWindowFrame(mode, hasValueOffset, dateOffset);   // ROWS true, GROUPS false
+   }
+
+   /**
+    * MySQL's interval literal has no surrounding quotes: {@code INTERVAL 7 DAY}.
+    */
+   @Override
+   public String formatWindowFrameInterval(int offset, String unit) {
+      return "INTERVAL " + offset + " " + unit.toUpperCase();
+   }
+
+   /**
     * Get a sql string for replacing the table name so a row limit is added
     * to restrict the number of rows from the table.
     */

--- a/core/src/main/java/inetsoft/uql/jdbc/MySQLHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/MySQLHelper.java
@@ -146,11 +146,14 @@ public class MySQLHelper extends SQLHelper {
    }
 
    /**
-    * MySQL's interval literal has no surrounding quotes: {@code INTERVAL 7 DAY}.
+    * MySQL's interval literal has no surrounding quotes: {@code INTERVAL 7 DAY}. MySQL happens
+    * to support QUARTER natively, but quarter/week are still normalized to month/day first
+    * (see {@link SQLHelper#normalizeFrameInterval}) to keep rendering uniform across dialects.
     */
    @Override
    public String formatWindowFrameInterval(int offset, String unit) {
-      return "INTERVAL " + offset + " " + unit.toUpperCase();
+      Object[] normalized = normalizeFrameInterval(offset, unit);
+      return "INTERVAL " + normalized[0] + " " + ((String) normalized[1]).toUpperCase();
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/jdbc/OracleSQLHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/OracleSQLHelper.java
@@ -321,6 +321,33 @@ class OracleSQLHelper extends SQLHelper {
       return 1000;
    }
 
+   /**
+    * Oracle supports RANGE frames with a numeric or date/time (INTERVAL) value offset, e.g.
+    * {@code RANGE BETWEEN INTERVAL '7' DAY PRECEDING AND CURRENT ROW}. GROUPS frames were only
+    * added in Oracle 21c; left denied here (falls back to the correct in-memory engine).
+    */
+   @Override
+   public boolean supportsWindowFrame(String mode, boolean hasValueOffset, boolean dateOffset) {
+      if(!supportsOperation(WINDOW_FUNCTION)) {
+         return false;
+      }
+
+      if("RANGE".equals(mode)) {
+         return true;   // peer, numeric value, and date INTERVAL offsets all supported
+      }
+
+      return super.supportsWindowFrame(mode, hasValueOffset, dateOffset);   // ROWS true, GROUPS false
+   }
+
+   /**
+    * Oracle's date/time interval literal quotes only the numeral; the unit keyword is
+    * unquoted and conventionally upper-cased, e.g. {@code INTERVAL '7' DAY}.
+    */
+   @Override
+   public String formatWindowFrameInterval(int offset, String unit) {
+      return "INTERVAL '" + offset + "' " + unit.toUpperCase();
+   }
+
    private static Set keywords = new HashSet(); // keywords
 
    static {

--- a/core/src/main/java/inetsoft/uql/jdbc/OracleSQLHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/OracleSQLHelper.java
@@ -341,11 +341,14 @@ class OracleSQLHelper extends SQLHelper {
 
    /**
     * Oracle's date/time interval literal quotes only the numeral; the unit keyword is
-    * unquoted and conventionally upper-cased, e.g. {@code INTERVAL '7' DAY}.
+    * unquoted and conventionally upper-cased, e.g. {@code INTERVAL '7' DAY}. Oracle's
+    * INTERVAL literal only accepts YEAR/MONTH/DAY/HOUR/MINUTE/SECOND (no QUARTER or WEEK),
+    * so quarter/week are normalized first (see {@link SQLHelper#normalizeFrameInterval}).
     */
    @Override
    public String formatWindowFrameInterval(int offset, String unit) {
-      return "INTERVAL '" + offset + "' " + unit.toUpperCase();
+      Object[] normalized = normalizeFrameInterval(offset, unit);
+      return "INTERVAL '" + normalized[0] + "' " + ((String) normalized[1]).toUpperCase();
    }
 
    private static Set keywords = new HashSet(); // keywords

--- a/core/src/main/java/inetsoft/uql/jdbc/PostgreSQLHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/PostgreSQLHelper.java
@@ -124,6 +124,47 @@ public class PostgreSQLHelper extends SQLHelper {
       return sql;
    }
 
+   /**
+    * PostgreSQL supports ROWS + RANGE (peer, numeric, and date INTERVAL) window frames
+    * unconditionally, and GROUPS frames from version 11 onward.
+    * formatWindowFrameInterval inherits the base {@code INTERVAL '<n> <unit>'} literal, which
+    * is correct PostgreSQL syntax.
+    */
+   @Override
+   public boolean supportsWindowFrame(String mode, boolean hasValueOffset, boolean dateOffset) {
+      if(!supportsOperation(WINDOW_FUNCTION)) {
+         return false;
+      }
+
+      if("GROUPS".equals(mode)) {
+         return pgVersionAtLeast(11);   // GROUPS is Postgres 11+
+      }
+
+      return true;   // ROWS + RANGE (peer, numeric, and date INTERVAL) all supported
+   }
+
+   /**
+    * Check if the connected PostgreSQL version is at least the given major version. Mirrors
+    * the version-parse pattern in {@link MySQLHelper#supportsOperation(String, String)}:
+    * permissive (returns true) when the version is unknown or unparseable.
+    */
+   private boolean pgVersionAtLeast(int major) {
+      JDBCDataSource dx = uniformSql == null ? null : uniformSql.getDataSource();
+      String version = dx == null ? null : dx.getProductVersion();
+
+      if(version == null) {
+         return true;   // can't prove too old -> permissive
+      }
+
+      try {
+         int actualMajor = Integer.parseInt(version.split("\\.")[0]);
+         return actualMajor >= major;
+      }
+      catch(Exception ex) {
+         return true;   // unparseable -> permissive
+      }
+   }
+
    private static Set keywords = new HashSet(); // keywords
 
    static {

--- a/core/src/main/java/inetsoft/uql/jdbc/SQLHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/SQLHelper.java
@@ -722,11 +722,36 @@ public class SQLHelper implements KeywordProvider {
    }
 
    /**
+    * Normalize a frame interval offset+unit to a universally-supported ANSI interval field:
+    * {@code quarter} -> 3 * offset months, {@code week} -> 7 * offset days (both exact
+    * equivalents). All other units pass through unchanged.
+    * <p>
+    * {@code quarter} and {@code week} are not valid {@code INTERVAL} literal fields on every
+    * dialect (e.g. {@code quarter} is rejected by base/PostgreSQL, Oracle, Databricks/Spark, and
+    * Vertica; {@code week} is rejected by Oracle), so every {@code formatWindowFrameInterval}
+    * implementation must normalize BEFORE rendering, ensuring only the six universally-valid
+    * ANSI interval fields (year/month/day/hour/minute/second) ever reach the literal.
+    * @return a 2-element array: {@code {normalizedOffset, normalizedUnit}}.
+    */
+   protected static Object[] normalizeFrameInterval(int offset, String unit) {
+      if("quarter".equalsIgnoreCase(unit)) {
+         return new Object[] { offset * 3, "month" };
+      }
+
+      if("week".equalsIgnoreCase(unit)) {
+         return new Object[] { offset * 7, "day" };
+      }
+
+      return new Object[] { offset, unit };
+   }
+
+   /**
     * Render a date/time window-frame offset as this dialect's INTERVAL literal.
     * Base (ANSI / Postgres): {@code INTERVAL '<n> <unit>'}. Overridden where syntax differs.
     */
    public String formatWindowFrameInterval(int offset, String unit) {
-      return "INTERVAL '" + offset + " " + unit + "'";
+      Object[] normalized = normalizeFrameInterval(offset, unit);
+      return "INTERVAL '" + normalized[0] + " " + normalized[1] + "'";
    }
 
    public String getConnectionTestQuery() {

--- a/core/src/main/java/inetsoft/uql/jdbc/SQLHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/SQLHelper.java
@@ -697,6 +697,38 @@ public class SQLHelper implements KeywordProvider {
       return !unsupported.contains(key);
    }
 
+   /**
+    * Whether this dialect can push a window frame of the given shape down as SQL.
+    * @param mode "ROWS" | "RANGE" | "GROUPS".
+    * @param hasValueOffset a PRECEDING/FOLLOWING bound with a real offset is present
+    *        (false = pure peer frame: only UNBOUNDED/CURRENT ROW bounds).
+    * @param dateOffset the value offset is a date/time INTERVAL (offsetUnit set), not numeric.
+    * Base default: deny unless near-universal — ROWS and RANGE-peer only, and only where
+    * window functions are supported at all. Dialects override to opt into more.
+    */
+   public boolean supportsWindowFrame(String mode, boolean hasValueOffset, boolean dateOffset) {
+      if(!supportsOperation(WINDOW_FUNCTION)) {
+         return false;
+      }
+
+      switch(mode) {
+      case "ROWS":
+         return true;                         // row-count frames are universal
+      case "RANGE":
+         return !hasValueOffset;              // peer frame only; value/date offsets are opt-in
+      default:                                // GROUPS and anything else
+         return false;
+      }
+   }
+
+   /**
+    * Render a date/time window-frame offset as this dialect's INTERVAL literal.
+    * Base (ANSI / Postgres): {@code INTERVAL '<n> <unit>'}. Overridden where syntax differs.
+    */
+   public String formatWindowFrameInterval(int offset, String unit) {
+      return "INTERVAL '" + offset + " " + unit + "'";
+   }
+
    public String getConnectionTestQuery() {
       return SQLHelper.getConnectionTestQuery(getSQLHelperType());
    }

--- a/core/src/main/java/inetsoft/uql/jdbc/VerticaHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/VerticaHelper.java
@@ -55,4 +55,32 @@ public class VerticaHelper extends SQLHelper {
    public boolean isApplyMaxRowsToTopLevel() {
       return true;
    }
+
+   /**
+    * Vertica supports RANGE frames with a numeric or date/time (INTERVAL) value offset, e.g.
+    * {@code RANGE BETWEEN INTERVAL '7 days' PRECEDING AND CURRENT ROW}. GROUPS frames are not
+    * part of Vertica's documented window-frame grammar; left denied here (falls back to the
+    * correct in-memory engine).
+    */
+   @Override
+   public boolean supportsWindowFrame(String mode, boolean hasValueOffset, boolean dateOffset) {
+      if(!supportsOperation(WINDOW_FUNCTION)) {
+         return false;
+      }
+
+      if("RANGE".equals(mode)) {
+         return true;   // peer, numeric value, and date INTERVAL offsets all supported
+      }
+
+      return super.supportsWindowFrame(mode, hasValueOffset, dateOffset);   // ROWS true, GROUPS false
+   }
+
+   /**
+    * Vertica's interval literal quotes the quantity and unit together, with a plural,
+    * lower-cased unit, e.g. {@code INTERVAL '7 days'}.
+    */
+   @Override
+   public String formatWindowFrameInterval(int offset, String unit) {
+      return "INTERVAL '" + offset + " " + unit.toLowerCase() + "s'";
+   }
 }

--- a/core/src/main/java/inetsoft/uql/jdbc/VerticaHelper.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/VerticaHelper.java
@@ -77,10 +77,13 @@ public class VerticaHelper extends SQLHelper {
 
    /**
     * Vertica's interval literal quotes the quantity and unit together, with a plural,
-    * lower-cased unit, e.g. {@code INTERVAL '7 days'}.
+    * lower-cased unit, e.g. {@code INTERVAL '7 days'}. Vertica's INTERVAL literal doesn't
+    * accept QUARTER, so quarter/week are normalized first
+    * (see {@link SQLHelper#normalizeFrameInterval}).
     */
    @Override
    public String formatWindowFrameInterval(int offset, String unit) {
-      return "INTERVAL '" + offset + " " + unit.toLowerCase() + "s'";
+      Object[] normalized = normalizeFrameInterval(offset, unit);
+      return "INTERVAL '" + normalized[0] + " " + ((String) normalized[1]).toLowerCase() + "s'";
    }
 }

--- a/core/src/test/java/inetsoft/report/composition/execution/WindowRoutingTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/WindowRoutingTest.java
@@ -399,23 +399,67 @@ class WindowRoutingTest {
    }
 
    /**
-    * Dialect capability gate (Phase 4): PostgreSQL pushes RANGE/GROUPS down as SQL; every other
-    * dialect falls back to the in-memory {@link WindowTableLens} engine for those modes. ROWS
-    * pushes on every dialect, unchanged from Phase 3.
+    * Phase 5: {@link AssetQuery#framePushable(WindowExpressionRef, SQLHelper)} no longer
+    * hardcodes a Postgres-only gate — it derives the frame's shape (mode, value-offset
+    * presence, date-INTERVAL-ness) from the ref and consults
+    * {@link SQLHelper#supportsWindowFrame}. PostgreSQL opts in fully (ROWS/RANGE/GROUPS,
+    * including a date-valued RANGE offset); the base {@link SQLHelper} grants only ROWS and a
+    * peer (no-value-offset) RANGE, denying a date-valued RANGE offset and GROUPS — byte-parity
+    * with the retired {@code PG_PUSHABLE} v1 capability map for PostgreSQL, per
+    * {@link inetsoft.uql.jdbc.PostgreSQLHelper#supportsWindowFrame}.
     */
    @Test
-   void framePushable_postgresYesOthersNo() {
-      SQLHelper postgresHelper = new PostgreSQLHelper();
-      SQLHelper otherHelper = new SQLHelper();   // getSQLHelperType() == "default"
+   void framePushable_consultsHelper() {
+      WindowExpressionRef pgRange = rangeDateRef();         // RANGE, offsetUnit=day
+      assertTrue(AssetQuery.framePushable(pgRange, new PostgreSQLHelper()));
+      assertFalse(AssetQuery.framePushable(pgRange, new SQLHelper()));   // base denies date-RANGE
 
-      assertTrue(AssetQuery.framePushable("RANGE", postgresHelper));
-      assertTrue(AssetQuery.framePushable("GROUPS", postgresHelper));
-      assertFalse(AssetQuery.framePushable("RANGE", otherHelper));
-      assertFalse(AssetQuery.framePushable("GROUPS", otherHelper));
-      assertTrue(AssetQuery.framePushable("ROWS", otherHelper));    // ROWS pushes everywhere
-      assertTrue(AssetQuery.framePushable("ROWS", postgresHelper));
-      assertTrue(AssetQuery.framePushable("ROWS", null));           // no dialect (tabular source)
-      assertFalse(AssetQuery.framePushable("RANGE", null));
+      WindowExpressionRef rows = rowsRef();
+      assertTrue(AssetQuery.framePushable(rows, new SQLHelper()));       // ROWS everywhere
+      assertTrue(AssetQuery.framePushable(rows, new PostgreSQLHelper()));
+
+      WindowExpressionRef groups = groupsRef();
+      assertTrue(AssetQuery.framePushable(groups, new PostgreSQLHelper()));
+      assertFalse(AssetQuery.framePushable(groups, new SQLHelper()));    // base denies GROUPS
+
+      // frame-less ref: always pushable (no dialect-specific frame syntax emitted at all)
+      WindowExpressionRef frameLess = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0,
+         List.of(new ColumnRef(new AttributeRef(null, "stage"))),
+         List.of(desc(new ColumnRef(new AttributeRef(null, "amount")))));
+      frameLess.setName("rn");
+      assertTrue(AssetQuery.framePushable(frameLess, new SQLHelper()));
+      assertTrue(AssetQuery.framePushable(frameLess, null));
+   }
+
+   /** RANGE frame with a date-valued (INTERVAL) offset — e.g. a 7-day trailing window. */
+   private static WindowExpressionRef rangeDateRef() {
+      WindowExpressionRef w = new WindowExpressionRef(
+         "SUM", new ColumnRef(new AttributeRef(null, "amount")), 0,
+         List.of(), List.of(asc(new ColumnRef(new AttributeRef(null, "amount")))));
+      w.setFrame("RANGE", "PRECEDING", 7, "CURRENT_ROW", 0, "day");
+      w.setName("trailing");
+      return w;
+   }
+
+   /** ROWS frame with a value offset — pushable on every dialect. */
+   private static WindowExpressionRef rowsRef() {
+      WindowExpressionRef w = new WindowExpressionRef(
+         "AVG", new ColumnRef(new AttributeRef(null, "amount")), 0,
+         List.of(), List.of(desc(new ColumnRef(new AttributeRef(null, "amount")))));
+      w.setFrame("PRECEDING", 2, "CURRENT_ROW", 0);
+      w.setName("ma");
+      return w;
+   }
+
+   /** GROUPS frame — PostgreSQL 11+ only; the base helper denies it. */
+   private static WindowExpressionRef groupsRef() {
+      WindowExpressionRef w = new WindowExpressionRef(
+         "SUM", new ColumnRef(new AttributeRef(null, "amount")), 0,
+         List.of(), List.of(asc(new ColumnRef(new AttributeRef(null, "amount")))));
+      w.setFrame("GROUPS", "PRECEDING", 1, "CURRENT_ROW", 0, null);
+      w.setName("grp");
+      return w;
    }
 
    /**

--- a/core/src/test/java/inetsoft/report/composition/execution/WindowRoutingTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/WindowRoutingTest.java
@@ -432,6 +432,63 @@ class WindowRoutingTest {
       assertTrue(AssetQuery.framePushable(frameLess, null));
    }
 
+   /**
+    * Phase 5 Task 3: {@link PreAssetQuery#expandWindowFrameTokens} is the dialect-rewrite seam
+    * (piggybacking on the same pass that rewrites {@code field['..']} identifier tokens in
+    * {@code PreAssetQuery.getExpressionColumn}) that expands the canonical
+    * {@code WINFRAME_INTERVAL(<n>,<unit>)} token {@code WindowExpressionRef} now emits for a
+    * date-valued RANGE frame offset into the dialect's real {@code INTERVAL} literal.
+    * <p>
+    * Byte-parity gate: PostgreSQL's {@code formatWindowFrameInterval} inherits the base
+    * {@code INTERVAL '<n> <unit>'} literal unchanged (Task 1), so this must render byte-identical
+    * to the pre-Phase-5 hardcoded Postgres literal.
+    */
+   @Test
+   void expandWindowFrameTokens_expandsTokenPerDialect_postgresByteParity() {
+      WindowExpressionRef ref = rangeDateRef();   // RANGE, PRECEDING 7 day .. CURRENT ROW
+
+      String rendered = PreAssetQuery.expandWindowFrameTokens(ref.getExpression(), new PostgreSQLHelper());
+
+      assertTrue(rendered.contains("RANGE BETWEEN INTERVAL '7 day' PRECEDING AND CURRENT ROW"),
+         "PostgreSQL must render the byte-identical Phase 4 literal via the token seam: " + rendered);
+      assertFalse(rendered.contains("WINFRAME_INTERVAL"),
+         "no raw token may survive expansion: " + rendered);
+   }
+
+   @Test
+   void expandWindowFrameTokens_noTokenPassesThroughUnchanged() {
+      String noToken =
+         "ROW_NUMBER() OVER (PARTITION BY field['stage'] ORDER BY field['amount'] DESC)";
+      assertEquals(noToken, PreAssetQuery.expandWindowFrameTokens(noToken, new PostgreSQLHelper()),
+         "an expression with no window-frame token must be returned unchanged");
+      assertEquals(noToken, PreAssetQuery.expandWindowFrameTokens(noToken, null),
+         "a null helper must not affect token-less expressions either");
+   }
+
+   @Test
+   void expandWindowFrameTokens_numericOffset_hasNoTokenToExpand() {
+      // Numeric-offset frames never emit a WINFRAME_INTERVAL token in the first place (frameOffsetSql
+      // returns a bare integer when frameOffsetUnit is null) -- this pins that the rewrite pass is a
+      // pure no-op on that output, i.e. it never mistakes a numeric RANGE frame's bare offset for a
+      // token.
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "SUM", new ColumnRef(new AttributeRef(null, "amount")), 0,
+         List.of(), List.of(asc(new ColumnRef(new AttributeRef(null, "amount")))));
+      ref.setFrame("RANGE", "PRECEDING", 1000, "CURRENT_ROW", 0, null);
+
+      String expr = ref.getExpression();
+      assertEquals(expr, PreAssetQuery.expandWindowFrameTokens(expr, new PostgreSQLHelper()));
+   }
+
+   @Test
+   void expandWindowFrameTokens_nullHelperFallsBackToAnsiDefault() {
+      String withToken =
+         "SUM(x) OVER (RANGE BETWEEN WINFRAME_INTERVAL(3,month) PRECEDING AND CURRENT ROW)";
+      String rendered = PreAssetQuery.expandWindowFrameTokens(withToken, null);
+      assertEquals(
+         "SUM(x) OVER (RANGE BETWEEN INTERVAL '3 month' PRECEDING AND CURRENT ROW)", rendered);
+   }
+
    /** RANGE frame with a date-valued (INTERVAL) offset — e.g. a 7-day trailing window. */
    private static WindowExpressionRef rangeDateRef() {
       WindowExpressionRef w = new WindowExpressionRef(

--- a/core/src/test/java/inetsoft/uql/asset/WindowExpressionRefTest.java
+++ b/core/src/test/java/inetsoft/uql/asset/WindowExpressionRefTest.java
@@ -404,14 +404,31 @@ class WindowExpressionRefTest {
    }
 
    @Test
-   void rangeDateFrame_emitsIntervalSql() {
+   void rangeDateFrame_emitsCanonicalIntervalToken() {
+      // Phase 5 Task 3: WindowExpressionRef no longer pre-renders the Postgres INTERVAL literal
+      // itself -- it emits a canonical WINFRAME_INTERVAL(<n>,<unit>) token that the dialect-rewrite
+      // seam (PreAssetQuery.getExpressionColumn / expandWindowFrameTokens) expands per dialect at
+      // render time. See PreAssetQueryWindowFrameTokenTest for the token -> literal expansion.
       WindowExpressionRef ref = new WindowExpressionRef(
          "SUM", new AttributeRef("amt"), 0, List.of(new AttributeRef("stage")),
          List.of(sort("d", XConstants.SORT_ASC)));
       ref.setFrame("RANGE", "PRECEDING", 7, "CURRENT_ROW", 0, "day");
       assertTrue(ref.getExpression().contains(
-         "RANGE BETWEEN INTERVAL '7 day' PRECEDING AND CURRENT ROW"));
+         "RANGE BETWEEN WINFRAME_INTERVAL(7,day) PRECEDING AND CURRENT ROW"));
+      assertFalse(ref.getExpression().contains("INTERVAL '7 day'"),
+         "the ref must no longer pre-render the Postgres literal itself: " + ref.getExpression());
       assertEquals("day", ref.getFrameOffsetUnit());
+   }
+
+   @Test
+   void dateOffset_emitsCanonicalIntervalToken() {
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "SUM", new AttributeRef("amt"), 0, List.of(new AttributeRef("stage")),
+         List.of(sort("d", XConstants.SORT_ASC)));
+      ref.setFrame("RANGE", "PRECEDING", 7, "CURRENT_ROW", 0, "day");
+
+      assertTrue(ref.getExpression().contains("WINFRAME_INTERVAL(7,day)"));
+      assertFalse(ref.getExpression().contains("INTERVAL '7 day'"));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/uql/jdbc/WindowFrameCapabilityTest.java
+++ b/core/src/test/java/inetsoft/uql/jdbc/WindowFrameCapabilityTest.java
@@ -70,4 +70,73 @@ class WindowFrameCapabilityTest {
       assertTrue(h.supportsWindowFrame("GROUPS", false, false));   // PG >= 11 (default permissive when version unknown)
       assertEquals("INTERVAL '7 day'", h.formatWindowFrameInterval(7, "day"));   // inherits base literal
    }
+
+   // ── Strong tier: opt-in RANGE value/date pushdown, GROUPS still denied ──
+
+   @Test
+   void oracle_rangeValueAndDate_noGroups() {
+      OracleSQLHelper h = new OracleSQLHelper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));   // peer
+      assertTrue(h.supportsWindowFrame("RANGE", true, false));    // numeric value
+      assertTrue(h.supportsWindowFrame("RANGE", true, true));     // date INTERVAL
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+      assertEquals("INTERVAL '7' DAY", h.formatWindowFrameInterval(7, "day"));
+   }
+
+   @Test
+   void mysql_rangeValueAndDate_noGroups() {
+      MySQLHelper h = new MySQLHelper();
+      // no UniformSQL wired -> getDataSource() is null -> WINDOW_FUNCTION version gate is
+      // permissive (see MySQLHelper#supportsOperation), same as WindowFunctionCapabilityTest.
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));
+      assertTrue(h.supportsWindowFrame("RANGE", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+      assertEquals("INTERVAL 7 DAY", h.formatWindowFrameInterval(7, "day"));
+   }
+
+   @Test
+   void db2_rangeValueAndDate_noGroups() {
+      DB2SQLHelper h = new DB2SQLHelper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));
+      assertTrue(h.supportsWindowFrame("RANGE", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+      assertEquals("7 DAYS", h.formatWindowFrameInterval(7, "day"));   // labeled duration, no INTERVAL keyword
+   }
+
+   @Test
+   void databricks_rangeValueAndDate_noGroups() {
+      DatabricksHelper h = new DatabricksHelper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));
+      assertTrue(h.supportsWindowFrame("RANGE", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+      assertEquals("INTERVAL 7 DAYS", h.formatWindowFrameInterval(7, "day"));
+   }
+
+   @Test
+   void vertica_rangeValueAndDate_noGroups() {
+      VerticaHelper h = new VerticaHelper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));
+      assertTrue(h.supportsWindowFrame("RANGE", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+      assertEquals("INTERVAL '7 days'", h.formatWindowFrameInterval(7, "day"));
+   }
+
+   @Test
+   void bigquery_numericRangeOnly_noInterval() {
+      GoogleBigQueryHelper h = new GoogleBigQueryHelper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));
+      assertTrue(h.supportsWindowFrame("RANGE", true, false));    // numeric
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));    // no date INTERVAL frame
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+   }
 }

--- a/core/src/test/java/inetsoft/uql/jdbc/WindowFrameCapabilityTest.java
+++ b/core/src/test/java/inetsoft/uql/jdbc/WindowFrameCapabilityTest.java
@@ -98,14 +98,13 @@ class WindowFrameCapabilityTest {
    }
 
    @Test
-   void db2_rangeValueAndDate_noGroups() {
+   void db2_rangeNumericOnly_dateDenied_noGroups() {
       DB2SQLHelper h = new DB2SQLHelper();
       assertTrue(h.supportsWindowFrame("ROWS", true, false));
-      assertTrue(h.supportsWindowFrame("RANGE", false, false));
-      assertTrue(h.supportsWindowFrame("RANGE", true, false));
-      assertTrue(h.supportsWindowFrame("RANGE", true, true));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));    // peer
+      assertTrue(h.supportsWindowFrame("RANGE", true, false));     // numeric value offset (ANSI, well-established)
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));     // date offset: unverified syntax, deny (fail-safe)
       assertFalse(h.supportsWindowFrame("GROUPS", false, false));
-      assertEquals("7 DAYS", h.formatWindowFrameInterval(7, "day"));   // labeled duration, no INTERVAL keyword
    }
 
    @Test

--- a/core/src/test/java/inetsoft/uql/jdbc/WindowFrameCapabilityTest.java
+++ b/core/src/test/java/inetsoft/uql/jdbc/WindowFrameCapabilityTest.java
@@ -138,4 +138,192 @@ class WindowFrameCapabilityTest {
       assertFalse(h.supportsWindowFrame("RANGE", true, true));    // no date INTERVAL frame
       assertFalse(h.supportsWindowFrame("GROUPS", false, false));
    }
+
+   // ── Conservative tier: ROWS + RANGE-peer only (base default, unmodified) ────
+   // These dialects have WINDOW_FUNCTION == true (no supportsOperation override found for any
+   // of them) and no supportsWindowFrame override, so they land on the base matrix row exactly:
+   // ROWS true, RANGE-peer true, RANGE-value/date false, GROUPS false. No code change; these
+   // tests confirm + lock the contract.
+
+   @Test
+   void sqlServer_rowsAndRangePeer_denyValueDateAndGroups() {
+      SQLServerHelper h = new SQLServerHelper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));    // peer
+      assertFalse(h.supportsWindowFrame("RANGE", true, false));    // no value-offset RANGE
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));     // no date INTERVAL frame
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));  // no GROUPS
+   }
+
+   @Test
+   void snowflake_rowsAndRangePeer_denyValueDateAndGroups() {
+      SnowflakeHelper h = new SnowflakeHelper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));    // peer
+      assertFalse(h.supportsWindowFrame("RANGE", true, false));    // Snowflake RANGE is peer-only
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+   }
+
+   @Test
+   void clickhouse_rowsAndRangePeer_denyValueDateAndGroups() {
+      ClickhouseHelper h = new ClickhouseHelper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+   }
+
+   @Test
+   void hive_rowsAndRangePeer_denyValueDateAndGroups() {
+      HiveHelper h = new HiveHelper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+   }
+
+   @Test
+   void impala_rowsAndRangePeer_denyValueDateAndGroups() {
+      ImpalaHelper h = new ImpalaHelper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+   }
+
+   @Test
+   void exasol_rowsAndRangePeer_denyValueDateAndGroups() {
+      ExasolHelper h = new ExasolHelper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+   }
+
+   // ── No window functions at all: base denies everything ──────────────────────
+
+   @Test
+   void access_noWindowFunctions_denyEverything() {
+      AccessSQLHelper h = new AccessSQLHelper();
+      // Access has no window functions; AccessSQLHelper.supportsOperation(WINDOW_FUNCTION)
+      // already returns false, so the base capability gate denies ROWS/RANGE-peer too.
+      assertFalse(h.supportsWindowFrame("ROWS", true, false));
+      assertFalse(h.supportsWindowFrame("RANGE", false, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+   }
+
+   @Test
+   void mongo_noWindowFunctions_denyEverything() {
+      MongoHelper h = new MongoHelper();
+      // MongoHelper already gates WINDOW_FUNCTION off (supportsOperation(op, info) override).
+      assertFalse(h.supportsWindowFrame("ROWS", true, false));
+      assertFalse(h.supportsWindowFrame("RANGE", false, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+   }
+
+   @Test
+   void derby_noWindowFunctions_denyEverything() {
+      // Note: unlike the rest of the "long tail" below, DerbyHelper unconditionally denies
+      // WINDOW_FUNCTION (not version-gated), so it lands in the no-window-function tier
+      // alongside Access/Mongo -- base denies ROWS/RANGE-peer too, not just RANGE-value/GROUPS.
+      DerbyHelper h = new DerbyHelper();
+      assertFalse(h.supportsWindowFrame("ROWS", true, false));
+      assertFalse(h.supportsWindowFrame("RANGE", false, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+   }
+
+   // ── Long tail: inherit base (ROWS/RANGE-peer true, RANGE-value/date/GROUPS false) ───────
+   // Verified via source: none of these override supportsOperation(WINDOW_FUNCTION) or
+   // supportsWindowFrame, so WINDOW_FUNCTION defaults true and the base matrix row applies in
+   // full (including ROWS/RANGE-peer, safe to assert here since it was independently verified,
+   // not merely assumed).
+
+   @Test
+   void h2_inheritsBase_rowsAndRangePeerTrue_denyValueDateAndGroups() {
+      H2Helper h = new H2Helper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+   }
+
+   @Test
+   void sybase_inheritsBase_rowsAndRangePeerTrue_denyValueDateAndGroups() {
+      SybaseHelper h = new SybaseHelper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+   }
+
+   @Test
+   void denodo_inheritsBase_rowsAndRangePeerTrue_denyValueDateAndGroups() {
+      DenodoSQLHelper h = new DenodoSQLHelper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+   }
+
+   @Test
+   void dremio_inheritsBase_rowsAndRangePeerTrue_denyValueDateAndGroups() {
+      DremioHelper h = new DremioHelper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+   }
+
+   @Test
+   void ingres_inheritsBase_rowsAndRangePeerTrue_denyValueDateAndGroups() {
+      IngresHelper h = new IngresHelper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+   }
+
+   @Test
+   void luciddb_inheritsBase_rowsAndRangePeerTrue_denyValueDateAndGroups() {
+      LucidDbHelper h = new LucidDbHelper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, false));
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+   }
+
+   // ── Informix: genuine divergence found + fixed ───────────────────────────────
+   // InformixSQLHelper extends DB2SQLHelper for unrelated SQL-generation quirks (MAXROWS
+   // suppression, alias-length limiting, keyword list) -- NOT because Informix and DB2 (LUW)
+   // share verified window-frame syntax. Without its own override, Informix would silently
+   // inherit DB2SQLHelper's Task-4 RANGE-value opt-in (a claim never researched for Informix
+   // specifically). InformixSQLHelper now overrides supportsWindowFrame to reproduce the
+   // conservative base row directly instead of falling through to DB2SQLHelper's override.
+
+   @Test
+   void informix_doesNotInheritDb2RangeValueOptIn_deniesValueDateAndGroups() {
+      InformixSQLHelper h = new InformixSQLHelper();
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));     // peer
+      assertFalse(h.supportsWindowFrame("RANGE", true, false));     // NOT DB2's numeric opt-in
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+   }
 }

--- a/core/src/test/java/inetsoft/uql/jdbc/WindowFrameCapabilityTest.java
+++ b/core/src/test/java/inetsoft/uql/jdbc/WindowFrameCapabilityTest.java
@@ -60,6 +60,20 @@ class WindowFrameCapabilityTest {
       assertEquals("INTERVAL '7 day'", new SQLHelper().formatWindowFrameInterval(7, "day"));
    }
 
+   // ── quarter/week normalization: neither is a valid ANSI interval field on every dialect
+   // (quarter fails on base/PG, Oracle, Databricks/Spark, Vertica; week fails on Oracle), so
+   // both are normalized to an exact equivalent (quarter -> 3*offset month, week -> 7*offset
+   // day) BEFORE rendering, universally across dialects. day/month/etc. offsets are byte-
+   // identical to pre-normalization behavior (pass through unchanged).
+
+   @Test
+   void base_interval_quarterAndWeek_normalizedToMonthAndDay() {
+      SQLHelper h = new SQLHelper();
+      assertEquals("INTERVAL '21 month'", h.formatWindowFrameInterval(7, "quarter"));
+      assertEquals("INTERVAL '14 day'", h.formatWindowFrameInterval(2, "week"));
+      assertEquals("INTERVAL '7 day'", h.formatWindowFrameInterval(7, "day"));   // unchanged
+   }
+
    // ── PostgreSQL: opts into everything (byte-parity anchor) ───────────────
 
    @Test
@@ -69,6 +83,9 @@ class WindowFrameCapabilityTest {
       assertTrue(h.supportsWindowFrame("RANGE", true, true));
       assertTrue(h.supportsWindowFrame("GROUPS", false, false));   // PG >= 11 (default permissive when version unknown)
       assertEquals("INTERVAL '7 day'", h.formatWindowFrameInterval(7, "day"));   // inherits base literal
+      // PG rejects INTERVAL '<n> quarter'; normalized to month (inherits base normalization).
+      assertEquals("INTERVAL '21 month'", h.formatWindowFrameInterval(7, "quarter"));
+      assertEquals("INTERVAL '14 day'", h.formatWindowFrameInterval(2, "week"));
    }
 
    // ── Strong tier: opt-in RANGE value/date pushdown, GROUPS still denied ──
@@ -82,6 +99,10 @@ class WindowFrameCapabilityTest {
       assertTrue(h.supportsWindowFrame("RANGE", true, true));     // date INTERVAL
       assertFalse(h.supportsWindowFrame("GROUPS", false, false));
       assertEquals("INTERVAL '7' DAY", h.formatWindowFrameInterval(7, "day"));
+      // Oracle's INTERVAL literal only accepts YEAR/MONTH/DAY/HOUR/MINUTE/SECOND; quarter and
+      // week are normalized to month/day before rendering.
+      assertEquals("INTERVAL '21' MONTH", h.formatWindowFrameInterval(7, "quarter"));
+      assertEquals("INTERVAL '14' DAY", h.formatWindowFrameInterval(2, "week"));
    }
 
    @Test
@@ -95,6 +116,10 @@ class WindowFrameCapabilityTest {
       assertTrue(h.supportsWindowFrame("RANGE", true, true));
       assertFalse(h.supportsWindowFrame("GROUPS", false, false));
       assertEquals("INTERVAL 7 DAY", h.formatWindowFrameInterval(7, "day"));
+      // MySQL happens to support "quarter" natively, but normalizing to month is still correct
+      // (exact equivalent) and keeps the rendering path uniform across dialects.
+      assertEquals("INTERVAL 21 MONTH", h.formatWindowFrameInterval(7, "quarter"));
+      assertEquals("INTERVAL 14 DAY", h.formatWindowFrameInterval(2, "week"));
    }
 
    @Test
@@ -116,6 +141,8 @@ class WindowFrameCapabilityTest {
       assertTrue(h.supportsWindowFrame("RANGE", true, true));
       assertFalse(h.supportsWindowFrame("GROUPS", false, false));
       assertEquals("INTERVAL 7 DAYS", h.formatWindowFrameInterval(7, "day"));
+      // Spark's INTERVAL literal doesn't accept "quarter"; normalized to month before rendering.
+      assertEquals("INTERVAL 21 MONTHS", h.formatWindowFrameInterval(7, "quarter"));
    }
 
    @Test
@@ -127,6 +154,8 @@ class WindowFrameCapabilityTest {
       assertTrue(h.supportsWindowFrame("RANGE", true, true));
       assertFalse(h.supportsWindowFrame("GROUPS", false, false));
       assertEquals("INTERVAL '7 days'", h.formatWindowFrameInterval(7, "day"));
+      // Vertica's INTERVAL literal doesn't accept "quarter"; normalized to month before rendering.
+      assertEquals("INTERVAL '21 months'", h.formatWindowFrameInterval(7, "quarter"));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/uql/jdbc/WindowFrameCapabilityTest.java
+++ b/core/src/test/java/inetsoft/uql/jdbc/WindowFrameCapabilityTest.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.jdbc;
+
+import inetsoft.test.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link SQLHelper#supportsWindowFrame(String, boolean, boolean)} and
+ * {@link SQLHelper#formatWindowFrameInterval(int, String)}, and the PostgreSQL override.
+ *
+ * NOTE: as with {@link WindowFunctionCapabilityTest}, a bare helper has no UniformSQL wired to
+ * a JDBCDataSource, so uniformSql.getDataSource() is null and any version gate falls back to
+ * its permissive default.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WindowFrameCapabilityTest {
+
+   // ── Base SQLHelper: default-deny ────────────────────────────────────────
+
+   @Test
+   void base_defaultDeny() {
+      SQLHelper h = new SQLHelper();   // generic base; WINDOW_FUNCTION defaults true
+      // ROWS + RANGE-peer allowed; RANGE value/date + GROUPS denied
+      assertTrue(h.supportsWindowFrame("ROWS", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", false, false));   // peer
+      assertFalse(h.supportsWindowFrame("RANGE", true, false));   // numeric value offset
+      assertFalse(h.supportsWindowFrame("RANGE", true, true));    // date INTERVAL
+      assertFalse(h.supportsWindowFrame("GROUPS", false, false));
+   }
+
+   @Test
+   void base_interval_ansi() {
+      assertEquals("INTERVAL '7 day'", new SQLHelper().formatWindowFrameInterval(7, "day"));
+   }
+
+   // ── PostgreSQL: opts into everything (byte-parity anchor) ───────────────
+
+   @Test
+   void postgres_full() {
+      PostgreSQLHelper h = new PostgreSQLHelper();
+      assertTrue(h.supportsWindowFrame("RANGE", true, false));
+      assertTrue(h.supportsWindowFrame("RANGE", true, true));
+      assertTrue(h.supportsWindowFrame("GROUPS", false, false));   // PG >= 11 (default permissive when version unknown)
+      assertEquals("INTERVAL '7 day'", h.formatWindowFrameInterval(7, "day"));   // inherits base literal
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceWindowColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceWindowColumnsTest.java
@@ -253,7 +253,10 @@ class WorksheetTableServiceWindowColumnsTest {
 
       ColumnRef added = (ColumnRef) table.getColumnSelection(false).getAttribute("s");
       String expr = ((WindowExpressionRef) added.getDataRef()).getExpression();
-      assertTrue(expr.contains("RANGE BETWEEN INTERVAL '7 day' PRECEDING AND CURRENT ROW"),
+      // Phase 5 Task 3: getExpression() now emits the canonical WINFRAME_INTERVAL token, not the
+      // pre-rendered Postgres literal -- the dialect-rewrite seam (PreAssetQuery.getExpressionColumn)
+      // expands it to "INTERVAL '7 day'" for Postgres at render time.
+      assertTrue(expr.contains("RANGE BETWEEN WINFRAME_INTERVAL(7,day) PRECEDING AND CURRENT ROW"),
                  "unexpected expression: " + expr);
    }
 
@@ -542,7 +545,8 @@ class WorksheetTableServiceWindowColumnsTest {
 
       ColumnRef added = (ColumnRef) table.getColumnSelection(false).getAttribute("s");
       String expr = ((WindowExpressionRef) added.getDataRef()).getExpression();
-      assertTrue(expr.contains("INTERVAL '7 day'"), "unexpected expression: " + expr);
+      // Case-normalization happens before frame storage; the emitted token is unaffected either way.
+      assertTrue(expr.contains("WINFRAME_INTERVAL(7,day)"), "unexpected expression: " + expr);
    }
 
    // ─── PR #4235 review Fix C: numeric RANGE offset on a date/time order key ────────────────


### PR DESCRIPTION
## Window functions Phase 5 — dialect-aware frame pushdown

Moves window-frame pushdown capability + dialect frame-SQL rendering into the `SQLHelper` hierarchy, replacing Phase 4's hardcoded Postgres-only gate. Every StyleBI database type now pushes down the frame shapes it supports and falls back to the in-memory `WindowTableLens` for the rest. **Community-repo only** (wiz-services frame validation is dialect-agnostic — no wiz change).

### Design: default-deny, opt-in per verified dialect
Getting a capability *wrong-high* → a loud DB syntax error on that dialect; *wrong-low* → the correct in-memory fallback. So the base `SQLHelper` denies the advanced frame shapes and each dialect opts in only to what's verified from its SQL reference. Every one of the 23 helpers + the generic base has a defined, safe answer.

### Commits
- **`SQLHelper` API** — `supportsWindowFrame(mode, hasValueOffset, dateOffset)` (base: ROWS + RANGE-peer only, gated on `WINDOW_FUNCTION`; denies RANGE value/date + GROUPS) and `formatWindowFrameInterval(offset, unit)`. **PostgreSQL opts in fully** (GROUPS gated ≥11) — the byte-parity anchor.
- **`AssetQuery`** — `framePushable` consults `helper.supportsWindowFrame(...)` (derives mode / value-offset / date-offset from the `WindowExpressionRef`); the hardcoded `"postgresql"` + `PG_PUSHABLE` gate is retired.
- **Rendering** — `WindowExpressionRef` emits a canonical `WINFRAME_INTERVAL(n,unit)` token for a date offset; `PreAssetQuery.getExpressionColumn` expands it per-dialect via `formatWindowFrameInterval`. Numeric/frame-less output unchanged.
- **Opt-in overrides** — Oracle / MySQL / DB2 / Databricks / Vertica / BigQuery, each with its verified capability + INTERVAL literal (`INTERVAL '7' DAY` / `INTERVAL 7 DAY` / …). DB2 & BigQuery deny date-offset (unverified / unsupported) → in-memory. GROUPS denied for all non-PG.
- **Conservative tier** — SQL Server, Snowflake, Clickhouse, Hive, Impala, Exasol + the long tail inherit the base (ROWS + RANGE-peer); Access/Mongo/Derby have no window functions → all-deny. Informix (which `extends DB2SQLHelper`) is overridden back to the conservative row so it doesn't inherit DB2's opt-in.
- **Portability fix** — `quarter` / `week` are normalized to exact equivalents (3×month / 7×day) so every dialect's INTERVAL literal uses only the universally-valid ANSI fields (also closes a latent Postgres `quarter` gap).

### Capability matrix (encoded per helper)
| Tier | Dialects | Frame pushdown |
|---|---|---|
| Full incl. GROUPS | PostgreSQL 11+ | ROWS / RANGE(peer+num+date) / GROUPS |
| RANGE value + date | Oracle, MySQL 8+, Databricks, Vertica | ROWS / RANGE(peer+num+date) |
| RANGE numeric only | DB2, BigQuery | ROWS / RANGE(peer+num); date → in-memory |
| ROWS + RANGE-peer | SQL Server, Snowflake, Clickhouse, Hive, Impala, Exasol, + long tail | value/date/GROUPS → in-memory |
| No window functions | Access, Mongo, Derby | all → in-memory |

### Byte-parity & verification
- **Postgres byte-parity:** capability set == Phase-4 `PG_PUSHABLE`; interval literal == base `INTERVAL '<n> <unit>'`; ROWS/frame-less/numeric-RANGE untouched.
- Unit: `WindowFrameCapabilityTest` 26/26 (all 23 dialects + base), routing + rendering suites green.
- Live (Postgres, `local-996`): date-RANGE / numeric-RANGE / GROUPS return correct values end-to-end with no raw-token leak (proving the token→dialect-render seam works on the real pushdown path). The whole-branch review traced that no raw token can reach the DB.
- **Deferred (documented):** live pushdown verification on non-Postgres dialects (needs DB instances — doc + SQL-string verified here); EXCLUDE / NULLS / fractional offsets remain out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
