### PR TITLE
fix(query): window-expression column mergeable when UniformSQL not yet built (intermittent JS-eval fallback)

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
@@ -1629,7 +1629,15 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
          UniformSQL sql = getUniformSQL();
 
          if(sql == null) {
-            return false;
+            // The UniformSQL may not be built yet on an early mergeability probe. Most
+            // SQLExpressionRefs (DateRangeRef/NumericRangeRef/NamedRangeRef) can't decide without the
+            // dbtype the helper supplies, so stay conservative for them. A WindowExpressionRef is
+            // unconditionally mergeable and DB-type-independent (its OVER(...) with field['..'] tokens
+            // is always rewritable), so a null-SQL probe must not report it non-mergeable — doing so
+            // froze the whole base query as non-mergeable depending on probe/build ordering, making a
+            // sql=true expression layered over a window mirror intermittently fall back to in-memory
+            // JS evaluation instead of SQL pushdown.
+            return exp instanceof WindowExpressionRef;
          }
 
          SQLHelper helper = getSQLHelper(sql);


### PR DESCRIPTION
Fixes #4240.

## Problem

A worksheet MIRROR with a `sql=true` expression column (e.g. `CASE WHEN field['prev'] IS NULL THEN 0 ELSE field['prev'] END`), layered over a BASE mirror that has a `windowColumns` column (`WindowExpressionRef`, e.g. `LAG(...) OVER (...)`), **intermittently** fell back to in-memory Rhino evaluation of the raw SQL text instead of SQL pushdown — throwing `JavaScript error: SyntaxError: <eval>:1:5 Expected ; but found WHEN`. Same request, sometimes clean pushdown, sometimes the crash.

## Root cause

`PreAssetQuery.isAttributeMergeable` (`report/composition/execution/PreAssetQuery.java`), `SQLExpressionRef` branch:

```java
UniformSQL sql = getUniformSQL();
if(sql == null) {
   return false;   // "SQL not built yet" treated as "not mergeable"
}
SQLHelper helper = getSQLHelper(sql);
sexp.setDBType(helper.getSQLHelperType());   // dbtype needed by most SQLExpressionRefs...
...
return sexp.isMergeable();
```

`getUniformSQL()` is null on an early mergeability probe and non-null later (it's lazily built — `MirrorQuery`/`JoinQuery`/`BoundQuery` build `nquery` then expose its `UniformSQL`). The `sql==null → false` is correct for **DateRangeRef / NumericRangeRef / NamedRangeRef** — their `isMergeable()` reads `dbtype` (e.g. `!dbtype.equals("access")`, `"derby"→false`), which comes from the helper — but a **`WindowExpressionRef` is unconditionally mergeable and DB-type-independent** (its `OVER(...)` with `field['..']` tokens is always rewritable). Reporting it non-mergeable during a null-SQL probe froze the whole base query as non-mergeable (`isQueryMergeable` memoizes the first answer and never resets), cascading through `MirrorQuery.isSourceMergeable` into the JS-formula fallback. Whether the first probe hit before or after the base's SQL was built decided the outcome → the intermittency.

## Fix

In the null-`UniformSQL` branch, return `true` for a `WindowExpressionRef` (mergeable regardless of build timing / dbtype); keep the conservative `false` for the dbtype-dependent SQLExpressionRefs:

```java
if(sql == null) {
   return exp instanceof WindowExpressionRef;
}
```

Blast radius is that single branch. DateRange/NumericRange/NamedRange behavior is unchanged. (A separate latent issue — `isQueryMergeable` ignoring its `sub` arg in the memo — only misbehaves when `isSQLMergeable()==false`, a deliberate force-in-memory config, and is **not** the intermittent window symptom; left as-is.)

## Verification (image `local-998`, suitecrm)

- **11 / 11** independent `sql=true` CASE-over-window mirrors pushed down (`isSqlExpression=true`), **0** JS-eval failures (was ~50%).
- A materialized case computes correctly (`gK` = LAG(amount) per row).
- A month-grouped aggregate (`DateRangeRef`) still returns all 12 months — no regression on the conservative path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)