### PR TITLE
Bug #75720, allow "Organization Roles" ADMIN grant to create roles

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/user/RoleController.java
+++ b/core/src/main/java/inetsoft/web/admin/security/user/RoleController.java
@@ -101,9 +101,16 @@ public class RoleController {
                                        @DecodePathVariable("provider") String providerName)
    {
       String currOrgId = OrganizationManager.getInstance().getCurrentOrgID();
+      String rootOrgRoleID = new IdentityID("Organization Roles", currOrgId).convertToKey();
 
+      // "Organization Roles" is an independent permission root from the global "Roles" root, and
+      // the wildcard resolution only merges the global "Roles" grant. Explicitly check the
+      // "Organization Roles" root so a user granted ADMIN on it (without being an org admin) can
+      // create org-scoped roles, mirroring the root check in getRole().
       if(!securityProvider.checkPermission(principal, ResourceType.SECURITY_ROLE,
-                                           IdentityID.getIdentityRootResorucePath(currOrgId), ResourceAction.ADMIN))
+                                           IdentityID.getIdentityRootResorucePath(currOrgId), ResourceAction.ADMIN) &&
+         !securityProvider.checkPermission(principal, ResourceType.SECURITY_ROLE,
+                                           rootOrgRoleID, ResourceAction.ADMIN))
       {
          return null;
       }

--- a/core/src/test/java/inetsoft/web/admin/security/user/RoleControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/security/user/RoleControllerTest.java
@@ -23,11 +23,12 @@ package inetsoft.web.admin.security.user;
  * Class type: behavioral-orchestration controller — RoleController has real in-controller
  * logic in createRole(), editRole(), and deleteIdentities().
  *
- * Coverage scope (6 cases in 3 groups):
+ * Coverage scope (7 cases in 3 groups):
  *
  * --- createRole() ---
  *
  *  [no permission]               checkPermission() returns false → null returned immediately
+ *  [org-roles admin]             wildcard "Roles" root false but "Organization Roles" root true → passes gate
  *
  * --- deleteIdentities() ---
  *
@@ -44,6 +45,7 @@ package inetsoft.web.admin.security.user;
  * with Mockito.mockStatic() using lenient() where possible.
  */
 
+import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.security.*;
 import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.util.Identity;
@@ -136,6 +138,26 @@ class RoleControllerTest {
 
       assertNull(result);
       verify(securityProvider, never()).getAuthenticationProvider();
+   }
+
+   // [org-roles admin] wildcard "Roles" root false but "Organization Roles" root true → passes gate
+   @Test
+   void createRole_orgRoleAdminPermission_proceedsPastGate() {
+      String rootOrgRoleID = new IdentityID("Organization Roles", "host-org").convertToKey();
+      when(securityProvider.checkPermission(eq(principal), eq(ResourceType.SECURITY_ROLE),
+                                            anyString(), eq(ResourceAction.ADMIN)))
+         .thenAnswer(inv -> rootOrgRoleID.equals(inv.getArgument(2)));
+
+      try(MockedStatic<SUtil> sutilStatic = mockStatic(SUtil.class)) {
+         sutilStatic.when(() -> SUtil.getActionRecord(any(HttpServletRequest.class), anyString(),
+                                                      nullable(String.class), anyString()))
+            .thenReturn(mock(ActionRecord.class));
+
+         controller.createRole(httpRequest, principal, "myProvider");
+      }
+
+      // gate passed → getProvider() reached, which calls getAuthenticationProvider()
+      verify(securityProvider).getAuthenticationProvider();
    }
 
    // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

In Enterprise Manager, a user granted EM access plus **Administrator** permission on the **Organization Roles** security-tree node (but who is not an org administrator by role) could not create a new role — the New Role action failed silently with no error.

## Root Cause

`RoleController.createRole` gated on `checkPermission(SECURITY_ROLE, IdentityID.getIdentityRootResorucePath(currOrgId), ADMIN)`, where `getIdentityRootResorucePath` returns the wildcard resource `"*^orgID"`.

In `DefaultCheckPermissionStrategy`, resolving ADMIN on the `SECURITY_ROLE` **wildcard** resource only merges the **global `"Roles"`** root grant — it does `getRole(IdentityID("*", orgID))` → `null` → falls back to `new IdentityID("Roles", orgID)`. It never consults the **`"Organization Roles"`** root, which is a deliberately independent permission root. So the user's ADMIN grant on "Organization Roles" was invisible to this check → `checkPermission` returned false → `createRole` returned `null` (no dialog, no error).

The read path `RoleController.getRole` already checks **both** roots ("Roles" and "Organization Roles") plus the specific role, which is why the tree loads but role creation was blocked.

## Fix

Add an OR check for the "Organization Roles" root in `createRole`, keeping the existing wildcard check intact (purely additive), mirroring the root-check pattern in `getRole`. The created role is already org-scoped (`new IdentityID(name, currOrg)`), which is precisely the scope an "Organization Roles" admin should manage.

## Test Plan

- As a user with EM access + Administrator on the "Organization Roles" node (not an org admin), create a new role in EM → succeeds.
- Regression: site admins, org administrators, and users with global "Roles" ADMIN can still create roles.
- No over-broad access: creation of global/system roles is unaffected.
- `./mvnw test -pl core -Dtest=RoleControllerTest` → BUILD SUCCESS (6/6).

Fixes Redmine #75720.