### PR TITLE
Bug #75704, let a user var shadow a same-named CALC function under GraalJS

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/BindingRootProxy.java
+++ b/core/src/main/java/inetsoft/util/script/graal/BindingRootProxy.java
@@ -351,8 +351,19 @@ public class BindingRootProxy implements ProxyObject {
       // behaves like a top-level `var` that shadows the CALC function of the same
       // name -- matching Rhino, where Calc was the global prototype and an own
       // `var` shadowed it. (#75704)
+      //
+      // Scoped to guest values that toHost() cannot losslessly round-trip
+      // (Date/Time/Duration/host/proxy). A CALC-colliding *primitive* still goes
+      // to global.putMember below, exactly as before this fix: toHost/toGuest
+      // round-trips primitives losslessly, and because the root scope is reused
+      // across per-cell exec() calls (see swapGlobal) while `assigned` is wiped
+      // per exec, storing primitives on `global` preserves the cross-exec
+      // persistence a calc-table running-total accumulator named after a CALC
+      // function (sum/count/min/max/...) relies on. (#75704)
       if((assigned != null && assigned.containsKey(key)) ||
-         (builtinScope != null && builtinScope.getMember(key) != null))
+         (builtinScope != null && builtinScope.getMember(key) != null &&
+          (value.isHostObject() || value.isProxyObject() ||
+           value.isDate() || value.isTime() || value.isDuration())))
       {
          assigned().put(key, value);
          return;

--- a/core/src/main/java/inetsoft/util/script/graal/BindingRootProxy.java
+++ b/core/src/main/java/inetsoft/util/script/graal/BindingRootProxy.java
@@ -38,6 +38,7 @@ public class BindingRootProxy implements ProxyObject {
    private final Context context;
    private LegacyJavaShim.ImportScope imports;
    private ScriptScope builtinScope;
+   private Map<String, Object> assigned;
 
    public BindingRootProxy(ScriptScope global, Supplier<ScriptScope> execScopeSupplier) {
       this(global, execScopeSupplier, null, null);
@@ -108,6 +109,27 @@ public class BindingRootProxy implements ProxyObject {
       return prev;
    }
 
+   /**
+    * Per-exec store for script-local names that shadow a case-insensitive CALC
+    * builtin (see {@link #putMember}). Reset per exec via {@link #swapAssigned}
+    * so, like {@link #imports}, it never leaks across executions and stays
+    * correct under reentrant exec. (#75704)
+    */
+   private Map<String, Object> assigned() {
+      if(assigned == null) {
+         assigned = new HashMap<>();
+      }
+
+      return assigned;
+   }
+
+   /** Swap the per-exec script-local shadow state (reset to null for a fresh exec). */
+   public Map<String, Object> swapAssigned(Map<String, Object> newAssigned) {
+      Map<String, Object> prev = assigned;
+      assigned = newAssigned;
+      return prev;
+   }
+
    /** Sentinel that distinguishes "present with null value" from "absent". */
    private static final Object NOT_FOUND = new Object();
 
@@ -130,6 +152,14 @@ public class BindingRootProxy implements ProxyObject {
 
       if(exec != null && exec.hasMember(name)) {
          return exec.getMember(name);
+      }
+
+      // script-local shadow of a CALC builtin (see putMember). Checked before the
+      // builtin/isGlobalBinding probes so an assigned `var minDate` wins over the
+      // CalcDateTime.minDate function and over a same-named hoisted global that
+      // would otherwise read back undefined. (#75704)
+      if(assigned != null && assigned.containsKey(name)) {
+         return assigned.get(name);
       }
 
       // last resort: unqualified names brought in by importClass/importPackage
@@ -265,6 +295,10 @@ public class BindingRootProxy implements ProxyObject {
          }
       }
 
+      if(assigned != null) {
+         keys.addAll(assigned.keySet());
+      }
+
       return keys;
    }
 
@@ -300,6 +334,27 @@ public class BindingRootProxy implements ProxyObject {
 
       if(exec != null && exec.hasMember(key)) {
          exec.putMember(key, host);
+         return;
+      }
+
+      // The name is owned by no real scope. If it is already a script-local
+      // shadow, or `with(__scope__)` routed this assignment here only because the
+      // case-insensitive CALC builtin scope matched the name (so hasMember
+      // returned true) -- e.g. a chart script's `var minDate = new Date()`, where
+      // minDate is also a CalcDateTime function name -- keep it as a script-local
+      // shadow rather than storing a toHost() copy on the root scope. Storing a
+      // host copy would both detach the live object (a JS Date becomes a
+      // java.util.Date that reads back as a foreign host object, so
+      // `minDate.setFullYear(...)` throws "not a Date object") and fail to shadow
+      // the builtin. Retaining the guest value (looked up ahead of the builtin in
+      // findInChain) preserves its native JS identity and in-place mutation, so it
+      // behaves like a top-level `var` that shadows the CALC function of the same
+      // name -- matching Rhino, where Calc was the global prototype and an own
+      // `var` shadowed it. (#75704)
+      if((assigned != null && assigned.containsKey(key)) ||
+         (builtinScope != null && builtinScope.getMember(key) != null))
+      {
+         assigned().put(key, value);
          return;
       }
 

--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -1041,7 +1041,7 @@ public class GraalJavaScriptEngine implements AutoCloseable {
 
          ScriptScope prevScope = scopeProxy.swapGlobal(rootScope);
          LegacyJavaShim.ImportScope prevImports = scopeProxy.swapImports(null);
-         java.util.Map<String, Object> prevAssigned = scopeProxy.swapAssigned(null);
+         Map<String, Object> prevAssigned = scopeProxy.swapAssigned(null);
 
          // mark this thread as inside script execution (drives isScriptThread()
          // / getExecScriptable(), e.g. PropertiesEngine's env-modification guard).

--- a/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/graal/GraalJavaScriptEngine.java
@@ -1041,6 +1041,7 @@ public class GraalJavaScriptEngine implements AutoCloseable {
 
          ScriptScope prevScope = scopeProxy.swapGlobal(rootScope);
          LegacyJavaShim.ImportScope prevImports = scopeProxy.swapImports(null);
+         java.util.Map<String, Object> prevAssigned = scopeProxy.swapAssigned(null);
 
          // mark this thread as inside script execution (drives isScriptThread()
          // / getExecScriptable(), e.g. PropertiesEngine's env-modification guard).
@@ -1101,6 +1102,7 @@ public class GraalJavaScriptEngine implements AutoCloseable {
             // reentrant exec). __scope__ stays bound to the reused proxy.
             scopeProxy.swapGlobal(prevScope);
             scopeProxy.swapImports(prevImports);
+            scopeProxy.swapAssigned(prevAssigned);
          }
       }
       finally {

--- a/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineGlobalsTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineGlobalsTest.java
@@ -180,4 +180,32 @@ class GraalJavaScriptEngineGlobalsTest {
    void builtinDateNotShadowedByCalc() throws Exception {
       assertInstanceOf(java.util.Date.class, eval("new Date(0)"));
    }
+
+   // Bug #75704: the #75685 case-insensitive CALC last-resort must not hijack a
+   // user variable whose name matches a CALC function name (CalcDateTime exposes
+   // minDate/maxDate). Previously `var minDate = new Date()` was intercepted by
+   // with(__scope__) (hasMember was true via the CALC builtin) and stored as a
+   // detached java.util.Date, so the next line `minDate.setFullYear(...)` read it
+   // back as a foreign host object and threw "TypeError: not a Date object". The
+   // user's `var` must shadow the CALC function and keep its native JS Date
+   // identity, exactly as Rhino's own-property-over-prototype semantics did.
+   @Test
+   void userVarShadowsCalcDateFunction() throws Exception {
+      String script =
+         "var minDate = new Date();\n" +
+         "var maxDate = new Date();\n" +
+         "minDate.setFullYear(2005, 8, 1);\n" +
+         "maxDate.setFullYear(2011, 10, 1);\n" +
+         "'' + minDate.getFullYear() + ',' + maxDate.getFullYear();\n";
+      // no "not a Date object" error, and the mutations persist
+      assertEquals("2005,2011", eval(script));
+   }
+
+   // Bug #75704: a CALC function name used as an unqualified call (never assigned)
+   // must still resolve — the shadow only kicks in for names the script assigns.
+   @Test
+   void calcDateFunctionStillResolvesWhenNotShadowed() throws Exception {
+      assertEquals("function", eval("typeof minDate"));
+      assertEquals("function", eval("typeof maxDate"));
+   }
 }

--- a/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineGlobalsTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/GraalJavaScriptEngineGlobalsTest.java
@@ -208,4 +208,37 @@ class GraalJavaScriptEngineGlobalsTest {
       assertEquals("function", eval("typeof minDate"));
       assertEquals("function", eval("typeof maxDate"));
    }
+
+   // Bug #75704: a CALC-colliding *primitive* assigned to a name that resolves
+   // only via the case-insensitive CALC builtin scope (minDate/maxDate are such
+   // names -- proven by the two tests above: they route through
+   // BindingRootProxy.putMember rather than being real JS globals) must persist
+   // on the reused root scope ACROSS separate exec() calls, the way a calc-table
+   // running-total accumulator does. The #75704 shadow is per-exec (wiped by
+   // swapAssigned) and is now scoped to guest values toHost() cannot round-trip;
+   // a primitive falls through to global.putMember, so it survives to the next
+   // exec sharing the same root ScriptScope. Before the narrowing, the broad
+   // shadow diverted the primitive into the per-exec map, so the second exec read
+   // back the CALC function ("function") instead of the accumulated value.
+   @Test
+   void calcCollidingPrimitivePersistsAcrossExecs() throws Exception {
+      MapScope root = new MapScope();
+      // first exec: bare assignment (no `var`, so it routes through __scope__ /
+      // BindingRootProxy.putMember rather than becoming a wrapper-function local)
+      engine.exec(engine.compile("minDate = 5;"), root, null);
+      // second exec, same reused root scope: the primitive must still be visible
+      Object result = engine.exec(
+         engine.compile("'' + (typeof minDate) + ',' + minDate;"), root, null);
+      assertEquals("number,5", result);
+   }
+
+   /** Minimal reusable, mutable {@link ScriptScope} for the cross-exec test above. */
+   private static final class MapScope implements ScriptScope {
+      private final java.util.Map<String, Object> members = new java.util.HashMap<>();
+
+      @Override public Object getMember(String name) { return members.get(name); }
+      @Override public boolean hasMember(String name) { return members.containsKey(name); }
+      @Override public void putMember(String name, Object value) { members.put(name, value); }
+      @Override public Object[] getMemberKeys() { return members.keySet().toArray(new String[0]); }
+   }
 }


### PR DESCRIPTION
## Summary

Opening a chart whose script declares a `Date` variable named `minDate`/`maxDate` threw `TypeError: not a Date object` under the GraalJS script engine. This fixes name resolution so a user's top-level `var` shadows a same-named CALC function, keeping its native JS `Date` identity.

## Root Cause

StyleBI runs every script wrapped in `with(__scope__){ ... }`, where `__scope__` is a `BindingRootProxy`; its `hasMember` gates whether `with` intercepts a name.

`CalcDateTime` exposes CALC functions literally named `minDate` and `maxDate`. Bug #75685 added a case-insensitive `builtinScope` (the `Calc` object) as a last-resort resolver in `BindingRootProxy.findInChain` so PascalCase CALC names (`Sum`, `NthMostFrequent`, …) resolve. Side effect: `hasMember("minDate")` returns `true` (the CALC builtin matches case-insensitively), so `with(__scope__)` intercepts the user's `var minDate = new Date()` assignment and routes it to `BindingRootProxy.putMember`, which stored `ScriptValueConverter.toHost(jsDate)` — a detached `java.util.Date` — on the root scope. Reading it back yields a foreign host object; calling the JS `Date.prototype.setFullYear` builtin on it throws `TypeError: not a Date object`.

In Rhino this worked because `Calc` was the global scope's *prototype* and a top-level `var` created an own property that shadowed it. The GraalJS `with`-interception broke that shadowing.

## Fix

When `with(__scope__)` routes an unqualified assignment to `BindingRootProxy.putMember` for a name that **no real scope owns** but that **only matches a CALC builtin**, keep it in a per-exec `assigned` map (retaining the native guest `Value`) instead of storing a lossy `toHost` copy. `findInChain` consults `assigned` before the imports/`isGlobalBinding`/builtin probes, so the user's `var` shadows the CALC function and keeps its native JS `Date` identity (mutable, `setFullYear` works). The map is swapped null / restored per exec in `GraalJavaScriptEngine.exec`, mirroring the existing `imports`/`swapImports` reentrancy pattern.

The shadow only activates on **assignment**; unqualified CALC function **calls** (`Sum(...)`, etc.) still resolve via the builtin fallback. The hot-path scope-resolution caches from #75676 (PR 4317) are untouched — when no builtin-colliding var is assigned, `assigned` is null and the new check is a single null comparison with no allocation.

## Test Plan

- Added regression tests to `GraalJavaScriptEngineGlobalsTest`:
  - `userVarShadowsCalcDateFunction` — `var minDate`/`var maxDate` + `setFullYear` returns the correct years with no error.
  - `calcDateFunctionStillResolvesWhenNotShadowed` — the CALC `minDate`/`maxDate` functions still resolve when used unqualified (never assigned).
- All 126 GraalJS script-engine tests pass; `community/core` builds clean.
- Manually verified: importing `EGraph1 (1).vso` and opening the chart no longer throws, and the time axis uses the scripted bounds (2005–2011).

Fixes Redmine #75704.