### PR TITLE
Bug #75718, guard against null identity in IdentityService.getIdentityInfo

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -520,6 +520,16 @@ public class IdentityService {
          identity = provider.getRole(identityId);
       }
 
+      // The identity lookup can transiently return null (e.g. cache/storage
+      // staleness or a concurrent modification while an identity is being
+      // deleted). Guard against it so IdentityInfo isn't constructed from a
+      // null identity, which would throw an NPE that gets logged as a
+      // misleading "Failed to create info object for identity: null" error.
+      if(identity == null) {
+         LOG.debug("Identity not found, returning empty info: {} (type={})", identityId, type);
+         return new IdentityInfo();
+      }
+
       return new IdentityInfo(identity, provider);
    }
 

--- a/core/src/test/java/inetsoft/web/admin/security/IdentityServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/security/IdentityServiceTest.java
@@ -17,8 +17,11 @@
  */
 package inetsoft.web.admin.security;
 
+import inetsoft.sree.security.AuthenticationProvider;
 import inetsoft.sree.security.IdentityID;
+import inetsoft.sree.security.IdentityInfo;
 import inetsoft.sree.security.OrganizationContextHolder;
+import inetsoft.uql.util.Identity;
 import inetsoft.storage.KeyValueStorage;
 import inetsoft.storage.KeyValueStorageManager;
 import inetsoft.uql.asset.AssetEntry;
@@ -177,6 +180,21 @@ class IdentityServiceTest {
       doReturn(failing).when(emFavorites).remove(anyString());
 
       assertDoesNotThrow(() -> invokeRemoveUserEMFavorites(List.of(alice)));
+   }
+
+   @Test
+   void getIdentityInfo_nullIdentity_returnsEmptyInfo() {
+      IdentityID missing = new IdentityID("ghost", "org1");
+      AuthenticationProvider provider = mock(AuthenticationProvider.class);
+      // simulate a transient/stale lookup returning no identity
+      when(provider.getUser(missing)).thenReturn(null);
+
+      IdentityInfo info = service.getIdentityInfo(missing, Identity.USER, provider);
+
+      assertNotNull(info, "a null identity must not produce a null IdentityInfo");
+      assertNull(info.getIdentityID(), "empty info should have no identity id");
+      assertFalse(info.isActive(), "empty info should be inactive");
+      assertTrue(info.getMembers().isEmpty(), "empty info should have no members");
    }
 
    private static AssetEntry entryWithFavorites(IdentityID user) {


### PR DESCRIPTION
## Summary

Fixes an intermittent NPE that surfaced as a misleading `ERROR` log when deleting a user in Enterprise Manager:

```
i.s.s.IdentityInfo: Failed to create info object for identity: null
java.lang.NullPointerException: Cannot invoke "inetsoft.uql.util.Identity.getIdentityID()" because "identity" is null
    at inetsoft.sree.security.IdentityInfo.<init>(IdentityInfo.java:64)
    at inetsoft.web.admin.security.IdentityService.getIdentityInfo(IdentityService.java:523)
    at inetsoft.web.admin.security.IdentityService.deleteIdentities(IdentityService.java:213)
```

## Root Cause

`IdentityService.getIdentityInfo()` passed the result of `provider.getUser()` (or `getGroup()`/`getRole()`/`getOrganization()`) straight into `new IdentityInfo(identity, provider)` with no null check. During a rapid create-then-delete flow, that lookup can transiently return `null` (storage/cache staleness or a concurrent modification). Inside the constructor, `identity.getIdentityID()` then threw an NPE. The constructor's own `try/catch` caught it and logged the misleading `Failed to create info object for identity: null` error, returning an empty `IdentityInfo`. The delete itself still completed (it operates by id, not the fetched object), but the spurious error was reported to users.

## Fix

Add a null guard in `getIdentityInfo`: when the identity is not found, log at `debug` and return an empty `IdentityInfo()`. This yields an object that is field-for-field identical to the prior caught-NPE result, minus the misleading `ERROR` log and the exception. It is the only caller of the `IdentityInfo(Identity, provider)` constructor.

## Test Plan

- In EM, create `user0` with Enterprise Manager permission and Administrator permission on the *users* node.
- Log in as `user0`; repeatedly create and delete users.
- Confirm the `Failed to create info object for identity: null` error no longer appears in the logs and the delete still succeeds.
- Automated: `IdentityServiceTest` passes (7/7); `community/core` builds successfully.

Fixes Redmine #75718.