### PR TITLE
Update ai assistant package version to most recent build

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/router": "^21.2.15",
         "@ckeditor/ckeditor5-angular": "^9.1.0",
         "@ctrl/tinycolor": "^3.4.1",
-        "@inetsoft-technology/ai-assistant": "^0.0.20260708200331",
+        "@inetsoft-technology/ai-assistant": "^0.0.20260713195139",
         "@ng-bootstrap/ng-bootstrap": "^20.0.0",
         "@popperjs/core": "^2.11.8",
         "@thebespokepixel/es-tinycolor": "^2.1.1",
@@ -5030,9 +5030,9 @@
       }
     },
     "node_modules/@inetsoft-technology/ai-assistant": {
-      "version": "0.0.20260708200331",
-      "resolved": "https://npm.pkg.github.com/download/@inetsoft-technology/ai-assistant/0.0.20260708200331/4114422e1258d862e8232d49024f86905bb992a5",
-      "integrity": "sha512-C7Iwk2malAj4aeIY+OQzfSNtyZIwZYFW95PT4JL8dyMwO7AMtC5IunfJ5NP2IZcM/2jdtCo5Fn5ssfIOIhR9tA=="
+      "version": "0.0.20260713195139",
+      "resolved": "https://npm.pkg.github.com/download/@inetsoft-technology/ai-assistant/0.0.20260713195139/c1ae838e184363bbdcf11da78d0e5a13446ea699",
+      "integrity": "sha512-wxFkY2GiCOX3G4ub8e76T+LquJrSr0vPepdEA6VQWhPRm5tpZQjbcKQlkQ1DroGB/WHnbUPh/7OrohbrZG2kQA=="
     },
     "node_modules/@inquirer/ansi": {
       "version": "2.0.5",

--- a/web/package.json
+++ b/web/package.json
@@ -35,7 +35,7 @@
     "@angular/router": "^21.2.15",
     "@ckeditor/ckeditor5-angular": "^9.1.0",
     "@ctrl/tinycolor": "^3.4.1",
-    "@inetsoft-technology/ai-assistant": "^0.0.20260708200331",
+    "@inetsoft-technology/ai-assistant": "^0.0.20260713195139",
     "@ng-bootstrap/ng-bootstrap": "^20.0.0",
     "@popperjs/core": "^2.11.8",
     "@thebespokepixel/es-tinycolor": "^2.1.1",


### PR DESCRIPTION
## Summary
- Bump `@inetsoft-technology/ai-assistant` from `0.0.20260708200331` to `0.0.20260713195139` in `web/package.json` and `web/package-lock.json`, matching the newly published build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)