### PR TITLE
Bug #75760, key table style move by stable styleID to remove original

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/ChangeAssetController.java
+++ b/core/src/main/java/inetsoft/web/composer/ChangeAssetController.java
@@ -269,7 +269,13 @@ public class ChangeAssetController {
 
    private void changeTableStyle(AssetEntry parent, AssetEntry entry, Principal principal) throws Exception {
       LibManager manager = libManagerProvider.getManager(principal);
-      XTableStyle tableStyle = manager.getTableStyle(entry.getName());
+      // Look up by the stable style ID, not the leaf name. Style IDs are
+      // de-duplicated globally across folders, so a same-named style in another
+      // folder could otherwise be matched by the fuzzy by-name lookup, causing
+      // the remove/recreate below to operate on two different keys and leaving
+      // the original entry in place (bug #75760).
+      String styleID = entry.getProperty("styleID");
+      XTableStyle tableStyle = manager.getTableStyle(styleID);
       String folder = parent.getProperty("folder");
 
       if(!assetRepository.checkPermission(principal, ResourceType.TABLE_STYLE, tableStyle.getName(),
@@ -297,11 +303,13 @@ public class ChangeAssetController {
 
 
       XTableStyle style = tableStyle.clone();
-      manager.removeTableStyle(entry.getProperty("styleID"));
       String name = Tool.isEmptyString(folder) ? entry.getName() :
          folder + LibManager.SEPARATOR + entry.getName();
       style.setName(name);
-      manager.setTableStyle(style.getID(), style);
+      // Keep the ID stable so the remove and the recreate act on the same key.
+      style.setID(styleID);
+      manager.removeTableStyle(styleID);
+      manager.setTableStyle(styleID, style);
       manager.save();
    }
 

--- a/core/src/main/java/inetsoft/web/composer/ChangeAssetController.java
+++ b/core/src/main/java/inetsoft/web/composer/ChangeAssetController.java
@@ -278,6 +278,13 @@ public class ChangeAssetController {
       XTableStyle tableStyle = manager.getTableStyle(styleID);
       String folder = parent.getProperty("folder");
 
+      // Defensive guard: a null/legacy styleID (or one that no longer resolves) would
+      // otherwise NPE on the tableStyle.getName() permission checks below.
+      if(tableStyle == null) {
+         throw new MessageException("Table style not found: " +
+            (styleID != null ? styleID : entry.getName()));
+      }
+
       if(!assetRepository.checkPermission(principal, ResourceType.TABLE_STYLE, tableStyle.getName(),
          EnumSet.of(ResourceAction.DELETE)))
       {


### PR DESCRIPTION
## Summary

Moving a table style (Library → Table Styles) from one folder to another in the Composer library tree left the original in its source folder — the style appeared in **both** the source and destination folders.

## Root Cause

`ChangeAssetController.changeTableStyle()` implemented the move as delete-then-recreate but used two different keys:

- It looked the style up via `manager.getTableStyle(entry.getName())`, where `entry.getName()` is only the **leaf** path segment. `LibManager.getTableStyle` falls back to a **fuzzy by-name** lookup (`TableStyleLogicalLibrary.getByName(name, fuzzy=true)`), which can bind to a **different, same-named** style in another folder because style IDs are de-duplicated globally.
- It then **removed** by `entry.getProperty("styleID")` but **recreated** under `style.getID()` from the (possibly wrong) looked-up object.

When these keys diverged, the remove and the insert acted on different map keys, so the original was never removed and a new copy was written into the destination.

The library map is keyed by the stable style ID (`XTableStyle.getID()`), and the tree entry's `styleID` property is set to that ID. The sibling **rename** path (`LibManager.renameTableStyle` / `TableStyleLogicalLibrary.rename(oldName,newName,oid)`) correctly operates entirely through the stable `oid`.

## Fix

Key the whole operation to the tree-supplied `styleID`: look up, remove, and recreate all by `styleID`, keeping the ID stable — mirroring the rename path. This guarantees the remove and the recreate act on the same entry, so exactly one entry ends up in the destination.

## Test Plan

1. Import `BorderedLightBands.zip`; under Library → Table Styles → `Bands`, create Folder `A`.
2. As a user with R/W on `A` and Read on `Bands`, open Composer, select `BorderedLightBands`, and move it into Folder `A`.
3. Verify the style now appears **only** in Folder `A` and is removed from `Bands`.
4. Regression: a normal single-style move (no name collision) still moves correctly with no duplicate; renaming a table style still works.

Existing `core` library/table-style tests pass (`LogicalLibraryTest`, `TableStyleTest`, `ScriptLogicalLibraryTest`).

Fixes Redmine #75760.

🤖 Generated with [Claude Code](https://claude.com/claude-code)