### PR TITLE
Fix null "Change from previous" for unsorted part-date-group dimensions

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/data/DataSetRouter.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/data/DataSetRouter.java
@@ -18,6 +18,11 @@
 package inetsoft.report.composition.graph.data;
 
 import inetsoft.graph.data.DataSet;
+import inetsoft.graph.data.DataSetFilter;
+import inetsoft.report.composition.graph.VSDataSet;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.viewsheet.VSDataRef;
+import inetsoft.uql.viewsheet.XDimensionRef;
 
 import java.util.*;
 
@@ -55,12 +60,46 @@ public class DataSetRouter extends AbstractRouter {
 
       comp = data.getComparator(field);
 
+      if(comp == null) {
+         comp = getPartDateGroupComparator(data, field);
+      }
+
       if(comp != null) {
          Collections.sort(v, comp);
       }
 
       values = new Object[v.size()];
       v.toArray(values);
+   }
+
+   /**
+    * Fallback natural-order comparator for part-date-group dimensions (HourOfDay, DayOfWeek,
+    * MonthOfYear, Quarter, etc.) when no explicit sort comparator is configured. Values for
+    * these dimensions are always emitted as Integer, so numeric order is the natural calendar
+    * order. Scoped to previous/next calc navigation only (this router) — does not affect
+    * axis/legend ordering, which is controlled separately by CategoricalScale.
+    */
+   private static Comparator getPartDateGroupComparator(DataSet data, String field) {
+      DataSet root = data instanceof DataSetFilter
+         ? ((DataSetFilter) data).getRootDataSet() : data;
+
+      if(!(root instanceof VSDataSet)) {
+         return null;
+      }
+
+      VSDataRef ref = ((VSDataSet) root).getDataRef(field);
+
+      if(!(ref instanceof XDimensionRef)) {
+         return null;
+      }
+
+      XDimensionRef dim = (XDimensionRef) ref;
+
+      if((dim.getDateLevel() & XConstants.PART_DATE_GROUP) == 0) {
+         return null;
+      }
+
+      return Comparator.nullsLast(Comparator.comparingInt(val -> ((Number) val).intValue()));
    }
 
    @Override


### PR DESCRIPTION
## Summary
- `DataSetRouter` (used by `ValueOfColumn`/`ChangeColumn` for previous/next calc navigation) fell back to raw row-appearance order when a dimension has no explicit sort comparator.
- For part-date-group dimensions (e.g. `HourOfDay(order_time)`, `DayOfWeek`, `MonthOfYear`, `Quarter`) this meant whichever value appeared first in the raw data had no "previous" value, so the "Change from previous" calc returned null even when a numerically-earlier value existed elsewhere in the dataset.
- Added a natural numeric fallback comparator for part-date-group fields, used only when no explicit sort is configured, and scoped to router-based calc navigation only. Axis/legend ordering (`CategoricalScale`) is intentionally unchanged.

Repro: radar chart on `query1`, Color/Break-by = `HourOfDay(order_time)` (sort = None), Y = `Sum(contact_id)` + `Change from previous HourOfDay` (ChangeCalc/PREVIOUS) + `Moving Average of 3`. The hour that landed first in row-appearance order (e.g. hour=5) showed a null "Change from previous" value.

## Test plan
- [x] Built `core` module and confirmed no compile errors.
- [x] Reproduced original bug in the UI (radar chart, HourOfDay Color/Break-by, unsorted), confirmed "Change from previous HourOfDay" was null for the first-appearing hour.
- [x] Rebuilt with the fix and confirmed the same chart now shows a populated "Change from previous HourOfDay" value.
- [x] Confirmed axis/legend ordering for the unsorted HourOfDay dimension is visually unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)