### PR TITLE
fix(script): accept full-word date intervals and fail loud on unknown ones

### DIFF
--- a/core/src/main/java/inetsoft/util/script/JavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/JavaScriptEngine.java
@@ -310,6 +310,7 @@ public class JavaScriptEngine {
     * Add an interval to a date.
     */
    public static Date dateAdd(String interval, int amount, Object date) {
+      interval = normalizeDateInterval(interval);
       Date dateVal = getDate(date);
 
       if(dateVal != null) {
@@ -343,6 +344,7 @@ public class JavaScriptEngine {
     *    s      Second
     */
    public static double dateDiff(String interval, Object date1, Object date2) {
+      interval = normalizeDateInterval(interval);
       Date dateVal1 = getDate(date1);
       Date dateVal2 = getDate(date2);
 
@@ -410,6 +412,8 @@ public class JavaScriptEngine {
                                                  boolean applyWeekStart,
                                                  int forceDcToDateWeekOfMonth)
    {
+      interval = normalizeDateInterval(interval);
+
       if(forceDcToDateWeekOfMonth > 0 && "wm".equals(interval)) {
          return forceDcToDateWeekOfMonth;
       }
@@ -804,6 +808,63 @@ public class JavaScriptEngine {
       }
 
       return null;
+   }
+
+   /**
+    * Canonical (VBScript-style) interval tokens accepted by dateAdd / dateDiff / datePart.
+    * This is the UNION across all three functions; each still acts only on the subset that is
+    * meaningful for it (e.g. mq/wmq/wq/wy/dq are datePart-only).
+    */
+   private static final Set<String> VALID_DATE_INTERVALS = Set.of(
+      "yyyy", "q", "m", "y", "d", "w", "ww", "ws", "wm",
+      "h", "n", "s", "mq", "wmq", "wq", "wy", "dq");
+
+   /**
+    * Full-word (and common long-form) aliases → canonical short interval token. Lets a caller
+    * write the natural word — e.g. "day", which matches the vocabulary the wiz plugin's own
+    * dateGroupLevel uses — instead of the VBScript short code. NOTE: "week"/"weeks" map to "ww"
+    * (a real calendar week), NOT the short "w", which dateDiff counts as DAYS.
+    */
+   private static final Map<String, String> DATE_INTERVAL_ALIASES = Map.ofEntries(
+      Map.entry("year", "yyyy"), Map.entry("years", "yyyy"), Map.entry("yr", "yyyy"),
+      Map.entry("quarter", "q"), Map.entry("quarters", "q"),
+      Map.entry("month", "m"), Map.entry("months", "m"),
+      Map.entry("week", "ww"), Map.entry("weeks", "ww"),
+      Map.entry("day", "d"), Map.entry("days", "d"),
+      Map.entry("hour", "h"), Map.entry("hours", "h"), Map.entry("hr", "h"),
+      Map.entry("minute", "n"), Map.entry("minutes", "n"), Map.entry("min", "n"),
+      Map.entry("second", "s"), Map.entry("seconds", "s"), Map.entry("sec", "s"));
+
+   /**
+    * Normalize a date interval token for {@link #dateAdd}, {@link #dateDiff} and
+    * {@link #datePartForceWeekOfMonth}: trims + lower-cases it, maps a full-word alias
+    * (e.g. {@code "day" -> "d"}) to its canonical VBScript short token, and validates the result.
+    *
+    * <p>An unrecognized interval used to be handled SILENTLY — {@code dateDiff} fell through to
+    * {@code return 0} and {@code getDateInterval} defaulted to {@code DAY_OF_YEAR} — so a caller
+    * that wrote the natural full word (e.g. {@code dateDiff("day", d1, d2)}) got a
+    * plausible-but-wrong result (always 0) with no error at all. It now (a) accepts the full word
+    * and (b) fails loud on a genuinely unknown token, so a typo or wrong vocabulary surfaces
+    * instead of silently corrupting the computation.
+    */
+   private static String normalizeDateInterval(String interval) {
+      if(interval == null) {
+         throw new IllegalArgumentException(
+            "date interval is required; use one of: d/day, ww/week, m/month, q/quarter, " +
+            "yyyy/year, h/hour, n/minute, s/second");
+      }
+
+      String token = interval.trim().toLowerCase();
+      token = DATE_INTERVAL_ALIASES.getOrDefault(token, token);
+
+      if(!VALID_DATE_INTERVALS.contains(token)) {
+         throw new IllegalArgumentException(
+            "Unknown date interval '" + interval + "'. Use one of: d/day, ww/week, m/month, " +
+            "q/quarter, yyyy/year, h/hour, n/minute, s/second " +
+            "(or the datePart-only tokens wm, mq, wmq, wq, wy, dq).");
+      }
+
+      return token;
    }
 
    /**

--- a/core/src/test/java/inetsoft/util/script/JavaScriptEngineTest.java
+++ b/core/src/test/java/inetsoft/util/script/JavaScriptEngineTest.java
@@ -83,6 +83,65 @@ class JavaScriptEngineTest {
    }
 
    @Test
+   void dateDiffAcceptsFullWordIntervalAliases() {
+      // Regression: dateDiff("day", …) used to silently return 0 because only the VBScript short
+      // token "d" was recognized — a plausible-but-wrong result. Full words (matching the wiz
+      // plugin's dateGroupLevel vocabulary) now map to the canonical token.
+      java.util.Date d1 = toDate("2021-03-05T00:00:00");
+      java.util.Date d2 = toDate("2021-03-10T00:00:00");
+      assertEquals(JavaScriptEngine.dateDiff("d", d1, d2), JavaScriptEngine.dateDiff("day", d1, d2));
+      assertEquals(5, JavaScriptEngine.dateDiff("day", d1, d2));
+      assertEquals(5, JavaScriptEngine.dateDiff("DAYS", d1, d2)); // case-insensitive + plural
+
+      java.util.Date m1 = toDate("2021-01-15T00:00:00");
+      java.util.Date m2 = toDate("2021-04-15T00:00:00");
+      assertEquals(JavaScriptEngine.dateDiff("m", m1, m2), JavaScriptEngine.dateDiff("month", m1, m2));
+      assertEquals(1, JavaScriptEngine.dateDiff("quarter", m1, m2));
+      // "week"/"weeks" must map to real calendar weeks ("ww"), NOT the short "w" (which counts DAYS).
+      assertEquals(JavaScriptEngine.dateDiff("ww", d1, d2), JavaScriptEngine.dateDiff("week", d1, d2));
+   }
+
+   @Test
+   void dateAddAcceptsFullWordIntervalAliases() {
+      java.util.Date base = toDate("2021-03-05T00:00:00");
+      assertEquals(JavaScriptEngine.dateAdd("d", 5, base), JavaScriptEngine.dateAdd("day", 5, base));
+      assertEquals(JavaScriptEngine.dateAdd("m", 2, base), JavaScriptEngine.dateAdd("months", 2, base));
+      assertEquals(JavaScriptEngine.dateAdd("q", 1, base), JavaScriptEngine.dateAdd("quarter", 1, base));
+   }
+
+   @Test
+   void dateDiffFailsLoudOnUnknownInterval() {
+      // Fail loud instead of silently returning 0 for a genuinely unrecognized token.
+      java.util.Date d1 = toDate("2021-03-05T00:00:00");
+      java.util.Date d2 = toDate("2021-03-10T00:00:00");
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> JavaScriptEngine.dateDiff("fortnight", d1, d2));
+      assertTrue(ex.getMessage().contains("fortnight"), "message should name the bad token: " + ex.getMessage());
+   }
+
+   @Test
+   void dateAddFailsLoudOnUnknownInterval() {
+      java.util.Date base = toDate("2021-03-05T00:00:00");
+      assertThrows(IllegalArgumentException.class,
+         () -> JavaScriptEngine.dateAdd("fortnight", 3, base));
+   }
+
+   @Test
+   void datePartFailsLoudOnUnknownInterval() {
+      java.util.Date base = toDate("2021-03-05T00:00:00");
+      assertThrows(IllegalArgumentException.class,
+         () -> JavaScriptEngine.datePart("bogus", base, false));
+   }
+
+   @Test
+   void datePartStillAcceptsSpecializedTokens() {
+      // The datePart-only tokens (mq/wq/wy/dq/wm/…) must survive normalization untouched.
+      java.util.Date base = toDate("2021-08-15T00:00:00");   // August → Q3, month-of-quarter = 2
+      assertEquals(2, JavaScriptEngine.datePart("mq", base, false));
+      assertEquals(3, JavaScriptEngine.datePart("q", base, false));
+   }
+
+   @Test
    void DSTBoundaryIs23HourDiff() {
       java.util.Date d1 = toDate("2021-03-13T12:00");
       java.util.Date d2 = toDate("2021-03-14T12:00");


### PR DESCRIPTION
## Summary
`JavaScriptEngine.dateDiff` / `dateAdd` / `datePart` accept only VBScript-style **short** interval tokens (`'d'`, `'m'`, `'yyyy'`, `'q'`, `'ww'`, `'h'`, `'n'`, `'s'`, …). An unrecognized token was handled **silently**:
- `dateDiff` fell through to `return 0`
- `getDateInterval` defaulted to `DAY_OF_YEAR`

So a caller who wrote the natural full word — e.g. `dateDiff('day', d1, d2)` — got a **plausible-but-wrong** result (always `0`) with no error. The trap is sharp because the natural word is exactly the vocabulary the wiz plugin's own `dateGroupLevel` uses (`"day"`, `"month"`, `"year"`), so an LLM-authored expression column reaches for it.

### Fix
New `normalizeDateInterval()`, called at the top of `dateAdd`, `dateDiff`, and `datePartForceWeekOfMonth`:
- trims + lower-cases the token;
- maps a full-word alias to its canonical short token — `day/days→d`, `week/weeks→ww` (a **real calendar week**, deliberately *not* the short `w`, which `dateDiff` counts as DAYS), `month→m`, `quarter→q`, `year→yyyy`, `hour→h`, `minute→n`, `second→s` (plus `min`/`sec`/`hr`/`yr`);
- validates against the **union** of tokens the three functions accept (including the `datePart`-only `mq`/`wmq`/`wq`/`wy`/`dq`/`wm`), throwing `IllegalArgumentException` naming the offending token for anything else.

Forgiving where the intent is unambiguous, loud otherwise — per the project's tool-robustness principle (the deployed product is driven by an LLM that will make exactly this vocabulary mistake).

Found live on an odoo wiz sweep: a `LAG(order date)` window column fed a `dateDiff('day', prev, cur)` gap expression that silently produced **all-zero** gaps.

## Test plan
- [x] `JavaScriptEngineTest` — 48/48 pass (6 new: full-word aliases for dateDiff/dateAdd; `week`→`ww` not `w`; fail-loud on unknown token for all three; datePart specialized tokens still work).
- [x] `GraalJavaScriptEngineTest` + `GraalJavaScriptEngineGlobalsTest` — 14/14 (exercise the functions through real JS).
- [x] `DCMergeDatePartFilterTest` — 4/4 standalone (its failures in a combined run are a pre-existing cross-test static-init issue in `inetsoft.report.internal.Util`, reproduced identically on the unmodified baseline).
- [ ] Live image build + end-to-end verify (`dateDiff('day', …)` returns real gaps; `'fortnight'` fails loud) — in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>