### PR TITLE
75681, setOrientation and getOrientation can't auto complete

### DIFF
--- a/build-tools/tern-annotations/src/main/java/com/inetsoft/build/tern/TernAnnotationProcessor.java
+++ b/build-tools/tern-annotations/src/main/java/com/inetsoft/build/tern/TernAnnotationProcessor.java
@@ -227,15 +227,11 @@ public class TernAnnotationProcessor extends AbstractProcessor {
    }
 
    private String getEnclosingClassName(Element element) {
-      Element classElement = element.getEnclosingElement();
-      TypeElement classType = MoreElements.asType(classElement);
-      String name = classType.getSimpleName().toString();
-
-      if(classType.getNestingKind() == NestingKind.MEMBER) {
-         name = name + "." + getEnclosingClassName(classType);
-      }
-
-      return name;
+      // Delegate to getClassName so nested (member) enclosing classes are qualified
+      // parent-first (e.g. "TreemapElement.Orientation"), matching the keys registered
+      // for @TernClass. Building the name child-first here would mis-key static members
+      // of nested classes (e.g. enum constants).
+      return getClassName(element.getEnclosingElement());
    }
 
    private Set<ClassDef> getEnclosingClasses(Element element, Map<String, Set<String>> superClasses) {

--- a/core/src/main/java/inetsoft/graph/element/TreemapElement.java
+++ b/core/src/main/java/inetsoft/graph/element/TreemapElement.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.graph.element;
 
+import com.inetsoft.build.tern.*;
 import inetsoft.graph.GGraph;
 import inetsoft.graph.GraphConstants;
 import inetsoft.graph.aesthetic.VisualModel;
@@ -47,6 +48,7 @@ import java.util.stream.Collectors;
  * @version 10.0
  * @author InetSoft Technology Corp
  */
+@TernClass(url = "#cshid=TreemapElement")
 public class TreemapElement extends GraphElement {
   /**
     * Treemap layout algorithms.
@@ -58,7 +60,13 @@ public class TreemapElement extends GraphElement {
     * VGraph applies a global y-flip (y=0 at bottom), so TOP_LEFT requires a pre-flip of y
     * coordinates after layout.
     */
-   public enum Orientation { TOP_LEFT, BOTTOM_LEFT, TOP_RIGHT, BOTTOM_RIGHT }
+   @TernClass
+   public enum Orientation {
+      @TernField TOP_LEFT,
+      @TernField BOTTOM_LEFT,
+      @TernField TOP_RIGHT,
+      @TernField BOTTOM_RIGHT
+   }
 
    /**
     * Types of tree visualization.
@@ -137,6 +145,7 @@ public class TreemapElement extends GraphElement {
     * Get the treemap item anchor orientation. Defaults to {@link Orientation#TOP_LEFT}.
     * Only meaningful for {@link Type#TREEMAP}; ignored by CIRCLE, SUNBURST, and ICICLE types.
     */
+   @TernMethod
    public Orientation getOrientation() {
       return orientation;
    }
@@ -146,6 +155,7 @@ public class TreemapElement extends GraphElement {
     * Only meaningful for {@link Type#TREEMAP}; ignored by CIRCLE, SUNBURST, and ICICLE types.
     * @param orientation non-null orientation value
     */
+   @TernMethod
    public void setOrientation(Orientation orientation) {
       if(orientation == null) {
          throw new IllegalArgumentException("orientation must not be null");


### PR DESCRIPTION
Root Cause:

The script-editor auto-complete is driven by tern.js, whose definitions (js-functions.generated.json) are produced at compile time by the tern-annotations annotation processor. A Java type/method/field only appears in auto-complete if annotated with @TernClass / @TernMethod / @TernField.

TreemapElement was the only chart element with no tern annotations (all siblings — AreaElement, LineElement, PointElement, IntervalElement, SchemaElement — have them). Feature #75010 added the Orientation enum and getOrientation/setOrientation but not the annotations, so neither the methods nor the enum constants were emitted into the definitions.

There was also a latent bug in TernAnnotationProcessor.getEnclosingClassName(): it qualified nested-type names child-first (Orientation.TreemapElement) while @TernClass registration uses parent-first (TreemapElement.Orientation). For a nested type's static members (enum constants), this mismatch caused the constants to be mis-keyed and then dropped. No nested type had ever had annotated members, so it had never surfaced.

Fix:

1. core/.../graph/element/TreemapElement.java — added @TernClass on the class, @TernMethod on getOrientation/setOrientation, and @TernClass on the Orientation enum with @TernField on each constant.
2. build-tools/.../TernAnnotationProcessor.java — fixed getEnclosingClassName() to qualify nested types parent-first (delegating to getClassName), so nested-enum constants key correctly under TreemapElement.Orientation.

TreemapElement.Orientation.TOP_LEFT/BOTTOM_LEFT/TOP_RIGHT/BOTTOM_RIGHT and getOrientation/setOrientation now auto-complete.

Note: elem.setOrientation where elem = graph.getElement(0) will not auto-complete, because EGraph.getElement() is typed as an unknown return type in tern and the concrete element subtype can't be inferred statically — this is a pre-existing tern limitation, out of scope for this fix.