### PR TITLE
Bug #75784, preserve the theme id when renaming an organization

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
@@ -358,7 +358,18 @@ public abstract class AbstractEditableAuthenticationProvider
             if(Tool.equals(theme.getOrgID(), fromOrgId)) {
                CustomTheme clone = (CustomTheme) theme.clone();
                clone.setOrgID(toOrgId);
-               clone.setId(UUID.randomUUID().toString().replace("-", ""));
+
+               // A copy needs a brand-new id so the clone stays fully independent of the
+               // source org's theme (#74711). A rename removes the source theme below, so
+               // there is no id left to collide with and the id must be preserved instead:
+               // Organization.theme, the theme jar file name and any client-held or
+               // per-user theme id all reference it, and regenerating the id orphans them
+               // all (#75784). The fromOrgId == toOrgId case cannot preserve the id: the
+               // clone would then equal the original, collapse in the set below and be
+               // dropped by the deferred removal, so keep generating a new id there.
+               if(!replace || Tool.equals(fromOrgId, toOrgId)) {
+                  clone.setId(UUID.randomUUID().toString().replace("-", ""));
+               }
 
                String originalID = clone.getId();
                int i = 1;

--- a/core/src/test/java/inetsoft/sree/security/AbstractEditableAuthenticationProviderStaticDepTest.java
+++ b/core/src/test/java/inetsoft/sree/security/AbstractEditableAuthenticationProviderStaticDepTest.java
@@ -81,6 +81,9 @@ package inetsoft.sree.security;
  *  ├─ [C] theme with orgID==fromOrgId, replace=false → clone added, original kept
  *  ├─ [D] theme with orgID==fromOrgId, replace=true  → original removed, clone added,
  *  │       setOrgSelectedTheme(null, fromOrgId) called
+ *  ├─ [D2] theme with orgID==fromOrgId, replace=true → migrated theme keeps its id so
+ *  │       Organization.theme / jar name / client-held ids stay valid (#75784)
+ *  ├─ [D3] fromOrgId == toOrgId, replace=true        → id still regenerated, theme retained
  *  ├─ [E] global theme (orgID==null) with fromOrgId in organizations → toOrgId added to
  *  │       organizations, setOrgSelectedTheme(themeId, toOrgId) called; no clone created
  *  └─ [F] global theme (orgID==null) without fromOrgId in organizations → no action
@@ -419,6 +422,83 @@ class AbstractEditableAuthenticationProviderStaticDepTest {
          assertTrue(result.stream().anyMatch(t -> "toOrg".equals(t.getOrgID())));
 
          verify(mockManager).setOrgSelectedTheme(null, "fromOrg");
+      }
+   }
+
+   // [Path D2 — #75784] theme with orgID==fromOrgId, replace=true → the migrated theme keeps
+   //           its id (Organization.theme, the jar file name and client/user-held theme ids all
+   //           reference it), and the org selection pointer is moved to that same id
+   @Test
+   void copyThemes_matchingTheme_replaceTrue_themeIdPreserved() {
+      CustomTheme theme = new CustomTheme();
+      theme.setId("theme1");
+      theme.setOrgID("fromOrg");
+      theme.setJarPath("portal/fromOrg/theme/theme1.jar");
+      theme.setOrganizations(new ArrayList<>(List.of("fromOrg")));
+
+      try(MockedStatic<DataSpace> ds = mockStatic(DataSpace.class);
+          MockedStatic<CustomThemesManager> ctm = mockStatic(CustomThemesManager.class)) {
+
+         DataSpace mockDs = mock(DataSpace.class);
+         ds.when(DataSpace::getDataSpace).thenReturn(mockDs);
+
+         CustomThemesManager mockManager = mock(CustomThemesManager.class);
+         ctm.when(CustomThemesManager::getManager).thenReturn(mockManager);
+         when(mockManager.getCustomThemes()).thenReturn(new HashSet<>(Set.of(theme)));
+
+         String returnedId = provider.callCopyThemes("fromOrg", "toOrg", true);
+
+         @SuppressWarnings("unchecked")
+         ArgumentCaptor<Set<CustomTheme>> captor = ArgumentCaptor.forClass(Set.class);
+         verify(mockManager).setCustomThemes(captor.capture());
+
+         Set<CustomTheme> result = captor.getValue();
+         assertEquals(1, result.size(), "only the migrated theme expected");
+
+         CustomTheme migrated = result.iterator().next();
+         assertEquals("toOrg", migrated.getOrgID());
+         assertEquals("theme1", migrated.getId(),
+                      "a rename must preserve the theme id so references to it survive");
+         assertEquals("portal/toOrg/theme/theme1.jar", migrated.getJarPath(),
+                      "jar path must be re-scoped to the new org and still match the theme id");
+         assertEquals("theme1", returnedId, "returned id must be the preserved id");
+         verify(mockManager).setOrgSelectedTheme("theme1", "toOrg");
+      }
+   }
+
+   // [Path D3 — #75784] same org id with replace=true → the id must still be regenerated,
+   //           otherwise the clone would equal the original, collapse in the set and be dropped
+   //           by the deferred removal
+   @Test
+   void copyThemes_sameOrgId_replaceTrue_themeRetainedWithNewId() {
+      CustomTheme theme = new CustomTheme();
+      theme.setId("theme1");
+      theme.setOrgID("sameOrg");
+      theme.setOrganizations(new ArrayList<>());
+
+      try(MockedStatic<DataSpace> ds = mockStatic(DataSpace.class);
+          MockedStatic<CustomThemesManager> ctm = mockStatic(CustomThemesManager.class)) {
+
+         DataSpace mockDs = mock(DataSpace.class);
+         ds.when(DataSpace::getDataSpace).thenReturn(mockDs);
+
+         CustomThemesManager mockManager = mock(CustomThemesManager.class);
+         ctm.when(CustomThemesManager::getManager).thenReturn(mockManager);
+         when(mockManager.getCustomThemes()).thenReturn(new HashSet<>(Set.of(theme)));
+
+         provider.callCopyThemes("sameOrg", "sameOrg", true);
+
+         @SuppressWarnings("unchecked")
+         ArgumentCaptor<Set<CustomTheme>> captor = ArgumentCaptor.forClass(Set.class);
+         verify(mockManager).setCustomThemes(captor.capture());
+
+         Set<CustomTheme> result = captor.getValue();
+         assertEquals(1, result.size(), "the theme must not be dropped");
+
+         CustomTheme migrated = result.iterator().next();
+         assertEquals("sameOrg", migrated.getOrgID());
+         assertNotEquals("theme1", migrated.getId(),
+                         "id must be regenerated when the org id is unchanged");
       }
    }
 


### PR DESCRIPTION
## Summary

Renaming an organization (changing its org ID) lost the organization's default theme, and re-saving that theme afterwards failed with a 404. `copyThemes()` regenerated the theme's ID on every migration, including a rename, which orphaned every reference keyed by theme ID.

## Root Cause

EM org rename with a changed org ID flows `UserTreeService.editOrganization` → `IdentityService.setIdentity` → `setOrganizationInfo` → `syncIdentity` → `copyOrganization(..., replace=true)` → `AbstractEditableAuthenticationProvider.copyThemes(fromOrgId, toOrgId, true)`.

`copyThemes()` migrates an org-owned theme by cloning it, re-pointing `orgID`, and unconditionally regenerating its ID to a fresh UUID. A new UUID is genuinely required for an org **copy** so the clone stays independent of the source org's theme (#74711 / #74719). On a **rename** the source entry is deleted immediately afterwards, so there is no ID left to collide with — and regenerating it breaks every reference to the theme:

- `copyOrganizationInternal()` takes `Organization.theme` from the edited org model (the *pre-rename* theme ID from the EM form) rather than from `copyThemes()`'s returned `newOrgThemeId`. The org's default-theme pointer therefore dangled. The Theme `<mat-select>` in EM Security → Edit Organization binds by `theme.id`, so no option matched and the dropdown rendered blank — the "theme is missing" symptom.
- A theme ID held outside the store was invalidated the same way, including the `CustomThemeModel` loaded by EM Presentation → Themes. That page PUTs to `themes/${current.id}`, and `ThemeService.updateTheme` throws `NOT_FOUND` when the ID is gone — the reported `PUT .../themes/theme1 404`. It also explains why re-creating a theme named `theme1` produced ID `theme1` again: the UUID rename freed that ID.
- Secondary inconsistency: the migrated JAR kept its old file name while the theme ID became a UUID, so ID and JAR name diverged.

`copyThemes()` migrated the theme itself correctly; the defect was only the needless ID churn.

## Fix

Regenerate the theme ID only when it is actually needed:

```java
if(!replace || Tool.equals(fromOrgId, toOrgId)) {
   clone.setId(UUID.randomUUID().toString().replace("-", ""));
}
```

The `fromOrgId == toOrgId` clause keeps today's behavior in the degenerate same-ID case: preserving the ID there would make the clone `equals()` the original, collapse it in the working `HashSet`, and then have it dropped by the deferred `removeIf`. That case is not reachable from the current EM flow (`setOrganizationInfo` returns early whenever the org ID is unchanged) but is cheap to keep safe, and is covered by a test.

With the ID preserved, all three states agree without touching `copyOrganizationInternal`: the theme's own `id`, `Organization.theme`, and the `portal.org.selectedThemeId.<orgID>` pointer. Org copy/clone behavior is byte-for-byte unchanged.

## Test Plan

Added two unit tests to `AbstractEditableAuthenticationProviderStaticDepTest`:

- `copyThemes_matchingTheme_replaceTrue_themeIdPreserved` — a rename keeps the theme ID, re-scopes the JAR path to the new org, returns the preserved ID, and points `setOrgSelectedTheme` at it.
- `copyThemes_sameOrgId_replaceTrue_themeRetainedWithNewId` — the same-org-ID case still regenerates the ID and does not drop the theme.

Automated:

- `./mvnw clean install -pl core -am -DskipTests` → BUILD SUCCESS
- `./mvnw test -pl core -Dtest='inetsoft.sree.security.**,inetsoft.sree.portal.**,inetsoft.web.admin.security.**,inetsoft.web.admin.presentation.**'` → 738 tests, 0 failures, 0 errors, 13 pre-existing skips. Includes the pre-existing `copyThemes_*` cases, `OrgLifecycleThemeOrchestrationTest`, `IdentityThemeServiceTest` and `CustomThemesManagerTest`.

Manual regression checks:

1. Create an organization, create an org-owned theme, tick "Default for This Organization", save.
2. Rename the organization, changing both its name and its ID.
3. EM Security → Edit Organization → the Theme dropdown still shows the theme.
4. EM Presentation → Themes → the theme is still listed for the renamed org with "Default for This Organization" ticked; editing and applying it succeeds (no 404).
5. Portal still renders with the custom theme applied.
6. Org **copy/clone** still produces an independent theme with a new ID, and editing the clone's CSS does not affect the source org (#74711); a global theme's JAR is still not cloned into the new org (#74719).

Verified fixed by the reporter's scenario.

Fixes Redmine #75784.