### PR TITLE
bug-75664-1: fix null Change from previous when part-date-group field is ranked

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/data/DataSetRouter.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/data/DataSetRouter.java
@@ -58,10 +58,15 @@ public class DataSetRouter extends AbstractRouter {
          }
       }
 
-      comp = data.getComparator(field);
+      // Part-date-group fields (HourOfDay, DayOfWeek, MonthOfYear, Quarter) must navigate
+      // previous/next in natural calendar order regardless of any value-based sort/ranking
+      // comparator (e.g. a Top-N "Sort By Value" ranking) applied for display purposes —
+      // "previous hour" has no meaning in rank-value order. Only fall back to the dataset's
+      // own comparator for fields where no natural calendar order applies.
+      comp = getPartDateGroupComparator(data, field);
 
       if(comp == null) {
-         comp = getPartDateGroupComparator(data, field);
+         comp = data.getComparator(field);
       }
 
       if(comp != null) {
@@ -73,11 +78,13 @@ public class DataSetRouter extends AbstractRouter {
    }
 
    /**
-    * Fallback natural-order comparator for part-date-group dimensions (HourOfDay, DayOfWeek,
-    * MonthOfYear, Quarter, etc.) when no explicit sort comparator is configured. Values for
+    * Natural-order comparator for part-date-group dimensions (HourOfDay, DayOfWeek,
+    * MonthOfYear, Quarter, etc.), used in preference to any value-based sort/ranking
+    * comparator configured on the field (e.g. a Top-N "Sort By Value" ranking). Values for
     * these dimensions are always emitted as Integer, so numeric order is the natural calendar
-    * order. Scoped to previous/next calc navigation only (this router) — does not affect
-    * axis/legend ordering, which is controlled separately by CategoricalScale.
+    * order, and previous/next navigation only makes sense in that order. Scoped to
+    * previous/next calc navigation only (this router) — does not affect axis/legend
+    * ordering, which is controlled separately by CategoricalScale.
     */
    private static Comparator getPartDateGroupComparator(DataSet data, String field) {
       DataSet root = data instanceof DataSetFilter

--- a/core/src/test/java/inetsoft/report/composition/graph/calc/ValueOfColumnTest.java
+++ b/core/src/test/java/inetsoft/report/composition/graph/calc/ValueOfColumnTest.java
@@ -323,6 +323,51 @@ public class ValueOfColumnTest {
    }
 
    /**
+    * Regression test for Bug #75664 (ranking follow-up): PREVIOUS navigation on a
+    * part-date-group dimension (e.g. HourOfDay) must use natural calendar order even when
+    * the dimension has an explicit value-based sort comparator — as set by a Top-N/Bottom-N
+    * "Sort By Value" ranking. Without the fix, DataSetRouter would sort by the ranking's
+    * value order (e.g. by Sum(contact_id) desc) instead of numeric hour order, so "previous
+    * hour" would resolve to the wrong row or incorrectly return INVALID.
+    *
+    * Data is intentionally NOT in either row order or hour order (row order: 5, 2, 11), and
+    * the mock comparator sorts by an unrelated ranking value (id desc: 11, 5, 2) rather than
+    * by hour. Natural hour order is 2, 5, 11 — so "previous" of hour 5 must resolve to hour 2
+    * (id=20), not to whatever the ranking comparator would place before it.
+    */
+   @Test
+   void testPreviousOnPartDateGroupIgnoresRankingSortComparator() {
+      valueOfColumn = new ValueOfColumn("id", "sum(id)");
+      valueOfColumn.setChangeType(ValueOfCalc.PREVIOUS);
+      valueOfColumn.setDim("HourOfDay(order_time)");
+
+      DefaultTableLens tb = new DefaultTableLens(new Object[][]{
+         { "HourOfDay(order_time)", "id" },
+         { 5, 10 },
+         { 2, 20 },
+         { 11, 30 }
+      });
+
+      VSDimensionRef hourRef = mock(VSDimensionRef.class);
+      when(hourRef.getFullName()).thenReturn("HourOfDay(order_time)");
+      when(hourRef.getDateLevel()).thenReturn(XConstants.HOUR_OF_DAY_DATE_GROUP);
+      // Simulates a Top-N ranking's "Sort By Value" comparator: orders by id desc
+      // (11, 5, 2) rather than by natural hour order (2, 5, 11).
+      when(hourRef.createComparator(org.mockito.ArgumentMatchers.any()))
+         .thenReturn((a, b) -> Integer.compare((Integer) b, (Integer) a));
+
+      vsDataSet = new VSDataSet(tb, new VSDataRef[] { hourRef });
+
+      // Row 0 = hour 5. Natural-order previous is hour 2 (id=20).
+      Object result = valueOfColumn.calculate(vsDataSet, 0, false, false);
+      assertEquals(20, result);
+
+      // Row 1 = hour 2, the earliest hour → no previous → INVALID.
+      result = valueOfColumn.calculate(vsDataSet, 1, false, false);
+      assertEquals(CalcColumn.INVALID, result);
+   }
+
+   /**
     * check some basic functions
     */
    @Test


### PR DESCRIPTION
## Summary
- Follow-up to bug-75664: the earlier `DataSetRouter` fix only applied its natural numeric-order fallback for part-date-group dimensions (HourOfDay, DayOfWeek, MonthOfYear, Quarter) when the field had no explicit sort comparator.
- A Top-N/Bottom-N ranking with "Sort By Value" sets an explicit value-based comparator on the dimension, bypassing that fallback entirely — so "Change from previous" navigated by the ranking's value order instead of natural calendar order, producing wrong or null results (e.g. "Change from previous HourOfDay" blank at hour 5 when a Top-N ranking is applied to HourOfDay).
- Give the natural-order comparator priority over any value-based sort/ranking comparator for these fields, since "previous hour/day/month/quarter" only has meaning in calendar order.

## Test plan
- [x] Added `ValueOfColumnTest.testPreviousOnPartDateGroupIgnoresRankingSortComparator`, which mocks a ranking-style value comparator on an HourOfDay field and asserts "previous of hour 5" resolves to hour 2 (natural order) instead of whatever the ranking comparator would place before it.
- [x] Verified the new test fails without the fix (returns the ranking-order neighbor instead of the calendar-order neighbor) and passes with it.
- [x] `ValueOfColumnTest` (20 tests) and `ChangeColumnTest` (9 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)