### PR TITLE
75650, selected shape should match node shape on relation chart

### DIFF
--- a/core/src/main/java/inetsoft/graph/visual/RelationVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/RelationVO.java
@@ -121,7 +121,7 @@ public class RelationVO extends ElementVO {
          GTool.setRenderingHint(g2, false);
 
          Shape shape = screenShape;
-         Shape custom = resolveNodeShape(b);
+         Shape custom = resolveNodeShape(b, elem);
 
          if(custom != null) {
             shape = custom;
@@ -358,7 +358,8 @@ public class RelationVO extends ElementVO {
       }
 
       Rectangle2D b = getScreenTransform().createTransformedShape(this.shape).getBounds2D();
-      Shape custom = resolveNodeShape(b);
+      RelationElement elem = (RelationElement) ((RelationGeometry) getGeometry()).getElement();
+      Shape custom = resolveNodeShape(b, elem);
       return new Shape[] { custom != null ? custom : b };
    }
 
@@ -368,8 +369,7 @@ public class RelationVO extends ElementVO {
     * so the selection region matches what is drawn. GShape.NIL returns null from getShape()
     * and therefore also falls back to the rectangle.
     */
-   private Shape resolveNodeShape(Rectangle2D b) {
-      RelationElement elem = (RelationElement) ((RelationGeometry) getGeometry()).getElement();
+   static Shape resolveNodeShape(Rectangle2D b, RelationElement elem) {
       GShape nodeShape = elem.getNodeShape();
 
       if(nodeShape != null) {

--- a/core/src/main/java/inetsoft/graph/visual/RelationVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/RelationVO.java
@@ -121,27 +121,15 @@ public class RelationVO extends ElementVO {
          GTool.setRenderingHint(g2, false);
 
          Shape shape = screenShape;
-         GShape nodeShape = elem.getNodeShape();
+         Shape custom = resolveNodeShape(b);
 
-         if(nodeShape != null) {
-            Shape s = nodeShape.getShape(b.getX(), b.getY(), b.getWidth(), b.getHeight());
+         if(custom != null) {
+            shape = custom;
 
-            // GShape.NIL returns null, so the node falls back to the default rectangle.
-            if(s != null) {
-               // Custom shapes may be curved; enable anti-aliasing for smooth rendering.
+            // Custom shapes may be curved; enable anti-aliasing for smooth rendering.
+            // The rounded-rectangle fallback (no nodeShape set) keeps the default hint.
+            if(elem.getNodeShape() != null) {
                GTool.setRenderingHint(g2, true);
-               shape = s;
-            }
-         }
-         else {
-            double r = elem.getNodeCornerRadius();
-
-            if(r > 0) {
-               double shortDim = Math.min(b.getWidth(), b.getHeight());
-               // r is in [0, 0.5]; arc is the corner ellipse diameter
-               double arc = r * shortDim * 2;
-               shape = new RoundRectangle2D.Double(b.getX(), b.getY(),
-                                                   b.getWidth(), b.getHeight(), arc, arc);
             }
          }
 
@@ -358,9 +346,10 @@ public class RelationVO extends ElementVO {
 
    /**
     * Get linkable shapes.
-    * Note: always returns the bounding rectangle regardless of any custom nodeShape set on the
-    * element. For non-convex shapes (e.g. CROSS, XSHAPE) this means click/tooltip events will
-    * also fire in the empty corners — an acceptable bounding-box trade-off.
+    * Returns the rendered node shape (circle, triangle, …) when a custom nodeShape or
+    * corner radius is set, so the selection region matches the drawn node (Bug #75650);
+    * otherwise the bounding rectangle. GShape.NIL and open/stroked shapes still resolve
+    * to the bounding rectangle.
     */
    @Override
    public Shape[] getShapes() {
@@ -368,8 +357,36 @@ public class RelationVO extends ElementVO {
          return new Shape[0];
       }
 
-      Rectangle2D shape = getScreenTransform().createTransformedShape(this.shape).getBounds2D();
-      return new Shape[] { shape };
+      Rectangle2D b = getScreenTransform().createTransformedShape(this.shape).getBounds2D();
+      Shape custom = resolveNodeShape(b);
+      return new Shape[] { custom != null ? custom : b };
+   }
+
+   /**
+    * Resolve the custom node shape within the given screen-space bounds, or null when the
+    * node uses the default bounding rectangle. Mirrors the shape selection in {@link #paint}
+    * so the selection region matches what is drawn. GShape.NIL returns null from getShape()
+    * and therefore also falls back to the rectangle.
+    */
+   private Shape resolveNodeShape(Rectangle2D b) {
+      RelationElement elem = (RelationElement) ((RelationGeometry) getGeometry()).getElement();
+      GShape nodeShape = elem.getNodeShape();
+
+      if(nodeShape != null) {
+         return nodeShape.getShape(b.getX(), b.getY(), b.getWidth(), b.getHeight());
+      }
+
+      double r = elem.getNodeCornerRadius();
+
+      if(r > 0) {
+         double shortDim = Math.min(b.getWidth(), b.getHeight());
+         // r is in [0, 0.5]; arc is the corner ellipse diameter
+         double arc = r * shortDim * 2;
+         return new RoundRectangle2D.Double(b.getX(), b.getY(),
+                                            b.getWidth(), b.getHeight(), arc, arc);
+      }
+
+      return null;
    }
 
    @Override

--- a/core/src/main/java/inetsoft/report/composition/region/VisualObjectArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/VisualObjectArea.java
@@ -288,6 +288,18 @@ public class VisualObjectArea extends InteractiveArea implements MenuArea {
             .createTransformedShape(tshape);
          region = new AreaRegion(tshape);
       }
+      else if(vobj instanceof RelationVO && shape instanceof Path2D
+         && !new Area(shape).isEmpty())
+      {
+         // Custom relation node shapes (triangle, diamond, …) are closed paths; keep the
+         // outline so the selection highlight matches the rendered node (Bug #75650).
+         // Open/stroked node shapes (cross, star) enclose no area and fall through to the
+         // bounding-box branch below.
+         Shape tshape = trans.createTransformedShape(shape);
+         tshape = AffineTransform.getTranslateInstance(-p.getX(), -p.getY())
+            .createTransformedShape(tshape);
+         region = new AreaRegion(tshape);
+      }
       else {
          boolean isLine = shape instanceof Line2D;
          Rectangle2D.Double rect =

--- a/core/src/main/java/inetsoft/report/composition/region/VisualObjectArea.java
+++ b/core/src/main/java/inetsoft/report/composition/region/VisualObjectArea.java
@@ -289,12 +289,12 @@ public class VisualObjectArea extends InteractiveArea implements MenuArea {
          region = new AreaRegion(tshape);
       }
       else if(vobj instanceof RelationVO && shape instanceof Path2D
-         && !new Area(shape).isEmpty())
+         && isClosedNodeShape(shape))
       {
-         // Custom relation node shapes (triangle, diamond, …) are closed paths; keep the
-         // outline so the selection highlight matches the rendered node (Bug #75650).
-         // Open/stroked node shapes (cross, star) enclose no area and fall through to the
-         // bounding-box branch below.
+         // Custom relation node shapes (triangle, diamond, …) are single closed contours;
+         // keep the outline so the selection highlight matches the rendered node (Bug #75650).
+         // Open polylines (V/L/unfilled arrow) and multi-subpath strokes (cross/star/stick)
+         // fall through to the bounding-box branch below.
          Shape tshape = trans.createTransformedShape(shape);
          tshape = AffineTransform.getTranslateInstance(-p.getX(), -p.getY())
             .createTransformedShape(tshape);
@@ -361,6 +361,51 @@ public class VisualObjectArea extends InteractiveArea implements MenuArea {
       }
 
       return false;
+   }
+
+   /**
+    * A relation node shape yields an exact selection outline only when it is a single
+    * closed contour (triangle, diamond). Open polylines (V/L/unfilled arrow) whose start
+    * and end points differ would form a spurious filled polygon when Area implicitly
+    * closes them, and multi-subpath strokes (cross/star/stick) are not filled regions;
+    * both fall back to the bounding box (Bug #75650).
+    */
+   private static boolean isClosedNodeShape(Shape shape) {
+      double[] coords = new double[6];
+      double firstX = 0, firstY = 0, lastX = 0, lastY = 0;
+      int moveCount = 0;
+      boolean sawClose = false;
+
+      for(PathIterator it = shape.getPathIterator(null); !it.isDone(); it.next()) {
+         switch(it.currentSegment(coords)) {
+         case PathIterator.SEG_MOVETO:
+            if(++moveCount > 1) {
+               return false; // multiple subpaths -> stroke, not a single filled contour
+            }
+
+            firstX = lastX = coords[0];
+            firstY = lastY = coords[1];
+            break;
+         case PathIterator.SEG_CLOSE:
+            sawClose = true;
+            break;
+         case PathIterator.SEG_QUADTO:
+            lastX = coords[2];
+            lastY = coords[3];
+            break;
+         case PathIterator.SEG_CUBICTO:
+            lastX = coords[4];
+            lastY = coords[5];
+            break;
+         default: // SEG_LINETO
+            lastX = coords[0];
+            lastY = coords[1];
+         }
+      }
+
+      boolean closed = sawClose ||
+         (Math.abs(lastX - firstX) < 1e-6 && Math.abs(lastY - firstY) < 1e-6);
+      return closed && !new Area(shape).isEmpty();
    }
 
    /**

--- a/core/src/test/java/inetsoft/graph/visual/RelationVONodeShapeTest.java
+++ b/core/src/test/java/inetsoft/graph/visual/RelationVONodeShapeTest.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.graph.visual;
+
+import inetsoft.graph.aesthetic.GShape;
+import inetsoft.graph.element.RelationElement;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Shape;
+import java.awt.geom.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Guards that RelationVO.resolveNodeShape() returns a shape matching the rendered node,
+ * so the selection region matches what is painted (Bug #75650).
+ */
+class RelationVONodeShapeTest {
+   private static final Rectangle2D BOX = new Rectangle2D.Double(0, 0, 100, 60);
+
+   @Test
+   void circleResolvesToEllipse() {
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeShape(GShape.CIRCLE);
+      assertInstanceOf(Ellipse2D.class, RelationVO.resolveNodeShape(BOX, elem));
+   }
+
+   @Test
+   void triangleResolvesToClosedPath() {
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeShape(GShape.TRIANGLE);
+      Shape s = RelationVO.resolveNodeShape(BOX, elem);
+      assertInstanceOf(Path2D.class, s);
+      assertFalse(new Area(s).isEmpty(), "triangle is a closed, fillable contour");
+   }
+
+   @Test
+   void diamondResolvesToClosedPath() {
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeShape(GShape.DIAMOND);
+      Shape s = RelationVO.resolveNodeShape(BOX, elem);
+      assertInstanceOf(Path2D.class, s);
+      assertFalse(new Area(s).isEmpty(), "diamond is a closed, fillable contour");
+   }
+
+   @Test
+   void squareResolvesToRectangle() {
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeShape(GShape.SQUARE);
+      assertInstanceOf(Rectangle2D.class, RelationVO.resolveNodeShape(BOX, elem));
+   }
+
+   @Test
+   void nilResolvesToNullForBoundingBoxFallback() {
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeShape(GShape.NIL);
+      assertNull(RelationVO.resolveNodeShape(BOX, elem),
+                 "GShape.NIL returns null from getShape() -> bounding-box fallback");
+   }
+
+   @Test
+   void noShapeResolvesToNullForBoundingBoxFallback() {
+      RelationElement elem = new RelationElement("From", "To");
+      assertNull(RelationVO.resolveNodeShape(BOX, elem),
+                 "no custom shape and no corner radius -> bounding-box fallback");
+   }
+
+   @Test
+   void cornerRadiusResolvesToRoundRectangle() {
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeCornerRadius(0.2);
+      assertInstanceOf(RoundRectangle2D.class, RelationVO.resolveNodeShape(BOX, elem));
+   }
+
+   @Test
+   void nodeShapeWinsOverCornerRadius() {
+      // matches paint() precedence: nodeShape wins over nodeCornerRadius
+      RelationElement elem = new RelationElement("From", "To");
+      elem.setNodeCornerRadius(0.2);
+      elem.setNodeShape(GShape.CIRCLE);
+      assertInstanceOf(Ellipse2D.class, RelationVO.resolveNodeShape(BOX, elem));
+   }
+}


### PR DESCRIPTION
Root Cause:
The node selection highlight is drawn from the "linkable shape" returned by RelationVO.getShapes(), which always returned the node's bounding rectangle, ignoring any custom shape set via RelationElement.setNodeShape(). As a result the selection border was always a square even when the node was rendered as a circle (or other shape). Additionally, the selection-region builder (VisualObjectArea) only produced an exact outline for ellipses and polygons; closed paths such as triangle/diamond fell back to a bounding rectangle.

Fix:
- RelationVO.getShapes() now returns the actual rendered node shape (via a helper shared with paint(), so the highlight always matches the drawn node): circle > ellipse, triangle/diamond -> closed path, square/default -> rectangle. VisualObjectArea.getRegions() now builds an exact AreaRegion outline for closed relation-node paths (triangle, diamond), mirroring the existing funnel-bar handling. Open/stroked shapes (cross, star) enclose no area and remain a bounding-box region so the node stays selectable.

The selection border now matches the node shape (circle, triangle, diamond, etc.). Other chart types are unaffected.