### PR TITLE
Bug #75739, remove deleted org's membership from remaining themes

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/user/IdentityThemeService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/user/IdentityThemeService.java
@@ -67,6 +67,11 @@ public class IdentityThemeService {
          if(Tool.equals(orgID, theme.getOrgID())) {
             iterator.remove();
          }
+         else {
+            // strip the deleted org's membership from remaining (e.g. globally-shared)
+            // themes so a new org reusing this ID doesn't inherit a stale theme
+            theme.getOrganizations().remove(orgID);
+         }
       }
 
       customThemesManager.setCustomThemes(themes);


### PR DESCRIPTION
## Summary

In a multi-tenant deployment, deleting an organization left the deleted org's ID behind in every globally-shared theme's `organizations` list. When a new organization later reused the same ID, its users (with no personal theme preference) silently inherited the stale theme — while the EM Presentation → Themes pane showed no default set, so the admin-visible state and runtime behavior disagreed.

## Root Cause

`IdentityThemeService.removeTheme(String orgID)` only removed `CustomTheme` objects owned by the deleted org and reset that org's SreeEnv-backed selection pointer. It never stripped the deleted `orgID` from the remaining globally-shared themes' (`orgID == null`) `organizations` list. That list is exactly what `CustomThemesImpl.getUserTheme()` reads in its "match by organization" resolution step, with no cross-check against the SreeEnv pointer.

## Fix

`removeTheme(orgID)` now also strips `orgID` from every surviving theme's `organizations` list, mirroring the symmetric cleanup already performed on the org-rename path in `IdentityService.updateCustomThemeOrganization()`.

## Test Plan

1. Enable Security and Multi-Tenancy.
2. As site-admin, create a theme with "Visible to All Organizations".
3. Create org "acme"; in its Presentation → Themes set that theme as "Default for This Organization".
4. Delete org "acme".
5. Recreate an org reusing ID "acme"; add a user with no personal theme preference.
6. Log in as that user → the plain default theme is applied (previously the stale global theme leaked through).

Regression: verified the org-delete and org-"replace" migration call sites remain correct; ran theme unit tests (`CustomThemesManagerTest` + enterprise `CustomThemesImplTest`, `CustomThemesImplStaticDepTest`, `ThemeServiceTest`, `ThemesControllerTest`) — all pass.

Fixes Redmine #75739.