### PR TITLE
fix(worksheet): restore primary table after deleting it via delete_worksheet_table

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/DeleteWorksheetTablesResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/DeleteWorksheetTablesResponse.java
@@ -50,6 +50,13 @@ public class DeleteWorksheetTablesResponse {
    private boolean success;
    private String errorMessage;
 
+   /**
+    * The worksheet's primary table after this delete, or {@code null} if it has none
+    * (either it never had one, or its primary was deleted and no unambiguous
+    * replacement could be picked).
+    */
+   private String primaryTable;
+
    public String getWsId() {
       return wsId;
    }
@@ -96,5 +103,13 @@ public class DeleteWorksheetTablesResponse {
 
    public void setErrorMessage(String errorMessage) {
       this.errorMessage = errorMessage;
+   }
+
+   public String getPrimaryTable() {
+      return primaryTable;
+   }
+
+   public void setPrimaryTable(String primaryTable) {
+      this.primaryTable = primaryTable;
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -488,6 +488,7 @@ public class WorksheetTableService {
       }
 
       Set<String> deleteSet = new LinkedHashSet<>(request.getTableNames());
+      String previousPrimary = worksheet.getPrimaryAssemblyName();
 
       DeleteWorksheetTablesResponse response = new DeleteWorksheetTablesResponse();
       List<String> deleted = new ArrayList<>();
@@ -521,6 +522,16 @@ public class WorksheetTableService {
          deleted.add(name);
       }
 
+      // Worksheet.removeAssembly() clears the primary assembly to null when the deleted
+      // table was primary, with no replacement — restore it when there's an unambiguous
+      // candidate so a leaf table's own deletion doesn't orphan chart creation on the
+      // worksheet (see restorePrimaryAssembly()).
+      if(previousPrimary != null && deleted.contains(previousPrimary)
+         && worksheet.getPrimaryAssemblyName() == null)
+      {
+         restorePrimaryAssembly(worksheet);
+      }
+
       // Persist only when something changed.
       if(!deleted.isEmpty()) {
          WsServiceHelper.layoutGraph(layoutGraphService, worksheet);
@@ -532,7 +543,35 @@ public class WorksheetTableService {
       response.setNotFound(notFound);
       response.setSkipped(skipped);
       response.setSuccess(true);
+      response.setPrimaryTable(worksheet.getPrimaryAssemblyName());
       return response;
+   }
+
+   /**
+    * Reassigns the worksheet's primary table after its previous primary was deleted.
+    * Only acts when exactly one remaining table has no other remaining table depending
+    * on it (an unambiguous leaf) — mirrors the "don't guess" convention used when a
+    * batch's intended primary fails to build (see {@code addOneTable}): zero or multiple
+    * candidates leave the worksheet without a primary rather than silently picking one.
+    */
+   // Package-private (not private) so WorksheetTableServiceDeleteTablesTest can exercise it
+   // directly, mirroring the shouldProbe/applyWindowColumns test convention in this package.
+   void restorePrimaryAssembly(Worksheet worksheet) {
+      List<String> leaves = new ArrayList<>();
+
+      for(Assembly asm : worksheet.getAssemblies()) {
+         if(!(asm instanceof TableAssembly)) {
+            continue;
+         }
+
+         if(findExternalDependent(worksheet, asm.getName(), Collections.emptySet()) == null) {
+            leaves.add(asm.getName());
+         }
+      }
+
+      if(leaves.size() == 1) {
+         worksheet.setPrimaryAssembly(leaves.get(0));
+      }
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceDeleteTablesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceDeleteTablesTest.java
@@ -1,0 +1,120 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.MirrorTableAssembly;
+import inetsoft.uql.asset.PhysicalBoundTableAssembly;
+import inetsoft.uql.asset.TableAssembly;
+import inetsoft.uql.asset.Worksheet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for {@link WorksheetTableService#restorePrimaryAssembly}.
+ *
+ * <p>The bug: {@link Worksheet#removeAssembly} clears the worksheet's primary assembly to
+ * {@code null} when the deleted table was primary, but never assigns a replacement — there is
+ * no leaf-recomputation logic anywhere in the delete path. A caller who builds a chain of
+ * tables (A -> B, B primary), later adds a diagnostic leaf C on top of B and makes it primary,
+ * then deletes C, is left with a worksheet that has NO primary table even though B is once
+ * again the sole, unambiguous leaf. The next {@code create_viewsheet} call then fails with
+ * "Available worksheet columns: []" instead of resolving to B. {@code restorePrimaryAssembly}
+ * fixes this by re-picking the primary when exactly one remaining table qualifies as a leaf
+ * (no other remaining table depends on it) — mirroring the "don't guess when ambiguous"
+ * convention from the create-path primary-selection fixes: zero or multiple candidates leave
+ * the worksheet without a primary rather than silently picking one.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WorksheetTableServiceDeleteTablesTest {
+   private static WorksheetTableService service() {
+      // restorePrimaryAssembly and its helper (findExternalDependent) read only their
+      // parameters, never instance state, so null dependencies are safe here (mirrors
+      // WorksheetTableServiceShouldProbeTest / WorksheetTableServiceWindowColumnsTest).
+      return new WorksheetTableService(null, null, null, null, null, null, null, null, null);
+   }
+
+   @Test
+   void singleRemainingLeafBecomesPrimary() {
+      Worksheet ws = new Worksheet();
+      TableAssembly base = new PhysicalBoundTableAssembly(ws, "BASE");
+      ws.addAssembly(base);
+
+      // Simulate: BASE was primary, then a diagnostic mirror was added on top and made
+      // primary, then that mirror was deleted -- removeAssembly() already cleared primary.
+      ws.setPrimaryAssembly("BASE");
+      MirrorTableAssembly diag = new MirrorTableAssembly(ws, "DIAG", base);
+      ws.addAssembly(diag);
+      ws.setPrimaryAssembly("DIAG");
+      ws.removeAssembly("DIAG");
+      assertNull(ws.getPrimaryAssemblyName(), "removeAssembly should have cleared the primary");
+
+      service().restorePrimaryAssembly(ws);
+
+      assertEquals("BASE", ws.getPrimaryAssemblyName(),
+         "the sole remaining leaf table must be restored as primary");
+   }
+
+   @Test
+   void ambiguousLeavesLeavePrimaryNull() {
+      Worksheet ws = new Worksheet();
+      TableAssembly base = new PhysicalBoundTableAssembly(ws, "BASE");
+      ws.addAssembly(base);
+      TableAssembly leafA = new MirrorTableAssembly(ws, "LEAF_A", base);
+      ws.addAssembly(leafA);
+      TableAssembly leafB = new MirrorTableAssembly(ws, "LEAF_B", base);
+      ws.addAssembly(leafB);
+
+      // Simulate a deleted former primary (on top of LEAF_A) so the worksheet starts from
+      // primary==null, same as the real delete path, instead of relying on addAssembly()'s
+      // "first assembly added becomes primary" default -- which would make this a test of
+      // that default, not of restorePrimaryAssembly.
+      TableAssembly deletedPrimary = new MirrorTableAssembly(ws, "DELETED_PRIMARY", leafA);
+      ws.addAssembly(deletedPrimary);
+      ws.setPrimaryAssembly("DELETED_PRIMARY");
+      ws.removeAssembly("DELETED_PRIMARY");
+      assertNull(ws.getPrimaryAssemblyName(), "removeAssembly should have cleared the primary");
+
+      // Two independent leaves remain (LEAF_A, LEAF_B) -- there is no unambiguous choice.
+      service().restorePrimaryAssembly(ws);
+
+      assertNull(ws.getPrimaryAssemblyName(),
+         "ambiguous (multiple) leaf candidates must not be silently guessed");
+   }
+
+   @Test
+   void noRemainingTablesLeavePrimaryNull() {
+      Worksheet ws = new Worksheet();
+
+      service().restorePrimaryAssembly(ws);
+
+      assertNull(ws.getPrimaryAssemblyName(), "an empty worksheet has no candidate to restore");
+   }
+}


### PR DESCRIPTION
## Summary
- `Worksheet.removeAssembly()` clears the worksheet's primary assembly to `null` when the deleted table was primary, but never assigns a replacement — nothing in the delete path recomputes it.
- Repro: build a table chain (A -> B, B primary), add a scratch/diagnostic table C on top of B (making C primary), delete C once done with it. The worksheet is left with **no primary table** even though B is once again the sole, unambiguous leaf — the next `create_viewsheet` call fails with `"Available worksheet columns: []"` instead of resolving to B.
- `WorksheetTableService.deleteTables()` now calls a new `restorePrimaryAssembly()` when the deleted set included the previous primary: it re-picks the primary only when exactly **one** remaining table qualifies as an unambiguous leaf (no other remaining table depends on it) — mirroring the existing "don't guess" convention from the create-path primary-selection fix (a batch's intended-but-failed primary is never silently substituted). Zero or multiple candidates leave the worksheet without a primary rather than guessing.
- `DeleteWorksheetTablesResponse` now also reports the resulting `primaryTable`, so callers can detect the ambiguous case without a follow-up request.

Found and fixed while exercising `create_worksheet_table` / `delete_worksheet_table` through the wiz-chat plugin's MCP tools (per CLAUDE.md, plugin gaps found during testing get fixed as plugin robustness defects, not routed around).

## Test plan
- [x] New `WorksheetTableServiceDeleteTablesTest` (3 tests): sole-leaf restoration, ambiguous-leaves-stay-null, empty-worksheet-stays-null.
- [x] `mvn -pl community/core test -Dtest=WorksheetTableServiceDeleteTablesTest,WorksheetTableServiceShouldProbeTest,WorksheetTableServiceWindowColumnsTest` — 31/31 pass.
- [x] Full `inetsoft.web.wiz.**` + `WindowTableLensTest` suite — 369/369 pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>