### PR TITLE
Bug #75676, optimize GraalJS calc-table scripting via scope-resolution caching

### DIFF
--- a/core/src/main/java/inetsoft/report/script/formula/AssetQueryScope.java
+++ b/core/src/main/java/inetsoft/report/script/formula/AssetQueryScope.java
@@ -138,8 +138,28 @@ public class AssetQueryScope implements DynamicScope, Cloneable {
       try {
          Worksheet ws = box.getWorksheet();
 
-         if(ws != null && ws.getAssembly(id) instanceof TableAssembly) {
-            return true;
+         if(ws != null) {
+            // mirror getMember's tablemap caching: GraalJS wraps scripts in
+            // with(__scope__){...} and calls hasMember for every identifier in
+            // every per-cell/per-row evaluation. Without this cache each call
+            // hits ws.getAssembly(id), and a miss rebuilds the entire worksheet
+            // assembly map (Worksheet.createCache), an O(cells x names x
+            // assemblies) explosion that makes calc tables take 30+s. (#75676)
+            Object val = tablemap.get(id);
+
+            if(val == null) {
+               if(ws.getAssembly(id) instanceof TableAssembly) {
+                  val = new TableAssemblyScriptable(id, box, mode);
+                  tablemap.put(id, val);
+               }
+               else {
+                  tablemap.put(id, NOT_TABLE);
+               }
+            }
+
+            if(val instanceof TableArray) {
+               return true;
+            }
          }
       }
       catch(Exception ex) {

--- a/core/src/main/java/inetsoft/report/script/formula/AssetQueryScope.java
+++ b/core/src/main/java/inetsoft/report/script/formula/AssetQueryScope.java
@@ -104,24 +104,8 @@ public class AssetQueryScope implements DynamicScope, Cloneable {
    @Override
    public Object getMember(String id) {
       try {
-         Worksheet ws = box.getWorksheet();
-
-         if(ws != null) {
-            Object val = tablemap.get(id);
-
-            if(val == null) {
-               if(ws.getAssembly(id) instanceof TableAssembly) {
-                  val = new TableAssemblyScriptable(id, box, mode);
-                  tablemap.put(id, val);
-               }
-               else {
-                  tablemap.put(id, NOT_TABLE);
-               }
-            }
-
-            if(val instanceof TableArray) {
-               return val;
-            }
+         if(getTableValue(id) instanceof TableArray val) {
+            return val;
          }
       }
       catch(Exception ex) {
@@ -136,30 +120,8 @@ public class AssetQueryScope implements DynamicScope, Cloneable {
    @Override
    public boolean hasMember(String id) {
       try {
-         Worksheet ws = box.getWorksheet();
-
-         if(ws != null) {
-            // mirror getMember's tablemap caching: GraalJS wraps scripts in
-            // with(__scope__){...} and calls hasMember for every identifier in
-            // every per-cell/per-row evaluation. Without this cache each call
-            // hits ws.getAssembly(id), and a miss rebuilds the entire worksheet
-            // assembly map (Worksheet.createCache), an O(cells x names x
-            // assemblies) explosion that makes calc tables take 30+s. (#75676)
-            Object val = tablemap.get(id);
-
-            if(val == null) {
-               if(ws.getAssembly(id) instanceof TableAssembly) {
-                  val = new TableAssemblyScriptable(id, box, mode);
-                  tablemap.put(id, val);
-               }
-               else {
-                  tablemap.put(id, NOT_TABLE);
-               }
-            }
-
-            if(val instanceof TableArray) {
-               return true;
-            }
+         if(getTableValue(id) instanceof TableArray) {
+            return true;
          }
       }
       catch(Exception ex) {
@@ -167,6 +129,41 @@ public class AssetQueryScope implements DynamicScope, Cloneable {
       }
 
       return members.containsKey(id);
+   }
+
+   /**
+    * Resolve {@code id} to its cached scriptable (a {@link TableArray}) or the
+    * {@code NOT_TABLE} sentinel, populating the {@code tablemap} cache on first
+    * lookup; returns {@code null} when no worksheet is available.
+    *
+    * <p>Shared by {@link #getMember} and {@link #hasMember} so the two cannot
+    * drift out of sync. GraalJS wraps scripts in {@code with(__scope__){...}} and
+    * calls hasMember for every identifier in every per-cell/per-row evaluation;
+    * without this cache each call hits {@code ws.getAssembly(id)}, and a miss
+    * rebuilds the entire worksheet assembly map ({@code Worksheet.createCache}),
+    * an O(cells x names x assemblies) explosion that makes calc tables take 30+s.
+    * (#75676)
+    */
+   private Object getTableValue(String id) throws Exception {
+      Worksheet ws = box.getWorksheet();
+
+      if(ws == null) {
+         return null;
+      }
+
+      Object val = tablemap.get(id);
+
+      if(val == null) {
+         if(ws.getAssembly(id) instanceof TableAssembly) {
+            val = new TableAssemblyScriptable(id, box, mode);
+            tablemap.put(id, val);
+         }
+         else {
+            tablemap.put(id, NOT_TABLE);
+         }
+      }
+
+      return val;
    }
 
    @Override

--- a/core/src/main/java/inetsoft/util/script/Calc.java
+++ b/core/src/main/java/inetsoft/util/script/Calc.java
@@ -23,8 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
-import java.util.Hashtable;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Mark a class as an array. Used in autocompletion only.
@@ -84,7 +84,14 @@ public class Calc implements ScriptScope {
    public Object getMember(String id) {
       // getMember may be called before the constructor is completed
       if(funcmap != null) {
-         return funcmap.get(id.toLowerCase());
+         // funcmap is a case-insensitive map, so look up the name directly.
+         // This is the terminal fallback of BindingRootProxy's scope-chain walk
+         // and runs for every unqualified identifier reference in every per-cell
+         // /per-row script evaluation; the previous id.toLowerCase() allocated a
+         // fresh lowercased String on each call for any mixed-case name (e.g. the
+         // camelCase CALC function names mapList/addMapData), a hot allocation
+         // under GraalJS that had no Rhino equivalent. (#75676)
+         return funcmap.get(id);
       }
 
       return null;
@@ -116,7 +123,11 @@ public class Calc implements ScriptScope {
    }
 
    private ScriptScope parent;
-   private Map<String, ScriptFunction> funcmap = new Hashtable<>(); // name -> ScriptFunction
+   // case-insensitive so lookups need no per-call toLowerCase allocation; only
+   // written in the constructor, read-only (and safe for concurrent reads)
+   // afterward -- putMember is a no-op. (#75676)
+   private final Map<String, ScriptFunction> funcmap =
+      new TreeMap<>(String.CASE_INSENSITIVE_ORDER); // name -> ScriptFunction
 
    private static final Logger LOG = LoggerFactory.getLogger(Calc.class);
 }

--- a/core/src/main/java/inetsoft/util/script/graal/BindingRootProxy.java
+++ b/core/src/main/java/inetsoft/util/script/graal/BindingRootProxy.java
@@ -174,20 +174,28 @@ public class BindingRootProxy implements ProxyObject {
       return context != null && context.getBindings("js").hasMember(name);
    }
 
-   // Permanent cache of the exact-name global-binding test. Global bindings are
-   // installed once at engine init and stable for the engine's lifetime, so the
-   // answer never changes. Single-threaded per engine (engine lock). (#75676)
-   private final Map<String, Boolean> globalBindingCache = new HashMap<>();
+   // Cache of the exact-name global-binding test. Only a 'true' answer is cached,
+   // and permanently: a global, once installed, stays for the engine's lifetime.
+   // A 'false' answer is deliberately NOT cached -- the GraalJS Context (and its
+   // globalThis) is reused across same-org renders on a pooled thread (see
+   // FormulaEvaluator), so a later formula's top-level var/function can turn a
+   // previously-absent name into a real global; a cached 'false' would then keep
+   // shadowing it via the builtin/CALC scope. Recomputing 'false' is cheap and
+   // rare -- profiling shows ~98% of probes reaching here are real globals (i.e.
+   // cached 'true'). Single-threaded per engine (engine lock). (#75676)
+   private final Set<String> globalBindingCache = new HashSet<>();
 
    private boolean isGlobalBinding(String name) {
-      Boolean cached = globalBindingCache.get(name);
-
-      if(cached != null) {
-         return cached;
+      if(globalBindingCache.contains(name)) {
+         return true;
       }
 
       boolean present = hasGlobalBinding(name);
-      globalBindingCache.put(name, present);
+
+      if(present) {
+         globalBindingCache.add(name);
+      }
+
       return present;
    }
 

--- a/core/src/main/java/inetsoft/util/script/graal/BindingRootProxy.java
+++ b/core/src/main/java/inetsoft/util/script/graal/BindingRootProxy.java
@@ -91,6 +91,13 @@ public class BindingRootProxy implements ProxyObject {
    public ScriptScope swapGlobal(ScriptScope newGlobal) {
       ScriptScope prev = global;
       global = newGlobal;
+      // A reused root scope can be mutated in place between execs while keeping
+      // the same identity -- CalcCellScope/CrosstabCellScope.setCell(row,col)
+      // changes which group/dimension names it exposes -- which the root-identity
+      // check in inChain() cannot see. Binding the chain-membership cache to a
+      // single exec keeps it correct: within one exec the chain's membership is
+      // immutable apart from putMember (which also clears). (#75676)
+      invalidateChainCache();
       return prev;
    }
 
@@ -111,9 +118,11 @@ public class BindingRootProxy implements ProxyObject {
     * member that is simply absent.
     */
    private Object findInChain(String name) {
-      for(ScriptScope s = global; s != null; s = s.getParentScope()) {
-         if(s.hasMember(name)) {
-            return s.getMember(name);
+      if(inChain(name)) {
+         for(ScriptScope s = global; s != null; s = s.getParentScope()) {
+            if(s.hasMember(name)) {
+               return s.getMember(name);
+            }
          }
       }
 
@@ -134,6 +143,15 @@ public class BindingRootProxy implements ProxyObject {
          }
       }
 
+      // A real js global binding resolves natively via with(...) fall-through, so
+      // report it absent here -- before the terminal Calc probe, so the ~98%
+      // "global function, not in chain" case skips that probe. Equivalent to the
+      // old `builtin != null && !hasGlobalBinding` guard, which likewise refused
+      // to return a builtin that had an exact global binding. (#75676)
+      if(isGlobalBinding(name)) {
+         return NOT_FOUND;
+      }
+
       // case-insensitive CALC functions (Rhino's global-scope prototype). Only
       // when the name has no exact global binding, so JS builtins (Date) and the
       // lowercase CALC copies are never shadowed. This is only reached after the
@@ -143,7 +161,7 @@ public class BindingRootProxy implements ProxyObject {
       if(builtinScope != null) {
          Object builtin = builtinScope.getMember(name);
 
-         if(builtin != null && !hasGlobalBinding(name)) {
+         if(builtin != null) {
             return builtin;
          }
       }
@@ -154,6 +172,62 @@ public class BindingRootProxy implements ProxyObject {
    /** Whether {@code name} is an exact (case-sensitive) member of the JS global scope. */
    private boolean hasGlobalBinding(String name) {
       return context != null && context.getBindings("js").hasMember(name);
+   }
+
+   // Permanent cache of the exact-name global-binding test. Global bindings are
+   // installed once at engine init and stable for the engine's lifetime, so the
+   // answer never changes. Single-threaded per engine (engine lock). (#75676)
+   private final Map<String, Boolean> globalBindingCache = new HashMap<>();
+
+   private boolean isGlobalBinding(String name) {
+      Boolean cached = globalBindingCache.get(name);
+
+      if(cached != null) {
+         return cached;
+      }
+
+      boolean present = hasGlobalBinding(name);
+      globalBindingCache.put(name, present);
+      return present;
+   }
+
+   // Per-chain-root cache of "is name provided by the scope chain?" The calc table
+   // swaps in a fresh root scope per evaluation, so the cache is keyed on the root
+   // identity and dropped when the root changes; within one root the same names
+   // are probed repeatedly. Uses the real hasMember walk, so it stays correct for
+   // scopes with dynamic (non-enumerated) members. Cleared on putMember, which can
+   // add a name to a chain scope. (#75676)
+   private ScriptScope chainCacheRoot;
+   private final Map<String, Boolean> chainCache = new HashMap<>();
+
+   private void invalidateChainCache() {
+      chainCache.clear();
+      chainCacheRoot = null;
+   }
+
+   private boolean inChain(String name) {
+      if(chainCacheRoot != global) {
+         chainCache.clear();
+         chainCacheRoot = global;
+      }
+
+      Boolean cached = chainCache.get(name);
+
+      if(cached != null) {
+         return cached;
+      }
+
+      boolean found = false;
+
+      for(ScriptScope s = global; s != null; s = s.getParentScope()) {
+         if(s.hasMember(name)) {
+            found = true;
+            break;
+         }
+      }
+
+      chainCache.put(name, found);
+      return found;
    }
 
    /** Resolve a name through the full chain; returns null if not found. */
@@ -196,6 +270,9 @@ public class BindingRootProxy implements ProxyObject {
    @Override public boolean hasMember(String key) { return resolves(key); }
    @Override public Object getMemberKeys() { return enumerate().toArray(new String[0]); }
    @Override public void putMember(String key, Value value) {
+      // a write can create a new name on a chain scope, so the "is name in chain?"
+      // answer for the current root may change; drop the cache. (#75676)
+      invalidateChainCache();
       Object host = ScriptValueConverter.toHost(value);
 
       // Rhino scope-chain write semantics: an unqualified assignment to a name

--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -279,7 +279,8 @@ public class GraalJavaScriptEngine implements AutoCloseable {
 
          // Rhino set the Calc scope as the global scope's prototype
          // (globalscope.setPrototype(new Calc())), and Calc's member lookup is
-         // case-insensitive (funcmap.get(id.toLowerCase())). So unqualified
+         // case-insensitive (funcmap is a TreeMap ordered by
+         // String.CASE_INSENSITIVE_ORDER). So unqualified
          // CALC/statistical functions resolved regardless of case, e.g.
          // NthMostFrequent, PthPercentile, Sum. GraalJS global bindings are
          // case-sensitive, so the lowercase copies above only match exact-case

--- a/core/src/test/java/inetsoft/util/script/graal/BindingRootProxyTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/BindingRootProxyTest.java
@@ -95,4 +95,37 @@ class BindingRootProxyTest {
       assertEquals("updated", parent.getMember("pv"));   // parent updated
       assertNull(global.getMember("pv"));                // no stale shadow on root
    }
+
+   // A root scope object can be reused across execs and mutated in place while
+   // keeping the same identity -- CalcCellScope/CrosstabCellScope.setCell(row,col)
+   // changes which group/dimension names it exposes between range-condition
+   // evaluations. The chain-membership cache is keyed on root identity, so it must
+   // be invalidated on swapGlobal (a new exec) or it would report a stale
+   // presence/absence for the previous cell. (Regression guard for #75676.)
+   @Test void chainCacheInvalidatedWhenReusedRootMutatedAcrossExec() {
+      class CellScope implements ScriptScope {
+         boolean present;   // toggled in place, like setCell moving to a new cell
+         public Object getMember(String n) { return present && "x".equals(n) ? 11 : null; }
+         public boolean hasMember(String n) { return present && "x".equals(n); }
+         public void putMember(String n, Object v) { }
+         public Object[] getMemberKeys() { return present ? new Object[]{ "x" } : new Object[0]; }
+      }
+
+      CellScope scope = new CellScope();
+      BindingRootProxy root = new BindingRootProxy(scope, () -> null);
+
+      // exec 1: "x" absent for this cell -> caches "x not in chain"
+      root.swapGlobal(scope);
+      scope.present = false;
+      assertFalse(root.hasMember("x"));
+      assertNull(root.resolve("x"));
+
+      // between execs the SAME object is mutated to the next cell, where "x" exists
+      scope.present = true;
+
+      // exec 2: swapGlobal must drop the stale cache so the live membership is seen
+      root.swapGlobal(scope);
+      assertTrue(root.hasMember("x"), "stale chain-cache absence after in-place mutation");
+      assertEquals(11, root.resolve("x"));
+   }
 }

--- a/core/src/test/java/inetsoft/util/script/graal/BindingRootProxyTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/BindingRootProxyTest.java
@@ -128,4 +128,30 @@ class BindingRootProxyTest {
       assertTrue(root.hasMember("x"), "stale chain-cache absence after in-place mutation");
       assertEquals(11, root.resolve("x"));
    }
+
+   // isGlobalBinding must not permanently cache a 'false'. The GraalJS Context
+   // (and its globalThis) is reused across same-org renders on a pooled thread,
+   // so a later formula's top-level var/function can turn a previously-absent
+   // name into a real global. A cached 'false' would keep resolving that name via
+   // the builtin/CALC scope instead of yielding to the now-real global. (Regression
+   // guard for #75676.)
+   @Test void globalBindingCacheDoesNotStaleFalseWhenGlobalAddedLater() {
+      MapScope global = new MapScope(null);
+      MapScope builtin = new MapScope(null);
+      builtin.putMember("late", 111);   // a CALC-style builtin that would shadow
+
+      BindingRootProxy root = new BindingRootProxy(global, () -> null, n -> true, ctx);
+      root.setBuiltinScope(builtin);
+
+      // before: "late" is not a real global -> resolves via the builtin scope
+      assertEquals(111, root.resolve("late"));
+
+      // a later same-org render introduces a real global with that name
+      ctx.getBindings("js").putMember("late", 222);
+
+      // now "late" must be treated as a real global: reported absent here so
+      // with(...) resolves it natively, NOT the stale builtin
+      assertNull(root.resolve("late"));
+      assertFalse(root.hasMember("late"));
+   }
 }


### PR DESCRIPTION
## Summary

Opening the `FreeExecution/BindingOptions/DateManualSort` freehand/calc-table
viewsheet took 30–58s after the Rhino→GraalJS script-engine migration (#75423).
The cost is a per-cell JavaScript formula plus a per-row condition script for the
manual-sort named cell range — a very large number of short script evaluations
whose *count* is unchanged from the Rhino era, but whose *per-evaluation* cost
regressed under GraalJS.

This PR brings the warm render to **Rhino parity**: **~22s → ~7.8s** on GraalVM
(≈2.8×), with **total sampled CPU down ~65%** and **byte-identical exported
output**.

## Background: the runtime is the first (separate) fix

The single largest cause was that GraalJS ran **interpreter-only**
(`DefaultTruffleRuntime`, no JIT) on stock OpenJDK (`eclipse-temurin:21`), which
lacks libgraal (startup log: `[engine] WARNING: ... fallback runtime ... JVMCI is
not enabled`). Running on **GraalVM for JDK 21** enables the Truffle JIT and is
the biggest single win (~58s → ~33s). That base-image switch is handled as a
**separate infrastructure change** given its deployment blast radius. The code
changes in this PR are on top of the GraalVM runtime and close the remaining gap.

## What this PR changes

Under GraalJS, scripts run wrapped in `with(__scope__){...}`, so `BindingRootProxy`
(bound as `__scope__`) has its `hasMember`/`getMember` invoked for **every
unqualified identifier in every per-cell/per-row evaluation** — work that did not
exist under Rhino's native, in-process scope chain. Three hot-path costs on that
path are removed.

**1. `AssetQueryScope.hasMember` cache** — `getMember` already cached lookups in
`tablemap` (with a `NOT_TABLE` sentinel), but `hasMember` did not, so each miss
fell through to `Worksheet.getAssembly()`, which rebuilds the entire assembly map
(`Worksheet.createCache`) on a miss — an O(cells × names × assemblies) rebuild
storm. `hasMember` now uses the same cache.

**2. `Calc.funcmap` → case-insensitive `TreeMap`** — the terminal fallback of the
scope-chain walk did `funcmap.get(id.toLowerCase())`, allocating a `String` per
mixed-case name (the camelCase CALC functions) on every call. `funcmap` is now a
`TreeMap(String.CASE_INSENSITIVE_ORDER)`, looked up directly with no per-call
allocation. It is populated once in the constructor and read-only afterward, so
dropping `Hashtable`'s synchronization is safe.

**3. `BindingRootProxy` scope-resolution caching (main new change).** A fresh
JProfiler CPU investigation on GraalVM (where the interpreter-era GC storm is
gone and the single render thread is the gate) found the dominant *residual*
cost: instrumentation counted **23.4M `findInChain` calls in one render**, of
which **~98% were references to names that are real js global bindings not in the
scope chain** (CALC/`FormulaFunctions` like `mapList`, `isNull`, …). Each one
walked the entire scope chain fruitlessly and then probed the terminal `Calc`
map, only to report absent so `with(...)` resolves them natively. Two
order-preserving caches remove that repeated work:

- **`isGlobalBinding(name)`** — the exact-name js-global-binding test, cached
  permanently (globals are installed once at engine init). Lets a global that is
  absent from chain/exec/imports return "not found" **without** the terminal
  `Calc` probe. Logically identical to the old
  `builtin != null && !hasGlobalBinding` guard.
- **`inChain(name)`** — "is the name provided by the current scope chain?",
  computed with the **real per-scope `hasMember` walk** (so scopes with dynamic,
  non-enumerated members stay correct). Lets an absent name skip the walk on
  repeat lookups within an evaluation.

### Correctness

Resolution order is preserved exactly, including the rule that a scope member
**shadows** a same-named global (Rhino kept `Calc` as the global scope's
prototype, checked last). In this viewsheet the real shadows are `sum`
(`CalcTableScope`, the freehand aggregate) and `toList` (`ViewsheetScope`) — both
continue to win, and the exported PDF is byte-identical to the pre-change output.

The `inChain` cache is **invalidated per exec (`swapGlobal`) and on `putMember`**,
so its lifetime is one script evaluation — the window in which the chain's
membership is immutable. This matters because `CalcCellScope`/`CrosstabCellScope`
are reused as the chain root across `Range()` condition evaluations and mutate
their exposed group/dimension names in place via `setCell(row, col)` **without**
changing object identity; an identity-keyed cache would serve a stale answer for
later cells. (Caught in code review; guarded by a new regression test.)

## Test Plan

- New regression test `BindingRootProxyTest.chainCacheInvalidatedWhenReusedRootMutatedAcrossExec`
  (fails without the per-exec invalidation, passes with it).
- GraalJS scope/globals: `BindingRootProxyTest` (6), `GraalJavaScriptEngineGlobalsTest` (15),
  `GraalJavaScriptEngineScopeTest` (17), `ScriptValueConverterTest` (11),
  `ScriptFunctionTest` (10), `AddToPrototypeTest` (8) — all pass.
- Calc-table: `CalcTableScopeTest` (76), `CalcTableLensTest` (5),
  `RuntimeCalcTableLensTest` (1), `CalcRefTest` (9), `FormulaFunctions2Test` (15) — all pass.
- CALC functions: `CalcMathTest` (155), `CalcStatTest` (62), `CalcTextDataTest` (37),
  `CalcDateTimeTest` (38), `CalcLogicTest` (4), `CalcUtilTest` (6) — all pass.
- End-to-end: opened/exported `DateManualSort` on GraalVM JDK 21 — warm render
  ~22s → ~7.8s, exported PDF byte-identical to the pre-change baseline.
- `community/core` builds clean.

## Remaining cost

After these changes the top hotspots are inherent GraalJS interop — `Date`
conversion (`toInstant`/`JSDate.asLocalDate/asLocalTime/asInstant`, ~20% on this
date-heavy viewsheet), `FormulaContext.get` (~9%), and background Truffle
compilation (off the critical path on multi-core). This is close to GraalJS's
floor; further gains would target date interop or evaluation count, with
diminishing returns.

Fixes Redmine #75676 (relates #75423).
