### PR TITLE
Fix Bug #75712: boolean condition values stringified for VARCHAR-typed fields

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/util/ConditionListHandler.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/util/ConditionListHandler.java
@@ -491,6 +491,15 @@ public class ConditionListHandler {
 
       int sql_type = field.getSqlType();
 
+      // boolean-typed logical model attributes are often CASE WHEN expressions with no
+      // real backing column, so their reported sql type defaults to VARCHAR even though
+      // the generated SQL evaluates to a number. Coercing the boolean value to a string
+      // in that case produces a type mismatch against the numeric expression (e.g. Oracle
+      // ORA-00932), so leave boolean values as-is rather than stringifying them.
+      if(condValue instanceof Boolean && sql_type == Types.VARCHAR) {
+         return condValue;
+      }
+
       if(sql_type == Types.BOOLEAN || sql_type == Types.VARCHAR || sql_type == Types.INTEGER) {
          String sqlType = SQLTypes.getSQLTypes(null).convertToXType(sql_type);
          return CoreTool.getData(sqlType, condValue);

--- a/core/src/main/java/inetsoft/uql/jdbc/util/ConditionListHandler.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/util/ConditionListHandler.java
@@ -495,8 +495,12 @@ public class ConditionListHandler {
       // real backing column, so their reported sql type defaults to VARCHAR even though
       // the generated SQL evaluates to a number. Coercing the boolean value to a string
       // in that case produces a type mismatch against the numeric expression (e.g. Oracle
-      // ORA-00932), so leave boolean values as-is rather than stringifying them.
-      if(condValue instanceof Boolean && sql_type == Types.VARCHAR) {
+      // ORA-00932), so leave boolean values as-is rather than stringifying them. Scoped to
+      // expression-backed fields only (XExpression.EXPRESSION) so a real VARCHAR column
+      // filtered with a Boolean value is unaffected and keeps its existing string coercion.
+      if(condValue instanceof Boolean && sql_type == Types.VARCHAR &&
+         XExpression.EXPRESSION.equals(field.getType()))
+      {
          return condValue;
       }
 


### PR DESCRIPTION
## Summary
- Boolean-typed logical model attributes are frequently backed by `CASE WHEN ... THEN 1 ELSE 0 END` expressions with no real underlying column, so their reported JDBC sql type defaults to `VARCHAR` even though the generated SQL evaluates to a number.
- `ConditionListHandler.fixConditionValue()` was coercing an already-correct `Boolean` filter value into a `String` (`"true"`/`"false"`) whenever the field's reported sql type was `VARCHAR`, producing a type mismatch against the numeric expression on strict databases (Oracle `ORA-00932: inconsistent datatypes`) when a user filtered on the boolean column.
- Skip that coercion when the condition value is already a `Boolean` — it should be passed through untouched rather than stringified.

## Root cause
Reported after upgrading a dashboard from 1.0 to 1.1: two charts failed to render with "Failed to execute query" errors when filtering on boolean columns (`CompDay`, `Approved`) that are `CASE WHEN` expression attributes in the logical model. The `fixConditionValue()` coercion logic was added post-1.0 (Bug #71232 / #71789) and didn't account for boolean-typed expression columns whose sql type metadata defaults to VARCHAR.

## Test plan
- [x] Manually verified the code path: `fixConditionValue()` now returns the `Boolean` condition value unchanged when `sql_type == Types.VARCHAR`, instead of routing it through `CoreTool.getData("string", ...)`.
- [ ] Reviewer to confirm against the reporting customer's asset (boolean-typed `CASE WHEN` expression column filtered via checkbox) that the chart renders without the SQL expression failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)