### PR TITLE
Fix ShutdownException in ConditionItemTest and XConditionGroupTest (missing @SreeHome)

### DIFF
--- a/core/src/test/java/inetsoft/uql/ConditionItemTest.java
+++ b/core/src/test/java/inetsoft/uql/ConditionItemTest.java
@@ -17,14 +17,19 @@
  */
 package inetsoft.uql;
 
+import inetsoft.test.*;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.schema.XSchema;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.stream.Stream;
 
@@ -36,6 +41,10 @@ import static org.junit.jupiter.api.Assertions.*;
  * [ConditionItem] writeXML(PrintWriter) / parseXML(Element) - XML serialization round-trip,
  *             not branching logic; descoped per reviewer guidance.
  */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class, PluginsTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
 @Tag("core")
 class ConditionItemTest {
 

--- a/core/src/test/java/inetsoft/uql/XConditionGroupTest.java
+++ b/core/src/test/java/inetsoft/uql/XConditionGroupTest.java
@@ -18,9 +18,14 @@
 package inetsoft.uql;
 
 import inetsoft.report.filter.DCMergeCell;
+import inetsoft.test.*;
 import inetsoft.uql.schema.XSchema;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -58,6 +63,10 @@ import static org.junit.jupiter.api.Assertions.*;
  *             this [unit]-tier file. The simpler DCMergeCell branch (no subCol) is covered
  *             directly below since DCMergeCell is a plain single-method interface.
  */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class, PluginsTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
 @Tag("core")
 public class XConditionGroupTest {
 


### PR DESCRIPTION
## Problem

The tagged `core` CI job fails with 41 errors, all `inetsoft.util.ShutdownException: Spring application context is not available`, in two classes:

- `inetsoft.uql.ConditionItemTest` (25 errors)
- `inetsoft.uql.XConditionGroupTest` (16 errors)

## Root cause

Both classes construct/evaluate `Condition` objects:

- `new Condition()` → `Tool.isCaseSensitive()` → `SreeEnv.getProperty(...)`
- `Condition.evaluate()` → `CoreTool.getCollator()` → `SreeEnv.getProperty(...)`

`SreeEnv` requires a live Spring `ApplicationContext`, which in the test harness is provided only by the `@SreeHome` extension. **Neither class declared `@SreeHome`.**

These classes were newly tagged `@Tag("core")` in #4309, so the tagged CI job ran them for the first time. They appeared to pass intermittently only because `Tool.isCaseSensitive()` (`sinited`) and `CoreTool.getCollator()` (`hasCollator`) cache their result in JVM-wide statics — if an earlier `@SreeHome` test warmed those statics first, the later tests never hit Spring. Run cold, or ahead of any cache-warming test (the shared context is nulled after every `@SreeHome` class), the `SreeEnv` lookup throws.

Reproduced deterministically: running `ConditionItemTest` in isolation fails all 25 with `ShutdownException`.

## Fix

Add the standard `SpringExtension` + `@ContextConfiguration` + `@SreeHome` setup block (matching peer core tests such as `XNodeTableTest`) so both classes provide their own context.

## Verification

Both classes now pass **in isolation** (strongest check — no sibling test to incidentally warm the static caches):

```
Tests run: 52, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

The other 5 files newly tagged in #4309 (`AbstractConditionTest`, `ColumnSelectionTest`, `DrillPathTest`, `VariableTableTest`, `XFormatInfoTest`) were also checked in isolation — all pass and never touch the `SreeEnv` path, so no change is needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)