### PR TITLE
Bug #75751, scope tabular query cache key to the organization

### DIFF
--- a/core/src/main/java/inetsoft/uql/tabular/impl/TabularHandler.java
+++ b/core/src/main/java/inetsoft/uql/tabular/impl/TabularHandler.java
@@ -20,12 +20,14 @@ package inetsoft.uql.tabular.impl;
 import inetsoft.report.TableLens;
 import inetsoft.report.composition.execution.PostProcessor;
 import inetsoft.report.internal.XNodeMetaTable;
+import inetsoft.sree.security.OrganizationManager;
 import inetsoft.uql.*;
 import inetsoft.uql.schema.*;
 import inetsoft.uql.service.XHandler;
 import inetsoft.uql.tabular.*;
 import inetsoft.uql.util.*;
 import inetsoft.util.DataCacheVisitor;
+import inetsoft.util.Tool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -130,10 +132,25 @@ public class TabularHandler extends XHandler {
     * substituting, and the cache-clear paths (removeQueryCache/clearQueryCache)
     * also pass the unsubstituted data source, so the variable names are visible
     * and the write, read, and remove keys stay identical.
+    *
+    * The key is also scoped to the current organization. The base key only
+    * distinguishes data sources by their (non-globally-unique) full name, so
+    * without the organization prefix two data sources that happen to share a
+    * name in different organizations would collide on the same key and hit each
+    * other's cached results (Bug #75751). The org id is derived from the query
+    * user so that the write, read, and remove keys stay identical within a
+    * request even on scheduler/cluster paths where the thread-context principal
+    * may differ.
     */
    @Override
    public String getQueryKey(XQuery query, VariableTable qvars, Principal user) throws Exception {
       String key = super.getQueryKey(query, qvars, user);
+      String orgId = OrganizationManager.getInstance().getCurrentOrgID(user);
+
+      if(!Tool.isEmptyString(orgId)) {
+         key = orgId + "__" + key;
+      }
+
       XDataSource source = query.getDataSource();
 
       if(source instanceof TabularDataSource) {


### PR DESCRIPTION
## Summary

In multi-tenant deployments, different organizations were hitting each other's cached tabular (REST/etc.) query results. Reproduction: `admin` (default org) opens worksheet `ws3`, enters parameter `A`, and sees a UUID; `user0` in a different organization opens the same-named `ws3`, enters `A`, and sees the **same** UUID — a stale cross-org cache hit instead of a fresh query result.

## Root Cause

The tabular query result cache is a single process-global `DataCache<String, CEntry>` in `XSessionManager`; cross-org isolation depends entirely on the string key produced by `getQueryKey`. `TabularHandler.getQueryKey` built the key from `super.getQueryKey(...)`, which uses `XDataSource.getFullName()` — just the data source **name**, which is not globally unique across organizations — plus the query XML and variable values. Two organizations with same-named data sources therefore produced identical keys and shared cache entries.

JDBC is unaffected because `JDBCHandler.getQueryKey` keys on `JDBCDataSource.getIdentity()` (`url + user + defaultdb`), which is content-based. The rest of the codebase already scopes caches by organization via `OrganizationManager.getCurrentOrgID()` (e.g. the `XEngine` metadata cache and `DataSourceRegistry`); the tabular query cache simply missed this.

## Fix

Prefix the tabular query cache key with the current organization ID, derived from the query user principal via `OrganizationManager.getInstance().getCurrentOrgID(user)`. Deriving it from the passed `user` (rather than only the thread context) keeps the write, read, and remove keys identical within a request even on scheduler/cluster paths. The existing #75737 variable-value logic in the same method is unchanged.

## Test Plan

1. Enable Multi-Tenancy; grant `user0` Organization Administrator permission.
2. Import the attached `ws3` asset; as `admin`, open worksheet `ws3`, enter parameter `A`, view live data, and note the UUID.
3. As `user0` (a different organization) in another browser, open `ws3`, enter `A`, view live data.
4. Verify the UUID is now **different** from the one `admin` saw (a fresh query, not a cross-org cache hit).
5. Confirm that re-running within the same organization with the same parameter still returns the cached result (intra-org caching preserved).

Fixes Redmine #75751.