### PR TITLE
feat(wiz): on-demand dashboard-compose endpoint (/api/wiz/visualization/dashboard)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
@@ -68,8 +68,21 @@ public class WizViewsheetExportController {
 
    @PostMapping("/viewsheet/export-report")
    public ResponseEntity<?> exportReport(@RequestBody WizExportReportEvent event, Principal principal) {
-      AssetEntry entry = Tool.isEmptyString(event.getDashboardId())
-         ? null : AssetEntry.createAssetEntry(event.getDashboardId());
+      if(!"pdf".equalsIgnoreCase(event.getFormat())) {
+         return ResponseEntity.badRequest().body(Map.of(
+            "error", "Unsupported format: " + event.getFormat() + " (only pdf is supported in Phase 1)"));
+      }
+
+      AssetEntry entry;
+
+      try {
+         entry = Tool.isEmptyString(event.getDashboardId())
+            ? null : AssetEntry.createAssetEntry(event.getDashboardId());
+      }
+      catch(RuntimeException e) {
+         return ResponseEntity.badRequest().body(Map.of(
+            "error", "dashboardId is not a valid asset identifier: " + event.getDashboardId()));
+      }
 
       if(entry == null || entry.getPath() == null ||
          !entry.getPath().startsWith(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/"))

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
@@ -33,10 +33,10 @@ import inetsoft.web.wiz.model.WizExportReportEvent;
 import inetsoft.web.wiz.service.WizPrintLayoutBuilder;
 import inetsoft.web.wiz.service.WizVisualizationService;
 import inetsoft.web.wiz.service.WizVsService;
+import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ContentDisposition;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -67,7 +67,9 @@ public class WizViewsheetExportController {
    }
 
    @PostMapping("/viewsheet/export-report")
-   public ResponseEntity<?> exportReport(@RequestBody WizExportReportEvent event, Principal principal) {
+   public ResponseEntity<?> exportReport(@RequestBody WizExportReportEvent event, Principal principal,
+                                         HttpServletResponse servletResponse)
+   {
       if(!"pdf".equalsIgnoreCase(event.getFormat())) {
          return ResponseEntity.badRequest().body(Map.of(
             "error", "Unsupported format: " + event.getFormat() + " (only pdf is supported in Phase 1)"));
@@ -129,12 +131,26 @@ public class WizViewsheetExportController {
 
          byte[] bytes = out.toByteArray();
          String filename = (event.getTitle() == null ? "board" : event.getTitle()) + ".pdf";
-         HttpHeaders headers = new HttpHeaders();
-         headers.setContentType(MediaType.APPLICATION_PDF);
-         // NOT setContentDispositionFormData — that produces "form-data; name=..." (multipart
-         // upload semantics), not the "attachment; filename=..." a file download needs.
-         headers.setContentDisposition(ContentDisposition.attachment().filename(filename).build());
-         return new ResponseEntity<>(bytes, headers, 200);
+         // Write directly to the servlet response rather than returning a ResponseEntity<byte[]>
+         // (or ResponseEntity<ByteArrayResource>, also confirmed failing live). WebConfig's
+         // registered converters have no combination that can write an arbitrary byte[]/Resource
+         // body as application/pdf: the app's ByteArrayHttpMessageConverter bean is restricted to
+         // octet-stream/text-plain/openmetrics-text, and ResourceHttpMessageConverter (which does
+         // declare application/pdf) only writes Resource bodies — neither matches, and Spring
+         // throws HttpMessageNotWritableException for both (confirmed against a real running
+         // StyleBI instance exporting a real board). This direct-response pattern mirrors the
+         // enterprise ViewsheetApiController.exportViewsheet, which sidesteps the converter
+         // pipeline entirely and is proven to work for exactly this kind of binary export in this
+         // codebase. Returning null tells Spring MVC the response is already fully handled.
+         servletResponse.setContentType(MediaType.APPLICATION_PDF_VALUE);
+         // NOT setContentDispositionFormData equivalent — "attachment; filename=..." is what a
+         // file download needs, not "form-data; name=...".
+         servletResponse.setHeader("Content-Disposition",
+            ContentDisposition.attachment().filename(filename).build().toString());
+         servletResponse.setContentLength(bytes.length);
+         servletResponse.getOutputStream().write(bytes);
+         servletResponse.getOutputStream().flush();
+         return null;
       }
       catch(SecurityException e) {
          return ResponseEntity.status(403).body(Map.of("error", e.getMessage()));

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
@@ -1,0 +1,152 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.viewsheet.FileFormatInfo;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.util.Tool;
+import inetsoft.web.viewsheet.service.ExportResponse;
+import inetsoft.web.viewsheet.service.VSExportService;
+import inetsoft.web.wiz.model.WizExportReportEvent;
+import inetsoft.web.wiz.service.WizPrintLayoutBuilder;
+import inetsoft.web.wiz.service.WizVisualizationService;
+import inetsoft.web.wiz.service.WizVsService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.ByteArrayOutputStream;
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/wiz")
+public class WizViewsheetExportController {
+   public WizViewsheetExportController(ViewsheetService viewsheetService,
+                                       WizVsService wizVsService,
+                                       WizPrintLayoutBuilder printLayoutBuilder,
+                                       VSExportService exportService,
+                                       SecurityEngine securityEngine)
+   {
+      this.viewsheetService = viewsheetService;
+      this.wizVsService = wizVsService;
+      this.printLayoutBuilder = printLayoutBuilder;
+      this.exportService = exportService;
+      this.securityEngine = securityEngine;
+   }
+
+   @PostMapping("/viewsheet/export-report")
+   public ResponseEntity<?> exportReport(@RequestBody WizExportReportEvent event, Principal principal) {
+      AssetEntry entry = Tool.isEmptyString(event.getDashboardId())
+         ? null : AssetEntry.createAssetEntry(event.getDashboardId());
+
+      if(entry == null || entry.getPath() == null ||
+         !entry.getPath().startsWith(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/"))
+      {
+         return ResponseEntity.badRequest().body(Map.of(
+            "error", "dashboardId is not in the managed visualizations folder: " + event.getDashboardId()));
+      }
+
+      String runtimeId;
+
+      try {
+         runtimeId = viewsheetService.openViewsheet(entry, principal, true);
+      }
+      catch(Exception e) {
+         LOG.error("Failed to open composed dashboard for export: {}", event.getDashboardId(), e);
+         return ResponseEntity.status(404).body(Map.of("error", "Dashboard not found: " + event.getDashboardId()));
+      }
+
+      try {
+         if(!securityEngine.checkPermission(principal, ResourceType.VIEWSHEET_TOOLBAR_ACTION,
+            "Export", ResourceAction.READ))
+         {
+            return ResponseEntity.status(403).body(Map.of(
+               "error", "Permission denied: viewsheet export"));
+         }
+
+         RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
+         Viewsheet viewsheet = rvs.getViewsheet();
+
+         List<WizPrintLayoutBuilder.ChartCaption> charts = event.getCharts() == null
+            ? List.of()
+            : event.getCharts().stream()
+               .map(c -> new WizPrintLayoutBuilder.ChartCaption(c.getTitle(), c.getCaption(), c.getOrder()))
+               .collect(Collectors.toList());
+
+         var printLayout = printLayoutBuilder.build(
+            viewsheet, event.getPageSize(), event.getTitle(), event.getRecap(), charts);
+         viewsheet.getLayoutInfo().setPrintLayout(printLayout);
+         wizVsService.persistViewsheet(viewsheet, event.getDashboardId(), principal);
+
+         ByteArrayOutputStream out = new ByteArrayOutputStream();
+         exportService.exportViewsheet(rvs, FileFormatInfo.EXPORT_TYPE_PDF, false, false, true,
+            false, false, new String[0], false, new ExportResponse(out), principal);
+
+         byte[] bytes = out.toByteArray();
+         String filename = (event.getTitle() == null ? "board" : event.getTitle()) + ".pdf";
+         HttpHeaders headers = new HttpHeaders();
+         headers.setContentType(MediaType.APPLICATION_PDF);
+         // NOT setContentDispositionFormData — that produces "form-data; name=..." (multipart
+         // upload semantics), not the "attachment; filename=..." a file download needs.
+         headers.setContentDisposition(ContentDisposition.attachment().filename(filename).build());
+         return new ResponseEntity<>(bytes, headers, 200);
+      }
+      catch(SecurityException e) {
+         return ResponseEntity.status(403).body(Map.of("error", e.getMessage()));
+      }
+      catch(IllegalArgumentException | IllegalStateException e) {
+         return ResponseEntity.status(400).body(Map.of("error", e.getMessage()));
+      }
+      catch(Exception e) {
+         LOG.error("Failed to export board PDF for dashboard {}", event.getDashboardId(), e);
+         return ResponseEntity.status(500).body(Map.of("error", "Failed to export board PDF"));
+      }
+      finally {
+         try {
+            viewsheetService.closeViewsheet(runtimeId, principal);
+         }
+         catch(Exception ignore) {
+            LOG.warn("Failed to close runtime [{}] after export", runtimeId);
+         }
+      }
+   }
+
+   private final ViewsheetService viewsheetService;
+   private final WizVsService wizVsService;
+   private final WizPrintLayoutBuilder printLayoutBuilder;
+   private final VSExportService exportService;
+   private final SecurityEngine securityEngine;
+   private static final Logger LOG = LoggerFactory.getLogger(WizViewsheetExportController.class);
+}

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
@@ -206,6 +206,11 @@ public class WizViewsheetExportController {
             .sorted(Comparator.comparingInt(WizExportReportEvent.ChartEntry::getOrder))
             .collect(Collectors.toList());
 
+      if(charts.isEmpty()) {
+         return ResponseEntity.badRequest().body(Map.of(
+            "error", "charts are required"));
+      }
+
       List<PptxDeckMerger.ChartSlide> chartSlides = new ArrayList<>();
 
       for(WizExportReportEvent.ChartEntry chart : charts) {

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
@@ -30,6 +30,7 @@ import inetsoft.util.Tool;
 import inetsoft.web.viewsheet.service.ExportResponse;
 import inetsoft.web.viewsheet.service.VSExportService;
 import inetsoft.web.wiz.model.WizExportReportEvent;
+import inetsoft.web.wiz.service.PptxDeckMerger;
 import inetsoft.web.wiz.service.WizPrintLayoutBuilder;
 import inetsoft.web.wiz.service.WizVisualizationService;
 import inetsoft.web.wiz.service.WizVsService;
@@ -46,6 +47,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.io.ByteArrayOutputStream;
 import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -57,24 +60,34 @@ public class WizViewsheetExportController {
                                        WizVsService wizVsService,
                                        WizPrintLayoutBuilder printLayoutBuilder,
                                        VSExportService exportService,
-                                       SecurityEngine securityEngine)
+                                       SecurityEngine securityEngine,
+                                       PptxDeckMerger pptxDeckMerger)
    {
       this.viewsheetService = viewsheetService;
       this.wizVsService = wizVsService;
       this.printLayoutBuilder = printLayoutBuilder;
       this.exportService = exportService;
       this.securityEngine = securityEngine;
+      this.pptxDeckMerger = pptxDeckMerger;
    }
 
    @PostMapping("/viewsheet/export-report")
    public ResponseEntity<?> exportReport(@RequestBody WizExportReportEvent event, Principal principal,
                                          HttpServletResponse servletResponse)
    {
-      if(!"pdf".equalsIgnoreCase(event.getFormat())) {
+      String format = event.getFormat() == null ? "" : event.getFormat().toLowerCase();
+
+      if(!format.equals("pdf") && !format.equals("pptx")) {
          return ResponseEntity.badRequest().body(Map.of(
-            "error", "Unsupported format: " + event.getFormat() + " (only pdf is supported in Phase 1)"));
+            "error", "Unsupported format: " + event.getFormat() + " (pdf or pptx)"));
       }
 
+      if(format.equals("pptx")) {
+         return exportPptx(event, principal, servletResponse);
+      }
+
+      // pdf path below is unchanged from Phase 1 (uses a single composed dashboard viewsheet,
+      // not the per-chart pptx flow above).
       AssetEntry entry;
 
       try {
@@ -172,10 +185,121 @@ public class WizViewsheetExportController {
       }
    }
 
+   private ResponseEntity<?> exportPptx(WizExportReportEvent event, Principal principal,
+                                        HttpServletResponse servletResponse)
+   {
+      try {
+         if(!securityEngine.checkPermission(principal, ResourceType.VIEWSHEET_TOOLBAR_ACTION,
+            "Export", ResourceAction.READ))
+         {
+            return ResponseEntity.status(403).body(Map.of(
+               "error", "Permission denied: viewsheet export"));
+         }
+      }
+      catch(SecurityException e) {
+         return ResponseEntity.status(403).body(Map.of("error", e.getMessage()));
+      }
+
+      List<WizExportReportEvent.ChartEntry> charts = event.getCharts() == null
+         ? List.of()
+         : event.getCharts().stream()
+            .sorted(Comparator.comparingInt(WizExportReportEvent.ChartEntry::getOrder))
+            .collect(Collectors.toList());
+
+      List<PptxDeckMerger.ChartSlide> chartSlides = new ArrayList<>();
+
+      for(WizExportReportEvent.ChartEntry chart : charts) {
+         chartSlides.add(exportOneChartForPptx(chart, principal));
+      }
+
+      boolean allFailed = !chartSlides.isEmpty() &&
+         chartSlides.stream().allMatch(PptxDeckMerger.ChartSlide::failed);
+
+      if(allFailed) {
+         return ResponseEntity.badRequest().body(Map.of(
+            "error", "No renderable charts (all failed to export)"));
+      }
+
+      try {
+         byte[] deck = pptxDeckMerger.mergeSlides(event.getTitle(), event.getRecap(), chartSlides);
+         String filename = (event.getTitle() == null ? "board" : event.getTitle()) + ".pptx";
+         servletResponse.setContentType(
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation");
+         servletResponse.setHeader("Content-Disposition",
+            ContentDisposition.attachment().filename(filename).build().toString());
+         servletResponse.setContentLength(deck.length);
+         servletResponse.getOutputStream().write(deck);
+         servletResponse.getOutputStream().flush();
+         return null;
+      }
+      catch(Exception e) {
+         LOG.error("Failed to merge pptx deck", e);
+         return ResponseEntity.status(500).body(Map.of("error", "Failed to export board PowerPoint"));
+      }
+   }
+
+   /** Opens and exports one chart's own saved visualization individually (not a composed
+    *  dashboard). A failure here becomes a failed ChartSlide rather than propagating -- the
+    *  caller decides whether the whole export aborts (only if every chart failed). An
+    *  out-of-folder savedId is treated the same as an open/export failure: a per-chart
+    *  placeholder, not a request-level abort (deliberate divergence from the pdf path's strict
+    *  dashboardId guard, which gates the single asset the whole pdf export depends on). */
+   private PptxDeckMerger.ChartSlide exportOneChartForPptx(WizExportReportEvent.ChartEntry chart,
+                                                           Principal principal)
+   {
+      AssetEntry entry;
+
+      try {
+         entry = Tool.isEmptyString(chart.getSavedId()) ? null : AssetEntry.createAssetEntry(chart.getSavedId());
+      }
+      catch(RuntimeException e) {
+         LOG.warn("Chart savedId is not a valid asset identifier: {}", chart.getSavedId());
+         return new PptxDeckMerger.ChartSlide(chart.getTitle(), chart.getCaption(), null, true);
+      }
+
+      if(entry == null || entry.getPath() == null ||
+         !entry.getPath().startsWith(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/"))
+      {
+         LOG.warn("Chart savedId is not in the managed visualizations folder: {}", chart.getSavedId());
+         return new PptxDeckMerger.ChartSlide(chart.getTitle(), chart.getCaption(), null, true);
+      }
+
+      String runtimeId;
+
+      try {
+         runtimeId = viewsheetService.openViewsheet(entry, principal, true);
+      }
+      catch(Exception e) {
+         LOG.warn("Failed to open chart for pptx export: {}", chart.getSavedId(), e);
+         return new PptxDeckMerger.ChartSlide(chart.getTitle(), chart.getCaption(), null, true);
+      }
+
+      try {
+         RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
+         ByteArrayOutputStream out = new ByteArrayOutputStream();
+         exportService.exportViewsheet(rvs, FileFormatInfo.EXPORT_TYPE_POWERPOINT, false, false, true,
+            false, false, new String[0], false, new ExportResponse(out), principal);
+         return new PptxDeckMerger.ChartSlide(chart.getTitle(), chart.getCaption(), out.toByteArray(), false);
+      }
+      catch(Exception e) {
+         LOG.warn("Failed to export chart for pptx: {}", chart.getSavedId(), e);
+         return new PptxDeckMerger.ChartSlide(chart.getTitle(), chart.getCaption(), null, true);
+      }
+      finally {
+         try {
+            viewsheetService.closeViewsheet(runtimeId, principal);
+         }
+         catch(Exception ignore) {
+            LOG.warn("Failed to close runtime [{}] after pptx chart export", runtimeId);
+         }
+      }
+   }
+
    private final ViewsheetService viewsheetService;
    private final WizVsService wizVsService;
    private final WizPrintLayoutBuilder printLayoutBuilder;
    private final VSExportService exportService;
    private final SecurityEngine securityEngine;
+   private final PptxDeckMerger pptxDeckMerger;
    private static final Logger LOG = LoggerFactory.getLogger(WizViewsheetExportController.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizVisualizationController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizVisualizationController.java
@@ -20,11 +20,14 @@ package inetsoft.web.wiz.controller;
 
 import inetsoft.sree.security.SecurityException;
 import inetsoft.web.composer.model.TreeNodeModel;
+import inetsoft.web.wiz.model.WizDashboardEvent;
+import inetsoft.web.wiz.model.WizDashboardResult;
 import inetsoft.web.wiz.model.WizVisualizationRenderEvent;
 import inetsoft.web.wiz.model.WizVisualizationRenderResult;
 import inetsoft.web.wiz.model.WizVisualizationSaveEvent;
 import inetsoft.web.wiz.model.WizVisualizationSaveResult;
 import inetsoft.web.wiz.service.RenderNotReadyException;
+import inetsoft.web.wiz.service.WizDashboardService;
 import inetsoft.web.wiz.service.WizVisualizationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,8 +43,11 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/wiz/visualization")
 public class WizVisualizationController {
-   public WizVisualizationController(WizVisualizationService wizVisualizationService) {
+   public WizVisualizationController(WizVisualizationService wizVisualizationService,
+                                     WizDashboardService wizDashboardService)
+   {
       this.wizVisualizationService = wizVisualizationService;
+      this.wizDashboardService = wizDashboardService;
    }
 
    /**
@@ -101,6 +107,28 @@ public class WizVisualizationController {
       }
    }
 
+   /**
+    * Composes a wiz dashboard viewsheet from a list of previously-saved visualization
+    * viewsheets.
+    */
+   @PostMapping(value = "/dashboard", produces = MediaType.APPLICATION_JSON_VALUE)
+   public ResponseEntity<?> dashboard(@RequestBody WizDashboardEvent event, Principal principal) {
+      try {
+         WizDashboardResult result = wizDashboardService.composeDashboard(event, principal);
+         return ResponseEntity.ok(result);
+      }
+      catch(SecurityException e) {
+         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("error", e.getMessage()));
+      }
+      catch(IllegalArgumentException e) {
+         return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+      }
+      catch(Exception e) {
+         LOG.error("Failed to compose dashboard", e);
+         return ResponseEntity.internalServerError().body(Map.of("error", "An unexpected error occurred. Please try again."));
+      }
+   }
+
    @DeleteMapping(
       value = "/delete",
       consumes = MediaType.APPLICATION_JSON_VALUE,
@@ -124,5 +152,6 @@ public class WizVisualizationController {
    }
 
    private final WizVisualizationService wizVisualizationService;
+   private final WizDashboardService wizDashboardService;
    private static final Logger LOG = LoggerFactory.getLogger(WizVisualizationController.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDashboardEvent.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDashboardEvent.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * Request body for POST /api/wiz/visualization/dashboard.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WizDashboardEvent {
+   public String getName() {
+      return name;
+   }
+
+   public void setName(String name) {
+      this.name = name;
+   }
+
+   public List<String> getIdentifiers() {
+      return identifiers;
+   }
+
+   public void setIdentifiers(List<String> identifiers) {
+      this.identifiers = identifiers;
+   }
+
+   /** When set, overwrite this existing dashboard asset (update-in-place); else create new. */
+   public String getExistingIdentifier() {
+      return existingIdentifier;
+   }
+
+   public void setExistingIdentifier(String existingIdentifier) {
+      this.existingIdentifier = existingIdentifier;
+   }
+
+   private String name;
+   private List<String> identifiers;
+   private String existingIdentifier;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDashboardResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDashboardResult.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+/**
+ * Response body for POST /api/wiz/visualization/dashboard.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class WizDashboardResult {
+   public String getSavedViewsheetIdentifier() {
+      return savedViewsheetIdentifier;
+   }
+
+   public void setSavedViewsheetIdentifier(String savedViewsheetIdentifier) {
+      this.savedViewsheetIdentifier = savedViewsheetIdentifier;
+   }
+
+   /** Curated identifiers that could not be merged (e.g. deleted) and were skipped. */
+   public List<String> getSkipped() {
+      return skipped;
+   }
+
+   public void setSkipped(List<String> skipped) {
+      this.skipped = skipped;
+   }
+
+   private String savedViewsheetIdentifier;
+   private List<String> skipped;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizExportReportEvent.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizExportReportEvent.java
@@ -1,0 +1,123 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * Request body for POST /api/wiz/viewsheet/export-report.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WizExportReportEvent {
+   public String getDashboardId() {
+      return dashboardId;
+   }
+
+   public void setDashboardId(String dashboardId) {
+      this.dashboardId = dashboardId;
+   }
+
+   public String getFormat() {
+      return format;
+   }
+
+   public void setFormat(String format) {
+      this.format = format;
+   }
+
+   public String getPageSize() {
+      return pageSize;
+   }
+
+   public void setPageSize(String pageSize) {
+      this.pageSize = pageSize;
+   }
+
+   public String getTitle() {
+      return title;
+   }
+
+   public void setTitle(String title) {
+      this.title = title;
+   }
+
+   public String getRecap() {
+      return recap;
+   }
+
+   public void setRecap(String recap) {
+      this.recap = recap;
+   }
+
+   public List<ChartEntry> getCharts() {
+      return charts;
+   }
+
+   public void setCharts(List<ChartEntry> charts) {
+      this.charts = charts;
+   }
+
+   private String dashboardId;
+   private String format;
+   private String pageSize;
+   private String title;
+   private String recap;
+   private List<ChartEntry> charts;
+
+   @JsonIgnoreProperties(ignoreUnknown = true)
+   public static class ChartEntry {
+      public String getSavedId() {
+         return savedId;
+      }
+
+      public void setSavedId(String savedId) {
+         this.savedId = savedId;
+      }
+
+      public String getTitle() {
+         return title;
+      }
+
+      public void setTitle(String title) {
+         this.title = title;
+      }
+
+      public String getCaption() {
+         return caption;
+      }
+
+      public void setCaption(String caption) {
+         this.caption = caption;
+      }
+
+      public int getOrder() {
+         return order;
+      }
+
+      public void setOrder(int order) {
+         this.order = order;
+      }
+
+      private String savedId;
+      private String title;
+      private String caption;
+      private int order;
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/PptxDeckMerger.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/PptxDeckMerger.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+public interface PptxDeckMerger {
+   record ChartSlide(String title, String caption, byte[] singleSlideDeckBytes, boolean failed) {}
+
+   /**
+    * @param title the board name (rendered on a leading title/recap slide)
+    * @param recap optional findings-recap paragraph, rendered under the title on the same slide
+    * @param slides one entry per kept chart, in display order. A non-failed entry's
+    *               singleSlideDeckBytes is a single-slide .pptx produced by exporting that
+    *               chart's own saved visualization via VSExportService/PPTVSExporter
+    *               (FileFormatInfo.EXPORT_TYPE_POWERPOINT). A failed entry's caption/title are
+    *               still used (for the placeholder slide's text); singleSlideDeckBytes may be
+    *               null/empty and must not be read.
+    * @return a merged multi-slide .pptx: one title/recap slide, then one slide per chart
+    *         (imported content + caption, or a text-only "failed to render" placeholder)
+    */
+   byte[] mergeSlides(String title, String recap, java.util.List<ChartSlide> slides) throws Exception;
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -1,0 +1,206 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.IdentityID;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.WizUtil;
+import inetsoft.util.Catalog;
+import inetsoft.util.Tool;
+import inetsoft.web.wiz.model.WizDashboardEvent;
+import inetsoft.web.wiz.model.WizDashboardResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Composes a wiz dashboard viewsheet from a list of previously-saved visualization
+ * viewsheets (POST /api/wiz/visualization/dashboard).
+ *
+ * <p>Steps:
+ * <ol>
+ *   <li>Validate {@code name} and a non-empty {@code identifiers} list.</li>
+ *   <li>Parse every identifier and guard that its path is under
+ *       {@link WizVisualizationService#VISUALIZATION_COMPONENTS_FOLDER_PATH} (fail loud
+ *       otherwise).</li>
+ *   <li>Action-level permission check (mirrors {@link WizVisualizationService#renderVisualization}),
+ *       performed <b>before</b> any runtime viewsheet is opened.</li>
+ *   <li>Mint a fresh, empty wiz-dashboard runtime viewsheet via
+ *       {@link ViewsheetService#openTemporaryViewsheet(String, AssetEntry, Principal, Viewsheet.WizInfo)}
+ *       with a 1-arg {@link Viewsheet.WizInfo#WizInfo(boolean)} (the 3-arg constructor leaves
+ *       {@code isWizSheet()} false, which breaks {@link AddVisualizationService#addVisualization}).</li>
+ *   <li>Merge each visualization in turn via {@link AddVisualizationServiceProxy#addVisualization}
+ *       (not {@code addVisualizationsByIds}, which forces a measured 3-column grid) using a
+ *       deterministic single-column vertical stack (x=0, y=running total of
+ *       {@link #DASHBOARD_ROW_HEIGHT}). A per-visualization failure is logged and the identifier
+ *       recorded in {@link WizDashboardResult#getSkipped()} rather than failing the whole
+ *       compose; if every visualization is skipped, the compose fails loud
+ *       ({@link IllegalArgumentException}, mapped by the controller to 400).</li>
+ *   <li>Persist via {@link WizUtil#saveWizSheet}, which finalizes the temporary dashboard
+ *       worksheet and then runs the save callback, in the same order the Composer uses (a bare
+ *       {@code viewsheetService.setViewsheet} call would skip the finalize step and leave the
+ *       dashboard pointing at a temp worksheet entry).</li>
+ *   <li>Always close the runtime in a {@code finally} block.</li>
+ * </ol>
+ *
+ * <p><b>Test coverage note:</b> only the pre-open validation/guard/permission branches above are
+ * unit-tested here ({@link WizDashboardServiceTest}). The happy-path compose+save and the
+ * all-visualizations-skipped-&gt;400 path both require a live {@link ViewsheetService}/asset
+ * engine to open a real runtime viewsheet and merge worksheets, and are verified later in the A4
+ * integration test.
+ */
+@Service
+public class WizDashboardService {
+   public WizDashboardService(ViewsheetService viewsheetService,
+                               AddVisualizationServiceProxy addVisualizationService,
+                               SecurityEngine securityEngine)
+   {
+      this.viewsheetService = viewsheetService;
+      this.addVisualizationService = addVisualizationService;
+      this.securityEngine = securityEngine;
+   }
+
+   public WizDashboardResult composeDashboard(WizDashboardEvent event, Principal principal)
+      throws Exception
+   {
+      if(event == null || Tool.isEmptyString(event.getName())) {
+         throw new IllegalArgumentException("name is required");
+      }
+
+      List<String> identifiers = event.getIdentifiers();
+
+      if(identifiers == null || identifiers.isEmpty()) {
+         throw new IllegalArgumentException("identifiers are required");
+      }
+
+      // Parse + managed-folder guard for every input identifier (fail loud on out-of-folder).
+      List<AssetEntry> entries = new ArrayList<>();
+
+      for(String id : identifiers) {
+         AssetEntry entry = AssetEntry.createAssetEntry(id);
+
+         if(entry == null || entry.getPath() == null ||
+            !entry.getPath().startsWith(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/"))
+         {
+            throw new IllegalArgumentException(
+               "Identifier is not in the managed visualizations folder: " + id);
+         }
+
+         entries.add(entry);
+      }
+
+      // Action-level gate, mirroring WizVisualizationService#renderVisualization — performed
+      // before any runtime viewsheet is opened.
+      if(!securityEngine.checkPermission(principal, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(
+            Catalog.getCatalog().getString("composer.authorization.permissionDenied"));
+      }
+
+      // Mint a fresh, empty wiz-dashboard runtime. The 1-arg WizInfo(true) sets isWizSheet()=true;
+      // the 3-arg WizInfo(true, null, null) sets isWizVisualization() instead and leaves
+      // isWizSheet()=false, which AddVisualizationService#addVisualization requires.
+      String runtimeId = viewsheetService.openTemporaryViewsheet(
+         null, null, principal, new Viewsheet.WizInfo(true));
+
+      try {
+         List<String> skipped = new ArrayList<>();
+         int mergedCount = 0;
+         int cumulativeY = 0;
+
+         for(int i = 0; i < entries.size(); i++) {
+            try {
+               addVisualizationService.addVisualization(
+                  runtimeId, entries.get(i), 0, cumulativeY, 1.0f, principal);
+               cumulativeY += DASHBOARD_ROW_HEIGHT;
+               mergedCount++;
+            }
+            catch(Exception ex) {
+               LOG.warn("Skipping unmergeable visualization [{}]: {}", identifiers.get(i), ex.getMessage());
+               skipped.add(identifiers.get(i));
+            }
+         }
+
+         if(mergedCount == 0) {
+            throw new IllegalArgumentException("No renderable visualizations to compose (all skipped)");
+         }
+
+         RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
+         AssetEntry savedVsEntry = resolveTargetEntry(event.getExistingIdentifier(), event.getName(), principal);
+
+         WizUtil.saveWizSheet(rvs, principal, savedVsEntry,
+            () -> viewsheetService.setViewsheet(rvs.getViewsheet(), savedVsEntry, principal, true, true));
+
+         WizDashboardResult result = new WizDashboardResult();
+         result.setSavedViewsheetIdentifier(savedVsEntry.toIdentifier());
+         result.setSkipped(skipped);
+         return result;
+      }
+      finally {
+         try {
+            viewsheetService.closeViewsheet(runtimeId, principal);
+         }
+         catch(Exception ignore) {
+            LOG.warn("Failed to close runtime [{}] after dashboard compose", runtimeId);
+         }
+      }
+   }
+
+   /** Build the components-folder target entry; overwrite the existing one when provided. */
+   private AssetEntry resolveTargetEntry(String existingIdentifier, String name, Principal principal) {
+      IdentityID pId = IdentityID.getIdentityIDFromKey(principal.getName());
+
+      if(!Tool.isEmptyString(existingIdentifier)) {
+         AssetEntry existing = AssetEntry.createAssetEntry(existingIdentifier);
+
+         if(existing == null || existing.getPath() == null ||
+            !existing.getPath().startsWith(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/"))
+         {
+            throw new IllegalArgumentException("existingIdentifier is not in the managed visualizations folder");
+         }
+
+         existing.setAlias(name);
+         return existing;
+      }
+
+      String newPath = WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/" + UUID.randomUUID();
+      AssetEntry entry = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, newPath, pId);
+      entry.setAlias(name);
+      return entry;
+   }
+
+   /** Single-column vertical stride between successive merged visualizations, in pixels. */
+   private static final int DASHBOARD_ROW_HEIGHT = 420;
+
+   private final ViewsheetService viewsheetService;
+   private final AddVisualizationServiceProxy addVisualizationService;
+   private final SecurityEngine securityEngine;
+   private static final Logger LOG = LoggerFactory.getLogger(WizDashboardService.class);
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -79,8 +79,9 @@ public class WizPrintLayoutBuilder {
          int captionY = i == 0 ? TITLE_BLOCK_HEIGHT_PT : pageTop;
          int chartY = captionY + CAPTION_HEIGHT_PT;
 
-         // Build caption text: just the caption field if present and non-empty, otherwise title
-         String captionText = (c.caption() != null && !c.caption().isBlank()) ? c.caption() : c.title();
+         // Build caption text: title always shown, caption appended after an em-dash when present.
+         String captionText = c.title() +
+            (c.caption() != null && !c.caption().isBlank() ? " — " + c.caption() : "");
          vsLayouts.add(textLayout("wizExportCaption_" + i, captionText,
             new Point(0, captionY), new Dimension(PAGE_CONTENT_WIDTH_PT, CAPTION_HEIGHT_PT)));
          vsLayouts.add(new VSAssemblyLayout(assembly.getName(), new Point(0, chartY),

--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -21,10 +21,17 @@ import inetsoft.graph.internal.DimensionD;
 import inetsoft.report.Margin;
 import inetsoft.report.Size;
 import inetsoft.report.internal.PaperSize;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.AnnotationVSUtil;
+import inetsoft.uql.viewsheet.internal.TextVSAssemblyInfo;
 import inetsoft.uql.viewsheet.vslayout.PrintInfo;
 import inetsoft.uql.viewsheet.vslayout.PrintLayout;
+import inetsoft.uql.viewsheet.vslayout.VSAssemblyLayout;
+import inetsoft.uql.viewsheet.vslayout.VSEditableAssemblyLayout;
 
+import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +51,45 @@ public class WizPrintLayoutBuilder {
       layout.setPrintInfo(buildPrintInfo(pageSize));
       layout.setHeaderLayouts(new ArrayList<>());
       layout.setFooterLayouts(new ArrayList<>());
-      layout.setVSAssemblyLayouts(new ArrayList<>());
+
+      List<VSAssembly> topLevel = resolveTopLevelAssemblies(dashboard);
+
+      if(topLevel.size() != charts.size()) {
+         throw new IllegalStateException(
+            "Dashboard has " + topLevel.size() + " top-level assemblies but " + charts.size() +
+            " charts were requested — the composed dashboard and the board's curation have " +
+            "desynced (see WizPrintLayoutBuilder's Javadoc / the plan's Global Constraints risk note)");
+      }
+
+      List<ChartCaption> ordered = charts.stream()
+         .sorted(java.util.Comparator.comparingInt(ChartCaption::order))
+         .collect(java.util.stream.Collectors.toList());
+
+      List<VSAssemblyLayout> vsLayouts = new ArrayList<>();
+      int page = 0;
+
+      // Page 1: title + recap header block.
+      vsLayouts.add(textLayout("wizExportTitleRecap", buildTitleRecapText(title, recap),
+         new Point(0, 0), new Dimension(PAGE_CONTENT_WIDTH_PT, TITLE_BLOCK_HEIGHT_PT)));
+
+      for(int i = 0; i < ordered.size(); i++) {
+         ChartCaption c = ordered.get(i);
+         VSAssembly assembly = topLevel.get(i);
+         int pageTop = page * PAGE_HEIGHT_PT;
+         int captionY = i == 0 ? TITLE_BLOCK_HEIGHT_PT : pageTop;
+         int chartY = captionY + CAPTION_HEIGHT_PT;
+
+         // Build caption text: just the caption field if present and non-empty, otherwise title
+         String captionText = (c.caption() != null && !c.caption().isBlank()) ? c.caption() : c.title();
+         vsLayouts.add(textLayout("wizExportCaption_" + i, captionText,
+            new Point(0, captionY), new Dimension(PAGE_CONTENT_WIDTH_PT, CAPTION_HEIGHT_PT)));
+         vsLayouts.add(new VSAssemblyLayout(assembly.getName(), new Point(0, chartY),
+            new Dimension(PAGE_CONTENT_WIDTH_PT, CHART_HEIGHT_PT)));
+
+         page++;
+      }
+
+      layout.setVSAssemblyLayouts(vsLayouts);
       return layout;
    }
 
@@ -74,4 +119,58 @@ public class WizPrintLayoutBuilder {
    private static final float MARGIN_BOTTOM_IN = 0.55f;
    private static final float MARGIN_LEFT_IN = 0.47f;
    private static final float MARGIN_RIGHT_IN = 0.47f;
+
+   /** Mirrors AbstractLayout.apply()'s own filter for which assemblies need a layout entry
+    *  (annotations and container children are skipped there too — see AbstractLayout.java). */
+   private List<VSAssembly> resolveTopLevelAssemblies(Viewsheet dashboard) {
+      List<VSAssembly> result = new ArrayList<>();
+
+      if(dashboard.getAssemblies() == null) {
+         return result;
+      }
+
+      for(Assembly a : dashboard.getAssemblies()) {
+         if(!(a instanceof VSAssembly vsAssembly)) {
+            continue;
+         }
+
+         if(AnnotationVSUtil.isAnnotation(vsAssembly) || vsAssembly.getContainer() != null) {
+            continue;
+         }
+
+         result.add(vsAssembly);
+      }
+
+      result.sort(java.util.Comparator.comparingInt(
+         a -> a.getVSAssemblyInfo().getPixelOffset().y));
+      return result;
+   }
+
+   private String buildTitleRecapText(String title, String recap) {
+      StringBuilder sb = new StringBuilder(title == null ? "" : title);
+
+      if(recap != null && !recap.isBlank()) {
+         sb.append("\n").append(recap);
+      }
+
+      return sb.toString();
+   }
+
+   private VSEditableAssemblyLayout textLayout(String name, String text, Point pos, Dimension size) {
+      TextVSAssemblyInfo info = new TextVSAssemblyInfo();
+      info.setTextValue(text);
+      info.setText(text);
+      return new VSEditableAssemblyLayout(info, name, pos, size);
+   }
+
+   /** Points-per-inch used by VsToReportConverter's print-layout-to-report conversion
+    *  (see VsToReportConverter.java:3226, INCH_POINT = 72) — VSAssemblyLayout position/size
+    *  values feed that same pipeline, so page/content geometry below is expressed in points.
+    *  CONFIRM in Task 3's integration test that content doesn't clip/overlap across the page
+    *  boundary; adjust these constants if it does. */
+   private static final int PAGE_HEIGHT_PT = 11 * 72;   // ~A4/Letter portrait height, conservative
+   private static final int PAGE_CONTENT_WIDTH_PT = 8 * 72;
+   private static final int TITLE_BLOCK_HEIGHT_PT = 100;
+   private static final int CAPTION_HEIGHT_PT = 30;
+   private static final int CHART_HEIGHT_PT = 400;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -30,6 +30,7 @@ import inetsoft.uql.viewsheet.vslayout.PrintInfo;
 import inetsoft.uql.viewsheet.vslayout.PrintLayout;
 import inetsoft.uql.viewsheet.vslayout.VSAssemblyLayout;
 import inetsoft.uql.viewsheet.vslayout.VSEditableAssemblyLayout;
+import org.springframework.stereotype.Component;
 
 import java.awt.*;
 import java.util.ArrayList;
@@ -41,6 +42,7 @@ import java.util.Map;
  * (POST /api/wiz/viewsheet/export-report): a title/recap header block, followed by each kept
  * chart on its own page with a caption line, rebuilt fresh (idempotent) on every export call.
  */
+@Component
 public class WizPrintLayoutBuilder {
    public record ChartCaption(String title, String caption, int order) {}
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.graph.internal.DimensionD;
+import inetsoft.report.Margin;
+import inetsoft.report.Size;
+import inetsoft.report.internal.PaperSize;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.vslayout.PrintInfo;
+import inetsoft.uql.viewsheet.vslayout.PrintLayout;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds a {@link PrintLayout} for the board-export "Component A" endpoint
+ * (POST /api/wiz/viewsheet/export-report): a title/recap header block, followed by each kept
+ * chart on its own page with a caption line, rebuilt fresh (idempotent) on every export call.
+ */
+public class WizPrintLayoutBuilder {
+   public record ChartCaption(String title, String caption, int order) {}
+
+   public PrintLayout build(Viewsheet dashboard, String pageSize, String title, String recap,
+                             List<ChartCaption> charts)
+   {
+      PrintLayout layout = new PrintLayout();
+      layout.setPrintInfo(buildPrintInfo(pageSize));
+      layout.setHeaderLayouts(new ArrayList<>());
+      layout.setFooterLayouts(new ArrayList<>());
+      layout.setVSAssemblyLayouts(new ArrayList<>());
+      return layout;
+   }
+
+   private PrintInfo buildPrintInfo(String pageSize) {
+      String canonicalName = PAGE_SIZE_NAMES.get(pageSize == null ? "" : pageSize.toLowerCase());
+
+      if(canonicalName == null) {
+         throw new IllegalArgumentException("Unknown pageSize: " + pageSize + " (expected a4 or letter)");
+      }
+
+      Size size = PaperSize.getSize(canonicalName);
+      PrintInfo info = new PrintInfo();
+      info.setPaperType(canonicalName);
+      info.setUnit("inches");
+      info.setSize(new DimensionD(size.width, size.height));
+      info.setMargin(new Margin(MARGIN_TOP_IN, MARGIN_LEFT_IN, MARGIN_BOTTOM_IN, MARGIN_RIGHT_IN));
+      return info;
+   }
+
+   private static final Map<String, String> PAGE_SIZE_NAMES = Map.of(
+      "a4", "A4 [210x297 mm]",
+      "letter", "Letter [8.5x11 in]"
+   );
+
+   /** ~14mm top/bottom, ~12mm left/right (design spec), converted to inches (PrintInfo's native unit). */
+   private static final float MARGIN_TOP_IN = 0.55f;
+   private static final float MARGIN_BOTTOM_IN = 0.55f;
+   private static final float MARGIN_LEFT_IN = 0.47f;
+   private static final float MARGIN_RIGHT_IN = 0.47f;
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetExportControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetExportControllerTest.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.viewsheet.service.VSExportService;
+import inetsoft.web.wiz.model.WizExportReportEvent;
+import inetsoft.web.wiz.service.WizPrintLayoutBuilder;
+import inetsoft.web.wiz.service.WizVisualizationService;
+import inetsoft.web.wiz.service.WizVsService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class WizViewsheetExportControllerTest {
+
+   private static String managedDashboardIdentifier() {
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/dash1", null);
+      return entry.toIdentifier();
+   }
+
+   /** Deliberately outside VISUALIZATION_COMPONENTS_FOLDER_PATH — built the same way
+    *  managedDashboardIdentifier() is, not a hand-rolled identifier string. */
+   private static String unmanagedIdentifier() {
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, "some/other/folder/x", null);
+      return entry.toIdentifier();
+   }
+
+   private static WizExportReportEvent event(String dashboardId) {
+      WizExportReportEvent ev = new WizExportReportEvent();
+      ev.setDashboardId(dashboardId);
+      ev.setFormat("pdf");
+      ev.setPageSize("a4");
+      ev.setTitle("Q39 Board");
+      ev.setCharts(List.of());
+      return ev;
+   }
+
+   @Test
+   void rejectsIdentifierOutsideComponentsFolder() throws Exception {
+      ViewsheetService vs = mock(ViewsheetService.class);
+      WizViewsheetExportController ctrl = new WizViewsheetExportController(
+         vs, mock(WizVsService.class), mock(WizPrintLayoutBuilder.class),
+         mock(VSExportService.class), mock(SecurityEngine.class));
+
+      ResponseEntity<?> resp = ctrl.exportReport(event(unmanagedIdentifier()), mock(Principal.class));
+
+      assertEquals(400, resp.getStatusCode().value());
+      verify(vs, never()).openViewsheet(any(), any(), anyBoolean());
+   }
+
+   @Test
+   void deniesExportWhenPermissionMissing() throws Exception {
+      ViewsheetService vs = mock(ViewsheetService.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      when(vs.openViewsheet(any(), eq(principal), eq(true))).thenReturn("rt1");
+      when(sec.checkPermission(eq(principal), eq(ResourceType.VIEWSHEET_TOOLBAR_ACTION),
+         eq("Export"), eq(ResourceAction.READ))).thenReturn(false);
+
+      WizViewsheetExportController ctrl = new WizViewsheetExportController(
+         vs, mock(WizVsService.class), mock(WizPrintLayoutBuilder.class),
+         mock(VSExportService.class), sec);
+
+      ResponseEntity<?> resp = ctrl.exportReport(event(managedDashboardIdentifier()), principal);
+
+      assertEquals(403, resp.getStatusCode().value());
+      // Permission is checked before getViewsheet() is ever called (see the controller's
+      // check-then-fetch order), so no stub for getViewsheet is needed here.
+      verify(vs, never()).getViewsheet(any(), any());
+      verify(vs).closeViewsheet("rt1", principal); // always closed, even on 403
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetExportControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetExportControllerTest.java
@@ -30,11 +30,16 @@ import inetsoft.web.wiz.model.WizExportReportEvent;
 import inetsoft.web.wiz.service.WizPrintLayoutBuilder;
 import inetsoft.web.wiz.service.WizVisualizationService;
 import inetsoft.web.wiz.service.WizVsService;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
+import java.io.ByteArrayOutputStream;
 import java.security.Principal;
 import java.util.List;
 
@@ -70,6 +75,28 @@ class WizViewsheetExportControllerTest {
       return ev;
    }
 
+   /** A ServletOutputStream backed by a plain ByteArrayOutputStream so tests can capture what
+    *  the controller writes, matching the enterprise ViewsheetApiController's own direct-response
+    *  pattern (no compatible HttpMessageConverter exists for a byte[]/Resource body declared as
+    *  application/pdf in this app's WebConfig — confirmed live, see the controller's comment). */
+   private static ServletOutputStream capturingOutputStream(ByteArrayOutputStream sink) {
+      return new ServletOutputStream() {
+         @Override
+         public boolean isReady() {
+            return true;
+         }
+
+         @Override
+         public void setWriteListener(WriteListener writeListener) {
+         }
+
+         @Override
+         public void write(int b) {
+            sink.write(b);
+         }
+      };
+   }
+
    @Test
    void rejectsIdentifierOutsideComponentsFolder() throws Exception {
       ViewsheetService vs = mock(ViewsheetService.class);
@@ -77,7 +104,8 @@ class WizViewsheetExportControllerTest {
          vs, mock(WizVsService.class), mock(WizPrintLayoutBuilder.class),
          mock(VSExportService.class), mock(SecurityEngine.class));
 
-      ResponseEntity<?> resp = ctrl.exportReport(event(unmanagedIdentifier()), mock(Principal.class));
+      ResponseEntity<?> resp = ctrl.exportReport(
+         event(unmanagedIdentifier()), mock(Principal.class), mock(HttpServletResponse.class));
 
       assertEquals(400, resp.getStatusCode().value());
       verify(vs, never()).openViewsheet(any(), any(), anyBoolean());
@@ -96,7 +124,8 @@ class WizViewsheetExportControllerTest {
          vs, mock(WizVsService.class), mock(WizPrintLayoutBuilder.class),
          mock(VSExportService.class), sec);
 
-      ResponseEntity<?> resp = ctrl.exportReport(event(managedDashboardIdentifier()), principal);
+      ResponseEntity<?> resp = ctrl.exportReport(
+         event(managedDashboardIdentifier()), principal, mock(HttpServletResponse.class));
 
       assertEquals(403, resp.getStatusCode().value());
       // Permission is checked before getViewsheet() is ever called (see the controller's
@@ -115,14 +144,14 @@ class WizViewsheetExportControllerTest {
       WizExportReportEvent ev = event(managedDashboardIdentifier());
       ev.setFormat("xlsx");
 
-      ResponseEntity<?> resp = ctrl.exportReport(ev, mock(Principal.class));
+      ResponseEntity<?> resp = ctrl.exportReport(ev, mock(Principal.class), mock(HttpServletResponse.class));
 
       assertEquals(400, resp.getStatusCode().value());
       verify(vs, never()).openViewsheet(any(), any(), anyBoolean());
    }
 
    @Test
-   void happyPathBuildsLayoutPersistsAndReturnsExportedBytes() throws Exception {
+   void happyPathBuildsLayoutPersistsAndWritesExportedBytesDirectlyToServletResponse() throws Exception {
       ViewsheetService vs = mock(ViewsheetService.class);
       WizVsService wizVsService = mock(WizVsService.class);
       WizPrintLayoutBuilder builder = mock(WizPrintLayoutBuilder.class);
@@ -132,6 +161,9 @@ class WizViewsheetExportControllerTest {
       RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
       Viewsheet viewsheet = mock(Viewsheet.class);
       inetsoft.uql.viewsheet.vslayout.LayoutInfo layoutInfo = mock(inetsoft.uql.viewsheet.vslayout.LayoutInfo.class);
+      HttpServletResponse servletResponse = mock(HttpServletResponse.class);
+      ByteArrayOutputStream written = new ByteArrayOutputStream();
+      when(servletResponse.getOutputStream()).thenReturn(capturingOutputStream(written));
 
       when(viewsheet.getLayoutInfo()).thenReturn(layoutInfo);
       when(vs.openViewsheet(any(), eq(principal), eq(true))).thenReturn("rt1");
@@ -158,12 +190,17 @@ class WizViewsheetExportControllerTest {
       WizExportReportEvent ev = event(managedDashboardIdentifier());
       ev.setPageSize("letter");
 
-      ResponseEntity<?> resp = ctrl.exportReport(ev, principal);
+      ResponseEntity<?> resp = ctrl.exportReport(ev, principal, servletResponse);
 
-      assertEquals(200, resp.getStatusCode().value());
-      assertArrayEquals(fakePdf, (byte[]) resp.getBody());
-      assertEquals(MediaType.APPLICATION_PDF, resp.getHeaders().getContentType());
-      assertTrue(resp.getHeaders().getFirst("Content-Disposition").contains("Q39 Board.pdf"));
+      // Success path writes directly to the servlet response and returns null — Spring MVC
+      // treats a null return from a non-void handler as "response already fully handled."
+      assertNull(resp);
+      assertArrayEquals(fakePdf, written.toByteArray());
+      verify(servletResponse).setContentType(MediaType.APPLICATION_PDF_VALUE);
+      verify(servletResponse).setContentLength(fakePdf.length);
+      ArgumentCaptor<String> dispositionCaptor = ArgumentCaptor.forClass(String.class);
+      verify(servletResponse).setHeader(eq("Content-Disposition"), dispositionCaptor.capture());
+      assertTrue(dispositionCaptor.getValue().contains("Q39 Board.pdf"));
       verify(layoutInfo).setPrintLayout(fakeLayout);
       verify(wizVsService).persistViewsheet(viewsheet, managedDashboardIdentifier(), principal);
       verify(vs).closeViewsheet("rt1", principal);

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetExportControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetExportControllerTest.java
@@ -369,6 +369,35 @@ class WizViewsheetExportControllerTest {
    }
 
    @Test
+   void pptxEmptyChartsRejectedUpfront() throws Exception {
+      // Mirrors WizDashboardService.composeDashboard's upfront "identifiers are required" guard
+      // (identifiers == null || identifiers.isEmpty() -> IllegalArgumentException before any
+      // asset is touched). The pptx path only had the later "all failed to export" guard, which
+      // short-circuits via !chartSlides.isEmpty() and silently lets an empty/null charts[] fall
+      // through to pptxDeckMerger.mergeSlides(title, recap, List.of()) instead of being rejected.
+      ViewsheetService vs = mock(ViewsheetService.class);
+      PptxDeckMerger merger = mock(PptxDeckMerger.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+
+      WizViewsheetExportController ctrl = new WizViewsheetExportController(
+         vs, mock(WizVsService.class), mock(WizPrintLayoutBuilder.class),
+         mock(VSExportService.class), sec, merger);
+
+      WizExportReportEvent ev = new WizExportReportEvent();
+      ev.setFormat("pptx");
+      ev.setTitle("Board");
+      ev.setCharts(null);
+
+      ResponseEntity<?> resp = ctrl.exportReport(ev, principal, mock(HttpServletResponse.class));
+
+      assertEquals(400, resp.getStatusCode().value());
+      verify(merger, never()).mergeSlides(any(), any(), any());
+      verify(vs, never()).openViewsheet(any(), any(), anyBoolean());
+   }
+
+   @Test
    void pptxChartOutsideComponentsFolderBecomesPlaceholderNotAbort() throws Exception {
       // Consistent with the "one bad chart doesn't abort" decision: an out-of-folder savedId is
       // still just "this one chart didn't work," same as an open/export failure -- NOT a

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetExportControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetExportControllerTest.java
@@ -103,4 +103,20 @@ class WizViewsheetExportControllerTest {
       verify(vs, never()).getViewsheet(any(), any());
       verify(vs).closeViewsheet("rt1", principal); // always closed, even on 403
    }
+
+   @Test
+   void rejectsUnsupportedFormat() throws Exception {
+      ViewsheetService vs = mock(ViewsheetService.class);
+      WizViewsheetExportController ctrl = new WizViewsheetExportController(
+         vs, mock(WizVsService.class), mock(WizPrintLayoutBuilder.class),
+         mock(VSExportService.class), mock(SecurityEngine.class));
+
+      WizExportReportEvent ev = event(managedDashboardIdentifier());
+      ev.setFormat("xlsx");
+
+      ResponseEntity<?> resp = ctrl.exportReport(ev, mock(Principal.class));
+
+      assertEquals(400, resp.getStatusCode().value());
+      verify(vs, never()).openViewsheet(any(), any(), anyBoolean());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetExportControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetExportControllerTest.java
@@ -24,9 +24,12 @@ import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.FileFormatInfo;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.viewsheet.service.ExportResponse;
 import inetsoft.web.viewsheet.service.VSExportService;
 import inetsoft.web.wiz.model.WizExportReportEvent;
+import inetsoft.web.wiz.service.PptxDeckMerger;
 import inetsoft.web.wiz.service.WizPrintLayoutBuilder;
 import inetsoft.web.wiz.service.WizVisualizationService;
 import inetsoft.web.wiz.service.WizVsService;
@@ -97,12 +100,28 @@ class WizViewsheetExportControllerTest {
       };
    }
 
+   private static String managedChartIdentifier(String suffix) {
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/" + suffix, null);
+      return entry.toIdentifier();
+   }
+
+   private static WizExportReportEvent.ChartEntry chartEntry(String savedId, String title, String caption, int order) {
+      WizExportReportEvent.ChartEntry c = new WizExportReportEvent.ChartEntry();
+      c.setSavedId(savedId);
+      c.setTitle(title);
+      c.setCaption(caption);
+      c.setOrder(order);
+      return c;
+   }
+
    @Test
    void rejectsIdentifierOutsideComponentsFolder() throws Exception {
       ViewsheetService vs = mock(ViewsheetService.class);
       WizViewsheetExportController ctrl = new WizViewsheetExportController(
          vs, mock(WizVsService.class), mock(WizPrintLayoutBuilder.class),
-         mock(VSExportService.class), mock(SecurityEngine.class));
+         mock(VSExportService.class), mock(SecurityEngine.class), mock(PptxDeckMerger.class));
 
       ResponseEntity<?> resp = ctrl.exportReport(
          event(unmanagedIdentifier()), mock(Principal.class), mock(HttpServletResponse.class));
@@ -122,7 +141,7 @@ class WizViewsheetExportControllerTest {
 
       WizViewsheetExportController ctrl = new WizViewsheetExportController(
          vs, mock(WizVsService.class), mock(WizPrintLayoutBuilder.class),
-         mock(VSExportService.class), sec);
+         mock(VSExportService.class), sec, mock(PptxDeckMerger.class));
 
       ResponseEntity<?> resp = ctrl.exportReport(
          event(managedDashboardIdentifier()), principal, mock(HttpServletResponse.class));
@@ -139,7 +158,7 @@ class WizViewsheetExportControllerTest {
       ViewsheetService vs = mock(ViewsheetService.class);
       WizViewsheetExportController ctrl = new WizViewsheetExportController(
          vs, mock(WizVsService.class), mock(WizPrintLayoutBuilder.class),
-         mock(VSExportService.class), mock(SecurityEngine.class));
+         mock(VSExportService.class), mock(SecurityEngine.class), mock(PptxDeckMerger.class));
 
       WizExportReportEvent ev = event(managedDashboardIdentifier());
       ev.setFormat("xlsx");
@@ -185,7 +204,7 @@ class WizViewsheetExportControllerTest {
          eq(false), eq(false), any(String[].class), eq(false), any(), eq(principal));
 
       WizViewsheetExportController ctrl = new WizViewsheetExportController(
-         vs, wizVsService, builder, exportService, sec);
+         vs, wizVsService, builder, exportService, sec, mock(PptxDeckMerger.class));
 
       WizExportReportEvent ev = event(managedDashboardIdentifier());
       ev.setPageSize("letter");
@@ -204,5 +223,208 @@ class WizViewsheetExportControllerTest {
       verify(layoutInfo).setPrintLayout(fakeLayout);
       verify(wizVsService).persistViewsheet(viewsheet, managedDashboardIdentifier(), principal);
       verify(vs).closeViewsheet("rt1", principal);
+   }
+
+   @Test
+   void pptxHappyPathExportsEachChartIndividuallyAndMerges() throws Exception {
+      ViewsheetService vs = mock(ViewsheetService.class);
+      WizVsService wizVsService = mock(WizVsService.class);
+      WizPrintLayoutBuilder builder = mock(WizPrintLayoutBuilder.class);
+      VSExportService exportService = mock(VSExportService.class);
+      PptxDeckMerger merger = mock(PptxDeckMerger.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      HttpServletResponse servletResponse = mock(HttpServletResponse.class);
+      ByteArrayOutputStream written = new ByteArrayOutputStream();
+      when(servletResponse.getOutputStream()).thenReturn(capturingOutputStream(written));
+      when(sec.checkPermission(eq(principal), eq(ResourceType.VIEWSHEET_TOOLBAR_ACTION),
+         eq("Export"), eq(ResourceAction.READ))).thenReturn(true);
+
+      String chart1Id = managedChartIdentifier("c1");
+      String chart2Id = managedChartIdentifier("c2");
+      RuntimeViewsheet rvs1 = mock(RuntimeViewsheet.class);
+      RuntimeViewsheet rvs2 = mock(RuntimeViewsheet.class);
+      when(vs.openViewsheet(argThat(e -> e != null && e.toIdentifier().equals(chart1Id)), eq(principal), eq(true)))
+         .thenReturn("rt-c1");
+      when(vs.openViewsheet(argThat(e -> e != null && e.toIdentifier().equals(chart2Id)), eq(principal), eq(true)))
+         .thenReturn("rt-c2");
+      when(vs.getViewsheet("rt-c1", principal)).thenReturn(rvs1);
+      when(vs.getViewsheet("rt-c2", principal)).thenReturn(rvs2);
+
+      byte[] chart1Bytes = "chart1-deck".getBytes();
+      byte[] chart2Bytes = "chart2-deck".getBytes();
+      doAnswer(inv -> { ((ExportResponse) inv.getArgument(9)).getOutputStream().write(chart1Bytes); return null; })
+         .when(exportService).exportViewsheet(eq(rvs1), eq(FileFormatInfo.EXPORT_TYPE_POWERPOINT),
+            anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(),
+            any(String[].class), anyBoolean(), any(), eq(principal));
+      doAnswer(inv -> { ((ExportResponse) inv.getArgument(9)).getOutputStream().write(chart2Bytes); return null; })
+         .when(exportService).exportViewsheet(eq(rvs2), eq(FileFormatInfo.EXPORT_TYPE_POWERPOINT),
+            anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(),
+            any(String[].class), anyBoolean(), any(), eq(principal));
+
+      byte[] fakeDeck = "%PPTX-fake".getBytes();
+      when(merger.mergeSlides(eq("Q39 Board"), isNull(), argThat(list ->
+         list.size() == 2 &&
+         list.get(0).title().equals("First") && java.util.Arrays.equals(list.get(0).singleSlideDeckBytes(), chart1Bytes) &&
+         list.get(1).title().equals("Second") && java.util.Arrays.equals(list.get(1).singleSlideDeckBytes(), chart2Bytes) &&
+         !list.get(0).failed() && !list.get(1).failed()
+      ))).thenReturn(fakeDeck);
+
+      WizViewsheetExportController ctrl = new WizViewsheetExportController(
+         vs, wizVsService, builder, exportService, sec, merger);
+
+      WizExportReportEvent ev = new WizExportReportEvent();
+      ev.setFormat("pptx");
+      ev.setTitle("Q39 Board");
+      ev.setCharts(List.of(
+         chartEntry(chart1Id, "First", "cap one", 0),
+         chartEntry(chart2Id, "Second", "cap two", 1)));
+
+      ResponseEntity<?> resp = ctrl.exportReport(ev, principal, servletResponse);
+
+      assertNull(resp);
+      assertArrayEquals(fakeDeck, written.toByteArray());
+      verify(servletResponse).setContentType("application/vnd.openxmlformats-officedocument.presentationml.presentation");
+      verify(vs).closeViewsheet("rt-c1", principal);
+      verify(vs).closeViewsheet("rt-c2", principal);
+      // pptx never touches the dashboard/print-layout machinery
+      verify(builder, never()).build(any(), any(), any(), any(), any());
+      verify(wizVsService, never()).persistViewsheet(any(), any(), any());
+   }
+
+   @Test
+   void pptxChartOpenFailureBecomesPlaceholderNotAbort() throws Exception {
+      // NOTE: adapted from the brief's literal test, which stubbed only a single chart that
+      // fails to open and then asserted assertNull(resp) (success/merge). With exactly one
+      // chart in the request, "one chart failed" and "all charts failed" are the same event,
+      // which directly contradicts pptxAllChartsFailedAbortsLoud below (same single-failing-
+      // chart setup, asserting a 400 abort instead). That is an internal contradiction in the
+      // brief's two tests, not a real behavioral distinction, so this test adds a second,
+      // successful chart -- now "one of two failed" genuinely exercises "some failed, not all
+      // failed, don't abort" without colliding with the all-failed test.
+      ViewsheetService vs = mock(ViewsheetService.class);
+      VSExportService exportService = mock(VSExportService.class);
+      PptxDeckMerger merger = mock(PptxDeckMerger.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      HttpServletResponse servletResponse = mock(HttpServletResponse.class);
+      when(servletResponse.getOutputStream()).thenReturn(capturingOutputStream(new ByteArrayOutputStream()));
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+
+      String badId = managedChartIdentifier("broken");
+      String goodId = managedChartIdentifier("ok");
+      RuntimeViewsheet rvsGood = mock(RuntimeViewsheet.class);
+      when(vs.openViewsheet(argThat(e -> e != null && e.toIdentifier().equals(badId)), eq(principal), eq(true)))
+         .thenThrow(new RuntimeException("boom"));
+      when(vs.openViewsheet(argThat(e -> e != null && e.toIdentifier().equals(goodId)), eq(principal), eq(true)))
+         .thenReturn("rt-good");
+      when(vs.getViewsheet("rt-good", principal)).thenReturn(rvsGood);
+      doAnswer(inv -> { ((ExportResponse) inv.getArgument(9)).getOutputStream().write("good".getBytes()); return null; })
+         .when(exportService).exportViewsheet(eq(rvsGood), eq(FileFormatInfo.EXPORT_TYPE_POWERPOINT),
+            anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(),
+            any(String[].class), anyBoolean(), any(), eq(principal));
+
+      when(merger.mergeSlides(any(), any(), argThat(list ->
+         list.size() == 2 &&
+         list.get(0).failed() && list.get(0).title().equals("Broken") &&
+         !list.get(1).failed() && list.get(1).title().equals("OK")
+      ))).thenReturn("deck".getBytes());
+
+      WizViewsheetExportController ctrl = new WizViewsheetExportController(
+         vs, mock(WizVsService.class), mock(WizPrintLayoutBuilder.class), exportService, sec, merger);
+
+      WizExportReportEvent ev = new WizExportReportEvent();
+      ev.setFormat("pptx");
+      ev.setTitle("Board");
+      ev.setCharts(List.of(chartEntry(badId, "Broken", null, 0), chartEntry(goodId, "OK", null, 1)));
+
+      ResponseEntity<?> resp = ctrl.exportReport(ev, principal, servletResponse);
+
+      assertNull(resp, "one failed chart among others still produces a deck, doesn't abort");
+      verify(merger).mergeSlides(any(), any(), any());
+   }
+
+   @Test
+   void pptxAllChartsFailedAbortsLoud() throws Exception {
+      ViewsheetService vs = mock(ViewsheetService.class);
+      PptxDeckMerger merger = mock(PptxDeckMerger.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+      when(vs.openViewsheet(any(), eq(principal), eq(true))).thenThrow(new RuntimeException("boom"));
+
+      WizViewsheetExportController ctrl = new WizViewsheetExportController(
+         vs, mock(WizVsService.class), mock(WizPrintLayoutBuilder.class),
+         mock(VSExportService.class), sec, merger);
+
+      WizExportReportEvent ev = new WizExportReportEvent();
+      ev.setFormat("pptx");
+      ev.setTitle("Board");
+      ev.setCharts(List.of(chartEntry(managedChartIdentifier("only"), "Only", null, 0)));
+
+      ResponseEntity<?> resp = ctrl.exportReport(ev, principal, mock(HttpServletResponse.class));
+
+      assertEquals(400, resp.getStatusCode().value());
+      verify(merger, never()).mergeSlides(any(), any(), any());
+   }
+
+   @Test
+   void pptxChartOutsideComponentsFolderBecomesPlaceholderNotAbort() throws Exception {
+      // Consistent with the "one bad chart doesn't abort" decision: an out-of-folder savedId is
+      // still just "this one chart didn't work," same as an open/export failure -- NOT a
+      // request-level 400 (unlike the PDF path's strict dashboardId guard, which gates the single
+      // asset the whole export depends on).
+      //
+      // NOTE: adapted from the brief's literal single-chart version of this test. With only one
+      // chart total, "the out-of-folder chart failed" and "all charts failed" are the same event,
+      // which would make this test collide with the all-charts-failed-aborts contract (confirmed
+      // by running it as originally written: it actually got a 400, "resolve the folder-guard
+      // test/implementation disagreement" per the brief's own Step 5 note). A second, successful
+      // chart is added so this test isolates "one bad (out-of-folder) chart among others doesn't
+      // abort" without re-litigating the all-failed case, which pptxAllChartsFailedAbortsLoud
+      // already covers on its own.
+      ViewsheetService vs = mock(ViewsheetService.class);
+      VSExportService exportService = mock(VSExportService.class);
+      PptxDeckMerger merger = mock(PptxDeckMerger.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      HttpServletResponse servletResponse = mock(HttpServletResponse.class);
+      when(servletResponse.getOutputStream()).thenReturn(capturingOutputStream(new ByteArrayOutputStream()));
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+
+      String goodId = managedChartIdentifier("ok");
+      RuntimeViewsheet rvsGood = mock(RuntimeViewsheet.class);
+      when(vs.openViewsheet(argThat(e -> e != null && e.toIdentifier().equals(goodId)), eq(principal), eq(true)))
+         .thenReturn("rt-good");
+      when(vs.getViewsheet("rt-good", principal)).thenReturn(rvsGood);
+      doAnswer(inv -> { ((ExportResponse) inv.getArgument(9)).getOutputStream().write("good".getBytes()); return null; })
+         .when(exportService).exportViewsheet(eq(rvsGood), eq(FileFormatInfo.EXPORT_TYPE_POWERPOINT),
+            anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(),
+            any(String[].class), anyBoolean(), any(), eq(principal));
+
+      when(merger.mergeSlides(any(), any(), argThat(list ->
+         list.size() == 2 &&
+         list.get(0).failed() && list.get(0).title().equals("Bad") &&
+         !list.get(1).failed() && list.get(1).title().equals("OK")
+      ))).thenReturn("deck".getBytes());
+
+      WizExportReportEvent ev = new WizExportReportEvent();
+      ev.setFormat("pptx");
+      ev.setTitle("Board");
+      AssetEntry outside = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, "some/other/folder/x", null);
+      ev.setCharts(List.of(
+         chartEntry(outside.toIdentifier(), "Bad", null, 0),
+         chartEntry(goodId, "OK", null, 1)));
+
+      WizViewsheetExportController ctrl = new WizViewsheetExportController(
+         vs, mock(WizVsService.class), mock(WizPrintLayoutBuilder.class),
+         exportService, sec, merger);
+
+      ResponseEntity<?> resp = ctrl.exportReport(ev, principal, servletResponse);
+
+      assertNull(resp, "out-of-folder chart is a placeholder, not a request-level abort");
+      verify(vs, never()).openViewsheet(argThat(e -> e != null && e.toIdentifier().equals(outside.toIdentifier())), any(), anyBoolean());
+      verify(merger).mergeSlides(any(), any(), any());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetExportControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetExportControllerTest.java
@@ -32,6 +32,7 @@ import inetsoft.web.wiz.service.WizVisualizationService;
 import inetsoft.web.wiz.service.WizVsService;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import java.security.Principal;
@@ -118,5 +119,53 @@ class WizViewsheetExportControllerTest {
 
       assertEquals(400, resp.getStatusCode().value());
       verify(vs, never()).openViewsheet(any(), any(), anyBoolean());
+   }
+
+   @Test
+   void happyPathBuildsLayoutPersistsAndReturnsExportedBytes() throws Exception {
+      ViewsheetService vs = mock(ViewsheetService.class);
+      WizVsService wizVsService = mock(WizVsService.class);
+      WizPrintLayoutBuilder builder = mock(WizPrintLayoutBuilder.class);
+      VSExportService exportService = mock(VSExportService.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet viewsheet = mock(Viewsheet.class);
+      inetsoft.uql.viewsheet.vslayout.LayoutInfo layoutInfo = mock(inetsoft.uql.viewsheet.vslayout.LayoutInfo.class);
+
+      when(viewsheet.getLayoutInfo()).thenReturn(layoutInfo);
+      when(vs.openViewsheet(any(), eq(principal), eq(true))).thenReturn("rt1");
+      when(vs.getViewsheet("rt1", principal)).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(sec.checkPermission(eq(principal), eq(ResourceType.VIEWSHEET_TOOLBAR_ACTION),
+         eq("Export"), eq(ResourceAction.READ))).thenReturn(true);
+
+      var fakeLayout = new inetsoft.uql.viewsheet.vslayout.PrintLayout();
+      when(builder.build(eq(viewsheet), eq("letter"), eq("Q39 Board"), isNull(), anyList()))
+         .thenReturn(fakeLayout);
+
+      byte[] fakePdf = "%PDF-1.4 fake".getBytes();
+      doAnswer(inv -> {
+         inetsoft.web.viewsheet.service.ExportResponse resp = inv.getArgument(9);
+         resp.getOutputStream().write(fakePdf);
+         return null;
+      }).when(exportService).exportViewsheet(eq(rvs), anyInt(), eq(false), eq(false), eq(true),
+         eq(false), eq(false), any(String[].class), eq(false), any(), eq(principal));
+
+      WizViewsheetExportController ctrl = new WizViewsheetExportController(
+         vs, wizVsService, builder, exportService, sec);
+
+      WizExportReportEvent ev = event(managedDashboardIdentifier());
+      ev.setPageSize("letter");
+
+      ResponseEntity<?> resp = ctrl.exportReport(ev, principal);
+
+      assertEquals(200, resp.getStatusCode().value());
+      assertArrayEquals(fakePdf, (byte[]) resp.getBody());
+      assertEquals(MediaType.APPLICATION_PDF, resp.getHeaders().getContentType());
+      assertTrue(resp.getHeaders().getFirst("Content-Disposition").contains("Q39 Board.pdf"));
+      verify(layoutInfo).setPrintLayout(fakeLayout);
+      verify(wizVsService).persistViewsheet(viewsheet, managedDashboardIdentifier(), principal);
+      verify(vs).closeViewsheet("rt1", principal);
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizVisualizationControllerDashboardTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizVisualizationControllerDashboardTest.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.web.wiz.model.WizDashboardEvent;
+import inetsoft.web.wiz.model.WizDashboardResult;
+import inetsoft.web.wiz.service.WizDashboardService;
+import inetsoft.web.wiz.service.WizVisualizationService;
+import org.junit.jupiter.api.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Verifies {@link WizVisualizationController#dashboard} maps
+ * {@link WizDashboardService#composeDashboard} outcomes to the correct HTTP status.
+ */
+@Tag("core")
+class WizVisualizationControllerDashboardTest {
+   private WizVisualizationController controller(WizDashboardService dash) {
+      return new WizVisualizationController(mock(WizVisualizationService.class), dash);
+   }
+
+   @Test
+   void returnsIdentifierOnSuccess() throws Exception {
+      WizDashboardService dash = mock(WizDashboardService.class);
+      WizDashboardResult r = new WizDashboardResult();
+      r.setSavedViewsheetIdentifier("dash1"); r.setSkipped(List.of());
+      when(dash.composeDashboard(any(), any())).thenReturn(r);
+      ResponseEntity<?> resp = controller(dash).dashboard(new WizDashboardEvent(), mock(Principal.class));
+      assertEquals(HttpStatus.OK, resp.getStatusCode());
+      assertSame(r, resp.getBody());
+   }
+
+   @Test
+   void mapsSecurityTo403() throws Exception {
+      WizDashboardService dash = mock(WizDashboardService.class);
+      when(dash.composeDashboard(any(), any())).thenThrow(new inetsoft.sree.security.SecurityException("denied"));
+      ResponseEntity<?> resp = controller(dash).dashboard(new WizDashboardEvent(), mock(Principal.class));
+      assertEquals(HttpStatus.FORBIDDEN, resp.getStatusCode());
+   }
+
+   @Test
+   void mapsIllegalArgumentTo400() throws Exception {
+      WizDashboardService dash = mock(WizDashboardService.class);
+      when(dash.composeDashboard(any(), any())).thenThrow(new IllegalArgumentException("empty"));
+      ResponseEntity<?> resp = controller(dash).dashboard(new WizDashboardEvent(), mock(Principal.class));
+      assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+   }
+
+   @Test
+   void mapsGenericExceptionTo500() throws Exception {
+      WizDashboardService dash = mock(WizDashboardService.class);
+      when(dash.composeDashboard(any(), any())).thenThrow(new RuntimeException("boom"));
+      ResponseEntity<?> resp = controller(dash).dashboard(new WizDashboardEvent(), mock(Principal.class));
+      assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizVisualizationControllerRenderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizVisualizationControllerRenderTest.java
@@ -21,6 +21,7 @@ import inetsoft.sree.security.SecurityException;
 import inetsoft.web.wiz.model.WizVisualizationRenderEvent;
 import inetsoft.web.wiz.model.WizVisualizationRenderResult;
 import inetsoft.web.wiz.service.RenderNotReadyException;
+import inetsoft.web.wiz.service.WizDashboardService;
 import inetsoft.web.wiz.service.WizVisualizationService;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -49,7 +50,7 @@ class WizVisualizationControllerRenderTest {
       when(svc.renderVisualization(any(), any())).thenReturn(r);
 
       ResponseEntity<?> resp =
-         new WizVisualizationController(svc).render(new WizVisualizationRenderEvent(), mock(Principal.class));
+         new WizVisualizationController(svc, mock(WizDashboardService.class)).render(new WizVisualizationRenderEvent(), mock(Principal.class));
 
       assertEquals(HttpStatus.OK, resp.getStatusCode());
       assertSame(r, resp.getBody());
@@ -61,7 +62,7 @@ class WizVisualizationControllerRenderTest {
       when(svc.renderVisualization(any(), any())).thenThrow(new RenderNotReadyException(2));
 
       ResponseEntity<?> resp =
-         new WizVisualizationController(svc).render(new WizVisualizationRenderEvent(), mock(Principal.class));
+         new WizVisualizationController(svc, mock(WizDashboardService.class)).render(new WizVisualizationRenderEvent(), mock(Principal.class));
 
       assertEquals(HttpStatus.SERVICE_UNAVAILABLE, resp.getStatusCode());
       assertTrue(resp.getHeaders().containsKey("Retry-After"));
@@ -73,7 +74,7 @@ class WizVisualizationControllerRenderTest {
       when(svc.renderVisualization(any(), any())).thenThrow(new SecurityException("permission denied"));
 
       ResponseEntity<?> resp =
-         new WizVisualizationController(svc).render(new WizVisualizationRenderEvent(), mock(Principal.class));
+         new WizVisualizationController(svc, mock(WizDashboardService.class)).render(new WizVisualizationRenderEvent(), mock(Principal.class));
 
       assertEquals(HttpStatus.FORBIDDEN, resp.getStatusCode());
    }
@@ -84,7 +85,7 @@ class WizVisualizationControllerRenderTest {
       when(svc.renderVisualization(any(), any())).thenThrow(new IllegalArgumentException("bad id"));
 
       ResponseEntity<?> resp =
-         new WizVisualizationController(svc).render(new WizVisualizationRenderEvent(), mock(Principal.class));
+         new WizVisualizationController(svc, mock(WizDashboardService.class)).render(new WizVisualizationRenderEvent(), mock(Principal.class));
 
       assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
    }
@@ -95,7 +96,7 @@ class WizVisualizationControllerRenderTest {
       when(svc.renderVisualization(any(), any())).thenThrow(new RuntimeException("boom"));
 
       ResponseEntity<?> resp =
-         new WizVisualizationController(svc).render(new WizVisualizationRenderEvent(), mock(Principal.class));
+         new WizVisualizationController(svc, mock(WizDashboardService.class)).render(new WizVisualizationRenderEvent(), mock(Principal.class));
 
       assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
    }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceTest.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.web.wiz.model.WizDashboardEvent;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the pre-open validation/guard/permission branches that
+ * {@link WizDashboardService#composeDashboard} owns directly (name/identifiers validation,
+ * the managed-folder guard applied to every identifier, and the permission check performed
+ * before any runtime viewsheet is opened).
+ *
+ * <p>The happy-path compose+save and the all-skipped-visualizations-&gt;400 path require a live
+ * {@code ViewsheetService}/{@code AssetRepository} engine (opening a real temporary viewsheet,
+ * merging worksheets, finalizing/persisting) and are not unit-testable here — they are verified
+ * later in the A4 integration test.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizDashboardServiceTest {
+   private WizDashboardService createService(ViewsheetService vs, AddVisualizationServiceProxy add,
+                                              SecurityEngine sec)
+      throws Exception
+   {
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+      return new WizDashboardService(vs, add, sec);
+   }
+
+   @Test
+   void rejectsEmptyIdentifiers() throws Exception {
+      WizDashboardService svc = createService(mock(ViewsheetService.class),
+         mock(AddVisualizationServiceProxy.class), mock(SecurityEngine.class));
+      WizDashboardEvent ev = new WizDashboardEvent();
+      ev.setName("D");
+      ev.setIdentifiers(List.of());
+      assertThrows(IllegalArgumentException.class, () -> svc.composeDashboard(ev, mock(Principal.class)));
+   }
+
+   @Test
+   void rejectsIdentifierOutsideComponentsFolder() throws Exception {
+      WizDashboardService svc = createService(mock(ViewsheetService.class),
+         mock(AddVisualizationServiceProxy.class), mock(SecurityEngine.class));
+      AssetEntry outside = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         "some/unmanaged/vs1", null);
+      WizDashboardEvent ev = new WizDashboardEvent();
+      ev.setName("D");
+      ev.setIdentifiers(List.of(outside.toIdentifier()));
+      assertThrows(IllegalArgumentException.class, () -> svc.composeDashboard(ev, mock(Principal.class)));
+   }
+
+   @Test
+   void throwsSecurityExceptionWhenPermissionDenied() throws Exception {
+      ViewsheetService vs = mock(ViewsheetService.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(false);
+      WizDashboardService svc = new WizDashboardService(vs, mock(AddVisualizationServiceProxy.class), sec);
+      // identifier UNDER the components folder so the folder guard passes and the permission
+      // check is reached:
+      String id = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/vs1", null).toIdentifier();
+      WizDashboardEvent ev = new WizDashboardEvent();
+      ev.setName("D");
+      ev.setIdentifiers(List.of(id));
+      assertThrows(inetsoft.sree.security.SecurityException.class,
+         () -> svc.composeDashboard(ev, mock(Principal.class)));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
@@ -102,8 +102,8 @@ class WizPrintLayoutBuilderTest {
          ((TextVSAssemblyInfo) t.getInfo()).getText().contains("Q39 Board") &&
          ((TextVSAssemblyInfo) t.getInfo()).getText().contains("Premium drives revenue."));
       assertTrue(hasTitleRecap, "one editable block carries both the title and the recap");
-      assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().equals("cap one")));
-      assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().equals("cap two")));
+      assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().equals("First — cap one")));
+      assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().equals("Second — cap two")));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
@@ -1,15 +1,32 @@
 package inetsoft.web.wiz.service;
 
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.TextVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.TextVSAssemblyInfo;
 import inetsoft.uql.viewsheet.vslayout.PrintLayout;
+import inetsoft.uql.viewsheet.vslayout.VSAssemblyLayout;
+import inetsoft.uql.viewsheet.vslayout.VSEditableAssemblyLayout;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.awt.*;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
 @Tag("core")
 class WizPrintLayoutBuilderTest {
    private final WizPrintLayoutBuilder builder = new WizPrintLayoutBuilder();
@@ -43,5 +60,63 @@ class WizPrintLayoutBuilderTest {
       PrintLayout layout = builder.build(vs, "a4", "Board", null, List.of());
       assertTrue(layout.getHeaderLayouts().isEmpty());
       assertTrue(layout.getFooterLayouts().isEmpty());
+   }
+
+   private static TextVSAssembly textAssembly(Viewsheet vs, String name, int y) {
+      TextVSAssembly a = new TextVSAssembly(vs, name);
+      TextVSAssemblyInfo info = (TextVSAssemblyInfo) a.getVSAssemblyInfo();
+      info.setPixelOffset(new Point(0, y));
+      info.setPixelSize(new Dimension(800, 400));
+      vs.addAssembly(a);
+      return a;
+   }
+
+   @Test
+   void oneVSAssemblyLayoutPerTopLevelChartPlusOneEditableTextPerCaptionAndTitle() {
+      Viewsheet vs = new Viewsheet();
+      textAssembly(vs, "Chart1", 0);
+      textAssembly(vs, "Chart1_2", 420);
+      List<WizPrintLayoutBuilder.ChartCaption> charts = List.of(
+         new WizPrintLayoutBuilder.ChartCaption("First", "cap one", 0),
+         new WizPrintLayoutBuilder.ChartCaption("Second", "cap two", 1)
+      );
+
+      PrintLayout layout = builder.build(vs, "a4", "Q39 Board", "Premium drives revenue.", charts);
+
+      List<VSAssemblyLayout> all = layout.getVSAssemblyLayouts();
+      long chartRefs = all.stream()
+         .filter(l -> !(l instanceof VSEditableAssemblyLayout))
+         .filter(l -> l.getName().equals("Chart1") || l.getName().equals("Chart1_2"))
+         .count();
+      assertEquals(2, chartRefs, "one plain VSAssemblyLayout per existing chart assembly");
+
+      long editableTextBlocks = all.stream().filter(l -> l instanceof VSEditableAssemblyLayout).count();
+      // 1 title/recap block + 2 per-chart captions = 3
+      assertEquals(3, editableTextBlocks);
+
+      List<VSEditableAssemblyLayout> texts = all.stream()
+         .filter(l -> l instanceof VSEditableAssemblyLayout)
+         .map(l -> (VSEditableAssemblyLayout) l)
+         .collect(Collectors.toList());
+      boolean hasTitleRecap = texts.stream().anyMatch(t ->
+         ((TextVSAssemblyInfo) t.getInfo()).getText().contains("Q39 Board") &&
+         ((TextVSAssemblyInfo) t.getInfo()).getText().contains("Premium drives revenue."));
+      assertTrue(hasTitleRecap, "one editable block carries both the title and the recap");
+      assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().equals("cap one")));
+      assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().equals("cap two")));
+   }
+
+   @Test
+   void skipsContainerChildrenAndAnnotationsWhenCountingTopLevelAssemblies() {
+      // A dashboard with exactly 1 top-level chart but a mismatched charts list (size 2)
+      // must fail loud rather than silently misattribute a caption.
+      Viewsheet vs = new Viewsheet();
+      textAssembly(vs, "Chart1", 0);
+      List<WizPrintLayoutBuilder.ChartCaption> charts = List.of(
+         new WizPrintLayoutBuilder.ChartCaption("First", "cap one", 0),
+         new WizPrintLayoutBuilder.ChartCaption("Second", "cap two", 1)
+      );
+      assertThrows(IllegalStateException.class,
+         () -> builder.build(vs, "a4", "Board", null, charts));
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
@@ -1,0 +1,47 @@
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.vslayout.PrintLayout;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+@Tag("core")
+class WizPrintLayoutBuilderTest {
+   private final WizPrintLayoutBuilder builder = new WizPrintLayoutBuilder();
+
+   @Test
+   void buildsA4PrintInfoInPortraitInches() {
+      Viewsheet vs = mock(Viewsheet.class);
+      PrintLayout layout = builder.build(vs, "a4", "Q39 Board", "Premium drives revenue.", List.of());
+      assertEquals("A4 [210x297 mm]", layout.getPrintInfo().getPaperType());
+      assertEquals("inches", layout.getPrintInfo().getUnit());
+      assertFalse(layout.isHorizontalScreen()); // portrait
+   }
+
+   @Test
+   void buildsLetterPrintInfo() {
+      Viewsheet vs = mock(Viewsheet.class);
+      PrintLayout layout = builder.build(vs, "LETTER", "Board", null, List.of());
+      assertEquals("Letter [8.5x11 in]", layout.getPrintInfo().getPaperType());
+   }
+
+   @Test
+   void rejectsUnknownPageSize() {
+      Viewsheet vs = mock(Viewsheet.class);
+      assertThrows(IllegalArgumentException.class,
+         () -> builder.build(vs, "tabloid", "Board", null, List.of()));
+   }
+
+   @Test
+   void headerAndFooterLayoutsAreEmpty() {
+      Viewsheet vs = mock(Viewsheet.class);
+      PrintLayout layout = builder.build(vs, "a4", "Board", null, List.of());
+      assertTrue(layout.getHeaderLayouts().isEmpty());
+      assertTrue(layout.getFooterLayouts().isEmpty());
+   }
+}

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.io.viewsheet;
+
+import inetsoft.web.wiz.service.PptxDeckMerger;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFSlide;
+import org.apache.poi.xslf.usermodel.XSLFTextBox;
+
+import java.awt.Dimension;
+import java.awt.geom.Rectangle2D;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+/**
+ * Builds a multi-slide .pptx from independently-exported single-chart decks (POST
+ * /api/wiz/viewsheet/export-report, format=pptx). Merges at this wiz layer rather than
+ * extending PPTVSExporter itself — PPTVSExporter has no multi-slide mechanism today (it calls
+ * XMLSlideShow.createSlide() exactly once) and is shared by every PowerPoint export in the
+ * product, not just wiz's.
+ */
+public class PoiPptxDeckMerger implements PptxDeckMerger {
+   @Override
+   public byte[] mergeSlides(String title, String recap, List<ChartSlide> slides) throws Exception {
+      try(XMLSlideShow merged = new XMLSlideShow()) {
+         merged.setPageSize(new Dimension(SLIDE_WIDTH_PT, SLIDE_HEIGHT_PT));
+
+         addTitleSlide(merged, title, recap);
+
+         for(ChartSlide slide : slides) {
+            if(slide.failed()) {
+               XSLFSlide target = merged.createSlide();
+               addFailurePlaceholder(target, slide.title());
+               addCaption(target, slide.title(), slide.caption());
+            }
+            else {
+               try(XMLSlideShow source =
+                  new XMLSlideShow(new ByteArrayInputStream(slide.singleSlideDeckBytes())))
+               {
+                  XSLFSlide target = merged.createSlide();
+                  target.importContent(source.getSlides().get(0));
+
+                  // Added AFTER importContent, not before: empirically verified (see this
+                  // task's report) that importContent REPLACES the target slide's shape tree
+                  // wholesale — a caption added before importContent is wiped out. Adding it
+                  // after is the only ordering under which it survives.
+                  addCaption(target, slide.title(), slide.caption());
+               }
+            }
+         }
+
+         ByteArrayOutputStream out = new ByteArrayOutputStream();
+         merged.write(out);
+         return out.toByteArray();
+      }
+   }
+
+   private void addTitleSlide(XMLSlideShow show, String title, String recap) {
+      XSLFSlide slide = show.createSlide();
+      XSLFTextBox titleBox = slide.createTextBox();
+      titleBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT,
+         SLIDE_WIDTH_PT - 2 * MARGIN_PT, 80));
+      titleBox.setText(title == null ? "" : title);
+
+      if(recap != null && !recap.isBlank()) {
+         XSLFTextBox recapBox = slide.createTextBox();
+         recapBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT + 90,
+            SLIDE_WIDTH_PT - 2 * MARGIN_PT, SLIDE_HEIGHT_PT - 2 * MARGIN_PT - 90));
+         recapBox.setText(recap);
+      }
+   }
+
+   private void addCaption(XSLFSlide slide, String title, String caption) {
+      XSLFTextBox captionBox = slide.createTextBox();
+      captionBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT / 2.0,
+         SLIDE_WIDTH_PT - 2 * MARGIN_PT, 40));
+      String text = (title == null ? "" : title) +
+         (caption != null && !caption.isBlank() ? " — " + caption : "");
+      captionBox.setText(text);
+   }
+
+   private void addFailurePlaceholder(XSLFSlide slide, String title) {
+      XSLFTextBox box = slide.createTextBox();
+      box.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT + 90,
+         SLIDE_WIDTH_PT - 2 * MARGIN_PT, 60));
+      box.setText("Failed to render: " + (title == null ? "" : title));
+   }
+
+   /** 16:9 widescreen in points (1in = 72pt): 13.33in x 7.5in. */
+   private static final int SLIDE_WIDTH_PT = 960;
+   private static final int SLIDE_HEIGHT_PT = 540;
+   private static final int MARGIN_PT = 40;
+}

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/web/wiz/config/PptxDeckMergerConfig.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/web/wiz/config/PptxDeckMergerConfig.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.config;
+
+import inetsoft.report.io.viewsheet.PoiPptxDeckMerger;
+import inetsoft.web.wiz.service.PptxDeckMerger;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Provides the real (POI-backed) PptxDeckMerger as a Spring bean. Lives in this package
+ * (inetsoft.web.wiz.config), physically inside the inetsoft-xml-formats module, so that
+ * WebConfig's existing component scan (basePackages = "inetsoft.web") picks it up at runtime —
+ * package name drives Spring's scan, not which Maven module a class was compiled from. This
+ * keeps WizViewsheetExportController's PptxDeckMerger collaborator constructor-injected and
+ * mockable exactly like its other four Phase 1 collaborators, unlike OfficeExporterFactory's
+ * own static-reflection getInstance() pattern (not appropriate here since our consumer is a
+ * Spring-managed controller, not a static utility method).
+ */
+@Configuration
+public class PptxDeckMergerConfig {
+   @Bean
+   public PptxDeckMerger pptxDeckMerger() {
+      return new PoiPptxDeckMerger();
+   }
+}

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
@@ -1,0 +1,115 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.io.viewsheet;
+
+import inetsoft.web.wiz.service.PptxDeckMerger;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFSlide;
+import org.apache.poi.xslf.usermodel.XSLFTextBox;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.awt.geom.Rectangle2D;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class PoiPptxDeckMergerTest {
+   private final PptxDeckMerger merger = new PoiPptxDeckMerger();
+
+   /** Builds a single-slide deck with one text box, simulating a real chart export's output
+    *  well enough to exercise importContent — the real chart content is opaque shapes to us. */
+   private static byte[] oneSlideDeckWithText(String text) throws Exception {
+      try(XMLSlideShow show = new XMLSlideShow()) {
+         XSLFSlide slide = show.createSlide();
+         XSLFTextBox box = slide.createTextBox();
+         box.setAnchor(new Rectangle2D.Double(10, 10, 400, 100));
+         box.setText(text);
+         ByteArrayOutputStream out = new ByteArrayOutputStream();
+         show.write(out);
+         return out.toByteArray();
+      }
+   }
+
+   private static String allText(XSLFSlide slide) {
+      StringBuilder sb = new StringBuilder();
+      slide.getShapes().forEach(s -> {
+         if(s instanceof XSLFTextBox tb) {
+            sb.append(tb.getText()).append('\n');
+         }
+      });
+      return sb.toString();
+   }
+
+   @Test
+   void mergesTitleSlidePlusOnePerChart() throws Exception {
+      byte[] chart1 = oneSlideDeckWithText("CHART_ONE_MARKER");
+      byte[] chart2 = oneSlideDeckWithText("CHART_TWO_MARKER");
+      List<PptxDeckMerger.ChartSlide> slides = List.of(
+         new PptxDeckMerger.ChartSlide("First", "cap one", chart1, false),
+         new PptxDeckMerger.ChartSlide("Second", "cap two", chart2, false)
+      );
+
+      byte[] merged = merger.mergeSlides("Q39 Board", "Premium drives revenue.", slides);
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         assertEquals(3, result.getSlides().size(), "title slide + 2 chart slides");
+
+         String titleSlideText = allText(result.getSlides().get(0));
+         assertTrue(titleSlideText.contains("Q39 Board"));
+         assertTrue(titleSlideText.contains("Premium drives revenue."));
+
+         String slide1Text = allText(result.getSlides().get(1));
+         assertTrue(slide1Text.contains("First"), "caption title present: " + slide1Text);
+         assertTrue(slide1Text.contains("cap one"), "caption text present: " + slide1Text);
+         assertTrue(slide1Text.contains("CHART_ONE_MARKER"), "imported chart content present: " + slide1Text);
+
+         String slide2Text = allText(result.getSlides().get(2));
+         assertTrue(slide2Text.contains("CHART_TWO_MARKER"));
+      }
+   }
+
+   @Test
+   void failedChartGetsPlaceholderSlideInsteadOfImportedContent() throws Exception {
+      List<PptxDeckMerger.ChartSlide> slides = List.of(
+         new PptxDeckMerger.ChartSlide("Broken", "n/a", null, true)
+      );
+
+      byte[] merged = merger.mergeSlides("Board", null, slides);
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         assertEquals(2, result.getSlides().size());
+         String slideText = allText(result.getSlides().get(1));
+         assertTrue(slideText.toLowerCase().contains("failed"), "placeholder text present: " + slideText);
+         assertTrue(slideText.contains("Broken"), "chart title present in placeholder: " + slideText);
+      }
+   }
+
+   @Test
+   void noRecapOmitsRecapTextButStillShowsTitle() throws Exception {
+      byte[] merged = merger.mergeSlides("Board Only", null, List.of());
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         assertEquals(1, result.getSlides().size(), "title slide only, no charts");
+         assertTrue(allText(result.getSlides().get(0)).contains("Board Only"));
+      }
+   }
+}


### PR DESCRIPTION
## Wiz: on-demand dashboard-compose endpoint — `POST /api/wiz/visualization/dashboard`

Headlessly composes several already-saved wiz visualizations into ONE wiz-dashboard viewsheet (single-column vertical stack) and saves it into the components folder. The compose logic already existed but was reachable only through the interactive Angular Composer over STOMP; this exposes it as a REST route the plugin can drive.

> Companion to wiz-services PR `inetsoft-technology/stylebi-wiz#1251` (Session Dashboard Phase 3), which consumes this endpoint. **Stacked on** the render-endpoint branch `feat/wiz-render-endpoint` (companion PR stylebi#4291) — merge that first. **Live compose verification is pending** (see below).

### What's here (3 commits)
- Models `WizDashboardEvent {name, identifiers, existingIdentifier?}` / `WizDashboardResult {savedViewsheetIdentifier, skipped}`.
- `WizDashboardService.composeDashboard(...)` — validate → per-identifier managed-folder guard → `SecurityEngine` permission → mint a fresh **wiz-dashboard** runtime (`new Viewsheet.WizInfo(true)`) → loop `AddVisualizationService.addVisualization(...)` with deterministic y-offsets (single-column, no measured-bounds dependency) → **skip-with-note** per unmergeable viz (empty set → 400) → `WizUtil.saveWizSheet(...)` (finalize temp worksheet + persist, the Composer's order) → **close runtime in `finally`**. Overwrite when `existingIdentifier` is given (update-in-place).
- `WizVisualizationController` `POST /dashboard` → 200 / 403 (checked `SecurityException`) / 400 / 500.

### Auth / lifecycle
No new security wiring (`/api/wiz/**` is JWT-gated). Managed-folder allowlist + `VIEWSHEET/ACCESS` check before any runtime opens, plus per-viz `WORKSHEET`/READ-ACL enforcement inside the merge. Runtime always closed on every path; the temp `__wiz_ws__` worksheet is promoted (not orphaned).

### Tests
`WizDashboardServiceTest` (validation/folder-guard/permission branches) + `WizVisualizationControllerDashboardTest` (all status mappings) — 4/4 + 5/5; `community/core` compiles. Built TDD, one task per commit; each task + the whole branch code-reviewed (opus verdict: ready to merge, contingent on the integration run below).

### Pending — MUST run before release
- **Live headless compose (A4)** needs a running server / image rebuild: compose a dashboard from 2–3 saved chart ids, open it in StyleBI (confirm single-column stack, promoted permanent worksheet, no orphaned temp), verify update-in-place overwrite and the skip path. The compose/save happy path has no automated coverage (needs a live `VGraphPair` engine) — this integration is the release gate.
- Minor: `DASHBOARD_ROW_HEIGHT=420` is a fixed stride; a chart taller than that could overlap the next — eyeball during A4, derive from measured height in a follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
