### PR TITLE
feat(wiz): full markdown in board PDF via a MarkdownPresenter

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
@@ -2281,10 +2281,43 @@ public class VsToReportConverter {
     * Convert vs text to report text and add to fixed position in
     * the report section.
     */
+   /** Board-export insights/recap text boxes are named "wizMarkdown*" and hold markdown. */
+   private boolean isMarkdownTextBox(String name) {
+      return name != null && name.startsWith("wizMarkdown");
+   }
+
+   /** Render markdown text via a {@link inetsoft.web.wiz.service.MarkdownPresenter} painter so
+    *  headers, bullets, and inline bold/italic survive in the report/PDF. */
+   private void addMarkdownElement(TextVSAssembly assembly, String markdown, String sectionName) {
+      Rectangle bounds = getPixelBounds(assembly);
+      inetsoft.web.wiz.service.MarkdownPresenter presenter =
+         new inetsoft.web.wiz.service.MarkdownPresenter();
+      VSCompositeFormat fmt = assembly.getVSAssemblyInfo().getFormat();
+
+      if(fmt != null && fmt.getFont() != null) {
+         presenter.setFont(fmt.getFont());
+      }
+
+      inetsoft.report.painter.PresenterPainter painter =
+         new inetsoft.report.painter.PresenterPainter(markdown, presenter);
+      inetsoft.report.internal.PainterElementDef elem =
+         new inetsoft.report.internal.PainterElementDef(report, painter);
+      elem.setZIndex(assembly.getZIndex());
+      addElement0(bounds, elem, sectionName);
+   }
+
    private void addText(TextVSAssembly assembly, String sectionName) {
       String text = assembly.getText();
 
       if(text == null || "".equals(text.trim())) {
+         return;
+      }
+
+      // Board-export insights/recap boxes carry markdown (named "wizMarkdown*"); render them
+      // richly via a MarkdownPresenter painter (headers/bullets/inline bold+italic) instead of a
+      // single-font text box.
+      if(isMarkdownTextBox(assembly.getAbsoluteName())) {
+         addMarkdownElement(assembly, text, sectionName);
          return;
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/MarkdownPresenter.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MarkdownPresenter.java
@@ -1,0 +1,323 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.report.ReportElement;
+import inetsoft.report.internal.ExpandablePresenter;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An {@link ExpandablePresenter} that renders markdown ({@link MarkdownModel}) directly to a
+ * report graphics context — headers, bullet lists, and paragraphs with inline bold/italic runs —
+ * so board exports (and anything else that paints a Presenter) keep formatting instead of
+ * flattening it. Wraps text to the paint width, computes its own preferred height, and paints a
+ * vertical slice (for page breaks) the same way {@link inetsoft.report.painter.HTMLPresenter} does.
+ */
+public class MarkdownPresenter implements ExpandablePresenter {
+   public MarkdownPresenter() {
+   }
+
+   public void setBodyColor(Color bodyColor) {
+      this.bodyColor = bodyColor;
+   }
+
+   public void setAccentColor(Color accentColor) {
+      this.accentColor = accentColor;
+   }
+
+   @Override
+   public boolean isPresenterOf(Class type) {
+      return true;
+   }
+
+   @Override
+   public boolean isPresenterOf(Object obj) {
+      return obj != null;
+   }
+
+   @Override
+   public boolean isFill() {
+      return true;
+   }
+
+   @Override
+   public void setFont(Font font) {
+      if(font != null) {
+         this.baseFont = font;
+         this.layoutCache = null;
+      }
+   }
+
+   @Override
+   public void setBackground(Color bg) {
+      this.background = bg;
+   }
+
+   @Override
+   public String getDisplayName() {
+      return "Markdown";
+   }
+
+   @Override
+   public boolean isRawDataRequired() {
+      return false;
+   }
+
+   @Override
+   public Dimension getPreferredSize(Object v) {
+      return getPreferredSize(v, DEFAULT_WIDTH);
+   }
+
+   @Override
+   public Dimension getPreferredSize(Object v, float width) {
+      int w = Math.max(1, (int) width);
+      return new Dimension(w, layout(v, w).height);
+   }
+
+   @Override
+   public float getHeightAdjustment(Object obj, ReportElement elem, Dimension pd,
+                                    float starty, float bufw, float bufh)
+   {
+      // If everything up to the intended break already fits, no adjustment.
+      if(obj == null || bufh <= 0 || starty + bufh >= pd.height) {
+         return 0;
+      }
+
+      // If a line straddles the intended break, pull the break back to that line's top so no line
+      // is cut in half across a page boundary.
+      Layout layout = layout(obj, (int) bufw);
+      float breakAt = starty + bufh;
+
+      for(Line line : layout.lines) {
+         if(line.top < breakAt && line.top + line.height > breakAt) {
+            return breakAt - line.top;
+         }
+      }
+
+      return 0;
+   }
+
+   @Override
+   public void paint(Graphics g, Object v, int x, int y, int w, int h) {
+      paint(g, v, x, y, w, h, 0, -1);
+   }
+
+   @Override
+   public void paint(Graphics g, Object v, int x, int y, int w, int h, float bufy, float bufh) {
+      Layout layout = layout(v, w);
+      Shape oclip = g.getClip();
+      Font ofont = g.getFont();
+      Color ocolor = g.getColor();
+
+      if(background != null) {
+         g.setColor(background);
+         g.fillRect(x, y, w, h);
+      }
+
+      g.clipRect(x, y, w, h);
+      float top = bufy;
+      float bottom = bufh < 0 ? Float.MAX_VALUE : bufy + bufh;
+
+      for(Line line : layout.lines) {
+         if(line.top + line.height <= top || line.top >= bottom) {
+            continue;
+         }
+
+         int baseline = (int) (y + line.top - bufy + line.ascent);
+
+         for(Run run : line.runs) {
+            g.setFont(run.font);
+            g.setColor(run.color);
+            g.drawString(run.text, x + run.x, baseline);
+         }
+      }
+
+      g.setClip(oclip);
+      g.setFont(ofont);
+      g.setColor(ocolor);
+   }
+
+   // ------------------------------------------------------------------------
+   // Layout
+   // ------------------------------------------------------------------------
+
+   private Layout layout(Object v, int width) {
+      String md = v == null ? "" : v.toString();
+
+      if(layoutCache != null && width == cacheWidth && md.equals(cacheValue)) {
+         return layoutCache;
+      }
+
+      Layout layout = buildLayout(md, width);
+      cacheValue = md;
+      cacheWidth = width;
+      layoutCache = layout;
+      return layout;
+   }
+
+   private Layout buildLayout(String md, int width) {
+      List<Line> lines = new ArrayList<>();
+      int y = 0;
+      boolean firstBlock = true;
+
+      for(MarkdownModel.Block block : MarkdownModel.parse(md)) {
+         if(!firstBlock) {
+            y += BLOCK_GAP;
+         }
+
+         firstBlock = false;
+
+         int bodySize = baseFont.getSize();
+         int indent = block.type() == MarkdownModel.BlockType.BULLET ? BULLET_INDENT : 0;
+         List<Token> tokens = new ArrayList<>();
+
+         if(block.type() == MarkdownModel.BlockType.BULLET) {
+            // Hanging "•" marker at the block's left edge; text starts at the indent.
+            tokens.add(new Token("•", deriveFont(true, false, bodySize), accentColor, 0));
+         }
+
+         int headerSize = bodySize + Math.max(1, 5 - block.level());
+         boolean heading = block.type() == MarkdownModel.BlockType.HEADING;
+
+         for(MarkdownModel.Span span : block.spans()) {
+            Font font = deriveFont(heading || span.bold(), span.italic(), heading ? headerSize : bodySize);
+            Color color = heading ? accentColor : bodyColor;
+
+            for(String word : splitWords(span.text())) {
+               tokens.add(new Token(word, font, color, indent));
+            }
+         }
+
+         y = layoutTokens(lines, tokens, width, indent, y);
+      }
+
+      return new Layout(lines, y);
+   }
+
+   /** Greedy word-wrap of styled tokens into positioned lines; returns the y past the block. */
+   private int layoutTokens(List<Line> lines, List<Token> tokens, int width, int wrapX, int y) {
+      List<Run> runs = new ArrayList<>();
+      int curX = 0;
+      int lineAscent = 0;
+      int lineHeight = 0;
+      boolean lineStarted = false;
+
+      for(Token token : tokens) {
+         FontMetrics fm = metrics(token.font);
+         int wordW = fm.stringWidth(token.text);
+         boolean bulletMarker = token.wrapX == 0 && !lineStarted && "•".equals(token.text);
+
+         int startX = bulletMarker ? 0 : token.wrapX;
+
+         if(!lineStarted) {
+            curX = startX;
+         }
+         else {
+            int spaceW = metrics(token.font).charWidth(' ');
+
+            if(curX + spaceW + wordW > width) {
+               // wrap
+               lines.add(new Line(y, lineHeight, lineAscent, runs));
+               y += lineHeight;
+               runs = new ArrayList<>();
+               curX = wrapX;
+               lineAscent = 0;
+               lineHeight = 0;
+               lineStarted = false;
+            }
+            else {
+               curX += spaceW;
+            }
+         }
+
+         runs.add(new Run(token.text, token.font, token.color, curX));
+         curX += wordW;
+         lineAscent = Math.max(lineAscent, fm.getAscent());
+         lineHeight = Math.max(lineHeight, fm.getHeight());
+         lineStarted = true;
+      }
+
+      if(lineStarted) {
+         lines.add(new Line(y, lineHeight, lineAscent, runs));
+         y += lineHeight;
+      }
+
+      return y;
+   }
+
+   private static List<String> splitWords(String text) {
+      List<String> words = new ArrayList<>();
+
+      for(String w : text.split("\\s+")) {
+         if(!w.isEmpty()) {
+            words.add(w);
+         }
+      }
+
+      return words;
+   }
+
+   private Font deriveFont(boolean bold, boolean italic, int size) {
+      int style = (bold ? Font.BOLD : 0) | (italic ? Font.ITALIC : 0);
+      return baseFont.deriveFont(style, size);
+   }
+
+   private FontMetrics metrics(Font font) {
+      return metricsCache.computeIfAbsent(font, f -> {
+         if(measuring == null) {
+            BufferedImage img = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+            measuring = img.createGraphics();
+         }
+
+         return measuring.getFontMetrics(f);
+      });
+   }
+
+   private record Token(String text, Font font, Color color, int wrapX) {
+   }
+
+   private record Run(String text, Font font, Color color, int x) {
+   }
+
+   private record Line(int top, int height, int ascent, List<Run> runs) {
+   }
+
+   private record Layout(List<Line> lines, int height) {
+   }
+
+   private static final int DEFAULT_WIDTH = 400;
+   private static final int BLOCK_GAP = 6;
+   private static final int BULLET_INDENT = 16;
+
+   private Font baseFont = new Font(Font.SANS_SERIF, Font.PLAIN, 11);
+   private Color background;
+   private Color bodyColor = new Color(0x2B2B2B);
+   private Color accentColor = new Color(0x3B6EA5);
+
+   private transient String cacheValue;
+   private transient int cacheWidth = -1;
+   private transient Layout layoutCache;
+   private transient Graphics2D measuring;
+   private final transient Map<Font, FontMetrics> metricsCache = new HashMap<>();
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/MarkdownPresenter.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MarkdownPresenter.java
@@ -21,6 +21,8 @@ import inetsoft.report.ReportElement;
 import inetsoft.report.internal.ExpandablePresenter;
 
 import java.awt.*;
+import java.awt.font.FontRenderContext;
+import java.awt.font.GlyphVector;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -139,17 +141,55 @@ public class MarkdownPresenter implements ExpandablePresenter {
       float top = bufy;
       float bottom = bufh < 0 ? Float.MAX_VALUE : bufy + bufh;
 
+      Graphics2D g2 = g instanceof Graphics2D ? (Graphics2D) g : null;
+
       for(Line line : layout.lines) {
          if(line.top + line.height <= top || line.top >= bottom) {
             continue;
          }
 
-         int baseline = (int) (y + line.top - bufy + line.ascent);
+         float baseline = y + line.top - bufy + line.ascent;
 
-         for(Run run : line.runs) {
-            g.setFont(run.font);
-            g.setColor(run.color);
-            g.drawString(run.text, x + run.x, baseline);
+         if(line.marker != null) {
+            drawSegment(g, g2, line.marker.font, line.marker.color, line.marker.text, x, baseline);
+         }
+
+         // Coalesce consecutive same-style words into one draw call (joined by real spaces) so
+         // inter-word spacing is laid out from the font's own glyph advances. Rendering goes through
+         // drawGlyphVector, which paints glyph outlines at those exact advances — bypassing the
+         // PDF text engine's char-spacing reconciliation (PDFPrinter caps per-char stretch at 0.8,
+         // so drawString renders derived bold/italic fonts narrower than their metrics report, and
+         // that error accumulates into a visible gap at each style boundary). Because both layout
+         // and paint measure with the same canonical FontRenderContext (FRC), positions match the
+         // rendered output exactly on every device.
+         float cx = x + line.startX;
+         List<Run> runs = line.runs;
+         int i = 0;
+
+         while(i < runs.size()) {
+            Run first = runs.get(i);
+            StringBuilder segment = new StringBuilder();
+
+            if(first.spaceBefore) {
+               segment.append(' ');
+            }
+
+            segment.append(first.text);
+            int j = i + 1;
+
+            while(j < runs.size() && runs.get(j).font.equals(first.font)
+                  && runs.get(j).color.equals(first.color))
+            {
+               if(runs.get(j).spaceBefore) {
+                  segment.append(' ');
+               }
+
+               segment.append(runs.get(j).text);
+               j++;
+            }
+
+            cx += drawSegment(g, g2, first.font, first.color, segment.toString(), cx, baseline);
+            i = j;
          }
       }
 
@@ -189,81 +229,104 @@ public class MarkdownPresenter implements ExpandablePresenter {
          firstBlock = false;
 
          int bodySize = baseFont.getSize();
-         int indent = block.type() == MarkdownModel.BlockType.BULLET ? BULLET_INDENT : 0;
-         List<Token> tokens = new ArrayList<>();
-
-         if(block.type() == MarkdownModel.BlockType.BULLET) {
-            // Hanging "•" marker at the block's left edge; text starts at the indent.
-            tokens.add(new Token("•", deriveFont(true, false, bodySize), accentColor, 0));
-         }
-
-         int headerSize = bodySize + Math.max(1, 5 - block.level());
          boolean heading = block.type() == MarkdownModel.BlockType.HEADING;
+         boolean bullet = block.type() == MarkdownModel.BlockType.BULLET;
+         int size = heading ? bodySize + Math.max(1, 5 - block.level()) : bodySize;
+         int textX = bullet ? BULLET_INDENT : 0;
+         Run marker = bullet ? new Run("•", deriveFont(true, false, bodySize), accentColor, false) : null;
+
+         // Flatten spans into styled words; spaceBefore marks a single inter-word gap.
+         List<Run> words = new ArrayList<>();
+         boolean firstWord = true;
 
          for(MarkdownModel.Span span : block.spans()) {
-            Font font = deriveFont(heading || span.bold(), span.italic(), heading ? headerSize : bodySize);
+            Font font = deriveFont(heading || span.bold(), span.italic(), size);
             Color color = heading ? accentColor : bodyColor;
 
             for(String word : splitWords(span.text())) {
-               tokens.add(new Token(word, font, color, indent));
+               words.add(new Run(word, font, color, !firstWord));
+               firstWord = false;
             }
          }
 
-         y = layoutTokens(lines, tokens, width, indent, y);
+         y = wrapBlock(lines, words, marker, textX, width, y);
       }
 
       return new Layout(lines, y);
    }
 
-   /** Greedy word-wrap of styled tokens into positioned lines; returns the y past the block. */
-   private int layoutTokens(List<Line> lines, List<Token> tokens, int width, int wrapX, int y) {
-      List<Run> runs = new ArrayList<>();
-      int curX = 0;
-      int lineAscent = 0;
-      int lineHeight = 0;
-      boolean lineStarted = false;
+   /** Greedy word-wrap into lines. Positions are resolved at paint time from the device metrics;
+    *  here we only decide line breaks (using approximate layout metrics) and per-run spacing. */
+   private int wrapBlock(List<Line> lines, List<Run> words, Run marker, int textX, int width, int y) {
+      List<Run> cur = new ArrayList<>();
+      float cx = textX;
+      int ascent = 0;
+      int height = 0;
+      boolean markerOnThisLine = marker != null;
 
-      for(Token token : tokens) {
-         FontMetrics fm = metrics(token.font);
-         int wordW = fm.stringWidth(token.text);
-         boolean bulletMarker = token.wrapX == 0 && !lineStarted && "•".equals(token.text);
-
-         int startX = bulletMarker ? 0 : token.wrapX;
-
-         if(!lineStarted) {
-            curX = startX;
-         }
-         else {
-            int spaceW = metrics(token.font).charWidth(' ');
-
-            if(curX + spaceW + wordW > width) {
-               // wrap
-               lines.add(new Line(y, lineHeight, lineAscent, runs));
-               y += lineHeight;
-               runs = new ArrayList<>();
-               curX = wrapX;
-               lineAscent = 0;
-               lineHeight = 0;
-               lineStarted = false;
-            }
-            else {
-               curX += spaceW;
-            }
-         }
-
-         runs.add(new Run(token.text, token.font, token.color, curX));
-         curX += wordW;
-         lineAscent = Math.max(lineAscent, fm.getAscent());
-         lineHeight = Math.max(lineHeight, fm.getHeight());
-         lineStarted = true;
+      if(markerOnThisLine) {
+         FontMetrics mfm = metrics(marker.font);
+         ascent = mfm.getAscent();
+         height = mfm.getHeight();
       }
 
-      if(lineStarted) {
-         lines.add(new Line(y, lineHeight, lineAscent, runs));
-         y += lineHeight;
+      for(Run word : words) {
+         FontMetrics fm = metrics(word.font);
+         float wordW = advance(word.font, word.text);
+         boolean spaceBefore = word.spaceBefore && !cur.isEmpty();
+         float spaceW = spaceBefore ? advance(word.font, " ") : 0;
+
+         if(!cur.isEmpty() && cx + spaceW + wordW > width) {
+            lines.add(new Line(y, height, ascent, textX, markerOnThisLine ? marker : null, cur));
+            y += height;
+            cur = new ArrayList<>();
+            cx = textX;
+            ascent = 0;
+            height = 0;
+            markerOnThisLine = false;
+            spaceBefore = false;
+            spaceW = 0;
+         }
+
+         cur.add(new Run(word.text, word.font, word.color, spaceBefore));
+         cx += spaceW + wordW;
+         ascent = Math.max(ascent, fm.getAscent());
+         height = Math.max(height, fm.getHeight());
+      }
+
+      if(!cur.isEmpty()) {
+         lines.add(new Line(y, height, ascent, textX, markerOnThisLine ? marker : null, cur));
+         y += height;
       }
 
       return y;
+   }
+
+   /**
+    * Draw one styled segment at the baseline and return its advance width. Uses drawGlyphVector so
+    * the rendered glyph positions match the advances used for layout ({@link #advance}); falls back
+    * to drawString on a non-Graphics2D device.
+    */
+   private float drawSegment(Graphics g, Graphics2D g2, Font font, Color color, String text,
+                             float x, float baseline)
+   {
+      g.setColor(color);
+
+      if(g2 != null) {
+         GlyphVector gv = font.createGlyphVector(FRC, text);
+         g2.drawGlyphVector(gv, x, baseline);
+         return (float) gv.getGlyphPosition(gv.getNumGlyphs()).getX();
+      }
+
+      g.setFont(font);
+      g.drawString(text, Math.round(x), Math.round(baseline));
+      return advance(font, text);
+   }
+
+   /** Horizontal advance of a string from the font's own glyph metrics (device-independent). */
+   private float advance(Font font, String text) {
+      GlyphVector gv = font.createGlyphVector(FRC, text);
+      return (float) gv.getGlyphPosition(gv.getNumGlyphs()).getX();
    }
 
    private static List<String> splitWords(String text) {
@@ -294,13 +357,10 @@ public class MarkdownPresenter implements ExpandablePresenter {
       });
    }
 
-   private record Token(String text, Font font, Color color, int wrapX) {
+   private record Run(String text, Font font, Color color, boolean spaceBefore) {
    }
 
-   private record Run(String text, Font font, Color color, int x) {
-   }
-
-   private record Line(int top, int height, int ascent, List<Run> runs) {
+   private record Line(int top, int height, int ascent, int startX, Run marker, List<Run> runs) {
    }
 
    private record Layout(List<Line> lines, int height) {
@@ -309,6 +369,10 @@ public class MarkdownPresenter implements ExpandablePresenter {
    private static final int DEFAULT_WIDTH = 400;
    private static final int BLOCK_GAP = 6;
    private static final int BULLET_INDENT = 16;
+
+   /** Canonical render context used for BOTH layout measurement and glyph-vector painting, so
+    *  positions are identical and device-independent (antialias + fractional metrics on). */
+   private static final FontRenderContext FRC = new FontRenderContext(null, true, true);
 
    private Font baseFont = new Font(Font.SANS_SERIF, Font.PLAIN, 11);
    private Color background;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -108,10 +108,9 @@ public class WizPrintLayoutBuilder {
 
          if(c.insightsMarkdown() != null && !c.insightsMarkdown().isBlank()) {
             int insightsY = chartY + CHART_HEIGHT_PT;
-            // Render insights structurally: headers, bullets, and paragraphs each get their own
-            // styled box (a report text box carries a single font, so structure — not inline bold —
-            // is what we preserve on the PDF side).
-            addStructuredBlocks(vsLayouts, "wizExportInsights_" + i + "_", c.insightsMarkdown(), insightsY);
+            // One markdown box; MarkdownPresenter renders headers/bullets/inline bold+italic and
+            // the converter paints it via a presenter painter (see VsToReportConverter).
+            addMarkdownBlock(vsLayouts, "wizMarkdownInsights_" + i, c.insightsMarkdown(), insightsY);
          }
 
          page++;
@@ -201,74 +200,32 @@ public class WizPrintLayoutBuilder {
 
       if(recap != null && !recap.isBlank()) {
          y += SUMMARY_GAP_PT;
-         y = addStructuredBlocks(vsLayouts, "wizExportSummary_", recap, y);
+         y = addMarkdownBlock(vsLayouts, "wizMarkdownSummary", recap, y);
       }
 
       return y + HEADER_BOTTOM_GAP_PT;
    }
 
    /**
-    * Lays out a markdown block sequence as a vertical stack of styled text boxes starting at
-    * {@code startY}: headings bold in the accent color, bullets with a hanging "•" indent, and
-    * paragraphs as body text. Inline bold/italic is flattened (one font per report text box).
-    * Returns the y just past the last block.
+    * Adds a single text box holding raw markdown, named so {@link VsToReportConverter} renders it
+    * with a {@link MarkdownPresenter} (headers, bullets, inline bold/italic). The box height is the
+    * presenter's preferred height at the content width, so the layout reserves the right space.
+    * Returns the y just past the box.
     */
-   private int addStructuredBlocks(List<VSAssemblyLayout> vsLayouts, String namePrefix,
-                                   String markdown, int startY)
+   private int addMarkdownBlock(List<VSAssemblyLayout> vsLayouts, String name, String markdown,
+                                int startY)
    {
-      int y = startY;
-      int idx = 0;
+      MarkdownPresenter presenter = new MarkdownPresenter();
+      // Match the font the converter will hand the presenter (the box's body font) so the
+      // height we reserve equals what gets painted.
+      presenter.setFont(inetsoft.uql.viewsheet.internal.VSAssemblyInfo.getDefaultFont(Font.PLAIN, BODY_FONT_PT));
+      int h = presenter.getPreferredSize(markdown, PAGE_CONTENT_WIDTH_PT).height + BLOCK_GAP_PT;
 
-      for(MarkdownModel.Block block : MarkdownModel.parse(markdown)) {
-         String text = block.plainText();
-         int x = 0;
-         int width = PAGE_CONTENT_WIDTH_PT;
-         int fontStyle;
-         int fontPt;
-         String color;
-
-         switch(block.type()) {
-         case HEADING:
-            fontStyle = Font.BOLD;
-            fontPt = Math.max(BODY_FONT_PT + 1, 15 - Math.max(0, block.level() - 1));
-            color = CAPTION_COLOR;
-            break;
-         case BULLET:
-            fontStyle = Font.PLAIN;
-            fontPt = BODY_FONT_PT;
-            color = SUMMARY_COLOR;
-            text = "•  " + text;
-            x = BULLET_INDENT_PT;
-            width = PAGE_CONTENT_WIDTH_PT - BULLET_INDENT_PT;
-            break;
-         default:
-            fontStyle = Font.PLAIN;
-            fontPt = BODY_FONT_PT;
-            color = SUMMARY_COLOR;
-         }
-
-         int h = estimateTextHeightPt(text, fontPt, width);
-         vsLayouts.add(styledTextLayout(namePrefix + (idx++), text, new Point(x, y),
-            new Dimension(width, h), fontStyle, fontPt, color, false));
-         y += h + BLOCK_GAP_PT;
-      }
-
-      return y;
-   }
-
-   /** Estimate a wrapped text block's height in points from headless font metrics. */
-   private int estimateTextHeightPt(String text, int fontPt, int widthPt) {
-      java.awt.Font font = new java.awt.Font(java.awt.Font.SANS_SERIF, java.awt.Font.PLAIN, fontPt);
-      java.awt.image.BufferedImage img =
-         new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_INT_ARGB);
-      java.awt.Graphics2D g = img.createGraphics();
-      java.awt.FontMetrics fm = g.getFontMetrics(font);
-      g.dispose();
-
-      double avgCharWidth = fm.stringWidth("abcdefghijklmnopqrstuvwxyz") / 26.0;
-      int charsPerLine = Math.max(1, (int) (widthPt / avgCharWidth));
-      int lines = Math.max(1, (int) Math.ceil(text.length() / (double) charsPerLine));
-      return lines * fm.getHeight() + 2;
+      // The box carries the raw markdown as its text and a plain body font; the converter reads
+      // that font for the presenter and paints the markdown (the box's own text is not drawn).
+      vsLayouts.add(styledTextLayout(name, markdown, new Point(0, startY),
+         new Dimension(PAGE_CONTENT_WIDTH_PT, h), Font.PLAIN, BODY_FONT_PT, SUMMARY_COLOR, false));
+      return startY + h;
    }
 
    /** "Generated <Month D, YYYY>" for the current server date. */
@@ -310,9 +267,8 @@ public class WizPrintLayoutBuilder {
    private static final int CAPTION_FONT_PT = 13;
    private static final String CAPTION_COLOR = "0x3B6EA5";   // slate-blue accent
    private static final int CHART_HEIGHT_PT = 400;
-   // Structured-block (insights/recap) type + spacing.
+   // Markdown insights/recap box: body font + trailing gap.
    private static final int BODY_FONT_PT = 11;
-   private static final int BULLET_INDENT_PT = 16;
    private static final int BLOCK_GAP_PT = 4;
 
    // Report-header geometry + type (points / font sizes / hex colors).

--- a/core/src/test/java/inetsoft/web/wiz/service/MarkdownPresenterTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MarkdownPresenterTest.java
@@ -1,0 +1,114 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class MarkdownPresenterTest {
+   private final MarkdownPresenter presenter = new MarkdownPresenter();
+
+   @Test
+   void emptyContentHasZeroHeight() {
+      assertEquals(0, presenter.getPreferredSize("", 400).height);
+      assertEquals(0, presenter.getPreferredSize(null, 400).height);
+   }
+
+   @Test
+   void narrowerWidthWrapsToGreaterHeight() {
+      String md = "The premium band is about 69% of all revenue across every one of the ten categories.";
+      int wide = presenter.getPreferredSize(md, 600).height;
+      int narrow = presenter.getPreferredSize(md, 150).height;
+      assertTrue(wide > 0);
+      assertTrue(narrow > wide, "narrower width wraps to more lines: narrow=" + narrow + " wide=" + wide);
+   }
+
+   @Test
+   void headersBulletsAndParagraphsStackVertically() {
+      String md = "## Heading\n\nA paragraph of prose.\n- first bullet\n- second bullet";
+      int h = presenter.getPreferredSize(md, 500).height;
+      // heading + paragraph + 2 bullets => clearly multiple lines tall
+      assertTrue(h > 40, "structured content stacks: " + h);
+   }
+
+   @Test
+   void paintDrawsVisibleContent() {
+      String md = "**Bold lead.** then *italic* and normal text.\n- a bullet point";
+      int w = 400;
+      int h = presenter.getPreferredSize(md, w).height + 10;
+      BufferedImage img = new BufferedImage(w, Math.max(1, h), BufferedImage.TYPE_INT_ARGB);
+      Graphics2D g = img.createGraphics();
+      g.setColor(Color.WHITE);
+      g.fillRect(0, 0, w, h);
+      presenter.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
+
+      assertDoesNotThrow(() -> presenter.paint(g, md, 0, 0, w, h));
+
+      int nonWhite = 0;
+
+      for(int px = 0; px < w; px++) {
+         for(int py = 0; py < h; py++) {
+            if((img.getRGB(px, py) & 0x00FFFFFF) != 0x00FFFFFF) {
+               nonWhite++;
+            }
+         }
+      }
+
+      g.dispose();
+      assertTrue(nonWhite > 50, "rendered glyphs leave visible pixels: " + nonWhite);
+   }
+
+   @Test
+   void paintSliceClipsToVerticalWindow() {
+      // A tall block; painting only the top slice should draw fewer pixels than the full height.
+      StringBuilder sb = new StringBuilder();
+
+      for(int i = 0; i < 20; i++) {
+         sb.append("- bullet line number ").append(i).append("\n");
+      }
+
+      String md = sb.toString();
+      int w = 400;
+      int full = presenter.getPreferredSize(md, w).height;
+      BufferedImage img = new BufferedImage(w, full, BufferedImage.TYPE_INT_ARGB);
+      Graphics2D g = img.createGraphics();
+      g.setColor(Color.WHITE);
+      g.fillRect(0, 0, w, full);
+      // paint only the top third
+      presenter.paint(g, md, 0, 0, w, full / 3, 0, full / 3f);
+      g.dispose();
+
+      int nonWhiteBottom = 0;
+
+      for(int py = full * 2 / 3; py < full; py++) {
+         for(int px = 0; px < w; px++) {
+            if((img.getRGB(px, py) & 0x00FFFFFF) != 0x00FFFFFF) {
+               nonWhiteBottom++;
+            }
+         }
+      }
+
+      assertEquals(0, nonWhiteBottom, "bottom of the block must be clipped out of the top slice");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
@@ -123,7 +123,7 @@ class WizPrintLayoutBuilderTest {
    }
 
    @Test
-   void addsStrippedInsightsBlockBelowChartWithoutResizingTheChart() {
+   void addsMarkdownInsightsBoxBelowChartWithoutResizingTheChart() {
       Viewsheet vs = new Viewsheet();
       textAssembly(vs, "Chart1", 0);
       List<WizPrintLayoutBuilder.ChartCaption> charts = List.of(
@@ -147,23 +147,17 @@ class WizPrintLayoutBuilderTest {
          .filter(l -> l instanceof VSEditableAssemblyLayout)
          .map(l -> (VSEditableAssemblyLayout) l)
          .collect(Collectors.toList());
-      // report header (title + date + summary) + caption + insights (paragraph + bullet = 2) = 6
-      assertEquals(6, texts.size());
+      // report header (title + date + summary) + caption + insights = 5 (insights is one markdown box)
+      assertEquals(5, texts.size());
 
-      // The bold paragraph and the bullet become separate structured boxes (one font per box);
-      // inline bold is flattened, bullet marker rendered.
-      VSEditableAssemblyLayout para = texts.stream()
-         .filter(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().contains("Bold finding"))
+      // The insights box is named "wizMarkdown*" (so the converter renders it via MarkdownPresenter)
+      // and carries the RAW markdown as its value; stripping/styling happens at paint time.
+      VSEditableAssemblyLayout insights = texts.stream()
+         .filter(t -> t.getName().startsWith("wizMarkdownInsights"))
          .findFirst().orElseThrow();
-      assertFalse(((TextVSAssemblyInfo) para.getInfo()).getText().contains("**"),
-         "no raw markdown syntax survives: " + ((TextVSAssemblyInfo) para.getInfo()).getText());
-
-      VSEditableAssemblyLayout bullet = texts.stream()
-         .filter(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().contains("point one"))
-         .findFirst().orElseThrow();
-      String bulletText = ((TextVSAssemblyInfo) bullet.getInfo()).getText();
-      assertTrue(bulletText.startsWith("•"), "bullet marker rendered: " + bulletText);
-      assertFalse(bulletText.contains("- point"), "raw bullet dash stripped: " + bulletText);
+      String raw = ((TextVSAssemblyInfo) insights.getInfo()).getText();
+      assertTrue(raw.contains("**Bold**"), "raw markdown preserved for the presenter: " + raw);
+      assertTrue(raw.contains("- point one"), "raw bullet preserved for the presenter: " + raw);
    }
 
    @Test
@@ -183,7 +177,7 @@ class WizPrintLayoutBuilderTest {
    }
 
    @Test
-   void reportHeaderSplitsTitleDateAndStrippedSummaryWithStyledFonts() {
+   void reportHeaderSplitsTitleDateAndMarkdownSummaryWithStyledFonts() {
       Viewsheet vs = new Viewsheet();
       textAssembly(vs, "Chart1", 0);
       List<WizPrintLayoutBuilder.ChartCaption> charts = List.of(
@@ -211,12 +205,14 @@ class WizPrintLayoutBuilderTest {
       assertTrue(((TextVSAssemblyInfo) date.getInfo()).getText().startsWith("Generated "),
          "date line: " + ((TextVSAssemblyInfo) date.getInfo()).getText());
 
+      // The summary is a markdown box (rendered richly by MarkdownPresenter at paint time); it
+      // carries the RAW recap markdown as its value.
       VSEditableAssemblyLayout summary = texts.stream()
-         .filter(t -> t.getName().startsWith("wizExportSummary"))
+         .filter(t -> t.getName().startsWith("wizMarkdownSummary"))
          .findFirst().orElseThrow();
       String summaryText = ((TextVSAssemblyInfo) summary.getInfo()).getText();
       assertTrue(summaryText.contains("Premium units run the business"), "recap kept: " + summaryText);
-      assertFalse(summaryText.contains("**"), "recap markdown stripped: " + summaryText);
+      assertTrue(summaryText.contains("**"), "raw markdown preserved for the presenter: " + summaryText);
    }
 
    @Test


### PR DESCRIPTION
## What

Brings the board **PDF** export to parity with the PPTX: insights and the recap now render **full markdown** — headers, bullet lists, and **inline bold**/*italic* — instead of the "structural only" flattening (a report text box carries a single font).

## How

New **`MarkdownPresenter`** (`ExpandablePresenter`) renders `MarkdownModel` directly to the report graphics:
- its own word-wrap over mixed-style runs (headers bold/larger/slate, bullets with a hanging "•", paragraphs),
- `getPreferredSize(v, width)` for height,
- `paint(..., bufy, bufh)` painting only a vertical slice, so the report framework can paginate it across pages (the same contract `HTMLPresenter` uses).

**Wiring:** `WizPrintLayoutBuilder` emits insights/recap as single `wizMarkdown*` text boxes holding the raw markdown, sized by the presenter's preferred height; `VsToReportConverter` renders any `wizMarkdown*` box via a `PresenterPainter(MarkdownPresenter)` instead of a plain text box. Charts, crosstab, and ordinary text boxes are untouched.

This uses StyleBI's own presenter/painter mechanism (the same one annotations use) — no markdown→HTML detour, full control over the themed typography.

## Verification

Live PDF export: page-1 recap and per-chart insights render bold lead-ins, italics, and bullet lists, and paginate cleanly at the print layout's fixed positions; crosstab and charts unaffected.

Tests: `MarkdownPresenterTest` 5 (sizing/wrap/paint/vertical-slice), `MarkdownModelTest` 6, `WizPrintLayoutBuilderTest` 12.

## Depends on

Builds on #4339 (markdown model + PPTX rich text / PDF structural) — merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)