### PR TITLE
feat(wiz): create-binding support for sortByCol/groupOthers/discrete/secondaryY/visible/summarize/percentage

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/CrosstabBinding.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/CrosstabBinding.java
@@ -47,7 +47,17 @@ public class CrosstabBinding implements BindingInfo {
       this.aggregates = aggregates;
    }
 
+   public String getPercentageByValue() {
+      return percentageByValue;
+   }
+
+   public void setPercentageByValue(String percentageByValue) {
+      this.percentageByValue = percentageByValue;
+   }
+
    private List<DimensionFieldInfo> rows;
    private List<DimensionFieldInfo> cols;
    private List<MeasureFieldInfo> aggregates;
+   // Crosstab-level percentage direction, paired with a PERCENT calculateInfo. Optional.
+   private String percentageByValue;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/DimensionFieldInfo.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/DimensionFieldInfo.java
@@ -79,6 +79,14 @@ public class DimensionFieldInfo extends SimpleFieldInfo {
       this.sortByCol = sortByCol;
    }
 
+   public Boolean getSummarize() {
+      return summarize;
+   }
+
+   public void setSummarize(Boolean summarize) {
+      this.summarize = summarize;
+   }
+
    private String dateGroupLevel;
    private Ranking ranking;
    private String fullName;
@@ -86,4 +94,6 @@ public class DimensionFieldInfo extends SimpleFieldInfo {
    private boolean numericBin = false;
    private List<String> manualOrder;
    private String sortByCol;
+   // Crosstab subtotal visibility for row/col dimensions; null = default. Ignored by chart/table.
+   private Boolean summarize;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/DimensionFieldInfo.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/DimensionFieldInfo.java
@@ -71,10 +71,19 @@ public class DimensionFieldInfo extends SimpleFieldInfo {
       this.manualOrder = manualOrder;
    }
 
+   public String getSortByCol() {
+      return sortByCol;
+   }
+
+   public void setSortByCol(String sortByCol) {
+      this.sortByCol = sortByCol;
+   }
+
    private String dateGroupLevel;
    private Ranking ranking;
    private String fullName;
    private boolean timeSeries = false;
    private boolean numericBin = false;
    private List<String> manualOrder;
+   private String sortByCol;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/MeasureFieldInfo.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/MeasureFieldInfo.java
@@ -78,6 +78,14 @@ public class MeasureFieldInfo extends SimpleFieldInfo {
       this.secondaryY = secondaryY;
    }
 
+   public String getPercentage() {
+      return percentage;
+   }
+
+   public void setPercentage(String percentage) {
+      this.percentage = percentage;
+   }
+
    private String aggregateFormula;
    private String fullName;
    private String secondaryField;
@@ -85,4 +93,6 @@ public class MeasureFieldInfo extends SimpleFieldInfo {
    private CalculateInfo calculateInfo;
    private boolean discrete = false;
    private boolean secondaryY = false;
+   // Crosstab percentage display for aggregates: "None" | "GrandTotal" | "Group". Ignored by chart/table.
+   private String percentage;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/MeasureFieldInfo.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/MeasureFieldInfo.java
@@ -62,9 +62,27 @@ public class MeasureFieldInfo extends SimpleFieldInfo {
       this.calculateInfo = calculateInfo;
    }
 
+   public boolean isDiscrete() {
+      return discrete;
+   }
+
+   public void setDiscrete(boolean discrete) {
+      this.discrete = discrete;
+   }
+
+   public boolean isSecondaryY() {
+      return secondaryY;
+   }
+
+   public void setSecondaryY(boolean secondaryY) {
+      this.secondaryY = secondaryY;
+   }
+
    private String aggregateFormula;
    private String fullName;
    private String secondaryField;
    private Integer nOrP;
    private CalculateInfo calculateInfo;
+   private boolean discrete = false;
+   private boolean secondaryY = false;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/Ranking.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/Ranking.java
@@ -45,7 +45,16 @@ public class Ranking {
       this.rankingCol = rankingCol;
    }
 
+   public boolean isGroupOthers() {
+      return groupOthers;
+   }
+
+   public void setGroupOthers(boolean groupOthers) {
+      this.groupOthers = groupOthers;
+   }
+
    private int optionValue;
    private int rankingN;
    private String rankingCol;
+   private boolean groupOthers = false;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/SimpleFieldInfo.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/SimpleFieldInfo.java
@@ -35,5 +35,15 @@ public class SimpleFieldInfo extends FieldInfo {
       this.order = order;
    }
 
+   public Boolean getVisible() {
+      return visible;
+   }
+
+   public void setVisible(Boolean visible) {
+      this.visible = visible;
+   }
+
    private Integer order;
+   // Column visibility for table `details`; null = default (visible). Ignored by chart/crosstab.
+   private Boolean visible;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -702,12 +702,21 @@ public class WizAutoBindingService {
                dim.setRankingOptionValue(String.valueOf(r.getOptionValue()));
                dim.setRankingNValue(String.valueOf(r.getRankingN()));
                dim.setRankingColValue(r.getRankingCol());
+               // Group non-ranked values as "Others" vs. discard them. Only meaningful when
+               // ranking is active, so it lives inside the ranking block.
+               dim.setGroupOthersValue(String.valueOf(r.isGroupOthers()));
             }
 
             applyDateGroup(dim, dimFc);
 
             if(dimFc.isNumericBin()) {
                WizardRecommenderUtil.applyNumericBin(dim);
+            }
+
+            // Aggregate column to sort bars by; only consulted when order is value-based
+            // (17 value-asc / 18 value-desc). Harmless to set for other orders.
+            if(dimFc.getSortByCol() != null && !dimFc.getSortByCol().isEmpty()) {
+               dim.setSortByColValue(dimFc.getSortByCol());
             }
          }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -750,6 +750,13 @@ public class WizAutoBindingService {
                   agg.setCalculator(calc);
                }
             }
+
+            // discrete (plot un-aggregated) and secondaryY (plot on the secondary Y axis) are
+            // mutually exclusive: an un-aggregated measure has no place on the secondary axis, so a
+            // discrete measure never lands there regardless of what the caller asked for.
+            boolean discrete = meaFc.isDiscrete();
+            agg.setDiscrete(discrete);
+            agg.setSecondaryY(!discrete && meaFc.isSecondaryY());
          }
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -751,12 +751,14 @@ public class WizAutoBindingService {
                }
             }
 
-            // discrete (plot un-aggregated) and secondaryY (plot on the secondary Y axis) are
-            // mutually exclusive: an un-aggregated measure has no place on the secondary axis, so a
-            // discrete measure never lands there regardless of what the caller asked for.
-            boolean discrete = meaFc.isDiscrete();
-            agg.setDiscrete(discrete);
-            agg.setSecondaryY(!discrete && meaFc.isSecondaryY());
+            // Apply discrete (plot un-aggregated) and secondaryY (secondary Y axis) INDEPENDENTLY,
+            // matching the interactive editor (ChartAggregateInfoFactory.updateAggregateRef). The
+            // invalid both-true combination is rejected upstream (fail-loud in the plugin's
+            // normalizeFieldConfigs), so this path must not silently normalize a value away — a client
+            // doing get_current_chart_state -> edit -> re-apply would otherwise lose a value here that
+            // the editor would have kept.
+            agg.setDiscrete(meaFc.isDiscrete());
+            agg.setSecondaryY(meaFc.isSecondaryY());
          }
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
@@ -23,6 +23,7 @@ import inetsoft.uql.asset.DateRangeRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.viewsheet.VSAggregateRef;
 import inetsoft.uql.viewsheet.VSDimensionRef;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
 import inetsoft.web.binding.model.graph.CalculateInfo;
 import inetsoft.web.wiz.model.DimensionFieldInfo;
 import inetsoft.web.wiz.model.MeasureFieldInfo;
@@ -116,6 +117,12 @@ final class WizFieldInfoFactory {
       info.setAggregateFormula(agg.getFormulaValue());
       info.setFullName(agg.getFullName());
       info.setCalculateInfo(CalculateInfo.createCalcInfo(agg.getCalculator()));
+
+      if(agg instanceof VSChartAggregateRef chartAgg) {
+         info.setDiscrete(chartAgg.isDiscrete());
+         info.setSecondaryY(chartAgg.isSecondaryY());
+      }
+
       return info;
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
@@ -47,6 +47,7 @@ final class WizFieldInfoFactory {
       info.setFullName(crosstabDimFullName(dim));
       applyDateGroup(info, dim);
       applyRanking(info, dim);
+      info.setSummarize(dim.isSubTotalVisible());
       return info;
    }
 
@@ -108,7 +109,17 @@ final class WizFieldInfoFactory {
       info.setField(agg.getColumnValue());
       info.setAggregateFormula(agg.getFormula() != null ? agg.getFormula().getFormulaName() : null);
       info.setCalculateInfo(CalculateInfo.createCalcInfo(agg.getCalculator()));
+      info.setPercentage(percentageName(agg.getPercentageOption()));
       return info;
+   }
+
+   /** Reverse of WizVsService#percentageOption: XConstants option → wiz percentage name. */
+   private static String percentageName(int option) {
+      return switch(option) {
+         case XConstants.PERCENTAGE_OF_GRANDTOTAL -> "GrandTotal";
+         case XConstants.PERCENTAGE_OF_GROUP -> "Group";
+         default -> "None";
+      };
    }
 
    static MeasureFieldInfo createChartMeasureFieldInfo(VSAggregateRef agg) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
@@ -122,6 +122,13 @@ final class WizFieldInfoFactory {
    private static DimensionFieldInfo baseDimensionFieldInfo(VSDimensionRef dim) {
       DimensionFieldInfo info = new DimensionFieldInfo();
       info.setField(dim.getGroupColumnValue());
+
+      String sortByCol = dim.getSortByColValue();
+
+      if(sortByCol != null && !sortByCol.isEmpty()) {
+         info.setSortByCol(sortByCol);
+      }
+
       return info;
    }
 
@@ -139,6 +146,7 @@ final class WizFieldInfoFactory {
          }
 
          ranking.setRankingCol(dim.getRankingColValue());
+         ranking.setGroupOthers(dim.isGroupOthers());
          info.setRanking(ranking);
       }
    }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -2190,7 +2190,14 @@ public class WizVsService {
                attr.setDataType(field.getType());
             }
 
-            columns.addAttribute(new ColumnRef(attr));
+            ColumnRef col = new ColumnRef(attr);
+
+            // Column visibility: null = default (visible); false hides the column.
+            if(field.getVisible() != null) {
+               col.setVisible(field.getVisible());
+            }
+
+            columns.addAttribute(col);
          }
 
          table.setColumnSelection(columns);
@@ -2298,6 +2305,11 @@ public class WizVsService {
                .map(this::createVSAggregateRef)
                .toArray(DataRef[]::new);
             cinfo.setDesignAggregates(aggrs);
+         }
+
+         // Crosstab-level percentage direction (paired with a PERCENT calculateInfo). Optional.
+         if(binding.getPercentageByValue() != null && !binding.getPercentageByValue().isEmpty()) {
+            cinfo.setPercentageByValue(binding.getPercentageByValue());
          }
 
          crosstab.setVSCrosstabInfo(cinfo);
@@ -2436,6 +2448,20 @@ public class WizVsService {
          ref.setRankingNValue(String.valueOf(ranking.getRankingN()));
          ref.setRankingColValue(ranking.getRankingCol());
          ref.setRankingOptionValue(String.valueOf(ranking.getOptionValue()));
+         ref.setGroupOthersValue(String.valueOf(ranking.isGroupOthers()));
+      }
+
+      if(field.getSortByCol() != null && !field.getSortByCol().isEmpty()) {
+         ref.setSortByColValue(field.getSortByCol());
+      }
+
+      if(field.getManualOrder() != null && !field.getManualOrder().isEmpty()) {
+         ref.setManualOrderList(new java.util.ArrayList<>(field.getManualOrder()));
+      }
+
+      // Crosstab subtotal visibility for this row/col dimension.
+      if(field.getSummarize() != null) {
+         ref.setSubTotalVisibleValue(String.valueOf(field.getSummarize()));
       }
 
       return ref;
@@ -2453,6 +2479,12 @@ public class WizVsService {
          ref.setSecondaryColumnValue(field.getSecondaryField());
       }
 
+      // Nth/Pth parameter (NthLargest/NthSmallest/NthMostFrequent/PthPercentile). Previously not
+      // applied on the crosstab path, so an N/P edit was silently dropped.
+      if(field.getNOrP() != null) {
+         ref.setN(field.getNOrP());
+      }
+
       if(field.getCalculateInfo() != null) {
          Calculator calc = field.getCalculateInfo().toCalculator();
 
@@ -2461,7 +2493,27 @@ public class WizVsService {
          }
       }
 
+      // Crosstab percentage display for this aggregate.
+      if(field.getPercentage() != null) {
+         ref.setPercentageOption(percentageOption(field.getPercentage()));
+      }
+
       return ref;
+   }
+
+   /**
+    * Map a wiz percentage name to the XConstants percentage option; unknown/"none" → NONE.
+    */
+   private static int percentageOption(String percentage) {
+      if(percentage == null) {
+         return XConstants.PERCENTAGE_NONE;
+      }
+
+      return switch(percentage.trim().toLowerCase()) {
+         case "grandtotal" -> XConstants.PERCENTAGE_OF_GRANDTOTAL;
+         case "group" -> XConstants.PERCENTAGE_OF_GROUP;
+         default -> XConstants.PERCENTAGE_NONE;
+      };
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -2379,6 +2379,10 @@ public class WizVsService {
          }
       }
 
+      // discrete / secondaryY applied independently (matching the editor); dropped here before this fix.
+      ref.setDiscrete(field.isDiscrete());
+      ref.setSecondaryY(field.isSecondaryY());
+
       return ref;
    }
 
@@ -2413,6 +2417,12 @@ public class WizVsService {
          ref.setRankingNValue(String.valueOf(ranking.getRankingN()));
          ref.setRankingColValue(ranking.getRankingCol());
          ref.setRankingOptionValue(String.valueOf(ranking.getOptionValue()));
+         // group-non-ranked-as-Others (core to Pareto); dropped here before this fix.
+         ref.setGroupOthersValue(String.valueOf(ranking.isGroupOthers()));
+      }
+
+      if(dim != null && dim.getSortByCol() != null && !dim.getSortByCol().isEmpty()) {
+         ref.setSortByColValue(dim.getSortByCol());
       }
 
       if(dim != null && dim.isNumericBin()) {


### PR DESCRIPTION
## What this branch changes, and why

Adds the create/apply binding capabilities the field-edit path exposes but the create-binding models lacked. Without a backing field these properties were silently dropped on deserialize (`@JsonIgnoreProperties(ignoreUnknown=true)`), so the corresponding edits were no-ops.

### Model additions
- `DimensionFieldInfo.sortByCol`, `Ranking.groupOthers` — value-sort column and group-non-ranked-as-Others.
- `MeasureFieldInfo.discrete`, `MeasureFieldInfo.secondaryY` — plot un-aggregated / on the secondary Y axis (mutually exclusive).
- `SimpleFieldInfo.visible` — hide a table detail column.
- `DimensionFieldInfo.summarize` — crosstab subtotal visibility.
- `MeasureFieldInfo.percentage`, `CrosstabBinding.percentageByValue` — crosstab percentage display + direction.

### Apply wiring
- `WizAutoBindingService.applyFieldConfig`: apply groupOthers, sortByCol, discrete, secondaryY (discrete forces secondaryY off — mutually exclusive).
- `WizVsService`: table `visible` (ColumnRef.setVisible); crosstab `createVSDimensionRef` now applies groupOthers/sortByCol/manualOrder/summarize; crosstab `createVSAggregateRef` now applies nOrP (previously dropped) and percentage; crosstab-level percentageByValue.
- `WizFieldInfoFactory`: echo the new fields back so `get_current_chart_state` round-trips. calculateInfo `CUSTOM` subtype is already supported by the backend.

### Why
These properties are the create-side counterparts of what the field-edit binding already accepts. Aligning the create/apply models lets the recommender and the plugin's create tool set ranking-others, discrete/secondary-axis, table column visibility, and crosstab subtotals/percentage, and closes several silent-drop gaps (notably crosstab nOrP).
