### PR TITLE
Bug #75749, fix Auto Alias dialog crash for search-selected tables

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.ts
@@ -315,9 +315,8 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
       node.children.forEach(child => this.refreshTreeSelectStatus(child));
    }
 
-   private refreshLeafNodeSelectStatus(node: TreeNodeModel) {
-      const childData: PhysicalModelTreeNodeModel = <PhysicalModelTreeNodeModel> node.data;
-      let findTable = this.physicalModel.tables
+   private findMatchingTable(childData: PhysicalModelTreeNodeModel): PhysicalTableModel {
+      return this.physicalModel.tables
          .find((table) => {
             if(!table.alias) {
                return this.getTablePath(table) == childData.path;
@@ -327,6 +326,11 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
                   this.databaseName + "/" + (table.alias || table.name) == childData.path;
             }
          });
+   }
+
+   private refreshLeafNodeSelectStatus(node: TreeNodeModel) {
+      const childData: PhysicalModelTreeNodeModel = <PhysicalModelTreeNodeModel> node.data;
+      let findTable = this.findMatchingTable(childData);
 
       if(findTable) {
          childData.selected = true;
@@ -1261,8 +1265,12 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
    keepSelectedNodes(node: TreeNodeModel) {
       if(node.leaf) {
          const childData: PhysicalModelTreeNodeModel = <PhysicalModelTreeNodeModel> node.data;
-         childData.selected = this.physicalModel.tables
-            .some(table => table.path == childData.path);
+         const findTable = this.findMatchingTable(childData);
+         childData.selected = !!findTable;
+
+         if(findTable) {
+            childData.baseTable = findTable.baseTable;
+         }
       }
       else {
          if(node.children && node.children.length > 0) {


### PR DESCRIPTION
## Summary
- In the Physical View editor, searching for a table and selecting "Auto Alias" from its context menu could crash with `TypeError: Cannot read properties of undefined (reading 'qualifiedName')` in `PhysicalTableAliasesDialog`, instead of opening the dialog.
- Root cause: the search-tree's "is this table already in the model" check (`keepSelectedNodes`) used a looser path-only match, while normal tree browsing (`refreshLeafNodeSelectStatus`) matches alias-type table entries by `qualifiedName` plus an alias-derived path. When a table exists in the model only as an alias (no separate entry for the real/underlying table), the alias entry's `path` is inherited from the real table's metadata — so the search-tree's path-only check incorrectly marked the raw table's tree node as selected, exposing the "Auto Alias" action on a node with no genuinely matching model entry. Invoking that action resolved the target by `qualifiedName`, found nothing, and left `editingTable` undefined, which the dialog then crashed on.
- Fix: extracted the matching predicate from `refreshLeafNodeSelectStatus` into a shared `findMatchingTable()` helper and made `keepSelectedNodes` use it, so search-tree and normal-tree selection state now agree.

## Test plan
- [x] `npx tsc --noEmit` on the portal project passes
- [x] Reproduced with the reporter's asset (a physical model where a table exists only as an alias of another): before the fix, searching for the aliased-from table and selecting "Auto Alias" crashed; after the fix, the action no longer appears on that node (confirmed by reporter).