### PR TITLE
Bug #75727, register RemoteIpValve so X-Forwarded-Proto/Host are honored

### DIFF
--- a/server/src/main/resources/META-INF/spring/inetsoft.web.InetsoftApplication.imports
+++ b/server/src/main/resources/META-INF/spring/inetsoft.web.InetsoftApplication.imports
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryAutoConfiguration
+org.springframework.boot.autoconfigure.web.embedded.EmbeddedWebServerFactoryCustomizerAutoConfiguration
 org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration
 org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration
 org.springframework.boot.autoconfigure.web.servlet.MultipartAutoConfiguration


### PR DESCRIPTION
## Summary
- `InetsoftApplication` uses `@ImportAutoConfiguration` with a curated allowlist (`META-INF/spring/inetsoft.web.InetsoftApplication.imports`) instead of the normal `@EnableAutoConfiguration` scan, and that allowlist was missing `EmbeddedWebServerFactoryCustomizerAutoConfiguration` — the class that registers `TomcatWebServerFactoryCustomizer`, which wires Tomcat's `RemoteIpValve` based on `server.forward-headers-strategy`/`server.tomcat.remoteip.*`.
- Without that valve, `request.getScheme()`/`getServerName()` always reflected the raw connection scheme, never `X-Forwarded-Proto`/`X-Forwarded-Host`, regardless of `internal-proxies` config or peer IP — so behind any TLS-terminating reverse proxy (AKS/EKS/GKE ingress-nginx, or any similar topology), login/EM redirects and other URLs built via `LinkUriArgumentResolver` came back `http://` instead of `https://`, causing mixed-content browser blocks.
- Confirmed via a loopback repro (`curl 127.0.0.1:8080` from inside the pod with `X-Forwarded-Proto: https`) that the scheme still wasn't rewritten even from an unconditionally-trusted peer, which rules out any proxy-CIDR/trust-range issue and isolates the bug to the valve never being registered at all.
- Fix: add the missing autoconfiguration class to the imports allowlist so the existing `server.forward-headers-strategy: native` setting (already correct, no change needed) actually takes effect.

## Test plan
- [ ] Build and start the server; confirm `RemoteIpValve` appears in the Tomcat engine's valve pipeline at startup
- [ ] `curl -H "X-Forwarded-Proto: https" -H "Host: <test-host>" http://127.0.0.1:8080/em` returns a `Location` header with `https://`, not `http://`
- [ ] Confirm requests from an untrusted (non-loopback, non-RFC1918) peer still use the raw connection scheme — the bug-75678 header-spoofing protection remains intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)