### PR TITLE
Bug #75730, return not-found error for non-existent group in getGroupModel

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
@@ -558,6 +558,11 @@ public class UserTreeService {
 
       final Group group = currentProvider.getGroup(groupID);
 
+      if(group == null) {
+         throw new MessageException(Catalog.getCatalog().getString(
+            "em.security.groupNotFound", groupID.getName()));
+      }
+
       if(!OrganizationManager.getInstance().isSiteAdmin(principal)) {
          if(Arrays.stream(group.getRoles()).anyMatch(currentProvider::isSystemAdministratorRole)) {
             throw new MessageException(Catalog.getCatalog().getString("em.security.orgAdmin.identityPermissionDenied"));

--- a/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
@@ -572,7 +572,7 @@ public class UserTreeService {
       IdentityInfo info = identityService
          .getIdentityInfo(groupID, Identity.GROUP, currentProvider);
 
-      String org = group == null ? null : group.getOrganizationID();
+      String org = group.getOrganizationID();
       if(org == null || "".equals(org)) {
          org = Organization.getDefaultOrganizationID();
       }

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -4686,6 +4686,7 @@ em.security.ldap.serverDesc=The type of LDAP Server.
 em.security.ldap.userSearchBaseDesc=The base directory from which user searches will be performed.
 em.security.ldap.userSearchFilterDesc=The search filter used to find system users.
 em.security.userNotFound=User not found: {0}
+em.security.groupNotFound=Group not found: {0}
 em.security.multitenant.ldapNotCompatible=Multi-Tenancy is not compatible with LDAP.
 em.security.noOrgAdmin=Cannot delete selected identities. Organization administrator cannot be removed.
 em.security.noSystemAdmin=Cannot delete selected identities. The last system administrator cannot be removed.


### PR DESCRIPTION
## Summary

`UserTreeService.getGroupModel()` (backing `GET /api/em/security/providers/{provider}/groups/{group}/`) did not validate that the requested group exists. Requesting a group name that was never created caused the endpoint to fail with a 500 NullPointerException instead of a clean not-found error.

## Root Cause

`currentProvider.getGroup(groupID)` returns `null` for a non-existent group (verified: `FileAuthenticationProvider.getGroup()` returns `groupStorage.get(...)`; `AuthenticationChain.getGroup()` returns `.orElse(null)`). `getGroupModel()` never null-checked the result, so it dereferenced the null `group` — at `group.getRoles()` in the non-site-admin branch, and again at `Arrays.asList(group.getRoles())` when building the model for a site admin — producing an NPE.

The sibling method `getUserModel()` already handles this correctly by null-checking the user and throwing a `MessageException` with catalog key `em.security.userNotFound`.

Note: the Redmine description speculated the endpoint returned a fabricated HTTP 200 with an empty model. Independent tracing showed the actual behavior is a 500 NPE (the model build dereferences `group` directly). The underlying defect — no existence check — is the same, and the fix resolves both interpretations.

## Fix

Added a `group == null` check immediately after the lookup (before any dereference) that throws a `MessageException` using the new `em.security.groupNotFound` catalog key, mirroring `getUserModel()`. Added the catalog entry next to `em.security.userNotFound`.

## Test Plan

- As an EM security admin, request the group edit endpoint for a group name that has never been created → now returns a clean "Group not found" error instead of a 500.
- Requesting an existing group still returns its model unchanged.
- Root/"Groups" node requests are unaffected (they return earlier via `getRootGroupModel`/`getRootGroupModelForOrg`).
- `community/core` builds successfully; `GroupControllerTest` passes (3/3).

Fixes Redmine #75730.

🤖 Generated with [Claude Code](https://claude.com/claude-code)