### PR TITLE
Bug #75670, execute relation chart node color/size dynamic values

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/RelationVSChartInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/RelationVSChartInfo.java
@@ -423,6 +423,25 @@ public class RelationVSChartInfo extends MergedVSChartInfo implements RelationCh
          list.addAll(targetField.getDynamicValues());
       }
 
+      // VSDimensionRef-backed node color/size aesthetic refs are excluded from getAestheticRefs()
+      // (bug #75253), so super.getDynamicValues() does not cover them. Add their dynamic values
+      // here so a node color/size bound to a variable or script expression is executed; otherwise
+      // the runtime value is never resolved and graph generation falls back to the literal
+      // expression as a column name, causing "Column not found". VSAggregateRef-backed node fields
+      // still flow through getAestheticRefs() and are already covered, so guard on VSDimensionRef
+      // to avoid executing them twice. (Bug #75670)
+      if(nodeColorField instanceof VSAestheticRef &&
+         nodeColorField.getDataRef() instanceof VSDimensionRef)
+      {
+         list.addAll(((VSAestheticRef) nodeColorField).getDynamicValues());
+      }
+
+      if(nodeSizeField instanceof VSAestheticRef &&
+         nodeSizeField.getDataRef() instanceof VSDimensionRef)
+      {
+         list.addAll(((VSAestheticRef) nodeSizeField).getDynamicValues());
+      }
+
       return list;
    }
 


### PR DESCRIPTION
## Summary

Relation/network charts whose **node color** or **node size** aesthetic is bound to a dynamic expression (`=parameter.Pfield`) or variable (`$(Ptarget)`) failed to render, popping up a warning `Column not found: =parameter.Pfield in <columns>` and showing "Failed to generate graph".

## Root Cause

A chart's dynamic values are executed via `ViewsheetSandbox.updateAssembly()` → `assembly.getDynamicValues()` → `ChartVSAssemblyInfo.getDynamicValues()` → `cinfo.getDynamicValues()`.

`RelationVSChartInfo.getDynamicValues()` added the source/target field dynamic values but **not** the `nodeColorField` / `nodeSizeField` values. Node color/size backed by a `VSDimensionRef` are also excluded from `getAestheticRefs()` (bug #75253), so the parent `VSChartInfo.getDynamicValues()` did not cover them either.

Consequently the `=parameter.X` script/variable bound to node color was never executed, its `DynamicValue.rvalue` stayed null, `RelationVSChartInfo.updateNodeAestheticRef()` → `VSDimensionRef.update0()` read a null runtime value and produced no runtime ref (`rdataRef == null`), and graph generation fell back to the literal design-time expression name as a column → `ColumnNotFoundException`. Static node bindings worked because they need no script execution; the main source/target binding worked because those values were already in `getDynamicValues()`.

## Fix

Add the `VSDimensionRef`-backed `nodeColorField` / `nodeSizeField` dynamic values to `RelationVSChartInfo.getDynamicValues()`. `VSAggregateRef`-backed node fields still flow through `getAestheticRefs()` and are already covered, so the add is guarded on `VSDimensionRef` (mirroring the existing `updateNodeAestheticRef()` guard) to avoid executing them twice.

## Test Plan

1. Import `Chart_BindingTree.vso` (attached to Redmine #75670) and open the viewsheet in the portal.
2. Before the fix: both charts show "Failed to generate graph" and a `Column not found: =parameter.Pfield` / `=parameter.Ptarget` warning.
3. After the fix: both relation charts render correctly; node color/size resolve to the parameter-selected column, and no warning appears.
4. Regression check: relation charts with static node color/size, and node size bound to a measure (`VSAggregateRef`), still render correctly and their dynamic values are not executed twice.

Fixes Redmine #75670.