### PR TITLE
Bug #75684, register graph Scale base class as a chart-script global

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -1422,7 +1422,10 @@ public class GraalJavaScriptEngine implements AutoCloseable {
       putClassProxy(bindings, "TriCoord",      "inetsoft.graph.coord.TriCoord");
       putClassProxy(bindings, "FacetCoord",    "inetsoft.graph.coord.FacetCoord");
 
-      // scales / ranges
+      // scales / ranges. Scale is the abstract base class; scripts don't
+      // construct it but reference its scale-option constants (Scale.TICKS,
+      // Scale.ZERO, ...) passed to Scale.setScaleOption(int) (Bug #75684).
+      putClassProxy(bindings, "Scale",            "inetsoft.graph.scale.Scale");
       putClassProxy(bindings, "LinearScale",      "inetsoft.graph.scale.LinearScale");
       putClassProxy(bindings, "LogScale",          "inetsoft.graph.scale.LogScale");
       putClassProxy(bindings, "PowerScale",        "inetsoft.graph.scale.PowerScale");

--- a/core/src/main/java/inetsoft/web/binding/VSScriptableController.java
+++ b/core/src/main/java/inetsoft/web/binding/VSScriptableController.java
@@ -102,7 +102,7 @@ public class VSScriptableController {
       "PlotSpec", "IntervalElement", "LineElement",
       "SchemaElement", "PointElement", "AreaElement", "PolarCoord",
       "RectCoord", "Rect25Coord", "ParallelCoord", "TriCoord",
-      "FacetCoord", "LinearScale", "LogScale",
+      "FacetCoord", "Scale", "LinearScale", "LogScale",
       "PowerScale", "TimeScale", "CategoricalScale", "LinearRange",
       "StackRange", "MultiTextFrame", "PieShapeFrame",
       "BrightnessColorFrame",

--- a/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineGlobalsTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineGlobalsTest.java
@@ -113,4 +113,16 @@ class GraalJavaScriptEngineGlobalsTest {
       Object result = eval("new SVGShape()");
       assertInstanceOf(inetsoft.graph.aesthetic.SVGShape.class, result);
    }
+
+   // Bug #75684: chart scripts reference the abstract Scale base class for its
+   // scale-option constants, e.g. qscale.setScaleOption(Scale.TICKS). Scale was
+   // not registered as a global (only its subclasses were), so the script failed
+   // with "ReferenceError: Scale is not defined".
+   @Test
+   void scaleConstantResolves() throws Exception {
+      // Scale.TICKS == 1 (a public static final int on the abstract base class)
+      Object result = eval("Scale.TICKS");
+      assertInstanceOf(Double.class, result);
+      assertEquals(1.0, result);
+   }
 }


### PR DESCRIPTION
## Summary

A viewsheet chart script fails to render with `ReferenceError: Scale is not defined` on `qscale.setScaleOption(Scale.TICKS);`. This is a gap in the Rhino→GraalJS script-engine migration (Feature #75423).

## Root Cause

`GraalJavaScriptEngine.installChartClasses()` registers `inetsoft.graph.*` classes as JS globals so chart scripts can reference them by simple name (Bug #75524). It registered every scale *subclass* (`LinearScale`, `LogScale`, `CategoricalScale`, `TimeScale`, ...) but **not** the abstract base class `inetsoft.graph.scale.Scale`, which holds the scale-option constants (`public static final int TICKS/ZERO/NO_NULL/GAPS/...`). Scripts pass these to `Scale.setScaleOption(int)` as `Scale.TICKS`, so the unqualified name `Scale` resolved to nothing under GraalJS.

## Fix

- Register `Scale` (`inetsoft.graph.scale.Scale`) in `installChartClasses()` via `putClassProxy`, alongside the sibling scale classes. `JavaClassProxy` delegates static-field reads to the host type, so `Scale.TICKS` and the other constants resolve. `Scale` is abstract and never constructed by scripts — only its constants are read.
- Add `"Scale"` to `VSScriptableController.CHART_CLASSES` so it appears in the binding-editor script autocomplete tree, consistent with the other chart classes.
- Add a regression test (`scaleConstantResolves`) asserting `Scale.TICKS` resolves to `1.0`.

## Test Plan

- `./mvnw test -pl core -Dtest=GraalJavaScriptEngineGlobalsTest` → 11/11 pass (including the new test).
- Import the attached `EGraph_2.zip` viewsheet and open it in the portal; the chart now renders without the `ReferenceError`.

Fixes Redmine #75684.

🤖 Generated with [Claude Code](https://claude.com/claude-code)