### PR TITLE
Bug #75740, route My Reports folder delete by owner to avoid deleting same-named root folder

### DIFF
--- a/core/src/main/java/inetsoft/web/RecycleUtils.java
+++ b/core/src/main/java/inetsoft/web/RecycleUtils.java
@@ -88,6 +88,15 @@ public final class RecycleUtils {
                                                        Principal principal, RecycleBin recycleBin)
       throws Exception
    {
+      // A "My Reports" folder entry can arrive with an owner set but a path that is not
+      // prefixed with the My Reports folder. Without the prefix, the scope/registry
+      // resolution below would incorrectly target the global repository and delete a
+      // same-named root folder. Normalize using the authoritative owner so the operation
+      // stays within the owning user's repository.
+      if(owner != null && !SUtil.isMyReport(path)) {
+         path = Tool.MY_DASHBOARD + "/" + path;
+      }
+
       String newName = UUID.randomUUID().toString().replaceAll("-", "");
       String npath = getRecycleBinPath(newName);
       writeLock.lock();

--- a/core/src/main/java/inetsoft/web/RecycleUtils.java
+++ b/core/src/main/java/inetsoft/web/RecycleUtils.java
@@ -93,7 +93,7 @@ public final class RecycleUtils {
       // resolution below would incorrectly target the global repository and delete a
       // same-named root folder. Normalize using the authoritative owner so the operation
       // stays within the owning user's repository.
-      if(owner != null && !SUtil.isMyReport(path)) {
+      if(path != null && owner != null && !SUtil.isMyReport(path)) {
          path = Tool.MY_DASHBOARD + "/" + path;
       }
 


### PR DESCRIPTION
## Summary

Deleting a folder from **My Reports** (a user's private repository) could delete a same-named folder in the **root (global) repository** instead, causing unintended data loss. A user with only READ permission on the root folder could trigger its deletion, so this is a security defect.

## Root Cause

`RecycleUtils.moveRepositoryFolderToRecycleBin(path, name, owner, …)` decided which `RepletRegistry` (user vs global) and which asset scope (`USER_SCOPE` vs `GLOBAL_SCOPE`) to operate on **solely from the `path` string**, via `SUtil.isMyReport(path)` / `SUtil.isMyDashboard(path)`.

A My Reports folder entry can legitimately arrive with a non-null `owner` but a `path` that is **not** prefixed with `"My Dashboards"` (e.g. `"Examples"`). In that case both predicates return `false`, so the delete targeted the **global** registry and moved the root repository's folder to the recycle bin, leaving the user's own folder untouched.

The authoritative identity check is `RepositoryEntry.isMyReport()` = `SUtil.isMyReport(getPath()) || getOwner() != null`; global folder entries are always created with `owner == null`, and user-registry folders are always stored prefixed as `"My Dashboards/<name>"`.

## Fix

Normalize the path using the authoritative `owner` at the top of `moveRepositoryFolderToRecycleBin`: when `owner != null` and the path is not already a My Reports path, prepend the `"My Dashboards"` prefix. After normalization the registry/scope resolution, `changeFolder`, permission read/write, and recycle-bin restore all correctly stay within the owning user's repository.

## Test Plan

- Create user `user0` with READ permission on the `Examples` folder under the root repository.
- Log in as `user0`, create an `Examples` folder under My Reports, then delete it.
- Verify only the user's `Examples` folder is removed and the root repository's `Examples` folder remains.
- Regression: deleting a global folder (`owner == null`) and deleting an already-prefixed My Reports folder both behave as before; sheet deletes (via `moveSheetToRecycleBin`) are unaffected.
- `community/core` builds; `RepositoryRecycleBinControllerTest` and `ContentRepositoryTreeControllerTest` pass (14 tests).

Fixes Redmine #75740.