### PR TITLE
Fix blank cells for column names with special characters after Convert to Freehand Table

### DIFF
--- a/core/src/main/java/inetsoft/report/LayoutTool.java
+++ b/core/src/main/java/inetsoft/report/LayoutTool.java
@@ -2362,7 +2362,7 @@ public class LayoutTool {
    private static String escapeColName(String name) {
       return name.chars().mapToObj(cc -> {
             if(isSpecialMarker((char) cc)) {
-               return "\\\\" + (char) cc;
+               return "\\" + (char) cc;
             }
             else if(cc == '\'') {
                return "\\" + (char) cc;


### PR DESCRIPTION
## Summary
- `LayoutTool.escapeColName()` was escaping "special marker" characters (`? @ { } , = ; &`) with two literal backslashes instead of one when generating the calc-table cell script (`data['<column name>']`) during Convert to Freehand Table.
- The double backslash survives JS-engine parsing as an escaped backslash followed by the literal marker, producing a runtime string that no longer matches the real column name — so any column whose name contains one of these characters (most commonly a comma, e.g. `YYYY, MMM D`) renders blank after conversion.
- Fixed to use a single backslash, matching the sibling branch for `'` two lines below, which the script engine correctly reduces via identity-escape back to the literal character.

## Test plan
- [x] Reproduced with a table containing date-format columns named with embedded commas (e.g. `YYYY, MMM D`); confirmed cells were blank after "Convert to Freehand Table" before the fix.
- [x] Applied the fix and confirmed the freehand table now shows correct values for all columns, including comma-containing ones.
- [x] `core` module compiles cleanly.

Bug: bug-75665