### PR TITLE
75645, dash line not easy to see on circular network graph

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -3777,7 +3777,7 @@ public abstract class GraphGenerator {
             // PlotDescriptor.smoothLines is reused here as the chord-curve toggle for
             // CIRCULAR; the element-side flag is smoothEdges (bends edges, not lines).
             elem.setSmoothEdges(desc.getPlotDescriptor().isSmoothLines());
-            elem.addShapeBorder(GShape.CIRCLE, GDefaults.DEFAULT_LINE_COLOR, GLine.MEDIUM_DASH);
+            elem.addShapeBorder(GShape.CIRCLE, Color.LIGHT_GRAY, GLine.MEDIUM_DASH);
             break;
          }
 


### PR DESCRIPTION
Root Cause:
The dashed guide ring drawn around the circular network/relation chart was registered with GDefaults.DEFAULT_LINE_COLOR (0xeeeeee, ~238,238,238), an almost-white gray. Against the plot background this made the ring nearly invisible in both the light and dark themes.

Fix:
Changed the ring's shape-border color to Color.LIGHT_GRAY (0xC0C0C0) at the single call site in GraphGenerator (CHART_CIRCULAR branch). The shared GDefaults.DEFAULT_LINE_COLOR constant was left unchanged so axis lines and other borders that rely on it are unaffected; only the circular chart's guide ring is impacted.