### PR TITLE
Bug #75737, include tabular data source variables in query cache key

### DIFF
--- a/core/src/main/java/inetsoft/uql/tabular/TabularUtil.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularUtil.java
@@ -54,11 +54,26 @@ public class TabularUtil {
     * Find all variables embedded in the properties of the bean.
     */
    public static List<UserVariable> findVariables(Object bean) {
+      return findVariables(bean, false);
+   }
+
+   /**
+    * Find all variables embedded in the properties of the bean.
+    * @param excludeSecrets when true, variables embedded in password-flagged
+    * properties or secret HTTP parameters are omitted. Use this when the
+    * variables feed into a value that must not expose secret data, such as a
+    * query cache key (Bug #75737).
+    */
+   public static List<UserVariable> findVariables(Object bean, boolean excludeSecrets) {
       List<PropertyMeta> props = findProperties(bean.getClass());
       List<UserVariable> vars = new ArrayList<>();
 
       for(PropertyMeta prop : props) {
          if(prop.isAnnotated()) {
+            if(excludeSecrets && prop.getProperty().password()) {
+               continue;
+            }
+
             Object val = prop.getValue(bean);
 
             if(val != null) {
@@ -92,10 +107,10 @@ public class TabularUtil {
                   findVariables(vars, (QueryParameter[]) val);
                }
                else if(val instanceof HttpParameter) {
-                  findVariables(vars, (HttpParameter) val);
+                  findVariables(vars, excludeSecrets, (HttpParameter) val);
                }
                else if(val instanceof HttpParameter[]) {
-                  findVariables(vars, (HttpParameter[]) val);
+                  findVariables(vars, excludeSecrets, (HttpParameter[]) val);
                }
                else if(val instanceof RestParameters) {
                   RestParameters params = (RestParameters) val;
@@ -109,7 +124,7 @@ public class TabularUtil {
                         findVariables(vars, (QueryParameter) obj);
                      }
                      else if(obj instanceof HttpParameter) {
-                        findVariables(vars, (HttpParameter) obj);
+                        findVariables(vars, excludeSecrets, (HttpParameter) obj);
                      }
                   }
                }
@@ -135,9 +150,15 @@ public class TabularUtil {
       }
    }
 
-   private static void findVariables(List<UserVariable> vars, HttpParameter... parameters) {
+   private static void findVariables(List<UserVariable> vars, boolean excludeSecrets,
+                                     HttpParameter... parameters)
+   {
       for(final HttpParameter parameter : parameters) {
          if(parameter != null) {
+            if(excludeSecrets && parameter.isSecret()) {
+               continue;
+            }
+
             final String name = parameter.getName();
             final String value = parameter.getValue();
 

--- a/core/src/main/java/inetsoft/uql/tabular/impl/TabularHandler.java
+++ b/core/src/main/java/inetsoft/uql/tabular/impl/TabularHandler.java
@@ -29,8 +29,7 @@ import inetsoft.util.DataCacheVisitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import java.lang.reflect.Array;
 import java.security.Principal;
 import java.util.*;
 
@@ -63,12 +62,16 @@ public class TabularHandler extends XHandler {
       query.setDataSource(xds);
 
       TabularUtil.fillNullVariablesWithEmptyString(runtime, query, params);
-      TabularUtil.replaceVariables(xds, params);
-      TabularUtil.replaceVariables(query, params);
 
+      // Check the cache before substituting variables so that getQueryKey sees
+      // the unsubstituted data source (variable names still visible) and
+      // produces the same key as the cache-clear paths (Bug #75737).
       if(isQueryCached(query, params, user, visitor)) {
          return new XNode();
       }
+
+      TabularUtil.replaceVariables(xds, params);
+      TabularUtil.replaceVariables(query, params);
 
       TabularExecutor executor = Drivers.getInstance().getTabularExecutor(xds);
       XTableNode tbl = null;
@@ -112,20 +115,21 @@ public class TabularHandler extends XHandler {
 
    /**
     * Get a query key for query caching. In addition to the base key, the
-    * variable-substituted content of the tabular data source is included so
-    * that variables embedded in data source fields (e.g. "Query HTTP
-    * Parameters", URL, or authentication parameters) produce distinct cache
-    * keys when their values change. Without this, a stale cached result would
-    * be returned after the variable value changes (Bug #75737).
+    * resolved values of the variables embedded in the tabular data source
+    * fields (e.g. "Query HTTP Parameters", URL, or authentication parameters)
+    * are included so that a change in any of those values produces a distinct
+    * cache key. Without this, a stale cached result would be returned after the
+    * variable value changes (Bug #75737).
     *
-    * The data source is cloned and the variables are substituted here so that
-    * the key is computed consistently regardless of whether the caller already
-    * substituted the data source. execute() substitutes before checking the
-    * cache, but the cache-clear paths (removeQueryCache/clearQueryCache) pass
-    * the unsubstituted data source; re-substituting on a clone keeps the write,
-    * read, and remove keys identical. Cloning is required to avoid mutating the
-    * shared (registry) data source; TabularDataSource clones deep-copy their
-    * variable-bearing fields (as execute() also relies on).
+    * Only the resolved variable values are used -- not a serialization of the
+    * whole data source -- so that encrypted credential/secret fields (whose
+    * ciphertext changes on every call because a fresh random IV is generated)
+    * do not make the key non-deterministic and defeat caching/eviction for
+    * authenticated data sources. This relies on getQueryKey being called with
+    * the unsubstituted data source: execute() checks the cache before
+    * substituting, and the cache-clear paths (removeQueryCache/clearQueryCache)
+    * also pass the unsubstituted data source, so the variable names are visible
+    * and the write, read, and remove keys stay identical.
     */
    @Override
    public String getQueryKey(XQuery query, VariableTable qvars, Principal user) throws Exception {
@@ -133,20 +137,56 @@ public class TabularHandler extends XHandler {
       XDataSource source = query.getDataSource();
 
       if(source instanceof TabularDataSource) {
-         TabularDataSource<?> ds = (TabularDataSource<?>) source.clone();
+         TreeMap<String, String> values = new TreeMap<>();
 
-         if(qvars != null) {
-            TabularUtil.replaceVariables(ds, qvars);
+         // exclude secret/password fields so credential values are never
+         // embedded in the (in-memory, cluster-replicated) cache key
+         for(UserVariable var : TabularUtil.findVariables(source, true)) {
+            String name = var == null ? null : var.getName();
+
+            if(name != null && !values.containsKey(name)) {
+               Object value = qvars == null ? null : qvars.get(name);
+               values.put(name, variableValueToKey(value));
+            }
          }
 
-         StringWriter buf = new StringWriter();
-         PrintWriter writer = new PrintWriter(buf);
-         ds.writeXML(writer);
-         writer.flush();
-         key = key + "__" + buf;
+         if(!values.isEmpty()) {
+            key = key + "__" + values;
+         }
       }
 
       return key;
+   }
+
+   /**
+    * Produce a deterministic, content-based string for a variable value used in
+    * the cache key. Missing values are normalized to "" so the key matches
+    * whether or not fillNullVariablesWithEmptyString has been applied. Array
+    * values are joined by content (mirroring XUtil.replaceVariable) so that two
+    * arrays with equal elements produce the same key rather than relying on
+    * Object.toString()'s identity hash.
+    */
+   private static String variableValueToKey(Object value) {
+      if(value == null) {
+         return "";
+      }
+
+      if(value.getClass().isArray()) {
+         StringBuilder buf = new StringBuilder();
+         int len = Array.getLength(value);
+
+         for(int i = 0; i < len; i++) {
+            if(i > 0) {
+               buf.append(',');
+            }
+
+            buf.append(Array.get(value, i));
+         }
+
+         return buf.toString();
+      }
+
+      return value.toString();
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/tabular/impl/TabularHandler.java
+++ b/core/src/main/java/inetsoft/uql/tabular/impl/TabularHandler.java
@@ -29,6 +29,8 @@ import inetsoft.util.DataCacheVisitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.security.Principal;
 import java.util.*;
 
@@ -106,6 +108,45 @@ public class TabularHandler extends XHandler {
       }
 
       return tbl;
+   }
+
+   /**
+    * Get a query key for query caching. In addition to the base key, the
+    * variable-substituted content of the tabular data source is included so
+    * that variables embedded in data source fields (e.g. "Query HTTP
+    * Parameters", URL, or authentication parameters) produce distinct cache
+    * keys when their values change. Without this, a stale cached result would
+    * be returned after the variable value changes (Bug #75737).
+    *
+    * The data source is cloned and the variables are substituted here so that
+    * the key is computed consistently regardless of whether the caller already
+    * substituted the data source. execute() substitutes before checking the
+    * cache, but the cache-clear paths (removeQueryCache/clearQueryCache) pass
+    * the unsubstituted data source; re-substituting on a clone keeps the write,
+    * read, and remove keys identical. Cloning is required to avoid mutating the
+    * shared (registry) data source; TabularDataSource clones deep-copy their
+    * variable-bearing fields (as execute() also relies on).
+    */
+   @Override
+   public String getQueryKey(XQuery query, VariableTable qvars, Principal user) throws Exception {
+      String key = super.getQueryKey(query, qvars, user);
+      XDataSource source = query.getDataSource();
+
+      if(source instanceof TabularDataSource) {
+         TabularDataSource<?> ds = (TabularDataSource<?>) source.clone();
+
+         if(qvars != null) {
+            TabularUtil.replaceVariables(ds, qvars);
+         }
+
+         StringWriter buf = new StringWriter();
+         PrintWriter writer = new PrintWriter(buf);
+         ds.writeXML(writer);
+         writer.flush();
+         key = key + "__" + buf;
+      }
+
+      return key;
    }
 
    /**


### PR DESCRIPTION
## Summary

A worksheet table bound to a REST/tabular data source returned **stale cached data** after changing a variable value used in the data source's **"Query HTTP Parameters"** (a data-source-level `queryHttpParameters` field). Repro: open `ws3`, enter `Tag=A` → live data → UUID1; reopen, enter `Tag=B` → live data → same UUID (expected a different UUID since A ≠ B).

## Root Cause

The query-result cache in `XSessionManager.dataCache` is keyed by `XHandler.getQueryKey(query, qvars, user)`. That key includes only:
- variables from `query.getVariableNames()` — for a `TabularQuery` this scans **only the query**, not its data source, so a data-source-level variable like `$(Tag)` is absent;
- `query.writeXML()` — the query itself has no variables;
- `source.getFullName()` — the data source **name only**, never its content.

`TabularHandler.execute()` substitutes `$(Tag)` → `A`/`B` into the cloned data source *before* the cache check, but that substituted content never enters the key. So `Tag=A` and `Tag=B` produce an identical key → stale cache hit. (The higher-level `AssetDataCache.DataKey` includes all box variables via `vars.printKey()`, so it correctly misses; the request reaches this lower cache where the bug manifests.)

## Fix

Override `getQueryKey` in `TabularHandler` to append the variable-substituted tabular data source content to the base key. It **clones the data source and re-substitutes variables internally** so the key is computed consistently whether or not the caller pre-substituted:
- `execute()` substitutes before checking the cache (re-substitution on the clone is idempotent);
- the cache-clear paths (`XEngine.removeQueryCache` / `BoundQuery.clearQueryCache`) pass the unsubstituted data source — re-substituting on a clone keeps the write, read, and remove keys identical, so refresh/eviction still targets the right entry.

Cloning is required to avoid mutating the shared registry data source; `AbstractRestDataSource.clone()` deep-copies its variable-bearing fields (the same invariant `execute()` already relies on). Guarded by `instanceof TabularDataSource`, so JDBC (own SQL-based key) and XMLA (base key) are unaffected.

## Test Plan

- Open `ws3`, enter `Tag=A` → live data → note UUID. Reopen, enter `Tag=B` → live data → **different UUID** returned. ✅ (verified)
- Refresh live data with the same `Tag` value after the upstream result changes → new data fetched (eviction targets the correct cache entry).
- Regression: data sources with no variables still share cache entries for identical queries (key content is stable between runs).
- Build: `./mvnw clean install -pl core -am -DskipTests` succeeds; `TabularTableAssemblyTest` and `RestJsonDataSourceTest` pass.

Fixes Redmine #75737.