### PR TITLE
feat(worksheet-structure): include column description in /ws/structure

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetStructure.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetStructure.java
@@ -66,12 +66,13 @@ public class WorksheetStructure {
 
    public static class Column {
       private String name; private String alias; private String type;
-      private String expression; private int refType;
+      private String expression; private int refType; private String description;
       public String getName() { return name; } public void setName(String v) { this.name = v; }
       public String getAlias() { return alias; } public void setAlias(String v) { this.alias = v; }
       public String getType() { return type; } public void setType(String v) { this.type = v; }
       public String getExpression() { return expression; } public void setExpression(String v) { this.expression = v; }
       public int getRefType() { return refType; } public void setRefType(int v) { this.refType = v; }
+      public String getDescription() { return description; } public void setDescription(String v) { this.description = v; }
    }
 
    public static class SourceRef {

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -665,7 +665,9 @@ public class MetadataApiService {
       column.setName(columnRef.getAttribute());
       column.setAlias(columnRef.getAlias());
       column.setRefType(columnRef.getRefType());
-      column.setDescription(columnRef.getDescription());
+      // ColumnRef.getDescription() returns "" (not null) when unset; normalize to null so an absent
+      // description behaves like alias/expression (null when not applicable), matching createColumnMeta.
+      column.setDescription(Tool.isEmptyString(columnRef.getDescription()) ? null : columnRef.getDescription());
 
       if(columnRef.getTypeNode() != null) {
          column.setType(columnRef.getTypeNode().getType());

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -516,7 +516,9 @@ public class MetadataApiService {
       WorksheetTableMeta.WSColumnMeta columnMeta = new WorksheetTableMeta.WSColumnMeta();
       columnMeta.setName(columnRef.getAttribute());
       columnMeta.setAlias(columnRef.getAlias());
-      columnMeta.setDescription(columnRef.getDescription());
+      // ColumnRef.getDescription() returns "" (not null) when unset; normalize to null so an absent
+      // description behaves like alias/expression (null when not applicable).
+      columnMeta.setDescription(Tool.isEmptyString(columnRef.getDescription()) ? null : columnRef.getDescription());
 
       if(columnRef.getTypeNode() != null) {
          columnMeta.setType(columnRef.getTypeNode().getType());

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -665,6 +665,7 @@ public class MetadataApiService {
       column.setName(columnRef.getAttribute());
       column.setAlias(columnRef.getAlias());
       column.setRefType(columnRef.getRefType());
+      column.setDescription(columnRef.getDescription());
 
       if(columnRef.getTypeNode() != null) {
          column.setType(columnRef.getTypeNode().getType());

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceStructureTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceStructureTest.java
@@ -177,6 +177,30 @@ class MetadataApiServiceStructureTest {
       assertEquals("field['a'] + field['b']", expression.getExpression());
    }
 
+   @Test
+   void mapsDescriptionForColumns() {
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly t = new PhysicalBoundTableAssembly(ws, "accounts");
+      ColumnSelection cs = new ColumnSelection();
+
+      // A column carrying a StyleBI column description (the same source /ws/worksheet-model's
+      // createColumnMeta already reads via columnRef.getDescription()).
+      ColumnRef described = new ColumnRef(new AttributeRef(null, "industry"));
+      described.setDescription("The industry sector of the account");
+      cs.addAttribute(described);
+
+      // A column with no description — its structure column description must stay null.
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "annual_revenue")));
+
+      t.setColumnSelection(cs, false);
+
+      var columns = MetadataApiService.extractStructureColumns(t);
+
+      assertEquals(2, columns.size());
+      assertEquals("The industry sector of the account", columns.get(0).getDescription());
+      assertNull(columns.get(1).getDescription(), "column without a description should not carry one");
+   }
+
    // ---- extractStructureSource ----
 
    @Test


### PR DESCRIPTION
Populate WorksheetStructure.Column.description from columnRef.getDescription() in createStructureColumn, so the visualization / insight layer can annotate available fields directly from /ws/structure — the same description source the worksheet-model path (createColumnMeta) already exposed.