### PR TITLE
feat(wiz): board-export rendering polish (treemap healing, PDF header/styling, PPTX insights titles)

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/VSChartInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/VSChartInfo.java
@@ -958,6 +958,38 @@ public class VSChartInfo extends AbstractChartInfo implements ContentObject, Dat
          list.toArray(temp);
          setRTGroupFields(temp);
 
+         // #treemap-heal: a treemap-family chart whose hierarchy dimensions were bound on the
+         // X slot with an empty group slot renders empty, because SeparateGraphGenerator reads
+         // the treemap hierarchy only from the group slot. Move any RT X *dimension* refs into
+         // the RT group slot so such charts render as treemaps on every render path. No-op for
+         // correctly-built treemaps (group already populated) and for non-treemap charts.
+         if(GraphTypes.isTreemap(getRTChartType()) || GraphTypes.isTreemap(getChartType())) {
+            ChartRef[] rtGroupHeal = getRTGroupFields();
+
+            if(rtGroupHeal == null || rtGroupHeal.length == 0) {
+               ChartRef[] rtXHeal = getRTXFields();
+
+               if(rtXHeal != null && rtXHeal.length > 0) {
+                  List<ChartRef> healDims = new ArrayList<>();
+                  List<ChartRef> healKeepX = new ArrayList<>();
+
+                  for(ChartRef ref : rtXHeal) {
+                     if(ref instanceof XAggregateRef) {
+                        healKeepX.add(ref);
+                     }
+                     else {
+                        healDims.add(ref);
+                     }
+                  }
+
+                  if(!healDims.isEmpty()) {
+                     setRTGroupFields(healDims.toArray(new ChartRef[0]));
+                     setRTXFields(healKeepX.toArray(new ChartRef[0]));
+                  }
+               }
+            }
+         }
+
          // only not found the period dimension, period is true
          period = false;
          periodRef = pdim;

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
@@ -2281,10 +2281,43 @@ public class VsToReportConverter {
     * Convert vs text to report text and add to fixed position in
     * the report section.
     */
+   /** Board-export insights/recap text boxes are named "wizMarkdown*" and hold markdown. */
+   private boolean isMarkdownTextBox(String name) {
+      return name != null && name.startsWith("wizMarkdown");
+   }
+
+   /** Render markdown text via a {@link inetsoft.web.wiz.service.MarkdownPresenter} painter so
+    *  headers, bullets, and inline bold/italic survive in the report/PDF. */
+   private void addMarkdownElement(TextVSAssembly assembly, String markdown, String sectionName) {
+      Rectangle bounds = getPixelBounds(assembly);
+      inetsoft.web.wiz.service.MarkdownPresenter presenter =
+         new inetsoft.web.wiz.service.MarkdownPresenter();
+      VSCompositeFormat fmt = assembly.getVSAssemblyInfo().getFormat();
+
+      if(fmt != null && fmt.getFont() != null) {
+         presenter.setFont(fmt.getFont());
+      }
+
+      inetsoft.report.painter.PresenterPainter painter =
+         new inetsoft.report.painter.PresenterPainter(markdown, presenter);
+      inetsoft.report.internal.PainterElementDef elem =
+         new inetsoft.report.internal.PainterElementDef(report, painter);
+      elem.setZIndex(assembly.getZIndex());
+      addElement0(bounds, elem, sectionName);
+   }
+
    private void addText(TextVSAssembly assembly, String sectionName) {
       String text = assembly.getText();
 
       if(text == null || "".equals(text.trim())) {
+         return;
+      }
+
+      // Board-export insights/recap boxes carry markdown (named "wizMarkdown*"); render them
+      // richly via a MarkdownPresenter painter (headers/bullets/inline bold+italic) instead of a
+      // single-font text box.
+      if(isMarkdownTextBox(assembly.getAbsoluteName())) {
+         addMarkdownElement(assembly, text, sectionName);
          return;
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -137,6 +137,33 @@ public class ViewsheetRuntimeController {
                vs.setWizInfo(new Viewsheet.WizInfo(true, null, null));
             }
          }
+
+         // #treemap-heal: some saved treemap-family charts were built with hierarchy dims on the
+         // X slot and an empty group slot (a wiz binding-path defect, fixed at create time in
+         // WizVsService#applyChartBinding — but pre-existing saved assets still have the old
+         // shape). SeparateGraphGenerator's treemap branch reads hierarchy dims only from the
+         // group slot, so those assets render as an empty cartesian chart. Heal them here on every
+         // open so the live/companion viewer renders correctly regardless of how the asset was
+         // originally saved; normalizeTreemapBindingToGroup is a no-op for already-correct
+         // treemaps and non-treemap charts. Mutating the ChartInfo alone is not enough — the
+         // sandbox may already hold a cached (empty) VGraphPair/data for this assembly from a
+         // prior render, so reset it the same way every other in-place chart mutation in
+         // WizVsService does (e.g. removeVisualization): resetDataMap + clearGraph, forcing the
+         // browser's on-demand render (see the sampled-preview comment below) to recompute against
+         // the healed binding instead of serving the stale empty plot.
+         if(assembly instanceof ChartVSAssembly chart && rvs != null) {
+            wizVsService.normalizeTreemapBindingToGroup(chart.getVSChartInfo());
+
+            rvs.getViewsheetSandbox().ifPresent(box -> {
+               box.resetDataMap(assembly.getName());
+
+               try {
+                  box.clearGraph(assembly.getName());
+               }
+               catch(Exception ignore) {
+               }
+            });
+         }
       }
       catch(Exception ex) {
          log.warn("Could not configure reopened wiz runtime {} for re-binding: {}", runtimeId, ex.getMessage());
@@ -253,7 +280,13 @@ public class ViewsheetRuntimeController {
          }
 
          try {
-            WizVsService.VerifyResult vr = wizVsService.verifyChartData(rvs, assembly.getName());
+            // getVGraphPair (used by verifyChartData) only supports ChartVSAssembly - it casts
+            // unconditionally and throws ClassCastException on a Table/Crosstab assembly, which
+            // findChartAssembly's first-assembly fallback can legitimately hand back for a saved
+            // "table"/"crosstab" wiz visualization. Route those through the TableLens-based path.
+            WizVsService.VerifyResult vr = assembly instanceof ChartVSAssembly
+               ? wizVsService.verifyChartData(rvs, assembly.getName())
+               : wizVsService.verifyTableData(rvs, assembly.getName());
             result.setHasData(vr.hasData());
             result.setRowCount(vr.rowCount());
          }

--- a/core/src/main/java/inetsoft/web/wiz/service/MarkdownModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MarkdownModel.java
@@ -1,0 +1,169 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Lightweight, defensive parser that turns the markdown authored for a saved visualization's
+ * "insights" (and a board's recap) into a small block/span model for styled rendering in the
+ * board exports — headers, bullets, and paragraphs, each carrying inline bold/italic spans.
+ *
+ * <p>Like {@link MarkdownPlainText} this is a regex transform, not a full CommonMark parser: it
+ * handles the constructs the insights actually use (hash headers; dash/star/plus bullets; bold
+ * via double-star or double-underscore; italic via single-star or single-underscore) and never
+ * throws on malformed input. Intra-word underscores (e.g. price_band) are intentionally NOT
+ * treated as italics -- the underscore emphasis pattern requires word boundaries.</p>
+ */
+public final class MarkdownModel {
+   private MarkdownModel() {
+   }
+
+   public enum BlockType { HEADING, BULLET, PARAGRAPH }
+
+   /** An inline run of text with its emphasis flags. */
+   public record Span(String text, boolean bold, boolean italic) {
+   }
+
+   /** A block-level element. {@code level} is the heading depth (1-6) or 0 otherwise. */
+   public record Block(BlockType type, int level, List<Span> spans) {
+      public String plainText() {
+         StringBuilder sb = new StringBuilder();
+
+         for(Span s : spans) {
+            sb.append(s.text());
+         }
+
+         return sb.toString();
+      }
+   }
+
+   /** Parse markdown into a flat list of blocks. Consecutive non-blank prose lines merge into
+    *  one paragraph; a blank line, header, or bullet ends the current paragraph. */
+   public static List<Block> parse(String markdown) {
+      List<Block> blocks = new ArrayList<>();
+
+      if(markdown == null) {
+         return blocks;
+      }
+
+      String[] lines = markdown.replace("\r\n", "\n").replace("\r", "\n").split("\n", -1);
+      StringBuilder para = new StringBuilder();
+
+      for(String raw : lines) {
+         String line = raw.strip();
+
+         if(line.isEmpty()) {
+            flushParagraph(para, blocks);
+            continue;
+         }
+
+         Matcher header = HEADER.matcher(line);
+         Matcher bullet = BULLET.matcher(line);
+
+         if(header.find()) {
+            flushParagraph(para, blocks);
+            blocks.add(new Block(BlockType.HEADING, header.group(1).length(),
+                                  parseInline(line.substring(header.end()))));
+         }
+         else if(bullet.find()) {
+            flushParagraph(para, blocks);
+            blocks.add(new Block(BlockType.BULLET, 1, parseInline(line.substring(bullet.end()))));
+         }
+         else {
+            if(para.length() > 0) {
+               para.append(' ');
+            }
+
+            para.append(line);
+         }
+      }
+
+      flushParagraph(para, blocks);
+      return blocks;
+   }
+
+   private static void flushParagraph(StringBuilder para, List<Block> blocks) {
+      if(para.length() > 0) {
+         blocks.add(new Block(BlockType.PARAGRAPH, 0, parseInline(para.toString())));
+         para.setLength(0);
+      }
+   }
+
+   /** Split a line into bold/italic/plain spans (handles one level of nesting, e.g. bold > italic). */
+   static List<Span> parseInline(String text) {
+      return parseInline(text, false, false);
+   }
+
+   private static List<Span> parseInline(String text, boolean inheritBold, boolean inheritItalic) {
+      List<Span> spans = new ArrayList<>();
+
+      if(text.isEmpty()) {
+         return spans;
+      }
+
+      Matcher m = INLINE.matcher(text);
+      int last = 0;
+
+      while(m.find()) {
+         if(m.start() > last) {
+            spans.add(new Span(text.substring(last, m.start()), inheritBold, inheritItalic));
+         }
+
+         // Recurse into the matched content so nested emphasis (bold containing italic, etc.) is
+         // preserved rather than left as literal ** / * inside the outer span.
+         if(m.group(1) != null) {
+            spans.addAll(parseInline(m.group(1), true, inheritItalic));
+         }
+         else if(m.group(2) != null) {
+            spans.addAll(parseInline(m.group(2), true, inheritItalic));
+         }
+         else if(m.group(3) != null) {
+            spans.addAll(parseInline(m.group(3), inheritBold, true));
+         }
+         else if(m.group(4) != null) {
+            spans.addAll(parseInline(m.group(4), inheritBold, true));
+         }
+
+         last = m.end();
+      }
+
+      if(last < text.length()) {
+         spans.add(new Span(text.substring(last), inheritBold, inheritItalic));
+      }
+
+      if(spans.isEmpty()) {
+         spans.add(new Span(text, inheritBold, inheritItalic));
+      }
+
+      return spans;
+   }
+
+   private static final Pattern HEADER = Pattern.compile("^(#{1,6})\\s+");
+   private static final Pattern BULLET = Pattern.compile("^[-*+]\\s+");
+   // Order matters: bold (** / __) before italic (* / _). Italic markers require word boundaries
+   // so intra-word underscores/stars (price_band, a*b) are left as literal text.
+   private static final Pattern INLINE = Pattern.compile(
+      "\\*\\*(.+?)\\*\\*" +
+      "|__(.+?)__" +
+      "|(?<![\\w*])\\*(?!\\s)(.+?)(?<!\\s)\\*(?![\\w])" +
+      "|(?<![\\w_])_(?!\\s)(.+?)(?<!\\s)_(?![\\w])");
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/MarkdownPresenter.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MarkdownPresenter.java
@@ -1,0 +1,323 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.report.ReportElement;
+import inetsoft.report.internal.ExpandablePresenter;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An {@link ExpandablePresenter} that renders markdown ({@link MarkdownModel}) directly to a
+ * report graphics context — headers, bullet lists, and paragraphs with inline bold/italic runs —
+ * so board exports (and anything else that paints a Presenter) keep formatting instead of
+ * flattening it. Wraps text to the paint width, computes its own preferred height, and paints a
+ * vertical slice (for page breaks) the same way {@link inetsoft.report.painter.HTMLPresenter} does.
+ */
+public class MarkdownPresenter implements ExpandablePresenter {
+   public MarkdownPresenter() {
+   }
+
+   public void setBodyColor(Color bodyColor) {
+      this.bodyColor = bodyColor;
+   }
+
+   public void setAccentColor(Color accentColor) {
+      this.accentColor = accentColor;
+   }
+
+   @Override
+   public boolean isPresenterOf(Class type) {
+      return true;
+   }
+
+   @Override
+   public boolean isPresenterOf(Object obj) {
+      return obj != null;
+   }
+
+   @Override
+   public boolean isFill() {
+      return true;
+   }
+
+   @Override
+   public void setFont(Font font) {
+      if(font != null) {
+         this.baseFont = font;
+         this.layoutCache = null;
+      }
+   }
+
+   @Override
+   public void setBackground(Color bg) {
+      this.background = bg;
+   }
+
+   @Override
+   public String getDisplayName() {
+      return "Markdown";
+   }
+
+   @Override
+   public boolean isRawDataRequired() {
+      return false;
+   }
+
+   @Override
+   public Dimension getPreferredSize(Object v) {
+      return getPreferredSize(v, DEFAULT_WIDTH);
+   }
+
+   @Override
+   public Dimension getPreferredSize(Object v, float width) {
+      int w = Math.max(1, (int) width);
+      return new Dimension(w, layout(v, w).height);
+   }
+
+   @Override
+   public float getHeightAdjustment(Object obj, ReportElement elem, Dimension pd,
+                                    float starty, float bufw, float bufh)
+   {
+      // If everything up to the intended break already fits, no adjustment.
+      if(obj == null || bufh <= 0 || starty + bufh >= pd.height) {
+         return 0;
+      }
+
+      // If a line straddles the intended break, pull the break back to that line's top so no line
+      // is cut in half across a page boundary.
+      Layout layout = layout(obj, (int) bufw);
+      float breakAt = starty + bufh;
+
+      for(Line line : layout.lines) {
+         if(line.top < breakAt && line.top + line.height > breakAt) {
+            return breakAt - line.top;
+         }
+      }
+
+      return 0;
+   }
+
+   @Override
+   public void paint(Graphics g, Object v, int x, int y, int w, int h) {
+      paint(g, v, x, y, w, h, 0, -1);
+   }
+
+   @Override
+   public void paint(Graphics g, Object v, int x, int y, int w, int h, float bufy, float bufh) {
+      Layout layout = layout(v, w);
+      Shape oclip = g.getClip();
+      Font ofont = g.getFont();
+      Color ocolor = g.getColor();
+
+      if(background != null) {
+         g.setColor(background);
+         g.fillRect(x, y, w, h);
+      }
+
+      g.clipRect(x, y, w, h);
+      float top = bufy;
+      float bottom = bufh < 0 ? Float.MAX_VALUE : bufy + bufh;
+
+      for(Line line : layout.lines) {
+         if(line.top + line.height <= top || line.top >= bottom) {
+            continue;
+         }
+
+         int baseline = (int) (y + line.top - bufy + line.ascent);
+
+         for(Run run : line.runs) {
+            g.setFont(run.font);
+            g.setColor(run.color);
+            g.drawString(run.text, x + run.x, baseline);
+         }
+      }
+
+      g.setClip(oclip);
+      g.setFont(ofont);
+      g.setColor(ocolor);
+   }
+
+   // ------------------------------------------------------------------------
+   // Layout
+   // ------------------------------------------------------------------------
+
+   private Layout layout(Object v, int width) {
+      String md = v == null ? "" : v.toString();
+
+      if(layoutCache != null && width == cacheWidth && md.equals(cacheValue)) {
+         return layoutCache;
+      }
+
+      Layout layout = buildLayout(md, width);
+      cacheValue = md;
+      cacheWidth = width;
+      layoutCache = layout;
+      return layout;
+   }
+
+   private Layout buildLayout(String md, int width) {
+      List<Line> lines = new ArrayList<>();
+      int y = 0;
+      boolean firstBlock = true;
+
+      for(MarkdownModel.Block block : MarkdownModel.parse(md)) {
+         if(!firstBlock) {
+            y += BLOCK_GAP;
+         }
+
+         firstBlock = false;
+
+         int bodySize = baseFont.getSize();
+         int indent = block.type() == MarkdownModel.BlockType.BULLET ? BULLET_INDENT : 0;
+         List<Token> tokens = new ArrayList<>();
+
+         if(block.type() == MarkdownModel.BlockType.BULLET) {
+            // Hanging "•" marker at the block's left edge; text starts at the indent.
+            tokens.add(new Token("•", deriveFont(true, false, bodySize), accentColor, 0));
+         }
+
+         int headerSize = bodySize + Math.max(1, 5 - block.level());
+         boolean heading = block.type() == MarkdownModel.BlockType.HEADING;
+
+         for(MarkdownModel.Span span : block.spans()) {
+            Font font = deriveFont(heading || span.bold(), span.italic(), heading ? headerSize : bodySize);
+            Color color = heading ? accentColor : bodyColor;
+
+            for(String word : splitWords(span.text())) {
+               tokens.add(new Token(word, font, color, indent));
+            }
+         }
+
+         y = layoutTokens(lines, tokens, width, indent, y);
+      }
+
+      return new Layout(lines, y);
+   }
+
+   /** Greedy word-wrap of styled tokens into positioned lines; returns the y past the block. */
+   private int layoutTokens(List<Line> lines, List<Token> tokens, int width, int wrapX, int y) {
+      List<Run> runs = new ArrayList<>();
+      int curX = 0;
+      int lineAscent = 0;
+      int lineHeight = 0;
+      boolean lineStarted = false;
+
+      for(Token token : tokens) {
+         FontMetrics fm = metrics(token.font);
+         int wordW = fm.stringWidth(token.text);
+         boolean bulletMarker = token.wrapX == 0 && !lineStarted && "•".equals(token.text);
+
+         int startX = bulletMarker ? 0 : token.wrapX;
+
+         if(!lineStarted) {
+            curX = startX;
+         }
+         else {
+            int spaceW = metrics(token.font).charWidth(' ');
+
+            if(curX + spaceW + wordW > width) {
+               // wrap
+               lines.add(new Line(y, lineHeight, lineAscent, runs));
+               y += lineHeight;
+               runs = new ArrayList<>();
+               curX = wrapX;
+               lineAscent = 0;
+               lineHeight = 0;
+               lineStarted = false;
+            }
+            else {
+               curX += spaceW;
+            }
+         }
+
+         runs.add(new Run(token.text, token.font, token.color, curX));
+         curX += wordW;
+         lineAscent = Math.max(lineAscent, fm.getAscent());
+         lineHeight = Math.max(lineHeight, fm.getHeight());
+         lineStarted = true;
+      }
+
+      if(lineStarted) {
+         lines.add(new Line(y, lineHeight, lineAscent, runs));
+         y += lineHeight;
+      }
+
+      return y;
+   }
+
+   private static List<String> splitWords(String text) {
+      List<String> words = new ArrayList<>();
+
+      for(String w : text.split("\\s+")) {
+         if(!w.isEmpty()) {
+            words.add(w);
+         }
+      }
+
+      return words;
+   }
+
+   private Font deriveFont(boolean bold, boolean italic, int size) {
+      int style = (bold ? Font.BOLD : 0) | (italic ? Font.ITALIC : 0);
+      return baseFont.deriveFont(style, size);
+   }
+
+   private FontMetrics metrics(Font font) {
+      return metricsCache.computeIfAbsent(font, f -> {
+         if(measuring == null) {
+            BufferedImage img = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+            measuring = img.createGraphics();
+         }
+
+         return measuring.getFontMetrics(f);
+      });
+   }
+
+   private record Token(String text, Font font, Color color, int wrapX) {
+   }
+
+   private record Run(String text, Font font, Color color, int x) {
+   }
+
+   private record Line(int top, int height, int ascent, List<Run> runs) {
+   }
+
+   private record Layout(List<Line> lines, int height) {
+   }
+
+   private static final int DEFAULT_WIDTH = 400;
+   private static final int BLOCK_GAP = 6;
+   private static final int BULLET_INDENT = 16;
+
+   private Font baseFont = new Font(Font.SANS_SERIF, Font.PLAIN, 11);
+   private Color background;
+   private Color bodyColor = new Color(0x2B2B2B);
+   private Color accentColor = new Color(0x3B6EA5);
+
+   private transient String cacheValue;
+   private transient int cacheWidth = -1;
+   private transient Layout layoutCache;
+   private transient Graphics2D measuring;
+   private final transient Map<Font, FontMetrics> metricsCache = new HashMap<>();
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -24,8 +24,10 @@ import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
 import inetsoft.sree.security.SecurityException;
+import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.WizUtil;
 import inetsoft.util.Catalog;
@@ -81,11 +83,13 @@ import java.util.UUID;
 public class WizDashboardService {
    public WizDashboardService(ViewsheetService viewsheetService,
                                AddVisualizationServiceProxy addVisualizationService,
-                               SecurityEngine securityEngine)
+                               SecurityEngine securityEngine,
+                               WizVsService wizVsService)
    {
       this.viewsheetService = viewsheetService;
       this.addVisualizationService = addVisualizationService;
       this.securityEngine = securityEngine;
+      this.wizVsService = wizVsService;
    }
 
    public WizDashboardResult composeDashboard(WizDashboardEvent event, Principal principal)
@@ -153,6 +157,23 @@ public class WizDashboardService {
          }
 
          RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
+
+         // #treemap-heal: a merged visualization may be a treemap-family chart saved with its
+         // hierarchy dims on the X slot and an empty group slot (see
+         // WizVsService#normalizeTreemapBindingToGroup) — SeparateGraphGenerator's treemap branch
+         // reads hierarchy dims only from the group slot, so an un-healed chart renders as an
+         // empty cartesian layout. Heal every merged chart assembly here, BEFORE the composed
+         // dashboard is saved, so the saved asset the export renders from (not a live runtime)
+         // already carries the durable group-slot structure. No-op for non-treemap charts and
+         // already-correctly-structured treemaps.
+         if(rvs.getViewsheet() != null) {
+            for(Assembly a : rvs.getViewsheet().getAssemblies()) {
+               if(a instanceof ChartVSAssembly chart) {
+                  wizVsService.normalizeTreemapBindingToGroup(chart.getVSChartInfo());
+               }
+            }
+         }
+
          AssetEntry savedVsEntry = resolveTargetEntry(event.getExistingIdentifier(), event.getName(), principal);
 
          WizUtil.saveWizSheet(rvs, principal, savedVsEntry,
@@ -202,5 +223,6 @@ public class WizDashboardService {
    private final ViewsheetService viewsheetService;
    private final AddVisualizationServiceProxy addVisualizationService;
    private final SecurityEngine securityEngine;
+   private final WizVsService wizVsService;
    private static final Logger LOG = LoggerFactory.getLogger(WizDashboardService.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -20,6 +20,7 @@ package inetsoft.web.wiz.service;
 import inetsoft.graph.internal.DimensionD;
 import inetsoft.report.Margin;
 import inetsoft.report.Size;
+import inetsoft.report.StyleConstants;
 import inetsoft.report.internal.PaperSize;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.viewsheet.VSAssembly;
@@ -80,15 +81,16 @@ public class WizPrintLayoutBuilder {
       List<VSAssemblyLayout> vsLayouts = new ArrayList<>();
       int page = 0;
 
-      // Page 1: title + recap header block.
-      vsLayouts.add(textLayout("wizExportTitleRecap", buildTitleRecapText(title, recap),
-         new Point(0, 0), new Dimension(PAGE_CONTENT_WIDTH_PT, TITLE_BLOCK_HEIGHT_PT)));
+      // Page 1: report-style header — a prominent title, a "Generated <date>" line closed by a
+      // thin rule, and the session recap as a markdown-stripped summary. Split into separate text
+      // boxes because a single box can only carry one font. Returns the y where the body begins.
+      int headerBottom = addReportHeader(vsLayouts, title, recap);
 
       for(int i = 0; i < ordered.size(); i++) {
          ChartCaption c = ordered.get(i);
          VSAssembly assembly = topLevel.get(i);
          int pageTop = page * PAGE_HEIGHT_PT;
-         int captionY = i == 0 ? TITLE_BLOCK_HEIGHT_PT : pageTop;
+         int captionY = i == 0 ? headerBottom : pageTop;
          int chartY = captionY + CAPTION_HEIGHT_PT;
 
          // Build caption text: title always shown, caption appended after an em-dash when present.
@@ -165,20 +167,70 @@ public class WizPrintLayoutBuilder {
       return result;
    }
 
-   private String buildTitleRecapText(String title, String recap) {
-      StringBuilder sb = new StringBuilder(title == null ? "" : title);
+   /**
+    * Emits the page-1 report header (title, generated-date line + rule, recap summary) and
+    * returns the y-coordinate (in points) where the body content should start.
+    */
+   private int addReportHeader(List<VSAssemblyLayout> vsLayouts, String title, String recap) {
+      String heading = title == null || title.isBlank() ? "Analysis Report" : title.trim();
+      int y = 0;
 
-      if(recap != null && !recap.isBlank()) {
-         sb.append("\n").append(recap);
+      vsLayouts.add(styledTextLayout("wizExportTitle", heading, new Point(0, y),
+         new Dimension(PAGE_CONTENT_WIDTH_PT, TITLE_HEIGHT_PT),
+         Font.BOLD, TITLE_FONT_PT, TITLE_COLOR, false));
+      y += TITLE_HEIGHT_PT;
+
+      vsLayouts.add(styledTextLayout("wizExportDate", generatedDateLine(), new Point(0, y),
+         new Dimension(PAGE_CONTENT_WIDTH_PT, DATE_HEIGHT_PT),
+         Font.PLAIN, DATE_FONT_PT, DATE_COLOR, true));
+      y += DATE_HEIGHT_PT;
+
+      String summary = recap == null ? "" : MarkdownPlainText.strip(recap).trim();
+
+      if(!summary.isEmpty()) {
+         y += SUMMARY_GAP_PT;
+         vsLayouts.add(styledTextLayout("wizExportSummary", summary, new Point(0, y),
+            new Dimension(PAGE_CONTENT_WIDTH_PT, SUMMARY_HEIGHT_PT),
+            Font.PLAIN, SUMMARY_FONT_PT, SUMMARY_COLOR, false));
+         y += SUMMARY_HEIGHT_PT;
       }
 
-      return sb.toString();
+      return y + HEADER_BOTTOM_GAP_PT;
    }
 
    private VSEditableAssemblyLayout textLayout(String name, String text, Point pos, Dimension size) {
       TextVSAssemblyInfo info = new TextVSAssemblyInfo();
       info.setTextValue(text);
       info.setText(text);
+      return new VSEditableAssemblyLayout(info, name, pos, size);
+   }
+
+   /** "Generated <Month D, YYYY>" for the current server date. */
+   String generatedDateLine() {
+      return "Generated " + java.time.LocalDate.now()
+         .format(java.time.format.DateTimeFormatter.ofPattern("MMMM d, yyyy", java.util.Locale.US));
+   }
+
+   private VSEditableAssemblyLayout styledTextLayout(String name, String text, Point pos,
+                                                     Dimension size, int fontStyle, int fontSize,
+                                                     String foreground, boolean bottomRule)
+   {
+      TextVSAssemblyInfo info = new TextVSAssemblyInfo();
+      info.setTextValue(text);
+      info.setText(text);
+
+      inetsoft.uql.viewsheet.VSFormat fmt = info.getFormat().getDefaultFormat();
+      fmt.setFontValue(inetsoft.uql.viewsheet.internal.VSAssemblyInfo.getDefaultFont(fontStyle, fontSize));
+      fmt.setForegroundValue(foreground);
+      fmt.setAlignmentValue(StyleConstants.H_LEFT | StyleConstants.V_CENTER);
+      fmt.setWrappingValue(true);
+
+      if(bottomRule) {
+         fmt.setBordersValue(new java.awt.Insets(0, 0, StyleConstants.THIN_LINE, 0));
+         fmt.setBorderColorsValue(new inetsoft.uql.viewsheet.BorderColors(
+            RULE_COLOR, RULE_COLOR, RULE_COLOR, RULE_COLOR));
+      }
+
       return new VSEditableAssemblyLayout(info, name, pos, size);
    }
 
@@ -189,8 +241,23 @@ public class WizPrintLayoutBuilder {
     *  boundary; adjust these constants if it does. */
    private static final int PAGE_HEIGHT_PT = 11 * 72;   // ~A4/Letter portrait height, conservative
    private static final int PAGE_CONTENT_WIDTH_PT = 8 * 72;
-   private static final int TITLE_BLOCK_HEIGHT_PT = 100;
    private static final int CAPTION_HEIGHT_PT = 30;
    private static final int CHART_HEIGHT_PT = 400;
    private static final int INSIGHTS_HEIGHT_PT = 150;
+
+   // Report-header geometry + type (points / font sizes / hex colors).
+   // TITLE_HEIGHT_PT fits a two-line wrapped title at TITLE_FONT_PT so the date line below it
+   // is never crowded; a short one-line title just centers with extra whitespace.
+   private static final int TITLE_HEIGHT_PT = 54;
+   private static final int TITLE_FONT_PT = 20;
+   private static final String TITLE_COLOR = "0x1a1a1a";
+   private static final int DATE_HEIGHT_PT = 18;
+   private static final int DATE_FONT_PT = 9;
+   private static final String DATE_COLOR = "0x888888";
+   private static final int SUMMARY_GAP_PT = 6;
+   private static final int SUMMARY_HEIGHT_PT = 64;
+   private static final int SUMMARY_FONT_PT = 11;
+   private static final String SUMMARY_COLOR = "0x2b2b2b";
+   private static final int HEADER_BOTTOM_GAP_PT = 12;
+   private static final Color RULE_COLOR = new Color(0xcccccc);
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -55,6 +55,12 @@ public class WizPrintLayoutBuilder {
    {
       PrintLayout layout = new PrintLayout();
       layout.setPrintInfo(buildPrintInfo(pageSize));
+      // scaleFont defaults to 0f on a bare PrintLayout; AbstractLayout.apply() then stamps
+      // RScaleFont=0 onto every assembly's cell formats, and VSCompositeFormat.getFont()
+      // multiplies the font size by rscaleFont — so table/crosstab cells render at font size 0
+      // (invisible text, and zero-width auto columns) while charts (painted by the graph engine)
+      // are unaffected. 1f == "no font scaling", matching an interactively-created print layout.
+      layout.setScaleFont(1f);
       layout.setHeaderLayouts(new ArrayList<>());
       layout.setFooterLayouts(new ArrayList<>());
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -80,6 +80,9 @@ public class WizPrintLayoutBuilder {
 
       List<VSAssemblyLayout> vsLayouts = new ArrayList<>();
       int page = 0;
+      // Stride each subsequent chart to the real printable page height (paper minus top/bottom
+      // margins), not a fixed 11in — otherwise later pages drift down and leave awkward whitespace.
+      int pageStride = pageContentHeightPt(pageSize);
 
       // Page 1: report-style header — a prominent title, a "Generated <date>" line closed by a
       // thin rule, and the session recap as a markdown-stripped summary. Split into separate text
@@ -89,15 +92,17 @@ public class WizPrintLayoutBuilder {
       for(int i = 0; i < ordered.size(); i++) {
          ChartCaption c = ordered.get(i);
          VSAssembly assembly = topLevel.get(i);
-         int pageTop = page * PAGE_HEIGHT_PT;
+         int pageTop = page * pageStride;
          int captionY = i == 0 ? headerBottom : pageTop;
          int chartY = captionY + CAPTION_HEIGHT_PT;
 
          // Build caption text: title always shown, caption appended after an em-dash when present.
+         // Styled as a slate-blue bold section header with a thin accent rule above the chart.
          String captionText = c.title() +
             (c.caption() != null && !c.caption().isBlank() ? " — " + c.caption() : "");
-         vsLayouts.add(textLayout("wizExportCaption_" + i, captionText,
-            new Point(0, captionY), new Dimension(PAGE_CONTENT_WIDTH_PT, CAPTION_HEIGHT_PT)));
+         vsLayouts.add(styledTextLayout("wizExportCaption_" + i, captionText,
+            new Point(0, captionY), new Dimension(PAGE_CONTENT_WIDTH_PT, CAPTION_HEIGHT_PT),
+            Font.BOLD, CAPTION_FONT_PT, CAPTION_COLOR, true));
          vsLayouts.add(new VSAssemblyLayout(assembly.getName(), new Point(0, chartY),
             new Dimension(PAGE_CONTENT_WIDTH_PT, CHART_HEIGHT_PT)));
 
@@ -112,6 +117,13 @@ public class WizPrintLayoutBuilder {
 
       layout.setVSAssemblyLayouts(vsLayouts);
       return layout;
+   }
+
+   /** Printable content height in points: paper height minus top/bottom margins. */
+   private int pageContentHeightPt(String pageSize) {
+      String canonicalName = PAGE_SIZE_NAMES.get(pageSize == null ? "" : pageSize.toLowerCase());
+      Size size = PaperSize.getSize(canonicalName);
+      return (int) Math.round((size.height - MARGIN_TOP_IN - MARGIN_BOTTOM_IN) * 72);
    }
 
    private PrintInfo buildPrintInfo(String pageSize) {
@@ -239,9 +251,10 @@ public class WizPrintLayoutBuilder {
     *  values feed that same pipeline, so page/content geometry below is expressed in points.
     *  CONFIRM in Task 3's integration test that content doesn't clip/overlap across the page
     *  boundary; adjust these constants if it does. */
-   private static final int PAGE_HEIGHT_PT = 11 * 72;   // ~A4/Letter portrait height, conservative
    private static final int PAGE_CONTENT_WIDTH_PT = 8 * 72;
    private static final int CAPTION_HEIGHT_PT = 30;
+   private static final int CAPTION_FONT_PT = 13;
+   private static final String CAPTION_COLOR = "0x3B6EA5";   // slate-blue accent
    private static final int CHART_HEIGHT_PT = 400;
    private static final int INSIGHTS_HEIGHT_PT = 150;
 
@@ -259,5 +272,6 @@ public class WizPrintLayoutBuilder {
    private static final int SUMMARY_FONT_PT = 11;
    private static final String SUMMARY_COLOR = "0x2b2b2b";
    private static final int HEADER_BOTTOM_GAP_PT = 12;
-   private static final Color RULE_COLOR = new Color(0xcccccc);
+   // Slate-blue accent (matches the chart palette + PPTX): the header rule and caption rules.
+   private static final Color RULE_COLOR = new Color(0x3B6EA5);
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -108,8 +108,10 @@ public class WizPrintLayoutBuilder {
 
          if(c.insightsMarkdown() != null && !c.insightsMarkdown().isBlank()) {
             int insightsY = chartY + CHART_HEIGHT_PT;
-            vsLayouts.add(textLayout("wizExportInsights_" + i, MarkdownPlainText.strip(c.insightsMarkdown()),
-               new Point(0, insightsY), new Dimension(PAGE_CONTENT_WIDTH_PT, INSIGHTS_HEIGHT_PT)));
+            // Render insights structurally: headers, bullets, and paragraphs each get their own
+            // styled box (a report text box carries a single font, so structure — not inline bold —
+            // is what we preserve on the PDF side).
+            addStructuredBlocks(vsLayouts, "wizExportInsights_" + i + "_", c.insightsMarkdown(), insightsY);
          }
 
          page++;
@@ -197,24 +199,76 @@ public class WizPrintLayoutBuilder {
          Font.PLAIN, DATE_FONT_PT, DATE_COLOR, true));
       y += DATE_HEIGHT_PT;
 
-      String summary = recap == null ? "" : MarkdownPlainText.strip(recap).trim();
-
-      if(!summary.isEmpty()) {
+      if(recap != null && !recap.isBlank()) {
          y += SUMMARY_GAP_PT;
-         vsLayouts.add(styledTextLayout("wizExportSummary", summary, new Point(0, y),
-            new Dimension(PAGE_CONTENT_WIDTH_PT, SUMMARY_HEIGHT_PT),
-            Font.PLAIN, SUMMARY_FONT_PT, SUMMARY_COLOR, false));
-         y += SUMMARY_HEIGHT_PT;
+         y = addStructuredBlocks(vsLayouts, "wizExportSummary_", recap, y);
       }
 
       return y + HEADER_BOTTOM_GAP_PT;
    }
 
-   private VSEditableAssemblyLayout textLayout(String name, String text, Point pos, Dimension size) {
-      TextVSAssemblyInfo info = new TextVSAssemblyInfo();
-      info.setTextValue(text);
-      info.setText(text);
-      return new VSEditableAssemblyLayout(info, name, pos, size);
+   /**
+    * Lays out a markdown block sequence as a vertical stack of styled text boxes starting at
+    * {@code startY}: headings bold in the accent color, bullets with a hanging "•" indent, and
+    * paragraphs as body text. Inline bold/italic is flattened (one font per report text box).
+    * Returns the y just past the last block.
+    */
+   private int addStructuredBlocks(List<VSAssemblyLayout> vsLayouts, String namePrefix,
+                                   String markdown, int startY)
+   {
+      int y = startY;
+      int idx = 0;
+
+      for(MarkdownModel.Block block : MarkdownModel.parse(markdown)) {
+         String text = block.plainText();
+         int x = 0;
+         int width = PAGE_CONTENT_WIDTH_PT;
+         int fontStyle;
+         int fontPt;
+         String color;
+
+         switch(block.type()) {
+         case HEADING:
+            fontStyle = Font.BOLD;
+            fontPt = Math.max(BODY_FONT_PT + 1, 15 - Math.max(0, block.level() - 1));
+            color = CAPTION_COLOR;
+            break;
+         case BULLET:
+            fontStyle = Font.PLAIN;
+            fontPt = BODY_FONT_PT;
+            color = SUMMARY_COLOR;
+            text = "•  " + text;
+            x = BULLET_INDENT_PT;
+            width = PAGE_CONTENT_WIDTH_PT - BULLET_INDENT_PT;
+            break;
+         default:
+            fontStyle = Font.PLAIN;
+            fontPt = BODY_FONT_PT;
+            color = SUMMARY_COLOR;
+         }
+
+         int h = estimateTextHeightPt(text, fontPt, width);
+         vsLayouts.add(styledTextLayout(namePrefix + (idx++), text, new Point(x, y),
+            new Dimension(width, h), fontStyle, fontPt, color, false));
+         y += h + BLOCK_GAP_PT;
+      }
+
+      return y;
+   }
+
+   /** Estimate a wrapped text block's height in points from headless font metrics. */
+   private int estimateTextHeightPt(String text, int fontPt, int widthPt) {
+      java.awt.Font font = new java.awt.Font(java.awt.Font.SANS_SERIF, java.awt.Font.PLAIN, fontPt);
+      java.awt.image.BufferedImage img =
+         new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_INT_ARGB);
+      java.awt.Graphics2D g = img.createGraphics();
+      java.awt.FontMetrics fm = g.getFontMetrics(font);
+      g.dispose();
+
+      double avgCharWidth = fm.stringWidth("abcdefghijklmnopqrstuvwxyz") / 26.0;
+      int charsPerLine = Math.max(1, (int) (widthPt / avgCharWidth));
+      int lines = Math.max(1, (int) Math.ceil(text.length() / (double) charsPerLine));
+      return lines * fm.getHeight() + 2;
    }
 
    /** "Generated <Month D, YYYY>" for the current server date. */
@@ -256,7 +310,10 @@ public class WizPrintLayoutBuilder {
    private static final int CAPTION_FONT_PT = 13;
    private static final String CAPTION_COLOR = "0x3B6EA5";   // slate-blue accent
    private static final int CHART_HEIGHT_PT = 400;
-   private static final int INSIGHTS_HEIGHT_PT = 150;
+   // Structured-block (insights/recap) type + spacing.
+   private static final int BODY_FONT_PT = 11;
+   private static final int BULLET_INDENT_PT = 16;
+   private static final int BLOCK_GAP_PT = 4;
 
    // Report-header geometry + type (points / font sizes / hex colors).
    // TITLE_HEIGHT_PT fits a two-line wrapped title at TITLE_FONT_PT so the date line below it
@@ -268,8 +325,6 @@ public class WizPrintLayoutBuilder {
    private static final int DATE_FONT_PT = 9;
    private static final String DATE_COLOR = "0x888888";
    private static final int SUMMARY_GAP_PT = 6;
-   private static final int SUMMARY_HEIGHT_PT = 64;
-   private static final int SUMMARY_FONT_PT = 11;
    private static final String SUMMARY_COLOR = "0x2b2b2b";
    private static final int HEADER_BOTTOM_GAP_PT = 12;
    // Slate-blue accent (matches the chart palette + PPTX): the header rule and caption rules.

--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -108,10 +108,9 @@ public class WizPrintLayoutBuilder {
 
          if(c.insightsMarkdown() != null && !c.insightsMarkdown().isBlank()) {
             int insightsY = chartY + CHART_HEIGHT_PT;
-            // Render insights structurally: headers, bullets, and paragraphs each get their own
-            // styled box (a report text box carries a single font, so structure — not inline bold —
-            // is what we preserve on the PDF side).
-            addStructuredBlocks(vsLayouts, "wizExportInsights_" + i + "_", c.insightsMarkdown(), insightsY);
+            // One markdown box; MarkdownPresenter renders headers/bullets/inline bold+italic and
+            // the converter paints it via a presenter painter (see VsToReportConverter).
+            addMarkdownBlock(vsLayouts, "wizMarkdownInsights_" + i, c.insightsMarkdown(), insightsY);
          }
 
          page++;
@@ -201,74 +200,32 @@ public class WizPrintLayoutBuilder {
 
       if(recap != null && !recap.isBlank()) {
          y += SUMMARY_GAP_PT;
-         y = addStructuredBlocks(vsLayouts, "wizExportSummary_", recap, y);
+         y = addMarkdownBlock(vsLayouts, "wizMarkdownSummary", recap, y);
       }
 
       return y + HEADER_BOTTOM_GAP_PT;
    }
 
    /**
-    * Lays out a markdown block sequence as a vertical stack of styled text boxes starting at
-    * {@code startY}: headings bold in the accent color, bullets with a hanging "•" indent, and
-    * paragraphs as body text. Inline bold/italic is flattened (one font per report text box).
-    * Returns the y just past the last block.
+    * Adds a single text box holding raw markdown, named so {@link VsToReportConverter} renders it
+    * with a {@link MarkdownPresenter} (headers, bullets, inline bold/italic). The box height is the
+    * presenter's preferred height at the content width, so the layout reserves the right space.
+    * Returns the y just past the box.
     */
-   private int addStructuredBlocks(List<VSAssemblyLayout> vsLayouts, String namePrefix,
-                                   String markdown, int startY)
+   private int addMarkdownBlock(List<VSAssemblyLayout> vsLayouts, String name, String markdown,
+                                int startY)
    {
-      int y = startY;
-      int idx = 0;
+      MarkdownPresenter presenter = new MarkdownPresenter();
+      // Match the font the converter will hand the presenter (the box's body font) so the
+      // height we reserve equals what gets painted.
+      presenter.setFont(inetsoft.uql.viewsheet.internal.VSAssemblyInfo.getDefaultFont(Font.PLAIN, BODY_FONT_PT));
+      int h = presenter.getPreferredSize(markdown, PAGE_CONTENT_WIDTH_PT).height + BLOCK_GAP_PT;
 
-      for(MarkdownModel.Block block : MarkdownModel.parse(markdown)) {
-         String text = block.plainText();
-         int x = 0;
-         int width = PAGE_CONTENT_WIDTH_PT;
-         int fontStyle;
-         int fontPt;
-         String color;
-
-         switch(block.type()) {
-         case HEADING:
-            fontStyle = Font.BOLD;
-            fontPt = Math.max(BODY_FONT_PT + 1, 15 - Math.max(0, block.level() - 1));
-            color = CAPTION_COLOR;
-            break;
-         case BULLET:
-            fontStyle = Font.PLAIN;
-            fontPt = BODY_FONT_PT;
-            color = SUMMARY_COLOR;
-            text = "•  " + text;
-            x = BULLET_INDENT_PT;
-            width = PAGE_CONTENT_WIDTH_PT - BULLET_INDENT_PT;
-            break;
-         default:
-            fontStyle = Font.PLAIN;
-            fontPt = BODY_FONT_PT;
-            color = SUMMARY_COLOR;
-         }
-
-         int h = estimateTextHeightPt(text, fontPt, width);
-         vsLayouts.add(styledTextLayout(namePrefix + (idx++), text, new Point(x, y),
-            new Dimension(width, h), fontStyle, fontPt, color, false));
-         y += h + BLOCK_GAP_PT;
-      }
-
-      return y;
-   }
-
-   /** Estimate a wrapped text block's height in points from headless font metrics. */
-   private int estimateTextHeightPt(String text, int fontPt, int widthPt) {
-      java.awt.Font font = new java.awt.Font(java.awt.Font.SANS_SERIF, java.awt.Font.PLAIN, fontPt);
-      java.awt.image.BufferedImage img =
-         new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_INT_ARGB);
-      java.awt.Graphics2D g = img.createGraphics();
-      java.awt.FontMetrics fm = g.getFontMetrics(font);
-      g.dispose();
-
-      double avgCharWidth = fm.stringWidth("abcdefghijklmnopqrstuvwxyz") / 26.0;
-      int charsPerLine = Math.max(1, (int) (widthPt / avgCharWidth));
-      int lines = Math.max(1, (int) Math.ceil(text.length() / (double) charsPerLine));
-      return lines * fm.getHeight() + 2;
+      // The box carries the raw markdown as its text and a plain body font; the converter reads
+      // that font for the presenter and paints the markdown (the box's own text is not drawn).
+      vsLayouts.add(styledTextLayout(name, markdown, new Point(0, startY),
+         new Dimension(PAGE_CONTENT_WIDTH_PT, h), Font.PLAIN, BODY_FONT_PT, SUMMARY_COLOR, false));
+      return startY + h;
    }
 
    /** "Generated <Month D, YYYY>" for the current server date. */
@@ -310,9 +267,8 @@ public class WizPrintLayoutBuilder {
    private static final int CAPTION_FONT_PT = 13;
    private static final String CAPTION_COLOR = "0x3B6EA5";   // slate-blue accent
    private static final int CHART_HEIGHT_PT = 400;
-   // Structured-block (insights/recap) type + spacing.
+   // Markdown insights/recap box: body font + trailing gap.
    private static final int BODY_FONT_PT = 11;
-   private static final int BULLET_INDENT_PT = 16;
    private static final int BLOCK_GAP_PT = 4;
 
    // Report-header geometry + type (points / font sizes / hex colors).

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -20,6 +20,7 @@ package inetsoft.web.wiz.service;
 
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.analytic.composition.event.VSEventUtil;
+import inetsoft.graph.aesthetic.LinearSizeFrame;
 import inetsoft.graph.data.*;
 import inetsoft.report.composition.graph.GraphUtil;
 import inetsoft.report.TableLens;
@@ -1134,6 +1135,41 @@ public class WizVsService {
    }
 
    /**
+    * Execute a Table or Crosstab assembly's data to verify the saved visualization actually
+    * renders, without materializing the rows. Mirrors {@link #verifyChartData} for the
+    * non-chart wiz visualization types: {@link ViewsheetSandbox#getVGraphPair} only supports
+    * {@link ChartVSAssembly} (it casts unconditionally), so a table/crosstab assembly must be
+    * verified via its {@link TableLens} instead.
+    */
+   public VerifyResult verifyTableData(RuntimeViewsheet rvs, String assemblyName) throws Exception {
+      Optional<ViewsheetSandbox> boxOpt = rvs.getViewsheetSandbox();
+
+      if(boxOpt.isEmpty()) {
+         return new VerifyResult(false, 0);
+      }
+
+      TableLens table = boxOpt.get().getTableData(assemblyName);
+
+      if(table == null) {
+         return new VerifyResult(false, 0);
+      }
+
+      // Throws IllegalArgumentException carrying the real cause when the query failed.
+      checkFailedQuery(table);
+
+      int headerRows = table.getHeaderRowCount();
+      int rowCount = 0;
+      int r = headerRows;
+
+      while(table.moreRows(r)) {
+         rowCount++;
+         r++;
+      }
+
+      return new VerifyResult(rowCount > 0, rowCount);
+   }
+
+   /**
     * Extracts tabular data from a Table or Crosstab assembly via its TableLens.
     * Row 0 through headerRowCount-1 are header rows; data begins at headerRowCount.
     * <p>
@@ -2109,6 +2145,13 @@ public class WizVsService {
          if(binding.getPath() != null) {
             chartInfo.setPathField(createChartRef(binding.getPath()));
          }
+
+         // #treemap-heal: the x/y-based construction above is not what SeparateGraphGenerator's
+         // treemap-family branch reads at render time — it reads the hierarchy dims only from the
+         // GROUP slot (SeparateGraphGenerator:452-457), so a chart left with dims on x/y and an
+         // empty group renders as an empty cartesian layout. Re-slot now so the asset that gets
+         // persisted is durable across save/reopen, not just correct for this first render.
+         normalizeTreemapBindingToGroup(chartInfo);
       }
       else {
          // Default: Bar, 3D Bar, Area, Point, Step Area, Interval, Line, Step Line, Jump Line,
@@ -2164,6 +2207,72 @@ public class WizVsService {
          chartType == GraphTypes.CHART_SUNBURST ||
          chartType == GraphTypes.CHART_CIRCLE_PACKING ||
          chartType == GraphTypes.CHART_ICICLE;
+   }
+
+   /**
+    * Re-slot a mis-structured treemap-family chart so it renders durably. Treemaps
+    * (and sunburst/circle-packing/icicle) render from the GROUP slot; a chart built with the
+    * hierarchy dims on the X slot and an empty group renders as an empty cartesian chart on
+    * reopen. This moves any X/Y dimension fields into the group slot and ensures the size
+    * aesthetic is set, mirroring ChangeChartTypeProcessor.copyToTreemap. Idempotent: a no-op
+    * when the group slot already carries dims (a correctly-built treemap) or when the chart is
+    * not a treemap-family type.
+    */
+   public void normalizeTreemapBindingToGroup(VSChartInfo info) {
+      if(info == null || !isTreeMapChartType(info.getChartType())) {
+         return;
+      }
+
+      ChartRef[] groupFields = info.getGroupFields();
+
+      if(groupFields != null && groupFields.length > 0) {
+         // Already correctly structured — either a correctly-built treemap, or one already
+         // healed by a prior call. Never disturb a populated group slot.
+         return;
+      }
+
+      List<ChartRef> dims = new ArrayList<>();
+      List<ChartRef> measures = new ArrayList<>();
+      collectTreemapDimsAndMeasures(info.getXFields(), dims, measures);
+      collectTreemapDimsAndMeasures(info.getYFields(), dims, measures);
+
+      if(dims.isEmpty()) {
+         // Nothing to re-slot (e.g. an empty binding, or x/y hold only measures).
+         return;
+      }
+
+      info.removeXFields();
+      info.removeYFields();
+      dims.forEach(info::addGroupField);
+
+      if(info.getSizeField() == null && !measures.isEmpty()) {
+         AestheticRef aref = new VSAestheticRef();
+         aref.setDataRef(measures.get(0));
+         aref.setVisualFrame(new LinearSizeFrame());
+         info.setSizeField(aref);
+      }
+   }
+
+   /** Split {@code fields} into dimension vs. measure refs, per ChangeChartTypeProcessor.copyToTreemap. */
+   private void collectTreemapDimsAndMeasures(ChartRef[] fields, List<ChartRef> dims,
+                                              List<ChartRef> measures)
+   {
+      if(fields == null) {
+         return;
+      }
+
+      for(ChartRef field : fields) {
+         if(field == null) {
+            continue;
+         }
+
+         if(field instanceof XAggregateRef) {
+            measures.add(field);
+         }
+         else {
+            dims.add(field);
+         }
+      }
    }
 
    private AestheticRef createAestheticRef(SimpleFieldInfo field) {

--- a/core/src/test/java/inetsoft/web/wiz/service/MarkdownModelTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MarkdownModelTest.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class MarkdownModelTest {
+   @Test
+   void classifiesHeadingsBulletsAndParagraphs() {
+      List<MarkdownModel.Block> blocks = MarkdownModel.parse(
+         "## Premium share\n\nPremium items carry the business.\n- point one\n- point two");
+
+      assertEquals(4, blocks.size());
+      assertEquals(MarkdownModel.BlockType.HEADING, blocks.get(0).type());
+      assertEquals(2, blocks.get(0).level());
+      assertEquals("Premium share", blocks.get(0).plainText());
+      assertEquals(MarkdownModel.BlockType.PARAGRAPH, blocks.get(1).type());
+      assertEquals(MarkdownModel.BlockType.BULLET, blocks.get(2).type());
+      assertEquals("point one", blocks.get(2).plainText());
+      assertEquals(MarkdownModel.BlockType.BULLET, blocks.get(3).type());
+   }
+
+   @Test
+   void mergesConsecutiveProseLinesIntoOneParagraph() {
+      List<MarkdownModel.Block> blocks = MarkdownModel.parse("line one\nline two\n\nsecond para");
+      assertEquals(2, blocks.size());
+      assertEquals("line one line two", blocks.get(0).plainText());
+      assertEquals("second para", blocks.get(1).plainText());
+   }
+
+   @Test
+   void parsesInlineBoldAndItalicSpans() {
+      List<MarkdownModel.Span> spans = MarkdownModel.parseInline("**Premium** drives ~69% of *all* revenue");
+      // bold "Premium" | " drives ~69% of " | italic "all" | " revenue"
+      assertEquals("Premium", spans.get(0).text());
+      assertTrue(spans.get(0).bold());
+      assertFalse(spans.get(0).italic());
+      assertTrue(spans.stream().anyMatch(s -> s.italic() && s.text().equals("all")));
+      assertTrue(spans.stream().anyMatch(s -> !s.bold() && !s.italic() && s.text().contains("drives")));
+      // reassembled plain text loses no characters
+      assertEquals("Premium drives ~69% of all revenue",
+         spans.stream().map(MarkdownModel.Span::text).reduce("", String::concat));
+   }
+
+   @Test
+   void handlesItalicNestedInsideBold() {
+      List<MarkdownModel.Span> spans = MarkdownModel.parseInline("**not the same order as *share*.**");
+      // no raw markers survive
+      assertFalse(spans.stream().anyMatch(s -> s.text().contains("*")), "markers consumed");
+      // "share" is bold AND italic; the rest is bold-only
+      assertTrue(spans.stream().anyMatch(s -> s.text().equals("share") && s.bold() && s.italic()));
+      assertTrue(spans.stream().anyMatch(s -> s.text().contains("not the same order") && s.bold() && !s.italic()));
+      assertEquals("not the same order as share.",
+         spans.stream().map(MarkdownModel.Span::text).reduce("", String::concat));
+   }
+
+   @Test
+   void doesNotItalicizeIntraWordUnderscores() {
+      List<MarkdownModel.Span> spans = MarkdownModel.parseInline("group by price_band and premium_pct");
+      assertEquals(1, spans.size(), "intra-word underscores are literal, not italic markers");
+      assertFalse(spans.get(0).italic());
+      assertEquals("group by price_band and premium_pct", spans.get(0).text());
+   }
+
+   @Test
+   void emptyAndNullAreSafe() {
+      assertTrue(MarkdownModel.parse(null).isEmpty());
+      assertTrue(MarkdownModel.parse("").isEmpty());
+      assertTrue(MarkdownModel.parse("   \n  \n").isEmpty());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/MarkdownPresenterTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MarkdownPresenterTest.java
@@ -1,0 +1,114 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class MarkdownPresenterTest {
+   private final MarkdownPresenter presenter = new MarkdownPresenter();
+
+   @Test
+   void emptyContentHasZeroHeight() {
+      assertEquals(0, presenter.getPreferredSize("", 400).height);
+      assertEquals(0, presenter.getPreferredSize(null, 400).height);
+   }
+
+   @Test
+   void narrowerWidthWrapsToGreaterHeight() {
+      String md = "The premium band is about 69% of all revenue across every one of the ten categories.";
+      int wide = presenter.getPreferredSize(md, 600).height;
+      int narrow = presenter.getPreferredSize(md, 150).height;
+      assertTrue(wide > 0);
+      assertTrue(narrow > wide, "narrower width wraps to more lines: narrow=" + narrow + " wide=" + wide);
+   }
+
+   @Test
+   void headersBulletsAndParagraphsStackVertically() {
+      String md = "## Heading\n\nA paragraph of prose.\n- first bullet\n- second bullet";
+      int h = presenter.getPreferredSize(md, 500).height;
+      // heading + paragraph + 2 bullets => clearly multiple lines tall
+      assertTrue(h > 40, "structured content stacks: " + h);
+   }
+
+   @Test
+   void paintDrawsVisibleContent() {
+      String md = "**Bold lead.** then *italic* and normal text.\n- a bullet point";
+      int w = 400;
+      int h = presenter.getPreferredSize(md, w).height + 10;
+      BufferedImage img = new BufferedImage(w, Math.max(1, h), BufferedImage.TYPE_INT_ARGB);
+      Graphics2D g = img.createGraphics();
+      g.setColor(Color.WHITE);
+      g.fillRect(0, 0, w, h);
+      presenter.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
+
+      assertDoesNotThrow(() -> presenter.paint(g, md, 0, 0, w, h));
+
+      int nonWhite = 0;
+
+      for(int px = 0; px < w; px++) {
+         for(int py = 0; py < h; py++) {
+            if((img.getRGB(px, py) & 0x00FFFFFF) != 0x00FFFFFF) {
+               nonWhite++;
+            }
+         }
+      }
+
+      g.dispose();
+      assertTrue(nonWhite > 50, "rendered glyphs leave visible pixels: " + nonWhite);
+   }
+
+   @Test
+   void paintSliceClipsToVerticalWindow() {
+      // A tall block; painting only the top slice should draw fewer pixels than the full height.
+      StringBuilder sb = new StringBuilder();
+
+      for(int i = 0; i < 20; i++) {
+         sb.append("- bullet line number ").append(i).append("\n");
+      }
+
+      String md = sb.toString();
+      int w = 400;
+      int full = presenter.getPreferredSize(md, w).height;
+      BufferedImage img = new BufferedImage(w, full, BufferedImage.TYPE_INT_ARGB);
+      Graphics2D g = img.createGraphics();
+      g.setColor(Color.WHITE);
+      g.fillRect(0, 0, w, full);
+      // paint only the top third
+      presenter.paint(g, md, 0, 0, w, full / 3, 0, full / 3f);
+      g.dispose();
+
+      int nonWhiteBottom = 0;
+
+      for(int py = full * 2 / 3; py < full; py++) {
+         for(int px = 0; px < w; px++) {
+            if((img.getRGB(px, py) & 0x00FFFFFF) != 0x00FFFFFF) {
+               nonWhiteBottom++;
+            }
+         }
+      }
+
+      assertEquals(0, nonWhiteBottom, "bottom of the block must be clipped out of the top slice");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceTest.java
@@ -63,7 +63,7 @@ class WizDashboardServiceTest {
       throws Exception
    {
       when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
-      return new WizDashboardService(vs, add, sec);
+      return new WizDashboardService(vs, add, sec, mock(WizVsService.class));
    }
 
    @Test
@@ -93,7 +93,8 @@ class WizDashboardServiceTest {
       ViewsheetService vs = mock(ViewsheetService.class);
       SecurityEngine sec = mock(SecurityEngine.class);
       when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(false);
-      WizDashboardService svc = new WizDashboardService(vs, mock(AddVisualizationServiceProxy.class), sec);
+      WizDashboardService svc = new WizDashboardService(vs, mock(AddVisualizationServiceProxy.class), sec,
+         mock(WizVsService.class));
       // identifier UNDER the components folder so the folder guard passes and the permission
       // check is reached:
       String id = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,

--- a/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
@@ -174,6 +174,19 @@ class WizPrintLayoutBuilderTest {
    }
 
    @Test
+   void setsScaleFontToOneSoTableCellFontsAreNotZeroSized() {
+      Viewsheet vs = mock(Viewsheet.class);
+      PrintLayout layout = builder.build(vs, "letter", "Board", null, List.of());
+      // A bare PrintLayout leaves scaleFont at its 0f default; AbstractLayout.apply() then stamps
+      // RScaleFont=0 onto every assembly's cell formats, and VSCompositeFormat.getFont() multiplies
+      // the font size by rscaleFont — so crosstab/table cells render at font size 0 (invisible text
+      // and zero-width auto columns) while charts, painted by the graph engine, are unaffected.
+      // 1f == "no font scaling", matching an interactively-created print layout.
+      assertEquals(1f, layout.getScaleFont(),
+         "crosstab/table cell fonts must not be scaled to zero in the board-export print layout");
+   }
+
+   @Test
    void threeArgChartCaptionStillCompilesAndOmitsInsights() {
       Viewsheet vs = new Viewsheet();
       textAssembly(vs, "Chart1", 0);

--- a/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
@@ -147,16 +147,23 @@ class WizPrintLayoutBuilderTest {
          .filter(l -> l instanceof VSEditableAssemblyLayout)
          .map(l -> (VSEditableAssemblyLayout) l)
          .collect(Collectors.toList());
-      // report header (title + date + summary) + caption + insights = 5
-      assertEquals(5, texts.size());
+      // report header (title + date + summary) + caption + insights (paragraph + bullet = 2) = 6
+      assertEquals(6, texts.size());
 
-      VSEditableAssemblyLayout insights = texts.stream()
+      // The bold paragraph and the bullet become separate structured boxes (one font per box);
+      // inline bold is flattened, bullet marker rendered.
+      VSEditableAssemblyLayout para = texts.stream()
          .filter(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().contains("Bold finding"))
          .findFirst().orElseThrow();
-      String insightsText = ((TextVSAssemblyInfo) insights.getInfo()).getText();
-      assertTrue(insightsText.contains("Bold finding"), "markdown bold stripped: " + insightsText);
-      assertTrue(insightsText.contains("• point one"), "markdown bullet normalized: " + insightsText);
-      assertFalse(insightsText.contains("**"), "no raw markdown syntax survives: " + insightsText);
+      assertFalse(((TextVSAssemblyInfo) para.getInfo()).getText().contains("**"),
+         "no raw markdown syntax survives: " + ((TextVSAssemblyInfo) para.getInfo()).getText());
+
+      VSEditableAssemblyLayout bullet = texts.stream()
+         .filter(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().contains("point one"))
+         .findFirst().orElseThrow();
+      String bulletText = ((TextVSAssemblyInfo) bullet.getInfo()).getText();
+      assertTrue(bulletText.startsWith("•"), "bullet marker rendered: " + bulletText);
+      assertFalse(bulletText.contains("- point"), "raw bullet dash stripped: " + bulletText);
    }
 
    @Test
@@ -204,7 +211,8 @@ class WizPrintLayoutBuilderTest {
       assertTrue(((TextVSAssemblyInfo) date.getInfo()).getText().startsWith("Generated "),
          "date line: " + ((TextVSAssemblyInfo) date.getInfo()).getText());
 
-      VSEditableAssemblyLayout summary = texts.stream().filter(t -> t.getName().equals("wizExportSummary"))
+      VSEditableAssemblyLayout summary = texts.stream()
+         .filter(t -> t.getName().startsWith("wizExportSummary"))
          .findFirst().orElseThrow();
       String summaryText = ((TextVSAssemblyInfo) summary.getInfo()).getText();
       assertTrue(summaryText.contains("Premium units run the business"), "recap kept: " + summaryText);

--- a/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
@@ -123,7 +123,7 @@ class WizPrintLayoutBuilderTest {
    }
 
    @Test
-   void addsStrippedInsightsBlockBelowChartWithoutResizingTheChart() {
+   void addsMarkdownInsightsBoxBelowChartWithoutResizingTheChart() {
       Viewsheet vs = new Viewsheet();
       textAssembly(vs, "Chart1", 0);
       List<WizPrintLayoutBuilder.ChartCaption> charts = List.of(
@@ -147,23 +147,17 @@ class WizPrintLayoutBuilderTest {
          .filter(l -> l instanceof VSEditableAssemblyLayout)
          .map(l -> (VSEditableAssemblyLayout) l)
          .collect(Collectors.toList());
-      // report header (title + date + summary) + caption + insights (paragraph + bullet = 2) = 6
-      assertEquals(6, texts.size());
+      // report header (title + date + summary) + caption + insights = 5 (insights is one markdown box)
+      assertEquals(5, texts.size());
 
-      // The bold paragraph and the bullet become separate structured boxes (one font per box);
-      // inline bold is flattened, bullet marker rendered.
-      VSEditableAssemblyLayout para = texts.stream()
-         .filter(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().contains("Bold finding"))
+      // The insights box is named "wizMarkdown*" (so the converter renders it via MarkdownPresenter)
+      // and carries the RAW markdown as its value; stripping/styling happens at paint time.
+      VSEditableAssemblyLayout insights = texts.stream()
+         .filter(t -> t.getName().startsWith("wizMarkdownInsights"))
          .findFirst().orElseThrow();
-      assertFalse(((TextVSAssemblyInfo) para.getInfo()).getText().contains("**"),
-         "no raw markdown syntax survives: " + ((TextVSAssemblyInfo) para.getInfo()).getText());
-
-      VSEditableAssemblyLayout bullet = texts.stream()
-         .filter(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().contains("point one"))
-         .findFirst().orElseThrow();
-      String bulletText = ((TextVSAssemblyInfo) bullet.getInfo()).getText();
-      assertTrue(bulletText.startsWith("•"), "bullet marker rendered: " + bulletText);
-      assertFalse(bulletText.contains("- point"), "raw bullet dash stripped: " + bulletText);
+      String raw = ((TextVSAssemblyInfo) insights.getInfo()).getText();
+      assertTrue(raw.contains("**Bold**"), "raw markdown preserved for the presenter: " + raw);
+      assertTrue(raw.contains("- point one"), "raw bullet preserved for the presenter: " + raw);
    }
 
    @Test
@@ -183,7 +177,7 @@ class WizPrintLayoutBuilderTest {
    }
 
    @Test
-   void reportHeaderSplitsTitleDateAndStrippedSummaryWithStyledFonts() {
+   void reportHeaderSplitsTitleDateAndMarkdownSummaryWithStyledFonts() {
       Viewsheet vs = new Viewsheet();
       textAssembly(vs, "Chart1", 0);
       List<WizPrintLayoutBuilder.ChartCaption> charts = List.of(
@@ -211,12 +205,14 @@ class WizPrintLayoutBuilderTest {
       assertTrue(((TextVSAssemblyInfo) date.getInfo()).getText().startsWith("Generated "),
          "date line: " + ((TextVSAssemblyInfo) date.getInfo()).getText());
 
+      // The summary is a markdown box (rendered richly by MarkdownPresenter at paint time); it
+      // carries the RAW recap markdown as its value.
       VSEditableAssemblyLayout summary = texts.stream()
-         .filter(t -> t.getName().startsWith("wizExportSummary"))
+         .filter(t -> t.getName().startsWith("wizMarkdownSummary"))
          .findFirst().orElseThrow();
       String summaryText = ((TextVSAssemblyInfo) summary.getInfo()).getText();
       assertTrue(summaryText.contains("Premium units run the business"), "recap kept: " + summaryText);
-      assertFalse(summaryText.contains("**"), "recap markdown stripped: " + summaryText);
+      assertTrue(summaryText.contains("**"), "raw markdown preserved for the presenter: " + summaryText);
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
@@ -91,17 +91,19 @@ class WizPrintLayoutBuilderTest {
       assertEquals(2, chartRefs, "one plain VSAssemblyLayout per existing chart assembly");
 
       long editableTextBlocks = all.stream().filter(l -> l instanceof VSEditableAssemblyLayout).count();
-      // 1 title/recap block + 2 per-chart captions = 3
-      assertEquals(3, editableTextBlocks);
+      // report header (title + generated-date + summary) + 2 per-chart captions = 5
+      assertEquals(5, editableTextBlocks);
 
       List<VSEditableAssemblyLayout> texts = all.stream()
          .filter(l -> l instanceof VSEditableAssemblyLayout)
          .map(l -> (VSEditableAssemblyLayout) l)
          .collect(Collectors.toList());
-      boolean hasTitleRecap = texts.stream().anyMatch(t ->
-         ((TextVSAssemblyInfo) t.getInfo()).getText().contains("Q39 Board") &&
-         ((TextVSAssemblyInfo) t.getInfo()).getText().contains("Premium drives revenue."));
-      assertTrue(hasTitleRecap, "one editable block carries both the title and the recap");
+      assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().equals("Q39 Board")),
+         "the title box carries the board name on its own");
+      assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().startsWith("Generated ")),
+         "a generated-date line is present");
+      assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().contains("Premium drives revenue.")),
+         "the recap becomes the summary box");
       assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().equals("First — cap one")));
       assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().equals("Second — cap two")));
    }
@@ -145,8 +147,8 @@ class WizPrintLayoutBuilderTest {
          .filter(l -> l instanceof VSEditableAssemblyLayout)
          .map(l -> (VSEditableAssemblyLayout) l)
          .collect(Collectors.toList());
-      // title/recap + caption + insights = 3
-      assertEquals(3, texts.size());
+      // report header (title + date + summary) + caption + insights = 5
+      assertEquals(5, texts.size());
 
       VSEditableAssemblyLayout insights = texts.stream()
          .filter(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().contains("Bold finding"))
@@ -169,8 +171,50 @@ class WizPrintLayoutBuilderTest {
 
       long editableTextBlocks = layout.getVSAssemblyLayouts().stream()
          .filter(l -> l instanceof VSEditableAssemblyLayout).count();
-      // title/recap + caption only = 2 (same as the baseline before this feature)
-      assertEquals(2, editableTextBlocks);
+      // report header (title + date + summary) + caption, no insights block = 4
+      assertEquals(4, editableTextBlocks);
+   }
+
+   @Test
+   void reportHeaderSplitsTitleDateAndStrippedSummaryWithStyledFonts() {
+      Viewsheet vs = new Viewsheet();
+      textAssembly(vs, "Chart1", 0);
+      List<WizPrintLayoutBuilder.ChartCaption> charts = List.of(
+         new WizPrintLayoutBuilder.ChartCaption("First", "cap one", 0)
+      );
+
+      PrintLayout layout = builder.build(vs, "letter", "Odoo — Category Revenue (Q39)",
+         "**Premium units run the business** — the $1,500+ band is ~69% of revenue.", charts);
+
+      List<VSEditableAssemblyLayout> texts = layout.getVSAssemblyLayouts().stream()
+         .filter(l -> l instanceof VSEditableAssemblyLayout)
+         .map(l -> (VSEditableAssemblyLayout) l)
+         .collect(Collectors.toList());
+
+      VSEditableAssemblyLayout title = texts.stream().filter(t -> t.getName().equals("wizExportTitle"))
+         .findFirst().orElseThrow();
+      assertEquals("Odoo — Category Revenue (Q39)", ((TextVSAssemblyInfo) title.getInfo()).getText());
+      // title is rendered larger than the 11pt body default
+      assertTrue(((TextVSAssemblyInfo) title.getInfo()).getFormat().getFont().getSize() > 11,
+         "title uses a larger-than-body font");
+      assertTrue(((TextVSAssemblyInfo) title.getInfo()).getFormat().getFont().isBold(), "title is bold");
+
+      VSEditableAssemblyLayout date = texts.stream().filter(t -> t.getName().equals("wizExportDate"))
+         .findFirst().orElseThrow();
+      assertTrue(((TextVSAssemblyInfo) date.getInfo()).getText().startsWith("Generated "),
+         "date line: " + ((TextVSAssemblyInfo) date.getInfo()).getText());
+
+      VSEditableAssemblyLayout summary = texts.stream().filter(t -> t.getName().equals("wizExportSummary"))
+         .findFirst().orElseThrow();
+      String summaryText = ((TextVSAssemblyInfo) summary.getInfo()).getText();
+      assertTrue(summaryText.contains("Premium units run the business"), "recap kept: " + summaryText);
+      assertFalse(summaryText.contains("**"), "recap markdown stripped: " + summaryText);
+   }
+
+   @Test
+   void generatedDateLineIsHumanReadable() {
+      assertTrue(new WizPrintLayoutBuilder().generatedDateLine().matches("Generated \\w+ \\d{1,2}, \\d{4}"),
+         "expected e.g. 'Generated July 21, 2026'");
    }
 
    @Test
@@ -198,6 +242,7 @@ class WizPrintLayoutBuilderTest {
 
       long editableTextBlocks = layout.getVSAssemblyLayouts().stream()
          .filter(l -> l instanceof VSEditableAssemblyLayout).count();
-      assertEquals(2, editableTextBlocks, "the 3-arg compatibility constructor omits insights");
+      // null recap -> report header is title + date only (no summary box), + caption = 3
+      assertEquals(3, editableTextBlocks, "the 3-arg compatibility constructor omits insights");
    }
 }

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
@@ -17,7 +17,7 @@
  */
 package inetsoft.report.io.viewsheet;
 
-import inetsoft.web.wiz.service.MarkdownPlainText;
+import inetsoft.web.wiz.service.MarkdownModel;
 import inetsoft.web.wiz.service.PptxDeckMerger;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
 import org.apache.poi.xslf.usermodel.XSLFSlide;
@@ -93,13 +93,15 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
       styleBox(titleBox, true, TITLE_FONT_PT, ACCENT);
 
       if(recap != null && !recap.isBlank()) {
-         // Strip markdown so the recap reads as clean prose (it is authored as markdown, like the
-         // per-chart insights) rather than showing raw ** / - / # syntax on the cover slide.
+         // Render the recap's markdown (headers/bullets/bold/italic) as styled paragraphs+runs
+         // rather than stripping it to plain text. Short enough to fit the cover box.
          XSLFTextBox recapBox = slide.createTextBox();
          recapBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT + 130,
             SLIDE_WIDTH_PT - 2 * MARGIN_PT, SLIDE_HEIGHT_PT - 2 * MARGIN_PT - 130));
-         recapBox.setText(MarkdownPlainText.strip(recap));
-         styleBox(recapBox, false, RECAP_FONT_PT, BODY_COLOR);
+
+         for(MarkdownModel.Block block : MarkdownModel.parse(recap)) {
+            appendBlock(recapBox, block, RECAP_FONT_PT);
+         }
       }
    }
 
@@ -131,20 +133,128 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
       box.setText("Failed to render: " + (title == null ? "" : title));
    }
 
-   /** Appends one or more insights-only slides (no chart image, just a text box near the full
-    *  slide) so long insights are never truncated — each slide holds as much stripped text as
-    *  fits per {@link #chunkInsightsText}. */
+   /** Appends one or more insights-only slides, rendering the insights markdown as styled
+    *  paragraphs/bullets/headers (bold + italic runs preserved). Blocks are packed onto slides by
+    *  estimated height so nothing is truncated; a single block taller than a whole slide falls
+    *  back to a plain word-split across slides. */
    private void addInsightsSlides(XMLSlideShow show, String insightsMarkdown) {
-      String stripped = MarkdownPlainText.strip(insightsMarkdown);
+      List<MarkdownModel.Block> blocks = MarkdownModel.parse(insightsMarkdown);
 
-      for(String chunk : chunkInsightsText(stripped)) {
+      if(blocks.isEmpty()) {
+         return;
+      }
+
+      double boxWidthPt = SLIDE_WIDTH_PT - 2 * MARGIN_PT;
+      double boxHeightPt = SLIDE_HEIGHT_PT - 2 * MARGIN_PT;
+
+      List<List<MarkdownModel.Block>> pages = new ArrayList<>();
+      List<MarkdownModel.Block> current = new ArrayList<>();
+      double used = 0;
+
+      for(MarkdownModel.Block block : blocks) {
+         double h = estimateBlockHeightPt(block, boxWidthPt);
+
+         if(h > boxHeightPt) {
+            // Pathological single block taller than a slide: flush, then split its plain text.
+            if(!current.isEmpty()) {
+               pages.add(current);
+               current = new ArrayList<>();
+               used = 0;
+            }
+
+            for(String chunk : chunkInsightsText(block.plainText())) {
+               pages.add(List.of(new MarkdownModel.Block(MarkdownModel.BlockType.PARAGRAPH, 0,
+                  List.of(new MarkdownModel.Span(chunk, false, false)))));
+            }
+
+            continue;
+         }
+
+         if(used + h > boxHeightPt && !current.isEmpty()) {
+            pages.add(current);
+            current = new ArrayList<>();
+            used = 0;
+         }
+
+         current.add(block);
+         used += h;
+      }
+
+      if(!current.isEmpty()) {
+         pages.add(current);
+      }
+
+      for(List<MarkdownModel.Block> pageBlocks : pages) {
          XSLFSlide slide = show.createSlide();
          XSLFTextBox box = slide.createTextBox();
          box.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT,
             SLIDE_WIDTH_PT - 2 * MARGIN_PT, SLIDE_HEIGHT_PT - 2 * MARGIN_PT));
-         XSLFTextRun run = box.setText(chunk);
-         run.setFontSize(INSIGHTS_FONT_SIZE_PT);
+
+         for(MarkdownModel.Block block : pageBlocks) {
+            appendBlock(box, block, INSIGHTS_FONT_SIZE_PT);
+         }
       }
+   }
+
+   /** Append one markdown block to a text box as a styled paragraph (with per-span bold/italic). */
+   private void appendBlock(XSLFTextBox box, MarkdownModel.Block block, double bodySize) {
+      XSLFTextParagraph p = box.addNewTextParagraph();
+      p.setSpaceAfter(6.0);
+
+      switch(block.type()) {
+      case HEADING:
+         appendSpans(p, block.spans(), headingFontPt(block.level(), bodySize), ACCENT, true);
+         break;
+      case BULLET:
+         p.setLeftMargin(20.0);
+         p.setIndent(-14.0);
+         XSLFTextRun bullet = p.addNewTextRun();
+         bullet.setText("•  ");
+         bullet.setFontSize(bodySize);
+         bullet.setFontColor(ACCENT);
+         bullet.setBold(true);
+         appendSpans(p, block.spans(), bodySize, BODY_COLOR, false);
+         break;
+      default:
+         appendSpans(p, block.spans(), bodySize, BODY_COLOR, false);
+      }
+   }
+
+   private void appendSpans(XSLFTextParagraph p, List<MarkdownModel.Span> spans, double size,
+                            Color color, boolean forceBold)
+   {
+      for(MarkdownModel.Span span : spans) {
+         if(span.text().isEmpty()) {
+            continue;
+         }
+
+         XSLFTextRun run = p.addNewTextRun();
+         run.setText(span.text());
+         run.setFontSize(size);
+         run.setFontColor(color);
+         run.setBold(forceBold || span.bold());
+         run.setItalic(span.italic());
+      }
+   }
+
+   private double headingFontPt(int level, double bodySize) {
+      return Math.max(bodySize + 2, 26 - Math.max(0, level - 1) * 3);
+   }
+
+   private double estimateBlockHeightPt(MarkdownModel.Block block, double boxWidthPt) {
+      double fontPt = block.type() == MarkdownModel.BlockType.HEADING
+         ? headingFontPt(block.level(), INSIGHTS_FONT_SIZE_PT) : INSIGHTS_FONT_SIZE_PT;
+      Font font = new Font(Font.SANS_SERIF, Font.PLAIN, (int) Math.round(fontPt));
+      BufferedImage measuring = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+      Graphics2D g = measuring.createGraphics();
+      FontMetrics fm = g.getFontMetrics(font);
+      g.dispose();
+
+      double avgCharWidthPt = fm.stringWidth("abcdefghijklmnopqrstuvwxyz") / 26.0;
+      double usableWidth = block.type() == MarkdownModel.BlockType.BULLET ? boxWidthPt - 20 : boxWidthPt;
+      int charsPerLine = Math.max(1, (int) (usableWidth / avgCharWidthPt));
+      int lines = Math.max(1, (int) Math.ceil(block.plainText().length() / (double) charsPerLine));
+      return lines * fm.getHeight() + BLOCK_SPACING_PT;
    }
 
    /** Estimates a per-slide character budget from real font metrics (measured headlessly via
@@ -201,4 +311,5 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
    private static final double TITLE_FONT_PT = 34.0;
    private static final double RECAP_FONT_PT = 17.0;
    private static final double CAPTION_FONT_PT = 22.0;
+   private static final double BLOCK_SPACING_PT = 8.0;   // approx paragraph gap for height estimation
 }

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
@@ -74,7 +74,7 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
             }
 
             if(slide.insightsMarkdown() != null && !slide.insightsMarkdown().isBlank()) {
-               addInsightsSlides(merged, slide.insightsMarkdown());
+               addInsightsSlides(merged, slide.title(), slide.insightsMarkdown());
             }
          }
 
@@ -136,8 +136,11 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
    /** Appends one or more insights-only slides, rendering the insights markdown as styled
     *  paragraphs/bullets/headers (bold + italic runs preserved). Blocks are packed onto slides by
     *  estimated height so nothing is truncated; a single block taller than a whole slide falls
-    *  back to a plain word-split across slides. */
-   private void addInsightsSlides(XMLSlideShow show, String insightsMarkdown) {
+    *  back to a plain word-split across slides. Every insights slide carries a title identifying
+    *  the chart it belongs to ("Insights: <chart title>", or bare "Insights" with no chart
+    *  title); slides after the first for the same chart append " (cont'd)" so it's clear a
+    *  continuation slide is still the same chart's insights, not a new topic. */
+   private void addInsightsSlides(XMLSlideShow show, String chartTitle, String insightsMarkdown) {
       List<MarkdownModel.Block> blocks = MarkdownModel.parse(insightsMarkdown);
 
       if(blocks.isEmpty()) {
@@ -145,7 +148,9 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
       }
 
       double boxWidthPt = SLIDE_WIDTH_PT - 2 * MARGIN_PT;
-      double boxHeightPt = SLIDE_HEIGHT_PT - 2 * MARGIN_PT;
+      // Content budget shrinks by the title box's reserved height: the title now occupies space
+      // the content box used to have exclusive use of.
+      double boxHeightPt = SLIDE_HEIGHT_PT - 2 * MARGIN_PT - INSIGHTS_TITLE_HEIGHT_PT;
 
       List<List<MarkdownModel.Block>> pages = new ArrayList<>();
       List<MarkdownModel.Block> current = new ArrayList<>();
@@ -184,16 +189,30 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
          pages.add(current);
       }
 
-      for(List<MarkdownModel.Block> pageBlocks : pages) {
-         XSLFSlide slide = show.createSlide();
-         XSLFTextBox box = slide.createTextBox();
-         box.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT,
-            SLIDE_WIDTH_PT - 2 * MARGIN_PT, SLIDE_HEIGHT_PT - 2 * MARGIN_PT));
+      String heading = chartTitle == null || chartTitle.isBlank()
+         ? "Insights" : "Insights: " + chartTitle;
 
-         for(MarkdownModel.Block block : pageBlocks) {
+      for(int i = 0; i < pages.size(); i++) {
+         XSLFSlide slide = show.createSlide();
+         addInsightsTitle(slide, i == 0 ? heading : heading + " (cont'd)");
+
+         XSLFTextBox box = slide.createTextBox();
+         box.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT + INSIGHTS_TITLE_HEIGHT_PT,
+            boxWidthPt, boxHeightPt));
+
+         for(MarkdownModel.Block block : pages.get(i)) {
             appendBlock(box, block, INSIGHTS_FONT_SIZE_PT);
          }
       }
+   }
+
+   /** Title box for an insights-only slide, styled like the chart caption boxes (bold, ACCENT). */
+   private void addInsightsTitle(XSLFSlide slide, String text) {
+      XSLFTextBox titleBox = slide.createTextBox();
+      titleBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT,
+         SLIDE_WIDTH_PT - 2 * MARGIN_PT, INSIGHTS_TITLE_HEIGHT_PT));
+      titleBox.setText(text);
+      styleBox(titleBox, true, INSIGHTS_TITLE_FONT_PT, ACCENT);
    }
 
    /** Append one markdown block to a text box as a styled paragraph (with per-span bold/italic). */
@@ -312,4 +331,6 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
    private static final double RECAP_FONT_PT = 17.0;
    private static final double CAPTION_FONT_PT = 22.0;
    private static final double BLOCK_SPACING_PT = 8.0;   // approx paragraph gap for height estimation
+   private static final double INSIGHTS_TITLE_FONT_PT = 22.0;
+   private static final int INSIGHTS_TITLE_HEIGHT_PT = 40;
 }

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
@@ -22,8 +22,10 @@ import inetsoft.web.wiz.service.PptxDeckMerger;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
 import org.apache.poi.xslf.usermodel.XSLFSlide;
 import org.apache.poi.xslf.usermodel.XSLFTextBox;
+import org.apache.poi.xslf.usermodel.XSLFTextParagraph;
 import org.apache.poi.xslf.usermodel.XSLFTextRun;
 
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
@@ -86,24 +88,40 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
       XSLFSlide slide = show.createSlide();
       XSLFTextBox titleBox = slide.createTextBox();
       titleBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT,
-         SLIDE_WIDTH_PT - 2 * MARGIN_PT, 80));
-      titleBox.setText(title == null ? "" : title);
+         SLIDE_WIDTH_PT - 2 * MARGIN_PT, 120));
+      titleBox.setText(title == null || title.isBlank() ? "Analysis Report" : title);
+      styleBox(titleBox, true, TITLE_FONT_PT, ACCENT);
 
       if(recap != null && !recap.isBlank()) {
+         // Strip markdown so the recap reads as clean prose (it is authored as markdown, like the
+         // per-chart insights) rather than showing raw ** / - / # syntax on the cover slide.
          XSLFTextBox recapBox = slide.createTextBox();
-         recapBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT + 90,
-            SLIDE_WIDTH_PT - 2 * MARGIN_PT, SLIDE_HEIGHT_PT - 2 * MARGIN_PT - 90));
-         recapBox.setText(recap);
+         recapBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT + 130,
+            SLIDE_WIDTH_PT - 2 * MARGIN_PT, SLIDE_HEIGHT_PT - 2 * MARGIN_PT - 130));
+         recapBox.setText(MarkdownPlainText.strip(recap));
+         styleBox(recapBox, false, RECAP_FONT_PT, BODY_COLOR);
       }
    }
 
    private void addCaption(XSLFSlide slide, String title, String caption) {
       XSLFTextBox captionBox = slide.createTextBox();
       captionBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT / 2.0,
-         SLIDE_WIDTH_PT - 2 * MARGIN_PT, 40));
+         SLIDE_WIDTH_PT - 2 * MARGIN_PT, 44));
       String text = (title == null ? "" : title) +
          (caption != null && !caption.isBlank() ? " — " + caption : "");
       captionBox.setText(text);
+      styleBox(captionBox, true, CAPTION_FONT_PT, ACCENT);
+   }
+
+   /** Apply a uniform bold/size/color to every run in every paragraph of a text box. */
+   private void styleBox(XSLFTextBox box, boolean bold, double fontSize, Color color) {
+      for(XSLFTextParagraph paragraph : box.getTextParagraphs()) {
+         for(XSLFTextRun run : paragraph.getTextRuns()) {
+            run.setBold(bold);
+            run.setFontSize(fontSize);
+            run.setFontColor(color);
+         }
+      }
    }
 
    private void addFailurePlaceholder(XSLFSlide slide, String title) {
@@ -176,4 +194,11 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
    private static final int SLIDE_HEIGHT_PT = 540;
    private static final int MARGIN_PT = 40;
    private static final double INSIGHTS_FONT_SIZE_PT = 16.0;
+   // Slate-blue accent (matches the chart palette + the PDF report), used for the cover title and
+   // per-slide captions; recap/body stays a dark near-black.
+   private static final Color ACCENT = new Color(0x3B6EA5);
+   private static final Color BODY_COLOR = new Color(0x2B2B2B);
+   private static final double TITLE_FONT_PT = 34.0;
+   private static final double RECAP_FONT_PT = 17.0;
+   private static final double CAPTION_FONT_PT = 22.0;
 }

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
@@ -290,7 +290,7 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
       g.dispose();
 
       double boxWidthPt = SLIDE_WIDTH_PT - 2 * MARGIN_PT;
-      double boxHeightPt = SLIDE_HEIGHT_PT - 2 * MARGIN_PT;
+      double boxHeightPt = SLIDE_HEIGHT_PT - 2 * MARGIN_PT - INSIGHTS_TITLE_HEIGHT_PT;
       double avgCharWidthPt = fm.stringWidth("abcdefghijklmnopqrstuvwxyz") / 26.0;
       int charsPerLine = Math.max(1, (int) (boxWidthPt / avgCharWidthPt));
       int linesPerSlide = Math.max(1, (int) (boxHeightPt / fm.getHeight()));

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
@@ -103,6 +103,44 @@ class PoiPptxDeckMergerTest {
    }
 
    @Test
+   void titleSlideRecapPreservesBoldRunsAndBulletMarkers() throws Exception {
+      byte[] merged = merger.mergeSlides("Board",
+         "**Bold lead.** then normal text.\n- a bullet point", List.of());
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         boolean hasBoldLead = false;
+         boolean hasNormal = false;
+         boolean hasBulletMarker = false;
+
+         for(var shape : result.getSlides().get(0).getShapes()) {
+            if(shape instanceof XSLFTextBox tb) {
+               for(var paragraph : tb.getTextParagraphs()) {
+                  for(var run : paragraph.getTextRuns()) {
+                     String t = run.getRawText();
+
+                     if(t.contains("Bold lead") && run.isBold()) {
+                        hasBoldLead = true;
+                     }
+
+                     if(t.contains("normal text") && !run.isBold()) {
+                        hasNormal = true;
+                     }
+
+                     if(t.contains("•")) {
+                        hasBulletMarker = true;
+                     }
+                  }
+               }
+            }
+         }
+
+         assertTrue(hasBoldLead, "bold lead-in preserved as a bold run");
+         assertTrue(hasNormal, "trailing prose stays non-bold");
+         assertTrue(hasBulletMarker, "bullet marker rendered");
+      }
+   }
+
+   @Test
    void failedChartGetsPlaceholderSlideInsteadOfImportedContent() throws Exception {
       List<PptxDeckMerger.ChartSlide> slides = List.of(
          new PptxDeckMerger.ChartSlide("Broken", "n/a", null, true)

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
@@ -59,6 +59,18 @@ class PoiPptxDeckMergerTest {
       return sb.toString();
    }
 
+   /** Concatenates text from every textbox on the slide EXCEPT one starting with "Insights"
+    *  (the title box this feature adds) — lets tests assert on body content in isolation. */
+   private static String contentTextExcludingInsightsTitle(XSLFSlide slide) {
+      StringBuilder sb = new StringBuilder();
+      slide.getShapes().forEach(s -> {
+         if(s instanceof XSLFTextBox tb && !tb.getText().startsWith("Insights")) {
+            sb.append(tb.getText()).append('\n');
+         }
+      });
+      return sb.toString();
+   }
+
    @Test
    void mergesTitleSlidePlusOnePerChart() throws Exception {
       byte[] chart1 = oneSlideDeckWithText("CHART_ONE_MARKER");
@@ -213,7 +225,7 @@ class PoiPptxDeckMergerTest {
 
          int totalWords = 0;
          for(int i = 2; i < result.getSlides().size(); i++) {
-            String text = allText(result.getSlides().get(i)).trim();
+            String text = contentTextExcludingInsightsTitle(result.getSlides().get(i)).trim();
             assertTrue(text.matches("(WORD ?)+"),
                "slide " + i + " must contain only whole WORD tokens, got: " + text);
             totalWords += text.split("\\s+").length;
@@ -233,6 +245,66 @@ class PoiPptxDeckMergerTest {
       try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
          assertEquals(3, result.getSlides().size(), "title + placeholder + insights slide");
          assertTrue(allText(result.getSlides().get(2)).contains("Finding survives despite the render failure."));
+      }
+   }
+
+   @Test
+   void insightsSlideTitledWithChartName() throws Exception {
+      byte[] chart1 = oneSlideDeckWithText("CHART_MARKER");
+      List<PptxDeckMerger.ChartSlide> slides = List.of(
+         new PptxDeckMerger.ChartSlide("Revenue by Region", "cap", chart1, false,
+            "Premium pricing drives most of the category revenue.")
+      );
+
+      byte[] merged = merger.mergeSlides("Board", null, slides);
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         assertEquals(3, result.getSlides().size(), "title + chart + one insights slide");
+         String insightsText = allText(result.getSlides().get(2));
+         assertTrue(insightsText.contains("Insights: Revenue by Region"),
+            "insights slide titled with chart name: " + insightsText);
+         assertFalse(insightsText.contains("cont'd"), "single insights slide has no continuation marker");
+      }
+   }
+
+   @Test
+   void insightsSlideFallsBackToBareInsightsWhenChartHasNoTitle() throws Exception {
+      byte[] chart1 = oneSlideDeckWithText("CHART_MARKER");
+      List<PptxDeckMerger.ChartSlide> slides = List.of(
+         new PptxDeckMerger.ChartSlide(null, null, chart1, false, "A short finding.")
+      );
+
+      byte[] merged = merger.mergeSlides("Board", null, slides);
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         String insightsText = allText(result.getSlides().get(2));
+         assertTrue(insightsText.contains("Insights"), "bare Insights heading present: " + insightsText);
+         assertFalse(insightsText.contains("Insights:"), "no dangling colon with no title: " + insightsText);
+      }
+   }
+
+   @Test
+   void continuationInsightsSlidesMarkedContd() throws Exception {
+      byte[] chart1 = oneSlideDeckWithText("CHART_MARKER");
+      String longInsights = "WORD ".repeat(6000).trim();
+      List<PptxDeckMerger.ChartSlide> slides = List.of(
+         new PptxDeckMerger.ChartSlide("Revenue by Region", "cap", chart1, false, longInsights)
+      );
+
+      byte[] merged = merger.mergeSlides("Board", null, slides);
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         assertTrue(result.getSlides().size() > 3, "must span more than one insights slide");
+
+         String firstInsightsText = allText(result.getSlides().get(2));
+         assertTrue(firstInsightsText.contains("Insights: Revenue by Region"));
+         assertFalse(firstInsightsText.contains("cont'd"), "first insights slide has no continuation marker");
+
+         for(int i = 3; i < result.getSlides().size(); i++) {
+            String text = allText(result.getSlides().get(i));
+            assertTrue(text.contains("Insights: Revenue by Region (cont'd)"),
+               "slide " + i + " must carry the continuation title: " + text);
+         }
       }
    }
 }

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
@@ -88,6 +88,21 @@ class PoiPptxDeckMergerTest {
    }
 
    @Test
+   void titleSlideRecapIsMarkdownStripped() throws Exception {
+      byte[] merged = merger.mergeSlides("Q39 Board",
+         "**Premium units run the business.** The $1,500+ band is ~69%.\n- top band in every category", List.of());
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         String titleSlideText = allText(result.getSlides().get(0));
+         assertTrue(titleSlideText.contains("Premium units run the business."),
+            "recap text kept: " + titleSlideText);
+         assertFalse(titleSlideText.contains("**"), "raw markdown emphasis stripped: " + titleSlideText);
+         assertTrue(titleSlideText.contains("top band in every category"), "bullet text kept: " + titleSlideText);
+         assertFalse(titleSlideText.contains("- top band"), "raw bullet dash stripped: " + titleSlideText);
+      }
+   }
+
+   @Test
    void failedChartGetsPlaceholderSlideInsteadOfImportedContent() throws Exception {
       List<PptxDeckMerger.ChartSlide> slides = List.of(
          new PptxDeckMerger.ChartSlide("Broken", "n/a", null, true)


### PR DESCRIPTION
## Summary
- Heal treemap-family charts whose hierarchy dims land on X / an empty group slot (both at runtime and when built), so the board-export path doesn't render them broken.
- Fix `PrintLayout.scaleFont` defaulting to 0 in the board-export print layout, which zeroed out crosstab/table cell fonts.
- Add a report-style header (title, date, recap) to the board PDF export, then style it with the slate-blue accent used elsewhere, then render its markdown with full formatting via a `MarkdownPresenter` (not just plain text).
- Title PPTX insights-only slides with the chart they belong to (`"Insights: <chart title>"`, `" (cont'd)"` on overflow) — previously these slides had no heading, making it unclear which chart a floating insights slide was for once separated from its chart's own captioned slide.

## Test plan
- [x] `PoiPptxDeckMergerTest` (12/12 passing) — new/updated coverage for insights-slide titles, no-title fallback, and multi-slide continuation markers
- [x] `WizPrintLayoutBuilderTest`, `MarkdownModelTest`, `MarkdownPresenterTest` (existing suites, unaffected by the final two commits)
- [x] Live E2E: rebuilt local image, exported a real board as PPTX via the viz-chat plugin tools, confirmed insights slide titles render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)