### PR TITLE
Bug #75775, add EM static resources to the public-resource whitelist

### DIFF
--- a/core/src/main/java/inetsoft/web/security/AbstractSecurityFilter.java
+++ b/core/src/main/java/inetsoft/web/security/AbstractSecurityFilter.java
@@ -688,7 +688,35 @@ public abstract class AbstractSecurityFilter
          return false;
       }
 
+      if(!isNavigationRequest(request)) {
+         SUtil.sendError(response, HttpServletResponse.SC_UNAUTHORIZED);
+         return false;
+      }
+
       return true;
+   }
+
+   /**
+    * Determines if an HTTP request is a navigation (document) request, i.e. one for which a
+    * redirect to an HTML login page is meaningful. A subresource request (script, stylesheet,
+    * image, font, ...) hands the response body to the script or style parser instead, so a login
+    * page returned for one of those is executed as JavaScript or CSS rather than prompting the
+    * user to log in.
+    *
+    * @param request the HTTP request object.
+    *
+    * @return {@code true} if the request is a navigation request or its type could not be
+    *         determined; {@code false} if it is known to be a subresource request.
+    */
+   private boolean isNavigationRequest(HttpServletRequest request) {
+      // Sec-Fetch-Dest is sent by all current browsers, but only to a trustworthy origin (HTTPS
+      // or localhost). Requests without it (plain HTTP origins, older browsers, non-browser
+      // clients) are treated as navigation requests, preserving the prior behavior. This is
+      // therefore a second line of defense only; a resource that must load without a session has
+      // to be listed in publicResources.
+      String fetchDest = request.getHeader("Sec-Fetch-Dest");
+      return fetchDest == null || Arrays.stream(navigationFetchDestinations)
+         .anyMatch(dest -> dest.equalsIgnoreCase(fetchDest));
    }
 
    protected boolean isAnonymousPrincipal(SRPrincipal principal) {
@@ -771,6 +799,23 @@ public abstract class AbstractSecurityFilter
       "/app/*.ttf",
       "/app/*.woff",
       "/app/assets/**",
+      // the Enterprise Manager static resources must be public for the same reason as the
+      // /app resources above: they are fetched by the browser before a session exists (or after
+      // one has been invalidated), and a login page returned in their place is executed by the
+      // script or style parser instead of being displayed (Bug #75775)
+      "/em/*.js",
+      "/em/*.css",
+      "/em/*.cur",
+      "/em/*.eot",
+      "/em/*.ico",
+      "/em/*.png",
+      "/em/*.svg",
+      "/em/*.ttf",
+      "/em/*.woff",
+      "/em/assets/**",
+      // the icon font and cursor images referenced by em/styles.css are emitted into a media
+      // subdirectory, which the single-segment patterns above cannot match
+      "/em/media/**",
       "/ping",
       "/css/**",
       "/images/**",
@@ -778,6 +823,13 @@ public abstract class AbstractSecurityFilter
       "/webjars/**",
       "/sso/jwks",
       "/robots.txt",
+   };
+   /**
+    * The Sec-Fetch-Dest values that identify a request whose response is displayed as a document
+    * and for which a redirect to the login page is therefore meaningful.
+    */
+   private static final String[] navigationFetchDestinations = {
+      "document", "iframe", "frame", "embed", "object"
    };
    protected static final String ORG_COOKIE = "X-INETSOFT-ORGID";
    /**

--- a/core/src/main/java/inetsoft/web/security/DefaultAuthorizationFilter.java
+++ b/core/src/main/java/inetsoft/web/security/DefaultAuthorizationFilter.java
@@ -59,7 +59,11 @@ public class DefaultAuthorizationFilter extends AbstractSecurityFilter {
          principal = (SRPrincipal) SUtil.getPrincipal(httpRequest);
       }
 
-      if(!provider.getAuthenticationProvider().isVirtual() && !isPublicResource(httpRequest) &&
+      // both branches below consult this, so match the request against the public resource
+      // patterns only once
+      boolean publicResource = isPublicResource(httpRequest);
+
+      if(!provider.getAuthenticationProvider().isVirtual() && !publicResource &&
          !isPublicApi(httpRequest) && !isTeamWebsocketEndpoint(httpRequest))
       {
          Cookie[] cookies = ((HttpServletRequest) request).getCookies();
@@ -78,7 +82,7 @@ public class DefaultAuthorizationFilter extends AbstractSecurityFilter {
       }
       // public EM resources (the static assets of the Enterprise Manager web application) are
       // exempt from the EM access check, just like the public resources of the portal
-      else if(isEnterpriseManager(httpRequest) && !isPublicResource(httpRequest)) {
+      else if(isEnterpriseManager(httpRequest) && !publicResource) {
          if(principal == null || isAnonymousPrincipal(principal) ||
             !provider.checkPermission(principal, ResourceType.EM, "*", ResourceAction.ACCESS))
          {

--- a/core/src/main/java/inetsoft/web/security/DefaultAuthorizationFilter.java
+++ b/core/src/main/java/inetsoft/web/security/DefaultAuthorizationFilter.java
@@ -76,7 +76,9 @@ public class DefaultAuthorizationFilter extends AbstractSecurityFilter {
             unauthorized = true;
          }
       }
-      else if(isEnterpriseManager(httpRequest)) {
+      // public EM resources (the static assets of the Enterprise Manager web application) are
+      // exempt from the EM access check, just like the public resources of the portal
+      else if(isEnterpriseManager(httpRequest) && !isPublicResource(httpRequest)) {
          if(principal == null || isAnonymousPrincipal(principal) ||
             !provider.checkPermission(principal, ResourceType.EM, "*", ResourceAction.ACCESS))
          {

--- a/core/src/test/java/inetsoft/web/security/DefaultAuthorizationFilterTest.java
+++ b/core/src/test/java/inetsoft/web/security/DefaultAuthorizationFilterTest.java
@@ -347,6 +347,140 @@ class DefaultAuthorizationFilterTest {
       assertNotEquals(HttpServletResponse.SC_FOUND, response.getStatus());
    }
 
+   // ── EM static resources are public (Bug #75775) ──────────────────────────
+
+   @Test
+   void doFilter_emScript_noSession_passesThroughWithoutRedirect() throws Exception {
+      // /em/scripts.js used to be treated as a protected resource, so an unauthenticated request
+      // for it was answered with a redirect to login.html. A <script> load has no
+      // X-Requested-With header, so the browser followed the redirect and executed the login page
+      // as JavaScript, leaving the EM with a blank page and a syntax error.
+      MockHttpServletRequest request = request("GET", "/em/scripts.js");
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      when(mockEngine.containsAnonymous(any())).thenReturn(false);
+
+      filter.doFilter(request, response, chain);
+
+      verify(chain).doFilter(eq(request), any());
+      assertNotEquals(HttpServletResponse.SC_FOUND, response.getStatus());
+      assertNull(response.getRedirectedUrl());
+   }
+
+   @Test
+   void doFilter_emStylesheet_noSession_passesThroughWithoutRedirect() throws Exception {
+      MockHttpServletRequest request = request("GET", "/em/styles.css");
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      when(mockEngine.containsAnonymous(any())).thenReturn(false);
+
+      filter.doFilter(request, response, chain);
+
+      verify(chain).doFilter(eq(request), any());
+      assertNotEquals(HttpServletResponse.SC_FOUND, response.getStatus());
+   }
+
+   @Test
+   void doFilter_emLazyChunk_noSession_passesThroughWithoutRedirect() throws Exception {
+      // the EM build emits ~120 lazily loaded route chunks alongside the entry point bundles
+      MockHttpServletRequest request = request("GET", "/em/chunk-2KU2435C.js");
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      when(mockEngine.containsAnonymous(any())).thenReturn(false);
+
+      filter.doFilter(request, response, chain);
+
+      verify(chain).doFilter(eq(request), any());
+      assertNotEquals(HttpServletResponse.SC_FOUND, response.getStatus());
+   }
+
+   @Test
+   void doFilter_emMediaFont_noSession_passesThroughWithoutRedirect() throws Exception {
+      // the icon font lives one segment deeper than the entry point bundles, so it is matched by
+      // "/em/media/**" rather than by "/em/*.woff"
+      MockHttpServletRequest request = request("GET", "/em/media/InetSoft-Icons.woff");
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      when(mockEngine.containsAnonymous(any())).thenReturn(false);
+
+      filter.doFilter(request, response, chain);
+
+      verify(chain).doFilter(eq(request), any());
+      assertNotEquals(HttpServletResponse.SC_FOUND, response.getStatus());
+   }
+
+   @Test
+   void doFilter_emMonitoringPath_noSession_stillRedirectsToLogin() throws Exception {
+      // guards against the new patterns widening far enough to expose an EM endpoint: "*" matches
+      // within a single path segment only, so nothing under /em/monitoring/** becomes public
+      MockHttpServletRequest request = request(
+         "GET", "/em/monitoring/server/debug/key-value-storage-dump");
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      when(mockEngine.containsAnonymous(any())).thenReturn(false);
+
+      filter.doFilter(request, response, chain);
+
+      assertEquals(HttpServletResponse.SC_FOUND, response.getStatus());
+      assertTrue(response.getRedirectedUrl().contains("login.html?requestedUrl="));
+      verifyNoInteractions(chain);
+   }
+
+   @Test
+   void doFilter_emScript_virtualProvider_noPrincipal_notBlockedByEmAccessCheck() throws Exception {
+      // The EM access check in the else-if branch must not re-block the now-public EM resources;
+      // otherwise whitelisting them has no effect at all.
+      when(mockProvider.isVirtual()).thenReturn(true);
+      MockHttpServletRequest request = request("GET", "/em/scripts.js");
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilter(request, response, chain);
+
+      verify(chain).doFilter(eq(request), any());
+      assertNotEquals(HttpServletResponse.SC_FOUND, response.getStatus());
+      verify(mockProvider, never())
+         .checkPermission(any(), eq(ResourceType.EM), anyString(), any());
+   }
+
+   @Test
+   void doFilter_emPage_noSession_stillRedirectsToLogin() throws Exception {
+      // only the static resources are public; the EM pages themselves are still protected
+      MockHttpServletRequest request = request("GET", "/em/settings");
+      request.addHeader("Sec-Fetch-Dest", "document");
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      when(mockEngine.containsAnonymous(any())).thenReturn(false);
+
+      filter.doFilter(request, response, chain);
+
+      assertEquals(HttpServletResponse.SC_FOUND, response.getStatus());
+      assertTrue(response.getRedirectedUrl().contains("login.html?requestedUrl="));
+      verifyNoInteractions(chain);
+   }
+
+   // ── subresource requests get a 401 instead of an HTML redirect ────────────
+
+   @Test
+   void doFilter_unauthorizedSubresourceRequest_returns401InsteadOfRedirect() throws Exception {
+      MockHttpServletRequest request = request("GET", "/portal/dashboard-script");
+      request.addHeader("Sec-Fetch-Dest", "script");
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      when(mockEngine.containsAnonymous(any())).thenReturn(false);
+
+      filter.doFilter(request, response, chain);
+
+      assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+      assertNull(response.getRedirectedUrl());
+      verifyNoInteractions(chain);
+   }
+
+   @Test
+   void doFilter_unauthorizedIframeRequest_stillRedirectsToLogin() throws Exception {
+      MockHttpServletRequest request = request("GET", "/em/settings");
+      request.addHeader("Sec-Fetch-Dest", "iframe");
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      when(mockEngine.containsAnonymous(any())).thenReturn(false);
+
+      filter.doFilter(request, response, chain);
+
+      assertEquals(HttpServletResponse.SC_FOUND, response.getStatus());
+      assertTrue(response.getRedirectedUrl().contains("login.html?requestedUrl="));
+   }
+
    // ── helpers ────────────────────────────────────────────────────────────────
 
    private static MockHttpServletRequest request(String method, String path) {


### PR DESCRIPTION
## Summary

Logging in to the Enterprise Manager after the same session had been logged out from the portal in another tab left the EM as a blank white page, with `Uncaught SyntaxError: Unexpected identifier 'file'` in `scripts.js`. The request for `/em/scripts.js` returned `200 text/html` whose body was `login.html?requestedUrl=.../em/scripts.js` — the server had redirected a JavaScript asset request to the login page, and the browser executed that HTML as JavaScript.

## Root Cause

`AbstractSecurityFilter.publicResources` whitelisted the portal's static bundles (`/app/*.js`, `/app/*.css`, `/app/assets/**`, ...) but had no `/em/*` counterparts. The EM Angular build emits `/em/main.js`, `/em/polyfills.js`, `/em/scripts.js`, ~120 lazily loaded route chunks, `/em/styles.css` and an icon font under `/em/media/`, so every EM asset request was a protected request.

When one arrived without a valid principal, `DefaultAuthorizationFilter` marked it unauthorized, and `shouldSendAuthenticationRedirect()` only answered with a 401 for XHR and WebSocket requests. A `<script src>` or `<link>` load sends no `X-Requested-With` header, so it received a 302 to `login.html`, which the browser followed and handed to the script or style parser. The portal never hit this because `/app/*.js` was already public.

Whitelisting the resources on its own has no effect: it makes the first branch of `DefaultAuthorizationFilter.doFilter()` false, which routes the request into the Enterprise Manager branch, and that branch still demands a principal with EM access.

## Fix

- Added the EM static resources to `publicResources`: `/em/*.{js,css,cur,eot,ico,png,svg,ttf,woff}`, `/em/assets/**` and `/em/media/**`. These mirror the existing `/app` entries. `/em/media/**` is needed separately because `AntPathMatcher`'s `*` does not match across a path separator, and `em/styles.css` references `./media/InetSoft-Icons.woff`.
- `DefaultAuthorizationFilter`'s Enterprise Manager branch now also requires `!isPublicResource(...)`, so the newly public resources are not re-blocked by the EM access check.
- As a second line of defense, `shouldSendAuthenticationRedirect()` now answers an unauthorized request with a 401 rather than a login page redirect whenever `Sec-Fetch-Dest` identifies it as a subresource request (anything other than `document`/`iframe`/`frame`/`embed`/`object`). A missing header is still treated as a navigation request, so behavior is unchanged for older browsers, non-browser clients, and plain-HTTP origins (the header is only sent to trustworthy origins). This makes the whole failure class — a login page executed as script or style — impossible for any asset, present or future, but it is defense in depth only: the whitelist is what actually fixes this bug.

### Scope of the new public paths

`*` matches within a single path segment, so `/em/monitoring/**`, `/em/settings/**`, `/em/auditing/**`, `/em/content/data-space/file/download` and `/api/em/**` are all unaffected. Of the controllers mapped under `/em`, only `GlobalStyleController` (theme CSS, `/em/assets/**`) and `TemplateLocalizationController` (`/em/*.js`) serve any of the newly public paths; both already tolerate a null principal, which is the path the already-public `/app/*.js` has always taken. No API, data, config, download or monitoring endpoint becomes reachable.

## Test Plan

Added 9 tests to `DefaultAuthorizationFilterTest`, including negative guards that `/em/settings`, `/em/monitoring/server/debug/key-value-storage-dump` and iframe requests still redirect to the login page.

Verified by stashing the two main-code changes and re-running the suite: 6 of the 9 new tests fail without the fix, including `expected: <401> but was: <302>` for the subresource case, which is exactly the reported symptom. The 3 that pass in both states are the intentional regression guards.

```
./mvnw install -pl core -DskipTests                → BUILD SUCCESS
./mvnw test -pl core -Dtest=DefaultAuthorizationFilterTest,AnonymousUserFilterTest,\
  InvalidateSessionFilterTest,SecurityFilterChainOrderingTest,LogoutFilterTest
                                                   → Tests run: 75, Failures: 0, Errors: 0
```

Manual verification of the original repro: log in to EM in one tab, log in to the portal with the same account in a second tab, log out from the portal, then log in again on the EM page. The EM now loads instead of showing a blank page, icons render, and `/em/scripts.js` is never answered with `text/html`. `/em/settings` while logged out still redirects to the login page.

## Note

The fix makes this failure mode benign regardless of why the session is momentarily invalid at that instant; the underlying timing window (most plausibly the `login.js` handoff, where `authenticateUser()` performs the session-creating AJAX GET before `window.location.href` navigates) was not diagnosed and is unchanged.

`/app/media/**` has the same pre-existing gap for the portal bundle. It was left out as outside the scope of this bug and is a candidate for a follow-up.

Fixes Redmine #75775.