### PR TITLE
Fix node color reverting to default palette on legacy VSO import

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/aesthetic/CategoricalColorFrameWrapper.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/aesthetic/CategoricalColorFrameWrapper.java
@@ -279,6 +279,13 @@ public class CategoricalColorFrameWrapper extends ColorFrameWrapper {
          final String value = clrsNode.getAttribute("value");
          frame.setShareColors("true".equals(value));
       }
+      else {
+         // legacy viewsheets saved before the Share Colors feature existed have no
+         // <shareColors> element. writeContents() always writes it for current saves, so
+         // its absence means this frame's colors were never meant to sync with other
+         // frames bound to the same column; default to false to preserve them.
+         frame.setShareColors(false);
+      }
 
       if((clrsNode = Tool.getChildNodeByTagName(tag, "colorValueFrame")) != null) {
          colorValueFrame = "true".equals(clrsNode.getAttribute("value"));


### PR DESCRIPTION
## Summary
- `CategoricalColorFrame.shareColors` defaults to `true`, causing categorical color frames bound to the same column (e.g. a relation/tree chart's main `Color` and its `Node > Color`) to sync/overwrite each other's colors via a shared cache keyed on column name.
- Legacy viewsheets saved before this feature existed have no `<shareColors>` XML element, so on import the frame fell back to the `true` default and had its saved colors silently replaced by another frame bound to the same column, reverting to default-palette colors (e.g. `sharedcolor.vso`, Redmine #75661).
- `writeContents()` always writes the `<shareColors>` tag for anything saved by the current app, so the tag's absence reliably identifies pre-feature legacy assets.

## Fix
In `CategoricalColorFrameWrapper.parseContents()`, default `shareColors` to `false` when the tag is absent, preserving each frame's independently saved colors for legacy imports. No behavior change for viewsheets saved by the current version.

## Test plan
- [ ] Import a legacy VSO with distinct main-color and node-color mappings on the same bound column and confirm both are preserved (matching pre-import appearance) instead of one reverting to default palette colors.
- [ ] Confirm the "Share Colors" checkbox still functions correctly for viewsheets saved by the current version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)