### PR TITLE
Bug #75690, allow script JS functions to adapt to Java functional interfaces

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/ScriptHostAccess.java
+++ b/core/src/main/java/inetsoft/util/script/graal/ScriptHostAccess.java
@@ -169,6 +169,16 @@ public final class ScriptHostAccess {
                   .allowMapAccess(true)
                   .allowIterableAccess(true)
                   .allowIteratorAccess(true)
+                  // Rhino parity: Rhino auto-adapted a JS function to a single-method
+                  // Java interface, so scripts could pass a lambda where a functional
+                  // interface is expected (e.g. Stream.filter(Predicate),
+                  // Stream.forEach(Consumer) via graph shape scripting). GraalJS refuses
+                  // this by default ("Unsupported target type"); allow a guest function
+                  // to implement any @FunctionalInterface-annotated type. This is the
+                  // same allowance the built-in HostAccess.ALL/EXPLICIT presets use, and
+                  // it does not widen class reachability (still gated by classFilter) or
+                  // permit implementing arbitrary/abstract types. (#75690)
+                  .allowImplementationsAnnotatedBy(FunctionalInterface.class)
                   // FIX 2: Deny reflective escape paths even when allowPublicAccess(true) is set.
                   // denyAccess takes precedence over allowPublicAccess for the listed classes.
                   // denyAccess(Object.class, false) blocks only methods declared on Object itself

--- a/core/src/test/java/inetsoft/util/script/graal/ScriptHostAccessTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/ScriptHostAccessTest.java
@@ -159,6 +159,38 @@ class ScriptHostAccessTest {
       }
    }
 
+   /**
+    * Bug #75690 (follow-up): the fix is intentionally general (any
+    * {@code @FunctionalInterface}), not just Predicate/Consumer. Verify a
+    * Comparator — a single-method interface whose method returns int rather than
+    * boolean/void — also adapts from a JS function.
+    */
+   @Test void jsFunctionAdaptsToComparator() {
+      try(Context ctx = newContext()) {
+         ctx.getBindings("js").putMember("h", new Sample());
+         // natural-order Comparator; the JS function's numeric result adapts to int
+         Object max = ScriptValueConverter.toHost(
+            ctx.eval("js", "h.maxBy((a, b) => a - b)"));
+         assertEquals(3, ((Number) max).intValue());
+      }
+   }
+
+   /**
+    * Bug #75690 (follow-up): the allowance is scoped to
+    * {@code @FunctionalInterface} types. A JS object must NOT be able to satisfy a
+    * plain multi-method interface, confirming the widening did not open arbitrary
+    * interface implementation.
+    */
+   @Test void jsObjectDoesNotSatisfyMultiMethodInterface() {
+      try(Context ctx = newContext()) {
+         ctx.getBindings("js").putMember("h", new Sample());
+         assertThrows(PolyglotException.class,
+            () -> ctx.eval("js",
+               "h.useMulti({ first: function() { return 'a'; }, " +
+               "second: function() { return 'b'; } })"));
+      }
+   }
+
    public static class Sample {
       @org.graalvm.polyglot.HostAccess.Export public String allowed() { return "ok"; }
       public String denied() { return "no"; }
@@ -166,5 +198,19 @@ class ScriptHostAccessTest {
       public java.util.stream.Stream<Integer> numbers() {
          return java.util.stream.Stream.of(1, 2, 3);
       }
+      @org.graalvm.polyglot.HostAccess.Export
+      public int maxBy(java.util.Comparator<Integer> cmp) {
+         return java.util.stream.Stream.of(1, 2, 3).max(cmp).get();
+      }
+      @org.graalvm.polyglot.HostAccess.Export
+      public String useMulti(MultiMethod m) {
+         return m.first() + m.second();
+      }
+   }
+
+   /** Plain (non-@FunctionalInterface) multi-method interface for the negative case. */
+   public interface MultiMethod {
+      String first();
+      String second();
    }
 }

--- a/core/src/test/java/inetsoft/util/script/graal/ScriptHostAccessTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/ScriptHostAccessTest.java
@@ -139,8 +139,32 @@ class ScriptHostAccessTest {
       }
    }
 
+   /**
+    * Bug #75690: Rhino auto-adapted a JS function to a single-method Java
+    * interface, so scripts could pass a lambda to a Java method expecting a
+    * functional interface (e.g. Stream.filter(Predicate), Stream.forEach(Consumer)
+    * via graph shape scripting). GraalJS refuses this unless the HostAccess policy
+    * allows implementing @FunctionalInterface types.
+    */
+   @Test void jsFunctionAdaptsToFunctionalInterface() {
+      try(Context ctx = newContext()) {
+         ctx.getBindings("js").putMember("h", new Sample());
+         // Predicate via Stream.filter
+         Object count = ScriptValueConverter.toHost(
+            ctx.eval("js", "h.numbers().filter(n => n > 1).count()"));
+         assertEquals(2L, ((Number) count).longValue());
+         // Consumer via Stream.forEach
+         assertDoesNotThrow(() -> ctx.eval("js",
+            "var seen = []; h.numbers().forEach(n => seen.push(n));"));
+      }
+   }
+
    public static class Sample {
       @org.graalvm.polyglot.HostAccess.Export public String allowed() { return "ok"; }
       public String denied() { return "no"; }
+      @org.graalvm.polyglot.HostAccess.Export
+      public java.util.stream.Stream<Integer> numbers() {
+         return java.util.stream.Stream.of(1, 2, 3);
+      }
    }
 }


### PR DESCRIPTION
## Summary

Chart shape scripts that pass a JS arrow function to a Java method expecting a functional interface (e.g. `frame.getAllShapes().filter(a => a instanceof GShape.ImageShape).forEach(...)`) failed at runtime with:

```
Cannot convert 'a => a instanceof GShape.ImageShape'(language: JavaScript, type: Function)
to Java type 'java.util.function.Predicate': Unsupported target type. (line 7)
```

`CategoricalShapeFrame.getAllShapes()` returns a `java.util.stream.Stream`, so the script calls `Stream.filter(Predicate)` and `Stream.forEach(Consumer)` with JS lambdas.

## Root Cause

The GraalJS `HostAccess` policy built in `ScriptHostAccess.hostAccess()` never enabled guest-function → Java functional-interface adaptation. Rhino did this automatically (auto-adapting a JS function to a single-method interface), so under the GraalJS migration this capability was lost and any script passing a JS function where a functional interface is expected fails.

## Fix

Add `.allowImplementationsAnnotatedBy(FunctionalInterface.class)` to the `HostAccess` builder. This lets a guest function implement any `@FunctionalInterface`-annotated type (`Predicate`, `Consumer`, `Function`, `Comparator`, etc.), restoring Rhino parity. It's the same allowance GraalVM's built-in `HostAccess.ALL`/`EXPLICIT` presets use.

The change is additive and does not weaken the sandbox: the `Java.type(...)` class-lookup allow-list (`classFilter`) is untouched, thread creation stays disabled, and dangerous classes remain denied. The narrower annotated form is used rather than `allowAllImplementations(true)`.

## Test Plan

- Added `ScriptHostAccessTest.jsFunctionAdaptsToFunctionalInterface`, exercising both `Stream.filter(Predicate)` and `Stream.forEach(Consumer)` with JS lambdas. Verified the test fails with the exact reported error when the fix is reverted, and passes with it.
- `./mvnw -pl core test -Dtest=ScriptHostAccessTest` → 11/11 pass.
- Manually verified in the portal: importing/opening `ShapseApply.vso` no longer raises the conversion error.

Fixes Redmine #75690.

🤖 Generated with [Claude Code](https://claude.com/claude-code)