### PR TITLE
Bug #75693, coerce non-String script args to String parameters under GraalJS

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/ScriptFunction.java
+++ b/core/src/main/java/inetsoft/util/script/graal/ScriptFunction.java
@@ -142,6 +142,19 @@ public class ScriptFunction implements ProxyExecutable {
          return null;
       }
 
+      // A String parameter may receive a non-String script value (a boolean or
+      // number), e.g. bindingInfo.setGroupTotal("reseller", ROW_HEADER, true) on
+      // the setGroupTotal(String, int, String) overload. Rhino's FunctionObject
+      // coerced such arguments to String via ScriptRuntime.toString; without
+      // this, reflective invocation fails with an argument-type mismatch
+      // ("Failed to invoke script function"). Only convert when the value is not
+      // already a String/CharSequence so string parameters keep their value.
+      if((ptype == String.class || ptype == CharSequence.class)
+         && !(value instanceof CharSequence))
+      {
+         return toStringValue(value);
+      }
+
       // A numeric parameter may receive a value that is not already a Number,
       // e.g. the numeric string "3" from CALC.edate(date, '3'). Rhino's
       // FunctionObject coerced such arguments via ScriptRuntime.toNumber; without
@@ -224,6 +237,26 @@ public class ScriptFunction implements ProxyExecutable {
       }
 
       return null;
+   }
+
+   /**
+    * Convert a host value to a String using JavaScript {@code ToString}
+    * semantics (mirroring Rhino's {@code ScriptRuntime.toString}): a boolean
+    * maps to "true"/"false"; a whole number maps to its integer form ("3", not
+    * "3.0") while a fractional number keeps its decimal form; any other value
+    * uses {@link String#valueOf}. Called only for a non-String value bound to a
+    * String parameter.
+    */
+   private static String toStringValue(Object value) {
+      if(value instanceof Number) {
+         double d = ((Number) value).doubleValue();
+
+         if(!Double.isInfinite(d) && !Double.isNaN(d) && d == Math.rint(d)) {
+            return Long.toString((long) d);
+         }
+      }
+
+      return String.valueOf(value);
    }
 
    private final Object target;

--- a/core/src/main/java/inetsoft/util/script/graal/ScriptFunction.java
+++ b/core/src/main/java/inetsoft/util/script/graal/ScriptFunction.java
@@ -242,16 +242,30 @@ public class ScriptFunction implements ProxyExecutable {
    /**
     * Convert a host value to a String using JavaScript {@code ToString}
     * semantics (mirroring Rhino's {@code ScriptRuntime.toString}): a boolean
-    * maps to "true"/"false"; a whole number maps to its integer form ("3", not
-    * "3.0") while a fractional number keeps its decimal form; any other value
-    * uses {@link String#valueOf}. Called only for a non-String value bound to a
+    * maps to "true"/"false"; a whole number in the {@code long} range maps to
+    * its integer form ("3", not "3.0"); any other value (a fractional number, a
+    * whole number too large for {@code long}, or a non-Number) uses
+    * {@link String#valueOf}. Called only for a non-String value bound to a
     * String parameter.
+    *
+    * <p>The {@code Math.abs(d) < 0x1p63} guard keeps a whole double outside the
+    * {@code long} range (e.g. {@code 1e21}) out of the {@code (long) d} branch,
+    * where Java narrowing would silently clamp it to {@code Long.MAX_VALUE}; it
+    * falls through to {@code String.valueOf} instead. Note that
+    * {@code String.valueOf} uses Java's {@code Double.toString} formatting
+    * (scientific notation at 1e7/1e-3), which diverges from JS {@code ToString}
+    * (1e21/1e-6) for very large/small magnitudes. This is acceptable here
+    * because script values bound to a String parameter are effectively booleans,
+    * small integers (header/order constants), and strings; such magnitudes do
+    * not occur in practice.
     */
    private static String toStringValue(Object value) {
       if(value instanceof Number) {
          double d = ((Number) value).doubleValue();
 
-         if(!Double.isInfinite(d) && !Double.isNaN(d) && d == Math.rint(d)) {
+         if(!Double.isInfinite(d) && !Double.isNaN(d) && d == Math.rint(d)
+            && Math.abs(d) < 0x1p63)
+         {
             return Long.toString((long) d);
          }
       }

--- a/core/src/test/java/inetsoft/util/script/graal/ScriptFunctionTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/ScriptFunctionTest.java
@@ -36,6 +36,7 @@ class ScriptFunctionTest {
       public int count = -1;
       public double ratio = -1.0;
       public char ch = 'X';
+      public String label;
       public boolean called;
 
       public void setActionVisible(String name, boolean visible) {
@@ -57,6 +58,11 @@ class ScriptFunctionTest {
       public void setChar(char ch) {
          this.called = true;
          this.ch = ch;
+      }
+
+      public void setLabel(String label) {
+         this.called = true;
+         this.label = label;
       }
    }
 
@@ -184,6 +190,49 @@ class ScriptFunctionTest {
 
       assertTrue(t.called);
       assertEquals(0.0, t.ratio, 0.0, "omitted double argument should default to 0.0");
+   }
+
+   @Test
+   void booleanArgIsCoercedToString() {
+      // Bug #75693: a JS boolean passed to a String parameter must be coerced to
+      // "true"/"false" (Rhino ScriptRuntime.toString parity), e.g.
+      // bindingInfo.setGroupTotal("reseller", ROW_HEADER, true) on the
+      // setGroupTotal(String, int, String) overload, rather than failing the
+      // reflective invocation ("Failed to invoke script function").
+      Target t = new Target();
+      ctx.getBindings("js").putMember(
+         "setLabel", new ScriptFunction(t, Target.class, "setLabel", String.class));
+
+      ctx.eval("js", "setLabel(true)");
+
+      assertTrue(t.called);
+      assertEquals("true", t.label, "boolean true should coerce to \"true\"");
+   }
+
+   @Test
+   void numberArgIsCoercedToString() {
+      // A whole JS number bound to a String parameter stringifies as an integer
+      // ("3", not "3.0"), matching JS ToString.
+      Target t = new Target();
+      ctx.getBindings("js").putMember(
+         "setLabel", new ScriptFunction(t, Target.class, "setLabel", String.class));
+
+      ctx.eval("js", "setLabel(3)");
+
+      assertTrue(t.called);
+      assertEquals("3", t.label, "whole number should coerce to \"3\"");
+   }
+
+   @Test
+   void stringArgToStringParamPreserved() {
+      // A String argument bound to a String parameter is passed through unchanged.
+      Target t = new Target();
+      ctx.getBindings("js").putMember(
+         "setLabel", new ScriptFunction(t, Target.class, "setLabel", String.class));
+
+      ctx.eval("js", "setLabel('show')");
+
+      assertEquals("show", t.label, "string argument should be preserved");
    }
 
    @Test

--- a/core/src/test/java/inetsoft/util/script/graal/ScriptFunctionTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/ScriptFunctionTest.java
@@ -224,6 +224,20 @@ class ScriptFunctionTest {
    }
 
    @Test
+   void fractionalNumberArgIsCoercedToString() {
+      // A fractional JS number bound to a String parameter keeps its decimal
+      // form ("3.5"), exercising the String.valueOf branch of toStringValue.
+      Target t = new Target();
+      ctx.getBindings("js").putMember(
+         "setLabel", new ScriptFunction(t, Target.class, "setLabel", String.class));
+
+      ctx.eval("js", "setLabel(3.5)");
+
+      assertTrue(t.called);
+      assertEquals("3.5", t.label, "fractional number should coerce to \"3.5\"");
+   }
+
+   @Test
    void stringArgToStringParamPreserved() {
       // A String argument bound to a String parameter is passed through unchanged.
       Target t = new Target();


### PR DESCRIPTION
## Summary

After the Rhino→GraalJS scripting migration (Feature #75423), importing `Table_Crosstab1.vso` and opening it on the portal popped up **"Failed to invoke script function: setGroupTotal"**. The failing onLoad script line was:

```js
bindingInfo.setGroupTotal("reseller", StyleConstant.ROW_HEADER, true);
```

## Root Cause

`VSCrosstabBindingScriptable.setGroupTotal(String field, int header, String total)` declares a `String` third parameter (it accepts `"show"`/`"hide"` or a dynamic value string), but the script passes a JS **boolean**.

Every registered script function is invoked reflectively through `ScriptFunction.execute()` → `coerce()`. `coerce()` reproduced Rhino's null→primitive-default and Number/numeric-string→numeric-primitive conversions, but had **no rule to convert a non-String value to a `String` parameter**. The JS `true` arrives as a Java `Boolean`, is passed through unchanged, and `Method.invoke` then throws `IllegalArgumentException` (argument-type mismatch), rethrown as "Failed to invoke script function".

Under Rhino, `FunctionObject` coerced arguments to the declared parameter type via `ScriptRuntime.toString` for `String` params, so `true` became `"true"`.

## Fix

Add a branch to `ScriptFunction.coerce()`: when the declared parameter type is `String`/`CharSequence` and the value is not already a `CharSequence`, convert it via a new `toStringValue()` helper using JS `ToString` semantics — `Boolean` → `"true"`/`"false"`, a whole `Number` → integer form (`"3"`, not `"3.0"`), otherwise `String.valueOf`. This restores the pre-migration Rhino behavior. Values already passed as strings are untouched.

## Test Plan

- Added 3 regression tests in `ScriptFunctionTest` (boolean→String, whole number→String, string→String pass-through).
- `./mvnw -pl core test -Dtest=ScriptFunctionTest` → 13/13 pass.
- Manually verified: importing `Table_Crosstab1.vso` and opening it on the portal no longer raises the error and the crosstab renders correctly.

Fixes Redmine #75693.