### PR TITLE
Fix test isolation leak in SecurityEnginePermissionTest

### DIFF
--- a/core/src/test/java/inetsoft/sree/security/SecurityEnginePermissionTest.java
+++ b/core/src/test/java/inetsoft/sree/security/SecurityEnginePermissionTest.java
@@ -87,10 +87,10 @@ class SecurityEnginePermissionTest {
    @AfterEach
    void tearDown() {
       SreeEnv.setProperty("security.enabled", "false");
-      SreeEnv.setProperty("security.datasource.everyone", "false");
-      SreeEnv.setProperty("security.script.everyone", "false");
-      SreeEnv.setProperty("security.tablestyle.everyone", "false");
-      SreeEnv.setProperty("security.scheduletask.everyone", "false");
+      SreeEnv.remove("security.datasource.everyone");
+      SreeEnv.remove("security.script.everyone");
+      SreeEnv.remove("security.tablestyle.everyone");
+      SreeEnv.remove("security.scheduletask.everyone");
 
       SecurityEngine.updateSecurityDatasourceEveryoneValue();
       SecurityEngine.updateSecurityScriptEveryoneValue();


### PR DESCRIPTION
## Summary
- `SecurityEnginePermissionTest.tearDown()` forced `security.script.everyone`, `security.tablestyle.everyone`, and `security.scheduletask.everyone` (plus `security.datasource.everyone`) to `"false"` after every test instead of restoring their default state.
- Because these are global `SreeEnv`-backed static caches in `SecurityEngine`, the leftover `"false"` state leaked into later test classes run in the same Surefire JVM fork.
- This caused `PermissionMatrixResourcesS5Test`'s new "everyone fallback" tests (`scriptEveryone_*`, `tableStyleEveryone_*`, `scheduleTaskFolderEveryone_*`) to see stale DENY instead of the expected default ALLOW, failing intermittently in CI depending on test class ordering.
- Fix: `tearDown()` now removes the properties (`SreeEnv.remove`) instead of forcing `"false"`, restoring the true default (`"true"`) for subsequent tests.

## Test plan
- [x] Reproduced the failure locally by running `SecurityEnginePermissionTest` immediately before `PermissionMatrixResourcesS5Test` in the same fork
- [x] Verified the fix resolves it for that pair
- [x] Ran the full `inetsoft.sree.security.**` package (633 tests) — 0 failures, 0 errors after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)