### PR TITLE
feat(wiz): preserve markdown formatting in board PDF + PPTX exports

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/MarkdownModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MarkdownModel.java
@@ -1,0 +1,169 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Lightweight, defensive parser that turns the markdown authored for a saved visualization's
+ * "insights" (and a board's recap) into a small block/span model for styled rendering in the
+ * board exports — headers, bullets, and paragraphs, each carrying inline bold/italic spans.
+ *
+ * <p>Like {@link MarkdownPlainText} this is a regex transform, not a full CommonMark parser: it
+ * handles the constructs the insights actually use (hash headers; dash/star/plus bullets; bold
+ * via double-star or double-underscore; italic via single-star or single-underscore) and never
+ * throws on malformed input. Intra-word underscores (e.g. price_band) are intentionally NOT
+ * treated as italics -- the underscore emphasis pattern requires word boundaries.</p>
+ */
+public final class MarkdownModel {
+   private MarkdownModel() {
+   }
+
+   public enum BlockType { HEADING, BULLET, PARAGRAPH }
+
+   /** An inline run of text with its emphasis flags. */
+   public record Span(String text, boolean bold, boolean italic) {
+   }
+
+   /** A block-level element. {@code level} is the heading depth (1-6) or 0 otherwise. */
+   public record Block(BlockType type, int level, List<Span> spans) {
+      public String plainText() {
+         StringBuilder sb = new StringBuilder();
+
+         for(Span s : spans) {
+            sb.append(s.text());
+         }
+
+         return sb.toString();
+      }
+   }
+
+   /** Parse markdown into a flat list of blocks. Consecutive non-blank prose lines merge into
+    *  one paragraph; a blank line, header, or bullet ends the current paragraph. */
+   public static List<Block> parse(String markdown) {
+      List<Block> blocks = new ArrayList<>();
+
+      if(markdown == null) {
+         return blocks;
+      }
+
+      String[] lines = markdown.replace("\r\n", "\n").replace("\r", "\n").split("\n", -1);
+      StringBuilder para = new StringBuilder();
+
+      for(String raw : lines) {
+         String line = raw.strip();
+
+         if(line.isEmpty()) {
+            flushParagraph(para, blocks);
+            continue;
+         }
+
+         Matcher header = HEADER.matcher(line);
+         Matcher bullet = BULLET.matcher(line);
+
+         if(header.find()) {
+            flushParagraph(para, blocks);
+            blocks.add(new Block(BlockType.HEADING, header.group(1).length(),
+                                  parseInline(line.substring(header.end()))));
+         }
+         else if(bullet.find()) {
+            flushParagraph(para, blocks);
+            blocks.add(new Block(BlockType.BULLET, 1, parseInline(line.substring(bullet.end()))));
+         }
+         else {
+            if(para.length() > 0) {
+               para.append(' ');
+            }
+
+            para.append(line);
+         }
+      }
+
+      flushParagraph(para, blocks);
+      return blocks;
+   }
+
+   private static void flushParagraph(StringBuilder para, List<Block> blocks) {
+      if(para.length() > 0) {
+         blocks.add(new Block(BlockType.PARAGRAPH, 0, parseInline(para.toString())));
+         para.setLength(0);
+      }
+   }
+
+   /** Split a line into bold/italic/plain spans (handles one level of nesting, e.g. bold > italic). */
+   static List<Span> parseInline(String text) {
+      return parseInline(text, false, false);
+   }
+
+   private static List<Span> parseInline(String text, boolean inheritBold, boolean inheritItalic) {
+      List<Span> spans = new ArrayList<>();
+
+      if(text.isEmpty()) {
+         return spans;
+      }
+
+      Matcher m = INLINE.matcher(text);
+      int last = 0;
+
+      while(m.find()) {
+         if(m.start() > last) {
+            spans.add(new Span(text.substring(last, m.start()), inheritBold, inheritItalic));
+         }
+
+         // Recurse into the matched content so nested emphasis (bold containing italic, etc.) is
+         // preserved rather than left as literal ** / * inside the outer span.
+         if(m.group(1) != null) {
+            spans.addAll(parseInline(m.group(1), true, inheritItalic));
+         }
+         else if(m.group(2) != null) {
+            spans.addAll(parseInline(m.group(2), true, inheritItalic));
+         }
+         else if(m.group(3) != null) {
+            spans.addAll(parseInline(m.group(3), inheritBold, true));
+         }
+         else if(m.group(4) != null) {
+            spans.addAll(parseInline(m.group(4), inheritBold, true));
+         }
+
+         last = m.end();
+      }
+
+      if(last < text.length()) {
+         spans.add(new Span(text.substring(last), inheritBold, inheritItalic));
+      }
+
+      if(spans.isEmpty()) {
+         spans.add(new Span(text, inheritBold, inheritItalic));
+      }
+
+      return spans;
+   }
+
+   private static final Pattern HEADER = Pattern.compile("^(#{1,6})\\s+");
+   private static final Pattern BULLET = Pattern.compile("^[-*+]\\s+");
+   // Order matters: bold (** / __) before italic (* / _). Italic markers require word boundaries
+   // so intra-word underscores/stars (price_band, a*b) are left as literal text.
+   private static final Pattern INLINE = Pattern.compile(
+      "\\*\\*(.+?)\\*\\*" +
+      "|__(.+?)__" +
+      "|(?<![\\w*])\\*(?!\\s)(.+?)(?<!\\s)\\*(?![\\w])" +
+      "|(?<![\\w_])_(?!\\s)(.+?)(?<!\\s)_(?![\\w])");
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -108,8 +108,10 @@ public class WizPrintLayoutBuilder {
 
          if(c.insightsMarkdown() != null && !c.insightsMarkdown().isBlank()) {
             int insightsY = chartY + CHART_HEIGHT_PT;
-            vsLayouts.add(textLayout("wizExportInsights_" + i, MarkdownPlainText.strip(c.insightsMarkdown()),
-               new Point(0, insightsY), new Dimension(PAGE_CONTENT_WIDTH_PT, INSIGHTS_HEIGHT_PT)));
+            // Render insights structurally: headers, bullets, and paragraphs each get their own
+            // styled box (a report text box carries a single font, so structure — not inline bold —
+            // is what we preserve on the PDF side).
+            addStructuredBlocks(vsLayouts, "wizExportInsights_" + i + "_", c.insightsMarkdown(), insightsY);
          }
 
          page++;
@@ -197,24 +199,76 @@ public class WizPrintLayoutBuilder {
          Font.PLAIN, DATE_FONT_PT, DATE_COLOR, true));
       y += DATE_HEIGHT_PT;
 
-      String summary = recap == null ? "" : MarkdownPlainText.strip(recap).trim();
-
-      if(!summary.isEmpty()) {
+      if(recap != null && !recap.isBlank()) {
          y += SUMMARY_GAP_PT;
-         vsLayouts.add(styledTextLayout("wizExportSummary", summary, new Point(0, y),
-            new Dimension(PAGE_CONTENT_WIDTH_PT, SUMMARY_HEIGHT_PT),
-            Font.PLAIN, SUMMARY_FONT_PT, SUMMARY_COLOR, false));
-         y += SUMMARY_HEIGHT_PT;
+         y = addStructuredBlocks(vsLayouts, "wizExportSummary_", recap, y);
       }
 
       return y + HEADER_BOTTOM_GAP_PT;
    }
 
-   private VSEditableAssemblyLayout textLayout(String name, String text, Point pos, Dimension size) {
-      TextVSAssemblyInfo info = new TextVSAssemblyInfo();
-      info.setTextValue(text);
-      info.setText(text);
-      return new VSEditableAssemblyLayout(info, name, pos, size);
+   /**
+    * Lays out a markdown block sequence as a vertical stack of styled text boxes starting at
+    * {@code startY}: headings bold in the accent color, bullets with a hanging "•" indent, and
+    * paragraphs as body text. Inline bold/italic is flattened (one font per report text box).
+    * Returns the y just past the last block.
+    */
+   private int addStructuredBlocks(List<VSAssemblyLayout> vsLayouts, String namePrefix,
+                                   String markdown, int startY)
+   {
+      int y = startY;
+      int idx = 0;
+
+      for(MarkdownModel.Block block : MarkdownModel.parse(markdown)) {
+         String text = block.plainText();
+         int x = 0;
+         int width = PAGE_CONTENT_WIDTH_PT;
+         int fontStyle;
+         int fontPt;
+         String color;
+
+         switch(block.type()) {
+         case HEADING:
+            fontStyle = Font.BOLD;
+            fontPt = Math.max(BODY_FONT_PT + 1, 15 - Math.max(0, block.level() - 1));
+            color = CAPTION_COLOR;
+            break;
+         case BULLET:
+            fontStyle = Font.PLAIN;
+            fontPt = BODY_FONT_PT;
+            color = SUMMARY_COLOR;
+            text = "•  " + text;
+            x = BULLET_INDENT_PT;
+            width = PAGE_CONTENT_WIDTH_PT - BULLET_INDENT_PT;
+            break;
+         default:
+            fontStyle = Font.PLAIN;
+            fontPt = BODY_FONT_PT;
+            color = SUMMARY_COLOR;
+         }
+
+         int h = estimateTextHeightPt(text, fontPt, width);
+         vsLayouts.add(styledTextLayout(namePrefix + (idx++), text, new Point(x, y),
+            new Dimension(width, h), fontStyle, fontPt, color, false));
+         y += h + BLOCK_GAP_PT;
+      }
+
+      return y;
+   }
+
+   /** Estimate a wrapped text block's height in points from headless font metrics. */
+   private int estimateTextHeightPt(String text, int fontPt, int widthPt) {
+      java.awt.Font font = new java.awt.Font(java.awt.Font.SANS_SERIF, java.awt.Font.PLAIN, fontPt);
+      java.awt.image.BufferedImage img =
+         new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_INT_ARGB);
+      java.awt.Graphics2D g = img.createGraphics();
+      java.awt.FontMetrics fm = g.getFontMetrics(font);
+      g.dispose();
+
+      double avgCharWidth = fm.stringWidth("abcdefghijklmnopqrstuvwxyz") / 26.0;
+      int charsPerLine = Math.max(1, (int) (widthPt / avgCharWidth));
+      int lines = Math.max(1, (int) Math.ceil(text.length() / (double) charsPerLine));
+      return lines * fm.getHeight() + 2;
    }
 
    /** "Generated <Month D, YYYY>" for the current server date. */
@@ -256,7 +310,10 @@ public class WizPrintLayoutBuilder {
    private static final int CAPTION_FONT_PT = 13;
    private static final String CAPTION_COLOR = "0x3B6EA5";   // slate-blue accent
    private static final int CHART_HEIGHT_PT = 400;
-   private static final int INSIGHTS_HEIGHT_PT = 150;
+   // Structured-block (insights/recap) type + spacing.
+   private static final int BODY_FONT_PT = 11;
+   private static final int BULLET_INDENT_PT = 16;
+   private static final int BLOCK_GAP_PT = 4;
 
    // Report-header geometry + type (points / font sizes / hex colors).
    // TITLE_HEIGHT_PT fits a two-line wrapped title at TITLE_FONT_PT so the date line below it
@@ -268,8 +325,6 @@ public class WizPrintLayoutBuilder {
    private static final int DATE_FONT_PT = 9;
    private static final String DATE_COLOR = "0x888888";
    private static final int SUMMARY_GAP_PT = 6;
-   private static final int SUMMARY_HEIGHT_PT = 64;
-   private static final int SUMMARY_FONT_PT = 11;
    private static final String SUMMARY_COLOR = "0x2b2b2b";
    private static final int HEADER_BOTTOM_GAP_PT = 12;
    // Slate-blue accent (matches the chart palette + PPTX): the header rule and caption rules.

--- a/core/src/test/java/inetsoft/web/wiz/service/MarkdownModelTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MarkdownModelTest.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class MarkdownModelTest {
+   @Test
+   void classifiesHeadingsBulletsAndParagraphs() {
+      List<MarkdownModel.Block> blocks = MarkdownModel.parse(
+         "## Premium share\n\nPremium items carry the business.\n- point one\n- point two");
+
+      assertEquals(4, blocks.size());
+      assertEquals(MarkdownModel.BlockType.HEADING, blocks.get(0).type());
+      assertEquals(2, blocks.get(0).level());
+      assertEquals("Premium share", blocks.get(0).plainText());
+      assertEquals(MarkdownModel.BlockType.PARAGRAPH, blocks.get(1).type());
+      assertEquals(MarkdownModel.BlockType.BULLET, blocks.get(2).type());
+      assertEquals("point one", blocks.get(2).plainText());
+      assertEquals(MarkdownModel.BlockType.BULLET, blocks.get(3).type());
+   }
+
+   @Test
+   void mergesConsecutiveProseLinesIntoOneParagraph() {
+      List<MarkdownModel.Block> blocks = MarkdownModel.parse("line one\nline two\n\nsecond para");
+      assertEquals(2, blocks.size());
+      assertEquals("line one line two", blocks.get(0).plainText());
+      assertEquals("second para", blocks.get(1).plainText());
+   }
+
+   @Test
+   void parsesInlineBoldAndItalicSpans() {
+      List<MarkdownModel.Span> spans = MarkdownModel.parseInline("**Premium** drives ~69% of *all* revenue");
+      // bold "Premium" | " drives ~69% of " | italic "all" | " revenue"
+      assertEquals("Premium", spans.get(0).text());
+      assertTrue(spans.get(0).bold());
+      assertFalse(spans.get(0).italic());
+      assertTrue(spans.stream().anyMatch(s -> s.italic() && s.text().equals("all")));
+      assertTrue(spans.stream().anyMatch(s -> !s.bold() && !s.italic() && s.text().contains("drives")));
+      // reassembled plain text loses no characters
+      assertEquals("Premium drives ~69% of all revenue",
+         spans.stream().map(MarkdownModel.Span::text).reduce("", String::concat));
+   }
+
+   @Test
+   void handlesItalicNestedInsideBold() {
+      List<MarkdownModel.Span> spans = MarkdownModel.parseInline("**not the same order as *share*.**");
+      // no raw markers survive
+      assertFalse(spans.stream().anyMatch(s -> s.text().contains("*")), "markers consumed");
+      // "share" is bold AND italic; the rest is bold-only
+      assertTrue(spans.stream().anyMatch(s -> s.text().equals("share") && s.bold() && s.italic()));
+      assertTrue(spans.stream().anyMatch(s -> s.text().contains("not the same order") && s.bold() && !s.italic()));
+      assertEquals("not the same order as share.",
+         spans.stream().map(MarkdownModel.Span::text).reduce("", String::concat));
+   }
+
+   @Test
+   void doesNotItalicizeIntraWordUnderscores() {
+      List<MarkdownModel.Span> spans = MarkdownModel.parseInline("group by price_band and premium_pct");
+      assertEquals(1, spans.size(), "intra-word underscores are literal, not italic markers");
+      assertFalse(spans.get(0).italic());
+      assertEquals("group by price_band and premium_pct", spans.get(0).text());
+   }
+
+   @Test
+   void emptyAndNullAreSafe() {
+      assertTrue(MarkdownModel.parse(null).isEmpty());
+      assertTrue(MarkdownModel.parse("").isEmpty());
+      assertTrue(MarkdownModel.parse("   \n  \n").isEmpty());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
@@ -147,16 +147,23 @@ class WizPrintLayoutBuilderTest {
          .filter(l -> l instanceof VSEditableAssemblyLayout)
          .map(l -> (VSEditableAssemblyLayout) l)
          .collect(Collectors.toList());
-      // report header (title + date + summary) + caption + insights = 5
-      assertEquals(5, texts.size());
+      // report header (title + date + summary) + caption + insights (paragraph + bullet = 2) = 6
+      assertEquals(6, texts.size());
 
-      VSEditableAssemblyLayout insights = texts.stream()
+      // The bold paragraph and the bullet become separate structured boxes (one font per box);
+      // inline bold is flattened, bullet marker rendered.
+      VSEditableAssemblyLayout para = texts.stream()
          .filter(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().contains("Bold finding"))
          .findFirst().orElseThrow();
-      String insightsText = ((TextVSAssemblyInfo) insights.getInfo()).getText();
-      assertTrue(insightsText.contains("Bold finding"), "markdown bold stripped: " + insightsText);
-      assertTrue(insightsText.contains("• point one"), "markdown bullet normalized: " + insightsText);
-      assertFalse(insightsText.contains("**"), "no raw markdown syntax survives: " + insightsText);
+      assertFalse(((TextVSAssemblyInfo) para.getInfo()).getText().contains("**"),
+         "no raw markdown syntax survives: " + ((TextVSAssemblyInfo) para.getInfo()).getText());
+
+      VSEditableAssemblyLayout bullet = texts.stream()
+         .filter(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().contains("point one"))
+         .findFirst().orElseThrow();
+      String bulletText = ((TextVSAssemblyInfo) bullet.getInfo()).getText();
+      assertTrue(bulletText.startsWith("•"), "bullet marker rendered: " + bulletText);
+      assertFalse(bulletText.contains("- point"), "raw bullet dash stripped: " + bulletText);
    }
 
    @Test
@@ -204,7 +211,8 @@ class WizPrintLayoutBuilderTest {
       assertTrue(((TextVSAssemblyInfo) date.getInfo()).getText().startsWith("Generated "),
          "date line: " + ((TextVSAssemblyInfo) date.getInfo()).getText());
 
-      VSEditableAssemblyLayout summary = texts.stream().filter(t -> t.getName().equals("wizExportSummary"))
+      VSEditableAssemblyLayout summary = texts.stream()
+         .filter(t -> t.getName().startsWith("wizExportSummary"))
          .findFirst().orElseThrow();
       String summaryText = ((TextVSAssemblyInfo) summary.getInfo()).getText();
       assertTrue(summaryText.contains("Premium units run the business"), "recap kept: " + summaryText);

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
@@ -17,7 +17,7 @@
  */
 package inetsoft.report.io.viewsheet;
 
-import inetsoft.web.wiz.service.MarkdownPlainText;
+import inetsoft.web.wiz.service.MarkdownModel;
 import inetsoft.web.wiz.service.PptxDeckMerger;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
 import org.apache.poi.xslf.usermodel.XSLFSlide;
@@ -93,13 +93,15 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
       styleBox(titleBox, true, TITLE_FONT_PT, ACCENT);
 
       if(recap != null && !recap.isBlank()) {
-         // Strip markdown so the recap reads as clean prose (it is authored as markdown, like the
-         // per-chart insights) rather than showing raw ** / - / # syntax on the cover slide.
+         // Render the recap's markdown (headers/bullets/bold/italic) as styled paragraphs+runs
+         // rather than stripping it to plain text. Short enough to fit the cover box.
          XSLFTextBox recapBox = slide.createTextBox();
          recapBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT + 130,
             SLIDE_WIDTH_PT - 2 * MARGIN_PT, SLIDE_HEIGHT_PT - 2 * MARGIN_PT - 130));
-         recapBox.setText(MarkdownPlainText.strip(recap));
-         styleBox(recapBox, false, RECAP_FONT_PT, BODY_COLOR);
+
+         for(MarkdownModel.Block block : MarkdownModel.parse(recap)) {
+            appendBlock(recapBox, block, RECAP_FONT_PT);
+         }
       }
    }
 
@@ -131,20 +133,128 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
       box.setText("Failed to render: " + (title == null ? "" : title));
    }
 
-   /** Appends one or more insights-only slides (no chart image, just a text box near the full
-    *  slide) so long insights are never truncated — each slide holds as much stripped text as
-    *  fits per {@link #chunkInsightsText}. */
+   /** Appends one or more insights-only slides, rendering the insights markdown as styled
+    *  paragraphs/bullets/headers (bold + italic runs preserved). Blocks are packed onto slides by
+    *  estimated height so nothing is truncated; a single block taller than a whole slide falls
+    *  back to a plain word-split across slides. */
    private void addInsightsSlides(XMLSlideShow show, String insightsMarkdown) {
-      String stripped = MarkdownPlainText.strip(insightsMarkdown);
+      List<MarkdownModel.Block> blocks = MarkdownModel.parse(insightsMarkdown);
 
-      for(String chunk : chunkInsightsText(stripped)) {
+      if(blocks.isEmpty()) {
+         return;
+      }
+
+      double boxWidthPt = SLIDE_WIDTH_PT - 2 * MARGIN_PT;
+      double boxHeightPt = SLIDE_HEIGHT_PT - 2 * MARGIN_PT;
+
+      List<List<MarkdownModel.Block>> pages = new ArrayList<>();
+      List<MarkdownModel.Block> current = new ArrayList<>();
+      double used = 0;
+
+      for(MarkdownModel.Block block : blocks) {
+         double h = estimateBlockHeightPt(block, boxWidthPt);
+
+         if(h > boxHeightPt) {
+            // Pathological single block taller than a slide: flush, then split its plain text.
+            if(!current.isEmpty()) {
+               pages.add(current);
+               current = new ArrayList<>();
+               used = 0;
+            }
+
+            for(String chunk : chunkInsightsText(block.plainText())) {
+               pages.add(List.of(new MarkdownModel.Block(MarkdownModel.BlockType.PARAGRAPH, 0,
+                  List.of(new MarkdownModel.Span(chunk, false, false)))));
+            }
+
+            continue;
+         }
+
+         if(used + h > boxHeightPt && !current.isEmpty()) {
+            pages.add(current);
+            current = new ArrayList<>();
+            used = 0;
+         }
+
+         current.add(block);
+         used += h;
+      }
+
+      if(!current.isEmpty()) {
+         pages.add(current);
+      }
+
+      for(List<MarkdownModel.Block> pageBlocks : pages) {
          XSLFSlide slide = show.createSlide();
          XSLFTextBox box = slide.createTextBox();
          box.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT,
             SLIDE_WIDTH_PT - 2 * MARGIN_PT, SLIDE_HEIGHT_PT - 2 * MARGIN_PT));
-         XSLFTextRun run = box.setText(chunk);
-         run.setFontSize(INSIGHTS_FONT_SIZE_PT);
+
+         for(MarkdownModel.Block block : pageBlocks) {
+            appendBlock(box, block, INSIGHTS_FONT_SIZE_PT);
+         }
       }
+   }
+
+   /** Append one markdown block to a text box as a styled paragraph (with per-span bold/italic). */
+   private void appendBlock(XSLFTextBox box, MarkdownModel.Block block, double bodySize) {
+      XSLFTextParagraph p = box.addNewTextParagraph();
+      p.setSpaceAfter(6.0);
+
+      switch(block.type()) {
+      case HEADING:
+         appendSpans(p, block.spans(), headingFontPt(block.level(), bodySize), ACCENT, true);
+         break;
+      case BULLET:
+         p.setLeftMargin(20.0);
+         p.setIndent(-14.0);
+         XSLFTextRun bullet = p.addNewTextRun();
+         bullet.setText("•  ");
+         bullet.setFontSize(bodySize);
+         bullet.setFontColor(ACCENT);
+         bullet.setBold(true);
+         appendSpans(p, block.spans(), bodySize, BODY_COLOR, false);
+         break;
+      default:
+         appendSpans(p, block.spans(), bodySize, BODY_COLOR, false);
+      }
+   }
+
+   private void appendSpans(XSLFTextParagraph p, List<MarkdownModel.Span> spans, double size,
+                            Color color, boolean forceBold)
+   {
+      for(MarkdownModel.Span span : spans) {
+         if(span.text().isEmpty()) {
+            continue;
+         }
+
+         XSLFTextRun run = p.addNewTextRun();
+         run.setText(span.text());
+         run.setFontSize(size);
+         run.setFontColor(color);
+         run.setBold(forceBold || span.bold());
+         run.setItalic(span.italic());
+      }
+   }
+
+   private double headingFontPt(int level, double bodySize) {
+      return Math.max(bodySize + 2, 26 - Math.max(0, level - 1) * 3);
+   }
+
+   private double estimateBlockHeightPt(MarkdownModel.Block block, double boxWidthPt) {
+      double fontPt = block.type() == MarkdownModel.BlockType.HEADING
+         ? headingFontPt(block.level(), INSIGHTS_FONT_SIZE_PT) : INSIGHTS_FONT_SIZE_PT;
+      Font font = new Font(Font.SANS_SERIF, Font.PLAIN, (int) Math.round(fontPt));
+      BufferedImage measuring = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+      Graphics2D g = measuring.createGraphics();
+      FontMetrics fm = g.getFontMetrics(font);
+      g.dispose();
+
+      double avgCharWidthPt = fm.stringWidth("abcdefghijklmnopqrstuvwxyz") / 26.0;
+      double usableWidth = block.type() == MarkdownModel.BlockType.BULLET ? boxWidthPt - 20 : boxWidthPt;
+      int charsPerLine = Math.max(1, (int) (usableWidth / avgCharWidthPt));
+      int lines = Math.max(1, (int) Math.ceil(block.plainText().length() / (double) charsPerLine));
+      return lines * fm.getHeight() + BLOCK_SPACING_PT;
    }
 
    /** Estimates a per-slide character budget from real font metrics (measured headlessly via
@@ -201,4 +311,5 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
    private static final double TITLE_FONT_PT = 34.0;
    private static final double RECAP_FONT_PT = 17.0;
    private static final double CAPTION_FONT_PT = 22.0;
+   private static final double BLOCK_SPACING_PT = 8.0;   // approx paragraph gap for height estimation
 }

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
@@ -103,6 +103,44 @@ class PoiPptxDeckMergerTest {
    }
 
    @Test
+   void titleSlideRecapPreservesBoldRunsAndBulletMarkers() throws Exception {
+      byte[] merged = merger.mergeSlides("Board",
+         "**Bold lead.** then normal text.\n- a bullet point", List.of());
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         boolean hasBoldLead = false;
+         boolean hasNormal = false;
+         boolean hasBulletMarker = false;
+
+         for(var shape : result.getSlides().get(0).getShapes()) {
+            if(shape instanceof XSLFTextBox tb) {
+               for(var paragraph : tb.getTextParagraphs()) {
+                  for(var run : paragraph.getTextRuns()) {
+                     String t = run.getRawText();
+
+                     if(t.contains("Bold lead") && run.isBold()) {
+                        hasBoldLead = true;
+                     }
+
+                     if(t.contains("normal text") && !run.isBold()) {
+                        hasNormal = true;
+                     }
+
+                     if(t.contains("•")) {
+                        hasBulletMarker = true;
+                     }
+                  }
+               }
+            }
+         }
+
+         assertTrue(hasBoldLead, "bold lead-in preserved as a bold run");
+         assertTrue(hasNormal, "trailing prose stays non-bold");
+         assertTrue(hasBulletMarker, "bullet marker rendered");
+      }
+   }
+
+   @Test
    void failedChartGetsPlaceholderSlideInsteadOfImportedContent() throws Exception {
       List<PptxDeckMerger.ChartSlide> slides = List.of(
          new PptxDeckMerger.ChartSlide("Broken", "n/a", null, true)


### PR DESCRIPTION
## What

Insights and the board recap were flattened to plain text before rendering (bold/italic/headers/bullets stripped). This keeps the formatting, via a small shared block/span model, `MarkdownModel`.

**PPTX (`PoiPptxDeckMerger`) — full rich text:** headers, real bullet lists, and inline **bold**/*italic* runs (including italic nested inside bold). Insights blocks are packed onto slides by estimated height so nothing is truncated; a single oversized block still falls back to the word-safe split.

**PDF (`WizPrintLayoutBuilder`) — structural:** headers, hanging-indent bullets, and paragraphs each become their own styled box. A report text box carries a single font, so structure is preserved while inline bold is flattened (the deliberate PDF/PPTX split we chose).

`MarkdownModel` is a defensive regex parser (never throws); intra-word underscores like `price_band` are not treated as italics.

## Verification

Live PDF + PPTX exports rendered and inspected: PPTX cover + insights show bold lead-ins, italics (incl. nested), and bullet lists; PDF insights show distinct paragraphs and indented bullet lists. No truncation on long insights.

Tests: `MarkdownModelTest` 6, `WizPrintLayoutBuilderTest` 12, `PoiPptxDeckMergerTest` 9.

## Depends on

Builds on #4333 (scaleFont), #4335 (report header), #4338 (accent styling) — all merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)