### PR TITLE
fix(wiz): saved table/crosstab visualizations fail verify with ClassCastException

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -253,7 +253,13 @@ public class ViewsheetRuntimeController {
          }
 
          try {
-            WizVsService.VerifyResult vr = wizVsService.verifyChartData(rvs, assembly.getName());
+            // getVGraphPair (used by verifyChartData) only supports ChartVSAssembly - it casts
+            // unconditionally and throws ClassCastException on a Table/Crosstab assembly, which
+            // findChartAssembly's first-assembly fallback can legitimately hand back for a saved
+            // "table"/"crosstab" wiz visualization. Route those through the TableLens-based path.
+            WizVsService.VerifyResult vr = assembly instanceof ChartVSAssembly
+               ? wizVsService.verifyChartData(rvs, assembly.getName())
+               : wizVsService.verifyTableData(rvs, assembly.getName());
             result.setHasData(vr.hasData());
             result.setRowCount(vr.rowCount());
          }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1555,6 +1555,41 @@ public class WizVsService {
    }
 
    /**
+    * Execute a Table or Crosstab assembly's data to verify the saved visualization actually
+    * renders, without materializing the rows. Mirrors {@link #verifyChartData} for the
+    * non-chart wiz visualization types: {@link ViewsheetSandbox#getVGraphPair} only supports
+    * {@link ChartVSAssembly} (it casts unconditionally), so a table/crosstab assembly must be
+    * verified via its {@link TableLens} instead.
+    */
+   public VerifyResult verifyTableData(RuntimeViewsheet rvs, String assemblyName) throws Exception {
+      Optional<ViewsheetSandbox> boxOpt = rvs.getViewsheetSandbox();
+
+      if(boxOpt.isEmpty()) {
+         return new VerifyResult(false, 0);
+      }
+
+      TableLens table = boxOpt.get().getTableData(assemblyName);
+
+      if(table == null) {
+         return new VerifyResult(false, 0);
+      }
+
+      // Throws IllegalArgumentException carrying the real cause when the query failed.
+      checkFailedQuery(table);
+
+      int headerRows = table.getHeaderRowCount();
+      int rowCount = 0;
+      int r = headerRows;
+
+      while(table.moreRows(r)) {
+         rowCount++;
+         r++;
+      }
+
+      return new VerifyResult(rowCount > 0, rowCount);
+   }
+
+   /**
     * Extracts tabular data from a Table or Crosstab assembly via its TableLens.
     * Row 0 through headerRowCount-1 are header rows; data begins at headerRowCount.
     * <p>

--- a/core/src/test/java/inetsoft/web/wiz/controller/ViewsheetRuntimeControllerVerifyDispatchTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/ViewsheetRuntimeControllerVerifyDispatchTest.java
@@ -1,0 +1,139 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.TableVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.model.VerifyViewsheetResult;
+import inetsoft.web.wiz.service.WizVisualizationService;
+import inetsoft.web.wiz.service.WizVsService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@code getVGraphPair} (used by {@code WizVsService#verifyChartData}) only supports
+ * {@link ChartVSAssembly} — it casts unconditionally and throws {@code ClassCastException} on
+ * any other assembly type. {@code findChartAssembly}'s "fall back to the first assembly" path
+ * can legitimately hand back a {@link TableVSAssembly} for a saved "table"/"crosstab" wiz
+ * visualization (there is no chart in the sheet at all), so {@code verifyViewsheet} must route
+ * a non-chart assembly through {@code verifyTableData} instead. Regression for the 500
+ * (ClassCastException) hit when verifying a saved table-type wiz visualization.
+ */
+@Tag("core")
+class ViewsheetRuntimeControllerVerifyDispatchTest {
+
+   private static String managedIdentifier() {
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/abc", null);
+      return entry.toIdentifier();
+   }
+
+   private static ViewsheetService grantedViewsheetService(Principal principal, String runtimeId,
+                                                            RuntimeViewsheet rvs) throws Exception
+   {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      when(vsService.openViewsheet(any(AssetEntry.class), eq(principal), eq(true)))
+         .thenReturn(runtimeId);
+      when(vsService.getViewsheet(runtimeId, principal)).thenReturn(rvs);
+      return vsService;
+   }
+
+   private static SecurityEngine grantedSecurityEngine(Principal principal) throws Exception {
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      return securityEngine;
+   }
+
+   @Test
+   void routesTableAssemblyThroughVerifyTableDataNotVerifyChartData() throws Exception {
+      Principal principal = mock(Principal.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      TableVSAssembly table = mock(TableVSAssembly.class);
+      when(table.getName()).thenReturn("Table1");
+      when(vs.getAssemblies()).thenReturn(new Assembly[] { table });
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetService vsService = grantedViewsheetService(principal, "rt1", rvs);
+      SecurityEngine securityEngine = grantedSecurityEngine(principal);
+      WizVsService wizVsService = mock(WizVsService.class);
+      when(wizVsService.verifyTableData(rvs, "Table1"))
+         .thenReturn(new WizVsService.VerifyResult(true, 5));
+
+      ViewsheetRuntimeController controller =
+         new ViewsheetRuntimeController(vsService, wizVsService, securityEngine);
+
+      VerifyViewsheetResult result = controller.verifyViewsheet(managedIdentifier(), null, principal);
+
+      assertTrue(result.isHasData(), "table assembly with 5 rows should report hasData");
+      assertEquals(5, result.getRowCount());
+      verify(wizVsService).verifyTableData(rvs, "Table1");
+      verify(wizVsService, never()).verifyChartData(any(), any());
+   }
+
+   @Test
+   void routesChartAssemblyThroughVerifyChartDataAsBefore() throws Exception {
+      Principal principal = mock(Principal.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getName()).thenReturn("Chart1");
+      when(vs.getAssemblies()).thenReturn(new Assembly[] { chart });
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetService vsService = grantedViewsheetService(principal, "rt2", rvs);
+      SecurityEngine securityEngine = grantedSecurityEngine(principal);
+      WizVsService wizVsService = mock(WizVsService.class);
+      when(wizVsService.verifyChartData(rvs, "Chart1"))
+         .thenReturn(new WizVsService.VerifyResult(true, 29));
+
+      ViewsheetRuntimeController controller =
+         new ViewsheetRuntimeController(vsService, wizVsService, securityEngine);
+
+      VerifyViewsheetResult result = controller.verifyViewsheet(managedIdentifier(), null, principal);
+
+      assertTrue(result.isHasData(), "chart assembly with 29 rows should report hasData");
+      assertEquals(29, result.getRowCount());
+      verify(wizVsService).verifyChartData(rvs, "Chart1");
+      verify(wizVsService, never()).verifyTableData(any(), any());
+   }
+}


### PR DESCRIPTION
## Summary

- `ViewsheetSandbox.getVGraphPair` (used by `WizVsService.verifyChartData`) casts unconditionally to `ChartVSAssembly`. `ViewsheetRuntimeController.findChartAssembly` legitimately falls back to the sheet's first assembly when there's no chart in it at all — which happens for a saved wiz visualization whose `visualizationType` is `"table"` or `"crosstab"` (no chart present by design).
- Verifying one of these via `/viewsheet/verify` therefore hit a `ClassCastException` deep in the sandbox and surfaced to the caller as a bare HTTP 500, with no indication of the real cause.
- Discovered live: a saved "table" wiz visualization with real, correct data (confirmed separately) 500'd on verify.
- Adds `WizVsService.verifyTableData`, a `TableLens`-based equivalent of `verifyChartData` (mirrors the existing `extractTableLensData` row-extraction pattern already used elsewhere in the same class), and has the controller dispatch on the resolved assembly's actual type (`ChartVSAssembly` → `verifyChartData`, everything else → `verifyTableData`) instead of assuming every saved visualization is a chart.

## Test plan

- [x] Added `ViewsheetRuntimeControllerVerifyDispatchTest` — 2 tests: a `TableVSAssembly`-only sheet dispatches to `verifyTableData` (not `verifyChartData`), and a `ChartVSAssembly`-only sheet still dispatches to `verifyChartData` as before (no regression).
- [x] Existing `ViewsheetRuntimeControllerSecurityTest` still green.
- [x] Verified live: rebuilt (`community/core`-only, no new beans) and redeployed; `/viewsheet/verify` on the previously-broken saved table now returns `hasData:true, rowCount:10` instead of a 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)