### PR TITLE
Bug #75745, fix embedded viewsheet thisParameter stringifying as [object Object]

### DIFF
--- a/core/src/main/java/inetsoft/uql/script/VariableScriptable.java
+++ b/core/src/main/java/inetsoft/uql/script/VariableScriptable.java
@@ -198,11 +198,13 @@ public class VariableScriptable implements ScriptScope {
          String name = (String) names.nextElement();
 
          try {
+            Object val = vars.get(name);
+
             if(sb.length() > 0) {
                sb.append(", ");
             }
 
-            sb.append(name).append('=').append(vars.get(name));
+            sb.append(name).append('=').append(val);
          }
          catch(Exception ignore) {
          }

--- a/core/src/main/java/inetsoft/uql/script/VariableScriptable.java
+++ b/core/src/main/java/inetsoft/uql/script/VariableScriptable.java
@@ -184,10 +184,31 @@ public class VariableScriptable implements ScriptScope {
    }
 
    /**
-    * Convert to string form.
+    * Convert to string form. Scripts sometimes concatenate a scope object
+    * (e.g. {@code thisParameter} on an embedded viewsheet, or the top-level
+    * {@code parameter} global) directly instead of dereferencing a specific
+    * variable name; list the variable names/values rather than falling back
+    * to Java's default {@code Object.toString()}.
     */
    public String toString() {
-      return vars.toString();
+      StringBuilder sb = new StringBuilder();
+      Enumeration names = vars.keys();
+
+      while(names.hasMoreElements()) {
+         String name = (String) names.nextElement();
+
+         try {
+            if(sb.length() > 0) {
+               sb.append(", ");
+            }
+
+            sb.append(name).append('=').append(vars.get(name));
+         }
+         catch(Exception ignore) {
+         }
+      }
+
+      return sb.toString();
    }
 
    private ScriptScope parent;

--- a/core/src/main/java/inetsoft/util/script/graal/ScopeProxy.java
+++ b/core/src/main/java/inetsoft/util/script/graal/ScopeProxy.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.util.script.graal;
 
+import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.graalvm.polyglot.proxy.ProxyObject;
 import java.util.Arrays;
 
@@ -39,6 +40,15 @@ public class ScopeProxy implements ProxyObject {
 
    @Override
    public Object getMember(String key) {
+      // GraalJS's string-coercion (ToPrimitive) looks up a callable "toString"/
+      // "valueOf" *member* on this proxy rather than calling the underlying
+      // ScriptScope's Java toString(), so a scope object concatenated directly
+      // into a string (e.g. an embedded viewsheet's "thisParameter") would
+      // otherwise stringify as the generic "[object Object]".
+      if("toString".equals(key) && !scope.hasMember(key)) {
+         return (ProxyExecutable) args -> scope.toString();
+      }
+
       return ScriptValueConverter.toGuest(scope.getMember(key));
    }
 
@@ -49,7 +59,7 @@ public class ScopeProxy implements ProxyObject {
 
    @Override
    public boolean hasMember(String key) {
-      return scope.hasMember(key);
+      return scope.hasMember(key) || "toString".equals(key);
    }
 
    @Override

--- a/core/src/test/java/inetsoft/uql/script/VariableScriptableTest.java
+++ b/core/src/test/java/inetsoft/uql/script/VariableScriptableTest.java
@@ -138,8 +138,26 @@ class VariableScriptableTest {
    }
 
    @Test
-   void testToString() {
-      when(mockVariableTable.toString()).thenReturn("VariableTableString");
-      assertEquals("VariableTableString", variableScriptable.toString());
+   void testToString() throws Exception {
+      Enumeration<String> mockKeys = mock(Enumeration.class);
+      when(mockKeys.hasMoreElements()).thenReturn(true, true, false);
+      when(mockKeys.nextElement()).thenReturn("key1", "key2");
+      when(mockVariableTable.keys()).thenReturn(mockKeys);
+      when(mockVariableTable.get("key1")).thenReturn("value1");
+      when(mockVariableTable.get("key2")).thenReturn("value2");
+
+      assertEquals("key1=value1, key2=value2", variableScriptable.toString());
+   }
+
+   @Test
+   void testToStringSkipsFailedGet() throws Exception {
+      Enumeration<String> mockKeys = mock(Enumeration.class);
+      when(mockKeys.hasMoreElements()).thenReturn(true, true, false);
+      when(mockKeys.nextElement()).thenReturn("key1", "key2");
+      when(mockVariableTable.keys()).thenReturn(mockKeys);
+      when(mockVariableTable.get("key1")).thenThrow(new RuntimeException("boom"));
+      when(mockVariableTable.get("key2")).thenReturn("value2");
+
+      assertEquals("key2=value2", variableScriptable.toString());
    }
 }


### PR DESCRIPTION
## Summary
- `Viewsheet1.thisParameter` (an embedded viewsheet's parameter scope) rendered as the generic `[object Object]` when concatenated directly into a string, e.g. `'...' + Viewsheet1.thisParameter`.
- Root cause: GraalJS resolves string coercion via a callable `toString`/`valueOf` **member** lookup on the object, never the underlying Java `Object.toString()` override. `ScopeProxy` (the GraalJS bridge for `ScriptScope` objects such as `VariableScriptable`) exposed no such member, so GraalJS fell back to its default `[object Object]`.
- Fix: `ScopeProxy.getMember("toString")` now returns a callable that delegates to the scope's `toString()`. `VariableScriptable.toString()` — previously dead code, never reachable from script — now builds an actual `key=value, ...` listing of its variable table.
- This is a general fix for any `ScriptScope`-backed value stringified directly (also covers the top-level `parameter` global), not just embedded-viewsheet `thisParameter`.

## Test plan
- [x] Verified both modified files compile cleanly against the project sourcepath/classpath
- [x] Reproduced with `VS_embedded.vso`: selecting radio button B on the embedded viewsheet now shows `myBox=B, pid=15.0, ...` instead of `[object Object]` in the `Viewsheet1.thisParameter` output