### PR TITLE
Bug #75748, wait for database provider org cache before reporting no organizations

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationProvider.java
@@ -877,7 +877,7 @@ public class DatabaseAuthenticationProvider extends AbstractAuthenticationProvid
       return getCacheInterval();
    }
 
-   boolean isCacheInitialized() {
+   public boolean isCacheInitialized() {
       DatabaseAuthenticationCache cache = getCache(false);
       return cache != null && cache.isInitialized();
    }

--- a/core/src/main/java/inetsoft/web/admin/security/user/SecurityTreeServer.java
+++ b/core/src/main/java/inetsoft/web/admin/security/user/SecurityTreeServer.java
@@ -87,6 +87,12 @@ public class SecurityTreeServer {
          currOrgID = currOrgID == null ? Organization.getDefaultOrganizationID() : currOrgID;
          String[] orgIds = provider.getOrganizationIDs();
 
+         if(isMultiTenant && orgIds.length == 0 && provider instanceof DatabaseAuthenticationProvider dbProvider &&
+            dbProvider.isCacheEnabled() && !dbProvider.isCacheInitialized())
+         {
+            orgIds = waitForOrganizationCache(dbProvider);
+         }
+
          if(isMultiTenant && orgIds.length == 0) {
             throw new MessageException(Catalog.getCatalog().getString("em.security.provider.db.noOrg"));
          }
@@ -133,6 +139,30 @@ public class SecurityTreeServer {
       }
    }
 
+   /**
+    * The provider's organization cache is loaded asynchronously, so a request that arrives
+    * right after a provider switch/edit can observe an empty organization list even though
+    * the underlying database has organizations. Poll briefly for the cache to finish its
+    * initial load before treating the provider as having no organizations.
+    */
+   private String[] waitForOrganizationCache(DatabaseAuthenticationProvider provider) {
+      long deadline = System.currentTimeMillis() + CACHE_WAIT_TIMEOUT;
+
+      while(!provider.isCacheInitialized() && System.currentTimeMillis() < deadline) {
+         try {
+            Thread.sleep(CACHE_POLL_INTERVAL);
+         }
+         catch(InterruptedException e) {
+            Thread.currentThread().interrupt();
+            break;
+         }
+      }
+
+      return provider.getOrganizationIDs();
+   }
+
+   private static final long CACHE_WAIT_TIMEOUT = 5000L;
+   private static final long CACHE_POLL_INTERVAL = 100L;
    private final boolean namedUsers;
    private final UserTreeService userTreeService;
    private final SecurityEngine securityEngine;


### PR DESCRIPTION
## Summary
- Switching to a newly configured `DatabaseAuthenticationProvider` (e.g. H2) in multi-tenant mode could throw `MessageException: "There is no organization in target provider!"` even though the database genuinely has organizations, because the provider's organization cache loads asynchronously (`executor.submit(...)`) and `getOrganizationIDs()` could observe an empty, still-loading cache immediately after a provider switch.
- `SecurityTreeServer.getSecurityTree()` now polls briefly (up to 5s, 100ms interval) for the provider's cache to finish its initial load before treating the organization list as empty, only for `DatabaseAuthenticationProvider` instances with caching enabled and not yet initialized. Other providers and already-initialized/genuinely-empty providers are unaffected.
- Made `DatabaseAuthenticationProvider.isCacheInitialized()` public so it can be checked from `SecurityTreeServer`.

## Test plan
- [x] `core` module compiles cleanly with the change
- [ ] Manually reproduce: configure a Database (H2) security provider with multi-tenancy enabled, save, then immediately navigate to Security > Users — tree should load instead of erroring