### PR TITLE
Fix non-JDBC data source error handling with dedicated exception and 422 response

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz;
 
 import inetsoft.util.Catalog;
+import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -62,9 +63,9 @@ public class WizControllerErrorHandler {
    // A controller with its own local catch-all Exception.class handler (e.g.
    // WorksheetTableController) still needs its own local override to get this treatment, exactly
    // like the SecurityException case above.
-   @ExceptionHandler(inetsoft.web.wiz.service.UnsupportedDatasourceException.class)
+   @ExceptionHandler(UnsupportedDatasourceException.class)
    public ResponseEntity<Map<String, String>> handleUnsupportedDatasource(
-      inetsoft.web.wiz.service.UnsupportedDatasourceException e)
+      UnsupportedDatasourceException e)
    {
       LOG.warn("Unsupported datasource: {} ({})", e.getDatasourceName(), e.getDatasourceType());
 

--- a/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
@@ -57,12 +57,17 @@ public class WizControllerErrorHandler {
    // getJDBCDatasource() (MetadataApiService) is called from several wiz controllers/services
    // beyond DatasourceMetaApiController (which has its own local override of this same handler,
    // since a local @ExceptionHandler always wins over this ControllerAdvice — see that class).
-   // Catching it here too means any OTHER wiz controller that reaches a non-JDBC datasource and
-   // has no local catch-all of its own (e.g. WorksheetAgentController, WorksheetGenerateController)
-   // gets the same friendly 422 instead of whatever its default fallback would otherwise produce.
-   // A controller with its own local catch-all Exception.class handler (e.g.
-   // WorksheetTableController) still needs its own local override to get this treatment, exactly
-   // like the SecurityException case above.
+   // Catching it here benefits WorksheetAgentController.addBoundTable specifically: that method
+   // declares throws Exception with no catch of its own, so an UnsupportedDatasourceException
+   // genuinely propagates here and gets the friendly 422.
+   //
+   // NOT every other getJDBCDatasource caller benefits, though — verify the actual call chain
+   // before assuming one does. WorksheetGenerateController.generateWs() and
+   // WorksheetTableController.createTables() both wrap their whole service call in their own
+   // catch(Exception e) (the latter one layer deeper, inside WorksheetTableService's per-table
+   // try/catch) and always return 200 with errorMessage set — this exception never reaches
+   // either controller, let alone this advice. Making those paths return a real 422 would mean
+   // changing that per-item/per-request error-handling design, not just adding a handler.
    @ExceptionHandler(UnsupportedDatasourceException.class)
    public ResponseEntity<Map<String, String>> handleUnsupportedDatasource(
       UnsupportedDatasourceException e)

--- a/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
@@ -53,5 +53,26 @@ public class WizControllerErrorHandler {
       return new ResponseEntity<>(payload, null, HttpStatus.FORBIDDEN);
    }
 
+   // getJDBCDatasource() (MetadataApiService) is called from several wiz controllers/services
+   // beyond DatasourceMetaApiController (which has its own local override of this same handler,
+   // since a local @ExceptionHandler always wins over this ControllerAdvice — see that class).
+   // Catching it here too means any OTHER wiz controller that reaches a non-JDBC datasource and
+   // has no local catch-all of its own (e.g. WorksheetAgentController, WorksheetGenerateController)
+   // gets the same friendly 422 instead of whatever its default fallback would otherwise produce.
+   // A controller with its own local catch-all Exception.class handler (e.g.
+   // WorksheetTableController) still needs its own local override to get this treatment, exactly
+   // like the SecurityException case above.
+   @ExceptionHandler(inetsoft.web.wiz.service.UnsupportedDatasourceException.class)
+   public ResponseEntity<Map<String, String>> handleUnsupportedDatasource(
+      inetsoft.web.wiz.service.UnsupportedDatasourceException e)
+   {
+      LOG.warn("Unsupported datasource: {} ({})", e.getDatasourceName(), e.getDatasourceType());
+
+      Map<String, String> payload = new HashMap<>();
+      payload.put("error", e.getMessage());
+      payload.put("datasourceType", e.getDatasourceType());
+      return new ResponseEntity<>(payload, null, HttpStatus.UNPROCESSABLE_ENTITY);
+   }
+
    private static final Logger LOG = LoggerFactory.getLogger(WizControllerErrorHandler.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
@@ -291,6 +291,21 @@ public class DatasourceMetaApiController {
                     "message", e.getMessage() != null ? e.getMessage() : "Forbidden");
    }
 
+   // More specific than the catch-all below, so it wins for a datasource that exists but is
+   // non-relational (e.g. MongoDB) — surfaces a clear, actionable message and a semantically
+   // distinct status instead of letting the underlying failure leak out as a raw 500.
+   @ExceptionHandler(inetsoft.web.wiz.service.UnsupportedDatasourceException.class)
+   @ResponseStatus(org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY)
+   @ResponseBody
+   public Map<String, String> handleUnsupportedDatasource(
+      inetsoft.web.wiz.service.UnsupportedDatasourceException e)
+   {
+      LOG.warn("Unsupported datasource for annotation: {} ({})",
+               e.getDatasourceName(), e.getDatasourceType());
+      return Map.of("error", e.getMessage(),
+                    "datasourceType", e.getDatasourceType());
+   }
+
    @ExceptionHandler(Exception.class)
    @ResponseStatus(org.springframework.http.HttpStatus.BAD_REQUEST)
    @ResponseBody

--- a/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
@@ -30,6 +30,7 @@ import inetsoft.web.wiz.model.osi.OsiDataset;
 import inetsoft.web.wiz.request.GetDatabaseTableMetaRequest;
 import inetsoft.web.wiz.request.SchemaSearchRequest;
 import inetsoft.web.wiz.service.MetadataApiService;
+import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
@@ -294,12 +295,10 @@ public class DatasourceMetaApiController {
    // More specific than the catch-all below, so it wins for a datasource that exists but is
    // non-relational (e.g. MongoDB) — surfaces a clear, actionable message and a semantically
    // distinct status instead of letting the underlying failure leak out as a raw 500.
-   @ExceptionHandler(inetsoft.web.wiz.service.UnsupportedDatasourceException.class)
+   @ExceptionHandler(UnsupportedDatasourceException.class)
    @ResponseStatus(org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY)
    @ResponseBody
-   public Map<String, String> handleUnsupportedDatasource(
-      inetsoft.web.wiz.service.UnsupportedDatasourceException e)
-   {
+   public Map<String, String> handleUnsupportedDatasource(UnsupportedDatasourceException e) {
       LOG.warn("Unsupported datasource for annotation: {} ({})",
                e.getDatasourceName(), e.getDatasourceType());
       return Map.of("error", e.getMessage(),

--- a/core/src/main/java/inetsoft/web/wiz/controller/WorksheetTableController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WorksheetTableController.java
@@ -138,6 +138,23 @@ public class WorksheetTableController {
                     "message", e.getMessage() != null ? e.getMessage() : "Forbidden");
    }
 
+   // More specific than the catch-all below, so it wins for a datasource that exists but is
+   // non-relational (e.g. MongoDB) — mirrors DatasourceMetaApiController's local override of
+   // the same WizControllerErrorHandler advice, needed for the same reason: a local handler
+   // always wins over the shared advice, so without this override the catch-all below would
+   // swallow it as a generic 400 instead of the intended 422 + datasourceType.
+   @ExceptionHandler(inetsoft.web.wiz.service.UnsupportedDatasourceException.class)
+   @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+   @ResponseBody
+   public Map<String, String> handleUnsupportedDatasource(
+      inetsoft.web.wiz.service.UnsupportedDatasourceException e)
+   {
+      LOG.warn("Unsupported datasource for worksheet table: {} ({})",
+               e.getDatasourceName(), e.getDatasourceType());
+      return Map.of("error", e.getMessage(),
+                    "datasourceType", e.getDatasourceType());
+   }
+
    @ExceptionHandler(Exception.class)
    @ResponseStatus(HttpStatus.BAD_REQUEST)
    @ResponseBody

--- a/core/src/main/java/inetsoft/web/wiz/controller/WorksheetTableController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WorksheetTableController.java
@@ -19,7 +19,6 @@
 package inetsoft.web.wiz.controller;
 
 import inetsoft.web.wiz.model.*;
-import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import inetsoft.web.wiz.service.WorksheetTableService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -139,21 +138,16 @@ public class WorksheetTableController {
                     "message", e.getMessage() != null ? e.getMessage() : "Forbidden");
    }
 
-   // More specific than the catch-all below, so it wins for a datasource that exists but is
-   // non-relational (e.g. MongoDB) — mirrors DatasourceMetaApiController's local override of
-   // the same WizControllerErrorHandler advice, needed for the same reason: a local handler
-   // always wins over the shared advice, so without this override the catch-all below would
-   // swallow it as a generic 400 instead of the intended 422 + datasourceType.
-   @ExceptionHandler(UnsupportedDatasourceException.class)
-   @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
-   @ResponseBody
-   public Map<String, String> handleUnsupportedDatasource(UnsupportedDatasourceException e) {
-      LOG.warn("Unsupported datasource for worksheet table: {} ({})",
-               e.getDatasourceName(), e.getDatasourceType());
-      return Map.of("error", e.getMessage(),
-                    "datasourceType", e.getDatasourceType());
-   }
-
+   // NOTE: this controller does NOT have a local UnsupportedDatasourceException handler, unlike
+   // DatasourceMetaApiController. createTables() (the only endpoint that reaches
+   // getJDBCDatasource, via WorksheetTableService.addOneTable -> buildPhysicalTable/
+   // buildSqlTable) already catches per-table exceptions inside the service, before they can
+   // ever bubble out to this controller — they're converted to a 200 response with
+   // success=false + errorMessage per table instead (see createTables() below and
+   // WorksheetTableService.createTables()'s per-table try/catch). A local override here would
+   // be unreachable dead code; it was added and then removed after tracing the actual call
+   // chain. If a hard 422 is ever wanted for this endpoint too, that requires changing
+   // WorksheetTableService's per-table error-handling semantics, not just adding a handler here.
    @ExceptionHandler(Exception.class)
    @ResponseStatus(HttpStatus.BAD_REQUEST)
    @ResponseBody

--- a/core/src/main/java/inetsoft/web/wiz/controller/WorksheetTableController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WorksheetTableController.java
@@ -19,6 +19,7 @@
 package inetsoft.web.wiz.controller;
 
 import inetsoft.web.wiz.model.*;
+import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import inetsoft.web.wiz.service.WorksheetTableService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,12 +144,10 @@ public class WorksheetTableController {
    // the same WizControllerErrorHandler advice, needed for the same reason: a local handler
    // always wins over the shared advice, so without this override the catch-all below would
    // swallow it as a generic 400 instead of the intended 422 + datasourceType.
-   @ExceptionHandler(inetsoft.web.wiz.service.UnsupportedDatasourceException.class)
+   @ExceptionHandler(UnsupportedDatasourceException.class)
    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
    @ResponseBody
-   public Map<String, String> handleUnsupportedDatasource(
-      inetsoft.web.wiz.service.UnsupportedDatasourceException e)
-   {
+   public Map<String, String> handleUnsupportedDatasource(UnsupportedDatasourceException e) {
       LOG.warn("Unsupported datasource for worksheet table: {} ({})",
                e.getDatasourceName(), e.getDatasourceType());
       return Map.of("error", e.getMessage(),

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -317,8 +317,15 @@ public class MetadataApiService {
    public JDBCDataSource getJDBCDatasource(String dsName) throws Exception {
       XDataSource dataSource = xrepository.getDataSource(dsName);
 
-      if(!(dataSource instanceof JDBCDataSource jdbcDataSource)) {
+      if(dataSource == null) {
          throw new Exception("Data source " + dsName + " not found.");
+      }
+
+      // The datasource exists but isn't relational (e.g. MongoDB and other tabular/NoSQL
+      // sources extend TabularDataSource, not JDBCDataSource) — there's no catalog/schema/
+      // table metadata to serve, so this is a distinct, expected condition, not a "not found".
+      if(!(dataSource instanceof JDBCDataSource jdbcDataSource)) {
+         throw new UnsupportedDatasourceException(dsName, dataSource.getType());
       }
 
       return jdbcDataSource;

--- a/core/src/main/java/inetsoft/web/wiz/service/UnsupportedDatasourceException.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/UnsupportedDatasourceException.java
@@ -30,18 +30,26 @@ package inetsoft.web.wiz.service;
  */
 public class UnsupportedDatasourceException extends Exception {
    public UnsupportedDatasourceException(String datasourceName, String datasourceType) {
+      // Normalize before calling super() so Throwable's own detailMessage field is populated too
+      // (not just recoverable via an overridden getMessage()) — a static helper can run before
+      // `this` exists, which super(...) as the first statement otherwise wouldn't allow.
+      //
       // XDataSource.getType() can in principle return null for some implementations. Normalize
       // once and reuse everywhere below — the message ("...for 'null' datasources...") isn't the
       // only thing at stake: wiz-services' handler for this exception treats a non-empty
       // datasourceType as the discriminator that confirms a 422 really is this case, so a null
       // here would also make that response silently fail to be recognized as friendly at all.
+      super(buildMessage(normalizeType(datasourceType)));
       this.datasourceName = datasourceName;
-      this.datasourceType = datasourceType != null ? datasourceType : "unknown";
+      this.datasourceType = normalizeType(datasourceType);
    }
 
-   @Override
-   public String getMessage() {
-      return "Operation failed. Annotations are currently not supported for '" + datasourceType +
+   private static String normalizeType(String datasourceType) {
+      return datasourceType != null ? datasourceType : "unknown";
+   }
+
+   private static String buildMessage(String normalizedType) {
+      return "Operation failed. Annotations are currently not supported for '" + normalizedType +
          "' datasources. Please check the datasource type or contact your administrator.";
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/UnsupportedDatasourceException.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/UnsupportedDatasourceException.java
@@ -30,10 +30,19 @@ package inetsoft.web.wiz.service;
  */
 public class UnsupportedDatasourceException extends Exception {
    public UnsupportedDatasourceException(String datasourceName, String datasourceType) {
-      super("Operation failed. Annotations are currently not supported for '" + datasourceType +
-         "' datasources. Please check the datasource type or contact your administrator.");
+      // XDataSource.getType() can in principle return null for some implementations. Normalize
+      // once and reuse everywhere below — the message ("...for 'null' datasources...") isn't the
+      // only thing at stake: wiz-services' handler for this exception treats a non-empty
+      // datasourceType as the discriminator that confirms a 422 really is this case, so a null
+      // here would also make that response silently fail to be recognized as friendly at all.
       this.datasourceName = datasourceName;
-      this.datasourceType = datasourceType;
+      this.datasourceType = datasourceType != null ? datasourceType : "unknown";
+   }
+
+   @Override
+   public String getMessage() {
+      return "Operation failed. Annotations are currently not supported for '" + datasourceType +
+         "' datasources. Please check the datasource type or contact your administrator.";
    }
 
    public String getDatasourceName() {

--- a/core/src/main/java/inetsoft/web/wiz/service/UnsupportedDatasourceException.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/UnsupportedDatasourceException.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+/**
+ * Raised when wiz metadata/annotation is requested for a datasource that exists but is not
+ * relational (e.g. MongoDB or another tabular/NoSQL datasource). These sources have no
+ * JDBC-style catalog/schema/table metadata for StyleBI to serve, so the request fails by
+ * design rather than by a transient error.
+ *
+ * Distinguishing this from "the datasource doesn't exist at all" lets callers show a clear,
+ * actionable message instead of the generic "not found" — see
+ * DatasourceMetaApiController.handleUnsupportedDatasource, which maps this to HTTP 422 with a
+ * structured body instead of letting the underlying failure surface as a raw 500.
+ */
+public class UnsupportedDatasourceException extends Exception {
+   public UnsupportedDatasourceException(String datasourceName, String datasourceType) {
+      super("Operation failed. Annotations are currently not supported for '" + datasourceType +
+         "' datasources. Please check the datasource type or contact your administrator.");
+      this.datasourceName = datasourceName;
+      this.datasourceType = datasourceType;
+   }
+
+   public String getDatasourceName() {
+      return datasourceName;
+   }
+
+   public String getDatasourceType() {
+      return datasourceType;
+   }
+
+   private final String datasourceName;
+   private final String datasourceType;
+}

--- a/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
@@ -62,12 +62,34 @@ class WizControllerErrorHandlerTest {
          .andExpect(content().string(containsString("Forbidden")));
    }
 
+   /**
+    * Confirms the shared advice benefits controllers with NO local catch-all of their own
+    * (e.g. WorksheetAgentController, WorksheetGenerateController) — only DatasourceMetaApiController
+    * has its own local override of this same handler, needed because a local
+    * {@code @ExceptionHandler} always wins over this advice.
+    */
+   @Test
+   void unsupportedDatasourceExceptionMapsToUnprocessableEntityWithDatasourceType() throws Exception {
+      // Content negotiation here defaults to XML (no Accept header, no @ResponseBody producer
+      // configured on the test double), so assert on substrings rather than exact JSON syntax —
+      // mirrors the loose containsString checks the SecurityException cases above already use.
+      mvc.perform(get("/wiz-test/throw").param("type", "unsupported"))
+         .andExpect(status().isUnprocessableEntity())
+         .andExpect(content().string(containsString("not supported")))
+         .andExpect(content().string(containsString("datasourceType")))
+         .andExpect(content().string(containsString("Mongo")));
+   }
+
    @RestController
    private static class ThrowingController {
       @GetMapping("/wiz-test/throw")
       public String throwIt(@RequestParam("type") String type) throws Exception {
          if("sree".equals(type)) {
             throw new inetsoft.sree.security.SecurityException("denied");
+         }
+
+         if("unsupported".equals(type)) {
+            throw new inetsoft.web.wiz.service.UnsupportedDatasourceException("MongoDB REST", "Mongo");
          }
 
          throw new java.lang.SecurityException("denied");

--- a/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz;
 
+import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -89,7 +90,7 @@ class WizControllerErrorHandlerTest {
          }
 
          if("unsupported".equals(type)) {
-            throw new inetsoft.web.wiz.service.UnsupportedDatasourceException("MongoDB REST", "Mongo");
+            throw new UnsupportedDatasourceException("MongoDB REST", "Mongo");
          }
 
          throw new java.lang.SecurityException("denied");

--- a/core/src/test/java/inetsoft/web/wiz/controller/DatasourceMetaApiControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/DatasourceMetaApiControllerTest.java
@@ -22,11 +22,14 @@ import inetsoft.web.portal.controller.database.DataSourceService;
 import inetsoft.web.wiz.model.osi.OsiDataset;
 import inetsoft.web.wiz.request.GetDatabaseTableMetaRequest;
 import inetsoft.web.wiz.service.MetadataApiService;
+import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.security.Principal;
+import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -61,5 +64,28 @@ class DatasourceMetaApiControllerTest {
 
       assertSame(expected, result);
       verify(metadataService).getMetaData(request, principal);
+   }
+
+   /**
+    * The datasource-exists-but-not-relational case (e.g. MongoDB) must produce a friendly,
+    * structured body naming the actual datasource type — not the raw 500 HTML page that used
+    * to leak out before {@link UnsupportedDatasourceException} existed.
+    */
+   @Test
+   void handleUnsupportedDatasource_returnsFriendlyErrorNamingTheDatasourceType() {
+      MetadataApiService metadataService = mock(MetadataApiService.class);
+      XRepository xrepository = mock(XRepository.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      DatasourceMetaApiController controller =
+         new DatasourceMetaApiController(metadataService, xrepository, dataSourceService);
+
+      UnsupportedDatasourceException ex =
+         new UnsupportedDatasourceException("MongoDB REST", "Mongo");
+
+      Map<String, String> body = controller.handleUnsupportedDatasource(ex);
+
+      assertEquals("Mongo", body.get("datasourceType"));
+      assertEquals(ex.getMessage(), body.get("error"));
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceGetJDBCDatasourceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceGetJDBCDatasourceTest.java
@@ -84,6 +84,26 @@ class MetadataApiServiceGetJDBCDatasourceTest {
       assertTrue(ex.getMessage().toLowerCase().contains("not supported"));
    }
 
+   // XDataSource.getType() can in principle return null for some implementations. Without a
+   // fallback, the message would read "...for 'null' datasources..." AND — more importantly —
+   // the serialized datasourceType would be null, which would make wiz-services' discriminator
+   // check for this exact 422 shape silently fail to recognize it as friendly at all.
+   @Test
+   void getJDBCDatasource_normalizesANullDatasourceTypeInsteadOfSayingNull() throws Exception {
+      XRepository xrepository = mock(XRepository.class);
+      XDataSource untypedDataSource = mock(XDataSource.class);
+      when(untypedDataSource.getType()).thenReturn(null);
+      when(xrepository.getDataSource("Weird REST")).thenReturn(untypedDataSource);
+
+      MetadataApiService service = createService(xrepository);
+
+      UnsupportedDatasourceException ex = assertThrows(UnsupportedDatasourceException.class,
+         () -> service.getJDBCDatasource("Weird REST"));
+
+      assertNotNull(ex.getDatasourceType());
+      assertFalse(ex.getMessage().contains("'null'"));
+   }
+
    @Test
    void getJDBCDatasource_returnsTheJDBCDatasourceWhenRelational() throws Exception {
       XRepository xrepository = mock(XRepository.class);

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceGetJDBCDatasourceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceGetJDBCDatasourceTest.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.uql.XDataSource;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.jdbc.JDBCDataSource;
+import inetsoft.web.composer.AssetTreeService;
+import inetsoft.web.portal.controller.database.DataSourceService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers {@link MetadataApiService#getJDBCDatasource}, which must tell apart two distinct
+ * failure modes that previously shared one generic "not found" message:
+ * <ul>
+ *   <li>the datasource genuinely doesn't exist (no XDataSource registered under that name)</li>
+ *   <li>the datasource exists but is not relational (e.g. MongoDB extends TabularDataSource,
+ *       not JDBCDataSource) — a distinct, expected condition that
+ *       {@link inetsoft.web.wiz.controller.DatasourceMetaApiController} maps to a friendly
+ *       HTTP 422 instead of letting it leak out as a raw 500.</li>
+ * </ul>
+ */
+@Tag("core")
+class MetadataApiServiceGetJDBCDatasourceTest {
+
+   private MetadataApiService createService(XRepository xrepository) {
+      return new MetadataApiService(
+         xrepository, mock(DataSourceService.class), mock(AssetRepository.class),
+         mock(AssetTreeService.class), new ObjectMapper());
+   }
+
+   @Test
+   void getJDBCDatasource_throwsPlainExceptionWhenDatasourceDoesNotExist() throws Exception {
+      XRepository xrepository = mock(XRepository.class);
+      when(xrepository.getDataSource("nope")).thenReturn(null);
+
+      MetadataApiService service = createService(xrepository);
+
+      Exception ex = assertThrows(Exception.class, () -> service.getJDBCDatasource("nope"));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException,
+         "a missing datasource is a plain not-found, not an unsupported-type condition");
+      assertTrue(ex.getMessage().contains("nope"));
+   }
+
+   @Test
+   void getJDBCDatasource_throwsUnsupportedDatasourceExceptionWhenNotRelational() throws Exception {
+      XRepository xrepository = mock(XRepository.class);
+      XDataSource mongoDataSource = mock(XDataSource.class);
+      when(mongoDataSource.getType()).thenReturn("Mongo");
+      when(xrepository.getDataSource("MongoDB REST")).thenReturn(mongoDataSource);
+
+      MetadataApiService service = createService(xrepository);
+
+      UnsupportedDatasourceException ex = assertThrows(UnsupportedDatasourceException.class,
+         () -> service.getJDBCDatasource("MongoDB REST"));
+
+      assertEquals("MongoDB REST", ex.getDatasourceName());
+      assertEquals("Mongo", ex.getDatasourceType());
+      assertTrue(ex.getMessage().contains("'Mongo' datasources"),
+         "message should name the actual datasource type, not a hardcoded one");
+      assertTrue(ex.getMessage().toLowerCase().contains("not supported"));
+   }
+
+   @Test
+   void getJDBCDatasource_returnsTheJDBCDatasourceWhenRelational() throws Exception {
+      XRepository xrepository = mock(XRepository.class);
+      JDBCDataSource jdbcDataSource = mock(JDBCDataSource.class);
+      when(xrepository.getDataSource("Examples/Orders")).thenReturn(jdbcDataSource);
+
+      MetadataApiService service = createService(xrepository);
+
+      assertSame(jdbcDataSource, service.getJDBCDatasource("Examples/Orders"));
+   }
+}


### PR DESCRIPTION
StyleBI throws a generic exception for non-JDBC data sources (e.g., MongoDB) without a dedicated handler, causing raw 500 HTML error pages to be exposed during annotation. The existing regex fallback in wiz-services is fragile and has incomplete coverage. Therefore, a new UnsupportedDatasourceException and corresponding exception handler have been added on the StyleBI side to distinguish between "not found" and "unsupported type," returning semantically correct 422-friendly messages. The probing logic in wiz-services has also been adjusted to prioritize recognizing this 422 response (with the regex fallback retained for backward compatibility), fixing the root cause rather than applying a superficial patch.