### PR TITLE
feat(wiz): portal multi-assembly — add/clone assembly instead of in-place edit

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/AutoBindingRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/AutoBindingRequest.java
@@ -139,6 +139,14 @@ public class AutoBindingRequest {
       this.sampleMaxRows = sampleMaxRows;
    }
 
+   public boolean isPortal() {
+      return portal;
+   }
+
+   public void setPortal(boolean portal) {
+      this.portal = portal;
+   }
+
    /**
     * Recommendation-computation RVS ID. Null on first call; returned by the server
     * and passed back on subsequent calls to reuse the same RVS.
@@ -169,4 +177,14 @@ public class AutoBindingRequest {
     * #75456: sampled-preview row cap; null/&lt;=0 = full data (default).
     */
    private Integer sampleMaxRows;
+
+   /**
+    * True when the request originates from a Portal chat conversation (as opposed to an MCP tool
+    * call). In that mode every turn ADDS a NEW assembly to the conversation's viewsheet — cloning the
+    * existing primary and applying the new condition to the clone in the modification-only path, or
+    * binding a fresh assembly alongside the existing ones in the standard path — instead of mutating
+    * the single existing chart in place, so multiple states coexist for comparison. When false the
+    * legacy single-assembly, modify-in-place behavior is kept.
+    */
+   private boolean portal;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/CreateVisualizationModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/CreateVisualizationModel.java
@@ -96,12 +96,29 @@ public class CreateVisualizationModel {
       this.sampleMaxRows = sampleMaxRows;
    }
 
+   /**
+    * True when the request originates from a Portal chat conversation (as opposed to an MCP tool
+    * call). In that mode every turn ADDS a NEW assembly to the conversation's viewsheet — cloning the
+    * existing primary and applying the new condition to the clone in the modification-only path, or
+    * binding a fresh assembly alongside the existing ones in the standard path — instead of mutating
+    * the single existing chart in place, so multiple states coexist for comparison. When false the
+    * legacy single-assembly, modify-in-place behavior is kept.
+    */
+   public boolean isPortal() {
+      return portal;
+   }
+
+   public void setPortal(boolean portal) {
+      this.portal = portal;
+   }
+
    private String visualizationType;
    private VisualizationConfig config;
    private String runtimeId;
    private String viewsheetIdentifier;
    private VisualizationConditionModel conditionModel;
    private Integer sampleMaxRows;
+   private boolean portal;
    private transient VSAssembly primaryAssembly;
    private transient boolean keepCondition;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -318,6 +318,7 @@ public class WizAutoBindingService {
             // #75456: carry the data-mode (full vs sampled) into the render so the chart aggregates
             // the chosen amount of data; null/<=0 = full (the agent always omits this).
             vsModel.setSampleMaxRows(request.getSampleMaxRows());
+            vsModel.setPortal(request.isPortal());
 
             WizVsService.PostAssemblyHook hook = (wizRvs, asm) -> {
                if(asm instanceof ChartVSAssembly) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -269,7 +269,21 @@ public class WizVsService {
                VSAssembly clone = (VSAssembly) sourceAssembly.clone();
                clone.getVSAssemblyInfo().setName(
                   AssetUtil.getNextName(targetVs, clone.getAssemblyType()));
+
+               // clone() deep-copies the source's VSAssemblyInfo, which carries isPrimary=true,
+               // so both source and clone would report isPrimary()==true. Demote every existing
+               // primary (the source) before promoting the clone, keeping exactly one primary.
+               // The clone becomes the new primary so the next turn's findPrimaryAssembly()
+               // returns it and clones build on the prior turn's edit instead of branching from
+               // the stale original state each time.
+               for(Assembly a : targetVs.getAssemblies()) {
+                  if(a instanceof VSAssembly va && va.isPrimary()) {
+                     va.setPrimary(false);
+                  }
+               }
+
                targetVs.addAssembly(clone);
+               clone.setPrimary(true);
                // The clone becomes the active chart; the source stays untouched and visible.
                assembly = clone;
             }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -39,6 +39,7 @@ import inetsoft.sree.security.SecurityEngine;
 import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
+import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.schema.*;
@@ -258,16 +259,32 @@ public class WizVsService {
             if(sourceAssembly instanceof DataVSAssembly dataAsm) {
                SourceInfo srcInfo = dataAsm.getSourceInfo();
                wsTableName = srcInfo != null ? srcInfo.getSource() : null;
-               // Snapshot the existing condition so a failure can roll back the in-place change.
-               previousCondition = dataAsm.getPreConditionList() != null
-                  ? dataAsm.getPreConditionList().clone() : null;
             }
 
-            // Apply the filter to the EXISTING primary assembly in place — keep its name and
-            // identity. Copying to a unique "<name>_1" assembly (the old behavior) broke
-            // save_viewsheet: save loads the persisted viewsheet and looks the assembly up by name,
-            // so it never found the renamed copy, and every filter call churned a new assembly.
-            assembly = sourceAssembly;
+            if(model.isPortal()) {
+               // Portal multi-assembly: DO NOT mutate the existing chart. Clone the primary assembly
+               // (same binding) into a NEW assembly and add it to the viewsheet; the new condition is
+               // applied to the clone only, so the prior state and the new state coexist for comparison.
+               // Layout of the added assembly is handled by StyleBI, not positioned here.
+               VSAssembly clone = (VSAssembly) sourceAssembly.clone();
+               clone.getVSAssemblyInfo().setName(
+                  AssetUtil.getNextName(targetVs, clone.getAssemblyType()));
+               targetVs.addAssembly(clone);
+               // The clone becomes the active chart; the source stays untouched and visible.
+               assembly = clone;
+            }
+            else {
+               // Legacy in-place filter: apply to the EXISTING primary assembly, keeping its name and
+               // identity. Copying to a unique "<name>_1" assembly (an older behavior) broke
+               // save_viewsheet, which looks the assembly up by name and never found the renamed copy.
+               if(sourceAssembly instanceof DataVSAssembly dataAsm) {
+                  // Snapshot the existing condition so a failure can roll back the in-place change.
+                  previousCondition = dataAsm.getPreConditionList() != null
+                     ? dataAsm.getPreConditionList().clone() : null;
+               }
+
+               assembly = sourceAssembly;
+            }
          }
          else {
             SourceContext ctx = resolveSourceContext(model, user);
@@ -565,7 +582,12 @@ public class WizVsService {
             }
 
             if(!createdRuntimeId) {
-               if(modificationOnly) {
+               if(modificationOnly && model.isPortal()) {
+                  // Portal clone: the change this call made was a freshly ADDED assembly, so undo it by
+                  // removing that clone. The original assembly was never touched.
+                  previousVs.removeAssembly(assembly.getName());
+               }
+               else if(modificationOnly) {
                   // In-place filter: restore the assembly's prior condition rather than removing
                   // the (existing) assembly, which was mutated, not added, this call.
                   if(assembly instanceof DataVSAssembly dataAsm) {


### PR DESCRIPTION
When a Portal-conversation request carries `portal: true`, keep the prior chart state so a follow-up produces a new coexisting assembly rather than mutating the existing one.

- CreateVisualizationModel / AutoBindingRequest: accept the `portal` flag.
- WizVsService.createViewsheetInternal:
  - modificationOnly + portal: clone the primary assembly (same binding) into a new assembly and apply the condition to the clone; the source stays untouched. Isolate the aggregate condition to the clone so the shared ws table is not polluted. Roll back by removing the added clone on failure.
  - standard create + portal: add the new assembly without removing the existing one. Layout of added assemblies is left to StyleBI (no manual pixel placement).
- WizAutoBindingService: thread the portal flag through the autoBinding path.