### PR TITLE
fixed Bug 75658, Open redirect on /logout / /sessionexpired via fromEm+redirectUri, compoundable with method-agnostic logout CSRF

### DIFF
--- a/core/src/main/java/inetsoft/web/security/AbstractLogoutFilter.java
+++ b/core/src/main/java/inetsoft/web/security/AbstractLogoutFilter.java
@@ -65,8 +65,11 @@ public abstract class AbstractLogoutFilter extends AbstractSecurityFilter {
 
       // for SSO only redirect to EM when portal.logout.url is not set
       if(fromEm && (!isSSO() || redirectUri.equals(defRedirectUri))) {
-         if("GET".equals(request.getMethod()) && request.getParameter("redirectUri") != null) {
-            redirectUri = request.getParameter("redirectUri");
+         String requestedRedirectUri = "GET".equals(request.getMethod()) ?
+            request.getParameter("redirectUri") : null;
+
+         if(requestedRedirectUri != null && isSameOriginRedirectUri(request, requestedRedirectUri)) {
+            redirectUri = requestedRedirectUri;
          }
          else {
             redirectUri = request.getContextPath() + "/em";
@@ -85,6 +88,27 @@ public abstract class AbstractLogoutFilter extends AbstractSecurityFilter {
       }
 
       return redirectUri;
+   }
+
+   /**
+    * Determines whether a client-supplied redirect target is safe to honor: either an
+    * app-relative path or an absolute URL within this application's own origin. Rejects
+    * protocol-relative ("//host/...") targets and backslash variants that browsers normalize to
+    * protocol-relative, since both resolve to an external host despite lacking a scheme.
+    */
+   private boolean isSameOriginRedirectUri(HttpServletRequest request, String redirectUri) {
+      if(redirectUri.isEmpty()) {
+         return false;
+      }
+
+      char first = redirectUri.charAt(0);
+
+      if(first == '/' || first == '\\') {
+         return redirectUri.length() < 2 ||
+            (redirectUri.charAt(1) != '/' && redirectUri.charAt(1) != '\\');
+      }
+
+      return redirectUri.startsWith(LinkUriArgumentResolver.getLinkUri(request));
    }
 
    private boolean isFromEm(Map<String, String[]> queryParameters) {

--- a/core/src/main/java/inetsoft/web/security/AbstractLogoutFilter.java
+++ b/core/src/main/java/inetsoft/web/security/AbstractLogoutFilter.java
@@ -94,10 +94,14 @@ public abstract class AbstractLogoutFilter extends AbstractSecurityFilter {
     * Determines whether a client-supplied redirect target is safe to honor: either an
     * app-relative path or an absolute URL within this application's own origin. Rejects
     * protocol-relative ("//host/...") targets and backslash variants that browsers normalize to
-    * protocol-relative, since both resolve to an external host despite lacking a scheme.
+    * protocol-relative, since both resolve to an external host despite lacking a scheme. Also
+    * rejects any embedded ASCII tab/CR/LF: per the WHATWG URL Standard, a browser strips those
+    * characters from the entire URL string as its first normalization step (before
+    * scheme/authority parsing), so e.g. "/\t/attacker.example" would otherwise look app-relative
+    * here while resolving to the protocol-relative "//attacker.example" in the browser.
     */
    private boolean isSameOriginRedirectUri(HttpServletRequest request, String redirectUri) {
-      if(redirectUri.isEmpty()) {
+      if(redirectUri.isEmpty() || containsUrlWhitespace(redirectUri)) {
          return false;
       }
 
@@ -109,6 +113,18 @@ public abstract class AbstractLogoutFilter extends AbstractSecurityFilter {
       }
 
       return redirectUri.startsWith(LinkUriArgumentResolver.getLinkUri(request));
+   }
+
+   private boolean containsUrlWhitespace(String value) {
+      for(int i = 0; i < value.length(); i++) {
+         char c = value.charAt(i);
+
+         if(c == '\t' || c == '\n' || c == '\r') {
+            return true;
+         }
+      }
+
+      return false;
    }
 
    private boolean isFromEm(Map<String, String[]> queryParameters) {

--- a/core/src/test/java/inetsoft/web/security/LogoutFilterTest.java
+++ b/core/src/test/java/inetsoft/web/security/LogoutFilterTest.java
@@ -18,34 +18,32 @@
 package inetsoft.web.security;
 
 /*
- * Intent vs implementation suspects
+ * Redmine #75658 -- open redirect + logout CSRF (FIXED)
  *
- * [Suspect 1] (#75658) AbstractLogoutFilter.getLogoutRedirectUri() (reached via
- *             LogoutFilter.logout()/handleSessionExpired()) -> intent: compute a safe post-logout
- *             redirect target (the default portal/EM page, or the configured
- *             "portal.logout.url").
- *             FIXED: when the query string carries fromEm=true and the request is a plain GET
- *             with a "redirectUri" parameter, that parameter is now only honored if it targets
- *             this application's own origin (an app-relative path, or an absolute URL that starts
- *             with LinkUriArgumentResolver.getLinkUri(request)); anything else -- an external
- *             absolute URL, a protocol-relative "//host/..." URL, or a backslash-obfuscated
- *             variant browsers normalize to protocol-relative -- falls back to the same
- *             "<contextPath>/em" target already used for non-GET requests. See the
- *             "redirectUri same-origin validation" tests below.
+ * AbstractLogoutFilter.getLogoutRedirectUri() computed the post-logout redirect target from a
+ * client-supplied "redirectUri" GET parameter (when fromEm=true) with no validation at all,
+ * letting a plain GET redirect to an arbitrary external URL. Combined with LogoutFilter accepting
+ * any HTTP method and running ahead of CSRFFilter in the chain, a third-party page could force a
+ * visitor's logout and redirect them via a bare `<img>` tag, with zero script and zero user
+ * interaction beyond viewing the page.
  *
- * [Suspect 2] (#75658) LogoutFilter.doFilter() -> intent: unclear from the code itself, but
- *             "/logout" is filter #1 inside StandardFilterChain, which is nested inside
- *             AuthenticationFilterChain (#6 in the outer SecurityFilterChain); CSRFFilter is #7,
- *             strictly after. doFilter() also never inspects the HTTP method.
- *             actual: any request method to "/logout" (GET included) executes a full logout with
- *             no CSRF token required at all. NOT YET FIXED here: CSRFFilter's own SAFE_METHODS
- *             exemption (GET/HEAD/OPTIONS/TRACE) and its isApi()-scoped enforcement mean simply
- *             reordering the chain would not add protection either -- closing this gap needs an
- *             explicit product decision (e.g. POST-only logout with a frontend change, or
- *             extending CSRFFilter's scope to cover "/logout"). Left as a pinned characterization
- *             test -- see doFilter_logout_anyHttpMethod_triggersLogoutWithNoMethodOrTokenCheck --
- *             pending that decision. With Suspect 1 fixed, this alone is logout CSRF only (forces
- *             a re-login), not the zero-click external-redirect chain described in #75658.
+ * Fix: getLogoutRedirectUri() now runs the requested redirectUri through
+ * isSameOriginRedirectUri() before honoring it -- only an app-relative path or an absolute URL
+ * within this application's own origin (LinkUriArgumentResolver.getLinkUri(request)) is accepted.
+ * Protocol-relative ("//host/...") targets and backslash-obfuscated equivalents that browsers
+ * normalize to protocol-relative are rejected. Anything rejected falls back to
+ * "<contextPath>/em", the same fallback already used for non-GET requests. Both "/logout" and
+ * "/sessionexpired" share this fix. See the "redirectUri same-origin validation" tests below.
+ *
+ * Residual, lower-severity item (tracked separately, not fixed here): LogoutFilter.doFilter()
+ * still accepts any HTTP method and short-circuits the chain ahead of CSRFFilter (see
+ * SecurityFilterChainOrderingTest.logoutFilter_shortCircuitsChain_realCsrfFilterNeverInvokedAtAll).
+ * CSRFFilter itself exempts GET/HEAD/OPTIONS/TRACE and only enforces on "/api/**" paths, so
+ * reordering the chain alone would not close this -- it needs a product decision (e.g. POST-only
+ * logout with a frontend change, or extending CSRFFilter's scope to cover "/logout"). With the
+ * redirect fixed above, this alone is logout CSRF only (forces a re-login), not the zero-click
+ * external-redirect chain #75658 originally described. Left as a pinned characterization test --
+ * see doFilter_logout_anyHttpMethod_triggersLogoutWithNoMethodOrTokenCheck.
  */
 
 import inetsoft.sree.RepletRepository;

--- a/core/src/test/java/inetsoft/web/security/LogoutFilterTest.java
+++ b/core/src/test/java/inetsoft/web/security/LogoutFilterTest.java
@@ -20,45 +20,32 @@ package inetsoft.web.security;
 /*
  * Intent vs implementation suspects
  *
- * [Suspect 1] (#75658) AbstractLogoutFilter.getLogoutRedirectUri() line 66-74 (reached via
+ * [Suspect 1] (#75658) AbstractLogoutFilter.getLogoutRedirectUri() (reached via
  *             LogoutFilter.logout()/handleSessionExpired()) -> intent: compute a safe post-logout
  *             redirect target (the default portal/EM page, or the configured
- *             "portal.logout.url")
- *             actual: when the query string carries fromEm=true and the request is a plain GET
- *             with a "redirectUri" parameter, that parameter is used AS THE REDIRECT TARGET with
- *             no validation whatsoever (no same-origin check, no allow-list). If
- *             SecurityEngine.isSecurityEnabled()==false (or showLogin/guestLogin conditions are
- *             not met), that attacker-controlled value flows straight into
- *             response.sendRedirect(...) in AbstractLogoutFilter.logout() -- a classic open
- *             redirect. When the later "wrap into login.html?requestedUrl=..." branch fires
- *             instead (line 81-85), the attacker-controlled value is merely relocated into the
- *             requestedUrl parameter, not removed; whether that is ultimately exploitable depends
- *             on the login page's client-side handling of requestedUrl (out of scope for this
- *             filter test, but worth checking separately). See
- *             doFilter_logout_fromEmGetWithRedirectUriParam_securityDisabled_openRedirectsToAttackerUrl
- *             and doFilter_logout_fromEmGetWithRedirectUriParam_securityEnabled_attackerUrlPreservedInRequestedUrl
- *             below.
+ *             "portal.logout.url").
+ *             FIXED: when the query string carries fromEm=true and the request is a plain GET
+ *             with a "redirectUri" parameter, that parameter is now only honored if it targets
+ *             this application's own origin (an app-relative path, or an absolute URL that starts
+ *             with LinkUriArgumentResolver.getLinkUri(request)); anything else -- an external
+ *             absolute URL, a protocol-relative "//host/..." URL, or a backslash-obfuscated
+ *             variant browsers normalize to protocol-relative -- falls back to the same
+ *             "<contextPath>/em" target already used for non-GET requests. See the
+ *             "redirectUri same-origin validation" tests below.
  *
  * [Suspect 2] (#75658) LogoutFilter.doFilter() -> intent: unclear from the code itself, but
  *             "/logout" is filter #1 inside StandardFilterChain, which is nested inside
  *             AuthenticationFilterChain (#6 in the outer SecurityFilterChain); CSRFFilter is #7,
  *             strictly after. doFilter() also never inspects the HTTP method.
  *             actual: any request method to "/logout" (GET included) executes a full logout with
- *             no CSRF token required at all -- a classic "logout CSRF" that becomes materially
- *             worse combined with Suspect 1: a third-party page that merely loads
- *             `<img src=".../logout?fromEm=true&redirectUri=https://attacker.example/...">` logs
- *             an already-authenticated visitor out and redirects their browser to an
- *             attacker-controlled URL, with no script execution and no user interaction beyond
- *             viewing the page. See
- *             doFilter_logout_anyHttpMethod_triggersLogoutWithNoMethodOrTokenCheck below (proves
- *             the method-agnostic part from within this filter; the "ahead of CSRFFilter in the
- *             chain" part is an architectural fact that can only be demonstrated by a real
- *             multi-filter ordering test -- see docs/superpowers/specs/2026-07-14-penetration-filter-test-plan.md
- *             §2.6).
- *
- * Neither suspect is patched in the production filter here; both are pinned down as passing
- * characterization tests below. Tracked together as Redmine #75658 (open redirect + logout CSRF /
- * method-agnostic logout ahead of CSRFFilter).
+ *             no CSRF token required at all. NOT YET FIXED here: CSRFFilter's own SAFE_METHODS
+ *             exemption (GET/HEAD/OPTIONS/TRACE) and its isApi()-scoped enforcement mean simply
+ *             reordering the chain would not add protection either -- closing this gap needs an
+ *             explicit product decision (e.g. POST-only logout with a frontend change, or
+ *             extending CSRFFilter's scope to cover "/logout"). Left as a pinned characterization
+ *             test -- see doFilter_logout_anyHttpMethod_triggersLogoutWithNoMethodOrTokenCheck --
+ *             pending that decision. With Suspect 1 fixed, this alone is logout CSRF only (forces
+ *             a re-login), not the zero-click external-redirect chain described in #75658.
  */
 
 import inetsoft.sree.RepletRepository;
@@ -169,10 +156,10 @@ class LogoutFilterTest {
       verifyNoInteractions(chain);
    }
 
-   // ── suspect 1 (#75658): open redirect via fromEm + redirectUri ─────────────
+   // ── suspect 1 (#75658): redirectUri same-origin validation ─────────────────
 
    @Test
-   void doFilter_logout_fromEmGetWithRedirectUriParam_securityDisabled_openRedirectsToAttackerUrl()
+   void doFilter_logout_fromEmGetWithCrossOriginRedirectUriParam_securityDisabled_fallsBackToEmPath()
       throws Exception
    {
       when(mockEngine.isSecurityEnabled()).thenReturn(false);
@@ -185,12 +172,12 @@ class LogoutFilterTest {
 
       filter.doFilter(request, response, chain);
 
-      // The server issues a 302 straight to the attacker's URL -- no wrapping, no validation.
-      assertEquals(ATTACKER_URL, response.getRedirectedUrl());
+      // An external redirectUri is rejected -- same fallback as the POST case below.
+      assertEquals("/em", response.getRedirectedUrl());
    }
 
    @Test
-   void doFilter_logout_fromEmGetWithRedirectUriParam_securityEnabled_attackerUrlPreservedInRequestedUrl()
+   void doFilter_logout_fromEmGetWithCrossOriginRedirectUriParam_securityEnabled_wrapsSanitizedFallback()
       throws Exception
    {
       when(mockEngine.isSecurityEnabled()).thenReturn(true);
@@ -203,19 +190,19 @@ class LogoutFilterTest {
 
       filter.doFilter(request, response, chain);
 
-      // Not a raw redirect this time, but the attacker's URL is still carried forward verbatim
-      // (URL-encoded) inside requestedUrl -- the payload is relocated, not removed.
+      // The attacker URL must not appear anywhere in the redirect target, sanitized or not.
       String redirected = response.getRedirectedUrl();
       assertNotNull(redirected);
       assertTrue(redirected.startsWith("http://localhost/login.html?requestedUrl="));
-      assertTrue(redirected.contains(java.net.URLEncoder.encode(ATTACKER_URL, "UTF-8")));
+      assertFalse(redirected.contains(java.net.URLEncoder.encode(ATTACKER_URL, "UTF-8")));
+      assertTrue(redirected.contains(java.net.URLEncoder.encode("/em", "UTF-8")));
    }
 
    @Test
-   void doFilter_sessionExpired_fromEmGetWithRedirectUriParam_securityDisabled_alsoOpenRedirects()
+   void doFilter_sessionExpired_fromEmGetWithCrossOriginRedirectUriParam_securityDisabled_alsoFallsBack()
       throws Exception
    {
-      // Same vulnerable getLogoutRedirectUri() is shared by both entry points.
+      // Same sanitized getLogoutRedirectUri() is shared by both entry points.
       when(mockEngine.isSecurityEnabled()).thenReturn(false);
       MockHttpServletRequest request = request("GET", "/sessionexpired");
       request.setQueryString("fromEm=true");
@@ -226,17 +213,93 @@ class LogoutFilterTest {
 
       filter.doFilter(request, response, chain);
 
-      assertEquals(ATTACKER_URL, response.getRedirectedUrl());
+      assertEquals("/em", response.getRedirectedUrl());
+   }
+
+   @Test
+   void doFilter_logout_fromEmGetWithProtocolRelativeRedirectUriParam_securityDisabled_fallsBackToEmPath()
+      throws Exception
+   {
+      // "//attacker.example/evil" has no scheme but browsers resolve it against the current
+      // scheme, making it just as dangerous as a fully-qualified external URL.
+      when(mockEngine.isSecurityEnabled()).thenReturn(false);
+      MockHttpServletRequest request = request("GET", "/logout");
+      request.setQueryString("fromEm=true");
+      request.setParameter("redirectUri", "//attacker.example/evil");
+      MockHttpSession session = (MockHttpSession) request.getSession(true);
+      session.setAttribute(RepletRepository.PRINCIPAL_COOKIE, namedPrincipal());
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilter(request, response, chain);
+
+      assertEquals("/em", response.getRedirectedUrl());
+   }
+
+   @Test
+   void doFilter_logout_fromEmGetWithBackslashObfuscatedRedirectUriParam_securityDisabled_fallsBackToEmPath()
+      throws Exception
+   {
+      // Browsers normalize a leading "/\" (or "\\") into "//", turning this into a
+      // protocol-relative external redirect just like the plain "//" case.
+      when(mockEngine.isSecurityEnabled()).thenReturn(false);
+      MockHttpServletRequest request = request("GET", "/logout");
+      request.setQueryString("fromEm=true");
+      request.setParameter("redirectUri", "/\\attacker.example/evil");
+      MockHttpSession session = (MockHttpSession) request.getSession(true);
+      session.setAttribute(RepletRepository.PRINCIPAL_COOKIE, namedPrincipal());
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilter(request, response, chain);
+
+      assertEquals("/em", response.getRedirectedUrl());
+   }
+
+   @Test
+   void doFilter_logout_fromEmGetWithAppRelativeRedirectUriParam_securityDisabled_isHonored()
+      throws Exception
+   {
+      // A plain app-relative path is legitimate (e.g. deep-linking back into the portal) and must
+      // still work after the fix.
+      when(mockEngine.isSecurityEnabled()).thenReturn(false);
+      MockHttpServletRequest request = request("GET", "/logout");
+      request.setQueryString("fromEm=true");
+      request.setParameter("redirectUri", "/portal/embed");
+      MockHttpSession session = (MockHttpSession) request.getSession(true);
+      session.setAttribute(RepletRepository.PRINCIPAL_COOKIE, namedPrincipal());
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilter(request, response, chain);
+
+      assertEquals("/portal/embed", response.getRedirectedUrl());
+   }
+
+   @Test
+   void doFilter_logout_fromEmGetWithSameOriginAbsoluteRedirectUriParam_securityDisabled_isHonored()
+      throws Exception
+   {
+      // AdminPageController builds redirectUri from LinkUriArgumentResolver.transformUri(request)
+      // -- a same-origin absolute URL -- for the SSO logout link on the restricted-access page.
+      // That legitimate flow must keep working.
+      when(mockEngine.isSecurityEnabled()).thenReturn(false);
+      MockHttpServletRequest request = request("GET", "/logout");
+      request.setQueryString("fromEm=true");
+      request.setParameter("redirectUri", "http://localhost/em/");
+      MockHttpSession session = (MockHttpSession) request.getSession(true);
+      session.setAttribute(RepletRepository.PRINCIPAL_COOKIE, namedPrincipal());
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilter(request, response, chain);
+
+      assertEquals("http://localhost/em/", response.getRedirectedUrl());
    }
 
    @Test
    void doFilter_logout_fromEmPostRequest_redirectUriParamIgnored_fallsBackToEmPath()
       throws Exception
    {
-      // The vulnerable branch is gated on "GET".equals(request.getMethod()) -- a POST with the
-      // same parameters does NOT get hijacked, it falls back to the plain "/em" path instead. This
-      // is exactly what makes the GET variant the practical attack vector: it is trivially
-      // deliverable via a plain <img>/<a> tag with no script and no user interaction.
+      // The redirectUri-from-parameter branch is gated on "GET".equals(request.getMethod()) -- a
+      // POST with the same parameters does NOT read the parameter at all, it falls back to the
+      // plain "/em" path instead.
       when(mockEngine.isSecurityEnabled()).thenReturn(false);
       MockHttpServletRequest request = request("POST", "/logout");
       request.setQueryString("fromEm=true");

--- a/core/src/test/java/inetsoft/web/security/LogoutFilterTest.java
+++ b/core/src/test/java/inetsoft/web/security/LogoutFilterTest.java
@@ -35,6 +35,14 @@ package inetsoft.web.security;
  * "<contextPath>/em", the same fallback already used for non-GET requests. Both "/logout" and
  * "/sessionexpired" share this fix. See the "redirectUri same-origin validation" tests below.
  *
+ * Follow-up hardening: the initial fix's app-relative check only inspected the literal second
+ * character for "/" or "\\". Per the WHATWG URL Standard, a browser strips every ASCII tab/CR/LF
+ * from the whole URL string as its first normalization step, before scheme/authority parsing --
+ * so "/\t/attacker.example" passed the original check (charAt(1) is a tab, not "/" or "\\") while
+ * resolving to the protocol-relative "//attacker.example" once the browser processed the Location
+ * header. isSameOriginRedirectUri() now rejects any redirectUri containing an embedded tab, CR,
+ * or LF outright. See the "TabObfuscated"/"NewlineObfuscated" tests below.
+ *
  * Residual, lower-severity item (tracked separately, not fixed here): LogoutFilter.doFilter()
  * still accepts any HTTP method and short-circuits the chain ahead of CSRFFilter (see
  * SecurityFilterChainOrderingTest.logoutFilter_shortCircuitsChain_realCsrfFilterNeverInvokedAtAll).
@@ -243,6 +251,46 @@ class LogoutFilterTest {
       MockHttpServletRequest request = request("GET", "/logout");
       request.setQueryString("fromEm=true");
       request.setParameter("redirectUri", "/\\attacker.example/evil");
+      MockHttpSession session = (MockHttpSession) request.getSession(true);
+      session.setAttribute(RepletRepository.PRINCIPAL_COOKIE, namedPrincipal());
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilter(request, response, chain);
+
+      assertEquals("/em", response.getRedirectedUrl());
+   }
+
+   @Test
+   void doFilter_logout_fromEmGetWithTabObfuscatedRedirectUriParam_securityDisabled_fallsBackToEmPath()
+      throws Exception
+   {
+      // Per the WHATWG URL Standard, a browser strips every ASCII tab/CR/LF from the whole URL
+      // string as its very first normalization step, before scheme/authority parsing. So
+      // "/\t/attacker.example" -- which looks app-relative to a naive "second char isn't / or \"
+      // check -- is exactly "//attacker.example" once the browser processes the Location header:
+      // a protocol-relative bypass of the check added for the plain "//" and "/\" cases.
+      when(mockEngine.isSecurityEnabled()).thenReturn(false);
+      MockHttpServletRequest request = request("GET", "/logout");
+      request.setQueryString("fromEm=true");
+      request.setParameter("redirectUri", "/\t/attacker.example");
+      MockHttpSession session = (MockHttpSession) request.getSession(true);
+      session.setAttribute(RepletRepository.PRINCIPAL_COOKIE, namedPrincipal());
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilter(request, response, chain);
+
+      assertEquals("/em", response.getRedirectedUrl());
+   }
+
+   @Test
+   void doFilter_logout_fromEmGetWithNewlineObfuscatedRedirectUriParam_securityDisabled_fallsBackToEmPath()
+      throws Exception
+   {
+      // Same bypass technique with an embedded CR/LF instead of a tab.
+      when(mockEngine.isSecurityEnabled()).thenReturn(false);
+      MockHttpServletRequest request = request("GET", "/logout");
+      request.setQueryString("fromEm=true");
+      request.setParameter("redirectUri", "/\r\n/attacker.example");
       MockHttpSession session = (MockHttpSession) request.getSession(true);
       session.setAttribute(RepletRepository.PRINCIPAL_COOKIE, namedPrincipal());
       MockHttpServletResponse response = new MockHttpServletResponse();


### PR DESCRIPTION
**Summary**
Post-logout redirect logic trusts a client-supplied `redirectUri` query parameter when `fromEm=true` on a GET, with no same-origin or allow-list check. `LogoutFilter` also accepts any HTTP method and runs before `CSRFFilter`, so logout needs no CSRF token. Combined, a third-party page can log the victim out and send the browser to an attacker URL with no script and no intentional user action beyond loading the page.

**fixed**
community/core/src/main/java/inetsoft/web/security/AbstractLogoutFilter.java
- getLogoutRedirectUri() no longer trusts the client-supplied redirectUri GET parameter blindly. A new isSameOriginRedirectUri() check only accepts:
  - app-relative paths (/em, /portal/embed, …)
  - absolute URLs that start with this app's own origin (LinkUriArgumentResolver.getLinkUri(request)) — this is exactly the form AdminPageController's legitimate SSO-logout link already produces, so that flow keeps working
  - Rejects protocol-relative (//attacker.example/...) and backslash-obfuscated (/\attacker.example/...) variants that browsers normalize to protocol-relative
  - Anything else falls back to <contextPath>/em, the same fallback already used for non-GET requests

/logout and /sessionexpired both go through this method, so both are fixed; SSOLogoutFilter in enterprise/ inherits it too, no changes needed there.

community/core/src/test/java/inetsoft/web/security/LogoutFilterTest.java (TDD: written first, watched fail, then fix applied)
- Updated the file-level "suspect" comment to mark Suspect 1 (open redirect) fixed
- Turned the old characterization tests (which asserted the attacker URL survived) into regression tests asserting the sanitized fallback
- Added tests for protocol-relative and backslash-obfuscated bypass attempts, plus tests proving legitimate app-relative and same-origin-absolute redirectUri values still work

Ran LogoutFilterTest alone (RED → 5 failures for the expected reason → GREEN → 15/15 pass), then the whole inetsoft.web.security.*Test package (120/120 pass, no regressions).

What I did not touch — Suspect 2 (logout CSRF / method-agnostic logout): SecurityFilterChainOrderingTest.java (already in the repo) proves LogoutFilter short-circuits the chain before CSRFFilter ever runs. But CSRFFilter itself exempts GET (and all SAFE_METHODS) and only enforces on /api/** paths — so reordering the filter chain alone wouldn't add protection. Properly closing this needs a product decision (e.g., make logout POST-only, which requires a frontend change since LogoutService.logout() currently does a plain document.location.replace(...) GET navigation; or extend CSRFFilter's scope to cover /logout). With the open redirect now fixed, this remaining gap is logout CSRF only (forces a re-login) — the report itself rates that "usually low severity" on its own. Let me know if you want me to pursue a specific approach for that part too.
