### PR TITLE
feat(wiz): native adaptive dashboard layouts via ViewsheetLayout/DeviceRegistry

### DIFF
--- a/core/src/main/java/inetsoft/analytic/composition/ViewsheetEngine.java
+++ b/core/src/main/java/inetsoft/analytic/composition/ViewsheetEngine.java
@@ -130,6 +130,7 @@ public class ViewsheetEngine extends WorksheetEngine implements ViewsheetService
 
                vsLayout = layoutInfo.matchDPI(dpi, vsLayout);
                viewsheet = vsLayout.apply(viewsheet);
+               enforceWizFixedSizeLayout(viewsheet);
             }
          }
 
@@ -145,6 +146,23 @@ public class ViewsheetEngine extends WorksheetEngine implements ViewsheetService
       }
 
       return super.createRuntimeSheet(entry, sheet, user);
+   }
+
+   /**
+    * ViewsheetLayout.parseAttributes() hardcodes scaleToScreen/fitToWidth back to
+    * true on every reload (a deliberate, documented product decision for ordinary
+    * device-based layouts - see the comment there). Wiz-composed board dashboards
+    * rely on a fixed-size, internally-scrollable chart tile instead, so re-force
+    * both flags off for those specifically, without touching the shared
+    * ViewsheetLayout parsing behavior everyone else uses.
+    */
+   static void enforceWizFixedSizeLayout(Viewsheet viewsheet) {
+      Viewsheet.WizInfo wizInfo = viewsheet.getWizInfo();
+
+      if(wizInfo != null && wizInfo.isWizSheet() && viewsheet.getViewsheetInfo() != null) {
+         viewsheet.getViewsheetInfo().setScaleToScreen(false);
+         viewsheet.getViewsheetInfo().setFitToWidth(false);
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/AddVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/AddVisualizationService.java
@@ -49,6 +49,12 @@ import java.util.List;
 @ClusterProxy
 public class AddVisualizationService {
 
+   /** Result of merging one visualization into the dashboard. {@code assemblyName} is the
+    *  merged chart's own name within the dashboard Viewsheet (used to build per-tier adaptive
+    *  layouts). {@code tableName} is the merged chart's own bound table name (used to scope
+    *  per-chart filters) -- {@code null} if the merged assembly isn't a {@link ChartVSAssembly}. */
+   public record MergedVisualizationInfo(String assemblyName, String tableName) {}
+
    public AddVisualizationService(ViewsheetService viewsheetService,
                                   AssetRepository assetRepository,
                                   WsMergeService wsMergeService,
@@ -74,11 +80,11 @@ public class AddVisualizationService {
     *                  whatever size it was saved at (the drag-and-drop composer path never
     *                  resizes).
     * @param principal the current user.
-    * @return the merged chart's own bound table name, or {@code null} if the merged assembly is
-    *         not a {@link ChartVSAssembly} or has no table name.
+    * @return the merged chart's own assembly name and bound table name (see
+    *         {@link MergedVisualizationInfo}).
     */
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
-   public String addVisualization(@ClusterProxyKey String runtimeId,
+   public MergedVisualizationInfo addVisualization(@ClusterProxyKey String runtimeId,
                                   AssetEntry vizEntry,
                                   int xOffset, int yOffset, float scale,
                                   Dimension pixelSize,
@@ -88,7 +94,7 @@ public class AddVisualizationService {
       return doAddVisualization(runtimeId, vizEntry, xOffset, yOffset, scale, pixelSize, principal);
    }
 
-   private String doAddVisualization(String runtimeId,
+   private MergedVisualizationInfo doAddVisualization(String runtimeId,
                                      AssetEntry vizEntry,
                                      int xOffset, int yOffset, float scale,
                                      Dimension pixelSize,
@@ -216,12 +222,12 @@ public class AddVisualizationService {
       dashVS.repopulateWorksheet(assetRepository, principal);
 
       // Step 2: merge viewsheet assemblies
-      String mergedTableName = mergeViewsheet(rvs, vizVS, dashVS, wsRenameMap, xOffset, yOffset, scale, pixelSize);
+      MergedVisualizationInfo mergedInfo = mergeViewsheet(rvs, vizVS, dashVS, wsRenameMap, xOffset, yOffset, scale, pixelSize);
 
       // Step 3: record merged visualization
       wizInfo.addMergedVisualization(vizEntry.toIdentifier());
 
-      return mergedTableName;
+      return mergedInfo;
    }
 
    // ---------------------------------------------------------------------------
@@ -233,13 +239,14 @@ public class AddVisualizationService {
     * resolution, WS binding renames, and drop-position offsets.
     */
    /**
-    * @return the merged chart's own bound table name (see {@link ChartVSAssembly#getTableName()}),
-    *         or {@code null} if the visualization's single assembly isn't a chart or has no
-    *         table name. A saved visualization is always a single-assembly Viewsheet (see
-    *         WizVisualizationService's "Build new single-assembly ViewSheet" step), so at most
-    *         one cloned assembly in this method's loop is ever a chart.
+    * @return the merged chart's own assembly name and bound table name (see
+    *         {@link MergedVisualizationInfo}); {@code tableName} is {@code null} if the
+    *         visualization's single assembly isn't a chart or has no table name. A saved
+    *         visualization is always a single-assembly Viewsheet (see WizVisualizationService's
+    *         "Build new single-assembly ViewSheet" step), so at most one cloned assembly in this
+    *         method's loop is ever a chart.
     */
-   private String mergeViewsheet(RuntimeViewsheet rvs, Viewsheet vizVS, Viewsheet dashVS,
+   private MergedVisualizationInfo mergeViewsheet(RuntimeViewsheet rvs, Viewsheet vizVS, Viewsheet dashVS,
                                  Map<String, String> wsRenameMap,
                                  int xOffset, int yOffset, float scale,
                                  Dimension pixelSize)
@@ -293,6 +300,7 @@ public class AddVisualizationService {
       }
 
       String mergedTableName = null;
+      String mergedAssemblyName = null;
 
       // Pass 2: patch references, apply offset, and add to dashVS
       for(VSAssembly cloned : clones) {
@@ -326,13 +334,14 @@ public class AddVisualizationService {
          // graph entry. Mirrors the same clearGraph-after-in-place-mutation pattern used by
          // WizAutoBindingService/WizVsService for other runtime mutations.
          rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(cloned.getName()));
+         mergedAssemblyName = cloned.getName();
 
          if(cloned instanceof ChartVSAssembly chart) {
             mergedTableName = chart.getTableName();
          }
       }
 
-      return mergedTableName;
+      return new MergedVisualizationInfo(mergedAssemblyName, mergedTableName);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -108,7 +108,20 @@ import java.util.List;
 @Component
 public class WizDashboardFilterBuilder {
    public record FilterRequest(String field, String dataType, String label) {}
-   public record FilterResult(List<String> applied, List<String> skipped) {}
+
+   public record FilterResult(List<String> applied, List<String> skipped,
+                               List<FilterControlPlacement> placements) {
+      /** Compatibility constructor for existing callers/tests that only care about
+       *  applied/skipped (e.g. {@code WizDashboardServiceGridTest}'s
+       *  {@code applyFiltersMapsSpecsToFilterRequestsAndReturnsBuilderResult}, which constructs
+       *  a {@code FilterResult} directly as its mocked return value) -- defaults
+       *  {@code placements} to empty rather than requiring every such call site to be touched. */
+      public FilterResult(List<String> applied, List<String> skipped) {
+         this(applied, skipped, List.of());
+      }
+   }
+
+   public record FilterControlPlacement(String assemblyName, java.awt.Point position, java.awt.Dimension size) {}
 
    /**
     * Builds one selection control per request, binds it to each merged chart's own final bound
@@ -134,6 +147,7 @@ public class WizDashboardFilterBuilder {
    public FilterResult build(Viewsheet vs, Worksheet baseWorksheet, List<FilterRequest> requests) {
       List<String> applied = new ArrayList<>();
       List<String> skipped = new ArrayList<>();
+      List<FilterControlPlacement> placements = new ArrayList<>();
       int x = FILTER_BAR_X;
       int y = FILTER_BAR_Y;
       List<String> chartTableNames = mergedChartTableNames(vs);
@@ -154,19 +168,22 @@ public class WizDashboardFilterBuilder {
             titled.setTitleValue(req.label());
          }
 
+         Point pos = new Point(x, y);
+         java.awt.Dimension size = new java.awt.Dimension(FILTER_CONTROL_WIDTH, FILTER_CONTROL_HEIGHT);
          control.setTableNames(tables);
-         control.setPixelOffset(new Point(x, y));
+         control.setPixelOffset(pos);
          // Explicit compact size: SelectionList/TimeSlider's own default pixel size is not
          // reliably short, and WizDashboardService reserves only FILTER_BAR_ROW_HEIGHT (120px)
          // above the charts -- an oversized control here would visually collide with the first
          // chart row instead of leaving the intended small gap.
-         control.setPixelSize(new java.awt.Dimension(FILTER_CONTROL_WIDTH, FILTER_CONTROL_HEIGHT));
+         control.setPixelSize(size);
          vs.addAssembly(control);
          applied.add(req.field());
+         placements.add(new FilterControlPlacement(control.getName(), pos, size));
          x += FILTER_CONTROL_WIDTH;
       }
 
-      return new FilterResult(applied, skipped);
+      return new FilterResult(applied, skipped, placements);
    }
 
    /**
@@ -175,17 +192,18 @@ public class WizDashboardFilterBuilder {
     * no multi-table candidate search — the single {@code chartTableName} IS the candidate, so
     * binding is unambiguous by construction (no residual name-collision risk across charts).
     *
-    * @return {@code true} if the field was found on the chart's table and a control was added,
-    *         {@code false} if skipped (field not present on this chart's own table).
+    * @return the placement (assembly name/position/size) of the created control, if the field
+    *         was found on the chart's table and a control was added; {@code null} if skipped
+    *         (field not present on this chart's own table).
     */
-   public boolean buildPerChart(Viewsheet vs, Worksheet baseWorksheet, int x, int y,
-                                 FilterRequest request, String chartTableName)
+   public FilterControlPlacement buildPerChart(Viewsheet vs, Worksheet baseWorksheet, int x, int y,
+                                                FilterRequest request, String chartTableName)
    {
       List<String> tables = AddFilterService.findColumnMatchingChartTables(
          baseWorksheet, List.of(chartTableName), request.field());
 
       if(tables.isEmpty()) {
-         return false;
+         return null;
       }
 
       ColumnRef colRef = AddFilterService.buildColumnRef(request.field(), request.dataType());
@@ -195,11 +213,13 @@ public class WizDashboardFilterBuilder {
          titled.setTitleValue(request.label());
       }
 
+      Point pos = new Point(x, y);
+      java.awt.Dimension size = new java.awt.Dimension(FILTER_CONTROL_WIDTH, FILTER_CONTROL_HEIGHT);
       control.setTableNames(tables);
-      control.setPixelOffset(new Point(x, y));
-      control.setPixelSize(new java.awt.Dimension(FILTER_CONTROL_WIDTH, FILTER_CONTROL_HEIGHT));
+      control.setPixelOffset(pos);
+      control.setPixelSize(size);
       vs.addAssembly(control);
-      return true;
+      return new FilterControlPlacement(control.getName(), pos, size);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -202,6 +202,7 @@ public class WizDashboardService {
          // name. Both are looked up after this loop when placing per-chart filters.
          java.util.Map<String, java.awt.Rectangle> tileBounds = new java.util.HashMap<>();
          java.util.Map<String, String> identifierToTableName = new java.util.HashMap<>();
+         java.util.Map<String, String> identifierToAssemblyName = new java.util.HashMap<>();
 
          int cumulativeY = topOffset;   // stack path only
 
@@ -243,7 +244,7 @@ public class WizDashboardService {
             java.awt.Dimension pixelSize = grid ? tilePixelSize(spans[i], rowSpans[i]) : null;
 
             try {
-               String mergedTableName = addVisualizationService.addVisualization(
+               AddVisualizationService.MergedVisualizationInfo mergedInfo = addVisualizationService.addVisualization(
                   runtimeId, entries.get(i), x, y, 1.0f, pixelSize, principal);
 
                if(grid) {
@@ -251,8 +252,12 @@ public class WizDashboardService {
                   tileBounds.put(identifiers.get(i),
                      new java.awt.Rectangle(x, tileTopY, pixelSize.width, tileHeight));
 
-                  if(mergedTableName != null) {
-                     identifierToTableName.put(identifiers.get(i), mergedTableName);
+                  if(mergedInfo.tableName() != null) {
+                     identifierToTableName.put(identifiers.get(i), mergedInfo.tableName());
+                  }
+
+                  if(mergedInfo.assemblyName() != null) {
+                     identifierToAssemblyName.put(identifiers.get(i), mergedInfo.assemblyName());
                   }
                }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -214,6 +214,10 @@ public class WizDashboardService {
 
          for(int i = 0; i < entries.size(); i++) {
             int x, y, tileTopY;
+            // Declared here (rather than inside the `if(grid)` block below) so it's also in
+            // scope for the pixelSize computation further down, which needs placement.width()/
+            // height() regardless of which branch set x/y/tileTopY.
+            TilePlacement placement = grid ? placements.get(i) : null;
 
             if(grid) {
                // tiles[] and identifiers[] are consumed purely positionally below (spans[i]
@@ -228,7 +232,6 @@ public class WizDashboardService {
                      "in the same order as identifiers");
                }
 
-               TilePlacement placement = placements.get(i);
                x = placement.x() + CANVAS_MARGIN;
                tileTopY = placement.y() + topOffset + CANVAS_MARGIN;
                // The chart itself starts BELOW the reserved filter strip, if this tile has one --
@@ -247,7 +250,14 @@ public class WizDashboardService {
             // otherwise a tile's computed (spanCols, spanRows) only ever reserved grid drop-
             // position spacing and never resized the chart itself. The stack path has no
             // per-visualization span data, so it passes null and preserves the chart's saved size.
-            java.awt.Dimension pixelSize = grid ? tilePixelSize(spans[i], rowSpans[i]) : null;
+            // placement.height() includes the +PER_CHART_FILTER_ROW_HEIGHT reservation (and any
+            // stretch growth) -- subtract the filter reservation back out here so the CHART itself
+            // (not its tile's filter header strip) gets resized; any stretch growth survives this
+            // subtraction since it was added on top of the same base natural+filter height.
+            java.awt.Dimension pixelSize = grid ?
+               new java.awt.Dimension(placement.width(),
+                  placement.height() - (hasPerChartFilter[i] ? PER_CHART_FILTER_ROW_HEIGHT : 0)) :
+               null;
 
             try {
                AddVisualizationService.MergedVisualizationInfo mergedInfo = addVisualizationService.addVisualization(

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -319,9 +319,10 @@ public class WizDashboardService {
                      continue;
                   }
 
-                  boolean applied = applyPerChartFilter(vs, baseWs, spec, bounds.x, bounds.y, tableName);
+                  WizDashboardFilterBuilder.FilterControlPlacement placement =
+                     applyPerChartFilter(vs, baseWs, spec, bounds.x, bounds.y, tableName);
 
-                  if(applied) {
+                  if(placement != null) {
                      perChartFiltersApplied.add(spec.getField());
                   }
                   else {
@@ -426,8 +427,9 @@ public class WizDashboardService {
     * {@link WizDashboardFilterBuilder#buildPerChart}. Package-visible seam for unit testing
     * (mirrors {@link #applyFilters}), independent of the live-engine-only compose+save path.
     */
-   boolean applyPerChartFilter(Viewsheet vs, Worksheet baseWs, WizDashboardEvent.PerChartFilterSpec spec,
-                               int x, int y, String chartTableName)
+   WizDashboardFilterBuilder.FilterControlPlacement applyPerChartFilter(
+      Viewsheet vs, Worksheet baseWs, WizDashboardEvent.PerChartFilterSpec spec,
+      int x, int y, String chartTableName)
    {
       WizDashboardFilterBuilder.FilterRequest req =
          new WizDashboardFilterBuilder.FilterRequest(spec.getField(), spec.getDataType(), spec.getLabel());

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -30,6 +30,9 @@ import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.WizUtil;
+import inetsoft.uql.viewsheet.vslayout.LayoutInfo;
+import inetsoft.uql.viewsheet.vslayout.VSAssemblyLayout;
+import inetsoft.uql.viewsheet.vslayout.ViewsheetLayout;
 import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
 import inetsoft.web.wiz.model.WizDashboardEvent;
@@ -345,6 +348,33 @@ public class WizDashboardService {
             }
          }
 
+         // Adaptive layouts are grid-only (mirroring the per-chart-filter and per-chart-filter-
+         // gutter features) and skip any dashboard with a per-chart filter -- see the plan's
+         // Global Constraints for why. Build them from the SAME identifiers/spans/assembly-name
+         // tracking the merge loop above already populated.
+         boolean hasPerChartFiltersRequested = event.getPerChartFilters() != null &&
+            !event.getPerChartFilters().isEmpty();
+
+         if(grid && !hasPerChartFiltersRequested) {
+            List<WizDashboardFilterBuilder.FilterControlPlacement> filterPlacements = new ArrayList<>();
+
+            if(filterResult != null) {
+               filterPlacements.addAll(filterResult.placements());
+            }
+
+            String[] assemblyNamesInOrder = identifiers.stream()
+               .map(identifierToAssemblyName::get)
+               .filter(java.util.Objects::nonNull)
+               .toArray(String[]::new);
+
+            if(assemblyNamesInOrder.length == identifiers.size()) {
+               LayoutInfo layoutInfo = new LayoutInfo();
+               layoutInfo.setViewsheetLayouts(
+                  buildAlternateLayouts(assemblyNamesInOrder, spans, rowSpans, topOffset, filterPlacements));
+               rvs.getViewsheet().setLayoutInfo(layoutInfo);
+            }
+         }
+
          WizUtil.saveWizSheet(rvs, principal, savedVsEntry,
             () -> viewsheetService.setViewsheet(rvs.getViewsheet(), savedVsEntry, principal, true, true));
 
@@ -562,6 +592,98 @@ public class WizDashboardService {
       int[] unitRowSpans = new int[spanCols.length];
       java.util.Arrays.fill(unitRowSpans, 1);
       return gridOrigin(spanCols, unitRowSpans, layoutColumns, i);
+   }
+
+   /** Compact tile size forced on every chart in the Mobile tier, ignoring its own type-based
+    *  span -- desktop tile constants (900x600 cap) are far too large for a phone screen. */
+   private static final int MOBILE_TILE_WIDTH = 350;
+   private static final int MOBILE_TILE_HEIGHT = 300;
+
+   /**
+    * Builds the Mobile/Wide/Ultrawide {@link ViewsheetLayout} variants for a composed dashboard,
+    * reusing the same {@link #gridOrigin}/{@link #tilePixelSize} math the base (default) layout
+    * already uses, computed for different column counts -- Mobile forces every chart to a fixed
+    * {@link #MOBILE_TILE_WIDTH}x{@link #MOBILE_TILE_HEIGHT} tile stacked vertically, ignoring its
+    * own span entirely.
+    *
+    * <p>Every chart AND every filter control (from {@code filterPlacements}, carried over
+    * UNCHANGED at its base position/size into all three tiers -- a deliberate scope limit, see
+    * the plan's Global Constraints) gets a {@link VSAssemblyLayout} entry in every returned
+    * layout: {@link AbstractLayout#apply} hides any assembly with no entry when a layout is
+    * selected, so omitting one here would make it vanish on that tier.
+    *
+    * <p>Callers must not invoke this for a dashboard with any per-chart filter (see Global
+    * Constraints) -- this method has no per-tile Y-shift logic for that case.
+    */
+   static List<ViewsheetLayout> buildAlternateLayouts(
+      String[] assemblyNames, int[] spanCols, int[] spanRows, int topOffset,
+      List<WizDashboardFilterBuilder.FilterControlPlacement> filterPlacements)
+   {
+      List<ViewsheetLayout> layouts = new ArrayList<>();
+      layouts.add(buildMobileLayout(assemblyNames, topOffset, filterPlacements));
+      layouts.add(buildGridTierLayout(assemblyNames, spanCols, spanRows, topOffset, filterPlacements,
+         3, WizDeviceBootstrapService.WIDE_DEVICE_ID));
+      layouts.add(buildGridTierLayout(assemblyNames, spanCols, spanRows, topOffset, filterPlacements,
+         4, WizDeviceBootstrapService.ULTRAWIDE_DEVICE_ID));
+      return layouts;
+   }
+
+   private static ViewsheetLayout buildMobileLayout(
+      String[] assemblyNames, int topOffset,
+      List<WizDashboardFilterBuilder.FilterControlPlacement> filterPlacements)
+   {
+      ViewsheetLayout layout = new ViewsheetLayout();
+      layout.setName("Mobile");
+      layout.setMobileOnly(true);
+      layout.setDeviceIds(new String[]{ WizDeviceBootstrapService.MOBILE_DEVICE_ID });
+
+      List<VSAssemblyLayout> assemblyLayouts = new ArrayList<>();
+      int y = topOffset + CANVAS_MARGIN;
+
+      for(String assemblyName : assemblyNames) {
+         assemblyLayouts.add(new VSAssemblyLayout(assemblyName, new java.awt.Point(CANVAS_MARGIN, y),
+            new java.awt.Dimension(MOBILE_TILE_WIDTH, MOBILE_TILE_HEIGHT)));
+         y += MOBILE_TILE_HEIGHT + TILE_GUTTER;
+      }
+
+      addFilterControlLayouts(assemblyLayouts, filterPlacements);
+      layout.setVSAssemblyLayouts(assemblyLayouts);
+      return layout;
+   }
+
+   private static ViewsheetLayout buildGridTierLayout(
+      String[] assemblyNames, int[] spanCols, int[] spanRows, int topOffset,
+      List<WizDashboardFilterBuilder.FilterControlPlacement> filterPlacements,
+      int layoutColumns, String deviceId)
+   {
+      ViewsheetLayout layout = new ViewsheetLayout();
+      layout.setName(deviceId);
+      layout.setMobileOnly(false);
+      layout.setDeviceIds(new String[]{ deviceId });
+
+      boolean[] noPerChartFilters = new boolean[assemblyNames.length];
+      List<VSAssemblyLayout> assemblyLayouts = new ArrayList<>();
+
+      for(int i = 0; i < assemblyNames.length; i++) {
+         java.awt.Point origin = gridOrigin(spanCols, spanRows, noPerChartFilters, layoutColumns, i);
+         java.awt.Dimension size = tilePixelSize(spanCols[i], spanRows[i]);
+         java.awt.Point pos = new java.awt.Point(origin.x + CANVAS_MARGIN, origin.y + topOffset + CANVAS_MARGIN);
+         assemblyLayouts.add(new VSAssemblyLayout(assemblyNames[i], pos, size));
+      }
+
+      addFilterControlLayouts(assemblyLayouts, filterPlacements);
+      layout.setVSAssemblyLayouts(assemblyLayouts);
+      return layout;
+   }
+
+   private static void addFilterControlLayouts(
+      List<VSAssemblyLayout> assemblyLayouts,
+      List<WizDashboardFilterBuilder.FilterControlPlacement> filterPlacements)
+   {
+      for(WizDashboardFilterBuilder.FilterControlPlacement placement : filterPlacements) {
+         assemblyLayouts.add(new VSAssemblyLayout(
+            placement.assemblyName(), placement.position(), placement.size()));
+      }
    }
 
    private final ViewsheetService viewsheetService;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -520,6 +520,135 @@ public class WizDashboardService {
    }
 
    /**
+    * The (x, y, width, height) footprint assigned to a tile by {@link #computeGridLayout}. Height
+    * may be larger than the tile's own natural {@link #tilePixelSize} height if the stretch pass
+    * grew it to match a taller neighbor sharing its band -- see the design spec's Stretch pass
+    * section (docs/superpowers/specs/2026-07-25-dashboard-2d-grid-packing-design.md, in the
+    * stylebi-wiz repo). Package-private for unit testing.
+    */
+   record TilePlacement(int x, int y, int width, int height) {}
+
+   /**
+    * Tracks one open column within the CURRENT (still-open) band during
+    * {@link #computeGridLayout}'s single pass: its fixed x-position and slot width (set by
+    * whichever tile first opened it), the indices (into the tiles arrays) of every tile stacked
+    * into it so far in order, and its running content height (columnY) -- the y-offset, relative
+    * to the band's top, where the NEXT tile stacked into this column would start.
+    */
+   private static final class Column {
+      final int x;
+      final int slotWidth;
+      final List<Integer> tileIndices = new ArrayList<>();
+      int columnY;
+
+      Column(int x, int slotWidth) {
+         this.x = x;
+         this.slotWidth = slotWidth;
+      }
+   }
+
+   /**
+    * Computes every tile's final (x, y, width, height) footprint in one pass, per the
+    * shelf-skyline algorithm in
+    * docs/superpowers/specs/2026-07-25-dashboard-2d-grid-packing-design.md (stylebi-wiz repo):
+    * tiles are processed once, in the given order, into a sequence of bands. Within a band, each
+    * tile first tries to open a new column to the right (same width check {@code gridOrigin} used
+    * to use); failing that, it stacks into whichever existing column in the band is wide enough
+    * for it and has the least accumulated height so far (no height ceiling -- a stacked column may
+    * end up taller than its siblings, which the stretch pass corrects for); failing that too (no
+    * open column is wide enough), the band closes, every column shorter than the band's tallest
+    * has its LAST tile stretched to close the gap, and a fresh band starts with this tile as its
+    * first column. Replaces the old per-tile-index {@code gridOrigin}, which could not support the
+    * stretch pass (whether tile i stretches depends on later tiles that might still join its
+    * column, and on the band's eventual final height -- neither knowable from a partial replay).
+    *
+    * <p>Package-private for unit testing.
+    */
+   static List<TilePlacement> computeGridLayout(
+      int[] spanCols, int[] spanRows, boolean[] hasPerChartFilter, int layoutColumns)
+   {
+      int n = spanCols.length;
+      TilePlacement[] result = new TilePlacement[n];
+      int availableRowWidth = layoutColumns * DASHBOARD_COL_WIDTH + (layoutColumns - 1) * TILE_GUTTER;
+
+      int cumulativeY = 0;
+      List<Column> band = new ArrayList<>();
+      int rowWidthUsed = 0;
+
+      for(int k = 0; k < n; k++) {
+         java.awt.Dimension natural = tilePixelSize(spanCols[k], spanRows[k]);
+         int tileWidth = natural.width;
+         int tileHeight = natural.height + (hasPerChartFilter[k] ? PER_CHART_FILTER_ROW_HEIGHT : 0);
+         int neededWidthForNewColumn =
+            rowWidthUsed == 0 ? tileWidth : rowWidthUsed + TILE_GUTTER + tileWidth;
+
+         if(neededWidthForNewColumn <= availableRowWidth) {
+            int x = rowWidthUsed == 0 ? 0 : rowWidthUsed + TILE_GUTTER;
+            Column column = new Column(x, tileWidth);
+            column.tileIndices.add(k);
+            column.columnY = tileHeight;
+            band.add(column);
+            result[k] = new TilePlacement(x, cumulativeY, tileWidth, tileHeight);
+            rowWidthUsed = x + tileWidth;
+            continue;
+         }
+
+         Column target = null;
+
+         for(Column column : band) {
+            if(column.slotWidth >= tileWidth && (target == null || column.columnY < target.columnY)) {
+               target = column;
+            }
+         }
+
+         if(target != null) {
+            int y = cumulativeY + target.columnY + TILE_GUTTER;
+            target.tileIndices.add(k);
+            target.columnY += TILE_GUTTER + tileHeight;
+            result[k] = new TilePlacement(target.x, y, tileWidth, tileHeight);
+            continue;
+         }
+
+         closeBand(band, result);
+         int bandHeight = band.stream().mapToInt(c -> c.columnY).max().orElse(0);
+         cumulativeY += bandHeight + TILE_GUTTER;
+         band = new ArrayList<>();
+         rowWidthUsed = 0;
+
+         Column column = new Column(0, tileWidth);
+         column.tileIndices.add(k);
+         column.columnY = tileHeight;
+         band.add(column);
+         result[k] = new TilePlacement(0, cumulativeY, tileWidth, tileHeight);
+         rowWidthUsed = tileWidth;
+      }
+
+      closeBand(band, result);
+
+      return java.util.Arrays.asList(result);
+   }
+
+   /**
+    * Stretch pass: for every column in the closing band shorter than the band's tallest column,
+    * grows the LAST tile placed in that column so its rendered height closes the gap. Never
+    * shrinks a tile.
+    */
+   private static void closeBand(List<Column> band, TilePlacement[] result) {
+      int bandHeight = band.stream().mapToInt(c -> c.columnY).max().orElse(0);
+
+      for(Column column : band) {
+         int shortfall = bandHeight - column.columnY;
+
+         if(shortfall > 0) {
+            int lastTileIndex = column.tileIndices.get(column.tileIndices.size() - 1);
+            TilePlacement old = result[lastTileIndex];
+            result[lastTileIndex] =
+               new TilePlacement(old.x(), old.y(), old.width(), old.height() + shortfall);
+         }
+      }
+   }
+
+   /**
     * Row-major grid origin for the tile at flat index {@code i}, given per-tile column spans,
     * row spans, AND whether each tile has a per-chart filter (which adds
     * {@link #PER_CHART_FILTER_ROW_HEIGHT} to that tile's contribution to its row's reserved

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -704,6 +704,11 @@ public class WizDashboardService {
       layout.setName("Mobile");
       layout.setMobileOnly(true);
       layout.setDeviceIds(new String[]{ WizDeviceBootstrapService.MOBILE_DEVICE_ID });
+      // ViewsheetLayout defaults both flags to true, which forces the runtime viewsheet into
+      // "scale to screen" mode and stretches every tile's assigned pixel size to fill the actual
+      // browser width -- defeating the whole point of a fixed, pixel-exact adaptive grid.
+      layout.setScaleToScreen(false);
+      layout.setFitToWidth(false);
 
       List<VSAssemblyLayout> assemblyLayouts = new ArrayList<>();
       int y = topOffset + CANVAS_MARGIN;
@@ -728,6 +733,10 @@ public class WizDashboardService {
       layout.setName(deviceId);
       layout.setMobileOnly(false);
       layout.setDeviceIds(new String[]{ deviceId });
+      // See buildMobileLayout's comment: without this, the runtime viewsheet scales every tile up
+      // to fill the actual browser width instead of rendering the pixel-exact computed grid.
+      layout.setScaleToScreen(false);
+      layout.setFitToWidth(false);
 
       boolean[] noPerChartFilters = new boolean[assemblyNames.length];
       List<TilePlacement> placements = computeGridLayout(spanCols, spanRows, noPerChartFilters, layoutColumns);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -527,46 +527,60 @@ public class WizDashboardService {
     * an implicit all-false {@code hasPerChartFilter}, so their behavior is unchanged by this
     * parameter's addition.
     *
-    * <p>Packing is still row-major/left-to-right/wrap-at-{@code layoutColumns} — each row's
-    * HEIGHT is {@code max} of the tiles placed in it's {@link #tilePixelSize} height (the same
-    * CAPPED height {@code composeDashboard} actually renders each chart at, plus
-    * {@link #PER_CHART_FILTER_ROW_HEIGHT} for any tile with a per-chart filter), instead of
-    * always {@code DASHBOARD_ROW_HEIGHT}. A tile's own Y depends only on the finalized height of
-    * every row strictly before it, and every such row is fully scanned (all its tiles' heights
-    * folded into that row's height, then closed out) before the loop reaches index {@code i} —
-    * so no 2D occupancy grid is needed; a tile with spanRows > 1 does not "block" cells in the
-    * row below for placement purposes (that would be true masonry/skyline packing, deliberately
-    * not implemented — see the Phase 4 design spec). Returns the (x,y) drop origin in pixels.
+    * <p>Packing is based on each tile's ACTUAL rendered pixel width (from {@link #tilePixelSize},
+    * the same capped value {@code composeDashboard} renders each chart at) against the row's
+    * real pixel budget ({@code layoutColumns * DASHBOARD_COL_WIDTH + (layoutColumns-1) *
+    * TILE_GUTTER}) — NOT each tile's nominal {@code spanCols} count. A chart type's declared span
+    * only determines its rendered size (via {@link #tilePixelSize}'s cap); it no longer
+    * independently reserves grid space, so two tiles whose nominal spans wouldn't fit together at
+    * a given column count can still share a row when their ACTUAL capped widths do fit — this is
+    * what lets same-span oversized tiles pack more densely at wider column counts instead of
+    * wastefully wrapping.
+    *
+    * <p>Still row-major/left-to-right — each row's HEIGHT is {@code max} of the tiles placed in
+    * it's {@link #tilePixelSize} height (the same CAPPED height {@code composeDashboard} actually
+    * renders each chart at, plus {@link #PER_CHART_FILTER_ROW_HEIGHT} for any tile with a
+    * per-chart filter), instead of always {@code DASHBOARD_ROW_HEIGHT} — this part is unchanged
+    * from before. A tile's own Y depends only on the finalized height of every row strictly
+    * before it, and every such row is fully scanned (all its tiles' heights folded into that
+    * row's height, then closed out) before the loop reaches index {@code i} — so no 2D occupancy
+    * grid is needed; a tile with spanRows > 1 does not "block" cells in the row below for
+    * placement purposes (that would be true masonry/skyline packing, deliberately not
+    * implemented — see the Phase 4 design spec). Returns the (x,y) drop origin in pixels.
     * Package-private for unit testing.
     */
    static java.awt.Point gridOrigin(int[] spanCols, int[] spanRows, boolean[] hasPerChartFilter,
                                      int layoutColumns, int i)
    {
-      int col = 0;
+      int availableRowWidth = layoutColumns * DASHBOARD_COL_WIDTH + (layoutColumns - 1) * TILE_GUTTER;
+      int rowWidthUsed = 0;   // actual pixel width of tiles placed so far in the CURRENT (still-open) row
       int cumulativeY = 0;
       int rowHeightPx = DASHBOARD_ROW_HEIGHT;   // tallest capped tile height seen so far in the CURRENT (still-open) row
 
       for(int k = 0; k <= i; k++) {
-         int span = Math.max(1, Math.min(spanCols[k], layoutColumns));
+         int tileWidthPx = tilePixelSize(spanCols[k], spanRows[k]).width;
          int tileHeightPx = tilePixelSize(spanCols[k], spanRows[k]).height +
             (hasPerChartFilter[k] ? PER_CHART_FILTER_ROW_HEIGHT : 0);
+         int neededWidth = rowWidthUsed == 0 ? tileWidthPx : rowWidthUsed + TILE_GUTTER + tileWidthPx;
 
-         if(col + span > layoutColumns) {   // doesn't fit in the current row → close it out
+         if(neededWidth > availableRowWidth) {   // doesn't fit in the current row → close it out
             cumulativeY += rowHeightPx + TILE_GUTTER;
-            col = 0;
+            rowWidthUsed = 0;
             rowHeightPx = DASHBOARD_ROW_HEIGHT;
          }
 
+         int x = rowWidthUsed == 0 ? 0 : rowWidthUsed + TILE_GUTTER;
+
          if(k == i) {
-            return new java.awt.Point(col * (DASHBOARD_COL_WIDTH + TILE_GUTTER), cumulativeY);
+            return new java.awt.Point(x, cumulativeY);
          }
 
          rowHeightPx = Math.max(rowHeightPx, tileHeightPx);
-         col += span;
+         rowWidthUsed = x + tileWidthPx;
 
-         if(col >= layoutColumns) {   // row exactly full → close it out now
+         if(rowWidthUsed >= availableRowWidth) {   // row exactly full → close it out now
             cumulativeY += rowHeightPx + TILE_GUTTER;
-            col = 0;
+            rowWidthUsed = 0;
             rowHeightPx = DASHBOARD_ROW_HEIGHT;
          }
       }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -184,7 +184,7 @@ public class WizDashboardService {
          int topOffset = hasFilters ? FILTER_BAR_ROW_HEIGHT : 0;
 
          // Which tiles have a per-chart filter targeting them, keyed by identifier -- computed
-         // once, up front, so gridOrigin can factor extra row height into EVERY tile's
+         // once, up front, so computeGridLayout can factor extra row height into EVERY tile's
          // reservation (not just the ones with a filter), and so the merge loop below can look
          // up "does THIS tile need extra height" by flat index without re-deriving it each time.
          boolean[] hasPerChartFilter = new boolean[entries.size()];
@@ -207,6 +207,9 @@ public class WizDashboardService {
          java.util.Map<String, String> identifierToTableName = new java.util.HashMap<>();
          java.util.Map<String, String> identifierToAssemblyName = new java.util.HashMap<>();
 
+         List<TilePlacement> placements =
+            grid ? computeGridLayout(spans, rowSpans, hasPerChartFilter, layoutColumns) : null;
+
          int cumulativeY = topOffset;   // stack path only
 
          for(int i = 0; i < entries.size(); i++) {
@@ -225,11 +228,11 @@ public class WizDashboardService {
                      "in the same order as identifiers");
                }
 
-               java.awt.Point origin = gridOrigin(spans, rowSpans, hasPerChartFilter, layoutColumns, i);
-               x = origin.x + CANVAS_MARGIN;
-               tileTopY = origin.y + topOffset + CANVAS_MARGIN;
+               TilePlacement placement = placements.get(i);
+               x = placement.x() + CANVAS_MARGIN;
+               tileTopY = placement.y() + topOffset + CANVAS_MARGIN;
                // The chart itself starts BELOW the reserved filter strip, if this tile has one --
-               // the tile's own reserved footprint (computed via gridOrigin above) already
+               // the tile's own reserved footprint (computed via computeGridLayout above) already
                // accounts for that extra height, so this only affects where the CHART renders
                // within it, not how much space the tile as a whole takes.
                y = tileTopY + (hasPerChartFilter[i] ? PER_CHART_FILTER_ROW_HEIGHT : 0);
@@ -438,7 +441,7 @@ public class WizDashboardService {
     * entry — see {@link WizDashboardFilterBuilder}'s class Javadoc). This method does not load
     * or reload the worksheet itself.</p>
     *
-    * <p>Package-private seam for unit testing (mirrors {@link #gridOrigin}) — lets
+    * <p>Package-private seam for unit testing (mirrors {@link #computeGridLayout}) — lets
     * {@link WizDashboardServiceGridTest} exercise the mapping/delegation with a mocked
     * {@link WizDashboardFilterBuilder}, independent of the live-engine-only compose+save path.
     */
@@ -493,8 +496,8 @@ public class WizDashboardService {
     *  column/row span -- without this, a full-width/full-height tile (e.g. 2 cols x 2 rows)
     *  stretches to fill its entire reserved grid cell (1280x840), rendering far larger than a
     *  normal single chart. The tile still RESERVES its full span for grid positioning (see
-    *  {@link #gridOrigin}); only the rendered chart size is capped, leaving a margin of unused
-    *  space inside an oversized cell rather than a stretched chart. */
+    *  {@link #computeGridLayout}); only the rendered chart size is capped, leaving a margin of
+    *  unused space inside an oversized cell rather than a stretched chart. */
    private static final int MAX_TILE_WIDTH = 900;
    private static final int MAX_TILE_HEIGHT = 600;
 
@@ -511,7 +514,7 @@ public class WizDashboardService {
     * The rendered pixel size for a tile spanning {@code spanCols} columns and {@code spanRows}
     * rows: its natural span-based footprint ({@code spanCols * DASHBOARD_COL_WIDTH} by
     * {@code spanRows * DASHBOARD_ROW_HEIGHT}), capped at {@link #MAX_TILE_WIDTH} by
-    * {@link #MAX_TILE_HEIGHT}. Package-private for unit testing (mirrors {@link #gridOrigin}).
+    * {@link #MAX_TILE_HEIGHT}. Package-private for unit testing (mirrors {@link #computeGridLayout}).
     */
    static java.awt.Dimension tilePixelSize(int spanCols, int spanRows) {
       int width = Math.min(spanCols * DASHBOARD_COL_WIDTH, MAX_TILE_WIDTH);
@@ -552,15 +555,16 @@ public class WizDashboardService {
     * shelf-skyline algorithm in
     * docs/superpowers/specs/2026-07-25-dashboard-2d-grid-packing-design.md (stylebi-wiz repo):
     * tiles are processed once, in the given order, into a sequence of bands. Within a band, each
-    * tile first tries to open a new column to the right (same width check {@code gridOrigin} used
-    * to use); failing that, it stacks into whichever existing column in the band is wide enough
-    * for it and has the least accumulated height so far (no height ceiling -- a stacked column may
-    * end up taller than its siblings, which the stretch pass corrects for); failing that too (no
-    * open column is wide enough), the band closes, every column shorter than the band's tallest
-    * has its LAST tile stretched to close the gap, and a fresh band starts with this tile as its
-    * first column. Replaces the old per-tile-index {@code gridOrigin}, which could not support the
-    * stretch pass (whether tile i stretches depends on later tiles that might still join its
-    * column, and on the band's eventual final height -- neither knowable from a partial replay).
+    * tile first tries to open a new column to the right (same width check the old row-major
+    * packer used); failing that, it stacks into whichever existing column in the band is wide
+    * enough for it and has the least accumulated height so far (no height ceiling -- a stacked
+    * column may end up taller than its siblings, which the stretch pass corrects for); failing
+    * that too (no open column is wide enough), the band closes, every column shorter than the
+    * band's tallest has its LAST tile stretched to close the gap, and a fresh band starts with
+    * this tile as its first column. Replaces the old per-tile-index row-major packer, which could
+    * not support the stretch pass (whether tile i stretches depends on later tiles that might
+    * still join its column, and on the band's eventual final height -- neither knowable from a
+    * partial replay).
     *
     * <p>Package-private for unit testing.
     */
@@ -648,95 +652,6 @@ public class WizDashboardService {
       }
    }
 
-   /**
-    * Row-major grid origin for the tile at flat index {@code i}, given per-tile column spans,
-    * row spans, AND whether each tile has a per-chart filter (which adds
-    * {@link #PER_CHART_FILTER_ROW_HEIGHT} to that tile's contribution to its row's reserved
-    * height). This is the primary implementation; the two overloads below delegate to it with
-    * an implicit all-false {@code hasPerChartFilter}, so their behavior is unchanged by this
-    * parameter's addition.
-    *
-    * <p>Packing is based on each tile's ACTUAL rendered pixel width (from {@link #tilePixelSize},
-    * the same capped value {@code composeDashboard} renders each chart at) against the row's
-    * real pixel budget ({@code layoutColumns * DASHBOARD_COL_WIDTH + (layoutColumns-1) *
-    * TILE_GUTTER}) — NOT each tile's nominal {@code spanCols} count. A chart type's declared span
-    * only determines its rendered size (via {@link #tilePixelSize}'s cap); it no longer
-    * independently reserves grid space, so two tiles whose nominal spans wouldn't fit together at
-    * a given column count can still share a row when their ACTUAL capped widths do fit — this is
-    * what lets same-span oversized tiles pack more densely at wider column counts instead of
-    * wastefully wrapping.
-    *
-    * <p>Still row-major/left-to-right — each row's HEIGHT is {@code max} of the tiles placed in
-    * it's {@link #tilePixelSize} height (the same CAPPED height {@code composeDashboard} actually
-    * renders each chart at, plus {@link #PER_CHART_FILTER_ROW_HEIGHT} for any tile with a
-    * per-chart filter), instead of always {@code DASHBOARD_ROW_HEIGHT} — this part is unchanged
-    * from before. A tile's own Y depends only on the finalized height of every row strictly
-    * before it, and every such row is fully scanned (all its tiles' heights folded into that
-    * row's height, then closed out) before the loop reaches index {@code i} — so no 2D occupancy
-    * grid is needed; a tile with spanRows > 1 does not "block" cells in the row below for
-    * placement purposes (that would be true masonry/skyline packing, deliberately not
-    * implemented — see the Phase 4 design spec). Returns the (x,y) drop origin in pixels.
-    * Package-private for unit testing.
-    */
-   static java.awt.Point gridOrigin(int[] spanCols, int[] spanRows, boolean[] hasPerChartFilter,
-                                     int layoutColumns, int i)
-   {
-      int availableRowWidth = layoutColumns * DASHBOARD_COL_WIDTH + (layoutColumns - 1) * TILE_GUTTER;
-      int rowWidthUsed = 0;   // actual pixel width of tiles placed so far in the CURRENT (still-open) row
-      int cumulativeY = 0;
-      int rowHeightPx = DASHBOARD_ROW_HEIGHT;   // tallest capped tile height seen so far in the CURRENT (still-open) row
-
-      for(int k = 0; k <= i; k++) {
-         int tileWidthPx = tilePixelSize(spanCols[k], spanRows[k]).width;
-         int tileHeightPx = tilePixelSize(spanCols[k], spanRows[k]).height +
-            (hasPerChartFilter[k] ? PER_CHART_FILTER_ROW_HEIGHT : 0);
-         int neededWidth = rowWidthUsed == 0 ? tileWidthPx : rowWidthUsed + TILE_GUTTER + tileWidthPx;
-
-         if(neededWidth > availableRowWidth) {   // doesn't fit in the current row → close it out
-            cumulativeY += rowHeightPx + TILE_GUTTER;
-            rowWidthUsed = 0;
-            rowHeightPx = DASHBOARD_ROW_HEIGHT;
-         }
-
-         int x = rowWidthUsed == 0 ? 0 : rowWidthUsed + TILE_GUTTER;
-
-         if(k == i) {
-            return new java.awt.Point(x, cumulativeY);
-         }
-
-         rowHeightPx = Math.max(rowHeightPx, tileHeightPx);
-         rowWidthUsed = x + tileWidthPx;
-
-         if(rowWidthUsed >= availableRowWidth) {   // row exactly full → close it out now
-            cumulativeY += rowHeightPx + TILE_GUTTER;
-            rowWidthUsed = 0;
-            rowHeightPx = DASHBOARD_ROW_HEIGHT;
-         }
-      }
-
-      return new java.awt.Point(0, 0);   // unreachable (i is always in range)
-   }
-
-   /**
-    * Back-compat overload for callers without per-chart filter data (implicit
-    * {@code hasPerChartFilter[k] == false} for every tile).
-    */
-   static java.awt.Point gridOrigin(int[] spanCols, int[] spanRows, int layoutColumns, int i) {
-      boolean[] noFilters = new boolean[spanCols.length];
-      return gridOrigin(spanCols, spanRows, noFilters, layoutColumns, i);
-   }
-
-   /**
-    * Back-compat overload for callers with only column spans (implicit {@code spanRows[k] == 1}
-    * for every tile — i.e. every row is exactly {@code DASHBOARD_ROW_HEIGHT}, matching Phase 2's
-    * original behavior exactly).
-    */
-   static java.awt.Point gridOrigin(int[] spanCols, int layoutColumns, int i) {
-      int[] unitRowSpans = new int[spanCols.length];
-      java.util.Arrays.fill(unitRowSpans, 1);
-      return gridOrigin(spanCols, unitRowSpans, layoutColumns, i);
-   }
-
    /** Compact tile size forced on every chart in the Mobile tier, ignoring its own type-based
     *  span -- desktop tile constants (900x600 cap) are far too large for a phone screen. */
    private static final int MOBILE_TILE_WIDTH = 350;
@@ -744,8 +659,8 @@ public class WizDashboardService {
 
    /**
     * Builds the Mobile/Wide/Ultrawide {@link ViewsheetLayout} variants for a composed dashboard,
-    * reusing the same {@link #gridOrigin}/{@link #tilePixelSize} math the base (default) layout
-    * already uses, computed for different column counts -- Mobile forces every chart to a fixed
+    * reusing the same {@link #computeGridLayout}/{@link #tilePixelSize} math the base (default)
+    * layout already uses, computed for different column counts -- Mobile forces every chart to a fixed
     * {@link #MOBILE_TILE_WIDTH}x{@link #MOBILE_TILE_HEIGHT} tile stacked vertically, ignoring its
     * own span entirely.
     *
@@ -805,12 +720,14 @@ public class WizDashboardService {
       layout.setDeviceIds(new String[]{ deviceId });
 
       boolean[] noPerChartFilters = new boolean[assemblyNames.length];
+      List<TilePlacement> placements = computeGridLayout(spanCols, spanRows, noPerChartFilters, layoutColumns);
       List<VSAssemblyLayout> assemblyLayouts = new ArrayList<>();
 
       for(int i = 0; i < assemblyNames.length; i++) {
-         java.awt.Point origin = gridOrigin(spanCols, spanRows, noPerChartFilters, layoutColumns, i);
-         java.awt.Dimension size = tilePixelSize(spanCols[i], spanRows[i]);
-         java.awt.Point pos = new java.awt.Point(origin.x + CANVAS_MARGIN, origin.y + topOffset + CANVAS_MARGIN);
+         TilePlacement placement = placements.get(i);
+         java.awt.Point pos = new java.awt.Point(
+            placement.x() + CANVAS_MARGIN, placement.y() + topOffset + CANVAS_MARGIN);
+         java.awt.Dimension size = new java.awt.Dimension(placement.width(), placement.height());
          assemblyLayouts.add(new VSAssemblyLayout(assemblyNames[i], pos, size));
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDeviceBootstrapService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDeviceBootstrapService.java
@@ -1,0 +1,70 @@
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.viewsheet.vslayout.DeviceInfo;
+import inetsoft.uql.viewsheet.vslayout.DeviceRegistry;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Registers the three shared, width-bound devices the wiz dashboard-generation feature's
+ * adaptive layouts match against ({@link WizDashboardService}) -- idempotent, self-healing on
+ * every boot, so a rebuilt/reset environment never needs a manual setup step. Device profiles
+ * are global/org-wide infrastructure ({@link DeviceRegistry}), not per-dashboard, so registration
+ * happens once here rather than at dashboard-generation time.
+ */
+@Component
+public class WizDeviceBootstrapService {
+   /** Width < 768px AND the client-reported mobile flag -- see {@link WizDashboardService}'s
+    *  Mobile tier. */
+   public static final String MOBILE_DEVICE_ID = "wiz-mobile";
+
+   /** Width 2020-2699px, any mobile flag -- see {@link WizDashboardService}'s Wide tier. */
+   public static final String WIDE_DEVICE_ID = "wiz-wide";
+
+   /** Width >= 2700px, any mobile flag -- see {@link WizDashboardService}'s Ultrawide tier. */
+   public static final String ULTRAWIDE_DEVICE_ID = "wiz-ultrawide";
+
+   public WizDeviceBootstrapService() {
+      this(DeviceRegistry.getRegistry());
+   }
+
+   /** Package-visible constructor for unit testing with a mocked registry. */
+   WizDeviceBootstrapService(DeviceRegistry registry) {
+      this.registry = registry;
+   }
+
+   @PostConstruct
+   public void ensureDevicesRegistered() {
+      ensureDevice(MOBILE_DEVICE_ID, "Wiz Mobile", 0, 767);
+      ensureDevice(WIDE_DEVICE_ID, "Wiz Wide", 2020, 2699);
+      ensureDevice(ULTRAWIDE_DEVICE_ID, "Wiz Ultrawide", 2700, Integer.MAX_VALUE);
+   }
+
+   private void ensureDevice(String id, String name, int minWidth, int maxWidth) {
+      try {
+         if(registry.getDevice(id) != null) {
+            return;
+         }
+
+         DeviceInfo device = new DeviceInfo();
+         device.setId(id);
+         device.setName(name);
+         device.setMinWidth(minWidth);
+         device.setMaxWidth(maxWidth);
+         registry.setDevice(device);
+      }
+      catch(Exception ex) {
+         // Fail soft: a permission gap (non-default-org, non-enterprise-admin principal at
+         // boot) or a storage error must not block server startup. The affected tier(s) simply
+         // never match at view time -- every dashboard falls back to the base 2-column layout,
+         // identical to behavior before this feature existed.
+         LOG.warn("Failed to register wiz device '{}' -- its adaptive-layout tier will never " +
+            "match until this is resolved", id, ex);
+      }
+   }
+
+   private final DeviceRegistry registry;
+   private static final Logger LOG = LoggerFactory.getLogger(WizDeviceBootstrapService.class);
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDeviceBootstrapService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDeviceBootstrapService.java
@@ -5,6 +5,7 @@ import inetsoft.uql.viewsheet.vslayout.DeviceRegistry;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 /**
@@ -13,8 +14,16 @@ import org.springframework.stereotype.Component;
  * every boot, so a rebuilt/reset environment never needs a manual setup step. Device profiles
  * are global/org-wide infrastructure ({@link DeviceRegistry}), not per-dashboard, so registration
  * happens once here rather than at dashboard-generation time.
+ *
+ * <p>{@code @Lazy(false)} is required: the app sets {@code spring.main.lazy-initialization: true}
+ * globally ({@code community/server/src/main/resources/application.yaml}), and nothing else in
+ * the codebase injects this bean, so without this annotation Spring never instantiates it and
+ * {@link #ensureDevicesRegistered()} never runs -- mirrors {@link inetsoft.web.ServerLifecycleService},
+ * the other {@code @PostConstruct}-only bootstrap bean in this codebase, which carries the same
+ * annotation for the same reason.
  */
 @Component
+@Lazy(false)
 public class WizDeviceBootstrapService {
    /** Width < 768px AND the client-reported mobile flag -- see {@link WizDashboardService}'s
     *  Mobile tier. */

--- a/core/src/test/java/inetsoft/analytic/composition/ViewsheetEngineWizLayoutTest.java
+++ b/core/src/test/java/inetsoft/analytic/composition/ViewsheetEngineWizLayoutTest.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.analytic.composition;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.Viewsheet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class ViewsheetEngineWizLayoutTest {
+   // ViewsheetLayout.parseAttributes() hardcodes scaleToScreen/fitToWidth back to true on
+   // every reload of a persisted device-based layout (deliberate, documented product decision
+   // -- see the comment in that method). ViewsheetEngine.createRuntimeSheet() applies the
+   // matched tier's layout and then calls enforceWizFixedSizeLayout(), which must re-disable
+   // both flags for a wiz-composed dashboard (Viewsheet.WizInfo#isWizSheet() == true), so the
+   // dashboard's fixed-size, internally-scrollable chart tiles survive the reload.
+   @Test
+   void reDisablesScaleToScreenAndFitToWidthForAWizSheet() {
+      Viewsheet viewsheet = new Viewsheet();
+      viewsheet.setWizInfo(new Viewsheet.WizInfo(true));
+      viewsheet.getViewsheetInfo().setScaleToScreen(true);
+      viewsheet.getViewsheetInfo().setFitToWidth(true);
+
+      ViewsheetEngine.enforceWizFixedSizeLayout(viewsheet);
+
+      assertFalse(viewsheet.getViewsheetInfo().isScaleToScreen());
+      assertFalse(viewsheet.getViewsheetInfo().isFitToWidth());
+   }
+
+   // Ordinary (non-wiz) device-based viewsheets must keep StyleBI's documented shared
+   // behavior untouched -- the override is scoped to wiz-composed dashboards only.
+   @Test
+   void leavesScaleToScreenAndFitToWidthAloneForANonWizSheet() {
+      Viewsheet viewsheet = new Viewsheet();
+      viewsheet.getViewsheetInfo().setScaleToScreen(true);
+      viewsheet.getViewsheetInfo().setFitToWidth(true);
+
+      ViewsheetEngine.enforceWizFixedSizeLayout(viewsheet);
+
+      assertTrue(viewsheet.getViewsheetInfo().isScaleToScreen());
+      assertTrue(viewsheet.getViewsheetInfo().isFitToWidth());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/AddVisualizationServiceGraphStalenessTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/AddVisualizationServiceGraphStalenessTest.java
@@ -43,6 +43,7 @@ import java.util.HashMap;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -146,7 +147,7 @@ class AddVisualizationServiceGraphStalenessTest {
    }
 
    @Test
-   void addVisualizationReturnsTheMergedChartsOwnTableName() throws Exception {
+   void addVisualizationReturnsTheMergedChartsOwnTableNameAndAssemblyName() throws Exception {
       ViewsheetService vsService = mock(ViewsheetService.class);
       AssetRepository assetRepository = mock(AssetRepository.class);
       WsMergeService wsMergeService = mock(WsMergeService.class);
@@ -185,8 +186,10 @@ class AddVisualizationServiceGraphStalenessTest {
       AddVisualizationService service =
          new AddVisualizationService(vsService, assetRepository, wsMergeService, securityEngine);
 
-      String tableName = service.addVisualization("rt-1", vizEntry, 0, 0, 1.0f, null, principal);
+      AddVisualizationService.MergedVisualizationInfo result =
+         service.addVisualization("rt-1", vizEntry, 0, 0, 1.0f, null, principal);
 
-      assertEquals("CHART_TABLE", tableName);
+      assertEquals("CHART_TABLE", result.tableName());
+      assertNotNull(result.assemblyName());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -112,6 +112,25 @@ class WizDashboardFilterBuilderTest {
    }
 
    @Test
+   void buildReturnsThePlacementOfEachAppliedControl() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name"));
+
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(vs, "RadarChart");
+      boundToTable(chart, "CHART_FINAL");
+      vs.addAssembly(chart);
+
+      WizDashboardFilterBuilder.FilterResult result = builder.build(
+         vs, ws, List.of(new WizDashboardFilterBuilder.FilterRequest("category_name", "string", "Category")));
+
+      assertEquals(1, result.placements().size());
+      assertNotNull(result.placements().get(0).assemblyName());
+      assertEquals(new java.awt.Point(WizDashboardService.CANVAS_MARGIN, WizDashboardService.CANVAS_MARGIN),
+         result.placements().get(0).position());
+   }
+
+   @Test
    void firstControlIsOffsetByTheCanvasMarginNotFlushAgainstTheEdge() {
       Worksheet ws = new Worksheet();
       ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name"));
@@ -143,10 +162,11 @@ class WizDashboardFilterBuilderTest {
 
       Viewsheet vs = new Viewsheet();
 
-      boolean applied = builder.buildPerChart(vs, ws, 100, 200,
+      WizDashboardFilterBuilder.FilterControlPlacement placement = builder.buildPerChart(vs, ws, 100, 200,
          new WizDashboardFilterBuilder.FilterRequest("product_name", "string", "Product"), "CHART_FINAL");
 
-      assertTrue(applied);
+      assertNotNull(placement);
+      assertEquals(new java.awt.Point(100, 200), placement.position());
 
       AbstractSelectionVSAssembly control = java.util.Arrays.stream(vs.getAssemblies())
          .filter(a -> a instanceof AbstractSelectionVSAssembly)
@@ -159,16 +179,16 @@ class WizDashboardFilterBuilderTest {
    }
 
    @Test
-   void buildPerChartReturnsFalseWhenTheFieldIsNotOnTheSpecifiedTable() {
+   void buildPerChartReturnsNullWhenSkipped() {
       Worksheet ws = new Worksheet();
       ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name"));
 
       Viewsheet vs = new Viewsheet();
 
-      boolean applied = builder.buildPerChart(vs, ws, 0, 0,
+      WizDashboardFilterBuilder.FilterControlPlacement placement = builder.buildPerChart(vs, ws, 0, 0,
          new WizDashboardFilterBuilder.FilterRequest("product_name", "string", "Product"), "CHART_FINAL");
 
-      assertFalse(applied);
+      assertNull(placement);
       assertEquals(0, vs.getAssemblies().length, "no control should be added when the field isn't on the table");
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -111,7 +111,7 @@ class WizDashboardServiceGridTest {
    void computeGridLayoutIncludesPerChartFilterHeightWhenStackingAndStretching() {
       // Same shape as computeGridLayoutStacksAShorterTileBesideATallOneAndStretchesTheShorterSide,
       // but C (the tile that stacks under A) has a per-chart filter, adding 120px to its height
-      // used for packing/stretch purposes -- exactly like gridOrigin already did.
+      // used for packing/stretch purposes -- exactly like the old gridOrigin used to.
       int[] spans =    { 1, 1, 1, 2 };
       int[] rowSpans = { 1, 2, 1, 1 };
       boolean[] hasFilter = { false, false, true, false };
@@ -148,8 +148,8 @@ class WizDashboardServiceGridTest {
    // viewsheet and merge worksheets (see WizDashboardServiceTest's class Javadoc), so the
    // filters[] -> WizDashboardFilterBuilder wiring is covered here instead via the
    // package-visible applyFilters(Viewsheet, Worksheet, List<FilterSpec>) seam, with a mocked
-   // WizDashboardFilterBuilder — mirroring how gridOrigin is unit-tested independent of a live
-   // engine.
+   // WizDashboardFilterBuilder — mirroring how computeGridLayout is unit-tested independent of a
+   // live engine.
 
    private WizDashboardService serviceWith(WizDashboardFilterBuilder filterBuilder) {
       return new WizDashboardService(mock(ViewsheetService.class), mock(AddVisualizationServiceProxy.class),

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -154,6 +154,34 @@ class WizDashboardServiceGridTest {
    }
 
    @Test
+   void twoOversizedTilesPackIntoTheSameRowWhenTheirActualCappedWidthsFit() {
+      // Two 2-col-span tiles. At layoutColumns=2 each nominally-2-col tile would take a whole
+      // row by itself (see fullWidthTileTakesWholeRow) -- but at layoutColumns=3, the available
+      // row width (3*W + 2*G = 1968) comfortably fits both tiles' ACTUAL CAPPED widths (900 each,
+      // 1824 total incl. one gutter), even though their NOMINAL spans (2+2=4) would have exceeded
+      // 3 columns under the old column-unit model. This is the exact case that motivated this fix.
+      int[] spans = { 2, 2 };
+      int[] rowSpans = { 1, 1 };
+
+      assertEquals(new Point(0, 0),   WizDashboardService.gridOrigin(spans, rowSpans, 3, 0));
+      assertEquals(new Point(924, 0), WizDashboardService.gridOrigin(spans, rowSpans, 3, 1));
+   }
+
+   @Test
+   void oversizedTilesStillWrapWhenTheyGenuinelyDoNotFit() {
+      // Three 2-col-span tiles at layoutColumns=4 (available row width = 4*W + 3*G = 2632).
+      // Two tiles' actual capped widths fit (900 + 24 + 900 = 1824 <= 2632), but a third would
+      // need 1824 + 24 + 900 = 2748 > 2632 -- so it correctly wraps to a new row instead of being
+      // crammed in, proving the fix doesn't over-pack when there truly isn't room.
+      int[] spans = { 2, 2, 2 };
+      int[] rowSpans = { 1, 1, 1 };
+
+      assertEquals(new Point(0, 0),     WizDashboardService.gridOrigin(spans, rowSpans, 4, 0));
+      assertEquals(new Point(924, 0),   WizDashboardService.gridOrigin(spans, rowSpans, 4, 1));
+      assertEquals(new Point(0, H + G), WizDashboardService.gridOrigin(spans, rowSpans, 4, 2));
+   }
+
+   @Test
    void tilePixelSizeUsesTheNaturalSpanFootprintWhenUnderTheCap() {
       // 1x1 -> 640x420; well under the 900x600 cap.
       assertEquals(new java.awt.Dimension(W, H), WizDashboardService.tilePixelSize(1, 1));

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -214,8 +214,11 @@ class WizDashboardServiceGridTest {
    @Test
    void applyPerChartFilterMapsSpecToRequestAndDelegatesToBuildPerChart() {
       WizDashboardFilterBuilder filterBuilder = mock(WizDashboardFilterBuilder.class);
+      WizDashboardFilterBuilder.FilterControlPlacement expectedPlacement =
+         new WizDashboardFilterBuilder.FilterControlPlacement("Selection1",
+            new java.awt.Point(100, 200), new java.awt.Dimension(200, 100));
       when(filterBuilder.buildPerChart(any(), any(), eq(100), eq(200), any(), eq("CHART_TABLE")))
-         .thenReturn(true);
+         .thenReturn(expectedPlacement);
 
       WizDashboardService svc = serviceWith(filterBuilder);
       Viewsheet vs = mock(Viewsheet.class);
@@ -226,9 +229,10 @@ class WizDashboardServiceGridTest {
       spec.setDataType("string");
       spec.setLabel("Standalone");
 
-      boolean applied = svc.applyPerChartFilter(vs, baseWs, spec, 100, 200, "CHART_TABLE");
+      WizDashboardFilterBuilder.FilterControlPlacement placement =
+         svc.applyPerChartFilter(vs, baseWs, spec, 100, 200, "CHART_TABLE");
 
-      assertTrue(applied);
+      assertSame(expectedPlacement, placement);
       verify(filterBuilder).buildPerChart(eq(vs), eq(baseWs), eq(100), eq(200),
          eq(new WizDashboardFilterBuilder.FilterRequest("Standalone", "string", "Standalone")),
          eq("CHART_TABLE"));

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -284,6 +284,30 @@ class WizDashboardServiceGridTest {
    }
 
    @Test
+   void everyAdaptiveTierDisablesScaleToScreenAndFitToWidth() {
+      // ViewsheetLayout defaults BOTH flags to true (its own constructor). Left at the default,
+      // ViewsheetLayout#apply() forces the runtime viewsheet into "scale to screen" mode, which
+      // stretches every tile's carefully-computed pixel-exact size to fill whatever the actual
+      // browser width happens to be -- e.g. a 900px-wide tile rendering at ~2414px on a 2560px-wide
+      // window. The adaptive tiers are meant to be a FIXED, pixel-exact grid per device tier, so
+      // both flags must be explicitly disabled on every tier this method builds.
+      String[] assemblyNames = { "Chart1" };
+      int[] spans = { 1 };
+      int[] rowSpans = { 1 };
+      List<ViewsheetLayout> layouts =
+         WizDashboardService.buildAlternateLayouts(assemblyNames, spans, rowSpans, 0, List.of());
+
+      assertEquals(3, layouts.size());
+
+      for(ViewsheetLayout layout : layouts) {
+         assertFalse(layout.isScaleToScreen(),
+            "scaleToScreen must be disabled on tier " + layout.getName());
+         assertFalse(layout.isFitToWidth(),
+            "fitToWidth must be disabled on tier " + layout.getName());
+      }
+   }
+
+   @Test
    void wideTierStacksAFourthChartUnderTheFirstAndStretchesTheOthersToMatch() {
       // Same shape as computeGridLayoutOpensColumnsUntilRowWidthIsExhaustedThenStacksAndStretches
       // TheOthers in WizDashboardServiceGridTest's packing tests: four 1x1-span charts at the Wide

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -47,141 +47,6 @@ class WizDashboardServiceGridTest {
    private static final int G = 24;    // TILE_GUTTER -- spacing added between adjacent tiles
 
    @Test
-   void twoUnitTilesFillRowThenWrap() {
-      int[] spans = { 1, 1, 1 };
-      assertEquals(new Point(0, 0),       WizDashboardService.gridOrigin(spans, 2, 0));
-      assertEquals(new Point(W + G, 0),   WizDashboardService.gridOrigin(spans, 2, 1));
-      assertEquals(new Point(0, H + G),   WizDashboardService.gridOrigin(spans, 2, 2)); // wrapped
-   }
-
-   @Test
-   void gridOriginAddsTileGutterBetweenAdjacentColumnsAndRows() {
-      int[] spans = { 1, 1, 1 };
-      // Same 3-tile wrap-at-2-columns layout as twoUnitTilesFillRowThenWrap, but asserting the
-      // gutter is present: tile1 starts G pixels further right than a flush W would put it, and
-      // the wrapped row starts G pixels further down than a flush H would put it.
-      assertEquals(new Point(0, 0),       WizDashboardService.gridOrigin(spans, 2, 0));
-      assertEquals(new Point(W + G, 0),   WizDashboardService.gridOrigin(spans, 2, 1));
-      assertEquals(new Point(0, H + G),   WizDashboardService.gridOrigin(spans, 2, 2));
-   }
-
-   @Test
-   void fullWidthTileTakesWholeRow() {
-      int[] spans = { 2, 1, 1 };   // tile0 spans both columns
-      assertEquals(new Point(0, 0),        WizDashboardService.gridOrigin(spans, 2, 0));
-      assertEquals(new Point(0, H + G),    WizDashboardService.gridOrigin(spans, 2, 1)); // pushed to row 2
-      assertEquals(new Point(W + G, H + G), WizDashboardService.gridOrigin(spans, 2, 2));
-   }
-
-   @Test
-   void unitTileAfterFullWidthStartsFreshRow() {
-      int[] spans = { 1, 2 };   // tile0 unit in row0 col0; tile1 full-width can't fit → row1
-      assertEquals(new Point(0, 0),     WizDashboardService.gridOrigin(spans, 2, 0));
-      assertEquals(new Point(0, H + G), WizDashboardService.gridOrigin(spans, 2, 1));
-   }
-
-   @Test
-   void tallTileReservesItsRowHeightForShorterNeighbors() {
-      int[] spans = { 2, 1, 1 };     // tile0: 2 cols wide; tile1, tile2: 1 col each
-      int[] rowSpans = { 2, 1, 1 };  // tile0: 2 ROWS tall; tile1, tile2: 1 row each
-
-      // tile0 (2x2) fills the whole row by itself (spanCols=2 == layoutColumns) -> row 0.
-      assertEquals(new Point(0, 0), WizDashboardService.gridOrigin(spans, rowSpans, 2, 0));
-      // tile1 and tile2 (1x1 each) wrap into what would be "row 1". tile0's reserved height is
-      // its CAPPED tilePixelSize height (2x2 -> 900x600, both dimensions over the 900x600 cap),
-      // not the raw 2*H=840 -- reserving the raw span height left a dead gap below a capped tile.
-      // Plus TILE_GUTTER between the two rows.
-      assertEquals(new Point(0, 600 + G),     WizDashboardService.gridOrigin(spans, rowSpans, 2, 1));
-      assertEquals(new Point(W + G, 600 + G), WizDashboardService.gridOrigin(spans, rowSpans, 2, 2));
-   }
-
-   @Test
-   void shortTileNextToTallTileSharesTheTallRowsHeightNotItsOwn() {
-      int[] spans = { 1, 1 };       // tile0 and tile1 share one row (1 col each, layoutColumns=2)
-      int[] rowSpans = { 2, 1 };    // tile0: 2 rows tall; tile1: 1 row tall
-
-      // Both are in the SAME row (col 0 and col 1), so both share row index 0 -> same Y.
-      assertEquals(new Point(0, 0),     WizDashboardService.gridOrigin(spans, rowSpans, 2, 0));
-      assertEquals(new Point(W + G, 0), WizDashboardService.gridOrigin(spans, rowSpans, 2, 1));
-   }
-
-   @Test
-   void threeRowsOfMixedHeightsCompoundCumulativeYCorrectly() {
-      // Row 0: one 2x2 tile (fills both columns, 2 rows tall) -> capped tilePixelSize height 600.
-      // Row 1: one 2x1 tile (fills both columns, 1 row tall) -> uncapped height 420 (== H).
-      // Row 2: two 1x1 tiles. TILE_GUTTER is added between each pair of consecutive rows.
-      int[] spans =    { 2, 2, 1, 1 };
-      int[] rowSpans = { 2, 1, 1, 1 };
-
-      assertEquals(new Point(0, 0),                     WizDashboardService.gridOrigin(spans, rowSpans, 2, 0));
-      assertEquals(new Point(0, 600 + G),               WizDashboardService.gridOrigin(spans, rowSpans, 2, 1));
-      assertEquals(new Point(0, 600 + G + H + G),       WizDashboardService.gridOrigin(spans, rowSpans, 2, 2));
-      assertEquals(new Point(W + G, 600 + G + H + G),   WizDashboardService.gridOrigin(spans, rowSpans, 2, 3));
-   }
-
-   @Test
-   void aTileWithAPerChartFilterReservesExtraRowHeight() {
-      int[] spans = { 2, 2 };       // two full-width tiles, one per row
-      int[] rowSpans = { 1, 1 };
-      boolean[] hasFilter = { true, false };   // only tile0 has a per-chart filter
-
-      // tile0's row reserves its normal height (H=420) PLUS PER_CHART_FILTER_ROW_HEIGHT (120),
-      // PLUS TILE_GUTTER before row1.
-      assertEquals(new Point(0, H + 120 + G),
-         WizDashboardService.gridOrigin(spans, rowSpans, hasFilter, 2, 1));
-   }
-
-   @Test
-   void rowHeightReservationTakesTheMaxAcrossTilesInTheRowIncludingPerChartFilterExtras() {
-      int[] spans =    { 1, 1, 2 };   // tile0, tile1 share row0 (1 col each); tile2 is full-width row1
-      int[] rowSpans = { 1, 1, 1 };
-      boolean[] hasFilter = { false, true, false };   // only tile1 (in row0) has a filter
-
-      // row0's height is max(tile0's H, tile1's H+120) = H+120, even though tile0 itself has none.
-      // Plus TILE_GUTTER before row1.
-      assertEquals(new Point(0, H + 120 + G),
-         WizDashboardService.gridOrigin(spans, rowSpans, hasFilter, 2, 2));
-   }
-
-   @Test
-   void gridOriginFourArgOverloadIsUnaffectedByTheNewParameter() {
-      // Re-assert one of the existing mixed-height cases through the OLD 4-arg overload, proving
-      // it still delegates to an implicit all-false hasPerChartFilter and its behavior is
-      // byte-for-byte unchanged by this task.
-      int[] spans =    { 2, 2, 1, 1 };
-      int[] rowSpans = { 2, 1, 1, 1 };
-      assertEquals(new Point(0, 600 + G + H + G), WizDashboardService.gridOrigin(spans, rowSpans, 2, 2));
-   }
-
-   @Test
-   void twoOversizedTilesPackIntoTheSameRowWhenTheirActualCappedWidthsFit() {
-      // Two 2-col-span tiles. At layoutColumns=2 each nominally-2-col tile would take a whole
-      // row by itself (see fullWidthTileTakesWholeRow) -- but at layoutColumns=3, the available
-      // row width (3*W + 2*G = 1968) comfortably fits both tiles' ACTUAL CAPPED widths (900 each,
-      // 1824 total incl. one gutter), even though their NOMINAL spans (2+2=4) would have exceeded
-      // 3 columns under the old column-unit model. This is the exact case that motivated this fix.
-      int[] spans = { 2, 2 };
-      int[] rowSpans = { 1, 1 };
-
-      assertEquals(new Point(0, 0),   WizDashboardService.gridOrigin(spans, rowSpans, 3, 0));
-      assertEquals(new Point(924, 0), WizDashboardService.gridOrigin(spans, rowSpans, 3, 1));
-   }
-
-   @Test
-   void oversizedTilesStillWrapWhenTheyGenuinelyDoNotFit() {
-      // Three 2-col-span tiles at layoutColumns=4 (available row width = 4*W + 3*G = 2632).
-      // Two tiles' actual capped widths fit (900 + 24 + 900 = 1824 <= 2632), but a third would
-      // need 1824 + 24 + 900 = 2748 > 2632 -- so it correctly wraps to a new row instead of being
-      // crammed in, proving the fix doesn't over-pack when there truly isn't room.
-      int[] spans = { 2, 2, 2 };
-      int[] rowSpans = { 1, 1, 1 };
-
-      assertEquals(new Point(0, 0),     WizDashboardService.gridOrigin(spans, rowSpans, 4, 0));
-      assertEquals(new Point(924, 0),   WizDashboardService.gridOrigin(spans, rowSpans, 4, 1));
-      assertEquals(new Point(0, H + G), WizDashboardService.gridOrigin(spans, rowSpans, 4, 2));
-   }
-
-   @Test
    void tilePixelSizeUsesTheNaturalSpanFootprintWhenUnderTheCap() {
       // 1x1 -> 640x420; well under the 900x600 cap.
       assertEquals(new java.awt.Dimension(W, H), WizDashboardService.tilePixelSize(1, 1));
@@ -416,6 +281,35 @@ class WizDashboardServiceGridTest {
       // A single 1-col-span chart lands at the grid origin (0,0) regardless of column count.
       assertEquals(new Point(24, 24), wide.getVSAssemblyLayout("Chart1").getPosition());
       assertEquals(new Point(24, 24), ultrawide.getVSAssemblyLayout("Chart1").getPosition());
+   }
+
+   @Test
+   void wideTierStacksAFourthChartUnderTheFirstAndStretchesTheOthersToMatch() {
+      // Same shape as computeGridLayoutOpensColumnsUntilRowWidthIsExhaustedThenStacksAndStretches
+      // TheOthers in WizDashboardServiceGridTest's packing tests: four 1x1-span charts at the Wide
+      // tier's layoutColumns=3.
+      String[] assemblyNames = { "Chart1", "Chart2", "Chart3", "Chart4" };
+      int[] spans =    { 1, 1, 1, 1 };
+      int[] rowSpans = { 1, 1, 1, 1 };
+
+      List<ViewsheetLayout> layouts =
+         WizDashboardService.buildAlternateLayouts(assemblyNames, spans, rowSpans, 0, List.of());
+
+      ViewsheetLayout wide = layouts.stream()
+         .filter(l -> java.util.Arrays.asList(l.getDeviceIds()).contains(WizDeviceBootstrapService.WIDE_DEVICE_ID))
+         .findFirst().orElseThrow();
+
+      assertEquals(new Point(24, 24), wide.getVSAssemblyLayout("Chart1").getPosition());
+      assertEquals(new java.awt.Dimension(640, 420), wide.getVSAssemblyLayout("Chart1").getSize());
+
+      assertEquals(new Point(688, 24), wide.getVSAssemblyLayout("Chart2").getPosition());
+      assertEquals(new java.awt.Dimension(640, 864), wide.getVSAssemblyLayout("Chart2").getSize());
+
+      assertEquals(new Point(1352, 24), wide.getVSAssemblyLayout("Chart3").getPosition());
+      assertEquals(new java.awt.Dimension(640, 864), wide.getVSAssemblyLayout("Chart3").getSize());
+
+      assertEquals(new Point(24, 468), wide.getVSAssemblyLayout("Chart4").getPosition());
+      assertEquals(new java.awt.Dimension(640, 420), wide.getVSAssemblyLayout("Chart4").getSize());
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -195,6 +195,88 @@ class WizDashboardServiceGridTest {
       assertEquals(new java.awt.Dimension(900, 600), WizDashboardService.tilePixelSize(2, 2));
    }
 
+   // --- 2D grid packing (computeGridLayout) ---------------------------------------------------
+
+   @Test
+   void computeGridLayoutStacksAShorterTileBesideATallOneAndStretchesTheShorterSide() {
+      // layoutColumns=2 -> availableRowWidth = 2*640 + 24 = 1304.
+      // A: 1x1 (640x420). B: 1x2 (640x600, capped). C: 1x1 (640x420). D: 2x1 (900x420).
+      int[] spans =    { 1, 1, 1, 2 };
+      int[] rowSpans = { 1, 2, 1, 1 };
+      boolean[] noFilters = new boolean[4];
+
+      List<WizDashboardService.TilePlacement> placements =
+         WizDashboardService.computeGridLayout(spans, rowSpans, noFilters, 2);
+
+      // A opens column 0 (x=0). B fits as a new column (640+24+640=1304<=1304) at x=664.
+      // C doesn't fit as a new column (1304+24+640=1968>1304) -> stacks under A (column 0's
+      // columnY=420 is smaller than column 1's 600) at y=420+24=444.
+      // D doesn't fit as a new column, AND its 900px width exceeds both columns' 640px slots ->
+      // no column fits -> band closes. Band height = max(A+C's column = 864, B's column = 600) =
+      // 864. B's column is shorter -> its only (and therefore last) tile, B, stretches from 600
+      // to 864. D starts a fresh band at cumulativeY = 864 + 24 = 888.
+      assertEquals(new WizDashboardService.TilePlacement(0, 0, 640, 420), placements.get(0));    // A
+      assertEquals(new WizDashboardService.TilePlacement(664, 0, 640, 864), placements.get(1));  // B, stretched
+      assertEquals(new WizDashboardService.TilePlacement(0, 444, 640, 420), placements.get(2));  // C
+      assertEquals(new WizDashboardService.TilePlacement(0, 888, 900, 420), placements.get(3));  // D
+   }
+
+   @Test
+   void computeGridLayoutOpensColumnsUntilRowWidthIsExhaustedThenStacksAndStretchesTheOthers() {
+      // layoutColumns=3 -> availableRowWidth = 3*640 + 2*24 = 1968. Four 1x1 unit tiles (640x420
+      // each): the first three exactly fill the row's width as three separate columns
+      // (640+24+640+24+640 = 1968), the fourth can't open a new column and stacks under the
+      // first (ties broken in favor of the earliest-opened column).
+      int[] spans =    { 1, 1, 1, 1 };
+      int[] rowSpans = { 1, 1, 1, 1 };
+      boolean[] noFilters = new boolean[4];
+
+      List<WizDashboardService.TilePlacement> placements =
+         WizDashboardService.computeGridLayout(spans, rowSpans, noFilters, 3);
+
+      assertEquals(new WizDashboardService.TilePlacement(0, 0, 640, 420), placements.get(0));
+      // Columns 1 and 2 both stretch from 420 to 864 to match column 0's stacked height
+      // (420 + 24 + 420 = 864) once the band closes.
+      assertEquals(new WizDashboardService.TilePlacement(664, 0, 640, 864), placements.get(1));
+      assertEquals(new WizDashboardService.TilePlacement(1328, 0, 640, 864), placements.get(2));
+      assertEquals(new WizDashboardService.TilePlacement(0, 444, 640, 420), placements.get(3));
+   }
+
+   @Test
+   void computeGridLayoutIncludesPerChartFilterHeightWhenStackingAndStretching() {
+      // Same shape as computeGridLayoutStacksAShorterTileBesideATallOneAndStretchesTheShorterSide,
+      // but C (the tile that stacks under A) has a per-chart filter, adding 120px to its height
+      // used for packing/stretch purposes -- exactly like gridOrigin already did.
+      int[] spans =    { 1, 1, 1, 2 };
+      int[] rowSpans = { 1, 2, 1, 1 };
+      boolean[] hasFilter = { false, false, true, false };
+
+      List<WizDashboardService.TilePlacement> placements =
+         WizDashboardService.computeGridLayout(spans, rowSpans, hasFilter, 2);
+
+      // A: column 0 opens at columnY=420. C stacks under A: y=420+24=444, height=420+120=540,
+      // column 0's columnY becomes 444+540=984. B (column 1) stays at columnY=600 until D closes
+      // the band: bandHeight=max(984, 600)=984, so column 1 (B, the only/last tile in it)
+      // stretches from 600 to 984. Column 0's last tile is C, already at the band height (984) ->
+      // no further stretch for C.
+      assertEquals(new WizDashboardService.TilePlacement(0, 0, 640, 420), placements.get(0));     // A
+      assertEquals(new WizDashboardService.TilePlacement(664, 0, 640, 984), placements.get(1));   // B, stretched
+      assertEquals(new WizDashboardService.TilePlacement(0, 444, 640, 540), placements.get(2));   // C, filter height included
+      assertEquals(new WizDashboardService.TilePlacement(0, 1008, 900, 420), placements.get(3));  // D
+   }
+
+   @Test
+   void computeGridLayoutSingleTileNeedsNoStretch() {
+      int[] spans = { 1 };
+      int[] rowSpans = { 1 };
+      boolean[] noFilters = new boolean[1];
+
+      List<WizDashboardService.TilePlacement> placements =
+         WizDashboardService.computeGridLayout(spans, rowSpans, noFilters, 2);
+
+      assertEquals(new WizDashboardService.TilePlacement(0, 0, 640, 420), placements.get(0));
+   }
+
    // --- Task 3: composeDashboard's filter-bar invocation seam ---------------------------------
    //
    // composeDashboard itself needs a live ViewsheetService/asset engine to open a runtime

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -22,6 +22,8 @@ import inetsoft.sree.security.SecurityEngine;
 import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.vslayout.ViewsheetLayout;
+import inetsoft.uql.viewsheet.vslayout.VSAssemblyLayout;
 import inetsoft.web.wiz.model.WizDashboardEvent;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -236,5 +238,92 @@ class WizDashboardServiceGridTest {
       verify(filterBuilder).buildPerChart(eq(vs), eq(baseWs), eq(100), eq(200),
          eq(new WizDashboardFilterBuilder.FilterRequest("Standalone", "string", "Standalone")),
          eq("CHART_TABLE"));
+   }
+
+   // --- Task 5: buildAlternateLayouts (Mobile/Wide/Ultrawide adaptive layouts) ----------------
+
+   @Test
+   void buildAlternateLayoutsProducesThreeTiersEachCoveringEveryChartAndFilterControl() {
+      String[] assemblyNames = { "Chart1", "Chart2" };
+      int[] spans = { 2, 1 };
+      int[] rowSpans = { 1, 1 };
+      List<WizDashboardFilterBuilder.FilterControlPlacement> filterPlacements = List.of(
+         new WizDashboardFilterBuilder.FilterControlPlacement("Selection1", new Point(24, 24),
+            new java.awt.Dimension(200, 100)));
+
+      List<ViewsheetLayout> layouts =
+         WizDashboardService.buildAlternateLayouts(assemblyNames, spans, rowSpans, 0, filterPlacements);
+
+      assertEquals(3, layouts.size());
+
+      for(ViewsheetLayout layout : layouts) {
+         // Every chart AND every filter control must have an entry, or AbstractLayout#apply
+         // hides it entirely when this layout is selected.
+         assertNotNull(layout.getVSAssemblyLayout("Chart1"));
+         assertNotNull(layout.getVSAssemblyLayout("Chart2"));
+         assertNotNull(layout.getVSAssemblyLayout("Selection1"));
+      }
+   }
+
+   @Test
+   void mobileTierForcesEveryChartToAFixedFullWidthTileIgnoringItsOwnSpan() {
+      String[] assemblyNames = { "Chart1", "Chart2" };
+      int[] spans = { 2, 1 };       // Chart1 is a 2-col-span type -- ignored on Mobile
+      int[] rowSpans = { 2, 1 };    // Chart1 is also a 2-row-span type -- ignored on Mobile
+      List<ViewsheetLayout> layouts =
+         WizDashboardService.buildAlternateLayouts(assemblyNames, spans, rowSpans, 0, List.of());
+
+      ViewsheetLayout mobile = layouts.stream()
+         .filter(l -> l.isMobileOnly())
+         .findFirst().orElseThrow();
+
+      VSAssemblyLayout chart1 = mobile.getVSAssemblyLayout("Chart1");
+      VSAssemblyLayout chart2 = mobile.getVSAssemblyLayout("Chart2");
+      assertEquals(new java.awt.Dimension(350, 300), chart1.getSize());
+      assertEquals(new java.awt.Dimension(350, 300), chart2.getSize());
+      // Stacked vertically: Chart1 at row 0, Chart2 at row 1 (300 + 24 gutter below it).
+      assertEquals(new Point(24, 24), chart1.getPosition());
+      assertEquals(new Point(24, 24 + 300 + 24), chart2.getPosition());
+   }
+
+   @Test
+   void wideAndUltrawideTiersAreNotMobileOnlyAndUseTheRequestedColumnCount() {
+      String[] assemblyNames = { "Chart1" };
+      int[] spans = { 1 };
+      int[] rowSpans = { 1 };
+      List<ViewsheetLayout> layouts =
+         WizDashboardService.buildAlternateLayouts(assemblyNames, spans, rowSpans, 0, List.of());
+
+      ViewsheetLayout wide = layouts.stream()
+         .filter(l -> java.util.Arrays.asList(l.getDeviceIds()).contains(WizDeviceBootstrapService.WIDE_DEVICE_ID))
+         .findFirst().orElseThrow();
+      ViewsheetLayout ultrawide = layouts.stream()
+         .filter(l -> java.util.Arrays.asList(l.getDeviceIds()).contains(WizDeviceBootstrapService.ULTRAWIDE_DEVICE_ID))
+         .findFirst().orElseThrow();
+
+      assertFalse(wide.isMobileOnly());
+      assertFalse(ultrawide.isMobileOnly());
+      // A single 1-col-span chart lands at the grid origin (0,0) regardless of column count.
+      assertEquals(new Point(24, 24), wide.getVSAssemblyLayout("Chart1").getPosition());
+      assertEquals(new Point(24, 24), ultrawide.getVSAssemblyLayout("Chart1").getPosition());
+   }
+
+   @Test
+   void carriesOverFilterControlPlacementsUnchangedIntoEveryTier() {
+      String[] assemblyNames = { "Chart1" };
+      int[] spans = { 1 };
+      int[] rowSpans = { 1 };
+      WizDashboardFilterBuilder.FilterControlPlacement placement =
+         new WizDashboardFilterBuilder.FilterControlPlacement("Selection1", new Point(24, 24),
+            new java.awt.Dimension(200, 100));
+
+      List<ViewsheetLayout> layouts =
+         WizDashboardService.buildAlternateLayouts(assemblyNames, spans, rowSpans, 0, List.of(placement));
+
+      for(ViewsheetLayout layout : layouts) {
+         VSAssemblyLayout controlLayout = layout.getVSAssemblyLayout("Selection1");
+         assertEquals(new Point(24, 24), controlLayout.getPosition());
+         assertEquals(new java.awt.Dimension(200, 100), controlLayout.getSize());
+      }
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDeviceBootstrapServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDeviceBootstrapServiceTest.java
@@ -1,0 +1,56 @@
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.viewsheet.vslayout.DeviceInfo;
+import inetsoft.uql.viewsheet.vslayout.DeviceRegistry;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class WizDeviceBootstrapServiceTest {
+   @Test
+   void registersAllThreeDevicesWhenNoneExist() {
+      DeviceRegistry registry = mock(DeviceRegistry.class);
+      when(registry.getDevice(anyString())).thenReturn(null);
+
+      new WizDeviceBootstrapService(registry).ensureDevicesRegistered();
+
+      verify(registry).setDevice(argThat(d ->
+         d.getId().equals(WizDeviceBootstrapService.MOBILE_DEVICE_ID) &&
+         d.getMinWidth() == 0 && d.getMaxWidth() == 767));
+      verify(registry).setDevice(argThat(d ->
+         d.getId().equals(WizDeviceBootstrapService.WIDE_DEVICE_ID) &&
+         d.getMinWidth() == 2020 && d.getMaxWidth() == 2699));
+      verify(registry).setDevice(argThat(d ->
+         d.getId().equals(WizDeviceBootstrapService.ULTRAWIDE_DEVICE_ID) &&
+         d.getMinWidth() == 2700 && d.getMaxWidth() == Integer.MAX_VALUE));
+   }
+
+   @Test
+   void skipsDevicesThatAlreadyExist() {
+      DeviceRegistry registry = mock(DeviceRegistry.class);
+      DeviceInfo existing = new DeviceInfo();
+      existing.setId(WizDeviceBootstrapService.MOBILE_DEVICE_ID);
+      when(registry.getDevice(WizDeviceBootstrapService.MOBILE_DEVICE_ID)).thenReturn(existing);
+      when(registry.getDevice(WizDeviceBootstrapService.WIDE_DEVICE_ID)).thenReturn(null);
+      when(registry.getDevice(WizDeviceBootstrapService.ULTRAWIDE_DEVICE_ID)).thenReturn(null);
+
+      new WizDeviceBootstrapService(registry).ensureDevicesRegistered();
+
+      verify(registry, never()).setDevice(argThat(d -> d.getId().equals(WizDeviceBootstrapService.MOBILE_DEVICE_ID)));
+      verify(registry).setDevice(argThat(d -> d.getId().equals(WizDeviceBootstrapService.WIDE_DEVICE_ID)));
+      verify(registry).setDevice(argThat(d -> d.getId().equals(WizDeviceBootstrapService.ULTRAWIDE_DEVICE_ID)));
+   }
+
+   @Test
+   void doesNotThrowWhenRegistryWriteFails() {
+      DeviceRegistry registry = mock(DeviceRegistry.class);
+      when(registry.getDevice(anyString())).thenReturn(null);
+      doThrow(new RuntimeException("boom")).when(registry).setDevice(any());
+
+      assertDoesNotThrow(() -> new WizDeviceBootstrapService(registry).ensureDevicesRegistered());
+   }
+}


### PR DESCRIPTION
## Summary
- Adds a self-healing device bootstrap (`WizDeviceBootstrapService`, `@PostConstruct`) that idempotently registers 3 shared width-bound devices (`wiz-mobile`/`wiz-wide`/`wiz-ultrawide`) used by dashboard-generation's adaptive layouts.
- Extends `AddVisualizationService.addVisualization` and `WizDashboardFilterBuilder.build`/`buildPerChart` to expose each merged chart's and filter control's own assembly name/position/size (needed to build per-tier layout entries without hiding anything).
- `WizDashboardService.composeDashboard` now builds and attaches Mobile/Wide/Ultrawide `ViewsheetLayout` variants alongside the existing base (2-column) dashboard, reusing the grid-packing math for different column counts. StyleBI's own viewer picks the correct tier live, based on the real screen width/mobile flag reported at open time — no regeneration needed to adapt to a different screen.
- Scope limit (disclosed in the plan): boards with any per-chart filter skip adaptive-layout generation and stay on the base tier only, to avoid combinatorial interaction between per-chart-filter Y-shifts and column count.
- **Fix:** `WizDeviceBootstrapService` was missing `@Lazy(false)`. This app sets `spring.main.lazy-initialization: true` globally, and nothing else in the codebase injects this bean, so Spring never instantiated it — its `@PostConstruct` registration never ran, in any environment, since the feature was written. The three adaptive devices were never actually registered, so every dashboard silently fell back to the base 2-column layout regardless of window width. `@Lazy(false)` mirrors `ServerLifecycleService`, the other `@PostConstruct`-only bootstrap bean in this codebase, which already carries the same annotation for the same reason.
- **`WizDashboardService`'s tile packing replaced with a real 2D "shelf-skyline" packer** (`computeGridLayout`, replacing the old row-major `gridOrigin`): short tiles can now stack vertically beside a tall neighbor (e.g. a bar chart stacking under a radar chart) instead of only ever sitting side-by-side in strict rows, and whichever side of a shared row ends up shorter stretches to match the taller side (never shrinks). Applies uniformly to the base 2-column layout and both Wide/Ultrawide adaptive tiers.

## Test plan
- [x] `mvn -pl community/core test -Dtest='inetsoft.web.wiz.**'` — BUILD SUCCESS (527/527, includes new `WizDeviceBootstrapServiceTest` + grid-packing tests)
- [x] Per-task review (spec compliance + code quality) — Approved on all tasks across both the adaptive-layouts feature and the 2D grid-packing feature; one Critical finding on the grid-packing work (base-tier chart resize left wired to the old sizing call) was caught in review, fixed, and re-reviewed clean
- [x] Two final whole-branch reviews (cross-repo, most capable model) — both ready to merge, no Critical/Important findings outstanding
- [x] Live verification against locally-rebuilt images: dashboard regenerates and reopens correctly with `LayoutInfo` attached; adaptive devices confirmed registered after the `@Lazy(false)` fix; grid-packing regression-checked via the plugin's own MCP tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)
