### PR TITLE
75642, radar chart series hover issue

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -3354,10 +3354,14 @@ public class SVGAnimationDOMInjector {
          // Area/line hover uses JS-only inline style.opacity (no inetsoft-active class is set).
          // CSS :has(.inetsoft-area.inetsoft-active) rules are not used because CSS :has()
          // cannot scope to a single facet panel within one SVG — all panels would be affected.
-         // Radar polygon dimming via CSS :hover only — no inetsoft-active toggling for radar.
-         // Hovering inside a polygon's hit area dims sibling polygons; vertex points produce
-         // no dim effect. pointer-events:all on the group makes the filled interior reactive.
-         // Per-series point dimming is injected in injectRadarAnimation() once N is known.
+         // Radar dimming via CSS :hover only — no inetsoft-active toggling for radar. Two
+         // activation sources, both wired per-series in injectRadarAnimation() once N is known:
+         // (A) hovering a series' transparent outline hit band (pointer-events:stroke) and
+         // (B) hovering a series' vertex point. The real polygon path is set to pointer-events:none
+         // there, so the filled interior is NOT reactive — that is what lets overlapping series
+         // behind the front one still be reached. The generic :has(.inetsoft-radar:hover) rule
+         // below dims sibling polygons when source (A) fires; the base pointer-events:all remains
+         // as a design-time/noanim fallback (injectRadarAnimation does not run in that mode).
          ".inetsoft-radar{pointer-events:all}" +
          "svg.ready:has(.inetsoft-radar:hover) .inetsoft-radar:not(:hover)" +
          "{opacity:" + dim + "!important}" +

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -36,6 +36,10 @@ public class SVGAnimationDOMInjector {
 
    static final String SVG_NS = "http://www.w3.org/2000/svg";
 
+   /** On-screen width (px, via non-scaling-stroke) of the transparent hit band traced along each
+    *  radar series' outline, giving a comfortable hover target along the line. */
+   private static final int RADAR_HIT_STROKE_WIDTH = 12;
+
    /** Entry point: inject animations into the live DOM document in-place. */
    public static void injectAnimation(Document doc, String animHint) {
       injectAnimation(doc.getDocumentElement(), animHint);
@@ -67,6 +71,13 @@ public class SVGAnimationDOMInjector {
       // highlighting to work, but the entrance animation must be suppressed. Return before
       // injecting any animation and without setting data-animated, so the Angular directive adds
       // the .ready class immediately (the .ready-gated A1 types highlight without a delay).
+      //
+      // Note: radar per-series hover setup (group reclassification to .inetsoft-radar, data-row
+      // assignment, the outline hit band, and vertex-point pointer-events) lives in
+      // injectRadarAnimation and therefore does not run here. Radar hover-dim was already a no-op
+      // in noanim mode before this change (the groups keep their inetsoft-line/inetsoft-area
+      // class, which the radar hover rules never match), so this is a pre-existing design-time
+      // limitation, not a regression introduced by the #75642 overlap fix.
       if(animHint.contains(":" + SVGSupport.ANIMATION_FLAG_NOANIM)) {
          return;
       }
@@ -3060,11 +3071,19 @@ public class SVGAnimationDOMInjector {
 
       for(int i = 0; i < n; i++) {
          perSeriesCss.append(String.format(java.util.Locale.US,
-            // When series i's polygon is CSS-hovered (mouse inside the interior), dim the
-            // vertex points of all other series. The hovered series' own points are excluded
-            // by :not([data-row=i]) so they stay at full opacity.
+            // When series i's outline band is CSS-hovered, dim the vertex points of all other
+            // series. The hovered series' own points are excluded by :not([data-row=i]) so they
+            // stay at full opacity.
             "svg.ready:has(.inetsoft-radar[data-row=\"%d\"]:hover) .inetsoft-point:not([data-row=\"%d\"])" +
-            "{opacity:" + dim + "!important}", i, i));
+            "{opacity:" + dim + "!important}" +
+            // Second, precise activation source: hovering series i's vertex point. Vertices are
+            // per-series elements painted on top, so they stay individually reachable even when
+            // the polygons overlap heavily (near-identical series). Hovering a vertex dims every
+            // other series' polygon and points, leaving series i at full opacity.
+            "svg.ready:has(.inetsoft-point[data-row=\"%d\"]:hover) .inetsoft-radar:not([data-row=\"%d\"])" +
+            "{opacity:" + dim + "!important}" +
+            "svg.ready:has(.inetsoft-point[data-row=\"%d\"]:hover) .inetsoft-point:not([data-row=\"%d\"])" +
+            "{opacity:" + dim + "!important}", i, i, i, i, i, i));
       }
 
       appendStyle(svgRoot, doc, perSeriesCss.toString());
@@ -3081,42 +3100,68 @@ public class SVGAnimationDOMInjector {
             "opacity:0;animation:inetsoft-radar-grow %.2fs %s %.2fs both",
             cx, cy, AnimationConstants.DURATION, AnimationConstants.EASING, delay));
 
-         // For line radar the path has fill="none": inject a ghost fill and a hit area.
          Element path = firstDescendantPath(g);
 
-         if(path != null && "none".equals(path.getAttribute("fill"))) {
+         if(path != null) {
             String pathD = path.getAttribute("d");
+            boolean lineStyle = "none".equals(path.getAttribute("fill"));
 
             if(!pathD.isEmpty()) {
-               // Ghost fill — semi-transparent copy of the polygon, inside the group so it
-               // inherits the spring animation.  pointer-events:none keeps interaction on the
-               // explicit hit path added below.
-               int[] rgb = parseColorData(g.getAttribute("data-" + SVGSupport.ATTR_COLOR));
+               if(lineStyle) {
+                  // Line radar: the real path is fill="none". Inject a ghost fill — a
+                  // semi-transparent copy inside the group so it inherits the spring animation.
+                  // pointer-events:none keeps interaction on the explicit hit band added below.
+                  int[] rgb = parseColorData(g.getAttribute("data-" + SVGSupport.ATTR_COLOR));
 
-               if(rgb != null) {
-                  Element ghostPath = doc.createElementNS(SVG_NS, "path");
-                  ghostPath.setAttribute("d", pathD);
-                  ghostPath.setAttribute("fill",
-                     String.format("rgba(%d,%d,%d,0.12)", rgb[0], rgb[1], rgb[2]));
-                  ghostPath.setAttribute("stroke", "none");
-                  ghostPath.setAttribute("pointer-events", "none");
-                  // path may be nested inside a Batik intermediate style <g>; insertBefore
-                  // requires the reference node to be a direct child of the receiver.
-                  Element pathParent = (Element) path.getParentNode();
-                  pathParent.insertBefore(ghostPath, path);
+                  if(rgb != null) {
+                     Element ghostPath = doc.createElementNS(SVG_NS, "path");
+                     ghostPath.setAttribute("d", pathD);
+                     ghostPath.setAttribute("fill",
+                        String.format("rgba(%d,%d,%d,0.12)", rgb[0], rgb[1], rgb[2]));
+                     ghostPath.setAttribute("stroke", "none");
+                     ghostPath.setAttribute("pointer-events", "none");
+                     // path may be nested inside a Batik intermediate style <g>; insertBefore
+                     // requires the reference node to be a direct child of the receiver.
+                     Element pathParent = (Element) path.getParentNode();
+                     pathParent.insertBefore(ghostPath, path);
+                  }
                }
+               // The real polygon path must NOT capture pointer events over its interior:
+               // overlapping series are painted back-to-front, so the largest (front) polygon
+               // would otherwise swallow every hover and the underlying series could never be
+               // highlighted. This applies to BOTH styles because the group carries
+               // pointer-events:all (base hover CSS), and pointer-events:all captures the whole
+               // geometric fill region even for a line-style path whose fill="none" — so simply
+               // relying on fill="none" to opt the interior out does not work here. The outline
+               // hit band below becomes the sole hit target for the series.
+               mergeStyle(path, "pointer-events:none");
 
-               // Hit path — rgba(0,0,0,0) is transparent but still captures pointer events
-               // (unlike fill="none" which opts the filled area out of pointer events entirely).
-               // Append to path's parent for the same reason as the ghost path above.
+               // Outline hit band (both styles) — a transparent stroke that traces the polygon
+               // edge. Because it strokes the outline (not the interior), each series stays
+               // reachable by its own edge regardless of how the filled areas overlap.
+               // vector-effect:non-scaling-stroke keeps the band a constant on-screen width
+               // independent of the chart's coordinate scale; pointer-events:stroke makes only
+               // the band (not its hollow interior) reactive, so it never re-blocks the series
+               // painted beneath it. It is a descendant of the .inetsoft-radar group, so
+               // :hover on it satisfies the group's per-series dim rules.
                Element hitPath = doc.createElementNS(SVG_NS, "path");
                hitPath.setAttribute("d", pathD);
-               hitPath.setAttribute("fill", "rgba(0,0,0,0)");
-               hitPath.setAttribute("stroke", "none");
-               hitPath.setAttribute("pointer-events", "all");
+               hitPath.setAttribute("fill", "none");
+               hitPath.setAttribute("stroke", "rgba(0,0,0,0)");
+               hitPath.setAttribute("stroke-width", String.valueOf(RADAR_HIT_STROKE_WIDTH));
+               hitPath.setAttribute("vector-effect", "non-scaling-stroke");
+               hitPath.setAttribute("pointer-events", "stroke");
                path.getParentNode().appendChild(hitPath);
             }
          }
+      }
+
+      // Make radar vertex points reactive so hovering a vertex activates its series (the second
+      // activation source wired in the per-series CSS above). Points sit on top of the polygons
+      // and are distinct per series, so they remain individually selectable when the polygons are
+      // nearly identical and their outline bands overlap.
+      for(Element pt : collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_POINT)) {
+         mergeStyle(pt, "pointer-events:all");
       }
 
       // Points and value labels appear after all polygons have settled.

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -3057,13 +3057,15 @@ public class SVGAnimationDOMInjector {
       // during the entrance animation.
       //
       // Two activation sources exist:
-      //   A) Polygon interior — mouse over the hit path inside .inetsoft-radar[data-row=i].
-      //      The hit path is a descendant of .inetsoft-radar, so :hover propagates up to it.
+      //   A) Outline hit band — mouse over the transparent stroke band traced around the
+      //      polygon edge (a descendant of .inetsoft-radar[data-row=i], so :hover propagates
+      //      up to the group). The real polygon interior is pointer-events:none and does not
+      //      participate in hit-testing.
       //   B) Vertex circle   — .inetsoft-point[data-row=i] circles are painted AFTER radar
-      //      groups (later DOM order → higher z-order), so they sit on top of the hit paths.
-      //      Without an explicit CSS :hover rule keyed on .inetsoft-point, the full vertex
-      //      circle area would not trigger the dim effect (only the thin crescent of hit-path
-      //      area visible around the circle edge would activate .inetsoft-radar:hover).
+      //      groups (later DOM order → higher z-order), so they sit on top of the outline
+      //      bands at each vertex. Without an explicit CSS :hover rule keyed on .inetsoft-point,
+      //      only the thin crescent of band area visible around the circle's edge would
+      //      activate .inetsoft-radar:hover.
       //
       // Both sources dim the same set of targets:
       //   • sibling radar polygons  (not[data-row=i])

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -2992,13 +2992,16 @@ public class SVGAnimationDOMInjector {
     * groups and AreaVO emits {@code inetsoft-area} groups — both are collected and
     * re-classified to {@code inetsoft-radar} so hover CSS targets the correct class.
     *
-    * <p>For line-style radar ({@code CHART_RADAR}) the path has {@code fill="none"}, so:
-    * <ul>
-    *   <li>A semi-transparent ghost fill path is injected inside the group (inherits animation).
-    *   <li>A transparent hit path is appended so the enclosed area captures pointer events.
-    * </ul>
-    * Fill-style radar ({@code CHART_FILL_RADAR}) already has a filled path; neither extra
-    * element is needed.
+    * <p>Hover targeting is by outline, not fill: overlapping series are painted back-to-front, so
+    * a filled interior would let the front-most polygon swallow every hover. For both line- and
+    * fill-style radar the real polygon path is set to {@code pointer-events:none} and a transparent
+    * <b>outline hit band</b> ({@code stroke:rgba(0,0,0,0)}, {@code pointer-events:stroke}) is
+    * appended inside the group, so each series stays reachable by its edge regardless of overlap.
+    *
+    * <p>Only line-style radar ({@code CHART_RADAR}), whose real path is {@code fill="none"},
+    * additionally gets a semi-transparent ghost fill path injected inside the group (inherits the
+    * animation) so the polygon still reads as filled. Fill-style radar ({@code CHART_FILL_RADAR})
+    * already has a real filled path and needs no ghost fill.
     */
    private static void injectRadarAnimation(Element svgRoot, Document doc) {
       // Collect both line and area annotation groups — radar uses one or the other.

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -725,6 +725,44 @@ class SVGAnimationDOMInjectorTest {
    }
 
    /**
+    * The per-series CSS injected for radar must emit the vertex-point activation selectors
+    * (activation source B). This guards the generated selector text itself — the DOM-structure
+    * tests would still pass if a refactor silently broke the selector string (all the format
+    * args are the same variable {@code i}, so an accidental reordering wouldn't be caught there).
+    */
+   @Test
+   void radar_perSeriesVertexHoverCssEmitted() throws Exception {
+      Document doc = newDocument();
+
+      for(int i = 0; i < 2; i++) {
+         Element g = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
+         g.setAttribute("class", SVGSupport.ANNOTATION_LINE);
+         g.setAttribute("data-row", String.valueOf(i));
+         g.setAttribute("data-" + SVGSupport.ATTR_COLOR, "60,105,138");
+         Element path = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "path");
+         path.setAttribute("d", "M 100 50 L 150 150 L 50 150 Z");
+         path.setAttribute("fill", "none");
+         g.appendChild(path);
+         doc.getDocumentElement().appendChild(g);
+      }
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_RADAR);
+      String css = allStyleContent(doc.getDocumentElement());
+
+      // Hovering series 0's vertex point must dim other series' polygons and other series' points.
+      assertTrue(css.contains(
+         "svg.ready:has(.inetsoft-point[data-row=\"0\"]:hover) .inetsoft-radar:not([data-row=\"0\"])"),
+         "vertex hover must dim other series' polygons");
+      assertTrue(css.contains(
+         "svg.ready:has(.inetsoft-point[data-row=\"0\"]:hover) .inetsoft-point:not([data-row=\"0\"])"),
+         "vertex hover must dim other series' points");
+      // And the pre-existing outline-band source: hovering series 1's band dims other points.
+      assertTrue(css.contains(
+         "svg.ready:has(.inetsoft-radar[data-row=\"1\"]:hover) .inetsoft-point:not([data-row=\"1\"])"),
+         "outline-band hover must dim other series' points");
+   }
+
+   /**
     * Two radar series groups should animate with the second series delayed by
     * {@code stagger = 0.25 s} relative to the first.
     */

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -633,8 +633,8 @@ class SVGAnimationDOMInjectorTest {
       assertTrue(g.getAttribute("style").contains("inetsoft-radar-grow"),
                  "radar group must receive the spring-scale animation");
 
-      // fill="none" path triggers ghost-fill (prepended) + hit-path (appended) injection.
-      // Child count: ghost-fill path + original path + hit path = 3.
+      // fill="none" path triggers ghost-fill (prepended) + outline hit band (appended) injection.
+      // Child count: ghost-fill path + original path + hit band = 3.
       int childCount = 0;
       Node child = g.getFirstChild();
       while(child != null) {
@@ -642,16 +642,86 @@ class SVGAnimationDOMInjectorTest {
          child = child.getNextSibling();
       }
       assertEquals(3, childCount,
-                   "ghost-fill path and hit path must be injected for fill=none radar polygon");
+                   "ghost-fill path and outline hit band must be injected for fill=none radar polygon");
 
-      // Hit path is the last Element child.
+      // Outline hit band is the last Element child: a transparent stroke tracing the polygon edge
+      // (fill:none, pointer-events:stroke) so each series stays reachable regardless of overlap.
       Node last = g.getLastChild();
       while(last != null && !(last instanceof Element)) last = last.getPreviousSibling();
       assertNotNull(last, "group must have at least one child element");
-      assertEquals("rgba(0,0,0,0)", ((Element) last).getAttribute("fill"),
-                   "last child must be the transparent hit path");
-      assertEquals("all", ((Element) last).getAttribute("pointer-events"),
-                   "hit path must capture pointer events");
+      assertEquals("none", ((Element) last).getAttribute("fill"),
+                   "hit band must not fill its interior");
+      assertEquals("rgba(0,0,0,0)", ((Element) last).getAttribute("stroke"),
+                   "hit band must be a transparent stroke");
+      assertEquals("stroke", ((Element) last).getAttribute("pointer-events"),
+                   "hit band must capture pointer events on its stroke only");
+
+      // The real line path must be neutralized too: it inherits pointer-events:all from the group,
+      // which captures the whole geometric interior even though fill="none", so without this it
+      // would keep swallowing hover for the series painted beneath it.
+      assertTrue(path.getAttribute("style").contains("pointer-events:none"),
+                 "line-style radar real path must have pointer-events:none");
+   }
+
+   /**
+    * Fill-style radar (the polygon path already has a real fill) must have its fill made
+    * non-interactive (pointer-events:none) so the front polygon no longer swallows hover events
+    * for the series painted beneath it, and must still receive the transparent outline hit band.
+    * Vertex points must be made reactive so they can serve as the precise per-series hover target.
+    */
+   @Test
+   void radar_fillStyleDisablesFillHitAndAddsOutlineBand() throws Exception {
+      Document doc = newDocument();
+
+      // Fill-style radar polygon: a real filled path (not fill="none").
+      Element g = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
+      g.setAttribute("class", SVGSupport.ANNOTATION_AREA);
+      g.setAttribute("data-row", "0");
+      g.setAttribute("data-" + SVGSupport.ATTR_COLOR, "60,105,138");
+      Element path = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "path");
+      path.setAttribute("d", "M 100 50 L 150 150 L 50 150 Z");
+      path.setAttribute("fill", "rgb(60,105,138)");
+      g.appendChild(path);
+      doc.getDocumentElement().appendChild(g);
+
+      // A vertex point for the series, which must be made reactive.
+      Element pt = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
+      pt.setAttribute("class", SVGSupport.ANNOTATION_POINT);
+      pt.setAttribute("data-row", "0");
+      Element circle = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "circle");
+      pt.appendChild(circle);
+      doc.getDocumentElement().appendChild(pt);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_RADAR);
+
+      assertEquals(SVGSupport.ANNOTATION_RADAR, g.getAttribute("class"),
+                   "inetsoft-area group must be reclassified to inetsoft-radar");
+      // The real fill path must be made non-interactive so its interior stops swallowing hover.
+      assertTrue(path.getAttribute("style").contains("pointer-events:none"),
+                 "fill-style radar path must have pointer-events:none");
+
+      // No ghost fill is injected for fill-style radar: only the original path + outline hit band.
+      int childCount = 0;
+      Node child = g.getFirstChild();
+      while(child != null) {
+         if(child instanceof Element) childCount++;
+         child = child.getNextSibling();
+      }
+      assertEquals(2, childCount,
+                   "fill-style radar must gain only the outline hit band (no ghost fill)");
+
+      // Outline hit band is the last Element child.
+      Node last = g.getLastChild();
+      while(last != null && !(last instanceof Element)) last = last.getPreviousSibling();
+      assertNotNull(last, "group must have at least one child element");
+      assertEquals("none", ((Element) last).getAttribute("fill"),
+                   "hit band must not fill its interior");
+      assertEquals("stroke", ((Element) last).getAttribute("pointer-events"),
+                   "hit band must capture pointer events on its stroke only");
+
+      // Vertex points are made reactive so they can serve as the precise per-series hover target.
+      assertTrue(pt.getAttribute("style").contains("pointer-events:all"),
+                 "radar vertex points must be made reactive");
    }
 
    /**

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
@@ -644,10 +644,12 @@ export class ChartInlineSvgDirective implements OnDestroy {
          }
       }
 
-      // Radar hover is driven entirely by CSS :hover on polygon groups (hit paths injected
-      // server-side have pointer-events:all so the filled interior is reactive). Vertex points
-      // intentionally produce no dim effect — no JS activation and no inetsoft-active toggling.
-      // The elementGroupMap is cleared so canvas-reported hover events are a no-op.
+      // Radar hover is driven entirely by CSS :hover on polygon groups. The server injects a
+      // transparent outline hit band per series (pointer-events:stroke) so each series is reachable
+      // by its edge regardless of how the filled areas overlap, plus per-series rules keyed on
+      // vertex-point hover so a series can also be picked precisely by its vertex when polygons are
+      // near-identical. No JS activation and no inetsoft-active toggling are involved here; the
+      // elementGroupMap is cleared so canvas-reported hover events are a no-op.
       const radarGroups = Array.from(
          this.element.nativeElement.querySelectorAll(".inetsoft-radar") as NodeListOf<Element>);
 


### PR DESCRIPTION
Root Cause:
Radar-chart series highlighting on hover is driven entirely by server-injected CSS :hover on the .inetsoft-radar polygon groups (single-tile radar has no JS hover path). The series polygons overlap and are painted back-to-front, so the largest/front polygon sits on top of the others. Because its path had pointer-events:all (inherited from the base .inetsoft-radar rule), it captured pointer events across its whole area -- including its interior even for line-style radar where fill="none" (pointer-events:all captures the geometric fill region regardless of paint). As a result the front series swallowed every hover and the series stacked beneath it could never be highlighted.

Fix:
In SVGAnimationDOMInjector.injectRadarAnimation, changed the radar hover hit target from the filled interior to each series' outline:
- For every series, inject a transparent outline "hit band" (fill:none, transparent stroke, stroke-width 12 with vector-effect:non-scaling-stroke, pointer-events:stroke) as a child of its .inetsoft-radar group, so each series is individually reachable by its edge regardless of how the filled areas overlap.
- Set the real polygon path to pointer-events:none for both line- and fill-style radar so its interior no longer swallows events for the series painted beneath it.
- Added a second, precise activation source for near-identical polygons: hovering a series' vertex point now highlights that series (per-series CSS keyed on .inetsoft-point[data-row=i]:hover, with radar vertex points made pointer-events:all).

Hovering on/near a series' line or its vertex dots now highlights that series and dims the rest, including previously unreachable underlying series. (The empty filled interior is intentionally transparent to hover, which is what makes the stacked series reachable.)