### PR TITLE
Bug #75755, preserve user-configured query HTTP parameters for GraphQL

### DIFF
--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/graphql/GraphQLRuntime.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/graphql/GraphQLRuntime.java
@@ -36,8 +36,17 @@ public class GraphQLRuntime extends RestJsonRuntime {
    }
 
    private void addParams(GraphQLQuery query, AbstractGraphQLDataSource dataSource, boolean postRequest) {
-      final Set<HttpParameter> httpParams =
-         new HashSet<>(Arrays.asList(dataSource.getRequestParameters()));
+      final Set<HttpParameter> httpParams = new LinkedHashSet<>();
+
+      // preserve the user-configured query HTTP parameters (e.g. an Authorization
+      // header); otherwise they are overwritten below and lost during execution
+      final HttpParameter[] existing = dataSource.getQueryHttpParameters();
+
+      if(existing != null) {
+         httpParams.addAll(Arrays.asList(existing));
+      }
+
+      httpParams.addAll(Arrays.asList(dataSource.getRequestParameters()));
 
       if(!postRequest) {
          final String variables = query.getVariables();


### PR DESCRIPTION
## Summary

A generic GraphQL tabular data source (type `GraphQL`) configured with `authType=NONE` and a manually-added `Authorization: bearer <token>` header (stored in the data source's `queryHttpParameters`) sent its request **unauthenticated** during execution. GitHub responded with `403 rate limit exceeded` because the Authorization header never reached the request.

## Root Cause

`GraphQLRuntime.addParams()` rebuilt the data source's `queryHttpParameters` from scratch:

- It seeded its working set from `dataSource.getRequestParameters()`, which is an `OAuthDataSource` default returning an **empty** array (only endpoint-specific connectors such as Monday/Shopify override it — the generic `GraphQLDataSource` does not).
- It optionally added the GraphQL `query`/`variables` params (GET mode only).
- It then called `dataSource.setQueryHttpParameters(...)`, **overwriting** the user-configured parameters — discarding the `Authorization` header before `HttpHandler` could add it to the request.

## Fix

Seed the working set with the existing `dataSource.getQueryHttpParameters()` (the user config) in addition to `getRequestParameters()`, before adding the GraphQL params and calling `setQueryHttpParameters()`.

This is safe from cross-run accumulation because `TabularHandler.execute()` clones the data source (deep-copying `queryHttpParameters`) before every `runQuery()` call, so `addParams()` always mutates a fresh clone reflecting the persisted config. Endpoint GraphQL connectors that override `getRequestParameters()` are unaffected — their fixed params are still added, now merged with (rather than replacing) any user params.

## Test Plan

- Import the `TC-9` test case, open the worksheet, run query → live data. The request now carries `Authorization: bearer <token>` and GitHub returns authenticated data instead of the 403 rate-limit error.
- `./mvnw test -pl connectors/inetsoft-rest` — all 103 tests pass.
- Verify existing REST/GraphQL connectors (GitHub named connector, OAuth flows) continue to work — no regression, since those paths rely on `getRequestParameters()` and/or the authenticator, both of which are preserved.

Fixes Redmine #75755.