### PR TITLE
Bug #75633, egraph time axis broken for script-built datasets under GraalJS

### DIFF
--- a/core/src/main/java/inetsoft/util/script/ScriptUtil.java
+++ b/core/src/main/java/inetsoft/util/script/ScriptUtil.java
@@ -33,6 +33,18 @@ public class ScriptUtil {
       if(obj instanceof Value) {
          obj = ScriptValueConverter.toHost((Value) obj);
       }
+      // A JS Date coerced to an Object target (e.g. an element of the Object[][]
+      // passed to new DefaultDataSet([["Date","Qty"],[new Date(),200]])) arrives
+      // as a foreign polyglot object rather than a Value or a java.util.Date, so
+      // the branch above misses it and the date-ness is lost. Recover it here so
+      // downstream code (e.g. TimeScale.init) sees a real Date. (#75633)
+      else if(obj != null) {
+         Date date = ScriptValueConverter.toHostDate(obj);
+
+         if(date != null) {
+            return date;
+         }
+      }
 
       // Restore the legacy Rhino Wrapper.unwrap() behavior: an XTableArray
       // (the scriptable returned by XUtil.runQuery) unwraps to its underlying

--- a/core/src/main/java/inetsoft/util/script/graal/ScriptValueConverter.java
+++ b/core/src/main/java/inetsoft/util/script/graal/ScriptValueConverter.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.util.script.graal;
 
+import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
 import java.time.Instant;
 import java.util.*;
@@ -137,5 +138,46 @@ public final class ScriptValueConverter {
       }
 
       return v;
+   }
+
+   /**
+    * If {@code value} is a foreign polyglot value representing a date/time,
+    * return it as a {@link Date}; otherwise return {@code null}.
+    *
+    * <p>When a JS {@code Date} is coerced to an {@code Object} target (e.g. an
+    * element of the {@code Object[][]} passed to
+    * {@code new DefaultDataSet([["Date","Qty"],[new Date(),200]])}), GraalJS
+    * hands it to host code as a foreign polyglot object (a {@code PolyglotMap}
+    * object view) rather than a {@link Value} or a {@link Date}, so
+    * {@link #toHost(Value)} never sees it and the value's date-ness is lost — a
+    * {@code TimeScale} built over such a column then finds no dates and renders a
+    * degenerate axis. Re-wrapping the object through the current context recovers
+    * a {@link Value} whose {@code isDate()/isInstant()} report the date, matching
+    * the Rhino behavior where a native JS Date unwrapped to a {@link Date}.
+    * Requires an active polyglot context (script execution); returns {@code null}
+    * when none is present. (#75633)
+    */
+   public static Date toHostDate(Object value) {
+      // Only a foreign polyglot value needs date recovery (a JS Date coerced to an
+      // Object target arrives as a com.oracle.truffle.polyglot.* object). Everything
+      // else — nulls, scalars, ordinary host objects — is skipped cheaply so the
+      // common non-script call sites never pay for (nor risk) a context lookup;
+      // Context.getCurrent() throws when no context is entered. (#75633)
+      if(value == null || !value.getClass().getName().startsWith("com.oracle.truffle.")) {
+         return null;
+      }
+
+      try {
+         Value v = Context.getCurrent().asValue(value);
+
+         if(v.isDate() && v.isInstant()) {
+            return new Date(v.asInstant().toEpochMilli());
+         }
+      }
+      catch(Exception ignore) {
+         // no context entered, or not a date-like value; fall through
+      }
+
+      return null;
    }
 }

--- a/core/src/test/java/inetsoft/util/script/graal/ScriptUtilDateUnwrapTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/ScriptUtilDateUnwrapTest.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util.script.graal;
+
+import inetsoft.util.script.ScriptUtil;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.Value;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression test for Bug #75633: a JS Date placed in a host data structure
+ * (e.g. new DefaultDataSet([["Date","Qty"],[new Date(),200]])) is coerced by
+ * GraalJS to a foreign polyglot object rather than a java.util.Date. ScriptUtil
+ * .unwrap (called by GTool.unwrap while building the dataset) must recover the
+ * date so a TimeScale over that column sees real dates instead of nulls.
+ */
+@Tag("core")
+class ScriptUtilDateUnwrapTest {
+   private Context newCtx() {
+      Engine engine = Engine.newBuilder().option("engine.WarnInterpreterOnly", "false").build();
+      return Context.newBuilder("js")
+         .engine(engine)
+         .allowHostAccess(ScriptHostAccess.hostAccess())
+         .allowHostClassLookup(ScriptHostAccess.classFilter())
+         .build();
+   }
+
+   @Test
+   void jsDateInObjectArrayUnwrapsToJavaDate() {
+      try(Context ctx = newCtx()) {
+         Value arr = ctx.eval("js",
+            "var date1 = new Date(); date1.setFullYear(2008,9,1);\n" +
+            "[['Date','Quantity'],[date1,200]];\n");
+
+         // The Object[][] that DefaultDataSet's constructor receives: the JS Date
+         // element is coerced to a foreign polyglot object, NOT a java.util.Date.
+         Object[][] host = arr.as(Object[][].class);
+         Object dateElem = host[1][0];
+         Object numElem = host[1][1];
+         assertFalse(dateElem instanceof Date,
+                     "precondition: raw coerced element is not yet a Date");
+
+         // DefaultDataSet runs its GTool.unwrap (-> ScriptUtil.unwrap) while the
+         // script context is current; simulate that by entering the context.
+         ctx.enter();
+
+         try {
+            Object unwrappedDate = ScriptUtil.unwrap(dateElem);
+            Object unwrappedNum = ScriptUtil.unwrap(numElem);
+
+            assertInstanceOf(Date.class, unwrappedDate,
+                             "JS Date element must unwrap to java.util.Date (#75633)");
+            assertEquals(2008, ((Date) unwrappedDate).getYear() + 1900);
+            assertFalse(unwrappedNum instanceof Date,
+                        "numeric element must not become a Date");
+         }
+         finally {
+            ctx.leave();
+         }
+      }
+   }
+
+   @Test
+   void nonDateValuesUnwrapUnchanged() {
+      try(Context ctx = newCtx()) {
+         ctx.enter();
+
+         try {
+            assertEquals("abc", ScriptUtil.unwrap("abc"));
+            assertEquals(5, ScriptUtil.unwrap(5));
+            assertNull(ScriptUtil.unwrap(null));
+         }
+         finally {
+            ctx.leave();
+         }
+      }
+   }
+}


### PR DESCRIPTION
## Summary

A viewsheet chart whose script builds an `EGraph` from a script-created dataset renders a degenerate x-axis — two wide bars with no axis labels — instead of the expected time axis. This is a Rhino→GraalJS migration regression (Feature #75423). Example script:

```js
var arr = [["Date","Quantity"], [date1,200], [date2,300]];
dataset = new DefaultDataSet(arr);
var tscale = new TimeScale("Date");
tscale.setMin(minDate); tscale.setMax(maxDate); tscale.setType(TimeScale.YEAR);
graph.setScale("Date", tscale);
```

## Root Cause

Under GraalJS, when the JS array is coerced into the `Object[][]` that `DefaultDataSet`'s constructor takes, each JS `Date` element becomes a foreign polyglot object (`com.oracle.truffle.polyglot.PolyglotMap`) — not a `java.util.Date`, and not even a `Value`. `DefaultDataSet` calls `GTool.unwrap` → `ScriptUtil.unwrap` on each cell "in case values are from JS", but that path only converted `instanceof Value`, so the date passed through unconverted. `TimeScale.init()` then found no `java.util.Date` values, set `nodata=true`, and `getUnitCount()` returned 2 (two wide bars) while `getTicks()` returned empty (no labels). Under Rhino a native JS Date unwrapped to a `java.util.Date`.

## Fix

- `ScriptValueConverter.toHostDate(Object)`: recovers a `java.util.Date` from a foreign polyglot date value by re-wrapping it through the current context and checking `isDate()/isInstant()`. Gated on the `com.oracle.truffle.` class prefix so ordinary host values (and non-script call sites) skip the context lookup entirely; the context access is wrapped in try/catch because `Context.getCurrent()` throws when no context is entered.
- `ScriptUtil.unwrap(Object)`: for a non-`Value` object, returns the recovered `Date` when `toHostDate` yields one; otherwise falls through unchanged (existing `Value`/`XTableArray`/`TableArray`/`Double` handling is untouched).

## Test Plan

- New regression test `ScriptUtilDateUnwrapTest`: a JS Date placed in an `Object[][]` unwraps to `java.util.Date` (year preserved), a numeric element is not converted, and non-date values pass through unchanged.
- Verified `ChartVSAScriptableTest` and the full `graal` script test package pass.
- Manually verified `EGraph1.vso` now renders thin interval bars over a 2005–2011 year axis with labels.

Fixes Redmine #75633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)