### PR TITLE
fix(wiz): secondaryY now actually renders as a dual-axis chart

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1174,6 +1174,27 @@ public class WizVsService {
             targetVs.addAssembly(assembly);
             assembly.setPrimary(true);
 
+            // Re-binding a chart on an ALREADY-EXECUTED runtime (createdRuntimeId == false) carries a
+            // real staleness trap: rebindAssembly clones the replaced assembly's VSAssemblyInfo,
+            // including its cached RUNTIME chart refs (getRTYFields()/getRTXFields() prefer that
+            // non-empty runtime cache over the fresh design-time fields we just applied). A measure's
+            // secondaryY (or any other attribute-only rebind) landing on the new DESIGN ref is then
+            // silently ignored by the graph generator, which reads the stale RUNTIME ref instead — the
+            // chart renders as if nothing changed. Clear the runtime ref caches (forcing the next
+            // execution to resolve fresh ones from the new design binding) and drop the sandbox's
+            // cached graph so that re-resolution actually happens. Second, previously-undiscovered
+            // instance of the "wiz in-place chart mutation staleness" class of bug (community #3907).
+            if(!createdRuntimeId && assembly instanceof ChartVSAssembly chartAssembly) {
+               VSChartInfo cinfo = chartAssembly.getVSChartInfo();
+
+               if(cinfo != null) {
+                  cinfo.setRTXFields(new ChartRef[0]);
+                  cinfo.setRTYFields(new ChartRef[0]);
+               }
+
+               rvs.getViewsheetSandbox().ifPresent(sandbox -> sandbox.clearGraph(assembly.getName()));
+            }
+
             // Sync pre-condition from the replaced assembly to the new one when the caller
             // is performing a visualization type change (e.g. table → chart).
             if(model.isKeepCondition() &&
@@ -2411,7 +2432,11 @@ public class WizVsService {
       }
       else if(ref instanceof VSAggregateRef agg) {
          if(seen.add(agg.getFullName())) {
-            measures.add(WizFieldInfoFactory.createMeasureFieldInfo(agg));
+            // Chart-specific: must use the chart variant (not createMeasureFieldInfo) so
+            // discrete/secondaryY are copied from the real VSChartAggregateRef — this echo
+            // feeds the wiz API response's `binding.measures[]`, which callers (e.g. the
+            // wiz-services plugin) use to confirm secondaryY was actually applied.
+            measures.add(WizFieldInfoFactory.createChartMeasureFieldInfo(agg));
          }
       }
    }
@@ -3111,6 +3136,43 @@ public class WizVsService {
          {
             chartInfo.setPathField(createChartRef(binding.getPath()));
          }
+      }
+
+      // A measure's secondaryY (set above via createVSChartAggregateRef) creates a second,
+      // independently-scaled Scale (DefaultGraphGenerator.fixCoordProperties splits y-fields into
+      // yfields/y2fields and calls coord.setYScale2(...) on ONE shared coordinate) whenever the two
+      // measures are on ONE shared coordinate to begin with. AbstractChartInfo.separated defaults to
+      // true, which routes rendering through SeparateGraphGenerator instead — a small-multiples
+      // renderer giving each measure its OWN independent panel/coordinate, so there is no shared
+      // plot for a second scale to attach to at all (confirmed live: the secondaryY measure got its
+      // own single-axis panel, the primary measure another, untouched — two panels, not one
+      // dual-axis plot). Forcing separated=false switches to DefaultGraphGenerator, which supports a
+      // real two-scale coordinate.
+      //
+      // Once on that shared coordinate, RectCoord.createAxis() already keeps BOTH y-axes visible by
+      // default: it gates the second axis on `yscale.getAxisSpec().getAxisStyle() & AXIS_SINGLE2`,
+      // and AxisSpec's own default style (AXIS_DOUBLE = 0x3) already satisfies that check (0x3 & 0x12
+      // != 0) with no further configuration. Do NOT also set labelOnSecondaryAxis anywhere (chart- or
+      // ref-level) to "help" — that flag ORs in AXIS_LABEL_OPPOSITE_SIDE (0x10), and RectCoord hides
+      // the PRIMARY axis's own labels whenever that bit is set (`(style & 0x10) == 0` gates
+      // yaxis1.setLabelVisible), regardless of which descriptor it came from. That flag exists for a
+      // DIFFERENT, mutually exclusive case — relocating a single measure's labels to the right and
+      // hiding the original position entirely (e.g. Pareto's percentage axis, per its own Bug #74171
+      // comment) — not for a genuine two-axis combo chart, which needs BOTH axes' own labels intact.
+      boolean hasSecondaryY = false;
+      ChartRef[] yfields = chartInfo.getYFields();
+
+      if(yfields != null) {
+         for(ChartRef f : yfields) {
+            if(f instanceof VSChartAggregateRef agg && agg.isSecondaryY()) {
+               hasSecondaryY = true;
+               break;
+            }
+         }
+      }
+
+      if(hasSecondaryY) {
+         chartInfo.setSeparatedGraph(false);
       }
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/service/WizFieldInfoFactoryTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizFieldInfoFactoryTest.java
@@ -23,8 +23,11 @@ import inetsoft.test.SreeHome;
 import inetsoft.uql.XConstants;
 import inetsoft.uql.asset.DateRangeRef;
 import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.viewsheet.VSAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
 import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
 import inetsoft.web.wiz.model.DimensionFieldInfo;
+import inetsoft.web.wiz.model.MeasureFieldInfo;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -81,5 +84,50 @@ class WizFieldInfoFactoryTest {
       assertEquals("status", info.getField());
       assertEquals("status", info.getFullName());            // NOT "Year(status)"
       assertFalse(info.getFullName().startsWith("Year("));   // explicit guard against the regression
+   }
+
+   /**
+    * Regression for classifyChartRef's measure echo (WizVsService): a chart measure bound to the
+    * secondary Y axis (VSChartAggregateRef.setSecondaryY(true)) must echo back {@code secondaryY:
+    * true} so callers (e.g. the wiz-services plugin) can confirm the placement was actually applied.
+    * Only createChartMeasureFieldInfo — not the generic/crosstab createMeasureFieldInfo — checks
+    * {@code instanceof VSChartAggregateRef} and copies discrete/secondaryY.
+    */
+   @Test
+   void chartMeasureEchoCarriesSecondaryYAndDiscreteFromChartAggregateRef() {
+      VSChartAggregateRef agg = new VSChartAggregateRef();
+      agg.setColumnValue("Sales");
+      agg.setFormulaValue("Sum");
+      agg.setSecondaryY(true);
+      agg.setDiscrete(true);
+
+      MeasureFieldInfo info = WizFieldInfoFactory.createChartMeasureFieldInfo(agg);
+
+      assertEquals("Sales", info.getField());
+      assertEquals("Sum", info.getAggregateFormula());
+      assertTrue(info.isSecondaryY());   // copied from VSChartAggregateRef
+      assertTrue(info.isDiscrete());     // copied from VSChartAggregateRef
+   }
+
+   /**
+    * The generic/crosstab variant has no notion of secondaryY/discrete at all — it never checks
+    * {@code instanceof VSChartAggregateRef} — so it must NOT echo secondaryY:true even when the
+    * underlying ref is in fact a VSChartAggregateRef with secondaryY set. This is what made the
+    * pre-fix classifyChartRef bug possible: calling this variant on a chart aggregate silently
+    * dropped the secondaryY placement in the API response.
+    */
+   @Test
+   void plainMeasureEchoNeverCarriesSecondaryYEvenFromAChartAggregateRef() {
+      VSChartAggregateRef agg = new VSChartAggregateRef();
+      agg.setColumnValue("Sales");
+      agg.setFormulaValue("Sum");
+      agg.setSecondaryY(true);
+      agg.setDiscrete(true);
+
+      MeasureFieldInfo info = WizFieldInfoFactory.createMeasureFieldInfo((VSAggregateRef) agg);
+
+      assertEquals("Sales", info.getField());
+      assertFalse(info.isSecondaryY());  // generic variant never copies it — always default false
+      assertFalse(info.isDiscrete());    // generic variant never copies it — always default false
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceClassifyChartRefSecondaryYTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceClassifyChartRefSecondaryYTest.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.web.wiz.model.CreateViewsheetResult;
+import inetsoft.web.wiz.model.MeasureFieldInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * End-to-end regression (through the public {@link WizVsService#collectFlatBinding}, which is
+ * only called for {@code ChartVSAssembly} — never crosstab) for the classifyChartRef fix: a chart
+ * measure bound to the secondary Y axis must echo back {@code secondaryY: true} in the wiz API's
+ * flat binding response, not silently default to false. See
+ * {@link WizFieldInfoFactoryTest#chartMeasureEchoCarriesSecondaryYAndDiscreteFromChartAggregateRef}
+ * for the narrower factory-level coverage of the same fix; this test additionally proves the fix
+ * is wired all the way through classifyChartRef → collectChartFlatBinding → collectFlatBinding.
+ *
+ * <p>WizVsService's constructor has no side effects (see {@link WizVsServiceFilterCopyTest}), so
+ * its three collaborators can be plain Mockito mocks that this code path never touches.
+ * collectFlatBinding only reads the assembly's (real, un-mocked) VSChartInfo — no runtime
+ * viewsheet, security check, or sandbox execution is involved — so the assembly itself only needs
+ * a stubbed {@code getVSChartInfo()}.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizVsServiceClassifyChartRefSecondaryYTest {
+   @Test
+   void collectFlatBindingEchoesSecondaryYTrueForAChartMeasureOnTheSecondaryAxis() {
+      WizVsService service = new WizVsService(
+         mock(ViewsheetService.class), mock(AssetRepository.class), mock(SecurityEngine.class));
+
+      VSChartAggregateRef agg = new VSChartAggregateRef();
+      agg.setColumnValue("Sales");
+      agg.setFormulaValue("Sum");
+      agg.setSecondaryY(true);
+
+      VSChartInfo info = new VSChartInfo();
+      info.addYField(agg);
+
+      ChartVSAssembly assembly = mock(ChartVSAssembly.class);
+      when(assembly.getVSChartInfo()).thenReturn(info);
+
+      CreateViewsheetResult.FlatBinding binding = service.collectFlatBinding(assembly);
+
+      List<MeasureFieldInfo> measures = binding.getMeasures();
+      assertEquals(1, measures.size());
+      assertTrue(measures.get(0).isSecondaryY());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRebindClearsStaleRuntimeChartRefsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRebindClearsStaleRuntimeChartRefsTest.java
@@ -1,0 +1,205 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.PhysicalBoundTableAssembly;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.graph.DefaultVSChartInfo;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.web.wiz.model.CreateViewsheetResult;
+import inetsoft.web.wiz.model.CreateVisualizationModel;
+import inetsoft.web.wiz.model.VisualizationConfig;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression test for the "wiz in-place chart mutation staleness" class of bug (community #3907),
+ * second instance, fixed in {@code WizVsService#createViewsheetInternal} right after a chart
+ * assembly is (re)bound onto an ALREADY-EXECUTED runtime ({@code createdRuntimeId == false}).
+ *
+ * <p>{@code rebindAssembly} clones the caller-supplied primary assembly's {@code VSAssemblyInfo}
+ * -- {@code ChartVSAssemblyInfo.clone(false)} deep-clones the design {@code VSChartInfo} but does
+ * NOT clone its RUNTIME ref caches
+ * ({@code getRTYFields()}/{@code getRTXFields()}; {@code AbstractChartInfo.clone()} never touches
+ * them, so they survive as the SAME array reference). A prior execution's runtime refs riding
+ * along on a freshly rebound design (e.g. a measure's {@code secondaryY} flip) then silently
+ * shadow the new design binding at render time -- the chart appears to ignore the rebind
+ * entirely. The fix clears both RT ref arrays and drops the sandbox's cached graph immediately
+ * after the rebound assembly is added to the runtime, forcing the next render to resolve fresh
+ * refs from the new design binding.
+ *
+ * <p>Rather than driving two full sequential executions through a real {@link ViewsheetSandbox}
+ * (heavy, and not what the fix changed), this test proves the fix's actual mechanism directly:
+ * given a primary assembly whose {@code VSChartInfo} already carries non-empty, stale RT ref
+ * arrays alongside a fresh design binding (exactly the shape {@code rebindAssembly}'s clone
+ * produces), the rebound assembly's {@code VSChartInfo} must come out of
+ * {@code createViewsheetInternal} with those RT arrays cleared, and the sandbox's cached graph for
+ * that assembly must have been dropped -- both are the necessary and sufficient conditions for
+ * the next render to resolve the new design binding instead of the stale runtime one. Follows the
+ * {@link WizVsServiceFilterCopyTest} construction pattern (real {@link WizVsService} wrapped in a
+ * spy so the heavy sandbox-execution/binding-echo/persistence machinery can be stubbed out).
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizVsServiceRebindClearsStaleRuntimeChartRefsTest {
+
+   @Test
+   void rebindingAChartOnAnAlreadyExecutedRuntimeClearsStaleRTRefsAndDropsTheCachedGraph()
+      throws Exception
+   {
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+      Principal user = mock(Principal.class);
+
+      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine);
+      WizVsService service = spy(real);
+
+      // Source worksheet resolveSourceContext must find, with a primary table assembly.
+      AssetEntry sourceWsEntry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, "ws1", null);
+      Worksheet worksheet = new Worksheet();
+      PhysicalBoundTableAssembly baseTable = new PhysicalBoundTableAssembly(worksheet, "BASE");
+      worksheet.addAssembly(baseTable);
+      worksheet.setPrimaryAssembly("BASE");
+      when(engine.getSheet(any(AssetEntry.class), eq(user), eq(true), any()))
+         .thenReturn(worksheet);
+
+      // An EXISTING, already-executed runtime (createdRuntimeId == false: model supplies
+      // runtimeId "rt-1" below). Real Viewsheet -- in this (non-"createdRuntimeId") path,
+      // createViewsheetInternal's targetVs IS this same vs object (mutated in place), so no
+      // separate captured-argument bookkeeping is needed to inspect the result.
+      Viewsheet vs = new Viewsheet(sourceWsEntry, false, true, null, null);
+      ViewsheetSandbox sandbox = mock(ViewsheetSandbox.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getID()).thenReturn("rt-1");
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(sandbox));
+      when(viewsheetService.getViewsheet(eq("rt-1"), eq(user))).thenReturn(rvs);
+
+      // Bypass the heavy, separately-tested sandbox-execution/binding-echo/persistence machinery --
+      // this test is only about the RT-ref-clearing wiring itself.
+      doReturn(new CreateViewsheetResult()).when(service).executeAndExtract(any(), any(), anyInt());
+      doReturn(null).when(service).collectFlatBinding(any());
+      doReturn("vs-identifier").when(service).persistViewsheet(any(), any(), any());
+
+      // The wizard setup path's fully-configured primary assembly: a fresh DESIGN binding (Sales
+      // on the secondary axis) plus a STALE RUNTIME ref cache left over from a prior execution
+      // (of an earlier binding) that rebindAssembly's clone carries forward unchanged.
+      Viewsheet wizardVs = new Viewsheet();
+      ChartVSAssembly preConfigured = new ChartVSAssembly(wizardVs, "wizardChart");
+      preConfigured.setPrimary(true);
+      DefaultVSChartInfo chartInfo = new DefaultVSChartInfo();
+
+      VSChartAggregateRef designY = new VSChartAggregateRef();
+      designY.setColumnValue("Sales");
+      designY.setFormulaValue("Sum");
+      designY.setSecondaryY(true);
+      chartInfo.addYField(designY);
+
+      VSChartDimensionRef designX = new VSChartDimensionRef();
+      designX.setGroupColumnValue("Category");
+      chartInfo.addXField(designX);
+
+      VSChartAggregateRef staleRTY = new VSChartAggregateRef();
+      staleRTY.setColumnValue("StaleMeasure");
+      chartInfo.setRTYFields(new inetsoft.uql.viewsheet.graph.ChartRef[] { staleRTY });
+
+      VSChartDimensionRef staleRTX = new VSChartDimensionRef();
+      staleRTX.setGroupColumnValue("StaleDim");
+      chartInfo.setRTXFields(new inetsoft.uql.viewsheet.graph.ChartRef[] { staleRTX });
+
+      preConfigured.setVSChartInfo(chartInfo);
+
+      // Sanity check on the test's own fixture: the staleness must actually be present before the
+      // fix runs, else this test would trivially pass for the wrong reason.
+      assertEquals(1, chartInfo.getRTYFields().length);
+      assertEquals(1, chartInfo.getRTXFields().length);
+
+      VisualizationConfig.DataSource dataSource = new VisualizationConfig.DataSource();
+      dataSource.setSource(sourceWsEntry.toIdentifier());
+      VisualizationConfig config = new VisualizationConfig();
+      config.setData(dataSource);
+
+      CreateVisualizationModel model = new CreateVisualizationModel();
+      model.setRuntimeId("rt-1");
+      model.setConfig(config);
+      model.setPrimaryAssembly(preConfigured);
+
+      CreateViewsheetResult result = service.createViewsheet(model, user);
+
+      VSAssembly reboundAssembly = vs.getAssembly(result.getAssemblyName());
+      ChartVSAssembly reboundChart = assertInstanceOf(ChartVSAssembly.class, reboundAssembly);
+      VSChartInfo reboundInfo = reboundChart.getVSChartInfo();
+
+      // getRTYFields()/getRTXFields() fall back to the DESIGN fields once the RT array is empty
+      // (AbstractChartInfo: "ryrefs != null && ryrefs.length > 0 ? ryrefs : getYFields()") -- so an
+      // empty-length check alone would pass even with the bug present, since both the stale RT
+      // array and the design array here happen to have exactly one element. The real assertion is
+      // WHICH ref resolves: it must be the fresh design measure ("Sales"), not the stale runtime
+      // one ("StaleMeasure") that a rebind-without-the-fix would keep shadowing it with.
+      assertEquals(1, reboundInfo.getRTYFields().length);
+      assertEquals("Sales", ((VSChartAggregateRef) reboundInfo.getRTYFields()[0]).getColumnValue(),
+                   "stale RT Y ref must be cleared so it falls through to the fresh design binding");
+
+      assertEquals(1, reboundInfo.getRTXFields().length);
+      assertEquals("Category", ((VSChartDimensionRef) reboundInfo.getRTXFields()[0]).getGroupColumnValue(),
+                   "stale RT X ref must be cleared so it falls through to the fresh design binding");
+
+      // The sandbox's cached graph for this assembly must also be dropped, forcing re-resolution
+      // against the now-clean design binding on the next render.
+      verify(sandbox).clearGraph(result.getAssemblyName());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceSecondaryYAxisRenderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceSecondaryYAxisRenderTest.java
@@ -1,0 +1,241 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.PhysicalBoundTableAssembly;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.ViewsheetInfo;
+import inetsoft.uql.viewsheet.graph.ChartRef;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.web.wiz.model.ChartBinding;
+import inetsoft.web.wiz.model.CreateViewsheetResult;
+import inetsoft.web.wiz.model.CreateVisualizationModel;
+import inetsoft.web.wiz.model.MeasureFieldInfo;
+import inetsoft.web.wiz.model.SimpleFieldInfo;
+import inetsoft.web.wiz.model.VisualizationConfig;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * End-to-end regression (through the public {@link WizVsService#createViewsheet}, which is the
+ * only reachable entry point to the private {@code applyChartBinding} for a brand-new chart
+ * assembly — see {@code createAssembly -> createChartAssembly -> applyChartBinding}) for the
+ * dual-Y-axis rendering fix.
+ *
+ * <p>Setting {@code secondaryY} on a chart measure alone only creates a second Y scale
+ * ({@code DefaultGraphGenerator.fixCoordProperties}) — it does NOT, by itself, produce a real
+ * side-by-side dual-axis render, because {@link inetsoft.uql.viewsheet.graph.AbstractChartInfo}'s
+ * {@code separated} flag defaults to {@code true}, which routes rendering through
+ * {@code SeparateGraphGenerator} (one independent small-multiples panel per measure — confirmed
+ * live to render as two single-axis panels, not one combo chart). The fix forces
+ * {@code chartInfo.setSeparatedGraph(false)} whenever any Y measure has {@code secondaryY=true},
+ * which switches rendering to {@code DefaultGraphGenerator} (the renderer that supports one
+ * shared coordinate with two Y scales).
+ *
+ * <p>The fix deliberately does NOT also set {@code labelOnSecondaryAxis} anywhere (chart- or
+ * ref-level AxisDescriptor) — an earlier version of this fix did, "to help," and that regressed
+ * the PRIMARY axis's own labels to invisible: {@code labelOnSecondaryAxis} ORs in
+ * {@code AXIS_LABEL_OPPOSITE_SIDE}, and {@code RectCoord} hides the primary axis's labels
+ * whenever that bit is set on either descriptor (see {@code applyChartBinding}'s Bug #74171
+ * comment). Once on the shared coordinate, {@code RectCoord.createAxis()} already keeps both
+ * Y-axes visible by default via {@code AxisSpec}'s default {@code AXIS_DOUBLE} style, with no
+ * further configuration needed. This test both covers the actual fix (separated=false) and
+ * guards against that labelOnSecondaryAxis regression coming back.
+ *
+ * <p>Follows the {@link WizVsServiceFilterCopyTest} construction pattern: a real {@link WizVsService}
+ * wrapped in a Mockito spy so the heavy, separately-tested sandbox-execution machinery
+ * ({@code executeAndExtract}, {@code collectFlatBinding}, {@code persistViewsheet}) can be stubbed
+ * out, while {@code createAssembly}/{@code createChartAssembly}/{@code applyChartBinding} run for
+ * real against a real {@link Viewsheet} and {@link VSChartInfo} — no reflection into the private
+ * method is used or needed.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizVsServiceSecondaryYAxisRenderTest {
+
+   @Test
+   void chartWithASecondaryYMeasureForcesSharedCoordinateAndSecondaryAxisLabels() throws Exception {
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+      Principal user = mock(Principal.class);
+
+      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine);
+      WizVsService service = spy(real);
+
+      // Source worksheet resolveSourceContext must find, with a primary table assembly.
+      AssetEntry sourceWsEntry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, "ws1", null);
+      Worksheet worksheet = new Worksheet();
+      PhysicalBoundTableAssembly baseTable = new PhysicalBoundTableAssembly(worksheet, "BASE");
+      worksheet.addAssembly(baseTable);
+      worksheet.setPrimaryAssembly("BASE");
+      when(engine.getSheet(any(AssetEntry.class), eq(user), eq(true), any()))
+         .thenReturn(worksheet);
+
+      // A brand-new temporary runtime (createdRuntimeId == true; Fix 1's RT-ref-staleness branch
+      // is deliberately NOT exercised here -- see WizVsServiceRebindClearsStaleRuntimeChartRefsTest).
+      when(viewsheetService.openTemporaryViewsheet(any(), any(), eq(user), any())).thenReturn("rt-1");
+      Viewsheet sourceVs = mock(Viewsheet.class);
+      when(sourceVs.getWizInfo()).thenReturn(new Viewsheet.WizInfo(true, null, null));
+      // rvs is a plain mock -- its setViewsheet(targetVs) call (further down the real code path,
+      // right after the assembly is created) does NOT make subsequent rvs.getViewsheet() calls
+      // return targetVs; getViewsheetInfo().isMetadata() is read again off this SAME stubbed
+      // sourceVs afterward, so it needs a non-null ViewsheetInfo too (the captured targetVs
+      // argument below is unaffected by this and is still the real object the assembly was added
+      // to).
+      ViewsheetInfo sourceVsInfo = mock(ViewsheetInfo.class);
+      when(sourceVsInfo.isMetadata()).thenReturn(false);
+      when(sourceVs.getViewsheetInfo()).thenReturn(sourceVsInfo);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(sourceVs);
+      when(rvs.getID()).thenReturn("rt-1");
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.empty());
+      when(viewsheetService.getViewsheet(anyString(), eq(user))).thenReturn(rvs);
+
+      // Bypass the heavy, separately-tested sandbox-execution/binding-echo/persistence machinery --
+      // this test is only about what applyChartBinding does to the freshly-built VSChartInfo.
+      doReturn(new CreateViewsheetResult()).when(service).executeAndExtract(any(), any(), anyInt());
+      doReturn(null).when(service).collectFlatBinding(any());
+      doReturn("vs-identifier").when(service).persistViewsheet(any(), any(), any());
+
+      // Two Y measures: "Sales" on the secondary axis, "Profit" left on the primary.
+      MeasureFieldInfo salesOnSecondary = new MeasureFieldInfo();
+      salesOnSecondary.setField("Sales");
+      salesOnSecondary.setAggregateFormula("Sum");
+      salesOnSecondary.setSecondaryY(true);
+
+      MeasureFieldInfo profitOnPrimary = new MeasureFieldInfo();
+      profitOnPrimary.setField("Profit");
+      profitOnPrimary.setAggregateFormula("Sum");
+      profitOnPrimary.setSecondaryY(false);
+
+      SimpleFieldInfo category = new SimpleFieldInfo();
+      category.setField("Category");
+
+      ChartBinding binding = new ChartBinding();
+      binding.setX(List.of(category));
+      binding.setY(List.of(salesOnSecondary, profitOnPrimary));
+
+      VisualizationConfig.DataSource dataSource = new VisualizationConfig.DataSource();
+      dataSource.setSource(sourceWsEntry.toIdentifier());
+
+      VisualizationConfig config = new VisualizationConfig();
+      config.setTitle("Sales and Profit by Category");
+      config.setData(dataSource);
+      config.setBindingInfo(binding);
+
+      CreateVisualizationModel model = new CreateVisualizationModel();
+      model.setVisualizationType("bar");
+      model.setConfig(config);
+
+      CreateViewsheetResult result = service.createViewsheet(model, user);
+
+      ArgumentCaptor<Viewsheet> targetVsCaptor = ArgumentCaptor.forClass(Viewsheet.class);
+      verify(rvs).setViewsheet(targetVsCaptor.capture());
+      Viewsheet targetVs = targetVsCaptor.getValue();
+
+      ChartVSAssembly chartAssembly =
+         (ChartVSAssembly) targetVs.getAssembly(result.getAssemblyName());
+      assertNotNull(chartAssembly, "chart assembly must have been added to the target viewsheet");
+      VSChartInfo chartInfo = chartAssembly.getVSChartInfo();
+      assertNotNull(chartInfo);
+
+      // The core render fix: a shared coordinate (NOT one small-multiples panel per measure).
+      assertFalse(chartInfo.isSeparatedGraph(),
+                  "a chart with a secondaryY measure must render through DefaultGraphGenerator, " +
+                  "not SeparateGraphGenerator");
+
+      // Regression guard: the fix must NOT set labelOnSecondaryAxis on the chart-level
+      // AxisDescriptor. RectCoord already keeps both Y-axes visible via AxisSpec's default
+      // AXIS_DOUBLE style once separated=false; setting labelOnSecondaryAxis here ORs in
+      // AXIS_LABEL_OPPOSITE_SIDE, which hides the PRIMARY axis's own labels entirely (a real
+      // regression an earlier version of this fix introduced -- see applyChartBinding's #74171
+      // comment).
+      assertFalse(chartInfo.getAxisDescriptor().isLabelOnSecondaryAxis(),
+                  "the chart-level AxisDescriptor must stay untouched -- setting " +
+                  "labelOnSecondaryAxis here hides the primary axis's own labels (regression, " +
+                  "see #74171)");
+
+      ChartRef[] yFields = chartInfo.getYFields();
+      assertEquals(2, yFields.length);
+
+      VSChartAggregateRef secondaryRef = null;
+      VSChartAggregateRef primaryRef = null;
+
+      for(ChartRef ref : yFields) {
+         VSChartAggregateRef agg = (VSChartAggregateRef) ref;
+
+         if(agg.isSecondaryY()) {
+            secondaryRef = agg;
+         }
+         else {
+            primaryRef = agg;
+         }
+      }
+
+      assertNotNull(secondaryRef, "expected one Y measure with secondaryY=true (Sales)");
+      assertNotNull(primaryRef, "expected one Y measure with secondaryY=false (Profit)");
+
+      // Regression guard: the primary (non-secondaryY) measure's OWN ref-level AxisDescriptor must
+      // NOT be flipped. An earlier version of this fix did flip it defensively, which hid the
+      // primary axis's own labels entirely (labelOnSecondaryAxis on a linear measure axis hides
+      // that axis -- see the #74171 comment in applyChartBinding). Only the chart-level descriptor
+      // (asserted above) should carry labelOnSecondaryAxis=true.
+      assertFalse(primaryRef.getAxisDescriptor().isLabelOnSecondaryAxis(),
+                  "the non-secondaryY measure's own ref-level AxisDescriptor must stay untouched, " +
+                  "else its axis labels are hidden entirely (regression -- see #74171)");
+   }
+}


### PR DESCRIPTION
## Summary

`secondaryY` on a chart measure (`VSChartAggregateRef.setSecondaryY(true)`) was accepted, persisted, and even echoed back correctly in the wiz API response, but the chart never actually rendered with a second Y axis. Three separate bugs, found only by rendering the chart and looking at the actual pixels (via `get_board_export_bundle`'s SVG → PNG, since API-response and XML-persistence checks alone were not sufficient proof of correct rendering):

1. **API echo bug** — `classifyChartRef` built the wiz API response's `binding.measures[]` via `WizFieldInfoFactory.createMeasureFieldInfo` (the generic/crosstab variant), which never copies `discrete`/`secondaryY` from the real `VSChartAggregateRef`. Swapped to the existing `createChartMeasureFieldInfo` variant. Response-echo only, not a rendering bug on its own.
2. **RT-ref staleness on rebind** — re-binding a chart on an already-executed runtime left stale `getRTYFields()`/`getRTXFields()` runtime caches (from `rebindAssembly`'s clone of the old `VSAssemblyInfo`) shadowing the freshly-applied design binding. Reset the RT ref caches and clear the sandbox's cached graph right after a rebind. Second independent instance of the "wiz in-place chart mutation staleness" bug class (community #3907).
3. **The actual blocker** — `AbstractChartInfo.separated` defaults to `true`, routing rendering through `SeparateGraphGenerator` (a small-multiples renderer giving each measure its own independent panel, with no shared plot for a second Y-scale). Force `separated=false` whenever any Y-measure has `secondaryY=true`, switching to `DefaultGraphGenerator`, which supports one shared coordinate with two Y-scales. Once on that coordinate, `RectCoord.createAxis()` already keeps both y-axes visible by default via `AxisSpec`'s own default style — no further per-measure axis-descriptor configuration is needed (an earlier attempt to also set `labelOnSecondaryAxis` actively broke this by hiding the primary axis's own labels — documented in the code comment for future readers).

## Test plan
- [x] `WizFieldInfoFactoryTest` + `WizVsServiceClassifyChartRefSecondaryYTest` — bug 1 regression
- [x] `WizVsServiceRebindClearsStaleRuntimeChartRefsTest` — bug 2 regression
- [x] `WizVsServiceSecondaryYAxisRenderTest` — bug 3 regression
- [x] Full `inetsoft.web.wiz.service.*Test` suite: 328 tests, 0 failures
- [x] Live-verified: built a local Jib image, created a 2-measure line chart with `secondaryY` on one measure via the wiz REST API, confirmed via rendered SVG→PNG screenshots (and the developer's own browser) that it now renders as a genuine side-by-side dual-Y-axis combo chart

Companion PR in `stylebi-wiz` (wiz-services): forces a rebind when the recommender ignores a requested `secondaryY`, and fixes an MCP session-tracking gap that dropped chart identity on every existing-runtime rebind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)