### PR TITLE
Bug #75724, fix extended-view More Options crash by removing stray ngbDropdown

### DIFF
--- a/web/projects/portal/src/app/portal/data/asset-item-list-view/asset-item-list-view.component.html
+++ b/web/projects/portal/src/app/portal/data/asset-item-list-view/asset-item-list-view.component.html
@@ -145,9 +145,9 @@
                             <span class="content-ellipse px-1">{{column.value(child)}}</span>
                           </span>
                           @if (isFirst) {
-                            <div class="d-flex align-items-center action-style truncate-addon" ngbDropdown>
+                            <div class="d-flex align-items-center action-style truncate-addon">
                               <i class="menu-vertical-icon action-color no-caret" title="_#(More Options)"
-                              ngbDropdownToggle (click)="onContextmenu.emit([child, $event])"></i>
+                              (click)="onContextmenu.emit([child, $event])"></i>
                             </div>
                           }
                         </div>

--- a/web/projects/portal/src/app/portal/data/asset-item-list-view/asset-item-list-view.component.ts
+++ b/web/projects/portal/src/app/portal/data/asset-item-list-view/asset-item-list-view.component.ts
@@ -20,7 +20,6 @@ import { AssetItem } from "../model/datasources/database/asset-item";
 import { SortOptions } from "../../../../../../shared/util/sort/sort-options";
 import { SortTypes } from "../../../../../../shared/util/sort/sort-types";
 import { MultiObjectSelectList } from "../../../common/util/multi-object-select-list";
-import { NgbDropdown, NgbDropdownToggle } from "@ng-bootstrap/ng-bootstrap";
 import { RouterLink } from "@angular/router";
 import { NgClass } from "@angular/common";
 
@@ -42,7 +41,7 @@ export interface ListColumn {
     selector: "asset-item-list-view",
     templateUrl: "./asset-item-list-view.component.html",
     styleUrls: ["./asset-item-list-view.component.scss"],
-    imports: [NgClass, RouterLink, NgbDropdown, NgbDropdownToggle]
+    imports: [NgClass, RouterLink]
 })
 export class AssetItemListViewComponent {
    @Input() set assets(assets: AssetItem[]) {


### PR DESCRIPTION
## Summary

Clicking the ⋮ **More Options** menu on an *Extended View* / *Extended Model* row in the portal Data Source → Data Model view threw a browser console error after the Angular 21 / ng-bootstrap upgrade:

```
ERROR TypeError: can't access property "nativeElement", this._menu is undefined
    at ng-bootstrap-ng-bootstrap-dropdown.mjs (NgbDropdown open/toggle)
```

## Root Cause

The shared `asset-item-list-view` component renders the ⋮ icon two ways. Parent rows (Logical Model, Physical View) use a plain `<i (click)="onContextmenu.emit(...)">`. The child rows (Extended View / Extended Model) wrapped the same icon in `ngbDropdown` + `ngbDropdownToggle` **but had no `[ngbDropdownMenu]` element**.

Both parent and child rows already drive StyleBI's own custom context menu via `onContextmenu.emit(...)` (`dropdownService.open(...)`), so the ng-bootstrap dropdown on the child row was never functional. After the ng-bootstrap upgrade, `NgbDropdown` eagerly dereferences `this._menu.nativeElement` when toggled, and since `_menu` (the missing `ngbDropdownMenu`) is `undefined`, it crashes.

## Fix

Remove the stray `ngbDropdown` / `ngbDropdownToggle` directives from the child row so it matches the parent row (the click only emits the custom context-menu event), and remove the now-unused `NgbDropdown` / `NgbDropdownToggle` imports and standalone `imports[]` entries from the component.

## Test Plan

1. Import `Orders.zip`, open the datasource on the portal.
2. Expand Examples/Orders/Data Model → **Order View**.
3. Click the ⋮ **More Options** on the **Default Connection** (Extended View) row.
4. Verify the context menu opens (e.g. Delete) with no console error.
5. Verify parent rows (Logical Model, Physical View) ⋮ menu still works.

Verified: `npm run build` (all projects), `asset-item-list-view.component.tl.spec.ts` (34/34 pass), and ESLint all pass.

Fixes Redmine #75724.