### PR TITLE
Bug #75735, prevent org copy/rename from wiping all custom themes

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
@@ -310,6 +310,20 @@ public abstract class AbstractEditableAuthenticationProvider
       CustomThemesManager manager = CustomThemesManager.getManager();
       manager.loadThemes();
       Set<CustomTheme> themes = new HashSet<>(manager.getCustomThemes());
+
+      // setCustomThemes() below does a full replace of the entire CustomThemes store. If
+      // no themes could be read there is nothing to migrate, and persisting an empty set
+      // (e.g. when the themes failed to load) would wipe every custom theme across all
+      // orgs. Skip persistence entirely in that case so a failed/empty read cannot delete
+      // the store.
+      if(themes.isEmpty()) {
+         if(replace) {
+            manager.setOrgSelectedTheme(null, fromOrgId);
+         }
+
+         return null;
+      }
+
       List<CustomTheme> sourceThemes = new ArrayList<>();
 
       for(CustomTheme t : themes) {
@@ -322,8 +336,9 @@ public abstract class AbstractEditableAuthenticationProvider
       }
 
       if(replace) {
-         themes.removeIf(t -> Tool.equals(t.getOrgID(), fromOrgId));
-
+         // Do not remove the renamed org's themes up front: they are removed only after
+         // their replacement clone has been successfully built (see the end of the
+         // migration loop), so a clone failure can never drop the source theme.
          for(CustomTheme t : themes) {
             if(Tool.isEmptyString(t.getOrgID()) && t.getOrganizations() != null && t.getOrganizations().contains(fromOrgId)) {
                List<String> newOrgs = new ArrayList<>(t.getOrganizations());
@@ -334,6 +349,9 @@ public abstract class AbstractEditableAuthenticationProvider
       }
 
       String newOrgThemeId = null;
+      // Ids of the renamed org's source themes whose clone succeeded; only these
+      // originals are removed after the migration loop (see below).
+      Set<String> migratedOriginalIds = new HashSet<>();
 
       for(CustomTheme theme : sourceThemes) {
          try {
@@ -394,6 +412,10 @@ public abstract class AbstractEditableAuthenticationProvider
                }
 
                themes.add(clone);
+
+               if(replace) {
+                  migratedOriginalIds.add(theme.getId());
+               }
             }
             else if(Tool.isEmptyString(theme.getOrgID())
                && theme.getOrganizations() != null
@@ -420,6 +442,11 @@ public abstract class AbstractEditableAuthenticationProvider
       }
 
       if(replace) {
+         // Now that the clones have been added, remove only the originals of the renamed
+         // org that were successfully migrated. Themes whose clone failed are kept rather
+         // than lost.
+         themes.removeIf(t -> Tool.equals(t.getOrgID(), fromOrgId)
+            && migratedOriginalIds.contains(t.getId()));
          manager.setOrgSelectedTheme(null, fromOrgId);
       }
 

--- a/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
@@ -379,14 +379,13 @@ public abstract class AbstractEditableAuthenticationProvider
                   }
                }
 
-               if(theme.getOrganizations().contains(fromOrgId)) {
+               boolean migrateOrgSelection = theme.getOrganizations().contains(fromOrgId);
+
+               if(migrateOrgSelection) {
                   List<String> newOrgs = clone.getOrganizations();
                   newOrgs.remove(fromOrgId);
                   newOrgs.add(toOrgId);
                   clone.setOrganizations(newOrgs);
-
-                  manager.setOrgSelectedTheme(clone.getId(), toOrgId);
-                  newOrgThemeId = clone.getId();
                }
 
                if(!Tool.isEmptyString(clone.getJarPath())) {
@@ -412,6 +411,15 @@ public abstract class AbstractEditableAuthenticationProvider
                }
 
                themes.add(clone);
+
+               // Wire up the org's selected-theme pointer and the returned id only after
+               // the clone has been fully built and added to the working set. Doing this
+               // earlier (before the jar-copy step, which can throw) could leave the org
+               // pointing at a clone that was never persisted when a later step failed.
+               if(migrateOrgSelection) {
+                  manager.setOrgSelectedTheme(clone.getId(), toOrgId);
+                  newOrgThemeId = clone.getId();
+               }
 
                if(replace) {
                   migratedOriginalIds.add(theme.getId());

--- a/core/src/test/java/inetsoft/sree/security/AbstractEditableAuthenticationProviderStaticDepTest.java
+++ b/core/src/test/java/inetsoft/sree/security/AbstractEditableAuthenticationProviderStaticDepTest.java
@@ -272,6 +272,28 @@ class AbstractEditableAuthenticationProviderStaticDepTest {
       }
    }
 
+   // [Path A2] getCustomThemes() returns empty (e.g. themes failed to load) → persistence is
+   //           skipped entirely, so an empty/failed read cannot wipe the whole theme store.
+   //           For replace=true, setOrgSelectedTheme(null, fromOrgId) still fires.
+   @Test
+   void copyThemes_emptyThemeSet_skipsPersistence() {
+      try(MockedStatic<DataSpace> ds = mockStatic(DataSpace.class);
+          MockedStatic<CustomThemesManager> ctm = mockStatic(CustomThemesManager.class)) {
+
+         DataSpace mockDs = mock(DataSpace.class);
+         ds.when(DataSpace::getDataSpace).thenReturn(mockDs);
+
+         CustomThemesManager mockManager = mock(CustomThemesManager.class);
+         ctm.when(CustomThemesManager::getManager).thenReturn(mockManager);
+         when(mockManager.getCustomThemes()).thenReturn(new HashSet<>());
+
+         provider.callCopyThemes("fromOrg", "toOrg", true);
+
+         verify(mockManager, never()).setCustomThemes(any());
+         verify(mockManager).setOrgSelectedTheme(null, "fromOrg");
+      }
+   }
+
    // [Path B] no theme matches fromOrgId → setCustomThemes called with original (unchanged) set
    @Test
    void copyThemes_noMatchingTheme_setCustomThemesWithOriginal() {

--- a/core/src/test/java/inetsoft/sree/security/AbstractEditableAuthenticationProviderStaticDepTest.java
+++ b/core/src/test/java/inetsoft/sree/security/AbstractEditableAuthenticationProviderStaticDepTest.java
@@ -294,6 +294,41 @@ class AbstractEditableAuthenticationProviderStaticDepTest {
       }
    }
 
+   // [Path A3] clone fails for a fromOrgId-owned theme during a replace=true rename →
+   //           the original is retained in the persisted set (deferred-removal /
+   //           migratedOriginalIds path), not dropped, and no half-built clone is persisted.
+   @Test
+   void copyThemes_cloneFailsForFromOrgTheme_replaceTrue_originalRetained() {
+      CustomTheme theme = spy(new CustomTheme());
+      theme.setId("theme-1");
+      theme.setOrgID("fromOrg");
+      theme.setOrganizations(new ArrayList<>());
+      doThrow(new RuntimeException("clone failed")).when(theme).clone();
+
+      try(MockedStatic<DataSpace> ds = mockStatic(DataSpace.class);
+          MockedStatic<CustomThemesManager> ctm = mockStatic(CustomThemesManager.class)) {
+
+         DataSpace mockDs = mock(DataSpace.class);
+         ds.when(DataSpace::getDataSpace).thenReturn(mockDs);
+
+         CustomThemesManager mockManager = mock(CustomThemesManager.class);
+         ctm.when(CustomThemesManager::getManager).thenReturn(mockManager);
+         when(mockManager.getCustomThemes()).thenReturn(new HashSet<>(Set.of(theme)));
+
+         provider.callCopyThemes("fromOrg", "toOrg", true);
+
+         @SuppressWarnings("unchecked")
+         ArgumentCaptor<Set<CustomTheme>> captor = ArgumentCaptor.forClass(Set.class);
+         verify(mockManager).setCustomThemes(captor.capture());
+
+         Set<CustomTheme> result = captor.getValue();
+         assertTrue(result.stream().anyMatch(t -> "fromOrg".equals(t.getOrgID())),
+                    "original fromOrg theme must be retained when its clone fails");
+         assertFalse(result.stream().anyMatch(t -> "toOrg".equals(t.getOrgID())),
+                     "no half-built clone should be persisted when cloning failed");
+      }
+   }
+
    // [Path B] no theme matches fromOrgId → setCustomThemes called with original (unchanged) set
    @Test
    void copyThemes_noMatchingTheme_setCustomThemesWithOriginal() {


### PR DESCRIPTION
Bug #75735, prevent org copy/rename from wiping all custom themes

## Summary

Renaming or copying an organization could delete every custom theme across all organizations. After the operation the Presentation → Themes list is empty, existing themes return 404, and even creating a new theme fails because the persisted CustomThemes store has been wiped.

## Cause

`AbstractEditableAuthenticationProvider.copyThemes()` migrates themes for the affected org and then persists the result with `CustomThemesManager.setCustomThemes()`, which performs a full replace of the entire CustomThemes store. Two problems make that full replace destructive:

1. The renamed org's themes are removed from the working set before their replacement clones are built. If a clone fails (the per-theme catch only logs and continues), the original is already gone and is lost.
2. If the current themes cannot be read, `getCustomThemes()` returns an empty set; persisting that empty set overwrites the store and deletes every theme, including global themes and themes belonging to unrelated orgs.

## Fix

1. If no themes were read, skip persistence entirely (return early) so a failed/empty read can never overwrite the store with an empty set.
2. Defer removal of the renamed org's originals until after their clone has been successfully added. Only successfully-migrated originals are removed, so a clone failure keeps the source theme instead of dropping it.

## Scope / risk

Change is confined to `copyThemes()`; the copy path (replace = false) and the normal successful rename path are unchanged. Relies on `CustomTheme.equals()` excluding `organizations`, so appending an org to a shared global theme does not affect set membership.

## Note

This prevents future data loss. It does not restore themes already wiped in an affected environment (the theme JARs survive in blob storage, but the id / name / orgID metadata is gone); such an environment must be rebuilt or the themes re-created.