### PR TITLE
Bug #75662, dispatch getMember for '=' expression and '{}' summary table ranges

### DIFF
--- a/core/src/main/java/inetsoft/report/script/TableArray.java
+++ b/core/src/main/java/inetsoft/report/script/TableArray.java
@@ -97,8 +97,15 @@ public class TableArray implements ArrayObject, ScriptArrayScope {
       // present so the read is dispatched — otherwise data['Col'] reads as
       // undefined and group expansion collapses to zero rows. Mirrors the
       // column-existence check in TableRow.hasMember. (#75423)
+      //
+      // The leading '=' (expression, e.g. table['=state + ", " + id']) and '{}'
+      // (summary, e.g. table['{Sum(id)}']) forms are also resolved lazily in
+      // getMember via NamedCellRange -- Util.findColumn can never match them as
+      // literal columns, so they must be reported present here too, otherwise the
+      // reference resolves to undefined and indexing it (e.g. [row]) throws. (#75662)
       if(id.indexOf('@') >= 0 || id.indexOf('?') >= 0 || id.indexOf(':') >= 0 ||
-         id.indexOf("^_^") >= 0 || id.startsWith("*"))
+         id.indexOf("^_^") >= 0 || id.startsWith("*") ||
+         id.startsWith("=") || id.startsWith("{"))
       {
          return true;
       }

--- a/core/src/test/java/inetsoft/report/script/TableArrayTest.java
+++ b/core/src/test/java/inetsoft/report/script/TableArrayTest.java
@@ -77,6 +77,21 @@ class TableArrayTest {
    }
 
    @Test
+   void hasMemberReportsExpressionAndSummaryRangesPresent() {
+      // #75662: table['=<expr>'] (expression range, evaluated per row) and
+      // table['{<agg>}'] (summary range) are resolved lazily in getMember via
+      // NamedCellRange. Util.findColumn can never match them as literal columns,
+      // so hasMember must report them present -- otherwise the reference reads as
+      // undefined and indexing it (e.g. table['=col2 + col3'][row]) throws.
+      TableArray arr = new TableArray(table());
+
+      assertTrue(arr.hasMember("=col1 + col2"),
+         "leading-'=' expression range must be present so GraalJS dispatches getMember");
+      assertTrue(arr.hasMember("{Sum(col2)}"),
+         "'{...}' summary range must be present so GraalJS dispatches getMember");
+   }
+
+   @Test
    void hasMemberRejectsNonColumns() {
       TableArray arr = new TableArray(table());
 


### PR DESCRIPTION
## Summary

A script worksheet with a formula (expression) column that references another table via the expression-range syntax `Base['=state + ", " + id'][row]` failed to load, popping up:

```
expression failed: JavaScript error: TypeError: Cannot read property '1' of undefined (line 1)
```

## Root Cause

Regression from the Rhino→GraalJS migration (Feature #75423). Under Rhino, a scriptable's `get()` was always invoked on a property read; under GraalJS, `getMember()` is only called when `hasMember()` first reports the member present.

`Base` resolves to `TableAssemblyScriptable extends TableArray`. The `#75423` migration added a dynamic-key check to `TableArray.hasMember` to report cell-range references (`@`, `?`, `:`, `^_^`, `*`) as present, but it omitted the leading `=` (expression) form — which `NamedCellRange` parses as an expression evaluated per row — and the `{...}` (summary) form. So `Base['=state + ", " + id']` fell through to `Util.findColumn`, which can't match an expression string, `hasMember` returned false, `getMember` was never dispatched, the reference resolved to `undefined`, and `undefined[row]` threw.

## Fix

Extend the dynamic-key check in `TableArray.hasMember` to also return `true` for ids starting with `=` (expression range) or `{` (summary range), so GraalJS dispatches to `getMember`, which resolves them through `CellRange`/`NamedCellRange` as before.

## Test Plan

- Added regression test `hasMemberReportsExpressionAndSummaryRangesPresent` in `TableArrayTest`.
- `./mvnw test -pl core -Dtest=TableArrayTest` → 7/7 pass.
- Manual: open the `script` worksheet (attached to the issue) against a MySQL source, show live data on `sql2`; the table now loads with the expression columns computed and no JavaScript error. Verified by reporter/QA.
- No regression: the change only adds keys that dispatch to `getMember`; literal columns and the previously-covered `@/?/:/*` forms are unaffected.

Fixes Redmine #75662.