### PR TITLE
Bug #75748, fix trailer row count restore in ExportUtil.getColType()

### DIFF
--- a/core/src/main/java/inetsoft/report/io/viewsheet/ExportUtil.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/ExportUtil.java
@@ -724,7 +724,7 @@ public class ExportUtil {
                Class<?> type = runtime.getColType(c);
 
                if(setTrailer) {
-                  runtime.setTrailerColCount(trailerRowCount);
+                  runtime.setTrailerRowCount(trailerRowCount);
                }
 
                return type;


### PR DESCRIPTION
## Summary
- Exporting a viewsheet containing a Freehand/Calc table to PDF/PNG/Excel/etc. could paint ordinary data rows with the table style's dark trailer border/background color instead of the correct light body color, even when the calc table has no configured trailer rows (`trow=0`). The live portal viewer was unaffected.
- Root cause: `ExportUtil.getColType()` (added for Bug #59833) temporarily bumps a `RuntimeCalcTableLens`'s trailer row count to correctly infer a trailer/total row's data type, using the internal "quickCheck" optimization crosstab's own trailer row count (which reflects its aggregate column count, unrelated to the calc table's actual trailer row configuration). The restore step called `setTrailerColCount()` instead of `setTrailerRowCount()`, so the row count bump was never undone — it stayed permanently inflated for the rest of that export, causing `TableStyle` to misclassify the last N data rows as trailer rows.
- Fix: correct the restore call to use `setTrailerRowCount()`, matching the value it saved and the field it actually bumped.

## Test plan
- [x] `core` module compiles (`mvnw -pl core -am compile`)
- [x] Reproduced with a Freehand table using a table style with a distinct trailer-row color: before the fix, export showed the dark trailer color duplicated onto ordinary interior/last rows; after the fix, export matches the live portal viewer (confirmed by reporter).