### PR TITLE
Bug #75744, return 404 instead of 500 when export selection matches no assets

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/deploy/DeployService.java
+++ b/core/src/main/java/inetsoft/web/admin/deploy/DeployService.java
@@ -660,7 +660,7 @@ public class DeployService {
       List<String> paths = getExportPaths(includes, excludes);
 
       if(paths == null || paths.isEmpty()) {
-         throw new Exception("No assets match selection");
+         throw new MissingResourceException("No assets match selection");
       }
 
       createExport(paths, findCheckedAssets(excludeDependencies), name, principal, output);


### PR DESCRIPTION
## Summary

Exporting non-existent assets (e.g. via the DSL shell `:file export-assets` or the public `POST /api/public/files/export-assets` API) returned a raw HTTP 500 Internal Server Error page instead of a meaningful client error.

## Root Cause

`DeployService.exportAssets()` threw a generic `java.lang.Exception("No assets match selection")` when the include patterns resolved to no assets. The shared `@ControllerAdvice` (`AdminExceptionHandler` / `ApiExceptionHandler`) maps a plain `Exception` to HTTP 500, so a client-side "nothing matched" condition was reported as an internal server error.

## Fix

Throw `MissingResourceException` (already imported in `DeployService`) instead of a generic `Exception`. It is already mapped to **HTTP 404** by the ControllerAdvice. The exception is thrown before any bytes are written to the response output stream, so the response is not committed and the advice can set the status and JSON error body.

## Test Plan

- Export a non-existent asset selection → API now returns 404 with a JSON body (`{"code":2,"type":"MissingResourceException","message":"No assets match selection"}`) instead of a 500 HTML page.
- Export a valid asset selection → unchanged (200 with the ZIP).
- EM admin export path is unaffected (it uses a separate `DeployUtil.createExport` code path and does not call `DeployService.exportAssets`).
- `inetsoft-core` builds successfully.

Fixes Redmine #75744.