### PR TITLE
fixed Bug 75126,  75139 have fxied by others

### DIFF
--- a/web/projects/em/src/app/settings/schedule/import-export/import-task-dialog/import-task-dialog.component.tl.spec.ts
+++ b/web/projects/em/src/app/settings/schedule/import-export/import-task-dialog/import-task-dialog.component.tl.spec.ts
@@ -29,9 +29,8 @@
  * Fixed:
  *   Bug A — handleImportError() uses error.error?.message ?? error.message so a null/empty
  *     error body (e.g. HTTP 500) still opens the ERROR dialog instead of throwing TypeError.
- *
- * Deferred (type-only, no runtime/UI impact — see import-task-response.ts):
- *   Bug B — failedTasks is typed as `[]` but the API returns string[]. Tests assign with `as any`.
+ *   Bug B — failedTasks is now typed as `string[]` (matches the API's Java List<String>),
+ *     removing the `as any` casts previously needed to assign non-empty fixture arrays.
  *
  * KEY contracts:
  *   - finish() collects selection.selected values and sends their `.task` strings in POST body.
@@ -307,8 +306,7 @@ describe("ImportTaskDialogComponent — onImportComplete(): dialog type and clos
    it("should open a WARNING dialog listing failed task names when failedTasks is non-empty", async () => {
       const { comp, matDialogSpy, dialogRefSpy } = await renderComp({ dialogClosesWith: undefined });
 
-      // Bug B deferred: failedTasks typed as []; cast needed for non-empty fixture arrays
-      const response: ImportTaskResponse = { failedTasks: ["Task1", "Task2"] as any, failed: true };
+      const response: ImportTaskResponse = { failedTasks: ["Task1", "Task2"], failed: true };
       comp.onImportComplete(response);
 
       expect(matDialogSpy.open).toHaveBeenCalledTimes(1);
@@ -325,7 +323,7 @@ describe("ImportTaskDialogComponent — onImportComplete(): dialog type and clos
    it("should open an INFO dialog on full success and close the outer dialog with true", async () => {
       const { comp, matDialogSpy, dialogRefSpy } = await renderComp({ dialogClosesWith: undefined });
 
-      const response: ImportTaskResponse = { failedTasks: [] as any, failed: false };
+      const response: ImportTaskResponse = { failedTasks: [], failed: false };
       comp.onImportComplete(response);
 
       expect(matDialogSpy.open).toHaveBeenCalledTimes(1);

--- a/web/projects/em/src/app/settings/schedule/import-export/import-task-dialog/import-task-dialog.component.tl.spec.ts
+++ b/web/projects/em/src/app/settings/schedule/import-export/import-task-dialog/import-task-dialog.component.tl.spec.ts
@@ -26,17 +26,12 @@
  *   Group 4 [Risk 2]  — masterToggle(): select all / deselect all toggle
  *   Group 5 [Risk 2]  — onImportComplete(): success dialog vs partial-failure warning dialog
  *
- * Confirmed bugs (it.failing until source is fixed):
+ * Fixed:
+ *   Bug A — handleImportError() uses error.error?.message ?? error.message so a null/empty
+ *     error body (e.g. HTTP 500) still opens the ERROR dialog instead of throwing TypeError.
  *
- *   Bug A — handleImportError() missing optional chaining on error.error.message:
- *     `error.error.message` throws TypeError when error.error is null (e.g. null JSON body on
- *     500). handleUploadError() uses a fixed message string and is unaffected.
- *     Fix: `error.error?.message` with a fallback (e.g. `error.message`).
- *
- *   Bug B — ImportTaskResponse.failedTasks typed as `[]` (empty tuple), not `string[]`:
- *     model/import-task-response.ts defines `failedTasks: []` but runtime/API returns task name
- *     strings (Java: List<String>). Tests use `as any` to assign string arrays. Component uses
- *     .length and .join() correctly. Fix: change to `failedTasks: string[]`.
+ * Deferred (type-only, no runtime/UI impact — see import-task-response.ts):
+ *   Bug B — failedTasks is typed as `[]` but the API returns string[]. Tests assign with `as any`.
  *
  * KEY contracts:
  *   - finish() collects selection.selected values and sends their `.task` strings in POST body.
@@ -312,7 +307,7 @@ describe("ImportTaskDialogComponent — onImportComplete(): dialog type and clos
    it("should open a WARNING dialog listing failed task names when failedTasks is non-empty", async () => {
       const { comp, matDialogSpy, dialogRefSpy } = await renderComp({ dialogClosesWith: undefined });
 
-      // Bug B — `as any` required until failedTasks is string[] in import-task-response.ts
+      // Bug B deferred: failedTasks typed as []; cast needed for non-empty fixture arrays
       const response: ImportTaskResponse = { failedTasks: ["Task1", "Task2"] as any, failed: true };
       comp.onImportComplete(response);
 
@@ -344,15 +339,12 @@ describe("ImportTaskDialogComponent — onImportComplete(): dialog type and clos
 });
 
 // ════════════════════════════════════════════════════════════════════════════
-// Confirmed bug — handleImportError() null error.error body
+// handleImportError() — null error.error body (Bug A regression)
 // ════════════════════════════════════════════════════════════════════════════
 
 describe("ImportTaskDialogComponent — handleImportError(): null error body", () => {
 
-   // Bug A — handleImportError() reads error.error.message without optional chaining.
-   // Null JSON body (network/500) makes error.error null → TypeError before dialog opens.
-   // Fix: error.error?.message ?? error.message (or equivalent fallback).
-   it.fails("should open error dialog from handleImportError when error.error is null", async () => {
+   it("should open error dialog from handleImportError when error.error is null", async () => {
       const { comp, matDialogSpy } = await renderComp();
       const error = new HttpErrorResponse({
          error: null,

--- a/web/projects/em/src/app/settings/schedule/import-export/import-task-dialog/import-task-dialog.component.ts
+++ b/web/projects/em/src/app/settings/schedule/import-export/import-task-dialog/import-task-dialog.component.ts
@@ -159,7 +159,7 @@ export class ImportTaskDialogComponent {
       this.dialog.open(MessageDialog, {
          data: {
             title: "_#(js:Error)",
-            content: error.error.message,
+            content: error.error?.message ?? error.message,
             type: MessageDialogType.ERROR
          }
       });

--- a/web/projects/em/src/app/settings/schedule/model/import-task-response.ts
+++ b/web/projects/em/src/app/settings/schedule/model/import-task-response.ts
@@ -16,6 +16,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 export interface ImportTaskResponse {
+   // Intentionally left as `[]` (empty tuple). The API returns string[] (Java List<String>),
+   // and callers use .length/.join() correctly at runtime. Type-only mismatch — no UI impact;
+   // not changing the interface here (tests may need `as any` when assigning non-empty arrays).
    failedTasks: [];
    failed: boolean;
 }

--- a/web/projects/em/src/app/settings/schedule/model/import-task-response.ts
+++ b/web/projects/em/src/app/settings/schedule/model/import-task-response.ts
@@ -16,9 +16,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 export interface ImportTaskResponse {
-   // Intentionally left as `[]` (empty tuple). The API returns string[] (Java List<String>),
-   // and callers use .length/.join() correctly at runtime. Type-only mismatch — no UI impact;
-   // not changing the interface here (tests may need `as any` when assigning non-empty arrays).
-   failedTasks: [];
+   failedTasks: string[];
    failed: boolean;
 }

--- a/web/projects/em/src/app/settings/schedule/schedule-cycle-editor-page/schedule-cycle-editor-page.component.tl.spec.ts
+++ b/web/projects/em/src/app/settings/schedule/schedule-cycle-editor-page/schedule-cycle-editor-page.component.tl.spec.ts
@@ -28,12 +28,9 @@
  *   Group 5 [Risk 2]  — copyCondition(): COPY_OF_PREFIX stripping for nested copies
  *   Group 6 [Risk 2]  — deleteConditions(): confirmed dialog splices condition and adjusts index
  *
- * Confirmed bugs (it.failing until source is fixed):
- *   Bug #75126:
- *   Bug A — save() missing optional chaining on error.error.message:
- *     loadModel() uses `error.error?.message` (safe); save() uses `error.error.message`
- *     (unsafe). Null JSON body makes error.error null → TypeError in the RxJS error handler.
- *     Fix: align save() with loadModel() — guard with `error.error?.message`.
+ * Fixed:
+ *   Bug A — save() guards with error.error?.message (same as loadModel()) so a null/empty
+ *     error body no longer throws TypeError in the RxJS error handler.
  *
  * KEY contracts:
  *   - valid = conditionsValid && optionsValid && name.valid && taskChanged (ALL four required).
@@ -268,10 +265,8 @@ describe("ScheduleCycleEditorPageComponent — save(): success and error paths",
       expect(dialogData.content).toContain("Cycle name already exists");
    });
 
-   // Bug A — save() error handler reads error.error.message without optional chaining (loadModel is safe).
-   // Null JSON body → TypeError in save() subscribe; no dialog. Fix: use error.error?.message like loadModel().
-   // Spy http.post so the real save() subscribe error callback runs with a null body (same as MSW 500/null).
-   it.fails("should not throw when save error body is null", async () => {
+   // Bug A regression: null JSON body must not throw; no dialog when there is no message.
+   it("should not throw when save error body is null", async () => {
       const { comp, dialogMock } = await renderComponent();
       const httpError = new HttpErrorResponse({
          error: null,

--- a/web/projects/em/src/app/settings/schedule/schedule-cycle-editor-page/schedule-cycle-editor-page.component.ts
+++ b/web/projects/em/src/app/settings/schedule/schedule-cycle-editor-page/schedule-cycle-editor-page.component.ts
@@ -288,7 +288,7 @@ export class ScheduleCycleEditorPageComponent implements OnInit, OnDestroy {
             this.taskChanged = false;
          },
          (error: HttpErrorResponse) => {
-            if(error.error.message) {
+            if(error.error?.message) {
                this.dialog.open(MessageDialog, {
                   width: "500px",
                   data: {

--- a/web/projects/portal/src/app/portal/data/data-navigation-tree/data-sources-tree-view.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/portal/data/data-navigation-tree/data-sources-tree-view.component.interaction.tl.spec.ts
@@ -28,7 +28,7 @@
  * |       |   datasourceChanged, datasourceFolderChanged, onCreateEvent)   |       |
  * | 3     | ngOnInit: router.events NavigationEnd, route.queryParamMap     |   4   |
  * | 4     | processSetComposedDashboardCommand                             |   1   |
- * | 5     | changeDataSourcesTree — Bug #75600 (fixed)                      |   1   |
+ * | 5     | changeDataSourcesTree — Bug #75600 deep-ancestor expand (fixed)|   1   |
  * | 6     | changeDataSourcesTree — functional behavior                    |   4   |
  * | 7     | changeFolder                                                   |   3   |
  * | 8     | getPrivateWorksheetNodeParent                                  |   2   |
@@ -59,10 +59,12 @@
  *   deleteDataModelFolder, deleteFolder
  *
  * Fixed bugs:
- *   Bug #75600 — changeDataSourcesTree — data-sources-tree-view.component.ts:369: `return false` was
- *     hard-coded at the end of the function instead of `return found`. The caller never
- *     learned a node was found, so parent.expanded was never set from a recursive result.
- *     Fixed by returning `found`.
+ *   Bug A / #75600 — changeDataSourcesTree returned hard-coded `false` instead of `found`.
+ *     Direct parent still expanded via local `found`, but ancestors at depth ≥ 2 never got
+ *     `expanded = true`. Fixed by `return found`. Regression: Group 5 deep-nest expand.
+ *   Bug B — getDataNavigationTree() set loading=true then subscribed with no error callback.
+ *     On GET ../api/portal/data/tree failure, spinner never cleared. Fixed with error handler
+ *     that sets loading=false. Regression: Group 1 "loading=false even when tree fetch fails".
  *
  * Out of scope for Pass 1 (Pass 3):
  *   getEntryLabel, getIconFunction, getAssetIcon
@@ -157,6 +159,7 @@ describe("DataSourcesTreeViewComponent — ngOnInit: getDataNavigationTree", () 
       await waitFor(() => expect(comp.loading).toBe(false));
    });
 
+   // Bug B regression: GET failure must clear loading (error callback), or the tree spinner sticks.
    it("should set loading=false even when the tree fetch fails", async () => {
       server.use(
          http.get("*/api/portal/data/tree", () =>
@@ -292,28 +295,48 @@ describe("DataSourcesTreeViewComponent — processSetComposedDashboardCommand", 
 });
 
 // ---------------------------------------------------------------------------
-// Group 5 — changeDataSourcesTree Bug #75600 (fixed) [Risk 3]
+// Group 5 — changeDataSourcesTree Bug A / #75600 deep-ancestor expand (fixed) [Risk 3]
 // ---------------------------------------------------------------------------
 
 describe("DataSourcesTreeViewComponent — changeDataSourcesTree (Bug #75600, fixed)", () => {
-   // Bug #75600 fixed: line ~369 used to return `return false` unconditionally instead of
-   // `return found`. This meant the caller never learned that a node was found, so
-   // parent.expanded was never set from a recursive call result. Now that the method returns
-   // `found`, this assertion passes.
-   it("should return true when a matching node is found in children", async () => {
+   // Bug A / #75600: with `return false`, only the direct parent of the match expanded; ancestors
+   // at depth ≥ 2 stayed collapsed. Returning `found` propagates expand up the chain.
+   it("should expand all ancestors when a deeply nested node is found", async () => {
       const { comp } = await renderComponent();
       await waitFor(() => expect(comp.rootNode).toBeTruthy());
 
-      const matchingChild = makeNode({
+      const leaf = makeNode({
          type: PortalDataType.FOLDER,
-         data: { path: "/myPath", scope: 1, name: "myFolder", properties: {} } as any,
+         label: "partition",
+         expanded: false,
+         data: { path: "/db/folder/partition", scope: 1, name: "partition", properties: {} } as any,
       });
-      comp.rootNode = makeRootNode([matchingChild]);
+      const mid = makeNode({
+         type: PortalDataType.FOLDER,
+         label: "folder",
+         expanded: false,
+         children: [leaf],
+         data: { path: "/db/folder", scope: 1, name: "folder", properties: {} } as any,
+      });
+      const top = makeNode({
+         type: PortalDataType.FOLDER,
+         label: "db",
+         expanded: false,
+         children: [mid],
+         data: { path: "/db", scope: 1, name: "db", properties: {} } as any,
+      });
+      comp.rootNode = makeRootNode([top]);
+      comp.rootNode.expanded = false;
 
-      const result = comp.changeDataSourcesTree("/myPath", "1", PortalDataType.FOLDER, comp.rootNode);
+      const result = comp.changeDataSourcesTree(
+         "/db/folder/partition", "1", PortalDataType.FOLDER, comp.rootNode);
 
-      // This fails because the function always returns false regardless of whether a match was found
       expect(result).toBe(true);
+      expect(comp.selectedNodes).toContain(leaf);
+      expect(leaf.expanded).toBe(true);
+      expect(mid.expanded).toBe(true);
+      expect(top.expanded).toBe(true);
+      expect(comp.rootNode.expanded).toBe(true);
    });
 });
 
@@ -352,7 +375,7 @@ describe("DataSourcesTreeViewComponent — changeDataSourcesTree functional beha
       expect(matchingChild.expanded).toBe(true);
    });
 
-   it("should return true when a top-level child matches (Bug #75600, fixed)", async () => {
+   it("should return true when a top-level child matches", async () => {
       const { comp } = await renderComponent();
       await waitFor(() => expect(comp.rootNode).toBeTruthy());
 
@@ -364,7 +387,6 @@ describe("DataSourcesTreeViewComponent — changeDataSourcesTree functional beha
 
       const result = comp.changeDataSourcesTree("/x", "1", PortalDataType.FOLDER, comp.rootNode);
 
-      // Bug #75600 fixed: the method now returns `found` instead of a hard-coded `false`.
       expect(result).toBe(true);
    });
 


### PR DESCRIPTION
Bug A
Summary:
In `handleImportError()`, the code reads `error.error.message` without optional chaining. When the import POST fails with a null or empty JSON body (e.g. HTTP 500), `error.error` is `null`, causing a `TypeError` before the error dialog opens. The user gets no feedback and `loading` may remain stuck.

Bug B

Summary:
In `import-task-response.ts`, `failedTasks` is declared as `[]` (empty tuple), but the API returns task name strings (`List<String>` on the backend). The component uses `.length` and `.join()` correctly at runtime, but TypeScript rejects valid string arrays unless cast with `as any`.

Bug C: ScheduleCycleEditorPageComponent.ts

Summary:
In `save()`, the HTTP error callback reads `error.error.message` without optional chaining. `loadModel()` already guards with `error.error?.message` and closes the page when there is no message, but `save()` uses `if (error.error.message)` directly. When the save POST fails with a null or empty JSON body (e.g. HTTP 500), `error.error` is `null`, causing a `TypeError` inside the RxJS error handler. No error dialog is shown and the user gets no feedback.