### PR TITLE
75643, boxplot outlier should animate with rest of box plot features.

### DIFF
--- a/core/src/main/java/inetsoft/graph/element/PointElement.java
+++ b/core/src/main/java/inetsoft/graph/element/PointElement.java
@@ -46,6 +46,13 @@ public class PointElement extends StackableElement {
    public static final String HINT_GANTT_MILESTONE = "gantt_milestone";
 
    /**
+    * Hint marking this point element as the outlier markers of a box plot; the value is
+    * {@code "true"} when set, absent otherwise. Used so the SVG entrance animation stamps a
+    * shared data-group key on the points and fades them in together with their box/whisker.
+    */
+   public static final String HINT_BOXPLOT_OUTLIER = "boxplot_outlier";
+
+   /**
     * Create an empty element. Dims and vars must be added explicitly.
     */
    public PointElement() {

--- a/core/src/main/java/inetsoft/graph/visual/ElementVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/ElementVO.java
@@ -20,6 +20,7 @@ package inetsoft.graph.visual;
 import inetsoft.graph.*;
 import inetsoft.graph.coord.Coordinate;
 import inetsoft.graph.coord.RectCoord;
+import inetsoft.graph.data.DataSet;
 import inetsoft.graph.element.GraphElement;
 import inetsoft.graph.geometry.ElementGeometry;
 import inetsoft.graph.geometry.Geometry;
@@ -206,6 +207,53 @@ public abstract class ElementVO extends VisualObject {
     */
    public void setSubRowIndexes(int[] subridxs) {
       this.subridxs = subridxs;
+   }
+
+   /**
+    * Get the group key identifying which data group (dimension tuple) this VO belongs to,
+    * or {@code null} if none was assigned.  Used to fade box-plot boxes/whiskers and their
+    * outlier points in together as one group (see the box-plot animation injector).
+    */
+   public String getGroupKey() {
+      return groupKey;
+   }
+
+   /**
+    * Set the group key identifying this VO's data group.
+    */
+   public void setGroupKey(String groupKey) {
+      this.groupKey = groupKey;
+   }
+
+   /**
+    * Compute a group key from a row's grouping-dimension values.  VOs sharing the same
+    * dimension values (e.g. a box-plot box and the outlier points over it, which carry the
+    * same grouping dims in {@link inetsoft.graph.data.BoxDataSet}) produce an identical key,
+    * so downstream code can tie them together without relying on screen geometry.
+    *
+    * @return the joined dimension values, or {@code null} when no usable dims/data exist.
+    */
+   protected static String computeGroupKey(DataSet data, int subRowIndex, String[] dims) {
+      if(data == null || dims == null || dims.length == 0 || subRowIndex < 0) {
+         return null;
+      }
+
+      StringBuilder key = new StringBuilder();
+
+      for(String dim : dims) {
+         int col = data.indexOfHeader(dim);
+         Object val = col >= 0 ? data.getData(col, subRowIndex) : null;
+
+         if(key.length() > 0) {
+            // 0x1F unit separator cannot occur inside a data value, so the joined key of two
+            // distinct dimension tuples can never collide.
+            key.append('\u001F');
+         }
+
+         key.append(val);
+      }
+
+      return key.toString();
    }
 
    /**
@@ -462,4 +510,5 @@ public abstract class ElementVO extends VisualObject {
    private int[] subridxs;
    private String mname;
    private int cidx;
+   private String groupKey; // data group (dimension tuple) this VO belongs to; null if unused
 }

--- a/core/src/main/java/inetsoft/graph/visual/PointVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/PointVO.java
@@ -132,6 +132,12 @@ public class PointVO extends ElementVO {
       if(shp == GShape.NIL) {
          radius = 0;
       }
+
+      // For box-plot outliers, tag each point with its data group so the entrance animation
+      // fades it in together with the box/whisker it belongs to. (75643)
+      if("true".equals(elem.getHint(PointElement.HINT_BOXPLOT_OUTLIER))) {
+         setGroupKey(computeGroupKey(coord.getDataSet(), obj.getSubRowIndex(), elem.getDims()));
+      }
    }
 
    /**
@@ -154,10 +160,16 @@ public class PointVO extends ElementVO {
          annotAttrs.put(SVGSupport.ATTR_COL,   String.valueOf(getColIndex()));
          annotAttrs.put(SVGSupport.ATTR_ROW,   String.valueOf(getRowIndex()));
          annotAttrs.put(SVGSupport.ATTR_SIZE,  String.valueOf(radius));
+
          if(pointColor != null) {
             annotAttrs.put(SVGSupport.ATTR_COLOR,
                pointColor.getRed() + "," + pointColor.getGreen() + "," + pointColor.getBlue());
          }
+
+         if(getGroupKey() != null) {
+            annotAttrs.put(SVGSupport.ATTR_GROUP, getGroupKey());
+         }
+
          svg.beginAnnotationGroup(g, SVGSupport.ANNOTATION_POINT, annotAttrs);
       }
 

--- a/core/src/main/java/inetsoft/graph/visual/SchemaVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/SchemaVO.java
@@ -32,6 +32,7 @@ import inetsoft.util.graphics.SVGSupport;
 
 import java.awt.*;
 import java.awt.geom.*;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -68,6 +69,12 @@ public class SchemaVO extends ElementVO {
          vtext.setAlignmentX(GraphConstants.CENTER_ALIGNMENT);
          vtext.setAlignmentY(GraphConstants.MIDDLE_ALIGNMENT);
       }
+
+      // For a box plot, tag this box/whisker with its data group so the entrance animation
+      // can fade it in together with the outlier points over it. (75643)
+      if(painter instanceof BoxPainter) {
+         setGroupKey(computeGroupKey(coord.getDataSet(), geom.getSubRowIndex(), elem.getDims()));
+      }
    }
 
    /**
@@ -95,11 +102,16 @@ public class SchemaVO extends ElementVO {
       if(svg != null) {
          double screenCx = painter.getShape(0).getBounds2D().getCenterX();
          String annotClass = isBoxPlot() ? SVGSupport.ANNOTATION_BOX : SVGSupport.ANNOTATION_CANDLE;
-         svg.beginAnnotationGroup(g0, annotClass, Map.of(
-            SVGSupport.ATTR_COL, String.valueOf(getColIndex()),
-            SVGSupport.ATTR_ROW, String.valueOf(getRowIndex()),
-            SVGSupport.ATTR_X,   String.format(java.util.Locale.US, "%.1f", screenCx)
-         ));
+         Map<String, String> annotAttrs = new HashMap<>();
+         annotAttrs.put(SVGSupport.ATTR_COL, String.valueOf(getColIndex()));
+         annotAttrs.put(SVGSupport.ATTR_ROW, String.valueOf(getRowIndex()));
+         annotAttrs.put(SVGSupport.ATTR_X,   String.format(java.util.Locale.US, "%.1f", screenCx));
+
+         if(getGroupKey() != null) {
+            annotAttrs.put(SVGSupport.ATTR_GROUP, getGroupKey());
+         }
+
+         svg.beginAnnotationGroup(g0, annotClass, annotAttrs);
       }
 
       try {

--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -3663,6 +3663,9 @@ public abstract class GraphGenerator {
          PointElement outlier = new PointElement();
          outlier.setSizeFrame(new StaticSizeFrame(1));
          outlier.setShapeFrame(new StaticShapeFrame(GShape.FILLED_CIRCLE));
+         // Tag the outliers so the SVG entrance animation fades them in together with their
+         // box/whisker (both share the same grouping dims in BoxDataSet). (75643)
+         outlier.setHint(PointElement.HINT_BOXPLOT_OUTLIER, "true");
 
          elements.add(new SchemaElement(new BoxPainter()));
          elements.add(outlier);

--- a/core/src/main/java/inetsoft/util/graphics/SVGSupport.java
+++ b/core/src/main/java/inetsoft/util/graphics/SVGSupport.java
@@ -155,6 +155,9 @@ public interface SVGSupport {
    String ATTR_SIZE   = "size";
    /** {@code data-x} — screen X center in pixels, used to sort schema VOs left-to-right. */
    String ATTR_X      = "x";
+   /** {@code data-group} — data group (dimension tuple) key shared by a box-plot box and the
+    *  outlier points drawn over it, so the animation injector fades them in together. */
+   String ATTR_GROUP  = "group";
    /** {@code data-y} — screen Y center in pixels, used to sort relation nodes top-to-bottom. */
    String ATTR_Y      = "y";
    /** {@code data-level} — nesting depth from {@code TreemapGeometry.getLevel()}; leaf=0, root=highest. */

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -2860,12 +2860,67 @@ public class SVGAnimationDOMInjector {
    /**
     * Inject staggered fade-in animation for box-plot charts.
     *
-    * <p>Each {@code inetsoft-box} annotation group (one per box) fades in left-to-right.
-    * Delays are distributed across {@link AnimationConstants#STAGGER_WINDOW}.
+    * <p>A box plot draws two kinds of visual object over one {@code BoxDataSet}: the box/whisker
+    * glyph ({@code inetsoft-box}) and the outlier markers ({@code inetsoft-point}).  The boxes fade
+    * in left-to-right by screen X center, exactly as before.  Each box and its outliers share a
+    * {@code data-group} key (the grouping dimension tuple); that key is used only to give each
+    * outlier point the SAME delay as its box, so points fade in with their box — it never affects
+    * the box ordering.
     */
    private static void injectBoxAnimation(Element svgRoot, Document doc) {
-      injectXPositionFadeAnimation(svgRoot, doc,
-         SVGSupport.ANNOTATION_BOX, "inetsoft-box-fade");
+      appendStyle(svgRoot, doc,
+         "@keyframes inetsoft-box-fade{from{opacity:0}to{opacity:1}}");
+
+      List<Element> boxes = collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_BOX);
+
+      if(boxes.isEmpty()) {
+         return;
+      }
+
+      // Stagger boxes left-to-right by screen X center so the entrance order is unchanged.
+      boxes.sort(Comparator.comparingDouble(SVGAnimationDOMInjector::boxScreenX));
+
+      int n = boxes.size();
+      String groupAttr = "data-" + SVGSupport.ATTR_GROUP;
+      // group key -> the delay of the box that owns it, so outlier points can fade in with it.
+      Map<String, Double> groupDelay = new HashMap<>();
+
+      // Boxes/whiskers: A1 pattern — style the annotation group itself; hover dim is .ready-gated.
+      for(int i = 0; i < n; i++) {
+         Element box = boxes.get(i);
+         double delay = AnimationConstants.staggerDelay(i, n);
+         box.setAttribute("style", boxFadeStyle(delay));
+         groupDelay.putIfAbsent(box.getAttribute(groupAttr), delay);
+      }
+
+      // Outlier points: A2 pattern — style the inner children so the outer .inetsoft-point group's
+      // opacity stays free for the hover-dim CSS.  Each point inherits its box's delay via the
+      // shared data-group key (fallback 0 if a point has no matching box, which should not happen).
+      List<Element> points = collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_POINT);
+
+      for(Element point : points) {
+         double delay = groupDelay.getOrDefault(point.getAttribute(groupAttr), 0.0);
+         applyAnimStyleToChildren(point, boxFadeStyle(delay));
+      }
+   }
+
+   /** Screen X center of a box annotation group from its {@code data-x} attribute (0 if absent). */
+   private static double boxScreenX(Element g) {
+      String s = g.getAttribute("data-" + SVGSupport.ATTR_X);
+
+      try {
+         return s.isEmpty() ? 0.0 : Double.parseDouble(s);
+      }
+      catch(NumberFormatException e) {
+         return 0.0;
+      }
+   }
+
+   /** Build the box-plot fade-in inline style for the given stagger delay (seconds). */
+   private static String boxFadeStyle(double delay) {
+      return String.format(java.util.Locale.US,
+         "animation:inetsoft-box-fade %.2fs %s %.2fs both",
+         AnimationConstants.DURATION, AnimationConstants.EASING, delay);
    }
 
    /**

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -801,26 +801,51 @@ class SVGAnimationDOMInjectorTest {
    }
 
    /**
-    * Box-plot groups follow the same left-to-right delay ordering as candle groups —
-    * both use {@link SVGAnimationDOMInjector#injectXPositionFadeAnimation}.
+    * Boxes fade in left-to-right by screen X center (unchanged ordering), and each outlier point
+    * fades in with the exact delay of its box via the shared {@code data-group} key.  The DOM
+    * order here is deliberately the reverse of the x order to prove the ordering derives from
+    * {@code data-x}, and that the group tag only maps a point to its box's delay — not the order.
     */
    @Test
-   void box_leftToRightDelayOrdering() throws Exception {
+   void box_pointsFadeInWithTheirBoxByGroup() throws Exception {
       Document doc = newDocument();
-      Element left  = addAnnotGroup(doc, SVGSupport.ANNOTATION_BOX,
-                                    Map.of("row", "0", "col", "0", "x", "50"),
-                                    0, 0, 10, 50);
-      Element right = addAnnotGroup(doc, SVGSupport.ANNOTATION_BOX,
-                                    Map.of("row", "1", "col", "0", "x", "150"),
-                                    100, 0, 10, 50);
+      // boxA is first in the DOM but sits to the RIGHT (x=150); boxB is second but to the LEFT (x=50).
+      Element boxA = addAnnotGroup(doc, SVGSupport.ANNOTATION_BOX,
+                                   Map.of("row", "0", "col", "0", "x", "150", "group", "A"),
+                                   0, 0, 10, 50);
+      Element boxB = addAnnotGroup(doc, SVGSupport.ANNOTATION_BOX,
+                                   Map.of("row", "1", "col", "0", "x", "50", "group", "B"),
+                                   100, 0, 10, 50);
+      // One outlier point per group; the animation lands on the inner child (A2 pattern).
+      Element pointA = addAnnotGroup(doc, SVGSupport.ANNOTATION_POINT,
+                                     Map.of("row", "0", "col", "0", "size", "3", "group", "A"),
+                                     5, 5, 2, 2);
+      Element pointB = addAnnotGroup(doc, SVGSupport.ANNOTATION_POINT,
+                                     Map.of("row", "1", "col", "0", "size", "3", "group", "B"),
+                                     105, 5, 2, 2);
 
       SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_BOX);
 
-      double delayLeft  = parseDelay(left.getAttribute("style"));
-      double delayRight = parseDelay(right.getAttribute("style"));
+      double delayBoxA = parseDelay(boxA.getAttribute("style"));
+      double delayBoxB = parseDelay(boxB.getAttribute("style"));
+      double delayPointA = parseDelay(firstChildStyle(pointA));
+      double delayPointB = parseDelay(firstChildStyle(pointB));
 
-      assertEquals(0.0, delayLeft,  0.01, "leftmost box must start with delay 0");
-      assertTrue(delayRight > delayLeft, "right box (x=150) must animate after left (x=50)");
+      // Left box (B, x=50) animates first at delay 0; right box (A, x=150) animates later —
+      // ordering is by screen x, NOT by DOM/tag order.
+      assertEquals(0.0, delayBoxB, 0.01, "leftmost box (x=50) must start with delay 0");
+      assertTrue(delayBoxA > delayBoxB, "right box (x=150) must animate after the left box");
+
+      // Each outlier point fades in with the exact delay of its own box's group.
+      assertEquals(delayBoxA, delayPointA, 0.001, "point in group A must fade in with box A");
+      assertEquals(delayBoxB, delayPointB, 0.001, "point in group B must fade in with box B");
+
+      // Boxes animate on the group itself (A1); the point group's own opacity stays free so the
+      // hover-dim CSS can override it (A2 pattern applies animation to the inner child instead).
+      assertTrue(boxA.getAttribute("style").contains("inetsoft-box-fade"),
+                 "box animation must be applied to the group element");
+      assertTrue(pointA.getAttribute("style").isEmpty(),
+                 "point group's own opacity must stay free for hover dim (A2 pattern)");
    }
 
    // -------------------------------------------------------------------------


### PR DESCRIPTION
Root Cause:
A box-plot chart is rendered from a single BoxDataSet as two separate visual elements: the box/whisker glyphs (SchemaElement/BoxPainter -> "inetsoft-box" SVG groups) and the outlier data points (PointElement -> "inetsoft-point" groups). The SVG entrance animation emitted a single "box" hint whose injector (injectBoxAnimation) only animated the inetsoft-box groups. The outlier points were never given a fade animation, so they appeared immediately at full opacity while the boxes faded in.

Fix:
The box and its outlier points now share a data-driven "data-group" key (the grouping dimension tuple, which every BoxDataSet row carries -- box rows and outlier rows alike). SchemaVO (box) and the outlier PointVO both stamp this key on their SVG annotation groups. injectBoxAnimation still staggers the boxes left-to-right by screen X (unchanged entrance order) and now uses the shared key to give each outlier point the exact fade-in delay of the box it belongs to. Result: the outlier points fade in gradually together with their box and whisker instead of showing immediately.