### PR TITLE
feat(wiz): let the modify-only path name the chart to filter

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/CreateVisualizationModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/CreateVisualizationModel.java
@@ -101,6 +101,26 @@ public class CreateVisualizationModel {
    }
 
    /**
+    * Which chart the "modificationOnly" path acts on (see
+    * {@code WizVsService.createViewsheetInternal}). Null — the default and every pre-existing
+    * caller — means the viewsheet's current PRIMARY assembly, i.e. the chart created or copied most
+    * recently.
+    *
+    * <p>Naming one is required when the caller edits a chart that is NOT the newest: in a
+    * multi-chart conversation a filter built against an earlier chart's fields would otherwise be
+    * applied to a different chart, which at best filters the wrong chart and at worst references
+    * columns that chart does not bind. Ignored outside the modificationOnly path (the standard
+    * create/rebind path produces its own fresh assembly).
+    */
+   public String getAssemblyName() {
+      return assemblyName;
+   }
+
+   public void setAssemblyName(String assemblyName) {
+      this.assemblyName = assemblyName;
+   }
+
+   /**
     * #75456: row cap for sampled-preview mode. Null or &lt;=0 = full data (the default and the
     * agent path); &gt;0 = aggregate at most this many detail rows (faster on heavy/non-mergeable
     * sources, but Sum/Count may be approximate).
@@ -117,6 +137,7 @@ public class CreateVisualizationModel {
    private VisualizationConfig config;
    private String runtimeId;
    private String viewsheetIdentifier;
+   private String assemblyName;
    private VisualizationConditionModel conditionModel;
    private Integer sampleMaxRows;
    private transient VSAssembly primaryAssembly;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1088,19 +1088,17 @@ public class WizVsService {
             VSAssembly modAssembly = sourceAssembly;
 
             // Copy-then-apply: duplicate the source BEFORE applying the condition, so the original is
-            // left untouched and the filter lands on a new, parallel copy instead. Captured BEFORE the
-            // duplicate runs, because the assembly that gets demoted is whichever is currently primary
-            // — not necessarily the source, which may be an earlier chart the caller named explicitly.
-            // Rollback restores THAT assembly's primary flag, so recording the source here instead
-            // would promote the wrong chart and leave the viewsheet with two primaries.
+            // left untouched and the filter lands on a new, parallel copy instead. The assembly that
+            // loses primary status is whichever currently holds it — not necessarily the source,
+            // which may be an earlier chart the caller named explicitly — so take it from the
+            // duplication result rather than assuming; rollback restores THAT assembly's flag.
             if(model.isCopy()) {
-               VSAssembly previousPrimary = findPrimaryAssembly(targetVs);
-               VSAssembly duplicated = duplicateAssembly(rvs, sourceAssembly);
+               AssemblyDuplication duplicated = duplicateAssembly(rvs, sourceAssembly);
 
                if(duplicated != null) {
-                  demotedOriginal = previousPrimary;
-                  rollbackCopy = duplicated;
-                  modAssembly = duplicated;
+                  demotedOriginal = duplicated.demoted();
+                  rollbackCopy = duplicated.copy();
+                  modAssembly = duplicated.copy();
                }
                else {
                   copyNote = "Copy requested but could not be created; filter applied in place.";
@@ -1782,7 +1780,8 @@ public class WizVsService {
          return null;
       }
 
-      return duplicateAssembly(rvs, source);
+      AssemblyDuplication duplication = duplicateAssembly(rvs, source);
+      return duplication == null ? null : duplication.copy();
    }
 
    /**
@@ -1803,7 +1802,7 @@ public class WizVsService {
     * <p>Returns null if {@code source}'s type has no registered rebind factory (ASSEMBLY_FACTORIES)
     * — the caller should fall back to applying in place.
     */
-   public VSAssembly duplicateAssembly(RuntimeViewsheet rvs, VSAssembly source) {
+   public AssemblyDuplication duplicateAssembly(RuntimeViewsheet rvs, VSAssembly source) {
       Viewsheet vs = rvs.getViewsheet();
       String newName = uniqueAssemblyName(vs, source.getName());
       VSAssembly copy = rebindAssembly(vs, newName, source);
@@ -1816,16 +1815,27 @@ public class WizVsService {
       // `source`, which may be an earlier chart the caller named explicitly. Demoting `source`
       // unconditionally would leave the real primary promoted alongside the new copy, i.e. two
       // primaries in one viewsheet.
-      VSAssembly currentPrimary = findPrimaryAssembly(vs);
+      VSAssembly demoted = findPrimaryAssembly(vs);
 
-      if(currentPrimary != null) {
-         currentPrimary.setPrimary(false);
+      if(demoted != null) {
+         demoted.setPrimary(false);
       }
 
       vs.addAssembly(copy);
       copy.setPrimary(true);
-      return copy;
+      return new AssemblyDuplication(copy, demoted);
    }
+
+   /**
+    * The outcome of {@link #duplicateAssembly}: the new copy, and the assembly that lost primary
+    * status to it ({@code null} when the viewsheet had no primary).
+    *
+    * <p>{@code demoted} is returned rather than left for the caller to re-derive: it is NOT
+    * necessarily the duplicated source, so a caller that needs to undo the promotion (rollback)
+    * would otherwise have to call {@code findPrimaryAssembly} itself just before duplicating and
+    * trust that nothing in between changes primary state — an invariant no compiler enforces.
+    */
+   public record AssemblyDuplication(VSAssembly copy, VSAssembly demoted) {}
 
    /**
     * Throws if the lens chain contains failed-query fallback data. When a live query fails

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1071,30 +1071,40 @@ public class WizVsService {
 
          if(modificationOnly) {
             targetVs = vs;
-            VSAssembly sourceAssembly = findPrimaryAssembly(targetVs);
+            // An explicit assemblyName names the chart to modify; without one, fall back to the
+            // primary assembly (the chart created or copied most recently), which is what every
+            // caller predating this parameter relies on. A caller editing a chart OTHER than the
+            // newest MUST name it — its condition was built against that chart's fields.
+            VSAssembly sourceAssembly = model.getAssemblyName() != null
+               ? targetVs.getAssembly(model.getAssemblyName())
+               : findPrimaryAssembly(targetVs);
 
             if(sourceAssembly == null) {
-               throw new IllegalStateException("No primary assembly found in viewsheet for modification");
+               throw new IllegalStateException(model.getAssemblyName() != null
+                  ? "Assembly \"" + model.getAssemblyName() + "\" not found in viewsheet for modification"
+                  : "No primary assembly found in viewsheet for modification");
             }
 
             VSAssembly modAssembly = sourceAssembly;
 
-            // Copy-then-apply: duplicate the current primary BEFORE applying the condition, so the
-            // original is left untouched and the filter lands on a new, parallel copy instead.
-            // Reuses the same duplicatePrimaryAssembly the chart color/format/highlight paths use —
-            // sourceAssembly is guaranteed primary here (that's how findPrimaryAssembly found it), so
-            // duplicatePrimaryAssembly's precondition is always satisfied.
+            // Copy-then-apply: duplicate the source BEFORE applying the condition, so the original is
+            // left untouched and the filter lands on a new, parallel copy instead. Captured BEFORE the
+            // duplicate runs, because the assembly that gets demoted is whichever is currently primary
+            // — not necessarily the source, which may be an earlier chart the caller named explicitly.
+            // Rollback restores THAT assembly's primary flag, so recording the source here instead
+            // would promote the wrong chart and leave the viewsheet with two primaries.
             if(model.isCopy()) {
-               VSAssembly duplicated = duplicatePrimaryAssembly(rvs, sourceAssembly);
+               VSAssembly previousPrimary = findPrimaryAssembly(targetVs);
+               VSAssembly duplicated = duplicateAssembly(rvs, sourceAssembly);
 
                if(duplicated != null) {
-                  demotedOriginal = sourceAssembly;
+                  demotedOriginal = previousPrimary;
                   rollbackCopy = duplicated;
                   modAssembly = duplicated;
                }
                else {
                   copyNote = "Copy requested but could not be created; filter applied in place.";
-                  LOG.warn("createViewsheetInternal (modificationOnly): duplicatePrimaryAssembly " +
+                  LOG.warn("createViewsheetInternal (modificationOnly): duplicateAssembly " +
                      "failed for {}; falling back to in-place apply.", sourceAssembly.getName());
                }
             }
@@ -1427,11 +1437,16 @@ public class WizVsService {
                if(modificationOnly) {
                   if(rollbackCopy != null) {
                      // A copy was made for this call; undo it — remove the duplicate and restore the
-                     // original as primary. The original's condition was never touched, so there is
-                     // nothing to restore on it (mirrors setChartFormat/setChartColors/applyHighlight's
-                     // identical copy rollback).
+                     // demoted assembly as primary. Neither the source nor the demoted assembly had
+                     // its condition touched, so there is nothing to restore on them (mirrors
+                     // setChartFormat/setChartColors/applyHighlight's identical copy rollback).
+                     // demotedOriginal is null only if the viewsheet had no primary to begin with, in
+                     // which case there is nothing to restore.
                      previousVs.removeAssembly(rollbackCopy.getName());
-                     demotedOriginal.setPrimary(true);
+
+                     if(demotedOriginal != null) {
+                        demotedOriginal.setPrimary(true);
+                     }
                   }
                   else if(assembly instanceof DataVSAssembly dataAsm) {
                      // No copy — assembly IS the original, mutated in place; restore its prior
@@ -1767,6 +1782,28 @@ public class WizVsService {
          return null;
       }
 
+      return duplicateAssembly(rvs, source);
+   }
+
+   /**
+    * Duplicates {@code source} within {@code rvs}'s viewsheet under a unique name, promotes the copy
+    * to primary, and demotes (never deletes) whichever assembly was primary before.
+    *
+    * <p>Unlike {@link #duplicatePrimaryAssembly}, {@code source} need NOT be the current primary.
+    * That matters when the caller has explicitly named an EARLIER chart to modify: the copy must be
+    * taken from the chart the caller named, while the assembly losing primary status is whatever
+    * held it. Callers needing rollback must therefore record the previous primary themselves (see
+    * {@code createViewsheetInternal}'s modificationOnly branch) — the demoted assembly is not
+    * necessarily {@code source}.
+    *
+    * <p>Use {@link #duplicatePrimaryAssembly} instead when the source is supposed to already BE the
+    * primary and a mismatch means the caller's assembly name is stale: it refuses rather than
+    * silently duplicating the wrong chart.
+    *
+    * <p>Returns null if {@code source}'s type has no registered rebind factory (ASSEMBLY_FACTORIES)
+    * — the caller should fall back to applying in place.
+    */
+   public VSAssembly duplicateAssembly(RuntimeViewsheet rvs, VSAssembly source) {
       Viewsheet vs = rvs.getViewsheet();
       String newName = uniqueAssemblyName(vs, source.getName());
       VSAssembly copy = rebindAssembly(vs, newName, source);
@@ -1775,9 +1812,16 @@ public class WizVsService {
          return null;
       }
 
-      // source is confirmed primary above, so demote it specifically — not "whichever assembly happens
-      // to be primary" — for a second layer of defense against demoting the wrong assembly.
-      source.setPrimary(false);
+      // Demote whichever assembly currently holds primary — resolved rather than assumed to be
+      // `source`, which may be an earlier chart the caller named explicitly. Demoting `source`
+      // unconditionally would leave the real primary promoted alongside the new copy, i.e. two
+      // primaries in one viewsheet.
+      VSAssembly currentPrimary = findPrimaryAssembly(vs);
+
+      if(currentPrimary != null) {
+         currentPrimary.setPrimary(false);
+      }
+
       vs.addAssembly(copy);
       copy.setPrimary(true);
       return copy;

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceDuplicateAssemblyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceDuplicateAssemblyTest.java
@@ -1,0 +1,195 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.test.*;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.sree.security.SecurityEngine;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * duplicateAssembly is the copy-then-apply entry point for the modificationOnly (in-place filter)
+ * path, where the chart being copied is NOT necessarily the current primary: a wiz turn may name an
+ * earlier chart explicitly. It must therefore duplicate whatever source it is given while demoting
+ * whichever assembly actually holds primary, and report that demoted assembly back so the caller can
+ * undo the promotion on rollback.
+ *
+ * <p>This is the difference from {@link WizVsServiceDuplicatePrimaryAssemblyTest}'s subject, which
+ * additionally REFUSES a non-primary source (protecting callers whose assembly name comes from the
+ * client and may be stale). The tests below deliberately cover the case that method rejects.
+ *
+ * <p>Real Viewsheet/ChartVSAssembly instances are used (not Mockito mocks) for the same reason as
+ * that sibling test: rebindAssembly dispatches on src.getClass() against a Class-keyed factory map
+ * (ASSEMBLY_FACTORIES), which a mock's synthetic subclass never matches.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizVsServiceDuplicateAssemblyTest {
+   private static WizVsService newService() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+      return new WizVsService(vsService, engine, sec);
+   }
+
+   private static RuntimeViewsheet rvsOf(Viewsheet vs) {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      return rvs;
+   }
+
+   @Test
+   void duplicatesANonPrimarySourceAndDemotesTheActualPrimary() throws Exception {
+      // The scenario this method exists for: the user asked to filter an EARLIER chart, so the copy
+      // must be taken from that chart while the newest chart is the one that loses primary status.
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly earlier = new ChartVSAssembly(vs, "Chart1");
+      earlier.setPrimary(false);
+      vs.addAssembly(earlier);
+
+      ChartVSAssembly newest = new ChartVSAssembly(vs, "Chart2");
+      newest.setPrimary(true);
+      vs.addAssembly(newest);
+
+      WizVsService service = newService();
+      WizVsService.AssemblyDuplication result = service.duplicateAssembly(rvsOf(vs), earlier);
+
+      assertNotNull(result, "a non-primary source must still be duplicated");
+      // The copy derives from the named source, not from whatever was primary.
+      assertTrue(result.copy().getName().startsWith("Chart1"));
+      assertTrue(result.copy().isPrimary());
+      // The assembly that lost primary is the one that HELD it — not the source.
+      assertSame(newest, result.demoted());
+      assertFalse(newest.isPrimary());
+   }
+
+   @Test
+   void leavesExactlyOnePrimaryBehind() throws Exception {
+      // The specific corruption this method's demote-the-real-primary logic prevents: demoting the
+      // source instead would be a no-op on an already-non-primary chart, leaving the old primary
+      // promoted alongside the new copy.
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly earlier = new ChartVSAssembly(vs, "Chart1");
+      earlier.setPrimary(false);
+      vs.addAssembly(earlier);
+
+      ChartVSAssembly newest = new ChartVSAssembly(vs, "Chart2");
+      newest.setPrimary(true);
+      vs.addAssembly(newest);
+
+      WizVsService service = newService();
+      service.duplicateAssembly(rvsOf(vs), earlier);
+
+      long primaries = Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof VSAssembly vsa && vsa.isPrimary())
+         .count();
+      assertEquals(1, primaries, "exactly one assembly may be primary");
+   }
+
+   @Test
+   void keepsTheSourceInTheViewsheet() throws Exception {
+      // Copy-then-apply's whole point: the chart the user named is left untouched, so its message in
+      // the conversation still renders what it rendered before.
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly earlier = new ChartVSAssembly(vs, "Chart1");
+      earlier.setPrimary(false);
+      vs.addAssembly(earlier);
+
+      ChartVSAssembly newest = new ChartVSAssembly(vs, "Chart2");
+      newest.setPrimary(true);
+      vs.addAssembly(newest);
+
+      WizVsService service = newService();
+      service.duplicateAssembly(rvsOf(vs), earlier);
+
+      Assembly source = vs.getAssembly("Chart1");
+      assertNotNull(source, "the duplicated source must not be removed");
+      assertFalse(((VSAssembly) source).isPrimary());
+   }
+
+   @Test
+   void reportsANullDemotedAssemblyWhenNothingWasPrimary() throws Exception {
+      // Nothing to restore on rollback in this case — the caller must tolerate a null rather than NPE
+      // (see createViewsheetInternal's rollback branch).
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly source = new ChartVSAssembly(vs, "Chart1");
+      source.setPrimary(false);
+      vs.addAssembly(source);
+
+      WizVsService service = newService();
+      WizVsService.AssemblyDuplication result = service.duplicateAssembly(rvsOf(vs), source);
+
+      assertNotNull(result);
+      assertNull(result.demoted());
+      assertTrue(result.copy().isPrimary());
+   }
+
+   @Test
+   void duplicatesAPrimarySourceAndReportsItAsTheDemotedOne() throws Exception {
+      // The ordinary case (source IS primary) must keep behaving exactly as duplicatePrimaryAssembly
+      // did — that method now delegates here, so this pins the shared behaviour.
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly source = new ChartVSAssembly(vs, "Chart1");
+      source.setPrimary(true);
+      vs.addAssembly(source);
+
+      WizVsService service = newService();
+      WizVsService.AssemblyDuplication result = service.duplicateAssembly(rvsOf(vs), source);
+
+      assertNotNull(result);
+      assertSame(source, result.demoted());
+      assertFalse(source.isPrimary());
+      assertTrue(result.copy().isPrimary());
+      assertNotEquals("Chart1", result.copy().getName());
+   }
+
+   @Test
+   void returnsNullForAnAssemblyTypeWithNoRebindFactory() throws Exception {
+      // CalcTableVSAssembly has no ASSEMBLY_FACTORIES entry; the caller falls back to applying in
+      // place rather than failing the request.
+      Viewsheet vs = new Viewsheet();
+      inetsoft.uql.viewsheet.CalcTableVSAssembly source =
+         new inetsoft.uql.viewsheet.CalcTableVSAssembly(vs, "Calc1");
+      source.setPrimary(true);
+      vs.addAssembly(source);
+
+      WizVsService service = newService();
+
+      assertNull(service.duplicateAssembly(rvsOf(vs), source));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFilterCopyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFilterCopyTest.java
@@ -46,6 +46,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -62,8 +63,11 @@ import static org.mockito.Mockito.when;
  * createViewsheetInternal's "modificationOnly" (in-place filter) path's copy-then-apply wiring
  * (model.isCopy()) mirrors setChartFormat/setChartColors/applyHighlight's duplicate-before-apply +
  * rollback-on-failure pattern exactly — see {@link WizAutoBindingServiceSetChartColorsTest} for the
- * equivalent coverage on that path, and {@link WizVsServiceDuplicatePrimaryAssemblyTest} for
- * duplicatePrimaryAssembly's own correctness (not re-tested here).
+ * equivalent coverage on that path, and {@link WizVsServiceDuplicatePrimaryAssemblyTest} /
+ * {@link WizVsServiceDuplicateAssemblyTest} for the duplication helpers' own correctness (not
+ * re-tested here). This path calls {@code duplicateAssembly} — not {@code duplicatePrimaryAssembly}
+ * — because the chart it copies need not be the current primary: the caller may name an earlier
+ * chart via {@code assemblyName}.
  *
  * <p>executeAndExtract/collectFlatBinding are stubbed via a Mockito spy on a real WizVsService
  * instance, same as {@link WizVsServiceApplyHighlightCopyTest} — this isolates the copy-then-apply
@@ -143,10 +147,53 @@ class WizVsServiceFilterCopyTest {
    }
 
    @Test
-   void copyFalseNeverCallsDuplicatePrimaryAssembly() throws Exception {
+   void noAssemblyNameResolvesThePrimaryAssembly() throws Exception {
+      // Back-compat: every caller predating the assemblyName parameter omits it and must keep
+      // targeting the primary — the chart created or copied most recently.
       service.createViewsheet(request(false), user);
 
-      verify(service, never()).duplicatePrimaryAssembly(any(), any());
+      verify(assembly).setPreConditionList(any());
+      verify(vs, never()).getAssembly(anyString());
+   }
+
+   @Test
+   void anExplicitAssemblyNameTargetsThatChartInsteadOfThePrimary() throws Exception {
+      // The reason this parameter exists: a wiz turn editing an EARLIER chart must filter THAT
+      // chart, whose fields the conditionModel was built against — not whichever is primary now.
+      ChartVSAssembly earlier = mock(ChartVSAssembly.class);
+      when(earlier.getName()).thenReturn("vs_0");
+      when(earlier.isPrimary()).thenReturn(false);
+      when(vs.getAssembly("vs_0")).thenReturn(earlier);
+
+      CreateVisualizationModel model = request(false);
+      model.setAssemblyName("vs_0");
+      CreateViewsheetResult result = service.createViewsheet(model, user);
+
+      verify(earlier).setPreConditionList(any());
+      verify(assembly, never()).setPreConditionList(any());
+      assertEquals("vs_0", result.getAssemblyName());
+   }
+
+   @Test
+   void anUnknownAssemblyNameFailsLoudlyRatherThanSilentlyUsingThePrimary() throws Exception {
+      // Falling back to the primary here would apply the condition to a chart the caller did not
+      // name — the exact failure this parameter was added to prevent — so it must throw instead.
+      when(vs.getAssembly("nope")).thenReturn(null);
+
+      CreateVisualizationModel model = request(false);
+      model.setAssemblyName("nope");
+
+      IllegalStateException ex =
+         assertThrows(IllegalStateException.class, () -> service.createViewsheet(model, user));
+      assertTrue(ex.getMessage().contains("nope"), "the message should name the missing assembly");
+      verify(assembly, never()).setPreConditionList(any());
+   }
+
+   @Test
+   void copyFalseNeverDuplicatesTheAssembly() throws Exception {
+      service.createViewsheet(request(false), user);
+
+      verify(service, never()).duplicateAssembly(any(), any());
       verify(assembly).setPreConditionList(any());
    }
 
@@ -155,7 +202,8 @@ class WizVsServiceFilterCopyTest {
       ChartVSAssembly copy = mock(ChartVSAssembly.class);
       when(copy.getName()).thenReturn("vs_1_copy1");
 
-      doReturn(copy).when(service).duplicatePrimaryAssembly(rvs, assembly);
+      doReturn(new WizVsService.AssemblyDuplication(copy, assembly))
+         .when(service).duplicateAssembly(rvs, assembly);
 
       CreateViewsheetResult result = service.createViewsheet(request(true), user);
 
@@ -168,7 +216,7 @@ class WizVsServiceFilterCopyTest {
 
    @Test
    void copyTrueButDuplicationFailsFallsBackToInPlaceWithANote() throws Exception {
-      doReturn(null).when(service).duplicatePrimaryAssembly(rvs, assembly);
+      doReturn(null).when(service).duplicateAssembly(rvs, assembly);
 
       CreateViewsheetResult result = service.createViewsheet(request(true), user);
 
@@ -180,7 +228,7 @@ class WizVsServiceFilterCopyTest {
 
    @Test
    void copySucceedsThenApplyThrowsRollsBackTheDuplicateAndRestoresTheOriginalAsPrimary() throws Exception {
-      // Force the condition-application step itself to throw AFTER duplicatePrimaryAssembly has
+      // Force the condition-application step itself to throw AFTER duplicateAssembly has
       // already mutated the live runtime (added the copy, demoted the original, promoted the copy)
       // but before persistViewsheet ever runs. That live-runtime mutation must be undone, not left
       // dangling — mirrors WizAutoBindingServiceSetChartColorsTest.copySucceedsThenApplyThrowsRollsBack...
@@ -188,7 +236,8 @@ class WizVsServiceFilterCopyTest {
       when(copy.getName()).thenReturn("vs_1_copy1");
       doThrow(new RuntimeException("boom")).when(copy).setPreConditionList(any());
 
-      doReturn(copy).when(service).duplicatePrimaryAssembly(rvs, assembly);
+      doReturn(new WizVsService.AssemblyDuplication(copy, assembly))
+         .when(service).duplicateAssembly(rvs, assembly);
 
       assertThrows(RuntimeException.class, () -> service.createViewsheet(request(true), user));
 
@@ -206,7 +255,8 @@ class WizVsServiceFilterCopyTest {
       ChartVSAssembly copy = mock(ChartVSAssembly.class);
       when(copy.getName()).thenReturn("vs_1_copy1");
 
-      doReturn(copy).when(service).duplicatePrimaryAssembly(rvs, assembly);
+      doReturn(new WizVsService.AssemblyDuplication(copy, assembly))
+         .when(service).duplicateAssembly(rvs, assembly);
       doThrow(new RuntimeException("sandbox execution failed"))
          .when(service).executeAndExtract(any(), eq(copy), anyInt());
 
@@ -224,7 +274,8 @@ class WizVsServiceFilterCopyTest {
       ChartVSAssembly copy = mock(ChartVSAssembly.class);
       when(copy.getName()).thenReturn("vs_1_copy1");
 
-      doReturn(copy).when(service).duplicatePrimaryAssembly(rvs, assembly);
+      doReturn(new WizVsService.AssemblyDuplication(copy, assembly))
+         .when(service).duplicateAssembly(rvs, assembly);
       doThrow(new IllegalArgumentException("invalid identifier"))
          .when(service).persistViewsheet(any(), any(), any());
 


### PR DESCRIPTION
## Problem

`/viewsheet/create`'s `modificationOnly` branch always resolved its target with `findPrimaryAssembly` — whichever chart was created or copied most recently.

That is correct while a conversation edits its newest chart, but wiz now resolves edits to a *specific* chart: a user can say "add a filter to the customer-count-by-state chart" three charts later. The `conditionModel` is then built against **that** chart's fields and applied to a **different** chart. At best the wrong chart is filtered; at worst the condition references columns the newest chart does not bind and the request fails.

There was no way for the caller to say which chart it meant.

## Change

**`CreateVisualizationModel.assemblyName`** (optional). Null keeps the existing primary-assembly resolution, so every current caller behaves exactly as before — the wiz side only sends it when it has a reason to override the default.

**`duplicateAssembly`, split out of `duplicatePrimaryAssembly`.** The existing method could not be reused for the copy-then-apply step:

- it requires `source` to *be* the primary, so with `source` an earlier chart the guard rejects the call outright;
- and it demotes `source` itself. Simply lifting the guard would demote nothing (an earlier chart is already non-primary) while still promoting the copy — **leaving two primaries in one viewsheet**.

`duplicateAssembly` demotes whichever assembly actually holds primary and places no constraint on `source`. `duplicatePrimaryAssembly` keeps its guard and delegates: that guard protects `setChartFormat` / `setChartColors` / `applyHighlight`, whose `assemblyName` comes from the client and may be stale, where "duplicate whatever happens to be primary" would silently act on an unrelated chart. Those three callers are untouched.

**Rollback bookkeeping follows.** `modificationOnly` now records the *previously-primary* assembly instead of `source`, since after this change they are no longer the same assembly — restoring `source` would promote the wrong chart. It also tolerates a viewsheet that had no primary to restore.

## Compatibility

Additive. Existing callers omit the field and get the current behaviour unchanged. The wiz client sends it only for a copy it just made or an explicitly resolved target chart; against a server predating this change the property is ignored (`@JsonIgnoreProperties(ignoreUnknown = true)`), degrading to primary-assembly resolution.

## Verification

`./mvnw -o compile -pl core` passes. Not yet exercised end-to-end — that needs a rebuilt server; the wiz-side counterpart is inetsoft-technology/stylebi-wiz#1321.