### PR TITLE
feat(wiz): report-style header for board PDF export (title, date, summary)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -20,6 +20,7 @@ package inetsoft.web.wiz.service;
 import inetsoft.graph.internal.DimensionD;
 import inetsoft.report.Margin;
 import inetsoft.report.Size;
+import inetsoft.report.StyleConstants;
 import inetsoft.report.internal.PaperSize;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.viewsheet.VSAssembly;
@@ -80,15 +81,16 @@ public class WizPrintLayoutBuilder {
       List<VSAssemblyLayout> vsLayouts = new ArrayList<>();
       int page = 0;
 
-      // Page 1: title + recap header block.
-      vsLayouts.add(textLayout("wizExportTitleRecap", buildTitleRecapText(title, recap),
-         new Point(0, 0), new Dimension(PAGE_CONTENT_WIDTH_PT, TITLE_BLOCK_HEIGHT_PT)));
+      // Page 1: report-style header — a prominent title, a "Generated <date>" line closed by a
+      // thin rule, and the session recap as a markdown-stripped summary. Split into separate text
+      // boxes because a single box can only carry one font. Returns the y where the body begins.
+      int headerBottom = addReportHeader(vsLayouts, title, recap);
 
       for(int i = 0; i < ordered.size(); i++) {
          ChartCaption c = ordered.get(i);
          VSAssembly assembly = topLevel.get(i);
          int pageTop = page * PAGE_HEIGHT_PT;
-         int captionY = i == 0 ? TITLE_BLOCK_HEIGHT_PT : pageTop;
+         int captionY = i == 0 ? headerBottom : pageTop;
          int chartY = captionY + CAPTION_HEIGHT_PT;
 
          // Build caption text: title always shown, caption appended after an em-dash when present.
@@ -165,20 +167,70 @@ public class WizPrintLayoutBuilder {
       return result;
    }
 
-   private String buildTitleRecapText(String title, String recap) {
-      StringBuilder sb = new StringBuilder(title == null ? "" : title);
+   /**
+    * Emits the page-1 report header (title, generated-date line + rule, recap summary) and
+    * returns the y-coordinate (in points) where the body content should start.
+    */
+   private int addReportHeader(List<VSAssemblyLayout> vsLayouts, String title, String recap) {
+      String heading = title == null || title.isBlank() ? "Analysis Report" : title.trim();
+      int y = 0;
 
-      if(recap != null && !recap.isBlank()) {
-         sb.append("\n").append(recap);
+      vsLayouts.add(styledTextLayout("wizExportTitle", heading, new Point(0, y),
+         new Dimension(PAGE_CONTENT_WIDTH_PT, TITLE_HEIGHT_PT),
+         Font.BOLD, TITLE_FONT_PT, TITLE_COLOR, false));
+      y += TITLE_HEIGHT_PT;
+
+      vsLayouts.add(styledTextLayout("wizExportDate", generatedDateLine(), new Point(0, y),
+         new Dimension(PAGE_CONTENT_WIDTH_PT, DATE_HEIGHT_PT),
+         Font.PLAIN, DATE_FONT_PT, DATE_COLOR, true));
+      y += DATE_HEIGHT_PT;
+
+      String summary = recap == null ? "" : MarkdownPlainText.strip(recap).trim();
+
+      if(!summary.isEmpty()) {
+         y += SUMMARY_GAP_PT;
+         vsLayouts.add(styledTextLayout("wizExportSummary", summary, new Point(0, y),
+            new Dimension(PAGE_CONTENT_WIDTH_PT, SUMMARY_HEIGHT_PT),
+            Font.PLAIN, SUMMARY_FONT_PT, SUMMARY_COLOR, false));
+         y += SUMMARY_HEIGHT_PT;
       }
 
-      return sb.toString();
+      return y + HEADER_BOTTOM_GAP_PT;
    }
 
    private VSEditableAssemblyLayout textLayout(String name, String text, Point pos, Dimension size) {
       TextVSAssemblyInfo info = new TextVSAssemblyInfo();
       info.setTextValue(text);
       info.setText(text);
+      return new VSEditableAssemblyLayout(info, name, pos, size);
+   }
+
+   /** "Generated <Month D, YYYY>" for the current server date. */
+   String generatedDateLine() {
+      return "Generated " + java.time.LocalDate.now()
+         .format(java.time.format.DateTimeFormatter.ofPattern("MMMM d, yyyy", java.util.Locale.US));
+   }
+
+   private VSEditableAssemblyLayout styledTextLayout(String name, String text, Point pos,
+                                                     Dimension size, int fontStyle, int fontSize,
+                                                     String foreground, boolean bottomRule)
+   {
+      TextVSAssemblyInfo info = new TextVSAssemblyInfo();
+      info.setTextValue(text);
+      info.setText(text);
+
+      inetsoft.uql.viewsheet.VSFormat fmt = info.getFormat().getDefaultFormat();
+      fmt.setFontValue(inetsoft.uql.viewsheet.internal.VSAssemblyInfo.getDefaultFont(fontStyle, fontSize));
+      fmt.setForegroundValue(foreground);
+      fmt.setAlignmentValue(StyleConstants.H_LEFT | StyleConstants.V_CENTER);
+      fmt.setWrappingValue(true);
+
+      if(bottomRule) {
+         fmt.setBordersValue(new java.awt.Insets(0, 0, StyleConstants.THIN_LINE, 0));
+         fmt.setBorderColorsValue(new inetsoft.uql.viewsheet.BorderColors(
+            RULE_COLOR, RULE_COLOR, RULE_COLOR, RULE_COLOR));
+      }
+
       return new VSEditableAssemblyLayout(info, name, pos, size);
    }
 
@@ -189,8 +241,23 @@ public class WizPrintLayoutBuilder {
     *  boundary; adjust these constants if it does. */
    private static final int PAGE_HEIGHT_PT = 11 * 72;   // ~A4/Letter portrait height, conservative
    private static final int PAGE_CONTENT_WIDTH_PT = 8 * 72;
-   private static final int TITLE_BLOCK_HEIGHT_PT = 100;
    private static final int CAPTION_HEIGHT_PT = 30;
    private static final int CHART_HEIGHT_PT = 400;
    private static final int INSIGHTS_HEIGHT_PT = 150;
+
+   // Report-header geometry + type (points / font sizes / hex colors).
+   // TITLE_HEIGHT_PT fits a two-line wrapped title at TITLE_FONT_PT so the date line below it
+   // is never crowded; a short one-line title just centers with extra whitespace.
+   private static final int TITLE_HEIGHT_PT = 54;
+   private static final int TITLE_FONT_PT = 20;
+   private static final String TITLE_COLOR = "0x1a1a1a";
+   private static final int DATE_HEIGHT_PT = 18;
+   private static final int DATE_FONT_PT = 9;
+   private static final String DATE_COLOR = "0x888888";
+   private static final int SUMMARY_GAP_PT = 6;
+   private static final int SUMMARY_HEIGHT_PT = 64;
+   private static final int SUMMARY_FONT_PT = 11;
+   private static final String SUMMARY_COLOR = "0x2b2b2b";
+   private static final int HEADER_BOTTOM_GAP_PT = 12;
+   private static final Color RULE_COLOR = new Color(0xcccccc);
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
@@ -91,17 +91,19 @@ class WizPrintLayoutBuilderTest {
       assertEquals(2, chartRefs, "one plain VSAssemblyLayout per existing chart assembly");
 
       long editableTextBlocks = all.stream().filter(l -> l instanceof VSEditableAssemblyLayout).count();
-      // 1 title/recap block + 2 per-chart captions = 3
-      assertEquals(3, editableTextBlocks);
+      // report header (title + generated-date + summary) + 2 per-chart captions = 5
+      assertEquals(5, editableTextBlocks);
 
       List<VSEditableAssemblyLayout> texts = all.stream()
          .filter(l -> l instanceof VSEditableAssemblyLayout)
          .map(l -> (VSEditableAssemblyLayout) l)
          .collect(Collectors.toList());
-      boolean hasTitleRecap = texts.stream().anyMatch(t ->
-         ((TextVSAssemblyInfo) t.getInfo()).getText().contains("Q39 Board") &&
-         ((TextVSAssemblyInfo) t.getInfo()).getText().contains("Premium drives revenue."));
-      assertTrue(hasTitleRecap, "one editable block carries both the title and the recap");
+      assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().equals("Q39 Board")),
+         "the title box carries the board name on its own");
+      assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().startsWith("Generated ")),
+         "a generated-date line is present");
+      assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().contains("Premium drives revenue.")),
+         "the recap becomes the summary box");
       assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().equals("First — cap one")));
       assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().equals("Second — cap two")));
    }
@@ -145,8 +147,8 @@ class WizPrintLayoutBuilderTest {
          .filter(l -> l instanceof VSEditableAssemblyLayout)
          .map(l -> (VSEditableAssemblyLayout) l)
          .collect(Collectors.toList());
-      // title/recap + caption + insights = 3
-      assertEquals(3, texts.size());
+      // report header (title + date + summary) + caption + insights = 5
+      assertEquals(5, texts.size());
 
       VSEditableAssemblyLayout insights = texts.stream()
          .filter(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().contains("Bold finding"))
@@ -169,8 +171,50 @@ class WizPrintLayoutBuilderTest {
 
       long editableTextBlocks = layout.getVSAssemblyLayouts().stream()
          .filter(l -> l instanceof VSEditableAssemblyLayout).count();
-      // title/recap + caption only = 2 (same as the baseline before this feature)
-      assertEquals(2, editableTextBlocks);
+      // report header (title + date + summary) + caption, no insights block = 4
+      assertEquals(4, editableTextBlocks);
+   }
+
+   @Test
+   void reportHeaderSplitsTitleDateAndStrippedSummaryWithStyledFonts() {
+      Viewsheet vs = new Viewsheet();
+      textAssembly(vs, "Chart1", 0);
+      List<WizPrintLayoutBuilder.ChartCaption> charts = List.of(
+         new WizPrintLayoutBuilder.ChartCaption("First", "cap one", 0)
+      );
+
+      PrintLayout layout = builder.build(vs, "letter", "Odoo — Category Revenue (Q39)",
+         "**Premium units run the business** — the $1,500+ band is ~69% of revenue.", charts);
+
+      List<VSEditableAssemblyLayout> texts = layout.getVSAssemblyLayouts().stream()
+         .filter(l -> l instanceof VSEditableAssemblyLayout)
+         .map(l -> (VSEditableAssemblyLayout) l)
+         .collect(Collectors.toList());
+
+      VSEditableAssemblyLayout title = texts.stream().filter(t -> t.getName().equals("wizExportTitle"))
+         .findFirst().orElseThrow();
+      assertEquals("Odoo — Category Revenue (Q39)", ((TextVSAssemblyInfo) title.getInfo()).getText());
+      // title is rendered larger than the 11pt body default
+      assertTrue(((TextVSAssemblyInfo) title.getInfo()).getFormat().getFont().getSize() > 11,
+         "title uses a larger-than-body font");
+      assertTrue(((TextVSAssemblyInfo) title.getInfo()).getFormat().getFont().isBold(), "title is bold");
+
+      VSEditableAssemblyLayout date = texts.stream().filter(t -> t.getName().equals("wizExportDate"))
+         .findFirst().orElseThrow();
+      assertTrue(((TextVSAssemblyInfo) date.getInfo()).getText().startsWith("Generated "),
+         "date line: " + ((TextVSAssemblyInfo) date.getInfo()).getText());
+
+      VSEditableAssemblyLayout summary = texts.stream().filter(t -> t.getName().equals("wizExportSummary"))
+         .findFirst().orElseThrow();
+      String summaryText = ((TextVSAssemblyInfo) summary.getInfo()).getText();
+      assertTrue(summaryText.contains("Premium units run the business"), "recap kept: " + summaryText);
+      assertFalse(summaryText.contains("**"), "recap markdown stripped: " + summaryText);
+   }
+
+   @Test
+   void generatedDateLineIsHumanReadable() {
+      assertTrue(new WizPrintLayoutBuilder().generatedDateLine().matches("Generated \\w+ \\d{1,2}, \\d{4}"),
+         "expected e.g. 'Generated July 21, 2026'");
    }
 
    @Test
@@ -198,6 +242,7 @@ class WizPrintLayoutBuilderTest {
 
       long editableTextBlocks = layout.getVSAssemblyLayouts().stream()
          .filter(l -> l instanceof VSEditableAssemblyLayout).count();
-      assertEquals(2, editableTextBlocks, "the 3-arg compatibility constructor omits insights");
+      // null recap -> report header is title + date only (no summary box), + caption = 3
+      assertEquals(3, editableTextBlocks, "the 3-arg compatibility constructor omits insights");
    }
 }


### PR DESCRIPTION
## What

Turns the board PDF export's page-1 header into a proper analysis-report header.

**Before:** the board name and the session recap were concatenated into a single default-11pt text box, so the title read like body text and the recap's markdown (`**...**`) showed raw.

**After:**
- a prominent **bold title** (20pt; falls back to "Analysis Report" when the board is unnamed),
- a **"Generated ⟨Month D, YYYY⟩"** line (server date via `LocalDate.now()`) closed by a thin rule,
- the recap rendered as a **markdown-stripped summary** paragraph.

Each element is its own text box (a text box carries one font), with explicit font/size/color; the header height is computed so the body flows directly below it, and the title box fits a two-line wrapped title so the date line is never crowded. Server-generated date means no wiz-services change.

## Verification

Live board PDF export — page 1 now shows a large bold title, a "Generated July 21, 2026" line + rule, and the recap as clean stripped summary text, with the first chart flowing below. Charts/crosstab render unchanged.

`WizPrintLayoutBuilderTest`: 12/12 pass (added `reportHeaderSplitsTitleDateAndStrippedSummaryWithStyledFonts` and `generatedDateLineIsHumanReadable`; updated the header-block counts in the existing tests).

## Depends on

Builds on #4333 (print-layout `scaleFont=1`), already merged — without it the header/table fonts render at size 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)