### PR TITLE
TreeMapElement not available in script.

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -1407,12 +1407,20 @@ public class GraalJavaScriptEngine implements AutoCloseable {
       putClassProxy(bindings, "AxisSpec",   "inetsoft.graph.AxisSpec");
       putClassProxy(bindings, "PlotSpec",   "inetsoft.graph.PlotSpec");
 
-      // elements
+      // elements. Rhino auto-imported the whole inetsoft.graph.element package, so
+      // every concrete element type must be registered here or chart scripts that
+      // reference it by simple name (e.g. new TreemapElement(),
+      // TreemapElement.Orientation.TOP_RIGHT) fail with "X is not defined".
       putClassProxy(bindings, "IntervalElement", "inetsoft.graph.element.IntervalElement");
       putClassProxy(bindings, "LineElement",     "inetsoft.graph.element.LineElement");
       putClassProxy(bindings, "SchemaElement",   "inetsoft.graph.element.SchemaElement");
       putClassProxy(bindings, "PointElement",    "inetsoft.graph.element.PointElement");
       putClassProxy(bindings, "AreaElement",     "inetsoft.graph.element.AreaElement");
+      putClassProxy(bindings, "TreemapElement",  "inetsoft.graph.element.TreemapElement");
+      putClassProxy(bindings, "MekkoElement",    "inetsoft.graph.element.MekkoElement");
+      putClassProxy(bindings, "ParaboxElement",  "inetsoft.graph.element.ParaboxElement");
+      putClassProxy(bindings, "PolygonElement",  "inetsoft.graph.element.PolygonElement");
+      putClassProxy(bindings, "RelationElement", "inetsoft.graph.element.RelationElement");
 
       // coords
       putClassProxy(bindings, "PolarCoord",    "inetsoft.graph.coord.PolarCoord");

--- a/core/src/main/java/inetsoft/web/binding/VSScriptableController.java
+++ b/core/src/main/java/inetsoft/web/binding/VSScriptableController.java
@@ -100,7 +100,9 @@ public class VSScriptableController {
    public static final String[] CHART_CLASSES = new String[] {
       "EGraph", "LegendSpec", "TitleSpec", "TextSpec", "AxisSpec",
       "PlotSpec", "IntervalElement", "LineElement",
-      "SchemaElement", "PointElement", "AreaElement", "PolarCoord",
+      "SchemaElement", "PointElement", "AreaElement", "TreemapElement",
+      "MekkoElement", "ParaboxElement", "PolygonElement", "RelationElement",
+      "PolarCoord",
       "RectCoord", "Rect25Coord", "ParallelCoord", "TriCoord",
       "FacetCoord", "LinearScale", "LogScale",
       "PowerScale", "TimeScale", "CategoricalScale", "LinearRange",

--- a/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineGlobalsTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineGlobalsTest.java
@@ -113,4 +113,28 @@ class GraalJavaScriptEngineGlobalsTest {
       Object result = eval("new SVGShape()");
       assertInstanceOf(inetsoft.graph.aesthetic.SVGShape.class, result);
    }
+
+   // Bug: Rhino auto-imported the whole inetsoft.graph.element package, so every
+   // element type resolved by simple name. The GraalJS class whitelist
+   // (installChartClasses) omitted the newer element types, so chart scripts such
+   // as elem.setOrientation(TreemapElement.Orientation.TOP_RIGHT) failed with
+   // "TreemapElement is not defined".
+   @Test
+   void treemapElementResolves() throws Exception {
+      // exact real-script usage: elem.setOrientation(TreemapElement.Orientation.TOP_RIGHT)
+      assertEquals("TOP_RIGHT", eval("String(TreemapElement.Orientation.TOP_RIGHT)"));
+   }
+
+   // The element types resolve to class proxies (typeof != 'undefined'). Actually
+   // constructing them pulls in inetsoft.graph.internal.GDefaults, whose static
+   // init needs a full graphics environment unavailable in this headless test, so
+   // only name resolution is asserted here.
+   @Test
+   void newChartElementTypesResolve() throws Exception {
+      assertNotEquals("undefined", eval("typeof TreemapElement"));
+      assertNotEquals("undefined", eval("typeof MekkoElement"));
+      assertNotEquals("undefined", eval("typeof ParaboxElement"));
+      assertNotEquals("undefined", eval("typeof PolygonElement"));
+      assertNotEquals("undefined", eval("typeof RelationElement"));
+   }
 }


### PR DESCRIPTION
  Root cause

  GraalJavaScriptEngine.installChartClasses() (commit 911f0f894, Bug #75524).

  That whitelist registered only 5 of the 10 concrete element classes — IntervalElement, LineElement, SchemaElement, PointElement, AreaElement — and omitted the newer types: TreemapElement,
  MekkoElement, ParaboxElement, PolygonElement, RelationElement. So elem.setOrientation(TreemapElement.Orientation.TOP_RIGHT) threw ReferenceError: TreemapElement is not defined.

  I confirmed against the legacy engine (../merge/sr13_7/.../JavaScriptEngine.java), whose DefaultPackages auto-imported the whole inetsoft.graph.element package — so all these types were
  reachable by simple name under Rhino.

  Fix

  - GraalJavaScriptEngine.java — registered the 5 missing element classes as JavaClassProxy globals (serves both new TreemapElement() and static/nested access like TreemapElement.Orientation.TOP_RIGHT).
  - VSScriptableController.java — added the same 5 to CHART_CLASSES so they appear in the script editor's autocomplete tree (that list had the identical gap).
  - GraalJavaScriptEngineGlobalsTest.java — added two tests: the exact repro (TreemapElement.Orientation.TOP_RIGHT → "TOP_RIGHT") and resolution checks for all 5 types.

  Verification

  Tests confirmed the fix directly: before, the repro failed with TreemapElement is not defined; after, all 12 tests in the suite pass. (Constructing the elements pulls in GDefaults, whose
  static init needs a graphics environment absent in the headless test JVM, so the tests assert name/enum resolution — which is the actual bug and the exact form used in the failing script.)