### PR TITLE
feat(export): title PPTX insights slides with the chart they belong to

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
@@ -74,7 +74,7 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
             }
 
             if(slide.insightsMarkdown() != null && !slide.insightsMarkdown().isBlank()) {
-               addInsightsSlides(merged, slide.insightsMarkdown());
+               addInsightsSlides(merged, slide.title(), slide.insightsMarkdown());
             }
          }
 
@@ -136,8 +136,11 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
    /** Appends one or more insights-only slides, rendering the insights markdown as styled
     *  paragraphs/bullets/headers (bold + italic runs preserved). Blocks are packed onto slides by
     *  estimated height so nothing is truncated; a single block taller than a whole slide falls
-    *  back to a plain word-split across slides. */
-   private void addInsightsSlides(XMLSlideShow show, String insightsMarkdown) {
+    *  back to a plain word-split across slides. Every insights slide carries a title identifying
+    *  the chart it belongs to ("Insights: <chart title>", or bare "Insights" with no chart
+    *  title); slides after the first for the same chart append " (cont'd)" so it's clear a
+    *  continuation slide is still the same chart's insights, not a new topic. */
+   private void addInsightsSlides(XMLSlideShow show, String chartTitle, String insightsMarkdown) {
       List<MarkdownModel.Block> blocks = MarkdownModel.parse(insightsMarkdown);
 
       if(blocks.isEmpty()) {
@@ -145,7 +148,9 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
       }
 
       double boxWidthPt = SLIDE_WIDTH_PT - 2 * MARGIN_PT;
-      double boxHeightPt = SLIDE_HEIGHT_PT - 2 * MARGIN_PT;
+      // Content budget shrinks by the title box's reserved height: the title now occupies space
+      // the content box used to have exclusive use of.
+      double boxHeightPt = SLIDE_HEIGHT_PT - 2 * MARGIN_PT - INSIGHTS_TITLE_HEIGHT_PT;
 
       List<List<MarkdownModel.Block>> pages = new ArrayList<>();
       List<MarkdownModel.Block> current = new ArrayList<>();
@@ -184,16 +189,30 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
          pages.add(current);
       }
 
-      for(List<MarkdownModel.Block> pageBlocks : pages) {
-         XSLFSlide slide = show.createSlide();
-         XSLFTextBox box = slide.createTextBox();
-         box.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT,
-            SLIDE_WIDTH_PT - 2 * MARGIN_PT, SLIDE_HEIGHT_PT - 2 * MARGIN_PT));
+      String heading = chartTitle == null || chartTitle.isBlank()
+         ? "Insights" : "Insights: " + chartTitle;
 
-         for(MarkdownModel.Block block : pageBlocks) {
+      for(int i = 0; i < pages.size(); i++) {
+         XSLFSlide slide = show.createSlide();
+         addInsightsTitle(slide, i == 0 ? heading : heading + " (cont'd)");
+
+         XSLFTextBox box = slide.createTextBox();
+         box.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT + INSIGHTS_TITLE_HEIGHT_PT,
+            boxWidthPt, boxHeightPt));
+
+         for(MarkdownModel.Block block : pages.get(i)) {
             appendBlock(box, block, INSIGHTS_FONT_SIZE_PT);
          }
       }
+   }
+
+   /** Title box for an insights-only slide, styled like the chart caption boxes (bold, ACCENT). */
+   private void addInsightsTitle(XSLFSlide slide, String text) {
+      XSLFTextBox titleBox = slide.createTextBox();
+      titleBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT,
+         SLIDE_WIDTH_PT - 2 * MARGIN_PT, INSIGHTS_TITLE_HEIGHT_PT));
+      titleBox.setText(text);
+      styleBox(titleBox, true, INSIGHTS_TITLE_FONT_PT, ACCENT);
    }
 
    /** Append one markdown block to a text box as a styled paragraph (with per-span bold/italic). */
@@ -312,4 +331,6 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
    private static final double RECAP_FONT_PT = 17.0;
    private static final double CAPTION_FONT_PT = 22.0;
    private static final double BLOCK_SPACING_PT = 8.0;   // approx paragraph gap for height estimation
+   private static final double INSIGHTS_TITLE_FONT_PT = 22.0;
+   private static final int INSIGHTS_TITLE_HEIGHT_PT = 40;
 }

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
@@ -290,7 +290,7 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
       g.dispose();
 
       double boxWidthPt = SLIDE_WIDTH_PT - 2 * MARGIN_PT;
-      double boxHeightPt = SLIDE_HEIGHT_PT - 2 * MARGIN_PT;
+      double boxHeightPt = SLIDE_HEIGHT_PT - 2 * MARGIN_PT - INSIGHTS_TITLE_HEIGHT_PT;
       double avgCharWidthPt = fm.stringWidth("abcdefghijklmnopqrstuvwxyz") / 26.0;
       int charsPerLine = Math.max(1, (int) (boxWidthPt / avgCharWidthPt));
       int linesPerSlide = Math.max(1, (int) (boxHeightPt / fm.getHeight()));

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
@@ -59,6 +59,18 @@ class PoiPptxDeckMergerTest {
       return sb.toString();
    }
 
+   /** Concatenates text from every textbox on the slide EXCEPT one starting with "Insights"
+    *  (the title box this feature adds) — lets tests assert on body content in isolation. */
+   private static String contentTextExcludingInsightsTitle(XSLFSlide slide) {
+      StringBuilder sb = new StringBuilder();
+      slide.getShapes().forEach(s -> {
+         if(s instanceof XSLFTextBox tb && !tb.getText().startsWith("Insights")) {
+            sb.append(tb.getText()).append('\n');
+         }
+      });
+      return sb.toString();
+   }
+
    @Test
    void mergesTitleSlidePlusOnePerChart() throws Exception {
       byte[] chart1 = oneSlideDeckWithText("CHART_ONE_MARKER");
@@ -213,7 +225,7 @@ class PoiPptxDeckMergerTest {
 
          int totalWords = 0;
          for(int i = 2; i < result.getSlides().size(); i++) {
-            String text = allText(result.getSlides().get(i)).trim();
+            String text = contentTextExcludingInsightsTitle(result.getSlides().get(i)).trim();
             assertTrue(text.matches("(WORD ?)+"),
                "slide " + i + " must contain only whole WORD tokens, got: " + text);
             totalWords += text.split("\\s+").length;
@@ -233,6 +245,66 @@ class PoiPptxDeckMergerTest {
       try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
          assertEquals(3, result.getSlides().size(), "title + placeholder + insights slide");
          assertTrue(allText(result.getSlides().get(2)).contains("Finding survives despite the render failure."));
+      }
+   }
+
+   @Test
+   void insightsSlideTitledWithChartName() throws Exception {
+      byte[] chart1 = oneSlideDeckWithText("CHART_MARKER");
+      List<PptxDeckMerger.ChartSlide> slides = List.of(
+         new PptxDeckMerger.ChartSlide("Revenue by Region", "cap", chart1, false,
+            "Premium pricing drives most of the category revenue.")
+      );
+
+      byte[] merged = merger.mergeSlides("Board", null, slides);
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         assertEquals(3, result.getSlides().size(), "title + chart + one insights slide");
+         String insightsText = allText(result.getSlides().get(2));
+         assertTrue(insightsText.contains("Insights: Revenue by Region"),
+            "insights slide titled with chart name: " + insightsText);
+         assertFalse(insightsText.contains("cont'd"), "single insights slide has no continuation marker");
+      }
+   }
+
+   @Test
+   void insightsSlideFallsBackToBareInsightsWhenChartHasNoTitle() throws Exception {
+      byte[] chart1 = oneSlideDeckWithText("CHART_MARKER");
+      List<PptxDeckMerger.ChartSlide> slides = List.of(
+         new PptxDeckMerger.ChartSlide(null, null, chart1, false, "A short finding.")
+      );
+
+      byte[] merged = merger.mergeSlides("Board", null, slides);
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         String insightsText = allText(result.getSlides().get(2));
+         assertTrue(insightsText.contains("Insights"), "bare Insights heading present: " + insightsText);
+         assertFalse(insightsText.contains("Insights:"), "no dangling colon with no title: " + insightsText);
+      }
+   }
+
+   @Test
+   void continuationInsightsSlidesMarkedContd() throws Exception {
+      byte[] chart1 = oneSlideDeckWithText("CHART_MARKER");
+      String longInsights = "WORD ".repeat(6000).trim();
+      List<PptxDeckMerger.ChartSlide> slides = List.of(
+         new PptxDeckMerger.ChartSlide("Revenue by Region", "cap", chart1, false, longInsights)
+      );
+
+      byte[] merged = merger.mergeSlides("Board", null, slides);
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         assertTrue(result.getSlides().size() > 3, "must span more than one insights slide");
+
+         String firstInsightsText = allText(result.getSlides().get(2));
+         assertTrue(firstInsightsText.contains("Insights: Revenue by Region"));
+         assertFalse(firstInsightsText.contains("cont'd"), "first insights slide has no continuation marker");
+
+         for(int i = 3; i < result.getSlides().size(); i++) {
+            String text = allText(result.getSlides().get(i));
+            assertTrue(text.contains("Insights: Revenue by Region (cont'd)"),
+               "slide " + i + " must carry the continuation title: " + text);
+         }
       }
    }
 }


### PR DESCRIPTION
## Summary
- Insights-only slides in the native PPTX board export previously had no heading, making it unclear which chart a floating insights slide was for once separated from its chart's own captioned slide.
- Each insights slide now reads `"Insights: <chart title>"` (or bare `"Insights"` if the chart has no title), with `" (cont'd)"` appended on continuation slides when insights overflow.
- Includes a follow-up fix: the long-single-block chunking fallback (`chunkInsightsText`) wasn't accounting for the new title box's reserved height, so it could size chunks against the full slide height and overrun the (now title-shortened) content box.

Design: `docs/superpowers/specs/2026-07-21-pptx-insights-slide-title-design.md` and plan: `docs/superpowers/plans/2026-07-21-pptx-insights-slide-title.md` in the `stylebi-wiz` repo.

## Test plan
- [x] `PoiPptxDeckMergerTest` — 12/12 passing (3 new tests: chart-title heading, no-title fallback, multi-slide continuation marker; 1 existing test updated to isolate body content from the new title box)
- [x] Live E2E: rebuilt local StyleBI image, exported a real board as PPTX via the viz-chat plugin tools, confirmed insights slide titles render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)