### PR TITLE
Bug #75765, prevent IndexOutOfBoundsException when balancing schedule tasks

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/TaskBalancer.java
+++ b/core/src/main/java/inetsoft/sree/schedule/TaskBalancer.java
@@ -243,7 +243,8 @@ public class TaskBalancer {
 
          BitSet bitSet = slots.get(i);
 
-         for(int j = bitSet.nextClearBit(0); j < slotsPerThread;
+         for(int j = bitSet.nextClearBit(0);
+             j < slotsPerThread && conditionIndex < conditions.size();
              j = bitSet.nextClearBit(j))
          {
             TimeCondition condition = conditions.get(conditionIndex++);


### PR DESCRIPTION
## Summary

Saving a schedule task in Enterprise Manager (e.g. copying a condition and saving) intermittently threw `java.lang.IndexOutOfBoundsException: Index N out of bounds for length N` from `TaskBalancer.balanceTasks`, aborting the save.

## Root Cause

In `TaskBalancer.balanceTasks(TimeRange, List<ScheduleTask>, List<TimeCondition>)`, the loop that fills "all but the last thread's slots" read `conditions.get(conditionIndex++)` without bounding `conditionIndex` against `conditions.size()`.

`requiredThreads` is budgeted from `conditions.size() + hardCoded`, on the assumption that each hard-coded slot removes one clear slot from the threads being filled. But `fillSlots()` never uses the initial empty `slots.get(0)` bitset — it appends a brand-new `BitSet` per hard-coded slot — so thread `i=0` always consumes a full `slotsPerThread`, and the total clear slots across the first `requiredThreads-1` bitsets can exceed `conditions.size()`. `conditionIndex` then overruns the list.

The behavior is timing-dependent (`slotsPerThread`/`interval`/`start` derive from `LocalTime.now()` relative to the time range), which is why it did not reproduce consistently. Reproduced in simulation with `conditions.size()=6`, `slotsPerThread=4`, `hardCoded=3`, matching the exact reported error.

This is original code (not a regression) and a sibling of the earlier OOM fix in the same method (#71118).

## Fix

Add a bounds guard to the inner loop so it stops once every condition has been placed:

```java
for(int j = bitSet.nextClearBit(0);
    j < slotsPerThread && conditionIndex < conditions.size();
    j = bitSet.nextClearBit(j))
```

Overflow only occurs *after* all conditions are already placed, so the guard just stops the excess reads; no condition is left unplaced. The downstream `distribute(...)` block (guarded by `conditionIndex < conditions.size()`) and the remaining-fill loop are unchanged, and the under-consumption path is unaffected.

## Test Plan

- `./mvnw test -pl core -Dtest=TaskBalancerTest` — all 31 existing tests pass.
- `./mvnw clean install -pl core -am -DskipTests` — BUILD SUCCESS.
- Manual: import the task from the issue, copy the first condition, and save repeatedly — no longer throws.

Fixes Redmine #75765.