### PR TITLE
fix(window): support in-memory windowColumns over non-SQL-mergeable bases

### DIFF
--- a/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
+++ b/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
@@ -148,6 +148,35 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
       return table.getHeaderColCount();
    }
 
+   /**
+    * Delegate the column identifier of a pass-through (base) column to the underlying table,
+    * mirroring {@link #getColType}. This is required for correctness, not just cosmetics:
+    * downstream column resolution (e.g. {@code AssetQuery.getVisibleTableLens} ->
+    * {@code AssetUtil.findColumn}) matches a table-qualified identifier (e.g.
+    * {@code "ROUND_JS.product_id"}) against the lens, and only falls back to a header match when
+    * the identifier is present but different. The base table's headers are the bare, unqualified
+    * names, so if this lens reported a {@code null} identifier for its pass-through columns (the
+    * default from {@link AbstractTableLens}, which reads a local map this lens never populates),
+    * those columns fail to resolve and get silently projected away — leaving only the window
+    * column(s) and an empty/near-empty result. A locally-set identifier (via
+    * {@link #setColumnIdentifier}) still wins; otherwise we delegate base columns to the
+    * underlying table and give window columns their spec header as a sensible default.
+    */
+   @Override
+   public String getColumnIdentifier(int col) {
+      String local = super.getColumnIdentifier(col);
+
+      if(local != null) {
+         return local;
+      }
+
+      if(col < ncols) {
+         return table.getColumnIdentifier(col);
+      }
+
+      return specs[col - ncols].header;
+   }
+
    @Override
    public Class<?> getColType(int col) {
       if(col < ncols) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -21,7 +21,6 @@ package inetsoft.web.wiz.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.report.TableLens;
-import inetsoft.report.composition.execution.AssetQuery;
 import inetsoft.report.composition.execution.AssetQuerySandbox;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
@@ -275,28 +274,12 @@ public class WorksheetTableService {
          table.setColumnSelection(table.getColumnSelection(false), false);
       }
 
-      // 8. Conservative gate: reject windowColumns when the base table can't fully SQL-merge.
-      // AssetQuery DOES have an in-memory fallback for a non-mergeable base (getWindowTableLens →
-      // buildWindowLens → WindowTableLens), so this is not a hard product limitation in general.
-      // But when the window's partitionBy/orderBy/arg references an ALIASED aggregate column (e.g.
-      // ORDER BY a SUM(...) AS product_revenue), the non-merged aggregation path silently drops
-      // that alias — AssetQuery.getAggCalcHeader only preserves a caller alias for a
-      // CalcFieldFormula, not a plain SumFormula/CountFormula/etc — so buildWindowSpecs then can't
-      // resolve the ref by name and throws. That thrown RuntimeException should fail loud, but
-      // WizVsService.extractChartData's catch-all currently downgrades any non-IllegalArgumentException
-      // failure to a silent empty CreateViewsheetResult instead of surfacing it — which is how this
-      // reached the viewer as a wrongly-empty chart with no error anywhere. Both of those are real
-      // StyleBI-core bugs (well beyond this wiz-only service) that are NOT fixed here — this gate is
-      // a narrow, conservative mitigation scoped to windowColumns until they are. It can reject a
-      // windowColumns table whose base is non-mergeable but whose window refs are all plain
-      // (non-aliased-aggregate) columns, which the in-memory path could likely compute correctly —
-      // that's an accepted false-positive tradeoff for turning a silent wrong/empty result into a
-      // clear, actionable error today.
-      if(request.getWindowColumns() != null && !request.getWindowColumns().isEmpty()) {
-         requireWindowColumnsMergeable(worksheet, table, user);
-      }
-
-      // 9. Execution probe for render-time-executable tables.
+      // 8. Execution probe for render-time-executable tables. windowColumns are probed here too:
+      // when the base can't fully SQL-merge, AssetQuery computes the window in-memory
+      // (getWindowTableLens → buildWindowLens → WindowTableLens), which is a fully supported path
+      // (WindowTableLens delegates its base columns' identifiers so downstream column resolution
+      // still finds them — see WindowTableLens.getColumnIdentifier). The probe surfaces any
+      // genuine render-time failure instead of letting it reach the viewer as an empty result.
       if(shouldProbe(request)) {
          probeExecutable(worksheet, table, user);
       }
@@ -354,55 +337,6 @@ public class WorksheetTableService {
 
       List<WorksheetTable.WindowColumnInfo> winCols = request.getWindowColumns();
       return winCols != null && !winCols.isEmpty();
-   }
-
-   /**
-    * Conservatively require {@code table} to be fully SQL-mergeable before allowing
-    * {@code windowColumns} on it. This is NOT because a non-mergeable base is fundamentally
-    * uncomputable — {@code AssetQuery} has a genuine in-memory fallback for that
-    * ({@code getWindowTableLens} → {@code buildWindowLens} → {@code WindowTableLens}). The gate
-    * exists because, in the current codebase, a window whose {@code partitionBy}/{@code orderBy}/
-    * arg references an ALIASED aggregate column (e.g. {@code ORDER BY SUM(...) AS revenue}) hits a
-    * real bug on that in-memory path: {@code AssetQuery.getAggCalcHeader} only preserves a caller
-    * alias for a {@code CalcFieldFormula}, not a plain {@code SumFormula}/{@code CountFormula}/etc,
-    * so the non-merged aggregate's header silently reverts to the pre-aggregate column's raw name
-    * and {@code buildWindowSpecs} can't resolve the alias — it throws, but that exception is then
-    * swallowed by {@code WizVsService.extractChartData}'s catch-all (which downgrades any
-    * non-{@link IllegalArgumentException} failure to a silently-empty result) rather than
-    * surfacing it. Both of those are StyleBI-core bugs with a blast radius well beyond this
-    * wiz-only service and are NOT fixed here — this check is a narrow, conservative mitigation
-    * until they are, using the same authoritative {@link AssetQuery#isSourceMergeable0()} the
-    * runtime query-planning path relies on (mirrors the pattern
-    * {@link AssetQuerySandbox#executeQuery} uses). It can over-reject a windowColumns table whose
-    * base is non-mergeable but whose window refs are all plain (non-aliased-aggregate) columns —
-    * an accepted false-positive tradeoff for turning today's silent wrong/empty result into a
-    * clear, actionable error.
-    */
-   private void requireWindowColumnsMergeable(Worksheet worksheet, AbstractTableAssembly table,
-                                              Principal user)
-      throws Exception
-   {
-      AssetQuerySandbox box = new AssetQuerySandbox(worksheet);
-      box.setBaseUser(user);
-
-      try {
-         AssetQuery query = AssetQuery.createAssetQuery(
-            table, AssetQuerySandbox.RUNTIME_MODE, box, false, -1L, true, false);
-
-         if(!query.isSourceMergeable0()) {
-            throw new IllegalArgumentException(
-               "windowColumns on table \"" + table.getName() + "\" cannot be computed: its base " +
-               "data is not fully SQL-mergeable. A common cause is a windowColumns partitionBy/" +
-               "orderBy/column ref pointing at an ALIASED aggregate (e.g. ORDER BY a Sum(...) " +
-               "alias) — try referencing a plain (non-aggregate) column instead, or removing " +
-               "windowColumns from this table. Other causes (an upstream JS-evaluated expression " +
-               "column, an unsupported subquery shape, etc.) can also block SQL merging — if " +
-               "none of those apply, compute this table's logic in a \"sql query table\" instead.");
-         }
-      }
-      finally {
-         box.dispose();
-      }
    }
 
    /**

--- a/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
+++ b/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
@@ -538,4 +538,44 @@ class WindowTableLensTest {
       assertTrue(ex.getMessage().contains("null ORDER BY"),
                  "error should name the null-order-value cause: " + ex.getMessage());
    }
+
+   @Test
+   void columnIdentifier_delegatesBaseColumnsToUnderlyingTable() {
+      // Regression: WindowTableLens must expose its pass-through (base) columns' identifiers by
+      // delegating to the underlying table, exactly as it delegates getColType. Without this the
+      // base columns report a null identifier, and a downstream column-resolution step that matches
+      // a table-qualified identifier (AssetQuery.getVisibleTableLens -> AssetUtil.findColumn) fails
+      // to locate them and silently projects them away — leaving only the window column and a
+      // wrongly-empty chart. The window column itself has no base identifier; it defaults to its
+      // spec header.
+      DefaultTableLens t = base();                 // cols: stage(0), amount(1)
+      t.setColumnIdentifier(0, "T.stage");
+      t.setColumnIdentifier(1, "T.amount");
+
+      WindowTableLens.Spec spec = new WindowTableLens.Spec(
+         "rn", "ROW_NUMBER", -1, 0, new int[]{0}, new int[]{1}, new boolean[]{false});
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{spec});
+
+      assertEquals("T.stage", lens.getColumnIdentifier(0),
+                   "base column identifier must be delegated to the underlying table");
+      assertEquals("T.amount", lens.getColumnIdentifier(1),
+                   "base column identifier must be delegated to the underlying table");
+      assertEquals("rn", lens.getColumnIdentifier(2),
+                   "window column identifier defaults to the spec header");
+   }
+
+   @Test
+   void columnIdentifier_localOverrideWinsOverBaseDelegation() {
+      // An explicitly-set identifier on the lens itself takes precedence over base delegation.
+      DefaultTableLens t = base();
+      t.setColumnIdentifier(0, "T.stage");
+
+      WindowTableLens.Spec spec = new WindowTableLens.Spec(
+         "rn", "ROW_NUMBER", -1, 0, new int[]{0}, new int[]{1}, new boolean[]{false});
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{spec});
+      lens.setColumnIdentifier(0, "OVERRIDE.stage");
+
+      assertEquals("OVERRIDE.stage", lens.getColumnIdentifier(0),
+                   "a locally-set identifier must win over base delegation");
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceShouldProbeTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceShouldProbeTest.java
@@ -35,12 +35,12 @@ import static org.junit.jupiter.api.Assertions.*;
  * Regression tests for {@link WorksheetTableService#shouldProbe}.
  *
  * <p>The bug: a {@code windowColumns}-bearing request was never probed, so a render-time failure
- * in the pushed-down {@code OVER(...)} SQL (e.g. when the base table can't fully SQL-merge because
- * an upstream JS-evaluated expression column blocks the merge) never got the chance to surface at
- * construction time — it silently reached the viewer as an empty result instead. The fix extends
- * {@code shouldProbe} to also probe {@code windowColumns} requests, mirroring the existing
- * {@code expressionColumns} check (see also {@link WorksheetTableService#requireWindowColumnsMergeable}
- * for the eager fail-loud mergeability gate this pairs with).
+ * in the {@code OVER(...)} evaluation (whether pushed down as SQL, or computed in-memory when the
+ * base table can't fully SQL-merge — e.g. an upstream JS-evaluated expression column blocks the
+ * merge) never got the chance to surface at construction time. The fix extends {@code shouldProbe}
+ * to also probe {@code windowColumns} requests, mirroring the existing {@code expressionColumns}
+ * check, so a genuine render-time failure fails loud at creation instead of reaching the viewer as
+ * an empty result.
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)


### PR DESCRIPTION
## Summary
`windowColumns` (ROW_NUMBER/RANK/LAG/etc) over a base that can't fully SQL-merge — any lineage with a JS-evaluated expression column, or a window ordered/partitioned by an aliased aggregate — are computed **in-memory** by `AssetQuery.getWindowTableLens` → `buildWindowLens` → `WindowTableLens`. That path silently produced a wrongly-**empty** chart: the window column survived but every pass-through base column vanished.

**Root cause:** `WindowTableLens` overrides `getColType` to delegate base columns to its underlying table, but never overrode `getColumnIdentifier` — so it reported a `null` identifier for *all* columns (the `AbstractTableLens` default reads a local map this lens never populates). Downstream, `AssetQuery.getVisibleTableLens` resolves each bound column against the lens via `AssetUtil.findColumn` (`exact=true`), which needs an identifier match (null → miss) or an exact header match. The selection columns carry table-qualified names (`ROUND_JS.product_id`) while the base exposes bare headers (`product_id`), so header match also missed and the pass-through columns were projected away — leaving only the window column. In the SQL-merged case there is no `WindowTableLens`, so JDBC identifiers flow through intact — which is why only the non-mergeable / in-memory path was affected.

**Fix:** override `WindowTableLens.getColumnIdentifier` to delegate base (`col < ncols`) columns to the underlying table and default window columns to their spec header, mirroring the existing `getColType` delegation. A locally-set identifier still wins.

**Follow-on:** with the root cause fixed, the conservative pre-emptive gate from #4258 (`requireWindowColumnsMergeable`, which rejected *any* non-SQL-mergeable windowColumns base) is now counterproductive — it would reject cases that now compute correctly — so it is removed. The `shouldProbe` extension from that PR is **kept**: windowColumns tables are still probed at creation so a genuine render-time failure surfaces instead of reaching the viewer empty.

## Test plan
- [x] New `WindowTableLensTest` cases: base-identifier delegation to the underlying table, and local-override precedence.
- [x] Full window suite passes: `WindowTableLensTest` (28), `WindowRoutingTest`, `WindowExpressionRefTest`, `WindowExpressionDetectionTest`, `WorksheetTableServiceWindowColumnsTest`.
- [x] Full wiz service suite passes (181), incl. `WorksheetTableServiceShouldProbeTest` (shouldProbe still probes windowColumns).
- [x] Live-verified against the `odoo` datasource: a per-category `RANK`/`DENSE_RANK` ordered by a JS `Math.round(...)` expression column now renders all 120 rows **fully declaratively** (previously 0 rows), with correct tie handling (`RANK` skips positions, `DENSE_RANK` does not). Same shape with an aliased-aggregate order key also verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>