### PR TITLE
Apply embed container size to table/crosstab and keep tracking it across type switches

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshService.java
@@ -115,6 +115,15 @@ public class VSRefreshService {
                   embedAssemblyInfo.setAssemblyName(event.getAssemblyName());
                   rvs.setEmbedAssemblyInfo(embedAssemblyInfo);
                }
+               // The embedded assembly can be swapped out for a differently-named one on the
+               // same runtime (e.g. WizAutoBindingService#changeType removes the old primary
+               // assembly and places a new one when the user switches viz type). Re-point the
+               // tracked name on every explicit embed refresh, or applyEmbedChartSize()'s name
+               // check keeps comparing against the original (now-gone) assembly forever and
+               // silently stops sizing the new one.
+               else if(embedAssemblyInfo != null && event.getEmbed()) {
+                  embedAssemblyInfo.setAssemblyName(event.getAssemblyName());
+               }
 
                if(embedAssemblyInfo != null) {
                   embedAssemblyInfo.setAssemblySize(event.getAssemblySize());

--- a/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
@@ -1584,7 +1584,8 @@ public class CoreLifecycleService {
       }
    }
 
-   // This only applies to embedded charts; other assembly types intentionally remain unchanged.
+   // Applies to embedded charts and table-data assemblies (table/crosstab/calc-table); other
+   // assembly types intentionally remain unchanged.
    private void applyEmbedChartSize(RuntimeViewsheet rvs, VSAssembly assembly) {
       String name = assembly == null ? null : assembly.getAbsoluteName();
 
@@ -1601,9 +1602,20 @@ public class CoreLifecycleService {
 
       AssemblyInfo info = assembly.getInfo();
 
-      if(info instanceof ChartVSAssemblyInfo && assemblySize != null) {
+      if(assemblySize == null) {
+         return;
+      }
+
+      if(info instanceof ChartVSAssemblyInfo) {
          // Apply the embed container size before building the runtime chart model.
          ((ChartVSAssemblyInfo) info).setMaxSize(assemblySize);
+         info.setPixelSize(assemblySize);
+      }
+      else if(info instanceof TableDataVSAssemblyInfo) {
+         // Without this, a programmatically-created table/crosstab (no composer-authored
+         // layout) keeps its own default pixel size instead of the embed container's actual
+         // size, leaving blank space in the container around the smaller-than-container table.
+         ((TableDataVSAssemblyInfo) info).setMaxSize(assemblySize);
          info.setPixelSize(assemblySize);
       }
    }

--- a/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
@@ -1596,15 +1596,11 @@ public class CoreLifecycleService {
       EmbedAssemblyInfo embedAssemblyInfo = rvs.getEmbedAssemblyInfo();
       Dimension assemblySize = embedAssemblyInfo.getAssemblySize();
 
-      if(!Tool.equals(name, embedAssemblyInfo.getAssemblyName())) {
+      if(!Tool.equals(name, embedAssemblyInfo.getAssemblyName()) || assemblySize == null) {
          return;
       }
 
       AssemblyInfo info = assembly.getInfo();
-
-      if(assemblySize == null) {
-         return;
-      }
 
       if(info instanceof ChartVSAssemblyInfo) {
          // Apply the embed container size before building the runtime chart model.

--- a/core/src/test/java/inetsoft/web/viewsheet/controller/VSRefreshServiceEmbedAssemblyTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/controller/VSRefreshServiceEmbedAssemblyTest.java
@@ -1,0 +1,136 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.viewsheet.controller;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.util.XSessionService;
+import inetsoft.web.embed.EmbedAssemblyInfo;
+import inetsoft.web.composer.vs.VSObjectTreeService;
+import inetsoft.web.viewsheet.event.RefreshVSAssemblyEvent;
+import inetsoft.web.viewsheet.service.CommandDispatcher;
+import inetsoft.web.viewsheet.service.CoreLifecycleService;
+import inetsoft.web.viewsheet.service.ParameterService;
+import inetsoft.web.viewsheet.service.VSBookmarkService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Dimension;
+import java.security.Principal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression coverage for the bug where switching a wiz-embedded visualization's type (e.g.
+ * table -&gt; crosstab, or back) left the newly-swapped-in assembly without the embed
+ * container's pixel size, reproducing the "blank space on the right" bug for the *second* and
+ * later type switches even though the very first render of either type was fine.
+ *
+ * <p>Root cause: {@code WizAutoBindingService#changeType} replaces the viewsheet's primary
+ * assembly with a differently-named one on every type switch (same {@code wizRuntimeId}, new
+ * assembly name) rather than mutating one assembly in place. The embed component always resends
+ * an {@code embed=true} {@link RefreshVSAssemblyEvent} with its (new) assembly name after
+ * remounting, but {@link VSRefreshService#refreshVsAssembly} only ever wrote
+ * {@link EmbedAssemblyInfo#setAssemblyName} the *first* time an {@code EmbedAssemblyInfo} was
+ * created for a runtime — every later switch kept comparing against the original, now-removed
+ * assembly's name in {@code CoreLifecycleService#applyEmbedChartSize}, so the size was silently
+ * never applied to the new assembly.
+ */
+@Tag("core")
+class VSRefreshServiceEmbedAssemblyTest {
+   private VSRefreshService createService() {
+      return new VSRefreshService(
+         mock(CoreLifecycleService.class), mock(ViewsheetService.class),
+         mock(VSObjectTreeService.class), mock(VSBookmarkService.class),
+         mock(ParameterService.class), mock(XSessionService.class));
+   }
+
+   @Test
+   void reEmbedTracksTheCurrentlyEmbeddedAssemblyAcrossATypeSwitch() throws Exception {
+      String runtimeId = "wiz-runtime-1";
+      Principal principal = mock(Principal.class);
+      CommandDispatcher dispatcher = mock(CommandDispatcher.class);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      ViewsheetSandbox box = mock(ViewsheetSandbox.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+      // Neither assembly needs to actually exist for this test: refreshVsAssembly only needs the
+      // embed-info bookkeeping to run, which happens before the (skipped, assembly == null) call
+      // to refreshAssemblyAndDependencies.
+      when(vs.getAssembly(any(String.class))).thenReturn(null);
+
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      when(viewsheetService.getViewsheet(runtimeId, principal)).thenReturn(rvs);
+
+      VSRefreshService service = new VSRefreshService(
+         mock(CoreLifecycleService.class), viewsheetService,
+         mock(VSObjectTreeService.class), mock(VSBookmarkService.class),
+         mock(ParameterService.class), mock(XSessionService.class));
+
+      Dimension containerSize = new Dimension(908, 600);
+
+      // First render: a table assembly is embedded and sized.
+      RefreshVSAssemblyEvent tableEvent = RefreshVSAssemblyEvent.builder()
+         .vsRuntimeId(runtimeId)
+         .assemblyName("vs_table_1")
+         .embed(true)
+         .assemblySize(containerSize)
+         .build();
+
+      // The real rvs.getEmbedAssemblyInfo()/setEmbedAssemblyInfo() round-trip through a plain
+      // field on the (here mocked) RuntimeViewsheet - stub it with a simple in-memory holder so
+      // the second call sees what the first call stored, exactly as the real class behaves.
+      final EmbedAssemblyInfo[] stored = new EmbedAssemblyInfo[1];
+      when(rvs.getEmbedAssemblyInfo()).thenAnswer(inv -> stored[0]);
+      org.mockito.Mockito.doAnswer(inv -> {
+         stored[0] = inv.getArgument(0);
+         return null;
+      }).when(rvs).setEmbedAssemblyInfo(any());
+
+      service.refreshVsAssembly(runtimeId, tableEvent, dispatcher, "", principal);
+
+      assertEquals("vs_table_1", rvs.getEmbedAssemblyInfo().getAssemblyName());
+      assertEquals(containerSize, rvs.getEmbedAssemblyInfo().getAssemblySize());
+
+      // User switches type: changeType() replaced the table assembly with a differently-named
+      // crosstab assembly on the SAME runtime. The embed component remounts and resends its
+      // (embed=true) refresh with the new assembly name and the same container size.
+      RefreshVSAssemblyEvent crosstabEvent = RefreshVSAssemblyEvent.builder()
+         .vsRuntimeId(runtimeId)
+         .assemblyName("vs_crosstab_2")
+         .embed(true)
+         .assemblySize(containerSize)
+         .build();
+
+      service.refreshVsAssembly(runtimeId, crosstabEvent, dispatcher, "", principal);
+
+      assertEquals("vs_crosstab_2", rvs.getEmbedAssemblyInfo().getAssemblyName(),
+         "the embed target must follow the currently-embedded assembly across a type switch, " +
+         "or applyEmbedChartSize() keeps comparing against the original (now-gone) assembly " +
+         "name forever and silently stops sizing the new one");
+      assertEquals(containerSize, rvs.getEmbedAssemblyInfo().getAssemblySize());
+   }
+}

--- a/core/src/test/java/inetsoft/web/viewsheet/service/CoreLifecycleServiceEmbedSizeTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/service/CoreLifecycleServiceEmbedSizeTest.java
@@ -1,0 +1,148 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.viewsheet.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.internal.license.LicenseManager;
+import inetsoft.sree.internal.cluster.Cluster;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.uql.asset.internal.AssemblyInfo;
+import inetsoft.uql.service.DataSourceRegistry;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.CrosstabVSAssemblyInfo;
+import inetsoft.web.binding.service.DataRefModelFactoryService;
+import inetsoft.web.composer.vs.controller.VSLayoutService;
+import inetsoft.web.embed.EmbedAssemblyInfo;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.web.viewsheet.model.VSObjectModelFactoryService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.Dimension;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression coverage for the bug where an embedded crosstab (or table/gauge/text/image)
+ * rendered blank in the Wiz chat viewer while an embedded chart rendered correctly.
+ *
+ * Root cause: {@code applyEmbedChartSize} only pushed the embed container's size onto the
+ * assembly's pixel size when the assembly was a {@link ChartVSAssemblyInfo}. A
+ * programmatically-created crosstab (no composer-authored layout) therefore kept the
+ * {@code AssetUtil} default size (100x20), rendering as an all-but-invisible sliver.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class CoreLifecycleServiceEmbedSizeTest {
+   private CoreLifecycleService createService() {
+      return new CoreLifecycleService(
+         mock(VSObjectModelFactoryService.class), mock(ViewsheetService.class),
+         mock(VSLayoutService.class), mock(ParameterService.class),
+         mock(VSCompositionService.class), mock(DataRefModelFactoryService.class),
+         null, null, mock(LicenseManager.class), mock(SecurityEngine.class),
+         mock(Cluster.class), mock(DataSourceRegistry.class));
+   }
+
+   private void invokeApplyEmbedChartSize(CoreLifecycleService service, RuntimeViewsheet rvs,
+                                           VSAssembly assembly) throws Exception
+   {
+      Method method = CoreLifecycleService.class
+         .getDeclaredMethod("applyEmbedChartSize", RuntimeViewsheet.class, VSAssembly.class);
+      method.setAccessible(true);
+      method.invoke(service, rvs, assembly);
+   }
+
+   @Test
+   void appliesContainerSizeToEmbeddedCrosstab() throws Exception {
+      Dimension containerSize = new Dimension(908, 600);
+      EmbedAssemblyInfo embedAssemblyInfo = new EmbedAssemblyInfo();
+      embedAssemblyInfo.setAssemblyName("vs_crosstab_1");
+      embedAssemblyInfo.setAssemblySize(containerSize);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getEmbedAssemblyInfo()).thenReturn(embedAssemblyInfo);
+
+      CrosstabVSAssemblyInfo info = new CrosstabVSAssemblyInfo();
+      VSAssembly assembly = mock(VSAssembly.class);
+      when(assembly.getAbsoluteName()).thenReturn("vs_crosstab_1");
+      when(assembly.getInfo()).thenReturn((AssemblyInfo) info);
+
+      invokeApplyEmbedChartSize(createService(), rvs, assembly);
+
+      assertEquals(containerSize, info.getPixelSize(),
+         "the embed container size must drive the crosstab's pixel size, or it renders at " +
+         "the AssetUtil default (100x20)");
+      assertEquals(containerSize, info.getMaxSize(),
+         "BaseTableModel overrides objectFormat's position/size from getMaxSize() when set, " +
+         "mirroring how chart uses max-mode size — pixel size alone is not enough");
+   }
+
+   @Test
+   void chartsStillGetMaxModeSizeInAdditionToPixelSize() throws Exception {
+      Dimension containerSize = new Dimension(908, 600);
+      EmbedAssemblyInfo embedAssemblyInfo = new EmbedAssemblyInfo();
+      embedAssemblyInfo.setAssemblyName("vs_chart_1");
+      embedAssemblyInfo.setAssemblySize(containerSize);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getEmbedAssemblyInfo()).thenReturn(embedAssemblyInfo);
+
+      ChartVSAssemblyInfo info = new ChartVSAssemblyInfo();
+      VSAssembly assembly = mock(VSAssembly.class);
+      when(assembly.getAbsoluteName()).thenReturn("vs_chart_1");
+      when(assembly.getInfo()).thenReturn((AssemblyInfo) info);
+
+      invokeApplyEmbedChartSize(createService(), rvs, assembly);
+
+      assertEquals(containerSize, info.getPixelSize());
+      assertEquals(containerSize, info.getMaxSize());
+   }
+
+   @Test
+   void doesNotTouchAssemblyOutsideTheEmbedTarget() throws Exception {
+      EmbedAssemblyInfo embedAssemblyInfo = new EmbedAssemblyInfo();
+      embedAssemblyInfo.setAssemblyName("vs_crosstab_1");
+      embedAssemblyInfo.setAssemblySize(new Dimension(908, 600));
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getEmbedAssemblyInfo()).thenReturn(embedAssemblyInfo);
+
+      CrosstabVSAssemblyInfo info = new CrosstabVSAssemblyInfo();
+      Dimension originalSize = info.getPixelSize();
+      VSAssembly assembly = mock(VSAssembly.class);
+      when(assembly.getAbsoluteName()).thenReturn("some_other_assembly");
+
+      invokeApplyEmbedChartSize(createService(), rvs, assembly);
+
+      assertEquals(originalSize, info.getPixelSize());
+   }
+}

--- a/core/src/test/java/inetsoft/web/viewsheet/service/CoreLifecycleServiceEmbedSizeTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/service/CoreLifecycleServiceEmbedSizeTest.java
@@ -54,8 +54,9 @@ import static org.mockito.Mockito.when;
  *
  * Root cause: {@code applyEmbedChartSize} only pushed the embed container's size onto the
  * assembly's pixel size when the assembly was a {@link ChartVSAssemblyInfo}. A
- * programmatically-created crosstab (no composer-authored layout) therefore kept the
- * {@code AssetUtil} default size (100x20), rendering as an all-but-invisible sliver.
+ * programmatically-created crosstab (no composer-authored layout) therefore kept its own
+ * default pixel size ({@link CrosstabVSAssemblyInfo}'s constructor default of 400x240) instead
+ * of the embed container's actual size, rendering far smaller than the space it was given.
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)


### PR DESCRIPTION
## Summary

Two related bugs in the wiz embed sizing path, both surfacing as blank space in the embed container around a table/crosstab that renders smaller than the container it's given:

- **`CoreLifecycleService#applyEmbedChartSize` only sized charts.** It pushed the embed container's pixel size onto `ChartVSAssemblyInfo` only. A programmatically-created table/crosstab/calc-table (`TableDataVSAssemblyInfo`) kept its own default size instead of the container's actual size, leaving blank space around the smaller-than-container table. Fixed by also sizing `TableDataVSAssemblyInfo` the same way.

- **Switching a wiz visualization's type (e.g. table → crosstab) still left the newly-displayed assembly undersized**, even with the fix above. `WizAutoBindingService#changeType` doesn't mutate the existing assembly in place — it replaces the viewsheet's primary assembly with a differently-named one on the same runtime. The embed component always resends an `embed=true` `RefreshVSAssemblyEvent` with its *current* assembly name after remounting, but `VSRefreshService#refreshVsAssembly` only ever wrote `EmbedAssemblyInfo#setAssemblyName` the *first* time an `EmbedAssemblyInfo` was created for a runtime — every later type switch kept comparing against the original, now-replaced assembly's name in `applyEmbedChartSize`, so the size silently stopped being applied after the very first switch (in either direction). Fixed by re-pointing the tracked assembly name on every explicit embed refresh, not just the first.

## Test plan

- [x] Added `CoreLifecycleServiceEmbedSizeTest` — covers chart and crosstab sizing via `applyEmbedChartSize`
- [x] Added `VSRefreshServiceEmbedAssemblyTest` — simulates a table → crosstab type switch (same runtime, new assembly name) and asserts the embed target's tracked assembly name follows the switch
- [x] Both tests verified to fail without their corresponding fix and pass with it (temporarily reverted each fix, confirmed the new test fails with the expected assertion message, then restored the fix and confirmed it passes)
- [x] `mvn -pl core -am test` for both new test classes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)