### PR TITLE
Bug #75728, return 404 for non-existent role in Get Role API

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/VirtualAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/VirtualAuthenticationProvider.java
@@ -66,6 +66,33 @@ public class VirtualAuthenticationProvider
    }
 
    /**
+    * Get a role object from the role ID. Only the roles defined by this virtual
+    * provider ({@link #getRoles()}) resolve to a non-null role; any other role
+    * identity returns {@code null}. This overrides the fabricating default in
+    * {@link AbstractAuthenticationProvider#getRole(IdentityID)} so that callers
+    * (e.g. the security API) can detect a non-existent role, consistent with
+    * {@link #getUser(IdentityID)}.
+    *
+    * @param roleIdentity the roleIdentity of the role.
+    *
+    * @return the named role object or {@code null} if no such role exists.
+    */
+   @Override
+   public Role getRole(IdentityID roleIdentity) {
+      if(roleIdentity == null) {
+         return null;
+      }
+
+      for(IdentityID role : getRoles()) {
+         if(role.equals(roleIdentity)) {
+            return new Role(roleIdentity);
+         }
+      }
+
+      return null;
+   }
+
+   /**
     * Check the authentication of specific entity.
     *
     * @param userIdentity the unique identification of the user.

--- a/core/src/test/java/inetsoft/sree/security/provider/VirtualAuthenticationProviderTest.java
+++ b/core/src/test/java/inetsoft/sree/security/provider/VirtualAuthenticationProviderTest.java
@@ -213,6 +213,36 @@ class VirtualAuthenticationProviderTest
    }
 
    // -----------------------------------------------------------------------
+   // getRole() — only getRoles() entries resolve; everything else is null
+   // (Bug #75728: unknown role names must resolve to null so the security API
+   //  can return 404 instead of a fabricated role)
+   // -----------------------------------------------------------------------
+
+   @Test
+   void getRole_existingRole_returnsRole() {
+      for(IdentityID roleId : provider.getRoles()) {
+         Role role = provider.getRole(roleId);
+         assertNotNull(role, "Known role must resolve to a non-null Role: " + roleId.name);
+         assertEquals(roleId, role.getIdentityID(),
+            "Returned role must carry the requested identity");
+      }
+   }
+
+   @Test
+   void getRole_nonExistentRole_returnsNull() {
+      IdentityID unknown =
+         new IdentityID("__no_such_role__", Organization.getDefaultOrganizationID());
+      assertNull(provider.getRole(unknown),
+         "Unknown role name must resolve to null (the bug #75728 fix)");
+   }
+
+   @Test
+   void getRole_nullIdentity_returnsNull() {
+      assertNull(provider.getRole(null),
+         "getRole(null) must return null without throwing");
+   }
+
+   // -----------------------------------------------------------------------
    // addUser() — admin is accepted; non-admin is silently dropped
    // Lines 264–269
    // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The public REST API `GET /api/public/security/roles/{rolename}` returned **HTTP 200** with a fabricated (empty) role object when queried for a **non-existent** role under default config (security disabled). It should return **404**.

## Root Cause

`SecurityApiService.getRole()` guards non-existent roles with `if(securityProvider.getRole(role) == null) throw new MissingResourceException(...)` (mapped to 404), mirroring `getUser`/`getGroup`. This relies on the provider returning `null` for a missing role.

However, `AbstractAuthenticationProvider.getRole()` returns `new Role(roleIdentity)` — a fabricated, non-null role for **any** name — contradicting its own Javadoc ("or `null` if no such role exists"). The concrete providers `FileAuthenticationProvider`, `DatabaseAuthenticationProvider`, and `LdapAuthenticationProvider` all override `getRole()` and correctly return `null`. The **only** runtime provider inheriting the fabricating default is `VirtualAuthenticationProvider`, which is active when security is disabled (the reported "default config"). As a result the null-guard never tripped and the API returned 200 with a synthesized empty role.

`getUser`/`getGroup` were unaffected because `VirtualAuthenticationProvider.getUser` returns `null` for unknown users and the inherited `getGroup` returns `null`.

## Fix

Override `getRole()` in `VirtualAuthenticationProvider` so it resolves only the roles the provider actually defines (`Everyone`, `Administrator` — the same set returned by its existing `getRoles()`) and returns `null` for any other role identity. This is consistent with how the provider already overrides `getUser`/`getUsers`/`getRoles`/`getOrganization`.

## Test Plan

- Start the server with default config (security disabled), authenticate as `admin` via the web API.
- **Security → Get Role** with a non-existent role name (e.g. `role1234`) → now returns **404** (previously 200).
- **Security → Get Role** with an existing role (e.g. `Administrator`) → still returns **200**.
- Regression: `getUser`/`getGroup` behavior unchanged; role resolution under security-disabled mode unchanged (known roles still resolve; all `getRole()` call sites already tolerate `null`, as File/DB/LDAP providers already return `null`).
- `mvnw clean install -pl core -am -DskipTests` → BUILD SUCCESS.
- Community `inetsoft.sree.security.*` test suite → 559 passed, 0 failures.

Fixes Redmine #75728.