### PR TITLE
feat(wiz): scope /ws/structure to a generation with upstream closure

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
@@ -97,12 +97,21 @@ public class DatasourceMetaApiController {
       return metadataService.getWorksheetMetaData(WizUtil.decodeId(worksheetId), (XPrincipal) principal);
    }
 
+   /**
+    * Returns a worksheet's per-table structure.
+    *
+    * @param generation optional worksheet-table generation. When supplied, only the tables belonging
+    *    to that generation (by their {@code _<generation>} name suffix) are returned; omit it to get
+    *    every table (the MCP path, whose in-place edits need to see all tables, omits it).
+    */
    @GetMapping("/ws/structure/{id}")
    public WorksheetStructure getWorksheetStructure(
       @PathVariable("id") String worksheetId,
+      @RequestParam(value = "generation", required = false) Integer generation,
       Principal principal) throws Exception
    {
-      return metadataService.getWorksheetStructure(WizUtil.decodeId(worksheetId), (XPrincipal) principal);
+      return metadataService.getWorksheetStructure(
+         WizUtil.decodeId(worksheetId), generation, (XPrincipal) principal);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -669,7 +669,8 @@ public class MetadataApiService {
          // scope is the full list (a no-op, since primary is always present when nothing is filtered).
          List<WorksheetStructure.StructureTable> fallbackScope =
             (generation == null) ? tables : seedTables;
-         structure.setPrimaryTable(resolvePrimaryTable(primaryAssembly.getName(), fallbackScope));
+         structure.setPrimaryTable(
+            resolveScopedPrimaryTable(primaryAssembly.getName(), tables, fallbackScope, generation));
       }
 
       return structure;
@@ -726,6 +727,26 @@ public class MetadataApiService {
       }
 
       return tables.get(tables.size() - 1).getName();
+   }
+
+   /**
+    * The final primaryTable to report for a (possibly generation-scoped) response. A generation-scoped
+    * read that matched no tables returns an empty {@code tables} list, so primaryTable is {@code null}:
+    * the response is a self-contained subgraph and primaryTable must resolve within {@code tables} — a
+    * non-null primary pointing outside an empty list would break that contract. Otherwise it reconciles
+    * within {@code fallbackScope} (the seed for a scoped read, the full list when unfiltered), where an
+    * unfiltered empty worksheet keeps its original primary per {@link #resolvePrimaryTable}.
+    */
+   static String resolveScopedPrimaryTable(String primary,
+                                           List<WorksheetStructure.StructureTable> tables,
+                                           List<WorksheetStructure.StructureTable> fallbackScope,
+                                           Integer generation)
+   {
+      if(generation != null && (tables == null || tables.isEmpty())) {
+         return null;
+      }
+
+      return resolvePrimaryTable(primary, fallbackScope);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -54,6 +54,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.*;
+import java.util.regex.Matcher;
 
 @Service
 public class MetadataApiService {
@@ -561,8 +562,19 @@ public class MetadataApiService {
     * source, base tables, joins, conditions, and aggregate — for the wiz worksheet-structure
     * introspection endpoint. Mirrors {@link #getWorksheetMetaData} but captures per-table
     * provenance detail rather than just names/columns.
+    *
+    * @param generation optional worksheet-table generation to scope the result to. When non-null,
+    *    the result is that generation's tables (matched by their {@code _<generation>} name suffix)
+    *    PLUS their transitive upstream dependency closure: a scoped table may reuse a prior
+    *    generation's base table, which is pulled in and ordered ahead of its dependent so the
+    *    returned structure is self-contained (baseTables/joins resolve within it — no cross-
+    *    generation dangling references, and callers consume it without further filtering).
+    *    primaryTable is reconciled to this generation's own tables (the seed), never a pulled-in
+    *    upstream table. When null, every table is returned — the "no filter" contract used by MCP
+    *    callers, whose in-place edits must see all tables, and by legacy callers that predate
+    *    generation naming.
     */
-   public WorksheetStructure getWorksheetStructure(String wsId, XPrincipal principal)
+   public WorksheetStructure getWorksheetStructure(String wsId, Integer generation, XPrincipal principal)
       throws Exception
    {
       if(wsId == null || Tool.isEmptyString(wsId)) {
@@ -576,22 +588,71 @@ public class MetadataApiService {
          throw new Exception("Worksheet " + wsId + " not found.");
       }
 
-      List<WorksheetStructure.StructureTable> tables = new ArrayList<>();
+      // Enumerate table assemblies once in sheet order. That order is dependency order: a base /
+      // upstream table is added to the sheet before the table that references it, so emitting the
+      // kept tables in this order keeps an upstream table ahead of its dependents.
+      List<TableAssembly> tableAssemblies = new ArrayList<>();
 
       for(Assembly assembly : sheet.getAssemblies()) {
-         if(!(assembly instanceof TableAssembly tableAssembly)) {
+         if(assembly instanceof TableAssembly tableAssembly) {
+            tableAssemblies.add(tableAssembly);
+         }
+      }
+
+      // Decide which tables to build. With no generation this is every table (the MCP / legacy
+      // "no filter" contract). With a generation it is that generation's own tables (the seed) PLUS
+      // their transitive upstream dependency closure: a seed table may reuse a prior generation's
+      // base table (see applyGenerationToTables — references to tables outside the build batch are
+      // kept as-is), which must be pulled in — and ordered ahead of its dependent — so the returned
+      // structure is self-contained (baseTables/joins resolve within it, no cross-generation
+      // dangling references). wiz-services consumes this result directly without further filtering.
+      Set<String> keep = null;         // null => keep every table (no filter)
+      Set<String> seedNames = null;    // this generation's own tables — the primaryTable fallback scope
+
+      if(generation != null) {
+         List<String> enumerationOrder = new ArrayList<>();
+         Map<String, Set<String>> upstream = new HashMap<>();
+         seedNames = new LinkedHashSet<>();
+
+         for(TableAssembly tableAssembly : tableAssemblies) {
+            String name = tableAssembly.getName();
+            enumerationOrder.add(name);
+            upstream.put(name, collectUpstreamRefs(tableAssembly));
+
+            if(matchesGeneration(name, generation)) {
+               seedNames.add(name);
+            }
+         }
+
+         keep = new HashSet<>(expandToUpstreamClosure(enumerationOrder, upstream, seedNames));
+      }
+
+      List<WorksheetStructure.StructureTable> tables = new ArrayList<>();
+      List<WorksheetStructure.StructureTable> seedTables = new ArrayList<>();
+
+      for(TableAssembly tableAssembly : tableAssemblies) {   // sheet order => upstream before dependents
+         String name = tableAssembly.getName();
+
+         if(keep != null && !keep.contains(name)) {
             continue;
          }
 
+         WorksheetStructure.StructureTable built;
+
          try {
-            tables.add(buildStructureTable(tableAssembly));
+            built = buildStructureTable(tableAssembly);
          }
          catch(Exception ex) {
             // Best-effort: one malformed/unexpected assembly shouldn't fail the whole call.
-            WorksheetStructure.StructureTable partial = new WorksheetStructure.StructureTable();
-            partial.setName(tableAssembly.getName());
-            tables.add(partial);
-            log.debug("Failed to fully map worksheet assembly '{}'", tableAssembly.getName(), ex);
+            built = new WorksheetStructure.StructureTable();
+            built.setName(name);
+            log.debug("Failed to fully map worksheet assembly '{}'", name, ex);
+         }
+
+         tables.add(built);
+
+         if(seedNames != null && seedNames.contains(name)) {
+            seedTables.add(built);
          }
       }
 
@@ -603,10 +664,140 @@ public class MetadataApiService {
       WSAssembly primaryAssembly = worksheet.getPrimaryAssembly();
 
       if(primaryAssembly != null) {
-         structure.setPrimaryTable(primaryAssembly.getName());
+         // Reconcile primaryTable within THIS generation's own tables (the seed), never a pulled-in
+         // upstream table — so binding points at this generation's terminal table. Unfiltered, the
+         // scope is the full list (a no-op, since primary is always present when nothing is filtered).
+         List<WorksheetStructure.StructureTable> fallbackScope =
+            (generation == null) ? tables : seedTables;
+         structure.setPrimaryTable(resolvePrimaryTable(primaryAssembly.getName(), fallbackScope));
       }
 
       return structure;
+   }
+
+   /**
+    * The per-generation suffix wiz-services appends to a logical worksheet-table name
+    * ({@code applyGenerationToTables} → {@code <name>_<generation>}). StyleBI itself does not assign
+    * these; the tag is opaque to the backend and only parsed here to serve generation-scoped reads.
+    */
+   private static final java.util.regex.Pattern GENERATION_SUFFIX =
+      java.util.regex.Pattern.compile("_(\\d+)$");
+
+   /**
+    * Extract the trailing {@code _<n>} generation number from a worksheet-table name, or {@code null}
+    * when the name carries no such suffix (e.g. a table created before generation naming shipped).
+    * Only the FINAL {@code _<n>} is the generation tag — a name may legitimately contain other
+    * underscore+digit segments mid-name.
+    */
+   static Integer parseGeneration(String name) {
+      if(name == null || name.isEmpty()) {
+         return null;
+      }
+
+      Matcher matcher = GENERATION_SUFFIX.matcher(name);
+      return matcher.find() ? Integer.valueOf(matcher.group(1)) : null;
+   }
+
+   /**
+    * Whether a table with the given name should be included for the requested generation.
+    * {@code generation == null} is the "no filter" contract (MCP / legacy callers): everything is
+    * kept. Otherwise only tables whose name carries the matching {@code _<generation>} suffix pass;
+    * an unsuffixed (legacy) table has no generation and is excluded from a specific-generation read.
+    */
+   static boolean matchesGeneration(String name, Integer generation) {
+      return generation == null || generation.equals(parseGeneration(name));
+   }
+
+   /**
+    * Resolve the primaryTable name to report after generation filtering. If the original primary
+    * assembly survived the filter it is kept; otherwise it fell into a different generation, so fall
+    * back to the last kept table (the terminal/binding table by convention). Returns the original
+    * value unchanged when there is nothing to reconcile (null primary, or no tables left).
+    */
+   static String resolvePrimaryTable(String primary, List<WorksheetStructure.StructureTable> tables) {
+      if(primary == null || tables == null || tables.isEmpty()) {
+         return primary;
+      }
+
+      for(WorksheetStructure.StructureTable table : tables) {
+         if(primary.equals(table.getName())) {
+            return primary;
+         }
+      }
+
+      return tables.get(tables.size() - 1).getName();
+   }
+
+   /**
+    * The names of the tables {@code tableAssembly} directly depends on — its composed base tables
+    * plus each join edge's left/right table. Used to walk the upstream dependency closure during
+    * generation-scoped filtering, so a kept table's referenced (possibly other-generation) base
+    * tables are pulled into the result rather than left dangling.
+    */
+   static Set<String> collectUpstreamRefs(TableAssembly tableAssembly) {
+      Set<String> refs = new LinkedHashSet<>(extractStructureBaseTables(tableAssembly));
+
+      for(WorksheetStructure.JoinEdge join : extractStructureJoins(tableAssembly)) {
+         if(join.getLeftTable() != null) {
+            refs.add(join.getLeftTable());
+         }
+
+         if(join.getRightTable() != null) {
+            refs.add(join.getRightTable());
+         }
+      }
+
+      return refs;
+   }
+
+   /**
+    * Expand a generation seed set into its full upstream dependency closure, returned in
+    * {@code enumerationOrder}. Starting from the tables that matched the requested generation (seed),
+    * it transitively pulls in every table they reference via baseTables/joins — even when a
+    * referenced table belongs to another generation (a reused prior-generation base table) or
+    * carries no generation suffix. A reference to a name not present in {@code enumerationOrder}
+    * (a deleted orphan) is skipped. Emitting in enumeration order guarantees a pulled-in upstream
+    * table (created in an earlier generation, hence earlier in the sheet) precedes the downstream
+    * table that depends on it.
+    *
+    * @param enumerationOrder all table names in {@code sheet.getAssemblies()} order (dependency order)
+    * @param upstream         name -> the names it directly references (baseTables + join left/right)
+    * @param seed             names that matched the requested generation
+    * @return the names to include (seed + transitive upstream), ordered by {@code enumerationOrder}
+    */
+   static List<String> expandToUpstreamClosure(
+      List<String> enumerationOrder,
+      Map<String, Set<String>> upstream,
+      Set<String> seed)
+   {
+      Set<String> keep = new HashSet<>();
+      Deque<String> pending = new ArrayDeque<>(seed);
+
+      while(!pending.isEmpty()) {
+         String name = pending.pop();
+
+         if(!keep.add(name)) {
+            continue;
+         }
+
+         for(String ref : upstream.getOrDefault(name, Set.of())) {
+            if(!keep.contains(ref)) {
+               pending.push(ref);
+            }
+         }
+      }
+
+      // Emit in enumeration order so upstream (earlier-created) tables precede their dependents; a
+      // dangling ref to a name absent from the sheet is naturally dropped here (never in the order).
+      List<String> ordered = new ArrayList<>();
+
+      for(String name : enumerationOrder) {
+         if(keep.contains(name)) {
+            ordered.add(name);
+         }
+      }
+
+      return ordered;
    }
 
    private WorksheetStructure.StructureTable buildStructureTable(TableAssembly tableAssembly) {

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceStructureTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceStructureTest.java
@@ -466,6 +466,44 @@ class MetadataApiServiceStructureTest {
       assertNull(MetadataApiService.resolvePrimaryTable(null, java.util.List.of(structureTable("a_2"))));
    }
 
+   // ---- resolveScopedPrimaryTable ----
+
+   @Test
+   void scopedPrimaryTableIsNullWhenGenerationMatchesNoTables() {
+      // A generation-scoped read that matched nothing returns an empty tables list, so primaryTable
+      // must be null: the response is a self-contained subgraph and primaryTable must resolve within
+      // tables — a non-null primary pointing outside an empty list would violate that contract.
+      assertNull(MetadataApiService.resolveScopedPrimaryTable(
+         "sales_2", java.util.List.of(), java.util.List.of(), 2));
+   }
+
+   @Test
+   void scopedPrimaryTableKeepsPrimaryWithinSeed() {
+      var tables = java.util.List.of(structureTable("base_1"), structureTable("sales_2"));
+      var seed = java.util.List.of(structureTable("sales_2"));
+      assertEquals("sales_2",
+                   MetadataApiService.resolveScopedPrimaryTable("sales_2", tables, seed, 2));
+   }
+
+   @Test
+   void scopedPrimaryTableFallsBackToSeedLastWhenPrimaryOutsideSeed() {
+      // primary "other_1" is another generation's table; fall back to the seed's last table (this
+      // generation's terminal), never a pulled-in upstream table.
+      var tables = java.util.List.of(
+         structureTable("base_1"), structureTable("sales_2"), structureTable("agg_2"));
+      var seed = java.util.List.of(structureTable("sales_2"), structureTable("agg_2"));
+      assertEquals("agg_2",
+                   MetadataApiService.resolveScopedPrimaryTable("other_1", tables, seed, 2));
+   }
+
+   @Test
+   void scopedPrimaryTableUnfilteredKeepsOriginalOnEmpty() {
+      // generation == null (no scoping): an empty worksheet keeps its original primaryTable, matching
+      // the pre-filtering contract (only a generation-scoped no-match nulls it out).
+      assertEquals("a_only", MetadataApiService.resolveScopedPrimaryTable(
+         "a_only", java.util.List.of(), java.util.List.of(), null));
+   }
+
    // ---- collectUpstreamRefs ----
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceStructureTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceStructureTest.java
@@ -381,4 +381,209 @@ class MetadataApiServiceStructureTest {
       assertNull(MetadataApiService.extractStructureAggregate(null));
       assertNull(MetadataApiService.extractStructureAggregate(new AggregateInfo()));
    }
+
+   // ---- parseGeneration ----
+
+   @Test
+   void parsesTrailingGenerationSuffix() {
+      assertEquals(2, MetadataApiService.parseGeneration("sales_2"));
+   }
+
+   @Test
+   void parseGenerationReturnsNullWhenNoSuffix() {
+      assertNull(MetadataApiService.parseGeneration("sales"));
+   }
+
+   @Test
+   void parseGenerationTakesOnlyTrailingNumber() {
+      // A logical table name can itself contain underscores + digits mid-name; only the final
+      // `_<n>` is the generation tag applied by applyGenerationToTables.
+      assertEquals(3, MetadataApiService.parseGeneration("orders_1_3"));
+   }
+
+   @Test
+   void parseGenerationReturnsNullForNullOrBlank() {
+      assertNull(MetadataApiService.parseGeneration(null));
+      assertNull(MetadataApiService.parseGeneration(""));
+   }
+
+   // ---- matchesGeneration ----
+
+   @Test
+   void matchesGenerationAllowsEverythingWhenGenerationNull() {
+      // generation == null is the "no filter" path (MCP / legacy): every table is kept, whether or
+      // not it carries a suffix.
+      assertTrue(MetadataApiService.matchesGeneration("sales", null));
+      assertTrue(MetadataApiService.matchesGeneration("sales_2", null));
+   }
+
+   @Test
+   void matchesGenerationKeepsSameGeneration() {
+      assertTrue(MetadataApiService.matchesGeneration("sales_2", 2));
+   }
+
+   @Test
+   void matchesGenerationRejectsOtherGeneration() {
+      assertFalse(MetadataApiService.matchesGeneration("sales_1", 2));
+   }
+
+   @Test
+   void matchesGenerationRejectsUnsuffixedWhenGenerationSet() {
+      // A legacy/unsuffixed table has no generation, so a specific-generation request excludes it.
+      assertFalse(MetadataApiService.matchesGeneration("sales", 2));
+   }
+
+   // ---- resolvePrimaryTable ----
+
+   private static WorksheetStructure.StructureTable structureTable(String name) {
+      WorksheetStructure.StructureTable t = new WorksheetStructure.StructureTable();
+      t.setName(name);
+      return t;
+   }
+
+   @Test
+   void resolvePrimaryTableKeepsPrimaryWhenStillPresent() {
+      var tables = java.util.List.of(structureTable("a_2"), structureTable("b_2"));
+      assertEquals("b_2", MetadataApiService.resolvePrimaryTable("b_2", tables));
+   }
+
+   @Test
+   void resolvePrimaryTableFallsBackToLastWhenPrimaryFilteredOut() {
+      // primary "b_1" belongs to a different generation and was filtered out; fall back to the last
+      // kept table (the terminal/binding table by convention).
+      var tables = java.util.List.of(structureTable("a_2"), structureTable("c_2"));
+      assertEquals("c_2", MetadataApiService.resolvePrimaryTable("b_1", tables));
+   }
+
+   @Test
+   void resolvePrimaryTableKeepsOriginalWhenNoTablesLeft() {
+      assertEquals("b_1",
+                   MetadataApiService.resolvePrimaryTable("b_1", java.util.List.of()));
+   }
+
+   @Test
+   void resolvePrimaryTableHandlesNullPrimary() {
+      assertNull(MetadataApiService.resolvePrimaryTable(null, java.util.List.of(structureTable("a_2"))));
+   }
+
+   // ---- collectUpstreamRefs ----
+
+   @Test
+   void collectUpstreamRefsMergesBaseTablesAndJoinTables() {
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly left = physicalTable(ws, "t1", "id");
+      PhysicalBoundTableAssembly right = physicalTable(ws, "t2", "id");
+
+      TableAssemblyOperator.Operator op = new TableAssemblyOperator.Operator();
+      op.setLeftTable("t1");
+      op.setRightTable("t2");
+      op.setLeftAttribute(new AttributeRef(null, "id"));
+      op.setRightAttribute(new AttributeRef(null, "id"));
+      op.setOperation(TableAssemblyOperator.INNER_JOIN);
+
+      TableAssemblyOperator top = new TableAssemblyOperator();
+      top.addOperator(op);
+
+      RelationalJoinTableAssembly join = new RelationalJoinTableAssembly(
+         ws, "joined", new TableAssembly[] { left, right }, new TableAssemblyOperator[] { top });
+
+      var refs = MetadataApiService.collectUpstreamRefs(join);
+      assertTrue(refs.contains("t1"), "base/join left table should be an upstream ref");
+      assertTrue(refs.contains("t2"), "base/join right table should be an upstream ref");
+   }
+
+   @Test
+   void collectUpstreamRefsEmptyForPhysicalTable() {
+      Worksheet ws = new Worksheet();
+      assertTrue(MetadataApiService.collectUpstreamRefs(physicalTable(ws, "accounts", "id")).isEmpty(),
+                 "a physical bound table depends on no other worksheet table");
+   }
+
+   // ---- expandToUpstreamClosure ----
+
+   @Test
+   void closurePullsInReusedUpstreamFromEarlierGeneration() {
+      // sales_2 (this generation) reuses base_1 (a prior generation's physical table). base_1 must be
+      // pulled into the result even though it does not belong to generation 2.
+      var order = java.util.List.of("base_1", "sales_2");
+      var upstream = java.util.Map.of(
+         "base_1", java.util.Set.<String>of(),
+         "sales_2", java.util.Set.of("base_1"));
+      var seed = java.util.Set.of("sales_2");
+
+      assertEquals(java.util.List.of("base_1", "sales_2"),
+                   MetadataApiService.expandToUpstreamClosure(order, upstream, seed));
+   }
+
+   @Test
+   void closurePullsInMultiLevelUpstreamChain() {
+      // n_3 -> m_2 -> k_1: the whole transitive chain is included, not just the direct parent.
+      var order = java.util.List.of("k_1", "m_2", "n_3");
+      var upstream = java.util.Map.of(
+         "k_1", java.util.Set.<String>of(),
+         "m_2", java.util.Set.of("k_1"),
+         "n_3", java.util.Set.of("m_2"));
+      var seed = java.util.Set.of("n_3");
+
+      assertEquals(java.util.List.of("k_1", "m_2", "n_3"),
+                   MetadataApiService.expandToUpstreamClosure(order, upstream, seed));
+   }
+
+   @Test
+   void closureExcludesOtherGenerationTablesNotDependedOn() {
+      // unused_1 is another generation's table that nothing in the seed depends on — it stays out.
+      var order = java.util.List.of("base_1", "unused_1", "sales_2");
+      var upstream = java.util.Map.of(
+         "base_1", java.util.Set.<String>of(),
+         "unused_1", java.util.Set.<String>of(),
+         "sales_2", java.util.Set.of("base_1"));
+      var seed = java.util.Set.of("sales_2");
+
+      assertEquals(java.util.List.of("base_1", "sales_2"),
+                   MetadataApiService.expandToUpstreamClosure(order, upstream, seed));
+   }
+
+   @Test
+   void closureOrdersUpstreamBeforeDependent() {
+      // Regardless of iteration order in the upstream map, the RESULT follows enumerationOrder, which
+      // places a pulled-in upstream table ahead of the dependent that references it.
+      var order = java.util.List.of("base_1", "sales_2");
+      var upstream = java.util.Map.of(
+         "sales_2", java.util.Set.of("base_1"),
+         "base_1", java.util.Set.<String>of());
+      var seed = java.util.Set.of("sales_2");
+
+      var result = MetadataApiService.expandToUpstreamClosure(order, upstream, seed);
+      assertTrue(result.indexOf("base_1") < result.indexOf("sales_2"),
+                 "upstream base_1 must precede its dependent sales_2");
+   }
+
+   @Test
+   void closureSkipsDanglingReferenceToDeletedAssembly() {
+      // sales_2 references ghost_1, which no longer exists in the sheet (a deleted orphan). The
+      // reference is skipped silently: ghost_1 is absent from the result and no exception is thrown.
+      var order = java.util.List.of("sales_2");
+      var upstream = java.util.Map.of("sales_2", java.util.Set.of("ghost_1"));
+      var seed = java.util.Set.of("sales_2");
+
+      assertEquals(java.util.List.of("sales_2"),
+                   MetadataApiService.expandToUpstreamClosure(order, upstream, seed));
+   }
+
+   @Test
+   void closureKeepsSeedWhenNoUpstream() {
+      var order = java.util.List.of("a_2", "b_2");
+      var seed = java.util.Set.of("a_2", "b_2");
+
+      assertEquals(java.util.List.of("a_2", "b_2"),
+                   MetadataApiService.expandToUpstreamClosure(
+                      order, java.util.Map.<String, java.util.Set<String>>of(), seed));
+   }
+
+   @Test
+   void closureEmptyWhenSeedEmpty() {
+      var order = java.util.List.of("a_1", "b_1");
+      assertTrue(MetadataApiService.expandToUpstreamClosure(
+                    order, java.util.Map.of(), java.util.Set.of()).isEmpty());
+   }
 }


### PR DESCRIPTION
Add an optional `generation` query param to /ws/structure. When supplied, return that generation's tables (matched by their `_<generation>` name suffix) plus their transitive upstream dependency closure: a scoped table may reuse a prior generation's base table, which is pulled in and ordered ahead of its dependent so the returned structure is a self-contained subgraph (baseTables/joins resolve within it). primaryTable is reconciled to this generation's own tables. When omitted, every table is returned.

- DatasourceMetaApiController: pass through the generation query param
- MetadataApiService: seed filter -> upstream closure -> enumeration-order output; collectUpstreamRefs + expandToUpstreamClosure helpers; primaryTable fallback scoped to the seed
- MetadataApiServiceStructureTest: closure, multi-level chain, ordering, dangling-reference skip, and seed-scoped primaryTable fallback cases