### PR TITLE
Bug #75729, fix auto layout arrows anchoring to stale table positions

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/common-components/join-node-graph/join-node-graph.component.tl.spec.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/common-components/join-node-graph/join-node-graph.component.tl.spec.ts
@@ -114,7 +114,7 @@ describe("JoinNodeGraphComponent - single pass", () => {
 
    function createComponent(overrides: Partial<JoinNodeGraphComponent> = {}) {
       const comp = new JoinNodeGraphComponent(
-         { nativeElement: { focus: vi.fn(), clientWidth: 211 } } as any,
+         { nativeElement: { focus: vi.fn(), clientWidth: 211, style: {} } } as any,
          TestBed.inject(NgbModal),
          TestBed.inject(HttpClient),
          TestBed.inject(DataPhysicalModelService),

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/common-components/join-node-graph/join-node-graph.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/common-components/join-node-graph/join-node-graph.component.ts
@@ -90,6 +90,13 @@ export class JoinNodeGraphComponent implements AfterViewInit, OnChanges {
    // is back in the parent's lookup map and its endpoints are restored.
    ngOnChanges(changes: SimpleChanges): void {
       if(changes["graph"] && !changes["graph"].isFirstChange() && this.nodeGraph) {
+         // The style.top/left host bindings haven't been flushed to the DOM yet at this
+         // point in the CD cycle, so jsPlumb would anchor connections to the element's
+         // stale (pre-layout) position. Apply the new position eagerly so registration/
+         // connection below sees the correct coordinates (e.g. after auto layout moves
+         // every table at once).
+         this.nodeGraph.nativeElement.style.top = this.graph.bounds.y + "px";
+         this.nodeGraph.nativeElement.style.left = this.graph.bounds.x + "px";
          this.endPointsInit();
          this.onRegisterNode.emit([this.graph, this.nodeGraph.nativeElement]);
       }


### PR DESCRIPTION
## Summary
- Fixes join lines rendering disconnected/misplaced after using Physical View "Horizontal Layout" / "Vertical Layout" auto layout.
- Root cause: `JoinNodeGraphComponent.ngOnChanges` re-registers reused (`@for`-tracked) table nodes and synchronously re-connects jsPlumb edges before Angular flushes the `style.top`/`style.left` host bindings for the new position. jsPlumb anchors the connection to the DOM position at connect-time, so after auto layout moves every table at once, the arrows stayed anchored to each table's previous position while the table boxes rendered correctly at their new position.
- Fix: eagerly set the node element's `style.top`/`style.left` from the new bounds before re-registering/re-connecting, so jsPlumb always reads the current position.

## Test plan
- [x] Verified in browser: opened a physical view with several joined tables, clicked "Horizontal Layout", confirmed join lines now connect the correct tables at their new positions (previously arrows pointed to stale, empty locations).
- [ ] `npm run test:portal` (frontend unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)