### PR TITLE
feat(wiz): on-demand render-to-image endpoint (/api/wiz/visualization/render)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizVisualizationController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizVisualizationController.java
@@ -18,12 +18,17 @@
 
 package inetsoft.web.wiz.controller;
 
+import inetsoft.sree.security.SecurityException;
 import inetsoft.web.composer.model.TreeNodeModel;
+import inetsoft.web.wiz.model.WizVisualizationRenderEvent;
+import inetsoft.web.wiz.model.WizVisualizationRenderResult;
 import inetsoft.web.wiz.model.WizVisualizationSaveEvent;
 import inetsoft.web.wiz.model.WizVisualizationSaveResult;
+import inetsoft.web.wiz.service.RenderNotReadyException;
 import inetsoft.web.wiz.service.WizVisualizationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -65,6 +70,33 @@ public class WizVisualizationController {
       }
       catch(Exception e) {
          LOG.error("Failed to save visualization", e);
+         return ResponseEntity.internalServerError().body(Map.of("error", "An unexpected error occurred. Please try again."));
+      }
+   }
+
+   /**
+    * Renders a single saved visualization to an image (SVG or PNG) for the WIZ chat live-preview
+    * / embed flows.
+    */
+   @PostMapping(value = "/render", produces = MediaType.APPLICATION_JSON_VALUE)
+   public ResponseEntity<?> render(@RequestBody WizVisualizationRenderEvent event, Principal principal) {
+      try {
+         WizVisualizationRenderResult result = wizVisualizationService.renderVisualization(event, principal);
+         return ResponseEntity.ok(result);
+      }
+      catch(RenderNotReadyException e) {
+         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+            .header("Retry-After", String.valueOf(Math.max(1, e.getRetryAfter())))
+            .body(Map.of("error", "Chart image not ready, retry shortly"));
+      }
+      catch(SecurityException e) {
+         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("error", e.getMessage()));
+      }
+      catch(IllegalArgumentException e) {
+         return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+      }
+      catch(Exception e) {
+         LOG.error("Failed to render visualization", e);
          return ResponseEntity.internalServerError().body(Map.of("error", "An unexpected error occurred. Please try again."));
       }
    }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationRenderEvent.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationRenderEvent.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Request body for POST /api/wiz/visualization/render.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WizVisualizationRenderEvent {
+   public String getIdentifier() {
+      return identifier;
+   }
+
+   public void setIdentifier(String identifier) {
+      this.identifier = identifier;
+   }
+
+   public Integer getWidth() {
+      return width;
+   }
+
+   public void setWidth(Integer width) {
+      this.width = width;
+   }
+
+   public Integer getHeight() {
+      return height;
+   }
+
+   public void setHeight(Integer height) {
+      this.height = height;
+   }
+
+   /** "auto" (default) | "svg" | "png". */
+   public String getFormat() {
+      return format;
+   }
+
+   public void setFormat(String format) {
+      this.format = format;
+   }
+
+   private String identifier;
+   private Integer width;
+   private Integer height;
+   private String format;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationRenderResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationRenderResult.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Response body for POST /api/wiz/visualization/render.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class WizVisualizationRenderResult {
+   public String getImage() {
+      return image;
+   }
+
+   public void setImage(String image) {
+      this.image = image;
+   }
+
+   /** "svg" (raw markup in {@link #image}) or "png" ({@code data:image/png;base64,...} in {@link #image}). */
+   public String getFormat() {
+      return format;
+   }
+
+   public void setFormat(String format) {
+      this.format = format;
+   }
+
+   private String image;
+   private String format;
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/RenderNotReadyException.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/RenderNotReadyException.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.service;
+
+/** Signals the chart graph was not finished rendering (VGraphPair not ready). */
+public class RenderNotReadyException extends RuntimeException {
+   public RenderNotReadyException(int retryAfter) {
+      super("Chart image not ready; retry after " + retryAfter + "s");
+      this.retryAfter = retryAfter;
+   }
+   public int getRetryAfter() { return retryAfter; }
+   private final int retryAfter;
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -22,16 +22,22 @@ import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.WizUtil;
+import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
 import inetsoft.web.composer.model.TreeNodeModel;
 import inetsoft.web.service.BinaryTransferService;
 import inetsoft.web.viewsheet.controller.AssemblyImageService;
 import inetsoft.web.viewsheet.service.ExportResponse;
 import inetsoft.web.viewsheet.service.VSExportService;
+import inetsoft.web.wiz.model.WizVisualizationRenderEvent;
+import inetsoft.web.wiz.model.WizVisualizationRenderResult;
 import inetsoft.web.wiz.model.WizVisualizationSaveEvent;
 import inetsoft.web.wiz.model.WizVisualizationSaveResult;
 import org.slf4j.Logger;
@@ -57,13 +63,15 @@ public class WizVisualizationService {
                                    AssetRepository assetRepository,
                                    AssemblyImageService assemblyImageService,
                                    BinaryTransferService binaryTransferService,
-                                   VSExportService vsExportService)
+                                   VSExportService vsExportService,
+                                   SecurityEngine securityEngine)
    {
       this.viewsheetService = viewsheetService;
       this.assetRepository = assetRepository;
       this.assemblyImageService = assemblyImageService;
       this.binaryTransferService = binaryTransferService;
       this.vsExportService = vsExportService;
+      this.securityEngine = securityEngine;
    }
 
    /**
@@ -300,6 +308,131 @@ public class WizVisualizationService {
       }
 
       return result;
+   }
+
+   /**
+    * Renders a previously-saved wiz visualization to a standalone image (POST
+    * /api/wiz/visualization/render). Mirrors
+    * {@code inetsoft.web.wiz.controller.ViewsheetRuntimeController#verifyViewsheet}'s
+    * managed-folder guard and permission check, then opens the viewsheet, resolves its primary
+    * assembly, and renders it via the shared {@link #renderAssemblyToImage} path used by
+    * save-time thumbnails — retrying a bounded number of times if the chart graph is not yet
+    * ready ({@link RenderNotReadyException}).
+    *
+    * @throws RenderNotReadyException if the chart graph is still not ready after all retries;
+    *         callers should map this to a 503 + Retry-After.
+    */
+   public WizVisualizationRenderResult renderVisualization(WizVisualizationRenderEvent event,
+                                                            Principal principal)
+      throws Exception
+   {
+      if(event == null || Tool.isEmptyString(event.getIdentifier())) {
+         throw new IllegalArgumentException("identifier is required");
+      }
+
+      AssetEntry entry = AssetEntry.createAssetEntry(event.getIdentifier());
+
+      if(entry == null) {
+         throw new IllegalArgumentException("Invalid viewsheet identifier: " + event.getIdentifier());
+      }
+
+      String path = entry.getPath();
+
+      // Accept the same managed folders as ViewsheetRuntimeController#verifyViewsheet/openViewsheet.
+      if(path == null ||
+         !(path.startsWith(VISUALIZATION_ROOT_FOLDER_PATH + "/") ||
+           path.startsWith(VISUALIZATION_COMPONENTS_FOLDER_PATH + "/")))
+      {
+         throw new IllegalArgumentException(
+            "Viewsheet is not in the managed visualizations folder: " + path);
+      }
+
+      // Action-level gate ("Visual Composer -> Data Viewsheet"), mirroring verifyViewsheet.
+      if(!securityEngine.checkPermission(principal, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(
+            Catalog.getCatalog().getString("composer.authorization.permissionDenied"));
+      }
+
+      int width = event.getWidth() != null && event.getWidth() > 0
+         ? event.getWidth() : DEFAULT_RENDER_WIDTH;
+      int height = event.getHeight() != null && event.getHeight() > 0
+         ? event.getHeight() : DEFAULT_RENDER_HEIGHT;
+      // "auto"/"svg"/null → svg-first; only an explicit "png" forces the raster path.
+      boolean preferSvg = !"png".equalsIgnoreCase(event.getFormat());
+
+      String runtimeId = viewsheetService.openViewsheet(entry, principal, true);
+
+      try {
+         String assemblyName = resolvePrimaryAssemblyName(runtimeId, principal);
+
+         if(assemblyName == null) {
+            throw new IllegalStateException("No renderable assembly found in the saved visualization");
+         }
+
+         String[] rendered = null;
+         RenderNotReadyException lastNotReady = null;
+
+         for(int attempt = 0; attempt < RENDER_MAX_ATTEMPTS && rendered == null; attempt++) {
+            try {
+               rendered = renderAssemblyToImage(runtimeId, assemblyName, width, height, preferSvg, principal);
+            }
+            catch(RenderNotReadyException notReady) {
+               lastNotReady = notReady;
+               Thread.sleep(RENDER_RETRY_SLEEP_MS);
+            }
+         }
+
+         if(rendered == null && lastNotReady != null) {
+            // Let the controller map this to a 503 + Retry-After.
+            throw lastNotReady;
+         }
+
+         if(rendered == null) {
+            throw new IllegalStateException("Failed to render visualization image");
+         }
+
+         WizVisualizationRenderResult result = new WizVisualizationRenderResult();
+         result.setImage(rendered[0]);
+         result.setFormat(rendered[1]);
+         return result;
+      }
+      finally {
+         try {
+            viewsheetService.closeViewsheet(runtimeId, principal);
+         }
+         catch(Exception e) {
+            LOG.warn("Failed to close runtime [{}] after render", runtimeId, e);
+         }
+      }
+   }
+
+   /**
+    * Resolves the assembly to render for a saved wiz visualization: the first
+    * {@link ChartVSAssembly}, else the first {@link VSAssembly} — saved wiz visualizations are
+    * single-assembly, so this is unambiguous in practice.
+    */
+   private String resolvePrimaryAssemblyName(String runtimeId, Principal principal) {
+      try {
+         RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
+         Viewsheet vs = rvs != null ? rvs.getViewsheet() : null;
+         Assembly[] assemblies = vs != null ? vs.getAssemblies() : null;
+
+         if(assemblies == null || assemblies.length == 0) {
+            return null;
+         }
+
+         for(Assembly assembly : assemblies) {
+            if(assembly instanceof ChartVSAssembly chart) {
+               return chart.getName();
+            }
+         }
+
+         return assemblies[0] instanceof VSAssembly vsAssembly ? vsAssembly.getName() : null;
+      }
+      catch(Exception e) {
+         LOG.warn("Could not resolve assembly for runtime {}: {}", runtimeId, e.getMessage());
+         return null;
+      }
    }
 
    // ── Private helpers ───────────────────────────────────────────────────────────
@@ -912,9 +1045,16 @@ public class WizVisualizationService {
    private final AssemblyImageService assemblyImageService;
    private final BinaryTransferService binaryTransferService;
    private final VSExportService vsExportService;
+   private final SecurityEngine securityEngine;
    private static final Logger LOG = LoggerFactory.getLogger(WizVisualizationService.class);
    private static final int THUMBNAIL_WIDTH  = 400;
    private static final int THUMBNAIL_HEIGHT = 300;
+   /** Default render dimensions for /visualization/render when the request omits width/height. */
+   private static final int DEFAULT_RENDER_WIDTH = 800;
+   private static final int DEFAULT_RENDER_HEIGHT = 600;
+   /** Bounded retry for the render endpoint when the chart graph is not yet ready. */
+   private static final int RENDER_MAX_ATTEMPTS = 4;
+   private static final long RENDER_RETRY_SLEEP_MS = 500;
    private static final String SVG_NS = "http://www.w3.org/2000/svg";
    /** Drop SVG thumbnails larger than 512 KB to prevent oversized response payloads. */
    private static final int MAX_SVG_THUMBNAIL_BYTES = 512 * 1024;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -278,8 +278,10 @@ public class WizVisualizationService {
          // after get() succeeds, eliminating any cross-thread mutation race.
          Future<String[]> thumbnailFuture = THUMBNAIL_EXECUTOR.submit(() -> {
             try {
+               // enforceSizeCaps=true: preserve today's thumbnail behavior exactly — an
+               // over-cap image is skipped (returns null) rather than persisted.
                return renderAssemblyToImage(runtimeId, event.getAssemblyName(),
-                                             THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, true, principal);
+                                             THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, true, true, principal);
             }
             catch(Exception e) {
                LOG.warn("Failed to generate thumbnail for '{}' (non-fatal): {}",
@@ -357,6 +359,10 @@ public class WizVisualizationService {
          ? event.getWidth() : DEFAULT_RENDER_WIDTH;
       int height = event.getHeight() != null && event.getHeight() > 0
          ? event.getHeight() : DEFAULT_RENDER_HEIGHT;
+      // Clamp caller-supplied dimensions so an oversized request can't drive a
+      // resource-exhaustion render.
+      width = Math.min(width, MAX_RENDER_DIMENSION);
+      height = Math.min(height, MAX_RENDER_DIMENSION);
       // "auto"/"svg"/null → svg-first; only an explicit "png" forces the raster path.
       boolean preferSvg = !"png".equalsIgnoreCase(event.getFormat());
 
@@ -371,10 +377,20 @@ public class WizVisualizationService {
 
          String[] rendered = null;
          RenderNotReadyException lastNotReady = null;
+         boolean unrenderable = false;
 
-         for(int attempt = 0; attempt < RENDER_MAX_ATTEMPTS && rendered == null; attempt++) {
+         // enforceSizeCaps=false: the render endpoint wants the real chart image regardless
+         // of size, not a save-time-style thumbnail cap.
+         for(int attempt = 0; attempt < RENDER_MAX_ATTEMPTS && rendered == null && !unrenderable; attempt++) {
             try {
-               rendered = renderAssemblyToImage(runtimeId, assemblyName, width, height, preferSvg, principal);
+               rendered = renderAssemblyToImage(runtimeId, assemblyName, width, height, preferSvg, false, principal);
+
+               if(rendered == null) {
+                  // A null return (as opposed to a thrown RenderNotReadyException) means "no
+                  // image bytes / unrenderable" — this will not change on retry, so fail fast
+                  // instead of spinning the remaining attempts.
+                  unrenderable = true;
+               }
             }
             catch(RenderNotReadyException notReady) {
                lastNotReady = notReady;
@@ -445,12 +461,16 @@ public class WizVisualizationService {
     * viewsheet size, falling back to a full-viewsheet PNG export + crop for assembly types
     * (Crosstab, Table) that downloadAssemblyImage does not support.
     *
+    * @param enforceSizeCaps when {@code true}, images exceeding {@link #MAX_SVG_THUMBNAIL_BYTES}/
+    *        {@link #MAX_PNG_THUMBNAIL_BYTES} are dropped (returns {@code null}) — the save-time
+    *        thumbnail behavior. When {@code false}, the image is returned regardless of size —
+    *        used by the on-demand render endpoint, which wants the real chart, not a failure.
     * @return {@code {imageDataOrSvg, "svg"|"png"}}, or {@code null} if no image could be produced
     * @throws RenderNotReadyException if the chart graph has not finished rendering yet
     */
    private String[] renderAssemblyToImage(String runtimeId, String assemblyName,
                                            int width, int height, boolean preferSvg,
-                                           Principal principal)
+                                           boolean enforceSizeCaps, Principal principal)
       throws Exception
    {
       // Fetch once: validates ownership (prevents cross-session access) and
@@ -512,14 +532,15 @@ public class WizVisualizationService {
                   else {
                      LOG.debug("PNG was 1×1 or undecodable for '{}', using full-viewsheet fallback",
                                assemblyName);
-                     thumbnailValue = renderFallbackThumbnail(rvs, assemblyName, principal);
+                     thumbnailValue = renderFallbackThumbnail(
+                        rvs, assemblyName, enforceSizeCaps, principal);
                   }
                }
 
                return thumbnailValue != null ? new String[]{thumbnailValue, "png"} : null;
             }
             else {
-               if(imageBytes.length > MAX_SVG_THUMBNAIL_BYTES) {
+               if(enforceSizeCaps && imageBytes.length > MAX_SVG_THUMBNAIL_BYTES) {
                   LOG.debug("SVG thumbnail for '{}' is {} bytes (limit {}), skipping",
                             assemblyName, imageBytes.length,
                             MAX_SVG_THUMBNAIL_BYTES);
@@ -826,9 +847,12 @@ public class WizVisualizationService {
     * Exports the source runtime viewsheet as a full PNG and crops to the target assembly bounds.
     * Used as a fallback for assembly types (Crosstab, Table) that downloadAssemblyImage
     * does not support — those return a 1×1 placeholder PNG instead of real content.
+    *
+    * @param enforceSizeCaps when {@code true}, a result exceeding {@link #MAX_PNG_THUMBNAIL_BYTES}
+    *        is dropped (returns {@code null}); when {@code false}, it is returned as-is.
     */
    private String renderFallbackThumbnail(RuntimeViewsheet rvs, String assemblyName,
-                                           Principal principal)
+                                           boolean enforceSizeCaps, Principal principal)
    {
       try {
          Viewsheet vs = rvs.getViewsheet();
@@ -926,7 +950,7 @@ public class WizVisualizationService {
             return null;
          }
 
-         if(croppedBytes.length > MAX_PNG_THUMBNAIL_BYTES) {
+         if(enforceSizeCaps && croppedBytes.length > MAX_PNG_THUMBNAIL_BYTES) {
             LOG.debug("renderFallbackThumbnail: PNG thumbnail for '{}' is {} bytes (limit {}), skipping",
                       assemblyName, croppedBytes.length, MAX_PNG_THUMBNAIL_BYTES);
             return null;
@@ -1052,6 +1076,9 @@ public class WizVisualizationService {
    /** Default render dimensions for /visualization/render when the request omits width/height. */
    private static final int DEFAULT_RENDER_WIDTH = 800;
    private static final int DEFAULT_RENDER_HEIGHT = 600;
+   /** Clamp caller-supplied render width/height so an oversized request can't drive a
+    *  resource-exhaustion render. */
+   private static final int MAX_RENDER_DIMENSION = 4000;
    /** Bounded retry for the render endpoint when the chart graph is not yet ready. */
    private static final int RENDER_MAX_ATTEMPTS = 4;
    private static final long RENDER_RETRY_SLEEP_MS = 500;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -270,91 +270,11 @@ public class WizVisualizationService {
          // after get() succeeds, eliminating any cross-thread mutation race.
          Future<String[]> thumbnailFuture = THUMBNAIL_EXECUTOR.submit(() -> {
             try {
-               // Fetch once: validates ownership (prevents cross-session access) and
-               // is reused for the fallback path, avoiding redundant lookups.
-               RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
-
-               if(rvs == null) {
-                  LOG.warn("runtimeId '{}' not accessible for principal '{}', skipping thumbnail",
-                           runtimeId, principal.getName());
-                  return null;
-               }
-
-               Viewsheet preCheckVs = rvs.getViewsheet();
-
-               // Always attempt the lightweight primary path regardless of viewsheet size.
-               AssemblyImageService.ImageRenderResult imgResult =
-                  assemblyImageService.downloadAssemblyImage(
-                     runtimeId, Tool.byteEncode(event.getAssemblyName()),
-                     THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT,
-                     true, principal);
-
-               if(imgResult != null && imgResult.getRetryAfter() > 0) {
-                  LOG.debug("downloadAssemblyImage not yet ready for '{}' (retryAfter={}), skipping thumbnail",
-                            event.getAssemblyName(), imgResult.getRetryAfter());
-                  return null;
-               }
-
-               if(imgResult != null && imgResult.getImageData() != null) {
-                  byte[] imageBytes = binaryTransferService.getData(imgResult.getImageData());
-
-                  if(imageBytes != null && imageBytes.length > 0) {
-                     if(imgResult.isPng()) {
-                        // 1×1 is a StyleBI placeholder returned for assembly types that
-                        // downloadAssemblyImage does not support (e.g. Crosstab, Table).
-                        // In that case fall back to a full-viewsheet PNG export + crop.
-                        String thumbnailValue = null;
-                        try {
-                           BufferedImage decoded = ImageIO.read(new ByteArrayInputStream(imageBytes));
-
-                           if(decoded != null && decoded.getWidth() > 1 && decoded.getHeight() > 1) {
-                              thumbnailValue = "data:image/png;base64," +
-                                 Base64.getEncoder().encodeToString(imageBytes);
-                           }
-                        }
-                        catch(Exception e) {
-                           LOG.debug("Failed to decode PNG for '{}': {}. Attempting full-viewsheet fallback.",
-                                     event.getAssemblyName(), e.getMessage());
-                        }
-
-                        // Only use the expensive fallback if within the assembly-count limit.
-                        if(thumbnailValue == null) {
-                           if(preCheckVs != null &&
-                              preCheckVs.getAssemblies().length > MAX_ASSEMBLIES_FOR_FALLBACK_THUMBNAIL)
-                           {
-                              LOG.debug("Skipping fallback thumbnail for '{}': viewsheet has {} assemblies (limit {})",
-                                        event.getAssemblyName(), preCheckVs.getAssemblies().length,
-                                        MAX_ASSEMBLIES_FOR_FALLBACK_THUMBNAIL);
-                           }
-                           else {
-                              LOG.debug("PNG was 1×1 or undecodable for '{}', using full-viewsheet fallback",
-                                        event.getAssemblyName());
-                              thumbnailValue = renderFallbackThumbnail(rvs, event.getAssemblyName(), principal);
-                           }
-                        }
-
-                        return thumbnailValue != null ? new String[]{thumbnailValue, "png"} : null;
-                     }
-                     else {
-                        if(imageBytes.length > MAX_SVG_THUMBNAIL_BYTES) {
-                           LOG.debug("SVG thumbnail for '{}' is {} bytes (limit {}), skipping",
-                                     event.getAssemblyName(), imageBytes.length,
-                                     MAX_SVG_THUMBNAIL_BYTES);
-                        }
-                        else {
-                           return new String[]{
-                              normalizeSvgNamespace(new String(imageBytes, StandardCharsets.UTF_8)),
-                              "svg"
-                           };
-                        }
-                     }
-                  }
-               }
-
-               return null;
+               return renderAssemblyToImage(runtimeId, event.getAssemblyName(),
+                                             THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, true, principal);
             }
             catch(Exception e) {
-               LOG.warn("Failed to generate thumbnail for assembly '{}' (non-fatal): {}",
+               LOG.warn("Failed to generate thumbnail for '{}' (non-fatal): {}",
                         event.getAssemblyName(), e.getMessage());
                return null;
             }
@@ -383,6 +303,106 @@ public class WizVisualizationService {
    }
 
    // ── Private helpers ───────────────────────────────────────────────────────────
+
+   /**
+    * Renders the given assembly to an image, shared by the save-time thumbnail path and the
+    * (future) render endpoint. Fetches the runtime viewsheet once — validating ownership
+    * (prevents cross-session access) and reusing it for the fallback path, avoiding redundant
+    * lookups — then attempts the lightweight primary path (downloadAssemblyImage) regardless of
+    * viewsheet size, falling back to a full-viewsheet PNG export + crop for assembly types
+    * (Crosstab, Table) that downloadAssemblyImage does not support.
+    *
+    * @return {@code {imageDataOrSvg, "svg"|"png"}}, or {@code null} if no image could be produced
+    * @throws RenderNotReadyException if the chart graph has not finished rendering yet
+    */
+   private String[] renderAssemblyToImage(String runtimeId, String assemblyName,
+                                           int width, int height, boolean preferSvg,
+                                           Principal principal)
+      throws Exception
+   {
+      // Fetch once: validates ownership (prevents cross-session access) and
+      // is reused for the fallback path, avoiding redundant lookups.
+      RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
+
+      if(rvs == null) {
+         LOG.warn("runtimeId '{}' not accessible for principal '{}', skipping thumbnail",
+                  runtimeId, principal.getName());
+         return null;
+      }
+
+      Viewsheet preCheckVs = rvs.getViewsheet();
+
+      // Always attempt the lightweight primary path regardless of viewsheet size.
+      AssemblyImageService.ImageRenderResult imgResult =
+         assemblyImageService.downloadAssemblyImage(
+            runtimeId, Tool.byteEncode(assemblyName),
+            width, height, width, height,
+            preferSvg, principal);
+
+      if(imgResult != null && imgResult.getRetryAfter() > 0) {
+         LOG.debug("downloadAssemblyImage not yet ready for '{}' (retryAfter={}), skipping thumbnail",
+                   assemblyName, imgResult.getRetryAfter());
+         throw new RenderNotReadyException(imgResult.getRetryAfter());
+      }
+
+      if(imgResult != null && imgResult.getImageData() != null) {
+         byte[] imageBytes = binaryTransferService.getData(imgResult.getImageData());
+
+         if(imageBytes != null && imageBytes.length > 0) {
+            if(imgResult.isPng()) {
+               // 1×1 is a StyleBI placeholder returned for assembly types that
+               // downloadAssemblyImage does not support (e.g. Crosstab, Table).
+               // In that case fall back to a full-viewsheet PNG export + crop.
+               String thumbnailValue = null;
+               try {
+                  BufferedImage decoded = ImageIO.read(new ByteArrayInputStream(imageBytes));
+
+                  if(decoded != null && decoded.getWidth() > 1 && decoded.getHeight() > 1) {
+                     thumbnailValue = "data:image/png;base64," +
+                        Base64.getEncoder().encodeToString(imageBytes);
+                  }
+               }
+               catch(Exception e) {
+                  LOG.debug("Failed to decode PNG for '{}': {}. Attempting full-viewsheet fallback.",
+                            assemblyName, e.getMessage());
+               }
+
+               // Only use the expensive fallback if within the assembly-count limit.
+               if(thumbnailValue == null) {
+                  if(preCheckVs != null &&
+                     preCheckVs.getAssemblies().length > MAX_ASSEMBLIES_FOR_FALLBACK_THUMBNAIL)
+                  {
+                     LOG.debug("Skipping fallback thumbnail for '{}': viewsheet has {} assemblies (limit {})",
+                               assemblyName, preCheckVs.getAssemblies().length,
+                               MAX_ASSEMBLIES_FOR_FALLBACK_THUMBNAIL);
+                  }
+                  else {
+                     LOG.debug("PNG was 1×1 or undecodable for '{}', using full-viewsheet fallback",
+                               assemblyName);
+                     thumbnailValue = renderFallbackThumbnail(rvs, assemblyName, principal);
+                  }
+               }
+
+               return thumbnailValue != null ? new String[]{thumbnailValue, "png"} : null;
+            }
+            else {
+               if(imageBytes.length > MAX_SVG_THUMBNAIL_BYTES) {
+                  LOG.debug("SVG thumbnail for '{}' is {} bytes (limit {}), skipping",
+                            assemblyName, imageBytes.length,
+                            MAX_SVG_THUMBNAIL_BYTES);
+               }
+               else {
+                  return new String[]{
+                     normalizeSvgNamespace(new String(imageBytes, StandardCharsets.UTF_8)),
+                     "svg"
+                  };
+               }
+            }
+         }
+      }
+
+      return null;
+   }
 
    /**
     * Loads the source Worksheet, clones it, removes all tables not required by the

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizVisualizationControllerRenderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizVisualizationControllerRenderTest.java
@@ -1,0 +1,102 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.sree.security.SecurityException;
+import inetsoft.web.wiz.model.WizVisualizationRenderEvent;
+import inetsoft.web.wiz.model.WizVisualizationRenderResult;
+import inetsoft.web.wiz.service.RenderNotReadyException;
+import inetsoft.web.wiz.service.WizVisualizationService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Verifies {@link WizVisualizationController#render} maps
+ * {@link WizVisualizationService#renderVisualization} outcomes to the correct HTTP status,
+ * including the {@link RenderNotReadyException} -> 503 + Retry-After and
+ * {@link inetsoft.sree.security.SecurityException} -> 403 mappings.
+ */
+@Tag("core")
+class WizVisualizationControllerRenderTest {
+   @Test
+   void returnsImageOnSuccess() throws Exception {
+      WizVisualizationService svc = mock(WizVisualizationService.class);
+      WizVisualizationRenderResult r = new WizVisualizationRenderResult();
+      r.setImage("<svg/>");
+      r.setFormat("svg");
+      when(svc.renderVisualization(any(), any())).thenReturn(r);
+
+      ResponseEntity<?> resp =
+         new WizVisualizationController(svc).render(new WizVisualizationRenderEvent(), mock(Principal.class));
+
+      assertEquals(HttpStatus.OK, resp.getStatusCode());
+      assertSame(r, resp.getBody());
+   }
+
+   @Test
+   void mapsNotReadyTo503() throws Exception {
+      WizVisualizationService svc = mock(WizVisualizationService.class);
+      when(svc.renderVisualization(any(), any())).thenThrow(new RenderNotReadyException(2));
+
+      ResponseEntity<?> resp =
+         new WizVisualizationController(svc).render(new WizVisualizationRenderEvent(), mock(Principal.class));
+
+      assertEquals(HttpStatus.SERVICE_UNAVAILABLE, resp.getStatusCode());
+      assertTrue(resp.getHeaders().containsKey("Retry-After"));
+   }
+
+   @Test
+   void mapsSecurityExceptionTo403() throws Exception {
+      WizVisualizationService svc = mock(WizVisualizationService.class);
+      when(svc.renderVisualization(any(), any())).thenThrow(new SecurityException("permission denied"));
+
+      ResponseEntity<?> resp =
+         new WizVisualizationController(svc).render(new WizVisualizationRenderEvent(), mock(Principal.class));
+
+      assertEquals(HttpStatus.FORBIDDEN, resp.getStatusCode());
+   }
+
+   @Test
+   void mapsIllegalArgumentTo400() throws Exception {
+      WizVisualizationService svc = mock(WizVisualizationService.class);
+      when(svc.renderVisualization(any(), any())).thenThrow(new IllegalArgumentException("bad id"));
+
+      ResponseEntity<?> resp =
+         new WizVisualizationController(svc).render(new WizVisualizationRenderEvent(), mock(Principal.class));
+
+      assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+   }
+
+   @Test
+   void mapsGenericExceptionTo500() throws Exception {
+      WizVisualizationService svc = mock(WizVisualizationService.class);
+      when(svc.renderVisualization(any(), any())).thenThrow(new RuntimeException("boom"));
+
+      ResponseEntity<?> resp =
+         new WizVisualizationController(svc).render(new WizVisualizationRenderEvent(), mock(Principal.class));
+
+      assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVisualizationServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVisualizationServiceTest.java
@@ -19,6 +19,9 @@ package inetsoft.web.wiz.service;
 
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.sree.security.IdentityID;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
 import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
@@ -31,6 +34,7 @@ import inetsoft.util.MessageException;
 import inetsoft.web.service.BinaryTransferService;
 import inetsoft.web.viewsheet.controller.AssemblyImageService;
 import inetsoft.web.viewsheet.service.VSExportService;
+import inetsoft.web.wiz.model.WizVisualizationRenderEvent;
 import inetsoft.web.wiz.model.WizVisualizationSaveEvent;
 import inetsoft.web.wiz.model.WizVisualizationSaveResult;
 import org.junit.jupiter.api.Tag;
@@ -66,7 +70,7 @@ import static org.mockito.Mockito.*;
 @Tag("core")
 class WizVisualizationServiceTest {
    @Test
-   void rejectsSourcePathOutsideManagedFolders() {
+   void rejectsSourcePathOutsideManagedFolders() throws Exception {
       ViewsheetService viewsheetService = mock(ViewsheetService.class);
       AssetRepository assetRepository = mock(AssetRepository.class);
       WizVisualizationService service = createService(viewsheetService, assetRepository);
@@ -158,13 +162,72 @@ class WizVisualizationServiceTest {
          any(Viewsheet.class), any(AssetEntry.class), eq(principal), eq(true), eq(true));
    }
 
+   // ── renderVisualization: guard + permission branches ─────────────────────────
+   //
+   // The happy-path render (open → resolve assembly → renderAssemblyToImage → build result)
+   // cannot be unit-tested here: it requires a live rendering engine (real RuntimeViewsheet
+   // with a real VGraphPair) that this mocked-dependency harness does not provide. That path
+   // is verified end-to-end after the image rebuild (Task A5). This test class covers only
+   // the guard and permission-check branches, which are the logic this task owns.
+
+   @Test
+   void renderRejectsIdentifierOutsideManagedFolders() throws Exception {
+      WizVisualizationService service = createService(mock(ViewsheetService.class), mock(AssetRepository.class));
+
+      AssetEntry outside = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, "some/unmanaged/vs1", null);
+
+      WizVisualizationRenderEvent ev = new WizVisualizationRenderEvent();
+      ev.setIdentifier(outside.toIdentifier());
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> service.renderVisualization(ev, mock(Principal.class)));
+   }
+
+   @Test
+   void renderThrowsSecurityExceptionWhenPermissionDenied() throws Exception {
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(
+         any(Principal.class), eq(ResourceType.VIEWSHEET), anyString(), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      WizVisualizationService service = createService(
+         mock(ViewsheetService.class), mock(AssetRepository.class), securityEngine);
+
+      // Build an identifier UNDER VISUALIZATION_COMPONENTS_FOLDER_PATH so the folder guard
+      // passes and the permission check is actually reached.
+      AssetEntry inside = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/vs1", null);
+
+      WizVisualizationRenderEvent ev = new WizVisualizationRenderEvent();
+      ev.setIdentifier(inside.toIdentifier());
+
+      assertThrows(inetsoft.sree.security.SecurityException.class,
+                   () -> service.renderVisualization(ev, mock(Principal.class)));
+   }
+
    private static WizVisualizationService createService(ViewsheetService viewsheetService,
                                                           AssetRepository assetRepository)
+      throws Exception
+   {
+      SecurityEngine defaultSecurityEngine = mock(SecurityEngine.class);
+      when(defaultSecurityEngine.checkPermission(
+         any(Principal.class), any(ResourceType.class), anyString(), any(ResourceAction.class)))
+         .thenReturn(true);
+
+      return createService(viewsheetService, assetRepository, defaultSecurityEngine);
+   }
+
+   private static WizVisualizationService createService(ViewsheetService viewsheetService,
+                                                          AssetRepository assetRepository,
+                                                          SecurityEngine securityEngine)
    {
       return new WizVisualizationService(
          viewsheetService, assetRepository,
          mock(AssemblyImageService.class),
          mock(BinaryTransferService.class),
-         mock(VSExportService.class));
+         mock(VSExportService.class),
+         securityEngine);
    }
 }


### PR DESCRIPTION
## Wiz: on-demand render-to-image endpoint — `POST /api/wiz/visualization/render`

Renders an already-saved wiz visualization to an image on demand (SVG for charts, PNG for crosstab/table), so the wiz plugin's session-export feature can build reports/decks that show the actual charts. Exposes the existing save-time thumbnail renderer (`AssemblyImageService`) for an arbitrary saved identifier.

> Companion to the wiz-services PR `inetsoft-technology/stylebi-wiz#1249` (Session Export Phase 2), which consumes this endpoint. **Live end-to-end verification is pending** (see below).

### What's here (5 commits)
- Request/response models `WizVisualizationRenderEvent {identifier,width?,height?,format?}` / `WizVisualizationRenderResult {image,format}`.
- Extracted `renderAssemblyToImage(...)` shared by the save-time thumbnail path **and** the new render path (save behavior preserved byte-for-byte; thumbnail size-caps are enforced on save, skipped on render via an `enforceSizeCaps` flag). `RenderNotReadyException` signals a not-yet-computed chart graph.
- `WizVisualizationService.renderVisualization(...)` — validate → managed-folder guard → `SecurityEngine` permission check → `openViewsheet` → resolve primary assembly → bounded retry (rethrows `RenderNotReadyException` when exhausted) → **close runtime in `finally`** (mirrors `verifyViewsheet`). Dimensions clamped to 4000px.
- `WizVisualizationController` `POST /render` → `200 {image,format}` / `503`+`Retry-After` (graph not ready) / `403` (checked `inetsoft.sree.security.SecurityException`) / `400` / `500`.

### Auth / safety
No new security wiring — `/api/wiz/**` is JWT-gated by `WizServiceAuthenticationFilter`. Identical managed-folder allowlist + `ResourceType.VIEWSHEET`/`ACCESS` check as `viewsheet/open`/`verify`. Runtime is always closed on every exit path.

### Tests
`WizVisualizationServiceTest` (guard + permission-denied branches) and `WizVisualizationControllerRenderTest` (all 5 status mappings) — 10/10 pass; `community/core` compiles. Built TDD, one task per commit; each task + the whole branch were code-reviewed (final review verdict: ready to merge with the size-cap-leak fix, which is included as the last commit).

### Pending / not covered by unit tests
- **Live render smoke-test** (real chart → self-contained SVG; crosstab → PNG) needs a running server / image rebuild — deliberately not unit-tested (needs a live `VGraphPair` engine). Please verify against a deployed build before/at merge.
- Pre-existing `MAX_ASSEMBLIES_FOR_FALLBACK_THUMBNAIL` (>50 assemblies) throttle also applies on the render path (single-assembly saved vizzes never trip it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
