### PR TITLE
75639, hover treemap, icicle,circle packing hierarchical

### DIFF
--- a/core/src/main/java/inetsoft/graph/visual/TreemapVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/TreemapVO.java
@@ -36,6 +36,7 @@ import java.awt.geom.*;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
@@ -198,18 +199,9 @@ public class TreemapVO extends ElementVO {
 
          int[] childRows = gobj.getChildRows();
 
-         if(childRows != null && childRows.length > 0) {
-            StringBuilder sb = new StringBuilder();
-
-            for(int r : childRows) {
-               if(sb.length() > 0) {
-                  sb.append(',');
-               }
-
-               sb.append(r);
-            }
-
-            attrs.put(SVGSupport.ATTR_CHILDROWS, sb.toString());
+         if(childRows.length > 0) {
+            attrs.put(SVGSupport.ATTR_CHILDROWS,
+               IntStream.of(childRows).mapToObj(String::valueOf).collect(Collectors.joining(",")));
          }
 
          svg.beginAnnotationGroup(g, SVGSupport.ANNOTATION_TREEMAP, attrs);

--- a/core/src/main/java/inetsoft/graph/visual/TreemapVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/TreemapVO.java
@@ -33,6 +33,7 @@ import inetsoft.util.graphics.SVGSupport;
 
 import java.awt.*;
 import java.awt.geom.*;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.IntStream;
@@ -187,11 +188,31 @@ public class TreemapVO extends ElementVO {
       SVGSupport svg = SVGSupport.isSVGContext(g) ? SVGSupport.getInstance() : null;
 
       if(svg != null) {
-         svg.beginAnnotationGroup(g, SVGSupport.ANNOTATION_TREEMAP, Map.of(
-            SVGSupport.ATTR_ROW,   String.valueOf(getRowIndex()),
-            SVGSupport.ATTR_COL,   String.valueOf(getColIndex()),
-            SVGSupport.ATTR_LEVEL, String.valueOf(level)
-         ));
+         Map<String, String> attrs = new LinkedHashMap<>();
+         attrs.put(SVGSupport.ATTR_ROW,    String.valueOf(getRowIndex()));
+         attrs.put(SVGSupport.ATTR_COL,    String.valueOf(getColIndex()));
+         attrs.put(SVGSupport.ATTR_LEVEL,  String.valueOf(level));
+         // sub-row index (and, for containers, the descendant leaves' sub-rows) lets the hover
+         // handler keep the whole hovered subtree undimmed instead of just the hovered node.
+         attrs.put(SVGSupport.ATTR_SUBROW, String.valueOf(gobj.getSubRowIndex()));
+
+         int[] childRows = gobj.getChildRows();
+
+         if(childRows != null && childRows.length > 0) {
+            StringBuilder sb = new StringBuilder();
+
+            for(int r : childRows) {
+               if(sb.length() > 0) {
+                  sb.append(',');
+               }
+
+               sb.append(r);
+            }
+
+            attrs.put(SVGSupport.ATTR_CHILDROWS, sb.toString());
+         }
+
+         svg.beginAnnotationGroup(g, SVGSupport.ANNOTATION_TREEMAP, attrs);
       }
 
       try {

--- a/core/src/main/java/inetsoft/util/graphics/SVGSupport.java
+++ b/core/src/main/java/inetsoft/util/graphics/SVGSupport.java
@@ -159,6 +159,14 @@ public interface SVGSupport {
    String ATTR_Y      = "y";
    /** {@code data-level} — nesting depth from {@code TreemapGeometry.getLevel()}; leaf=0, root=highest. */
    String ATTR_LEVEL  = "level";
+   /** {@code data-subrow} — treemap/circle/sunburst/icicle node's sub-row index
+    *  ({@code TreemapGeometry.getSubRowIndex()}); an intermediate container shares this value with
+    *  its first leaf descendant, so subtree membership can be tested against {@link #ATTR_CHILDROWS}. */
+   String ATTR_SUBROW = "subrow";
+   /** {@code data-childrows} — comma-separated sub-row indices of a treemap container's descendant
+    *  leaves ({@code TreemapGeometry.getChildRows()}); absent on leaf nodes. Used by the hover
+    *  handler to keep a hovered container's whole subtree undimmed. */
+   String ATTR_CHILDROWS = "childrows";
    /** {@code data-id} — mxCell ID for relation/tree chart nodes, used to match edges to nodes. */
    String ATTR_NODE_ID = "id";
    /** {@code data-source} — source node's mxCell ID for relation/tree chart edges. */

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
@@ -174,6 +174,63 @@ describe("ChartInlineSvgDirective cross-tile dim", () => {
       });
    });
 
+   describe("activateTreemapDescendants (hierarchical hover)", () => {
+      // 3-level tree (leaf=0, root=highest): a top container P (level 2) with two mid containers
+      // C (level 1) and C2 (level 1), each holding one leaf (level 0). P, C and its leaf were all
+      // created from the same source row so they share data-subrow="0" (the "first-descended"
+      // chain); C2 and its leaf share data-subrow="1". Keys are unique by data-row/data-col.
+      const html = `
+         <svg>
+            <g class="inetsoft-treemap" data-row="0" data-col="0" data-level="2" data-subrow="0" data-childrows="0,1"></g>
+            <g class="inetsoft-treemap" data-row="0" data-col="1" data-level="1" data-subrow="0" data-childrows="0"></g>
+            <g class="inetsoft-treemap" data-row="0" data-col="2" data-level="0" data-subrow="0"></g>
+            <g class="inetsoft-treemap" data-row="1" data-col="1" data-level="1" data-subrow="1" data-childrows="1"></g>
+            <g class="inetsoft-treemap" data-row="1" data-col="2" data-level="0" data-subrow="1"></g>
+            <g class="inetsoft-treemap-label" data-row="0" data-col="2"></g>
+         </svg>`;
+
+      function isActive(host: HTMLElement, sel: string): boolean {
+         return host.querySelector(sel)!.classList.contains("inetsoft-active");
+      }
+
+      it("keeps the hovered mid container's subtree undimmed without activating its ancestor", () => {
+         const { dir, host } = makeDirective(html);
+         (dir as any).afterSvgInjected();
+         // Hover the mid container C (row 0, col 1).
+         dir.highlightElement(0, 1);
+         // C itself and its leaf (+ the leaf's label) stay undimmed.
+         expect(isActive(host, "[data-col='1'][data-row='0'].inetsoft-treemap")).toBe(true);
+         expect(isActive(host, "[data-col='2'][data-row='0'].inetsoft-treemap")).toBe(true);
+         expect(isActive(host, ".inetsoft-treemap-label")).toBe(true);
+         // The ancestor P shares C's data-subrow but must NOT be activated (it is not nested inside
+         // C) — the data-level guard excludes it. Unrelated sibling subtree stays dimmable too.
+         expect(isActive(host, "[data-col='0'][data-row='0'].inetsoft-treemap")).toBe(false);
+         expect(isActive(host, "[data-col='1'][data-row='1'].inetsoft-treemap")).toBe(false);
+         expect(isActive(host, "[data-col='2'][data-row='1'].inetsoft-treemap")).toBe(false);
+      });
+
+      it("activates the entire subtree when hovering the top container", () => {
+         const { dir, host } = makeDirective(html);
+         (dir as any).afterSvgInjected();
+         // Hover the top container P (row 0, col 0).
+         dir.highlightElement(0, 0);
+         expect(isActive(host, "[data-col='1'][data-row='0'].inetsoft-treemap")).toBe(true);
+         expect(isActive(host, "[data-col='2'][data-row='0'].inetsoft-treemap")).toBe(true);
+         expect(isActive(host, "[data-col='1'][data-row='1'].inetsoft-treemap")).toBe(true);
+         expect(isActive(host, "[data-col='2'][data-row='1'].inetsoft-treemap")).toBe(true);
+      });
+
+      it("activates only the leaf when hovering a leaf node", () => {
+         const { dir, host } = makeDirective(html);
+         (dir as any).afterSvgInjected();
+         // Hover the leaf under C (row 0, col 2) — no data-childrows, so nothing else lights up.
+         dir.highlightElement(0, 2);
+         expect(isActive(host, "[data-col='2'][data-row='0'].inetsoft-treemap")).toBe(true);
+         expect(isActive(host, "[data-col='1'][data-row='0'].inetsoft-treemap")).toBe(false);
+         expect(isActive(host, "[data-col='0'][data-row='0'].inetsoft-treemap")).toBe(false);
+      });
+   });
+
    describe("milestone point label activation (gantt)", () => {
       // <svg> sets svgRootEl; two milestone markers + labels keyed by data-row/col.
       const html = `

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
@@ -477,12 +477,20 @@ export class ChartInlineSvgDirective implements OnDestroy {
       if(!childRowsAttr) return; // leaf node — nothing nested to keep undimmed
 
       const childRows = new Set(childRowsAttr.split(","));
+      // data-subrow is shared along a "first-descended" chain (root→leaf created in one pass share
+      // one sub-row), so a container's subrow can also equal an ancestor's. Requiring a strictly
+      // smaller data-level (leaf=0, root=highest) keeps only genuine descendants and excludes those
+      // ancestors (and same-level siblings), which would otherwise stay undimmed.
+      const containerLevel = Number(containerEl.getAttribute("data-level"));
 
       for(const node of this.treemapGroups) {
          if(node === containerEl) continue; // already activated by activateKeys
 
          const sub = node.getAttribute("data-subrow");
-         if(sub == null || !childRows.has(sub)) continue;
+         const level = Number(node.getAttribute("data-level"));
+         if(sub == null || Number.isNaN(level) || level >= containerLevel || !childRows.has(sub)) {
+            continue;
+         }
 
          node.classList.add("inetsoft-active");
          this.activeTreemapDescendants.push(node);

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
@@ -102,6 +102,11 @@ export class ChartInlineSvgDirective implements OnDestroy {
    private relationEdges: Array<{el: Element, sourceId: string, targetId: string}> = [];
    /** Elements activated as neighbors of the current relation node (cleared on deactivation). */
    private activeRelationNeighbors: Element[] = [];
+   /** All treemap/circle-packing/sunburst/icicle node groups, used to find a hovered container's
+    *  descendants (matched by data-subrow against the container's data-childrows). */
+   private treemapGroups: Element[] = [];
+   /** Treemap descendant nodes + labels activated for the current hover (cleared on deactivation). */
+   private activeTreemapDescendants: Element[] = [];
    /** Ordered list of area series objects; one entry per (panel, series) pair. */
    private areaSeries: Array<{fillGroup: Element, lineGroup: Element, linePath: SVGGeometryElement}> = [];
    /** Pre-sampled SVG local-coordinate points per series for fast mousemove hit-testing. */
@@ -373,6 +378,9 @@ export class ChartInlineSvgDirective implements OnDestroy {
             if(el.classList.contains("inetsoft-relation")) {
                this.activateRelationNeighbors(el);
             }
+            else if(el.classList.contains("inetsoft-treemap")) {
+               this.activateTreemapDescendants(el);
+            }
          }
 
          const glyphs = this.labelGroupMap.get(key);
@@ -412,6 +420,11 @@ export class ChartInlineSvgDirective implements OnDestroy {
          n.classList.remove("inetsoft-active");
       }
       this.activeRelationNeighbors = [];
+
+      for(const n of this.activeTreemapDescendants) {
+         n.classList.remove("inetsoft-active");
+      }
+      this.activeTreemapDescendants = [];
    }
 
    // Activates neighbor nodes, their connecting edges, and neighbor labels.
@@ -446,6 +459,43 @@ export class ChartInlineSvgDirective implements OnDestroy {
                      this.activeRelationNeighbors.push(g);
                   });
                }
+            }
+         }
+      }
+   }
+
+   // Keep the whole subtree of a hovered treemap/circle-packing/sunburst/icicle container undimmed.
+   // Each node is a separate sibling group, so hovering a container activates only itself and the
+   // server :has() dim rule would dim its descendants along with unrelated nodes. data-childrows
+   // lists the container's descendant leaf sub-rows; because an intermediate container shares its
+   // data-subrow with its first leaf descendant, matching data-subrow against that set activates the
+   // full subtree — leaves and intermediate containers alike. Descendant labels are activated via
+   // labelGroupMap (keyed by the descendant's data-row/data-col, as tagged server-side).
+   // Cleared by deactivateCurrent() via the activeTreemapDescendants array.
+   private activateTreemapDescendants(containerEl: Element): void {
+      const childRowsAttr = containerEl.getAttribute("data-childrows");
+      if(!childRowsAttr) return; // leaf node — nothing nested to keep undimmed
+
+      const childRows = new Set(childRowsAttr.split(","));
+
+      for(const node of this.treemapGroups) {
+         if(node === containerEl) continue; // already activated by activateKeys
+
+         const sub = node.getAttribute("data-subrow");
+         if(sub == null || !childRows.has(sub)) continue;
+
+         node.classList.add("inetsoft-active");
+         this.activeTreemapDescendants.push(node);
+
+         const row = node.getAttribute("data-row");
+         const col = node.getAttribute("data-col");
+         if(row != null && col != null) {
+            const glyphs = this.labelGroupMap.get(`${row}-${col}`);
+            if(glyphs) {
+               glyphs.forEach(g => {
+                  g.classList.add("inetsoft-active");
+                  this.activeTreemapDescendants.push(g);
+               });
             }
          }
       }
@@ -525,6 +575,8 @@ export class ChartInlineSvgDirective implements OnDestroy {
       this.relationNodeIdMap.clear();
       this.relationEdges = [];
       this.activeRelationNeighbors = [];
+      this.treemapGroups = [];
+      this.activeTreemapDescendants = [];
       this._activeKeys = [];
       this.svgRootEl = this.element.nativeElement.querySelector("svg");
 
@@ -644,6 +696,12 @@ export class ChartInlineSvgDirective implements OnDestroy {
          const tgt = e.getAttribute("data-target");
          if(src && tgt) this.relationEdges.push({el: e, sourceId: src, targetId: tgt});
       }
+
+      // Cache treemap/circle-packing/sunburst/icicle node groups so activateTreemapDescendants can
+      // keep the hovered container's whole subtree undimmed (its descendants are separate sibling
+      // groups that the server :has() dim rule would otherwise dim along with unrelated nodes).
+      this.treemapGroups = Array.from(
+         this.element.nativeElement.querySelectorAll(".inetsoft-treemap") as NodeListOf<Element>);
 
       // Build label map from server-annotated label elements for all chart types that have
       // external text groups matched to data elements (bar, point/gantt-milestone, treemap/sunburst/icicle, mekko).


### PR DESCRIPTION
Root Cause:
Circle Packing, TreeMap, Icicle, and Sunburst are all rendered by the same TreemapElement/TreemapVO and each node — parent container and leaf alike — is emitted as a separate SVG group with the class "inetsoft-treemap". Hover dimming is driven by server-injected CSS (:has() rule) that dims every ".inetsoft-treemap:not(.inetsoft-active)" whenever a treemap node is active. The frontend only marked the single hovered node as active, so hovering a parent container left its nested child nodes without the active class and they were dimmed along with unrelated nodes.

Fix:
Keep the whole hovered subtree undimmed by activating a container's descendants on hover (no CSS change required). The backend now stamps two additional attributes on each treemap node group: data-subrow (the node's sub-row index) and, on container nodes, data-childrows (the sub-row indices of all descendant leaves, from TreemapGeometry.getChildRows()). On hover of a container, the chart directive (activateTreemapDescendants) adds inetsoft-active to every node whose data-subrow is in the container's data-childrows set, plus their labels. Because an intermediate container shares its sub-row index with its first leaf descendant, matching by sub-row captures the entire subtree (leaves and nested containers). This fixes all four hierarchical chart types uniformly.

Files changed:
- core/.../util/graphics/SVGSupport.java (new attribute constants)
- core/.../graph/visual/TreemapVO.java (stamp data-subrow / data-childrows)
- web/.../graph/objects/chart-inline-svg.directive.ts (activate hovered subtree)