### PR TITLE
75694, auto-complete missing function definitions

### DIFF
--- a/build-tools/tern-annotations/src/main/java/com/inetsoft/build/tern/TernAnnotationProcessor.java
+++ b/build-tools/tern-annotations/src/main/java/com/inetsoft/build/tern/TernAnnotationProcessor.java
@@ -17,6 +17,7 @@
  */
 package com.inetsoft.build.tern;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.auto.common.*;
@@ -159,16 +160,28 @@ public class TernAnnotationProcessor extends AbstractProcessor {
 
    private void generateDefinitionFile() {
       ObjectMapper mapper = new ObjectMapper();
-      ObjectNode definitionRoot = mapper.createObjectNode();
-
-      for(Map.Entry<String, ClassDef> e : definitions.entrySet()) {
-         definitionRoot.set(e.getKey(), e.getValue().toJson(mapper));
-      }
 
       try {
          FileObject file = processingEnv.getFiler().createResource(
             StandardLocation.CLASS_OUTPUT, "",
             processingEnv.getOptions().get("tern.outputFile"));
+
+         // Incremental compilation only presents the classes recompiled in this round,
+         // so this processor would otherwise overwrite the definition file with just that
+         // subset, dropping definitions for every class that wasn't recompiled (breaking
+         // script auto-complete for them). Seed the output with whatever was generated on a
+         // prior (e.g. clean) build and overlay the current round's classes on top so
+         // definitions accumulate instead of being clobbered. createResource() does not
+         // truncate the file until openOutputStream() is called, so the previous content is
+         // still readable here; read it with plain java.io to avoid the Filer restriction
+         // against reading and (re)creating the same path in one round. A clean build has no
+         // prior file and simply starts fresh. Trade-off: a class removed or renamed leaves a
+         // stale entry in an incrementally-built file until the next clean build.
+         ObjectNode definitionRoot = readExistingDefinitions(mapper, file);
+
+         for(Map.Entry<String, ClassDef> e : definitions.entrySet()) {
+            definitionRoot.set(e.getKey(), e.getValue().toJson(mapper));
+         }
 
          try(OutputStream output = file.openOutputStream()) {
             mapper.writerWithDefaultPrettyPrinter().writeValue(output, definitionRoot);
@@ -179,6 +192,25 @@ public class TernAnnotationProcessor extends AbstractProcessor {
       catch(Exception e) {
          logError("Failed to create definition file", e);
       }
+   }
+
+   private ObjectNode readExistingDefinitions(ObjectMapper mapper, FileObject file) {
+      try {
+         File existing = new File(file.toUri());
+
+         if(existing.isFile()) {
+            JsonNode node = mapper.readTree(existing);
+
+            if(node instanceof ObjectNode) {
+               return (ObjectNode) node;
+            }
+         }
+      }
+      catch(Exception e) {
+         // no readable prior file (e.g. clean build) - start fresh
+      }
+
+      return mapper.createObjectNode();
    }
 
    private void logInfo(String message) {


### PR DESCRIPTION
Root Cause:
The AxisSpec methods isLabelBetween/setLabelBetween (added for #74853) and isGridBetween/setGridBetween are correctly annotated with @TernMethod, so their script auto-complete definitions are generated into js-functions.generated.json by TernAnnotationProcessor at build time.

The problem was in that generation, not the annotations. TernAnnotationProcessor rewrites the entire definitions file on every compile, but an annotation processor's RoundEnvironment only exposes the classes recompiled in the current round. On an incremental compile (only changed classes recompiled), the file was overwritten with just that subset, dropping AxisSpec (and every other class not recompiled) from the definitions. This broke auto-complete for those methods until the next full/clean build. A clean build always produced the complete file, which is why the methods appeared after rebuilding from scratch.

Fix:
Changed TernAnnotationProcessor.generateDefinitionFile() to merge with the existing generated file instead of overwriting it. It now reads the previously generated definitions from disk (createResource does not truncate the file until openOutputStream is called, so the prior content is still readable; it is read via plain java.io to avoid javac's restriction on reading and re-creating the same path in one round), seeds the output with them, then overlays the current round's classes on top. Incremental compiles now accumulate definitions instead of clobbering them, while clean builds are unaffected (no prior file -> starts fresh).

File changed:
- build-tools/tern-annotations/src/main/java/com/inetsoft/build/tern/TernAnnotationProcessor.java