### PR TITLE
Bug #75738, unwrap CalcRef so calc-table $name references resolve to their values

### DIFF
--- a/core/src/main/java/inetsoft/util/script/ScriptUtil.java
+++ b/core/src/main/java/inetsoft/util/script/ScriptUtil.java
@@ -63,6 +63,22 @@ public class ScriptUtil {
          return ((inetsoft.report.script.TableArray) obj).unwrap();
       }
 
+      // Likewise for a CalcRef (the calc-table $name cell reference). It too was
+      // a Rhino Scriptable/Wrapper whose getDefaultValue() coerced it to its
+      // referenced cell value whenever host code consumed it as data. Under
+      // GraalJS the guest->host boundary (ScriptValueConverter.toHost) preserves
+      // the live CalcRef so indexing/spec access ($name['*'], $name[-1]) still
+      // works, but host utilities that treat a value as plain data (JSObject
+      // .split/convert/splitN, called from CALC aggregates like sum($x)/
+      // nthLargest($x)) go through this unwrap first. Resolve it here to its
+      // referenced value (a scalar or an Object[] of cell values) so those
+      // utilities see real data instead of falling back to Object.toString()
+      // (which produced "...CalcRef@<hash>" for a bare ref and 0 for numeric
+      // aggregates). (#75738)
+      if(obj instanceof inetsoft.report.script.formula.CalcRef) {
+         return ((inetsoft.report.script.formula.CalcRef) obj).unwrap();
+      }
+
       // @by larryl, if a calculation generates an invalid result, show null
       // instead of NaN of Infinity. This can be caused by performing a time
       // series comparison and the result fo the first or last item would

--- a/core/src/test/java/inetsoft/report/script/formula/CalcRefTest.java
+++ b/core/src/test/java/inetsoft/report/script/formula/CalcRefTest.java
@@ -222,6 +222,69 @@ public class CalcRefTest {
    }
 
 
+   /**
+    * Bug #75738: when a $name reference is consumed as plain data by host
+    * utilities (JSObject.split/splitN, called from CALC aggregates such as
+    * sum($x)/nthLargest($x)), ScriptUtil.unwrap must resolve the live CalcRef to
+    * its referenced scalar value instead of leaving the wrapper to fall back to
+    * Object.toString() (which produced "...CalcRef@<hash>" and 0).
+    */
+   @Test
+   void testScriptUtilUnwrapScalarRef() {
+      FormulaContext.pushCellLocation(point0);
+
+      try {
+         when(mockRuntimeCalcTableLens.getCellContext(0, 0)).thenReturn(mockContext);
+         provideMockGroup(mockContext, "cell1", 1, 42.0);
+
+         calcRef = new CalcRef(mockRuntimeCalcTableLens, "cell1");
+
+         assertEquals(42.0, inetsoft.util.script.ScriptUtil.unwrap(calcRef));
+         // split() string-splits a scalar (Tool.split), so a numeric ref reads
+         // back as its string form; splitN then parses it to the real number so
+         // numeric aggregates (sum/average/...) compute correctly.
+         assertArrayEquals(new Object[] { "42.0" },
+                           inetsoft.util.script.JSObject.split(calcRef));
+         assertArrayEquals(new double[] { 42.0 },
+                           inetsoft.util.script.JSObject.splitN(calcRef));
+      }
+      finally {
+         FormulaContext.popCellLocation();
+      }
+   }
+
+   /**
+    * Bug #75738: an array-valued group reference (multiple cell locations) must
+    * unwrap to the underlying Object[] of cell values, so JSObject.split/splitN
+    * see real data. This is the case the issue's proposed CalcRef.toString()
+    * fix would have broken (String.valueOf(Object[]) yields "[Ljava...@<hash>").
+    */
+   @Test
+   void testScriptUtilUnwrapArrayRef() {
+      FormulaContext.pushCellLocation(point0);
+
+      try {
+         when(mockRuntimeCalcTableLens.getCellContext(0, 0)).thenReturn(mockContext);
+         // group == null so unwrap() falls to the cmap multi-location branch
+         when(mockContext.getGroup("cell1")).thenReturn(null);
+         CalcCellMap mockCalcCellMap = provideMockCalcCellMap("cell1", new Point[] { point0, point1 });
+         when(mockRuntimeCalcTableLens.getObject(0, 0)).thenReturn(100.0);
+         when(mockRuntimeCalcTableLens.getObject(1, 0)).thenReturn(200.0);
+
+         calcRef = new CalcRef(mockRuntimeCalcTableLens, "cell1");
+
+         assertArrayEquals(new Object[] { 100.0, 200.0 },
+                           (Object[]) inetsoft.util.script.ScriptUtil.unwrap(calcRef));
+         assertArrayEquals(new Object[] { 100.0, 200.0 },
+                           inetsoft.util.script.JSObject.split(calcRef));
+         assertArrayEquals(new double[] { 100.0, 200.0 },
+                           inetsoft.util.script.JSObject.splitN(calcRef));
+      }
+      finally {
+         FormulaContext.popCellLocation();
+      }
+   }
+
    private CalcCellMap provideMockCalcCellMap(String cellName, Point[] points) {
       CalcCellMap mockCalcCellMap = mock(CalcCellMap.class);
       when(mockRuntimeCalcTableLens.getCalcCellMap()).thenReturn(mockCalcCellMap);


### PR DESCRIPTION
## Summary

A freehand/calc-table viewsheet showed two errors after the Rhino → GraalJS script-engine migration (Feature #75423):

- **FTable1** — `sum($scid2)` and a percentage-ratio total rendered as `0` / `0%`.
- **FTable3** — `nthLargest($calc_city, 1)` rendered the raw object string `inetsoft.report.script.formula.CalcRef@<hash>`.

## Root Cause

A `$name` calc-table reference resolves to a live `CalcRef` (implements `ScriptArrayScope`). CALC aggregate functions route the argument through `ReportGraalJavaScriptEngine.summarize()` → `JavaScriptEngine.split()` → `JSObject.split()`, which first calls `JavaScriptEngine.unwrap()` → `ScriptUtil.unwrap()` to reduce a value to plain data.

`ScriptUtil.unwrap()` already resolves the sibling Rhino-`Wrapper` analogs `XTableArray` and `TableArray` to their underlying data, but had **no case for `CalcRef`**. So a `CalcRef` passed through untouched and hit `JSObject.split()`'s final fallback `Tool.split(str.toString(), ',')`, invoking `Object.toString()` → the object string; `splitN()` then produced `[0.0]`, making numeric aggregates evaluate to `0`.

Under Rhino this worked because `CalcRef` was a `Scriptable` whose `getDefaultValue()` was consulted when it was coerced to data — a hook lost in the migration and only partially restored before (#75593 for JS-side coercion, #75595 for the result boundary), neither of which covers host utilities consuming a `CalcRef` mid-evaluation.

## Fix

Add a `CalcRef` case to `ScriptUtil.unwrap()`, beside the existing `XTableArray`/`TableArray` handling, resolving it to its referenced value (scalar or `Object[]`). This fixes every host-utility consumer (`split`/`splitN`/`splitStr`/`convert`) uniformly, for **both** scalar and array-valued references.

Note: the alternative of overriding `CalcRef.toString()` (returning `String.valueOf(unwrap())`) was rejected — for an array-valued group reference `unwrap()` returns an `Object[]`, so `String.valueOf(Object[])` yields `[Ljava.lang.Object;@…`, i.e. still broken. Unwrapping at the data-resolution layer is correct for both cases.

## Side Effects

- The guest→host boundary (`ScriptValueConverter.toHost`) still returns the live `CalcRef` (via `arrayProxy.getScope()`) and does not route through `ScriptUtil.unwrap`, so `$name['*']`, `$name[-1]`, `$name['.']` indexing/spec access is unaffected.
- `PropertyDescriptor.convert(CalcRef|Object[], TableLens.class)` returns `null` in both cases, so `summarize()`'s `(TableLens)` cast is unaffected (no new ClassCastException).
- `CalcTableLens.unwrapCalcRefs()` (#75595, result-boundary unwrap) is independent and unaffected.

## Test Plan

- Added `CalcRefTest.testScriptUtilUnwrapScalarRef` and `testScriptUtilUnwrapArrayRef` covering scalar and array-valued references through `ScriptUtil.unwrap` / `JSObject.split` / `JSObject.splitN`.
- `./mvnw test -pl core -Dtest=CalcRefTest,CalcTableLensTest,CalcTableScopeTest` — all pass.
- Manually verified by importing `FreeExecute1.vso` on the portal: FTable1 totals compute correctly and FTable3 no longer shows the `CalcRef@…` object string.

Fixes Redmine #75738.