### PR TITLE
Only honor X-Forwarded-Host/Proto from trusted proxies (bug-75678)

### DIFF
--- a/core/src/main/java/inetsoft/web/assistant/AssistantProxyController.java
+++ b/core/src/main/java/inetsoft/web/assistant/AssistantProxyController.java
@@ -147,26 +147,12 @@ public class AssistantProxyController {
       // Without these the assistant only sees its internal hostname (e.g. assistant-client)
       // instead of the public StyleBI hostname, causing redirect validation to fail in
       // non-localhost production deployments.
-      // Prefer an X-Forwarded-Host already set by an upstream trusted proxy; only fall back to
-      // the raw Host header when StyleBI is contacted directly. This prevents a client from
-      // spoofing the forwarded host when StyleBI is behind a load balancer that sets this header.
-      String forwardedHost = request.getHeader("x-forwarded-host");
-
-      if(forwardedHost == null) {
-         forwardedHost = request.getHeader(HttpHeaders.HOST);
-      }
-
-      if(forwardedHost != null) {
-         proxyRequest.setHeader("x-forwarded-host", forwardedHost);
-      }
-
-      String forwardedProto = request.getHeader("x-forwarded-proto");
-
-      if(forwardedProto == null) {
-         forwardedProto = request.getScheme();
-      }
-
-      proxyRequest.setHeader("x-forwarded-proto", forwardedProto);
+      // request.getServerName()/getScheme() already reflect X-Forwarded-Host/Proto when the
+      // connecting peer is a trusted proxy (server.forward-headers-strategy=native, Tomcat's
+      // RemoteIpValve), and the raw connection values otherwise, so these are safe to forward
+      // as-is without re-reading the inbound headers directly.
+      proxyRequest.setHeader("x-forwarded-host", LinkUriArgumentResolver.getRequestHost(request));
+      proxyRequest.setHeader("x-forwarded-proto", request.getScheme());
 
       // Disable compression so the response can be streamed incrementally.
       // Gzip requires buffering the full stream before decompression.

--- a/core/src/main/java/inetsoft/web/security/SecurityFilterChain.java
+++ b/core/src/main/java/inetsoft/web/security/SecurityFilterChain.java
@@ -21,7 +21,6 @@ import inetsoft.sree.security.AuthenticationService;
 import inetsoft.sree.web.SessionLicenseServiceProvider;
 import inetsoft.web.ThreadLocalCleanupFilter;
 import inetsoft.web.cluster.PauseClusterFilter;
-import org.springframework.web.filter.ForwardedHeaderFilter;
 
 import java.util.Arrays;
 
@@ -30,7 +29,6 @@ public class SecurityFilterChain extends DelegatingFilterChain {
                               AuthenticationService authenticationService)
    {
       super(Arrays.asList(
-         new ForwardedHeaderFilter(),
          new ThreadLocalCleanupFilter(),
          new SessionRefreshDisabledFilter(sessionLicenseServiceProvider, authenticationService),
          new SecurityHeaderFilter(sessionLicenseServiceProvider, authenticationService),

--- a/core/src/main/java/inetsoft/web/viewsheet/service/LinkUriArgumentResolver.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/LinkUriArgumentResolver.java
@@ -144,26 +144,28 @@ public class LinkUriArgumentResolver implements
       return null;
    }
 
+   /**
+    * The scheme is derived from {@code request.getScheme()}, which reflects the value of
+    * X-Forwarded-Proto only when the connecting peer is a trusted proxy (see Tomcat's
+    * RemoteIpValve, configured via server.forward-headers-strategy=native). This must not read
+    * the forwarded header directly, since that would bypass the trusted-proxy check.
+    */
    private static String getRequestScheme(HttpServletRequest request) {
-      String requestScheme = request.getHeader("X-Forwarded-Proto");
-
-      if(requestScheme == null) {
-         requestScheme = request.getScheme();
-      }
-
-      return requestScheme;
+      return request.getScheme();
    }
 
+   /**
+    * The host is derived from {@code request.getServerName()}, which reflects the value of
+    * X-Forwarded-Host only when the connecting peer is a trusted proxy (see Tomcat's
+    * RemoteIpValve, configured via server.forward-headers-strategy=native). This must not read
+    * the forwarded header directly, since that would bypass the trusted-proxy check.
+    */
    public static String getRequestHost(HttpServletRequest request) {
-      String host = request.getHeader("X-Forwarded-Host");
+      String host = request.getServerName();
+      int port = request.getServerPort();
 
-      if(host == null) {
-         host = request.getServerName();
-         int port = request.getServerPort();
-
-         if(port != 80 && port != 443) {
-            host = host + ":" + port;
-         }
+      if(port != 80 && port != 443) {
+         host = host + ":" + port;
       }
 
       return host;

--- a/core/src/test/java/inetsoft/web/viewsheet/service/LinkUriArgumentResolverTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/service/LinkUriArgumentResolverTest.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.viewsheet.service;
+
+/*
+ * X-Forwarded-Host/X-Forwarded-Proto spoofing (security review of PR #4265)
+ *
+ * getRequestHost()/getRequestScheme() used to read X-Forwarded-Host/X-Forwarded-Proto directly
+ * off the request with no trusted-proxy check, letting any client spoof the app's own perceived
+ * origin -- which LinkUriArgumentResolver.getLinkUri() is used as a same-origin trust anchor for
+ * (e.g. AbstractLogoutFilter's redirectUri check, SUtil.getLoginOrganization()'s subdomain-based
+ * tenant resolution).
+ *
+ * Fix: these headers are no longer read directly. Trust is now enforced at the servlet-container
+ * connector level via Tomcat's RemoteIpValve (server.forward-headers-strategy=native, see
+ * application.yaml), which only rewrites request.getScheme()/getServerName()/getServerPort() when
+ * the connecting peer is a trusted proxy. Application code just reads those servlet API values.
+ * MockHttpServletRequest never goes through a real valve, so these tests verify the resolver
+ * itself no longer honors the raw headers -- the valve's own trust decision is Tomcat's tested
+ * behavior, not something to re-verify here.
+ */
+
+import inetsoft.sree.SreeEnv;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.withSettings;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("core")
+public class LinkUriArgumentResolverTest {
+   private MockedStatic<SreeEnv> sreeEnvMock;
+
+   @BeforeEach
+   void setUp() {
+      sreeEnvMock = mockStatic(SreeEnv.class, withSettings().strictness(Strictness.LENIENT));
+      sreeEnvMock.when(() -> SreeEnv.getProperty(eq("replet.repository.servlet"))).thenReturn(null);
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnvMock.close();
+   }
+
+   @Test
+   void getRequestHost_ignoresForwardedHostHeader_usesServerName() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.setServerName("app.internal");
+      request.setServerPort(80);
+      request.addHeader("X-Forwarded-Host", "attacker.example");
+
+      assertEquals("app.internal", LinkUriArgumentResolver.getRequestHost(request));
+   }
+
+   @Test
+   void getRequestHost_includesNonStandardPort() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.setServerName("app.internal");
+      request.setServerPort(8443);
+      request.addHeader("X-Forwarded-Host", "attacker.example");
+
+      assertEquals("app.internal:8443", LinkUriArgumentResolver.getRequestHost(request));
+   }
+
+   @Test
+   void getLinkUri_ignoresForwardedProtoHeader_usesRequestScheme() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.setScheme("https");
+      request.setServerName("app.internal");
+      request.setServerPort(443);
+      request.addHeader("X-Forwarded-Proto", "http");
+      request.addHeader("X-Forwarded-Host", "attacker.example");
+
+      String linkUri = LinkUriArgumentResolver.getLinkUri(request);
+
+      assertEquals("https://app.internal/", linkUri);
+   }
+}

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -118,5 +118,10 @@ management:
     port: 8081
 server:
   shutdown: graceful
+  # Only trust X-Forwarded-* headers when the immediate TCP peer is a trusted proxy. Tomcat's
+  # RemoteIpValve (auto-configured by the "native" strategy) defaults internal-proxies to RFC1918
+  # private ranges + loopback, which covers standard container/LB topologies. Override via
+  # server.tomcat.remoteip.internal-proxies if the reverse proxy sits on a public IP.
+  forward-headers-strategy: native
   servlet:
     register-default-servlet: true


### PR DESCRIPTION
## Summary
- `X-Forwarded-Proto`/`X-Forwarded-Host` were trusted unconditionally with no trusted-proxy allow-list in three independent places: `SecurityFilterChain` hardcoded Spring's zero-config `ForwardedHeaderFilter`, `LinkUriArgumentResolver` re-read the same headers directly, and `AssistantProxyController` read them raw off the inbound request. Any client could spoof these to make the server believe its own origin was attacker-chosen, defeating same-origin checks built on `LinkUriArgumentResolver` (the `/logout` redirectUri guard, the login redirect, multi-tenant org resolution by subdomain, and the SSO JWT issuer URL).
- Enable `server.forward-headers-strategy=native` so Spring Boot configures Tomcat's `RemoteIpValve` at the connector level, which only honors forwarded headers when the immediate peer matches `server.tomcat.remoteip.internal-proxies` (defaults to RFC1918 + loopback). Remove the redundant `ForwardedHeaderFilter`, and stop reading the raw headers directly in `LinkUriArgumentResolver` and `AssistantProxyController` now that `request.getScheme()`/`getServerName()` are already valve-adjudicated.
- Out of scope (follow-up): `Tool.getRemoteAddr()`/`SUtil.getIpAddress()` still trust a client-supplied `remote_ip`/`X-Forwarded-For` header directly for audit logging — unrelated code path, not touched here.

## Test plan
- [x] `LinkUriArgumentResolverTest` (new, 3 tests) — confirms spoofed `X-Forwarded-Host`/`X-Forwarded-Proto` are ignored
- [x] `LogoutFilterTest` (17), `DefaultAuthorizationFilterTest` (13), `SecurityFilterChainOrderingTest` (7) — no regressions
- [x] `./mvnw clean install -pl core,server -am -DskipTests` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)