### PR TITLE
Bug #75682, register GraphElement class for chart scripting

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -1408,6 +1408,7 @@ public class GraalJavaScriptEngine implements AutoCloseable {
       putClassProxy(bindings, "PlotSpec",   "inetsoft.graph.PlotSpec");
 
       // elements
+      putClassProxy(bindings, "GraphElement",    "inetsoft.graph.element.GraphElement");
       putClassProxy(bindings, "IntervalElement", "inetsoft.graph.element.IntervalElement");
       putClassProxy(bindings, "LineElement",     "inetsoft.graph.element.LineElement");
       putClassProxy(bindings, "SchemaElement",   "inetsoft.graph.element.SchemaElement");

--- a/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineGlobalsTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineGlobalsTest.java
@@ -102,6 +102,14 @@ class GraalJavaScriptEngineGlobalsTest {
       assertInstanceOf(inetsoft.graph.aesthetic.GLine.class, result);
    }
 
+   // Bug #75682: GraphElement (abstract base of the element classes) holds the
+   // HINT_* constants used by elem.setHint(...); it must resolve as a bare global.
+   @Test
+   void graphElementHintConstantResolves() throws Exception {
+      assertEquals("shine", eval("GraphElement.HINT_SHINE"));
+      assertEquals("alpha", eval("GraphElement.HINT_ALPHA"));
+   }
+
    @Test
    void gTextureIsConstructable() throws Exception {
       Object result = eval("new GTexture()");


### PR DESCRIPTION
## Summary

An auto-generated chart script (from Feature #75423, the Rhino→GraalJS scripting migration) failed to render with:

```
Script execution error: ReferenceError: GraphElement is not defined (line 6)
```

The script references `GraphElement.HINT_SHINE` / `GraphElement.HINT_ALPHA` — the `HINT_*` constants declared on the abstract base class `inetsoft.graph.element.GraphElement` and passed to `elem.setHint(...)`.

## Root Cause

Under the old Rhino engine, every `inetsoft.graph.*` class was reachable in scripts by simple name via package-tree navigation. The GraalJS migration replaced this with an explicit allow-list in `GraalJavaScriptEngine.installChartClasses()`. That list registers the concrete element classes (`IntervalElement`, `LineElement`, `PointElement`, `AreaElement`, `SchemaElement`) but omitted their abstract base class `GraphElement`, which holds the `HINT_*` constants. As a result, a bare reference to `GraphElement` did not resolve and threw a `ReferenceError`.

## Fix

Register `GraphElement` in `installChartClasses()` via the same `putClassProxy(...)` pattern used for the other graph classes:

```java
putClassProxy(bindings, "GraphElement", "inetsoft.graph.element.GraphElement");
```

This makes `GraphElement` resolve as a bare global (a `JavaClassProxy` over the host type), so reading its `public static final` `HINT_*` constants succeeds — matching the previous Rhino behavior. This follows the existing precedent of `GraphConstants`, an all-static class registered the same way and likewise not present in `VSScriptableController.CHART_CLASSES` (which only feeds the script-editor autocomplete tree, not runtime name resolution).

## Test Plan

1. Import the attached `EGraph1.zip` viewsheet.
2. Open the viewsheet in the portal.
3. Verify the `Chart1` chart renders without the `ReferenceError: GraphElement is not defined` error (the chart script uses `elem.setHint(GraphElement.HINT_SHINE, ...)` and `elem.setHint(GraphElement.HINT_ALPHA, ...)`).

Regression check: the change only adds a new global binding; no existing binding, method, or shared utility is modified. GraalJS script-engine test suites pass.

Fixes Redmine #75682.