### PR TITLE
fixed bug 75656

### DIFF
--- a/core/src/main/java/inetsoft/web/security/AbstractSecurityFilter.java
+++ b/core/src/main/java/inetsoft/web/security/AbstractSecurityFilter.java
@@ -691,7 +691,7 @@ public abstract class AbstractSecurityFilter
       return true;
    }
 
-   private boolean isAnonymousPrincipal(SRPrincipal principal) {
+   protected boolean isAnonymousPrincipal(SRPrincipal principal) {
       if(principal == null || principal.getName() == null) {
          return false;
       }

--- a/core/src/main/java/inetsoft/web/security/DefaultAuthorizationFilter.java
+++ b/core/src/main/java/inetsoft/web/security/DefaultAuthorizationFilter.java
@@ -21,7 +21,6 @@ import inetsoft.sree.*;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.security.*;
 import inetsoft.sree.web.SessionLicenseServiceProvider;
-import inetsoft.uql.XPrincipal;
 import inetsoft.web.viewsheet.service.LinkUriArgumentResolver;
 import jakarta.servlet.*;
 import jakarta.servlet.http.*;
@@ -70,7 +69,7 @@ public class DefaultAuthorizationFilter extends AbstractSecurityFilter {
          recordedOrgID = recordedOrgID == null ? SUtil.getLoginOrganization(httpRequest) : recordedOrgID;
          recordedOrgID = recordedOrgID == null ? getCookieRecordedOrgID((HttpServletRequest) request) : recordedOrgID;
 
-         if((principal == null || principal.getName().equals(XPrincipal.ANONYMOUS)) &&
+         if((principal == null || isAnonymousPrincipal(principal)) &&
             // if there is a user explicitly named "anonymous", it is an allowed guest login
             (engine == null || !engine.containsAnonymous(recordedOrgID)))
          {
@@ -78,7 +77,7 @@ public class DefaultAuthorizationFilter extends AbstractSecurityFilter {
          }
       }
       else if(isEnterpriseManager(httpRequest)) {
-         if(principal == null || principal.getName().equals(XPrincipal.ANONYMOUS) ||
+         if(principal == null || isAnonymousPrincipal(principal) ||
             !provider.checkPermission(principal, ResourceType.EM, "*", ResourceAction.ACCESS))
          {
             unauthorized = true;

--- a/core/src/test/java/inetsoft/web/security/DefaultAuthorizationFilterTest.java
+++ b/core/src/test/java/inetsoft/web/security/DefaultAuthorizationFilterTest.java
@@ -49,51 +49,15 @@ package inetsoft.web.security;
  *             that org's intended guest scope, not arbitrary cross-tenant admin access. Worth
  *             hardening for multi-tenant deployments; not a high-severity dump by itself.
  *
- * [Suspect 3] (#75656) DefaultAuthorizationFilter.doFilter() line 73 -> intent: treat an
- *             already-anonymous principal the same as "no principal" for the generic auth gate
- *             (i.e. still subject to containsAnonymous(orgID))
- *             actual: the check is `principal.getName().equals(XPrincipal.ANONYMOUS)` -- a literal
- *             equals against the bare string "anonymous". SRPrincipal.getName() always returns
- *             client.getUserIdentity().convertToKey(), which (IdentityID.convertToKey(),
- *             unconditionally) appends KEY_DELIMITER + org -- e.g. "anonymous~;~default" -- never
- *             the bare literal. So this comparison is essentially never true for a real
- *             SRPrincipal, regardless of org. Once ANY anonymous session already exists in a
- *             request's HttpSession (created for any org, at any earlier time, by any path), every
- *             *subsequent* request in that same session sails through this filter's generic gate
- *             as if it were a fully authenticated, non-anonymous user -- containsAnonymous(orgID)
- *             was never even consulted for it. This was a materially worse version of the ordering
- *             RISK noted in AnonymousUserFilterTest: it was not just "AnonymousUserFilter has no
- *             gate of its own", it was that DefaultAuthorizationFilter's *own* re-check of an
- *             established anonymous principal didn't work either. Notably, this exact file already
- *             had the correct pattern nearby: line 139-140 uses
- *             `principal.getName().startsWith(ClientInfo.ANONYMOUS)` (which does work, since the
- *             delimiter comes after the name), and both AbstractSecurityFilter.isAnonymousPrincipal()
- *             and AbstractLogoutFilter.isGuestLogin() correctly parse the key via
- *             IdentityID.getIdentityIDFromKey(...).getName() first -- line 73 was the outlier. See
+ * [Suspect 3] (#75656) FIXED -- DefaultAuthorizationFilter.doFilter() used to compare
+ *             principal.getName() (the raw "name~;~org" key) directly against the bare literal
+ *             XPrincipal.ANONYMOUS, so it never matched a real anonymous principal. Now fixed via
+ *             isAnonymousPrincipal(), which parses the key first. See
  *             doFilter_anonymousPrincipal_orgDisallowsAnonymous_redirectsToLogin_guardsSuspect3Fix
- *             below (the regression guard for this exact bug), and
- *             SecurityFilterChainOrderingTest's two paired tests --
- *             reversedOrder_anonymousFilterBeforeAuthorizationFilter_atLeastStillAttemptsAnonymousAuth
- *             (order-independent fact) and
- *             reversedOrder_anonymousFilterBeforeAuthorizationFilter_stillRejectedAfterSuspect3Fix
- *             (correct post-fix behavior) -- which demonstrate the full, concrete consequence that
- *             existed before the fix: once AnonymousUserFilter establishes a session (which it will
- *             do unconditionally if it runs before this filter -- see AnonymousUserFilterTest),
- *             the bug let that anonymous session sail through as authorized on every later request,
- *             not just the one that created it.
- *             Tracked as Redmine #75656.
+ *             below and SecurityFilterChainOrderingTest's
+ *             reversedOrder_anonymousFilterBeforeAuthorizationFilter_stillRejectedAfterSuspect3Fix.
  *
- * FIXED: Suspect 3 (#75656) has been fixed. DefaultAuthorizationFilter.doFilter() now calls the
- * shared AbstractSecurityFilter.isAnonymousPrincipal(principal) helper (made protected for reuse)
- * at both the generic gate (line 72) and the EM else-if branch (line 80), which parses the
- * identity key via IdentityID.getIdentityIDFromKey(...).getName() before comparing to
- * XPrincipal.ANONYMOUS, instead of comparing the raw key. The two regression-guard tests --
- * doFilter_anonymousPrincipal_orgDisallowsAnonymous_redirectsToLogin_guardsSuspect3Fix here and
- * SecurityFilterChainOrderingTest's reversedOrder_..._stillRejectedAfterSuspect3Fix -- are enabled
- * and now pass, pinning down the fixed behavior. Suspect 1 and Suspect 2 remain unpatched in the
- * production filter and are pinned down as passing characterization tests below (not disabled).
- * See also the matching suspects in AnonymousUserFilterTest, and the write-up in
- * docs/superpowers/specs/2026-07-14-penetration-filter-test-plan.md §2.1.
+ * Suspect 1 and Suspect 2 remain unpatched; pinned down as passing characterization tests below.
  */
 
 import inetsoft.sree.ClientInfo;
@@ -393,10 +357,7 @@ class DefaultAuthorizationFilterTest {
 
    private static SRPrincipal anonymousPrincipal() {
       SRPrincipal principal = mock(SRPrincipal.class, withSettings().lenient());
-      // Real SRPrincipal.getName() always returns client.getUserIdentity().convertToKey(), which
-      // (IdentityID.convertToKey(), unconditionally) appends KEY_DELIMITER + org -- it is never
-      // the bare "anonymous" literal. See the file-header Suspect 3 note: this distinction is
-      // exactly what exposes the broken equals() check at doFilter() line 73.
+      // SRPrincipal.getName() returns the "name~;~org" identity key, not the bare literal.
       when(principal.getName()).thenReturn(XPrincipal.ANONYMOUS + IdentityID.KEY_DELIMITER + "default");
       return principal;
    }

--- a/core/src/test/java/inetsoft/web/security/DefaultAuthorizationFilterTest.java
+++ b/core/src/test/java/inetsoft/web/security/DefaultAuthorizationFilterTest.java
@@ -61,39 +61,38 @@ package inetsoft.web.security;
  *             request's HttpSession (created for any org, at any earlier time, by any path), every
  *             *subsequent* request in that same session sails through this filter's generic gate
  *             as if it were a fully authenticated, non-anonymous user -- containsAnonymous(orgID)
- *             is never even consulted for it. This is a materially worse version of the ordering
- *             RISK noted in AnonymousUserFilterTest: it is not just "AnonymousUserFilter has no
- *             gate of its own", it is that DefaultAuthorizationFilter's *own* re-check of an
- *             established anonymous principal doesn't work either. Notably, this exact file has
- *             the correct pattern nearby: line 139-140 uses
+ *             was never even consulted for it. This was a materially worse version of the ordering
+ *             RISK noted in AnonymousUserFilterTest: it was not just "AnonymousUserFilter has no
+ *             gate of its own", it was that DefaultAuthorizationFilter's *own* re-check of an
+ *             established anonymous principal didn't work either. Notably, this exact file already
+ *             had the correct pattern nearby: line 139-140 uses
  *             `principal.getName().startsWith(ClientInfo.ANONYMOUS)` (which does work, since the
  *             delimiter comes after the name), and both AbstractSecurityFilter.isAnonymousPrincipal()
  *             and AbstractLogoutFilter.isGuestLogin() correctly parse the key via
- *             IdentityID.getIdentityIDFromKey(...).getName() first -- line 73 is the outlier. See
+ *             IdentityID.getIdentityIDFromKey(...).getName() first -- line 73 was the outlier. See
  *             doFilter_anonymousPrincipal_orgDisallowsAnonymous_redirectsToLogin_guardsSuspect3Fix
- *             below (the @Disabled regression guard for this exact bug), and
+ *             below (the regression guard for this exact bug), and
  *             SecurityFilterChainOrderingTest's two paired tests --
  *             reversedOrder_anonymousFilterBeforeAuthorizationFilter_atLeastStillAttemptsAnonymousAuth
- *             (enabled; order-independent fact) and
+ *             (order-independent fact) and
  *             reversedOrder_anonymousFilterBeforeAuthorizationFilter_stillRejectedAfterSuspect3Fix
- *             (@Disabled; correct post-fix behavior) -- which demonstrate the full, concrete
- *             consequence: once AnonymousUserFilter establishes a session (which it will do
- *             unconditionally if it runs before this filter -- see AnonymousUserFilterTest), this
- *             bug lets that anonymous session sail through as authorized on every later request,
+ *             (correct post-fix behavior) -- which demonstrate the full, concrete consequence that
+ *             existed before the fix: once AnonymousUserFilter establishes a session (which it will
+ *             do unconditionally if it runs before this filter -- see AnonymousUserFilterTest),
+ *             the bug let that anonymous session sail through as authorized on every later request,
  *             not just the one that created it.
- *             Tracked as Redmine #75656. Confirmed live against current source (re-verified: see
- *             SRPrincipal.getName() -> IdentityID.convertToKey(), which unconditionally appends
- *             KEY_DELIMITER + org with no code path that omits it).
+ *             Tracked as Redmine #75656.
  *
- * Neither Suspect 1 nor Suspect 2 is patched in the production filter here; both are pinned down
- * as passing characterization tests below (not disabled). Suspect 3 (#75656) is now a CONFIRMED
- * defect: doFilter_anonymousPrincipal_orgDisallowsAnonymous_redirectsToLogin_guardsSuspect3Fix
- * below asserts the *correct* (intended) behavior and is marked @Disabled with the bug/fix
- * pointer, per this repo's test-generation convention for a single confirmed defect. Once
- * DefaultAuthorizationFilter.java:73 is fixed (see the @Disabled reason on that test for the
- * suggested fix), remove the @Disabled annotation -- the test should then pass unmodified and
- * becomes the permanent regression guard for this bug. See also the matching suspects in
- * AnonymousUserFilterTest, and the write-up in
+ * FIXED: Suspect 3 (#75656) has been fixed. DefaultAuthorizationFilter.doFilter() now calls the
+ * shared AbstractSecurityFilter.isAnonymousPrincipal(principal) helper (made protected for reuse)
+ * at both the generic gate (line 72) and the EM else-if branch (line 80), which parses the
+ * identity key via IdentityID.getIdentityIDFromKey(...).getName() before comparing to
+ * XPrincipal.ANONYMOUS, instead of comparing the raw key. The two regression-guard tests --
+ * doFilter_anonymousPrincipal_orgDisallowsAnonymous_redirectsToLogin_guardsSuspect3Fix here and
+ * SecurityFilterChainOrderingTest's reversedOrder_..._stillRejectedAfterSuspect3Fix -- are enabled
+ * and now pass, pinning down the fixed behavior. Suspect 1 and Suspect 2 remain unpatched in the
+ * production filter and are pinned down as passing characterization tests below (not disabled).
+ * See also the matching suspects in AnonymousUserFilterTest, and the write-up in
  * docs/superpowers/specs/2026-07-14-penetration-filter-test-plan.md §2.1.
  */
 
@@ -189,15 +188,6 @@ class DefaultAuthorizationFilterTest {
    }
 
    @Test
-   @Disabled("Suspect 3 (#75656): principal.getName().equals(XPrincipal.ANONYMOUS) at "
-      + "DefaultAuthorizationFilter.java:73 compares the raw identity key (name+delimiter+org), "
-      + "which SRPrincipal.getName()/IdentityID.convertToKey() always produce -- it is never "
-      + "equal to the bare \"anonymous\" literal, so this redirect never fires for a real "
-      + "anonymous principal today (currently passes through as if authenticated instead). "
-      + "Fix: parse the key first, e.g. IdentityID.getIdentityIDFromKey(principal.getName())"
-      + ".getName().equals(XPrincipal.ANONYMOUS), matching the startsWith(ClientInfo.ANONYMOUS) "
-      + "pattern already used a few lines down at line 139-140. Remove this @Disabled once fixed "
-      + "-- the assertions below already describe the correct behavior and should pass unmodified.")
    void doFilter_anonymousPrincipal_orgDisallowsAnonymous_redirectsToLogin_guardsSuspect3Fix()
       throws Exception
    {

--- a/core/src/test/java/inetsoft/web/security/SecurityFilterChainOrderingTest.java
+++ b/core/src/test/java/inetsoft/web/security/SecurityFilterChainOrderingTest.java
@@ -37,15 +37,8 @@ package inetsoft.web.security;
  * SSO isn't set up -- so it doesn't change any of the orderings this test exercises; included here
  * only for accuracy against StandardFilterChain.java:41-45.)
  *
- * Note: the reversed-order test originally written here ("reordering only wastes a session, the
- * response is still rejected") did NOT confirm what it expected at the time. It instead surfaced
- * DefaultAuthorizationFilterTest's Suspect 3 (#75656, a broken anonymous-principal equals() check)
- * in its full, concrete form: reordering AnonymousUserFilter before DefaultAuthorizationFilter was
- * a complete authorization bypass, not just a wasted session. That finding was split into two
- * tests below: one confirming the order-independent fact (AnonymousUserFilter always attempts
- * anonymous auth when it runs first, bug or no bug), and one asserting the correct post-fix
- * behavior (still rejected, even in the wrong order). #75656 is now fixed (see
- * DefaultAuthorizationFilter.isAnonymousPrincipal() usage) and both tests are enabled and passing.
+ * Note: #75656 (DefaultAuthorizationFilterTest's Suspect 3) is fixed -- see
+ * reversedOrder_anonymousFilterBeforeAuthorizationFilter_stillRejectedAfterSuspect3Fix below.
  *
  * No production code is touched here; this class only observes the composed behavior.
  */
@@ -205,14 +198,8 @@ class SecurityFilterChainOrderingTest {
    void reversedOrder_anonymousFilterBeforeAuthorizationFilter_atLeastStillAttemptsAnonymousAuth()
       throws Exception
    {
-      // Same org-disallows-anonymous setup as the correctly-ordered test above, but with the two
-      // filters registered in the *wrong* order, as if a future refactor accidentally swapped
-      // them. This much is independent of Suspect 3 / #75656 and stays true either way:
-      // AnonymousUserFilter has no org gate of its own (see AnonymousUserFilterTest), so it
-      // unconditionally attempts anonymous authentication when it runs first. The observable
-      // *consequence* of that (does the request ultimately get rejected or not) depends on
-      // whether DefaultAuthorizationFilter's own re-check of an established anonymous principal
-      // works -- see the test right below, which is the more informative one.
+      // Filters registered in the wrong order: AnonymousUserFilter has no org gate of its own, so
+      // it always attempts anonymous auth when it runs first, regardless of #75656.
       when(mockEngine.containsAnonymous(any())).thenReturn(false);
       SRPrincipal anonymousPrincipal = anonymousPrincipal();
       doReturn(anonymousPrincipal).when(authService).authenticate(any(ClientInfo.class), isNull());

--- a/core/src/test/java/inetsoft/web/security/SecurityFilterChainOrderingTest.java
+++ b/core/src/test/java/inetsoft/web/security/SecurityFilterChainOrderingTest.java
@@ -38,15 +38,14 @@ package inetsoft.web.security;
  * only for accuracy against StandardFilterChain.java:41-45.)
  *
  * Note: the reversed-order test originally written here ("reordering only wastes a session, the
- * response is still rejected") did NOT confirm what it expected. It instead surfaced
+ * response is still rejected") did NOT confirm what it expected at the time. It instead surfaced
  * DefaultAuthorizationFilterTest's Suspect 3 (#75656, a broken anonymous-principal equals() check)
- * in its full, concrete form: reordering AnonymousUserFilter before DefaultAuthorizationFilter is
- * a complete authorization bypass today, not just a wasted session. That finding is now split into
- * two tests below: an enabled one confirming the order-independent fact (AnonymousUserFilter
- * always attempts anonymous auth when it runs first, bug or no bug), and a @Disabled one asserting
- * the correct post-fix behavior (still rejected, even in the wrong order) -- remove its @Disabled
- * once DefaultAuthorizationFilter.java:73 is fixed, per the same #75656 fix referenced in
- * DefaultAuthorizationFilterTest.
+ * in its full, concrete form: reordering AnonymousUserFilter before DefaultAuthorizationFilter was
+ * a complete authorization bypass, not just a wasted session. That finding was split into two
+ * tests below: one confirming the order-independent fact (AnonymousUserFilter always attempts
+ * anonymous auth when it runs first, bug or no bug), and one asserting the correct post-fix
+ * behavior (still rejected, even in the wrong order). #75656 is now fixed (see
+ * DefaultAuthorizationFilter.isAnonymousPrincipal() usage) and both tests are enabled and passing.
  *
  * No production code is touched here; this class only observes the composed behavior.
  */
@@ -213,7 +212,7 @@ class SecurityFilterChainOrderingTest {
       // unconditionally attempts anonymous authentication when it runs first. The observable
       // *consequence* of that (does the request ultimately get rejected or not) depends on
       // whether DefaultAuthorizationFilter's own re-check of an established anonymous principal
-      // works -- see the @Disabled test right below, which is currently the more informative one.
+      // works -- see the test right below, which is the more informative one.
       when(mockEngine.containsAnonymous(any())).thenReturn(false);
       SRPrincipal anonymousPrincipal = anonymousPrincipal();
       doReturn(anonymousPrincipal).when(authService).authenticate(any(ClientInfo.class), isNull());
@@ -232,17 +231,6 @@ class SecurityFilterChainOrderingTest {
    }
 
    @Test
-   @Disabled("Suspect 3 (#75656): with AnonymousUserFilter and DefaultAuthorizationFilter "
-      + "registered in the wrong order, DefaultAuthorizationFilter.java:73's broken "
-      + "equals(XPrincipal.ANONYMOUS) check currently fails to recognize the anonymous principal "
-      + "AnonymousUserFilter just established, so containsAnonymous(orgID) is never re-consulted "
-      + "and the request incorrectly reaches the protected resource (200) even though the org "
-      + "never allowed anonymous access -- a full authorization bypass, not just a wasted session. "
-      + "Fix at DefaultAuthorizationFilter.java:73 (see DefaultAuthorizationFilterTest's "
-      + "doFilter_anonymousPrincipal_orgDisallowsAnonymous_redirectsToLogin_guardsSuspect3Fix for "
-      + "the suggested fix). Remove this @Disabled once fixed -- the assertion below already "
-      + "describes the correct behavior (still rejected, even in the wrong filter order) and "
-      + "should pass unmodified.")
    void reversedOrder_anonymousFilterBeforeAuthorizationFilter_stillRejectedAfterSuspect3Fix()
       throws Exception
    {


### PR DESCRIPTION
**Summary**
`DefaultAuthorizationFilter` is supposed to treat an already-anonymous principal the same as “no principal” for the generic auth gate: both must still pass `SecurityEngine.containsAnonymous(orgID)`. The implemented check uses a literal equality against the bare string `"anonymous"`, which never matches a real `SRPrincipal.getName()` value (`"anonymous~;~<orgId>"`). As a result, once any anonymous session is present in the `HttpSession`, every later request in that session skips `containsAnonymous` and is treated as a fully authenticated, non-anonymous user at this filter.

Root cause confirmed: DefaultAuthorizationFilter.doFilter() compared principal.getName() (which is always IdentityID.convertToKey(), e.g. anonymous~;~default) directly against the bare literal XPrincipal.ANONYMOUS ("anonymous"). This equality never holds for a real SRPrincipal, so both the generic auth gate (line 73) and the EM branch (line 81) treated any already-anonymous principal as fully authenticated, skipping containsAnonymous(orgID).

Fix (community/core/src/main/java/inetsoft/web/security/):
- DefaultAuthorizationFilter.java: replaced both broken principal.getName().equals(XPrincipal.ANONYMOUS) checks with isAnonymousPrincipal(principal), reusing the existing correct helper (removed the now-unused XPrincipal import).
- AbstractSecurityFilter.java: widened isAnonymousPrincipal() from private to protected so the subclass can reuse it, per the suggested fix.

Tests updated: the repo already had regression-guard tests written for this exact bug (#75656), marked @Disabled pending the fix — DefaultAuthorizationFilterTest.doFilter_anonymousPrincipal_orgDisallowsAnonymous_redirectsToLogin_guardsSuspect3Fix and SecurityFilterChainOrderingTest.reversedOrder_anonymousFilterBeforeAuthorizationFilter_stillRejectedAfterSuspect3Fix. Removed the @Disabled annotations and updated the stale file-header comments describing the bug as unfixed.

Verification: ran the full inetsoft.web.security test package — 116 tests, 0 failures/errors/skips, including the two newly-enabled regression guards passing unmodified.