### PR TITLE
Bug #75746, fix percent-of-grand-total showing blank after converting a crosstab to a freehand table

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AbstractCrosstabVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AbstractCrosstabVSAQuery.java
@@ -839,6 +839,34 @@ public abstract class AbstractCrosstabVSAQuery extends CubeVSAQuery
          }
       }
 
+      // Multiple aggregates (e.g. a raw sum and a "percent of total" calculator) can
+      // share the same underlying column and therefore the same measure name here.
+      // The calc table conversion (CalcTableVSAQuery.createCrosstabAssemblies) disambiguates
+      // duplicate aggregate binding values the same way ("name", "name.1", "name.2", ...), and
+      // a calc table's grand-total cells reference the measure by this bare, unqualified name
+      // (no "@group:value" suffix) -- so measureHeaders must use the identical disambiguated
+      // names or TableArray.hasMember() won't find the duplicate and the cell silently
+      // resolves to undefined/null.
+      Map<String, Integer> dupCounts = new HashMap<>();
+
+      for(int i = 0; i < measurename.length; i++) {
+         String name = measurename[i];
+
+         if(name == null) {
+            continue;
+         }
+
+         Integer dup = dupCounts.get(name);
+
+         if(dup == null) {
+            dupCounts.put(name, 1);
+         }
+         else {
+            dupCounts.put(name, dup + 1);
+            measurename[i] = name + "." + dup;
+         }
+      }
+
       return measurename;
    }
 

--- a/core/src/main/java/inetsoft/report/composition/execution/AbstractCrosstabVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AbstractCrosstabVSAQuery.java
@@ -816,6 +816,14 @@ public abstract class AbstractCrosstabVSAQuery extends CubeVSAQuery
                                      Map<String, String> calcHeaderMap)
    {
       String[] measurename = new String[formula.length];
+      // per-index original (pre-calc-prefix) name, only set where a calculator applies;
+      // used to rebuild calcHeaderMap below, keyed by the final (post-dedup) measurename,
+      // instead of putting into calcHeaderMap immediately -- two calculator aggregates on
+      // the same column (e.g. SUM(col) and AVG(col) both with "Percent of Grand Total")
+      // can compute the same prefixed name here, and an immediate put() would have one
+      // entry silently overwrite the other under a key that no longer matches either
+      // aggregate's final, deduped measurename.
+      String[] calcOriginalNames = applyCalc ? new String[formula.length] : null;
 
       for(int i = 0; i < formula.length; i++) {
          if(formula[i] instanceof CalcFieldFormula) {
@@ -832,10 +840,7 @@ public abstract class AbstractCrosstabVSAQuery extends CubeVSAQuery
             Calculator calc = ((VSAggregateRef) aggrs[i]).getCalculator();
             String originalName = measurename[i];
             measurename[i] = calc.getPrefix() + measurename[i];
-
-            if(calcHeaderMap != null) {
-               calcHeaderMap.put(measurename[i], originalName);
-            }
+            calcOriginalNames[i] = originalName;
          }
       }
 
@@ -864,6 +869,14 @@ public abstract class AbstractCrosstabVSAQuery extends CubeVSAQuery
          else {
             dupCounts.put(name, dup + 1);
             measurename[i] = name + "." + dup;
+         }
+      }
+
+      if(calcHeaderMap != null) {
+         for(int i = 0; i < measurename.length; i++) {
+            if(calcOriginalNames[i] != null) {
+               calcHeaderMap.put(measurename[i], calcOriginalNames[i]);
+            }
          }
       }
 

--- a/core/src/main/java/inetsoft/report/composition/execution/AbstractCrosstabVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AbstractCrosstabVSAQuery.java
@@ -853,14 +853,31 @@ public abstract class AbstractCrosstabVSAQuery extends CubeVSAQuery
       // names or TableArray.hasMember() won't find the duplicate and the cell silently
       // resolves to undefined/null.
       //
-      // Only CalcFieldFormula-backed entries (i.e. calculator-derived aggregates, the only
-      // ones a calc table's grand-total cells reference by this bare name) are renamed here,
-      // mirroring the CalcFieldFormula-only scoping CrossTabFilter.initCalcHeaders() already
-      // uses for the same kind of disambiguation. Occurrences are still counted across every
-      // aggregate -- including plain, non-calculator ones -- so a calc aggregate colliding
-      // with an earlier plain aggregate's name is still detected, but two plain aggregates
-      // colliding with each other are left as-is, so an ordinary live crosstab's visible
-      // summary-header text (CrossTabFilter.getHeaders()/addSummaryHeaders()) is unaffected.
+      // Only names shared by at least one CalcFieldFormula-backed (calculator-derived)
+      // aggregate are renamed here -- CalcTableVSAQuery.createCrosstabAssemblies dedups
+      // aggregate binding values unconditionally by position, regardless of formula type,
+      // so whichever aggregate is NOT the first occurrence of a colliding name -- plain or
+      // calculator-derived -- ends up bound to the disambiguated "name.1" in the calc
+      // table. Renaming only when the *later* occurrence itself is a CalcFieldFormula would
+      // miss the case where a calculator aggregate is first and a plain aggregate collides
+      // with it second: the plain aggregate's calc-table binding is still "name.1", but its
+      // measureHeaders entry would stay "name", reproducing the same null-lookup bug for
+      // that ordering. A name shared only by plain aggregates has no calc-table binding
+      // riding on it, so those are left as-is -- ordinary live crosstabs' visible
+      // summary-header text (CrossTabFilter.getHeaders()/addSummaryHeaders()) stays
+      // unaffected unless a calculator is actually involved in the collision.
+      Map<String, Boolean> hasCalcMember = new HashMap<>();
+
+      for(int i = 0; i < measurename.length; i++) {
+         String name = measurename[i];
+
+         if(name == null) {
+            continue;
+         }
+
+         hasCalcMember.merge(name, formula[i] instanceof CalcFieldFormula, Boolean::logicalOr);
+      }
+
       Map<String, Integer> dupCounts = new HashMap<>();
 
       for(int i = 0; i < measurename.length; i++) {
@@ -878,7 +895,7 @@ public abstract class AbstractCrosstabVSAQuery extends CubeVSAQuery
          else {
             dupCounts.put(name, dup + 1);
 
-            if(formula[i] instanceof CalcFieldFormula) {
+            if(hasCalcMember.get(name)) {
                measurename[i] = name + "." + dup;
             }
          }

--- a/core/src/main/java/inetsoft/report/composition/execution/AbstractCrosstabVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AbstractCrosstabVSAQuery.java
@@ -852,6 +852,15 @@ public abstract class AbstractCrosstabVSAQuery extends CubeVSAQuery
       // (no "@group:value" suffix) -- so measureHeaders must use the identical disambiguated
       // names or TableArray.hasMember() won't find the duplicate and the cell silently
       // resolves to undefined/null.
+      //
+      // Only CalcFieldFormula-backed entries (i.e. calculator-derived aggregates, the only
+      // ones a calc table's grand-total cells reference by this bare name) are renamed here,
+      // mirroring the CalcFieldFormula-only scoping CrossTabFilter.initCalcHeaders() already
+      // uses for the same kind of disambiguation. Occurrences are still counted across every
+      // aggregate -- including plain, non-calculator ones -- so a calc aggregate colliding
+      // with an earlier plain aggregate's name is still detected, but two plain aggregates
+      // colliding with each other are left as-is, so an ordinary live crosstab's visible
+      // summary-header text (CrossTabFilter.getHeaders()/addSummaryHeaders()) is unaffected.
       Map<String, Integer> dupCounts = new HashMap<>();
 
       for(int i = 0; i < measurename.length; i++) {
@@ -868,7 +877,10 @@ public abstract class AbstractCrosstabVSAQuery extends CubeVSAQuery
          }
          else {
             dupCounts.put(name, dup + 1);
-            measurename[i] = name + "." + dup;
+
+            if(formula[i] instanceof CalcFieldFormula) {
+               measurename[i] = name + "." + dup;
+            }
          }
       }
 

--- a/core/src/main/java/inetsoft/report/filter/CalcFieldFormula.java
+++ b/core/src/main/java/inetsoft/report/filter/CalcFieldFormula.java
@@ -388,9 +388,17 @@ public class CalcFieldFormula implements PercentageFormula, Formula2 {
    @Override
    public Object getOriginalResult() {
       int perType = getPercentageType();
+      // save/restore the cached result around the temporary type flip below --
+      // getResult() caches its return value in `result`, and if this formula is
+      // later read again via getResult() (e.g. this is the grand total cell,
+      // which is also used as another cell's percentage denominator), it must
+      // not see a stale value computed while percentageType was forced to NONE.
+      Object[] savedResult = this.result;
       setPercentageType(StyleConstants.PERCENTAGE_NONE);
+      clearResult();
       Object oresult = getResult();
       setPercentageType(perType);
+      this.result = savedResult;
 
       return oresult;
    }

--- a/core/src/test/java/inetsoft/report/filter/CalcFieldFormulaTest.java
+++ b/core/src/test/java/inetsoft/report/filter/CalcFieldFormulaTest.java
@@ -19,11 +19,16 @@ package inetsoft.report.filter;
 
 import inetsoft.report.StyleConstants;
 import inetsoft.report.composition.execution.AssetQuerySandbox;
-import inetsoft.test.SreeHome;
+import inetsoft.test.*;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.util.Tool;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -34,7 +39,11 @@ import static org.junit.jupiter.api.Assertions.*;
  * over their results. These tests cover the lifecycle methods (addValue, isNull, reset, clone)
  * and percentage-type behavior. Script evaluation is tested using a simple arithmetic expression.
  */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @SreeHome
+@Tag("core")
 public class CalcFieldFormulaTest {
 
    private AssetQuerySandbox box;
@@ -284,6 +293,54 @@ public class CalcFieldFormulaTest {
       CalcFieldFormula formula = buildSingleChildFormula("SUM", new SumFormula(), "SUM");
       formula.setDefaultResult(false);
       assertNull(formula.getOriginalResult());
+   }
+
+   /**
+    * Regression test for a bug where a formula used as another cell's percentage
+    * denominator (e.g. a crosstab's grand-total cell, queried via getOriginalResult()
+    * while computing every other row's percentage) would permanently return its raw,
+    * unpercentaged value from then on -- even after setTotal() was subsequently called
+    * to compute its own percentage. getResult() caches its return value, and the old
+    * getOriginalResult() implementation forced percentageType to NONE, called
+    * getResult() (caching the raw value), then restored percentageType without
+    * invalidating that cache.
+    */
+   @Test
+   void getOriginalResult_thenGetResult_stillComputesPercentageNotStaleRawValue() {
+      CalcFieldFormula formula = buildSingleChildFormula("SUM", new SumFormula(), "SUM");
+      formula.addValue(new Object[]{ null, Double.valueOf(10.0) });
+      formula.setPercentageType(StyleConstants.PERCENTAGE_OF_GRANDTOTAL);
+
+      // simulate this formula being read as another cell's percentage denominator,
+      // as CrossTabFilter.applyPercentage() does for every row sharing this grand total
+      Object original = formula.getOriginalResult();
+      assertEquals(10.0, ((Number) original).doubleValue(), 1e-10);
+
+      // now compute this formula's own percentage (e.g. the grand-total cell's own
+      // 100%, where its denominator is itself)
+      formula.setTotal(10.0);
+
+      Object result = formula.getResult();
+      assertNotNull(result);
+      assertEquals(1.0, ((Number) result).doubleValue(), 1e-10);
+   }
+
+   @Test
+   void getOriginalResult_doesNotDisturbAlreadyCachedPercentageResult() {
+      CalcFieldFormula formula = buildSingleChildFormula("SUM", new SumFormula(), "SUM");
+      formula.addValue(new Object[]{ null, Double.valueOf(10.0) });
+      formula.setPercentageType(StyleConstants.PERCENTAGE_OF_GRANDTOTAL);
+      formula.setTotal(20.0);
+
+      // cache the percentage result (10/20 = 0.5) before getOriginalResult() runs
+      Object result = formula.getResult();
+      assertEquals(0.5, ((Number) result).doubleValue(), 1e-10);
+
+      Object original = formula.getOriginalResult();
+      assertEquals(10.0, ((Number) original).doubleValue(), 1e-10);
+
+      // the previously-cached percentage result must still be intact afterward
+      assertEquals(0.5, ((Number) formula.getResult()).doubleValue(), 1e-10);
    }
 
    // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Converting a crosstab that uses a Calculator-based percentage aggregate (e.g. "Percent of Grand Total") to a freehand/calc table left the Grand Total row's percentage cell blank, while every other row (detail and subtotal) computed correctly.

Two bugs combined to cause this:

- **`CalcFieldFormula.getOriginalResult()`** temporarily forced `percentageType` to `NONE`, called `getResult()` (which caches its return value in `result`), then restored the type — but never invalidated that cache. The grand-total cell's formula instance is used both as the denominator for every other row's percentage *and* as the numerator for its own 100%, so by the time its own percentage was computed, it returned the stale cached raw value instead of `raw / total`.
- **`AbstractCrosstabVSAQuery.getMeasureHeader()`** didn't de-duplicate measure names for Calculator-based aggregates sharing an underlying column, so a raw-sum aggregate and a percent-of-total aggregate on the same column both resolved to the same bare measure name. A calc table's grand-total cells reference their measure by this bare, unqualified name (they have no row/col group to qualify it with), so the second aggregate's lookup missed the disambiguated name (`"name.1"`) the layout conversion actually generates, and silently resolved to `null`.

## Test plan
- [ ] Build a crosstab with row groups and an aggregate using a "Percent of Grand Total" calculator on top of another aggregate on the same column
- [ ] Right-click → Convert to Freehand Table
- [ ] Confirm the Grand Total row now shows 100% for the percent column (previously blank), matching the original crosstab's rendering
- [ ] Confirm detail and subtotal row percentages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)