### PR TITLE
fix(wiz): board-export crosstab/table cells render (print-layout scaleFont=1)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -55,6 +55,12 @@ public class WizPrintLayoutBuilder {
    {
       PrintLayout layout = new PrintLayout();
       layout.setPrintInfo(buildPrintInfo(pageSize));
+      // scaleFont defaults to 0f on a bare PrintLayout; AbstractLayout.apply() then stamps
+      // RScaleFont=0 onto every assembly's cell formats, and VSCompositeFormat.getFont()
+      // multiplies the font size by rscaleFont — so table/crosstab cells render at font size 0
+      // (invisible text, and zero-width auto columns) while charts (painted by the graph engine)
+      // are unaffected. 1f == "no font scaling", matching an interactively-created print layout.
+      layout.setScaleFont(1f);
       layout.setHeaderLayouts(new ArrayList<>());
       layout.setFooterLayouts(new ArrayList<>());
 

--- a/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
@@ -174,6 +174,19 @@ class WizPrintLayoutBuilderTest {
    }
 
    @Test
+   void setsScaleFontToOneSoTableCellFontsAreNotZeroSized() {
+      Viewsheet vs = mock(Viewsheet.class);
+      PrintLayout layout = builder.build(vs, "letter", "Board", null, List.of());
+      // A bare PrintLayout leaves scaleFont at its 0f default; AbstractLayout.apply() then stamps
+      // RScaleFont=0 onto every assembly's cell formats, and VSCompositeFormat.getFont() multiplies
+      // the font size by rscaleFont — so crosstab/table cells render at font size 0 (invisible text
+      // and zero-width auto columns) while charts, painted by the graph engine, are unaffected.
+      // 1f == "no font scaling", matching an interactively-created print layout.
+      assertEquals(1f, layout.getScaleFont(),
+         "crosstab/table cell fonts must not be scaled to zero in the board-export print layout");
+   }
+
+   @Test
    void threeArgChartCaptionStillCompilesAndOmitsInsights() {
       Viewsheet vs = new Viewsheet();
       textAssembly(vs, "Chart1", 0);


### PR DESCRIPTION
## Problem

In the board **PDF** export, a merged crosstab/table tile rendered its caption and insights but an **empty table body** — while the same crosstab renders correctly in the live viewer and in the PPTX export (which exports each viz individually).

## Root cause

The PDF path builds a `PrintLayout` via `WizPrintLayoutBuilder`, which left `PrintLayout.scaleFont` at its `0f` default. `AbstractLayout.apply()` stamps that value as `RScaleFont` onto every assembly's cell formats, and `VSCompositeFormat.getFont()` returns `font.deriveFont(size * rscaleFont)` — so every crosstab/table **cell font was sized to 0** and rendered invisibly (with zero-width auto columns as a knock-on). Charts were unaffected because they are painted by the graph engine, not cell fonts, so only tables/crosstabs came out blank in the composed-dashboard PDF.

## Fix

One line: set `scaleFont=1f` ("no scaling", matching an interactively-created print layout) in `WizPrintLayoutBuilder.build()`.

## Verification

- Live board PDF export: the crosstab now renders in full (all categories × price bands with revenue values); charts (treemap, bars) render unchanged — no regression.
- Added `WizPrintLayoutBuilderTest.setsScaleFontToOneSoTableCellFontsAreNotZeroSized` (asserts `scaleFont == 1f`; fails against the old `0f`). Full `WizPrintLayoutBuilderTest`: 10/10 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)