### PR TITLE
feat(wiz): persist and inherit worksheet column descriptions

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
@@ -211,6 +211,8 @@ public class WorksheetTable {
       /** ORDER BY clauses, in order; may be omitted/empty. */
       private List<OrderByInfo> orderBy;
       private String type;
+      /** Business meaning of this window column (english); persisted onto the output column. */
+      private String description;
       /** ROWS frame, e.g. {@code 2 PRECEDING .. CURRENT ROW}; omit for the function's default. */
       private WindowFrameInfo frame;
 
@@ -228,6 +230,8 @@ public class WorksheetTable {
       public void setOrderBy(List<OrderByInfo> orderBy) { this.orderBy = orderBy; }
       public String getType() { return type; }
       public void setType(String type) { this.type = type; }
+      public String getDescription() { return description; }
+      public void setDescription(String description) { this.description = description; }
       public WindowFrameInfo getFrame() { return frame; }
       public void setFrame(WindowFrameInfo frame) { this.frame = frame; }
    }
@@ -328,11 +332,15 @@ public class WorksheetTable {
    public static class GroupByFieldInfo {
       private String fieldName;
       private String dateGroupLevel;
+      /** Business meaning of the group-by output column (english); persisted onto the output column. */
+      private String description;
 
       public String getFieldName() { return fieldName; }
       public void setFieldName(String fieldName) { this.fieldName = fieldName; }
       public String getDateGroupLevel() { return dateGroupLevel; }
       public void setDateGroupLevel(String dateGroupLevel) { this.dateGroupLevel = dateGroupLevel; }
+      public String getDescription() { return description; }
+      public void setDescription(String description) { this.description = description; }
    }
 
    @JsonIgnoreProperties(ignoreUnknown = true)
@@ -343,6 +351,8 @@ public class WorksheetTable {
       private String alias;
       private String secondaryField;
       private Integer n;
+      /** Business meaning of the aggregated output column (english); persisted onto the output column. */
+      private String description;
 
       public String getFieldName() { return fieldName; }
       public void setFieldName(String fieldName) { this.fieldName = fieldName; }
@@ -354,6 +364,8 @@ public class WorksheetTable {
       public void setSecondaryField(String secondaryField) { this.secondaryField = secondaryField; }
       public Integer getN() { return n; }
       public void setN(Integer n) { this.n = n; }
+      public String getDescription() { return description; }
+      public void setDescription(String description) { this.description = description; }
    }
 
    // ─── Nested: flat condition item ──────────────────────────────────────────

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1554,6 +1554,14 @@ public class WorksheetTableService {
             // annotation. Aggregate MEASURES are handled separately below and DO take the model's
             // description, since aggregation genuinely changes the column's meaning.
             if(!Tool.isEmptyString(grp.getDescription())) {
+               // Best-effort: unlike the aggregate branch below (which falls back to the public
+               // `column` when privateCs lookup misses), a plain group whose fieldName does not
+               // resolve in privateCs leaves descTarget null and the model's group description is
+               // dropped. Setting it on the public `column` instead would not help — the public
+               // selection is regenerated as clones of privateCs, so a description must live on the
+               // private target to survive. A resolution miss here is unexpected (the group was
+               // already resolved against `cs` above) and rare; dropping the description is the
+               // accepted best-effort behavior, consistent with the rest of this method.
                ColumnRef descTarget = grp.getDateGroupLevel() != null
                   ? column
                   : (privateCs.getAttribute(grp.getFieldName()) instanceof ColumnRef pc ? pc : null);

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1354,6 +1354,11 @@ public class WorksheetTableService {
             colRef.setDataType(col.getType());
          }
 
+         // Business meaning of the window output column — surfaced by /ws/structure (data insight).
+         if(!Tool.isEmptyString(col.getDescription())) {
+            colRef.setDescription(col.getDescription());
+         }
+
          cs.addAttribute(colRef);
       }
 
@@ -1483,8 +1488,10 @@ public class WorksheetTableService {
 
    // ─── Aggregate info ───────────────────────────────────────────────────────
 
-   private void applyAggregateInfo(AbstractTableAssembly table,
-                                   WorksheetTable.AggregateInfo aggInfo)
+   // Package-private (not private) so WorksheetTableServiceAggregateDescriptionTest can invoke it
+   // directly without standing up the full createTable dependency graph, mirroring applyWindowColumns.
+   void applyAggregateInfo(AbstractTableAssembly table,
+                           WorksheetTable.AggregateInfo aggInfo)
    {
       if(aggInfo == null) {
          return;
@@ -1530,6 +1537,30 @@ public class WorksheetTableService {
                }
 
                column = dateColumn;
+            }
+
+            // Business meaning of the group-by output column. The public output column is a CLONE
+            // of the matching PRIVATE ColumnRef (see AbstractTableAssembly.setColumnSelection), so
+            // set the description on the private target for it to survive to /ws/structure. For a
+            // date-grouped column that target IS the DateRangeRef column just added to privateCs
+            // (referenced by `column`); otherwise it is the private column of the same name.
+            //
+            // PREFER an inherited annotation over the model's group description: a plain group-by
+            // dimension is a passthrough of an existing (often annotated) column — grouping does not
+            // change its business meaning — so keep the base column's description rather than let the
+            // model overwrite it with a lineage-restating one (e.g. "Company name from the joined ...
+            // data"). Only fill from the model when the target has no description yet: a freshly
+            // built date-grouped column (DateRangeRef carries none), or a group key with no upstream
+            // annotation. Aggregate MEASURES are handled separately below and DO take the model's
+            // description, since aggregation genuinely changes the column's meaning.
+            if(!Tool.isEmptyString(grp.getDescription())) {
+               ColumnRef descTarget = grp.getDateGroupLevel() != null
+                  ? column
+                  : (privateCs.getAttribute(grp.getFieldName()) instanceof ColumnRef pc ? pc : null);
+
+               if(descTarget != null && Tool.isEmptyString(descTarget.getDescription())) {
+                  descTarget.setDescription(grp.getDescription());
+               }
             }
 
             info.addGroup(new GroupRef(column));
@@ -1605,6 +1636,14 @@ public class WorksheetTableService {
 
                privateCs.addAttribute(syntheticCol);
                aggColumn = syntheticCol;
+            }
+
+            // Business meaning of the aggregated output column. aggColumn is the PRIVATE ColumnRef
+            // (the aliased base column for the first aggregate, or the synthetic column for 2nd+),
+            // which setColumnSelection clones into the public output column — so a description set
+            // here survives to /ws/structure (data insight).
+            if(!Tool.isEmptyString(agg.getDescription()) && aggColumn instanceof ColumnRef aggColRef) {
+               aggColRef.setDescription(agg.getDescription());
             }
 
             AggregateRef aggRef = new AggregateRef(aggColumn, secondaryCol, formula);

--- a/core/src/main/java/inetsoft/web/wiz/service/WsServiceHelper.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsServiceHelper.java
@@ -257,6 +257,15 @@ final class WsServiceHelper {
             attrRef.setDataType(attr.getDataType());
             ColumnRef col = new ColumnRef(attrRef);
 
+            // Carry the base column's business description onto the join's passthrough column so it
+            // survives to /ws/structure (and thence data insight). A join builds fresh ColumnRefs
+            // from its base tables rather than cloning them, so — unlike MirrorTableAssembly, which
+            // copies the description in updateColumnSelection — the description would otherwise be
+            // lost at every join hop. Skip empty/blank so an absent description stays absent.
+            if(attr instanceof ColumnRef baseCol && !Tool.isEmptyString(baseCol.getDescription())) {
+               col.setDescription(baseCol.getDescription());
+            }
+
             // Disambiguate a visible column whose NAME collides with one already added from another
             // base table. Downstream resolution (ColumnSelection.getAttribute / AssetUtil.findColumn)
             // matches by attribute NAME, ignoring the entity/table qualifier — so two same-named

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceAggregateDescriptionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceAggregateDescriptionTest.java
@@ -1,0 +1,153 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.PhysicalBoundTableAssembly;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.web.wiz.model.WorksheetTable;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Contract test for {@link WorksheetTableService#applyAggregateInfo}: a {@code description} on a
+ * group-by field or an aggregate must be persisted onto the corresponding PUBLIC output column, so
+ * that {@code /ws/structure} (and hence data insight's {@code primaryTableFields}) reads it back.
+ *
+ * <p>The public output column is a CLONE of the private column that the group/aggregate references
+ * (see {@code AbstractTableAssembly.setColumnSelection}); {@code ColumnRef.clone()} preserves the
+ * description, so setting it on the private target — as the service does — reaches the readback.
+ * This suite drives the package-private {@code applyAggregateInfo} directly, mirroring
+ * {@code WorksheetTableServiceWindowColumnsTest}.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WorksheetTableServiceAggregateDescriptionTest {
+   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+   private static WorksheetTableService service() {
+      // applyAggregateInfo uses only its parameters + table state + static helpers, never instance
+      // dependencies, so null deps are safe (mirrors WorksheetTableServiceWindowColumnsTest).
+      return new WorksheetTableService(null, null, null, null, null, null, null, null, null);
+   }
+
+   private static WorksheetTable.AggregateInfo aggInfo(String json) throws Exception {
+      return MAPPER.readValue(json, WorksheetTable.AggregateInfo.class);
+   }
+
+   /** Find a public output column by attribute name OR alias, matching how /ws/structure reads them. */
+   private static ColumnRef output(PhysicalBoundTableAssembly table, String nameOrAlias) {
+      ColumnSelection pub = table.getColumnSelection(true);
+
+      for(int i = 0; i < pub.getAttributeCount(); i++) {
+         DataRef ref = pub.getAttribute(i);
+
+         if(ref instanceof ColumnRef col
+            && (nameOrAlias.equals(col.getAttribute()) || nameOrAlias.equals(col.getAlias())))
+         {
+            return col;
+         }
+      }
+
+      return null;
+   }
+
+   @Test
+   void groupAndAggregateDescriptionsSurviveToPublicOutputColumns() throws Exception {
+      WorksheetTable.AggregateInfo info = aggInfo("""
+         {
+           "groups": [
+             { "fieldName": "CUSTOMER_ID", "description": "The customer identifier" }
+           ],
+           "aggregates": [
+             { "fieldName": "ORDER_ID", "formula": "DistinctCount", "alias": "TOTAL_ORDERS",
+               "description": "Distinct count of orders per customer" }
+           ]
+         }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "orders");
+      ColumnSelection cs = new ColumnSelection();
+      AttributeRef custRef = new AttributeRef(null, "CUSTOMER_ID");
+      custRef.setDataType(XSchema.STRING);
+      cs.addAttribute(new ColumnRef(custRef));
+      AttributeRef orderRef = new AttributeRef(null, "ORDER_ID");
+      orderRef.setDataType(XSchema.STRING);
+      cs.addAttribute(new ColumnRef(orderRef));
+      table.setColumnSelection(cs, false);
+
+      service().applyAggregateInfo(table, info);
+
+      ColumnRef groupOut = output(table, "CUSTOMER_ID");
+      assertNotNull(groupOut, "group-by output column CUSTOMER_ID should exist");
+      assertEquals("The customer identifier", groupOut.getDescription());
+
+      ColumnRef aggOut = output(table, "TOTAL_ORDERS");
+      assertNotNull(aggOut, "aggregate output column TOTAL_ORDERS should exist");
+      assertEquals("Distinct count of orders per customer", aggOut.getDescription());
+   }
+
+   @Test
+   void absentDescriptionLeavesOutputColumnDescriptionEmpty() throws Exception {
+      WorksheetTable.AggregateInfo info = aggInfo("""
+         {
+           "groups": [ { "fieldName": "CUSTOMER_ID" } ],
+           "aggregates": [
+             { "fieldName": "ORDER_ID", "formula": "Count", "alias": "ORDER_COUNT" }
+           ]
+         }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "orders");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "CUSTOMER_ID")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "ORDER_ID")));
+      table.setColumnSelection(cs, false);
+
+      service().applyAggregateInfo(table, info);
+
+      // ColumnRef.getDescription() returns "" (not null) when unset — matches /ws/structure's
+      // Tool.isEmptyString normalization, which then reports it as null downstream.
+      ColumnRef groupOut = output(table, "CUSTOMER_ID");
+      assertNotNull(groupOut);
+      assertTrue(groupOut.getDescription() == null || groupOut.getDescription().isEmpty());
+
+      ColumnRef aggOut = output(table, "ORDER_COUNT");
+      assertNotNull(aggOut);
+      assertTrue(aggOut.getDescription() == null || aggOut.getDescription().isEmpty());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceAggregateDescriptionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceAggregateDescriptionTest.java
@@ -150,4 +150,55 @@ class WorksheetTableServiceAggregateDescriptionTest {
       assertNotNull(aggOut);
       assertTrue(aggOut.getDescription() == null || aggOut.getDescription().isEmpty());
    }
+
+   /**
+    * The PR's core new behavior: a group-by dimension that already carries an INHERITED description
+    * (e.g. a physical-column annotation carried through join/mirror passthrough) keeps that
+    * description — the model's group description does NOT overwrite it. An aggregate MEASURE, by
+    * contrast, still takes the model's description, since aggregation changes the column's meaning.
+    */
+   @Test
+   void groupKeepsInheritedDescriptionOverModelDescription() throws Exception {
+      WorksheetTable.AggregateInfo info = aggInfo("""
+         {
+           "groups": [
+             { "fieldName": "COMPANY_NAME", "description": "Company name from the joined customers and orders data" }
+           ],
+           "aggregates": [
+             { "fieldName": "ORDER_ID", "formula": "DistinctCount", "alias": "TOTAL_ORDERS",
+               "description": "Distinct count of orders per customer" }
+           ]
+         }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "orders");
+      ColumnSelection cs = new ColumnSelection();
+      // Seed COMPANY_NAME with an inherited annotation BEFORE aggregation, simulating a passthrough
+      // dimension that carried its physical-column annotation through join/mirror.
+      AttributeRef companyRef = new AttributeRef(null, "COMPANY_NAME");
+      companyRef.setDataType(XSchema.STRING);
+      ColumnRef companyCol = new ColumnRef(companyRef);
+      companyCol.setDataType(XSchema.STRING);
+      companyCol.setDescription("The names of the companies associated with each customer");
+      cs.addAttribute(companyCol);
+      AttributeRef orderRef = new AttributeRef(null, "ORDER_ID");
+      orderRef.setDataType(XSchema.STRING);
+      cs.addAttribute(new ColumnRef(orderRef));
+      table.setColumnSelection(cs, false);
+
+      service().applyAggregateInfo(table, info);
+
+      // Group dimension keeps the inherited annotation, NOT the model's lineage-restating one.
+      ColumnRef groupOut = output(table, "COMPANY_NAME");
+      assertNotNull(groupOut, "group-by output column COMPANY_NAME should exist");
+      assertEquals("The names of the companies associated with each customer",
+                   groupOut.getDescription(),
+                   "inherited annotation must win over the model's group description");
+
+      // Aggregate measure still takes the model's description.
+      ColumnRef aggOut = output(table, "TOTAL_ORDERS");
+      assertNotNull(aggOut);
+      assertEquals("Distinct count of orders per customer", aggOut.getDescription());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceWindowColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceWindowColumnsTest.java
@@ -647,4 +647,41 @@ class WorksheetTableServiceWindowColumnsTest {
       assertTrue(ex.getMessage().contains("numeric order key"),
                  "unexpected message: " + ex.getMessage());
    }
+
+   @Test
+   void windowColumnDescriptionIsPersistedOnOutputColumn() throws Exception {
+      WorksheetTable req = request("""
+         {
+           "windowColumns": [
+             {
+               "name": "running_total",
+               "fn": "SUM",
+               "column": "amount",
+               "partitionBy": ["stage"],
+               "orderBy": [ { "field": "amount", "direction": "ASC" } ],
+               "description": "Cumulative amount within each stage"
+             }
+           ]
+         }
+         """);
+
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "deals");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "stage")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "amount")));
+      table.setColumnSelection(cs);
+
+      service().applyWindowColumns(table, req.getWindowColumns());
+
+      // Private selection carries the description directly...
+      ColumnRef added = (ColumnRef) table.getColumnSelection(false).getAttribute("running_total");
+      assertNotNull(added);
+      assertEquals("Cumulative amount within each stage", added.getDescription());
+
+      // ...and it survives to the PUBLIC selection (the clone that /ws/structure reads back).
+      ColumnRef output = (ColumnRef) table.getColumnSelection(true).getAttribute("running_total");
+      assertNotNull(output, "window column should appear in the public output selection");
+      assertEquals("Cumulative amount within each stage", output.getDescription());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WsServiceHelperCompositeDescriptionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WsServiceHelperCompositeDescriptionTest.java
@@ -1,0 +1,160 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.asset.*;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Contract test for {@link WsServiceHelper#initCompositeColumnSelection}: a join table builds fresh
+ * passthrough {@link ColumnRef}s from its base tables (it does not clone them), so it must copy each
+ * base column's {@code description} onto the passthrough column — otherwise the annotation/business
+ * meaning is lost at every join hop and never reaches {@code /ws/structure} (data insight).
+ *
+ * <p>Mirrors {@code MirrorTableAssembly.updateColumnSelection}, which already copies the description
+ * for mirror passthrough columns.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WsServiceHelperCompositeDescriptionTest {
+
+   private static ColumnRef describedColumn(String name, String type, String description) {
+      AttributeRef ref = new AttributeRef(null, name);
+      ref.setDataType(type);
+      ColumnRef col = new ColumnRef(ref);
+      col.setDataType(type);
+
+      if(description != null) {
+         col.setDescription(description);
+      }
+
+      return col;
+   }
+
+   private static PhysicalBoundTableAssembly physical(Worksheet ws, String name, ColumnRef... cols) {
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, name);
+      // A valid SourceInfo is required: the join's setColumnSelection runs checkValidity over its
+      // base bound tables, which throws "Prefix is null!" if a base has no source.
+      SourceInfo si = new SourceInfo(SourceInfo.PHYSICAL_TABLE, "postgres", "public." + name);
+      si.setProperty(SourceInfo.SCHEMA, "public");
+      si.setProperty(SourceInfo.CATALOG, "sales");
+      table.setSourceInfo(si);
+
+      ColumnSelection cs = new ColumnSelection();
+
+      for(ColumnRef c : cols) {
+         cs.addAttribute(c);
+      }
+
+      table.setColumnSelection(cs, false);
+      return table;
+   }
+
+   /** Find a column by attribute name OR alias in a selection — matches how /ws/structure reads them. */
+   private static ColumnRef find(ColumnSelection cs, String nameOrAlias) {
+      for(int i = 0; i < cs.getAttributeCount(); i++) {
+         DataRef r = cs.getAttribute(i);
+
+         if(r instanceof ColumnRef c
+            && (nameOrAlias.equals(c.getAttribute()) || nameOrAlias.equals(c.getAlias())))
+         {
+            return c;
+         }
+      }
+
+      return null;
+   }
+
+   @Test
+   void joinPassthroughColumnsInheritBaseDescriptions() {
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly orders = physical(ws, "ORDERS",
+         describedColumn("ORDER_ID", XSchema.INTEGER, "Unique identifier for each order"),
+         describedColumn("QUANTITY", XSchema.INTEGER, null));            // no description
+      PhysicalBoundTableAssembly customers = physical(ws, "CUSTOMERS",
+         describedColumn("CUSTOMER_ID", XSchema.INTEGER, "Unique identifier for each customer"),
+         describedColumn("COMPANY_NAME", XSchema.STRING, "Company name for the customer"));
+      ws.addAssembly(orders);
+      ws.addAssembly(customers);
+
+      RelationalJoinTableAssembly join = new RelationalJoinTableAssembly(
+         ws, "ORD_CUST_JOIN", new TableAssembly[]{ orders, customers }, new TableAssemblyOperator[0]);
+
+      WsServiceHelper.initCompositeColumnSelection(join);
+
+      ColumnSelection pub = join.getColumnSelection(true);
+
+      ColumnRef orderId = find(pub, "ORDER_ID");
+      assertNotNull(orderId, "join should expose ORDER_ID");
+      assertEquals("Unique identifier for each order", orderId.getDescription());
+
+      ColumnRef customerId = find(pub, "CUSTOMER_ID");
+      assertNotNull(customerId, "join should expose CUSTOMER_ID");
+      assertEquals("Unique identifier for each customer", customerId.getDescription());
+
+      ColumnRef companyName = find(pub, "COMPANY_NAME");
+      assertNotNull(companyName, "join should expose COMPANY_NAME");
+      assertEquals("Company name for the customer", companyName.getDescription());
+   }
+
+   @Test
+   void columnWithoutBaseDescriptionStaysEmpty() {
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly orders = physical(ws, "ORDERS",
+         describedColumn("QUANTITY", XSchema.INTEGER, null));            // no description
+      PhysicalBoundTableAssembly customers = physical(ws, "CUSTOMERS",
+         describedColumn("COMPANY_NAME", XSchema.STRING, "Company name for the customer"));
+      ws.addAssembly(orders);
+      ws.addAssembly(customers);
+
+      RelationalJoinTableAssembly join = new RelationalJoinTableAssembly(
+         ws, "ORD_CUST_JOIN", new TableAssembly[]{ orders, customers }, new TableAssemblyOperator[0]);
+
+      WsServiceHelper.initCompositeColumnSelection(join);
+
+      ColumnSelection pub = join.getColumnSelection(true);
+
+      // ColumnRef.getDescription() returns "" (not null) when unset; /ws/structure then normalizes
+      // that empty string to null. Either way it must NOT pick up a spurious description.
+      ColumnRef quantity = find(pub, "QUANTITY");
+      assertNotNull(quantity, "join should expose QUANTITY");
+      assertTrue(quantity.getDescription() == null || quantity.getDescription().isEmpty(),
+         "a column with no base description must not gain one");
+
+      ColumnRef companyName = find(pub, "COMPANY_NAME");
+      assertNotNull(companyName);
+      assertEquals("Company name for the customer", companyName.getDescription());
+   }
+}


### PR DESCRIPTION
Add a `description` slot to aggregate/group/window column specs in the /ws/table request model and persist each onto its output column so /ws/structure returns it (consumed by data insight).

- Physical columns and mirror expression/aggregate/window columns carry the model-authored description onto their output ColumnRef.
- Join passthrough columns now inherit the base column annotation (initCompositeColumnSelection), matching MirrorTableAssembly, so the annotation is not lost at each join hop.
- Group-by dimensions keep their inherited annotation rather than being overwritten with a generated lineage description; only genuinely derived columns (aggregate measures, expression, window) take the model description.