### PR TITLE
Bug #75677, fix time-typed calc field displaying raw epoch millis

### DIFF
--- a/core/src/main/java/inetsoft/util/CoreTool.java
+++ b/core/src/main/java/inetsoft/util/CoreTool.java
@@ -59,7 +59,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static inetsoft.util.Tool.buildString;
-import static inetsoft.util.Tool.isNumberClass;
 
 /**
  * Common utility methods without dependency on any inetsoft packages.
@@ -1732,13 +1731,8 @@ public class CoreTool {
             return null;
          }
       }
-      else if(isNumberClass(val.getClass())) {
-         try {
-            return new java.sql.Time(Long.parseLong(val.toString()));
-         }
-         catch(Exception e) {
-            return null;
-         }
+      else if(val instanceof Number) {
+         return new java.sql.Time(((Number) val).longValue());
       }
       else {
          return null;


### PR DESCRIPTION
## Summary

A viewsheet calculated field with declared data type `time` and a script such as `field['COL1'].getTime()` displayed the raw epoch milliseconds (e.g. `1347241415000`) instead of a formatted time value. This is a regression exposed by the Rhino → GraalJS script-engine migration (Feature #75423). No error was logged.

## Root Cause

`getTime()` returns epoch milliseconds. Under GraalJS the script result surfaces to Java as a `java.lang.Double` (`ScriptValueConverter.toHost` coerces every JS number → `Double`). Detail expression columns are converted to their declared type by `FormulaTableLens.TableRow2.getResult()` via `Tool.getData(java.sql.Time.class, result)` → `CoreTool.getTimeData(Double)`.

`getTimeData`'s numeric branch did `new java.sql.Time(Long.parseLong(val.toString()))`. For a `Double`, `val.toString()` is `"1.347241415E12"` (scientific notation), which `Long.parseLong` cannot parse — it threw, and the method returned `null`. `FormulaTableLens` then kept the raw `Double`, so the raw number was rendered.

The two sibling converters in the same class already handle `Number` correctly:
- `getDateData`: `((Number) val).longValue()`
- `getTimeInstantData`: `((Number) val).longValue()`

`getTimeData` was the only one using the lossy string round-trip.

## Fix

In `CoreTool.getTimeData`, convert a `Number` via `((Number) val).longValue()`, matching `getDateData`/`getTimeInstantData`. Also removed the now-unused `isNumberClass` static import.

## Test Plan

- Import the reproduction viewsheet (Redmine attachment `NT2.vso`), open it in the portal, and confirm the `cf-gettime` column now displays a formatted time value rather than raw epoch milliseconds.
- Regression check: integral `Number` inputs (Integer/Long) still convert identically; non-`Number` inputs (`Time`/`Date`/`String`/null) are unchanged.
- `./mvnw test -pl community/core -Dtest=ToolTest,ScriptValueConverterTest` — 54 tests pass.

Fixes Redmine #75677.