### PR TITLE
Bug #75680, fix chart candle/stock binding script under GraalJS

### DIFF
--- a/core/src/main/java/inetsoft/report/script/AbstractChartBindingScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/AbstractChartBindingScriptable.java
@@ -345,7 +345,7 @@ public abstract class AbstractChartBindingScriptable extends PropertyScriptable 
 
          if(ChartConstants.DATE.equals(ctype)) {
             int level = arr.length == 3 ?
-               Integer.parseInt(arr[2].toString()) :
+               Double.valueOf(arr[2].toString()).intValue() :
                DateRangeRef.YEAR_INTERVAL;
             ((BaseField) ref).setDataType(ctype);
             setDateLevelValue(dim, level);
@@ -377,7 +377,7 @@ public abstract class AbstractChartBindingScriptable extends PropertyScriptable 
          // and formula
          if(arr.length >= 2) {
             String cname = arr[0].toString();
-            int btype = Integer.parseInt(arr[1].toString());
+            int btype = Double.valueOf(arr[1].toString()).intValue();
             DataRef ref = createDataRef(cname);
             String formula = arr.length >= 3 ? arr[2].toString() : null;
             int poption = arr.length >= 4 ?
@@ -460,11 +460,11 @@ public abstract class AbstractChartBindingScriptable extends PropertyScriptable 
          // and formula
          if(arr.length >= 2) {
             String cname = arr[0].toString();
-            int btype = Integer.parseInt(arr[1].toString());
+            int btype = Double.valueOf(arr[1].toString()).intValue();
             DataRef ref = createDataRef(cname);
             String formula = arr.length >= 3 ? arr[2].toString() : null;
             int poption = arr.length >= 4 ?
-               Integer.parseInt(arr[3].toString()) :
+               Double.valueOf(arr[3].toString()).intValue() :
                XConstants.PERCENTAGE_NONE;
             String field2 = arr.length == 5 ? arr[4].toString() : null;
             DataRef secCol = field2 == null || "".equals(field2) ? null :


### PR DESCRIPTION
## Summary

A viewsheet chart script that calls `bindingInfo.setCandleBindingField([...])` (and the sibling stock/breakdown/path-field binding setters) failed under GraalJS with:

```
Script execution error in assembly: Chart1
Script failed:
Failed to invoke script function: setCandleBindingField
```

## Root Cause

The GraalJS migration surfaces **every** JS number as a Java `Double` (`ScriptValueConverter.toHost`). A binding array such as `["Stock Prices.High", Chart.HIGH, Chart.AVERAGE_FORMULA]` carries the int constant `Chart.HIGH` (`0`), which now arrives as `Double 0.0`. `AbstractChartBindingScriptable` parsed these numeric elements with `Integer.parseInt(arr[N].toString())`, i.e. `Integer.parseInt("0.0")`, throwing `NumberFormatException`. The reflective script-function dispatch caught it and rethrew as "Failed to invoke script function". Under Rhino these elements had unwrapped to `Integer`, so `"0"` parsed fine.

## Fix

Parse the numeric array elements via `Double.valueOf(arr[N].toString()).intValue()` — which accepts both `"0"` (Rhino) and `"0.0"` (GraalJS) — matching the pattern already used for the candle percentage option in the same file. Four spots in `AbstractChartBindingScriptable.java`:

- `setCandleBindingField` — binding type (the reported failure)
- `setStockBindingField` — binding type + percentage option
- `getChartRef` — date group level (reached from `setBreakdownFields` / `setPathField`)

## Test Plan

- Import `StockingBanding.zip` and open the viewsheet in the portal — the candle chart renders with no script error.
- `VSChartBindingScriptableTest` (27 tests) passes, confirming no regression on integer-style inputs.
- `./mvnw install -pl core -am -DskipTests` builds cleanly.

Fixes Redmine #75680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)