### PR TITLE
Bug #75667,Fix NPE on repeated MV creation by preserving boolean condition values

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/PreAssetQuery.java
@@ -4256,7 +4256,16 @@ public abstract class PreAssetQuery implements Serializable, Cloneable {
             field = new XExpression(col, XExpression.FIELD);
          }
 
-         if(ref instanceof AttributeRef attributeRef && attributeRef.isSqlTypeSet()) {
+         // Some JDBC drivers misreport a logically boolean column's SQL type (e.g. as
+         // VARCHAR instead of BOOLEAN/BIT) in their column metadata. Trusting that over
+         // the worksheet column's own logical type causes fixConditionValue() below to
+         // "fix" an already-correct Boolean condition value into a String, which some
+         // databases (e.g. H2) then refuse to compare against the actual BOOLEAN column.
+         // The worksheet's logical type is authoritative here, so check it first.
+         if(item.getAttribute() != null && XSchema.BOOLEAN.equals(item.getAttribute().getDataType())) {
+            field.setSqlType(java.sql.Types.BOOLEAN);
+         }
+         else if(ref instanceof AttributeRef attributeRef && attributeRef.isSqlTypeSet()) {
             field.setSqlType(((AttributeRef) ref).getSqlType());
          }
          else if(item.getAttribute() instanceof ColumnRef columnRef && columnRef.isSqlTypeSet()) {


### PR DESCRIPTION
Summary

  Fixes bug-75667: NullPointerException on second "Create MV" for a viewsheet with a boolean selection filter, when the underlying JDBC driver misreports the column's SQL type.

  Root cause: PreAssetQuery.PreConditionListHandler.createItem() trusted the driver-reported SQL type (AttributeRef/ColumnRef.getSqlType()) over the worksheet column's own logical type when building a       
  condition's XExpression. For a boolean column whose driver metadata incorrectly reports Types.VARCHAR instead of Types.BOOLEAN (observed with an older, non-JDBC4 H2 driver),
  ConditionListHandler.fixConditionValue() then "corrected" an already-valid Boolean.TRUE condition value into the string "true" to match the (wrong) VARCHAR type.

  That string bind is tolerated by some databases for a lone col = ? comparison, but is rejected once the condition is combined with another predicate via AND — which is exactly what happens on a second MV  
  creation, when LocalMVIncremental.mergeAppendCondition() merges the viewsheet's own selection filter into the incremental refresh query for the first time (the initial full MV build never hits this path). 
  H2 then throws:

  org.h2.jdbc.JdbcSQLSyntaxErrorException: Values of types "BOOLEAN" and "CHARACTER VARYING(4)" are not comparable

  That SQLExpressionFailedException is swallowed by AssetDataCache's background query processor rather than propagated, so LocalMVIncremental.update0() receives a null table lens and dereferences it
  unchecked at lens.moreRows(lens.getHeaderRowCount()), surfacing as an unrelated NPE in the Materialization dialog instead of the real error.

  Fix: in PreConditionListHandler.createItem(), when the condition's column is logically boolean (XSchema.BOOLEAN per the worksheet's own schema), force Types.BOOLEAN on the field ahead of any
  driver-reported SQL type, so the boolean value is never miscoerced to a string regardless of what the driver's column metadata claims.

  Root cause chain

  1. Old/non-JDBC4-compliant driver reports the boolean column's SQL type as VARCHAR.
  2. fixConditionValue() converts the correct Boolean.TRUE condition value into "true" (String) to match that reported type.
  3. H2 accepts the string bind for a single predicate but rejects it once ANDed with a second predicate.
  4. The resulting query failure is swallowed into a null table instead of propagating.
  5. LocalMVIncremental.update0() dereferences the null lens without a guard → NPE.
  6. Only reproduces on the second MV creation (incremental refresh path), never the first (full build).

  Testing

  Reproduced against a viewsheet bound to an H2 datasource with an old (pre-JDBC4) driver plugin, with a boolean selection filter on the source table. Confirmed via debug logging that the condition value    
  started as java.lang.Boolean and was being coerced to java.lang.String before the JDBC bind. After the fix, inputParameter #1="true" (java.lang.Boolean) is bound correctly and MV creation succeeds on      
  repeated runs.
