### PR TITLE
Bug #75766, clean up EM favorites when an organization is deleted

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/favorites/FavoritesController.java
+++ b/core/src/main/java/inetsoft/web/admin/favorites/FavoritesController.java
@@ -17,62 +17,25 @@
  */
 package inetsoft.web.admin.favorites;
 
-import inetsoft.storage.KeyValueStorage;
-import inetsoft.storage.KeyValueStorageManager;
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
-import java.util.Collections;
-import java.util.concurrent.*;
 
 @RestController
 public class FavoritesController {
-   public FavoritesController(KeyValueStorageManager keyValueStorageManager) {
-      this.keyValueStorageManager = keyValueStorageManager;
+   public FavoritesController(FavoritesService favoritesService) {
+      this.favoritesService = favoritesService;
    }
 
    @GetMapping("/api/em/favorites")
    public FavoriteList getFavorites(Principal user) {
-      FavoriteList list = favorites.get(user.getName());
-
-      if(list == null) {
-         list = new FavoriteList();
-         list.setFavorites(Collections.emptyList());
-      }
-
-      return list;
+      return favoritesService.getFavorites(user.getName());
    }
 
    @PutMapping("/api/em/favorites")
    public void setFavorites(@RequestBody FavoriteList userFavorites, Principal user) {
-      try {
-         if(userFavorites.getFavorites().isEmpty()) {
-            favorites.remove(user.getName()).get(10L, TimeUnit.SECONDS);
-         }
-         else {
-            favorites.put(user.getName(), userFavorites).get(10L, TimeUnit.SECONDS);
-         }
-      }
-      catch(InterruptedException | ExecutionException | TimeoutException e) {
-         throw new RuntimeException(e);
-      }
+      favoritesService.setFavorites(user.getName(), userFavorites);
    }
 
-   @PostConstruct
-   public void initStorage() {
-      favorites = keyValueStorageManager.getStorage("emFavorites");
-   }
-
-   @PreDestroy
-   public void closeStorage() throws Exception {
-      if(favorites != null) {
-         favorites.close();
-         favorites = null;
-      }
-   }
-
-   private final KeyValueStorageManager keyValueStorageManager;
-   private KeyValueStorage<FavoriteList> favorites;
+   private final FavoritesService favoritesService;
 }

--- a/core/src/main/java/inetsoft/web/admin/favorites/FavoritesService.java
+++ b/core/src/main/java/inetsoft/web/admin/favorites/FavoritesService.java
@@ -1,0 +1,173 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.favorites;
+
+import inetsoft.sree.security.IdentityID;
+import inetsoft.storage.KeyValueStorage;
+import inetsoft.storage.KeyValueStorageManager;
+import inetsoft.util.Tool;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.stream.Collectors;
+
+/**
+ * Owns the {@code emFavorites} key-value store and encapsulates all access to it, so
+ * callers (e.g. the favorites REST controller, identity/organization management) do not
+ * depend on how EM favorites are stored or keyed.
+ */
+@Service
+public class FavoritesService {
+   public FavoritesService(KeyValueStorageManager keyValueStorageManager) {
+      this.keyValueStorageManager = keyValueStorageManager;
+   }
+
+   @PostConstruct
+   public void initStorage() {
+      favorites = keyValueStorageManager.getStorage("emFavorites");
+   }
+
+   @PreDestroy
+   public void closeStorage() throws Exception {
+      if(favorites != null) {
+         favorites.close();
+         favorites = null;
+      }
+   }
+
+   /**
+    * Gets the EM favorites for the given identity.
+    *
+    * @param identityKey the identity key (see {@link IdentityID#convertToKey()}).
+    *
+    * @return the favorites, never {@code null}.
+    */
+   public FavoriteList getFavorites(String identityKey) {
+      FavoriteList list = favorites.get(identityKey);
+
+      if(list == null) {
+         list = new FavoriteList();
+         list.setFavorites(Collections.emptyList());
+      }
+
+      return list;
+   }
+
+   /**
+    * Stores the EM favorites for the given identity. An empty list removes the entry.
+    *
+    * @param identityKey   the identity key.
+    * @param userFavorites the favorites to store.
+    */
+   public void setFavorites(String identityKey, FavoriteList userFavorites) {
+      try {
+         if(userFavorites.getFavorites().isEmpty()) {
+            favorites.remove(identityKey).get(10L, TimeUnit.SECONDS);
+         }
+         else {
+            favorites.put(identityKey, userFavorites).get(10L, TimeUnit.SECONDS);
+         }
+      }
+      catch(InterruptedException | ExecutionException | TimeoutException e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   /**
+    * Moves the EM favorites entry from one identity key to another, e.g. when an identity
+    * is renamed or moved to another organization. Does nothing if there is no entry for
+    * {@code fromKey}.
+    *
+    * @param fromKey the source identity key.
+    * @param toKey   the target identity key.
+    */
+   public void moveFavorites(String fromKey, String toKey) {
+      FavoriteList list = favorites.get(fromKey);
+
+      if(list != null) {
+         try {
+            favorites.put(toKey, list).get(10L, TimeUnit.SECONDS);
+            favorites.remove(fromKey).get(10L, TimeUnit.SECONDS);
+         }
+         catch(InterruptedException | ExecutionException | TimeoutException e) {
+            LOG.error("Failed to move favorites from {} to {}", fromKey, toKey, e);
+         }
+      }
+   }
+
+   /**
+    * Removes the EM favorites entries for the given identities, so they are not left
+    * orphaned after the identities are deleted.
+    *
+    * @param identities the identities whose favorites should be removed.
+    */
+   public void removeFavorites(Collection<IdentityID> identities) {
+      if(identities == null || identities.isEmpty()) {
+         return;
+      }
+
+      for(IdentityID id : identities) {
+         if(id != null) {
+            try {
+               favorites.remove(id.convertToKey()).get(10L, TimeUnit.SECONDS);
+            }
+            catch(InterruptedException e) {
+               Thread.currentThread().interrupt();
+               LOG.warn("Interrupted while removing EM favorites for deleted user {}", id, e);
+            }
+            catch(Exception e) {
+               LOG.warn("Failed to remove EM favorites for deleted user {}", id, e);
+            }
+         }
+      }
+   }
+
+   /**
+    * Removes every EM favorites entry belonging to the given organization, so the members'
+    * favorites are not left orphaned after the organization is deleted.
+    *
+    * @param orgID the id of the organization being removed.
+    */
+   public void removeFavorites(String orgID) {
+      Set<String> keys = favorites.keys()
+         .filter(key -> Tool.equals(orgID, IdentityID.getIdentityIDFromKey(key).orgID))
+         .collect(Collectors.toSet());
+
+      if(!keys.isEmpty()) {
+         try {
+            favorites.removeAll(keys).get(10L, TimeUnit.SECONDS);
+         }
+         catch(InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted while removing EM favorites for deleted organization {}", orgID, e);
+         }
+         catch(Exception e) {
+            LOG.warn("Failed to remove EM favorites for deleted organization {}", orgID, e);
+         }
+      }
+   }
+
+   private final KeyValueStorageManager keyValueStorageManager;
+   private KeyValueStorage<FavoriteList> favorites;
+   private static final Logger LOG = LoggerFactory.getLogger(FavoritesService.class);
+}

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -54,7 +54,7 @@ import inetsoft.util.log.LogManager;
 import inetsoft.web.AutoSaveUtils;
 import inetsoft.web.session.IgniteSessionRepository;
 import inetsoft.web.RecycleBin;
-import inetsoft.web.admin.favorites.FavoriteList;
+import inetsoft.web.admin.favorites.FavoritesService;
 import inetsoft.web.admin.security.user.*;
 import org.apache.commons.io.IOUtils;
 import org.passay.*;
@@ -78,7 +78,7 @@ public class IdentityService {
                           IdentityThemeService themeService,
                           AuthenticationService authenticationService,
                           BlobStorageManager blobStorageManager,
-                          KeyValueStorageManager keyValueStorageManager,
+                          FavoritesService favoritesService,
                           Cluster cluster,
                           MVManager mvManager,
                           DataCycleManager dataCycleManager,
@@ -107,7 +107,7 @@ public class IdentityService {
       this.themeService = themeService;
       this.authenticationService = authenticationService;
       this.blobStorageManager = blobStorageManager;
-      this.keyValueStorageManager = keyValueStorageManager;
+      this.favoritesService = favoritesService;
       this.cluster = cluster;
       this.mvManager = mvManager;
       this.dataCycleManager = dataCycleManager;
@@ -628,6 +628,7 @@ public class IdentityService {
                CSSDictionary.resetDictionaryCache();
                themesManager.save();
                removeStorages(orgID);
+               favoritesService.removeFavorites(orgID);
                dataSourceRegistry.clearCache(orgID);
                FSService.clearServerNodeCache(orgID);
                XJobPool.resetOrgCache(orgID);
@@ -771,53 +772,6 @@ public class IdentityService {
       return false;
    }
 
-   public void deleteOrganizationMembers(String orgID, EditableAuthenticationProvider eprovider) {
-      IdentityID[] users = eprovider.getUsers();
-      IdentityID[] groups = eprovider.getGroups();
-      IdentityID[] roles = eprovider.getRoles();
-      KeyValueStorage<FavoriteList> favorites =
-         keyValueStorageManager.getStorage("emFavorites");
-
-      for(int i = 0; i < users.length; i++) {
-         FSUser user = (FSUser) eprovider.getUser(users[i]);
-
-         if(orgID.equals(user.getOrganizationID())) {
-            //users are tied to org, delete if deleted
-            repletRegistryManager.removeUser(user.getIdentityID());
-            eprovider.removeUser(user.getIdentityID());
-            addCopiedIdentityPermission(user.getIdentityID(), null, "", Identity.USER, false);
-
-            try {
-               favorites.remove(user.getIdentityID().convertToKey()).get(10L, TimeUnit.SECONDS);
-            }
-            catch(InterruptedException | ExecutionException | TimeoutException e) {
-               LOG.error("Failed to remove organization member: {}", user, e);
-            }
-         }
-      }
-
-      for(int i = 0; i < groups.length; i++) {
-         FSGroup group = (FSGroup) eprovider.getGroup(groups[i]);
-
-         if(orgID.equals(group.getOrganizationID())) {
-            //group is tied to org, delete if deleted
-            eprovider.removeGroup(group.getIdentityID());
-            addCopiedIdentityPermission(group.getIdentityID(), null,"", Identity.GROUP, false);
-         }
-      }
-
-      for(int i = 0; i < roles.length; i++) {
-         FSRole role = (FSRole) eprovider.getRole(roles[i]);
-
-         if(orgID.equals(role.getOrganizationID())) {
-            //role is tied to org, delete if deleted
-            eprovider.removeRole(role.getIdentityID());
-            addCopiedIdentityPermission(role.getIdentityID(), null, "", Identity.ROLE, false);
-         }
-      }
-
-   }
-
    private void updateOrganizationMembers(Organization identity, List<IdentityModel> memberModels,
                                           String oldOrgID,
                                           EditableAuthenticationProvider eprovider)
@@ -845,8 +799,6 @@ public class IdentityService {
       boolean orgNameChanged = !Tool.equals(orgIdChange, oldOrgID);
 
       AuthorizationChain authoc = ((AuthorizationChain) securityProvider.getAuthorizationProvider());
-      KeyValueStorage<FavoriteList> favorites =
-         keyValueStorageManager.getStorage("emFavorites");
 
       for(int i = 0; i < users.length; i++) {
          FSUser user = (FSUser) eprovider.getUser(users[i]);
@@ -881,18 +833,8 @@ public class IdentityService {
             eprovider.removeUser(oldID);
             repletRegistryManager.renameUser(oldID, user.getIdentityID());
             // Move em favorites to new user
-            FavoriteList userFav = favorites.get(oldID.convertToKey());
-
-            if(userFav != null) {
-               try {
-                  favorites.put(user.getIdentityID().convertToKey(), userFav)
-                     .get(10L, TimeUnit.SECONDS);
-                  favorites.remove(oldID.convertToKey()).get(10L, TimeUnit.SECONDS);
-               }
-               catch(InterruptedException | ExecutionException | TimeoutException e) {
-                  LOG.error("Failed to update organization member: {}", user, e);
-               }
-            }
+            favoritesService.moveFavorites(oldID.convertToKey(),
+                                           user.getIdentityID().convertToKey());
          }
          else if(!members.contains(user.getName())) {
             eprovider.removeUser(oldID);
@@ -2340,7 +2282,7 @@ public class IdentityService {
          return;
       }
 
-      removeUserEMFavorites(identityIDs);
+      favoritesService.removeFavorites(identityIDs);
 
       Map<String, Set<String>> userKeysByOrg = new HashMap<>();
 
@@ -2390,30 +2332,6 @@ public class IdentityService {
          }
       }
    }
-
-   /**
-    * Remove the deleted users' EM admin-panel favorites, which are stored per
-    * identity key in the emFavorites store and would otherwise be orphaned.
-    */
-   private void removeUserEMFavorites(Collection<IdentityID> identityIDs) {
-      KeyValueStorage<FavoriteList> favorites = keyValueStorageManager.getStorage("emFavorites");
-
-      for(IdentityID id : identityIDs) {
-         if(id != null) {
-            try {
-               favorites.remove(id.convertToKey()).get(10L, TimeUnit.SECONDS);
-            }
-            catch(InterruptedException e) {
-               Thread.currentThread().interrupt();
-               LOG.warn("Interrupted while removing EM favorites for deleted user {}", id, e);
-            }
-            catch(Exception e) {
-               LOG.warn("Failed to remove EM favorites for deleted user {}", id, e);
-            }
-         }
-      }
-   }
-
 
    public void updateIdentityPermissions(int type, IdentityID oldName, IdentityID newName, String oldOrgId, String newOrgId, boolean doReplace) {
       SecurityProvider provider = securityEngine.getSecurityProvider();
@@ -2857,7 +2775,7 @@ public class IdentityService {
    private final Logger LOG = LoggerFactory.getLogger(IdentityService.class);
    private final AuthenticationService authenticationService;
    private final BlobStorageManager blobStorageManager;
-   private final KeyValueStorageManager keyValueStorageManager;
+   private final FavoritesService favoritesService;
    private final Cluster cluster;
    private final MVManager mvManager;
    private final DataCycleManager dataCycleManager;

--- a/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
@@ -26,8 +26,6 @@ import inetsoft.sree.portal.CustomTheme;
 import inetsoft.sree.portal.CustomThemesManager;
 import inetsoft.sree.security.*;
 import inetsoft.sree.web.dashboard.DashboardRegistryManager;
-import inetsoft.storage.KeyValueStorage;
-import inetsoft.storage.KeyValueStorageManager;
 import inetsoft.uql.XRepository;
 import inetsoft.uql.asset.sync.DependencyStorageService;
 import inetsoft.uql.asset.sync.DependencyTool;
@@ -37,7 +35,7 @@ import inetsoft.uql.erm.vpm.VirtualPrivateModel;
 import inetsoft.uql.util.Identity;
 import inetsoft.util.*;
 import inetsoft.util.audit.*;
-import inetsoft.web.admin.favorites.FavoriteList;
+import inetsoft.web.admin.favorites.FavoritesService;
 import inetsoft.web.admin.general.LocalizationSettingsService;
 import inetsoft.web.admin.general.model.LocalizationModel;
 import inetsoft.web.admin.security.*;
@@ -62,7 +60,7 @@ public class UserTreeService {
                           SecurityEngine securityEngine,
                           IdentityThemeService themeService,
                           SimpMessagingTemplate messagingTemplate,
-                          KeyValueStorageManager keyValueStorageManager,
+                          FavoritesService favoritesService,
                           DataCycleManager dataCycleManager,
                           LicenseManager licenseManager,
                           MVManager mvManager,
@@ -82,7 +80,7 @@ public class UserTreeService {
       this.customThemesManager = customThemesManager;
       this.dashboardRegistryManager = dashboardRegistryManager;
       this.editOrganizationListener = new EditOrganizationListener(messagingTemplate, securityEngine);
-      this.keyValueStorageManager = keyValueStorageManager;
+      this.favoritesService = favoritesService;
       this.dataCycleManager = dataCycleManager;
       this.licenseManager = licenseManager;
       this.mvManager = mvManager;
@@ -1819,15 +1817,10 @@ public class UserTreeService {
       IndexedStorage storage = indexedStorage;
       MVManager mvManager = this.mvManager;
       DataCycleManager cycleManager = this.dataCycleManager;
-      KeyValueStorage<FavoriteList> favorites =
-         keyValueStorageManager.getStorage("emFavorites");
 
-      if(favorites != null && oldID != null && newID != null &&
-         favorites.contains(oldID.convertToKey()))
-      {
-         FavoriteList favoriteList = favorites.remove(oldID.convertToKey())
-            .get(10L, TimeUnit.SECONDS);
-         favorites.put(newID.convertToKey(), favoriteList).get(10L, TimeUnit.SECONDS);
+      if(oldID != null && newID != null) {
+         // Move em favorites to the renamed user
+         favoritesService.moveFavorites(oldID.convertToKey(), newID.convertToKey());
       }
 
       storage.migrateStorageData(oldID.getName(), newID.getName());
@@ -1928,7 +1921,7 @@ public class UserTreeService {
    private final IdentityThemeService themeService;
    private final SimpMessagingTemplate messagingTemplate;
    private final EditOrganizationListener editOrganizationListener;
-   private final KeyValueStorageManager keyValueStorageManager;
+   private final FavoritesService favoritesService;
    private final DataCycleManager dataCycleManager;
    private final LicenseManager licenseManager;
    private final MVManager mvManager;

--- a/core/src/test/java/inetsoft/sree/security/DashboardRegistryOrgLifecycleTest.java
+++ b/core/src/test/java/inetsoft/sree/security/DashboardRegistryOrgLifecycleTest.java
@@ -50,7 +50,7 @@ import inetsoft.sree.security.support.SecurityTestDataBuilder;
 import inetsoft.sree.web.dashboard.DashboardRegistry;
 import inetsoft.sree.web.dashboard.DashboardRegistryManager;
 import inetsoft.sree.web.dashboard.VSDashboard;
-import inetsoft.storage.KeyValueStorageManager;
+import inetsoft.web.admin.favorites.FavoritesService;
 import inetsoft.test.*;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
@@ -97,8 +97,9 @@ class DashboardRegistryOrgLifecycleTest {
    @Autowired
    private DataSpace dataSpace;
 
-   @Autowired
-   private KeyValueStorageManager keyValueStorageManager;
+   // No-op mock: these tests assert on dashboard-registry behavior, not EM favorites; the
+   // org-delete path only hands favorites cleanup off to this collaborator.
+   private final FavoritesService favoritesService = mock(FavoritesService.class);
 
    private SecurityTestDataBuilder builder;
 
@@ -311,7 +312,7 @@ class DashboardRegistryOrgLifecycleTest {
 
       IdentityService realService = new IdentityService(
          SecurityEngine.getSecurity(), SecurityEngine.getSecurity().getSecurityProvider(),
-         mock(IdentityThemeService.class), null, null, keyValueStorageManager, null, null,
+         mock(IdentityThemeService.class), null, null, favoritesService, null, null,
          mock(DataCycleManager.class), null, mock(LogManager.class), null, null, null,
          Optional.empty(),
          null, mock(CustomThemesManager.class), null,

--- a/core/src/test/java/inetsoft/sree/security/OrgLifecycleScopedPropertiesIntegrationTest.java
+++ b/core/src/test/java/inetsoft/sree/security/OrgLifecycleScopedPropertiesIntegrationTest.java
@@ -64,7 +64,7 @@ import inetsoft.sree.web.dashboard.DashboardRegistryManager;
 import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
-import inetsoft.storage.KeyValueStorageManager;
+import inetsoft.web.admin.favorites.FavoritesService;
 import inetsoft.uql.util.Identity;
 import inetsoft.util.DataSpace;
 import inetsoft.util.ThreadContext;
@@ -96,8 +96,9 @@ import static org.mockito.Mockito.*;
 @Tag("core")
 class OrgLifecycleScopedPropertiesIntegrationTest {
 
-   @Autowired
-   private KeyValueStorageManager keyValueStorageManager;
+   // No-op mock: these tests assert on scoped properties, not EM favorites; the org-delete
+   // path only hands favorites cleanup off to this collaborator.
+   private final FavoritesService favoritesService = mock(FavoritesService.class);
 
    @Autowired
    private DataSpace dataSpace;
@@ -205,7 +206,7 @@ class OrgLifecycleScopedPropertiesIntegrationTest {
 
       IdentityService realService = new IdentityService(
          SecurityEngine.getSecurity(), SecurityEngine.getSecurity().getSecurityProvider(),
-         mock(IdentityThemeService.class), null, null, keyValueStorageManager, null, null,
+         mock(IdentityThemeService.class), null, null, favoritesService, null, null,
          mock(DataCycleManager.class), null, mock(LogManager.class), null, null, null,
          Optional.empty(),
          null, mock(CustomThemesManager.class), null,

--- a/core/src/test/java/inetsoft/sree/security/PermissionMatrixOrgLifecycleTest.java
+++ b/core/src/test/java/inetsoft/sree/security/PermissionMatrixOrgLifecycleTest.java
@@ -56,8 +56,7 @@ import inetsoft.sree.internal.cluster.DistributedMap;
 import inetsoft.sree.internal.cluster.MockCluster;
 import inetsoft.sree.security.support.SecurityTestDataBuilder;
 import inetsoft.sree.web.dashboard.DashboardRegistryManager;
-import inetsoft.storage.KeyValueStorage;
-import inetsoft.storage.KeyValueStorageManager;
+import inetsoft.web.admin.favorites.FavoritesService;
 import inetsoft.test.*;
 import inetsoft.uql.util.Identity;
 import inetsoft.util.Catalog;
@@ -678,17 +677,16 @@ public class PermissionMatrixOrgLifecycleTest {
                     .anyMatch(id -> id.name.equals("alice")),
                 "precondition: alice must be a READ grantee at the source org before the rename");
 
-      // Collaborators unrelated to permission re-scoping (see method comment): favorites storage
-      // returns null so the em-favorites move is skipped; the two registry managers are no-op.
-      KeyValueStorageManager keyValueStorageManager = mock(KeyValueStorageManager.class);
-      when(keyValueStorageManager.getStorage("emFavorites"))
-         .thenReturn(mock(KeyValueStorage.class));
+      // Collaborators unrelated to permission re-scoping (see method comment): the favorites
+      // service is a no-op mock so the em-favorites move is skipped; the two registry managers
+      // are no-op.
+      FavoritesService favoritesService = mock(FavoritesService.class);
       RepletRegistryManager repletRegistryManager = mock(RepletRegistryManager.class);
       DashboardRegistryManager dashboardRegistryManager = mock(DashboardRegistryManager.class);
 
       IdentityService identityService = new IdentityService(
          SecurityEngine.getSecurity(), SecurityEngine.getSecurity().getSecurityProvider(),
-         null, null, null, keyValueStorageManager, null, null, null, null,
+         null, null, null, favoritesService, null, null, null, null,
          null, null, null, null, Optional.empty(), null, null, null,
          dashboardRegistryManager, null, null, null, null, null, null, null, null,
          repletRegistryManager, Optional.empty());

--- a/core/src/test/java/inetsoft/web/admin/favorites/FavoritesServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/favorites/FavoritesServiceTest.java
@@ -1,0 +1,211 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.favorites;
+
+import inetsoft.sree.security.IdentityID;
+import inetsoft.storage.KeyValueStorage;
+import inetsoft.storage.KeyValueStorageManager;
+import org.junit.jupiter.api.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Covers {@link FavoritesService}, which owns the emFavorites key-value store and is the
+ * single point of access to EM favorites.
+ */
+@Tag("core")
+class FavoritesServiceTest {
+   @SuppressWarnings("unchecked")
+   private final KeyValueStorage<FavoriteList> storage = mock(KeyValueStorage.class);
+   private FavoritesService service;
+
+   @BeforeEach
+   void setUp() {
+      KeyValueStorageManager manager = mock(KeyValueStorageManager.class);
+      doReturn(storage).when(manager).getStorage("emFavorites");
+      lenient().when(storage.put(anyString(), any())).thenReturn(completed(null));
+      lenient().when(storage.remove(anyString())).thenReturn(completed(null));
+      // removeAll returns Future<?> (wildcard), so doReturn avoids the generic-capture mismatch
+      lenient().doReturn(completed(null)).when(storage).removeAll(anySet());
+
+      service = new FavoritesService(manager);
+      service.initStorage();
+   }
+
+   @Test
+   void getFavorites_missingEntry_returnsEmptyList() {
+      when(storage.get("alice~;~org1")).thenReturn(null);
+
+      FavoriteList list = service.getFavorites("alice~;~org1");
+
+      assertNotNull(list, "must never return null");
+      assertTrue(list.getFavorites().isEmpty(), "missing entry should yield an empty list");
+   }
+
+   @Test
+   void getFavorites_existingEntry_returnsStoredList() {
+      FavoriteList stored = listOf(favorite("Users", "/settings/security/users"));
+      when(storage.get("alice~;~org1")).thenReturn(stored);
+
+      assertSame(stored, service.getFavorites("alice~;~org1"));
+   }
+
+   @Test
+   void setFavorites_nonEmpty_putsEntry() {
+      FavoriteList list = listOf(favorite("Users", "/settings/security/users"));
+
+      service.setFavorites("alice~;~org1", list);
+
+      verify(storage).put("alice~;~org1", list);
+      verify(storage, never()).remove(anyString());
+   }
+
+   @Test
+   void setFavorites_empty_removesEntry() {
+      service.setFavorites("alice~;~org1", listOf());
+
+      verify(storage).remove("alice~;~org1");
+      verify(storage, never()).put(anyString(), any());
+   }
+
+   @Test
+   void setFavorites_storageFailure_throws() throws Exception {
+      when(storage.put(anyString(), any())).thenReturn(failing());
+
+      assertThrows(RuntimeException.class,
+                   () -> service.setFavorites("alice~;~org1",
+                                              listOf(favorite("Users", "/settings/security/users"))));
+   }
+
+   @Test
+   void moveFavorites_presentEntry_movesToNewKey() {
+      FavoriteList list = listOf(favorite("Users", "/settings/security/users"));
+      when(storage.get("alice~;~org1")).thenReturn(list);
+
+      service.moveFavorites("alice~;~org1", "alice~;~org2");
+
+      verify(storage).put("alice~;~org2", list);
+      verify(storage).remove("alice~;~org1");
+   }
+
+   @Test
+   void moveFavorites_noEntry_doesNothing() {
+      when(storage.get("alice~;~org1")).thenReturn(null);
+
+      service.moveFavorites("alice~;~org1", "alice~;~org2");
+
+      verify(storage, never()).put(anyString(), any());
+      verify(storage, never()).remove(anyString());
+   }
+
+   @Test
+   void moveFavorites_storageFailure_doesNotThrow() throws Exception {
+      when(storage.get("alice~;~org1"))
+         .thenReturn(listOf(favorite("Users", "/settings/security/users")));
+      when(storage.put(anyString(), any())).thenReturn(failing());
+
+      assertDoesNotThrow(() -> service.moveFavorites("alice~;~org1", "alice~;~org2"));
+   }
+
+   @Test
+   void removeFavorites_identities_removesEachKey() {
+      IdentityID alice = new IdentityID("alice", "org1");
+      IdentityID bob = new IdentityID("bob", "org2");
+
+      service.removeFavorites(List.of(alice, bob));
+
+      verify(storage).remove(alice.convertToKey());
+      verify(storage).remove(bob.convertToKey());
+   }
+
+   @Test
+   void removeFavorites_identities_emptyOrNull_noStorageAccess() {
+      service.removeFavorites((Collection<IdentityID>) null);
+      service.removeFavorites(Collections.emptyList());
+
+      verify(storage, never()).remove(anyString());
+   }
+
+   @Test
+   void removeFavorites_identities_storageFailure_doesNotThrow() throws Exception {
+      when(storage.remove(anyString())).thenReturn(failing());
+
+      assertDoesNotThrow(() -> service.removeFavorites(List.of(new IdentityID("alice", "org1"))));
+   }
+
+   @Test
+   void removeFavorites_org_removesOnlyMatchingOrgKeys() {
+      IdentityID alice = new IdentityID("alice", "org1");
+      IdentityID bob = new IdentityID("bob", "org1");
+      IdentityID carol = new IdentityID("carol", "org2");
+      when(storage.keys()).thenReturn(
+         Stream.of(alice.convertToKey(), bob.convertToKey(), carol.convertToKey()));
+
+      service.removeFavorites("org1");
+
+      verify(storage).removeAll(Set.of(alice.convertToKey(), bob.convertToKey()));
+   }
+
+   @Test
+   void removeFavorites_org_noMatchingKeys_noRemoval() {
+      when(storage.keys()).thenReturn(Stream.of(new IdentityID("carol", "org2").convertToKey()));
+
+      service.removeFavorites("org1");
+
+      verify(storage, never()).removeAll(anySet());
+   }
+
+   @Test
+   void removeFavorites_org_storageFailure_doesNotThrow() throws Exception {
+      when(storage.keys()).thenReturn(Stream.of(new IdentityID("alice", "org1").convertToKey()));
+      doReturn(failing()).when(storage).removeAll(anySet());
+
+      assertDoesNotThrow(() -> service.removeFavorites("org1"));
+   }
+
+   private static CompletableFuture<FavoriteList> completed(FavoriteList value) {
+      return CompletableFuture.completedFuture(value);
+   }
+
+   private static Future<FavoriteList> failing() {
+      // A future whose get(...) throws ExecutionException, mirroring a failed storage op.
+      // Built as a real completed future (not a Mockito mock) so it can be passed inline to
+      // when(...).thenReturn(...) without tripping Mockito's unfinished-stubbing detection.
+      CompletableFuture<FavoriteList> future = new CompletableFuture<>();
+      future.completeExceptionally(new RuntimeException("boom"));
+      return future;
+   }
+
+   private static FavoriteList listOf(Favorite... favorites) {
+      FavoriteList list = new FavoriteList();
+      list.setFavorites(new ArrayList<>(Arrays.asList(favorites)));
+      return list;
+   }
+
+   private static Favorite favorite(String label, String path) {
+      Favorite favorite = new Favorite();
+      favorite.setLabel(label);
+      favorite.setPath(path);
+      return favorite;
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/security/IdentityServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/security/IdentityServiceTest.java
@@ -22,50 +22,43 @@ import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.IdentityInfo;
 import inetsoft.sree.security.OrganizationContextHolder;
 import inetsoft.uql.util.Identity;
-import inetsoft.storage.KeyValueStorage;
-import inetsoft.storage.KeyValueStorageManager;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.asset.internal.AssetFolder;
 import inetsoft.util.IndexedStorage;
+import inetsoft.web.admin.favorites.FavoritesService;
 import org.junit.jupiter.api.*;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Method;
 import java.util.*;
-import java.util.concurrent.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
- * Covers the orphaned-favorites cleanup that runs during user deletion:
- * removeUserFavorites (asset favorites in IndexedStorage) and removeUserEMFavorites
- * (EM admin-panel favorites in the emFavorites KeyValueStorage).
+ * Covers the orphaned-favorites cleanup that runs during user deletion: removeUserFavorites
+ * strips deleted users from shared-asset favorites lists (IndexedStorage) and delegates the
+ * EM admin-panel favorites cleanup to {@link FavoritesService}.
  *
- * The service is created without invoking its constructor and only the two storage
- * dependencies these methods touch are injected, so the tests stay decoupled from
- * the rest of the service's wiring.
+ * The service is created without invoking its constructor and only the dependencies these
+ * methods touch are injected, so the tests stay decoupled from the rest of the service's
+ * wiring.
  */
 @Tag("core")
 class IdentityServiceTest {
    private IndexedStorage indexedStorage;
-   private KeyValueStorageManager keyValueStorageManager;
-   private KeyValueStorage<?> emFavorites;
+   private FavoritesService favoritesService;
    private IdentityService service;
 
    @BeforeEach
    void setUp() {
       indexedStorage = mock(IndexedStorage.class);
-      keyValueStorageManager = mock(KeyValueStorageManager.class);
-      emFavorites = mock(KeyValueStorage.class);
-
-      doReturn(emFavorites).when(keyValueStorageManager).getStorage("emFavorites");
-      doReturn(CompletableFuture.completedFuture(null)).when(emFavorites).remove(anyString());
+      favoritesService = mock(FavoritesService.class);
 
       service = mock(IdentityService.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
       ReflectionTestUtils.setField(service, "indexedStorage", indexedStorage);
-      ReflectionTestUtils.setField(service, "keyValueStorageManager", keyValueStorageManager);
+      ReflectionTestUtils.setField(service, "favoritesService", favoritesService);
       // LOG is a final instance field set by the constructor, which the mock bypasses
       ReflectionTestUtils.setField(service, "LOG",
                                    org.slf4j.LoggerFactory.getLogger(IdentityService.class));
@@ -76,7 +69,7 @@ class IdentityServiceTest {
       invokeRemoveUserFavorites(Collections.emptyList());
 
       verifyNoInteractions(indexedStorage);
-      verifyNoInteractions(keyValueStorageManager);
+      verifyNoInteractions(favoritesService);
    }
 
    @Test
@@ -151,35 +144,27 @@ class IdentityServiceTest {
    }
 
    @Test
+   void removeUserFavorites_delegatesEMFavoritesRemovalToService() throws Exception {
+      IdentityID alice = new IdentityID("alice", "org1");
+      IdentityID bob = new IdentityID("bob", "org2");
+      List<IdentityID> ids = List.of(alice, bob);
+
+      invokeRemoveUserFavorites(ids);
+
+      // the EM favorites cleanup is delegated wholesale to the favorites service
+      verify(favoritesService).removeFavorites(ids);
+   }
+
+   @Test
    void removeUserFavorites_nullOrgUser_skipsAssetScan() throws Exception {
       IdentityID noOrg = new IdentityID("legacy", null);
 
       invokeRemoveUserFavorites(List.of(noOrg));
 
+      // a null-org user has no org-scoped folders to scan
       verify(indexedStorage, never()).getKeys(any(), any());
-      verify(emFavorites).remove(noOrg.convertToKey());
-   }
-
-   @Test
-   void removeUserEMFavorites_removesEachUserKey() throws Exception {
-      IdentityID alice = new IdentityID("alice", "org1");
-      IdentityID bob = new IdentityID("bob", "org2");
-
-      invokeRemoveUserEMFavorites(List.of(alice, bob));
-
-      verify(emFavorites).remove(alice.convertToKey());
-      verify(emFavorites).remove(bob.convertToKey());
-   }
-
-   @Test
-   void removeUserEMFavorites_storageFailure_doesNotThrow() throws Exception {
-      IdentityID alice = new IdentityID("alice", "org1");
-      Future<?> failing = mock(Future.class);
-      when(failing.get(anyLong(), any()))
-         .thenThrow(new ExecutionException(new RuntimeException("boom")));
-      doReturn(failing).when(emFavorites).remove(anyString());
-
-      assertDoesNotThrow(() -> invokeRemoveUserEMFavorites(List.of(alice)));
+      // but its EM favorites are still handed to the service for cleanup
+      verify(favoritesService).removeFavorites(List.of(noOrg));
    }
 
    @Test
@@ -206,12 +191,6 @@ class IdentityServiceTest {
 
    private void invokeRemoveUserFavorites(Collection<IdentityID> ids) throws Exception {
       Method m = IdentityService.class.getDeclaredMethod("removeUserFavorites", Collection.class);
-      m.setAccessible(true);
-      m.invoke(service, ids);
-   }
-
-   private void invokeRemoveUserEMFavorites(Collection<IdentityID> ids) throws Exception {
-      Method m = IdentityService.class.getDeclaredMethod("removeUserEMFavorites", Collection.class);
       m.setAccessible(true);
       m.invoke(service, ids);
    }


### PR DESCRIPTION
## Summary

EM homepage favorites are stored in a single install-wide `emFavorites` KeyValueStorage, keyed per user by identity string (`name~;~orgId`). When an organization was deleted, its members' favorites entries were never removed, so they remained as orphaned storage forever.

## Root Cause

The organization-delete flow (`IdentityService.setIdentity(...)`, the `Identity.ORGANIZATION` / `oID == null` branch) removes the org's member identities and its org-scoped storages via `removeStorages(orgID)`, but `emFavorites` is an install-wide bucket that `removeStorages` never touches. A method that would have done this (`IdentityService.deleteOrganizationMembers`) existed but had zero call sites — dead code.

## Fix

Encapsulate all access to the `emFavorites` store behind a new `FavoritesService` (@Service). `removeFavorites(String orgID)` removes every entry whose parsed key orgID matches the deleted org, and is invoked from the org-delete branch alongside `removeStorages`. `FavoritesController`, `IdentityService`, and `UserTreeService` now delegate to the service. Removed the dead `deleteOrganizationMembers` method and the redundant `removeUserEMFavorites` helper.

## Test Plan

1. Create an org + user, add an EM favorite, confirm the `user~;~orgId` entry exists.
2. Delete the org; confirm the entry is gone (previously survived).
3. Regression: org/user rename still migrates the entry; user delete still removes it.
4. New `FavoritesServiceTest` (14 tests) + updated `IdentityServiceTest` + org-lifecycle integration tests pass.

Fixes Redmine #75766.