### PR TITLE
fix: non-Cartesian charts wrongly reported as no-data in the viewer

### DIFF
--- a/web/projects/portal/src/app/common/graph-types.ts
+++ b/web/projects/portal/src/app/common/graph-types.ts
@@ -552,6 +552,17 @@ export class GraphTypes {
       return GraphTypes.isScatteredContour(type) || GraphTypes.isMapContour(type);
    }
 
+   /**
+    * Check if the graph is drawn on a rectangular (X/Y axis) coordinate. Polar (pie/radar),
+    * treemap-family, relation, and geo charts use non-Cartesian layouts and never populate
+    * axes, so axes.length is not a valid "has data" signal for them.
+    */
+   static isRect(type: number): boolean {
+      const notRect = GraphTypes.isPolar(type) || GraphTypes.isTreemap(type) ||
+         GraphTypes.isRelation(type) || GraphTypes.isGeo(type);
+      return !notRect;
+   }
+
    static isCompatible(type1: number, type2: number): boolean {
       if(type1 == type2) {
          return true;

--- a/web/projects/portal/src/app/graph/objects/chart-area.component.display.tl.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-area.component.display.tl.spec.ts
@@ -403,6 +403,24 @@ describe("ChartArea — noData", () => {
       comp.showEmptyArea = false;
       expect(comp.noData).toBe(false);
    });
+
+   // Treemap/sunburst/circle-packing/icicle, polar (pie/radar), relation, and geo charts never
+   // populate axes by design — an empty axes array does not mean the chart has no data for them.
+   it("should be false for a non-rect chart type with no axes but real data (server noData=false)", () => {
+      const { comp } = createComponent({
+         model: makeModel({ axes: [], chartType: GraphTypes.CHART_TREEMAP, noData: false } as any),
+      });
+      comp.showEmptyArea = false;
+      expect(comp.noData).toBe(false);
+   });
+
+   it("should be true for a non-rect chart type only when the server reports noData", () => {
+      const { comp } = createComponent({
+         model: makeModel({ axes: [], chartType: GraphTypes.CHART_RADAR, noData: true } as any),
+      });
+      comp.showEmptyArea = false;
+      expect(comp.noData).toBe(true);
+   });
 });
 
 // ---------------------------------------------------------------------------

--- a/web/projects/portal/src/app/graph/objects/chart-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-area.component.ts
@@ -951,8 +951,18 @@ export class ChartArea implements OnInit, OnChanges, OnDestroy {
     * Check whether the chart has any data (viewer/preview).
     */
    get noData(): boolean {
-      return !this.showEmptyArea && !this.model.invalid &&
-         (!this.model.axes || this.model.axes.length == 0);
+      if(this.showEmptyArea || this.model.invalid) {
+         return false;
+      }
+
+      // Non-Cartesian charts (treemap/sunburst/circle-packing/icicle, polar (pie/radar),
+      // relation, geo) never populate axes by design, so an empty axes array does not mean
+      // the chart has no data — defer to the server's own noData flag for those instead.
+      if(!GraphTypes.isRect(this.model.chartType)) {
+         return !!this.model.noData;
+      }
+
+      return !this.model.axes || this.model.axes.length == 0;
    }
 
    /**

--- a/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
@@ -1326,8 +1326,18 @@ export class VSChart extends AbstractVSObject<VSChartModel>
     * Check whether the chart has any data (composer).
     */
    get emptyChart(): boolean {
-      return this.showEmptyArea && !this.model.invalid &&
-         (!this.model.axes || this.model.axes.length == 0);
+      if(!this.showEmptyArea || this.model.invalid) {
+         return false;
+      }
+
+      // Non-Cartesian charts (treemap/sunburst/circle-packing/icicle, polar (pie/radar),
+      // relation, geo) never populate axes by design, so an empty axes array does not mean
+      // the chart has no data — defer to the server's own noData flag for those instead.
+      if(!GraphTypes.isRect(this.model.chartType)) {
+         return !!this.model.noData;
+      }
+
+      return !this.model.axes || this.model.axes.length == 0;
    }
 
    /**


### PR DESCRIPTION
## Summary

- `chart-area.component`'s `noData` getter and `vs-chart.component`'s `emptyChart` getter both used `axes.length == 0` as a proxy for "chart has no data." Treemap, sunburst, circle-packing, icicle, polar (pie/radar), relation, and geo charts never populate `axes` by design (see `GraphTypes.isRect()` on the Java side), so a fully-rendered chart of one of these types was indistinguishable from a genuinely empty one — the viewer/composer showed the `_#(data.query.columnResultEmpty)` ("No data is available!") placeholder over real data.
- Discovered live: a treemap built via the wiz plugin with real, reconciled revenue data showed this placeholder in the companion viewer, while a server-side re-execution of the same saved chart confirmed 29 correct rows.
- Adds `GraphTypes.isRect()` to the TS side, mirroring the existing Java helper, and only applies the axes-based heuristic to Cartesian chart types. For everything else, both getters now defer to the server's own `model.noData` flag, which already correctly reflects whether the graph actually built with data (`VSChartAreasService` only sets it true when `pair.getRealSizeVGraph() == null`), independent of chart type.

## Test plan

- [x] Added 2 regression tests to `chart-area.component.display.tl.spec.ts`: a non-rect chart type (treemap/radar) with no axes but `noData: false` is correctly reported as having data; a non-rect chart with a genuine server `noData: true` is still correctly reported as empty.
- [x] Full `chart-area.component.display.tl.spec.ts` suite passes (77/77).
- [x] Verified live: rebuilt the Angular bundle + Docker image, redeployed, and confirmed a previously-broken treemap now renders correctly in the live viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)