### PR TITLE
Bug #75759, re-scope recycle bin entries when cloning/renaming an org

### DIFF
--- a/core/src/main/java/inetsoft/web/RecycleBin.java
+++ b/core/src/main/java/inetsoft/web/RecycleBin.java
@@ -317,6 +317,37 @@ public class RecycleBin implements XMLSerializable, AutoCloseable {
       }
    }
 
+   /**
+    * Copies the recycle bin entries from one organization to another and re-scopes each
+    * entry to the target organization. Unlike {@link #copyStorageData(String, String)} (a raw
+    * bucket copy), this rewrites every entry's {@code originalUser} (and permission grants) from
+    * the source org to the target org and persists the result, so a cloned/renamed org's recycle
+    * bin references the new org's identities rather than the source org's. Used when an
+    * organization is created by clone or renamed. (Bug #75759)
+    */
+   public void migrateStorageData(Organization oorg, Organization norg) {
+      copyStorageData(oorg.getId(), norg.getId());
+
+      KeyValueStorage<Entry> nStorage = getStorage(norg.getId());
+      SortedMap<String, Entry> data = new TreeMap<>();
+      nStorage.stream().forEach(pair -> data.put(pair.getKey(), pair.getValue()));
+
+      try {
+         // re-scope originalUser/permission on the copied entries, then persist them.
+         // Run in the source org's context because migrateEntries()'s permission-grant lookup
+         // filters grants by the current org.
+         OrganizationManager.runInOrgScope(oorg.getId(), () -> {
+            migrateEntries(data, oorg, norg);
+            return null;
+         });
+
+         nStorage.putAll(data).get(2L, TimeUnit.MINUTES);
+      }
+      catch(Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
+
    @Override
    public void parseXML(Element tag) throws Exception {
       NodeList nodes = Tool.getChildNodesByTagName(tag, "entry");

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -1134,7 +1134,7 @@ public class IdentityService {
       try {
          dashboardManager.copyStorageData(oOrg.getId(), nOrg.getId());
          dependencyStorageService.copyStorageData(oOrg, nOrg);
-         recycleBin.copyStorageData(oOrg.getId(), nOrg.getId());
+         recycleBin.migrateStorageData(oOrg, nOrg);
          updateLibraryStorage(oOrg.getId(), nOrg.getId(), true);
          indexedStorage.copyStorageData(oOrg, nOrg, rename);
          indexedStorage.setInitialized(nOrg.getId());

--- a/core/src/test/java/inetsoft/web/RecycleBinOrgLifecycleTest.java
+++ b/core/src/test/java/inetsoft/web/RecycleBinOrgLifecycleTest.java
@@ -33,9 +33,12 @@ package inetsoft.web;
  *
  * 11b side discovery: migrateEntries() mutates the Entry objects in the Map handed to it
  * in-memory (originalUser/permission), but has no storage.put() call of its own anywhere in its
- * body -- so even INDEPENDENTLY of the already-confirmed "never called by copyStorages()" gap,
- * wiring it in as-is would not be sufficient on its own; a caller would also need to re-persist
- * each mutated Entry. See the test method for the empirical confirmation.
+ * body -- so wiring it in as-is is not sufficient on its own; a caller must also re-persist each
+ * mutated Entry. Bug #75759 addresses this via RecycleBin.migrateStorageData(), which copies,
+ * calls migrateEntries(), and then re-persists; copyStorages() now calls migrateStorageData()
+ * instead of the raw copyStorageData(). The 11a/11b/11c scenarios below still exercise the
+ * lower-level copyStorageData()/migrateEntries() directly (unchanged), and the dedicated
+ * migrateStorageData_* test verifies the wired-in fix.
  */
 
 import inetsoft.sree.RepositoryEntry;
@@ -141,10 +144,10 @@ class RecycleBinOrgLifecycleTest {
       recycleBin.addEntry("Recycle Bin/def456", "My Dashboards/report2", "report2", permission,
                           RepositoryEntry.VIEWSHEET, AssetRepository.USER_SCOPE, originalUser);
 
-      // Mirrors the real orchestration: copyStorages() only ever calls copyStorageData() (11a) --
-      // migrateEntries() is never invoked from there (confirmed by codebase-wide search, no call
-      // site anywhere). Calling it here by hand characterizes what it WOULD do if it were wired
-      // in, rather than asserting on dead code that never runs in production.
+      // Exercises copyStorageData() (11a) followed by a hand call to migrateEntries(), to
+      // characterize the two lower-level building blocks in isolation. The production wiring
+      // (copyStorages() -> RecycleBin.migrateStorageData(), which combines copy + migrate +
+      // re-persist) is covered separately by migrateStorageData_reScopesOriginalUser_andPersists.
       recycleBin.copyStorageData(fromOrgId, toOrgId);
 
       actAs(toOrgId);
@@ -239,6 +242,41 @@ class RecycleBinOrgLifecycleTest {
                 "so it returns an empty set here, migratePermissionGrants()'s " +
                 "'if(!grants.isEmpty())' guard skips setGrants() entirely, and the permission " +
                 "grant is left completely unchanged, still naming the source org");
+   }
+
+   // ── migrateStorageData(oorg, norg): copy + re-scope originalUser + persist (Bug #75759 fix) ──
+
+   @Test
+   void migrateStorageData_reScopesOriginalUser_andPersists_sourceUntouched() {
+      recycleBin = new RecycleBin(keyValueStorageManager);
+      String fromOrgId = "recyclebin_migrate_from";
+      String toOrgId = "recyclebin_migrate_to";
+
+      IdentityID originalUser = new IdentityID("alice", fromOrgId);
+
+      actAs(fromOrgId);
+      recycleBin.addEntry("Recycle Bin/mno345", "My Dashboards/report5", "report5", null,
+                          RepositoryEntry.VIEWSHEET, AssetRepository.USER_SCOPE, originalUser);
+
+      recycleBin.migrateStorageData(new Organization(fromOrgId), new Organization(toOrgId));
+
+      // a fresh read from the target bucket must show originalUser re-scoped to the target org
+      // (unlike copyStorageData's raw copy in 11a) -- this is the fix for #75759: the recycle-bin
+      // tree keys private users by originalUser, so the org segment must name the new org.
+      actAs(toOrgId);
+      RecycleBin.Entry migrated = recycleBin.getEntry("Recycle Bin/mno345");
+      assertNotNull(migrated, "migrate must produce the entry under the target org's own bucket");
+      assertEquals("My Dashboards/report5", migrated.getOriginalPath());
+      assertEquals(toOrgId, migrated.getOriginalUser().getOrgID(),
+                  "migrateStorageData() must re-scope originalUser's org segment to the target " +
+                  "org and persist it, so a fresh read shows the new org");
+
+      // source org's entry must be completely untouched by the migrate
+      actAs(fromOrgId);
+      RecycleBin.Entry source = recycleBin.getEntry("Recycle Bin/mno345");
+      assertNotNull(source, "migrate must not remove the source org's own entry");
+      assertEquals(fromOrgId, source.getOriginalUser().getOrgID(),
+                  "source org's entry must be completely untouched by the migrate");
    }
 
    // ── scenario 11c: removeStorage(orgID) -- whole bucket deleted ──


### PR DESCRIPTION
## Summary

When a new organization is created **by cloning** an existing org (or when an org is renamed), deleted **private** (user-owned) dashboards/folders were missing from the Enterprise Manager **Content → Repository → Recycle Bin tree** in the new org, even though they still appeared in the right-hand recycle-bin **table**.

## Root Cause

`IdentityService.copyStorages()` re-scopes every per-org storage to the new org **except** the recycle bin. `recycleBin.copyStorageData(oId, id)` performed a raw key/value bucket copy, leaving each `RecycleBin.Entry.originalUser` `IdentityID` scoped to the **source** org.

The EM recycle-bin tree builder (`ContentRepositoryTreeService.createUserNodes()`) keys private users by `entry.getOriginalUser()` and only emits a user's nodes when `recycleBinUsers.contains(user)`. Because `IdentityID.equals()` compares **both name and orgID**, the stale source-org `orgID` on the copied entries never matched the new org's users, so private deleted items were dropped from the tree. The table matches recycle entries by **path** (using `originalUser` only for a display label), so it was unaffected — hence the discrepancy.

An existing `RecycleBin.migrateEntries(...)` method already knew how to re-scope `originalUser`/permission grants, but it was never called from the clone/rename path and only mutated in memory (no persist).

## Fix

- Added `RecycleBin.migrateStorageData(Organization oorg, Organization norg)`: copies the entries (via the existing `copyStorageData`), reads the copied target entries back, re-scopes each entry's `originalUser` and permission grants via `migrateEntries()`, and **persists** the result. The `migrateEntries` call runs inside `OrganizationManager.runInOrgScope(oorg.getId(), ...)` because the permission-grant lookup filters grants by the current org.
- Changed `IdentityService.copyStorages()` to call `recycleBin.migrateStorageData(oOrg, nOrg)` instead of the raw `copyStorageData(...)`. This is the single call site for the recycle bin during org clone/rename.

The lower-level `copyStorageData(String,String)` and `migrateEntries(...)` are left unchanged; the source org's recycle-bin bucket is never mutated.

## Test Plan

Automated (`RecycleBinOrgLifecycleTest`, all 5 pass):
- New `migrateStorageData_reScopesOriginalUser_andPersists_sourceUntouched` asserts a fresh read from the target bucket shows `originalUser` re-scoped to the target org, and the source bucket is untouched.
- Existing 11a/11b/11c scenarios (direct `copyStorageData`/`migrateEntries`) remain green.

Manual:
1. Log in as admin of the host org; create a dashboard, save it as a private dashboard, then delete it (goes to Recycle Bin).
2. On the Security page, create a new org by **clone**.
3. On Content → Repository, expand Recycle Bin → Repository in the cloned org.
4. Verify the deleted **private** dashboard/folder now appears in the tree (previously missing), matching the table listing.

Fixes Redmine #75759.