### PR TITLE
Bug #75734, return sanitized 403 for @Secured denials on EM endpoints

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/AdminExceptionHandler.java
+++ b/core/src/main/java/inetsoft/web/admin/AdminExceptionHandler.java
@@ -124,9 +124,7 @@ public class AdminExceptionHandler {
       Throwable cause = e.getCause();
 
       if(cause instanceof SecurityException) {
-         LOG.debug("Access denied for resource", cause);
-         return ResponseEntity.status(HttpStatus.FORBIDDEN)
-            .body(new GenericError(cause.getClass().getSimpleName(), "Access denied"));
+         return accessDenied(cause);
       }
 
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -149,9 +147,19 @@ public class AdminExceptionHandler {
          description = "Access was denied because the user does not have the required permissions.")
    })
    public ResponseEntity<GenericError> handleAccessDenied(java.lang.SecurityException e) {
-      LOG.debug("Access denied for resource", e);
+      return accessDenied(e);
+   }
+
+   /**
+    * Builds a sanitized 403 response for an authorization denial. The exception is logged at
+    * debug level and the client receives a generic, localized message so that no principal,
+    * role, group, or organization details are exposed.
+    */
+   private ResponseEntity<GenericError> accessDenied(Throwable cause) {
+      LOG.debug("Access denied for resource", cause);
+      String msg = Catalog.getCatalog().getString("http.error.unauthorized");
       return ResponseEntity.status(HttpStatus.FORBIDDEN)
-         .body(new GenericError(e.getClass().getSimpleName(), "Access denied"));
+         .body(new GenericError(cause.getClass().getSimpleName(), msg));
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/admin/AdminExceptionHandler.java
+++ b/core/src/main/java/inetsoft/web/admin/AdminExceptionHandler.java
@@ -125,11 +125,33 @@ public class AdminExceptionHandler {
 
       if(cause instanceof SecurityException) {
          LOG.debug("Access denied for resource", cause);
-         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new GenericError(cause));
+         return ResponseEntity.status(HttpStatus.FORBIDDEN)
+            .body(new GenericError(cause.getClass().getSimpleName(), "Access denied"));
       }
 
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
          .body(handleGenericException(e));
+   }
+
+   /**
+    * Error handler for access denied. The {@link inetsoft.web.security.SecuredAspect} throws an unchecked
+    * {@link java.lang.SecurityException} when authorization fails; because it is unchecked,
+    * Spring AOP propagates it directly (unlike the checked {@link SecurityException} handled by
+    * {@link #handleUndeclaredThrowable(UndeclaredThrowableException)}). Map it to a sanitized 403
+    * so that authorization failures are not reported as server errors and no principal, role,
+    * group, or organization details are exposed to the client.
+    */
+   @ExceptionHandler(java.lang.SecurityException.class)
+   @ResponseBody
+   @ApiResponses({
+      @ApiResponse(
+         responseCode = "403",
+         description = "Access was denied because the user does not have the required permissions.")
+   })
+   public ResponseEntity<GenericError> handleAccessDenied(java.lang.SecurityException e) {
+      LOG.debug("Access denied for resource", e);
+      return ResponseEntity.status(HttpStatus.FORBIDDEN)
+         .body(new GenericError(e.getClass().getSimpleName(), "Access denied"));
    }
 
    /**


### PR DESCRIPTION
## Summary

Cluster monitoring GET endpoints (`/api/em/monitoring/cluster/cluster-status`, `/cluster-enabled`) returned **HTTP 500** instead of **403** when authorization was denied, and the 500 body leaked principal details (roles, groups, organization). This makes all `@Secured` EM admin endpoints return a proper, sanitized 403 on denial.

## Root Cause

`SecuredAspect.authorize()` throws an **unchecked** `java.lang.SecurityException` on denial:

```java
throw new java.lang.SecurityException("Unauthorized access to resource \"" + uri + "\" by user " + user);
```

(This was changed from the checked `inetsoft.sree.security.SecurityException` in a prior commit.) `AdminExceptionHandler` only mapped the **checked** exception to 403, via `handleUndeclaredThrowable()` — Spring AOP wraps *checked* exceptions in `UndeclaredThrowableException`. The unchecked `java.lang.SecurityException` is neither wrapped nor an `instanceof` the checked type, so it fell through to the generic `@ExceptionHandler(Exception.class)` → **500**. `GenericError(Throwable)` then copied the exception message — which contains `... by user <SRPrincipal.toString()>` (roles/groups/org) — into the response body.

## Fix

In `AdminExceptionHandler`:
1. Added `@ExceptionHandler(java.lang.SecurityException.class)` returning **403** with a sanitized `{"code":0,"type":"SecurityException","message":"Access denied"}` body; the detailed message is logged at `debug` only.
2. Sanitized the existing `handleUndeclaredThrowable` denial branch to also return `"Access denied"` instead of `new GenericError(cause)` (which leaked the same message).

Scope is limited to `AdminExceptionHandler` (the `@ControllerAdvice` for `inetsoft.web.admin` / `inetsoft.enterprise.web.admin`), so the global `SecuredAspect` behavior is untouched.

## Test Plan

1. Enable security + multi-tenancy; create a non-host org `org1`.
2. Log in as an Organization Administrator in `org1` who lacks Cluster monitoring access.
3. From the browser console:
   ```js
   fetch("/sree/api/em/monitoring/cluster/cluster-enabled", {credentials:"same-origin"}).then(r=>r.status);
   fetch("/sree/api/em/monitoring/cluster/cluster-status",  {credentials:"same-origin"}).then(r=>r.status);
   ```
4. Both should return **403** with body `{"message":"Access denied"}` — no username, roles, groups, org, or exception detail exposed.
5. Regression: an authorized Site Administrator still gets **200** with data; genuine server errors still return **500**.

Existing `ClusterControllerTest` passes (6/6).

Fixes Redmine #75734.