### PR TITLE
75628, normal bar does not need to support bridge line

### DIFF
--- a/core/src/main/java/inetsoft/graph/element/IntervalElement.java
+++ b/core/src/main/java/inetsoft/graph/element/IntervalElement.java
@@ -206,10 +206,14 @@ public class IntervalElement extends StackableElement {
       IntervalGeometry firstNegative = null; // first negative segment added to the current bar's stack
       double posIntervalSum = 0; // cumulative interval for positive stack
       double negIntervalSum = 0; // cumulative interval for negative stack
-      double[] prevBridgeX = (bridgeLineStyle != null) ? new double[getVarCount()] : null;
+      // Bridge lines are a waterfall-only feature. setBridgeLine() is a script-callable
+      // (@TernMethod) API on IntervalElement, which is shared by regular bar charts and
+      // waterfall charts; guard on the waterfall flag so a script enabling bridge lines on
+      // a non-waterfall bar chart is a no-op. (75628)
+      double[] prevBridgeX = (bridgeLineStyle != null && waterfall) ? new double[getVarCount()] : null;
       // Half-width (in category-slot units) of the bar at prevBridgeX, so a bridge
       // can inset each end by its own bar's width. (75626)
-      double[] prevBridgeHalf = (bridgeLineStyle != null) ? new double[getVarCount()] : null;
+      double[] prevBridgeHalf = (bridgeLineStyle != null && waterfall) ? new double[getVarCount()] : null;
       List<IntervalGeometry> posStackGeoms = new ArrayList<>();
       List<IntervalGeometry> negStackGeoms = new ArrayList<>();
 
@@ -783,7 +787,8 @@ public class IntervalElement extends StackableElement {
             Objects.equals(visualStacked, elem.visualStacked) &&
             cornerRadius == elem.cornerRadius && roundAllCorners == elem.roundAllCorners &&
             Objects.equals(bridgeLineColor, elem.bridgeLineColor) &&
-            Objects.equals(bridgeLineStyle, elem.bridgeLineStyle);
+            Objects.equals(bridgeLineStyle, elem.bridgeLineStyle) &&
+            waterfall == elem.waterfall;
       }
 
       return false;
@@ -816,6 +821,22 @@ public class IntervalElement extends StackableElement {
    public void setBridgeLine(Color lineColor, GLine lineStyle) {
       this.bridgeLineColor = lineColor;
       this.bridgeLineStyle = lineStyle;
+   }
+
+   /**
+    * Check whether this interval element belongs to a waterfall chart. Bridge lines are
+    * only drawn for waterfall charts.
+    */
+   public boolean isWaterfall() {
+      return waterfall;
+   }
+
+   /**
+    * Mark this interval element as belonging to a waterfall chart. Set by the graph
+    * generator; enables waterfall-only behavior such as bridge lines. (75628)
+    */
+   public void setWaterfall(boolean waterfall) {
+      this.waterfall = waterfall;
    }
 
    // Each bridge endpoint is inset from its bar's center by that bar's own half-width
@@ -918,6 +939,7 @@ public class IntervalElement extends StackableElement {
    private Boolean visualStacked;
    private Color bridgeLineColor = null;
    private GLine bridgeLineStyle = null;
+   private boolean waterfall = false;
    // Bridge endpoint placement, in fractions of a category slot, measured beyond the
    // bar edge (bridgeBarHalfWidth) so the connector never touches the bar. (75626)
    // BRIDGE_GAP: the slight gap at corner radius 0. BRIDGE_RADIUS_EASE: how much the

--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -3671,6 +3671,12 @@ public abstract class GraphGenerator {
          IntervalElement bar = new IntervalElement();
          IntervalElement sumBar = new IntervalElement();
 
+         // Mark both elements as waterfall so bridge lines (a waterfall-only feature
+         // enabled via the shared setBridgeLine script API) render for these bars but
+         // not for regular bar charts, which use IntervalElement too. (75628)
+         bar.setWaterfall(true);
+         sumBar.setWaterfall(true);
+
          bar.setCollisionModifier(GraphElement.STACK_SYMMETRIC);
          bar.setStackNegative(false);
          bar.setStackGroup(false);


### PR DESCRIPTION
Root Cause:
Bridge lines are a waterfall-only feature (feature #75007), but they were implemented on IntervalElement, which is the element type shared by both waterfall charts and regular bar charts. The setBridgeLine(Color, GLine) method is a script-callable (@TernMethod) API, and the bridge-drawing logic in IntervalElement only checked whether a bridge line style had been set (bridgeLineStyle != null). As a result, a chart script such as graph.getElement(0).setBridgeLine(java.awt.Color.LIGHT_GRAY, GLine.DASH_LINE) run against a regular bar chart would draw bridge lines, even though bridge lines are meaningful only for waterfall charts.

Fix:
Made bridge rendering waterfall-only. Added a dedicated "waterfall" flag to IntervalElement (with isWaterfall()/setWaterfall()); the graph generator sets it to true only when constructing waterfall elements (the intermediate bar and the sum bar). The bridge-drawing logic is now gated on (bridgeLineStyle != null && waterfall), so calling setBridgeLine on a non-waterfall bar chart is a no-op. Existing waterfall bridge-line behavior (including the facet-graph fix #75624) is fully preserved. The flag was also added to equalsContent for correctness.