### PR TITLE
Bug #75698, don't re-materialize merged SQL group expressions as JS formulas

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -1498,6 +1498,18 @@ public abstract class AssetQuery extends PreAssetQuery {
          return false;
       }
 
+      // A SQL expression on a mergeable source is computed by the data source and is
+      // already present in the base table; it must not be re-materialized as a script
+      // formula, which would evaluate the SQL text as JavaScript. (Bug #75698)
+      try {
+         if(column.isSQL() && isSourceMergeable() && isMergePreferred()) {
+            return false;
+         }
+      }
+      catch(Exception ex) {
+         // fall through and treat as a grouped expression
+      }
+
       AggregateInfo info = getAggregateInfo();
       return info != null && (info.containsGroup(column) ||
          info.getGroup(column) != null || info.getGroup(column.getName()) != null);


### PR DESCRIPTION
## Summary

On a mergeable data source (e.g. Oracle), a worksheet column whose formula is a **SQL** expression failed to load data when that column was changed to a **group** dimension. The error surfaced as a JavaScript syntax error because the raw SQL text was being evaluated by the script engine:

```
i.r.l.FormulaTableLens: JavaScript error: SyntaxError: <cmd>:2:8 Expected ) but found ORDERS
(select ORDERS.CATEGORIES.CATEGORY_ID as CATEGORY_ID from ORDERS.CATEGORIES where ...)
```

## Root Cause

Regression from bug #74855 (commit a58f665f7). That change added `isGroupedExpression()` and a `!groupedExpression` guard in `AssetQuery.getFormulaTableLens()` so that any expression column used as a group dimension is always re-materialized as a formula (needed for an in-memory histogram range column that had been stripped from the base table).

The override is too broad: a SQL expression on a mergeable source is pushed into the SQL `SELECT`/`GROUP BY` by `merge()`, computed by the database, and already present in the base table. Forcing it through `PostProcessor.formula` evaluates the SQL text as JavaScript, producing the syntax error.

## Fix

In `AssetQuery.isGroupedExpression()`, return `false` for a SQL expression on a mergeable source (`column.isSQL() && isSourceMergeable() && isMergePreferred()`), so it is trusted as-is from the base table and never re-materialized as a script formula. The `isSourceMergeable()` call is wrapped in try/catch (it declares `throws Exception`), mirroring the existing pattern in `addExpression()`.

The consuming skip in `getFormulaTableLens()` still requires `AssetUtil.findColumn(base, column, true) >= 0`, so the bug #74855 case (an in-memory range expression, not SQL, that is absent from the base) is still materialized — no regression.

## Test Plan

- Link an Oracle datasource, open worksheet `formula`, show live data with the SQL formula column set as a group → data loads, no "expression failed / JavaScript SyntaxError".
- Verify bug #74855 histogram data-tip range grouping still works.
- `./mvnw clean install -pl core -am -DskipTests` succeeds; `AssetQueryTest` passes.

Fixes Redmine #75698.