### PR TITLE
Bug #75717, fix NG0955 duplicate track keys in color picker pane

### DIFF
--- a/web/projects/portal/src/app/widget/color-picker/cp-color-pane.component.html
+++ b/web/projects/portal/src/app/widget/color-picker/cp-color-pane.component.html
@@ -38,7 +38,7 @@
         <div class="form-row-float-label color-picker-palette-row color-picker-recent">
           <table>
             <tr class="bb-gray">
-              @for (swatch of recentColors; track swatch) {
+              @for (swatch of recentColors; track $index) {
                 <td>
                   <button type="button" class="color-picker-swatch bd-gray"
                     [class.transparent-swatch]="swatch === ''"
@@ -57,7 +57,7 @@
         <div class="form-row-float-label color-picker-palette-row">
           <table>
             <tr>
-              @for (swatch of row; track swatch) {
+              @for (swatch of row; track $index) {
                 <td>
                   <button type="button" class="color-picker-swatch"
                     [ngClass]="{'color-picker-selected bd-selected' : color == swatch || !color && !swatch,


### PR DESCRIPTION
## Summary

Opening the chart highlight dialog (or any color picker) and clicking a color threw an Angular `NG0955` error ("The provided track expression resulted in duplicated keys"), reported at `cp-color-pane.component.html:41`.

## Root Cause

Two `@for` loops in `cp-color-pane.component.html` tracked by the color *value* (`track swatch`). The `recentColors` list is always padded with duplicate `null`/empty-string entries (`RecentColorService` initializes 8 `null`s; the getter falls back to 8 `""`s), so tracking by value produced duplicate keys and triggered NG0955 as soon as the pane rendered. The palette-row loop used the same anti-pattern (latent — would fail for any palette with repeated values).

## Fix

Changed both loops to `track $index`. The palettes are fixed-length positional rows replaced in place (no keyed reordering), so index tracking is the correct model. No change to selection/click behavior — the loop bodies still use `swatch` for bindings and `selectColor(swatch)`.

## Test Plan

- In composer, open a chart's highlight dialog and click a color swatch — no NG0955 error; color selection works.
- Verify recent-colors row and all palette rows render and are selectable.
- `npm run build` succeeds (AOT template compilation).
- `npm run test` passes (946 portal + 356 em tests, incl. `cp-color-pane.spec.ts`).

Fixes Redmine #75717.