### PR TITLE
Bug #75769, fix presentation properties lost after renaming organization ID

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
@@ -1254,26 +1254,30 @@ public class UserTreeService {
          checkDuplicateOrgIDs(model, oldOrg);
       }
 
-      boolean saveProperties = false;
+      OrganizationManager.runInOrgScope(oldOrg.getId(), () -> {
+         boolean saveProperties = false;
 
-      for(PropertyModel property: model.properties()) {
-         SreeEnv.setProperty(property.name(), property.value(), true);
-         saveProperties = true;
-      }
-
-      String[] propertyNames = {"max.row.count", "max.col.count", "max.cell.size", "max.user.count"};
-      List<String> properties = model.properties().stream().map(p -> p.name()).toList();
-
-      for(String key : propertyNames) {
-         if(SreeEnv.getProperty(key, false, true) != null && !properties.contains(key)) {
-            SreeEnv.setProperty(key, null, true);
+         for(PropertyModel property: model.properties()) {
+            SreeEnv.setProperty(property.name(), property.value(), true);
             saveProperties = true;
          }
-      }
 
-      if(saveProperties) {
-         SreeEnv.save();
-      }
+         String[] propertyNames = {"max.row.count", "max.col.count", "max.cell.size", "max.user.count"};
+         List<String> properties = model.properties().stream().map(p -> p.name()).toList();
+
+         for(String key : propertyNames) {
+            if(SreeEnv.getProperty(key, false, true) != null && !properties.contains(key)) {
+               SreeEnv.setProperty(key, null, true);
+               saveProperties = true;
+            }
+         }
+
+         if(saveProperties) {
+            SreeEnv.save();
+         }
+
+         return null;
+      });
 
       if(provider instanceof EditableAuthenticationProvider) {
          identityService.setIdentity(oldOrg, model, provider, principal);


### PR DESCRIPTION
## Summary
- With security + multi-tenancy enabled, renaming an organization's ID (e.g. `org0` → `org1`) caused all of that org's Presentation properties (EM → Security → Users → Organization → Properties tab) to disappear.
- Root cause: `UserTreeService.editOrganization()` saved the submitted Presentation properties via `SreeEnv.setProperty(name, value, orgScope=true)`, which resolves the org key prefix from `OrganizationManager.getCurrentOrgID()` — the **acting principal's own current org**, not the org actually being edited/renamed. Whenever the person performing the rename isn't currently scoped into that org (e.g. a Site Admin renaming a tenant org), the freshly submitted values got misfiled into the wrong org's key namespace before the rename's `copyScopedProperties()` migration ran, so nothing meaningful survived to the renamed org.
- Fix: wrap the property save block in `OrganizationManager.runInOrgScope(oldOrg.getId(), ...)`, the existing helper already used elsewhere in the codebase for this exact purpose, so properties are always written under the org actually being edited.

## Test plan
- [x] `./mvnw clean install -pl core -am -DskipTests` compiles cleanly
- [x] Manually reproduced and confirmed fixed: clone org from Host Organization, set Presentation properties as its org admin, rename the org's ID as Site Admin, confirm properties persist under the new org ID after rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)