### PR TITLE
fix(wiz): resolve the worksheet table name before browsing column values

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizBrowseDataController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizBrowseDataController.java
@@ -37,7 +37,9 @@ public class WizBrowseDataController {
     * the underlying worksheet.
     *
     * @param runtimeId           VS runtime ID (vsId)
-    * @param assemblyName        worksheet table/assembly name that owns the column
+    * @param assemblyName        the VS chart/table assembly's own presentation name (e.g.
+    *                            "Chart1") — the underlying worksheet table it's bound to is
+    *                            resolved internally from the assembly's {@code SourceInfo}
     * @param viewsheetIdentifier durable asset id, used to restore a reaped runtime (optional)
     * @param dataRefModel        column descriptor (classType, name, attribute, …)
     * @param principal           current user

--- a/core/src/main/java/inetsoft/web/wiz/service/WizBrowseDataService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizBrowseDataService.java
@@ -21,7 +21,11 @@ import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.cluster.*;
 import inetsoft.report.composition.*;
 import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.viewsheet.DataVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.composer.BrowseDataController;
 import inetsoft.web.composer.model.BrowseDataModel;
@@ -66,6 +70,28 @@ public class WizBrowseDataService {
          throw new IllegalStateException("No RuntimeWorksheet found for VS runtimeId=" + runtimeId);
       }
 
+      // `assemblyName` here is the VS chart's own presentation name (e.g. "Chart1"), not the
+      // worksheet table it's bound to — BrowseDataController.process() looks the name up against
+      // the base WORKSHEET's assemblies, so passing the chart name through unresolved always
+      // misses (silently: it returns null instead of erroring). Resolve the real worksheet table
+      // name from the chart assembly's SourceInfo first, mirroring the same resolution
+      // WizVsService does for aggregate-condition handling.
+      Viewsheet vs = rvs.getViewsheet();
+      VSAssembly chartAssembly = vs != null ? vs.getAssembly(assemblyName) : null;
+
+      if(!(chartAssembly instanceof DataVSAssembly dataAssembly)) {
+         throw new IllegalArgumentException(
+            "No chart assembly named '" + assemblyName + "' found in the viewsheet");
+      }
+
+      SourceInfo sourceInfo = dataAssembly.getSourceInfo();
+      String wsTableName = sourceInfo != null ? sourceInfo.getSource() : null;
+
+      if(wsTableName == null) {
+         throw new IllegalStateException(
+            "Chart assembly '" + assemblyName + "' has no bound worksheet table");
+      }
+
       BrowseDataController browseDataController = new BrowseDataController();
       DataRef dataRef = dataRefModel.createDataRef();
 
@@ -78,12 +104,18 @@ public class WizBrowseDataService {
       }
 
       browseDataController.setColumn((ColumnRef) dataRef);
-      browseDataController.setName(assemblyName);
+      browseDataController.setName(wsTableName);
 
       BrowseDataModel model = browseDataController.process(rws.getAssetQuerySandbox());
 
+      if(model == null) {
+         throw new IllegalArgumentException(
+            "Could not find column '" + ((ColumnRef) dataRef).getAttribute() +
+            "' on worksheet table '" + wsTableName + "'");
+      }
+
       WizBrowseDataResponse response = new WizBrowseDataResponse();
-      response.setValues(model != null ? model.values() : null);
+      response.setValues(model.values());
 
       // Echo the runtimeId only when a reaped runtime was restored (id changed) so the client adopts
       // the live runtime for its next edit instead of triggering a second restore.

--- a/core/src/main/java/inetsoft/web/wiz/service/WizBrowseDataService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizBrowseDataService.java
@@ -46,7 +46,9 @@ public class WizBrowseDataService {
     * Browse distinct values for a worksheet table column, accessed via a VS runtimeId.
     *
     * @param runtimeId           the VS runtime ID (vsId)
-    * @param assemblyName        the worksheet table/assembly name that owns the column
+    * @param assemblyName        the VS chart/table assembly's own presentation name (e.g.
+    *                            "Chart1") — the underlying worksheet table it's bound to is
+    *                            resolved internally from the assembly's {@code SourceInfo}
     * @param viewsheetIdentifier the durable asset id, used to restore a reaped runtime; may be null
     * @param dataRefModel        the column ref describing which column to browse
     * @param principal           the current user
@@ -70,13 +72,53 @@ public class WizBrowseDataService {
          throw new IllegalStateException("No RuntimeWorksheet found for VS runtimeId=" + runtimeId);
       }
 
-      // `assemblyName` here is the VS chart's own presentation name (e.g. "Chart1"), not the
-      // worksheet table it's bound to — BrowseDataController.process() looks the name up against
-      // the base WORKSHEET's assemblies, so passing the chart name through unresolved always
-      // misses (silently: it returns null instead of erroring). Resolve the real worksheet table
-      // name from the chart assembly's SourceInfo first, mirroring the same resolution
-      // WizVsService does for aggregate-condition handling.
-      Viewsheet vs = rvs.getViewsheet();
+      String wsTableName = resolveWorksheetTableName(rvs.getViewsheet(), assemblyName);
+
+      BrowseDataController browseDataController = new BrowseDataController();
+      DataRef dataRef = dataRefModel.createDataRef();
+
+      if(dataRef == null) {
+         throw new IllegalArgumentException("DataRefModel produced a null DataRef");
+      }
+
+      ColumnRef columnRef = dataRef instanceof ColumnRef ? (ColumnRef) dataRef : new ColumnRef(dataRef);
+
+      browseDataController.setColumn(columnRef);
+      browseDataController.setName(wsTableName);
+
+      BrowseDataModel model = browseDataController.process(rws.getAssetQuerySandbox());
+
+      // process() returns null for several distinct reasons (an unresolved column, the table lens
+      // not being ready yet, or an exception swallowed and only logged inside
+      // executeByDataSource()) — none of which we can tell apart here, so the message stays
+      // deliberately generic rather than guessing "unknown column" for every case.
+      if(model == null) {
+         throw new IllegalArgumentException(
+            "Browse data returned no result for column '" + columnRef.getAttribute() +
+            "' on worksheet table '" + wsTableName + "'");
+      }
+
+      WizBrowseDataResponse response = new WizBrowseDataResponse();
+      response.setValues(model.values());
+
+      // Echo the runtimeId only when a reaped runtime was restored (id changed) so the client adopts
+      // the live runtime for its next edit instead of triggering a second restore.
+      if(!runtimeId.equals(rvs.getID())) {
+         response.setRuntimeId(rvs.getID());
+      }
+
+      return response;
+   }
+
+   /**
+    * Resolves the worksheet table name that {@code assemblyName} (the VS chart's own presentation
+    * name, e.g. "Chart1") is bound to. {@link BrowseDataController#process} looks its {@code name}
+    * up against the base WORKSHEET's own assemblies — a different namespace — so passing the chart
+    * name through unresolved always misses (silently: it returns null instead of erroring). Mirrors
+    * the same {@code DataVSAssembly} → {@code SourceInfo} → {@code getSource()} resolution
+    * {@code WizVsService} does for aggregate-condition handling. Package-private for unit testing.
+    */
+   String resolveWorksheetTableName(Viewsheet vs, String assemblyName) {
       VSAssembly chartAssembly = vs != null ? vs.getAssembly(assemblyName) : null;
 
       if(!(chartAssembly instanceof DataVSAssembly dataAssembly)) {
@@ -92,38 +134,7 @@ public class WizBrowseDataService {
             "Chart assembly '" + assemblyName + "' has no bound worksheet table");
       }
 
-      BrowseDataController browseDataController = new BrowseDataController();
-      DataRef dataRef = dataRefModel.createDataRef();
-
-      if(dataRef == null) {
-         throw new IllegalArgumentException("DataRefModel produced a null DataRef");
-      }
-
-      if(!(dataRef instanceof ColumnRef)) {
-         dataRef = new ColumnRef(dataRef);
-      }
-
-      browseDataController.setColumn((ColumnRef) dataRef);
-      browseDataController.setName(wsTableName);
-
-      BrowseDataModel model = browseDataController.process(rws.getAssetQuerySandbox());
-
-      if(model == null) {
-         throw new IllegalArgumentException(
-            "Could not find column '" + ((ColumnRef) dataRef).getAttribute() +
-            "' on worksheet table '" + wsTableName + "'");
-      }
-
-      WizBrowseDataResponse response = new WizBrowseDataResponse();
-      response.setValues(model.values());
-
-      // Echo the runtimeId only when a reaped runtime was restored (id changed) so the client adopts
-      // the live runtime for its next edit instead of triggering a second restore.
-      if(!runtimeId.equals(rvs.getID())) {
-         response.setRuntimeId(rvs.getID());
-      }
-
-      return response;
+      return wsTableName;
    }
 
    private final ViewsheetService viewsheetService;

--- a/core/src/test/java/inetsoft/web/wiz/service/WizBrowseDataServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizBrowseDataServiceTest.java
@@ -1,0 +1,102 @@
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.viewsheet.DataVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+/**
+ * Regression coverage for {@link WizBrowseDataService#resolveWorksheetTableName}, extracted from
+ * the {@code browseData} fix that stopped the endpoint from silently returning an empty value
+ * list for every column on every chart (it was passing the VS chart's own presentation name where
+ * a worksheet table name was expected).
+ */
+@Tag("core")
+class WizBrowseDataServiceTest {
+   @Test
+   void resolvesWorksheetTableNameFromChartSourceInfo() {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      DataVSAssembly chartAssembly = mock(DataVSAssembly.class);
+      SourceInfo sourceInfo = mock(SourceInfo.class);
+
+      when(vs.getAssembly("Chart1")).thenReturn(chartAssembly);
+      when(chartAssembly.getSourceInfo()).thenReturn(sourceInfo);
+      when(sourceInfo.getSource()).thenReturn("JOIN_SO_SOL");
+
+      WizBrowseDataService service = new WizBrowseDataService(vsService);
+
+      assertEquals("JOIN_SO_SOL", service.resolveWorksheetTableName(vs, "Chart1"));
+   }
+
+   @Test
+   void throwsWhenChartAssemblyMissing() {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly("Chart1")).thenReturn(null);
+
+      WizBrowseDataService service = new WizBrowseDataService(vsService);
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> service.resolveWorksheetTableName(vs, "Chart1"));
+   }
+
+   @Test
+   void throwsWhenChartAssemblyIsNotADataVSAssembly() {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      VSAssembly nonDataAssembly = mock(VSAssembly.class);
+      when(vs.getAssembly("Chart1")).thenReturn(nonDataAssembly);
+
+      WizBrowseDataService service = new WizBrowseDataService(vsService);
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> service.resolveWorksheetTableName(vs, "Chart1"));
+   }
+
+   @Test
+   void throwsWhenSourceInfoMissing() {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      DataVSAssembly chartAssembly = mock(DataVSAssembly.class);
+      when(vs.getAssembly("Chart1")).thenReturn(chartAssembly);
+      when(chartAssembly.getSourceInfo()).thenReturn(null);
+
+      WizBrowseDataService service = new WizBrowseDataService(vsService);
+
+      assertThrows(IllegalStateException.class,
+                   () -> service.resolveWorksheetTableName(vs, "Chart1"));
+   }
+
+   @Test
+   void throwsWhenSourceInfoHasNoSource() {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      DataVSAssembly chartAssembly = mock(DataVSAssembly.class);
+      SourceInfo sourceInfo = mock(SourceInfo.class);
+      when(vs.getAssembly("Chart1")).thenReturn(chartAssembly);
+      when(chartAssembly.getSourceInfo()).thenReturn(sourceInfo);
+      when(sourceInfo.getSource()).thenReturn(null);
+
+      WizBrowseDataService service = new WizBrowseDataService(vsService);
+
+      assertThrows(IllegalStateException.class,
+                   () -> service.resolveWorksheetTableName(vs, "Chart1"));
+   }
+
+   @Test
+   void throwsWhenViewsheetIsNull() {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      WizBrowseDataService service = new WizBrowseDataService(vsService);
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> service.resolveWorksheetTableName(null, "Chart1"));
+   }
+}


### PR DESCRIPTION
## Summary
- `WizBrowseDataService.browseData()` passed the caller-supplied `assemblyName` (the VS chart's own presentation name, e.g. `"Chart1"`) straight through to `BrowseDataController.setName()`, but `process()` looks that name up against the base **worksheet's** assemblies — a different namespace (e.g. `"JOIN_SO_SOL"`). The chart's own name never resolves there, so `process()` silently returned `null` and the wiz `lookup_column_values` MCP tool always answered with an empty value list instead of erroring — for every column, on every chart, always.
- Fix resolves the real worksheet table name from the chart assembly's `SourceInfo` first (mirrors the same resolution `WizVsService` already does for aggregate-condition handling), and fails loud (`IllegalArgumentException`/`IllegalStateException`) when the chart assembly or its source table can't be found, instead of silently degrading to an empty result.
- Documents a known residual issue rather than silently leaving it: a genuinely unknown column name still returns an empty list instead of erroring, because the shared/legacy `BrowseDataController.findColumn()` silently inserts an unresolved name as a phantom column rather than failing. Not touched here since it's also used by the native composer UI — left as a follow-up.

## Test plan
- [x] `-pl community/core install` build succeeds (core-only change, no new Spring beans → AOT-safe).
- [x] Verified live via the wiz MCP plugin: `lookup_column_values` on a `windowColumns`/`dateGroupLevel`-derived column name (`"Month(JOIN_SO_SOL.date_order)"`) now returns the real 19 monthly values instead of an empty array.
- [x] Regression-checked a plain column (`"revenue"`) — still returns its 19 values correctly, no behavior change for the working case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)