### PR TITLE
fix(worksheet): register dateGroupLevel synthetic column for conditions

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -235,7 +235,8 @@ public class WorksheetTableService {
       // 3. Pre-aggregate conditions (WHERE).
       if(request.getPreAggregateCondition() != null && !request.getPreAggregateCondition().isEmpty()) {
          ConditionList preList = buildConditionList(
-            table.getColumnSelection(true), request.getPreAggregateCondition(), worksheet, false);
+            table.getColumnSelection(true), request.getPreAggregateCondition(), worksheet, false,
+            table.getColumnSelection(false));
          table.setPreConditionList(preList);
       }
 
@@ -247,15 +248,30 @@ public class WorksheetTableService {
       // 5. Post-aggregate conditions (HAVING).
       if(request.getPostAggregateCondition() != null && !request.getPostAggregateCondition().isEmpty()) {
          ConditionList postList = buildConditionList(
-            table.getColumnSelection(true), request.getPostAggregateCondition(), worksheet, true);
+            table.getColumnSelection(true), request.getPostAggregateCondition(), worksheet, true,
+            table.getColumnSelection(false));
          table.setPostConditionList(postList);
       }
 
       // 6. Ranking / top-N.
       if(request.getRankingCondition() != null && !request.getRankingCondition().isEmpty()) {
          ConditionList rankList = buildRankingConditionList(
-            table.getColumnSelection(true), request.getRankingCondition());
+            table.getColumnSelection(true), request.getRankingCondition(),
+            table.getColumnSelection(false));
          table.setRankingConditionList(rankList);
+      }
+
+      // 7. Persist any synthetic date-part column(s) that a condition/ranking dateGroupLevel
+      // registered into the private column selection (see applyDateGroupLevel). Mirrors the
+      // finalize step in applyAggregateInfo — without re-running setColumnSelection, the query
+      // engine's merge-eligibility check can't see the newly added column, and an unresolvable
+      // column falls back to StyleBI's in-memory condition evaluation, which defaults to
+      // matching every row instead of filtering or erroring.
+      if(hasDateGroupLevel(request.getPreAggregateCondition()) ||
+         hasDateGroupLevel(request.getPostAggregateCondition()) ||
+         hasDateGroupLevel(request.getRankingCondition()))
+      {
+         table.setColumnSelection(table.getColumnSelection(false), false);
       }
 
       // 8. Execution probe for render-time-executable tables.
@@ -1584,6 +1600,22 @@ public class WorksheetTableService {
                                     Worksheet worksheet,
                                     boolean isHaving)
    {
+      return buildConditionList(columns, items, worksheet, isHaving, null);
+   }
+
+   /**
+    * @param privateCs the table's private column selection, used to register a synthetic
+    *                  date-part column created by a {@code dateGroupLevel} (see
+    *                  {@link #applyDateGroupLevel}) so it can be resolved at query time. May be
+    *                  {@code null} (e.g. from unit tests that don't exercise dateGroupLevel),
+    *                  in which case the wrapped column is built but not registered.
+    */
+   ConditionList buildConditionList(ColumnSelection columns,
+                                    List<WorksheetTable.ConditionItem> items,
+                                    Worksheet worksheet,
+                                    boolean isHaving,
+                                    ColumnSelection privateCs)
+   {
       ConditionList list = new ConditionList();
 
       for(WorksheetTable.ConditionItem item : items) {
@@ -1594,14 +1626,15 @@ public class WorksheetTableService {
             list.append(new JunctionOperator(junctionType, item.resolveJunctionLevel()));
          }
 
-         appendConditionItem(list, item, columns, worksheet, isHaving);
+         appendConditionItem(list, item, columns, worksheet, isHaving, privateCs);
       }
 
       return list;
    }
 
    private ConditionList buildRankingConditionList(ColumnSelection columns,
-                                                   List<WorksheetTable.ConditionItem> items)
+                                                   List<WorksheetTable.ConditionItem> items,
+                                                   ColumnSelection privateCs)
    {
       ConditionList list = new ConditionList();
 
@@ -1612,15 +1645,71 @@ public class WorksheetTableService {
             list.append(new JunctionOperator(junctionType, item.resolveJunctionLevel()));
          }
 
-         appendRankingConditionItem(list, item, columns);
+         appendRankingConditionItem(list, item, columns, privateCs);
       }
 
       return list;
    }
 
+   /** True if any item in {@code items} carries a {@code dateGroupLevel}. Null-safe. */
+   private static boolean hasDateGroupLevel(List<WorksheetTable.ConditionItem> items) {
+      return items != null && items.stream().anyMatch(i -> i.getDateGroupLevel() != null);
+   }
+
+   /**
+    * Wraps {@code ref} in a {@link DateRangeRef} truncated/extracted to {@code dateGroupLevel} (e.g.
+    * "year", "month of year"), so a condition/ranking compares the date part instead of the raw
+    * timestamp — mirrors the grouping wrap in {@link #applyAggregateInfo}. No-op when
+    * {@code dateGroupLevel} is null or {@code ref} isn't a plain column.
+    *
+    * <p>When {@code privateCs} is non-null, also registers the synthetic column into it (mirroring
+    * {@link #applyAggregateInfo}'s GROUP BY registration) so the query engine can resolve it — an
+    * unregistered synthetic column that fails to SQL-merge falls back to StyleBI's in-memory
+    * condition evaluation, which can't find it by name and defaults to matching every row. The
+    * synthetic column is marked not-visible so it never leaks into the table's output columns.
+    */
+   private DataRef applyDateGroupLevel(DataRef ref, String dateGroupLevel, ColumnSelection privateCs) {
+      if(dateGroupLevel == null || !(ref instanceof ColumnRef column)) {
+         return ref;
+      }
+
+      int dgroup = getDateGroupLevel(dateGroupLevel);
+      String name = DateRangeRef.getName(column.getName(), dgroup);
+
+      // Reuse an already-registered synthetic column for the same base field + level (e.g. two
+      // condition leaves on the same date field/level) instead of adding a duplicate entry.
+      if(privateCs != null) {
+         DataRef existing = privateCs.getAttribute(name);
+
+         if(existing instanceof ColumnRef) {
+            return existing;
+         }
+      }
+
+      DateRangeRef rangeRef = new DateRangeRef(name, column.getDataRef(), dgroup);
+      rangeRef.setOriginalType(column.getDataType());
+      ColumnRef dateColumn = new ColumnRef(rangeRef);
+      dateColumn.setDataType(rangeRef.getDataType());
+      dateColumn.setVisible(false);
+
+      if(privateCs != null) {
+         int baseIdx = privateCs.indexOfAttribute(column);
+
+         if(baseIdx >= 0) {
+            privateCs.addAttribute(baseIdx, dateColumn);
+         }
+         else {
+            privateCs.addAttribute(dateColumn);
+         }
+      }
+
+      return dateColumn;
+   }
+
    private void appendRankingConditionItem(ConditionList list,
                                            WorksheetTable.ConditionItem item,
-                                           ColumnSelection columns)
+                                           ColumnSelection columns,
+                                           ColumnSelection privateCs)
    {
       if(item.getField() == null || item.getOperation() == null) {
          return;
@@ -1631,6 +1720,8 @@ public class WorksheetTableService {
       if(ref == null) {
          return;
       }
+
+      ref = applyDateGroupLevel(ref, item.getDateGroupLevel(), privateCs);
 
       int op = switch(item.getOperation()) {
          case "TOP_N"    -> XCondition.TOP_N;
@@ -1661,7 +1752,8 @@ public class WorksheetTableService {
                                     WorksheetTable.ConditionItem item,
                                     ColumnSelection columns,
                                     Worksheet worksheet,
-                                    boolean isHaving)
+                                    boolean isHaving,
+                                    ColumnSelection privateCs)
    {
       // Fail loud rather than silently skipping. A skipped item leaves a dangling JunctionOperator
       // in the ConditionList (the operator for this item was already appended by buildConditionList),
@@ -1684,6 +1776,12 @@ public class WorksheetTableService {
             "column selection. Add it to the table's columns (or omit columns to select all), " +
             "and reference it exactly as it appears in the selection.");
       }
+
+      // Truncate/extract to the requested date part BEFORE comparing, mirroring applyAggregateInfo's
+      // grouping wrap. Without this, a condition's dateGroupLevel was silently ignored: the raw
+      // timestamp column was compared directly against a date-part literal (e.g. "2025-01-01"),
+      // which never matches, silently zeroing every row instead of erroring.
+      ref = applyDateGroupLevel(ref, item.getDateGroupLevel(), privateCs);
 
       // For HAVING conditions, wrap the column in an AggregateRef when a formula is present.
       if(isHaving && item.getAggregateFormula() != null &&

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1632,9 +1632,10 @@ public class WorksheetTableService {
       return list;
    }
 
-   private ConditionList buildRankingConditionList(ColumnSelection columns,
-                                                   List<WorksheetTable.ConditionItem> items,
-                                                   ColumnSelection privateCs)
+   // Package-private for unit testing (WorksheetTableServiceConditionTest).
+   ConditionList buildRankingConditionList(ColumnSelection columns,
+                                           List<WorksheetTable.ConditionItem> items,
+                                           ColumnSelection privateCs)
    {
       ConditionList list = new ConditionList();
 

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceConditionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceConditionTest.java
@@ -270,6 +270,39 @@ class WorksheetTableServiceConditionTest {
    }
 
    @Test
+   void rankingConditionWithPartDateGroupLevelRegistersSyntheticColumn() throws Exception {
+      // Mirrors conditionWithPartDateGroupLevelRegistersSyntheticColumn but through
+      // buildRankingConditionList (TOP_N), the ranking-condition path appendRankingConditionItem
+      // also had to thread privateCs through.
+      WorksheetTable req = request("""
+         {
+           "rankingCondition": [
+             { "field": "order_date", "operation": "TOP_N", "dateGroupLevel": "month of year",
+               "values": [{ "type": "VALUE", "value": 3 }] }
+           ]
+         }
+         """);
+
+      ColumnSelection cs = columns("order_date");
+      ColumnSelection privateCs = columns("order_date");
+
+      ConditionList list = service().buildRankingConditionList(
+         cs, req.getRankingCondition(), privateCs);
+
+      String expectedName = DateRangeRef.getName(
+         "order_date", inetsoft.web.wiz.service.WizDateLevelUtil.getDateGroupLevel("month of year"));
+
+      DataRef conditionRef = list.getConditionItem(0).getAttribute();
+      assertEquals(expectedName, conditionRef.getName(),
+                   "ranking condition must reference the date-grouped synthetic column");
+
+      DataRef registered = privateCs.getAttribute(expectedName);
+      assertNotNull(registered,
+                     "ranking condition's Part-type dateGroupLevel synthetic column must also " +
+                     "be registered into the private ColumnSelection");
+   }
+
+   @Test
    void conditionDateGroupLevelReusesRegisteredColumnAcrossLeaves() throws Exception {
       // Two leaves on the same field + level must not create two private-selection entries.
       WorksheetTable req = request("""

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceConditionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceConditionTest.java
@@ -25,6 +25,7 @@ import inetsoft.uql.ColumnSelection;
 import inetsoft.uql.Condition;
 import inetsoft.uql.ConditionList;
 import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.DateRangeRef;
 import inetsoft.uql.asset.ExpressionValue;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.AttributeRef;
@@ -196,5 +197,121 @@ class WorksheetTableServiceConditionTest {
          service().buildConditionList(cs, req.getPreAggregateCondition(), new Worksheet(), false));
       assertTrue(ex.getMessage().contains("nonexistent_col"),
                  "error should name the unresolved FIELD column, got: " + ex.getMessage());
+   }
+
+   // ── dateGroupLevel on a condition. Regression for the silent match-all bug: a condition's
+   // dateGroupLevel wraps the column in a DateRangeRef but — unlike the working GROUP BY path in
+   // applyAggregateInfo — never registered the synthetic column into the table's private
+   // ColumnSelection. An unregistered column that fails to SQL-merge falls back to StyleBI's
+   // in-memory evaluation, which can't resolve it and defaults to matching every row. The fix
+   // threads the private ColumnSelection down so the synthetic column gets registered exactly
+   // like applyAggregateInfo's GROUP BY wrap does. ──
+
+   @Test
+   void conditionWithIntervalDateGroupLevelRegistersSyntheticColumn() throws Exception {
+      WorksheetTable req = request("""
+         {
+           "preAggregateCondition": [
+             { "field": "order_date", "operation": "EQUAL_TO", "dateGroupLevel": "year",
+               "values": [{ "type": "VALUE", "value": 2025 }] }
+           ]
+         }
+         """);
+
+      ColumnSelection cs = columns("order_date");
+      ColumnSelection privateCs = columns("order_date");
+
+      ConditionList list = service().buildConditionList(
+         cs, req.getPreAggregateCondition(), new Worksheet(), false, privateCs);
+
+      String expectedName = DateRangeRef.getName(
+         "order_date", inetsoft.web.wiz.service.WizDateLevelUtil.getDateGroupLevel("year"));
+
+      DataRef conditionRef = list.getConditionItem(0).getAttribute();
+      assertEquals(expectedName, conditionRef.getName(),
+                   "condition must reference the date-grouped synthetic column");
+
+      DataRef registered = privateCs.getAttribute(expectedName);
+      assertNotNull(registered,
+                     "synthetic date-group column must be registered into the private " +
+                     "ColumnSelection so the query engine can resolve it");
+      assertTrue(registered instanceof ColumnRef && !((ColumnRef) registered).isVisible(),
+                 "synthetic date-group column must be a hidden helper, not an output column");
+   }
+
+   @Test
+   void conditionWithPartDateGroupLevelRegistersSyntheticColumn() throws Exception {
+      WorksheetTable req = request("""
+         {
+           "preAggregateCondition": [
+             { "field": "order_date", "operation": "LESS_THAN", "dateGroupLevel": "month of year",
+               "values": [{ "type": "VALUE", "value": 5 }] }
+           ]
+         }
+         """);
+
+      ColumnSelection cs = columns("order_date");
+      ColumnSelection privateCs = columns("order_date");
+
+      ConditionList list = service().buildConditionList(
+         cs, req.getPreAggregateCondition(), new Worksheet(), false, privateCs);
+
+      String expectedName = DateRangeRef.getName(
+         "order_date", inetsoft.web.wiz.service.WizDateLevelUtil.getDateGroupLevel("month of year"));
+
+      DataRef conditionRef = list.getConditionItem(0).getAttribute();
+      assertEquals(expectedName, conditionRef.getName(),
+                   "condition must reference the date-grouped synthetic column");
+
+      DataRef registered = privateCs.getAttribute(expectedName);
+      assertNotNull(registered,
+                     "Part-type dateGroupLevel synthetic column must also be registered — this " +
+                     "is the case that previously silently matched every row");
+   }
+
+   @Test
+   void conditionDateGroupLevelReusesRegisteredColumnAcrossLeaves() throws Exception {
+      // Two leaves on the same field + level must not create two private-selection entries.
+      WorksheetTable req = request("""
+         {
+           "preAggregateCondition": [
+             { "field": "order_date", "operation": "GREATER_THAN", "dateGroupLevel": "year",
+               "values": [{ "type": "VALUE", "value": 2020 }] },
+             { "field": "order_date", "operation": "LESS_THAN", "dateGroupLevel": "year",
+               "junction": "and",
+               "values": [{ "type": "VALUE", "value": 2026 }] }
+           ]
+         }
+         """);
+
+      ColumnSelection cs = columns("order_date");
+      ColumnSelection privateCs = columns("order_date");
+      int before = privateCs.getAttributeCount();
+
+      service().buildConditionList(cs, req.getPreAggregateCondition(), new Worksheet(), false, privateCs);
+
+      assertEquals(before + 1, privateCs.getAttributeCount(),
+                   "the same synthetic date-group column must be reused, not duplicated");
+   }
+
+   @Test
+   void conditionWithoutDateGroupLevelLeavesPrivateSelectionUntouched() throws Exception {
+      // No dateGroupLevel => no synthetic column, and a null privateCs (as existing callers pass)
+      // must remain safe.
+      WorksheetTable req = request("""
+         {
+           "preAggregateCondition": [
+             { "field": "sales_stage", "operation": "EQUAL_TO",
+               "values": [{ "type": "VALUE", "value": "Closed Won" }] }
+           ]
+         }
+         """);
+
+      ColumnSelection cs = columns("sales_stage");
+
+      ConditionList list = service().buildConditionList(
+         cs, req.getPreAggregateCondition(), new Worksheet(), false, null);
+
+      assertEquals("sales_stage", list.getConditionItem(0).getAttribute().getName());
    }
 }


### PR DESCRIPTION
## Summary
- A `create_worksheet_table` `preAggregateCondition`/`postAggregateCondition`/`rankingCondition` with a `dateGroupLevel` was silently a no-op instead of filtering — the raw timestamp column was compared directly against a date-part literal (which never matches), so every row was silently kept instead of erroring or filtering.
- Wrapping the column in a `DateRangeRef` (mirroring `applyAggregateInfo`'s GROUP BY path) fixed Interval levels (e.g. `"year"`) but Part levels (e.g. `"month of year"`) stayed broken: the synthetic wrapped column was never registered into the table's private `ColumnSelection`, so when it failed to SQL-merge it fell back to StyleBI's in-memory condition evaluation, which can't resolve an unregistered column and defaults to matching every row.
- Threads the private `ColumnSelection` through `buildConditionList`/`buildRankingConditionList`/`appendConditionItem`/`appendRankingConditionItem` so the synthetic date-part column is registered exactly like the GROUP BY path (and marked not-visible so it never leaks into output columns).

## Test plan
- [x] New unit tests in `WorksheetTableServiceConditionTest`: Interval-level registration, Part-level registration, dedup-reuse across condition leaves, and a null-`privateCs` safety test for existing callers. All 9 tests pass.
- [x] Existing 4-arg `buildConditionList` callers (tests) unaffected — added a backward-compatible overload.
- [x] Live-verified via the wiz plugin against the `odoo` datasource: a declarative worksheet filtering Maintenance & Repair category revenue by `date_order` `dateGroupLevel:"month of year" < 5` now correctly returns $2,057,697.11 (previously identical to the $4,715,385.88 unfiltered total — the silent match-all bug). Confirmed no regression on Interval level (`"year"` filter correctly returns $3,545,767.42).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>