### PR TITLE
fix(worksheet): nest >=/<= (equal) expansion so it can't re-associate neighboring conditions

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1864,12 +1864,22 @@ public class WorksheetTableService {
       List<Integer> ops = mapOperation(item.getOperation(), item.getEqual());
       String dataType = ref.getDataType() != null ? ref.getDataType() : XSchema.STRING;
 
+      // When equal=true expands one operator into two (e.g. >= becomes "> OR ="), that internal OR
+      // must bind ONLY the expanded pair. XConditionGroup evaluates a flat ConditionList by level
+      // (higher level = tighter grouping), so if the pair's OR sits at the item's own level it
+      // re-associates with the surrounding AND/OR junctions (which buildConditionList appends at
+      // item.resolveJunctionLevel() == the item's level). That silently rewrites the logic — e.g.
+      // "a AND b>=x AND c" (intended "a AND (b>x OR b=x) AND c") collapses to
+      // "(a AND b>x) OR (b=x AND c)", dropping the c bound entirely. Nest the expanded pair one
+      // level deeper so it forms a self-contained "(> OR =)" group. A single-op condition is
+      // unchanged (keeps the item's level).
+      int opLevel = ops.size() > 1 ? item.getConditionLevel() + 1 : item.getConditionLevel();
       boolean firstOp = true;
 
       for(int op : ops) {
          if(!firstOp) {
             // LESS_THAN/GREATER_THAN with equal=true expand to two ops joined by OR (e.g. < OR =).
-            list.append(new JunctionOperator(JunctionOperator.OR, item.getConditionLevel()));
+            list.append(new JunctionOperator(JunctionOperator.OR, opLevel));
          }
 
          firstOp = false;
@@ -1884,7 +1894,7 @@ public class WorksheetTableService {
             }
          }
 
-         list.append(new ConditionItem(ref, ac, item.getConditionLevel()));
+         list.append(new ConditionItem(ref, ac, opLevel));
       }
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceConditionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceConditionTest.java
@@ -146,6 +146,83 @@ class WorksheetTableServiceConditionTest {
       assertTrue(list.isConditionItem(2), "index 2 must be a ConditionItem");
    }
 
+   // ── equal=true expansion nesting. Regression for a silent-wrong-result bug: a >=/<= condition
+   // expands to "(> OR =)", and that internal OR used to be emitted at the SAME level as the
+   // surrounding AND junctions. XConditionGroup evaluates a flat ConditionList by level, so the OR
+   // re-associated with its neighbours and silently rewrote the logic — e.g.
+   // "seq=1 AND date>=lo AND date<hi" collapsed to "(seq=1 AND date>lo) OR (date=lo AND date<hi)",
+   // dropping the date<hi bound and returning out-of-range rows with no error. The fix nests the
+   // expanded pair one level deeper so it forms a self-contained group. ──
+
+   @Test
+   void equalExpansionNestsDeeperThanSurroundingJunctions() throws Exception {
+      WorksheetTable req = request("""
+         {
+           "preAggregateCondition": [
+             { "field": "seq", "operation": "EQUAL_TO", "values": [{ "type": "VALUE", "value": 1 }] },
+             { "field": "d", "operation": "GREATER_THAN", "equal": true, "junction": "and",
+               "values": [{ "type": "VALUE", "value": "2025-10-01" }] },
+             { "field": "d", "operation": "LESS_THAN", "junction": "and",
+               "values": [{ "type": "VALUE", "value": "2026-01-01" }] }
+           ]
+         }
+         """);
+
+      ColumnSelection cs = columns("seq", "d");
+
+      ConditionList list = service().buildConditionList(
+         cs, req.getPreAggregateCondition(), new Worksheet(), false);
+
+      // seq=1 AND (d>lo OR d=lo) AND d<hi  →  7 elements.
+      assertEquals(7, list.getSize(), "3 leaves, with the middle >= expanded to (> OR =), => 7 elements");
+      assertTrue(list.isConditionItem(0), "0: seq condition");
+      assertTrue(list.isJunctionOperator(1), "1: AND before the date-range");
+      assertTrue(list.isConditionItem(2), "2: d > lo");
+      assertTrue(list.isJunctionOperator(3), "3: the equal-expansion OR");
+      assertTrue(list.isConditionItem(4), "4: d = lo");
+      assertTrue(list.isJunctionOperator(5), "5: AND before the upper bound");
+      assertTrue(list.isConditionItem(6), "6: d < hi");
+
+      int expansionOrLevel = list.getItem(3).getLevel();
+      int andBeforeRange = list.getItem(1).getLevel();
+      int andBeforeUpper = list.getItem(5).getLevel();
+
+      // The expansion OR must bind TIGHTER (deeper level) than the surrounding ANDs — otherwise it
+      // leaks out and re-associates the neighbouring conditions (the bug).
+      assertTrue(expansionOrLevel > andBeforeRange && expansionOrLevel > andBeforeUpper,
+                 "the equal-expansion OR (level " + expansionOrLevel + ") must nest deeper than the " +
+                 "surrounding AND junctions (levels " + andBeforeRange + ", " + andBeforeUpper + ")");
+      // The two expanded ConditionItems sit at the same deeper level as their OR.
+      assertEquals(expansionOrLevel, list.getItem(2).getLevel(), "d>lo at the expansion level");
+      assertEquals(expansionOrLevel, list.getItem(4).getLevel(), "d=lo at the expansion level");
+   }
+
+   @Test
+   void standaloneEqualExpansionStillBuildsOrPair() throws Exception {
+      // A lone >= must still expand to "(> OR =)" (size 3, uniform level) — no regression for the
+      // common single-condition case.
+      WorksheetTable req = request("""
+         {
+           "preAggregateCondition": [
+             { "field": "amount", "operation": "GREATER_THAN", "equal": true,
+               "values": [{ "type": "VALUE", "value": 100 }] }
+           ]
+         }
+         """);
+
+      ColumnSelection cs = columns("amount");
+
+      ConditionList list = service().buildConditionList(
+         cs, req.getPreAggregateCondition(), new Worksheet(), false);
+
+      assertEquals(3, list.getSize(), "lone >= expands to Condition, OR, Condition");
+      assertTrue(list.isConditionItem(0));
+      assertTrue(list.isJunctionOperator(1));
+      assertTrue(list.isConditionItem(2));
+      assertEquals(list.getItem(0).getLevel(), list.getItem(2).getLevel(),
+                   "both expanded items share one uniform level (evaluates as a plain >=)");
+   }
+
    // ── FIELD operand (compare a column against another column, e.g. amount > stage_avg). Regression
    // for the silent match-all bug: the FIELD arm used to wrap the bare column name in a JAVASCRIPT
    // ExpressionValue (an undefined JS identifier), so the operand evaluated to nothing and the filter


### PR DESCRIPTION
## Summary
A worksheet condition with `equal: true` (i.e. `>=` or `<=`) expands to two `XCondition` ops joined by OR — `(> OR =)`. `WorksheetTableService.appendConditionItem` emitted that internal OR at the **item's own `conditionLevel`** — the *same* level as the AND/OR junctions `buildConditionList` appends between sibling conditions. `XConditionGroup` evaluates a flat `ConditionList` by level (higher level = tighter binding), so at equal levels the expansion's OR re-associates with its neighbours and **silently rewrites the boolean logic**.

Concretely, a 3-condition `preAggregateCondition`:

```
seq = 1  AND  date >= lo  AND  date < hi
```

was built as the flat list `seq=1 AND date>lo OR date=lo AND date<hi`, which under AND-over-OR precedence collapses to:

```
(seq=1 AND date>lo)  OR  (date=lo AND date<hi)
```

The `date < hi` upper bound is dropped from the dominant clause, so the filter **silently returned out-of-range rows with no error**. Hit live building a Q4-2025 cohort filter (`seq=1 AND date>=2025-10-01 AND date<2026-01-01`): it returned first orders from Oct 2025 **through April 2026** (27 rows) instead of Oct–Dec 2025 (18). The same single `LESS_THAN` in isolation worked fine — only the compound-with-`equal` combination triggered it.

### Fix
When `equal=true` expands one operator into two, emit the expanded pair (both `ConditionItem`s **and** their OR) one `conditionLevel` deeper, forming a self-contained `(> OR =)` group that participates as a single unit at the outer level. Single-op conditions are unchanged (they keep the item's level).

Found while sweeping the wiz-chat plugin's MCP tools — a silent-wrong-result of exactly the kind CLAUDE.md says to fix in the plugin.

## Test plan
- [x] 2 new tests in `WorksheetTableServiceConditionTest`: the expansion OR nests strictly deeper than the surrounding AND junctions (compound case); a standalone `>=` still expands to a uniform `(> OR =)` pair (no regression).
- [x] `WorksheetTableServiceConditionTest` — 12/12 pass.
- [x] Full `inetsoft.web.wiz.service.*Test` — 187/187 pass, no regressions.
- [ ] Live image build + end-to-end verify (the Q4-2025 filter returns 18 rows, not 27) — in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>