### PR TITLE
Fix freehand table grand total showing 0

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/CalcTableVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/CalcTableVSAQuery.java
@@ -1189,35 +1189,15 @@ public class CalcTableVSAQuery extends DataVSAQuery {
     * Check if there exist grand total aggregate.
     */
    private boolean hasGrandTotal(TableLayout layout, XNode root) {
-      boolean hasAgg = false;
-      boolean hasGrp = false;
-
-      if(root != null) {
-         for(int i = 0; i < root.getChildCount(); i++) {
-            XNode child = root.getChild(i);
-            CalcAttr cattr = child == null ? null : (CalcAttr) child.getValue();
-
-            if(cattr == null) {
-               continue;
-            }
-
-            CellBinding bind = layout.getCellBinding(cattr.getRow(),
-                                                     cattr.getCol());
-
-            if(bind != null && bind.getType() == CellBinding.BIND_COLUMN &&
-               !bind.isEmpty())
-            {
-               if(bind.getBType() == CellBinding.SUMMARY) {
-                  hasAgg = true;
-               }
-               else if(bind.getBType() == CellBinding.GROUP) {
-                  hasGrp = true;
-               }
-            }
-         }
+      if(root == null) {
+         return false;
       }
 
-      return hasGrp && hasAgg;
+      Set<Integer> glevels = new HashSet<>();
+      Set<Integer> alevels = new HashSet<>();
+      collectLevels(layout, root, 0, glevels, alevels);
+
+      return !glevels.isEmpty() && !alevels.isEmpty();
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/script/TableArray.java
+++ b/core/src/main/java/inetsoft/report/script/TableArray.java
@@ -18,6 +18,7 @@
 package inetsoft.report.script;
 
 import inetsoft.report.*;
+import inetsoft.report.filter.CalcFilter;
 import inetsoft.report.filter.CrossFilter;
 import inetsoft.report.internal.*;
 import inetsoft.report.lens.AttributeTableLens;
@@ -110,6 +111,19 @@ public class TableArray implements ArrayObject, ScriptArrayScope {
       // for ids that actually name a row/col dimension -- a genuinely nonexistent
       // property should still report absent, not be over-claimed as present.
       if(lens instanceof CrossFilter && isCrosstabDimension((CrossFilter) lens, id)) {
+         return true;
+      }
+
+      // A bare (unqualified) reference to one of the crosstab's own measure/aggregate
+      // names, e.g. data['Sum(category_id)'] with no "@group:value" qualifier -- as
+      // generated for a calc table's grand-total cell, which has no row/col group to
+      // qualify with. The measure name never appears as a literal column header either
+      // (it varies per data cell path, not per fixed column), so without this check
+      // Util.findColumn below fails to find it, hasMember() reports it absent, and
+      // GraalJS never calls getMember() at all -- the reference silently resolves to
+      // undefined instead of dispatching to NamedCellRange/CrosstabGroupSelector, which
+      // do know how to resolve it.
+      if(lens instanceof CalcFilter && ((CalcFilter) lens).getMeasureHeaders().contains(id)) {
          return true;
       }
 

--- a/core/src/test/java/inetsoft/report/script/TableArrayTest.java
+++ b/core/src/test/java/inetsoft/report/script/TableArrayTest.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.report.script;
 
+import inetsoft.report.filter.CalcFilter;
 import inetsoft.report.lens.DefaultTableLens;
 import inetsoft.test.*;
 import inetsoft.uql.XTable;
@@ -26,6 +27,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -80,6 +84,44 @@ class TableArrayTest {
       assertFalse(arr.hasMember("nonexistent"));
       assertFalse(arr.hasMember("toString"));
       assertFalse(arr.hasMember("then"));
+   }
+
+   /**
+    * Minimal {@code CalcFilter} (e.g. a crosstab) stub exposing a fixed set of
+    * measure/aggregate headers, without needing a full CrossTabFilter setup.
+    */
+   private static class MeasureTableLens extends DefaultTableLens implements CalcFilter {
+      MeasureTableLens() {
+         super(new Object[][] {
+            { "col1", "col2" },
+            { "a", 1 }
+         });
+      }
+
+      @Override
+      public void setMeasureNames(String[] names) {
+      }
+
+      @Override
+      public List<String> getMeasureHeaders() {
+         return Arrays.asList("Sum(category_id)", "Sum(customer_id)");
+      }
+   }
+
+   @Test
+   void hasMemberReportsBareMeasureNamesPresent() {
+      // #75647: a calc table's grand-total cell has no row/col group, so its formula
+      // is a bare reference like data['Sum(category_id)'] with no "@group:value"
+      // qualifier. The measure name never appears as a literal column header (that
+      // identity varies per data cell, not per fixed column), so hasMember must
+      // special-case it the same way it already does for bare dimension names.
+      TableArray arr = new TableArray(new MeasureTableLens());
+
+      assertTrue(arr.hasMember("Sum(category_id)"),
+         "bare measure name must be present so GraalJS dispatches getMember");
+      assertTrue(arr.hasMember("Sum(customer_id)"));
+      assertFalse(arr.hasMember("Sum(nonexistent)"),
+         "a name that isn't a measure header must not be over-claimed as present");
    }
 
    @Test


### PR DESCRIPTION
## Summary
- A calc table's Grand Total row/column cells have no row/col group, so the generated formula is a bare, unqualified crosstab lookup like `none(data['Sum(category_id)'])`. Under GraalJS, `TableArray.hasMember()` only special-cased bare references to a crosstab's own **dimension** names (row/col headers), not its **measure** names — since a crosstab has no literal column headed `"Sum(category_id)"` (that identity varies per data cell, not per column), `Util.findColumn()` couldn't find it, `hasMember()` reported it absent, and GraalJS never called `getMember()` at all. The reference silently resolved to `undefined`/`0` instead of dispatching to the `NamedCellRange`/`CrosstabGroupSelector` logic that already knows how to resolve it correctly.
- Also fixes `CalcTableVSAQuery.hasGrandTotal()` to recurse the full row/column tree (matching the existing `hasSubTotal()`/`collectLevels()` pattern) instead of only checking direct children of the root, so grand-total visibility is detected correctly when the aggregate cell is nested more than one level deep.

## Test plan
- [ ] Build a freehand table with row grouping (e.g. `Year(orderdate)` → `state`) and aggregate columns, plus a Grand Total row and column bound to the same aggregates.
- [ ] Verify the Grand Total row/column now show the correct summed totals instead of 0, matching an equivalent crosstab's totals.
- [ ] Verify existing crosstab and freehand table tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)