### PR TITLE
Bug #75685, restore case-insensitive resolution of unqualified CALC functions

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/BindingRootProxy.java
+++ b/core/src/main/java/inetsoft/util/script/graal/BindingRootProxy.java
@@ -37,6 +37,7 @@ public class BindingRootProxy implements ProxyObject {
    private final Predicate<String> classFilter;
    private final Context context;
    private LegacyJavaShim.ImportScope imports;
+   private ScriptScope builtinScope;
 
    public BindingRootProxy(ScriptScope global, Supplier<ScriptScope> execScopeSupplier) {
       this(global, execScopeSupplier, null, null);
@@ -49,6 +50,19 @@ public class BindingRootProxy implements ProxyObject {
       this.execScopeSupplier = execScopeSupplier;
       this.classFilter = classFilter;
       this.context = context;
+   }
+
+   /**
+    * Case-insensitive last-resort scope for unqualified names (the CALC function
+    * scope). Consulted only after the normal chain, exec scope and legacy imports
+    * fail, and only for a name that has no exact global binding — so JS builtins
+    * (e.g. Date, whose lowercase 'date' is a CALC function) and the case-sensitive
+    * lowercase CALC copies always win. Rhino resolved these case-insensitively via
+    * the Calc global-scope prototype; GraalJS global bindings are case-sensitive,
+    * dropping PascalCase names like NthMostFrequent/Sum. (#75685)
+    */
+   public void setBuiltinScope(ScriptScope builtinScope) {
+      this.builtinScope = builtinScope;
    }
 
    /**
@@ -120,7 +134,21 @@ public class BindingRootProxy implements ProxyObject {
          }
       }
 
+      // case-insensitive CALC functions (Rhino's global-scope prototype). Only
+      // when the name has no exact global binding, so JS builtins (Date) and the
+      // lowercase CALC copies are never shadowed. The cheap case-insensitive
+      // lookup is tested first so non-CALC names skip the global-binding check.
+      // (#75685)
+      if(builtinScope != null && builtinScope.hasMember(name) && !hasGlobalBinding(name)) {
+         return builtinScope.getMember(name);
+      }
+
       return NOT_FOUND;
+   }
+
+   /** Whether {@code name} is an exact (case-sensitive) member of the JS global scope. */
+   private boolean hasGlobalBinding(String name) {
+      return context != null && context.getBindings("js").hasMember(name);
    }
 
    /** Resolve a name through the full chain; returns null if not found. */

--- a/core/src/main/java/inetsoft/util/script/graal/BindingRootProxy.java
+++ b/core/src/main/java/inetsoft/util/script/graal/BindingRootProxy.java
@@ -136,11 +136,16 @@ public class BindingRootProxy implements ProxyObject {
 
       // case-insensitive CALC functions (Rhino's global-scope prototype). Only
       // when the name has no exact global binding, so JS builtins (Date) and the
-      // lowercase CALC copies are never shadowed. The cheap case-insensitive
-      // lookup is tested first so non-CALC names skip the global-binding check.
-      // (#75685)
-      if(builtinScope != null && builtinScope.hasMember(name) && !hasGlobalBinding(name)) {
-         return builtinScope.getMember(name);
+      // lowercase CALC copies are never shadowed. This is only reached after the
+      // full chain (global/exec/imports) already missed — the terminal miss path
+      // — so a single case-insensitive lookup here (null means absent) matches
+      // Rhino's Calc-as-prototype cost and adds no repeated work on hits. (#75685)
+      if(builtinScope != null) {
+         Object builtin = builtinScope.getMember(name);
+
+         if(builtin != null && !hasGlobalBinding(name)) {
+            return builtin;
+         }
       }
 
       return NOT_FOUND;

--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -57,6 +57,12 @@ public class GraalJavaScriptEngine implements AutoCloseable {
    // (see exec). Recreated on (re)init because it is bound to the current context.
    private BindingRootProxy scopeProxy;
 
+   // The CALC function scope (case-insensitive member lookup). Installed as the
+   // __scope__ proxy's case-insensitive last-resort so unqualified CALC/statistical
+   // functions resolve regardless of case, matching Rhino (see installGlobalScope,
+   // ensureScopeProxy). (#75685)
+   private ScriptScope calcScope;
+
    // These config props are read on the per-script hot path (exec runs hundreds
    // of thousands of times for data-driven worksheet formula columns), and a raw
    // SreeEnv lookup per call is a measurable cost. SreeEnv.Value caches the value
@@ -269,6 +275,21 @@ public class GraalJavaScriptEngine implements AutoCloseable {
             if(!bindings.hasMember(name)) {
                bindings.putMember(name, calc.getMember(name));
             }
+         }
+
+         // Rhino set the Calc scope as the global scope's prototype
+         // (globalscope.setPrototype(new Calc())), and Calc's member lookup is
+         // case-insensitive (funcmap.get(id.toLowerCase())). So unqualified
+         // CALC/statistical functions resolved regardless of case, e.g.
+         // NthMostFrequent, PthPercentile, Sum. GraalJS global bindings are
+         // case-sensitive, so the lowercase copies above only match exact-case
+         // names. Expose the Calc scope to the __scope__ proxy so a name with no
+         // exact global binding (JS builtins and the lowercase copies above
+         // still win) resolves case-insensitively as a last resort. (#75685)
+         calcScope = calc;
+
+         if(scopeProxy != null) {
+            scopeProxy.setBuiltinScope(calc);
          }
       }
       catch(Throwable ex) {
@@ -652,6 +673,7 @@ public class GraalJavaScriptEngine implements AutoCloseable {
          scopeProxy = new BindingRootProxy(EMPTY_SCOPE,
                                            inetsoft.util.script.FormulaContext::getExecScriptScope,
                                            classFilter, context);
+         scopeProxy.setBuiltinScope(calcScope);
          context.getBindings("js").putMember("__scope__", scopeProxy);
       }
    }

--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -285,12 +285,10 @@ public class GraalJavaScriptEngine implements AutoCloseable {
          // case-sensitive, so the lowercase copies above only match exact-case
          // names. Expose the Calc scope to the __scope__ proxy so a name with no
          // exact global binding (JS builtins and the lowercase copies above
-         // still win) resolves case-insensitively as a last resort. (#75685)
+         // still win) resolves case-insensitively as a last resort. The proxy is
+         // (re)created and wired with this scope in ensureScopeProxy(), which
+         // always runs after this method during initScope(). (#75685)
          calcScope = calc;
-
-         if(scopeProxy != null) {
-            scopeProxy.setBuiltinScope(calc);
-         }
       }
       catch(Throwable ex) {
          LOG.warn("Failed to install CALC functions", ex);

--- a/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineGlobalsTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineGlobalsTest.java
@@ -148,4 +148,36 @@ class GraalJavaScriptEngineGlobalsTest {
       assertInstanceOf(Double.class, result);
       assertEquals(1.0, result);
    }
+
+   // Bug #75685: Rhino resolved unqualified CALC/statistical functions
+   // case-insensitively (Calc was the global scope's prototype and Calc.get()
+   // lowercases the key). Existing scripts call them in PascalCase, e.g.
+   // NthMostFrequent, PthPercentile, Sum. The GraalJS migration only copied the
+   // functions into the (case-sensitive) global bindings under their lowercase
+   // names, so PascalCase names threw "ReferenceError: X is not defined".
+   @Test
+   void calcFunctionsResolveCaseInsensitively() throws Exception {
+      // exact lowercase resolves and executes (unchanged behavior)
+      assertEquals(6.0, eval("sum([1,2,3])"));
+      // PascalCase names used by existing scripts now resolve + execute
+      assertEquals(6.0, eval("Sum([1,2,3])"));
+      assertEquals(2.0, eval("Average([1,2,3])"));
+      // formula-backed CALC functions (NthLargest/NthSmallest/NthMostFrequent/
+      // PthPercentile) instantiate report Formulas that need the Spring context
+      // to execute, which is unavailable in this unit test — but the bug is name
+      // resolution, so assert they resolve to a callable regardless of case.
+      assertEquals("function", eval("typeof NthLargest"));
+      assertEquals("function", eval("typeof NthSmallest"));
+      assertEquals("function", eval("typeof NthMostFrequent"));
+      assertEquals("function", eval("typeof PthPercentile"));
+      assertEquals("function", eval("typeof First"));
+   }
+
+   // The case-insensitive last-resort must not shadow JS builtins: Calc has a
+   // 'date' function, but the global Date constructor is an own property of the
+   // global object, so it must still win over the (prototype) Calc.date.
+   @Test
+   void builtinDateNotShadowedByCalc() throws Exception {
+      assertInstanceOf(java.util.Date.class, eval("new Date(0)"));
+   }
 }


### PR DESCRIPTION
## Summary

After the Rhino→GraalJS script-engine migration (Feature #75423), viewsheet/report scripts that call CALC/statistical functions with **PascalCase** names — `Sum`, `Average`, `First`, `NthLargest`, `NthSmallest`, `NthMostFrequent`, `PthPercentile` — throw `ReferenceError: X is not defined`. (Reported for a viewsheet whose Text assemblies render these, e.g. `NthMostFrequent(Group['customer_id'], 1)`.)

## Root Cause

In Rhino, the `Calc` function holder was set as the JS **global scope's prototype** (`globalscope.setPrototype(new Calc())`), and `Calc`'s member lookup is **case-insensitive** (`funcmap.get(id.toLowerCase())`). So unqualified CALC functions resolved regardless of case, as a last resort (after real globals/builtins and scope variables).

The GraalJS migration (`GraalJavaScriptEngine.installGlobalScope()`) instead copies each CALC function into the **case-sensitive** GraalJS global bindings under its **lowercase** key only. Only exact-lowercase names resolve; PascalCase names throw. (Qualified `CALC.NthMostFrequent(...)` still worked, because it goes through `Calc.getMember()` which lowercases — which is why the failure looked inconsistent.)

The PascalCase names can't be reconstructed from the all-lowercase method names (`nthmostfrequent` → can't derive `NthMostFrequent`), so restoring case-insensitive resolution is required.

## Fix

Expose the case-insensitive `Calc` scope to the `__scope__` proxy (`BindingRootProxy`) as a **last-resort** fallback in `findInChain`, consulted only after the normal scope chain, exec scope, and legacy imports — and only for a name that has **no exact global binding**. This mirrors Rhino's global-scope-prototype behavior:

1. `__scope__` (viewsheet/report/user scopes) — user vars & assemblies win
2. global object own properties — JS builtins (`Date`, …) and the lowercase CALC/aggregate copies win
3. **Calc scope, case-insensitive** — last resort; catches `Sum`, `NthMostFrequent`, `PthPercentile`, any casing

Because the fallback is skipped for any name with an exact global binding, JS builtins (e.g. `Date`, whose lowercase `date` is a CALC function) and the existing lowercase behavior are never shadowed.

## Test Plan

- New regression tests in `GraalJavaScriptEngineGlobalsTest`:
  - `Sum([1,2,3])` / `Average([1,2,3])` execute (PascalCase);
  - `NthLargest`/`NthSmallest`/`NthMostFrequent`/`PthPercentile`/`First` resolve to callables regardless of case;
  - `new Date(0)` still returns a `java.util.Date` (builtin not shadowed).
- Script-engine + CALC suites pass (131 tests, 0 failures); core compiles cleanly.
- Manually verified: importing `accessWS.zip` and opening the viewsheet no longer produces the `NthMostFrequent`/`PthPercentile`/`Sum`/etc. "is not defined" script errors.

Fixes Redmine #75685.