### PR TITLE
Bug #75750, clear saving indicator when composer save fails with a warning-level message

### DIFF
--- a/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.ts
@@ -1331,7 +1331,7 @@ export class VSPane extends CommandProcessor implements OnInit, OnDestroy, After
          this.notifications.info(command.message);
       }
       else {
-         if(command.type === "ERROR") {
+         if(command.type === "ERROR" || command.type === "WARNING") {
             this.vs.saving = false;
          }
 

--- a/web/projects/portal/src/app/composer/gui/ws/editor/ws-pane.component.risk.tl.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/ws/editor/ws-pane.component.risk.tl.spec.ts
@@ -193,7 +193,7 @@ describe("WSPaneComponent — processMessageCommand routing", () => {
       expect(comp.worksheet.saving).toBe(false);
    });
 
-   it("should NOT clear worksheet.saving for type=WARNING", async () => {
+   it("should set worksheet.saving=false for type=WARNING before showing modal", async () => {
       const { comp } = await renderComponent();
       comp.worksheet.saving = true;
 
@@ -201,7 +201,7 @@ describe("WSPaneComponent — processMessageCommand routing", () => {
          (comp as any).processMessageCommand({ type: "WARNING", message: "warn" });
       } catch { /* processMessageCommand0 may throw in test env — we only care about saving */ }
 
-      expect(comp.worksheet.saving).toBe(true);
+      expect(comp.worksheet.saving).toBe(false);
    });
 });
 

--- a/web/projects/portal/src/app/composer/gui/ws/editor/ws-pane.component.ts
+++ b/web/projects/portal/src/app/composer/gui/ws/editor/ws-pane.component.ts
@@ -1016,6 +1016,7 @@ export class WSPaneComponent extends CommandProcessor implements OnDestroy, OnIn
             this.notifications.info(command.message);
             break;
          case "WARNING":
+            this.worksheet.saving = false;
             this.processMessageCommand0(command, this.modalService, this.worksheetClient);
             break;
          case "ERROR":


### PR DESCRIPTION
## Summary
- `MessageException` defaults to `MessageCommand.WARNING`, but the composer save handlers (`viewsheet-pane.component.ts`, `ws-pane.component.ts`) only cleared the `saving` flag on `ERROR`, so a denied save (e.g. saving a globally-visible Default Organization dashboard as a non-default-org user) left the "Saving" indicator spinning forever, even after a page refresh.
- Clear `saving`/`vs.saving` for the `WARNING` case as well, matching the existing `ERROR` handling, since a WARNING message dialog is equally terminal (OK-only, no retry).
- Updated a pre-existing test that had pinned the old (buggy) behavior as expected.

## Test plan
- [x] `npm run test:portal:tl` — verified the previously bug-pinning test now asserts the corrected behavior and passes; no new regressions vs. baseline
- [ ] Manual repro: enable `security.exposedefaultorgtoall=true`, create org0/user0 (org admin), log in as user0, open Host org's Examples/Census in composer, attempt save — confirm "Saving" indicator clears immediately after the Warning dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)