### PR TITLE
Fix invalid HAVING clause for post-aggregation conditions on non-aggregating query levels

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
@@ -707,16 +707,38 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
       ConditionListHandler handler = new PostConditionListHandler();
       XUtil.convertDateCondition(conds, vars);
       XFilterNode fnode = createXFilterNode(handler, conds, nsql, vars);
-      XFilterNode oroot = nsql.getHaving();
 
-      if(oroot == null) {
-         nsql.setHaving(fnode);
+      // If this query level doesn't aggregate on its own (e.g. a mirror/pass-through
+      // over an already-aggregated subquery), the referenced columns are plain values
+      // from this level's perspective, so the condition must be a WHERE. A HAVING with
+      // no GROUP BY implicitly treats the whole result as one aggregate group, which
+      // strict dialects (e.g. Derby) reject once the SELECT list has non-aggregate
+      // columns.
+      if(aggregateInfo.isEmpty()) {
+         XFilterNode oroot = nsql.getWhere();
+
+         if(oroot == null) {
+            nsql.setWhere(fnode);
+         }
+         else {
+            XSet nroot = new XSet(XSet.AND);
+            nroot.addChild(oroot);
+            nroot.addChild(fnode);
+            nsql.setWhere(nroot);
+         }
       }
       else {
-         XSet nroot = new XSet(XSet.AND);
-         nroot.addChild(oroot);
-         nroot.addChild(fnode);
-         nsql.setHaving(nroot);
+         XFilterNode oroot = nsql.getHaving();
+
+         if(oroot == null) {
+            nsql.setHaving(fnode);
+         }
+         else {
+            XSet nroot = new XSet(XSet.AND);
+            nroot.addChild(oroot);
+            nroot.addChild(fnode);
+            nsql.setHaving(nroot);
+         }
       }
 
       conds.removeAllItems();

--- a/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
@@ -675,7 +675,13 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
       ColumnSelection columns = getTable().getColumnSelection();
       ConditionListWrapper wrapper = getPostConditionList();
       ConditionList conds = wrapper.getConditionList();
-      AggregateInfo aggregateInfo = getAggregateInfo();
+      // mergeGroupBy() (called before this method in merge()) clears the AggregateInfo
+      // returned by getAggregateInfo() in place once it successfully merges a real GROUP
+      // BY (gmerged == true), so getAggregateInfo() would look empty here even for a
+      // genuinely aggregating level. Use the pre-merge snapshot in that case, matching
+      // the existing gmerged ? ginfo : getAggregateInfo() idiom used elsewhere (see
+      // getAggregate()).
+      AggregateInfo aggregateInfo = gmerged ? ginfo : getAggregateInfo();
 
       // add required columns for post process
       // condition hide by vpm? do not merge it

--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -4345,8 +4345,12 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
          }
 
          // if is a crosstab or a rotated table, the condition list has to be
-         // post processed, otherwise we should check if aggregate info exists
-         boolean post = !tassembly.isPlain();
+         // post processed, otherwise we should check if aggregate info exists.
+         // isPlain() only reflects the crosstab UI flag, so also check for a
+         // non-empty AggregateInfo (e.g. a chart-bound table with group/aggregate
+         // columns) to avoid pushing a condition on an aggregated column into the
+         // SQL WHERE clause, which produces an invalid non-aggregate SELECT column.
+         boolean post = !tassembly.isPlain() || !tassembly.getAggregateInfo().isEmpty();
          ColumnSelection columns = tassembly.getColumnSelection(post);
          conds = VSUtil.normalizeConditionList(columns, conds);
 


### PR DESCRIPTION
## Summary
- A range slider bound to a chart's aggregate measure (via a `VS_ASSEMBLY` source) applies its selection as a post-runtime condition against a mirror/pass-through query level that wraps an already-aggregated subquery.
- `PreAssetQuery.mergeHaving()` always generated SQL `HAVING` for these conditions, even when the current query level performs no aggregation of its own. A `HAVING` with no `GROUP BY` forces the database to treat the whole result as one implicit aggregate group, so strict dialects (e.g. Derby) reject plain (non-aggregate) columns in the SELECT list — producing `Column reference '...' is invalid. When the SELECT list contains at least one aggregate then all entries must be valid aggregate expressions.`
- Fix: when `AggregateInfo` is empty at the current query level, the post condition is now merged into `WHERE` instead of `HAVING`.
- Also hardens the pre/post condition routing decision in `ViewsheetSandbox` to check for a non-empty `AggregateInfo`, not only the crosstab UI flag, so conditions on aggregated columns are routed to post-processing regardless of how the aggregation was defined.

## Test plan
- [x] Reproduced original bug: imported a viewsheet with a range slider bound (`VS_ASSEMBLY`) to a chart's aggregate measure; moving the slider triggered `SQLSyntaxErrorException` on Derby.
- [x] Applied fix, rebuilt, reproduced again: confirmed generated SQL now uses `WHERE` instead of `HAVING`, and the chart renders without error.
- [x] `mvn -pl core -am compile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)