### PR TITLE
Bug #75625, avoid per-execution direct-eval re-parse in script compile

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -74,6 +74,16 @@ public class GraalJavaScriptEngine implements AutoCloseable {
    private static final String RESULT_VAR = "__inetsoft_script_result__";
    private static final String HOIST_ERR_VAR = "__inetsoft_hoist_err__";
 
+   // Bug #75625: matches the `this` keyword as an identifier token. Used to decide
+   // whether a script body needs the (slower) direct-eval wrapper that binds
+   // top-level `this` to the scope (#75550). The match is deliberately
+   // conservative — a `this` inside a string literal or comment also matches and
+   // merely routes the body to the eval form, which is correct, just not the fast
+   // path. A `this`-binding cannot be used without writing the `this` token, so
+   // there are no false negatives.
+   private static final java.util.regex.Pattern THIS_REF =
+      java.util.regex.Pattern.compile("\\bthis\\b");
+
    // JS reserved words that must never be emitted as an unguarded identifier in
    // the generated hoist statements (typeof <keyword> is a SyntaxError, which
    // would break compilation of the whole script). A declared name can never be
@@ -427,6 +437,24 @@ public class GraalJavaScriptEngine implements AutoCloseable {
       // the body to strict eval, changing assignment/scope semantics — so remove
       // it to preserve the prior behavior.
       String body = stripStrictDirectives(cmd);
+
+      // Bug #75625: the direct-eval wrapper below re-parses the script body on
+      // *every* execution — GraalJS does not cache a direct eval's argument — so
+      // per-row/per-cell formula evaluation (calc/freehand tables, value and
+      // expression bindings) is ~7x slower and can leave a viewsheet "loading"
+      // for 10-20s. The eval form exists only to bind top-level `this` to the
+      // scope (#75550). When the body does not reference `this`, a plain
+      // top-level `with(__scope__){ ... }` script is equivalent and is parsed
+      // once and reused: it preserves the statement-list completion value (value/
+      // expression bindings) and top-level `var`/`function` declarations persist
+      // to the context global across executions naturally (so #75596 holds
+      // without the declaration hoist). Block-vs-object completion semantics
+      // (e.g. a bare `{a:1}`) are identical to the eval form because the body is
+      // still evaluated in statement position, not wrapped in `return (...)`.
+      if(!THIS_REF.matcher(body).find()) {
+         return Source.newBuilder("js", "with(__scope__){\n" + body + "\n}", "<cmd>")
+            .buildLiteral();
+      }
 
       // Bug #75596: top-level `var`/`function` declarations must persist across
       // executions on the same engine so a later script (e.g. an assembly script

--- a/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineScopeTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineScopeTest.java
@@ -192,6 +192,50 @@ class GraalJavaScriptEngineScopeTest {
          ((Number) engine.exec(engine.compile("color"), assembly, assembly)).doubleValue());
    }
 
+   // Bug #75625: a body that does not reference `this` must compile to the fast
+   // top-level `with(__scope__){...}` form (parsed once and reused), not the
+   // direct-eval wrapper that re-parses the body on every execution. Pinning the
+   // emitted wrapper guards the branch decision itself.
+   @Test void bodyWithoutThisUsesFastWithWrapper() throws Exception {
+      String code = compiledSource("parameter.region");
+      assertFalse(code.contains("eval("), "this-free body must not use the eval wrapper");
+      assertTrue(code.contains("with(__scope__)"), "this-free body must use the with wrapper");
+   }
+
+   // Bug #75625: a body that references `this` must still compile to the
+   // direct-eval-in-a-function form so top-level `this` binds to the scope (the
+   // #75550 behavior the fast path cannot provide).
+   @Test void bodyWithThisUsesEvalWrapper() throws Exception {
+      String code = compiledSource("this.parameter.region");
+      assertTrue(code.contains("eval("), "this-referencing body must keep the eval wrapper");
+   }
+
+   // Bug #75625: `this` appearing only inside a string literal is not a real
+   // this-reference, but the conservative detector still routes it to the eval
+   // form. This must remain correct (result unchanged); it is merely not the fast
+   // path.
+   @Test void thisInsideStringStillEvaluatesCorrectly() throws Exception {
+      MapScope scope = new MapScope();
+      Object src = engine.compile("\"this is text\"");
+      assertEquals("this is text", engine.exec(src, scope, scope));
+   }
+
+   // Bug #75625: the fast path must preserve the statement-list completion value
+   // for a multi-statement, this-free body (value/expression bindings depend on
+   // it) — the same guarantee the eval form provided.
+   @Test void fastPathPreservesStatementListCompletionValue() throws Exception {
+      String code = compiledSource("var y = 5;\ny * 2");
+      assertFalse(code.contains("eval("), "multi-statement this-free body must use the fast path");
+
+      MapScope scope = new MapScope();
+      assertEquals(10.0,
+         ((Number) engine.exec(engine.compile("var y = 5;\ny * 2"), scope, scope)).doubleValue());
+   }
+
+   private String compiledSource(String cmd) throws Exception {
+      return ((org.graalvm.polyglot.Source) engine.compile(cmd)).getCharacters().toString();
+   }
+
    private static ScriptScope makeParam(String k, String v) {
       MapScope p = new MapScope();
       p.putMember(k, v);


### PR DESCRIPTION
## Summary

Calc/Freehand table viewsheets whose cells use scripted formulas were very slow to load (10–20s, appearing stuck in "loading"), even on cache-warm re-runs where the database is out of the picture.

## Root Cause

`GraalJavaScriptEngine.compile()` wrapped every formula body in a JavaScript **direct `eval("<body>")`** inside a function. That form was introduced by Bug #75550 to bind top-level `this` to the scope (and preserve the completion value). However, GraalJS **re-parses a direct eval's argument on every execution** — a direct eval is never cached. Because a calc/freehand table evaluates each cell formula per expanded row, the same body was re-parsed thousands of times.

A JFR profile of the request thread showed **~98% of execution samples inside the GraalJS parser/translator** (`GraalJSTranslator.transform`, `JavaScriptTranslator.translateEvalScript`, `GraalJSEvaluator.parseDirectEval`) — i.e. JavaScript parsing, not query execution or even script execution.

This is a **separate** regression from the deadlock fixed by #75614 / PR #4225 (both surfaced as "loading", but this one is CPU spent re-parsing).

## Fix

In `compile()`, when the body does **not** reference `this`, compile to the fast pre-#75550 top-level `with(__scope__){ body }` script form, which is parsed once and reused. This form was independently verified to preserve:
- the statement-list completion value (value/expression bindings depend on it),
- `with`-scope unqualified name resolution,
- top-level `var`/`function` declaration persistence across executions (so Bug #75596 holds naturally, without the declaration hoist).

Bodies that reference `this` keep the existing `eval()`-in-a-function form, so the #75550 `this`-binding is unaffected. `this`-detection is a conservative `\bthis\b` match — a false positive (e.g. `this` in a string/comment) merely routes to the correct-but-slower eval form, and a `this`-binding cannot be used without the `this` token, so there are no false negatives.

Measured with a standalone GraalJS 24.1.2 benchmark: **~7× faster** per formula evaluation (e.g. 2250ms → 312ms for 200k single-expression runs), identical results.

## Test Plan

- Added 4 regression tests to `GraalJavaScriptEngineScopeTest` pinning the branch decision (this-free body → fast `with` wrapper; `this` body → eval wrapper) and the fast path's completion-value semantics.
- All 34 GraalJS engine tests pass (`GraalJavaScriptEngineScopeTest`, `GraalJavaScriptEngineTest`, `GraalJavaScriptEngineErrorTest`, `GraalJavaScriptEngineGlobalsTest`).
- `community/core` builds cleanly.
- Verified end-to-end on the reported asset (`SortOthersTable1`): load is now fast on cache hit, and a fresh JFR shows the GraalJS parse hotspot completely gone (28s/262 samples with the parser pinned → 12s/18 samples with zero `parseDirectEval`/`GraalJSTranslator` frames).

Fixes Redmine #75625.