### PR TITLE
feat(wiz): slate-blue accent styling for board PDF + PPTX exports

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -80,6 +80,9 @@ public class WizPrintLayoutBuilder {
 
       List<VSAssemblyLayout> vsLayouts = new ArrayList<>();
       int page = 0;
+      // Stride each subsequent chart to the real printable page height (paper minus top/bottom
+      // margins), not a fixed 11in — otherwise later pages drift down and leave awkward whitespace.
+      int pageStride = pageContentHeightPt(pageSize);
 
       // Page 1: report-style header — a prominent title, a "Generated <date>" line closed by a
       // thin rule, and the session recap as a markdown-stripped summary. Split into separate text
@@ -89,15 +92,17 @@ public class WizPrintLayoutBuilder {
       for(int i = 0; i < ordered.size(); i++) {
          ChartCaption c = ordered.get(i);
          VSAssembly assembly = topLevel.get(i);
-         int pageTop = page * PAGE_HEIGHT_PT;
+         int pageTop = page * pageStride;
          int captionY = i == 0 ? headerBottom : pageTop;
          int chartY = captionY + CAPTION_HEIGHT_PT;
 
          // Build caption text: title always shown, caption appended after an em-dash when present.
+         // Styled as a slate-blue bold section header with a thin accent rule above the chart.
          String captionText = c.title() +
             (c.caption() != null && !c.caption().isBlank() ? " — " + c.caption() : "");
-         vsLayouts.add(textLayout("wizExportCaption_" + i, captionText,
-            new Point(0, captionY), new Dimension(PAGE_CONTENT_WIDTH_PT, CAPTION_HEIGHT_PT)));
+         vsLayouts.add(styledTextLayout("wizExportCaption_" + i, captionText,
+            new Point(0, captionY), new Dimension(PAGE_CONTENT_WIDTH_PT, CAPTION_HEIGHT_PT),
+            Font.BOLD, CAPTION_FONT_PT, CAPTION_COLOR, true));
          vsLayouts.add(new VSAssemblyLayout(assembly.getName(), new Point(0, chartY),
             new Dimension(PAGE_CONTENT_WIDTH_PT, CHART_HEIGHT_PT)));
 
@@ -112,6 +117,13 @@ public class WizPrintLayoutBuilder {
 
       layout.setVSAssemblyLayouts(vsLayouts);
       return layout;
+   }
+
+   /** Printable content height in points: paper height minus top/bottom margins. */
+   private int pageContentHeightPt(String pageSize) {
+      String canonicalName = PAGE_SIZE_NAMES.get(pageSize == null ? "" : pageSize.toLowerCase());
+      Size size = PaperSize.getSize(canonicalName);
+      return (int) Math.round((size.height - MARGIN_TOP_IN - MARGIN_BOTTOM_IN) * 72);
    }
 
    private PrintInfo buildPrintInfo(String pageSize) {
@@ -239,9 +251,10 @@ public class WizPrintLayoutBuilder {
     *  values feed that same pipeline, so page/content geometry below is expressed in points.
     *  CONFIRM in Task 3's integration test that content doesn't clip/overlap across the page
     *  boundary; adjust these constants if it does. */
-   private static final int PAGE_HEIGHT_PT = 11 * 72;   // ~A4/Letter portrait height, conservative
    private static final int PAGE_CONTENT_WIDTH_PT = 8 * 72;
    private static final int CAPTION_HEIGHT_PT = 30;
+   private static final int CAPTION_FONT_PT = 13;
+   private static final String CAPTION_COLOR = "0x3B6EA5";   // slate-blue accent
    private static final int CHART_HEIGHT_PT = 400;
    private static final int INSIGHTS_HEIGHT_PT = 150;
 
@@ -259,5 +272,6 @@ public class WizPrintLayoutBuilder {
    private static final int SUMMARY_FONT_PT = 11;
    private static final String SUMMARY_COLOR = "0x2b2b2b";
    private static final int HEADER_BOTTOM_GAP_PT = 12;
-   private static final Color RULE_COLOR = new Color(0xcccccc);
+   // Slate-blue accent (matches the chart palette + PPTX): the header rule and caption rules.
+   private static final Color RULE_COLOR = new Color(0x3B6EA5);
 }

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
@@ -22,8 +22,10 @@ import inetsoft.web.wiz.service.PptxDeckMerger;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
 import org.apache.poi.xslf.usermodel.XSLFSlide;
 import org.apache.poi.xslf.usermodel.XSLFTextBox;
+import org.apache.poi.xslf.usermodel.XSLFTextParagraph;
 import org.apache.poi.xslf.usermodel.XSLFTextRun;
 
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
@@ -86,24 +88,40 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
       XSLFSlide slide = show.createSlide();
       XSLFTextBox titleBox = slide.createTextBox();
       titleBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT,
-         SLIDE_WIDTH_PT - 2 * MARGIN_PT, 80));
-      titleBox.setText(title == null ? "" : title);
+         SLIDE_WIDTH_PT - 2 * MARGIN_PT, 120));
+      titleBox.setText(title == null || title.isBlank() ? "Analysis Report" : title);
+      styleBox(titleBox, true, TITLE_FONT_PT, ACCENT);
 
       if(recap != null && !recap.isBlank()) {
+         // Strip markdown so the recap reads as clean prose (it is authored as markdown, like the
+         // per-chart insights) rather than showing raw ** / - / # syntax on the cover slide.
          XSLFTextBox recapBox = slide.createTextBox();
-         recapBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT + 90,
-            SLIDE_WIDTH_PT - 2 * MARGIN_PT, SLIDE_HEIGHT_PT - 2 * MARGIN_PT - 90));
-         recapBox.setText(recap);
+         recapBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT + 130,
+            SLIDE_WIDTH_PT - 2 * MARGIN_PT, SLIDE_HEIGHT_PT - 2 * MARGIN_PT - 130));
+         recapBox.setText(MarkdownPlainText.strip(recap));
+         styleBox(recapBox, false, RECAP_FONT_PT, BODY_COLOR);
       }
    }
 
    private void addCaption(XSLFSlide slide, String title, String caption) {
       XSLFTextBox captionBox = slide.createTextBox();
       captionBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT / 2.0,
-         SLIDE_WIDTH_PT - 2 * MARGIN_PT, 40));
+         SLIDE_WIDTH_PT - 2 * MARGIN_PT, 44));
       String text = (title == null ? "" : title) +
          (caption != null && !caption.isBlank() ? " — " + caption : "");
       captionBox.setText(text);
+      styleBox(captionBox, true, CAPTION_FONT_PT, ACCENT);
+   }
+
+   /** Apply a uniform bold/size/color to every run in every paragraph of a text box. */
+   private void styleBox(XSLFTextBox box, boolean bold, double fontSize, Color color) {
+      for(XSLFTextParagraph paragraph : box.getTextParagraphs()) {
+         for(XSLFTextRun run : paragraph.getTextRuns()) {
+            run.setBold(bold);
+            run.setFontSize(fontSize);
+            run.setFontColor(color);
+         }
+      }
    }
 
    private void addFailurePlaceholder(XSLFSlide slide, String title) {
@@ -176,4 +194,11 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
    private static final int SLIDE_HEIGHT_PT = 540;
    private static final int MARGIN_PT = 40;
    private static final double INSIGHTS_FONT_SIZE_PT = 16.0;
+   // Slate-blue accent (matches the chart palette + the PDF report), used for the cover title and
+   // per-slide captions; recap/body stays a dark near-black.
+   private static final Color ACCENT = new Color(0x3B6EA5);
+   private static final Color BODY_COLOR = new Color(0x2B2B2B);
+   private static final double TITLE_FONT_PT = 34.0;
+   private static final double RECAP_FONT_PT = 17.0;
+   private static final double CAPTION_FONT_PT = 22.0;
 }

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
@@ -88,6 +88,21 @@ class PoiPptxDeckMergerTest {
    }
 
    @Test
+   void titleSlideRecapIsMarkdownStripped() throws Exception {
+      byte[] merged = merger.mergeSlides("Q39 Board",
+         "**Premium units run the business.** The $1,500+ band is ~69%.\n- top band in every category", List.of());
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         String titleSlideText = allText(result.getSlides().get(0));
+         assertTrue(titleSlideText.contains("Premium units run the business."),
+            "recap text kept: " + titleSlideText);
+         assertFalse(titleSlideText.contains("**"), "raw markdown emphasis stripped: " + titleSlideText);
+         assertTrue(titleSlideText.contains("top band in every category"), "bullet text kept: " + titleSlideText);
+         assertFalse(titleSlideText.contains("- top band"), "raw bullet dash stripped: " + titleSlideText);
+      }
+   }
+
+   @Test
    void failedChartGetsPlaceholderSlideInsteadOfImportedContent() throws Exception {
       List<PptxDeckMerger.ChartSlide> slides = List.of(
          new PptxDeckMerger.ChartSlide("Broken", "n/a", null, true)


### PR DESCRIPTION
## What

Both board exports read flat/bland — section titles the same weight as body text, no visual identity. This gives them a consistent, tasteful **slate-blue (`#3B6EA5`, matching the chart palette)** treatment.

**PDF (`WizPrintLayoutBuilder`):**
- Chart captions become **bold 13pt slate-blue section headers** with a thin accent rule above the chart (were plain body-weight text).
- The page-1 report-header rule adopts the same accent.
- Per-chart **page stride uses the real printable page height** (paper minus top/bottom margins) instead of a fixed 11in — later pages no longer drift down with whitespace (the Q39 board went 5→4 pages).

**PPTX (`PoiPptxDeckMerger`):**
- Cover **title** rendered large + bold in the accent (falls back to "Analysis Report").
- Cover **recap is markdown-stripped** — it is authored as markdown (like the per-chart insights), so raw `**` / `-` / `#` no longer show on the cover.
- Per-slide **captions** rendered bold in the accent.

## Verification

Live PDF + PPTX exports rendered and inspected: PDF page-1 header + slate-blue section captions, tightened pagination; PPTX cover with big blue title + clean stripped recap, blue slide captions.

Tests: `WizPrintLayoutBuilderTest` 12/12; `PoiPptxDeckMergerTest` 8/8 (added `titleSlideRecapIsMarkdownStripped`).

## Depends on

Builds on #4333 (`scaleFont=1`) and #4335 (report header), both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)