### PR TITLE
fix(wiz): resize merged dashboard charts to their allocated tile footprint

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizComposerController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizComposerController.java
@@ -69,7 +69,7 @@ public class WizComposerController {
       String runtimeId = runtimeViewsheetRef.getRuntimeId();
       addVisualizationServiceProxy.addVisualization(
          runtimeId, event.getEntry(), event.getxOffset(), event.getyOffset(),
-         event.getScale(), principal);
+         event.getScale(), null, principal);
       dispatcher.sendCommand(new RefreshWizFiltersCommand());
       vsRefreshServiceProxy.refreshViewsheetAsync(this.runtimeViewsheetRef.getRuntimeId(),
          VSRefreshEvent.builder().confirmed(false).build(), principal, dispatcher, linkUri);

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDashboardEvent.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDashboardEvent.java
@@ -79,12 +79,21 @@ public class WizDashboardEvent {
       this.filters = filters;
    }
 
+   public List<PerChartFilterSpec> getPerChartFilters() {
+      return perChartFilters;
+   }
+
+   public void setPerChartFilters(List<PerChartFilterSpec> perChartFilters) {
+      this.perChartFilters = perChartFilters;
+   }
+
    private String name;
    private List<String> identifiers;
    private String existingIdentifier;
    private List<TileSpec> tiles;
    private Integer layoutColumns;
    private List<FilterSpec> filters;
+   private List<PerChartFilterSpec> perChartFilters;
 
    /** A single tile's placement within the dashboard grid layout. */
    @JsonIgnoreProperties(ignoreUnknown = true)
@@ -145,6 +154,49 @@ public class WizDashboardEvent {
          this.label = label;
       }
 
+      private String field;
+      private String dataType;
+      private String label;
+   }
+
+   /** A single chart-scoped filter, identified by which saved chart it targets. This list is
+    *  sparse (NOT positional like {@link TileSpec}) — only charts that need one have an entry;
+    *  {@link #identifier} must match one of {@link WizDashboardEvent#getIdentifiers()}. */
+   @JsonIgnoreProperties(ignoreUnknown = true)
+   public static class PerChartFilterSpec {
+      public String getIdentifier() {
+         return identifier;
+      }
+
+      public void setIdentifier(String identifier) {
+         this.identifier = identifier;
+      }
+
+      public String getField() {
+         return field;
+      }
+
+      public void setField(String field) {
+         this.field = field;
+      }
+
+      public String getDataType() {
+         return dataType;
+      }
+
+      public void setDataType(String dataType) {
+         this.dataType = dataType;
+      }
+
+      public String getLabel() {
+         return label;
+      }
+
+      public void setLabel(String label) {
+         this.label = label;
+      }
+
+      private String identifier;
       private String field;
       private String dataType;
       private String label;

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDashboardResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDashboardResult.java
@@ -62,8 +62,29 @@ public class WizDashboardResult {
       this.filtersSkipped = filtersSkipped;
    }
 
+   /** Per-chart filter fields that were applied to their target chart. */
+   public List<String> getPerChartFiltersApplied() {
+      return perChartFiltersApplied;
+   }
+
+   public void setPerChartFiltersApplied(List<String> perChartFiltersApplied) {
+      this.perChartFiltersApplied = perChartFiltersApplied;
+   }
+
+   /** Per-chart filter fields that could not be applied (target chart not merged, or the field
+    *  isn't on that chart's own table). */
+   public List<String> getPerChartFiltersSkipped() {
+      return perChartFiltersSkipped;
+   }
+
+   public void setPerChartFiltersSkipped(List<String> perChartFiltersSkipped) {
+      this.perChartFiltersSkipped = perChartFiltersSkipped;
+   }
+
    private String savedViewsheetIdentifier;
    private List<String> skipped;
    private List<String> filtersApplied;
    private List<String> filtersSkipped;
+   private List<String> perChartFiltersApplied;
+   private List<String> perChartFiltersSkipped;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/AddVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/AddVisualizationService.java
@@ -69,22 +69,28 @@ public class AddVisualizationService {
     * @param xOffset   horizontal drop position in scaled canvas coordinates.
     * @param yOffset   vertical drop position in scaled canvas coordinates.
     * @param scale     current canvas zoom scale.
+    * @param pixelSize when non-null, resizes the merged chart to this exact pixel footprint
+    *                  (e.g. a dashboard grid tile's allocated span); when null, the chart keeps
+    *                  whatever size it was saved at (the drag-and-drop composer path never
+    *                  resizes).
     * @param principal the current user.
     */
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void addVisualization(@ClusterProxyKey String runtimeId,
                                 AssetEntry vizEntry,
                                 int xOffset, int yOffset, float scale,
+                                Dimension pixelSize,
                                 Principal principal)
       throws Exception
    {
-      doAddVisualization(runtimeId, vizEntry, xOffset, yOffset, scale, principal);
+      doAddVisualization(runtimeId, vizEntry, xOffset, yOffset, scale, pixelSize, principal);
       return null;
    }
 
    private void doAddVisualization(String runtimeId,
                                    AssetEntry vizEntry,
                                    int xOffset, int yOffset, float scale,
+                                   Dimension pixelSize,
                                    Principal principal)
       throws Exception
    {
@@ -209,7 +215,7 @@ public class AddVisualizationService {
       dashVS.repopulateWorksheet(assetRepository, principal);
 
       // Step 2: merge viewsheet assemblies
-      mergeViewsheet(rvs, vizVS, dashVS, wsRenameMap, xOffset, yOffset, scale);
+      mergeViewsheet(rvs, vizVS, dashVS, wsRenameMap, xOffset, yOffset, scale, pixelSize);
 
       // Step 3: record merged visualization
       wizInfo.addMergedVisualization(vizEntry.toIdentifier());
@@ -225,7 +231,8 @@ public class AddVisualizationService {
     */
    private void mergeViewsheet(RuntimeViewsheet rvs, Viewsheet vizVS, Viewsheet dashVS,
                                Map<String, String> wsRenameMap,
-                               int xOffset, int yOffset, float scale)
+                               int xOffset, int yOffset, float scale,
+                               Dimension pixelSize)
    {
       if(scale <= 0f) {
          scale = 1f;
@@ -288,6 +295,14 @@ public class AddVisualizationService {
          // Apply drop position offset
          Point pos = cloned.getPixelOffset();
          cloned.setPixelOffset(new Point(pos.x + offsetX, pos.y + offsetY));
+
+         // Resize to the caller's requested footprint (e.g. a dashboard grid tile's allocated
+         // span) when given. A saved visualization is always a single-assembly Viewsheet (see
+         // WizVisualizationService's "Build new single-assembly ViewSheet" step), so this loop
+         // only ever touches the one content assembly the size was computed for.
+         if(pixelSize != null) {
+            cloned.setPixelSize(pixelSize);
+         }
 
          dashVS.addAssembly(cloned);
 
@@ -415,7 +430,7 @@ public class AddVisualizationService {
          Set<String> namesBefore = collectAssemblyNames(rvs.getViewsheet());
 
          try {
-            doAddVisualization(runtimeId, entry, colStartX, rowStartY, 1.0f, principal);
+            doAddVisualization(runtimeId, entry, colStartX, rowStartY, 1.0f, null, principal);
 
             Rectangle added = computeAddedBounds(rvs.getViewsheet(), namesBefore);
 

--- a/core/src/main/java/inetsoft/web/wiz/service/AddVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/AddVisualizationService.java
@@ -74,24 +74,25 @@ public class AddVisualizationService {
     *                  whatever size it was saved at (the drag-and-drop composer path never
     *                  resizes).
     * @param principal the current user.
+    * @return the merged chart's own bound table name, or {@code null} if the merged assembly is
+    *         not a {@link ChartVSAssembly} or has no table name.
     */
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
-   public Void addVisualization(@ClusterProxyKey String runtimeId,
-                                AssetEntry vizEntry,
-                                int xOffset, int yOffset, float scale,
-                                Dimension pixelSize,
-                                Principal principal)
+   public String addVisualization(@ClusterProxyKey String runtimeId,
+                                  AssetEntry vizEntry,
+                                  int xOffset, int yOffset, float scale,
+                                  Dimension pixelSize,
+                                  Principal principal)
       throws Exception
    {
-      doAddVisualization(runtimeId, vizEntry, xOffset, yOffset, scale, pixelSize, principal);
-      return null;
+      return doAddVisualization(runtimeId, vizEntry, xOffset, yOffset, scale, pixelSize, principal);
    }
 
-   private void doAddVisualization(String runtimeId,
-                                   AssetEntry vizEntry,
-                                   int xOffset, int yOffset, float scale,
-                                   Dimension pixelSize,
-                                   Principal principal)
+   private String doAddVisualization(String runtimeId,
+                                     AssetEntry vizEntry,
+                                     int xOffset, int yOffset, float scale,
+                                     Dimension pixelSize,
+                                     Principal principal)
       throws Exception
    {
       // Action-level gate ("Visual Composer -> Data Worksheet"): the wiz dashboard runtime
@@ -215,10 +216,12 @@ public class AddVisualizationService {
       dashVS.repopulateWorksheet(assetRepository, principal);
 
       // Step 2: merge viewsheet assemblies
-      mergeViewsheet(rvs, vizVS, dashVS, wsRenameMap, xOffset, yOffset, scale, pixelSize);
+      String mergedTableName = mergeViewsheet(rvs, vizVS, dashVS, wsRenameMap, xOffset, yOffset, scale, pixelSize);
 
       // Step 3: record merged visualization
       wizInfo.addMergedVisualization(vizEntry.toIdentifier());
+
+      return mergedTableName;
    }
 
    // ---------------------------------------------------------------------------
@@ -229,10 +232,17 @@ public class AddVisualizationService {
     * Copies all VSAssemblies from {@code vizVS} into {@code dashVS}, applying name-conflict
     * resolution, WS binding renames, and drop-position offsets.
     */
-   private void mergeViewsheet(RuntimeViewsheet rvs, Viewsheet vizVS, Viewsheet dashVS,
-                               Map<String, String> wsRenameMap,
-                               int xOffset, int yOffset, float scale,
-                               Dimension pixelSize)
+   /**
+    * @return the merged chart's own bound table name (see {@link ChartVSAssembly#getTableName()}),
+    *         or {@code null} if the visualization's single assembly isn't a chart or has no
+    *         table name. A saved visualization is always a single-assembly Viewsheet (see
+    *         WizVisualizationService's "Build new single-assembly ViewSheet" step), so at most
+    *         one cloned assembly in this method's loop is ever a chart.
+    */
+   private String mergeViewsheet(RuntimeViewsheet rvs, Viewsheet vizVS, Viewsheet dashVS,
+                                 Map<String, String> wsRenameMap,
+                                 int xOffset, int yOffset, float scale,
+                                 Dimension pixelSize)
    {
       if(scale <= 0f) {
          scale = 1f;
@@ -282,6 +292,8 @@ public class AddVisualizationService {
          clones.add(cloned);
       }
 
+      String mergedTableName = null;
+
       // Pass 2: patch references, apply offset, and add to dashVS
       for(VSAssembly cloned : clones) {
          // Patch WS table binding references
@@ -314,7 +326,13 @@ public class AddVisualizationService {
          // graph entry. Mirrors the same clearGraph-after-in-place-mutation pattern used by
          // WizAutoBindingService/WizVsService for other runtime mutations.
          rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(cloned.getName()));
+
+         if(cloned instanceof ChartVSAssembly chart) {
+            mergedTableName = chart.getTableName();
+         }
       }
+
+      return mergedTableName;
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -201,8 +201,10 @@ public class WizDashboardFilterBuilder {
       return AddFilterService.createFilterAssembly(vs, dtype, (ColumnRef) colRef);
    }
 
-   private static final int FILTER_BAR_X = 0;
-   private static final int FILTER_BAR_Y = 0;
+   /** Matches {@link WizDashboardService#CANVAS_MARGIN} so the filter bar aligns with the left
+    *  edge of the chart grid below it, instead of sitting flush against the canvas edge. */
+   private static final int FILTER_BAR_X = WizDashboardService.CANVAS_MARGIN;
+   private static final int FILTER_BAR_Y = WizDashboardService.CANVAS_MARGIN;
    private static final int FILTER_CONTROL_WIDTH = 200;
 
    /** Control height, in pixels — leaves a small margin under

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -170,6 +170,39 @@ public class WizDashboardFilterBuilder {
    }
 
    /**
+    * Builds ONE selection/range control scoped to exactly one chart's own table, positioned at
+    * the given fixed point (the top of that chart's own tile). Unlike {@link #build}, there is
+    * no multi-table candidate search — the single {@code chartTableName} IS the candidate, so
+    * binding is unambiguous by construction (no residual name-collision risk across charts).
+    *
+    * @return {@code true} if the field was found on the chart's table and a control was added,
+    *         {@code false} if skipped (field not present on this chart's own table).
+    */
+   public boolean buildPerChart(Viewsheet vs, Worksheet baseWorksheet, int x, int y,
+                                 FilterRequest request, String chartTableName)
+   {
+      List<String> tables = AddFilterService.findColumnMatchingChartTables(
+         baseWorksheet, List.of(chartTableName), request.field());
+
+      if(tables.isEmpty()) {
+         return false;
+      }
+
+      ColumnRef colRef = AddFilterService.buildColumnRef(request.field(), request.dataType());
+      AbstractSelectionVSAssembly control = createControlForType(vs, request.dataType(), colRef);
+
+      if(request.label() != null && control instanceof TitledVSAssembly titled) {
+         titled.setTitleValue(request.label());
+      }
+
+      control.setTableNames(tables);
+      control.setPixelOffset(new Point(x, y));
+      control.setPixelSize(new java.awt.Dimension(FILTER_CONTROL_WIDTH, FILTER_CONTROL_HEIGHT));
+      vs.addAssembly(control);
+      return true;
+   }
+
+   /**
     * Collects each merged chart's own final bound table name (its {@code SourceInfo.source},
     * exposed via {@link BindableVSAssembly#getTableName()}) — the candidate set
     * {@link AddFilterService#findColumnMatchingChartTables} matches against, instead of every

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -207,9 +207,17 @@ public class WizDashboardService {
                y = cumulativeY;
             }
 
+            // Resize the merged chart to its allocated tile footprint (grid path only) --
+            // otherwise a tile's computed (spanCols, spanRows) only ever reserved grid drop-
+            // position spacing and never resized the chart itself. The stack path has no
+            // per-visualization span data, so it passes null and preserves the chart's saved size.
+            java.awt.Dimension pixelSize = grid ?
+               new java.awt.Dimension(spans[i] * DASHBOARD_COL_WIDTH, rowSpans[i] * DASHBOARD_ROW_HEIGHT) :
+               null;
+
             try {
                addVisualizationService.addVisualization(
-                  runtimeId, entries.get(i), x, y, 1.0f, principal);
+                  runtimeId, entries.get(i), x, y, 1.0f, pixelSize, principal);
 
                if(!grid) {
                   cumulativeY += DASHBOARD_ROW_HEIGHT;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -457,9 +457,12 @@ public class WizDashboardService {
 
    /** Extra row height reserved, in pixels, for a tile that has a per-chart filter -- additive
     *  to (never counted against) {@link #MAX_TILE_HEIGHT}, so the chart's own rendered size is
-    *  untouched; only the tile grows to make room for the filter control above it. A compact
-    *  single-line selection control plus a small margin. */
-   private static final int PER_CHART_FILTER_ROW_HEIGHT = 60;
+    *  untouched; only the tile grows to make room for the filter control above it. Matches
+    *  {@link #FILTER_BAR_ROW_HEIGHT} exactly: {@link WizDashboardFilterBuilder#buildPerChart}
+    *  sizes its control with the SAME {@code FILTER_CONTROL_HEIGHT} (100px) the shared filter
+    *  bar uses -- there is no smaller "compact" control variant -- so the same 20px margin
+    *  applies here too. */
+   private static final int PER_CHART_FILTER_ROW_HEIGHT = 120;
 
    /**
     * The rendered pixel size for a tile spanning {@code spanCols} columns and {@code spanRows}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -358,6 +358,12 @@ public class WizDashboardService {
    private static final int MAX_TILE_WIDTH = 900;
    private static final int MAX_TILE_HEIGHT = 600;
 
+   /** Extra row height reserved, in pixels, for a tile that has a per-chart filter -- additive
+    *  to (never counted against) {@link #MAX_TILE_HEIGHT}, so the chart's own rendered size is
+    *  untouched; only the tile grows to make room for the filter control above it. A compact
+    *  single-line selection control plus a small margin. */
+   private static final int PER_CHART_FILTER_ROW_HEIGHT = 60;
+
    /**
     * The rendered pixel size for a tile spanning {@code spanCols} columns and {@code spanRows}
     * rows: its natural span-based footprint ({@code spanCols * DASHBOARD_COL_WIDTH} by
@@ -371,29 +377,36 @@ public class WizDashboardService {
    }
 
    /**
-    * Row-major grid origin for the tile at flat index {@code i}, given per-tile column AND row
-    * spans. Packing is still row-major/left-to-right/wrap-at-{@code layoutColumns} (identical
-    * grouping to the column-only overload below) — the only change is that each row's HEIGHT is
-    * now {@code max} of the tiles placed in it's {@link #tilePixelSize} height (the same CAPPED
-    * height {@code composeDashboard} actually renders each chart at), instead of always
-    * {@code DASHBOARD_ROW_HEIGHT}. Reserving the raw (uncapped) {@code spanRows * DASHBOARD_ROW_HEIGHT}
-    * here — while {@link #tilePixelSize} renders a shorter, capped chart — left a large dead gap
-    * between a capped tile and the row below it; reserving the same capped height eliminates it.
-    * A tile's own Y depends only on the finalized height of every row strictly before it, and
-    * every such row is fully scanned (all its tiles' heights folded into that row's height, then
-    * closed out) before the loop reaches index {@code i} — so no 2D occupancy grid is needed; a
-    * tile with spanRows > 1 does not "block" cells in the row below for placement purposes (that
-    * would be true masonry/skyline packing, deliberately not implemented — see the Phase 4 design
-    * spec). Returns the (x,y) drop origin in pixels. Package-private for unit testing.
+    * Row-major grid origin for the tile at flat index {@code i}, given per-tile column spans,
+    * row spans, AND whether each tile has a per-chart filter (which adds
+    * {@link #PER_CHART_FILTER_ROW_HEIGHT} to that tile's contribution to its row's reserved
+    * height). This is the primary implementation; the two overloads below delegate to it with
+    * an implicit all-false {@code hasPerChartFilter}, so their behavior is unchanged by this
+    * parameter's addition.
+    *
+    * <p>Packing is still row-major/left-to-right/wrap-at-{@code layoutColumns} — each row's
+    * HEIGHT is {@code max} of the tiles placed in it's {@link #tilePixelSize} height (the same
+    * CAPPED height {@code composeDashboard} actually renders each chart at, plus
+    * {@link #PER_CHART_FILTER_ROW_HEIGHT} for any tile with a per-chart filter), instead of
+    * always {@code DASHBOARD_ROW_HEIGHT}. A tile's own Y depends only on the finalized height of
+    * every row strictly before it, and every such row is fully scanned (all its tiles' heights
+    * folded into that row's height, then closed out) before the loop reaches index {@code i} —
+    * so no 2D occupancy grid is needed; a tile with spanRows > 1 does not "block" cells in the
+    * row below for placement purposes (that would be true masonry/skyline packing, deliberately
+    * not implemented — see the Phase 4 design spec). Returns the (x,y) drop origin in pixels.
+    * Package-private for unit testing.
     */
-   static java.awt.Point gridOrigin(int[] spanCols, int[] spanRows, int layoutColumns, int i) {
+   static java.awt.Point gridOrigin(int[] spanCols, int[] spanRows, boolean[] hasPerChartFilter,
+                                     int layoutColumns, int i)
+   {
       int col = 0;
       int cumulativeY = 0;
       int rowHeightPx = DASHBOARD_ROW_HEIGHT;   // tallest capped tile height seen so far in the CURRENT (still-open) row
 
       for(int k = 0; k <= i; k++) {
          int span = Math.max(1, Math.min(spanCols[k], layoutColumns));
-         int tileHeightPx = tilePixelSize(spanCols[k], spanRows[k]).height;
+         int tileHeightPx = tilePixelSize(spanCols[k], spanRows[k]).height +
+            (hasPerChartFilter[k] ? PER_CHART_FILTER_ROW_HEIGHT : 0);
 
          if(col + span > layoutColumns) {   // doesn't fit in the current row → close it out
             cumulativeY += rowHeightPx;
@@ -416,6 +429,15 @@ public class WizDashboardService {
       }
 
       return new java.awt.Point(0, 0);   // unreachable (i is always in range)
+   }
+
+   /**
+    * Back-compat overload for callers without per-chart filter data (implicit
+    * {@code hasPerChartFilter[k] == false} for every tile).
+    */
+   static java.awt.Point gridOrigin(int[] spanCols, int[] spanRows, int layoutColumns, int i) {
+      boolean[] noFilters = new boolean[spanCols.length];
+      return gridOrigin(spanCols, spanRows, noFilters, layoutColumns, i);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -199,21 +199,19 @@ public class WizDashboardService {
                }
 
                java.awt.Point origin = gridOrigin(spans, rowSpans, layoutColumns, i);
-               x = origin.x;
-               y = origin.y + topOffset;
+               x = origin.x + CANVAS_MARGIN;
+               y = origin.y + topOffset + CANVAS_MARGIN;
             }
             else {
-               x = 0;
-               y = cumulativeY;
+               x = CANVAS_MARGIN;
+               y = cumulativeY + CANVAS_MARGIN;
             }
 
             // Resize the merged chart to its allocated tile footprint (grid path only) --
             // otherwise a tile's computed (spanCols, spanRows) only ever reserved grid drop-
             // position spacing and never resized the chart itself. The stack path has no
             // per-visualization span data, so it passes null and preserves the chart's saved size.
-            java.awt.Dimension pixelSize = grid ?
-               new java.awt.Dimension(spans[i] * DASHBOARD_COL_WIDTH, rowSpans[i] * DASHBOARD_ROW_HEIGHT) :
-               null;
+            java.awt.Dimension pixelSize = grid ? tilePixelSize(spans[i], rowSpans[i]) : null;
 
             try {
                addVisualizationService.addVisualization(
@@ -345,6 +343,32 @@ public class WizDashboardService {
 
    /** Horizontal stride between grid columns, in pixels (paired with DASHBOARD_ROW_HEIGHT). */
    private static final int DASHBOARD_COL_WIDTH = 640;   // confirm vs composer default viz width
+
+   /** Left/top margin from the canvas edge, in pixels, applied uniformly to the filter bar and
+    *  every merged chart tile -- unmargined content rendered flush against the viewsheet edge.
+    *  Package-visible so {@link WizDashboardFilterBuilder} can align its own controls to it. */
+   static final int CANVAS_MARGIN = 24;
+
+   /** Ceiling on a merged chart's rendered width/height, in pixels, regardless of its tile's
+    *  column/row span -- without this, a full-width/full-height tile (e.g. 2 cols x 2 rows)
+    *  stretches to fill its entire reserved grid cell (1280x840), rendering far larger than a
+    *  normal single chart. The tile still RESERVES its full span for grid positioning (see
+    *  {@link #gridOrigin}); only the rendered chart size is capped, leaving a margin of unused
+    *  space inside an oversized cell rather than a stretched chart. */
+   private static final int MAX_TILE_WIDTH = 900;
+   private static final int MAX_TILE_HEIGHT = 600;
+
+   /**
+    * The rendered pixel size for a tile spanning {@code spanCols} columns and {@code spanRows}
+    * rows: its natural span-based footprint ({@code spanCols * DASHBOARD_COL_WIDTH} by
+    * {@code spanRows * DASHBOARD_ROW_HEIGHT}), capped at {@link #MAX_TILE_WIDTH} by
+    * {@link #MAX_TILE_HEIGHT}. Package-private for unit testing (mirrors {@link #gridOrigin}).
+    */
+   static java.awt.Dimension tilePixelSize(int spanCols, int spanRows) {
+      int width = Math.min(spanCols * DASHBOARD_COL_WIDTH, MAX_TILE_WIDTH);
+      int height = Math.min(spanRows * DASHBOARD_ROW_HEIGHT, MAX_TILE_HEIGHT);
+      return new java.awt.Dimension(width, height);
+   }
 
    /**
     * Row-major grid origin for the tile at flat index {@code i}, given per-tile column AND row

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -257,7 +257,7 @@ public class WizDashboardService {
                }
 
                if(!grid) {
-                  cumulativeY += DASHBOARD_ROW_HEIGHT;
+                  cumulativeY += DASHBOARD_ROW_HEIGHT + TILE_GUTTER;
                }
 
                mergedCount++;
@@ -441,6 +441,12 @@ public class WizDashboardService {
    /** Horizontal stride between grid columns, in pixels (paired with DASHBOARD_ROW_HEIGHT). */
    private static final int DASHBOARD_COL_WIDTH = 640;   // confirm vs composer default viz width
 
+   /** Spacing added between adjacent tiles, in pixels -- both horizontally (between columns)
+    *  and vertically (between rows), so tiles don't render flush against each other. Matches
+    *  {@link #CANVAS_MARGIN} for visual consistency. Applied unconditionally, independent of
+    *  {@code layoutColumns}. */
+   private static final int TILE_GUTTER = 24;
+
    /** Left/top margin from the canvas edge, in pixels, applied uniformly to the filter bar and
     *  every merged chart tile -- unmargined content rendered flush against the viewsheet edge.
     *  Package-visible so {@link WizDashboardFilterBuilder} can align its own controls to it. */
@@ -509,20 +515,20 @@ public class WizDashboardService {
             (hasPerChartFilter[k] ? PER_CHART_FILTER_ROW_HEIGHT : 0);
 
          if(col + span > layoutColumns) {   // doesn't fit in the current row → close it out
-            cumulativeY += rowHeightPx;
+            cumulativeY += rowHeightPx + TILE_GUTTER;
             col = 0;
             rowHeightPx = DASHBOARD_ROW_HEIGHT;
          }
 
          if(k == i) {
-            return new java.awt.Point(col * DASHBOARD_COL_WIDTH, cumulativeY);
+            return new java.awt.Point(col * (DASHBOARD_COL_WIDTH + TILE_GUTTER), cumulativeY);
          }
 
          rowHeightPx = Math.max(rowHeightPx, tileHeightPx);
          col += span;
 
          if(col >= layoutColumns) {   // row exactly full → close it out now
-            cumulativeY += rowHeightPx;
+            cumulativeY += rowHeightPx + TILE_GUTTER;
             col = 0;
             rowHeightPx = DASHBOARD_ROW_HEIGHT;
          }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -325,9 +325,15 @@ public class WizDashboardService {
                }
             }
          }
-         else if(event.getPerChartFilters() != null) {
-            // Requested but not applicable (non-grid path) -- report every one as skipped rather
-            // than silently dropping them.
+         if(!hasPerChartFilters && event.getPerChartFilters() != null) {
+            // Requested but not applicable (non-grid path, or an empty list) -- report every one
+            // as skipped rather than silently dropping them. Deliberately NOT an `else if` on the
+            // block above: that would only run when `hasFilters` is ALSO false, so a caller
+            // requesting the shared bar (hasFilters=true) on the non-grid path together with
+            // per-chart filters would take the `if` branch via hasFilters alone and this handling
+            // would never run at all -- silently losing the per-chart filters instead of skipping
+            // them. Checking `!hasPerChartFilters` directly (independent of `hasFilters`) covers
+            // every case: grid=false, or grid=true with an empty/absent list.
             for(WizDashboardEvent.PerChartFilterSpec spec : event.getPerChartFilters()) {
                perChartFiltersSkipped.add(spec.getField());
             }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -180,10 +180,33 @@ public class WizDashboardService {
          boolean hasFilters = event.getFilters() != null && !event.getFilters().isEmpty();
          int topOffset = hasFilters ? FILTER_BAR_ROW_HEIGHT : 0;
 
+         // Which tiles have a per-chart filter targeting them, keyed by identifier -- computed
+         // once, up front, so gridOrigin can factor extra row height into EVERY tile's
+         // reservation (not just the ones with a filter), and so the merge loop below can look
+         // up "does THIS tile need extra height" by flat index without re-deriving it each time.
+         boolean[] hasPerChartFilter = new boolean[entries.size()];
+
+         if(grid && event.getPerChartFilters() != null) {
+            java.util.Set<String> targeted = event.getPerChartFilters().stream()
+               .map(WizDashboardEvent.PerChartFilterSpec::getIdentifier)
+               .collect(java.util.stream.Collectors.toSet());
+
+            for(int i = 0; i < identifiers.size(); i++) {
+               hasPerChartFilter[i] = targeted.contains(identifiers.get(i));
+            }
+         }
+
+         // Records each grid tile's own (x, topY) origin and pixel size -- topY is the very top
+         // of the tile's reserved space (where a per-chart filter sits, if it has one), NOT the
+         // chart's own (possibly filter-shifted) y. Also records each merged chart's own table
+         // name. Both are looked up after this loop when placing per-chart filters.
+         java.util.Map<String, java.awt.Rectangle> tileBounds = new java.util.HashMap<>();
+         java.util.Map<String, String> identifierToTableName = new java.util.HashMap<>();
+
          int cumulativeY = topOffset;   // stack path only
 
          for(int i = 0; i < entries.size(); i++) {
-            int x, y;
+            int x, y, tileTopY;
 
             if(grid) {
                // tiles[] and identifiers[] are consumed purely positionally below (spans[i]
@@ -198,13 +221,19 @@ public class WizDashboardService {
                      "in the same order as identifiers");
                }
 
-               java.awt.Point origin = gridOrigin(spans, rowSpans, layoutColumns, i);
+               java.awt.Point origin = gridOrigin(spans, rowSpans, hasPerChartFilter, layoutColumns, i);
                x = origin.x + CANVAS_MARGIN;
-               y = origin.y + topOffset + CANVAS_MARGIN;
+               tileTopY = origin.y + topOffset + CANVAS_MARGIN;
+               // The chart itself starts BELOW the reserved filter strip, if this tile has one --
+               // the tile's own reserved footprint (computed via gridOrigin above) already
+               // accounts for that extra height, so this only affects where the CHART renders
+               // within it, not how much space the tile as a whole takes.
+               y = tileTopY + (hasPerChartFilter[i] ? PER_CHART_FILTER_ROW_HEIGHT : 0);
             }
             else {
                x = CANVAS_MARGIN;
-               y = cumulativeY + CANVAS_MARGIN;
+               tileTopY = cumulativeY + CANVAS_MARGIN;
+               y = tileTopY;
             }
 
             // Resize the merged chart to its allocated tile footprint (grid path only) --
@@ -214,8 +243,18 @@ public class WizDashboardService {
             java.awt.Dimension pixelSize = grid ? tilePixelSize(spans[i], rowSpans[i]) : null;
 
             try {
-               addVisualizationService.addVisualization(
+               String mergedTableName = addVisualizationService.addVisualization(
                   runtimeId, entries.get(i), x, y, 1.0f, pixelSize, principal);
+
+               if(grid) {
+                  int tileHeight = pixelSize.height + (hasPerChartFilter[i] ? PER_CHART_FILTER_ROW_HEIGHT : 0);
+                  tileBounds.put(identifiers.get(i),
+                     new java.awt.Rectangle(x, tileTopY, pixelSize.width, tileHeight));
+
+                  if(mergedTableName != null) {
+                     identifierToTableName.put(identifiers.get(i), mergedTableName);
+                  }
+               }
 
                if(!grid) {
                   cumulativeY += DASHBOARD_ROW_HEIGHT;
@@ -251,12 +290,47 @@ public class WizDashboardService {
          // would reproduce the same every-filter-skipped symptom this fix targets) — so the
          // filter builder sees the actual merged root tables.
          WizDashboardFilterBuilder.FilterResult filterResult = null;
+         List<String> perChartFiltersApplied = new ArrayList<>();
+         List<String> perChartFiltersSkipped = new ArrayList<>();
+         boolean hasPerChartFilters = grid && event.getPerChartFilters() != null &&
+            !event.getPerChartFilters().isEmpty();
 
-         if(hasFilters) {
+         if(hasFilters || hasPerChartFilters) {
             Viewsheet vs = rvs.getViewsheet();
             Worksheet baseWs = (Worksheet) assetRepository.getSheet(
                vs.getBaseEntry(), principal, false, AssetContent.ALL);
-            filterResult = applyFilters(vs, baseWs, event.getFilters());
+
+            if(hasFilters) {
+               filterResult = applyFilters(vs, baseWs, event.getFilters());
+            }
+
+            if(hasPerChartFilters) {
+               for(WizDashboardEvent.PerChartFilterSpec spec : event.getPerChartFilters()) {
+                  java.awt.Rectangle bounds = tileBounds.get(spec.getIdentifier());
+                  String tableName = identifierToTableName.get(spec.getIdentifier());
+
+                  if(bounds == null || tableName == null) {
+                     perChartFiltersSkipped.add(spec.getField());
+                     continue;
+                  }
+
+                  boolean applied = applyPerChartFilter(vs, baseWs, spec, bounds.x, bounds.y, tableName);
+
+                  if(applied) {
+                     perChartFiltersApplied.add(spec.getField());
+                  }
+                  else {
+                     perChartFiltersSkipped.add(spec.getField());
+                  }
+               }
+            }
+         }
+         else if(event.getPerChartFilters() != null) {
+            // Requested but not applicable (non-grid path) -- report every one as skipped rather
+            // than silently dropping them.
+            for(WizDashboardEvent.PerChartFilterSpec spec : event.getPerChartFilters()) {
+               perChartFiltersSkipped.add(spec.getField());
+            }
          }
 
          WizUtil.saveWizSheet(rvs, principal, savedVsEntry,
@@ -270,6 +344,9 @@ public class WizDashboardService {
             result.setFiltersApplied(filterResult.applied());
             result.setFiltersSkipped(filterResult.skipped());
          }
+
+         result.setPerChartFiltersApplied(perChartFiltersApplied);
+         result.setPerChartFiltersSkipped(perChartFiltersSkipped);
 
          return result;
       }
@@ -330,6 +407,20 @@ public class WizDashboardService {
          .map(f -> new WizDashboardFilterBuilder.FilterRequest(f.getField(), f.getDataType(), f.getLabel()))
          .collect(java.util.stream.Collectors.toList());
       return filterBuilder.build(vs, baseWs, reqs);
+   }
+
+   /**
+    * Maps a single {@link WizDashboardEvent.PerChartFilterSpec} to a
+    * {@link WizDashboardFilterBuilder.FilterRequest} and delegates to
+    * {@link WizDashboardFilterBuilder#buildPerChart}. Package-visible seam for unit testing
+    * (mirrors {@link #applyFilters}), independent of the live-engine-only compose+save path.
+    */
+   boolean applyPerChartFilter(Viewsheet vs, Worksheet baseWs, WizDashboardEvent.PerChartFilterSpec spec,
+                               int x, int y, String chartTableName)
+   {
+      WizDashboardFilterBuilder.FilterRequest req =
+         new WizDashboardFilterBuilder.FilterRequest(spec.getField(), spec.getDataType(), spec.getLabel());
+      return filterBuilder.buildPerChart(vs, baseWs, x, y, req, chartTableName);
    }
 
    /** Vertical row stride between successive merged visualizations, in pixels — used by both

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -374,41 +374,44 @@ public class WizDashboardService {
     * Row-major grid origin for the tile at flat index {@code i}, given per-tile column AND row
     * spans. Packing is still row-major/left-to-right/wrap-at-{@code layoutColumns} (identical
     * grouping to the column-only overload below) — the only change is that each row's HEIGHT is
-    * now {@code max(spanRows)} among the tiles placed in it, instead of always
-    * {@code DASHBOARD_ROW_HEIGHT}. A tile's own Y depends only on the finalized height of every
-    * row strictly before it, and every such row is fully scanned (all its tiles' spanRows folded
-    * into that row's height, then closed out) before the loop reaches index {@code i} — so no
-    * 2D occupancy grid is needed; a tile with spanRows > 1 does not "block" cells in the row
-    * below for placement purposes (that would be true masonry/skyline packing, deliberately not
-    * implemented — see the Phase 4 design spec). Returns the (x,y) drop origin in pixels.
-    * Package-private for unit testing.
+    * now {@code max} of the tiles placed in it's {@link #tilePixelSize} height (the same CAPPED
+    * height {@code composeDashboard} actually renders each chart at), instead of always
+    * {@code DASHBOARD_ROW_HEIGHT}. Reserving the raw (uncapped) {@code spanRows * DASHBOARD_ROW_HEIGHT}
+    * here — while {@link #tilePixelSize} renders a shorter, capped chart — left a large dead gap
+    * between a capped tile and the row below it; reserving the same capped height eliminates it.
+    * A tile's own Y depends only on the finalized height of every row strictly before it, and
+    * every such row is fully scanned (all its tiles' heights folded into that row's height, then
+    * closed out) before the loop reaches index {@code i} — so no 2D occupancy grid is needed; a
+    * tile with spanRows > 1 does not "block" cells in the row below for placement purposes (that
+    * would be true masonry/skyline packing, deliberately not implemented — see the Phase 4 design
+    * spec). Returns the (x,y) drop origin in pixels. Package-private for unit testing.
     */
    static java.awt.Point gridOrigin(int[] spanCols, int[] spanRows, int layoutColumns, int i) {
       int col = 0;
       int cumulativeY = 0;
-      int rowHeight = 1;   // tallest spanRows seen so far in the CURRENT (still-open) row
+      int rowHeightPx = DASHBOARD_ROW_HEIGHT;   // tallest capped tile height seen so far in the CURRENT (still-open) row
 
       for(int k = 0; k <= i; k++) {
          int span = Math.max(1, Math.min(spanCols[k], layoutColumns));
-         int rspan = Math.max(1, spanRows[k]);
+         int tileHeightPx = tilePixelSize(spanCols[k], spanRows[k]).height;
 
          if(col + span > layoutColumns) {   // doesn't fit in the current row → close it out
-            cumulativeY += rowHeight * DASHBOARD_ROW_HEIGHT;
+            cumulativeY += rowHeightPx;
             col = 0;
-            rowHeight = 1;
+            rowHeightPx = DASHBOARD_ROW_HEIGHT;
          }
 
          if(k == i) {
             return new java.awt.Point(col * DASHBOARD_COL_WIDTH, cumulativeY);
          }
 
-         rowHeight = Math.max(rowHeight, rspan);
+         rowHeightPx = Math.max(rowHeightPx, tileHeightPx);
          col += span;
 
          if(col >= layoutColumns) {   // row exactly full → close it out now
-            cumulativeY += rowHeight * DASHBOARD_ROW_HEIGHT;
+            cumulativeY += rowHeightPx;
             col = 0;
-            rowHeight = 1;
+            rowHeightPx = DASHBOARD_ROW_HEIGHT;
          }
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.service;
 
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
+import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.uql.erm.DataRef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,18 +120,7 @@ public class WsMergeService {
                // prevMirror's column selection so stacked mirrors (condMirror / cleanMirror)
                // can see all columns transitively, even when they override their own selection.
                // This runs unconditionally before the branch so any code path below benefits.
-               ColumnSelection baseColumns = existingTable.getColumnSelection(true);
-               ColumnSelection mirrorColumns = prevMirror.getColumnSelection(true).clone();
-
-               for(int i = 0; i < baseColumns.getAttributeCount(); i++) {
-                  DataRef col = baseColumns.getAttribute(i);
-
-                  if(mirrorColumns.getAttribute(col.getName()) == null) {
-                     mirrorColumns.addAttribute(col);
-                  }
-               }
-
-               prevMirror.setColumnSelection(mirrorColumns, true);
+               mergeMirrorColumns(prevMirror, baseName, existingTable.getColumnSelection(true));
 
                ConditionListWrapper srcPre = srcBound.getPreConditionList();
                ConditionListWrapper srcPost = srcBound.getPostConditionList();
@@ -332,8 +322,25 @@ public class WsMergeService {
    }
 
    /**
-    * Expands {@code base}'s public column selection with any columns from {@code srcTable}
-    * that are not already present (judged by column name).
+    * Expands {@code base}'s column selection with any columns from {@code srcTable} that are
+    * not already present (judged by column name) — both its public (output) selection AND its
+    * private (actually-selected/fetched) selection.
+    *
+    * <p>Only updating the public selection is not enough: {@link AbstractTableAssembly#resetColumnSelection}
+    * and the query-preparation validation path ({@code PreAssetQuery#validateColumnSelection})
+    * regenerate a table's public selection FROM its private selection (filtered to visible
+    * columns) whenever the table's column selection is next validated/reset during query
+    * construction — which silently discards a column added only to the public side. Confirmed
+    * live: a JS-expression column two mirror-hops downstream (a dashboard's merged
+    * {@code product_name} calc, depending on a hidden {@code product_name_json} base column)
+    * evaluated to {@code null} for every row once merged into a dashboard, even though an
+    * earlier version of this method correctly added {@code product_name_json} to the public
+    * selection at merge time — because nothing had added it to the private selection, so the
+    * very next {@code resetColumnSelection()} wiped it back out.</p>
+    *
+    * <p>{@code base} is a plain bound (non-mirror) table here, so the added private columns need
+    * no outer-attribute qualification — contrast {@link #mergeMirrorColumns}, which merges the
+    * same base's columns into the "prev" mirror stacked on top of it and DOES need it.</p>
     */
    private void mergeColumns(BoundTableAssembly base, BoundTableAssembly srcTable) {
       ColumnSelection baseColumns = base.getColumnSelection(true);
@@ -347,7 +354,60 @@ public class WsMergeService {
          }
       }
 
+      ColumnSelection basePrivate = base.getColumnSelection(false);
+
+      for(int i = 0; i < srcColumns.getAttributeCount(); i++) {
+         DataRef col = srcColumns.getAttribute(i);
+
+         if(basePrivate.getAttribute(col.getName()) == null) {
+            ColumnRef privateCol = (ColumnRef) ((ColumnRef) col).clone();
+            privateCol.setVisible(true);
+            basePrivate.addAttribute(privateCol);
+         }
+      }
+
+      base.setColumnSelection(basePrivate, false);
       base.setColumnSelection(baseColumns, true);
+   }
+
+   /**
+    * Expands {@code mirror}'s column selection with any columns from {@code baseColumns} (its
+    * own base table's public selection, named {@code baseName}) that are not already present —
+    * both public and private (see {@link #mergeColumns}'s javadoc for why both are required).
+    *
+    * <p>Unlike {@link #mergeColumns}, {@code mirror}'s PRIVATE selection references its base
+    * table's columns by OUTER ATTRIBUTE — qualified by the base's name (e.g. the existing
+    * {@code "PT_base.pt_id"}), not the base's bare column name. A newly-merged column added as a
+    * bare (unqualified) clone — the same shape {@code mergeColumns} correctly uses for a plain
+    * bound table — sits inconsistent with its siblings and never resolves back to the base
+    * table's actual data; {@link AssetUtil#getOuterAttribute} produces the same qualified shape
+    * the mirror's other private columns already have.</p>
+    */
+   private void mergeMirrorColumns(TableAssembly mirror, String baseName, ColumnSelection baseColumns) {
+      ColumnSelection mirrorPublic = mirror.getColumnSelection(true);
+
+      for(int i = 0; i < baseColumns.getAttributeCount(); i++) {
+         DataRef col = baseColumns.getAttribute(i);
+
+         if(mirrorPublic.getAttribute(col.getName()) == null) {
+            mirrorPublic.addAttribute(col);
+         }
+      }
+
+      ColumnSelection mirrorPrivate = mirror.getColumnSelection(false);
+
+      for(int i = 0; i < baseColumns.getAttributeCount(); i++) {
+         DataRef col = baseColumns.getAttribute(i);
+
+         if(mirrorPrivate.getAttribute(col.getName()) == null) {
+            ColumnRef privateCol = new ColumnRef(AssetUtil.getOuterAttribute(baseName, col));
+            privateCol.setVisible(true);
+            mirrorPrivate.addAttribute(privateCol);
+         }
+      }
+
+      mirror.setColumnSelection(mirrorPrivate, false);
+      mirror.setColumnSelection(mirrorPublic, true);
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/model/WizDashboardEventTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/WizDashboardEventTest.java
@@ -74,4 +74,23 @@ class WizDashboardEventTest {
       assertEquals("date", ev.getFilters().get(1).getDataType());
       assertNull(ev.getFilters().get(1).getLabel());
    }
+
+   @Test
+   void deserializesPerChartFilters() throws Exception {
+      String json = "{\"name\":\"B\",\"identifiers\":[\"v1\",\"v2\"]," +
+         "\"perChartFilters\":[{\"identifier\":\"v2\",\"field\":\"Standalone\"," +
+         "\"dataType\":\"string\",\"label\":\"Standalone\"}]}";
+      WizDashboardEvent ev = mapper.readValue(json, WizDashboardEvent.class);
+      assertEquals(1, ev.getPerChartFilters().size());
+      assertEquals("v2", ev.getPerChartFilters().get(0).getIdentifier());
+      assertEquals("Standalone", ev.getPerChartFilters().get(0).getField());
+      assertEquals("string", ev.getPerChartFilters().get(0).getDataType());
+      assertEquals("Standalone", ev.getPerChartFilters().get(0).getLabel());
+   }
+
+   @Test
+   void toleratesAbsentPerChartFilters() throws Exception {
+      WizDashboardEvent ev = mapper.readValue("{\"name\":\"B\",\"identifiers\":[\"v1\"]}", WizDashboardEvent.class);
+      assertNull(ev.getPerChartFilters());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/AddVisualizationServiceGraphStalenessTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/AddVisualizationServiceGraphStalenessTest.java
@@ -127,7 +127,7 @@ class AddVisualizationServiceGraphStalenessTest {
       AddVisualizationService service =
          new AddVisualizationService(vsService, assetRepository, wsMergeService, securityEngine);
 
-      service.addVisualization("rt-1", vizEntry, 0, 0, 1.0f, principal);
+      service.addVisualization("rt-1", vizEntry, 0, 0, 1.0f, null, principal);
 
       // The merged worksheet must be persisted, and dashVS's own cached base worksheet
       // repopulated from it, BEFORE the chart assembly is added -- otherwise the sandbox's

--- a/core/src/test/java/inetsoft/web/wiz/service/AddVisualizationServiceGraphStalenessTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/AddVisualizationServiceGraphStalenessTest.java
@@ -42,6 +42,7 @@ import java.security.Principal;
 import java.util.HashMap;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -142,5 +143,50 @@ class AddVisualizationServiceGraphStalenessTest {
       // The merged chart must also have its cached VGraphPair invalidated -- defense in depth
       // for any graph cached from a prior merge into the same running dashboard.
       verify(box).clearGraph("Chart1");
+   }
+
+   @Test
+   void addVisualizationReturnsTheMergedChartsOwnTableName() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WsMergeService wsMergeService = mock(WsMergeService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+
+      when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+
+      Viewsheet dashVS = new Viewsheet(null, true, false, null, null);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(dashVS);
+      when(rvs.getEntry()).thenReturn(null);
+      ViewsheetSandbox box = mock(ViewsheetSandbox.class);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+      when(vsService.getViewsheet(eq("rt-1"), eq(principal))).thenReturn(rvs);
+
+      AssetEntry vizWsEntry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, "ws1", null);
+      Viewsheet vizVS = new Viewsheet(vizWsEntry);
+      ChartVSAssembly chart = new ChartVSAssembly(vizVS, "Chart1");
+      chart.setSourceInfo(new inetsoft.uql.asset.SourceInfo(inetsoft.uql.asset.SourceInfo.ASSET, null, "CHART_TABLE"));
+      vizVS.addAssembly(chart);
+
+      AssetEntry vizEntry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, "viz1", null);
+      when(assetRepository.getSheet(eq(vizEntry), eq(principal), eq(true), any(AssetContent.class)))
+         .thenReturn(vizVS);
+      Worksheet vizWS = new Worksheet();
+      when(assetRepository.getSheet(eq(vizWsEntry), eq(principal), eq(true), any(AssetContent.class)))
+         .thenReturn(vizWS);
+      when(assetRepository.getSheet(any(AssetEntry.class), isNull(), eq(false), any(AssetContent.class)))
+         .thenReturn(new Worksheet());
+      when(wsMergeService.mergeWorksheet(eq(vizWS), any(Worksheet.class), anyString(), any()))
+         .thenReturn(new HashMap<>());
+
+      AddVisualizationService service =
+         new AddVisualizationService(vsService, assetRepository, wsMergeService, securityEngine);
+
+      String tableName = service.addVisualization("rt-1", vizEntry, 0, 0, 1.0f, null, principal);
+
+      assertEquals("CHART_TABLE", tableName);
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/AddVisualizationServicePixelSizeTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/AddVisualizationServicePixelSizeTest.java
@@ -1,0 +1,136 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.AssetContent;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.Dimension;
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression coverage for the merged chart's rendered SIZE, as distinct from its drop POSITION
+ * (already covered by {@link AddVisualizationServiceGraphStalenessTest} and the grid-origin tests
+ * in {@link WizDashboardServiceGridTest}): {@link AddVisualizationService#mergeViewsheet}
+ * previously called only {@code setPixelOffset} on each cloned assembly, never
+ * {@code setPixelSize} — so a dashboard tile's computed (spanCols, spanRows) footprint only ever
+ * reserved grid spacing and never resized the actual chart, which is why merged charts kept
+ * rendering at their original single-visualization size regardless of the tile they were placed
+ * into. {@link AddVisualizationService#addVisualization} now takes an explicit
+ * {@link Dimension} pixelSize parameter: non-null resizes the merged chart, null (the drag-and-
+ * drop composer path's behavior) leaves its saved size untouched.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class AddVisualizationServicePixelSizeTest {
+
+   @Test
+   void mergingAVisualizationAppliesTheGivenPixelSizeToTheMergedChart() throws Exception {
+      Fixture f = new Fixture();
+      Dimension requestedSize = new Dimension(1280, 840);
+
+      f.service.addVisualization("rt-1", f.vizEntry, 0, 0, 1.0f, requestedSize, f.principal);
+
+      assertEquals(requestedSize, ((ChartVSAssembly) f.dashVS.getAssembly("Chart1")).getPixelSize());
+   }
+
+   @Test
+   void mergingAVisualizationLeavesTheChartsOriginalSizeWhenPixelSizeIsNull() throws Exception {
+      Fixture f = new Fixture();
+      Dimension originalSize = f.chart.getPixelSize();
+
+      f.service.addVisualization("rt-1", f.vizEntry, 0, 0, 1.0f, null, f.principal);
+
+      assertEquals(originalSize, ((ChartVSAssembly) f.dashVS.getAssembly("Chart1")).getPixelSize());
+   }
+
+   /** Shared mock scaffolding for merging a single-chart visualization into an empty dashboard. */
+   private static final class Fixture {
+      final Viewsheet dashVS = new Viewsheet(null, true, false, null, null);
+      final ChartVSAssembly chart;
+      final AssetEntry vizEntry;
+      final Principal principal = mock(Principal.class);
+      final AddVisualizationService service;
+
+      Fixture() throws Exception {
+         ViewsheetService vsService = mock(ViewsheetService.class);
+         AssetRepository assetRepository = mock(AssetRepository.class);
+         WsMergeService wsMergeService = mock(WsMergeService.class);
+         SecurityEngine securityEngine = mock(SecurityEngine.class);
+
+         when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+
+         RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+         when(rvs.getViewsheet()).thenReturn(dashVS);
+         when(rvs.getEntry()).thenReturn(null);
+         ViewsheetSandbox box = mock(ViewsheetSandbox.class);
+         when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+         when(vsService.getViewsheet(eq("rt-1"), eq(principal))).thenReturn(rvs);
+
+         AssetEntry vizWsEntry = new AssetEntry(
+            AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, "ws1", null);
+         Viewsheet vizVS = new Viewsheet(vizWsEntry);
+         chart = new ChartVSAssembly(vizVS, "Chart1");
+         vizVS.addAssembly(chart);
+
+         vizEntry = new AssetEntry(
+            AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, "viz1", null);
+         when(assetRepository.getSheet(eq(vizEntry), eq(principal), eq(true), any(AssetContent.class)))
+            .thenReturn(vizVS);
+         Worksheet vizWS = new Worksheet();
+         when(assetRepository.getSheet(eq(vizWsEntry), eq(principal), eq(true), any(AssetContent.class)))
+            .thenReturn(vizWS);
+         when(assetRepository.getSheet(any(AssetEntry.class), isNull(), eq(false), any(AssetContent.class)))
+            .thenReturn(new Worksheet());
+         when(wsMergeService.mergeWorksheet(eq(vizWS), any(Worksheet.class), anyString(), any()))
+            .thenReturn(new HashMap<>());
+
+         service = new AddVisualizationService(vsService, assetRepository, wsMergeService, securityEngine);
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/AddVisualizationServiceSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/AddVisualizationServiceSecurityTest.java
@@ -70,7 +70,7 @@ class AddVisualizationServiceSecurityTest {
          new AddVisualizationService(vsService, assetRepository, wsMergeService, securityEngine);
 
       SecurityException ex = assertThrows(SecurityException.class,
-         () -> service.addVisualization("rt-1", vizEntry, 0, 0, 1.0f, principal));
+         () -> service.addVisualization("rt-1", vizEntry, 0, 0, 1.0f, null, principal));
 
       assertNotNull(ex.getMessage(), "SecurityException should carry a localized denial message");
 
@@ -102,7 +102,7 @@ class AddVisualizationServiceSecurityTest {
          new AddVisualizationService(vsService, assetRepository, wsMergeService, securityEngine);
 
       RuntimeException thrown = assertThrows(RuntimeException.class,
-         () -> service.addVisualization("rt-1", vizEntry, 0, 0, 1.0f, principal));
+         () -> service.addVisualization("rt-1", vizEntry, 0, 0, 1.0f, null, principal));
 
       assertEquals("marker-past-gate", thrown.getMessage(),
          "should fail past the gate on the marker, not be denied by SecurityException");
@@ -150,7 +150,7 @@ class AddVisualizationServiceSecurityTest {
          new AddVisualizationService(vsService, assetRepository, wsMergeService, securityEngine);
 
       assertThrows(Exception.class,
-         () -> service.addVisualization("rt-1", vizEntry, 0, 0, 1.0f, principal));
+         () -> service.addVisualization("rt-1", vizEntry, 0, 0, 1.0f, null, principal));
 
       // The attacker-controlled vizEntry must be loaded with the READ permission check ENABLED.
       verify(assetRepository).getSheet(eq(vizEntry), eq(principal), eq(true), any(AssetContent.class));

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -111,6 +111,28 @@ class WizDashboardFilterBuilderTest {
          "must bind only to the chart's own table, never GLOBAL_STATS");
    }
 
+   @Test
+   void firstControlIsOffsetByTheCanvasMarginNotFlushAgainstTheEdge() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name"));
+
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(vs, "RadarChart");
+      boundToTable(chart, "CHART_FINAL");
+      vs.addAssembly(chart);
+
+      builder.build(vs, ws, List.of(new WizDashboardFilterBuilder.FilterRequest("category_name", "string", "Category")));
+
+      AbstractSelectionVSAssembly control = java.util.Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof AbstractSelectionVSAssembly)
+         .map(a -> (AbstractSelectionVSAssembly) a)
+         .findFirst().orElseThrow();
+      assertEquals(WizDashboardService.CANVAS_MARGIN, control.getPixelOffset().x,
+         "must not sit flush against the canvas's left edge");
+      assertEquals(WizDashboardService.CANVAS_MARGIN, control.getPixelOffset().y,
+         "must not sit flush against the canvas's top edge");
+   }
+
    // ChartVSAssembly.setTableName(String) silently no-ops when getSourceInfo() is still null (it
    // builds a local SourceInfo but never calls setSourceInfo(...) to store it back) -- harmless
    // in production, where a chart's SourceInfo is always initialized before setTableName is

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -133,6 +133,45 @@ class WizDashboardFilterBuilderTest {
          "must not sit flush against the canvas's top edge");
    }
 
+   @Test
+   void buildPerChartBindsOnlyToTheSpecifiedTableEvenWhenAnotherTableExposesTheSameColumn() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "CHART_FINAL", "product_name"));
+      // A DIFFERENT table also exposes "product_name" -- buildPerChart must never match it,
+      // since only ONE table (the caller-specified chartTableName) is ever a candidate.
+      ws.addAssembly(physicalTable(ws, "OTHER_CHART_FINAL", "product_name"));
+
+      Viewsheet vs = new Viewsheet();
+
+      boolean applied = builder.buildPerChart(vs, ws, 100, 200,
+         new WizDashboardFilterBuilder.FilterRequest("product_name", "string", "Product"), "CHART_FINAL");
+
+      assertTrue(applied);
+
+      AbstractSelectionVSAssembly control = java.util.Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof AbstractSelectionVSAssembly)
+         .map(a -> (AbstractSelectionVSAssembly) a)
+         .findFirst().orElseThrow();
+      assertEquals(List.of("CHART_FINAL"), control.getTableNames(),
+         "must bind only to the specified chart table, never any other table exposing the same column");
+      assertEquals(100, control.getPixelOffset().x);
+      assertEquals(200, control.getPixelOffset().y);
+   }
+
+   @Test
+   void buildPerChartReturnsFalseWhenTheFieldIsNotOnTheSpecifiedTable() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name"));
+
+      Viewsheet vs = new Viewsheet();
+
+      boolean applied = builder.buildPerChart(vs, ws, 0, 0,
+         new WizDashboardFilterBuilder.FilterRequest("product_name", "string", "Product"), "CHART_FINAL");
+
+      assertFalse(applied);
+      assertEquals(0, vs.getAssemblies().length, "no control should be added when the field isn't on the table");
+   }
+
    // ChartVSAssembly.setTableName(String) silently no-ops when getSourceInfo() is still null (it
    // builds a local SourceInfo but never calls setSourceInfo(...) to store it back) -- harmless
    // in production, where a chart's SourceInfo is always initialized before setTableName is

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -195,4 +195,27 @@ class WizDashboardServiceGridTest {
       assertEquals(List.of(new WizDashboardFilterBuilder.FilterRequest("Region", "string", "Region")),
          captor.getValue());
    }
+
+   @Test
+   void applyPerChartFilterMapsSpecToRequestAndDelegatesToBuildPerChart() {
+      WizDashboardFilterBuilder filterBuilder = mock(WizDashboardFilterBuilder.class);
+      when(filterBuilder.buildPerChart(any(), any(), eq(100), eq(200), any(), eq("CHART_TABLE")))
+         .thenReturn(true);
+
+      WizDashboardService svc = serviceWith(filterBuilder);
+      Viewsheet vs = mock(Viewsheet.class);
+      Worksheet baseWs = mock(Worksheet.class);
+      WizDashboardEvent.PerChartFilterSpec spec = new WizDashboardEvent.PerChartFilterSpec();
+      spec.setIdentifier("v2");
+      spec.setField("Standalone");
+      spec.setDataType("string");
+      spec.setLabel("Standalone");
+
+      boolean applied = svc.applyPerChartFilter(vs, baseWs, spec, 100, 200, "CHART_TABLE");
+
+      assertTrue(applied);
+      verify(filterBuilder).buildPerChart(eq(vs), eq(baseWs), eq(100), eq(200),
+         eq(new WizDashboardFilterBuilder.FilterRequest("Standalone", "string", "Standalone")),
+         eq("CHART_TABLE"));
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -73,10 +73,11 @@ class WizDashboardServiceGridTest {
 
       // tile0 (2x2) fills the whole row by itself (spanCols=2 == layoutColumns) -> row 0.
       assertEquals(new Point(0, 0), WizDashboardService.gridOrigin(spans, rowSpans, 2, 0));
-      // tile1 and tile2 (1x1 each) wrap into what would be "row 1", but tile0 was 2 rows tall,
-      // so they must start at H*2, not H*1.
-      assertEquals(new Point(0, 2 * H), WizDashboardService.gridOrigin(spans, rowSpans, 2, 1));
-      assertEquals(new Point(W, 2 * H), WizDashboardService.gridOrigin(spans, rowSpans, 2, 2));
+      // tile1 and tile2 (1x1 each) wrap into what would be "row 1". tile0's reserved height is
+      // its CAPPED tilePixelSize height (2x2 -> 900x600, both dimensions over the 900x600 cap),
+      // not the raw 2*H=840 -- reserving the raw span height left a dead gap below a capped tile.
+      assertEquals(new Point(0, 600), WizDashboardService.gridOrigin(spans, rowSpans, 2, 1));
+      assertEquals(new Point(W, 600), WizDashboardService.gridOrigin(spans, rowSpans, 2, 2));
    }
 
    @Test
@@ -91,16 +92,16 @@ class WizDashboardServiceGridTest {
 
    @Test
    void threeRowsOfMixedHeightsCompoundCumulativeYCorrectly() {
-      // Row 0: one 2x2 tile (fills both columns, 2 rows tall).
-      // Row 1: one 2x1 tile (fills both columns, 1 row tall).
+      // Row 0: one 2x2 tile (fills both columns, 2 rows tall) -> capped tilePixelSize height 600.
+      // Row 1: one 2x1 tile (fills both columns, 1 row tall) -> uncapped height 420 (== H).
       // Row 2: two 1x1 tiles.
       int[] spans =    { 2, 2, 1, 1 };
       int[] rowSpans = { 2, 1, 1, 1 };
 
       assertEquals(new Point(0, 0),         WizDashboardService.gridOrigin(spans, rowSpans, 2, 0));
-      assertEquals(new Point(0, 2 * H),     WizDashboardService.gridOrigin(spans, rowSpans, 2, 1));
-      assertEquals(new Point(0, 3 * H),     WizDashboardService.gridOrigin(spans, rowSpans, 2, 2));
-      assertEquals(new Point(W, 3 * H),     WizDashboardService.gridOrigin(spans, rowSpans, 2, 3));
+      assertEquals(new Point(0, 600),       WizDashboardService.gridOrigin(spans, rowSpans, 2, 1));
+      assertEquals(new Point(0, 600 + H),   WizDashboardService.gridOrigin(spans, rowSpans, 2, 2));
+      assertEquals(new Point(W, 600 + H),   WizDashboardService.gridOrigin(spans, rowSpans, 2, 3));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -42,28 +42,40 @@ class WizDashboardServiceGridTest {
    // Column width / row height strides used by the packer (mirror the service constants).
    private static final int W = 640;   // DASHBOARD_COL_WIDTH  (confirm value in Task 2 Step 5)
    private static final int H = 420;   // DASHBOARD_ROW_HEIGHT (existing constant)
+   private static final int G = 24;    // TILE_GUTTER -- spacing added between adjacent tiles
 
    @Test
    void twoUnitTilesFillRowThenWrap() {
       int[] spans = { 1, 1, 1 };
-      assertEquals(new Point(0, 0),     WizDashboardService.gridOrigin(spans, 2, 0));
-      assertEquals(new Point(W, 0),     WizDashboardService.gridOrigin(spans, 2, 1));
-      assertEquals(new Point(0, H),     WizDashboardService.gridOrigin(spans, 2, 2)); // wrapped
+      assertEquals(new Point(0, 0),       WizDashboardService.gridOrigin(spans, 2, 0));
+      assertEquals(new Point(W + G, 0),   WizDashboardService.gridOrigin(spans, 2, 1));
+      assertEquals(new Point(0, H + G),   WizDashboardService.gridOrigin(spans, 2, 2)); // wrapped
+   }
+
+   @Test
+   void gridOriginAddsTileGutterBetweenAdjacentColumnsAndRows() {
+      int[] spans = { 1, 1, 1 };
+      // Same 3-tile wrap-at-2-columns layout as twoUnitTilesFillRowThenWrap, but asserting the
+      // gutter is present: tile1 starts G pixels further right than a flush W would put it, and
+      // the wrapped row starts G pixels further down than a flush H would put it.
+      assertEquals(new Point(0, 0),       WizDashboardService.gridOrigin(spans, 2, 0));
+      assertEquals(new Point(W + G, 0),   WizDashboardService.gridOrigin(spans, 2, 1));
+      assertEquals(new Point(0, H + G),   WizDashboardService.gridOrigin(spans, 2, 2));
    }
 
    @Test
    void fullWidthTileTakesWholeRow() {
       int[] spans = { 2, 1, 1 };   // tile0 spans both columns
-      assertEquals(new Point(0, 0),  WizDashboardService.gridOrigin(spans, 2, 0));
-      assertEquals(new Point(0, H),  WizDashboardService.gridOrigin(spans, 2, 1)); // pushed to row 2
-      assertEquals(new Point(W, H),  WizDashboardService.gridOrigin(spans, 2, 2));
+      assertEquals(new Point(0, 0),        WizDashboardService.gridOrigin(spans, 2, 0));
+      assertEquals(new Point(0, H + G),    WizDashboardService.gridOrigin(spans, 2, 1)); // pushed to row 2
+      assertEquals(new Point(W + G, H + G), WizDashboardService.gridOrigin(spans, 2, 2));
    }
 
    @Test
    void unitTileAfterFullWidthStartsFreshRow() {
       int[] spans = { 1, 2 };   // tile0 unit in row0 col0; tile1 full-width can't fit → row1
-      assertEquals(new Point(0, 0), WizDashboardService.gridOrigin(spans, 2, 0));
-      assertEquals(new Point(0, H), WizDashboardService.gridOrigin(spans, 2, 1));
+      assertEquals(new Point(0, 0),     WizDashboardService.gridOrigin(spans, 2, 0));
+      assertEquals(new Point(0, H + G), WizDashboardService.gridOrigin(spans, 2, 1));
    }
 
    @Test
@@ -76,8 +88,9 @@ class WizDashboardServiceGridTest {
       // tile1 and tile2 (1x1 each) wrap into what would be "row 1". tile0's reserved height is
       // its CAPPED tilePixelSize height (2x2 -> 900x600, both dimensions over the 900x600 cap),
       // not the raw 2*H=840 -- reserving the raw span height left a dead gap below a capped tile.
-      assertEquals(new Point(0, 600), WizDashboardService.gridOrigin(spans, rowSpans, 2, 1));
-      assertEquals(new Point(W, 600), WizDashboardService.gridOrigin(spans, rowSpans, 2, 2));
+      // Plus TILE_GUTTER between the two rows.
+      assertEquals(new Point(0, 600 + G),     WizDashboardService.gridOrigin(spans, rowSpans, 2, 1));
+      assertEquals(new Point(W + G, 600 + G), WizDashboardService.gridOrigin(spans, rowSpans, 2, 2));
    }
 
    @Test
@@ -86,22 +99,22 @@ class WizDashboardServiceGridTest {
       int[] rowSpans = { 2, 1 };    // tile0: 2 rows tall; tile1: 1 row tall
 
       // Both are in the SAME row (col 0 and col 1), so both share row index 0 -> same Y.
-      assertEquals(new Point(0, 0), WizDashboardService.gridOrigin(spans, rowSpans, 2, 0));
-      assertEquals(new Point(W, 0), WizDashboardService.gridOrigin(spans, rowSpans, 2, 1));
+      assertEquals(new Point(0, 0),     WizDashboardService.gridOrigin(spans, rowSpans, 2, 0));
+      assertEquals(new Point(W + G, 0), WizDashboardService.gridOrigin(spans, rowSpans, 2, 1));
    }
 
    @Test
    void threeRowsOfMixedHeightsCompoundCumulativeYCorrectly() {
       // Row 0: one 2x2 tile (fills both columns, 2 rows tall) -> capped tilePixelSize height 600.
       // Row 1: one 2x1 tile (fills both columns, 1 row tall) -> uncapped height 420 (== H).
-      // Row 2: two 1x1 tiles.
+      // Row 2: two 1x1 tiles. TILE_GUTTER is added between each pair of consecutive rows.
       int[] spans =    { 2, 2, 1, 1 };
       int[] rowSpans = { 2, 1, 1, 1 };
 
-      assertEquals(new Point(0, 0),         WizDashboardService.gridOrigin(spans, rowSpans, 2, 0));
-      assertEquals(new Point(0, 600),       WizDashboardService.gridOrigin(spans, rowSpans, 2, 1));
-      assertEquals(new Point(0, 600 + H),   WizDashboardService.gridOrigin(spans, rowSpans, 2, 2));
-      assertEquals(new Point(W, 600 + H),   WizDashboardService.gridOrigin(spans, rowSpans, 2, 3));
+      assertEquals(new Point(0, 0),                     WizDashboardService.gridOrigin(spans, rowSpans, 2, 0));
+      assertEquals(new Point(0, 600 + G),               WizDashboardService.gridOrigin(spans, rowSpans, 2, 1));
+      assertEquals(new Point(0, 600 + G + H + G),       WizDashboardService.gridOrigin(spans, rowSpans, 2, 2));
+      assertEquals(new Point(W + G, 600 + G + H + G),   WizDashboardService.gridOrigin(spans, rowSpans, 2, 3));
    }
 
    @Test
@@ -110,8 +123,9 @@ class WizDashboardServiceGridTest {
       int[] rowSpans = { 1, 1 };
       boolean[] hasFilter = { true, false };   // only tile0 has a per-chart filter
 
-      // tile0's row reserves its normal height (H=420) PLUS PER_CHART_FILTER_ROW_HEIGHT (120).
-      assertEquals(new Point(0, H + 120),
+      // tile0's row reserves its normal height (H=420) PLUS PER_CHART_FILTER_ROW_HEIGHT (120),
+      // PLUS TILE_GUTTER before row1.
+      assertEquals(new Point(0, H + 120 + G),
          WizDashboardService.gridOrigin(spans, rowSpans, hasFilter, 2, 1));
    }
 
@@ -122,7 +136,8 @@ class WizDashboardServiceGridTest {
       boolean[] hasFilter = { false, true, false };   // only tile1 (in row0) has a filter
 
       // row0's height is max(tile0's H, tile1's H+120) = H+120, even though tile0 itself has none.
-      assertEquals(new Point(0, H + 120),
+      // Plus TILE_GUTTER before row1.
+      assertEquals(new Point(0, H + 120 + G),
          WizDashboardService.gridOrigin(spans, rowSpans, hasFilter, 2, 2));
    }
 
@@ -133,7 +148,7 @@ class WizDashboardServiceGridTest {
       // byte-for-byte unchanged by this task.
       int[] spans =    { 2, 2, 1, 1 };
       int[] rowSpans = { 2, 1, 1, 1 };
-      assertEquals(new Point(0, 600 + H), WizDashboardService.gridOrigin(spans, rowSpans, 2, 2));
+      assertEquals(new Point(0, 600 + G + H + G), WizDashboardService.gridOrigin(spans, rowSpans, 2, 2));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -105,6 +105,38 @@ class WizDashboardServiceGridTest {
    }
 
    @Test
+   void aTileWithAPerChartFilterReservesExtraRowHeight() {
+      int[] spans = { 2, 2 };       // two full-width tiles, one per row
+      int[] rowSpans = { 1, 1 };
+      boolean[] hasFilter = { true, false };   // only tile0 has a per-chart filter
+
+      // tile0's row reserves its normal height (H=420) PLUS PER_CHART_FILTER_ROW_HEIGHT (60).
+      assertEquals(new Point(0, H + 60),
+         WizDashboardService.gridOrigin(spans, rowSpans, hasFilter, 2, 1));
+   }
+
+   @Test
+   void rowHeightReservationTakesTheMaxAcrossTilesInTheRowIncludingPerChartFilterExtras() {
+      int[] spans =    { 1, 1, 2 };   // tile0, tile1 share row0 (1 col each); tile2 is full-width row1
+      int[] rowSpans = { 1, 1, 1 };
+      boolean[] hasFilter = { false, true, false };   // only tile1 (in row0) has a filter
+
+      // row0's height is max(tile0's H, tile1's H+60) = H+60, even though tile0 itself has none.
+      assertEquals(new Point(0, H + 60),
+         WizDashboardService.gridOrigin(spans, rowSpans, hasFilter, 2, 2));
+   }
+
+   @Test
+   void gridOriginFourArgOverloadIsUnaffectedByTheNewParameter() {
+      // Re-assert one of the existing mixed-height cases through the OLD 4-arg overload, proving
+      // it still delegates to an implicit all-false hasPerChartFilter and its behavior is
+      // byte-for-byte unchanged by this task.
+      int[] spans =    { 2, 2, 1, 1 };
+      int[] rowSpans = { 2, 1, 1, 1 };
+      assertEquals(new Point(0, 600 + H), WizDashboardService.gridOrigin(spans, rowSpans, 2, 2));
+   }
+
+   @Test
    void tilePixelSizeUsesTheNaturalSpanFootprintWhenUnderTheCap() {
       // 1x1 -> 640x420; well under the 900x600 cap.
       assertEquals(new java.awt.Dimension(W, H), WizDashboardService.tilePixelSize(1, 1));

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -103,6 +103,20 @@ class WizDashboardServiceGridTest {
       assertEquals(new Point(W, 3 * H),     WizDashboardService.gridOrigin(spans, rowSpans, 2, 3));
    }
 
+   @Test
+   void tilePixelSizeUsesTheNaturalSpanFootprintWhenUnderTheCap() {
+      // 1x1 -> 640x420; well under the 900x600 cap.
+      assertEquals(new java.awt.Dimension(W, H), WizDashboardService.tilePixelSize(1, 1));
+      // 1 col x 2 rows -> 640x840 would exceed the height cap -> clamped to 600.
+      assertEquals(new java.awt.Dimension(W, 600), WizDashboardService.tilePixelSize(1, 2));
+   }
+
+   @Test
+   void tilePixelSizeCapsAFullWidthFullHeightTileAt900By600() {
+      // 2 cols x 2 rows -> natural footprint 1280x840, both dimensions exceed the cap.
+      assertEquals(new java.awt.Dimension(900, 600), WizDashboardService.tilePixelSize(2, 2));
+   }
+
    // --- Task 3: composeDashboard's filter-bar invocation seam ---------------------------------
    //
    // composeDashboard itself needs a live ViewsheetService/asset engine to open a runtime

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -110,8 +110,8 @@ class WizDashboardServiceGridTest {
       int[] rowSpans = { 1, 1 };
       boolean[] hasFilter = { true, false };   // only tile0 has a per-chart filter
 
-      // tile0's row reserves its normal height (H=420) PLUS PER_CHART_FILTER_ROW_HEIGHT (60).
-      assertEquals(new Point(0, H + 60),
+      // tile0's row reserves its normal height (H=420) PLUS PER_CHART_FILTER_ROW_HEIGHT (120).
+      assertEquals(new Point(0, H + 120),
          WizDashboardService.gridOrigin(spans, rowSpans, hasFilter, 2, 1));
    }
 
@@ -121,8 +121,8 @@ class WizDashboardServiceGridTest {
       int[] rowSpans = { 1, 1, 1 };
       boolean[] hasFilter = { false, true, false };   // only tile1 (in row0) has a filter
 
-      // row0's height is max(tile0's H, tile1's H+60) = H+60, even though tile0 itself has none.
-      assertEquals(new Point(0, H + 60),
+      // row0's height is max(tile0's H, tile1's H+120) = H+120, even though tile0 itself has none.
+      assertEquals(new Point(0, H + 120),
          WizDashboardService.gridOrigin(spans, rowSpans, hasFilter, 2, 2));
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/service/WsMergeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WsMergeServiceTest.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.PhysicalBoundTableAssembly;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.asset.TableAssembly;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Regression coverage for a live bug: when two charts merged into the same dashboard both bind
+ * to the same physical table (matched by {@code SourceInfo}, e.g. two charts both reading
+ * {@code product_template}) but one chart's own copy selects more columns than the other's,
+ * {@link WsMergeService#mergeColumns} only added the extra columns to the merged table's PUBLIC
+ * column selection -- never its PRIVATE (actually-selected/fetched) selection. The very next
+ * {@code resetColumnSelection()} call during query construction regenerates the public selection
+ * FROM the private one, silently discarding the merge and reverting the shared table back to only
+ * the narrower chart's columns. Confirmed live: a dashboard merging a "category" chart (whose own
+ * copy of the product_template table selects just 2 columns) with a "product" chart (whose own
+ * copy additionally selects a JSON name column used by a downstream JS-expression calc) ended up
+ * with the JS expression's dependency silently missing, evaluating to null for every row.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WsMergeServiceTest {
+   private final WsMergeService service = new WsMergeService();
+
+   private static PhysicalBoundTableAssembly physicalTable(Worksheet ws, String assemblyName,
+                                                            String... columns)
+   {
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, assemblyName);
+      SourceInfo si = new SourceInfo(SourceInfo.PHYSICAL_TABLE, "postgres", "public.product_template");
+      table.setSourceInfo(si);
+      ColumnSelection cs = new ColumnSelection();
+
+      for(String name : columns) {
+         AttributeRef ref = new AttributeRef(null, name);
+         ref.setDataType(XSchema.STRING);
+         ColumnRef col = new ColumnRef(ref);
+         col.setDataType(XSchema.STRING);
+         cs.addAttribute(col);
+      }
+
+      table.setColumnSelection(cs, false);
+      return table;
+   }
+
+   @Test
+   void mergingATableWithExtraColumnsAddsThemToBothPublicAndPrivateSelection() {
+      // dashWS already has a narrower chart's own copy of the shared physical table merged in.
+      Worksheet dashWS = new Worksheet();
+      dashWS.addAssembly(physicalTable(dashWS, "PT", "pt_id", "categ_id"));
+
+      // A second chart's own worksheet binds to the SAME physical source, but selects one more
+      // column (the JSON name column a downstream calc depends on).
+      Worksheet vizWS = new Worksheet();
+      vizWS.addAssembly(physicalTable(vizWS, "PT", "pt_id", "categ_id", "product_name_json"));
+
+      service.mergeWorksheet(vizWS, dashWS, "suffix1", new HashMap<>());
+
+      // ensureBaseHasPrevMirror renames the pre-existing "PT" to "PT_base" once a prevMirror is
+      // created over it -- that renamed table is where mergeColumns adds the extra column.
+      TableAssembly merged = (TableAssembly) dashWS.getAssembly("PT_base");
+      assertNotNull(merged, "expected the existing 'PT' to be promoted to 'PT_base'");
+
+      ColumnSelection privateCols = merged.getColumnSelection(false);
+      assertNotNull(privateCols.getAttribute("product_name_json"),
+         "merged column must be added to the PRIVATE selection, not just public -- otherwise " +
+         "the next resetColumnSelection() silently drops it again");
+
+      ColumnSelection publicCols = merged.getColumnSelection(true);
+      assertNotNull(publicCols.getAttribute("product_name_json"));
+
+      // "PT" (the prevMirror created over the renamed base) is the table downstream joins
+      // actually reference -- it needs the SAME fix independently: ensureBaseHasPrevMirror's own
+      // prevMirror-refresh step only updated the public selection until this fix, so "PT" is
+      // where the bug reproduced live even after mergeColumns alone was fixed.
+      TableAssembly prevMirror = (TableAssembly) dashWS.getAssembly("PT");
+      assertNotNull(prevMirror, "expected a prevMirror named 'PT' to be created");
+
+      // A mirror's PRIVATE selection references its base's columns by OUTER ATTRIBUTE --
+      // qualified by the base's name ("PT_base.product_name_json"), matching the qualified shape
+      // of its sibling columns ("PT_base.pt_id") -- not the base's bare column name.
+      ColumnSelection mirrorPrivateCols = prevMirror.getColumnSelection(false);
+      assertNotNull(mirrorPrivateCols.getAttribute("PT_base.product_name_json"),
+         "the prevMirror's PRIVATE selection must also get the merged column (outer-attribute " +
+         "qualified, matching its siblings), not just public");
+
+      ColumnSelection mirrorPublicCols = prevMirror.getColumnSelection(true);
+      assertNotNull(mirrorPublicCols.getAttribute("product_name_json"));
+   }
+}


### PR DESCRIPTION
## Summary
- `AddVisualizationService.mergeViewsheet` only ever called `setPixelOffset` (position) on a merged chart, never `setPixelSize` — so a dashboard tile's computed `(spanCols, spanRows)` footprint (added in #4367) only reserved grid drop-position spacing and never resized the chart itself. Composed dashboards kept rendering every chart at its original single-visualization size regardless of the tile it was placed into.
- `addVisualization`/`doAddVisualization`/`mergeViewsheet` now take an explicit `Dimension pixelSize` parameter. `WizDashboardService`'s grid path computes it per-tile from `spanCols`/`spanRows` × `DASHBOARD_COL_WIDTH`/`DASHBOARD_ROW_HEIGHT`; the single-column stack path and the drag-and-drop composer (`WizComposerController`) both pass `null`, preserving their existing behavior exactly.

## Test plan
- [x] New `AddVisualizationServicePixelSizeTest`: non-null `pixelSize` resizes the merged chart; `null` leaves the chart's original size untouched.
- [x] Updated the 4 existing call sites (`AddVisualizationServiceSecurityTest` ×3, `AddVisualizationServiceGraphStalenessTest` ×1) for the new signature.
- [x] Full `inetsoft.web.wiz.**` sweep: 505/505 passing.
- [x] Built `stylebi-enterprise-wiz:local-1000`, redeployed, and live-verified via the wiz plugin's own MCP tools: `materialize_board_dashboard` (0 skipped) + `verify_visualization` confirm the composed dashboard reopens cleanly with data.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>