### PR TITLE
feat(wiz): support copy-before-modify for chart color/format requests

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/ChartColorsRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChartColorsRequest.java
@@ -52,6 +52,11 @@ public class ChartColorsRequest {
    public Map<String, String> getCategoryColors() { return categoryColors; }
    public void setCategoryColors(Map<String, String> categoryColors) { this.categoryColors = categoryColors; }
 
+   /** When true, duplicate the assembly first (keeping the original untouched) and apply the color
+    *  change to the new copy instead of in place. Defaults to false. */
+   public boolean isCopy() { return copy; }
+   public void setCopy(boolean copy) { this.copy = copy; }
+
    private String wizRuntimeId;
    private String assemblyName;
    private String viewsheetIdentifier;
@@ -59,4 +64,5 @@ public class ChartColorsRequest {
    private String paletteName;
    private List<String> colorList;
    private Map<String, String> categoryColors;
+   private boolean copy;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
@@ -103,6 +103,11 @@ public class ChartFormatRequest {
    public Boolean getFillGapWithDash() { return fillGapWithDash; }
    public void setFillGapWithDash(Boolean fillGapWithDash) { this.fillGapWithDash = fillGapWithDash; }
 
+   /** When true, duplicate the assembly first (keeping the original untouched) and apply the format
+    *  change to the new copy instead of in place. Defaults to false. */
+   public boolean isCopy() { return copy; }
+   public void setCopy(boolean copy) { this.copy = copy; }
+
    /** The runtime viewsheet that holds the live chart (the plugin's active-chart runtimeId). */
    private String wizRuntimeId;
    /** The chart assembly name within that runtime. */
@@ -124,4 +129,5 @@ public class ChartFormatRequest {
    private Boolean fillTimeGap;
    private Boolean fillZero;
    private Boolean fillGapWithDash;
+   private boolean copy;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -2088,6 +2088,18 @@ public class WizAutoBindingService {
          throw new Exception("Chart assembly not found: " + request.getAssemblyName());
       }
 
+      // copy+apply: duplicate the assembly FIRST (keeping the original untouched) and apply the
+      // format change to the new copy instead. duplicatePrimaryAssembly is the single shared
+      // "copy" primitive (also used by setChartColors) — this never reimplements duplication here.
+      if(request.isCopy()) {
+         VSAssembly copy = wizVsService.duplicatePrimaryAssembly(rvs.getViewsheet(), chart);
+
+         if(copy instanceof ChartVSAssembly copiedChart) {
+            chart = copiedChart;
+         }
+      }
+
+      String targetAssemblyName = chart.getName();
       var info = chart.getChartInfo();
       ChartDescriptor desc = info.getChartDescriptor();
       VSChartInfo vsChartInfo = info.getVSChartInfo();
@@ -2211,7 +2223,7 @@ public class WizAutoBindingService {
       // staleness check (equalsContent against itself) can never detect the in-place mutation
       // above. Clear the cached graph explicitly — mirroring VSChartDataHandler — or every
       // subsequent render (including brand-new embed connections) serves the stale graph.
-      rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(request.getAssemblyName()));
+      rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(targetAssemblyName));
 
       // Commit the in-place mutation to the backing asset. save_viewsheet clones the assembly from
       // the PERSISTED viewsheet (not this live runtime), so a format/color change left only on the
@@ -2222,14 +2234,14 @@ public class WizAutoBindingService {
       }
 
       CreateViewsheetResult result =
-         wizVsService.fetchAssemblyData(effRuntimeId, request.getAssemblyName(), user);
+         wizVsService.fetchAssemblyData(effRuntimeId, targetAssemblyName, user);
 
       if(result == null) {
          result = new CreateViewsheetResult();
       }
 
       result.setRuntimeId(effRuntimeId);
-      result.setAssemblyName(request.getAssemblyName());
+      result.setAssemblyName(targetAssemblyName);
 
       if(request.getViewsheetIdentifier() != null) {
          result.setViewsheetIdentifier(request.getViewsheetIdentifier());
@@ -2289,6 +2301,18 @@ public class WizAutoBindingService {
          throw new Exception("Chart assembly not found: " + request.getAssemblyName());
       }
 
+      // copy+apply: duplicate the assembly FIRST (keeping the original untouched) and apply the
+      // color change to the new copy instead. duplicatePrimaryAssembly is the single shared
+      // "copy" primitive (also used by setChartFormat) — this never reimplements duplication here.
+      if(request.isCopy()) {
+         VSAssembly copy = wizVsService.duplicatePrimaryAssembly(rvs.getViewsheet(), chart);
+
+         if(copy instanceof ChartVSAssembly copiedChart) {
+            chart = copiedChart;
+         }
+      }
+
+      String targetAssemblyName = chart.getName();
       var info = chart.getChartInfo();
       VSChartInfo vsChartInfo = info.getVSChartInfo();
       AestheticRef colorField = vsChartInfo == null ? null : vsChartInfo.getColorField();
@@ -2324,7 +2348,7 @@ public class WizAutoBindingService {
       // staleness check (equalsContent against itself) can never detect the in-place mutation
       // above. Clear the cached graph explicitly — mirroring VSChartDataHandler — or every
       // subsequent render (including brand-new embed connections) serves the stale graph.
-      rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(request.getAssemblyName()));
+      rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(targetAssemblyName));
 
       // Commit the in-place mutation to the backing asset. save_viewsheet clones the assembly from
       // the PERSISTED viewsheet (not this live runtime), so a format/color change left only on the
@@ -2335,14 +2359,14 @@ public class WizAutoBindingService {
       }
 
       CreateViewsheetResult result =
-         wizVsService.fetchAssemblyData(effRuntimeId, request.getAssemblyName(), user);
+         wizVsService.fetchAssemblyData(effRuntimeId, targetAssemblyName, user);
 
       if(result == null) {
          result = new CreateViewsheetResult();
       }
 
       result.setRuntimeId(effRuntimeId);
-      result.setAssemblyName(request.getAssemblyName());
+      result.setAssemblyName(targetAssemblyName);
 
       if(request.getViewsheetIdentifier() != null) {
          result.setViewsheetIdentifier(request.getViewsheetIdentifier());

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -2526,6 +2526,42 @@ public class WizVsService {
    }
 
    /**
+    * Duplicates {@code source} into a new, uniquely-named assembly on {@code vs}, demotes any
+    * currently-primary assembly (kept, not removed), and sets the new assembly as primary.
+    * Reuses {@link #rebindAssembly} (clones the FULL {@code VSAssemblyInfo} — chart type, binding,
+    * and any previously-applied format/color/marker customizations) and {@link #uniqueAssemblyName},
+    * the same building blocks the standard create/rebind path already uses — this is the single
+    * shared "copy" primitive so callers (e.g. copy+apply on setChartColors/setChartFormat) never
+    * reimplement assembly duplication themselves.
+    *
+    * @return the new (now primary) assembly, or null when {@code source}'s type has no
+    *         {@code ASSEMBLY_FACTORIES} entry (see {@link #rebindAssembly}).
+    */
+   public VSAssembly duplicatePrimaryAssembly(Viewsheet vs, VSAssembly source) {
+      String newName = uniqueAssemblyName(vs, source.getName());
+      VSAssembly copy = rebindAssembly(vs, newName, source);
+
+      if(copy == null) {
+         return null;
+      }
+
+      Assembly[] existingAssemblies = vs.getAssemblies();
+
+      if(existingAssemblies != null) {
+         for(Assembly a : existingAssemblies) {
+            if(a instanceof VSAssembly va && va.isPrimary()) {
+               va.setPrimary(false);
+            }
+         }
+      }
+
+      vs.addAssembly(copy);
+      copy.setPrimary(true);
+
+      return copy;
+   }
+
+   /**
     * Returns the first assembly marked as primary in the viewsheet, or null if none exists.
     */
    private VSAssembly findPrimaryAssembly(Viewsheet vs) {

--- a/core/src/test/java/inetsoft/web/wiz/model/ChartColorsRequestTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/ChartColorsRequestTest.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * copy+apply wire contract: {@code copy} defaults to false (existing callers untouched) and
+ * deserializes when the caller explicitly asks to duplicate the assembly before applying colors.
+ */
+@Tag("core")
+class ChartColorsRequestTest {
+   @Test
+   void copyDefaultsToFalseWhenOmitted() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+      ChartColorsRequest req = mapper.readValue("{ \"wizRuntimeId\": \"rt-1\" }", ChartColorsRequest.class);
+      assertFalse(req.isCopy());
+   }
+
+   @Test
+   void copyDeserializesWhenTrue() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+      ChartColorsRequest req = mapper.readValue("{ \"copy\": true }", ChartColorsRequest.class);
+      assertTrue(req.isCopy());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/model/ChartFormatRequestTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/ChartFormatRequestTest.java
@@ -67,4 +67,18 @@ class ChartFormatRequestTest {
       assertEquals("T", req.getXAxisTitle());
       assertTrue(mapper.writeValueAsString(req).contains("\"xAxisTitle\":\"T\""));
    }
+
+   @Test
+   void copyDefaultsToFalseWhenOmitted() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+      ChartFormatRequest req = mapper.readValue("{ \"wizRuntimeId\": \"rt-1\" }", ChartFormatRequest.class);
+      assertFalse(req.isCopy());
+   }
+
+   @Test
+   void copyDeserializesWhenTrue() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+      ChartFormatRequest req = mapper.readValue("{ \"copy\": true }", ChartFormatRequest.class);
+      assertTrue(req.isCopy());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartColorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartColorsTest.java
@@ -53,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -76,11 +77,13 @@ class WizAutoBindingServiceSetChartColorsTest {
    private VSChartAggregateRef rtYAgg;
    private SecurityEngine securityEngine;
    private ViewsheetService viewsheetService;
+   private WizVsService wizVsService;
+   private ChartVSAssembly chart;
 
    @BeforeEach
    void setUp() throws Exception {
       viewsheetService = mock(ViewsheetService.class);
-      WizVsService wizVsService = mock(WizVsService.class);
+      wizVsService = mock(WizVsService.class);
       // collaborators not used by setChartColors; their classes can't be initialized in
       // a plain unit-test environment (no Spring context), so pass null instead of mocks.
       securityEngine = mock(SecurityEngine.class);
@@ -102,8 +105,9 @@ class WizAutoBindingServiceSetChartColorsTest {
       ChartVSAssemblyInfo info = mock(ChartVSAssemblyInfo.class);
       when(info.getVSChartInfo()).thenReturn(vsChartInfo);
 
-      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      chart = mock(ChartVSAssembly.class);
       when(chart.getChartInfo()).thenReturn(info);
+      when(chart.getName()).thenReturn("vs_1");
 
       Viewsheet vs = mock(Viewsheet.class);
       when(vs.getAssembly("vs_1")).thenReturn(chart);
@@ -170,5 +174,43 @@ class WizAutoBindingServiceSetChartColorsTest {
       verify(yAgg, never()).setColorFrame(any());
       verify(rtYAgg, never()).setColorFrame(any());
       verify(box, never()).clearGraph(anyString());
+   }
+
+   @Test
+   void doesNotDuplicateWhenCopyIsFalse() throws Exception {
+      service.setChartColors(staticRed(), null);
+
+      verify(wizVsService, never()).duplicatePrimaryAssembly(any(), any());
+   }
+
+   @Test
+   void copyDuplicatesFirstAndAppliesColorToTheNewAssemblyNotTheOriginal() throws Exception {
+      VSChartAggregateRef newYAgg = mock(VSChartAggregateRef.class);
+      VSChartAggregateRef newRtYAgg = mock(VSChartAggregateRef.class);
+      VSChartInfo newVsChartInfo = mock(VSChartInfo.class);
+      when(newVsChartInfo.getColorField()).thenReturn(null);
+      when(newVsChartInfo.getYFields()).thenReturn(new ChartRef[] { newYAgg });
+      when(newVsChartInfo.getXFields()).thenReturn(new ChartRef[0]);
+      when(newVsChartInfo.getRTYFields()).thenReturn(new ChartRef[] { newRtYAgg });
+      when(newVsChartInfo.getRTXFields()).thenReturn(new ChartRef[0]);
+
+      ChartVSAssemblyInfo newInfo = mock(ChartVSAssemblyInfo.class);
+      when(newInfo.getVSChartInfo()).thenReturn(newVsChartInfo);
+
+      ChartVSAssembly newChart = mock(ChartVSAssembly.class);
+      when(newChart.getChartInfo()).thenReturn(newInfo);
+      when(newChart.getName()).thenReturn("vs_1_1");
+      when(wizVsService.duplicatePrimaryAssembly(any(), eq(chart))).thenReturn(newChart);
+
+      ChartColorsRequest request = staticRed();
+      request.setCopy(true);
+
+      CreateViewsheetResult result = service.setChartColors(request, null);
+
+      verify(wizVsService).duplicatePrimaryAssembly(any(), eq(chart));
+      verify(newYAgg).setColorFrame(any());
+      verify(newRtYAgg).setColorFrame(any());
+      verify(yAgg, never()).setColorFrame(any());
+      assertEquals("vs_1_1", result.getAssemblyName());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
@@ -62,6 +62,7 @@ class WizAutoBindingServiceSetChartFormatTest {
    private WizVsService wizVsService;
    private Viewsheet vs;
    private ChartVSAssemblyInfo info;
+   private ChartVSAssembly chart;
    private ViewsheetSandbox box;
    private SecurityEngine securityEngine;
 
@@ -83,9 +84,10 @@ class WizAutoBindingServiceSetChartFormatTest {
       when(info.getChartDescriptor()).thenReturn(null);
       when(info.getVSChartInfo()).thenReturn(null);
 
-      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      chart = mock(ChartVSAssembly.class);
       when(chart.getChartInfo()).thenReturn(info);
       when(chart.getVSAssemblyInfo()).thenReturn(info);
+      when(chart.getName()).thenReturn("vs_1");
 
       vs = mock(Viewsheet.class);
       when(vs.getAssembly("vs_1")).thenReturn(chart);
@@ -171,5 +173,35 @@ class WizAutoBindingServiceSetChartFormatTest {
       verify(viewsheetService, never()).getViewsheet(anyString(), any());
       verify(info, never()).setTitleValue(any());
       verify(wizVsService, never()).persistViewsheet(any(), any(), any());
+   }
+
+   @Test
+   void doesNotDuplicateWhenCopyIsFalse() throws Exception {
+      service.setChartFormat(titleRequest("visualizations-xyz"), null);
+
+      verify(wizVsService, never()).duplicatePrimaryAssembly(any(), any());
+   }
+
+   @Test
+   void copyDuplicatesFirstAndAppliesFormatToTheNewAssemblyNotTheOriginal() throws Exception {
+      ChartVSAssemblyInfo newInfo = mock(ChartVSAssemblyInfo.class);
+      when(newInfo.getChartDescriptor()).thenReturn(null);
+      when(newInfo.getVSChartInfo()).thenReturn(null);
+
+      ChartVSAssembly newChart = mock(ChartVSAssembly.class);
+      when(newChart.getChartInfo()).thenReturn(newInfo);
+      when(newChart.getVSAssemblyInfo()).thenReturn(newInfo);
+      when(newChart.getName()).thenReturn("vs_1_1");
+      when(wizVsService.duplicatePrimaryAssembly(any(), eq(chart))).thenReturn(newChart);
+
+      ChartFormatRequest request = titleRequest("visualizations-xyz");
+      request.setCopy(true);
+
+      CreateViewsheetResult result = service.setChartFormat(request, null);
+
+      verify(wizVsService).duplicatePrimaryAssembly(any(), eq(chart));
+      verify(newInfo).setTitleValue("Contacts per Account");
+      verify(info, never()).setTitleValue(any());
+      assertEquals("vs_1_1", result.getAssemblyName());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceDuplicatePrimaryAssemblyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceDuplicatePrimaryAssemblyTest.java
@@ -1,0 +1,114 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * duplicatePrimaryAssembly is the single shared "copy" primitive: it reuses the existing
+ * uniqueAssemblyName + rebindAssembly building blocks (the same ones the standard create/rebind
+ * path already relies on) so copy+apply callers (setChartColors/setChartFormat) never reimplement
+ * assembly duplication themselves — the exact class of divergence that broke save_viewsheet for
+ * FILTER's old copy-to-"_1" behavior.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizVsServiceDuplicatePrimaryAssemblyTest {
+   private static WizVsService service() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+      return new WizVsService(vsService, engine, sec);
+   }
+
+   private static ChartVSAssembly primaryChart(Viewsheet vs, String name) {
+      ChartVSAssembly chart = new ChartVSAssembly(vs, name);
+      vs.addAssembly(chart);
+      chart.setPrimary(true);
+      return chart;
+   }
+
+   @Test
+   void returnsANewUniquelyNamedAssemblyMarkedPrimary() throws Exception {
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly original = primaryChart(vs, "Chart1");
+
+      VSAssembly copy = service().duplicatePrimaryAssembly(vs, original);
+
+      assertNotNull(copy);
+      assertNotEquals("Chart1", copy.getName());
+      assertTrue(copy.isPrimary());
+   }
+
+   @Test
+   void keepsTheOriginalAssemblyButDemotesItFromPrimary() throws Exception {
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly original = primaryChart(vs, "Chart1");
+
+      service().duplicatePrimaryAssembly(vs, original);
+
+      Assembly stillThere = vs.getAssembly("Chart1");
+      assertNotNull(stillThere, "the original assembly must not be removed");
+      assertFalse(((VSAssembly) stillThere).isPrimary(),
+         "the original assembly must be demoted once the copy becomes primary");
+   }
+
+   @Test
+   void addsTheCopyToTheSameViewsheetAlongsideTheOriginal() throws Exception {
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly original = primaryChart(vs, "Chart1");
+
+      VSAssembly copy = service().duplicatePrimaryAssembly(vs, original);
+
+      assertSame(copy, vs.getAssembly(copy.getName()));
+      assertEquals(2, vs.getAssemblies().length, "both the original and the copy must be present");
+   }
+
+   @Test
+   void returnsNullForAnAssemblyTypeWithNoRebindFactory() throws Exception {
+      Viewsheet vs = new Viewsheet();
+      VSAssembly unsupported = mock(VSAssembly.class);
+      when(unsupported.getName()).thenReturn("Weird1");
+
+      VSAssembly copy = service().duplicatePrimaryAssembly(vs, unsupported);
+
+      assertNull(copy);
+   }
+}


### PR DESCRIPTION
## Summary
- Add a `copy` flag to `ChartColorsRequest` / `ChartFormatRequest` so callers can duplicate the active chart's assembly before applying a color/format/marker change instead of mutating it in place.
- Add `WizVsService.duplicatePrimaryAssembly(vs, source)`, reusing the existing `uniqueAssemblyName` + `rebindAssembly` path so the clone keeps prior formatting/color customizations.
- `WizAutoBindingService.setChartColors` / `setChartFormat` (markers share the `/viewsheet/format` endpoint) duplicate the assembly first when `copy=true`.

Companion PR in `stylebi-wiz` wires this `copy` param through the MCP tool layer.

Based on `bug-75446-1` since that's where this branch was cut from (per repo convention for wiz-side changes here).

## Test plan
- [x] Full Java test suite — 193 tests passing (2 pre-existing unrelated failures in `MetadataApiServiceGetJDBCDatasourceTest`, confirmed baseline via git stash)
- [ ] End-to-end MCP tool call with `copy: true` (blocked this session by a stale MCP transport session; to be verified in a follow-up session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)