### PR TITLE
fix(wiz): restore and fix the date-comparison endpoint

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
@@ -54,6 +54,13 @@ public class WizViewsheetController {
       return run("create viewsheet", () -> wizVsService.createViewsheet(model, user));
    }
 
+   @PostMapping(value = "/viewsheet/date-comparison", produces = MediaType.APPLICATION_JSON_VALUE)
+   public ResponseEntity<?> applyDateComparison(@RequestBody ApplyDateComparisonModel model,
+                                                Principal user)
+   {
+      return run("apply date comparison", () -> wizVsService.applyDateComparison(model, user));
+   }
+
    @PostMapping("/viewsheet/validateBinding")
    public void validateBinding(@RequestBody CreateVisualizationModel model,
                                Principal user) throws Exception

--- a/core/src/main/java/inetsoft/web/wiz/model/ApplyDateComparisonModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ApplyDateComparisonModel.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import inetsoft.web.composer.model.vs.DateComparisonDialogModel;
+
+/**
+ * Request body for {@code POST /api/wiz/viewsheet/date-comparison}.
+ *
+ * <p>The wiz-services caller POSTs:
+ * {@code { runtimeId, viewsheetIdentifier?, assemblyName?, sampleMaxRows?,
+ * dateComparisonModel: { dateComparisonPaneModel: <PaneModel> } } }.
+ *
+ * <p>{@code dateComparisonModel} is a {@link DateComparisonDialogModel}, which Jackson binds
+ * directly; its {@code dateComparisonPaneModel.toDateComparisonInfo()} reuses StyleBI's own
+ * JSON-to-{@code DateComparisonInfo} conversion (no re-derivation here).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ApplyDateComparisonModel {
+   public String getRuntimeId() {
+      return runtimeId;
+   }
+
+   public void setRuntimeId(String runtimeId) {
+      this.runtimeId = runtimeId;
+   }
+
+   /** Optional; resolve the sole chart assembly if absent. */
+   public String getAssemblyName() {
+      return assemblyName;
+   }
+
+   public void setAssemblyName(String assemblyName) {
+      this.assemblyName = assemblyName;
+   }
+
+   public String getViewsheetIdentifier() {
+      return viewsheetIdentifier;
+   }
+
+   public void setViewsheetIdentifier(String viewsheetIdentifier) {
+      this.viewsheetIdentifier = viewsheetIdentifier;
+   }
+
+   public DateComparisonDialogModel getDateComparisonModel() {
+      return dateComparisonModel;
+   }
+
+   public void setDateComparisonModel(DateComparisonDialogModel dateComparisonModel) {
+      this.dateComparisonModel = dateComparisonModel;
+   }
+
+   public Integer getSampleMaxRows() {
+      return sampleMaxRows;
+   }
+
+   public void setSampleMaxRows(Integer sampleMaxRows) {
+      this.sampleMaxRows = sampleMaxRows;
+   }
+
+   private String runtimeId;
+   private String assemblyName;
+   private String viewsheetIdentifier;
+   private DateComparisonDialogModel dateComparisonModel;
+   private Integer sampleMaxRows;
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -44,6 +44,8 @@ import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.schema.*;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.graph.*;
+import inetsoft.uql.viewsheet.internal.DateCompareAbleAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.DateComparisonInfo;
 import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.VSUtil;
 import inetsoft.util.Catalog;
@@ -83,6 +85,90 @@ public class WizVsService {
                                                 PostAssemblyHook hook) throws Exception
    {
       return createViewsheetInternal(model, user, false, hook);
+   }
+
+   /**
+    * Applies a date comparison (period-over-period) to an existing runtime chart and returns the
+    * recomputed result in the same shape as {@code /viewsheet/create}.
+    *
+    * <p>Mirrors {@code DateComparisonDialogService.setDateComparison} for the mutate step:
+    * it casts the assembly info to {@link DateCompareAbleAssemblyInfo} and calls
+    * {@code setDateComparisonInfo(info)}, where {@code info} is produced by StyleBI's own
+    * {@code DateComparisonPaneModel.toDateComparisonInfo()} (no re-derivation here). The comparison
+    * series (prior-period + change columns) are expanded by {@code DateComparisonUtil} during query
+    * building, so reusing the wiz {@code executeAndExtract} -> {@code box.executeView} path picks
+    * them up without a STOMP {@code CommandDispatcher}.
+    *
+    * <p><b>Re-execution path (Step-4 sub-spike):</b> PRIMARY path used here is plain
+    * {@code executeAndExtract} (-> {@code box.executeView(name, true)}); this resets the data map and
+    * graph for the assembly first, so the next view build runs the date-comparison query expansion.
+    * FALLBACK (if the smoke test shows only the base columns and no comparison series): the native
+    * service expands inside {@code vsAssemblyInfoHandler.apply(rvs, assemblyInfo, viewsheetService,
+    * false, false, true, false, dispatcher, null, null, linkUri, null)}; that path requires a
+    * (possibly headless / no-op) {@code CommandDispatcher}. Switch to it only if {@code executeView}
+    * does not surface the comparison columns.
+    */
+   public CreateViewsheetResult applyDateComparison(ApplyDateComparisonModel model, Principal user)
+      throws Exception
+   {
+      if(model.getDateComparisonModel() == null ||
+         model.getDateComparisonModel().getDateComparisonPaneModel() == null)
+      {
+         throw new IllegalArgumentException("dateComparisonModel.dateComparisonPaneModel is required");
+      }
+
+      RuntimeViewsheet rvs = viewsheetService.getViewsheet(model.getRuntimeId(), user);
+      Viewsheet vs = getValidatedViewsheet(rvs);
+      VSAssembly assembly = resolveChartAssembly(vs, model.getAssemblyName());
+
+      VSAssemblyInfo assemblyInfo = assembly.getVSAssemblyInfo();
+
+      if(!(assemblyInfo instanceof DateCompareAbleAssemblyInfo)) {
+         throw new IllegalArgumentException(
+            "Assembly '" + assembly.getName() + "' does not support date comparison");
+      }
+
+      // REUSE StyleBI's own JSON->DateComparisonInfo conversion (do not re-derive).
+      DateComparisonInfo info = model.getDateComparisonModel().getDateComparisonPaneModel()
+         .toDateComparisonInfo();
+
+      // color aesthetic may change (mirrors DateComparisonDialogService.setDateComparison).
+      vs.clearSharedFrames();
+      ((DateCompareAbleAssemblyInfo) assemblyInfo).setDateComparisonInfo(info);
+
+      int sampleMaxRows = model.getSampleMaxRows() != null ? model.getSampleMaxRows() : 0;
+      CreateViewsheetResult result = executeAndExtract(rvs, assembly, sampleMaxRows);
+      // Order matters: executeAndExtract runs executeView, which populates the chart's RT refs;
+      // collectFlatBinding prefers RT refs, so it must come after. The binding itself is unchanged
+      // by the comparison, but recomputing it keeps the response shape identical to /viewsheet/create.
+      result.setBinding(collectFlatBinding(assembly));
+      result.setAssemblyName(assembly.getName());
+      result.setHasData(computeHasData(rvs.getViewsheet().getViewsheetInfo().isMetadata(), result));
+      return result;
+   }
+
+   /**
+    * Resolves the chart assembly to apply the comparison to: the named assembly if {@code name} is
+    * provided, otherwise the sole {@link ChartVSAssembly} in the viewsheet.
+    */
+   private VSAssembly resolveChartAssembly(Viewsheet vs, String name) {
+      if(name != null && !name.isEmpty()) {
+         VSAssembly a = vs.getAssembly(name);
+
+         if(a == null) {
+            throw new IllegalArgumentException("No assembly named '" + name + "'");
+         }
+
+         return a;
+      }
+
+      for(Assembly a : vs.getAssemblies()) {
+         if(a instanceof ChartVSAssembly) {
+            return (VSAssembly) a;
+         }
+      }
+
+      throw new IllegalArgumentException("No chart assembly found in viewsheet");
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -144,6 +144,21 @@ public class WizVsService {
       result.setBinding(collectFlatBinding(assembly));
       result.setAssemblyName(assembly.getName());
       result.setHasData(computeHasData(rvs.getViewsheet().getViewsheetInfo().isMetadata(), result));
+
+      // Persist the mutated DateComparisonInfo so it survives a subsequent save_viewsheet, which
+      // rebuilds the saved copy from the STORED shared viewsheet, not this live runtime (mirrors the
+      // same guarded write-back in removeVisualization — a transient/unsaved runtime has no
+      // persistent entry and is left runtime-only).
+      AssetEntry entry = rvs.getEntry();
+      String path = entry != null ? entry.getPath() : null;
+
+      if(path != null &&
+         (path.startsWith(WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/") ||
+          path.startsWith(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/")))
+      {
+         engine.setSheet(entry, vs, user, true);
+      }
+
       return result;
    }
 


### PR DESCRIPTION
## Summary
- Restores `POST /viewsheet/date-comparison` (`WizViewsheetController`/`WizVsService.applyDateComparison`), which was implemented and verified on 2026-06-30 but got orphaned when the submodule was later bumped from that feature branch to `stylebi-wiz-main-rebase` — that bump carried forward a sibling fix (`numericBin`) but not this one.
- Fixes a persistence bug found while restoring it: `applyDateComparison` only mutated the live `RuntimeViewsheet`'s assembly info; a subsequent `save_viewsheet` rebuilds the saved copy by re-reading the stored asset from the repository, so the comparison was silently dropped on every save. Adds the missing `engine.setSheet(entry, vs, user, true)` write-back, guarded to the managed visualization folders — mirrors the existing pattern already used in `removeVisualization` in the same file.

## Test plan
- [x] Cherry-picked cleanly onto current `stylebi-wiz-main-rebase` tip, `-pl community/core install` build succeeds (core-only, no new Spring beans → AOT-safe).
- [x] Verified live via the wiz MCP plugin: `apply_date_comparison` (YoY, monthly granularity) on a chart → correct comparison-expanded rows (`MonthOfYear`/`Year` columns, correct revenue values per year).
- [x] Verified the persistence fix specifically: `apply_date_comparison` → `save_viewsheet` (new saved id) → `reload_saved_visualization` → re-executed chart still carries the comparison-expanded columns (previously reverted to the base binding).
- [x] Traced the persistence bug with temporary `LOG.error` diagnostics (removed before this PR) — confirmed `inetsoft.*` loggers are ERROR-only in the target deployment, so `LOG.warn` was silently swallowed during initial diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)