### PR TITLE
Bug #75679, fix GraalJS regressions in viewsheet map-chart scripts

### DIFF
--- a/core/src/main/java/inetsoft/report/script/viewsheet/ChartVSAScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/viewsheet/ChartVSAScriptable.java
@@ -163,7 +163,10 @@ public class ChartVSAScriptable extends VSAScriptable implements CommonChartScri
       }
       else if(name.equals("chartStyle")) {
          value = JavaScriptEngine.unwrap(value);
-         getInfo().setChartStyle((Integer) value);
+         // under GraalJS every JS number unwraps to a Double (ScriptValueConverter
+         // .toHost), so a hard (Integer) cast throws ClassCastException. Coerce via
+         // Number so both the Rhino Integer and GraalJS Double forms work. (#75679)
+         getInfo().setChartStyle(((Number) value).intValue());
          return;
       }
       // support: data = runQuery(...) in the same way as in reports

--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -347,10 +347,30 @@ public class GraalJavaScriptEngine implements AutoCloseable {
    private void putConstantScope(Value bindings, String name, Class<?>... classes) {
       try {
          ConstantScope scope = new ConstantScope(classes);
+         installMapTypeConstants(scope);
          bindings.putMember(name, ScriptValueConverter.toGuest(scope));
       }
       catch(Throwable ex) {
          LOG.warn("Failed to install constant object " + name, ex);
+      }
+   }
+
+   /**
+    * Register the dynamic {@code MAP_TYPE_<TYPE>} constants (e.g.
+    * {@code MAP_TYPE_U.S.} = "U.S.") derived from the installed map data. These
+    * are not {@code public static final} fields, so the reflected
+    * {@link ConstantScope} does not pick them up; Rhino added them explicitly to
+    * both the {@code Chart} and {@code StyleConstant} scopes, so restore them
+    * here to keep {@code mapType = Chart["MAP_TYPE_U.S."]} working. (#75679)
+    */
+   private void installMapTypeConstants(ConstantScope scope) {
+      try {
+         for(String type : inetsoft.report.internal.graph.MapData.getMapTypes()) {
+            scope.putConstant("MAP_TYPE_" + type.toUpperCase(), type);
+         }
+      }
+      catch(Throwable ex) {
+         LOG.warn("Failed to install map type constants", ex);
       }
    }
 

--- a/core/src/test/java/inetsoft/report/script/viewsheet/ChartVSAScriptableTest.java
+++ b/core/src/test/java/inetsoft/report/script/viewsheet/ChartVSAScriptableTest.java
@@ -170,6 +170,12 @@ public class ChartVSAScriptableTest {
       //put chart style
       chartVSAScriptable.putMember("chartStyle", StyleConstants.CHART_LINE);
       assertEquals(StyleConstants.CHART_LINE, chartVSAssemblyInfo.getChartStyle());
+
+      //under GraalJS a numeric constant (e.g. Chart.CHART_MAP) unwraps to a
+      //Double, so chartStyle must be coerced via Number rather than a hard
+      //(Integer) cast that throws ClassCastException. (Bug #75679)
+      chartVSAScriptable.putMember("chartStyle", (double) StyleConstants.CHART_BAR);
+      assertEquals(StyleConstants.CHART_BAR, chartVSAssemblyInfo.getChartStyle());
    }
 
    @Test

--- a/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineGlobalsTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineGlobalsTest.java
@@ -86,6 +86,21 @@ class GraalJavaScriptEngineGlobalsTest {
       assertEquals(1.0, result);
    }
 
+   @Test
+   void chartMapTypeConstantResolves() throws Exception {
+      // MAP_TYPE_<TYPE> constants (e.g. Chart["MAP_TYPE_U.S."] == "U.S.") are
+      // derived dynamically from the installed map data, not from static final
+      // fields, so the reflected ConstantScope does not pick them up. The engine
+      // must register them explicitly (as Rhino did) for map scripts such as
+      // mapType = Chart["MAP_TYPE_U.S."] to work. (Bug #75679)
+      String[] types = inetsoft.report.internal.graph.MapData.getMapTypes();
+      Assumptions.assumeTrue(types.length > 0, "no map data installed");
+
+      String type = types[0];
+      Object result = eval("Chart['MAP_TYPE_" + type.toUpperCase() + "']");
+      assertEquals(type, result);
+   }
+
    // Bug: chart scripts construct these aesthetic classes, e.g.
    // elem.setLineFrame(new StaticLineFrame(new GLine(3))). GLine/GTexture/SVGShape
    // are Java classes with both public constructors and public static final


### PR DESCRIPTION
## Summary

Fixes two GraalJS-migration regressions (Feature #75423) triggered by opening a viewsheet whose chart uses an auto-generated map-binding script. Opening the viewsheet previously popped up `Script execution error in assembly: Chart1 / class java.lang.Double cannot be cast to class java.lang.Integer`, and once that was fixed the map still failed to render (map type defaulted to "World").

The failing script:
```js
query = "Query1";
chartStyle = Chart.CHART_MAP;
bindingInfo.geoFields = [["state", Chart.STRING]];
mapType = Chart["MAP_TYPE_U.S."];
bindingInfo.setMapLayer("state", Chart.STATE);
bindingInfo.addMapping("state", "I", "Idaho");
```

## Root Cause

**1. `chartStyle` ClassCastException.** `ChartVSAScriptable.putMember()` cast the value with a hard `(Integer) value`. Under Rhino a JS number constant arrived as an `Integer`; under GraalJS `JavaScriptEngine.unwrap()` → `ScriptValueConverter.toHost()` converts every JS number to a `java.lang.Double`, so the cast threw.

**2. `mapType` resolved to `undefined`.** `MAP_TYPE_<TYPE>` (e.g. `Chart["MAP_TYPE_U.S."]`) are not `public static final` fields — they are derived dynamically from `MapData.getMapTypes()`. The Rhino engine registered them onto the runtime `Chart` and `StyleConstant` scopes; the GraalJS migration replaced that with a `ConstantScope` that only reflects static final fields, so the `MAP_TYPE_*` members were dropped. `mapType` then became `undefined`, the map type fell back to `"World"`, and the U.S. `state` layer / `"Idaho"` lookups failed ("state layer is not supported by World", "Geographic code not found: Idaho").

## Fix

1. `ChartVSAScriptable.putMember()` — coerce via `((Number) value).intValue()` (handles both the legacy `Integer` and the GraalJS `Double`). `setChartStyle(int)` takes an int.
2. `GraalJavaScriptEngine` — restore the dynamic `MAP_TYPE_*` registration via a new `installMapTypeConstants(scope)` helper, invoked inside `putConstantScope` (whose only two callers, `Chart` and `StyleConstant`, mirror Rhino's `cons`/`vscons`).

## Test Plan

- Added `ChartVSAScriptableTest#testPutProperties` assertion covering a `Double` `chartStyle` value (the GraalJS form) — passes.
- Added `GraalJavaScriptEngineGlobalsTest#chartMapTypeConstantResolves` verifying `Chart["MAP_TYPE_<type>"]` resolves to the map-type string, driven off `MapData.getMapTypes()` — passes.
- Manually verified by the reporter: importing MapBinding.zip and opening the viewsheet no longer throws and the map renders (no "World"/"Idaho" warnings).

Fixes Redmine #75679.