### PR TITLE
fix(wiz): render treemap-family charts built with hierarchy dims on X

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/VSChartInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/VSChartInfo.java
@@ -958,6 +958,38 @@ public class VSChartInfo extends AbstractChartInfo implements ContentObject, Dat
          list.toArray(temp);
          setRTGroupFields(temp);
 
+         // #treemap-heal: a treemap-family chart whose hierarchy dimensions were bound on the
+         // X slot with an empty group slot renders empty, because SeparateGraphGenerator reads
+         // the treemap hierarchy only from the group slot. Move any RT X *dimension* refs into
+         // the RT group slot so such charts render as treemaps on every render path. No-op for
+         // correctly-built treemaps (group already populated) and for non-treemap charts.
+         if(GraphTypes.isTreemap(getRTChartType()) || GraphTypes.isTreemap(getChartType())) {
+            ChartRef[] rtGroupHeal = getRTGroupFields();
+
+            if(rtGroupHeal == null || rtGroupHeal.length == 0) {
+               ChartRef[] rtXHeal = getRTXFields();
+
+               if(rtXHeal != null && rtXHeal.length > 0) {
+                  List<ChartRef> healDims = new ArrayList<>();
+                  List<ChartRef> healKeepX = new ArrayList<>();
+
+                  for(ChartRef ref : rtXHeal) {
+                     if(ref instanceof XAggregateRef) {
+                        healKeepX.add(ref);
+                     }
+                     else {
+                        healDims.add(ref);
+                     }
+                  }
+
+                  if(!healDims.isEmpty()) {
+                     setRTGroupFields(healDims.toArray(new ChartRef[0]));
+                     setRTXFields(healKeepX.toArray(new ChartRef[0]));
+                  }
+               }
+            }
+         }
+
          // only not found the period dimension, period is true
          period = false;
          periodRef = pdim;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -20,6 +20,7 @@ package inetsoft.web.wiz.service;
 
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.analytic.composition.event.VSEventUtil;
+import inetsoft.graph.aesthetic.LinearSizeFrame;
 import inetsoft.graph.data.*;
 import inetsoft.report.composition.graph.GraphTypeUtil;
 import inetsoft.report.composition.graph.GraphUtil;
@@ -2524,6 +2525,13 @@ public class WizVsService {
          if(binding.getPath() != null) {
             chartInfo.setPathField(createChartRef(binding.getPath()));
          }
+
+         // #treemap-heal: the x/y-based construction above is not what SeparateGraphGenerator's
+         // treemap-family branch reads at render time — it reads the hierarchy dims only from the
+         // GROUP slot (SeparateGraphGenerator:452-457), so a chart left with dims on x/y and an
+         // empty group renders as an empty cartesian layout. Re-slot now so the asset that gets
+         // persisted is durable across save/reopen, not just correct for this first render.
+         normalizeTreemapBindingToGroup(chartInfo);
       }
       else {
          // Default: Bar, 3D Bar, Area, Point, Step Area, Interval, Line, Step Line, Jump Line,
@@ -2579,6 +2587,72 @@ public class WizVsService {
          chartType == GraphTypes.CHART_SUNBURST ||
          chartType == GraphTypes.CHART_CIRCLE_PACKING ||
          chartType == GraphTypes.CHART_ICICLE;
+   }
+
+   /**
+    * Re-slot a mis-structured treemap-family chart so it renders durably. Treemaps
+    * (and sunburst/circle-packing/icicle) render from the GROUP slot; a chart built with the
+    * hierarchy dims on the X slot and an empty group renders as an empty cartesian chart on
+    * reopen. This moves any X/Y dimension fields into the group slot and ensures the size
+    * aesthetic is set, mirroring ChangeChartTypeProcessor.copyToTreemap. Idempotent: a no-op
+    * when the group slot already carries dims (a correctly-built treemap) or when the chart is
+    * not a treemap-family type.
+    */
+   public void normalizeTreemapBindingToGroup(VSChartInfo info) {
+      if(info == null || !isTreeMapChartType(info.getChartType())) {
+         return;
+      }
+
+      ChartRef[] groupFields = info.getGroupFields();
+
+      if(groupFields != null && groupFields.length > 0) {
+         // Already correctly structured — either a correctly-built treemap, or one already
+         // healed by a prior call. Never disturb a populated group slot.
+         return;
+      }
+
+      List<ChartRef> dims = new ArrayList<>();
+      List<ChartRef> measures = new ArrayList<>();
+      collectTreemapDimsAndMeasures(info.getXFields(), dims, measures);
+      collectTreemapDimsAndMeasures(info.getYFields(), dims, measures);
+
+      if(dims.isEmpty()) {
+         // Nothing to re-slot (e.g. an empty binding, or x/y hold only measures).
+         return;
+      }
+
+      info.removeXFields();
+      info.removeYFields();
+      dims.forEach(info::addGroupField);
+
+      if(info.getSizeField() == null && !measures.isEmpty()) {
+         AestheticRef aref = new VSAestheticRef();
+         aref.setDataRef(measures.get(0));
+         aref.setVisualFrame(new LinearSizeFrame());
+         info.setSizeField(aref);
+      }
+   }
+
+   /** Split {@code fields} into dimension vs. measure refs, per ChangeChartTypeProcessor.copyToTreemap. */
+   private void collectTreemapDimsAndMeasures(ChartRef[] fields, List<ChartRef> dims,
+                                              List<ChartRef> measures)
+   {
+      if(fields == null) {
+         return;
+      }
+
+      for(ChartRef field : fields) {
+         if(field == null) {
+            continue;
+         }
+
+         if(field instanceof XAggregateRef) {
+            measures.add(field);
+         }
+         else {
+            dims.add(field);
+         }
+      }
    }
 
    private AestheticRef createAestheticRef(SimpleFieldInfo field) {


### PR DESCRIPTION
## Summary
A 2-level treemap built through the wiz explicit-binding path rendered as an **empty cartesian (bar) chart** after save/reopen — in the live viewer and in board PDF/PPTX export — even though the chart type and data were intact.

**Root cause:** the wiz path placed the treemap's hierarchy dimensions on the **X** slot with an **empty group** slot. `SeparateGraphGenerator`'s treemap-family branch reads the hierarchy dims **only** from the group slot (`getRTGroupFields()`), so the treemap got zero hierarchy dims and fell back to a cartesian layout with an empty plot. (The create-time preview looked right because it goes through `DefaultGraphGenerator`, which reads X; the durable reopen path uses `SeparateGraphGenerator`, which reads group.)

## Fix (two parts)
- **`WizVsService.applyChartBinding`** — after building a treemap-family chart, re-slot the hierarchy dims from X/Y into the **group** slot (mirroring `ChangeChartTypeProcessor.copyToTreemap`) so the persisted asset is durable across save/reopen. Idempotent no-op when the group slot is already populated (correctly-built treemaps) or for non-treemap charts.
- **`VSChartInfo.update`** — at RT-field computation, for a treemap-family type (`GraphTypes.isTreemap`) with an empty group and X dims present, move the RT X **dimension** refs into the RT group slot. A render-level safety net that heals such charts on every render path (embed, render endpoint, export). Gated so it never affects correctly-built treemaps or other chart types.

## Verification
Built into a local StyleBI image and verified end-to-end against a real Odoo board:
- `update_binding(treemap, [category, price_band, Sum(revenue)])` now returns `group=[category,price_band] + size=Sum(revenue)` (was `x=[...]`).
- The saved viz **persists through save→reopen** and renders as a proper nested `category → price_band` treemap (confirmed via `/api/wiz/visualization/render` and the board PDF export).

🤖 Generated with [Claude Code](https://claude.com/claude-code)