### PR TITLE
fix(wiz): resolve FIELD condition operand to a DataRef (was JS ExpressionValue → silent match-all)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1788,11 +1788,22 @@ public class WorksheetTableService {
          }
 
          case "FIELD" -> {
-            ExpressionValue ev = new ExpressionValue();
-            String expressoin = v.getValue() != null ? v.getValue().toString() : "";
-            ev.setExpression(expressoin);
-            ev.setType(ExpressionValue.JAVASCRIPT);
-            condition.addValue(ev);
+            // A FIELD operand compares the condition column against ANOTHER column (e.g.
+            // amount > stage_avg). Resolve the referenced column name to a DataRef against the
+            // table's ColumnSelection (same mechanism as appendRankingConditionItem) and add that
+            // as the operand value: Condition serializes a DataRef operand via its isfield branch,
+            // and reverseValue maps it back to "FIELD". Previously this wrapped the bare column name
+            // in a JavaScript ExpressionValue (an undefined identifier), so the comparison never
+            // became a column reference and the filter silently matched ALL rows.
+            String name = v.getValue() != null ? v.getValue().toString() : null;
+            DataRef ref = name != null ? columns.getAttribute(name) : null;
+
+            if(ref == null) {
+               throw new IllegalArgumentException(
+                  "FIELD condition operand references unknown column \"" + name + "\".");
+            }
+
+            condition.addValue(ref);
          }
 
          case "SUBQUERY" -> {

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceConditionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceConditionTest.java
@@ -22,10 +22,13 @@ import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
 import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.Condition;
 import inetsoft.uql.ConditionList;
 import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.ExpressionValue;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
 import inetsoft.web.wiz.model.WorksheetTable;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -140,5 +143,58 @@ class WorksheetTableServiceConditionTest {
       assertTrue(list.isConditionItem(0), "index 0 must be a ConditionItem");
       assertTrue(list.isJunctionOperator(1), "index 1 must be a JunctionOperator");
       assertTrue(list.isConditionItem(2), "index 2 must be a ConditionItem");
+   }
+
+   // ── FIELD operand (compare a column against another column, e.g. amount > stage_avg). Regression
+   // for the silent match-all bug: the FIELD arm used to wrap the bare column name in a JAVASCRIPT
+   // ExpressionValue (an undefined JS identifier), so the operand evaluated to nothing and the filter
+   // matched ALL rows. It must resolve to the referenced column's DataRef instead. ──
+
+   @Test
+   void fieldOperandResolvesToDataRefNotExpressionValue() throws Exception {
+      WorksheetTable req = request("""
+         {
+           "preAggregateCondition": [
+             { "field": "amount", "operation": "GREATER_THAN",
+               "values": [{ "type": "FIELD", "value": "stage_avg" }] }
+           ]
+         }
+         """);
+
+      ColumnSelection cs = columns("amount", "stage_avg");
+
+      ConditionList list = service().buildConditionList(
+         cs, req.getPreAggregateCondition(), new Worksheet(), false);
+
+      Condition cond = list.getConditionItem(0).getCondition();
+      assertEquals(1, cond.getValueCount(), "FIELD operand => exactly one operand value");
+
+      Object operand = cond.getValue(0);
+      assertFalse(operand instanceof ExpressionValue,
+                  "FIELD operand must NOT be a JS ExpressionValue (the bug)");
+      assertTrue(operand instanceof DataRef,
+                 "FIELD operand must be a DataRef, got: " + operand.getClass().getName());
+      assertEquals("stage_avg", ((DataRef) operand).getName(),
+                   "resolved DataRef must be the referenced column");
+   }
+
+   @Test
+   void fieldOperandUnknownColumnFailsLoud() throws Exception {
+      // An unresolvable FIELD column must throw (naming it), not silently drop to a no-op operand.
+      WorksheetTable req = request("""
+         {
+           "preAggregateCondition": [
+             { "field": "amount", "operation": "GREATER_THAN",
+               "values": [{ "type": "FIELD", "value": "nonexistent_col" }] }
+           ]
+         }
+         """);
+
+      ColumnSelection cs = columns("amount", "stage_avg");
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+         service().buildConditionList(cs, req.getPreAggregateCondition(), new Worksheet(), false));
+      assertTrue(ex.getMessage().contains("nonexistent_col"),
+                 "error should name the unresolved FIELD column, got: " + ex.getMessage());
    }
 }


### PR DESCRIPTION
Fixes #4241.

## Problem

On the wiz worksheet-builder endpoint `/ws/table`, a condition leaf operand of type **`FIELD`** (compare the condition column to another column, e.g. `amount > stage_avg`) is mishandled. `WorksheetTableService.addConditionValue`'s `FIELD` case wrapped the referenced column name in a **JavaScript `ExpressionValue`**:

```java
case "FIELD" -> {
   ExpressionValue ev = new ExpressionValue();
   ev.setExpression(v.getValue()...toString());   // bare column name, e.g. "stage_avg"
   ev.setType(ExpressionValue.JAVASCRIPT);
   condition.addValue(ev);
}
```

The bare column name is an **undefined JS identifier**, so the comparison never became a column reference — the filter silently matched **all rows** (a plausible-but-wrong result, no error). It also round-tripped back as the wrong type (`reverseValue` maps any `ExpressionValue` → `"EXPRESSION"`).

## Fix

Resolve the referenced name to a `DataRef` against the table's `ColumnSelection` and add that as the operand value — the same mechanism `appendRankingConditionItem` already uses (`columns.getAttribute(...)`). `Condition` already serializes a `DataRef` operand via its `isfield="true"` branch, and `reverseValue` (~L2314) maps a `DataRef` back to `"FIELD"`, so it round-trips correctly. When the referenced column can't be resolved, fail loud with `IllegalArgumentException` (matching `mapOperation`'s unknown-operation handling) rather than re-introducing a silent no-op.

`EXPRESSION` (→ `ExpressionValue`) and `SESSION_DATA` (→ `UserVariable`) were **not** affected — only `FIELD` was mis-typed.

## Verification

Built as image `local-997` and tested live (suitecrm): `amount > FIELD(stage_avg)` layered over an `AVG(amount) OVER (PARTITION BY sales_stage)` window mirror now filters to **104 / 200** opportunities (those above their own stage's average), matching the equivalent `sql query table` (`WHERE amount > stage_avg`) baseline. Before the fix the same condition returned all 200.

The wiz-services plugin currently guards FIELD operands (fail-loud → point to a sql query table) as an interim; once this ships in the deployed baseline that guard can be removed so column-vs-column conditions work natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)