### PR TITLE
75648, circular network with ring displayed rendered outside plot area.

### DIFF
--- a/core/src/main/java/inetsoft/graph/element/RelationElement.java
+++ b/core/src/main/java/inetsoft/graph/element/RelationElement.java
@@ -407,8 +407,9 @@ public class RelationElement extends GraphElement {
 
          // The border ring passes through node centers, so it can bulge past the node
          // bounding box between nodes. The node-only translation above leaves the ring's
-         // left/top edge at a negative coordinate the plot can't scroll to reveal (#75648).
-         // Shift nodes, edges and the cached center so the ring also starts at the origin.
+         // min-x/min-y edge (left/bottom in this post-flipY, y-up space) at a negative
+         // coordinate the plot can't scroll to reveal (#75648). Shift nodes, edges and the
+         // cached center so the ring's bounding box also starts at the origin.
          if(shapeBorderShape != null && layoutCenter != null && layoutRadius > 0) {
             double dx = Math.max(0, -(layoutCenter.getX() - layoutRadius));
             double dy = Math.max(0, -(layoutCenter.getY() - layoutRadius));

--- a/core/src/main/java/inetsoft/graph/element/RelationElement.java
+++ b/core/src/main/java/inetsoft/graph/element/RelationElement.java
@@ -404,6 +404,24 @@ public class RelationElement extends GraphElement {
          else {
             layoutRadius = 0;
          }
+
+         // The border ring passes through node centers, so it can bulge past the node
+         // bounding box between nodes. The node-only translation above leaves the ring's
+         // left/top edge at a negative coordinate the plot can't scroll to reveal (#75648).
+         // Shift nodes, edges and the cached center so the ring also starts at the origin.
+         if(shapeBorderShape != null && layoutCenter != null && layoutRadius > 0) {
+            double dx = Math.max(0, -(layoutCenter.getX() - layoutRadius));
+            double dy = Math.max(0, -(layoutCenter.getY() - layoutRadius));
+
+            if(dx > 0 || dy > 0) {
+               nodes.values()
+                  .forEach(v -> v.getMxCell().getGeometry().translate(dx, dy));
+               edges
+                  .forEach(v -> v.getEdge().getGeometry().translate(dx, dy));
+               layoutCenter = new Point2D.Double(layoutCenter.getX() + dx,
+                                                 layoutCenter.getY() + dy);
+            }
+         }
       }
       else {
          layoutCenter = null;

--- a/core/src/test/java/inetsoft/graph/element/RelationElementLayoutCenterTest.java
+++ b/core/src/test/java/inetsoft/graph/element/RelationElementLayoutCenterTest.java
@@ -37,6 +37,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.geom.Point2D;
 import java.util.ArrayList;
 import java.util.List;
@@ -202,6 +203,77 @@ class RelationElementLayoutCenterTest {
 
       assertEquals(1, ggraph.getEGraph().getFormCount(),
          "addShapeBorder must register exactly one BorderForm in the EGraph after layout");
+   }
+
+   /**
+    * Regression guard for #75648: with a border ring configured, a circular layout whose ring
+    * bulges past the node bounding box (odd node count -> no node at the min-x/min-y cardinal
+    * point) must be shifted so the ring's bounding box starts at non-negative coordinates;
+    * otherwise the arc is clipped and unreachable via scrolling. Also verifies the shift is a
+    * pure translation (every node stays on the ring, i.e. equidistant from the shifted center).
+    */
+   @Test
+   void borderRingBoundingBoxStartsAtNonNegativeCoordinates_circular() {
+      // Three nodes -> 120-degree spacing, so no node sits at the circle's min-x/min-y cardinal
+      // point; the ring therefore extends past the node bounding box and, without the shift,
+      // would land at a negative coordinate.
+      DefaultDataSet data = new DefaultDataSet(new Object[][]{
+         { "From", "To" },
+         { "A",    "B"  },
+         { "B",    "C"  },
+         { "C",    "A"  },
+      });
+
+      RelationElement element = new RelationElement("From", "To");
+      element.setAlgorithm(RelationElement.Algorithm.CIRCLE);
+      element.setSizeFrame(new StaticSizeFrame(5));
+      element.setNodeSizeFrame(new StaticSizeFrame(5));
+      // Large layout + small nodes so the ring radius dominates the node size: the ring then
+      // bulges left past the leftmost node (which sits at 150 degrees, not at the 180-degree
+      // cardinal), driving centerX - radius negative before the #75648 shift.
+      element.setNodeWidth(5);
+      element.setNodeHeight(5);
+      element.setLayoutSize(new Dimension(1000, 1000));
+      element.addShapeBorder(GShape.CIRCLE, Color.GRAY, GLine.MEDIUM_DASH);
+
+      EGraph egraph = new EGraph();
+      egraph.addElement(element);
+      RelationCoord coord = new RelationCoord();
+      egraph.setCoordinate(coord);
+      GGraph ggraph = egraph.createGGraph(coord, data);
+
+      List<RelationGeometry> nodes = new ArrayList<>();
+
+      for(int i = 0; i < ggraph.getGeometryCount(); i++) {
+         if(ggraph.getGeometry(i) instanceof RelationGeometry) {
+            nodes.add((RelationGeometry) ggraph.getGeometry(i));
+         }
+      }
+
+      Point2D center = element.getLayoutCenter();
+      double radius = element.getLayoutRadius();
+
+      assertNotNull(center, "circular layout with a border must populate layoutCenter");
+      assertTrue(radius > 0, "three-node circular layout must produce a positive radius");
+
+      // (1) The ring's bounding box (center +/- radius) must not start at a negative coordinate,
+      // so the whole ring stays inside the scrollable plot area.
+      assertTrue(center.getX() - radius >= -1e-6,
+         "ring min-x edge (centerX - radius) must be >= 0 after the #75648 shift, was "
+            + (center.getX() - radius));
+      assertTrue(center.getY() - radius >= -1e-6,
+         "ring min-y edge (centerY - radius) must be >= 0 after the #75648 shift, was "
+            + (center.getY() - radius));
+
+      // (2) The shift must be a pure translation: every node center stays on the ring, i.e.
+      // equidistant (== radius) from the shifted layoutCenter.
+      for(RelationGeometry n : nodes) {
+         mxGeometry g = n.getMxCell().getGeometry();
+         double d = center.distance(g.getX() + g.getWidth() / 2.0,
+                                    g.getY() + g.getHeight() / 2.0);
+         assertEquals(radius, d, 1e-6,
+            "node center must remain on the ring (equidistant from the shifted center)");
+      }
    }
 
    @Test

--- a/core/src/test/java/inetsoft/graph/element/RelationElementLayoutCenterTest.java
+++ b/core/src/test/java/inetsoft/graph/element/RelationElementLayoutCenterTest.java
@@ -26,8 +26,15 @@ import inetsoft.graph.coord.RelationCoord;
 import inetsoft.graph.data.DefaultDataSet;
 import inetsoft.graph.geometry.RelationGeometry;
 import inetsoft.graph.mxgraph.model.mxGeometry;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.awt.Color;
 import java.awt.geom.Point2D;
@@ -42,7 +49,11 @@ import static org.junit.jupiter.api.Assertions.*;
  * the edge geometry will subsequently report. Required by RelationEdgeGeometry.getEdges()
  * to bend smooth edges toward a meaningful pull point.
  */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @SreeHome
+@Tag("core")
 class RelationElementLayoutCenterTest {
    @Test
    void mxLayoutPopulatesLayoutCenterAsNodeCentroid_circular() {

--- a/core/src/test/java/inetsoft/graph/visual/RelationEdgeVOClipTest.java
+++ b/core/src/test/java/inetsoft/graph/visual/RelationEdgeVOClipTest.java
@@ -18,6 +18,7 @@
 package inetsoft.graph.visual;
 
 import inetsoft.graph.aesthetic.GShape;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.awt.Shape;
@@ -33,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Exercises the pure-geometry helpers {@code RelationEdgeVO.clipToBoundary} and
  * {@code RelationEdgeVO.segIntersect} directly (package-private for testability).
  */
+@Tag("core")
 class RelationEdgeVOClipTest {
    private static final double EPS = 1e-6;
    // flattened curves (ellipse) are approximated, so allow a small tolerance for CIRCLE

--- a/core/src/test/java/inetsoft/graph/visual/RelationVOInsideTextBoxTest.java
+++ b/core/src/test/java/inetsoft/graph/visual/RelationVOInsideTextBoxTest.java
@@ -19,7 +19,15 @@ package inetsoft.graph.visual;
 
 import inetsoft.graph.aesthetic.GShape;
 import inetsoft.graph.element.RelationElement;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.awt.geom.Rectangle2D;
 
@@ -30,6 +38,11 @@ import static org.junit.jupiter.api.Assertions.*;
  * (ex.png overflow case): the text-layout box must shrink to fit the curved boundary,
  * not the outer rectangle.
  */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
 class RelationVOInsideTextBoxTest {
    private static final double SQRT2_INSET = 1 - 1 / Math.sqrt(2);   // ~0.2929
    private static final double EPS = 1e-9;


### PR DESCRIPTION
Root Cause:
For a circular network chart (RelationElement.Algorithm.CIRCLE), the dashed ring is drawn as a circle centered on the node centroid, passing through the node centers. Between nodes the ring bulges past the node bounding box, so at the left/top of the circle (where typically no node sits) it extends to centerX - radius / centerY - radius.

RelationElement.mxLayout() normalizes the layout by translating node and edge geometry so content starts at non-negative coordinates, but that translation was computed from the node positions only — it did not account for the ring. As a result the ring's left/top arc landed at a negative coordinate, which the plot cannot scroll to reveal, so it was clipped (horizontal scrollbar already fully left, with unused space on the right).

Fix:
After the circular layout computes the ring center/radius, mxLayout() now also shifts the nodes, edges, and the cached layout center by the amount needed to bring the ring's left/top edge back to the origin (only when a border ring is configured and it would otherwise start at a negative coordinate). This is a pure translation, so relative node/edge/ring geometry and the overall scroll range are unchanged; the ring is simply repositioned fully inside the visible plot area.

  - Added @Tag("core") to all three tests so the <groups>core</groups> surefire filter picks them up.
  - Tagging surfaced that two of them (RelationElementLayoutCenterTest, RelationVOInsideTextBoxTest) had never actually run and lacked the Spring test harness — they errored on GDefaults/PropertiesEngine initialization. I added the same harness the passing RelationCoordMinSizeTest uses (@ExtendWith(SpringExtension.class), @ContextConfiguration(BaseTestConfiguration + ConfigurationContextInitializer), @DirtiesContext, @SreeHome). RelationEdgeVOClipTest is pure geometry and needed only the tag.
  - Notably, RelationElementLayoutCenterTest — which directly asserts the layoutCenter invariants I touched in the bug fix — now executes green, giving real coverage of the fix.