### PR TITLE
Bug #75663, return flat column values for by-name worksheet table script references

### DIFF
--- a/core/src/main/java/inetsoft/report/script/TableArray.java
+++ b/core/src/main/java/inetsoft/report/script/TableArray.java
@@ -168,6 +168,7 @@ public class TableArray implements ArrayObject, ScriptArrayScope {
          CellRange range = CellRange.parse(id);
          id = Tool.replaceAll(id, "^_^", ":");
          range.setProcessCalc(calcArray);
+         range.setBaseTableReference(isBaseTableReference());
          boolean subtable = id.startsWith("*");
          Collection cells = range.getCells(getTable(), subtable);
 
@@ -211,7 +212,15 @@ public class TableArray implements ArrayObject, ScriptArrayScope {
                }
             };
 
-            return new TableArray(sub);
+            // Propagate the base-table-reference flag so a chained column access
+            // on the returned subtable (e.g. table['*']['col']) keeps reading flat
+            // rather than re-routing through crosstab/grouped summary cells. (#75663)
+            return new TableArray(sub) {
+               @Override
+               protected boolean isBaseTableReference() {
+                  return TableArray.this.isBaseTableReference();
+               }
+            };
          }
          else {
             return range.getCollectionValue(cells, calcArray);
@@ -346,6 +355,17 @@ public class TableArray implements ArrayObject, ScriptArrayScope {
       result[length + 1] = "size";
 
       return result;
+   }
+
+   /**
+    * Check whether this array is a worksheet table referenced by name from a
+    * script (e.g. {@code table['col']}). Subclasses that represent a by-name
+    * worksheet table override this so a bare column reference reads the table's
+    * column values as a flat table instead of grouped/crosstab summary cells.
+    * (#75663)
+    */
+   protected boolean isBaseTableReference() {
+      return false;
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/script/formula/CellRange.java
+++ b/core/src/main/java/inetsoft/report/script/formula/CellRange.java
@@ -113,6 +113,24 @@ public abstract class CellRange implements Serializable, Cloneable {
       this.processCalc = calc;
    }
 
+   /**
+    * Set whether this range is resolved against a worksheet table referenced by
+    * name from a script (e.g. {@code table['col']} via TableAssemblyScriptable).
+    * When true, a bare column reference reads the table's column values as a flat
+    * table rather than being routed to grouped/crosstab summary cells. (#75663)
+    */
+   public void setBaseTableReference(boolean baseTableRef) {
+      this.baseTableRef = baseTableRef;
+   }
+
+   /**
+    * Check if this range is a by-name worksheet table reference. (#75663)
+    */
+   public boolean isBaseTableReference() {
+      return baseTableRef;
+   }
+
    protected boolean processCalc = false;
+   protected boolean baseTableRef = false;
    private static final Logger LOG = LoggerFactory.getLogger(CellRange.class);
 }

--- a/core/src/main/java/inetsoft/report/script/formula/CubeTableAssemblyScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/formula/CubeTableAssemblyScriptable.java
@@ -37,6 +37,17 @@ public class CubeTableAssemblyScriptable extends TableAssemblyScriptable {
       this.lens = lens;
    }
 
+   /**
+    * A cube/OLAP table is genuinely pivot-shaped (tuple/dimension addressed), so
+    * a by-name reference must retain the grouped/crosstab summary-cell routing.
+    * Unlike a plain worksheet table, its crosstab descriptor is not spurious, so
+    * this overrides the base-table (flat-read) behavior back to false. (#75663)
+    */
+   @Override
+   protected boolean isBaseTableReference() {
+      return false;
+   }
+
    @Override
    public XTable getTable() {
       // don't cache table data to keep in sync with AssetQuerySandbox.

--- a/core/src/main/java/inetsoft/report/script/formula/NamedCellRange.java
+++ b/core/src/main/java/inetsoft/report/script/formula/NamedCellRange.java
@@ -175,8 +175,15 @@ public class NamedCellRange extends CellRange {
    public Collection getCells(XTable table, boolean position) {
       TableDataDescriptor desc = (table instanceof TableLens) ? table.getDescriptor() : null;
 
+      // A worksheet table referenced by name from a script (e.g. table['col'])
+      // should return the column's values as a flat table. Skip the grouped/
+      // crosstab summary routing for such references: a shared source table may
+      // carry a runtime crosstab/aggregate structure (e.g. pushed down by a
+      // crosstab-optimized freehand table) that would otherwise collapse the
+      // reference to summary cells instead of the underlying column values.
+      // (#75663)
       if(summary ||
-         desc != null && !processCalc &&
+         desc != null && !processCalc && !baseTableRef &&
          (desc.getType() == TableDataDescriptor.GROUPED_TABLE ||
           desc.getType() == TableDataDescriptor.CROSSTAB_TABLE))
       {

--- a/core/src/main/java/inetsoft/report/script/formula/NamedCellRange.java
+++ b/core/src/main/java/inetsoft/report/script/formula/NamedCellRange.java
@@ -181,7 +181,12 @@ public class NamedCellRange extends CellRange {
       // carry a runtime crosstab/aggregate structure (e.g. pushed down by a
       // crosstab-optimized freehand table) that would otherwise collapse the
       // reference to summary cells instead of the underlying column values.
-      // (#75663)
+      // Note baseTableRef only suppresses the findSummaryTable walk below; the
+      // instanceof dispatch that follows is unchanged, so a top-level grouped or
+      // crosstab lens (a genuinely aggregated worksheet table) is still routed to
+      // the summary path. Only a lens that merely *reports* a grouped/crosstab
+      // descriptor while nesting the grouped/crosstab table under a non-summary
+      // filter -- the pushdown-pollution case -- is affected. (#75663)
       if(summary ||
          desc != null && !processCalc && !baseTableRef &&
          (desc.getType() == TableDataDescriptor.GROUPED_TABLE ||

--- a/core/src/main/java/inetsoft/report/script/formula/TableAssemblyScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/formula/TableAssemblyScriptable.java
@@ -113,6 +113,17 @@ public class TableAssemblyScriptable extends TableArray {
       }
    }
 
+   /**
+    * A worksheet table referenced by name from a script represents the table's
+    * own data, so a bare column reference should return that column's values as
+    * a flat table rather than being routed to grouped/crosstab summary cells.
+    * (#75663)
+    */
+   @Override
+   protected boolean isBaseTableReference() {
+      return true;
+   }
+
    @Override
    public XTable getElementTable() {
       // @by billh, fix customer bug bug1300398961679

--- a/core/src/test/java/inetsoft/report/script/TableArrayTest.java
+++ b/core/src/test/java/inetsoft/report/script/TableArrayTest.java
@@ -83,6 +83,14 @@ class TableArrayTest {
    }
 
    @Test
+   void isBaseTableReferenceDefaultsFalse() {
+      // #75663: a plain TableArray (e.g. a calc-table's own `data`, or a chart/
+      // table-bound array) is NOT a by-name worksheet-table reference, so it must
+      // retain the grouped/crosstab summary-cell routing in NamedCellRange.
+      assertFalse(new TableArray(table()).isBaseTableReference());
+   }
+
+   @Test
    void unwrapReturnsUnderlyingXTable() {
       // #75576: ScriptUtil.unwrap must unwrap a TableArray to its XTable so host
       // code (toList/mapList/etc.) can process a data['*@...'] subtable reference

--- a/core/src/test/java/inetsoft/report/script/formula/NamedCellRangeTest.java
+++ b/core/src/test/java/inetsoft/report/script/formula/NamedCellRangeTest.java
@@ -65,6 +65,19 @@ public class NamedCellRangeTest {
    }
 
    /**
+    * #75663: the base-table-reference flag defaults off and is settable, and drives
+    * whether a by-name worksheet-table column read bypasses grouped/crosstab
+    * summary routing in getCells.
+    */
+   @Test
+   void testBaseTableReferenceFlag() throws Exception {
+      NamedCellRange range = new NamedCellRange("col");
+      assertFalse(range.isBaseTableReference());
+      range.setBaseTableReference(true);
+      assertTrue(range.isBaseTableReference());
+   }
+
+   /**
     * test when summary is true will  throw exception
     */
    @Test

--- a/core/src/test/java/inetsoft/report/script/formula/NamedCellRangeTest.java
+++ b/core/src/test/java/inetsoft/report/script/formula/NamedCellRangeTest.java
@@ -18,6 +18,10 @@
 
 package inetsoft.report.script.formula;
 
+import inetsoft.report.TableDataDescriptor;
+import inetsoft.report.TableLens;
+import inetsoft.report.filter.*;
+import inetsoft.report.lens.DefaultTableLens;
 import inetsoft.test.*;
 import inetsoft.uql.XTable;
 import org.junit.jupiter.api.Test;
@@ -28,6 +32,8 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -89,5 +95,70 @@ public class NamedCellRangeTest {
       });
 
       assertTrue(exception.getMessage().contains("Summary reference is not supported in"));
+   }
+
+   /**
+    * #75663: getCells must bypass the grouped/crosstab summary routing when the
+    * range is a by-name worksheet-table reference (baseTableRef=true). This
+    * reproduces the reported pollution structure: a top lens that still exposes
+    * the table's flat detail columns but reports a CROSSTAB_TABLE descriptor and
+    * nests a CrossTabFilter -- as when a crosstab-optimized freehand table pushes
+    * aggregate info down into a shared base table. With the flag off, getCells
+    * walks down to the nested crosstab and returns summary cells; with it on, it
+    * reads the column's flat detail values instead.
+    */
+   @Test
+   void testGetCellsBypassesNestedCrosstabForBaseTableReference() throws Exception {
+      Object[][] data = {
+         { "col1", "col2", "col3" },
+         { "a", 1, 5.0 },
+         { "a", 1, 5.0 }, // duplicate group (a,1) so the crosstab sum (10.0) differs from detail
+         { "b", 3, 10.0 }
+      };
+
+      CrossTabFilter crosstab = new CrossTabFilter(
+         new DefaultTableLens(data), new int[]{ 0 }, new int[]{ 1 }, new int[]{ 2 },
+         new Formula[]{ new SumFormula() });
+      // the crosstab genuinely reports a CROSSTAB_TABLE descriptor
+      assertEquals(TableDataDescriptor.CROSSTAB_TABLE, crosstab.getDescriptor().getType());
+
+      TableLens polluted = new PollutedCrosstabLens(new DefaultTableLens(data), crosstab);
+
+      NamedCellRange range = new NamedCellRange("col3");
+
+      // flag off (default): routed down to the nested crosstab -> summary cells
+      Collection<?> summaryCells = range.getCells(polluted, false);
+
+      // flag on: reads the flat detail column values, skipping the crosstab routing
+      range.setBaseTableReference(true);
+      Collection<?> flatCells = range.getCells(polluted, false);
+
+      assertEquals(Arrays.asList(5.0, 5.0, 10.0), new ArrayList<>(flatCells));
+      assertNotEquals(new ArrayList<>(flatCells), new ArrayList<>(summaryCells));
+   }
+
+   /**
+    * Test double for the crosstab-pollution structure: its own cell data is the
+    * flat detail table (inherited from DefaultTableFilter), but it reports the
+    * nested crosstab's descriptor and returns the crosstab from getTable() so
+    * NamedCellRange.findSummaryTable can reach it.
+    */
+   private static final class PollutedCrosstabLens extends DefaultTableFilter {
+      private final CrossTabFilter crosstab;
+
+      PollutedCrosstabLens(TableLens detail, CrossTabFilter crosstab) {
+         super(detail);
+         this.crosstab = crosstab;
+      }
+
+      @Override
+      public TableDataDescriptor getDescriptor() {
+         return crosstab.getDescriptor();
+      }
+
+      @Override
+      public TableLens getTable() {
+         return crosstab;
+      }
    }
 }

--- a/core/src/test/java/inetsoft/report/script/formula/TableAssemblyScriptableTest.java
+++ b/core/src/test/java/inetsoft/report/script/formula/TableAssemblyScriptableTest.java
@@ -20,6 +20,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.*;
 
+import inetsoft.report.TableLens;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -115,6 +118,28 @@ class TableAssemblyScriptableTest {
       //test put object
       tableAssemblyScriptable.putMember("table", objData);
       assertNull(tableAssemblyScriptable.getElementTable());
+   }
+
+   /**
+    * #75663: a worksheet table referenced by name from a script reads its column
+    * values as a flat table, so its bare-column access must bypass the grouped/
+    * crosstab summary-cell routing (a shared source table can carry a spurious
+    * runtime crosstab descriptor pushed down by a crosstab-optimized freehand).
+    */
+   @Test
+   void isBaseTableReferenceTrueForWorksheetTable() {
+      assertTrue(tableAssemblyScriptable.isBaseTableReference());
+   }
+
+   /**
+    * #75663: a cube/OLAP table is genuinely pivot-shaped, so its by-name reference
+    * must retain the crosstab summary-cell routing (must NOT read flat).
+    */
+   @Test
+   void isBaseTableReferenceFalseForCubeTable() {
+      CubeTableAssemblyScriptable cube = new CubeTableAssemblyScriptable(
+         "testTable", mockSandbox, AssetQuerySandbox.LIVE_MODE, mock(TableLens.class));
+      assertFalse(cube.isBaseTableReference());
    }
 
    // Custom log appender for testing


### PR DESCRIPTION
## Summary

A calc-table (freehand) cell formula such as `sum(datiQuery['subentry'])` returned wrong values (e.g. `88` / count `1` instead of `5062` / `212`) when the referenced worksheet table (`datiQuery`) was also the source of a crosstab-optimized freehand table. An independent embedded copy of the same data (`datiQueryEmbed`) returned correct values.

## Root Cause

The freehand tables source `datiQuery` and qualify for the 2014-era crosstab optimization (`CalcTableVSAQuery` → `AbstractCrosstabVSAQuery.pushDownAggregate`). That optimization pushes the crosstab's group-by/aggregate **down into the shared underlying base table** (`datiQuery_O`, a snapshot embedded table) and does not restore it. As a result, every later plain execution of `datiQuery` (and `datiQueryMirror`, which chains through it) yields a lens whose descriptor is `CROSSTAB_TABLE`.

When the cell script reads `datiQuery['subentry']` (via `TableAssemblyScriptable` → `TableArray.getMember` → `NamedCellRange.getCells`), the crosstab descriptor combined with `processCalc=false` routed the reference through `findSummaryTable()` → `getCrosstabCells()`, returning a few summary cells instead of the 212 detail column values. `getCollectionValue` then collapsed the single-element result to a scalar.

The latent pollution only became visible now because the by-name worksheet-table script reference was restored under GraalJS (Bug #75526) and is the first consumer to re-execute the shared table after the pushdown.

## Fix

Scoped narrowly to the by-name worksheet-table script-reference path — the 2014 crosstab optimization is left untouched:

- `CellRange` gains a `baseTableReference` flag (default off).
- `TableArray.getMember` sets it from a new overridable `isBaseTableReference()` (false by default); the `*` subtable propagates it.
- `TableAssemblyScriptable` overrides it to `true` — a by-name worksheet table reference reads its column values as a flat table.
- `CubeTableAssemblyScriptable` overrides it to `false` — cube/OLAP tables are genuinely pivot-shaped and retain the summary-cell routing (no regression).
- `NamedCellRange.getCells` skips the grouped/crosstab summary routing when `baseTableReference` is set.

For the common case (a plain NORMAL-descriptor worksheet table) behavior is unchanged, since the summary routing only ran for GROUPED/CROSSTAB descriptors.

## Test Plan

- Added regression tests locking the per-class `isBaseTableReference()` contract (`TableArrayTest`, `TableAssemblyScriptableTest` incl. cube) and the `CellRange` flag (`NamedCellRangeTest`) — 19 tests pass in the three affected classes.
- Verified in the `CellDatablockTest` viewsheet (attached to the issue): the "VSO" (`datiQuery`) and "Mirrored" (`datiQueryMirror`) freehand script rows now show `sum=5062` / `count=212`, matching the "Embedded" and bound rows.

Fixes Redmine #75663.

🤖 Generated with [Claude Code](https://claude.com/claude-code)