### PR TITLE
Fix race in CSSDictionary.init() returning null styles

### DIFF
--- a/core/src/main/java/inetsoft/util/css/CSSDictionary.java
+++ b/core/src/main/java/inetsoft/util/css/CSSDictionary.java
@@ -392,9 +392,6 @@ public class CSSDictionary {
     */
    @SuppressWarnings("UnusedParameters")
    protected synchronized void init() {
-      // clear contains out-of-date css
-      clear();
-
       // clear data change listeners
       dmgr.clear();
 
@@ -423,6 +420,13 @@ public class CSSDictionary {
             }
          }
 
+         // parse into a local so this.css is never observed in a partially
+         // built (or null) state by concurrent readers. The change listener
+         // fires init() on the blob-storage callback thread; publishing the
+         // fully merged stylesheet in a single assignment at the end keeps
+         // getStyle() from returning null styles during re-initialization.
+         CascadingStyleSheet userCSS = null;
+
          if(cssDir != null && cssFile != null) {
             if(!space.exists(cssDir, cssFile)) {
                try {
@@ -436,18 +440,18 @@ public class CSSDictionary {
 
             this.ts = space.getLastModified(cssDir, cssFile);
             dmgr.addChangeListener(space, cssDir, cssFile, changeListener);
-            css = parse(cssDir, cssFile, false);
+            userCSS = parse(cssDir, cssFile, false);
          }
 
-         if(defaultReportCSS != null && !defaultReportCSS.equals(css)) {
+         if(defaultReportCSS != null && !defaultReportCSS.equals(userCSS)) {
             for(ICSSTopLevelRule rule : defaultReportCSS.getAllStyleRules()) {
                assert defaultCSS != null;
                defaultCSS.addRule(rule);
             }
          }
 
-         if(css != null) {
-            for(ICSSTopLevelRule rule : css.getAllStyleRules()) {
+         if(userCSS != null) {
+            for(ICSSTopLevelRule rule : userCSS.getAllStyleRules()) {
                assert defaultCSS != null;
                defaultCSS.addRule(rule);
             }
@@ -472,9 +476,13 @@ public class CSSDictionary {
             }
          }
 
+         // publish the fully built stylesheet in a single assignment, then
+         // rebuild the derived maps and drop any stale cached styles
          css = defaultCSS;
          initCSSClasses();
          initCSSIDs();
+         styleCache.clear();
+         selectorPresentCache.clear();
       }
       catch(Exception ex) {
          LOG.error("Failed to read {} from {}", cssFile, cssDir, ex);

--- a/core/src/test/java/inetsoft/util/css/CSSDictionaryRaceTest.java
+++ b/core/src/test/java/inetsoft/util/css/CSSDictionaryRaceTest.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util.css;
+
+import inetsoft.test.*;
+import inetsoft.util.DataChangeEvent;
+import inetsoft.util.DataSpace;
+import inetsoft.util.Tool;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.Tag;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.*;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+public class CSSDictionaryRaceTest {
+   @Test
+   void concurrentReinitShouldNotReturnNull() throws Exception {
+      CSSDictionary.resetDictionaryCache();
+      String name = "CSSDictionaryTest.multiple-classes.css";
+      DataSpace space = DataSpace.getDataSpace();
+
+      if(!space.exists("css", name)) {
+         space.withOutputStream("css", name, out ->
+            Tool.fileCopy(CSSDictionaryTest.class.getResourceAsStream(name), out));
+      }
+
+      CSSDictionary dict = CSSDictionary.getDictionary("css", name, false);
+      CSSParameter param = new CSSParameter("", "", "class-one,class-two", null);
+
+      // sanity: single-threaded read works
+      assertEquals(Color.BLUE, dict.getBackground(param));
+
+      AtomicBoolean stop = new AtomicBoolean(false);
+      AtomicReference<Throwable> failure = new AtomicReference<>();
+
+      // Background thread simulates the blob-storage change callback thread
+      // firing the CSS file's change listener (which calls init()).
+      Thread reinit = new Thread(() -> {
+         DataChangeEvent event = new DataChangeEvent("css", name, System.currentTimeMillis());
+         while(!stop.get()) {
+            dict.changeListener.dataChanged(event);
+         }
+      });
+      reinit.start();
+
+      try {
+         for(int i = 0; i < 200_000 && failure.get() == null; i++) {
+            Color bg = dict.getBackground(param);
+
+            if(bg == null) {
+               failure.set(new AssertionError(
+                  "getBackground returned null during concurrent re-init at iteration " + i));
+               break;
+            }
+         }
+      }
+      finally {
+         stop.set(true);
+         reinit.join();
+      }
+
+      if(failure.get() != null) {
+         throw new AssertionError(failure.get().getMessage(), failure.get());
+      }
+   }
+}


### PR DESCRIPTION
## Problem

`CSSDictionaryTest.shouldMatchClassOneAndTwo` failed intermittently in full-module test runs (passed in isolation):

```
expected: <java.awt.Color[r=0,g=0,b=255]> but was: <null>
```

`getBackground(...)` returned `null` instead of blue.

## Root cause

`CSSDictionary.init()` began with `clear()`, which sets `css = null`, then performed all parse/merge work before re-assigning `css` at the very end. The dictionary's `changeListener` fires `init()` on the **blob-storage callback thread** (triggered when the CSS file is written/modified in the `DataSpace`). A concurrent reader in `getStyle()` could observe the transient `null` window and return `null` styles.

In a full-suite run, thread scheduling lined the background event up with the test's `getBackground()` call; in isolation it did not — hence the flakiness. This is the same class of bug earlier commits addressed, but the non-atomic rebuild inside `init()` still left the window open.

## Fix

- Never null `this.css` mid-flight — removed the leading `clear()`.
- Parse the user CSS into a local (`userCSS`) instead of writing intermediate state into `this.css`.
- Publish the fully merged stylesheet in a **single assignment** at the end of `init()`, then rebuild the derived maps and clear the style caches.

Concurrent readers now always see either the previous complete stylesheet or the new complete one — never `null`.

## Verification

- New `CSSDictionaryRaceTest` (fires the change listener on a background thread while reading on the main thread): **failed before** the fix (null at iteration 246), **passes after** (200,000 concurrent reads during continuous re-init, zero nulls).
- Existing `CSSDictionaryTest`: **5/5 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)