### PR TITLE
75657, setWebGrid and isWebGrid can't auto complete

### DIFF
--- a/core/src/main/java/inetsoft/graph/coord/PolarCoord.java
+++ b/core/src/main/java/inetsoft/graph/coord/PolarCoord.java
@@ -1100,10 +1100,12 @@ public class PolarCoord extends Coordinate {
     * When enabled, concentric grid rings and the polar axis boundary are drawn
     * as N-sided polygons where N equals the number of theta-axis categories.
     */
+   @TernMethod
    public void setWebGrid(boolean webGrid) {
       this.webGrid = webGrid;
    }
 
+   @TernMethod
    public boolean isWebGrid() {
       return webGrid;
    }


### PR DESCRIPTION
Root Cause:
Chart-script auto-completion is generated at build time by the TernAnnotationProcessor (build-tools/tern-annotations/), which scans @TernClass-annotated classes and emits only methods marked @TernMethod into the Tern.js completion definitions used by the script editor.

PolarCoord is a @TernClass, and all of its script-exposed accessors (getHoleRatio/setHoleRatio, getPieRatio/setPieRatio, etc.) carry @TernMethod. The webGrid accessors added for feature #74973 (setWebGrid/isWebGrid) were missing the @TernMethod annotation, so the processor never emitted them and they did not appear in auto-completion in the radar chart script dialog.

Fix:
Added the @TernMethod annotation to isWebGrid() and setWebGrid(boolean) in core/src/main/java/inetsoft/graph/coord/PolarCoord.java, matching the sibling pieRatio accessors. This is a build-time-only change with no runtime behavior impact; it simply registers the two methods in the generated script auto-completion definitions.