### PR TITLE
feat(wiz): add replacePrevious flag to changeType to keep the old chart

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/AutoBindingRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/AutoBindingRequest.java
@@ -139,6 +139,14 @@ public class AutoBindingRequest {
       this.sampleMaxRows = sampleMaxRows;
    }
 
+   public boolean isReplacePrevious() {
+      return replacePrevious;
+   }
+
+   public void setReplacePrevious(boolean replacePrevious) {
+      this.replacePrevious = replacePrevious;
+   }
+
    /**
     * Recommendation-computation RVS ID. Null on first call; returned by the server
     * and passed back on subsequent calls to reuse the same RVS.
@@ -169,4 +177,11 @@ public class AutoBindingRequest {
     * #75456: sampled-preview row cap; null/&lt;=0 = full data (default).
     */
    private Integer sampleMaxRows;
+
+   /**
+    * Only set by {@code changeType}'s fallback path. {@code true} = in-place replace (remove the
+    * displaced primary); {@code false} (default, and always for the public autoBinding entry point)
+    * = keep the previous assembly and add the new one alongside it.
+    */
+   private boolean replacePrevious;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/ChangeTypeRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChangeTypeRequest.java
@@ -64,6 +64,14 @@ public class ChangeTypeRequest {
       this.viewsheetIdentifier = viewsheetIdentifier;
    }
 
+   public boolean isReplacePrevious() {
+      return replacePrevious;
+   }
+
+   public void setReplacePrevious(boolean replacePrevious) {
+      this.replacePrevious = replacePrevious;
+   }
+
    private String worksheetId;
    private String visualizationType;
    /**
@@ -82,4 +90,10 @@ public class ChangeTypeRequest {
     * Passed back so the viewsheet entry is overwritten in place rather than duplicated.
     */
    private String viewsheetIdentifier;
+   /**
+    * {@code true} = in-place replace (remove the previous primary, keep a single visualization) —
+    * the front-end click semantics. {@code false} (default) = keep the previous assembly and add
+    * the new one alongside it — the agent/MCP "create a new visualization" semantics.
+    */
+   private boolean replacePrevious;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/CreateVisualizationModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/CreateVisualizationModel.java
@@ -84,6 +84,20 @@ public class CreateVisualizationModel {
    }
 
    /**
+    * In-place replace: when {@code true}, {@code WizVsService} removes the displaced primary so the
+    * viewsheet keeps a single visualization (the front-end click semantics). When {@code false}
+    * (the default), the previous assembly is kept and the new one is added alongside it (the
+    * agent/MCP "create a new visualization" semantics).
+    */
+   public boolean isReplacePrevious() {
+      return replacePrevious;
+   }
+
+   public void setReplacePrevious(boolean replacePrevious) {
+      this.replacePrevious = replacePrevious;
+   }
+
+   /**
     * #75456: row cap for sampled-preview mode. Null or &lt;=0 = full data (the default and the
     * agent path); &gt;0 = aggregate at most this many detail rows (faster on heavy/non-mergeable
     * sources, but Sum/Count may be approximate).
@@ -104,4 +118,5 @@ public class CreateVisualizationModel {
    private Integer sampleMaxRows;
    private transient VSAssembly primaryAssembly;
    private transient boolean keepCondition;
+   private transient boolean replacePrevious;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -318,6 +318,9 @@ public class WizAutoBindingService {
             // #75456: carry the data-mode (full vs sampled) into the render so the chart aggregates
             // the chosen amount of data; null/<=0 = full (the agent always omits this).
             vsModel.setSampleMaxRows(request.getSampleMaxRows());
+            // Default false for the public autoBinding entry point; only changeType's fallback
+            // sets it to request an in-place replace of the displaced primary.
+            vsModel.setReplacePrevious(request.isReplacePrevious());
 
             WizVsService.PostAssemblyHook hook = (wizRvs, asm) -> {
                if(asm instanceof ChartVSAssembly) {
@@ -1948,6 +1951,8 @@ public class WizAutoBindingService {
          // autoBindingInternal() would skip creating a new RVS and fail on the same dead id again.
          fallback.setWizRuntimeId(wizRuntimeId);
          fallback.setViewsheetIdentifier(viewsheetIdentifier);
+         // Carry the in-place-replace intent into the fallback so the rebuilt path honors it too.
+         fallback.setReplacePrevious(request.isReplacePrevious());
          AutoBindingResponse resp = autoBindingInternal(fallback, user, true);
          CreateViewsheetResult result = resp.getVisualizationResult();
 
@@ -2021,6 +2026,9 @@ public class WizAutoBindingService {
       vsModel.setRuntimeId(wizRuntimeId);
       vsModel.setViewsheetIdentifier(viewsheetIdentifier);
       vsModel.setKeepCondition(true);
+      // Front-end click passes replacePrevious=true to replace in place; agent/MCP omit it so the
+      // old assembly is kept and the new one is added alongside it.
+      vsModel.setReplacePrevious(request.isReplacePrevious());
 
       final RuntimeViewsheet autoRvsForHook = capturedAutoBindingRvs;
       CreateViewsheetResult result = wizVsService.createViewsheetSkipExecution(vsModel, user,

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -537,9 +537,13 @@ public class WizVsService {
                result.setRuntimeId(runtimeId);
             }
 
-            // For skipExecution (changeType): remove the displaced primary before persisting
-            // so the stored viewsheet contains only the new assembly.
-            if(skipExecution && previousPrimaryAssembly != null && !createdRuntimeId) {
+            // Removal is gated purely by intent: replacePrevious=true means "replace the current chart
+            // in place" (the front-end click), so drop the displaced primary and keep a single
+            // visualization. replacePrevious=false (the agent/MCP default) keeps the old assembly —
+            // already demoted to non-primary above — and adds the new one alongside it. This is
+            // deliberately independent of skipExecution (which only controls sandbox execution): the
+            // two concerns are orthogonal, and replacePrevious is the single source of truth for delete.
+            if(model.isReplacePrevious() && previousPrimaryAssembly != null && !createdRuntimeId) {
                targetVs.removeAssembly(previousPrimaryAssembly.getName());
                removedPreviousPrimary = true;
             }

--- a/core/src/test/java/inetsoft/web/wiz/model/ReplacePreviousDefaultTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/ReplacePreviousDefaultTest.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The {@code replacePrevious} flag decides whether a chart-type change replaces the current chart in
+ * place (front-end click) or keeps it and adds a new one (agent/MCP). The safe default is
+ * {@code false} (keep the old, add a new) — the agent path relies on omitting it, so a flipped
+ * default would silently start deleting charts on every agent-triggered type change.
+ */
+@Tag("core")
+class ReplacePreviousDefaultTest {
+
+   @Test
+   void changeTypeRequest_defaultsToFalse_andRoundTrips() {
+      ChangeTypeRequest req = new ChangeTypeRequest();
+      assertFalse(req.isReplacePrevious(), "ChangeTypeRequest.replacePrevious must default to false (add-new)");
+      req.setReplacePrevious(true);
+      assertTrue(req.isReplacePrevious());
+   }
+
+   @Test
+   void createVisualizationModel_defaultsToFalse_andRoundTrips() {
+      CreateVisualizationModel model = new CreateVisualizationModel();
+      assertFalse(model.isReplacePrevious(), "CreateVisualizationModel.replacePrevious must default to false (add-new)");
+      model.setReplacePrevious(true);
+      assertTrue(model.isReplacePrevious());
+   }
+
+   @Test
+   void autoBindingRequest_defaultsToFalse_andRoundTrips() {
+      AutoBindingRequest req = new AutoBindingRequest();
+      assertFalse(req.isReplacePrevious(), "AutoBindingRequest.replacePrevious must default to false (add-new)");
+      req.setReplacePrevious(true);
+      assertTrue(req.isReplacePrevious());
+   }
+}


### PR DESCRIPTION
## What

`/viewsheet/changeType` previously **always** removed the displaced primary assembly. This adds a `replacePrevious` flag so agent/MCP-triggered chart-type changes can be **non-destructive** (keep the old chart, add a new one), while the front-end click keeps the current single-chart replace behavior.

- `replacePrevious=true` → remove the displaced primary and replace in place (front-end click).
- `replacePrevious=false` (default) → keep the old assembly and add the new one alongside it (agent/MCP).

## Changes

- Add `replacePrevious` to `ChangeTypeRequest`, `CreateVisualizationModel`, `AutoBindingRequest` (default `false`).
- Thread it through `WizAutoBindingService.changeType` (fast path + fallback autoBinding) and `autoBindingInternal`.
- Gate `removeAssembly` in `WizVsService.createViewsheetInternal` on `replacePrevious`, **decoupled from `skipExecution`** (which now only controls sandbox execution — the two concerns were previously conflated).
- Add `ReplacePreviousDefaultTest` locking the safe default (`false`).

## Behavior / compatibility

Default flips to non-destructive **only** when a caller omits the flag. The single caller that needs the old behavior (the wiz front-end click path) sends `replacePrevious=true` explicitly (companion PR: `inetsoft-technology/stylebi-wiz#1244`). No other callers of `changeType` exist.

## Testing

- `mvn -pl core test -Dtest=ReplacePreviousDefaultTest`: green; `core` compiles.
- The removal gating lives deep in `createViewsheetInternal` (private, RVS-dependent) and needs integration/manual verification in a running StyleBI.

## Known follow-up

Non-Cartesian targets (pie/treemap) are handled by a different wiz path (`update_binding`); confirming whether `changeType` reslots them correctly is tracked in the companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)