### PR TITLE
Fix embed CSS scoping and table export download URL

### DIFF
--- a/web/gulp/elements.js
+++ b/web/gulp/elements.js
@@ -66,11 +66,27 @@ gulp.task("elements:concat-css", function () {
       .pipe(gulp.dest("target/generated-resources/gulp/inetsoft/web/resources/elements/"));
 });
 
+// elements.scss scopes the shared/global CSS under all 6 custom element tags (they're all
+// registered from the same bundle - see main-elements.ts). Sass compiles the nested `:root`/
+// `body` selectors from the imported global stylesheet into a descendant combinator per tag
+// (e.g. "inetsoft-table :root"), which never matches anything since no such descendant exists
+// inside a custom element - so each tag needs its own replace down to a plain ancestor selector.
+const ELEMENT_TAGS = [
+   "inetsoft-chart", "inetsoft-crosstab", "inetsoft-table",
+   "inetsoft-gauge", "inetsoft-text", "inetsoft-image"
+];
+
 gulp.task("elements:sass", function () {
-   return gulp.src("projects/portal/src/elements.scss")
-      .pipe(sass())
-      .pipe(replace("inetsoft-chart :root", "inetsoft-chart"))
-      .pipe(replace("inetsoft-chart body", "inetsoft-chart"))
+   let stream = gulp.src("projects/portal/src/elements.scss")
+      .pipe(sass());
+
+   for(const tag of ELEMENT_TAGS) {
+      stream = stream
+         .pipe(replace(`${tag} :root`, tag))
+         .pipe(replace(`${tag} body`, tag));
+   }
+
+   return stream
       .pipe(postcss([cssnano()]))
       .pipe(gulp.dest("target/generated-resources/gulp/inetsoft/web/resources/app/"));
 });

--- a/web/projects/portal/src/app/vsobjects/objects/table/base-table.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/base-table.ts
@@ -1220,7 +1220,13 @@ export abstract class BaseTable<T extends BaseTableModel> extends AbstractVSObje
     * Exports the table
     */
    protected exportTable(): void {
-      const url = "../export/vs-table/" + Tool.encodeURIPath(this.viewsheetClient.runtimeId) +
+      // Build off vsInfo.linkUri (same convention as VSChart.saveImageAs()/getImageUrlPrefix())
+      // rather than a "../"-relative path: a relative path resolves against the *hosting page's*
+      // origin, which is wrong when this component is mounted as a standalone embed web
+      // component on a completely different origin (e.g. wiz's portal) instead of served
+      // directly by the StyleBI app itself.
+      const url = this.vsInfo.linkUri + "export/vs-table/" +
+         Tool.encodeURIPath(this.viewsheetClient.runtimeId) +
          "/" + encodeURIComponent(this.getAssemblyName());
       this.downloadService.download(url);
    }

--- a/web/projects/portal/src/app/vsobjects/objects/table/base-table.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/base-table.ts
@@ -1225,6 +1225,16 @@ export abstract class BaseTable<T extends BaseTableModel> extends AbstractVSObje
       // origin, which is wrong when this component is mounted as a standalone embed web
       // component on a completely different origin (e.g. wiz's portal) instead of served
       // directly by the StyleBI app itself.
+      //
+      // Guard against vsInfo/linkUri not being populated yet (mirrors VSChart's guard): in the
+      // embed components, updateVSInfo() is first called from processAddVSObjectCommand with no
+      // linkUri, so vsInfo.linkUri starts out null until processSetViewsheetInfoCommand arrives
+      // later - and the export toolbar action has no gate on that having happened. Without this
+      // check, clicking Export in that window would concatenate the string "null" into the url.
+      if(!this.vsInfo || !this.vsInfo.linkUri) {
+         return;
+      }
+
       const url = this.vsInfo.linkUri + "export/vs-table/" +
          Tool.encodeURIPath(this.viewsheetClient.runtimeId) +
          "/" + encodeURIComponent(this.getAssemblyName());

--- a/web/projects/portal/src/elements.scss
+++ b/web/projects/portal/src/elements.scss
@@ -15,6 +15,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-inetsoft-chart {
+inetsoft-chart, inetsoft-crosstab, inetsoft-table, inetsoft-gauge, inetsoft-text, inetsoft-image {
   @import "target/generated-resources/gulp/inetsoft/web/resources/elements/concat-elements";
 }


### PR DESCRIPTION
## Summary

Two bugs found while validating wiz's `stylebi-embed-elements` package against the table/crosstab embeds:

- **CSS only scoped to `inetsoft-chart`**: `elements.scss` wrapped the shared/global CSS (icon fonts, Bootstrap utility classes like `.visually-hidden`, and all encapsulated Angular component styles) under the `inetsoft-chart` ancestor selector only, even though the same `elements.js`/`elements.css` bundle registers `inetsoft-crosstab`/`inetsoft-table`/`inetsoft-gauge`/`inetsoft-text`/`inetsoft-image` as well (see `main-elements.ts`). Every non-chart tag silently got none of that CSS — the mini-toolbar's icon classes and `.visually-hidden` label-hiding utility never matched, so buttons rendered as unstyled default buttons showing the raw, untranslated `_#(js:...)` label text instead of an icon. Fixed by expanding the wrapper selector in `elements.scss` to all 6 tags, and correspondingly expanding the `elements:sass` gulp task's `:root`/`body` → bare-tag replacement (previously only handled for `inetsoft-chart`) to all 6.

- **Table export used a relative download URL**: `BaseTable.exportTable()` (shared by `VSTable`/`VSCrosstab`/`VSCalcTable`) built its download URL as `"../export/vs-table/" + runtimeId + "/" + assemblyName` — a relative path. That resolves against the *hosting page's* origin, which is correct when the Viewer/Composer app is served directly by StyleBI, but wrong when these components are mounted as standalone embed web components on an unrelated host page/origin. Since `DownloadTargetComponent` fires its `downloadStarted` (and the resulting "download started" info dialog) unconditionally regardless of whether the URL actually resolves, the UI showed success while nothing downloaded. Fixed by switching to the same `vsInfo.linkUri`-based absolute-URL convention already used everywhere else in the codebase for embed resource URLs (e.g. `VSChart.saveImageAs()`/`getImageUrlPrefix()`, `vs-image`/`vs-gauge`/`vs-text`, etc.).

## Test plan

- [x] Rebuilt the embed package (`npm run package:embed`) and confirmed in the compiled `elements.css` that icon/`.visually-hidden` rules are now emitted for all 6 tags (previously only `inetsoft-chart`), with no leftover unreplaced `<tag> :root`/`<tag> body` selectors
- [x] Confirmed in compiled `elements.js` that `exportTable()` now builds off `this.vsInfo.linkUri` with zero remaining `../export/vs-table` occurrences
- [x] `node --check` on both compiled bundles
- [x] Manually verified in wiz's portal (embedding these components): mini-toolbar icons render correctly (not raw text) and table Export now actually downloads a file

🤖 Generated with [Claude Code](https://claude.com/claude-code)