### PR TITLE
Bug #75782, fix database security provider organization cache never loading

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationCacheServiceImpl.java
+++ b/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationCacheServiceImpl.java
@@ -320,29 +320,34 @@ public class DatabaseAuthenticationCacheServiceImpl implements DatabaseAuthentic
          }
 
          try(DistributedTransaction tx = cluster.startTx()) {
-            lists.removeAll();
+            // Ignite doesn't allow the no-arg (clear-everything) removeAll() inside a
+            // transaction; only the keyed overload is transaction-safe.
             lists.put(ORG_LIST, new TreeSet<>(Arrays.asList(newOrganizations.result())));
             lists.put(USER_LIST, new TreeSet<>(Arrays.asList(newUsers.result())));
             lists.put(GROUP_LIST, new TreeSet<>(Arrays.asList(newGroups.result())));
             lists.put(ROLE_LIST, new TreeSet<>(Arrays.asList(newRoles.result())));
 
-            orgNames.removeAll();
+            orgNames.removeAll(new HashSet<>(orgNames.keySet()));
             orgNames.putAll(newOrgNames);
 
-            orgMembers.removeAll();
+            orgMembers.removeAll(new HashSet<>(orgMembers.keySet()));
             orgMembers.putAll(newOrgMembers);
 
-            orgRoles.removeAll();
+            orgRoles.removeAll(new HashSet<>(orgRoles.keySet()));
             orgRoles.putAll(newOrgRoles);
 
-            groupUsers.removeAll();
-            userRoles.removeAll();
+            groupUsers.removeAll(new HashSet<>(groupUsers.keySet()));
+            userRoles.removeAll(new HashSet<>(userRoles.keySet()));
             userRoles.putAll(newUserRoles.result());
-            userEmails.removeAll();
+            userEmails.removeAll(new HashSet<>(userEmails.keySet()));
 
             tx.commit();
             lastLoadTime.set(System.currentTimeMillis());
          }
+      }
+      catch(Exception ex) {
+         LOG.warn("Failed to load database authentication cache for provider '{}'", providerName, ex);
+         handleError();
       }
       finally {
          loadingCount.set(0);

--- a/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/db/DatabaseAuthenticationProvider.java
@@ -877,7 +877,7 @@ public class DatabaseAuthenticationProvider extends AbstractAuthenticationProvid
       return getCacheInterval();
    }
 
-   boolean isCacheInitialized() {
+   public boolean isCacheInitialized() {
       DatabaseAuthenticationCache cache = getCache(false);
       return cache != null && cache.isInitialized();
    }

--- a/core/src/main/java/inetsoft/web/admin/security/user/SecurityTreeServer.java
+++ b/core/src/main/java/inetsoft/web/admin/security/user/SecurityTreeServer.java
@@ -87,6 +87,12 @@ public class SecurityTreeServer {
          currOrgID = currOrgID == null ? Organization.getDefaultOrganizationID() : currOrgID;
          String[] orgIds = provider.getOrganizationIDs();
 
+         if(isMultiTenant && orgIds.length == 0 && provider instanceof DatabaseAuthenticationProvider dbProvider &&
+            dbProvider.isCacheEnabled() && !dbProvider.isCacheInitialized())
+         {
+            orgIds = waitForOrganizationCache(dbProvider);
+         }
+
          if(isMultiTenant && orgIds.length == 0) {
             throw new MessageException(Catalog.getCatalog().getString("em.security.provider.db.noOrg"));
          }
@@ -133,6 +139,30 @@ public class SecurityTreeServer {
       }
    }
 
+   /**
+    * The provider's organization cache is loaded asynchronously, so a request that arrives
+    * right after a provider switch/edit can observe an empty organization list even though
+    * the underlying database has organizations. Poll briefly for the cache to finish its
+    * initial load before treating the provider as having no organizations.
+    */
+   private String[] waitForOrganizationCache(DatabaseAuthenticationProvider provider) {
+      long deadline = System.currentTimeMillis() + CACHE_WAIT_TIMEOUT;
+
+      while(!provider.isCacheInitialized() && System.currentTimeMillis() < deadline) {
+         try {
+            Thread.sleep(CACHE_POLL_INTERVAL);
+         }
+         catch(InterruptedException e) {
+            Thread.currentThread().interrupt();
+            break;
+         }
+      }
+
+      return provider.getOrganizationIDs();
+   }
+
+   private static final long CACHE_WAIT_TIMEOUT = 5000L;
+   private static final long CACHE_POLL_INTERVAL = 100L;
    private final boolean namedUsers;
    private final UserTreeService userTreeService;
    private final SecurityEngine securityEngine;


### PR DESCRIPTION
## Summary
Switching Enterprise Manager to a `DatabaseAuthenticationProvider` (e.g. H2) in multi-tenant mode could throw `MessageException: "There is no organization in target provider!"` even when the database genuinely has organizations. Three separate issues contributed:

- **Root cause**: `DatabaseAuthenticationCacheServiceImpl.loadInternal()` called Ignite's no-arg `removeAll()` (clear-all-entries) on several distributed maps inside a `cluster.startTx()` transaction. Ignite explicitly rejects the no-arg `removeAll()` inside a transaction (`javax.cache.CacheException: Failed to invoke a non-transactional IgniteCache removeAll operation within a transaction`), so the organization/user/role cache load failed **every time, for any database-backed provider**, independent of configuration. Fixed by using the keyed `removeAll(Set<K>)` overload, which Ignite supports inside a transaction.
- **Silent failure**: the surrounding `try` block in `loadInternal()` had no `catch`, so the exception above (or any other future failure) was discarded by the executor with zero logging, making this defect invisible. Added exception handling + a warning log.
- **Async-load race**: `SecurityTreeServer.getSecurityTree()` read `provider.getOrganizationIDs()` immediately after a provider switch, before the provider's asynchronous cache load had a chance to complete, and treated a still-loading (temporarily empty) cache the same as a genuinely empty one. It now polls briefly for the cache to finish initializing before falling back to the existing empty-org-list check.

## Test plan
- [x] `core` module compiles cleanly with the change
- [x] Manually reproduced: configured a Database (H2) security provider with multi-tenancy enabled; before the fix, cache load failed on every attempt with the Ignite transaction exception (once logging was added) and Security > Users always errored; after the fix, the tree loads successfully with real organization data