### PR TITLE
feat(wiz): dashboard grid layout + auto filter bar, with two data-integrity fixes

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/ColumnRef.java
+++ b/core/src/main/java/inetsoft/uql/asset/ColumnRef.java
@@ -57,6 +57,11 @@ public class ColumnRef extends AbstractDataRef implements AssetObject, DataRefWr
            AttributeRef nattr = new AttributeRef(nname, attr.getAttribute());
            // keep caption, necessary for cube
            nattr.setCaption(attr.getCaption());
+           // keep data type -- AttributeRef's own dtype defaults to null, so without this the
+           // column silently falls back to XSchema.STRING (ColumnRef#getDataType()) the moment
+           // its qualifying table is renamed (e.g. a worksheet dedup-merge sharing a physical
+           // table across two charts), corrupting any join keyed on this column downstream.
+           nattr.setDataType(attr.getDataType());
            column.setDataRef(nattr);
            column.setView(nattr.getName());
         }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDashboardEvent.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDashboardEvent.java
@@ -70,11 +70,21 @@ public class WizDashboardEvent {
       this.layoutColumns = layoutColumns;
    }
 
+   /** Optional filter specs to apply to the dashboard's viewsheets. */
+   public List<FilterSpec> getFilters() {
+      return filters;
+   }
+
+   public void setFilters(List<FilterSpec> filters) {
+      this.filters = filters;
+   }
+
    private String name;
    private List<String> identifiers;
    private String existingIdentifier;
    private List<TileSpec> tiles;
    private Integer layoutColumns;
+   private List<FilterSpec> filters;
 
    /** A single tile's placement within the dashboard grid layout. */
    @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,5 +107,37 @@ public class WizDashboardEvent {
 
       private String identifier;
       private int spanCols = 1;   // default: one cell
+   }
+
+   /** A single filter control's target field within the dashboard filter bar. */
+   @JsonIgnoreProperties(ignoreUnknown = true)
+   public static class FilterSpec {
+      public String getField() {
+         return field;
+      }
+
+      public void setField(String field) {
+         this.field = field;
+      }
+
+      public String getDataType() {
+         return dataType;
+      }
+
+      public void setDataType(String dataType) {
+         this.dataType = dataType;
+      }
+
+      public String getLabel() {
+         return label;
+      }
+
+      public void setLabel(String label) {
+         this.label = label;
+      }
+
+      private String field;
+      private String dataType;
+      private String label;
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDashboardEvent.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDashboardEvent.java
@@ -52,7 +52,27 @@ public class WizDashboardEvent {
       this.existingIdentifier = existingIdentifier;
    }
 
+   public List<TileSpec> getTiles() { return tiles; }
+   public void setTiles(List<TileSpec> tiles) { this.tiles = tiles; }
+
+   public Integer getLayoutColumns() { return layoutColumns; }
+   public void setLayoutColumns(Integer layoutColumns) { this.layoutColumns = layoutColumns; }
+
    private String name;
    private List<String> identifiers;
    private String existingIdentifier;
+   private List<TileSpec> tiles;
+   private Integer layoutColumns;
+
+   @JsonIgnoreProperties(ignoreUnknown = true)
+   public static class TileSpec {
+      public String getIdentifier() { return identifier; }
+      public void setIdentifier(String identifier) { this.identifier = identifier; }
+
+      public int getSpanCols() { return spanCols; }
+      public void setSpanCols(int spanCols) { this.spanCols = spanCols; }
+
+      private String identifier;
+      private int spanCols = 1;   // default: one cell
+   }
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDashboardEvent.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDashboardEvent.java
@@ -52,11 +52,23 @@ public class WizDashboardEvent {
       this.existingIdentifier = existingIdentifier;
    }
 
-   public List<TileSpec> getTiles() { return tiles; }
-   public void setTiles(List<TileSpec> tiles) { this.tiles = tiles; }
+   /** Optional grid tile placements (identifier + column span); when absent, layout is unmanaged. */
+   public List<TileSpec> getTiles() {
+      return tiles;
+   }
 
-   public Integer getLayoutColumns() { return layoutColumns; }
-   public void setLayoutColumns(Integer layoutColumns) { this.layoutColumns = layoutColumns; }
+   public void setTiles(List<TileSpec> tiles) {
+      this.tiles = tiles;
+   }
+
+   /** Optional number of grid columns for the dashboard layout. */
+   public Integer getLayoutColumns() {
+      return layoutColumns;
+   }
+
+   public void setLayoutColumns(Integer layoutColumns) {
+      this.layoutColumns = layoutColumns;
+   }
 
    private String name;
    private List<String> identifiers;
@@ -64,13 +76,24 @@ public class WizDashboardEvent {
    private List<TileSpec> tiles;
    private Integer layoutColumns;
 
+   /** A single tile's placement within the dashboard grid layout. */
    @JsonIgnoreProperties(ignoreUnknown = true)
    public static class TileSpec {
-      public String getIdentifier() { return identifier; }
-      public void setIdentifier(String identifier) { this.identifier = identifier; }
+      public String getIdentifier() {
+         return identifier;
+      }
 
-      public int getSpanCols() { return spanCols; }
-      public void setSpanCols(int spanCols) { this.spanCols = spanCols; }
+      public void setIdentifier(String identifier) {
+         this.identifier = identifier;
+      }
+
+      public int getSpanCols() {
+         return spanCols;
+      }
+
+      public void setSpanCols(int spanCols) {
+         this.spanCols = spanCols;
+      }
 
       private String identifier;
       private int spanCols = 1;   // default: one cell

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDashboardEvent.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDashboardEvent.java
@@ -105,8 +105,17 @@ public class WizDashboardEvent {
          this.spanCols = spanCols;
       }
 
+      public int getSpanRows() {
+         return spanRows;
+      }
+
+      public void setSpanRows(int spanRows) {
+         this.spanRows = spanRows;
+      }
+
       private String identifier;
       private int spanCols = 1;   // default: one cell
+      private int spanRows = 1;   // default: one cell
    }
 
    /** A single filter control's target field within the dashboard filter bar. */

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDashboardResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDashboardResult.java
@@ -44,6 +44,26 @@ public class WizDashboardResult {
       this.skipped = skipped;
    }
 
+   /** Filter fields that were applied to at least one viewsheet in the dashboard. */
+   public List<String> getFiltersApplied() {
+      return filtersApplied;
+   }
+
+   public void setFiltersApplied(List<String> filtersApplied) {
+      this.filtersApplied = filtersApplied;
+   }
+
+   /** Filter fields that could not be applied to any viewsheet in the dashboard. */
+   public List<String> getFiltersSkipped() {
+      return filtersSkipped;
+   }
+
+   public void setFiltersSkipped(List<String> filtersSkipped) {
+      this.filtersSkipped = filtersSkipped;
+   }
+
    private String savedViewsheetIdentifier;
    private List<String> skipped;
+   private List<String> filtersApplied;
+   private List<String> filtersSkipped;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/AddFilterService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/AddFilterService.java
@@ -162,12 +162,17 @@ public class AddFilterService {
     * tables.</p>
     *
     * <p>Package-visible (reuse seam, decision (a)): this is the shared root-table/column-matching
-    * loop. {@link #findTablesWithColumn} calls it after reloading {@code ws} from the
-    * {@code AssetRepository} (needed because a runtime viewsheet's own base worksheet can be
-    * stale — see above). {@link WizDashboardFilterBuilder} calls it directly against
-    * {@code vs.getBaseWorksheet()} because it operates on an already-composed, in-memory
-    * dashboard {@code Viewsheet} that has no separate stale-runtime-object problem, so no
-    * {@code AssetRepository}/{@code Principal} reload is needed there.</p>
+    * loop. {@link #findTablesWithColumn} calls it after loading {@code ws} from the
+    * {@code AssetRepository} with {@code permission=false} (needed because a runtime
+    * viewsheet's own base worksheet can be stale — see above). {@link WizDashboardFilterBuilder#build}
+    * has the identical staleness problem (its caller, {@code WizDashboardService.composeDashboard},
+    * merges visualizations into a dashboard {@code Viewsheet} the exact same way
+    * {@code AddVisualizationService} does here), so it is deliberately <b>not</b> handed a
+    * {@code Viewsheet} to read {@code getBaseWorksheet()} from for matching — it takes an
+    * already-loaded {@code Worksheet} parameter instead, which its caller must load the same
+    * way this method does: directly from the repository with {@code permission=false}, not
+    * {@code permission=true} (which can fail the ACL check on this system-generated ephemeral
+    * entry).</p>
     */
    static List<String> findColumnMatchingRootTables(Worksheet ws, String attribute) {
       if(ws == null) {

--- a/core/src/main/java/inetsoft/web/wiz/service/AddFilterService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/AddFilterService.java
@@ -72,10 +72,7 @@ public class AddFilterService {
       }
 
       // Build the column DataRef from the entry properties
-      AttributeRef attrRef = new AttributeRef(attribute);
-      attrRef.setDataType(dtype);
-      ColumnRef colRef = new ColumnRef(attrRef);
-      colRef.setDataType(dtype);
+      ColumnRef colRef = buildColumnRef(attribute, dtype);
 
       // Find all root tables in the worksheet that expose this column (shared filter).
       // Load from assetRepository so we see the latest saved state of the wiz temp
@@ -118,6 +115,20 @@ public class AddFilterService {
    }
 
    /**
+    * Builds a {@link ColumnRef} for the given attribute name and data type.
+    *
+    * <p>Package-visible (reuse seam, decision (a)): {@link WizDashboardFilterBuilder} calls
+    * this identical construction instead of maintaining a second copy.</p>
+    */
+   static ColumnRef buildColumnRef(String attribute, String dtype) {
+      AttributeRef attrRef = new AttributeRef(attribute);
+      attrRef.setDataType(dtype);
+      ColumnRef colRef = new ColumnRef(attrRef);
+      colRef.setDataType(dtype);
+      return colRef;
+   }
+
+   /**
     * Returns the names of all visible root tables in the base worksheet that contain a column
     * matching the given {@code attribute} name (alias-first lookup).
     *
@@ -126,11 +137,6 @@ public class AddFilterService {
     * saves the merged wiz temp worksheet to the repository without reloading the runtime
     * viewsheet object. Using the runtime object would return stale data that does not yet
     * include tables merged by subsequent visualization additions.</p>
-    *
-    * <p>The wiz temp worksheet contains both the original source
-    * {@link BoundTableAssembly} instances and wiz-internal {@link MirrorTableAssembly}
-    * instances. Only root tables (those whose {@code getDependeds} set is empty) are
-    * considered, which correctly selects only the source tables.</p>
     */
    private List<String> findTablesWithColumn(Viewsheet vs, String attribute,
                                              Principal principal)
@@ -143,6 +149,27 @@ public class AddFilterService {
          ws = (Worksheet) assetRepository.getSheet(baseEntry, principal, false, AssetContent.ALL);
       }
 
+      return findColumnMatchingRootTables(ws, attribute);
+   }
+
+   /**
+    * Returns the names of all visible root tables in {@code ws} that contain a column matching
+    * the given {@code attribute} name (alias-first lookup).
+    *
+    * <p>The worksheet may contain both the original source {@link BoundTableAssembly} instances
+    * and wiz-internal {@link MirrorTableAssembly} instances. Only root tables (those whose
+    * {@code getDependeds} set is empty) are considered, which correctly selects only the source
+    * tables.</p>
+    *
+    * <p>Package-visible (reuse seam, decision (a)): this is the shared root-table/column-matching
+    * loop. {@link #findTablesWithColumn} calls it after reloading {@code ws} from the
+    * {@code AssetRepository} (needed because a runtime viewsheet's own base worksheet can be
+    * stale — see above). {@link WizDashboardFilterBuilder} calls it directly against
+    * {@code vs.getBaseWorksheet()} because it operates on an already-composed, in-memory
+    * dashboard {@code Viewsheet} that has no separate stale-runtime-object problem, so no
+    * {@code AssetRepository}/{@code Principal} reload is needed there.</p>
+    */
+   static List<String> findColumnMatchingRootTables(Worksheet ws, String attribute) {
       if(ws == null) {
          return Collections.emptyList();
       }
@@ -195,8 +222,12 @@ public class AddFilterService {
     *   <li>numeric types → TimeSlider with NUMBER range</li>
     *   <li>everything else → SelectionList</li>
     * </ul>
+    *
+    * <p>Package-visible (reuse seam, decision (b)): {@link WizDashboardFilterBuilder}'s
+    * {@code createControlForType} is a thin wrapper around this method — the data-type →
+    * control-type branch is not duplicated.</p>
     */
-   private AbstractSelectionVSAssembly createFilterAssembly(Viewsheet vs, String dtype,
+   static AbstractSelectionVSAssembly createFilterAssembly(Viewsheet vs, String dtype,
                                                             ColumnRef colRef)
    {
       if(XSchema.isNumericType(dtype) || XSchema.isDateType(dtype)) {
@@ -230,7 +261,7 @@ public class AddFilterService {
     * Returns the first available name of the form {@code base + N} (N = 1, 2, …) that
     * does not already exist as an assembly in {@code vs}.
     */
-   private String uniqueName(String base, Viewsheet vs) {
+   private static String uniqueName(String base, Viewsheet vs) {
       int counter = 1;
 
       while(vs.getAssembly(base + counter) != null) {

--- a/core/src/main/java/inetsoft/web/wiz/service/AddFilterService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/AddFilterService.java
@@ -220,6 +220,62 @@ public class AddFilterService {
    }
 
    /**
+    * Returns the names of {@code candidateTableNames} that (a) exist as visible tables in
+    * {@code ws} and (b) contain a column matching the given {@code attribute} name (alias-first
+    * lookup, same matching rule as {@link #findColumnMatchingRootTables}).
+    *
+    * <p>Unlike {@link #findColumnMatchingRootTables} — which only considers root/physical
+    * tables, so a selection filter ends up as a pre-condition on the shared physical source and
+    * cascades through every downstream join/mirror built on it — this checks only the specific
+    * tables named in {@code candidateTableNames} (typically each merged chart's own final bound
+    * table). That distinction matters for a chart whose worksheet computes a global aggregate
+    * (e.g. cross-category min/max for radar-chart normalization) downstream of the same shared
+    * root table: filtering the root table collapses that global aggregate to the filtered
+    * subset (e.g. min==max, so a normalization divide becomes 0/0), corrupting the chart, even
+    * though the persisted worksheet is otherwise correct. Filtering only the chart's own final
+    * table — which for a normalization pipeline is downstream of the already-computed global
+    * aggregate — filters the display rows without touching the aggregate's inputs.
+    *
+    * <p>Package-visible (reuse seam, mirrors {@link #findColumnMatchingRootTables}): used by
+    * {@link WizDashboardFilterBuilder#build} instead of the root-table matcher.
+    */
+   static List<String> findColumnMatchingChartTables(Worksheet ws, List<String> candidateTableNames,
+                                                      String attribute)
+   {
+      if(ws == null || candidateTableNames == null || candidateTableNames.isEmpty()) {
+         return Collections.emptyList();
+      }
+
+      List<String> result = new ArrayList<>();
+
+      for(String name : candidateTableNames) {
+         if(!(ws.getAssembly(name) instanceof TableAssembly table) ||
+            !table.isVisible() || !table.isVisibleTable())
+         {
+            continue;
+         }
+
+         ColumnSelection cols = table.getColumnSelection(true);
+
+         for(int i = 0; i < cols.getAttributeCount(); i++) {
+            if(!(cols.getAttribute(i) instanceof ColumnRef cref)) {
+               continue;
+            }
+
+            String colName = cref.getAlias() != null && !cref.getAlias().isEmpty()
+               ? cref.getAlias() : cref.getAttribute();
+
+            if(colName.equals(attribute)) {
+               result.add(name);
+               break;
+            }
+         }
+      }
+
+      return result;
+   }
+
+   /**
     * Creates a {@link SelectionListVSAssembly} or {@link TimeSliderVSAssembly} based on
     * the column data type:
     * <ul>

--- a/core/src/main/java/inetsoft/web/wiz/service/AddVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/AddVisualizationService.java
@@ -195,14 +195,24 @@ public class AddVisualizationService {
          updateVSBindings(dashVS, e.getKey(), e.getValue());
       }
 
+      // Save the merged dashboard worksheet back to the repository BEFORE merging in the new VS
+      // assemblies (Step 2, below). dashVS.addAssembly() fires a ViewsheetSandbox listener
+      // (actionPerformed -> reset0 -> ... -> ChartVSAQuery#createBaseTableAssembly0) SYNCHRONOUSLY,
+      // which resolves the newly-added chart's bound table through dashVS.getBaseWorksheet() --
+      // dashVS's own cached `ws` field, which is separate from the local `dashWS` object just
+      // merged above. Persisting first and then repopulating dashVS's cache (next line) ensures
+      // that listener sees the fully-merged worksheet instead of the pre-merge (or previous
+      // visualization's) snapshot, which otherwise makes the chart's own bound table (e.g.
+      // "RADAR_OUT") look missing and logs CubeVSAQuery's "is not a data block" error the moment
+      // the chart is merged in -- even though the persisted worksheet is correct throughout.
+      assetRepository.setSheet(dashVS.getBaseEntry(), dashWS, principal, true);
+      dashVS.repopulateWorksheet(assetRepository, principal);
+
       // Step 2: merge viewsheet assemblies
-      mergeViewsheet(vizVS, dashVS, wsRenameMap, xOffset, yOffset, scale);
+      mergeViewsheet(rvs, vizVS, dashVS, wsRenameMap, xOffset, yOffset, scale);
 
       // Step 3: record merged visualization
       wizInfo.addMergedVisualization(vizEntry.toIdentifier());
-
-      // Save the merged dashboard worksheet back to the repository
-      assetRepository.setSheet(dashVS.getBaseEntry(), dashWS, principal, true);
    }
 
    // ---------------------------------------------------------------------------
@@ -213,7 +223,7 @@ public class AddVisualizationService {
     * Copies all VSAssemblies from {@code vizVS} into {@code dashVS}, applying name-conflict
     * resolution, WS binding renames, and drop-position offsets.
     */
-   private void mergeViewsheet(Viewsheet vizVS, Viewsheet dashVS,
+   private void mergeViewsheet(RuntimeViewsheet rvs, Viewsheet vizVS, Viewsheet dashVS,
                                Map<String, String> wsRenameMap,
                                int xOffset, int yOffset, float scale)
    {
@@ -280,6 +290,15 @@ public class AddVisualizationService {
          cloned.setPixelOffset(new Point(pos.x + offsetX, pos.y + offsetY));
 
          dashVS.addAssembly(cloned);
+
+         // The dashboard runtime's sandbox may already hold a cached VGraphPair from before this
+         // merge (e.g. an earlier visualization merged into the same running dashboard). That
+         // cache is keyed by assembly name and never existed for this newly-added name, but the
+         // sandbox's worksheet snapshot predates this merge either way -- clearing it here forces
+         // a fresh execution against the just-merged worksheet instead of risking a stale/missing
+         // graph entry. Mirrors the same clearGraph-after-in-place-mutation pattern used by
+         // WizAutoBindingService/WizVsService for other runtime mutations.
+         rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(cloned.getName()));
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -50,14 +50,21 @@ import java.util.List;
  *       this builder call.</li>
  *   <li>{@code findColumnMatchingRootTables(Worksheet, String)} — the root-table/column-name
  *       matching loop, extracted from {@code findTablesWithColumn}'s body (reuse decision
- *       (a)). {@code AddFilterService.findTablesWithColumn} still does its own
- *       {@code AssetRepository}/{@code Principal} reload first (needed there because a
- *       *runtime* viewsheet's base worksheet can go stale after an async merge+save), then
- *       delegates to this shared loop. This builder instead calls the shared loop directly
- *       against {@code vs.getBaseWorksheet()} — no reload is needed here because this
- *       builder operates on an already-composed, in-memory dashboard {@code Viewsheet} that
- *       Task 3 built in one shot (not a runtime object edited incrementally across separate
- *       save/reload round-trips).</li>
+ *       (a)). {@code AddFilterService.findTablesWithColumn} does its own
+ *       {@code AssetRepository}/{@code Principal} reload first (needed there because
+ *       {@code AddVisualizationService} saves the merged worksheet to the repository and
+ *       repoints the runtime {@code Viewsheet}'s base entry via {@code setBaseEntry(...)}, but
+ *       never refreshes the runtime {@code Viewsheet}'s own transient {@code ws} field — so
+ *       {@code vs.getBaseWorksheet()} would otherwise return the stale/empty pre-merge
+ *       worksheet), then delegates to this shared loop. <b>This builder has the identical
+ *       staleness problem</b> — it also calls the shared loop directly against
+ *       {@code vs.getBaseWorksheet()}, applied to the very same kind of merged-then-not-reloaded
+ *       dashboard {@code Viewsheet}. It does <b>not</b> reload the worksheet itself: the caller
+ *       ({@link WizDashboardService#composeDashboard}) is responsible for calling
+ *       {@code vs.reloadBaseWorksheet(assetRepository, principal)} (or otherwise refreshing the
+ *       base worksheet from the repository) before invoking {@link #build}, exactly as
+ *       {@code AddFilterService.findTablesWithColumn} does inline. See
+ *       {@link #findMergedTablesWithColumn}'s Javadoc for the caller contract.</li>
  * </ul>
  *
  * <p><b>Confirmed signatures</b> (against the real {@code AddFilterService}, not the task
@@ -131,9 +138,18 @@ public class WizDashboardFilterBuilder {
 
    /**
     * Thin wrapper around the shared {@code AddFilterService.findColumnMatchingRootTables}
-    * loop, applied directly to this already-composed dashboard's base worksheet. See the
-    * class Javadoc reuse-seam note for why no {@code AssetRepository}/{@code Principal}
-    * reload is needed here (unlike {@code AddFilterService.findTablesWithColumn}).
+    * loop, applied directly to {@code vs.getBaseWorksheet()}.
+    *
+    * <p><b>Caller contract:</b> {@code vs}'s base worksheet must already have been reloaded
+    * from the repository (e.g. via {@code vs.reloadBaseWorksheet(assetRepository, principal)})
+    * by the caller before {@link #build} is invoked. This class does <b>not</b> do that reload
+    * itself — {@code vs.getBaseWorksheet()} reflects whatever was last loaded into the runtime
+    * {@code Viewsheet}'s transient {@code ws} field, which {@code AddVisualizationService}'s
+    * merge does not refresh (see the class Javadoc reuse-seam note). Calling {@link #build}
+    * against an un-reloaded {@code vs} silently returns every field in
+    * {@link FilterResult#skipped()} (this method returns an empty list for every column,
+    * since the "base worksheet" it sees has no merged tables) rather than failing loud — so
+    * getting the reload right in the caller matters.</p>
     */
    private List<String> findMergedTablesWithColumn(Viewsheet vs, String attribute) {
       Worksheet ws = vs.getBaseWorksheet();

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -21,6 +21,7 @@ import inetsoft.uql.asset.ColumnRef;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.*;
+import org.springframework.stereotype.Component;
 
 import java.awt.Point;
 import java.util.ArrayList;
@@ -75,6 +76,7 @@ import java.util.List;
  * {@code WizDashboardFilterBuilderTest} is limited to the pure data-type → control-type
  * branch via the package-visible {@link #createControlForType}.</p>
  */
+@Component
 public class WizDashboardFilterBuilder {
    public record FilterRequest(String field, String dataType, String label) {}
    public record FilterResult(List<String> applied, List<String> skipped) {}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -56,15 +56,18 @@ import java.util.List;
  *       repoints the runtime {@code Viewsheet}'s base entry via {@code setBaseEntry(...)}, but
  *       never refreshes the runtime {@code Viewsheet}'s own transient {@code ws} field — so
  *       {@code vs.getBaseWorksheet()} would otherwise return the stale/empty pre-merge
- *       worksheet), then delegates to this shared loop. <b>This builder has the identical
- *       staleness problem</b> — it also calls the shared loop directly against
- *       {@code vs.getBaseWorksheet()}, applied to the very same kind of merged-then-not-reloaded
- *       dashboard {@code Viewsheet}. It does <b>not</b> reload the worksheet itself: the caller
- *       ({@link WizDashboardService#composeDashboard}) is responsible for calling
- *       {@code vs.reloadBaseWorksheet(assetRepository, principal)} (or otherwise refreshing the
- *       base worksheet from the repository) before invoking {@link #build}, exactly as
- *       {@code AddFilterService.findTablesWithColumn} does inline. See
- *       {@link #findMergedTablesWithColumn}'s Javadoc for the caller contract.</li>
+ *       worksheet), loading with {@code permission=false} — deliberately, since the merged base
+ *       worksheet is a system-generated, already-gated internal/ephemeral entry, and a
+ *       {@code permission=true} load can fail the ACL check (or return a stripped sheet) for a
+ *       principal with no explicit grant on that ephemeral entry, reproducing the exact
+ *       every-filter-skipped symptom this reuse is meant to avoid — then delegates to this
+ *       shared loop. <b>This builder has the identical staleness problem</b> and is deliberately
+ *       <b>not</b> handed a {@code Viewsheet} to read {@code getBaseWorksheet()} from for
+ *       matching: {@link #build} instead takes the already-loaded {@code Worksheet} directly as
+ *       a parameter, so its caller ({@link WizDashboardService#composeDashboard}) is forced to
+ *       load it itself — with {@code permission=false} — exactly as
+ *       {@code AddFilterService.findTablesWithColumn} does inline, rather than risk a second
+ *       copy of the load drifting to a different (incorrect) permission flag over time.</li>
  * </ul>
  *
  * <p><b>Confirmed signatures</b> (against the real {@code AddFilterService}, not the task
@@ -77,9 +80,9 @@ import java.util.List;
  * title is set through a cast to the common {@link TitledVSAssembly} interface.</p>
  *
  * <p><b>Deferred to manual E2E</b> (per the brief; no synthetic worksheet fixture is
- * fabricated here): column-matching across merged root tables
- * ({@link #findMergedTablesWithColumn}) and actual runtime filtering of charts both require
- * a live composed dashboard with a real worksheet. The automated coverage in
+ * fabricated here): column-matching across merged root tables ({@link #build}'s table-lookup
+ * branch) and actual runtime filtering of charts both require a live composed dashboard with a
+ * real, permission=false-loaded worksheet. The automated coverage in
  * {@code WizDashboardFilterBuilderTest} is limited to the pure data-type → control-type
  * branch via the package-visible {@link #createControlForType}.</p>
  */
@@ -92,16 +95,29 @@ public class WizDashboardFilterBuilder {
     * Builds one selection control per request, binds it to every merged root table exposing
     * the column, positions the controls as a top filter bar, and adds them to {@code vs}.
     *
+    * <p><b>Caller contract:</b> {@code baseWorksheet} must be the dashboard's merged base
+    * worksheet, loaded directly from the repository with {@code permission=false} — i.e.
+    * {@code assetRepository.getSheet(vs.getBaseEntry(), principal, false, AssetContent.ALL)},
+    * the exact mirror of {@code AddFilterService.findTablesWithColumn}. Do <b>not</b> pass
+    * {@code vs.getBaseWorksheet()}: {@code AddVisualizationService}'s merge never refreshes the
+    * runtime {@code Viewsheet}'s own transient {@code ws} field, so it would be stale/empty; and
+    * do not load with {@code permission=true} ({@link Viewsheet#reloadBaseWorksheet}'s flag) —
+    * see the class Javadoc reuse-seam note for why that can fail the ACL check on this
+    * system-generated ephemeral entry. Passing a stale or wrongly-permissioned worksheet here
+    * does not fail loud: every field simply lands in {@link FilterResult#skipped()}, since this
+    * method has no way to distinguish "genuinely no matching table" from "caller loaded the
+    * wrong worksheet" — getting the load right in the caller matters.</p>
+    *
     * @return which fields bound to &gt;=1 table (applied) vs none (skipped).
     */
-   public FilterResult build(Viewsheet vs, List<FilterRequest> requests) {
+   public FilterResult build(Viewsheet vs, Worksheet baseWorksheet, List<FilterRequest> requests) {
       List<String> applied = new ArrayList<>();
       List<String> skipped = new ArrayList<>();
       int x = FILTER_BAR_X;
       int y = FILTER_BAR_Y;
 
       for(FilterRequest req : requests) {
-         List<String> tables = findMergedTablesWithColumn(vs, req.field());
+         List<String> tables = AddFilterService.findColumnMatchingRootTables(baseWorksheet, req.field());
 
          if(tables.isEmpty()) {
             skipped.add(req.field());
@@ -134,26 +150,6 @@ public class WizDashboardFilterBuilder {
     */
    AbstractSelectionVSAssembly createControlForType(Viewsheet vs, String dtype, DataRef colRef) {
       return AddFilterService.createFilterAssembly(vs, dtype, (ColumnRef) colRef);
-   }
-
-   /**
-    * Thin wrapper around the shared {@code AddFilterService.findColumnMatchingRootTables}
-    * loop, applied directly to {@code vs.getBaseWorksheet()}.
-    *
-    * <p><b>Caller contract:</b> {@code vs}'s base worksheet must already have been reloaded
-    * from the repository (e.g. via {@code vs.reloadBaseWorksheet(assetRepository, principal)})
-    * by the caller before {@link #build} is invoked. This class does <b>not</b> do that reload
-    * itself — {@code vs.getBaseWorksheet()} reflects whatever was last loaded into the runtime
-    * {@code Viewsheet}'s transient {@code ws} field, which {@code AddVisualizationService}'s
-    * merge does not refresh (see the class Javadoc reuse-seam note). Calling {@link #build}
-    * against an un-reloaded {@code vs} silently returns every field in
-    * {@link FilterResult#skipped()} (this method returns an empty list for every column,
-    * since the "base worksheet" it sees has no merged tables) rather than failing loud — so
-    * getting the reload right in the caller matters.</p>
-    */
-   private List<String> findMergedTablesWithColumn(Viewsheet vs, String attribute) {
-      Worksheet ws = vs.getBaseWorksheet();
-      return AddFilterService.findColumnMatchingRootTables(ws, attribute);
    }
 
    private static final int FILTER_BAR_X = 0;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -1,0 +1,144 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.viewsheet.*;
+
+import java.awt.Point;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds one selection control per {@link FilterRequest}, binds it to every merged root
+ * worksheet table exposing the requested column, and positions the controls as a top
+ * filter bar on an already-composed dashboard {@link Viewsheet}.
+ *
+ * <h2>Reuse seam (decided in Step 1, after reading {@code AddFilterService} in full)</h2>
+ *
+ * {@code AddFilterService} (the reference implementation of adding a single selection
+ * filter from the chat/composer flow) already contains three pieces this builder needs:
+ * <ul>
+ *   <li>{@code createFilterAssembly(Viewsheet, String, ColumnRef)} — the data-type →
+ *       control-type branch (numeric/date → {@link TimeSliderVSAssembly} with a
+ *       {@link SingleTimeInfo}; everything else → {@link SelectionListVSAssembly} via
+ *       {@code setDataRef}). Was {@code private}; changed to package-visible {@code static}
+ *       (it touches no instance state). {@link #createControlForType} below is a <b>thin
+ *       wrapper</b> around it (reuse decision (b) from the task brief) — no second copy of
+ *       the type-branch logic exists.</li>
+ *   <li>{@code buildColumnRef(String, String)} — the {@code AttributeRef}+{@code ColumnRef}
+ *       construction (was inlined at the old lines 75-78). Extracted to a package-visible
+ *       {@code static} helper (reuse decision (a)) that both {@code AddFilterService} and
+ *       this builder call.</li>
+ *   <li>{@code findColumnMatchingRootTables(Worksheet, String)} — the root-table/column-name
+ *       matching loop, extracted from {@code findTablesWithColumn}'s body (reuse decision
+ *       (a)). {@code AddFilterService.findTablesWithColumn} still does its own
+ *       {@code AssetRepository}/{@code Principal} reload first (needed there because a
+ *       *runtime* viewsheet's base worksheet can go stale after an async merge+save), then
+ *       delegates to this shared loop. This builder instead calls the shared loop directly
+ *       against {@code vs.getBaseWorksheet()} — no reload is needed here because this
+ *       builder operates on an already-composed, in-memory dashboard {@code Viewsheet} that
+ *       Task 3 built in one shot (not a runtime object edited incrementally across separate
+ *       save/reload round-trips).</li>
+ * </ul>
+ *
+ * <p><b>Confirmed signatures</b> (against the real {@code AddFilterService}, not the task
+ * brief's sketch, which diverged on one point): {@code ColumnRef} lives in
+ * {@code inetsoft.uql.asset} (not {@code inetsoft.uql.erm} as the brief assumed) and is
+ * built as {@code new ColumnRef(AttributeRef)} + {@code setDataType(String)}.
+ * {@code AbstractSelectionVSAssembly} does not itself declare {@code setTitleValue} — both
+ * {@code SelectionListVSAssembly} (via {@code CompositeVSAssembly extends TitledVSAssembly})
+ * and {@code TimeSliderVSAssembly} (implements {@code TitledVSAssembly} directly) do, so the
+ * title is set through a cast to the common {@link TitledVSAssembly} interface.</p>
+ *
+ * <p><b>Deferred to manual E2E</b> (per the brief; no synthetic worksheet fixture is
+ * fabricated here): column-matching across merged root tables
+ * ({@link #findMergedTablesWithColumn}) and actual runtime filtering of charts both require
+ * a live composed dashboard with a real worksheet. The automated coverage in
+ * {@code WizDashboardFilterBuilderTest} is limited to the pure data-type → control-type
+ * branch via the package-visible {@link #createControlForType}.</p>
+ */
+public class WizDashboardFilterBuilder {
+   public record FilterRequest(String field, String dataType, String label) {}
+   public record FilterResult(List<String> applied, List<String> skipped) {}
+
+   /**
+    * Builds one selection control per request, binds it to every merged root table exposing
+    * the column, positions the controls as a top filter bar, and adds them to {@code vs}.
+    *
+    * @return which fields bound to &gt;=1 table (applied) vs none (skipped).
+    */
+   public FilterResult build(Viewsheet vs, List<FilterRequest> requests) {
+      List<String> applied = new ArrayList<>();
+      List<String> skipped = new ArrayList<>();
+      int x = FILTER_BAR_X;
+      int y = FILTER_BAR_Y;
+
+      for(FilterRequest req : requests) {
+         List<String> tables = findMergedTablesWithColumn(vs, req.field());
+
+         if(tables.isEmpty()) {
+            skipped.add(req.field());
+            continue;
+         }
+
+         ColumnRef colRef = AddFilterService.buildColumnRef(req.field(), req.dataType());
+         AbstractSelectionVSAssembly control = createControlForType(vs, req.dataType(), colRef);
+
+         if(req.label() != null && control instanceof TitledVSAssembly titled) {
+            titled.setTitleValue(req.label());
+         }
+
+         control.setTableNames(tables);
+         control.setPixelOffset(new Point(x, y));
+         vs.addAssembly(control);
+         applied.add(req.field());
+         x += FILTER_CONTROL_WIDTH;
+      }
+
+      return new FilterResult(applied, skipped);
+   }
+
+   /**
+    * Package-visible for the unit test — the data-type → control-type branch. Thin wrapper
+    * around {@code AddFilterService.createFilterAssembly}; see the class Javadoc reuse-seam
+    * note. {@code colRef} is accepted as {@link DataRef} to match the test brief's helper
+    * signature but must in practice be a {@link ColumnRef} (as {@code AddFilterService}
+    * requires).
+    */
+   AbstractSelectionVSAssembly createControlForType(Viewsheet vs, String dtype, DataRef colRef) {
+      return AddFilterService.createFilterAssembly(vs, dtype, (ColumnRef) colRef);
+   }
+
+   /**
+    * Thin wrapper around the shared {@code AddFilterService.findColumnMatchingRootTables}
+    * loop, applied directly to this already-composed dashboard's base worksheet. See the
+    * class Javadoc reuse-seam note for why no {@code AssetRepository}/{@code Principal}
+    * reload is needed here (unlike {@code AddFilterService.findTablesWithColumn}).
+    */
+   private List<String> findMergedTablesWithColumn(Viewsheet vs, String attribute) {
+      Worksheet ws = vs.getBaseWorksheet();
+      return AddFilterService.findColumnMatchingRootTables(ws, attribute);
+   }
+
+   private static final int FILTER_BAR_X = 0;
+   private static final int FILTER_BAR_Y = 0;
+   private static final int FILTER_CONTROL_WIDTH = 200;
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.service;
 
+import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.asset.ColumnRef;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.DataRef;
@@ -28,9 +29,27 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Builds one selection control per {@link FilterRequest}, binds it to every merged root
- * worksheet table exposing the requested column, and positions the controls as a top
- * filter bar on an already-composed dashboard {@link Viewsheet}.
+ * Builds one selection control per {@link FilterRequest}, binds it to each merged chart's own
+ * final bound worksheet table that exposes the requested column, and positions the controls as
+ * a top filter bar on an already-composed dashboard {@link Viewsheet}.
+ *
+ * <h2>Binds to each chart's own table, not the shared root table</h2>
+ *
+ * An earlier version bound filters to every root/physical worksheet table exposing the column
+ * ({@link AddFilterService#findColumnMatchingRootTables}) — correct for a simple chart, but a
+ * selection filter is applied as a pre-condition on the named table, which then cascades
+ * through every join/mirror built on it. For a chart whose worksheet computes a global
+ * aggregate downstream of that same root table (e.g. cross-category min/max feeding a
+ * radar-chart normalization), filtering the root table collapses the aggregate to the filtered
+ * subset too — confirmed live: selecting one category made a radar chart's own normalization
+ * divide by zero (min==max after the collapse) and the chart went blank ("No data is
+ * available"), even though every other chart correctly filtered. {@link #build} now matches
+ * against each merged chart's own final bound table ({@link AddFilterService#findColumnMatchingChartTables})
+ * instead — for a normalization pipeline that table sits downstream of the already-computed
+ * aggregate, so filtering it only narrows the display rows. A chart whose own final table
+ * doesn't expose the column (e.g. one already permanently scoped to a single category, so the
+ * column was dropped before its last group-by) simply isn't bound to that filter, which is
+ * correct: it was never meaningfully controllable by it in the first place.
  *
  * <h2>Reuse seam (decided in Step 1, after reading {@code AddFilterService} in full)</h2>
  *
@@ -92,8 +111,10 @@ public class WizDashboardFilterBuilder {
    public record FilterResult(List<String> applied, List<String> skipped) {}
 
    /**
-    * Builds one selection control per request, binds it to every merged root table exposing
-    * the column, positions the controls as a top filter bar, and adds them to {@code vs}.
+    * Builds one selection control per request, binds it to each merged chart's own final bound
+    * table that exposes the column (see the class Javadoc for why this is NOT every root table
+    * exposing the column), positions the controls as a top filter bar, and adds them to
+    * {@code vs}.
     *
     * <p><b>Caller contract:</b> {@code baseWorksheet} must be the dashboard's merged base
     * worksheet, loaded directly from the repository with {@code permission=false} — i.e.
@@ -115,9 +136,11 @@ public class WizDashboardFilterBuilder {
       List<String> skipped = new ArrayList<>();
       int x = FILTER_BAR_X;
       int y = FILTER_BAR_Y;
+      List<String> chartTableNames = mergedChartTableNames(vs);
 
       for(FilterRequest req : requests) {
-         List<String> tables = AddFilterService.findColumnMatchingRootTables(baseWorksheet, req.field());
+         List<String> tables =
+            AddFilterService.findColumnMatchingChartTables(baseWorksheet, chartTableNames, req.field());
 
          if(tables.isEmpty()) {
             skipped.add(req.field());
@@ -144,6 +167,27 @@ public class WizDashboardFilterBuilder {
       }
 
       return new FilterResult(applied, skipped);
+   }
+
+   /**
+    * Collects each merged chart's own final bound table name (its {@code SourceInfo.source},
+    * exposed via {@link BindableVSAssembly#getTableName()}) — the candidate set
+    * {@link AddFilterService#findColumnMatchingChartTables} matches against, instead of every
+    * root worksheet table. Only {@link ChartVSAssembly} is considered: every visualization
+    * {@link AddVisualizationService} merges into a dashboard is a single saved chart, so this is
+    * the set of "each chart's own table," not an incidental subset of bindable assembly types.
+    * Package-visible for the unit test.
+    */
+   List<String> mergedChartTableNames(Viewsheet vs) {
+      List<String> names = new ArrayList<>();
+
+      for(Assembly a : vs.getAssemblies()) {
+         if(a instanceof ChartVSAssembly chart && chart.getTableName() != null) {
+            names.add(chart.getTableName());
+         }
+      }
+
+      return names;
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -133,6 +133,11 @@ public class WizDashboardFilterBuilder {
 
          control.setTableNames(tables);
          control.setPixelOffset(new Point(x, y));
+         // Explicit compact size: SelectionList/TimeSlider's own default pixel size is not
+         // reliably short, and WizDashboardService reserves only FILTER_BAR_ROW_HEIGHT (120px)
+         // above the charts -- an oversized control here would visually collide with the first
+         // chart row instead of leaving the intended small gap.
+         control.setPixelSize(new java.awt.Dimension(FILTER_CONTROL_WIDTH, FILTER_CONTROL_HEIGHT));
          vs.addAssembly(control);
          applied.add(req.field());
          x += FILTER_CONTROL_WIDTH;
@@ -155,4 +160,8 @@ public class WizDashboardFilterBuilder {
    private static final int FILTER_BAR_X = 0;
    private static final int FILTER_BAR_Y = 0;
    private static final int FILTER_CONTROL_WIDTH = 200;
+
+   /** Control height, in pixels — leaves a small margin under
+    *  {@link WizDashboardService#FILTER_BAR_ROW_HEIGHT} (120px), the reserved row above charts. */
+   private static final int FILTER_CONTROL_HEIGHT = 100;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -133,13 +133,36 @@ public class WizDashboardService {
       try {
          List<String> skipped = new ArrayList<>();
          int mergedCount = 0;
-         int cumulativeY = 0;
+
+         boolean grid = event.getTiles() != null && !event.getTiles().isEmpty();
+         int layoutColumns = event.getLayoutColumns() != null ?
+            Math.max(1, event.getLayoutColumns()) : 2;
+         int[] spans = grid ?
+            event.getTiles().stream().mapToInt(t -> Math.max(1, t.getSpanCols())).toArray() : null;
+
+         int cumulativeY = 0;   // stack path only
 
          for(int i = 0; i < entries.size(); i++) {
+            int x, y;
+
+            if(grid) {
+               java.awt.Point origin = gridOrigin(spans, layoutColumns, i);
+               x = origin.x;
+               y = origin.y;
+            }
+            else {
+               x = 0;
+               y = cumulativeY;
+            }
+
             try {
                addVisualizationService.addVisualization(
-                  runtimeId, entries.get(i), 0, cumulativeY, 1.0f, principal);
-               cumulativeY += DASHBOARD_ROW_HEIGHT;
+                  runtimeId, entries.get(i), x, y, 1.0f, principal);
+
+               if(!grid) {
+                  cumulativeY += DASHBOARD_ROW_HEIGHT;
+               }
+
                mergedCount++;
             }
             catch(Exception ex) {
@@ -198,6 +221,40 @@ public class WizDashboardService {
 
    /** Single-column vertical stride between successive merged visualizations, in pixels. */
    private static final int DASHBOARD_ROW_HEIGHT = 420;
+
+   /** Horizontal stride between grid columns, in pixels (paired with DASHBOARD_ROW_HEIGHT). */
+   private static final int DASHBOARD_COL_WIDTH = 640;   // confirm vs composer default viz width
+
+   /**
+    * Row-major grid origin for the tile at flat index {@code i}, given per-tile column spans.
+    * Returns the (x,y) drop origin in pixels. Package-private for unit testing.
+    */
+   static java.awt.Point gridOrigin(int[] spanCols, int layoutColumns, int i) {
+      int col = 0;
+      int row = 0;
+
+      for(int k = 0; k <= i; k++) {
+         int span = Math.max(1, Math.min(spanCols[k], layoutColumns));
+
+         if(col + span > layoutColumns) {   // doesn't fit in the current row → wrap
+            col = 0;
+            row++;
+         }
+
+         if(k == i) {
+            return new java.awt.Point(col * DASHBOARD_COL_WIDTH, row * DASHBOARD_ROW_HEIGHT);
+         }
+
+         col += span;
+
+         if(col >= layoutColumns) {   // row full → next row
+            col = 0;
+            row++;
+         }
+      }
+
+      return new java.awt.Point(0, 0);   // unreachable (i is always in range)
+   }
 
    private final ViewsheetService viewsheetService;
    private final AddVisualizationServiceProxy addVisualizationService;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -24,8 +24,10 @@ import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
 import inetsoft.sree.security.SecurityException;
+import inetsoft.uql.asset.AssetContent;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.WizUtil;
 import inetsoft.util.Catalog;
@@ -71,9 +73,12 @@ import java.util.UUID;
  *       purposes, so a caller sending them out of order would otherwise silently assign the
  *       wrong span to the wrong visualization.</li>
  *   <li>When {@code event.getFilters()} is non-empty, reserve a top row (offset every merged
- *       chart's y by {@link #DASHBOARD_ROW_HEIGHT}), reload the runtime {@code Viewsheet}'s base
- *       worksheet from the repository (see the note on {@link #applyFilters} below), and build a
- *       filter bar via {@link #applyFilters}/{@link WizDashboardFilterBuilder#build}, recording
+ *       chart's y by {@link #DASHBOARD_ROW_HEIGHT}), load the dashboard's merged base worksheet
+ *       directly from the repository with {@code permission=false} (see the note on
+ *       {@link #applyFilters} below — <b>not</b> {@code vs.getBaseWorksheet()}, which is stale,
+ *       and <b>not</b> {@code permission=true}, which can fail the ACL check on this
+ *       system-generated ephemeral entry), and build a filter bar via
+ *       {@link #applyFilters}/{@link WizDashboardFilterBuilder#build}, recording
  *       {@link WizDashboardResult#getFiltersApplied()}/{@link WizDashboardResult#getFiltersSkipped()}.
  *       Absent/empty {@code filters} leaves the grid and result identical to the no-filter-bar
  *       case.</li>
@@ -227,14 +232,20 @@ public class WizDashboardService {
          // worksheet to the repository via assetRepository.setSheet and repoints the runtime
          // Viewsheet's base entry via setBaseEntry(...), but never refreshes the runtime
          // Viewsheet's own transient `ws` cache — so vs.getBaseWorksheet() would still return
-         // the original empty temp worksheet. Reload it from the repository first (identical
-         // staleness/workaround to AddFilterService#findTablesWithColumn) so the filter builder
-         // sees the actual merged root tables.
+         // the original empty temp worksheet. Load the merged worksheet directly from the
+         // repository instead — with permission=false, exactly like
+         // AddFilterService#findTablesWithColumn (NOT Viewsheet#reloadBaseWorksheet, which uses
+         // permission=true and can fail the ACL check, or return a stripped sheet, for a
+         // principal with no explicit grant on this system-generated ephemeral entry — that
+         // would reproduce the same every-filter-skipped symptom this fix targets) — so the
+         // filter builder sees the actual merged root tables.
          WizDashboardFilterBuilder.FilterResult filterResult = null;
 
          if(hasFilters) {
-            rvs.getViewsheet().reloadBaseWorksheet(assetRepository, principal);
-            filterResult = applyFilters(rvs.getViewsheet(), event.getFilters());
+            Viewsheet vs = rvs.getViewsheet();
+            Worksheet baseWs = (Worksheet) assetRepository.getSheet(
+               vs.getBaseEntry(), principal, false, AssetContent.ALL);
+            filterResult = applyFilters(vs, baseWs, event.getFilters());
          }
 
          WizUtil.saveWizSheet(rvs, principal, savedVsEntry,
@@ -288,22 +299,26 @@ public class WizDashboardService {
     * Maps {@link WizDashboardEvent.FilterSpec}s to {@link WizDashboardFilterBuilder.FilterRequest}s
     * and builds the top filter bar against the already-merged dashboard {@code Viewsheet}.
     *
-    * <p><b>Caller contract:</b> {@code vs.getBaseWorksheet()} must already reflect the merged
-    * root tables — i.e. the caller must have called
-    * {@link Viewsheet#reloadBaseWorksheet(AssetRepository, Principal)} (or otherwise refreshed
-    * the base worksheet from the repository) first. This method does not reload it itself.</p>
+    * <p><b>Caller contract:</b> {@code baseWs} must be the dashboard's merged base worksheet,
+    * loaded directly from the repository with {@code permission=false} — i.e.
+    * {@code assetRepository.getSheet(vs.getBaseEntry(), principal, false, AssetContent.ALL)} —
+    * the exact mirror of {@code AddFilterService.findTablesWithColumn}. Do <b>not</b> pass
+    * {@code vs.getBaseWorksheet()} (stale — the merge never refreshes it) or a worksheet loaded
+    * with {@code permission=true} (can fail the ACL check on this system-generated ephemeral
+    * entry — see {@link WizDashboardFilterBuilder}'s class Javadoc). This method does not load
+    * or reload the worksheet itself.</p>
     *
     * <p>Package-private seam for unit testing (mirrors {@link #gridOrigin}) — lets
     * {@link WizDashboardServiceGridTest} exercise the mapping/delegation with a mocked
     * {@link WizDashboardFilterBuilder}, independent of the live-engine-only compose+save path.
     */
-   WizDashboardFilterBuilder.FilterResult applyFilters(Viewsheet vs,
+   WizDashboardFilterBuilder.FilterResult applyFilters(Viewsheet vs, Worksheet baseWs,
                                                         List<WizDashboardEvent.FilterSpec> specs)
    {
       List<WizDashboardFilterBuilder.FilterRequest> reqs = specs.stream()
          .map(f -> new WizDashboardFilterBuilder.FilterRequest(f.getField(), f.getDataType(), f.getLabel()))
          .collect(java.util.stream.Collectors.toList());
-      return filterBuilder.build(vs, reqs);
+      return filterBuilder.build(vs, baseWs, reqs);
    }
 
    /** Vertical row stride between successive merged visualizations, in pixels — used by both

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -64,10 +64,18 @@ import java.util.UUID;
  *       recorded in {@link WizDashboardResult#getSkipped()} rather than failing the whole
  *       compose; if every visualization is skipped, the compose fails loud
  *       ({@link IllegalArgumentException}, mapped by the controller to 400).</li>
+ *   <li>When {@code event.getFilters()} is non-empty, reserve a top row (offset every merged
+ *       chart's y by {@link #DASHBOARD_ROW_HEIGHT}) and build a filter bar via
+ *       {@link #applyFilters}/{@link WizDashboardFilterBuilder#build}, recording
+ *       {@link WizDashboardResult#getFiltersApplied()}/{@link WizDashboardResult#getFiltersSkipped()}.
+ *       Absent/empty {@code filters} leaves the grid and result identical to the no-filter-bar
+ *       case.</li>
  *   <li>Persist via {@link WizUtil#saveWizSheet}, which finalizes the temporary dashboard
  *       worksheet and then runs the save callback, in the same order the Composer uses (a bare
  *       {@code viewsheetService.setViewsheet} call would skip the finalize step and leave the
- *       dashboard pointing at a temp worksheet entry).</li>
+ *       dashboard pointing at a temp worksheet entry). The filter bar is built <b>before</b> this
+ *       call so its controls — added to the in-memory {@code Viewsheet} — are persisted
+ *       automatically.</li>
  *   <li>Always close the runtime in a {@code finally} block.</li>
  * </ol>
  *
@@ -81,11 +89,13 @@ import java.util.UUID;
 public class WizDashboardService {
    public WizDashboardService(ViewsheetService viewsheetService,
                                AddVisualizationServiceProxy addVisualizationService,
-                               SecurityEngine securityEngine)
+                               SecurityEngine securityEngine,
+                               WizDashboardFilterBuilder filterBuilder)
    {
       this.viewsheetService = viewsheetService;
       this.addVisualizationService = addVisualizationService;
       this.securityEngine = securityEngine;
+      this.filterBuilder = filterBuilder;
    }
 
    public WizDashboardResult composeDashboard(WizDashboardEvent event, Principal principal)
@@ -146,7 +156,12 @@ public class WizDashboardService {
                entries.size() + ")");
          }
 
-         int cumulativeY = 0;   // stack path only
+         // When a filter bar will be built (Task 3, below), reserve its own top row so the
+         // merged charts don't render underneath it.
+         boolean hasFilters = event.getFilters() != null && !event.getFilters().isEmpty();
+         int topOffset = hasFilters ? DASHBOARD_ROW_HEIGHT : 0;
+
+         int cumulativeY = topOffset;   // stack path only
 
          for(int i = 0; i < entries.size(); i++) {
             int x, y;
@@ -154,7 +169,7 @@ public class WizDashboardService {
             if(grid) {
                java.awt.Point origin = gridOrigin(spans, layoutColumns, i);
                x = origin.x;
-               y = origin.y;
+               y = origin.y + topOffset;
             }
             else {
                x = 0;
@@ -184,12 +199,23 @@ public class WizDashboardService {
          RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
          AssetEntry savedVsEntry = resolveTargetEntry(event.getExistingIdentifier(), event.getName(), principal);
 
+         // Build the top filter bar (Task 3) before save, so the controls it adds to the
+         // in-memory Viewsheet are persisted by the same WizUtil.saveWizSheet call below.
+         WizDashboardFilterBuilder.FilterResult filterResult = hasFilters ?
+            applyFilters(rvs.getViewsheet(), event.getFilters()) : null;
+
          WizUtil.saveWizSheet(rvs, principal, savedVsEntry,
             () -> viewsheetService.setViewsheet(rvs.getViewsheet(), savedVsEntry, principal, true, true));
 
          WizDashboardResult result = new WizDashboardResult();
          result.setSavedViewsheetIdentifier(savedVsEntry.toIdentifier());
          result.setSkipped(skipped);
+
+         if(filterResult != null) {
+            result.setFiltersApplied(filterResult.applied());
+            result.setFiltersSkipped(filterResult.skipped());
+         }
+
          return result;
       }
       finally {
@@ -223,6 +249,22 @@ public class WizDashboardService {
       AssetEntry entry = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, newPath, pId);
       entry.setAlias(name);
       return entry;
+   }
+
+   /**
+    * Maps {@link WizDashboardEvent.FilterSpec}s to {@link WizDashboardFilterBuilder.FilterRequest}s
+    * and builds the top filter bar against the already-merged dashboard {@code Viewsheet}.
+    * Package-private seam for unit testing (mirrors {@link #gridOrigin}) — lets
+    * {@link WizDashboardServiceGridTest} exercise the mapping/delegation with a mocked
+    * {@link WizDashboardFilterBuilder}, independent of the live-engine-only compose+save path.
+    */
+   WizDashboardFilterBuilder.FilterResult applyFilters(Viewsheet vs,
+                                                        List<WizDashboardEvent.FilterSpec> specs)
+   {
+      List<WizDashboardFilterBuilder.FilterRequest> reqs = specs.stream()
+         .map(f -> new WizDashboardFilterBuilder.FilterRequest(f.getField(), f.getDataType(), f.getLabel()))
+         .collect(java.util.stream.Collectors.toList());
+      return filterBuilder.build(vs, reqs);
    }
 
    /** Vertical row stride between successive merged visualizations, in pixels — used by both
@@ -266,5 +308,6 @@ public class WizDashboardService {
    private final ViewsheetService viewsheetService;
    private final AddVisualizationServiceProxy addVisualizationService;
    private final SecurityEngine securityEngine;
+   private final WizDashboardFilterBuilder filterBuilder;
    private static final Logger LOG = LoggerFactory.getLogger(WizDashboardService.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -39,6 +39,7 @@ import org.springframework.stereotype.Service;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -64,9 +65,15 @@ import java.util.UUID;
  *       recorded in {@link WizDashboardResult#getSkipped()} rather than failing the whole
  *       compose; if every visualization is skipped, the compose fails loud
  *       ({@link IllegalArgumentException}, mapped by the controller to 400).</li>
+ *   <li>When {@code tiles} are supplied, fail loud ({@link IllegalArgumentException}) if a
+ *       tile's {@code identifier} doesn't match the {@code identifiers} entry at the same index
+ *       — tiles and identifiers are consumed purely positionally (by index) for span/layout
+ *       purposes, so a caller sending them out of order would otherwise silently assign the
+ *       wrong span to the wrong visualization.</li>
  *   <li>When {@code event.getFilters()} is non-empty, reserve a top row (offset every merged
- *       chart's y by {@link #DASHBOARD_ROW_HEIGHT}) and build a filter bar via
- *       {@link #applyFilters}/{@link WizDashboardFilterBuilder#build}, recording
+ *       chart's y by {@link #DASHBOARD_ROW_HEIGHT}), reload the runtime {@code Viewsheet}'s base
+ *       worksheet from the repository (see the note on {@link #applyFilters} below), and build a
+ *       filter bar via {@link #applyFilters}/{@link WizDashboardFilterBuilder#build}, recording
  *       {@link WizDashboardResult#getFiltersApplied()}/{@link WizDashboardResult#getFiltersSkipped()}.
  *       Absent/empty {@code filters} leaves the grid and result identical to the no-filter-bar
  *       case.</li>
@@ -90,12 +97,14 @@ public class WizDashboardService {
    public WizDashboardService(ViewsheetService viewsheetService,
                                AddVisualizationServiceProxy addVisualizationService,
                                SecurityEngine securityEngine,
-                               WizDashboardFilterBuilder filterBuilder)
+                               WizDashboardFilterBuilder filterBuilder,
+                               AssetRepository assetRepository)
    {
       this.viewsheetService = viewsheetService;
       this.addVisualizationService = addVisualizationService;
       this.securityEngine = securityEngine;
       this.filterBuilder = filterBuilder;
+      this.assetRepository = assetRepository;
    }
 
    public WizDashboardResult composeDashboard(WizDashboardEvent event, Principal principal)
@@ -167,6 +176,18 @@ public class WizDashboardService {
             int x, y;
 
             if(grid) {
+               // tiles[] and identifiers[] are consumed purely positionally below (spans[i]
+               // paired with entries.get(i)/identifiers.get(i)) — guard that the caller actually
+               // sent them in the same order, rather than silently mis-assigning spans.
+               String tileIdentifier = event.getTiles().get(i).getIdentifier();
+
+               if(!Objects.equals(tileIdentifier, identifiers.get(i))) {
+                  throw new IllegalArgumentException(
+                     "tiles[" + i + "].identifier (" + tileIdentifier + ") does not match " +
+                     "identifiers[" + i + "] (" + identifiers.get(i) + ") — tiles must be listed " +
+                     "in the same order as identifiers");
+               }
+
                java.awt.Point origin = gridOrigin(spans, layoutColumns, i);
                x = origin.x;
                y = origin.y + topOffset;
@@ -201,8 +222,20 @@ public class WizDashboardService {
 
          // Build the top filter bar (Task 3) before save, so the controls it adds to the
          // in-memory Viewsheet are persisted by the same WizUtil.saveWizSheet call below.
-         WizDashboardFilterBuilder.FilterResult filterResult = hasFilters ?
-            applyFilters(rvs.getViewsheet(), event.getFilters()) : null;
+         //
+         // The merge loop above (AddVisualizationService#addVisualization) saves the merged
+         // worksheet to the repository via assetRepository.setSheet and repoints the runtime
+         // Viewsheet's base entry via setBaseEntry(...), but never refreshes the runtime
+         // Viewsheet's own transient `ws` cache — so vs.getBaseWorksheet() would still return
+         // the original empty temp worksheet. Reload it from the repository first (identical
+         // staleness/workaround to AddFilterService#findTablesWithColumn) so the filter builder
+         // sees the actual merged root tables.
+         WizDashboardFilterBuilder.FilterResult filterResult = null;
+
+         if(hasFilters) {
+            rvs.getViewsheet().reloadBaseWorksheet(assetRepository, principal);
+            filterResult = applyFilters(rvs.getViewsheet(), event.getFilters());
+         }
 
          WizUtil.saveWizSheet(rvs, principal, savedVsEntry,
             () -> viewsheetService.setViewsheet(rvs.getViewsheet(), savedVsEntry, principal, true, true));
@@ -254,7 +287,13 @@ public class WizDashboardService {
    /**
     * Maps {@link WizDashboardEvent.FilterSpec}s to {@link WizDashboardFilterBuilder.FilterRequest}s
     * and builds the top filter bar against the already-merged dashboard {@code Viewsheet}.
-    * Package-private seam for unit testing (mirrors {@link #gridOrigin}) — lets
+    *
+    * <p><b>Caller contract:</b> {@code vs.getBaseWorksheet()} must already reflect the merged
+    * root tables — i.e. the caller must have called
+    * {@link Viewsheet#reloadBaseWorksheet(AssetRepository, Principal)} (or otherwise refreshed
+    * the base worksheet from the repository) first. This method does not reload it itself.</p>
+    *
+    * <p>Package-private seam for unit testing (mirrors {@link #gridOrigin}) — lets
     * {@link WizDashboardServiceGridTest} exercise the mapping/delegation with a mocked
     * {@link WizDashboardFilterBuilder}, independent of the live-engine-only compose+save path.
     */
@@ -309,5 +348,6 @@ public class WizDashboardService {
    private final AddVisualizationServiceProxy addVisualizationService;
    private final SecurityEngine securityEngine;
    private final WizDashboardFilterBuilder filterBuilder;
+   private final AssetRepository assetRepository;
    private static final Logger LOG = LoggerFactory.getLogger(WizDashboardService.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -140,6 +140,12 @@ public class WizDashboardService {
          int[] spans = grid ?
             event.getTiles().stream().mapToInt(t -> Math.max(1, t.getSpanCols())).toArray() : null;
 
+         if(grid && spans.length != entries.size()) {
+            throw new IllegalArgumentException(
+               "tiles count (" + spans.length + ") does not match resolved visualization count (" +
+               entries.size() + ")");
+         }
+
          int cumulativeY = 0;   // stack path only
 
          for(int i = 0; i < entries.size(); i++) {
@@ -219,7 +225,8 @@ public class WizDashboardService {
       return entry;
    }
 
-   /** Single-column vertical stride between successive merged visualizations, in pixels. */
+   /** Vertical row stride between successive merged visualizations, in pixels — used by both
+    *  the single-column stack path and the grid path's row advance. */
    private static final int DASHBOARD_ROW_HEIGHT = 420;
 
    /** Horizontal stride between grid columns, in pixels (paired with DASHBOARD_ROW_HEIGHT). */

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -163,6 +163,8 @@ public class WizDashboardService {
             Math.max(1, event.getLayoutColumns()) : 2;
          int[] spans = grid ?
             event.getTiles().stream().mapToInt(t -> Math.max(1, t.getSpanCols())).toArray() : null;
+         int[] rowSpans = grid ?
+            event.getTiles().stream().mapToInt(t -> Math.max(1, t.getSpanRows())).toArray() : null;
 
          if(grid && spans.length != entries.size()) {
             throw new IllegalArgumentException(
@@ -196,7 +198,7 @@ public class WizDashboardService {
                      "in the same order as identifiers");
                }
 
-               java.awt.Point origin = gridOrigin(spans, layoutColumns, i);
+               java.awt.Point origin = gridOrigin(spans, rowSpans, layoutColumns, i);
                x = origin.x;
                y = origin.y + topOffset;
             }
@@ -337,34 +339,59 @@ public class WizDashboardService {
    private static final int DASHBOARD_COL_WIDTH = 640;   // confirm vs composer default viz width
 
    /**
-    * Row-major grid origin for the tile at flat index {@code i}, given per-tile column spans.
-    * Returns the (x,y) drop origin in pixels. Package-private for unit testing.
+    * Row-major grid origin for the tile at flat index {@code i}, given per-tile column AND row
+    * spans. Packing is still row-major/left-to-right/wrap-at-{@code layoutColumns} (identical
+    * grouping to the column-only overload below) — the only change is that each row's HEIGHT is
+    * now {@code max(spanRows)} among the tiles placed in it, instead of always
+    * {@code DASHBOARD_ROW_HEIGHT}. A tile's own Y depends only on the finalized height of every
+    * row strictly before it, and every such row is fully scanned (all its tiles' spanRows folded
+    * into that row's height, then closed out) before the loop reaches index {@code i} — so no
+    * 2D occupancy grid is needed; a tile with spanRows > 1 does not "block" cells in the row
+    * below for placement purposes (that would be true masonry/skyline packing, deliberately not
+    * implemented — see the Phase 4 design spec). Returns the (x,y) drop origin in pixels.
+    * Package-private for unit testing.
     */
-   static java.awt.Point gridOrigin(int[] spanCols, int layoutColumns, int i) {
+   static java.awt.Point gridOrigin(int[] spanCols, int[] spanRows, int layoutColumns, int i) {
       int col = 0;
-      int row = 0;
+      int cumulativeY = 0;
+      int rowHeight = 1;   // tallest spanRows seen so far in the CURRENT (still-open) row
 
       for(int k = 0; k <= i; k++) {
          int span = Math.max(1, Math.min(spanCols[k], layoutColumns));
+         int rspan = Math.max(1, spanRows[k]);
 
-         if(col + span > layoutColumns) {   // doesn't fit in the current row → wrap
+         if(col + span > layoutColumns) {   // doesn't fit in the current row → close it out
+            cumulativeY += rowHeight * DASHBOARD_ROW_HEIGHT;
             col = 0;
-            row++;
+            rowHeight = 1;
          }
 
          if(k == i) {
-            return new java.awt.Point(col * DASHBOARD_COL_WIDTH, row * DASHBOARD_ROW_HEIGHT);
+            return new java.awt.Point(col * DASHBOARD_COL_WIDTH, cumulativeY);
          }
 
+         rowHeight = Math.max(rowHeight, rspan);
          col += span;
 
-         if(col >= layoutColumns) {   // row full → next row
+         if(col >= layoutColumns) {   // row exactly full → close it out now
+            cumulativeY += rowHeight * DASHBOARD_ROW_HEIGHT;
             col = 0;
-            row++;
+            rowHeight = 1;
          }
       }
 
       return new java.awt.Point(0, 0);   // unreachable (i is always in range)
+   }
+
+   /**
+    * Back-compat overload for callers with only column spans (implicit {@code spanRows[k] == 1}
+    * for every tile — i.e. every row is exactly {@code DASHBOARD_ROW_HEIGHT}, matching Phase 2's
+    * original behavior exactly).
+    */
+   static java.awt.Point gridOrigin(int[] spanCols, int layoutColumns, int i) {
+      int[] unitRowSpans = new int[spanCols.length];
+      java.util.Arrays.fill(unitRowSpans, 1);
+      return gridOrigin(spanCols, unitRowSpans, layoutColumns, i);
    }
 
    private final ViewsheetService viewsheetService;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -171,9 +171,12 @@ public class WizDashboardService {
          }
 
          // When a filter bar will be built (Task 3, below), reserve its own top row so the
-         // merged charts don't render underneath it.
+         // merged charts don't render underneath it. Its controls are much shorter than a full
+         // chart tile, so this uses its own (smaller) row height rather than DASHBOARD_ROW_HEIGHT
+         // -- reserving a full chart-height row left a large empty gap between the filter bar and
+         // the charts below it.
          boolean hasFilters = event.getFilters() != null && !event.getFilters().isEmpty();
-         int topOffset = hasFilters ? DASHBOARD_ROW_HEIGHT : 0;
+         int topOffset = hasFilters ? FILTER_BAR_ROW_HEIGHT : 0;
 
          int cumulativeY = topOffset;   // stack path only
 
@@ -324,6 +327,11 @@ public class WizDashboardService {
    /** Vertical row stride between successive merged visualizations, in pixels — used by both
     *  the single-column stack path and the grid path's row advance. */
    private static final int DASHBOARD_ROW_HEIGHT = 420;
+
+   /** Reserved row height for the top filter bar, in pixels — matches the compact pixel size
+    *  {@link WizDashboardFilterBuilder} gives its selection/range controls, not a full chart
+    *  tile's height. */
+   static final int FILTER_BAR_ROW_HEIGHT = 120;
 
    /** Horizontal stride between grid columns, in pixels (paired with DASHBOARD_ROW_HEIGHT). */
    private static final int DASHBOARD_COL_WIDTH = 640;   // confirm vs composer default viz width

--- a/core/src/test/java/inetsoft/uql/asset/ColumnRefTest.java
+++ b/core/src/test/java/inetsoft/uql/asset/ColumnRefTest.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.asset;
+
+import inetsoft.uql.erm.AttributeRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class ColumnRefTest {
+   /**
+    * Regression test for a data-corruption bug: renaming a column's qualifying table (e.g. when
+    * a worksheet dedup-merge renames a shared physical table, as in
+    * WsMergeService#ensureBaseHasPrevMirror) rebuilds the column's AttributeRef but silently
+    * dropped its dataType (AttributeRef's field defaults to null), so any join keyed on that
+    * column downstream ends up typed null/"string" instead of its real type (e.g. "integer") --
+    * breaking the join and any chart depending on it. Discovered via a StyleBI dashboard
+    * composing two charts that share a physical source table.
+    *
+    * <p>Deliberately does NOT call {@code column.setDataType(...)} on the ColumnRef itself:
+    * {@link ColumnRef#getDataType()} returns its own cached {@code dtype} first, falling back to
+    * the wrapped ref's type only when that field is unset -- calling it here would mask the bug
+    * (the ColumnRef's own cache would win regardless of what happens to the wrapped ref). This
+    * matches how a join's own key ColumnRef is actually built -- typed only via its wrapped
+    * AttributeRef, with no override on the ColumnRef itself.</p>
+    */
+   @Test
+   void renameColumnPreservesDataType() {
+      AttributeRef attr = new AttributeRef("PT", "id");
+      attr.setDataType("integer");
+      attr.setCaption("Product Template Id");
+      ColumnRef column = new ColumnRef(attr);
+
+      assertEquals("integer", column.getDataType(), "sanity check: type resolves through the wrapped ref before rename");
+
+      ColumnRef.renameColumn(column, "PT", "PT_base");
+
+      assertEquals("PT_base", column.getEntity());
+      assertEquals("id", column.getAttribute());
+      assertEquals("integer", column.getDataType(), "renaming a column's table qualifier must preserve its data type");
+      assertEquals("Product Template Id", ((AttributeRef) column.getDataRef()).getCaption(), "caption must still be preserved");
+   }
+
+   @Test
+   void renameColumnLeavesNonMatchingEntityUntouched() {
+      AttributeRef attr = new AttributeRef("Other", "id");
+      attr.setDataType("integer");
+      ColumnRef column = new ColumnRef(attr);
+
+      ColumnRef.renameColumn(column, "PT", "PT_base");
+
+      assertEquals("Other", column.getEntity());
+      assertEquals("integer", column.getDataType());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/model/WizDashboardEventTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/WizDashboardEventTest.java
@@ -30,13 +30,14 @@ class WizDashboardEventTest {
    @Test
    void deserializesTilesAndLayoutColumns() throws Exception {
       String json = "{\"name\":\"B\",\"identifiers\":[\"v1\",\"v2\"]," +
-         "\"layoutColumns\":2,\"tiles\":[{\"identifier\":\"v1\",\"spanCols\":1}," +
-         "{\"identifier\":\"v2\",\"spanCols\":2}]}";
+         "\"layoutColumns\":2,\"tiles\":[{\"identifier\":\"v1\",\"spanCols\":1,\"spanRows\":1}," +
+         "{\"identifier\":\"v2\",\"spanCols\":2,\"spanRows\":2}]}";
       WizDashboardEvent ev = mapper.readValue(json, WizDashboardEvent.class);
       assertEquals(2, ev.getLayoutColumns());
       assertEquals(2, ev.getTiles().size());
       assertEquals("v2", ev.getTiles().get(1).getIdentifier());
       assertEquals(2, ev.getTiles().get(1).getSpanCols());
+      assertEquals(2, ev.getTiles().get(1).getSpanRows());
    }
 
    @Test
@@ -51,6 +52,13 @@ class WizDashboardEventTest {
       WizDashboardEvent ev = mapper.readValue(
          "{\"tiles\":[{\"identifier\":\"v1\"}]}", WizDashboardEvent.class);
       assertEquals(1, ev.getTiles().get(0).getSpanCols());
+   }
+
+   @Test
+   void spanRowsDefaultsToOneWhenOmitted() throws Exception {
+      WizDashboardEvent ev = mapper.readValue(
+         "{\"tiles\":[{\"identifier\":\"v1\"}]}", WizDashboardEvent.class);
+      assertEquals(1, ev.getTiles().get(0).getSpanRows());
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/model/WizDashboardEventTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/WizDashboardEventTest.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package inetsoft.web.wiz.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/core/src/test/java/inetsoft/web/wiz/model/WizDashboardEventTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/WizDashboardEventTest.java
@@ -35,4 +35,18 @@ class WizDashboardEventTest {
          "{\"tiles\":[{\"identifier\":\"v1\"}]}", WizDashboardEvent.class);
       assertEquals(1, ev.getTiles().get(0).getSpanCols());
    }
+
+   @Test
+   void deserializesFilters() throws Exception {
+      String json = "{\"name\":\"B\",\"identifiers\":[\"v1\"]," +
+         "\"filters\":[{\"field\":\"Region\",\"dataType\":\"string\",\"label\":\"Region\"}," +
+         "{\"field\":\"OrderDate\",\"dataType\":\"date\"}]}";
+      WizDashboardEvent ev = mapper.readValue(json, WizDashboardEvent.class);
+      assertEquals(2, ev.getFilters().size());
+      assertEquals("Region", ev.getFilters().get(0).getField());
+      assertEquals("string", ev.getFilters().get(0).getDataType());
+      assertEquals("Region", ev.getFilters().get(0).getLabel());
+      assertEquals("date", ev.getFilters().get(1).getDataType());
+      assertNull(ev.getFilters().get(1).getLabel());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/model/WizDashboardEventTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/WizDashboardEventTest.java
@@ -23,7 +23,7 @@ class WizDashboardEventTest {
    }
 
    @Test
-   void tolueratesAbsentTiles() throws Exception {
+   void toleratesAbsentTiles() throws Exception {
       WizDashboardEvent ev = mapper.readValue("{\"name\":\"B\",\"identifiers\":[\"v1\"]}", WizDashboardEvent.class);
       assertNull(ev.getTiles());
       assertNull(ev.getLayoutColumns());

--- a/core/src/test/java/inetsoft/web/wiz/model/WizDashboardEventTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/WizDashboardEventTest.java
@@ -1,0 +1,38 @@
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class WizDashboardEventTest {
+   private final ObjectMapper mapper = new ObjectMapper();
+
+   @Test
+   void deserializesTilesAndLayoutColumns() throws Exception {
+      String json = "{\"name\":\"B\",\"identifiers\":[\"v1\",\"v2\"]," +
+         "\"layoutColumns\":2,\"tiles\":[{\"identifier\":\"v1\",\"spanCols\":1}," +
+         "{\"identifier\":\"v2\",\"spanCols\":2}]}";
+      WizDashboardEvent ev = mapper.readValue(json, WizDashboardEvent.class);
+      assertEquals(2, ev.getLayoutColumns());
+      assertEquals(2, ev.getTiles().size());
+      assertEquals("v2", ev.getTiles().get(1).getIdentifier());
+      assertEquals(2, ev.getTiles().get(1).getSpanCols());
+   }
+
+   @Test
+   void tolueratesAbsentTiles() throws Exception {
+      WizDashboardEvent ev = mapper.readValue("{\"name\":\"B\",\"identifiers\":[\"v1\"]}", WizDashboardEvent.class);
+      assertNull(ev.getTiles());
+      assertNull(ev.getLayoutColumns());
+   }
+
+   @Test
+   void spanColsDefaultsToOneWhenOmitted() throws Exception {
+      WizDashboardEvent ev = mapper.readValue(
+         "{\"tiles\":[{\"identifier\":\"v1\"}]}", WizDashboardEvent.class);
+      assertEquals(1, ev.getTiles().get(0).getSpanCols());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/model/WizDashboardResultTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/WizDashboardResultTest.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package inetsoft.web.wiz.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/core/src/test/java/inetsoft/web/wiz/model/WizDashboardResultTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/WizDashboardResultTest.java
@@ -1,0 +1,22 @@
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class WizDashboardResultTest {
+   @Test
+   void serializesCoverageFields() throws Exception {
+      WizDashboardResult r = new WizDashboardResult();
+      r.setSavedViewsheetIdentifier("d1");
+      r.setSkipped(java.util.List.of());
+      r.setFiltersApplied(java.util.List.of("Region"));
+      r.setFiltersSkipped(java.util.List.of("OrderDate"));
+      String json = new ObjectMapper().writeValueAsString(r);
+      assertTrue(json.contains("\"filtersApplied\":[\"Region\"]"));
+      assertTrue(json.contains("\"filtersSkipped\":[\"OrderDate\"]"));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/AddFilterServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/AddFilterServiceTest.java
@@ -1,0 +1,135 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.PhysicalBoundTableAssembly;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.schema.XSchema;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression coverage for {@link AddFilterService#findColumnMatchingChartTables}: unlike
+ * {@link AddFilterService#findColumnMatchingRootTables} (every root/physical table exposing the
+ * column), this only considers the given candidate table names — so a table exposing the column
+ * that is NOT one of the caller's candidates (e.g. a chart's own final bound table list) is never
+ * returned, even if it would otherwise match. This scoping is what fixes a live bug: binding a
+ * dashboard filter to a shared root table cascaded through a chart's cross-category normalization
+ * (min/max) computation, collapsing it to the filtered subset and corrupting the chart.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class AddFilterServiceTest {
+   private static PhysicalBoundTableAssembly physicalTable(Worksheet ws, String assemblyName, String... columns) {
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, assemblyName);
+      SourceInfo si = new SourceInfo(SourceInfo.PHYSICAL_TABLE, "postgres", "public." + assemblyName);
+      table.setSourceInfo(si);
+
+      ColumnSelection cs = new ColumnSelection();
+
+      for(String name : columns) {
+         AttributeRef ref = new AttributeRef(null, name);
+         ref.setDataType(XSchema.STRING);
+         ColumnRef col = new ColumnRef(ref);
+         col.setDataType(XSchema.STRING);
+         cs.addAttribute(col);
+      }
+
+      table.setColumnSelection(cs, false);
+      return table;
+   }
+
+   @Test
+   void matchesOnlyCandidateTablesExposingTheColumn() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name", "revenue"));
+      ws.addAssembly(physicalTable(ws, "GLOBAL_STATS", "category_name", "min_revenue", "max_revenue"));
+      ws.addAssembly(physicalTable(ws, "OTHER_TABLE", "product_name"));
+
+      List<String> result = AddFilterService.findColumnMatchingChartTables(
+         ws, List.of("CHART_FINAL"), "category_name");
+
+      assertEquals(List.of("CHART_FINAL"), result,
+         "must match the requested candidate, and must NOT include GLOBAL_STATS even though it " +
+         "also exposes category_name -- it was not in the candidate list");
+   }
+
+   @Test
+   void skipsACandidateThatDoesNotExposeTheColumn() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "CHART_FINAL", "product_name"));
+
+      List<String> result = AddFilterService.findColumnMatchingChartTables(
+         ws, List.of("CHART_FINAL"), "category_name");
+
+      assertTrue(result.isEmpty());
+   }
+
+   @Test
+   void skipsACandidateNameThatDoesNotExistInTheWorksheet() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name"));
+
+      List<String> result = AddFilterService.findColumnMatchingChartTables(
+         ws, List.of("NONEXISTENT_TABLE"), "category_name");
+
+      assertTrue(result.isEmpty());
+   }
+
+   @Test
+   void returnsEmptyForNullOrEmptyInputs() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name"));
+
+      assertTrue(AddFilterService.findColumnMatchingChartTables(null, List.of("CHART_FINAL"), "category_name").isEmpty());
+      assertTrue(AddFilterService.findColumnMatchingChartTables(ws, null, "category_name").isEmpty());
+      assertTrue(AddFilterService.findColumnMatchingChartTables(ws, List.of(), "category_name").isEmpty());
+   }
+
+   @Test
+   void matchesMultipleCandidatesIndependently() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "RADAR_FINAL", "category_name", "norm_revenue"));
+      ws.addAssembly(physicalTable(ws, "MR_FINAL", "product_name"));
+
+      List<String> result = AddFilterService.findColumnMatchingChartTables(
+         ws, List.of("RADAR_FINAL", "MR_FINAL"), "category_name");
+
+      assertEquals(List.of("RADAR_FINAL"), result,
+         "MR_FINAL is a valid candidate but doesn't expose category_name, so it's correctly excluded");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/AddVisualizationServiceGraphStalenessTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/AddVisualizationServiceGraphStalenessTest.java
@@ -1,0 +1,146 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.AssetContent;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression test for a dashboard-compose data-staleness bug: merging a visualization into a
+ * dashboard's LIVE runtime viewsheet (as {@link WizDashboardService#composeDashboard} does, once
+ * per chart, via {@link AddVisualizationService#addVisualization}) calls
+ * {@code dashVS.addAssembly(clonedChart)} to attach the newly-merged chart. That call fires the
+ * {@link ViewsheetSandbox}'s {@code actionPerformed} listener SYNCHRONOUSLY (confirmed via a live
+ * stack-trace capture: {@code addAssembly -> AbstractSheet.fireEvent -> actionPerformed -> reset0
+ * -> ... -> ChartVSAQuery#createBaseTableAssembly0}), which resolves the chart's own bound table
+ * (e.g. "RADAR_OUT") through {@code dashVS.getBaseWorksheet()} — {@code dashVS}'s own cached
+ * {@code ws} field, which is a SEPARATE object from the freshly-merged {@code dashWS} local
+ * variable until that merged worksheet is both (a) persisted to the repository and (b) reloaded
+ * back into {@code dashVS} via {@link Viewsheet#repopulateWorksheet}. Doing those two steps
+ * AFTER the merge loop (where the bug was first, incorrectly, believed to be) is too late — the
+ * listener already ran and logged "is not a data block, or the data block was not found!" by
+ * then, even though the eventually-persisted worksheet is correct. The fix persists + repopulates
+ * BEFORE {@code mergeViewsheet} ever calls {@code addAssembly}.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class AddVisualizationServiceGraphStalenessTest {
+
+   @Test
+   void mergingAVisualizationPersistsAndRepopulatesTheWorksheetBeforeAddingTheChartAssembly()
+      throws Exception
+   {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WsMergeService wsMergeService = mock(WsMergeService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+
+      when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+
+      // Dashboard runtime viewsheet: a freshly created wiz sheet with no backing worksheet yet
+      // (the first visualization merged into it). Spied so addAssembly's call order relative to
+      // the repository can be verified without disturbing its real merge/listener behavior.
+      Viewsheet dashVS = spy(new Viewsheet(null, true, false, null, null));
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(dashVS);
+      when(rvs.getEntry()).thenReturn(null);
+      ViewsheetSandbox box = mock(ViewsheetSandbox.class);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+      when(vsService.getViewsheet(eq("rt-1"), eq(principal))).thenReturn(rvs);
+
+      // The visualization being merged in: one chart assembly, "Chart1".
+      AssetEntry vizWsEntry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, "ws1", null);
+      Viewsheet vizVS = new Viewsheet(vizWsEntry);
+      ChartVSAssembly chart = new ChartVSAssembly(vizVS, "Chart1");
+      vizVS.addAssembly(chart);
+
+      AssetEntry vizEntry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, "viz1", null);
+      when(assetRepository.getSheet(eq(vizEntry), eq(principal), eq(true), any(AssetContent.class)))
+         .thenReturn(vizVS);
+      Worksheet vizWS = new Worksheet();
+      when(assetRepository.getSheet(eq(vizWsEntry), eq(principal), eq(true), any(AssetContent.class)))
+         .thenReturn(vizWS);
+
+      // repopulateWorksheet's internal reload -- permission=false, principal=null (its own
+      // hardcoded call), against whatever temp entry doAddVisualization creates for the
+      // first-visualization branch.
+      when(assetRepository.getSheet(any(AssetEntry.class), isNull(), eq(false), any(AssetContent.class)))
+         .thenReturn(new Worksheet());
+
+      when(wsMergeService.mergeWorksheet(eq(vizWS), any(Worksheet.class), anyString(), any()))
+         .thenReturn(new HashMap<>());
+
+      AddVisualizationService service =
+         new AddVisualizationService(vsService, assetRepository, wsMergeService, securityEngine);
+
+      service.addVisualization("rt-1", vizEntry, 0, 0, 1.0f, principal);
+
+      // The merged worksheet must be persisted, and dashVS's own cached base worksheet
+      // repopulated from it, BEFORE the chart assembly is added -- otherwise the sandbox's
+      // addAssembly listener resolves the chart's bound table against the stale pre-merge
+      // worksheet and logs the "not a data block" error even though the eventually-persisted
+      // worksheet is correct.
+      InOrder order = inOrder(assetRepository, dashVS);
+      order.verify(assetRepository).setSheet(any(AssetEntry.class), any(Worksheet.class), eq(principal), anyBoolean());
+      order.verify(assetRepository).getSheet(any(AssetEntry.class), isNull(), eq(false), any(AssetContent.class));
+      order.verify(dashVS).addAssembly(any());
+
+      // The merged chart must also have its cached VGraphPair invalidated -- defense in depth
+      // for any graph cached from a prior merge into the same running dashboard.
+      verify(box).clearGraph("Chart1");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizDashboardFilterBuilderTest {
+   private final WizDashboardFilterBuilder builder = new WizDashboardFilterBuilder();
+
+   @Test
+   void categoricalFieldMakesASelectionList() {
+      Viewsheet vs = new Viewsheet();
+      // A field on NO table binds to nothing -> skipped, but the control TYPE is still decided
+      // by data type. Assert via a package-visible helper the builder exposes for the type choice:
+      AbstractSelectionVSAssembly a = builder.createControlForType(vs, "string", column("Region", "string"));
+      assertTrue(a instanceof SelectionListVSAssembly);
+   }
+
+   @Test
+   void dateAndNumericFieldsMakeRangeSliders() {
+      Viewsheet vs = new Viewsheet();
+      assertTrue(builder.createControlForType(vs, "date", column("OrderDate", "date")) instanceof TimeSliderVSAssembly);
+      assertTrue(builder.createControlForType(vs, "integer", column("Qty", "integer")) instanceof TimeSliderVSAssembly);
+   }
+
+   // Helper mirrors AddFilterService.buildColumnRef (AttributeRef + ColumnRef with dataType).
+   // NOTE: ColumnRef lives in inetsoft.uql.asset (not inetsoft.uql.erm as the task brief sketch
+   // assumed) — confirmed against AddFilterService's imports in Step 1.
+   private static inetsoft.uql.erm.DataRef column(String name, String dtype) {
+      inetsoft.uql.erm.AttributeRef attr = new inetsoft.uql.erm.AttributeRef(name);
+      attr.setDataType(dtype);
+      inetsoft.uql.asset.ColumnRef col = new inetsoft.uql.asset.ColumnRef(attr);
+      col.setDataType(dtype);
+      return col;
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -20,6 +20,13 @@ package inetsoft.web.wiz.service;
 import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.PhysicalBoundTableAssembly;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.viewsheet.*;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -27,6 +34,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -52,6 +61,83 @@ class WizDashboardFilterBuilderTest {
       Viewsheet vs = new Viewsheet();
       assertTrue(builder.createControlForType(vs, "date", column("OrderDate", "date")) instanceof TimeSliderVSAssembly);
       assertTrue(builder.createControlForType(vs, "integer", column("Qty", "integer")) instanceof TimeSliderVSAssembly);
+   }
+
+   @Test
+   void mergedChartTableNamesCollectsOnlyChartAssembliesOwnTables() {
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly radar = new ChartVSAssembly(vs, "RadarChart");
+      boundToTable(radar, "RADAR_FINAL");
+      vs.addAssembly(radar);
+      ChartVSAssembly mr = new ChartVSAssembly(vs, "MrChart");
+      boundToTable(mr, "MR_FINAL");
+      vs.addAssembly(mr);
+      // A non-chart assembly must not contribute a table name, even though it also implements
+      // BindableVSAssembly -- only ChartVSAssembly is considered (see the method's javadoc).
+      TextVSAssembly text = new TextVSAssembly(vs, "Title");
+      vs.addAssembly(text);
+
+      List<String> names = builder.mergedChartTableNames(vs);
+
+      assertEquals(List.of("RADAR_FINAL", "MR_FINAL"), names);
+   }
+
+   @Test
+   void buildBindsOnlyToTheChartsOwnTableNotAnUnrelatedTableSharingTheColumn() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name", "norm_revenue"));
+      // Simulates the shared global-aggregate table upstream of a chart's normalization step:
+      // it also exposes category_name, but no chart is bound to it directly, so it must never
+      // receive the filter (that was the root cause of the live "No data" regression: binding a
+      // filter to this kind of table cascades into the aggregate it feeds).
+      ws.addAssembly(physicalTable(ws, "GLOBAL_STATS", "category_name", "min_revenue", "max_revenue"));
+
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(vs, "RadarChart");
+      boundToTable(chart, "CHART_FINAL");
+      vs.addAssembly(chart);
+
+      WizDashboardFilterBuilder.FilterResult result = builder.build(
+         vs, ws, List.of(new WizDashboardFilterBuilder.FilterRequest("category_name", "string", "Category")));
+
+      assertEquals(List.of("category_name"), result.applied());
+      assertTrue(result.skipped().isEmpty());
+
+      AbstractSelectionVSAssembly control = java.util.Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof AbstractSelectionVSAssembly)
+         .map(a -> (AbstractSelectionVSAssembly) a)
+         .findFirst().orElseThrow();
+      assertEquals(List.of("CHART_FINAL"), control.getTableNames(),
+         "must bind only to the chart's own table, never GLOBAL_STATS");
+   }
+
+   // ChartVSAssembly.setTableName(String) silently no-ops when getSourceInfo() is still null (it
+   // builds a local SourceInfo but never calls setSourceInfo(...) to store it back) -- harmless
+   // in production, where a chart's SourceInfo is always initialized before setTableName is
+   // ever called, but a real gap for a bare `new ChartVSAssembly(...)` test fixture. Set the
+   // SourceInfo directly instead of relying on setTableName here.
+   private static void boundToTable(ChartVSAssembly chart, String tableName) {
+      SourceInfo source = new SourceInfo(SourceInfo.ASSET, null, tableName);
+      chart.setSourceInfo(source);
+   }
+
+   private static PhysicalBoundTableAssembly physicalTable(Worksheet ws, String assemblyName, String... columns) {
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, assemblyName);
+      SourceInfo si = new SourceInfo(SourceInfo.PHYSICAL_TABLE, "postgres", "public." + assemblyName);
+      table.setSourceInfo(si);
+
+      ColumnSelection cs = new ColumnSelection();
+
+      for(String name : columns) {
+         AttributeRef ref = new AttributeRef(null, name);
+         ref.setDataType(XSchema.STRING);
+         ColumnRef col = new ColumnRef(ref);
+         col.setDataType(XSchema.STRING);
+         cs.addAttribute(col);
+      }
+
+      table.setColumnSelection(cs, false);
+      return table;
    }
 
    // Helper mirrors AddFilterService.buildColumnRef (AttributeRef + ColumnRef with dataType).

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -66,6 +66,43 @@ class WizDashboardServiceGridTest {
       assertEquals(new Point(0, H), WizDashboardService.gridOrigin(spans, 2, 1));
    }
 
+   @Test
+   void tallTileReservesItsRowHeightForShorterNeighbors() {
+      int[] spans = { 2, 1, 1 };     // tile0: 2 cols wide; tile1, tile2: 1 col each
+      int[] rowSpans = { 2, 1, 1 };  // tile0: 2 ROWS tall; tile1, tile2: 1 row each
+
+      // tile0 (2x2) fills the whole row by itself (spanCols=2 == layoutColumns) -> row 0.
+      assertEquals(new Point(0, 0), WizDashboardService.gridOrigin(spans, rowSpans, 2, 0));
+      // tile1 and tile2 (1x1 each) wrap into what would be "row 1", but tile0 was 2 rows tall,
+      // so they must start at H*2, not H*1.
+      assertEquals(new Point(0, 2 * H), WizDashboardService.gridOrigin(spans, rowSpans, 2, 1));
+      assertEquals(new Point(W, 2 * H), WizDashboardService.gridOrigin(spans, rowSpans, 2, 2));
+   }
+
+   @Test
+   void shortTileNextToTallTileSharesTheTallRowsHeightNotItsOwn() {
+      int[] spans = { 1, 1 };       // tile0 and tile1 share one row (1 col each, layoutColumns=2)
+      int[] rowSpans = { 2, 1 };    // tile0: 2 rows tall; tile1: 1 row tall
+
+      // Both are in the SAME row (col 0 and col 1), so both share row index 0 -> same Y.
+      assertEquals(new Point(0, 0), WizDashboardService.gridOrigin(spans, rowSpans, 2, 0));
+      assertEquals(new Point(W, 0), WizDashboardService.gridOrigin(spans, rowSpans, 2, 1));
+   }
+
+   @Test
+   void threeRowsOfMixedHeightsCompoundCumulativeYCorrectly() {
+      // Row 0: one 2x2 tile (fills both columns, 2 rows tall).
+      // Row 1: one 2x1 tile (fills both columns, 1 row tall).
+      // Row 2: two 1x1 tiles.
+      int[] spans =    { 2, 2, 1, 1 };
+      int[] rowSpans = { 2, 1, 1, 1 };
+
+      assertEquals(new Point(0, 0),         WizDashboardService.gridOrigin(spans, rowSpans, 2, 0));
+      assertEquals(new Point(0, 2 * H),     WizDashboardService.gridOrigin(spans, rowSpans, 2, 1));
+      assertEquals(new Point(0, 3 * H),     WizDashboardService.gridOrigin(spans, rowSpans, 2, 2));
+      assertEquals(new Point(W, 3 * H),     WizDashboardService.gridOrigin(spans, rowSpans, 2, 3));
+   }
+
    // --- Task 3: composeDashboard's filter-bar invocation seam ---------------------------------
    //
    // composeDashboard itself needs a live ViewsheetService/asset engine to open a runtime

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Point;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class WizDashboardServiceGridTest {
+   // Column width / row height strides used by the packer (mirror the service constants).
+   private static final int W = 640;   // DASHBOARD_COL_WIDTH  (confirm value in Task 2 Step 5)
+   private static final int H = 420;   // DASHBOARD_ROW_HEIGHT (existing constant)
+
+   @Test
+   void twoUnitTilesFillRowThenWrap() {
+      int[] spans = { 1, 1, 1 };
+      assertEquals(new Point(0, 0),     WizDashboardService.gridOrigin(spans, 2, 0));
+      assertEquals(new Point(W, 0),     WizDashboardService.gridOrigin(spans, 2, 1));
+      assertEquals(new Point(0, H),     WizDashboardService.gridOrigin(spans, 2, 2)); // wrapped
+   }
+
+   @Test
+   void fullWidthTileTakesWholeRow() {
+      int[] spans = { 2, 1, 1 };   // tile0 spans both columns
+      assertEquals(new Point(0, 0),  WizDashboardService.gridOrigin(spans, 2, 0));
+      assertEquals(new Point(0, H),  WizDashboardService.gridOrigin(spans, 2, 1)); // pushed to row 2
+      assertEquals(new Point(W, H),  WizDashboardService.gridOrigin(spans, 2, 2));
+   }
+
+   @Test
+   void unitTileAfterFullWidthStartsFreshRow() {
+      int[] spans = { 1, 2 };   // tile0 unit in row0 col0; tile1 full-width can't fit → row1
+      assertEquals(new Point(0, 0), WizDashboardService.gridOrigin(spans, 2, 0));
+      assertEquals(new Point(0, H), WizDashboardService.gridOrigin(spans, 2, 1));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -17,12 +17,23 @@
  */
 package inetsoft.web.wiz.service;
 
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.model.WizDashboardEvent;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.awt.Point;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @Tag("core")
 class WizDashboardServiceGridTest {
@@ -51,5 +62,50 @@ class WizDashboardServiceGridTest {
       int[] spans = { 1, 2 };   // tile0 unit in row0 col0; tile1 full-width can't fit → row1
       assertEquals(new Point(0, 0), WizDashboardService.gridOrigin(spans, 2, 0));
       assertEquals(new Point(0, H), WizDashboardService.gridOrigin(spans, 2, 1));
+   }
+
+   // --- Task 3: composeDashboard's filter-bar invocation seam ---------------------------------
+   //
+   // composeDashboard itself needs a live ViewsheetService/asset engine to open a runtime
+   // viewsheet and merge worksheets (see WizDashboardServiceTest's class Javadoc), so the
+   // filters[] -> WizDashboardFilterBuilder wiring is covered here instead via the
+   // package-visible applyFilters(Viewsheet, List<FilterSpec>) seam, with a mocked
+   // WizDashboardFilterBuilder — mirroring how gridOrigin is unit-tested independent of a live
+   // engine.
+
+   private WizDashboardService serviceWith(WizDashboardFilterBuilder filterBuilder) {
+      return new WizDashboardService(mock(ViewsheetService.class), mock(AddVisualizationServiceProxy.class),
+         mock(SecurityEngine.class), filterBuilder);
+   }
+
+   private static WizDashboardEvent.FilterSpec filterSpec(String field, String dataType, String label) {
+      WizDashboardEvent.FilterSpec spec = new WizDashboardEvent.FilterSpec();
+      spec.setField(field);
+      spec.setDataType(dataType);
+      spec.setLabel(label);
+      return spec;
+   }
+
+   @Test
+   void applyFiltersMapsSpecsToFilterRequestsAndReturnsBuilderResult() {
+      WizDashboardFilterBuilder filterBuilder = mock(WizDashboardFilterBuilder.class);
+      WizDashboardFilterBuilder.FilterResult expected =
+         new WizDashboardFilterBuilder.FilterResult(List.of("Region"), List.of("MissingField"));
+      when(filterBuilder.build(any(), any())).thenReturn(expected);
+
+      WizDashboardService svc = serviceWith(filterBuilder);
+      Viewsheet vs = mock(Viewsheet.class);
+      WizDashboardEvent.FilterSpec spec = filterSpec("Region", "string", "Region");
+
+      WizDashboardFilterBuilder.FilterResult actual = svc.applyFilters(vs, List.of(spec));
+
+      assertSame(expected, actual);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<List<WizDashboardFilterBuilder.FilterRequest>> captor =
+         ArgumentCaptor.forClass(List.class);
+      verify(filterBuilder).build(eq(vs), captor.capture());
+      assertEquals(List.of(new WizDashboardFilterBuilder.FilterRequest("Region", "string", "Region")),
+         captor.getValue());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -20,6 +20,7 @@ package inetsoft.web.wiz.service;
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.sree.security.SecurityEngine;
 import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.wiz.model.WizDashboardEvent;
 import org.junit.jupiter.api.Tag;
@@ -70,7 +71,7 @@ class WizDashboardServiceGridTest {
    // composeDashboard itself needs a live ViewsheetService/asset engine to open a runtime
    // viewsheet and merge worksheets (see WizDashboardServiceTest's class Javadoc), so the
    // filters[] -> WizDashboardFilterBuilder wiring is covered here instead via the
-   // package-visible applyFilters(Viewsheet, List<FilterSpec>) seam, with a mocked
+   // package-visible applyFilters(Viewsheet, Worksheet, List<FilterSpec>) seam, with a mocked
    // WizDashboardFilterBuilder — mirroring how gridOrigin is unit-tested independent of a live
    // engine.
 
@@ -92,20 +93,21 @@ class WizDashboardServiceGridTest {
       WizDashboardFilterBuilder filterBuilder = mock(WizDashboardFilterBuilder.class);
       WizDashboardFilterBuilder.FilterResult expected =
          new WizDashboardFilterBuilder.FilterResult(List.of("Region"), List.of("MissingField"));
-      when(filterBuilder.build(any(), any())).thenReturn(expected);
+      when(filterBuilder.build(any(), any(), any())).thenReturn(expected);
 
       WizDashboardService svc = serviceWith(filterBuilder);
       Viewsheet vs = mock(Viewsheet.class);
+      Worksheet baseWs = mock(Worksheet.class);
       WizDashboardEvent.FilterSpec spec = filterSpec("Region", "string", "Region");
 
-      WizDashboardFilterBuilder.FilterResult actual = svc.applyFilters(vs, List.of(spec));
+      WizDashboardFilterBuilder.FilterResult actual = svc.applyFilters(vs, baseWs, List.of(spec));
 
       assertSame(expected, actual);
 
       @SuppressWarnings("unchecked")
       ArgumentCaptor<List<WizDashboardFilterBuilder.FilterRequest>> captor =
          ArgumentCaptor.forClass(List.class);
-      verify(filterBuilder).build(eq(vs), captor.capture());
+      verify(filterBuilder).build(eq(vs), eq(baseWs), captor.capture());
       assertEquals(List.of(new WizDashboardFilterBuilder.FilterRequest("Region", "string", "Region")),
          captor.getValue());
    }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.service;
 
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.sree.security.SecurityEngine;
+import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.wiz.model.WizDashboardEvent;
 import org.junit.jupiter.api.Tag;
@@ -75,7 +76,7 @@ class WizDashboardServiceGridTest {
 
    private WizDashboardService serviceWith(WizDashboardFilterBuilder filterBuilder) {
       return new WizDashboardService(mock(ViewsheetService.class), mock(AddVisualizationServiceProxy.class),
-         mock(SecurityEngine.class), filterBuilder);
+         mock(SecurityEngine.class), filterBuilder, mock(AssetRepository.class));
    }
 
    private static WizDashboardEvent.FilterSpec filterSpec(String field, String dataType, String label) {

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceTest.java
@@ -63,7 +63,7 @@ class WizDashboardServiceTest {
       throws Exception
    {
       when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
-      return new WizDashboardService(vs, add, sec);
+      return new WizDashboardService(vs, add, sec, mock(WizDashboardFilterBuilder.class));
    }
 
    @Test
@@ -93,7 +93,8 @@ class WizDashboardServiceTest {
       ViewsheetService vs = mock(ViewsheetService.class);
       SecurityEngine sec = mock(SecurityEngine.class);
       when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(false);
-      WizDashboardService svc = new WizDashboardService(vs, mock(AddVisualizationServiceProxy.class), sec);
+      WizDashboardService svc = new WizDashboardService(vs, mock(AddVisualizationServiceProxy.class), sec,
+         mock(WizDashboardFilterBuilder.class));
       // identifier UNDER the components folder so the folder guard passes and the permission
       // check is reached:
       String id = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceTest.java
@@ -63,7 +63,8 @@ class WizDashboardServiceTest {
       throws Exception
    {
       when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
-      return new WizDashboardService(vs, add, sec, mock(WizDashboardFilterBuilder.class));
+      return new WizDashboardService(vs, add, sec, mock(WizDashboardFilterBuilder.class),
+         mock(AssetRepository.class));
    }
 
    @Test
@@ -94,7 +95,7 @@ class WizDashboardServiceTest {
       SecurityEngine sec = mock(SecurityEngine.class);
       when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(false);
       WizDashboardService svc = new WizDashboardService(vs, mock(AddVisualizationServiceProxy.class), sec,
-         mock(WizDashboardFilterBuilder.class));
+         mock(WizDashboardFilterBuilder.class), mock(AssetRepository.class));
       // identifier UNDER the components folder so the folder guard passes and the permission
       // check is reached:
       String id = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
@@ -104,5 +105,33 @@ class WizDashboardServiceTest {
       ev.setIdentifiers(List.of(id));
       assertThrows(inetsoft.sree.security.SecurityException.class,
          () -> svc.composeDashboard(ev, mock(Principal.class)));
+   }
+
+   @Test
+   void rejectsTilesOutOfOrderWithIdentifiers() throws Exception {
+      // tiles[] and identifiers[] are consumed purely positionally by index (spans[i] paired
+      // with entries.get(i)); a caller sending tiles out of order relative to identifiers must
+      // fail loud rather than silently mis-assigning spans to the wrong visualization.
+      WizDashboardService svc = createService(mock(ViewsheetService.class),
+         mock(AddVisualizationServiceProxy.class), mock(SecurityEngine.class));
+
+      String id1 = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/id1", null).toIdentifier();
+      String id2 = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/id2", null).toIdentifier();
+
+      WizDashboardEvent.TileSpec tile0 = new WizDashboardEvent.TileSpec();
+      tile0.setIdentifier(id2);   // swapped: should be id1 to match identifiers[0]
+      tile0.setSpanCols(1);
+      WizDashboardEvent.TileSpec tile1 = new WizDashboardEvent.TileSpec();
+      tile1.setIdentifier(id1);
+      tile1.setSpanCols(1);
+
+      WizDashboardEvent ev = new WizDashboardEvent();
+      ev.setName("D");
+      ev.setIdentifiers(List.of(id1, id2));
+      ev.setTiles(List.of(tile0, tile1));
+
+      assertThrows(IllegalArgumentException.class, () -> svc.composeDashboard(ev, mock(Principal.class)));
    }
 }


### PR DESCRIPTION
## Summary
Phase 2/3 of StyleBI-native dashboard composition (building on the merged Phase 1 `/api/wiz/visualization/dashboard` endpoint, PR #4293):

- **Grid layout**: `composeDashboard` accepts `tiles[]`/`layoutColumns` and packs merged charts into a row-major grid instead of a single-column stack (`WizDashboardService#gridOrigin`).
- **Auto filter bar**: `WizDashboardEvent#filters` + `WizDashboardFilterBuilder` build a top filter row (selection lists / time sliders) bound to the dashboard's merged worksheet, reusing `AddFilterService`'s column/table resolution.
- **Two data-integrity fixes**, found and root-caused while verifying the above live end-to-end against a real multi-chart dashboard:
  1. `ColumnRef.renameColumn` dropped a column's data type when its table qualifier was renamed (e.g. the worksheet dedup-merge's shared-table `_base` rename), silently corrupting any join keyed on that column to `"string"`.
  2. `AddVisualizationService` merged a chart's worksheet into the dashboard's worksheet, then called `addAssembly()` — which synchronously fires the `ViewsheetSandbox`'s listener and resolves the chart's bound table against the dashboard `Viewsheet`'s *cached* base worksheet. That cache was only refreshed after the whole merge loop finished, so it was stale at the exact moment each chart was added, making every merged chart's own table look missing (`CubeVSAQuery`: "is not a data block, or the data block was not found!") even though the persisted worksheet was correct. This was the actual cause of composed dashboards rendering blank/placeholder charts. Fixed by persisting + repopulating the worksheet before merging in the new VS assembly, not after.

## Test plan
- [x] `ColumnRefTest` — RED before fix (asserted `"string"` instead of `"integer"`), GREEN after
- [x] `AddVisualizationServiceGraphStalenessTest` — RED before fix (verified ordering + `clearGraph`), GREEN after
- [x] `WizDashboardServiceTest`, `WizDashboardServiceGridTest`, `WizDashboardFilterBuilderTest`, `WizDashboardEventTest`, `WizDashboardResultTest`, `AddVisualizationServiceSecurityTest` — all passing
- [x] Full `community/core` suite: 4675/4675 passing, 0 failures, 0 errors
- [x] Live end-to-end verification: built a local StyleBI image with these commits, composed a real 2-chart dashboard (shared physical source table) repeatedly — zero "not a data block" errors across multiple regenerations (previously 100% reproducible, 4 errors per regenerate)