### PR TITLE
fix(wiz): fill the PPTX slide for crosstab/table tiles too

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
@@ -308,8 +308,8 @@ public class WizViewsheetExportController {
    }
 
    /**
-    * Enlarge the chart(s) in a to-be-exported single-chart runtime so the PPTX render fills the
-    * merged 16:9 slide instead of landing at the chart's small saved size in the top-left corner.
+    * Enlarge the chart/table assemblies in a to-be-exported single-viz runtime so the PPTX render
+    * fills the merged 16:9 slide instead of landing at the small saved size in the top-left corner.
     * PPTVSExporter renders each chart at its assembly pixel size (scaled by PIXEL_TO_POINT=0.75 to
     * slide points) and sizes the slide to fit it, so a ~400px saved chart becomes a small image on
     * the 960x540pt deck. Sizing the assembly to {@link #PPTX_CHART_W_PX}x{@link #PPTX_CHART_H_PX}
@@ -325,9 +325,15 @@ public class WizViewsheetExportController {
       }
 
       for(var assembly : vs.getAssemblies()) {
-         if(assembly instanceof inetsoft.uql.viewsheet.ChartVSAssembly chart) {
-            chart.getVSAssemblyInfo().setPixelOffset(new java.awt.Point(PPTX_CHART_X_PX, PPTX_CHART_Y_PX));
-            chart.getVSAssemblyInfo().setPixelSize(new java.awt.Dimension(PPTX_CHART_W_PX, PPTX_CHART_H_PX));
+         // Charts render as a scaled image and tables/crosstabs as a native PPT table; both are
+         // placed at the assembly's pixel bounds, so enlarging the assembly fills the slide for
+         // either kind. (VSAssembly is the common base carrying setPixelOffset/setPixelSize.)
+         if(assembly instanceof inetsoft.uql.viewsheet.ChartVSAssembly ||
+            assembly instanceof inetsoft.uql.viewsheet.TableDataVSAssembly)
+         {
+            inetsoft.uql.viewsheet.VSAssembly vsa = (inetsoft.uql.viewsheet.VSAssembly) assembly;
+            vsa.getVSAssemblyInfo().setPixelOffset(new java.awt.Point(PPTX_CHART_X_PX, PPTX_CHART_Y_PX));
+            vsa.getVSAssemblyInfo().setPixelSize(new java.awt.Dimension(PPTX_CHART_W_PX, PPTX_CHART_H_PX));
          }
       }
    }


### PR DESCRIPTION
## Summary
Follow-up to #4328. That PR made **chart** tiles fill the PPTX slide; **crosstab/table** tiles were still rendered at their small saved size in the top-left corner.

Tables/crosstabs render via PPT's native-table path but are still placed at the assembly's pixel bounds, so the same fix applies: enlarge `TableDataVSAssembly` (as well as `ChartVSAssembly`) in the throwaway export runtime before exporting, so crosstab/table slides fill the slide below the caption band. Runtime-only — the saved asset is untouched.

## Verification
Rebuilt locally and re-exported the Q39 board as PPTX: the crosstab slide now spans the slide width with all rows/columns legible (previously a tiny top-left table).

Note: a crosstab whose saved-viz display name is a raw asset UUID will show that UUID as its slide caption — that's a separate data/naming issue (the board tile's title), independent of this sizing fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)