### PR TITLE
Bug #75776, don't delete org storage on case-only rename

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
@@ -288,12 +288,22 @@ public abstract class AbstractEditableAuthenticationProvider
          manager.save();
          RepletRegistryManager.getInstance().clearOrgCache(fromOrgId);
 
-         try{
-            identityService.updateRepletRegistry(fromOrgId, null);
-            identityService.removeStorages(fromOrgId);
-         }
-         catch(Exception e) {
-            LOG.warn("Unable to remove old organization storage: "+e);
+         // Organization-scoped blob storage (indexed storage, replet registry, __mv,
+         // __mvws, __pdata, etc.) is bucketed by fromOrgId/newOrgID.toLowerCase(), so a
+         // rename that only changes letter case (e.g. "organization0" -> "Organization0")
+         // maps the old and new organization onto the exact same physical bucket. The
+         // content just migrated into that bucket for newOrgID must not then be deleted
+         // as if it belonged solely to the old organization.
+         boolean sameStorageBucket = fromOrgId.equalsIgnoreCase(newOrgID);
+
+         if(!sameStorageBucket) {
+            try {
+               identityService.updateRepletRegistry(fromOrgId, null);
+               identityService.removeStorages(fromOrgId);
+            }
+            catch(Exception e) {
+               LOG.warn("Unable to remove old organization storage: "+e);
+            }
          }
       }
       else {


### PR DESCRIPTION
## Summary
- Organization-scoped blob storage (indexed storage, replet registry, `__mv`, `__mvws`, `__pdata`, etc.) is bucketed by `orgID.toLowerCase()`. Renaming an org where only letter case changes (e.g. `organization0` -> `Organization0`) maps the old and new organization onto the exact same physical bucket.
- `copyOrganizationInternal()` migrates content into that bucket for the new org, then unconditionally deletes the "old" org's storage — which, for a case-only rename, is the same bucket, destroying everything just migrated (all viewsheets/worksheets, e.g. under `Examples`).
- Guard the destructive `updateRepletRegistry`/`removeStorages` cleanup calls to skip when `fromOrgId.equalsIgnoreCase(newOrgID)`, since nothing needs to be removed in that case.

## Test plan
- [x] `./mvnw -pl core -am compile -DskipTests` builds clean
- [x] `OrgLifecycleAssetContentMigrationTest` — 13/13 pass
- [x] `OrgLifecycleRepletRegistryIntegrationTest` — 3/3 pass
- [x] `AbstractEditableAuthenticationProviderTest` — 38/38 pass
- [x] `AbstractEditableAuthenticationProviderStaticDepTest` — 24/24 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)