### PR TITLE
Bug #75750, fix wrong border color painted on interior calc table/crosstab export row

### DIFF
--- a/core/src/main/java/inetsoft/report/io/viewsheet/VSCrosstabHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/VSCrosstabHelper.java
@@ -206,12 +206,13 @@ public abstract class VSCrosstabHelper extends VSTableDataHelper {
          return totalHeight;
       }
 
-      int infoRows = (int) Math.round((double) (info.getPixelSize().height -
-                                                info.getTitleHeight()) / AssetUtil.defh);
       int infoCols = (int) Math.round((double) info.getPixelSize().width / AssetUtil.defw);
 
-      boolean bottom = (span == null) ? irow == infoRows - 1
-         : (irow + span.height - 1 == infoRows - 1);
+      // compare real accumulated row height against the real table body height to find the
+      // last visible row; rows may not be the default height (AssetUtil.defh), so estimating
+      // the row count from pixel-height/defh (as done for infoCols below) can point at the
+      // wrong row and paint the widget's outer border color onto an interior row.
+      boolean bottom = totalHeight >= height - 0.01;
       boolean right = (span == null) ? icol == lens.getColCount() - 1
          : (icol + span.width == lens.getColCount());
 
@@ -219,11 +220,6 @@ public abstract class VSCrosstabHelper extends VSTableDataHelper {
          if(lens.getColCount() < infoCols) {
             right = (span == null) ? icol == lens.getColCount() - 1
                : (icol + span.width == lens.getColCount());
-         }
-
-         if(lens.getRowCount() < infoRows) {
-            bottom = (span == null) ? irow == lens.getRowCount() - 1
-               : (irow + span.height == lens.getRowCount());
          }
       }
 


### PR DESCRIPTION
## Summary
- Exporting a viewsheet containing a Freehand/Calc table (or Crosstab) to PDF/PNG/Excel/etc. could paint the table style's outer/trailer border color onto an interior data row instead of only the true last row, because `VSCrosstabHelper.writeTableDataCell()` estimated the last-visible-row index from `pixelHeight / defaultRowHeight` rather than the real accumulated row height. Rows with non-default heights caused the estimate to diverge from the actual last row.
- Replaced the estimate with a comparison of the already-tracked real accumulated row/span height against the real available table body height, which correctly identifies the true last row regardless of per-row height variance. Removed the now-redundant `isShrink()` special case that existed to patch this same estimate for a subset of cases.

## Test plan
- [x] `core` module compiles (`mvnw -pl core -am compile`)
- [x] Reproduced with the reporter's asset (Freehand table using the "Blue~Dark Header Borders" table style): before the fix, export showed the dark outer border duplicated on an interior row in addition to the true last row; after the fix, only the true last row gets the outer border color, matching the live portal viewer.