### PR TITLE
Add a copy boolean to ChartColorsRequest/ChartFormatRequest. 

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/ApplyHighlightModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ApplyHighlightModel.java
@@ -26,7 +26,7 @@ import java.util.List;
  * Request body for {@code POST /api/wiz/viewsheet/highlight}.
  *
  * <p>The wiz-services caller POSTs:
- * {@code { runtimeId, viewsheetIdentifier?, assemblyName?, sampleMaxRows?,
+ * {@code { runtimeId, viewsheetIdentifier?, assemblyName?, copy?, sampleMaxRows?,
  * highlightModel: { highlights: [ { name, field?, foreground?, background?, applyArea?, applyRow?,
  * fontInfo?, conditions: ConditionNode[] } ] } } }.
  *
@@ -55,6 +55,18 @@ public class ApplyHighlightModel {
       this.assemblyName = assemblyName;
    }
 
+   /** When true, duplicate the target assembly first and apply the highlight to the COPY instead of
+    *  mutating {@link #assemblyName} in place — the original chart is left untouched. Mirrors
+    *  {@code ChartColorsRequest}/{@code ChartFormatRequest}'s {@code copy} flag. Default false
+    *  (in-place, the existing behavior). */
+   public boolean isCopy() {
+      return copy;
+   }
+
+   public void setCopy(boolean copy) {
+      this.copy = copy;
+   }
+
    public String getViewsheetIdentifier() {
       return viewsheetIdentifier;
    }
@@ -81,6 +93,7 @@ public class ApplyHighlightModel {
 
    private String runtimeId;
    private String assemblyName;
+   private boolean copy;
    private String viewsheetIdentifier;
    private HighlightModel highlightModel;
    private Integer sampleMaxRows;

--- a/core/src/main/java/inetsoft/web/wiz/model/ChartColorsRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChartColorsRequest.java
@@ -36,6 +36,12 @@ public class ChartColorsRequest {
    public String getViewsheetIdentifier() { return viewsheetIdentifier; }
    public void setViewsheetIdentifier(String viewsheetIdentifier) { this.viewsheetIdentifier = viewsheetIdentifier; }
 
+   /** When true, duplicate the assembly first and apply these colors to the COPY instead of mutating
+    *  {@link #assemblyName} in place — the original chart is left untouched. Default false (in-place,
+    *  the existing behavior). */
+   public boolean isCopy() { return copy; }
+   public void setCopy(boolean copy) { this.copy = copy; }
+
    /** Hex #RRGGBB — one color for the measure(s) when no field is on the color aesthetic. */
    public String getStaticColor() { return staticColor; }
    public void setStaticColor(String staticColor) { this.staticColor = staticColor; }
@@ -55,6 +61,7 @@ public class ChartColorsRequest {
    private String wizRuntimeId;
    private String assemblyName;
    private String viewsheetIdentifier;
+   private boolean copy;
    private String staticColor;
    private String paletteName;
    private List<String> colorList;

--- a/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
@@ -38,6 +38,12 @@ public class ChartFormatRequest {
    public String getViewsheetIdentifier() { return viewsheetIdentifier; }
    public void setViewsheetIdentifier(String viewsheetIdentifier) { this.viewsheetIdentifier = viewsheetIdentifier; }
 
+   /** When true, duplicate the assembly first and apply this format to the COPY instead of mutating
+    *  {@link #assemblyName} in place — the original chart is left untouched. Default false (in-place,
+    *  the existing behavior). */
+   public boolean isCopy() { return copy; }
+   public void setCopy(boolean copy) { this.copy = copy; }
+
    /** The chart's overall (assembly-level) title — the heading shown above the plot; null = no change. */
    @JsonProperty("chartTitle")
    public String getChartTitle() { return chartTitle; }
@@ -109,6 +115,7 @@ public class ChartFormatRequest {
    private String assemblyName;
    /** Optional — carried back on the result so a subsequent save keeps the same identifier. */
    private String viewsheetIdentifier;
+   private boolean copy;
 
    private String chartTitle;
    private String xAxisTitle;

--- a/core/src/main/java/inetsoft/web/wiz/model/CreateVisualizationModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/CreateVisualizationModel.java
@@ -84,6 +84,23 @@ public class CreateVisualizationModel {
    }
 
    /**
+    * When true AND this call is otherwise eligible for the in-place "modificationOnly" path (see
+    * {@code WizVsService.createViewsheetInternal}: {@link #getConfig()}/{@link #getPrimaryAssembly()}
+    * are null and {@link #getConditionModel()} is set), duplicate the current primary assembly first
+    * and apply the condition to the COPY instead — the original chart is left untouched. Mirrors
+    * {@code ChartColorsRequest}/{@code ChartFormatRequest}/{@code ApplyHighlightModel}'s {@code copy}
+    * flag. Has no effect outside the modificationOnly path (the standard create/rebind path always
+    * produces a fresh assembly on its own). Default false (in-place, the existing behavior).
+    */
+   public boolean isCopy() {
+      return copy;
+   }
+
+   public void setCopy(boolean copy) {
+      this.copy = copy;
+   }
+
+   /**
     * #75456: row cap for sampled-preview mode. Null or &lt;=0 = full data (the default and the
     * agent path); &gt;0 = aggregate at most this many detail rows (faster on heavy/non-mergeable
     * sources, but Sum/Count may be approximate).
@@ -104,4 +121,5 @@ public class CreateVisualizationModel {
    private Integer sampleMaxRows;
    private transient VSAssembly primaryAssembly;
    private transient boolean keepCondition;
+   private boolean copy;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -2136,12 +2136,14 @@ public class WizAutoBindingService {
       var info = chart.getChartInfo();
       ChartDescriptor desc = info.getChartDescriptor();
       VSChartInfo vsChartInfo = info.getVSChartInfo();
+      CreateViewsheetResult result;
 
       // The copy (when one was made) has already been added to rvs.getViewsheet() and marked primary —
-      // demotedOriginal/rollbackCopy stay non-null only in that case. Nothing below here is persisted
-      // until persistViewsheet() further down, so a thrown exception must undo that live-runtime
-      // mutation first (remove the copy, restore the original's primary flag) rather than leave the
-      // runtime viewsheet with an added/promoted copy that the caller never learns about.
+      // demotedOriginal/rollbackCopy stay non-null only in that case. Nothing through persistViewsheet
+      // below is durably committed until persistViewsheet itself returns, so a thrown exception
+      // anywhere in this block must undo that live-runtime mutation (remove the copy, restore the
+      // original's primary flag) rather than leave the runtime viewsheet with an added/promoted copy
+      // that the caller never learns about.
       try {
          // Chart (assembly-level) title — the heading shown above the plot. Setting a value also makes
          // the title visible, so a chart that defaulted to the generic "Chart" heading shows the
@@ -2255,8 +2257,38 @@ public class WizAutoBindingService {
 
          // Invalidate the cached runtime descriptor so the change regenerates on re-execute.
          info.setRTChartDescriptor(null);
+
+         // The cached VGraphPair holds a reference to this same VSChartInfo, so the sandbox's
+         // staleness check (equalsContent against itself) can never detect the in-place mutation
+         // above. Clear the cached graph explicitly — mirroring VSChartDataHandler — or every
+         // subsequent render (including brand-new embed connections) serves the stale graph.
+         final String assemblyNameForGraphClear = targetAssemblyName;
+         rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(assemblyNameForGraphClear));
+
+         // Fetch BEFORE persisting: fetchAssemblyData only reads the live runtime sandbox (already
+         // mutated above), so its result doesn't depend on persist order, and keeping persistViewsheet
+         // as the LAST possibly-throwing step means the rollback below never fires once the copy has
+         // already been durably committed — after persistViewsheet succeeds, the copy is real, and
+         // rolling back the live runtime at that point would desync it from the persisted asset instead
+         // of undoing an in-progress change.
+         result = wizVsService.fetchAssemblyData(effRuntimeId, targetAssemblyName, user);
+
+         // Commit the mutation to the backing asset (the copy, when one was made — it was just added to
+         // rvs.getViewsheet() by duplicatePrimaryAssembly, so persisting here is what makes it show up in
+         // the persisted asset a later save_viewsheet call looks the assembly up from).
+         // save_viewsheet clones the assembly from the PERSISTED viewsheet (not this live runtime), so a
+         // format/color change left only on the runtime — the chart title above the plot in particular —
+         // is silently dropped on save. Mirrors how create/changeType call persistViewsheet so their
+         // changes survive a save.
+         if(request.getViewsheetIdentifier() != null) {
+            wizVsService.persistViewsheet(rvs.getViewsheet(), request.getViewsheetIdentifier(), user);
+         }
       }
-      catch(RuntimeException e) {
+      catch(Exception e) {
+         // Mirrors WizVsService.createViewsheet's own rollback (which wraps its persistViewsheet call
+         // inside the same try/catch that undoes the assembly swap): covers the mutation-application
+         // block above AND fetchAssemblyData/persistViewsheet, since all can leave the duplicated,
+         // promoted-to-primary copy dangling and unreported if they fail before it is durably committed.
          if(rollbackCopy != null) {
             rvs.getViewsheet().removeAssembly(rollbackCopy.getName());
             demotedOriginal.setPrimary(true);
@@ -2264,27 +2296,6 @@ public class WizAutoBindingService {
 
          throw e;
       }
-
-      // The cached VGraphPair holds a reference to this same VSChartInfo, so the sandbox's
-      // staleness check (equalsContent against itself) can never detect the in-place mutation
-      // above. Clear the cached graph explicitly — mirroring VSChartDataHandler — or every
-      // subsequent render (including brand-new embed connections) serves the stale graph.
-      final String assemblyNameForGraphClear = targetAssemblyName;
-      rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(assemblyNameForGraphClear));
-
-      // Commit the mutation to the backing asset (the copy, when one was made — it was just added to
-      // rvs.getViewsheet() by duplicatePrimaryAssembly, so persisting here is what makes it show up in
-      // the persisted asset a later save_viewsheet call looks the assembly up from).
-      // save_viewsheet clones the assembly from the PERSISTED viewsheet (not this live runtime), so a
-      // format/color change left only on the runtime — the chart title above the plot in particular —
-      // is silently dropped on save. Mirrors how create/changeType call persistViewsheet so their
-      // changes survive a save.
-      if(request.getViewsheetIdentifier() != null) {
-         wizVsService.persistViewsheet(rvs.getViewsheet(), request.getViewsheetIdentifier(), user);
-      }
-
-      CreateViewsheetResult result =
-         wizVsService.fetchAssemblyData(effRuntimeId, targetAssemblyName, user);
 
       if(result == null) {
          result = new CreateViewsheetResult();
@@ -2400,13 +2411,14 @@ public class WizAutoBindingService {
       var info = chart.getChartInfo();
       VSChartInfo vsChartInfo = info.getVSChartInfo();
       AestheticRef colorField = vsChartInfo == null ? null : vsChartInfo.getColorField();
+      CreateViewsheetResult result;
 
       // The copy (when one was made) has already been added to rvs.getViewsheet() and marked primary —
-      // demotedOriginal/rollbackCopy stay non-null only in that case. Nothing below here is persisted
-      // until persistViewsheet() further down, so a thrown exception (e.g. ColorPalettes.getPalette /
-      // parseColor rejecting bad input) must undo that live-runtime mutation first (remove the copy,
-      // restore the original's primary flag) rather than leave the runtime viewsheet with an
-      // added/promoted copy the caller never learns about.
+      // demotedOriginal/rollbackCopy stay non-null only in that case. Nothing through persistViewsheet
+      // below is durably committed until persistViewsheet itself returns, so a thrown exception (e.g.
+      // ColorPalettes.getPalette / parseColor rejecting bad input) anywhere in this block must undo that
+      // live-runtime mutation (remove the copy, restore the original's primary flag) rather than leave
+      // the runtime viewsheet with an added/promoted copy the caller never learns about.
       try {
          if(colorField == null || colorField.getDataRef() == null) {
             if(request.getStaticColor() != null) {
@@ -2433,8 +2445,38 @@ public class WizAutoBindingService {
          }
 
          info.setRTChartDescriptor(null);
+
+         // The cached VGraphPair holds a reference to this same VSChartInfo, so the sandbox's
+         // staleness check (equalsContent against itself) can never detect the in-place mutation
+         // above. Clear the cached graph explicitly — mirroring VSChartDataHandler — or every
+         // subsequent render (including brand-new embed connections) serves the stale graph.
+         final String assemblyNameForGraphClear = targetAssemblyName;
+         rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(assemblyNameForGraphClear));
+
+         // Fetch BEFORE persisting: fetchAssemblyData only reads the live runtime sandbox (already
+         // mutated above), so its result doesn't depend on persist order, and keeping persistViewsheet
+         // as the LAST possibly-throwing step means the rollback below never fires once the copy has
+         // already been durably committed — after persistViewsheet succeeds, the copy is real, and
+         // rolling back the live runtime at that point would desync it from the persisted asset instead
+         // of undoing an in-progress change.
+         result = wizVsService.fetchAssemblyData(effRuntimeId, targetAssemblyName, user);
+
+         // Commit the mutation to the backing asset (the copy, when one was made — it was just added to
+         // rvs.getViewsheet() by duplicatePrimaryAssembly, so persisting here is what makes it show up in
+         // the persisted asset a later save_viewsheet call looks the assembly up from).
+         // save_viewsheet clones the assembly from the PERSISTED viewsheet (not this live runtime), so a
+         // format/color change left only on the runtime — the chart title above the plot in particular —
+         // is silently dropped on save. Mirrors how create/changeType call persistViewsheet so their
+         // changes survive a save.
+         if(request.getViewsheetIdentifier() != null) {
+            wizVsService.persistViewsheet(rvs.getViewsheet(), request.getViewsheetIdentifier(), user);
+         }
       }
-      catch(RuntimeException e) {
+      catch(Exception e) {
+         // Mirrors WizVsService.createViewsheet's own rollback (which wraps its persistViewsheet call
+         // inside the same try/catch that undoes the assembly swap): covers the mutation-application
+         // block above AND fetchAssemblyData/persistViewsheet, since all can leave the duplicated,
+         // promoted-to-primary copy dangling and unreported if they fail before it is durably committed.
          if(rollbackCopy != null) {
             rvs.getViewsheet().removeAssembly(rollbackCopy.getName());
             demotedOriginal.setPrimary(true);
@@ -2442,27 +2484,6 @@ public class WizAutoBindingService {
 
          throw e;
       }
-
-      // The cached VGraphPair holds a reference to this same VSChartInfo, so the sandbox's
-      // staleness check (equalsContent against itself) can never detect the in-place mutation
-      // above. Clear the cached graph explicitly — mirroring VSChartDataHandler — or every
-      // subsequent render (including brand-new embed connections) serves the stale graph.
-      final String assemblyNameForGraphClear = targetAssemblyName;
-      rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(assemblyNameForGraphClear));
-
-      // Commit the mutation to the backing asset (the copy, when one was made — it was just added to
-      // rvs.getViewsheet() by duplicatePrimaryAssembly, so persisting here is what makes it show up in
-      // the persisted asset a later save_viewsheet call looks the assembly up from).
-      // save_viewsheet clones the assembly from the PERSISTED viewsheet (not this live runtime), so a
-      // format/color change left only on the runtime — the chart title above the plot in particular —
-      // is silently dropped on save. Mirrors how create/changeType call persistViewsheet so their
-      // changes survive a save.
-      if(request.getViewsheetIdentifier() != null) {
-         wizVsService.persistViewsheet(rvs.getViewsheet(), request.getViewsheetIdentifier(), user);
-      }
-
-      CreateViewsheetResult result =
-         wizVsService.fetchAssemblyData(effRuntimeId, targetAssemblyName, user);
 
       if(result == null) {
          result = new CreateViewsheetResult();

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -2106,6 +2106,28 @@ public class WizAutoBindingService {
          throw new Exception("Chart assembly not found: " + request.getAssemblyName());
       }
 
+      String note = null;
+      String targetAssemblyName = request.getAssemblyName();
+
+      // Copy-then-apply: duplicate the chart BEFORE applying the format change, so the original
+      // (request.getAssemblyName()) is left untouched and the requested change lands on a new,
+      // parallel copy instead. source (assembly) must already be the primary assembly — see
+      // WizVsService.duplicatePrimaryAssembly.
+      if(request.isCopy()) {
+         VSAssembly duplicated = wizVsService.duplicatePrimaryAssembly(rvs, assembly);
+
+         if(duplicated instanceof ChartVSAssembly dupChart) {
+            assembly = dupChart;
+            chart = dupChart;
+            targetAssemblyName = dupChart.getName();
+         }
+         else {
+            note = "Copy requested but could not be created; format applied in place.";
+            LOG.warn("setChartFormat: duplicatePrimaryAssembly failed for {}; falling back to in-place apply.",
+               request.getAssemblyName());
+         }
+      }
+
       var info = chart.getChartInfo();
       ChartDescriptor desc = info.getChartDescriptor();
       VSChartInfo vsChartInfo = info.getVSChartInfo();
@@ -2164,8 +2186,6 @@ public class WizAutoBindingService {
       }
 
       // Legend placement
-      String note = null;
-
       if(request.getLegendPosition() != null && desc != null && desc.getLegendsDescriptor() != null) {
          int layout = legendLayout(request.getLegendPosition());
 
@@ -2229,25 +2249,29 @@ public class WizAutoBindingService {
       // staleness check (equalsContent against itself) can never detect the in-place mutation
       // above. Clear the cached graph explicitly — mirroring VSChartDataHandler — or every
       // subsequent render (including brand-new embed connections) serves the stale graph.
-      rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(request.getAssemblyName()));
+      final String assemblyNameForGraphClear = targetAssemblyName;
+      rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(assemblyNameForGraphClear));
 
-      // Commit the in-place mutation to the backing asset. save_viewsheet clones the assembly from
-      // the PERSISTED viewsheet (not this live runtime), so a format/color change left only on the
-      // runtime — the chart title above the plot in particular — is silently dropped on save.
-      // Mirrors how create/changeType call persistViewsheet so their changes survive a save.
+      // Commit the mutation to the backing asset (the copy, when one was made — it was just added to
+      // rvs.getViewsheet() by duplicatePrimaryAssembly, so persisting here is what makes it show up in
+      // the persisted asset a later save_viewsheet call looks the assembly up from).
+      // save_viewsheet clones the assembly from the PERSISTED viewsheet (not this live runtime), so a
+      // format/color change left only on the runtime — the chart title above the plot in particular —
+      // is silently dropped on save. Mirrors how create/changeType call persistViewsheet so their
+      // changes survive a save.
       if(request.getViewsheetIdentifier() != null) {
          wizVsService.persistViewsheet(rvs.getViewsheet(), request.getViewsheetIdentifier(), user);
       }
 
       CreateViewsheetResult result =
-         wizVsService.fetchAssemblyData(effRuntimeId, request.getAssemblyName(), user);
+         wizVsService.fetchAssemblyData(effRuntimeId, targetAssemblyName, user);
 
       if(result == null) {
          result = new CreateViewsheetResult();
       }
 
       result.setRuntimeId(effRuntimeId);
-      result.setAssemblyName(request.getAssemblyName());
+      result.setAssemblyName(targetAssemblyName);
 
       if(request.getViewsheetIdentifier() != null) {
          result.setViewsheetIdentifier(request.getViewsheetIdentifier());
@@ -2307,10 +2331,31 @@ public class WizAutoBindingService {
          throw new Exception("Chart assembly not found: " + request.getAssemblyName());
       }
 
+      String note = null;
+      String targetAssemblyName = request.getAssemblyName();
+
+      // Copy-then-apply: duplicate the chart BEFORE applying the color change, so the original
+      // (request.getAssemblyName()) is left untouched and the requested change lands on a new,
+      // parallel copy instead. source (assembly) must already be the primary assembly — see
+      // WizVsService.duplicatePrimaryAssembly.
+      if(request.isCopy()) {
+         VSAssembly duplicated = wizVsService.duplicatePrimaryAssembly(rvs, assembly);
+
+         if(duplicated instanceof ChartVSAssembly dupChart) {
+            assembly = dupChart;
+            chart = dupChart;
+            targetAssemblyName = dupChart.getName();
+         }
+         else {
+            note = "Copy requested but could not be created; colors applied in place.";
+            LOG.warn("setChartColors: duplicatePrimaryAssembly failed for {}; falling back to in-place apply.",
+               request.getAssemblyName());
+         }
+      }
+
       var info = chart.getChartInfo();
       VSChartInfo vsChartInfo = info.getVSChartInfo();
       AestheticRef colorField = vsChartInfo == null ? null : vsChartInfo.getColorField();
-      String note = null;
 
       if(colorField == null || colorField.getDataRef() == null) {
          if(request.getStaticColor() != null) {
@@ -2342,25 +2387,29 @@ public class WizAutoBindingService {
       // staleness check (equalsContent against itself) can never detect the in-place mutation
       // above. Clear the cached graph explicitly — mirroring VSChartDataHandler — or every
       // subsequent render (including brand-new embed connections) serves the stale graph.
-      rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(request.getAssemblyName()));
+      final String assemblyNameForGraphClear = targetAssemblyName;
+      rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(assemblyNameForGraphClear));
 
-      // Commit the in-place mutation to the backing asset. save_viewsheet clones the assembly from
-      // the PERSISTED viewsheet (not this live runtime), so a format/color change left only on the
-      // runtime — the chart title above the plot in particular — is silently dropped on save.
-      // Mirrors how create/changeType call persistViewsheet so their changes survive a save.
+      // Commit the mutation to the backing asset (the copy, when one was made — it was just added to
+      // rvs.getViewsheet() by duplicatePrimaryAssembly, so persisting here is what makes it show up in
+      // the persisted asset a later save_viewsheet call looks the assembly up from).
+      // save_viewsheet clones the assembly from the PERSISTED viewsheet (not this live runtime), so a
+      // format/color change left only on the runtime — the chart title above the plot in particular —
+      // is silently dropped on save. Mirrors how create/changeType call persistViewsheet so their
+      // changes survive a save.
       if(request.getViewsheetIdentifier() != null) {
          wizVsService.persistViewsheet(rvs.getViewsheet(), request.getViewsheetIdentifier(), user);
       }
 
       CreateViewsheetResult result =
-         wizVsService.fetchAssemblyData(effRuntimeId, request.getAssemblyName(), user);
+         wizVsService.fetchAssemblyData(effRuntimeId, targetAssemblyName, user);
 
       if(result == null) {
          result = new CreateViewsheetResult();
       }
 
       result.setRuntimeId(effRuntimeId);
-      result.setAssemblyName(request.getAssemblyName());
+      result.setAssemblyName(targetAssemblyName);
 
       if(request.getViewsheetIdentifier() != null) {
          result.setViewsheetIdentifier(request.getViewsheetIdentifier());

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -2107,7 +2107,10 @@ public class WizAutoBindingService {
       }
 
       String note = null;
+      String copyNote = null;
       String targetAssemblyName = request.getAssemblyName();
+      VSAssembly demotedOriginal = null;
+      VSAssembly rollbackCopy = null;
 
       // Copy-then-apply: duplicate the chart BEFORE applying the format change, so the original
       // (request.getAssemblyName()) is left untouched and the requested change lands on a new,
@@ -2117,12 +2120,14 @@ public class WizAutoBindingService {
          VSAssembly duplicated = wizVsService.duplicatePrimaryAssembly(rvs, assembly);
 
          if(duplicated instanceof ChartVSAssembly dupChart) {
+            demotedOriginal = assembly;
+            rollbackCopy = dupChart;
             assembly = dupChart;
             chart = dupChart;
             targetAssemblyName = dupChart.getName();
          }
          else {
-            note = "Copy requested but could not be created; format applied in place.";
+            copyNote = "Copy requested but could not be created; format applied in place.";
             LOG.warn("setChartFormat: duplicatePrimaryAssembly failed for {}; falling back to in-place apply.",
                request.getAssemblyName());
          }
@@ -2132,118 +2137,133 @@ public class WizAutoBindingService {
       ChartDescriptor desc = info.getChartDescriptor();
       VSChartInfo vsChartInfo = info.getVSChartInfo();
 
-      // Chart (assembly-level) title — the heading shown above the plot. Setting a value also makes
-      // the title visible, so a chart that defaulted to the generic "Chart" heading shows the
-      // caller's text instead.
-      if(request.getChartTitle() != null &&
-         chart.getVSAssemblyInfo() instanceof ChartVSAssemblyInfo cinfo)
-      {
-         cinfo.setTitleValue(request.getChartTitle());
-         cinfo.setTitleVisible(true);
+      // The copy (when one was made) has already been added to rvs.getViewsheet() and marked primary —
+      // demotedOriginal/rollbackCopy stay non-null only in that case. Nothing below here is persisted
+      // until persistViewsheet() further down, so a thrown exception must undo that live-runtime
+      // mutation first (remove the copy, restore the original's primary flag) rather than leave the
+      // runtime viewsheet with an added/promoted copy that the caller never learns about.
+      try {
+         // Chart (assembly-level) title — the heading shown above the plot. Setting a value also makes
+         // the title visible, so a chart that defaulted to the generic "Chart" heading shows the
+         // caller's text instead.
+         if(request.getChartTitle() != null &&
+            chart.getVSAssemblyInfo() instanceof ChartVSAssemblyInfo cinfo)
+         {
+            cinfo.setTitleValue(request.getChartTitle());
+            cinfo.setTitleVisible(true);
+         }
+
+         // Axis titles
+         if(desc != null && desc.getTitlesDescriptor() != null) {
+            TitlesDescriptor titles = desc.getTitlesDescriptor();
+
+            if(request.getXAxisTitle() != null && titles.getXTitleDescriptor() != null) {
+               titles.getXTitleDescriptor().setTitleValue(request.getXAxisTitle());
+            }
+
+            if(request.getYAxisTitle() != null && titles.getYTitleDescriptor() != null) {
+               titles.getYTitleDescriptor().setTitleValue(request.getYAxisTitle());
+            }
+         }
+
+         // Y-axis scale — applied to each bound measure's axis descriptor.
+         boolean scaleChange = request.getYAxisMin() != null || request.getYAxisMax() != null ||
+            request.getYAxisIncrement() != null || request.getYAxisLogarithmic() != null;
+
+         if(scaleChange && vsChartInfo != null && vsChartInfo.getYFields() != null) {
+            for(ChartRef yref : vsChartInfo.getYFields()) {
+               if(yref == null || yref.getAxisDescriptor() == null) {
+                  continue;
+               }
+
+               AxisDescriptor ax = yref.getAxisDescriptor();
+
+               if(request.getYAxisMin() != null) {
+                  ax.setMinimum(request.getYAxisMin());
+               }
+
+               if(request.getYAxisMax() != null) {
+                  ax.setMaximum(request.getYAxisMax());
+               }
+
+               if(request.getYAxisIncrement() != null) {
+                  ax.setIncrement(request.getYAxisIncrement());
+               }
+
+               if(request.getYAxisLogarithmic() != null) {
+                  ax.setLogarithmicScale(request.getYAxisLogarithmic());
+               }
+            }
+         }
+
+         // Legend placement
+         if(request.getLegendPosition() != null && desc != null && desc.getLegendsDescriptor() != null) {
+            int layout = legendLayout(request.getLegendPosition());
+
+            if(layout < 0) {
+               note = "Unknown legendPosition '" + request.getLegendPosition() +
+                  "'; valid: none, top, right, bottom, left, in_place. Legend left unchanged.";
+            }
+            else {
+               desc.getLegendsDescriptor().setLayout(layout);
+            }
+         }
+
+         // Marker visibility, shape, and size
+         if((request.getMarkerVisible() != null || request.getMarkerShape() != null
+            || request.getMarkerSize() != null) && desc != null)
+         {
+            PlotDescriptor plot = desc.getPlotDescriptor();
+
+            if(plot != null) {
+               if(request.getMarkerVisible() != null) {
+                  plot.setPointLine(request.getMarkerVisible());
+               }
+
+               if(request.getMarkerShape() != null) {
+                  plot.setMarkerShape(request.getMarkerShape());
+               }
+
+               if(request.getMarkerSize() != null) {
+                  plot.setMarkerSize(request.getMarkerSize());
+               }
+            }
+         }
+
+         // Time-gap fill for line/area charts. fillTimeGap completes missing date periods (paired with
+         // the date dimension's timeSeries); fillZero=false fills with null (vs 0); fillGapWithDash
+         // chooses a dashed connector (true) vs a hard line break (false) across the null gap.
+         if((request.getFillTimeGap() != null || request.getFillZero() != null
+            || request.getFillGapWithDash() != null) && desc != null)
+         {
+            PlotDescriptor plot = desc.getPlotDescriptor();
+
+            if(plot != null) {
+               if(request.getFillTimeGap() != null) {
+                  plot.setFillTimeGap(request.getFillTimeGap());
+               }
+
+               if(request.getFillZero() != null) {
+                  plot.setFillZero(request.getFillZero());
+               }
+
+               if(request.getFillGapWithDash() != null) {
+                  plot.setFillGapWithDash(request.getFillGapWithDash());
+               }
+            }
+         }
+
+         // Invalidate the cached runtime descriptor so the change regenerates on re-execute.
+         info.setRTChartDescriptor(null);
       }
-
-      // Axis titles
-      if(desc != null && desc.getTitlesDescriptor() != null) {
-         TitlesDescriptor titles = desc.getTitlesDescriptor();
-
-         if(request.getXAxisTitle() != null && titles.getXTitleDescriptor() != null) {
-            titles.getXTitleDescriptor().setTitleValue(request.getXAxisTitle());
+      catch(RuntimeException e) {
+         if(rollbackCopy != null) {
+            rvs.getViewsheet().removeAssembly(rollbackCopy.getName());
+            demotedOriginal.setPrimary(true);
          }
 
-         if(request.getYAxisTitle() != null && titles.getYTitleDescriptor() != null) {
-            titles.getYTitleDescriptor().setTitleValue(request.getYAxisTitle());
-         }
+         throw e;
       }
-
-      // Y-axis scale — applied to each bound measure's axis descriptor.
-      boolean scaleChange = request.getYAxisMin() != null || request.getYAxisMax() != null ||
-         request.getYAxisIncrement() != null || request.getYAxisLogarithmic() != null;
-
-      if(scaleChange && vsChartInfo != null && vsChartInfo.getYFields() != null) {
-         for(ChartRef yref : vsChartInfo.getYFields()) {
-            if(yref == null || yref.getAxisDescriptor() == null) {
-               continue;
-            }
-
-            AxisDescriptor ax = yref.getAxisDescriptor();
-
-            if(request.getYAxisMin() != null) {
-               ax.setMinimum(request.getYAxisMin());
-            }
-
-            if(request.getYAxisMax() != null) {
-               ax.setMaximum(request.getYAxisMax());
-            }
-
-            if(request.getYAxisIncrement() != null) {
-               ax.setIncrement(request.getYAxisIncrement());
-            }
-
-            if(request.getYAxisLogarithmic() != null) {
-               ax.setLogarithmicScale(request.getYAxisLogarithmic());
-            }
-         }
-      }
-
-      // Legend placement
-      if(request.getLegendPosition() != null && desc != null && desc.getLegendsDescriptor() != null) {
-         int layout = legendLayout(request.getLegendPosition());
-
-         if(layout < 0) {
-            note = "Unknown legendPosition '" + request.getLegendPosition() +
-               "'; valid: none, top, right, bottom, left, in_place. Legend left unchanged.";
-         }
-         else {
-            desc.getLegendsDescriptor().setLayout(layout);
-         }
-      }
-
-      // Marker visibility, shape, and size
-      if((request.getMarkerVisible() != null || request.getMarkerShape() != null
-         || request.getMarkerSize() != null) && desc != null)
-      {
-         PlotDescriptor plot = desc.getPlotDescriptor();
-
-         if(plot != null) {
-            if(request.getMarkerVisible() != null) {
-               plot.setPointLine(request.getMarkerVisible());
-            }
-
-            if(request.getMarkerShape() != null) {
-               plot.setMarkerShape(request.getMarkerShape());
-            }
-
-            if(request.getMarkerSize() != null) {
-               plot.setMarkerSize(request.getMarkerSize());
-            }
-         }
-      }
-
-      // Time-gap fill for line/area charts. fillTimeGap completes missing date periods (paired with
-      // the date dimension's timeSeries); fillZero=false fills with null (vs 0); fillGapWithDash
-      // chooses a dashed connector (true) vs a hard line break (false) across the null gap.
-      if((request.getFillTimeGap() != null || request.getFillZero() != null
-         || request.getFillGapWithDash() != null) && desc != null)
-      {
-         PlotDescriptor plot = desc.getPlotDescriptor();
-
-         if(plot != null) {
-            if(request.getFillTimeGap() != null) {
-               plot.setFillTimeGap(request.getFillTimeGap());
-            }
-
-            if(request.getFillZero() != null) {
-               plot.setFillZero(request.getFillZero());
-            }
-
-            if(request.getFillGapWithDash() != null) {
-               plot.setFillGapWithDash(request.getFillGapWithDash());
-            }
-         }
-      }
-
-      // Invalidate the cached runtime descriptor so the change regenerates on re-execute.
-      info.setRTChartDescriptor(null);
 
       // The cached VGraphPair holds a reference to this same VSChartInfo, so the sandbox's
       // staleness check (equalsContent against itself) can never detect the in-place mutation
@@ -2277,11 +2297,30 @@ public class WizAutoBindingService {
          result.setViewsheetIdentifier(request.getViewsheetIdentifier());
       }
 
-      if(note != null) {
-         result.setNote(note);
+      String combinedNote = combineNotes(copyNote, note);
+
+      if(combinedNote != null) {
+         result.setNote(combinedNote);
       }
 
       return result;
+   }
+
+   /**
+    * Combines two independent, optional warning notes (e.g. a copy-fallback warning and a separate
+    * binding/legend validation warning) without either silently overwriting the other. Either or both
+    * may be null; returns null only when both are.
+    */
+   private static String combineNotes(String first, String second) {
+      if(first == null) {
+         return second;
+      }
+
+      if(second == null) {
+         return first;
+      }
+
+      return first + " " + second;
    }
 
    /** Maps a legend-position string to a {@link LegendsDescriptor} layout constant; -1 if unknown. */
@@ -2332,7 +2371,10 @@ public class WizAutoBindingService {
       }
 
       String note = null;
+      String copyNote = null;
       String targetAssemblyName = request.getAssemblyName();
+      VSAssembly demotedOriginal = null;
+      VSAssembly rollbackCopy = null;
 
       // Copy-then-apply: duplicate the chart BEFORE applying the color change, so the original
       // (request.getAssemblyName()) is left untouched and the requested change lands on a new,
@@ -2342,12 +2384,14 @@ public class WizAutoBindingService {
          VSAssembly duplicated = wizVsService.duplicatePrimaryAssembly(rvs, assembly);
 
          if(duplicated instanceof ChartVSAssembly dupChart) {
+            demotedOriginal = assembly;
+            rollbackCopy = dupChart;
             assembly = dupChart;
             chart = dupChart;
             targetAssemblyName = dupChart.getName();
          }
          else {
-            note = "Copy requested but could not be created; colors applied in place.";
+            copyNote = "Copy requested but could not be created; colors applied in place.";
             LOG.warn("setChartColors: duplicatePrimaryAssembly failed for {}; falling back to in-place apply.",
                request.getAssemblyName());
          }
@@ -2357,31 +2401,47 @@ public class WizAutoBindingService {
       VSChartInfo vsChartInfo = info.getVSChartInfo();
       AestheticRef colorField = vsChartInfo == null ? null : vsChartInfo.getColorField();
 
-      if(colorField == null || colorField.getDataRef() == null) {
-         if(request.getStaticColor() != null) {
-            if(vsChartInfo == null) {
-               note = "Chart has no binding info; static color could not be applied.";
+      // The copy (when one was made) has already been added to rvs.getViewsheet() and marked primary —
+      // demotedOriginal/rollbackCopy stay non-null only in that case. Nothing below here is persisted
+      // until persistViewsheet() further down, so a thrown exception (e.g. ColorPalettes.getPalette /
+      // parseColor rejecting bad input) must undo that live-runtime mutation first (remove the copy,
+      // restore the original's primary flag) rather than leave the runtime viewsheet with an
+      // added/promoted copy the caller never learns about.
+      try {
+         if(colorField == null || colorField.getDataRef() == null) {
+            if(request.getStaticColor() != null) {
+               if(vsChartInfo == null) {
+                  note = "Chart has no binding info; static color could not be applied.";
+               }
+               else {
+                  applyStaticColor(vsChartInfo, parseColor(request.getStaticColor()));
+               }
             }
-            else {
-               applyStaticColor(vsChartInfo, parseColor(request.getStaticColor()));
+
+            if(request.getPaletteName() != null || request.getColorList() != null ||
+               request.getCategoryColors() != null)
+            {
+               note = "This chart has no color dimension, so a palette/per-category colors can't apply. " +
+                  "Recreate with a dimension on the color aesthetic (fieldConfigs/explicitBindings), or use staticColor.";
             }
          }
-
-         if(request.getPaletteName() != null || request.getColorList() != null ||
-            request.getCategoryColors() != null)
-         {
-            note = "This chart has no color dimension, so a palette/per-category colors can't apply. " +
-               "Recreate with a dimension on the color aesthetic (fieldConfigs/explicitBindings), or use staticColor.";
+         else if(colorField.getDataRef() instanceof VSChartAggregateRef) {
+            note = applyGradient(colorField, request);
          }
-      }
-      else if(colorField.getDataRef() instanceof VSChartAggregateRef) {
-         note = applyGradient(colorField, request);
-      }
-      else {
-         note = applyCategoricalColors(colorField, request);
-      }
+         else {
+            note = applyCategoricalColors(colorField, request);
+         }
 
-      info.setRTChartDescriptor(null);
+         info.setRTChartDescriptor(null);
+      }
+      catch(RuntimeException e) {
+         if(rollbackCopy != null) {
+            rvs.getViewsheet().removeAssembly(rollbackCopy.getName());
+            demotedOriginal.setPrimary(true);
+         }
+
+         throw e;
+      }
 
       // The cached VGraphPair holds a reference to this same VSChartInfo, so the sandbox's
       // staleness check (equalsContent against itself) can never detect the in-place mutation
@@ -2415,8 +2475,10 @@ public class WizAutoBindingService {
          result.setViewsheetIdentifier(request.getViewsheetIdentifier());
       }
 
-      if(note != null) {
-         result.setNote(note);
+      String combinedNote = combineNotes(copyNote, note);
+
+      if(combinedNote != null) {
+         result.setNote(combinedNote);
       }
 
       return result;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1637,6 +1637,40 @@ public class WizVsService {
    }
 
    /**
+    * Duplicates {@code source} within {@code rvs}'s viewsheet under a unique name and promotes the
+    * copy to primary, demoting (never deleting) the previous primary assembly — mirrors the same
+    * rebind sequence the standard create() path uses (uniqueAssemblyName + rebindAssembly + demote/
+    * promote). {@code source} MUST already be the primary assembly of {@code rvs}'s viewsheet; this
+    * is the copy-then-apply entry point for setChartFormat/setChartColors (request.isCopy()) so the
+    * original chart is left untouched while the requested format/color change lands on a new,
+    * parallel copy. Returns null if {@code source}'s type has no registered rebind factory
+    * (ASSEMBLY_FACTORIES) — the caller should fall back to applying in place.
+    */
+   public VSAssembly duplicatePrimaryAssembly(RuntimeViewsheet rvs, VSAssembly source) {
+      Viewsheet vs = rvs.getViewsheet();
+      String newName = uniqueAssemblyName(vs, source.getName());
+      VSAssembly copy = rebindAssembly(vs, newName, source);
+
+      if(copy == null) {
+         return null;
+      }
+
+      Assembly[] existingAssemblies = vs.getAssemblies();
+
+      if(existingAssemblies != null) {
+         for(Assembly a : existingAssemblies) {
+            if(a instanceof VSAssembly va && va.isPrimary()) {
+               va.setPrimary(false);
+            }
+         }
+      }
+
+      vs.addAssembly(copy);
+      copy.setPrimary(true);
+      return copy;
+   }
+
+   /**
     * Throws if the lens chain contains failed-query fallback data. When a live query fails
     * (e.g. a computed-column expression that is invalid SQL for the data source), AssetQuery
     * substitutes design-time sample data instead of erroring, and the chart path replaces

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -207,6 +207,31 @@ public class WizVsService {
       boolean restored = !Objects.equals(runtimeId, rvs.getID());
       Viewsheet vs = getValidatedViewsheet(rvs);
       VSAssembly assembly = resolveTargetAssembly(vs, model.getAssemblyName());
+
+      String copyNote = null;
+      VSAssembly demotedOriginal = null;
+      VSAssembly rollbackCopy = null;
+
+      // Copy-then-apply: mirrors WizAutoBindingService.setChartFormat/setChartColors — duplicate the
+      // target BEFORE applying the highlight, so the original is left untouched and the highlight lands
+      // on a new, parallel copy instead. Reuses the same duplicatePrimaryAssembly this class already
+      // exposes for the chart color/format paths; no assembly-type-specific logic is needed here since
+      // ASSEMBLY_FACTORIES already covers chart/crosstab/table/output.
+      if(model.isCopy()) {
+         VSAssembly duplicated = duplicatePrimaryAssembly(rvs, assembly);
+
+         if(duplicated != null) {
+            demotedOriginal = assembly;
+            rollbackCopy = duplicated;
+            assembly = duplicated;
+         }
+         else {
+            copyNote = "Copy requested but could not be created; highlight applied in place.";
+            LOG.warn("applyHighlight: duplicatePrimaryAssembly failed for {}; falling back to in-place apply.",
+               model.getAssemblyName());
+         }
+      }
+
       VSAssemblyInfo assemblyInfo = assembly.getVSAssemblyInfo();
 
       // Resolve the assembly's candidate condition fields so condition values are coerced to each
@@ -214,44 +239,53 @@ public class WizVsService {
       ColumnSelection columns = assembly instanceof DataVSAssembly dataAssembly
          ? VSUtil.getBaseColumns(dataAssembly, true) : null;
 
-      if(assemblyInfo instanceof ChartVSAssemblyInfo chartAssemblyInfo) {
-         VSChartInfo chartInfo = chartAssemblyInfo.getVSChartInfo();
+      CreateViewsheetResult result;
 
-         // A chart colors its marks/labels from the highlight group on each binding ref that is a
-         // HighlightRef — every dimension (VSChartDimensionRef) AND measure (VSChartAggregateRef)
-         // implements HighlightRef, so ALL binding columns are highlightable, not just measures.
-         // GraphGenerator.getHighlightRefs() collects any HighlightRef whose group is non-null, and
-         // HLColorFrame is keyed by each ref's FULL name so a dimension's group colors that dimension's
-         // marks (e.g. word cloud, treemap) while it is a harmless no-op on a chart whose visual field
-         // is the measure. Attach on the DESIGN refs (getBindingRefs(false)); clearRuntime()/executeView
-         // regenerate the runtime refs as clones that carry the group, so it survives the re-render.
-         List<HighlightRef> highlightRefs = new ArrayList<>();
-         boolean wordCloud = GraphTypeUtil.isWordCloud(chartInfo);
+      // The copy (when one was made) has already been added to rvs.getViewsheet() and marked primary —
+      // demotedOriginal/rollbackCopy stay non-null only in that case. Nothing through persistViewsheet
+      // below is durably committed until persistViewsheet itself returns, so a thrown exception anywhere
+      // in this block must undo that live-runtime mutation (remove the copy, restore the original's
+      // primary flag) rather than leave the runtime viewsheet with an added/promoted copy the caller
+      // never learns about. Mirrors setChartFormat/setChartColors' identical rollback.
+      try {
+         if(assemblyInfo instanceof ChartVSAssemblyInfo chartAssemblyInfo) {
+            VSChartInfo chartInfo = chartAssemblyInfo.getVSChartInfo();
 
-         for(ChartRef ref : chartInfo.getBindingRefs(false)) {
-            if(ref instanceof HighlightRef hlRef) {
-               highlightRefs.add(hlRef);
+            // A chart colors its marks/labels from the highlight group on each binding ref that is a
+            // HighlightRef — every dimension (VSChartDimensionRef) AND measure (VSChartAggregateRef)
+            // implements HighlightRef, so ALL binding columns are highlightable, not just measures.
+            // GraphGenerator.getHighlightRefs() collects any HighlightRef whose group is non-null, and
+            // HLColorFrame is keyed by each ref's FULL name so a dimension's group colors that dimension's
+            // marks (e.g. word cloud, treemap) while it is a harmless no-op on a chart whose visual field
+            // is the measure. Attach on the DESIGN refs (getBindingRefs(false)); clearRuntime()/executeView
+            // regenerate the runtime refs as clones that carry the group, so it survives the re-render.
+            List<HighlightRef> highlightRefs = new ArrayList<>();
+            boolean wordCloud = GraphTypeUtil.isWordCloud(chartInfo);
+
+            for(ChartRef ref : chartInfo.getBindingRefs(false)) {
+               if(ref instanceof HighlightRef hlRef) {
+                  highlightRefs.add(hlRef);
+               }
             }
-         }
 
-         // A word cloud has no X/Y measure — its highlightable field is the TEXT aesthetic, which is
-         // NOT part of getBindingRefs(). GraphGenerator.getHighlightRefs() reads info.getTextField()
-         // for word clouds, so include it here to keep them highlightable like every other chart type.
-         if(wordCloud) {
-            AestheticRef textField = chartInfo.getTextField();
+            // A word cloud has no X/Y measure — its highlightable field is the TEXT aesthetic, which is
+            // NOT part of getBindingRefs(). GraphGenerator.getHighlightRefs() reads info.getTextField()
+            // for word clouds, so include it here to keep them highlightable like every other chart type.
+            if(wordCloud) {
+               AestheticRef textField = chartInfo.getTextField();
 
-            if(textField != null && textField.getDataRef() instanceof HighlightRef hlRef &&
-               !highlightRefs.contains(hlRef))
-            {
-               highlightRefs.add(hlRef);
+               if(textField != null && textField.getDataRef() instanceof HighlightRef hlRef &&
+                  !highlightRefs.contains(hlRef))
+               {
+                  highlightRefs.add(hlRef);
+               }
             }
-         }
 
-         // REPLACE semantics: clear any existing highlight on every ref first.
-         for(HighlightRef hlRef : highlightRefs) {
-            hlRef.setHighlightGroup(null);
-            hlRef.setTextHighlightGroup(null);
-         }
+            // REPLACE semantics: clear any existing highlight on every ref first.
+            for(HighlightRef hlRef : highlightRefs) {
+               hlRef.setHighlightGroup(null);
+               hlRef.setTextHighlightGroup(null);
+            }
 
          // A rule with applyArea=dataLabel styles the labels (text highlight); otherwise the marks (point
          // highlight). The color frame is keyed per ref, so apply each rule to every ref — each field's
@@ -318,72 +352,88 @@ public class WizVsService {
 
          // Drop cached runtime refs so the next executeView regenerates them (as clones carrying the group).
          chartInfo.clearRuntime();
-      }
-      else if(assemblyInfo instanceof TextVSAssemblyInfo textInfo) {
-         // A text output evaluates a highlight against its single scalar value
-         // (OutputVSAssemblyInfo.updateHighlight -> HighlightGroup.findGroup(value)), which ignores the
-         // condition field NAME entirely. The standard highlight dialog therefore exposes exactly ONE field —
-         // the canonical "value" ref (see HighlightDialogService) — so the dropdown only ever shows "Value".
-         // A condition keyed to any other name (e.g. a bound column like "Sum(Sales)") still evaluates
-         // correctly at runtime, which MASKS the problem, but it does NOT round-trip through that dialog: on
-         // reopen its field matches no option and the condition renders blank/broken. Force every condition
-         // field to "value" (typed from the scalar binding, mirroring HighlightDialogService) so a wiz-applied
-         // text highlight is the same shape a dialog-authored one would be.
-         ScalarBindingInfo sbi = textInfo.getScalarBindingInfo();
-         ColumnRef valueRef = new ColumnRef(new AttributeRef(null, "value"));
-         valueRef.setDataType(sbi != null ? sbi.getColumnType() : XSchema.STRING);
-         ColumnSelection valueCols = new ColumnSelection();
-         valueCols.addAttribute(valueRef);
+         }
+         else if(assemblyInfo instanceof TextVSAssemblyInfo textInfo) {
+            // A text output evaluates a highlight against its single scalar value
+            // (OutputVSAssemblyInfo.updateHighlight -> HighlightGroup.findGroup(value)), which ignores the
+            // condition field NAME entirely. The standard highlight dialog therefore exposes exactly ONE field —
+            // the canonical "value" ref (see HighlightDialogService) — so the dropdown only ever shows "Value".
+            // A condition keyed to any other name (e.g. a bound column like "Sum(Sales)") still evaluates
+            // correctly at runtime, which MASKS the problem, but it does NOT round-trip through that dialog: on
+            // reopen its field matches no option and the condition renders blank/broken. Force every condition
+            // field to "value" (typed from the scalar binding, mirroring HighlightDialogService) so a wiz-applied
+            // text highlight is the same shape a dialog-authored one would be.
+            ScalarBindingInfo sbi = textInfo.getScalarBindingInfo();
+            ColumnRef valueRef = new ColumnRef(new AttributeRef(null, "value"));
+            valueRef.setDataType(sbi != null ? sbi.getColumnType() : XSchema.STRING);
+            ColumnSelection valueCols = new ColumnSelection();
+            valueCols.addAttribute(valueRef);
 
-         HighlightGroup group = new HighlightGroup();
-         Set<String> usedNames = new HashSet<>();
+            HighlightGroup group = new HighlightGroup();
+            Set<String> usedNames = new HashSet<>();
 
-         for(ApplyHighlightModel.Highlight rule : hm.getHighlights()) {
-            String name = uniqueName(rule.getName(), usedNames);
-            Highlight hl = buildHighlight(rule, name, valueCols, false);
-            rebindOutputConditionFields(hl.getConditionGroup(), valueRef);
-            group.addHighlight(name, hl);
+            for(ApplyHighlightModel.Highlight rule : hm.getHighlights()) {
+               String name = uniqueName(rule.getName(), usedNames);
+               Highlight hl = buildHighlight(rule, name, valueCols, false);
+               rebindOutputConditionFields(hl.getConditionGroup(), valueRef);
+               group.addHighlight(name, hl);
+            }
+
+            textInfo.setHighlightGroup(group);
+         }
+         // NOTE: text is the ONLY output type wiz highlights. A gauge is a valid wiz output but is
+         // deliberately NOT highlightable, so it (and any other OutputVSAssemblyInfo) falls through to the
+         // else below and fails loud rather than getting a highlight group it has no UI to manage.
+         else if(assemblyInfo instanceof TableDataVSAssemblyInfo tableInfo &&
+                 (assembly instanceof TableVSAssembly || assembly instanceof CrosstabVSAssembly))
+         {
+            applyTableHighlight(rvs, assembly, tableInfo, hm, columns);
+         }
+         else {
+            throw new IllegalArgumentException(
+               "Assembly '" + assembly.getName() + "' (" + assemblyInfo.getClass().getSimpleName() +
+               ") does not support highlighting. Wiz highlights charts, tables, crosstabs, and text output " +
+               "(gauge and other output types are not highlightable).");
          }
 
-         textInfo.setHighlightGroup(group);
+         int sampleMaxRows = model.getSampleMaxRows() != null ? model.getSampleMaxRows() : 0;
+         result = executeAndExtract(rvs, assembly, sampleMaxRows);
+         // Order matters: executeAndExtract runs executeView (populates RT refs); collectFlatBinding prefers
+         // RT refs, so it must come after. The binding is unchanged by highlighting, but recomputing it keeps
+         // the response shape identical to /viewsheet/create.
+         result.setBinding(collectFlatBinding(assembly));
+         result.setAssemblyName(assembly.getName());
+         result.setHasData(computeHasData(rvs.getViewsheet().getViewsheetInfo().isMetadata(), result));
+
+         if(restored) {
+            result.setRuntimeId(rvs.getID());
+         }
+
+         // Persist the mutated highlight to the DURABLE viewsheet asset named by the request identifier
+         // (the ROOT/COMPONENTS entry the viewer reopens), NOT the live runtime's own entry. A wiz chart
+         // runs on a TEMPORARY runtime (openTemporaryViewsheet) whose entry is outside the managed folders,
+         // so the previous rvs.getEntry() guard skipped the write-back whenever the create-time runtime was
+         // still alive — leaving the highlight only on the ephemeral runtime and absent on reopen (the
+         // reopened ROOT asset never received it). persistViewsheet is the shared save choke point (managed-
+         // folder + ACL checks) and writes to the same asset a later save_viewsheet rebuilds from.
+         if(!Tool.isEmptyString(model.getViewsheetIdentifier())) {
+            result.setViewsheetIdentifier(persistViewsheet(vs, model.getViewsheetIdentifier(), user));
+         }
       }
-      // NOTE: text is the ONLY output type wiz highlights. A gauge is a valid wiz output but is
-      // deliberately NOT highlightable, so it (and any other OutputVSAssemblyInfo) falls through to the
-      // else below and fails loud rather than getting a highlight group it has no UI to manage.
-      else if(assemblyInfo instanceof TableDataVSAssemblyInfo tableInfo &&
-              (assembly instanceof TableVSAssembly || assembly instanceof CrosstabVSAssembly))
-      {
-         applyTableHighlight(rvs, assembly, tableInfo, hm, columns);
-      }
-      else {
-         throw new IllegalArgumentException(
-            "Assembly '" + assembly.getName() + "' (" + assemblyInfo.getClass().getSimpleName() +
-            ") does not support highlighting. Wiz highlights charts, tables, crosstabs, and text output " +
-            "(gauge and other output types are not highlightable).");
+      catch(Exception e) {
+         // Mirrors setChartFormat/setChartColors' identical rollback: covers the highlight-application
+         // block above AND executeAndExtract/persistViewsheet, since all can leave the duplicated,
+         // promoted-to-primary copy dangling and unreported if they fail before it is durably committed.
+         if(rollbackCopy != null) {
+            rvs.getViewsheet().removeAssembly(rollbackCopy.getName());
+            demotedOriginal.setPrimary(true);
+         }
+
+         throw e;
       }
 
-      int sampleMaxRows = model.getSampleMaxRows() != null ? model.getSampleMaxRows() : 0;
-      CreateViewsheetResult result = executeAndExtract(rvs, assembly, sampleMaxRows);
-      // Order matters: executeAndExtract runs executeView (populates RT refs); collectFlatBinding prefers
-      // RT refs, so it must come after. The binding is unchanged by highlighting, but recomputing it keeps
-      // the response shape identical to /viewsheet/create.
-      result.setBinding(collectFlatBinding(assembly));
-      result.setAssemblyName(assembly.getName());
-      result.setHasData(computeHasData(rvs.getViewsheet().getViewsheetInfo().isMetadata(), result));
-
-      if(restored) {
-         result.setRuntimeId(rvs.getID());
-      }
-
-      // Persist the mutated highlight to the DURABLE viewsheet asset named by the request identifier
-      // (the ROOT/COMPONENTS entry the viewer reopens), NOT the live runtime's own entry. A wiz chart
-      // runs on a TEMPORARY runtime (openTemporaryViewsheet) whose entry is outside the managed folders,
-      // so the previous rvs.getEntry() guard skipped the write-back whenever the create-time runtime was
-      // still alive — leaving the highlight only on the ephemeral runtime and absent on reopen (the
-      // reopened ROOT asset never received it). persistViewsheet is the shared save choke point (managed-
-      // folder + ACL checks) and writes to the same asset a later save_viewsheet rebuilds from.
-      if(!Tool.isEmptyString(model.getViewsheetIdentifier())) {
-         result.setViewsheetIdentifier(persistViewsheet(vs, model.getViewsheetIdentifier(), user));
+      if(copyNote != null) {
+         result.setNote(copyNote);
       }
 
       return result;
@@ -1522,9 +1572,13 @@ public class WizVsService {
    /**
     * Executes the sandbox view for {@code assembly} and extracts the result data.
     * Dispatches to the appropriate extract method based on assembly type.
+    *
+    * <p>Package-private (not private) so tests can stub it out via a Mockito spy — it drives the real
+    * ViewsheetSandbox, which is expensive to set up faithfully in a unit test, the same reason
+    * {@link #fetchAssemblyData} is already package-private.
     */
-   private CreateViewsheetResult executeAndExtract(RuntimeViewsheet rvs, VSAssembly assembly,
-                                                   int sampleMaxRows)
+   CreateViewsheetResult executeAndExtract(RuntimeViewsheet rvs, VSAssembly assembly,
+                                           int sampleMaxRows)
       throws Exception
    {
       Optional<ViewsheetSandbox> viewsheetSandbox = rvs.getViewsheetSandbox();

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1049,7 +1049,9 @@ public class WizVsService {
          final VSAssembly assembly;
          // Tracks the assembly displaced from primary in the standard path; restored on rollback.
          VSAssembly previousPrimaryAssembly = null;
-         // In modificationOnly (in-place filter), the assembly's prior condition, restored on rollback.
+         // In modificationOnly (in-place filter, no copy), the assembly's prior condition, restored
+         // on rollback. Not used when a copy was made (rollbackCopy below) — undoing that means
+         // removing the whole copy, not restoring a condition on it.
          ConditionList previousCondition = null;
          // Only relevant for the incremental standard path (non-null when base entry may be mutated).
          AssetEntry previousBaseEntry = null;
@@ -1057,6 +1059,11 @@ public class WizVsService {
             && model.getConditionModel() != null;
          // Track the worksheet table name for aggregate condition handling
          String wsTableName = null;
+         // Copy-then-apply (modificationOnly only): mirrors setChartFormat/setChartColors/
+         // applyHighlight's rollback-on-failure bookkeeping.
+         String copyNote = null;
+         VSAssembly demotedOriginal = null;
+         VSAssembly rollbackCopy = null;
 
          if(modificationOnly) {
             targetVs = vs;
@@ -1066,20 +1073,48 @@ public class WizVsService {
                throw new IllegalStateException("No primary assembly found in viewsheet for modification");
             }
 
-            // Get the worksheet table name from the source assembly's source info
-            if(sourceAssembly instanceof DataVSAssembly dataAsm) {
-               SourceInfo srcInfo = dataAsm.getSourceInfo();
-               wsTableName = srcInfo != null ? srcInfo.getSource() : null;
-               // Snapshot the existing condition so a failure can roll back the in-place change.
-               previousCondition = dataAsm.getPreConditionList() != null
-                  ? dataAsm.getPreConditionList().clone() : null;
+            VSAssembly modAssembly = sourceAssembly;
+
+            // Copy-then-apply: duplicate the current primary BEFORE applying the condition, so the
+            // original is left untouched and the filter lands on a new, parallel copy instead.
+            // Reuses the same duplicatePrimaryAssembly the chart color/format/highlight paths use —
+            // sourceAssembly is guaranteed primary here (that's how findPrimaryAssembly found it), so
+            // duplicatePrimaryAssembly's precondition is always satisfied.
+            if(model.isCopy()) {
+               VSAssembly duplicated = duplicatePrimaryAssembly(rvs, sourceAssembly);
+
+               if(duplicated != null) {
+                  demotedOriginal = sourceAssembly;
+                  rollbackCopy = duplicated;
+                  modAssembly = duplicated;
+               }
+               else {
+                  copyNote = "Copy requested but could not be created; filter applied in place.";
+                  LOG.warn("createViewsheetInternal (modificationOnly): duplicatePrimaryAssembly " +
+                     "failed for {}; falling back to in-place apply.", sourceAssembly.getName());
+               }
             }
 
-            // Apply the filter to the EXISTING primary assembly in place — keep its name and
-            // identity. Copying to a unique "<name>_1" assembly (the old behavior) broke
-            // save_viewsheet: save loads the persisted viewsheet and looks the assembly up by name,
-            // so it never found the renamed copy, and every filter call churned a new assembly.
-            assembly = sourceAssembly;
+            assembly = modAssembly;
+
+            // Get the worksheet table name from the target assembly's source info.
+            if(assembly instanceof DataVSAssembly dataAsm) {
+               SourceInfo srcInfo = dataAsm.getSourceInfo();
+               wsTableName = srcInfo != null ? srcInfo.getSource() : null;
+
+               // Only relevant when mutating in place (no copy): a copy's rollback removes the whole
+               // duplicate instead, so there is no prior condition on IT to snapshot.
+               if(rollbackCopy == null) {
+                  // Apply the filter to the EXISTING primary assembly in place — keep its name and
+                  // identity. Copying to a unique "<name>_1" assembly (the old, unconditional
+                  // behavior) broke save_viewsheet: save loads the persisted viewsheet and looks the
+                  // assembly up by name, so it never found the renamed copy, and every filter call
+                  // churned a new assembly. Snapshot the existing condition so a failure can roll
+                  // back the in-place change.
+                  previousCondition = dataAsm.getPreConditionList() != null
+                     ? dataAsm.getPreConditionList().clone() : null;
+               }
+            }
          }
          else {
             SourceContext ctx = resolveSourceContext(model, user);
@@ -1359,6 +1394,10 @@ public class WizVsService {
             String identifierToUse = model.getViewsheetIdentifier();
             result.setViewsheetIdentifier(persistViewsheet(targetVs, identifierToUse, user));
 
+            if(copyNote != null) {
+               result.setNote(copyNote);
+            }
+
             return result;
          }
          catch(Exception e) {
@@ -1378,9 +1417,17 @@ public class WizVsService {
 
             if(!createdRuntimeId) {
                if(modificationOnly) {
-                  // In-place filter: restore the assembly's prior condition rather than removing
-                  // the (existing) assembly, which was mutated, not added, this call.
-                  if(assembly instanceof DataVSAssembly dataAsm) {
+                  if(rollbackCopy != null) {
+                     // A copy was made for this call; undo it — remove the duplicate and restore the
+                     // original as primary. The original's condition was never touched, so there is
+                     // nothing to restore on it (mirrors setChartFormat/setChartColors/applyHighlight's
+                     // identical copy rollback).
+                     previousVs.removeAssembly(rollbackCopy.getName());
+                     demotedOriginal.setPrimary(true);
+                  }
+                  else if(assembly instanceof DataVSAssembly dataAsm) {
+                     // No copy — assembly IS the original, mutated in place; restore its prior
+                     // condition rather than removing it (it was mutated, not added, this call).
                      dataAsm.setPreConditionList(previousCondition);
                   }
                }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1647,6 +1647,17 @@ public class WizVsService {
     * (ASSEMBLY_FACTORIES) — the caller should fall back to applying in place.
     */
    public VSAssembly duplicatePrimaryAssembly(RuntimeViewsheet rvs, VSAssembly source) {
+      // Enforce the documented precondition rather than trust the caller: setChartFormat/setChartColors
+      // resolve `source` purely by the client-supplied assemblyName, with no guarantee it is still the
+      // current primary (e.g. a stale name from a prior turn, after an earlier copy=true call already
+      // promoted a different assembly). Demoting "whichever assembly happens to be primary" in that case
+      // would silently demote an unrelated chart and promote a duplicate of the wrong source.
+      if(!source.isPrimary()) {
+         LOG.warn("duplicatePrimaryAssembly: source \"{}\" is not the primary assembly; refusing to duplicate.",
+            source.getName());
+         return null;
+      }
+
       Viewsheet vs = rvs.getViewsheet();
       String newName = uniqueAssemblyName(vs, source.getName());
       VSAssembly copy = rebindAssembly(vs, newName, source);
@@ -1655,16 +1666,9 @@ public class WizVsService {
          return null;
       }
 
-      Assembly[] existingAssemblies = vs.getAssemblies();
-
-      if(existingAssemblies != null) {
-         for(Assembly a : existingAssemblies) {
-            if(a instanceof VSAssembly va && va.isPrimary()) {
-               va.setPrimary(false);
-            }
-         }
-      }
-
+      // source is confirmed primary above, so demote it specifically — not "whichever assembly happens
+      // to be primary" — for a second layer of defense against demoting the wrong assembly.
+      source.setPrimary(false);
       vs.addAssembly(copy);
       copy.setPrimary(true);
       return copy;

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartColorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartColorsTest.java
@@ -56,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -302,5 +303,63 @@ class WizAutoBindingServiceSetChartColorsTest {
       // Nothing was persisted or fetched — the exception must propagate before either.
       verify(wizVsService, never()).persistViewsheet(any(), any(), any());
       verify(wizVsService, never()).fetchAssemblyData(anyString(), anyString(), any());
+   }
+
+   /** A successful copy whose color application also succeeds cleanly (static color, no color field). */
+   private ChartVSAssembly successfulCopyChart() {
+      VSChartAggregateRef copyYAgg = mock(VSChartAggregateRef.class);
+      VSChartInfo copyChartInfo = mock(VSChartInfo.class);
+      when(copyChartInfo.getColorField()).thenReturn(null);
+      when(copyChartInfo.getYFields()).thenReturn(new ChartRef[] { copyYAgg });
+      when(copyChartInfo.getXFields()).thenReturn(new ChartRef[0]);
+      when(copyChartInfo.getRTYFields()).thenReturn(new ChartRef[0]);
+      when(copyChartInfo.getRTXFields()).thenReturn(new ChartRef[0]);
+      ChartVSAssemblyInfo copyInfo = mock(ChartVSAssemblyInfo.class);
+      when(copyInfo.getVSChartInfo()).thenReturn(copyChartInfo);
+      ChartVSAssembly copyChart = mock(ChartVSAssembly.class);
+      when(copyChart.getChartInfo()).thenReturn(copyInfo);
+      when(copyChart.getName()).thenReturn("vs_1_copy1");
+      return copyChart;
+   }
+
+   @Test
+   void copySucceedsButFetchAssemblyDataThrowsRollsBackTheDuplicate() throws Exception {
+      // fetchAssemblyData runs BEFORE persistViewsheet specifically so that, at the point this throws,
+      // nothing has been durably committed yet — the rollback below is always safe to perform.
+      ChartVSAssembly copy = successfulCopyChart();
+      when(wizVsService.duplicatePrimaryAssembly(rvs, chart)).thenReturn(copy);
+      when(wizVsService.fetchAssemblyData(eq("rt-1"), eq("vs_1_copy1"), any()))
+         .thenThrow(new RuntimeException("sandbox execution failed"));
+
+      ChartColorsRequest request = staticRed();
+      request.setCopy(true);
+
+      assertThrows(RuntimeException.class, () -> service.setChartColors(request, null));
+
+      verify(vs).removeAssembly("vs_1_copy1");
+      verify(chart).setPrimary(true);
+      verify(wizVsService, never()).persistViewsheet(any(), any(), any());
+   }
+
+   @Test
+   void copySucceedsButPersistViewsheetThrowsRollsBackTheDuplicate() throws Exception {
+      // The scenario claude[bot] flagged in re-review: a failure in persistViewsheet itself (bad
+      // identifier / repository save failure) must roll back the same as a failure earlier in the
+      // block — the copy was added and promoted live but never durably committed.
+      ChartVSAssembly copy = successfulCopyChart();
+      when(wizVsService.duplicatePrimaryAssembly(rvs, chart)).thenReturn(copy);
+      when(wizVsService.persistViewsheet(any(), any(), any()))
+         .thenThrow(new IllegalArgumentException("invalid identifier"));
+
+      ChartColorsRequest request = staticRed();
+      request.setCopy(true);
+      request.setViewsheetIdentifier("visualizations-xyz");
+
+      assertThrows(IllegalArgumentException.class, () -> service.setChartColors(request, null));
+
+      verify(vs).removeAssembly("vs_1_copy1");
+      verify(chart).setPrimary(true);
+      // fetchAssemblyData already ran (it comes before persist) — the failure is specifically in persist.
+      verify(wizVsService).fetchAssemblyData(eq("rt-1"), eq("vs_1_copy1"), any());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartColorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartColorsTest.java
@@ -24,8 +24,10 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.sree.security.SecurityEngine;
 import inetsoft.sree.security.SecurityException;
+import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.graph.AestheticRef;
 import inetsoft.uql.viewsheet.graph.ChartRef;
 import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
@@ -43,6 +45,7 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.awt.Color;
 import java.security.Principal;
@@ -76,11 +79,15 @@ class WizAutoBindingServiceSetChartColorsTest {
    private VSChartAggregateRef rtYAgg;
    private SecurityEngine securityEngine;
    private ViewsheetService viewsheetService;
+   private WizVsService wizVsService;
+   private RuntimeViewsheet rvs;
+   private Viewsheet vs;
+   private ChartVSAssembly chart;
 
    @BeforeEach
    void setUp() throws Exception {
       viewsheetService = mock(ViewsheetService.class);
-      WizVsService wizVsService = mock(WizVsService.class);
+      wizVsService = mock(WizVsService.class);
       // collaborators not used by setChartColors; their classes can't be initialized in
       // a plain unit-test environment (no Spring context), so pass null instead of mocks.
       securityEngine = mock(SecurityEngine.class);
@@ -102,14 +109,14 @@ class WizAutoBindingServiceSetChartColorsTest {
       ChartVSAssemblyInfo info = mock(ChartVSAssemblyInfo.class);
       when(info.getVSChartInfo()).thenReturn(vsChartInfo);
 
-      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      chart = mock(ChartVSAssembly.class);
       when(chart.getChartInfo()).thenReturn(info);
 
-      Viewsheet vs = mock(Viewsheet.class);
+      vs = mock(Viewsheet.class);
       when(vs.getAssembly("vs_1")).thenReturn(chart);
 
       box = mock(ViewsheetSandbox.class);
-      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      rvs = mock(RuntimeViewsheet.class);
       when(rvs.getViewsheet()).thenReturn(vs);
       when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
       when(rvs.getID()).thenReturn("rt-1");
@@ -170,5 +177,130 @@ class WizAutoBindingServiceSetChartColorsTest {
       verify(yAgg, never()).setColorFrame(any());
       verify(rtYAgg, never()).setColorFrame(any());
       verify(box, never()).clearGraph(anyString());
+   }
+
+   // ── copy=true (copy-then-apply) ──────────────────────────────────────────────────────────
+
+   @Test
+   void copyTrueDuplicatesBeforeApplyingAndTargetsTheCopy() throws Exception {
+      // A separate mock chart/measure-ref pair standing in for the duplicated assembly —
+      // duplicatePrimaryAssembly's real behavior (uniqueAssemblyName + rebind) is covered by
+      // WizVsServiceDuplicatePrimaryAssemblyTest; here wizVsService is mocked, so we just need to
+      // prove setChartColors WIRES the copy in and applies to it instead of the original.
+      VSChartAggregateRef copyYAgg = mock(VSChartAggregateRef.class);
+      VSChartInfo copyChartInfo = mock(VSChartInfo.class);
+      when(copyChartInfo.getColorField()).thenReturn(null);
+      when(copyChartInfo.getYFields()).thenReturn(new ChartRef[] { copyYAgg });
+      when(copyChartInfo.getXFields()).thenReturn(new ChartRef[0]);
+      when(copyChartInfo.getRTYFields()).thenReturn(new ChartRef[0]);
+      when(copyChartInfo.getRTXFields()).thenReturn(new ChartRef[0]);
+      ChartVSAssemblyInfo copyInfo = mock(ChartVSAssemblyInfo.class);
+      when(copyInfo.getVSChartInfo()).thenReturn(copyChartInfo);
+      ChartVSAssembly copyChart = mock(ChartVSAssembly.class);
+      when(copyChart.getChartInfo()).thenReturn(copyInfo);
+      when(copyChart.getName()).thenReturn("vs_1_copy1");
+
+      when(wizVsService.duplicatePrimaryAssembly(rvs, chart)).thenReturn(copyChart);
+      when(wizVsService.fetchAssemblyData("rt-1", "vs_1_copy1", null))
+         .thenReturn(new CreateViewsheetResult());
+
+      ChartColorsRequest request = staticRed();
+      request.setCopy(true);
+
+      CreateViewsheetResult result = service.setChartColors(request, null);
+
+      // Applied to the COPY's measure ref, never the original's.
+      verify(copyYAgg).setColorFrame(any());
+      verify(yAgg, never()).setColorFrame(any());
+      // The cached graph cleared is the copy's, not the original's.
+      verify(box).clearGraph("vs_1_copy1");
+      verify(box, never()).clearGraph("vs_1");
+      assertEquals("vs_1_copy1", result.getAssemblyName());
+   }
+
+   @Test
+   void copyFalseNeverCallsDuplicatePrimaryAssembly() throws Exception {
+      service.setChartColors(staticRed(), null);
+
+      verify(wizVsService, never()).duplicatePrimaryAssembly(any(), any());
+   }
+
+   @Test
+   void copyTrueButDuplicationFailsFallsBackToInPlaceWithANote() throws Exception {
+      when(wizVsService.duplicatePrimaryAssembly(rvs, chart)).thenReturn(null);
+
+      ChartColorsRequest request = staticRed();
+      request.setCopy(true);
+
+      CreateViewsheetResult result = service.setChartColors(request, null);
+
+      // Falls back to the ORIGINAL assembly rather than failing the whole request.
+      verify(yAgg).setColorFrame(any());
+      assertEquals("vs_1", result.getAssemblyName());
+      assertEquals("Copy requested but could not be created; colors applied in place.", result.getNote());
+   }
+
+   @Test
+   void copyFailureNoteSurvivesAlongsideAnUnrelatedBindingNote() throws Exception {
+      // Regression: the copy-fallback note used to be stored in the SAME `note` local later
+      // reassigned unconditionally by the color-binding logic, silently discarding the
+      // copy-failure warning whenever the color application itself also produced (or cleared) a
+      // note. Both must now survive, concatenated.
+      when(wizVsService.duplicatePrimaryAssembly(rvs, chart)).thenReturn(null);
+
+      ChartColorsRequest request = new ChartColorsRequest();
+      request.setWizRuntimeId("rt-1");
+      request.setAssemblyName("vs_1");
+      request.setPaletteName("Blues");
+      request.setCopy(true);
+      // colorField stays null (static/no-color-binding chart from setUp), so requesting a
+      // palette produces the "no color dimension" note in addition to the copy failure.
+
+      CreateViewsheetResult result = service.setChartColors(request, null);
+
+      assertEquals(
+         "Copy requested but could not be created; colors applied in place. " +
+         "This chart has no color dimension, so a palette/per-category colors can't apply. " +
+         "Recreate with a dimension on the color aesthetic (fieldConfigs/explicitBindings), or use staticColor.",
+         result.getNote());
+   }
+
+   @Test
+   void copySucceedsThenApplyThrowsRollsBackTheDuplicateAndRestoresTheOriginalAsPrimary() throws Exception {
+      // A categorical color field bound to an unknown palette makes ColorPalettes.getPalette(...)
+      // throw AFTER duplicatePrimaryAssembly has already mutated the live runtime (added the copy,
+      // demoted the original, promoted the copy) but BEFORE persistViewsheet ever runs. That
+      // live-runtime mutation must be undone, not left dangling.
+      AestheticRef colorField = mock(AestheticRef.class);
+      DataRef dimensionRef = mock(DataRef.class);
+      when(colorField.getDataRef()).thenReturn(dimensionRef);
+
+      VSChartAggregateRef copyYAgg = mock(VSChartAggregateRef.class);
+      VSChartInfo copyChartInfo = mock(VSChartInfo.class);
+      when(copyChartInfo.getColorField()).thenReturn(colorField);
+      when(copyChartInfo.getYFields()).thenReturn(new ChartRef[] { copyYAgg });
+      ChartVSAssemblyInfo copyInfo = mock(ChartVSAssemblyInfo.class);
+      when(copyInfo.getVSChartInfo()).thenReturn(copyChartInfo);
+      ChartVSAssembly copyChart = mock(ChartVSAssembly.class);
+      when(copyChart.getChartInfo()).thenReturn(copyInfo);
+      when(copyChart.getName()).thenReturn("vs_1_copy1");
+
+      when(wizVsService.duplicatePrimaryAssembly(rvs, chart)).thenReturn(copyChart);
+
+      ChartColorsRequest request = new ChartColorsRequest();
+      request.setWizRuntimeId("rt-1");
+      request.setAssemblyName("vs_1");
+      request.setPaletteName("NotARealPalette");
+      request.setCopy(true);
+
+      assertThrows(ResponseStatusException.class, () -> service.setChartColors(request, null));
+
+      // Rollback: the duplicated assembly is removed from the live viewsheet and the original is
+      // re-promoted to primary.
+      verify(vs).removeAssembly("vs_1_copy1");
+      verify(chart).setPrimary(true);
+      // Nothing was persisted or fetched — the exception must propagate before either.
+      verify(wizVsService, never()).persistViewsheet(any(), any(), any());
+      verify(wizVsService, never()).fetchAssemblyData(anyString(), anyString(), any());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
@@ -27,6 +27,8 @@ import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.uql.viewsheet.graph.ChartDescriptor;
+import inetsoft.uql.viewsheet.graph.LegendsDescriptor;
 import inetsoft.web.wiz.model.ChartFormatRequest;
 import inetsoft.web.wiz.model.CreateViewsheetResult;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,6 +45,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -64,6 +67,8 @@ class WizAutoBindingServiceSetChartFormatTest {
    private ChartVSAssemblyInfo info;
    private ViewsheetSandbox box;
    private SecurityEngine securityEngine;
+   private RuntimeViewsheet rvs;
+   private ChartVSAssembly chart;
 
    @BeforeEach
    void setUp() throws Exception {
@@ -83,7 +88,7 @@ class WizAutoBindingServiceSetChartFormatTest {
       when(info.getChartDescriptor()).thenReturn(null);
       when(info.getVSChartInfo()).thenReturn(null);
 
-      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      chart = mock(ChartVSAssembly.class);
       when(chart.getChartInfo()).thenReturn(info);
       when(chart.getVSAssemblyInfo()).thenReturn(info);
 
@@ -91,7 +96,7 @@ class WizAutoBindingServiceSetChartFormatTest {
       when(vs.getAssembly("vs_1")).thenReturn(chart);
 
       box = mock(ViewsheetSandbox.class);
-      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      rvs = mock(RuntimeViewsheet.class);
       when(rvs.getViewsheet()).thenReturn(vs);
       when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
       when(rvs.getID()).thenReturn("rt-1");
@@ -171,5 +176,109 @@ class WizAutoBindingServiceSetChartFormatTest {
       verify(viewsheetService, never()).getViewsheet(anyString(), any());
       verify(info, never()).setTitleValue(any());
       verify(wizVsService, never()).persistViewsheet(any(), any(), any());
+   }
+
+   // ── copy=true (copy-then-apply) ──────────────────────────────────────────────────────────
+
+   @Test
+   void copyTrueDuplicatesBeforeApplyingAndTargetsTheCopy() throws Exception {
+      // duplicatePrimaryAssembly's real behavior (uniqueAssemblyName + rebind) is covered by
+      // WizVsServiceDuplicatePrimaryAssemblyTest; wizVsService is mocked here, so this only needs to
+      // prove setChartFormat WIRES the copy in and applies to it instead of the original.
+      ChartVSAssemblyInfo copyInfo = mock(ChartVSAssemblyInfo.class);
+      ChartVSAssembly copyChart = mock(ChartVSAssembly.class);
+      when(copyChart.getChartInfo()).thenReturn(copyInfo);
+      when(copyChart.getVSAssemblyInfo()).thenReturn(copyInfo);
+      when(copyChart.getName()).thenReturn("vs_1_copy1");
+
+      when(wizVsService.duplicatePrimaryAssembly(rvs, chart)).thenReturn(copyChart);
+      when(wizVsService.fetchAssemblyData("rt-1", "vs_1_copy1", null))
+         .thenReturn(new CreateViewsheetResult());
+
+      ChartFormatRequest request = titleRequest("visualizations-xyz");
+      request.setCopy(true);
+
+      CreateViewsheetResult result = service.setChartFormat(request, null);
+
+      // Applied to the COPY's info, never the original's.
+      verify(copyInfo).setTitleValue("Contacts per Account");
+      verify(info, never()).setTitleValue(any());
+      // The cached graph cleared is the copy's, not the original's.
+      verify(box).clearGraph("vs_1_copy1");
+      verify(box, never()).clearGraph("vs_1");
+      assertEquals("vs_1_copy1", result.getAssemblyName());
+   }
+
+   @Test
+   void copyFalseNeverCallsDuplicatePrimaryAssembly() throws Exception {
+      service.setChartFormat(titleRequest("visualizations-xyz"), null);
+
+      verify(wizVsService, never()).duplicatePrimaryAssembly(any(), any());
+   }
+
+   @Test
+   void copyTrueButDuplicationFailsFallsBackToInPlaceWithANote() throws Exception {
+      when(wizVsService.duplicatePrimaryAssembly(rvs, chart)).thenReturn(null);
+
+      ChartFormatRequest request = titleRequest("visualizations-xyz");
+      request.setCopy(true);
+
+      CreateViewsheetResult result = service.setChartFormat(request, null);
+
+      // Falls back to the ORIGINAL assembly rather than failing the whole request.
+      verify(info).setTitleValue("Contacts per Account");
+      assertEquals("vs_1", result.getAssemblyName());
+      assertEquals("Copy requested but could not be created; format applied in place.", result.getNote());
+   }
+
+   @Test
+   void copyFailureNoteSurvivesAlongsideAnUnrelatedLegendNote() throws Exception {
+      // Regression: the copy-fallback note used to be stored in the SAME `note` local later
+      // reassigned unconditionally by the legend-validation logic, silently discarding the
+      // copy-failure warning whenever the legend position was ALSO invalid. Both must now
+      // survive, concatenated.
+      LegendsDescriptor legends = mock(LegendsDescriptor.class);
+      ChartDescriptor desc = mock(ChartDescriptor.class);
+      when(desc.getLegendsDescriptor()).thenReturn(legends);
+      when(info.getChartDescriptor()).thenReturn(desc);
+      when(wizVsService.duplicatePrimaryAssembly(rvs, chart)).thenReturn(null);
+
+      ChartFormatRequest request = new ChartFormatRequest();
+      request.setWizRuntimeId("rt-1");
+      request.setAssemblyName("vs_1");
+      request.setLegendPosition("sideways");
+      request.setCopy(true);
+
+      CreateViewsheetResult result = service.setChartFormat(request, null);
+
+      assertEquals(
+         "Copy requested but could not be created; format applied in place. " +
+         "Unknown legendPosition 'sideways'; valid: none, top, right, bottom, left, in_place. Legend left unchanged.",
+         result.getNote());
+   }
+
+   @Test
+   void copySucceedsThenApplyThrowsRollsBackTheDuplicateAndRestoresTheOriginalAsPrimary() throws Exception {
+      // Any throw between the successful duplication and persistViewsheet must roll back the
+      // live-runtime mutation duplicatePrimaryAssembly already made (copy added + promoted,
+      // original demoted) rather than leave it dangling and unreported.
+      ChartVSAssemblyInfo copyInfo = mock(ChartVSAssemblyInfo.class);
+      ChartVSAssembly copyChart = mock(ChartVSAssembly.class);
+      when(copyChart.getChartInfo()).thenReturn(copyInfo);
+      when(copyChart.getVSAssemblyInfo()).thenReturn(copyInfo);
+      when(copyChart.getName()).thenReturn("vs_1_copy1");
+      doThrow(new IllegalStateException("boom")).when(copyInfo).setTitleValue(anyString());
+
+      when(wizVsService.duplicatePrimaryAssembly(rvs, chart)).thenReturn(copyChart);
+
+      ChartFormatRequest request = titleRequest("visualizations-xyz");
+      request.setCopy(true);
+
+      assertThrows(IllegalStateException.class, () -> service.setChartFormat(request, null));
+
+      verify(vs).removeAssembly("vs_1_copy1");
+      verify(chart).setPrimary(true);
+      verify(wizVsService, never()).persistViewsheet(any(), any(), any());
+      verify(wizVsService, never()).fetchAssemblyData(anyString(), anyString(), any());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
@@ -281,4 +281,54 @@ class WizAutoBindingServiceSetChartFormatTest {
       verify(wizVsService, never()).persistViewsheet(any(), any(), any());
       verify(wizVsService, never()).fetchAssemblyData(anyString(), anyString(), any());
    }
+
+   /** A successful copy whose format application (title-only) also succeeds cleanly. */
+   private ChartVSAssembly successfulCopyChart() {
+      ChartVSAssemblyInfo copyInfo = mock(ChartVSAssemblyInfo.class);
+      ChartVSAssembly copyChart = mock(ChartVSAssembly.class);
+      when(copyChart.getChartInfo()).thenReturn(copyInfo);
+      when(copyChart.getVSAssemblyInfo()).thenReturn(copyInfo);
+      when(copyChart.getName()).thenReturn("vs_1_copy1");
+      return copyChart;
+   }
+
+   @Test
+   void copySucceedsButFetchAssemblyDataThrowsRollsBackTheDuplicate() throws Exception {
+      // fetchAssemblyData runs BEFORE persistViewsheet specifically so that, at the point this throws,
+      // nothing has been durably committed yet — the rollback below is always safe to perform.
+      ChartVSAssembly copy = successfulCopyChart();
+      when(wizVsService.duplicatePrimaryAssembly(rvs, chart)).thenReturn(copy);
+      when(wizVsService.fetchAssemblyData(eq("rt-1"), eq("vs_1_copy1"), any()))
+         .thenThrow(new RuntimeException("sandbox execution failed"));
+
+      ChartFormatRequest request = titleRequest("visualizations-xyz");
+      request.setCopy(true);
+
+      assertThrows(RuntimeException.class, () -> service.setChartFormat(request, null));
+
+      verify(vs).removeAssembly("vs_1_copy1");
+      verify(chart).setPrimary(true);
+      verify(wizVsService, never()).persistViewsheet(any(), any(), any());
+   }
+
+   @Test
+   void copySucceedsButPersistViewsheetThrowsRollsBackTheDuplicate() throws Exception {
+      // The scenario claude[bot] flagged in re-review: a failure in persistViewsheet itself (bad
+      // identifier / repository save failure) must roll back the same as a failure earlier in the
+      // block — the copy was added and promoted live but never durably committed.
+      ChartVSAssembly copy = successfulCopyChart();
+      when(wizVsService.duplicatePrimaryAssembly(rvs, chart)).thenReturn(copy);
+      when(wizVsService.persistViewsheet(any(), any(), any()))
+         .thenThrow(new IllegalArgumentException("invalid identifier"));
+
+      ChartFormatRequest request = titleRequest("visualizations-xyz");
+      request.setCopy(true);
+
+      assertThrows(IllegalArgumentException.class, () -> service.setChartFormat(request, null));
+
+      verify(vs).removeAssembly("vs_1_copy1");
+      verify(chart).setPrimary(true);
+      // fetchAssemblyData already ran (it comes before persist) — the failure is specifically in persist.
+      verify(wizVsService).fetchAssemblyData(eq("rt-1"), eq("vs_1_copy1"), any());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceApplyHighlightCopyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceApplyHighlightCopyTest.java
@@ -1,0 +1,200 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.TextVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
+import inetsoft.web.wiz.model.ApplyHighlightModel;
+import inetsoft.web.wiz.model.CreateViewsheetResult;
+import inetsoft.web.wiz.model.VisualizationConditionModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * applyHighlight's copy-then-apply wiring (model.isCopy()) mirrors setChartFormat/setChartColors'
+ * duplicate-before-apply + rollback-on-failure pattern exactly — see
+ * {@link WizAutoBindingServiceSetChartColorsTest} for the equivalent coverage on that path, and
+ * {@link WizVsServiceDuplicatePrimaryAssemblyTest} for duplicatePrimaryAssembly's own correctness
+ * (not re-tested here).
+ *
+ * <p>executeAndExtract/collectFlatBinding are stubbed via a Mockito spy on a real WizVsService
+ * instance (applyHighlight calls them on {@code this}, so an externally-injected mock collaborator
+ * — the pattern WizAutoBindingServiceSetChartColorsTest uses for wizVsService.fetchAssemblyData —
+ * isn't available here). This isolates the copy-then-apply wiring itself, the only new logic in
+ * this class, from the pre-existing (and separately untested) sandbox-execution machinery.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizVsServiceApplyHighlightCopyTest {
+   private WizVsService service;
+   private RuntimeViewsheet rvs;
+   private Viewsheet vs;
+   private VSAssembly assembly;
+   private TextVSAssemblyInfo assemblyInfo;
+
+   @BeforeEach
+   void setUp() throws Exception {
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+
+      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine);
+      service = spy(real);
+
+      // A simple TEXT output assembly — the highlight branch with the fewest collaborators to satisfy,
+      // since it doesn't need chart binding refs or a table lens like the chart/table branches do.
+      // Which branch runs is irrelevant to what's under test (the copy-then-apply wiring around
+      // whichever branch fires). getScalarBindingInfo() defaults to null, which the branch already
+      // handles (falls back to XSchema.STRING).
+      assemblyInfo = mock(TextVSAssemblyInfo.class);
+      assembly = mock(VSAssembly.class);
+      when(assembly.getName()).thenReturn("vs_1");
+      when(assembly.getVSAssemblyInfo()).thenReturn(assemblyInfo);
+
+      vs = mock(Viewsheet.class);
+      when(vs.getAssembly("vs_1")).thenReturn(assembly);
+      when(vs.getWizInfo()).thenReturn(new Viewsheet.WizInfo(true, null, null));
+      inetsoft.uql.viewsheet.ViewsheetInfo vsInfo = mock(inetsoft.uql.viewsheet.ViewsheetInfo.class);
+      when(vsInfo.isMetadata()).thenReturn(false);
+      when(vs.getViewsheetInfo()).thenReturn(vsInfo);
+
+      rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getID()).thenReturn("rt-1");
+      when(viewsheetService.getViewsheet(anyString(), any())).thenReturn(rvs);
+
+      // Bypass the real sandbox-execution machinery (private/heavy; not what this test covers).
+      doReturn(new CreateViewsheetResult()).when(service).executeAndExtract(any(), any(), anyInt());
+      doReturn(null).when(service).collectFlatBinding(any());
+   }
+
+   /** A minimal but genuinely valid highlight rule — a flat "Category = 'A'" condition. */
+   private static ApplyHighlightModel.Highlight simpleRule() {
+      ApplyHighlightModel.Highlight rule = new ApplyHighlightModel.Highlight();
+      rule.setName("r1");
+      rule.setForeground("#ff0000");
+      VisualizationConditionModel.ConditionSpec spec = new VisualizationConditionModel.ConditionSpec(
+         "Category", null, null, null, null, false, null, null,
+         List.of(new VisualizationConditionModel.ValueSpec("VALUE", "A", null)));
+      rule.setConditions(List.of(new VisualizationConditionModel.ConditionLeaf(null, spec)));
+      return rule;
+   }
+
+   private static ApplyHighlightModel request(boolean copy) {
+      ApplyHighlightModel model = new ApplyHighlightModel();
+      model.setRuntimeId("rt-1");
+      model.setAssemblyName("vs_1");
+      model.setCopy(copy);
+      ApplyHighlightModel.HighlightModel hm = new ApplyHighlightModel.HighlightModel();
+      hm.setHighlights(List.of(simpleRule()));
+      model.setHighlightModel(hm);
+      return model;
+   }
+
+   @Test
+   void copyFalseNeverCallsDuplicatePrimaryAssembly() throws Exception {
+      service.applyHighlight(request(false), null);
+
+      verify(service, never()).duplicatePrimaryAssembly(any(), any());
+      verify(assemblyInfo).setHighlightGroup(any());
+   }
+
+   @Test
+   void copyTrueDuplicatesBeforeApplyingAndTargetsTheCopy() throws Exception {
+      VSAssembly copy = mock(VSAssembly.class);
+      TextVSAssemblyInfo copyInfo = mock(TextVSAssemblyInfo.class);
+      when(copy.getName()).thenReturn("vs_1_copy1");
+      when(copy.getVSAssemblyInfo()).thenReturn(copyInfo);
+
+      doReturn(copy).when(service).duplicatePrimaryAssembly(rvs, assembly);
+
+      CreateViewsheetResult result = service.applyHighlight(request(true), null);
+
+      // Applied to the COPY's info, never the original's.
+      verify(copyInfo).setHighlightGroup(any());
+      verify(assemblyInfo, never()).setHighlightGroup(any());
+      assertEquals("vs_1_copy1", result.getAssemblyName());
+      assertNull(result.getNote());
+   }
+
+   @Test
+   void copyTrueButDuplicationFailsFallsBackToInPlaceWithANote() throws Exception {
+      doReturn(null).when(service).duplicatePrimaryAssembly(rvs, assembly);
+
+      CreateViewsheetResult result = service.applyHighlight(request(true), null);
+
+      // Falls back to the ORIGINAL assembly rather than failing the whole request.
+      verify(assemblyInfo).setHighlightGroup(any());
+      assertEquals("vs_1", result.getAssemblyName());
+      assertEquals("Copy requested but could not be created; highlight applied in place.", result.getNote());
+   }
+
+   @Test
+   void copySucceedsThenApplyThrowsRollsBackTheDuplicateAndRestoresTheOriginalAsPrimary() throws Exception {
+      // A copy whose info type matches NEITHER chart/output/table-data forces the "does not support
+      // highlighting" throw AFTER duplicatePrimaryAssembly has already mutated the live runtime
+      // (added the copy, demoted the original, promoted the copy) but before persistViewsheet ever
+      // runs. That live-runtime mutation must be undone, not left dangling — mirrors
+      // WizAutoBindingServiceSetChartColorsTest.copySucceedsThenApplyThrowsRollsBack...
+      VSAssembly copy = mock(VSAssembly.class);
+      VSAssemblyInfo unsupportedInfo = mock(VSAssemblyInfo.class);
+      when(copy.getName()).thenReturn("vs_1_copy1");
+      when(copy.getVSAssemblyInfo()).thenReturn(unsupportedInfo);
+
+      doReturn(copy).when(service).duplicatePrimaryAssembly(rvs, assembly);
+
+      assertThrows(IllegalArgumentException.class, () -> service.applyHighlight(request(true), null));
+
+      // Rollback: the duplicated assembly is removed from the live viewsheet and the original is
+      // re-promoted to primary.
+      verify(vs).removeAssembly("vs_1_copy1");
+      verify(assembly).setPrimary(true);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceApplyHighlightCopyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceApplyHighlightCopyTest.java
@@ -47,7 +47,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -196,5 +198,53 @@ class WizVsServiceApplyHighlightCopyTest {
       // re-promoted to primary.
       verify(vs).removeAssembly("vs_1_copy1");
       verify(assembly).setPrimary(true);
+   }
+
+   /** A successful copy whose highlight application also succeeds cleanly (TEXT branch). */
+   private VSAssembly successfulCopy() {
+      VSAssembly copy = mock(VSAssembly.class);
+      TextVSAssemblyInfo copyInfo = mock(TextVSAssemblyInfo.class);
+      when(copy.getName()).thenReturn("vs_1_copy1");
+      when(copy.getVSAssemblyInfo()).thenReturn(copyInfo);
+      return copy;
+   }
+
+   @Test
+   void copySucceedsButExecuteAndExtractThrowsRollsBackTheDuplicate() throws Exception {
+      // executeAndExtract runs BEFORE persistViewsheet specifically so that, at the point this throws,
+      // nothing has been durably committed yet — the rollback below is always safe to perform. Mirrors
+      // WizAutoBindingServiceSetChartColorsTest.copySucceedsButFetchAssemblyDataThrowsRollsBackTheDuplicate.
+      VSAssembly copy = successfulCopy();
+      doReturn(copy).when(service).duplicatePrimaryAssembly(rvs, assembly);
+      doThrow(new RuntimeException("sandbox execution failed"))
+         .when(service).executeAndExtract(any(), eq(copy), anyInt());
+
+      assertThrows(RuntimeException.class, () -> service.applyHighlight(request(true), null));
+
+      verify(vs).removeAssembly("vs_1_copy1");
+      verify(assembly).setPrimary(true);
+      verify(service, never()).persistViewsheet(any(), any(), any());
+   }
+
+   @Test
+   void copySucceedsButPersistViewsheetThrowsRollsBackTheDuplicate() throws Exception {
+      // The scenario flagged in the PR #4334 re-review: a failure in persistViewsheet itself (bad
+      // identifier / repository save failure) must roll back the same as a failure earlier in the
+      // block — the copy was added and promoted live but never durably committed. Mirrors
+      // WizAutoBindingServiceSetChartColorsTest.copySucceedsButPersistViewsheetThrowsRollsBackTheDuplicate.
+      VSAssembly copy = successfulCopy();
+      doReturn(copy).when(service).duplicatePrimaryAssembly(rvs, assembly);
+      doThrow(new IllegalArgumentException("invalid identifier"))
+         .when(service).persistViewsheet(any(), any(), any());
+
+      ApplyHighlightModel request = request(true);
+      request.setViewsheetIdentifier("visualizations-xyz");
+
+      assertThrows(IllegalArgumentException.class, () -> service.applyHighlight(request, null));
+
+      verify(vs).removeAssembly("vs_1_copy1");
+      verify(assembly).setPrimary(true);
+      // executeAndExtract already ran (it comes before persist) — the failure is specifically in persist.
+      verify(service).executeAndExtract(any(), eq(copy), anyInt());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceDuplicatePrimaryAssemblyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceDuplicatePrimaryAssemblyTest.java
@@ -1,0 +1,198 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.test.*;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.sree.security.SecurityEngine;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * duplicatePrimaryAssembly is the copy-then-apply entry point for setChartFormat/setChartColors
+ * (request.isCopy()): it must produce a NEW assembly carrying the source's binding/format state,
+ * promote it to primary, and demote (never delete) the previous primary — mirroring the standard
+ * create() path's own rebind sequence (uniqueAssemblyName + rebindAssembly + demote/promote). It
+ * also enforces its documented precondition that {@code source} must already be the primary
+ * assembly, refusing (returning null) rather than silently demoting an unrelated current-primary
+ * chart if a caller passes a stale, no-longer-primary source.
+ *
+ * Real Viewsheet/ChartVSAssembly instances are used (not Mockito mocks) because rebindAssembly
+ * dispatches on src.getClass() against a Class-keyed factory map (ASSEMBLY_FACTORIES) — a Mockito
+ * mock's class would never match ChartVSAssembly.class, so the "real assembly duplicated" path could
+ * never be exercised through mocks. Constructing a real Viewsheet/VSAssemblyInfo reads SreeEnv
+ * properties, which requires the minimal Spring/@SreeHome test context (same setup as
+ * ApplyParameterToInputTest / VSFormatTableLensTest).
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizVsServiceDuplicatePrimaryAssemblyTest {
+   private static WizVsService newService() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+      return new WizVsService(vsService, engine, sec);
+   }
+
+   private static RuntimeViewsheet rvsOf(Viewsheet vs) {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      return rvs;
+   }
+
+   @Test
+   void duplicatesUnderAUniqueNameAndPromotesItToPrimary() throws Exception {
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly source = new ChartVSAssembly(vs, "Chart1");
+      source.setPrimary(true);
+      vs.addAssembly(source);
+
+      WizVsService service = newService();
+      VSAssembly copy = service.duplicatePrimaryAssembly(rvsOf(vs), source);
+
+      assertNotNull(copy);
+      assertNotEquals("Chart1", copy.getName());
+      assertTrue(copy.isPrimary());
+      assertTrue(copy instanceof ChartVSAssembly);
+   }
+
+   @Test
+   void demotesButDoesNotDeleteThePreviousPrimary() throws Exception {
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly source = new ChartVSAssembly(vs, "Chart1");
+      source.setPrimary(true);
+      vs.addAssembly(source);
+
+      WizVsService service = newService();
+      service.duplicatePrimaryAssembly(rvsOf(vs), source);
+
+      // The original is still present in the viewsheet (not removed) — just no longer primary.
+      Assembly original = vs.getAssembly("Chart1");
+      assertNotNull(original);
+      assertFalse(((VSAssembly) original).isPrimary());
+   }
+
+   @Test
+   void copiesTheSourcesBindingAndFormatState() throws Exception {
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly source = new ChartVSAssembly(vs, "Chart1");
+      source.setPrimary(true);
+
+      if(source.getVSAssemblyInfo() instanceof ChartVSAssemblyInfo cinfo) {
+         cinfo.setTitleValue("Contacts per Account");
+         cinfo.setTitleVisible(true);
+      }
+
+      vs.addAssembly(source);
+
+      WizVsService service = newService();
+      VSAssembly copy = service.duplicatePrimaryAssembly(rvsOf(vs), source);
+
+      assertTrue(copy.getVSAssemblyInfo() instanceof ChartVSAssemblyInfo);
+      ChartVSAssemblyInfo copiedInfo = (ChartVSAssemblyInfo) copy.getVSAssemblyInfo();
+      assertEquals("Contacts per Account", copiedInfo.getTitleValue());
+
+      // Copy is independent — mutating the source afterward must not leak into the copy.
+      if(source.getVSAssemblyInfo() instanceof ChartVSAssemblyInfo cinfo) {
+         cinfo.setTitleValue("Changed after copy");
+      }
+
+      assertEquals("Contacts per Account", copiedInfo.getTitleValue());
+   }
+
+   @Test
+   void allocatesASeparateUniqueNameOnASecondDuplicate() throws Exception {
+      // Simulates a second copy-then-apply turn: the FIRST copy is now primary (the first copy is
+      // still there, unsaved) — a second duplicate call resolves against the CURRENT primary (the
+      // first copy), which must not collide with the first copy's own name.
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly source = new ChartVSAssembly(vs, "Chart1");
+      source.setPrimary(true);
+      vs.addAssembly(source);
+
+      WizVsService service = newService();
+      VSAssembly firstCopy = service.duplicatePrimaryAssembly(rvsOf(vs), source);
+      VSAssembly secondCopy = service.duplicatePrimaryAssembly(rvsOf(vs), firstCopy);
+
+      assertNotNull(secondCopy);
+      assertNotEquals(firstCopy.getName(), secondCopy.getName());
+      assertTrue(secondCopy.isPrimary());
+      assertFalse(firstCopy.isPrimary());
+   }
+
+   @Test
+   void refusesToDuplicateWhenSourceIsNoLongerPrimary() throws Exception {
+      // The documented precondition: source MUST already be primary. A caller (setChartFormat/
+      // setChartColors) that resolves the source purely by a client-supplied, possibly-stale
+      // assemblyName must not silently demote whatever chart currently IS primary — a completely
+      // unrelated assembly — and duplicate the wrong (stale) source instead.
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly source = new ChartVSAssembly(vs, "Chart1");
+      source.setPrimary(false);
+      vs.addAssembly(source);
+
+      ChartVSAssembly actualPrimary = new ChartVSAssembly(vs, "Chart2");
+      actualPrimary.setPrimary(true);
+      vs.addAssembly(actualPrimary);
+
+      WizVsService service = newService();
+      VSAssembly copy = service.duplicatePrimaryAssembly(rvsOf(vs), source);
+
+      assertNull(copy);
+      // The unrelated current-primary assembly must be left completely untouched.
+      assertTrue(actualPrimary.isPrimary());
+      assertEquals(2, vs.getAssemblies().length, "no assembly should have been added");
+   }
+
+   @Test
+   void returnsNullForAnAssemblyTypeWithNoRebindFactory() throws Exception {
+      // TableVSAssembly IS in ASSEMBLY_FACTORIES; use a type that is not, to exercise the fallback.
+      // GaugeVSAssembly/TextVSAssembly/CrosstabVSAssembly ARE registered too, so pick an assembly kind
+      // that has no factory entry at all: a plain abstract-ish stand-in is not available, so instead
+      // assert the documented contract directly against the registered set by using a type deliberately
+      // NOT in ASSEMBLY_FACTORIES — inetsoft.uql.viewsheet.CalcTableVSAssembly.
+      Viewsheet vs = new Viewsheet();
+      inetsoft.uql.viewsheet.CalcTableVSAssembly source =
+         new inetsoft.uql.viewsheet.CalcTableVSAssembly(vs, "Calc1");
+      source.setPrimary(true);
+      vs.addAssembly(source);
+
+      WizVsService service = newService();
+      VSAssembly copy = service.duplicatePrimaryAssembly(rvsOf(vs), source);
+
+      assertNull(copy);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFilterCopyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFilterCopyTest.java
@@ -1,0 +1,221 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.ViewsheetInfo;
+import inetsoft.web.wiz.model.CreateVisualizationModel;
+import inetsoft.web.wiz.model.CreateViewsheetResult;
+import inetsoft.web.wiz.model.VisualizationConditionModel;
+
+import java.security.Principal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * createViewsheetInternal's "modificationOnly" (in-place filter) path's copy-then-apply wiring
+ * (model.isCopy()) mirrors setChartFormat/setChartColors/applyHighlight's duplicate-before-apply +
+ * rollback-on-failure pattern exactly — see {@link WizAutoBindingServiceSetChartColorsTest} for the
+ * equivalent coverage on that path, and {@link WizVsServiceDuplicatePrimaryAssemblyTest} for
+ * duplicatePrimaryAssembly's own correctness (not re-tested here).
+ *
+ * <p>executeAndExtract/collectFlatBinding are stubbed via a Mockito spy on a real WizVsService
+ * instance, same as {@link WizVsServiceApplyHighlightCopyTest} — this isolates the copy-then-apply
+ * wiring itself, the only new logic in this path, from the pre-existing (and separately untested)
+ * sandbox-execution machinery.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizVsServiceFilterCopyTest {
+   private WizVsService service;
+   private RuntimeViewsheet rvs;
+   private Viewsheet vs;
+   private ChartVSAssembly assembly;
+   private Principal user;
+
+   @BeforeEach
+   void setUp() throws Exception {
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+      user = mock(Principal.class);
+
+      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine);
+      service = spy(real);
+
+      // The current primary assembly (isPrimary()=true) that findPrimaryAssembly resolves in the
+      // modificationOnly path. getViewsheet()=null makes VSUtil.getBaseColumns return an empty
+      // ColumnSelection (its documented behavior with no base worksheet) rather than needing a full
+      // binding setup — irrelevant to what this test covers (the copy-then-apply wiring, not
+      // condition-to-column resolution).
+      assembly = mock(ChartVSAssembly.class);
+      when(assembly.getName()).thenReturn("vs_1");
+      when(assembly.isPrimary()).thenReturn(true);
+
+      vs = mock(Viewsheet.class);
+      when(vs.getAssemblies()).thenReturn(new Assembly[] { assembly });
+      when(vs.getWizInfo()).thenReturn(new Viewsheet.WizInfo(true, null, null));
+      ViewsheetInfo vsInfo = mock(ViewsheetInfo.class);
+      when(vsInfo.isMetadata()).thenReturn(false);
+      when(vs.getViewsheetInfo()).thenReturn(vsInfo);
+
+      rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getID()).thenReturn("rt-1");
+      when(viewsheetService.getViewsheet(anyString(), any())).thenReturn(rvs);
+
+      // Bypass the real sandbox-execution machinery (private/heavy; not what this test covers).
+      doReturn(new CreateViewsheetResult()).when(service).executeAndExtract(any(), any(), anyInt());
+      doReturn(null).when(service).collectFlatBinding(any());
+      // persistViewsheet is always called unconditionally by createViewsheetInternal (unlike
+      // applyHighlight, which only persists when a viewsheetIdentifier is supplied); stub it out here
+      // so the base success-path tests don't need real repository-save machinery. Tests that
+      // specifically cover the persistViewsheet-throws rollback override this locally.
+      doReturn("vs-identifier").when(service).persistViewsheet(any(), any(), any());
+   }
+
+   /** A minimal but genuinely valid base condition — a flat "Category = 'A'" leaf. */
+   private static VisualizationConditionModel simpleCondition() {
+      VisualizationConditionModel cm = new VisualizationConditionModel();
+      VisualizationConditionModel.ConditionSpec spec = new VisualizationConditionModel.ConditionSpec(
+         "Category", null, null, null, null, false, null, null,
+         List.of(new VisualizationConditionModel.ValueSpec("VALUE", "A", null)));
+      cm.setBaseConditions(List.of(new VisualizationConditionModel.ConditionLeaf(null, spec)));
+      return cm;
+   }
+
+   private static CreateVisualizationModel request(boolean copy) {
+      CreateVisualizationModel model = new CreateVisualizationModel();
+      model.setRuntimeId("rt-1");
+      model.setConditionModel(simpleCondition());
+      model.setCopy(copy);
+      return model;
+   }
+
+   @Test
+   void copyFalseNeverCallsDuplicatePrimaryAssembly() throws Exception {
+      service.createViewsheet(request(false), user);
+
+      verify(service, never()).duplicatePrimaryAssembly(any(), any());
+      verify(assembly).setPreConditionList(any());
+   }
+
+   @Test
+   void copyTrueDuplicatesBeforeApplyingAndTargetsTheCopy() throws Exception {
+      ChartVSAssembly copy = mock(ChartVSAssembly.class);
+      when(copy.getName()).thenReturn("vs_1_copy1");
+
+      doReturn(copy).when(service).duplicatePrimaryAssembly(rvs, assembly);
+
+      CreateViewsheetResult result = service.createViewsheet(request(true), user);
+
+      // Applied to the COPY, never the original.
+      verify(copy).setPreConditionList(any());
+      verify(assembly, never()).setPreConditionList(any());
+      assertEquals("vs_1_copy1", result.getAssemblyName());
+      assertNull(result.getNote());
+   }
+
+   @Test
+   void copyTrueButDuplicationFailsFallsBackToInPlaceWithANote() throws Exception {
+      doReturn(null).when(service).duplicatePrimaryAssembly(rvs, assembly);
+
+      CreateViewsheetResult result = service.createViewsheet(request(true), user);
+
+      // Falls back to the ORIGINAL assembly rather than failing the whole request.
+      verify(assembly).setPreConditionList(any());
+      assertEquals("vs_1", result.getAssemblyName());
+      assertEquals("Copy requested but could not be created; filter applied in place.", result.getNote());
+   }
+
+   @Test
+   void copySucceedsThenApplyThrowsRollsBackTheDuplicateAndRestoresTheOriginalAsPrimary() throws Exception {
+      // Force the condition-application step itself to throw AFTER duplicatePrimaryAssembly has
+      // already mutated the live runtime (added the copy, demoted the original, promoted the copy)
+      // but before persistViewsheet ever runs. That live-runtime mutation must be undone, not left
+      // dangling — mirrors WizAutoBindingServiceSetChartColorsTest.copySucceedsThenApplyThrowsRollsBack...
+      ChartVSAssembly copy = mock(ChartVSAssembly.class);
+      when(copy.getName()).thenReturn("vs_1_copy1");
+      doThrow(new RuntimeException("boom")).when(copy).setPreConditionList(any());
+
+      doReturn(copy).when(service).duplicatePrimaryAssembly(rvs, assembly);
+
+      assertThrows(RuntimeException.class, () -> service.createViewsheet(request(true), user));
+
+      // Rollback: the duplicated assembly is removed from the live viewsheet and the original is
+      // re-promoted to primary.
+      verify(vs).removeAssembly("vs_1_copy1");
+      verify(assembly).setPrimary(true);
+   }
+
+   @Test
+   void copySucceedsButPersistViewsheetThrowsRollsBackTheDuplicate() throws Exception {
+      // Mirrors the scenario flagged in the highlight re-review: a failure in persistViewsheet itself
+      // must roll back the same as a failure earlier in the block.
+      ChartVSAssembly copy = mock(ChartVSAssembly.class);
+      when(copy.getName()).thenReturn("vs_1_copy1");
+
+      doReturn(copy).when(service).duplicatePrimaryAssembly(rvs, assembly);
+      doThrow(new IllegalArgumentException("invalid identifier"))
+         .when(service).persistViewsheet(any(), any(), any());
+
+      CreateVisualizationModel request = request(true);
+      request.setViewsheetIdentifier("visualizations-xyz");
+
+      assertThrows(IllegalArgumentException.class, () -> service.createViewsheet(request, user));
+
+      verify(vs).removeAssembly("vs_1_copy1");
+      verify(assembly).setPrimary(true);
+      // The condition was already applied to the copy (succeeded) — the failure is specifically in persist.
+      verify(copy).setPreConditionList(any());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFilterCopyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFilterCopyTest.java
@@ -49,6 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -195,6 +196,25 @@ class WizVsServiceFilterCopyTest {
       // re-promoted to primary.
       verify(vs).removeAssembly("vs_1_copy1");
       verify(assembly).setPrimary(true);
+   }
+
+   @Test
+   void copySucceedsButExecuteAndExtractThrowsRollsBackTheDuplicate() throws Exception {
+      // executeAndExtract runs BEFORE persistViewsheet specifically so that, at the point this throws,
+      // nothing has been durably committed yet — the rollback below is always safe to perform. Mirrors
+      // WizVsServiceApplyHighlightCopyTest.copySucceedsButExecuteAndExtractThrowsRollsBackTheDuplicate.
+      ChartVSAssembly copy = mock(ChartVSAssembly.class);
+      when(copy.getName()).thenReturn("vs_1_copy1");
+
+      doReturn(copy).when(service).duplicatePrimaryAssembly(rvs, assembly);
+      doThrow(new RuntimeException("sandbox execution failed"))
+         .when(service).executeAndExtract(any(), eq(copy), anyInt());
+
+      assertThrows(RuntimeException.class, () -> service.createViewsheet(request(true), user));
+
+      verify(vs).removeAssembly("vs_1_copy1");
+      verify(assembly).setPrimary(true);
+      verify(service, never()).persistViewsheet(any(), any(), any());
    }
 
    @Test


### PR DESCRIPTION
When set,WizAutoBindingService.setChartFormat/setChartColors first duplicates the target assembly via the new WizVsService.duplicatePrimaryAssembly (reuses the existing uniqueAssemblyName + rebindAssembly rebind sequence, mirroring the standard create() path) and redirects the mutation, clearGraph, persistViewsheet, and the returned assemblyName to the copy instead of the original. Falls back to applying in place (with a note) if duplication fails or is not requested.