### PR TITLE
feat(wiz): per-chart insights in board PDF/PowerPoint export

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
@@ -130,7 +130,8 @@ public class WizViewsheetExportController {
          List<WizPrintLayoutBuilder.ChartCaption> charts = event.getCharts() == null
             ? List.of()
             : event.getCharts().stream()
-               .map(c -> new WizPrintLayoutBuilder.ChartCaption(c.getTitle(), c.getCaption(), c.getOrder()))
+               .map(c -> new WizPrintLayoutBuilder.ChartCaption(
+                  c.getTitle(), c.getCaption(), c.getOrder(), c.getInsightsMarkdown()))
                .collect(Collectors.toList());
 
          var printLayout = printLayoutBuilder.build(
@@ -259,14 +260,16 @@ public class WizViewsheetExportController {
       }
       catch(RuntimeException e) {
          LOG.warn("Chart savedId is not a valid asset identifier: {}", chart.getSavedId());
-         return new PptxDeckMerger.ChartSlide(chart.getTitle(), chart.getCaption(), null, true);
+         return new PptxDeckMerger.ChartSlide(
+            chart.getTitle(), chart.getCaption(), null, true, chart.getInsightsMarkdown());
       }
 
       if(entry == null || entry.getPath() == null ||
          !entry.getPath().startsWith(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/"))
       {
          LOG.warn("Chart savedId is not in the managed visualizations folder: {}", chart.getSavedId());
-         return new PptxDeckMerger.ChartSlide(chart.getTitle(), chart.getCaption(), null, true);
+         return new PptxDeckMerger.ChartSlide(
+            chart.getTitle(), chart.getCaption(), null, true, chart.getInsightsMarkdown());
       }
 
       String runtimeId;
@@ -276,7 +279,8 @@ public class WizViewsheetExportController {
       }
       catch(Exception e) {
          LOG.warn("Failed to open chart for pptx export: {}", chart.getSavedId(), e);
-         return new PptxDeckMerger.ChartSlide(chart.getTitle(), chart.getCaption(), null, true);
+         return new PptxDeckMerger.ChartSlide(
+            chart.getTitle(), chart.getCaption(), null, true, chart.getInsightsMarkdown());
       }
 
       try {
@@ -284,11 +288,13 @@ public class WizViewsheetExportController {
          ByteArrayOutputStream out = new ByteArrayOutputStream();
          exportService.exportViewsheet(rvs, FileFormatInfo.EXPORT_TYPE_POWERPOINT, false, false, true,
             false, false, new String[0], false, new ExportResponse(out), principal);
-         return new PptxDeckMerger.ChartSlide(chart.getTitle(), chart.getCaption(), out.toByteArray(), false);
+         return new PptxDeckMerger.ChartSlide(
+            chart.getTitle(), chart.getCaption(), out.toByteArray(), false, chart.getInsightsMarkdown());
       }
       catch(Exception e) {
          LOG.warn("Failed to export chart for pptx: {}", chart.getSavedId(), e);
-         return new PptxDeckMerger.ChartSlide(chart.getTitle(), chart.getCaption(), null, true);
+         return new PptxDeckMerger.ChartSlide(
+            chart.getTitle(), chart.getCaption(), null, true, chart.getInsightsMarkdown());
       }
       finally {
          try {

--- a/core/src/main/java/inetsoft/web/wiz/model/WizExportReportEvent.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizExportReportEvent.java
@@ -115,9 +115,18 @@ public class WizExportReportEvent {
          this.order = order;
       }
 
+      public String getInsightsMarkdown() {
+         return insightsMarkdown;
+      }
+
+      public void setInsightsMarkdown(String insightsMarkdown) {
+         this.insightsMarkdown = insightsMarkdown;
+      }
+
       private String savedId;
       private String title;
       private String caption;
       private int order;
+      private String insightsMarkdown;
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/MarkdownPlainText.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MarkdownPlainText.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import java.util.regex.Pattern;
+
+/**
+ * Converts markdown (as produced for a saved visualization's "insights") into plain, wrapped
+ * text for the board export's PDF/PPTX layouts. A defensive regex-based transform, never a real
+ * markdown parser — it cannot throw on malformed/unbalanced markup; worst case is a stray
+ * leftover symbol in the output.
+ */
+public final class MarkdownPlainText {
+   private MarkdownPlainText() {
+   }
+
+   public static String strip(String markdown) {
+      if(markdown == null) {
+         return "";
+      }
+
+      String[] lines = markdown.split("\n", -1);
+      StringBuilder out = new StringBuilder();
+
+      for(int i = 0; i < lines.length; i++) {
+         String line = lines[i];
+         String trimmed = line.strip();
+         String result;
+
+         if(HEADER.matcher(trimmed).find()) {
+            result = HEADER.matcher(trimmed).replaceFirst("");
+         }
+         else if(BULLET.matcher(trimmed).find()) {
+            result = BULLET.matcher(trimmed).replaceFirst("• ");
+         }
+         else {
+            result = line;
+         }
+
+         result = BOLD_STAR.matcher(result).replaceAll("$1");
+         result = BOLD_UNDERSCORE.matcher(result).replaceAll("$1");
+         result = ITALIC_STAR.matcher(result).replaceAll("$1");
+         result = ITALIC_UNDERSCORE.matcher(result).replaceAll("$1");
+
+         out.append(result);
+
+         if(i < lines.length - 1) {
+            out.append("\n");
+         }
+      }
+
+      return out.toString();
+   }
+
+   private static final Pattern HEADER = Pattern.compile("^#{1,6}\\s+");
+   private static final Pattern BULLET = Pattern.compile("^[-*+]\\s+");
+   private static final Pattern BOLD_STAR = Pattern.compile("\\*\\*(.+?)\\*\\*");
+   private static final Pattern BOLD_UNDERSCORE = Pattern.compile("__(.+?)__");
+   private static final Pattern ITALIC_STAR = Pattern.compile("\\*(.+?)\\*");
+   private static final Pattern ITALIC_UNDERSCORE = Pattern.compile("_(.+?)_");
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/PptxDeckMerger.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/PptxDeckMerger.java
@@ -18,7 +18,13 @@
 package inetsoft.web.wiz.service;
 
 public interface PptxDeckMerger {
-   record ChartSlide(String title, String caption, byte[] singleSlideDeckBytes, boolean failed) {}
+   record ChartSlide(String title, String caption, byte[] singleSlideDeckBytes, boolean failed,
+                     String insightsMarkdown)
+   {
+      public ChartSlide(String title, String caption, byte[] singleSlideDeckBytes, boolean failed) {
+         this(title, caption, singleSlideDeckBytes, failed, null);
+      }
+   }
 
    /**
     * @param title the board name (rendered on a leading title/recap slide)
@@ -28,9 +34,12 @@ public interface PptxDeckMerger {
     *               chart's own saved visualization via VSExportService/PPTVSExporter
     *               (FileFormatInfo.EXPORT_TYPE_POWERPOINT). A failed entry's caption/title are
     *               still used (for the placeholder slide's text); singleSlideDeckBytes may be
-    *               null/empty and must not be read.
-    * @return a merged multi-slide .pptx: one title/recap slide, then one slide per chart
+    *               null/empty and must not be read. insightsMarkdown (either entry kind), if
+    *               non-blank, produces one or more dedicated insights-only slide(s) immediately
+    *               after the chart's own slide.
+    * @return a merged multi-slide .pptx: one title/recap slide, then for each chart one slide
     *         (imported content + caption, or a text-only "failed to render" placeholder)
+    *         optionally followed by insights-only slide(s)
     */
    byte[] mergeSlides(String title, String recap, java.util.List<ChartSlide> slides) throws Exception;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -44,7 +44,11 @@ import java.util.Map;
  */
 @Component
 public class WizPrintLayoutBuilder {
-   public record ChartCaption(String title, String caption, int order) {}
+   public record ChartCaption(String title, String caption, int order, String insightsMarkdown) {
+      public ChartCaption(String title, String caption, int order) {
+         this(title, caption, order, null);
+      }
+   }
 
    public PrintLayout build(Viewsheet dashboard, String pageSize, String title, String recap,
                              List<ChartCaption> charts)
@@ -88,6 +92,12 @@ public class WizPrintLayoutBuilder {
             new Point(0, captionY), new Dimension(PAGE_CONTENT_WIDTH_PT, CAPTION_HEIGHT_PT)));
          vsLayouts.add(new VSAssemblyLayout(assembly.getName(), new Point(0, chartY),
             new Dimension(PAGE_CONTENT_WIDTH_PT, CHART_HEIGHT_PT)));
+
+         if(c.insightsMarkdown() != null && !c.insightsMarkdown().isBlank()) {
+            int insightsY = chartY + CHART_HEIGHT_PT;
+            vsLayouts.add(textLayout("wizExportInsights_" + i, MarkdownPlainText.strip(c.insightsMarkdown()),
+               new Point(0, insightsY), new Dimension(PAGE_CONTENT_WIDTH_PT, INSIGHTS_HEIGHT_PT)));
+         }
 
          page++;
       }
@@ -176,4 +186,5 @@ public class WizPrintLayoutBuilder {
    private static final int TITLE_BLOCK_HEIGHT_PT = 100;
    private static final int CAPTION_HEIGHT_PT = 30;
    private static final int CHART_HEIGHT_PT = 400;
+   private static final int INSIGHTS_HEIGHT_PT = 150;
 }

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetExportControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetExportControllerTest.java
@@ -116,6 +116,14 @@ class WizViewsheetExportControllerTest {
       return c;
    }
 
+   private static WizExportReportEvent.ChartEntry chartEntry(
+      String savedId, String title, String caption, int order, String insightsMarkdown)
+   {
+      WizExportReportEvent.ChartEntry c = chartEntry(savedId, title, caption, order);
+      c.setInsightsMarkdown(insightsMarkdown);
+      return c;
+   }
+
    @Test
    void rejectsIdentifierOutsideComponentsFolder() throws Exception {
       ViewsheetService vs = mock(ViewsheetService.class);
@@ -223,6 +231,145 @@ class WizViewsheetExportControllerTest {
       verify(layoutInfo).setPrintLayout(fakeLayout);
       verify(wizVsService).persistViewsheet(viewsheet, managedDashboardIdentifier(), principal);
       verify(vs).closeViewsheet("rt1", principal);
+   }
+
+   @Test
+   void pdfPathForwardsChartInsightsMarkdownIntoChartCaptions() throws Exception {
+      ViewsheetService vs = mock(ViewsheetService.class);
+      WizVsService wizVsService = mock(WizVsService.class);
+      WizPrintLayoutBuilder builder = mock(WizPrintLayoutBuilder.class);
+      VSExportService exportService = mock(VSExportService.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet viewsheet = mock(Viewsheet.class);
+      inetsoft.uql.viewsheet.vslayout.LayoutInfo layoutInfo = mock(inetsoft.uql.viewsheet.vslayout.LayoutInfo.class);
+      HttpServletResponse servletResponse = mock(HttpServletResponse.class);
+      when(servletResponse.getOutputStream()).thenReturn(capturingOutputStream(new ByteArrayOutputStream()));
+      when(viewsheet.getLayoutInfo()).thenReturn(layoutInfo);
+      when(vs.openViewsheet(any(), eq(principal), eq(true))).thenReturn("rt1");
+      when(vs.getViewsheet("rt1", principal)).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(sec.checkPermission(eq(principal), eq(ResourceType.VIEWSHEET_TOOLBAR_ACTION),
+         eq("Export"), eq(ResourceAction.READ))).thenReturn(true);
+
+      var fakeLayout = new inetsoft.uql.viewsheet.vslayout.PrintLayout();
+      when(builder.build(any(), any(), any(), any(), anyList())).thenReturn(fakeLayout);
+
+      doAnswer(inv -> {
+         inetsoft.web.viewsheet.service.ExportResponse resp = inv.getArgument(9);
+         resp.getOutputStream().write("%PDF".getBytes());
+         return null;
+      }).when(exportService).exportViewsheet(eq(rvs), anyInt(), eq(false), eq(false), eq(true),
+         eq(false), eq(false), any(String[].class), eq(false), any(), eq(principal));
+
+      WizViewsheetExportController ctrl = new WizViewsheetExportController(
+         vs, wizVsService, builder, exportService, sec, mock(PptxDeckMerger.class));
+
+      WizExportReportEvent ev = event(managedDashboardIdentifier());
+      ev.setCharts(List.of(chartEntry(managedChartIdentifier("c1"), "First", "cap one", 0, "**Bold** finding")));
+
+      ResponseEntity<?> resp = ctrl.exportReport(ev, principal, servletResponse);
+
+      assertNull(resp);
+      verify(builder).build(eq(viewsheet), eq("a4"), eq("Q39 Board"), isNull(), argThat(list ->
+         list.size() == 1 &&
+         "**Bold** finding".equals(((WizPrintLayoutBuilder.ChartCaption) list.get(0)).insightsMarkdown())));
+   }
+
+   @Test
+   void pptxPathForwardsChartInsightsMarkdownIntoChartSlides() throws Exception {
+      ViewsheetService vs = mock(ViewsheetService.class);
+      WizVsService wizVsService = mock(WizVsService.class);
+      WizPrintLayoutBuilder builder = mock(WizPrintLayoutBuilder.class);
+      VSExportService exportService = mock(VSExportService.class);
+      PptxDeckMerger merger = mock(PptxDeckMerger.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      HttpServletResponse servletResponse = mock(HttpServletResponse.class);
+      when(servletResponse.getOutputStream()).thenReturn(capturingOutputStream(new ByteArrayOutputStream()));
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+
+      String chartId = managedChartIdentifier("c1");
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(vs.openViewsheet(argThat(e -> e != null && e.toIdentifier().equals(chartId)), eq(principal), eq(true)))
+         .thenReturn("rt-c1");
+      when(vs.getViewsheet("rt-c1", principal)).thenReturn(rvs);
+      doAnswer(inv -> { ((ExportResponse) inv.getArgument(9)).getOutputStream().write("chart-deck".getBytes()); return null; })
+         .when(exportService).exportViewsheet(eq(rvs), eq(FileFormatInfo.EXPORT_TYPE_POWERPOINT),
+            anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(),
+            any(String[].class), anyBoolean(), any(), eq(principal));
+
+      when(merger.mergeSlides(any(), any(), argThat(list ->
+         list.size() == 1 && "**Bold** finding".equals(list.get(0).insightsMarkdown())
+      ))).thenReturn("%PPTX-fake".getBytes());
+
+      WizViewsheetExportController ctrl = new WizViewsheetExportController(
+         vs, wizVsService, builder, exportService, sec, merger);
+
+      WizExportReportEvent ev = new WizExportReportEvent();
+      ev.setFormat("pptx");
+      ev.setTitle("Q39 Board");
+      ev.setCharts(List.of(chartEntry(chartId, "First", "cap one", 0, "**Bold** finding")));
+
+      ResponseEntity<?> resp = ctrl.exportReport(ev, principal, servletResponse);
+
+      assertNull(resp);
+      verify(merger).mergeSlides(any(), any(), argThat(list ->
+         "**Bold** finding".equals(list.get(0).insightsMarkdown())));
+   }
+
+   @Test
+   void failedPptxChartStillCarriesItsInsightsMarkdownIntoThePlaceholderSlide() throws Exception {
+      // NOTE: adapted from the brief's literal single-chart test, which collides with the
+      // all-charts-failed-aborts contract exactly like pptxChartOpenFailureBecomesPlaceholderNotAbort
+      // and pptxChartOutsideComponentsFolderBecomesPlaceholderNotAbort above -- with only one chart
+      // total, "the one chart failed" and "all charts failed" are the same event, so the
+      // controller's allFailed guard 400s instead of merging. A second, successful chart is added
+      // so this test isolates "the failed chart's insightsMarkdown survives into its placeholder
+      // slide" without re-triggering the all-failed abort that pptxAllChartsFailedAbortsLoud
+      // already covers on its own.
+      ViewsheetService vs = mock(ViewsheetService.class);
+      VSExportService exportService = mock(VSExportService.class);
+      PptxDeckMerger merger = mock(PptxDeckMerger.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      HttpServletResponse servletResponse = mock(HttpServletResponse.class);
+      when(servletResponse.getOutputStream()).thenReturn(capturingOutputStream(new ByteArrayOutputStream()));
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+
+      String badId = managedChartIdentifier("broken");
+      String goodId = managedChartIdentifier("ok");
+      when(vs.openViewsheet(argThat(e -> e != null && e.toIdentifier().equals(badId)), eq(principal), eq(true)))
+         .thenThrow(new RuntimeException("boom"));
+      RuntimeViewsheet rvsGood = mock(RuntimeViewsheet.class);
+      when(vs.openViewsheet(argThat(e -> e != null && e.toIdentifier().equals(goodId)), eq(principal), eq(true)))
+         .thenReturn("rt-good");
+      when(vs.getViewsheet("rt-good", principal)).thenReturn(rvsGood);
+      doAnswer(inv -> { ((ExportResponse) inv.getArgument(9)).getOutputStream().write("good".getBytes()); return null; })
+         .when(exportService).exportViewsheet(eq(rvsGood), eq(FileFormatInfo.EXPORT_TYPE_POWERPOINT),
+            anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(),
+            any(String[].class), anyBoolean(), any(), eq(principal));
+
+      when(merger.mergeSlides(any(), any(), argThat(list ->
+         list.size() == 2 && list.get(0).failed() &&
+         "Finding survives even though the chart failed to render.".equals(list.get(0).insightsMarkdown())
+      ))).thenReturn("%PPTX-fake".getBytes());
+
+      WizViewsheetExportController ctrl = new WizViewsheetExportController(
+         vs, mock(WizVsService.class), mock(WizPrintLayoutBuilder.class), exportService, sec, merger);
+
+      WizExportReportEvent ev = new WizExportReportEvent();
+      ev.setFormat("pptx");
+      ev.setTitle("Board");
+      ev.setCharts(List.of(
+         chartEntry(badId, "Broken", null, 0, "Finding survives even though the chart failed to render."),
+         chartEntry(goodId, "OK", null, 1)));
+
+      ResponseEntity<?> resp = ctrl.exportReport(ev, principal, servletResponse);
+
+      assertNull(resp);
+      verify(merger).mergeSlides(any(), any(), argThat(list -> list.get(0).failed()));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/MarkdownPlainTextTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MarkdownPlainTextTest.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class MarkdownPlainTextTest {
+   @Test
+   void stripsHeaders() {
+      assertEquals("Title\nBody text", MarkdownPlainText.strip("# Title\nBody text"));
+      assertEquals("Subheading", MarkdownPlainText.strip("### Subheading"));
+   }
+
+   @Test
+   void stripsBoldAndItalicMarkers() {
+      assertEquals("This is bold text", MarkdownPlainText.strip("This is **bold** text"));
+      assertEquals("This is bold text", MarkdownPlainText.strip("This is __bold__ text"));
+      assertEquals("This is italic text", MarkdownPlainText.strip("This is *italic* text"));
+      assertEquals("This is italic text", MarkdownPlainText.strip("This is _italic_ text"));
+   }
+
+   @Test
+   void normalizesBulletsToDotMarker() {
+      assertEquals("• item one\n• item two", MarkdownPlainText.strip("- item one\n* item two"));
+   }
+
+   @Test
+   void preservesBlankLinesAsParagraphBreaks() {
+      assertEquals("Para one\n\nPara two", MarkdownPlainText.strip("Para one\n\nPara two"));
+   }
+
+   @Test
+   void nullInputReturnsEmptyString() {
+      assertEquals("", MarkdownPlainText.strip(null));
+   }
+
+   @Test
+   void malformedMarkdownNeverThrows() {
+      assertDoesNotThrow(() -> MarkdownPlainText.strip("**unclosed bold"));
+      assertDoesNotThrow(() -> MarkdownPlainText.strip("# "));
+      assertDoesNotThrow(() -> MarkdownPlainText.strip("***"));
+      assertDoesNotThrow(() -> MarkdownPlainText.strip("- \n- \n-"));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
@@ -119,4 +119,72 @@ class WizPrintLayoutBuilderTest {
       assertThrows(IllegalStateException.class,
          () -> builder.build(vs, "a4", "Board", null, charts));
    }
+
+   @Test
+   void addsStrippedInsightsBlockBelowChartWithoutResizingTheChart() {
+      Viewsheet vs = new Viewsheet();
+      textAssembly(vs, "Chart1", 0);
+      List<WizPrintLayoutBuilder.ChartCaption> charts = List.of(
+         new WizPrintLayoutBuilder.ChartCaption("First", "cap one", 0, "**Bold** finding\n- point one")
+      );
+
+      PrintLayout layout = builder.build(vs, "a4", "Q39 Board", "Premium drives revenue.", charts);
+
+      List<VSAssemblyLayout> all = layout.getVSAssemblyLayouts();
+
+      VSAssemblyLayout chartLayout = all.stream()
+         .filter(l -> !(l instanceof VSEditableAssemblyLayout))
+         .filter(l -> l.getName().equals("Chart1"))
+         .findFirst().orElseThrow();
+      // 576x400 = PAGE_CONTENT_WIDTH_PT x CHART_HEIGHT_PT (private constants; hardcoded here since
+      // this test lives in the same package but not the same class, so private members aren't visible).
+      assertEquals(new Dimension(576, 400), chartLayout.getSize(),
+         "chart box is not resized when insights are present");
+
+      List<VSEditableAssemblyLayout> texts = all.stream()
+         .filter(l -> l instanceof VSEditableAssemblyLayout)
+         .map(l -> (VSEditableAssemblyLayout) l)
+         .collect(Collectors.toList());
+      // title/recap + caption + insights = 3
+      assertEquals(3, texts.size());
+
+      VSEditableAssemblyLayout insights = texts.stream()
+         .filter(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().contains("Bold finding"))
+         .findFirst().orElseThrow();
+      String insightsText = ((TextVSAssemblyInfo) insights.getInfo()).getText();
+      assertTrue(insightsText.contains("Bold finding"), "markdown bold stripped: " + insightsText);
+      assertTrue(insightsText.contains("• point one"), "markdown bullet normalized: " + insightsText);
+      assertFalse(insightsText.contains("**"), "no raw markdown syntax survives: " + insightsText);
+   }
+
+   @Test
+   void omitsInsightsBlockWhenBlank() {
+      Viewsheet vs = new Viewsheet();
+      textAssembly(vs, "Chart1", 0);
+      List<WizPrintLayoutBuilder.ChartCaption> charts = List.of(
+         new WizPrintLayoutBuilder.ChartCaption("First", "cap one", 0, "   ")
+      );
+
+      PrintLayout layout = builder.build(vs, "a4", "Q39 Board", "Premium drives revenue.", charts);
+
+      long editableTextBlocks = layout.getVSAssemblyLayouts().stream()
+         .filter(l -> l instanceof VSEditableAssemblyLayout).count();
+      // title/recap + caption only = 2 (same as the baseline before this feature)
+      assertEquals(2, editableTextBlocks);
+   }
+
+   @Test
+   void threeArgChartCaptionStillCompilesAndOmitsInsights() {
+      Viewsheet vs = new Viewsheet();
+      textAssembly(vs, "Chart1", 0);
+      List<WizPrintLayoutBuilder.ChartCaption> charts = List.of(
+         new WizPrintLayoutBuilder.ChartCaption("First", "cap one", 0)
+      );
+
+      PrintLayout layout = builder.build(vs, "a4", "Board", null, charts);
+
+      long editableTextBlocks = layout.getVSAssemblyLayouts().stream()
+         .filter(l -> l instanceof VSEditableAssemblyLayout).count();
+      assertEquals(2, editableTextBlocks, "the 3-arg compatibility constructor omits insights");
+   }
 }

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
@@ -17,15 +17,22 @@
  */
 package inetsoft.report.io.viewsheet;
 
+import inetsoft.web.wiz.service.MarkdownPlainText;
 import inetsoft.web.wiz.service.PptxDeckMerger;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
 import org.apache.poi.xslf.usermodel.XSLFSlide;
 import org.apache.poi.xslf.usermodel.XSLFTextBox;
+import org.apache.poi.xslf.usermodel.XSLFTextRun;
 
 import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
 import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -62,6 +69,10 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
                   // after is the only ordering under which it survives.
                   addCaption(target, slide.title(), slide.caption());
                }
+            }
+
+            if(slide.insightsMarkdown() != null && !slide.insightsMarkdown().isBlank()) {
+               addInsightsSlides(merged, slide.insightsMarkdown());
             }
          }
 
@@ -102,8 +113,67 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
       box.setText("Failed to render: " + (title == null ? "" : title));
    }
 
+   /** Appends one or more insights-only slides (no chart image, just a text box near the full
+    *  slide) so long insights are never truncated — each slide holds as much stripped text as
+    *  fits per {@link #chunkInsightsText}. */
+   private void addInsightsSlides(XMLSlideShow show, String insightsMarkdown) {
+      String stripped = MarkdownPlainText.strip(insightsMarkdown);
+
+      for(String chunk : chunkInsightsText(stripped)) {
+         XSLFSlide slide = show.createSlide();
+         XSLFTextBox box = slide.createTextBox();
+         box.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT,
+            SLIDE_WIDTH_PT - 2 * MARGIN_PT, SLIDE_HEIGHT_PT - 2 * MARGIN_PT));
+         XSLFTextRun run = box.setText(chunk);
+         run.setFontSize(INSIGHTS_FONT_SIZE_PT);
+      }
+   }
+
+   /** Estimates a per-slide character budget from real font metrics (measured headlessly via
+    *  java.awt.Font/FontMetrics — confirmed to work without a display) and splits plainText into
+    *  that many characters per chunk, snapping each split point back to the nearest preceding
+    *  space so a word is never broken across two slides. The one exception is a single token
+    *  longer than an entire slide's budget, which is hard-split (pathological input, not expected
+    *  from real insights text). */
+   private List<String> chunkInsightsText(String plainText) {
+      Font font = new Font(Font.SANS_SERIF, Font.PLAIN, (int) INSIGHTS_FONT_SIZE_PT);
+      BufferedImage measuring = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+      Graphics2D g = measuring.createGraphics();
+      FontMetrics fm = g.getFontMetrics(font);
+      g.dispose();
+
+      double boxWidthPt = SLIDE_WIDTH_PT - 2 * MARGIN_PT;
+      double boxHeightPt = SLIDE_HEIGHT_PT - 2 * MARGIN_PT;
+      double avgCharWidthPt = fm.stringWidth("abcdefghijklmnopqrstuvwxyz") / 26.0;
+      int charsPerLine = Math.max(1, (int) (boxWidthPt / avgCharWidthPt));
+      int linesPerSlide = Math.max(1, (int) (boxHeightPt / fm.getHeight()));
+      int charsPerSlide = charsPerLine * linesPerSlide;
+
+      List<String> chunks = new ArrayList<>();
+      String remaining = plainText.trim();
+
+      while(!remaining.isEmpty()) {
+         if(remaining.length() <= charsPerSlide) {
+            chunks.add(remaining);
+            break;
+         }
+
+         int splitAt = remaining.lastIndexOf(' ', charsPerSlide);
+
+         if(splitAt <= 0) {
+            splitAt = charsPerSlide; // pathological: no space within budget — hard split
+         }
+
+         chunks.add(remaining.substring(0, splitAt).trim());
+         remaining = remaining.substring(splitAt).trim();
+      }
+
+      return chunks;
+   }
+
    /** 16:9 widescreen in points (1in = 72pt): 13.33in x 7.5in. */
    private static final int SLIDE_WIDTH_PT = 960;
    private static final int SLIDE_HEIGHT_PT = 540;
    private static final int MARGIN_PT = 40;
+   private static final double INSIGHTS_FONT_SIZE_PT = 16.0;
 }

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
@@ -112,4 +112,74 @@ class PoiPptxDeckMergerTest {
          assertTrue(allText(result.getSlides().get(0)).contains("Board Only"));
       }
    }
+
+   @Test
+   void blankInsightsAddNoExtraSlide() throws Exception {
+      byte[] chart1 = oneSlideDeckWithText("CHART_MARKER");
+      List<PptxDeckMerger.ChartSlide> slides = List.of(
+         new PptxDeckMerger.ChartSlide("First", "cap", chart1, false, "   ")
+      );
+
+      byte[] merged = merger.mergeSlides("Board", null, slides);
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         assertEquals(2, result.getSlides().size(), "title + chart slide only, matching today's behavior");
+      }
+   }
+
+   @Test
+   void shortInsightsProduceExactlyOneFollowingSlide() throws Exception {
+      byte[] chart1 = oneSlideDeckWithText("CHART_MARKER");
+      List<PptxDeckMerger.ChartSlide> slides = List.of(
+         new PptxDeckMerger.ChartSlide("First", "cap", chart1, false,
+            "Premium pricing drives most of the category revenue.")
+      );
+
+      byte[] merged = merger.mergeSlides("Board", null, slides);
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         assertEquals(3, result.getSlides().size(), "title + chart + exactly one insights slide");
+         assertTrue(allText(result.getSlides().get(2))
+            .contains("Premium pricing drives most of the category revenue."));
+      }
+   }
+
+   @Test
+   void longInsightsSpanMultipleSlidesWithoutSplittingWords() throws Exception {
+      byte[] chart1 = oneSlideDeckWithText("CHART_MARKER");
+      String longInsights = "WORD ".repeat(6000).trim();
+      List<PptxDeckMerger.ChartSlide> slides = List.of(
+         new PptxDeckMerger.ChartSlide("First", "cap", chart1, false, longInsights)
+      );
+
+      byte[] merged = merger.mergeSlides("Board", null, slides);
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         // title slide + chart slide + N insights-only slides
+         assertTrue(result.getSlides().size() > 2, "long insights must span more than one slide");
+
+         int totalWords = 0;
+         for(int i = 2; i < result.getSlides().size(); i++) {
+            String text = allText(result.getSlides().get(i)).trim();
+            assertTrue(text.matches("(WORD ?)+"),
+               "slide " + i + " must contain only whole WORD tokens, got: " + text);
+            totalWords += text.split("\\s+").length;
+         }
+         assertEquals(6000, totalWords, "no words lost or duplicated across the split");
+      }
+   }
+
+   @Test
+   void failedChartInsightsStillGetTheirOwnSlide() throws Exception {
+      List<PptxDeckMerger.ChartSlide> slides = List.of(
+         new PptxDeckMerger.ChartSlide("Broken", "n/a", null, true, "Finding survives despite the render failure.")
+      );
+
+      byte[] merged = merger.mergeSlides("Board", null, slides);
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         assertEquals(3, result.getSlides().size(), "title + placeholder + insights slide");
+         assertTrue(allText(result.getSlides().get(2)).contains("Finding survives despite the render failure."));
+      }
+   }
 }


### PR DESCRIPTION
## Summary
Threads each chart's saved "insights" markdown into both native board export formats (previously only a short one-line caption was shown):

- **PDF** (`WizPrintLayoutBuilder`): adds a growable insights text box below each chart — no chart resize needed, since the report engine (`VsToReportConverter`/`StyleCore`) already auto-paginates any text box whose content exceeds its declared height.
- **PowerPoint** (`PoiPptxDeckMerger`): appends dedicated insights-only continuation slide(s) after each chart's own (unmodified) slide, chunked via real `java.awt.FontMetrics` measurement so text is never split mid-word.
- Markdown is stripped to plain text (`MarkdownPlainText`, new shared utility) rather than structurally rendered — headers/bold/italic markers removed, bullets normalized to `•`.
- A chart with no saved insights renders pixel-identical to before this feature.
- Insights are never truncated — long insights simply span more pages/slides.

Design spec: `docs/superpowers/specs/2026-07-19-board-export-insights-design.md` (stylebi-wiz repo)
Implementation plan: `docs/superpowers/plans/2026-07-19-board-export-insights.md` (stylebi-wiz repo)

Companion wiz-services PR (threads `insightsMarkdown` from Mongo through the wire contract): inetsoft-technology/stylebi-wiz#1268

## Test plan
- [x] `WizPrintLayoutBuilderTest` — 9/9 (chart box unresized when insights present, insights block omitted+layout pixel-identical when blank, 3-arg back-compat)
- [x] `PoiPptxDeckMergerTest` — 7/7 (chart slide untouched, blank→no extra slide, short→exactly one insights slide, long→multiple slides with no word split and exact word-count preserved, failed-chart insights still shown)
- [x] `MarkdownPlainTextTest` — 6/6 (headers/bold/italic/bullets stripped, blank-line paragraphs preserved, never throws on malformed input)
- [x] `WizViewsheetExportControllerTest` — 12/12 (DTO field threads into both PDF and PPTX paths, including all PPTX failure branches)
- [ ] Manual/live verification (rebuild deployed image, export a real board as PDF+PPTX with both short and deliberately-long insights, visually confirm pagination/continuation-slides) — not yet performed, requires a running StyleBI instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)