### PR TITLE
Bug #75714, fix chart snapshot blank/broken images from revoked blob URLs

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
@@ -1163,6 +1163,40 @@ export class VSChart extends AbstractVSObject<VSChartModel>
       // Canvases are blank after cloneNode; remove them (they're only selection overlays)
       Array.from(clone.querySelectorAll("canvas")).forEach((c: Element) => c.remove());
 
+      // Tile <img> elements use blob: object URLs owned by ChartImageDirective, which
+      // revokes them when a tile reloads or the directive is destroyed (Bug #75515). The
+      // cloned images are not managed by the directive, so once the underlying blob is
+      // revoked they fail to (re)load with net::ERR_FAILED, leaving the snapshot blank.
+      // Repoint each loaded tile's clone at a self-contained data URL captured from the
+      // already-decoded original, so the snapshot no longer depends on the blob URLs
+      // surviving. The element stays an <img> so existing tag/class CSS selectors (e.g.
+      // ".chart-plot-area__tile img { position: absolute }") still apply. (Bug #75714)
+      const originalImages = chartAreaEl.querySelectorAll("img");
+      const cloneImages = clone.querySelectorAll("img");
+
+      for(let i = 0; i < cloneImages.length; i++) {
+         const cloneImg = cloneImages[i] as HTMLImageElement;
+         const originalImg = originalImages[i] as HTMLImageElement;
+
+         // drawImage requires a fully decoded source image; blob tiles are same-origin so
+         // the canvas is never tainted. Anything not yet loaded would be broken anyway.
+         if(originalImg && originalImg.complete && originalImg.naturalWidth > 0) {
+            try {
+               const canvas = document.createElement("canvas");
+               canvas.width = originalImg.naturalWidth;
+               canvas.height = originalImg.naturalHeight;
+               canvas.getContext("2d").drawImage(originalImg, 0, 0);
+               cloneImg.src = canvas.toDataURL();
+            }
+            catch(e) {
+               cloneImg.remove();
+            }
+         }
+         else {
+            cloneImg.remove();
+         }
+      }
+
       container.appendChild(clone);
       this.chartSnapshot = clone;
    }


### PR DESCRIPTION
## Summary

In the chart wizard (and other chart re-render paths), switching chart type produced broken images / blank placeholders. Browser dev tools showed multiple `blob:` requests failing with `net::ERR_FAILED` (0.0 kB, ~2 ms), initiated by `captureChartSnapshot` in `vs-chart.component.ts`.

## Root Cause

`VSChart.captureChartSnapshot()` (added in Bug #74260) keeps the old chart visible while new tiles load by deep-cloning the `chart-area` DOM. Chart tile `<img>` elements have their `src` set to `blob:` object URLs created by `ChartImageDirective` via `URL.createObjectURL`.

Bug #75515 (memory-leak fix) added `URL.revokeObjectURL` when a tile reloads and in `ngOnDestroy`. The cloned `<img>` elements are plain, un-managed DOM that only hold the blob URL *string*. Once the directive revokes the underlying blob (which happens almost immediately on a chart-type change, as new tiles arrive), the clone's new `<img>` elements can no longer load that URL and fail with `net::ERR_FAILED`. The original images keep displaying because they had already decoded before revocation.

## Fix

In `captureChartSnapshot()`, after cloning, repoint each loaded tile's cloned `<img>` at a self-contained `data:` URL captured from the already-decoded original image (offscreen `<canvas>` + `drawImage` + `toDataURL()`). The snapshot no longer depends on the blob URLs surviving.

The element is kept as an `<img>` (not swapped to `<canvas>`) so existing tag/class CSS selectors — e.g. `.chart-plot-area__tile img { position: absolute }` — continue to apply and positioning is unchanged. Tiles that aren't fully loaded are removed from the clone (they'd be broken anyway). `ChartImageDirective` and the #75515 memory-leak fix are untouched.

## Test Plan

- In Composer, open the new chart wizard on datasource Data Worksheet/Examples/Sales Revenue.
- Switch chart types several times.
- Verify the preview never shows broken/blank placeholders and that dev tools show no `net::ERR_FAILED` `blob:` requests.
- Regression: verify normal chart rendering, resize, drill, brush, and the loading snapshot (old chart staying visible while new tiles load) still work.

Fixes Redmine #75714.