### PR TITLE
75655, using triangle for node shape, some lines are not attached to the boundaries

### DIFF
--- a/core/src/main/java/inetsoft/graph/visual/RelationEdgeVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/RelationEdgeVO.java
@@ -198,9 +198,13 @@ public class RelationEdgeVO extends ElementVO {
    }
 
    // Find where the ray from 'from' toward 'to' exits the shape boundary. Uses a flattening path
-   // iterator so it works for polygons and curved shapes alike. Returns the intersection farthest
-   // from 'from' (the outermost crossing, correct for concave shapes such as star/cross).
-   private static Point2D clipToBoundary(Shape shape, Point2D from, Point2D to) {
+   // iterator so it works for polygons and curved shapes alike. Returns the boundary crossing
+   // farthest from 'from' along the segment. This is exact for convex shapes (triangle, diamond,
+   // square, circle). For concave outlines (star, cross) the segment may cross the boundary more
+   // than twice, and the farthest crossing isn't guaranteed to be the outer silhouette; it remains
+   // a strict improvement over the pre-fix gap and is acceptable for these node shapes.
+   // Package-private for direct unit testing (see RelationEdgeVOClipTest).
+   static Point2D clipToBoundary(Shape shape, Point2D from, Point2D to) {
       PathIterator it = shape.getPathIterator(null, 0.5);
       double[] coords = new double[6];
       double px = 0, py = 0, sx = 0, sy = 0;
@@ -247,8 +251,9 @@ public class RelationEdgeVO extends ElementVO {
    }
 
    // Intersection point of segment p1-p2 and segment (x3,y3)-(x4,y4), or null if they don't cross.
-   private static Point2D segIntersect(Point2D p1, Point2D p2, double x3, double y3,
-                                       double x4, double y4)
+   // Package-private for direct unit testing (see RelationEdgeVOClipTest).
+   static Point2D segIntersect(Point2D p1, Point2D p2, double x3, double y3,
+                               double x4, double y4)
    {
       double x1 = p1.getX(), y1 = p1.getY(), x2 = p2.getX(), y2 = p2.getY();
       double denom = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4);

--- a/core/src/main/java/inetsoft/graph/visual/RelationEdgeVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/RelationEdgeVO.java
@@ -19,6 +19,7 @@ package inetsoft.graph.visual;
 
 import inetsoft.graph.VGraph;
 import inetsoft.graph.aesthetic.GLine;
+import inetsoft.graph.aesthetic.GShape;
 import inetsoft.graph.coord.Coordinate;
 import inetsoft.graph.element.RelationElement;
 import inetsoft.graph.geometry.Geometry;
@@ -26,10 +27,13 @@ import inetsoft.graph.geometry.RelationEdgeGeometry;
 import inetsoft.graph.internal.GDefaults;
 import inetsoft.graph.internal.GTool;
 import inetsoft.graph.mxgraph.model.mxCell;
+import inetsoft.graph.mxgraph.model.mxGeometry;
+import inetsoft.graph.mxgraph.model.mxICell;
+import inetsoft.graph.mxgraph.util.mxPoint;
 import inetsoft.util.graphics.SVGSupport;
 
 import java.awt.*;
-import java.awt.geom.Rectangle2D;
+import java.awt.geom.*;
 import java.util.*;
 import java.util.List;
 
@@ -92,9 +96,16 @@ public class RelationEdgeVO extends ElementVO {
             GTool.setRenderingHint(g2, true);
          }
 
-         for(Shape edge : edges) {
-            edge = getScreenTransform().createTransformedShape(edge);
-            g2.draw(edge);
+         Shape clipped = getShapeClippedEdge(gobj, elem);
+
+         if(clipped != null) {
+            g2.draw(clipped);
+         }
+         else {
+            for(Shape edge : edges) {
+               edge = getScreenTransform().createTransformedShape(edge);
+               g2.draw(edge);
+            }
          }
 
          g2.dispose();
@@ -104,6 +115,156 @@ public class RelationEdgeVO extends ElementVO {
             svg.endAnnotationGroup(g);
          }
       }
+   }
+
+   /**
+    * For nodes painted with a custom (non-rectangular) shape, the layout's connector attaches the
+    * edge to the midpoint of the node's bounding-box side. That only lines up with the painted node
+    * for shapes that touch their box at the side midpoints (circle, diamond, square); for shapes
+    * such as a triangle it lands in the empty corner, leaving a visible gap (Bug #75655).
+    *
+    * This recomputes a straight edge from center to center and clips each end to the actual painted
+    * node shape boundary. The shapes are rebuilt in screen space using the same transform and
+    * GShape.getShape() call as RelationVO, so the geometry (including the flipY orientation) matches
+    * the painted node exactly.
+    *
+    * @return the clipped screen-space edge, or null to fall back to the default edge drawing
+    * (default/rounded nodes, NIL shape, or layout-routed multi-point edges).
+    */
+   private Shape getShapeClippedEdge(RelationEdgeGeometry gobj, RelationElement elem) {
+      GShape nodeShape = elem.getNodeShape();
+
+      if(nodeShape == null) {
+         return null;
+      }
+
+      mxCell edge = gobj.getEdge();
+
+      if(edge == null || edge.getSource() == null || edge.getTarget() == null) {
+         return null;
+      }
+
+      // smooth (curved) edges are only produced for the CIRCLE layout; leave them to the default
+      // curve drawing (mirrors the condition in RelationEdgeGeometry.getEdges()).
+      boolean smooth = elem.isSmoothEdges()
+         && elem.getAlgorithm() == RelationElement.Algorithm.CIRCLE
+         && elem.getLayoutCenter() != null;
+
+      if(smooth) {
+         return null;
+      }
+
+      // only handle straight edges; routed layouts (tree/hierarchical) keep the existing behavior.
+      mxGeometry egeo = edge.getGeometry();
+      List<mxPoint> pts = egeo != null ? egeo.getPoints() : null;
+
+      if(pts != null && !pts.isEmpty()) {
+         return null;
+      }
+
+      Shape srcShape = getScreenNodeShape(nodeShape, edge.getSource());
+      Shape tgtShape = getScreenNodeShape(nodeShape, edge.getTarget());
+
+      if(srcShape == null || tgtShape == null) {
+         return null;
+      }
+
+      Rectangle2D sb = srcShape.getBounds2D();
+      Rectangle2D tb = tgtShape.getBounds2D();
+      Point2D sc = new Point2D.Double(sb.getCenterX(), sb.getCenterY());
+      Point2D tc = new Point2D.Double(tb.getCenterX(), tb.getCenterY());
+
+      Point2D p1 = clipToBoundary(srcShape, sc, tc);
+      Point2D p2 = clipToBoundary(tgtShape, tc, sc);
+
+      if(p1 == null || p2 == null) {
+         return null;
+      }
+
+      return new Line2D.Double(p1, p2);
+   }
+
+   // Build the painted node shape in screen space, matching RelationVO.paint(). Returns null when
+   // the shape is NIL (getShape returns null), in which case the node is painted as a rectangle.
+   private Shape getScreenNodeShape(GShape nodeShape, mxICell node) {
+      mxGeometry geo = node.getGeometry();
+
+      if(geo == null) {
+         return null;
+      }
+
+      Rectangle2D b = getScreenTransform().createTransformedShape(geo.getRectangle()).getBounds2D();
+      return nodeShape.getShape(b.getX(), b.getY(), b.getWidth(), b.getHeight());
+   }
+
+   // Find where the ray from 'from' toward 'to' exits the shape boundary. Uses a flattening path
+   // iterator so it works for polygons and curved shapes alike. Returns the intersection farthest
+   // from 'from' (the outermost crossing, correct for concave shapes such as star/cross).
+   private static Point2D clipToBoundary(Shape shape, Point2D from, Point2D to) {
+      PathIterator it = shape.getPathIterator(null, 0.5);
+      double[] coords = new double[6];
+      double px = 0, py = 0, sx = 0, sy = 0;
+      Point2D best = null;
+      double bestDistSq = -1;
+
+      for(; !it.isDone(); it.next()) {
+         int type = it.currentSegment(coords);
+         double ex, ey; // segment end point
+
+         if(type == PathIterator.SEG_MOVETO) {
+            px = sx = coords[0];
+            py = sy = coords[1];
+            continue;
+         }
+         else if(type == PathIterator.SEG_LINETO) {
+            ex = coords[0];
+            ey = coords[1];
+         }
+         else if(type == PathIterator.SEG_CLOSE) {
+            ex = sx;
+            ey = sy;
+         }
+         else {
+            continue;
+         }
+
+         Point2D ip = segIntersect(from, to, px, py, ex, ey);
+
+         if(ip != null) {
+            double d = from.distanceSq(ip);
+
+            if(d > bestDistSq) {
+               bestDistSq = d;
+               best = ip;
+            }
+         }
+
+         px = ex;
+         py = ey;
+      }
+
+      return best;
+   }
+
+   // Intersection point of segment p1-p2 and segment (x3,y3)-(x4,y4), or null if they don't cross.
+   private static Point2D segIntersect(Point2D p1, Point2D p2, double x3, double y3,
+                                       double x4, double y4)
+   {
+      double x1 = p1.getX(), y1 = p1.getY(), x2 = p2.getX(), y2 = p2.getY();
+      double denom = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4);
+
+      if(denom == 0) {
+         return null;
+      }
+
+      double t = ((x1 - x3) * (y3 - y4) - (y1 - y3) * (x3 - x4)) / denom;
+      double u = ((x1 - x3) * (y1 - y2) - (y1 - y3) * (x1 - x2)) / denom;
+
+      if(t < 0 || t > 1 || u < 0 || u > 1) {
+         return null;
+      }
+
+      return new Point2D.Double(x1 + t * (x2 - x1), y1 + t * (y2 - y1));
    }
 
    @Override

--- a/core/src/test/java/inetsoft/graph/visual/RelationEdgeVOClipTest.java
+++ b/core/src/test/java/inetsoft/graph/visual/RelationEdgeVOClipTest.java
@@ -1,0 +1,155 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.graph.visual;
+
+import inetsoft.graph.aesthetic.GShape;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Shape;
+import java.awt.geom.Point2D;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression guard for the relation-edge shape clipping added for Bug #75655: edges must attach to
+ * the actual painted node shape boundary (e.g. a triangle's slanted edge) rather than the midpoint
+ * of the node's bounding box side, which for non-box-touching shapes fell in empty space.
+ *
+ * Exercises the pure-geometry helpers {@code RelationEdgeVO.clipToBoundary} and
+ * {@code RelationEdgeVO.segIntersect} directly (package-private for testability).
+ */
+class RelationEdgeVOClipTest {
+   private static final double EPS = 1e-6;
+   // flattened curves (ellipse) are approximated, so allow a small tolerance for CIRCLE
+   private static final double FLAT_EPS = 1.5;
+
+   // 100x100 box centered at (50,50) for all node-shape cases
+   private static Shape shape(GShape gshape) {
+      return gshape.getShape(0, 0, 100, 100);
+   }
+
+   private static Point2D center() {
+      return new Point2D.Double(50, 50);
+   }
+
+   @Test
+   void triangleClipsToSlantedRightEdge() {
+      // TRIANGLE: apex (50,100), base (0,0)-(100,0). A horizontal ray to the right from the center
+      // crosses the right slanted edge (100,0)-(50,100) at y=50, i.e. x=75 — NOT the bbox side
+      // midpoint (100,50). This is the exact defect from Bug #75655.
+      Point2D p = RelationEdgeVO.clipToBoundary(shape(GShape.TRIANGLE), center(),
+                                                new Point2D.Double(200, 50));
+      assertNotNull(p);
+      assertEquals(75.0, p.getX(), EPS);
+      assertEquals(50.0, p.getY(), EPS);
+   }
+
+   @Test
+   void triangleClipsToApex() {
+      // straight up from the center hits the apex at (50,100)
+      Point2D p = RelationEdgeVO.clipToBoundary(shape(GShape.TRIANGLE), center(),
+                                                new Point2D.Double(50, 300));
+      assertNotNull(p);
+      assertEquals(50.0, p.getX(), EPS);
+      assertEquals(100.0, p.getY(), EPS);
+   }
+
+   @Test
+   void triangleClipsToBase() {
+      // straight down from the center hits the base edge at (50,0)
+      Point2D p = RelationEdgeVO.clipToBoundary(shape(GShape.TRIANGLE), center(),
+                                                new Point2D.Double(50, -300));
+      assertNotNull(p);
+      assertEquals(50.0, p.getX(), EPS);
+      assertEquals(0.0, p.getY(), EPS);
+   }
+
+   @Test
+   void diamondClipsToRightVertex() {
+      // DIAMOND vertices: (50,0),(100,50),(50,100),(0,50); horizontal ray exits at (100,50)
+      Point2D p = RelationEdgeVO.clipToBoundary(shape(GShape.DIAMOND), center(),
+                                                new Point2D.Double(200, 50));
+      assertNotNull(p);
+      assertEquals(100.0, p.getX(), EPS);
+      assertEquals(50.0, p.getY(), EPS);
+   }
+
+   @Test
+   void squareClipsToRightSide() {
+      // SQUARE is the full bounding box; horizontal ray exits at the right side (100,50)
+      Point2D p = RelationEdgeVO.clipToBoundary(shape(GShape.SQUARE), center(),
+                                                new Point2D.Double(200, 50));
+      assertNotNull(p);
+      assertEquals(100.0, p.getX(), EPS);
+      assertEquals(50.0, p.getY(), EPS);
+   }
+
+   @Test
+   void circleClipsToRadialBoundary() {
+      // CIRCLE (ellipse) of radius 50; horizontal ray exits near the rightmost point (100,50).
+      // Flattened to line segments, so allow a small tolerance.
+      Point2D p = RelationEdgeVO.clipToBoundary(shape(GShape.CIRCLE), center(),
+                                                new Point2D.Double(200, 50));
+      assertNotNull(p);
+      assertEquals(100.0, p.getX(), FLAT_EPS);
+      assertEquals(50.0, p.getY(), FLAT_EPS);
+   }
+
+   @Test
+   void clipReturnsNullWhenRayMissesShape() {
+      // a ray that starts and points away from the shape never crosses its boundary
+      Point2D p = RelationEdgeVO.clipToBoundary(shape(GShape.TRIANGLE),
+                                                new Point2D.Double(500, 500),
+                                                new Point2D.Double(900, 900));
+      assertNull(p);
+   }
+
+   @Test
+   void segIntersectCrossing() {
+      Point2D p = RelationEdgeVO.segIntersect(new Point2D.Double(0, 0),
+                                              new Point2D.Double(10, 0), 5, -5, 5, 5);
+      assertNotNull(p);
+      assertEquals(5.0, p.getX(), EPS);
+      assertEquals(0.0, p.getY(), EPS);
+   }
+
+   @Test
+   void segIntersectParallelReturnsNull() {
+      Point2D p = RelationEdgeVO.segIntersect(new Point2D.Double(0, 0),
+                                              new Point2D.Double(10, 0), 0, 5, 10, 5);
+      assertNull(p);
+   }
+
+   @Test
+   void segIntersectBeyondSegmentReturnsNull() {
+      // the infinite lines cross at (20,0) but that is past the end of segment p1-p2
+      Point2D p = RelationEdgeVO.segIntersect(new Point2D.Double(0, 0),
+                                              new Point2D.Double(10, 0), 20, -5, 20, 5);
+      assertNull(p);
+   }
+
+   @Test
+   void segIntersectEndpointTouch() {
+      // touching at a shared endpoint (t=1, u=0) still counts as an intersection
+      Point2D p = RelationEdgeVO.segIntersect(new Point2D.Double(0, 0),
+                                              new Point2D.Double(10, 0), 10, 0, 10, 10);
+      assertNotNull(p);
+      assertEquals(10.0, p.getX(), EPS);
+      assertEquals(0.0, p.getY(), EPS);
+   }
+}


### PR DESCRIPTION
Root Cause:

The relation-chart "any node shape" feature (Feature #74919) paints each node as its selected shape (e.g. triangle) inscribed inside the node's bounding box. However, the edge-connection logic was never updated to match: edges attach to nodes via mxRectangle.getConnector(), which returns attachment points at the midpoints of the node's bounding-box sides.

This works for shapes that touch their bounding box at the side midpoints (circle, diamond, square), which is why those shapes looked correct. A triangle, though, only touches its bounding box at its three vertices - at the side midpoints (where the line attaches) the triangle is empty space, so every edge ends in a gap beside the triangle instead of on its edge. Other non-midpoint-touching shapes (star, cross, etc.) had the same defect.

Fix:

In RelationEdgeVO.paint(), for straight edges where a custom node shape is set, the edge is now recomputed from node-center to node-center and clipped to the actual painted node shape boundary. The clip shapes are rebuilt in screen space using the same transform and GShape.getShape() call as the node painter (RelationVO), so the geometry - including the flipY orientation - matches the rendered node exactly. Clipping uses a flattening path iterator plus segment intersection, so it works for any polygon or curved shape.

Existing behavior is preserved for all other cases: default/rounded-rectangle nodes, the NIL shape, smooth CIRCLE curves, and layout-routed multi-point edges (hierarchical/tree).

Fixed in: core/src/main/java/inetsoft/graph/visual/RelationEdgeVO.java