### PR TITLE
Bug #75669, apply VPM trigger condition when script references it under GraalJS

### DIFF
--- a/core/src/main/java/inetsoft/uql/erm/HiddenColumns.java
+++ b/core/src/main/java/inetsoft/uql/erm/HiddenColumns.java
@@ -219,6 +219,18 @@ public class HiddenColumns extends VpmObject {
          }
       }
 
+      // Bug #75669: A hidden-columns trigger script activates its output by referencing
+      // (or assigning) the `hiddenColumns` variable, relying on that value becoming the
+      // script's completion value. Under Rhino a trailing statement that produced no
+      // value (e.g. a non-matching if in the last loop iteration) left the completion
+      // value intact; GraalJS follows current ECMAScript rules where such a statement
+      // yields undefined and clobbers the loop's completion value, so the reference no
+      // longer surfaces as the result. When the script used `hiddenColumns` but the
+      // completion value came back null, fall back to the (possibly reassigned) value.
+      if(result == null && scope.isVariableUsed("hiddenColumns")) {
+         result = scope.getMember("hiddenColumns");
+      }
+
       if(result == null) {
          return new String[0];
       }

--- a/core/src/main/java/inetsoft/uql/erm/vpm/VpmCondition.java
+++ b/core/src/main/java/inetsoft/uql/erm/vpm/VpmCondition.java
@@ -304,6 +304,18 @@ public class VpmCondition extends VpmObject {
          }
       }
 
+      // Bug #75669: A VPM trigger script activates its condition by referencing (or
+      // assigning) the `condition` variable, relying on that value becoming the script's
+      // completion value. Under Rhino a trailing statement that produced no value (e.g. a
+      // non-matching if in the last loop iteration) left the completion value intact;
+      // GraalJS follows current ECMAScript rules where such a statement yields undefined
+      // and clobbers the loop's completion value, so the reference no longer surfaces as
+      // the result. When the script used `condition` but the completion value came back
+      // null, fall back to the (possibly reassigned) condition value.
+      if(result == null && scope.isConditionUsed()) {
+         result = scope.getMember("condition");
+      }
+
       if(result == null) {
          return null;
       }

--- a/core/src/main/java/inetsoft/uql/script/VpmScope.java
+++ b/core/src/main/java/inetsoft/uql/script/VpmScope.java
@@ -45,10 +45,11 @@ public class VpmScope implements ScriptScope {
       throws Exception
    {
       Object script = null;
-      // Bug #75669: reset the condition-used flag so it only reflects access made by
-      // this script execution (the setUp putMember("condition", ...) in
-      // VpmCondition.evaluate happens before this call and must not count).
-      scope.conditionUsed = false;
+      // Bug #75669: reset the referenced-variable tracking so it only reflects access
+      // made by this script execution (the setUp putMember(...) calls in
+      // VpmCondition.evaluate / HiddenColumns.getHiddenColumns happen before this call
+      // and must not count).
+      scope.usedVars.clear();
       ScriptEnv senv = ScriptEnvRepository.getScriptEnv();
       senv.init();
       senv.put("vpm", new inetsoft.util.script.graal.ScopeProxy(scope));
@@ -177,16 +178,15 @@ public class VpmScope implements ScriptScope {
          return user == null ? null : XUtil.getUserName(user);
       }
 
-      // Bug #75669: record that the script referenced `condition`. Under Rhino a VPM
-      // trigger script activated its condition simply by referencing (or assigning)
-      // `condition`, relying on that value becoming the script's completion value. GraalJS
-      // follows current ECMAScript completion-value semantics (e.g. a trailing if(false)
-      // yields undefined, clobbering a loop's completion value), so the reference alone
-      // may no longer surface as the result; VpmCondition falls back to the condition
-      // value when it was used. See VpmCondition.evaluate().
-      if(CONDITION.equals(id)) {
-         conditionUsed = true;
-      }
+      // Bug #75669: record that the script referenced this variable. Under Rhino a VPM
+      // trigger script activated its output simply by referencing (or assigning) the
+      // relevant variable (e.g. `condition`, `hiddenColumns`), relying on that value
+      // becoming the script's completion value. GraalJS follows current ECMAScript
+      // completion-value semantics (e.g. a trailing if(false) yields undefined,
+      // clobbering a loop's completion value), so the reference alone may no longer
+      // surface as the result; callers fall back to the referenced variable's value when
+      // it was used. See VpmCondition.evaluate() and HiddenColumns.getHiddenColumns().
+      usedVars.add(id);
 
       // the ScopeProxy/HostAccess layer now handles array wrapping
       return members.get(id);
@@ -197,12 +197,18 @@ public class VpmScope implements ScriptScope {
     */
    @Override
    public void putMember(String id, Object value) {
-      // Bug #75669: assigning `condition` in the script also counts as using it.
-      if(CONDITION.equals(id)) {
-         conditionUsed = true;
-      }
+      // Bug #75669: assigning a variable in the script also counts as using it.
+      usedVars.add(id);
 
       members.put(id, value);
+   }
+
+   /**
+    * Determine whether the most recently executed script referenced or assigned the
+    * given variable. Reset at the start of each {@link #execute}.
+    */
+   public boolean isVariableUsed(String name) {
+      return usedVars.contains(name);
    }
 
    /**
@@ -210,7 +216,7 @@ public class VpmScope implements ScriptScope {
     * <code>condition</code> variable. Reset at the start of each {@link #execute}.
     */
    public boolean isConditionUsed() {
-      return conditionUsed;
+      return isVariableUsed(CONDITION);
    }
 
    /**
@@ -255,7 +261,7 @@ public class VpmScope implements ScriptScope {
    private Principal user;
    private VariableTable vars;
    private ScriptScope parent;
-   private boolean conditionUsed;
+   private final Set<String> usedVars = new HashSet<>();
    private final Map<String, Object> members = new LinkedHashMap<>();
 
    private static final String CONDITION = "condition";

--- a/core/src/main/java/inetsoft/uql/script/VpmScope.java
+++ b/core/src/main/java/inetsoft/uql/script/VpmScope.java
@@ -45,6 +45,10 @@ public class VpmScope implements ScriptScope {
       throws Exception
    {
       Object script = null;
+      // Bug #75669: reset the condition-used flag so it only reflects access made by
+      // this script execution (the setUp putMember("condition", ...) in
+      // VpmCondition.evaluate happens before this call and must not count).
+      scope.conditionUsed = false;
       ScriptEnv senv = ScriptEnvRepository.getScriptEnv();
       senv.init();
       senv.put("vpm", new inetsoft.util.script.graal.ScopeProxy(scope));
@@ -173,6 +177,17 @@ public class VpmScope implements ScriptScope {
          return user == null ? null : XUtil.getUserName(user);
       }
 
+      // Bug #75669: record that the script referenced `condition`. Under Rhino a VPM
+      // trigger script activated its condition simply by referencing (or assigning)
+      // `condition`, relying on that value becoming the script's completion value. GraalJS
+      // follows current ECMAScript completion-value semantics (e.g. a trailing if(false)
+      // yields undefined, clobbering a loop's completion value), so the reference alone
+      // may no longer surface as the result; VpmCondition falls back to the condition
+      // value when it was used. See VpmCondition.evaluate().
+      if(CONDITION.equals(id)) {
+         conditionUsed = true;
+      }
+
       // the ScopeProxy/HostAccess layer now handles array wrapping
       return members.get(id);
    }
@@ -182,7 +197,20 @@ public class VpmScope implements ScriptScope {
     */
    @Override
    public void putMember(String id, Object value) {
+      // Bug #75669: assigning `condition` in the script also counts as using it.
+      if(CONDITION.equals(id)) {
+         conditionUsed = true;
+      }
+
       members.put(id, value);
+   }
+
+   /**
+    * Determine whether the most recently executed script referenced or assigned the
+    * <code>condition</code> variable. Reset at the start of each {@link #execute}.
+    */
+   public boolean isConditionUsed() {
+      return conditionUsed;
    }
 
    /**
@@ -227,7 +255,10 @@ public class VpmScope implements ScriptScope {
    private Principal user;
    private VariableTable vars;
    private ScriptScope parent;
+   private boolean conditionUsed;
    private final Map<String, Object> members = new LinkedHashMap<>();
+
+   private static final String CONDITION = "condition";
 
    private static final Logger LOG =
       LoggerFactory.getLogger(VpmScope.class);

--- a/core/src/test/java/inetsoft/uql/script/VpmScopeTest.java
+++ b/core/src/test/java/inetsoft/uql/script/VpmScopeTest.java
@@ -215,4 +215,41 @@ class VpmScopeTest {
       assertEquals("x", VpmScope.execute("'x';", scope));
       assertFalse(scope.isConditionUsed());
    }
+
+   /**
+    * Bug #75669: the referenced-variable tracking is generic (not condition-specific), so
+    * a hidden-columns trigger script that references {@code hiddenColumns} inside a loop
+    * is detected the same way. Mirrors HiddenColumns.getHiddenColumns()'s fallback.
+    */
+   @Test
+   void testVariableUsedForHiddenColumns() throws Exception {
+      VpmScope scope = new VpmScope();
+      Principal user = new XPrincipal(new IdentityID("user1", "host-org"));
+      scope.setUser(user);
+      scope.putMember("hiddenColumns", new String[]{ "public.orders.discount" });
+      scope.putMember("groups", new String[]{ "group0", "group0_1" });
+
+      String loop =
+         "for(var i=0; i<groups.length; i++){\n" +
+         "   if(groups[i]=='group0'){\n" +
+         "      hiddenColumns;\n" +
+         "   }\n" +
+         "}";
+
+      // The trailing non-matching iteration clobbers the completion value under GraalJS...
+      assertNull(VpmScope.execute(loop, scope));
+      // ...but the script referenced `hiddenColumns`, which the fix records so the hidden
+      // columns are still applied.
+      assertTrue(scope.isVariableUsed("hiddenColumns"));
+      // an unrelated variable is not flagged as used
+      assertFalse(scope.isVariableUsed("condition"));
+
+      // When no group matches, `hiddenColumns` is never referenced -> flag stays false.
+      VpmScope noMatch = new VpmScope();
+      noMatch.setUser(user);
+      noMatch.putMember("hiddenColumns", new String[]{ "public.orders.discount" });
+      noMatch.putMember("groups", new String[]{ "groupX", "groupY" });
+      assertNull(VpmScope.execute(loop, noMatch));
+      assertFalse(noMatch.isVariableUsed("hiddenColumns"));
+   }
 }

--- a/core/src/test/java/inetsoft/uql/script/VpmScopeTest.java
+++ b/core/src/test/java/inetsoft/uql/script/VpmScopeTest.java
@@ -157,4 +157,62 @@ class VpmScopeTest {
       assertThrows(Exception.class, () -> VpmScope.execute("if(user == 'guest') {", scope),
                    "Expected exception for invalid statement");
    }
+
+   /**
+    * Bug #75669: a VPM trigger script that references {@code condition} inside a loop
+    * activated the condition under Rhino regardless of iteration order. Under GraalJS a
+    * trailing non-matching {@code if} clobbers the loop completion value with undefined,
+    * so the raw script result is null when the matching iteration is not last. The fix
+    * tracks that the script referenced {@code condition} so VpmCondition can fall back to
+    * the condition value.
+    */
+   @Test
+   void testConditionUsedWhenMatchNotLastIteration() throws Exception {
+      VpmScope scope = new VpmScope();
+      Principal user = new XPrincipal(new IdentityID("user1", "host-org"));
+      scope.setUser(user);
+      scope.putMember("condition", "public.orders.discount = 0.05");
+      // matching group ("group0") is first; a non-matching group is last, mirroring the
+      // transitive-group resolution order [group0, group0_1] from the reported case.
+      scope.putMember("groups", new String[]{ "group0", "group0_1" });
+
+      String loop =
+         "for(var i=0; i<groups.length; i++){\n" +
+         "   if(groups[i]=='group0'){\n" +
+         "      condition;\n" +
+         "   }\n" +
+         "}";
+
+      // The trailing non-matching iteration clobbers the completion value under GraalJS...
+      assertNull(VpmScope.execute(loop, scope));
+      // ...but the script referenced `condition`, which the fix records so the condition
+      // is still applied.
+      assertTrue(scope.isConditionUsed());
+
+      // When no group matches, `condition` is never referenced -> flag stays false.
+      VpmScope noMatch = new VpmScope();
+      noMatch.setUser(user);
+      noMatch.putMember("condition", "public.orders.discount = 0.05");
+      noMatch.putMember("groups", new String[]{ "groupX", "groupY" });
+      assertNull(VpmScope.execute(loop, noMatch));
+      assertFalse(noMatch.isConditionUsed());
+   }
+
+   /**
+    * Bug #75669: the condition-used flag must reflect only the current execution. The
+    * setup {@code putMember("condition", ...)} that VpmCondition performs before running
+    * the script (and any prior execution) must not leave the flag set.
+    */
+   @Test
+   void testConditionUsedResetPerExecution() throws Exception {
+      VpmScope scope = new VpmScope();
+      Principal user = new XPrincipal(new IdentityID("user1", "host-org"));
+      scope.setUser(user);
+      // pre-execution setup assignment (as VpmCondition.evaluate does) must not count
+      scope.putMember("condition", "public.orders.discount = 0.05");
+
+      // a script that never touches `condition`
+      assertEquals("x", VpmScope.execute("'x';", scope));
+      assertFalse(scope.isConditionUsed());
+   }
 }


### PR DESCRIPTION
## Summary

After the Rhino→GraalJS migration (Feature #75423), a VPM (Virtual Private Model) row-level-security trigger script stopped applying its condition for users in a **nested subgroup**. E.g. `user1` in `group0_1` (a subgroup of `group0`) was not filtered, while `user0` (direct member of `group0`) was.

## Root Cause

VPM trigger scripts activate a condition by referencing the `condition` variable and relying on it becoming the script's **completion value**, which `VpmCondition.evaluate()` uses as the SQL WHERE clause. The sample script is:

```javascript
for(var i=0; i<groups.length; i++){
   if(groups[i]=="group0"){
      condition;
   }
}
```

The `groups` array resolves correctly to `[group0, group0_1]` (group0 is present). The regression is a JavaScript **completion-value** semantics difference between the engines:

- **Rhino** (older spec): an `if(false)` with no `else` produced an *empty* completion, so the for-loop preserved the last non-empty completion value `V` (the `condition` string). The condition applied regardless of group order.
- **GraalJS** (current ECMAScript §14.6.7): `if(false)` returns `NormalCompletion(undefined)`, which **overwrites** the loop's completion value. When the matching iteration (`group0`, index 0) is followed by a non-matching one (`group0_1`, index 1), the script's completion value becomes `undefined` → `result == null` → no WHERE clause is injected.

Single-`if` conditions and cases where the matching iteration is last are unaffected, which matches the observed behavior (a user who is a *direct* member of `group0` works; a user in the nested subgroup does not).

## Fix

Honor the established VPM contract that referencing/assigning `condition` activates it:

- `VpmScope`: track whether the script referenced or assigned the `condition` member during execution (`isConditionUsed()`), reset at the start of each `execute()` so the pre-execution setup assignment does not count.
- `VpmCondition.evaluate()`: when the script's completion value is `null` but `condition` was used, fall back to the current (possibly reassigned) `condition` value.

The fallback only triggers when the completion value is `null`, so a legitimate non-null result is never overridden.

## Test Plan

- Added `VpmScopeTest.testConditionUsedWhenMatchNotLastIteration` — reproduces the exact loop with `groups=[group0, group0_1]`; asserts the raw completion value is `null` (confirming the GraalJS clobbering) while `isConditionUsed()` is `true`; and that a no-match run leaves the flag `false`.
- Added `VpmScopeTest.testConditionUsedResetPerExecution` — the pre-execution `putMember("condition", …)` setup must not leave the flag set.
- `VpmScopeTest` passes 9/9; `core` compiles.
- Manually verified on a running server: `user1` (in `group0_1`) is now filtered to `orders.discount = 0.05`, `user0` still works, and the other VPM rules are unaffected.

Fixes Redmine #75669.