### PR TITLE
Bug #75777, recycle discarded auto save files of saved sheets

### DIFF
--- a/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
+++ b/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
@@ -4074,21 +4074,25 @@ public final class VSEventUtil {
    }
 
    /**
-    * Delete auto saved file.
-    * 1 for saved dashboard, keep old logic, delete auto save file when select no.
-    * 2 for untitled dashboard, select no will move auto save file to recycle bin.
+    * Discard the auto saved file of a sheet by moving it to the recycle bin, so that it can
+    * still be recovered from the enterprise manager. This is called when the auto saved content
+    * is thrown away, i.e. when the sheet is closed, when it is opened without restoring the auto
+    * saved content, and when the stored sheet is loaded in place of it
+    * (AbstractAssetEngine.getSheet). When the sheet is saved the auto saved content is superseded
+    * instead of discarded, so the save paths delete the file rather than calling this method.
     */
    public static void deleteAutoSavedFile(AssetEntry entry, Principal user) {
-      if(entry.getScope() != AssetRepository.TEMPORARY_SCOPE) {
-         AutoSaveUtils.deleteAutoSaveFile(entry, user);
-         return;
+      // called while loading a sheet, so never let a storage failure fail the caller
+      try {
+         String savefile = AutoSaveUtils.getAutoSavedFile(entry, user);
+
+         if(AutoSaveUtils.exists(savefile, user)) {
+            String recyclefile = AutoSaveUtils.getAutoSavedFile(entry, user, true);
+            AutoSaveUtils.renameAutoSaveFile(savefile, recyclefile, user);
+         }
       }
-
-      String savefile = AutoSaveUtils.getAutoSavedFile(entry, user);
-
-      if(AutoSaveUtils.exists(savefile, user)) {
-         String recyclefile = AutoSaveUtils.getAutoSavedFile(entry, user, true);
-         AutoSaveUtils.renameAutoSaveFile(savefile, recyclefile, user);
+      catch(Exception e) {
+         LOG.debug("Failed to move the auto save file to the recycle bin: {}", entry, e);
       }
    }
 

--- a/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
+++ b/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
@@ -4080,8 +4080,18 @@ public final class VSEventUtil {
     * saved content, and when the stored sheet is loaded in place of it
     * (AbstractAssetEngine.getSheet). When the sheet is saved the auto saved content is superseded
     * instead of discarded, so the save paths delete the file rather than calling this method.
+    * An entry that already refers to a file in the recycle bin is ignored.
     */
    public static void deleteAutoSavedFile(AssetEntry entry, Principal user) {
+      // an entry that carries the name of an existing auto save file, i.e. one created by
+      // AutoSaveUtils.createAssetEntry() for the recycle bin, already refers to a discarded file,
+      // so there is nothing to discard. the name embeds the user and ip address of the session
+      // that created it and can not be recreated from the current user, so moving it again would
+      // only orphan it under a name attributed to the wrong user.
+      if(entry.getProperty("autoFileName") != null) {
+         return;
+      }
+
       // called while loading a sheet, so never let a storage failure fail the caller
       try {
          String savefile = AutoSaveUtils.getAutoSavedFile(entry, user);

--- a/core/src/main/java/inetsoft/web/AutoSaveService.java
+++ b/core/src/main/java/inetsoft/web/AutoSaveService.java
@@ -83,8 +83,9 @@ public class AutoSaveService {
       AbstractSheet sheet = repository.getSheet(entry, principal, false, AssetContent.ALL);
       IdentityID pId = IdentityID.getIdentityIDFromKey(principal.getName());
 
-      // Save auto save sheet to engine.
-      AssetEntry.Type type = id.startsWith("8^VIEWSHEET") ? AssetEntry.Type.VIEWSHEET :
+      // Save auto save sheet to engine. The scope of the auto save file is not necessarily the
+      // temporary scope, so get the type from the entry instead of matching the file name prefix.
+      AssetEntry.Type type = entry.isViewsheet() ? AssetEntry.Type.VIEWSHEET :
          AssetEntry.Type.WORKSHEET;
       AssetEntry nentry = new AssetEntry(AssetRepository.GLOBAL_SCOPE, type, assetName,
                                          pId);

--- a/core/src/main/java/inetsoft/web/AutoSaveUtils.java
+++ b/core/src/main/java/inetsoft/web/AutoSaveUtils.java
@@ -65,8 +65,11 @@ public final class AutoSaveUtils {
       String ip = paths.length > 4 ? paths[4] : null;
 
       String typeStr = "VIEWSHEET".equals(type) ? "^128^" : "^2^";
-      AssetEntry entry = AssetEntry.createAssetEntry(scope + typeStr + ouser + "^" + name +
-                                                        "^" + ip);
+      // the last field of an auto save file name is the ip address, not the organization id, so
+      // the entry must be created for the current organization. otherwise, for any scope other
+      // than the temporary scope, the ip address would be parsed as the organization id.
+      AssetEntry entry = AssetEntry.createAssetEntryForCurrentOrg(
+         scope + typeStr + ouser + "^" + name + "^" + ip);
       entry.setProperty("openAutoSaved", "true");
       entry.setProperty("autoFileName", autoFile);
       entry.setProperty("isRecycle", "true");
@@ -74,14 +77,16 @@ public final class AutoSaveUtils {
       return entry;
    }
 
-   // If saved vs, get its auto saved file by create file name.
-   // If unsaved vs(untitled vs), should get its auto save file from file name.  For its file name
-   // is fixed, will not changed by login user.
+   // If the entry carries the name of an existing auto save file, e.g. an entry created by
+   // createAssetEntry() for the recycle bin, use that name as is. The name of an auto save file
+   // contains the user and ip address of the session that created it, so it can not be recreated
+   // from the entry and the current user.
+   // Otherwise, create the file name from the entry and the current user.
    public static String getAutoSavedFile(AssetEntry entry, Principal user) {
       String fileName = entry.getProperty("autoFileName");
       boolean isRecycle = "true".equals(entry.getProperty("isRecycle"));
 
-      if(entry.getScope() == AssetRepository.TEMPORARY_SCOPE && fileName != null) {
+      if(fileName != null) {
          fileName = SUtil.addAutoSaveOrganization(fileName);
          return getAutoSavedByName(fileName, isRecycle);
       }

--- a/core/src/main/java/inetsoft/web/admin/content/repository/AutoSaveController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/AutoSaveController.java
@@ -63,7 +63,9 @@ public class AutoSaveController {
       for(int i = 0; i < ids.length; i++) {
          String path = ids[i];
          AutoSaveUtils.deleteAutoSaveFile(path, user);
-         int type = path.startsWith("8^WORKSHEET^") ? RepositoryEntry.AUTO_SAVE_WS :
+         // the scope of an auto save file is not necessarily the temporary scope, so match the
+         // type field of the file name instead of the whole prefix
+         int type = path.contains("^WORKSHEET^") ? RepositoryEntry.AUTO_SAVE_WS :
                  RepositoryEntry.AUTO_SAVE_VS;
          String objectName = Util.getObjectFullPath(type, path, user, null);
          ActionRecord actionRecord = SUtil.getActionRecord(user,

--- a/core/src/main/java/inetsoft/web/admin/content/repository/ContentRepositoryTreeService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/ContentRepositoryTreeService.java
@@ -52,6 +52,8 @@ import java.security.Principal;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -441,9 +443,10 @@ public class ContentRepositoryTreeService {
             long lastModify = AutoSaveUtils.getLastModified(file, principal);
 
             // if the auto save file in recycle bin is large than one week, remove it and do not show
-            // it.
+            // it. deleteAutoSaveFile() adds the recycle bin prefix to the name, so pass the name
+            // of the file instead of its path.
             if(lastWeek > lastModify) {
-               AutoSaveUtils.deleteAutoSaveFile(file, principal);
+               AutoSaveUtils.deleteAutoSaveFile(asset, principal);
                continue;
             }
 
@@ -476,7 +479,7 @@ public class ContentRepositoryTreeService {
                }
 
                ContentRepositoryTreeNode node = ContentRepositoryTreeNode.builder()
-                  .label(name)
+                  .label(denormalizeAssetName(name))
                   .path(asset)
                   .fullPath(asset)
                   .type(typeValue)
@@ -502,6 +505,29 @@ public class ContentRepositoryTreeService {
       addUserNodes(users, map, userNodes);
 
       return userNodes;
+   }
+
+   /**
+    * Reverse the escaping applied by Tool.normalizeFileName() when the asset path was written to
+    * the name of an auto save file, so that the tree shows the real asset path. Auto saved files
+    * of sheets that have been saved to a folder contain an escaped path separator.
+    */
+   private static String denormalizeAssetName(String name) {
+      if(name == null || name.indexOf('_') < 0) {
+         return name;
+      }
+
+      Matcher matcher = NORMALIZED_CHAR.matcher(name);
+      StringBuilder buffer = new StringBuilder();
+      int index = 0;
+
+      while(matcher.find()) {
+         buffer.append(name, index, matcher.start())
+            .append((char) Integer.parseInt(matcher.group(1)));
+         index = matcher.end();
+      }
+
+      return buffer.append(name.substring(index)).toString();
    }
 
    private void addUserNodes(List<String> users, HashMap<String,
@@ -2101,6 +2127,9 @@ public class ContentRepositoryTreeService {
 
    public static final String RECYCLE_BIN_FOLDER = "Recycle Bin";
    private static final Logger LOG = LoggerFactory.getLogger(ContentRepositoryTreeService.class);
+   // the characters escaped by Tool.normalizeFileName()
+   private static final Pattern NORMALIZED_CHAR =
+      Pattern.compile("_(34|42|44|47|58|59|60|62|63|92|124)_");
 
    private static final class UserNodes {
       UserNodes(IdentityID user) {

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/ComposerViewsheetService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/ComposerViewsheetService.java
@@ -42,6 +42,7 @@ import inetsoft.util.*;
 import inetsoft.util.audit.*;
 import inetsoft.util.log.LogUtil;
 import inetsoft.util.profile.Profile;
+import inetsoft.web.AutoSaveUtils;
 import inetsoft.web.composer.vs.VSObjectTreeNode;
 import inetsoft.web.composer.vs.VSObjectTreeService;
 import inetsoft.web.composer.vs.command.*;
@@ -155,6 +156,9 @@ public class ComposerViewsheetService {
          }
 
          rvs.setSavePoint(rvs.getCurrent());
+         // the auto saved content is superseded by the saved viewsheet, so discard it instead of
+         // keeping a stale copy that would be offered for restore or moved to the recycle bin
+         AutoSaveUtils.deleteAutoSaveFile(entry, principal);
 
          String mvmsg = checkMVMessage(rvs, entry);
 

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/SaveWorksheetDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/SaveWorksheetDialogService.java
@@ -19,7 +19,6 @@
 package inetsoft.web.composer.ws.dialog;
 
 import inetsoft.analytic.composition.ViewsheetService;
-import inetsoft.analytic.composition.event.VSEventUtil;
 import inetsoft.cluster.*;
 import inetsoft.report.composition.*;
 import inetsoft.report.composition.event.AssetEventUtil;
@@ -334,7 +333,9 @@ public class SaveWorksheetDialogService extends WorksheetControllerService {
          // successful, check and remove any auto-saved versions of the
          // Worksheet. If this action was a "save as", we should also delete
          // the auto-saved version of the original Worksheet (if one exists).
-         VSEventUtil.deleteAutoSavedFile(entry, principal);
+         // The saved worksheet supersedes the auto saved content, so delete it instead of
+         // moving it to the recycle bin.
+         AutoSaveUtils.deleteAutoSaveFile(entry, principal);
       }
       catch(Exception ex) {
          if(ex instanceof ConfirmException) {

--- a/core/src/main/java/inetsoft/web/composer/ws/service/SaveWorksheetService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/service/SaveWorksheetService.java
@@ -18,7 +18,6 @@
 package inetsoft.web.composer.ws.service;
 
 import inetsoft.analytic.composition.ViewsheetService;
-import inetsoft.analytic.composition.event.VSEventUtil;
 import inetsoft.cluster.*;
 import inetsoft.mv.MVManager;
 import inetsoft.report.*;
@@ -39,6 +38,7 @@ import inetsoft.uql.viewsheet.internal.CalcTableVSAssemblyInfo;
 import inetsoft.util.*;
 import inetsoft.util.audit.ActionRecord;
 import inetsoft.util.audit.Audit;
+import inetsoft.web.AutoSaveUtils;
 import inetsoft.web.composer.model.ws.SaveWSConfirmationModel;
 import inetsoft.web.composer.vs.command.ReopenSheetCommand;
 import inetsoft.web.composer.ws.WorksheetControllerService;
@@ -314,7 +314,9 @@ public class SaveWorksheetService extends WorksheetControllerService {
          // successful, check and remove any auto-saved versions of the
          // Worksheet. If this action was a "save as", we should also delete
          // the auto-saved version of the original Worksheet (if one exists).
-         VSEventUtil.deleteAutoSavedFile(entry, user);
+         // The saved worksheet supersedes the auto saved content, so delete it instead of
+         // moving it to the recycle bin.
+         AutoSaveUtils.deleteAutoSaveFile(entry, user);
       }
       catch(Exception ex) {
          if(ex instanceof ConfirmException) {

--- a/core/src/test/java/inetsoft/analytic/composition/event/VSEventUtilAutoSaveTest.java
+++ b/core/src/test/java/inetsoft/analytic/composition/event/VSEventUtilAutoSaveTest.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.analytic.composition.event;
+
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.web.AutoSaveUtils;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class VSEventUtilAutoSaveTest {
+   // Bug #75777: an entry created for a recycle bin file already refers to a discarded auto save
+   // file. The file name embeds the user and ip address of the session that created it, so the
+   // recycled name can not be recreated from the user performing the restore. Moving it again
+   // would rename the recycle bin entry to a name attributed to that user, orphaning it so that
+   // the explicit cleanup after the restore no longer finds it.
+   @Test
+   void deleteAutoSavedFile_recycledEntry_doesNotMoveFileAgain() {
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, "dashboard1", null);
+      entry.setProperty("autoFileName", AssetRepository.GLOBAL_SCOPE +
+         "^VIEWSHEET^alice^dashboard1^0_0_0_0_0_0_0_1~");
+      entry.setProperty("isRecycle", "true");
+
+      try(MockedStatic<AutoSaveUtils> utils = mockStatic(AutoSaveUtils.class)) {
+         VSEventUtil.deleteAutoSavedFile(entry, null);
+
+         utils.verifyNoInteractions();
+      }
+   }
+
+   // Bug #75777: an entry with no file name still refers to the active auto save file of the
+   // sheet, which is moved to the recycle bin so that it can be recovered from the enterprise
+   // manager.
+   @Test
+   void deleteAutoSavedFile_activeEntry_movesFileToRecycleBin() {
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, "dashboard1", null);
+      String savefile = AssetRepository.GLOBAL_SCOPE + "^VIEWSHEET^alice^dashboard1^ip~";
+      String recyclefile = AutoSaveUtils.RECYCLE_PREFIX + savefile;
+
+      try(MockedStatic<AutoSaveUtils> utils = mockStatic(AutoSaveUtils.class)) {
+         utils.when(() -> AutoSaveUtils.getAutoSavedFile(entry, null)).thenReturn(savefile);
+         utils.when(() -> AutoSaveUtils.getAutoSavedFile(entry, null, true)).thenReturn(recyclefile);
+         utils.when(() -> AutoSaveUtils.exists(savefile, null)).thenReturn(true);
+
+         VSEventUtil.deleteAutoSavedFile(entry, null);
+
+         utils.verify(() -> AutoSaveUtils.renameAutoSaveFile(savefile, recyclefile, null));
+      }
+   }
+
+   // The auto save file may have already been removed, e.g. by the weekly cleanup, in which case
+   // there is nothing to move.
+   @Test
+   void deleteAutoSavedFile_missingFile_doesNotRename() {
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, "dashboard1", null);
+      String savefile = AssetRepository.GLOBAL_SCOPE + "^VIEWSHEET^alice^dashboard1^ip~";
+
+      try(MockedStatic<AutoSaveUtils> utils = mockStatic(AutoSaveUtils.class)) {
+         utils.when(() -> AutoSaveUtils.getAutoSavedFile(entry, null)).thenReturn(savefile);
+         utils.when(() -> AutoSaveUtils.exists(savefile, null)).thenReturn(false);
+
+         VSEventUtil.deleteAutoSavedFile(entry, null);
+
+         utils.verify(() -> AutoSaveUtils.renameAutoSaveFile(anyString(), anyString(), any()),
+                      never());
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/AutoSaveUtilsTest.java
+++ b/core/src/test/java/inetsoft/web/AutoSaveUtilsTest.java
@@ -18,8 +18,11 @@
 package inetsoft.web;
 
 import inetsoft.sree.security.IdentityID;
+import inetsoft.sree.security.OrganizationManager;
 import inetsoft.storage.BlobStorage;
 import inetsoft.storage.BlobStorageManager;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
 import org.junit.jupiter.api.*;
 import org.mockito.MockedStatic;
 
@@ -89,5 +92,70 @@ class AutoSaveUtilsTest {
          assertDoesNotThrow(() -> AutoSaveUtils.deleteUserAutoSaveFiles(alice));
          verify(blobStorage, times(2)).delete(anyString());
       }
+   }
+
+   // Bug #75777: the last field of an auto save file name is the ip address. For any scope other
+   // than the temporary scope it used to be parsed as the organization id, which resolved the
+   // entry against the wrong storage.
+   @Test
+   void createAssetEntry_savedSheet_usesCurrentOrgNotIpAddress() {
+      IdentityID alice = new IdentityID("alice", "org1");
+      String autoFile = AssetRepository.GLOBAL_SCOPE + "^VIEWSHEET^" + alice.convertToKey() +
+         "^dashboard1^0_0_0_0_0_0_0_1~";
+
+      try(MockedStatic<OrganizationManager> oms =
+             mockStatic(OrganizationManager.class, withSettings().lenient()))
+      {
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         oms.when(OrganizationManager::getInstance).thenReturn(orgManager);
+         when(orgManager.getCurrentOrgID()).thenReturn("org1");
+
+         AssetEntry entry = AutoSaveUtils.createAssetEntry(autoFile);
+
+         assertNotNull(entry);
+         assertEquals("org1", entry.getOrgID());
+         assertEquals(AssetRepository.GLOBAL_SCOPE, entry.getScope());
+         assertTrue(entry.isViewsheet());
+         assertEquals(autoFile, entry.getProperty("autoFileName"));
+      }
+   }
+
+   // Bug #75777: the file name of an auto save file embeds the user and ip address of the session
+   // that created it, so an entry that carries the name must use it as is regardless of scope.
+   // Rebuilding the name from the current user would resolve the wrong file, or none at all.
+   @Test
+   void getAutoSavedFile_savedSheetWithFileName_keepsRecycledFileName() {
+      IdentityID alice = new IdentityID("alice", "org1");
+      String autoFile = AssetRepository.GLOBAL_SCOPE + "^VIEWSHEET^" + alice.convertToKey() +
+         "^dashboard1^0_0_0_0_0_0_0_1~";
+
+      try(MockedStatic<OrganizationManager> oms =
+             mockStatic(OrganizationManager.class, withSettings().lenient()))
+      {
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         oms.when(OrganizationManager::getInstance).thenReturn(orgManager);
+         when(orgManager.getCurrentOrgID()).thenReturn("org1");
+
+         AssetEntry entry = AutoSaveUtils.createAssetEntry(autoFile);
+
+         // createAssetEntry() flags the entry as a recycle bin entry, so the recycled copy of the
+         // exact file name is resolved, not one rebuilt from the admin performing the restore
+         assertEquals(AutoSaveUtils.RECYCLE_PREFIX + autoFile,
+                      AutoSaveUtils.getAutoSavedFile(entry, null));
+      }
+   }
+
+   // Bug #75777: an entry with no file name still resolves to the active area, which is what the
+   // composer's "Autosaved file exists. Restore?" check relies on.
+   @Test
+   void getAutoSavedFile_noFileName_buildsActiveFileName() {
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, "dashboard1", null);
+
+      String file = AutoSaveUtils.getAutoSavedFile(entry, null);
+
+      assertFalse(file.startsWith(AutoSaveUtils.RECYCLE_PREFIX));
+      assertTrue(file.startsWith(AssetRepository.GLOBAL_SCOPE + "^" + entry.getType() + "^"));
+      assertTrue(file.contains("^dashboard1^"));
    }
 }


### PR DESCRIPTION
## Summary

The EM **Content > Recycle Bin > Auto Saved Files** node was always empty for sheets that had been saved, even while the composer reported *"Autosaved file exists. Restore?"* for the very same sheet.

## Root Cause

Auto save files live in a per-org blob bucket in two areas: an active area, and a `recycle/`-prefixed area. The EM tree lists only the `recycle/` area.

A file only ever reached `recycle/` for untitled sheets (`TEMPORARY_SCOPE`):

- `VSEventUtil.deleteAutoSavedFile()` renamed the active file into `recycle/` only when the scope was `TEMPORARY_SCOPE`; **for every other scope it deleted the file outright.**
- `AutoSaveUtils.recycleUserAutoSave()` likewise filters to `TEMPORARY_SCOPE`.

So for a saved viewsheet or worksheet, discarding the auto saved content (closing the composer, or opening the sheet and declining the restore) destroyed the draft. It could never show up in the enterprise manager, and there was no way to recover it.

## Fix

**Discarding an auto save file recycles it, saving deletes it.**

- `VSEventUtil.deleteAutoSavedFile()` now moves the file to the recycle bin regardless of scope. This is the discard path: composer close, and open-without-restore. It is also called from `AbstractAssetEngine.getSheet(..., ALL)`, which previously routed non-temporary scopes through an exception-swallowing helper, so the body is wrapped in a `try`/`catch` to keep a storage failure from failing a sheet load.
- A saved sheet supersedes its auto saved content rather than discarding it, so the save paths delete the file:
  - `ComposerViewsheetService.saveViewsheet()` — new call. A plain save of an already-saved viewsheet previously never removed its stale auto save file at all, so a crash right after saving would offer to restore *pre-save* content.
  - `SaveWorksheetService` / `SaveWorksheetDialogService` — switched from `VSEventUtil.deleteAutoSavedFile()` to `AutoSaveUtils.deleteAutoSaveFile()`, preserving today's behavior at these sites.

**Latent bugs in code that only became reachable once non-temporary files can appear in EM:**

- `AutoSaveService.restoreAutoSaveAssets()` classified `1^VIEWSHEET^...` as a **worksheet** via `id.startsWith("8^VIEWSHEET")`; now derived from the entry.
- `AutoSaveUtils.createAssetEntry()` let `AssetEntry.createAssetEntry()` parse the file name's trailing **IP address** field as the entry's **organization id** for any non-temporary scope, resolving the entry against the wrong storage.
- `AutoSaveUtils.getAutoSavedFile()` honored the entry's stored file name only for `TEMPORARY_SCOPE`. An EM restore of any other file would rebuild the name from the *administrator performing the restore* (their user name and IP), find nothing, and silently restore the **saved sheet instead of the draft**.
- `AutoSaveController.deleteAutoSaveAssets()` had the same `8^WORKSHEET^` prefix assumption (audit label only).
- `ContentRepositoryTreeService.addRecycleAutoSaved()`: the "older than a week" purge passed an already `recycle/`-prefixed path to a method that prefixes it again, so it silently deleted nothing; and the node label displayed the raw `Tool.normalizeFileName()` escaping, e.g. `Sales_47_MyVS` instead of `Sales/MyVS`.

## Test Plan

Automated:

- `AutoSaveUtilsTest` — three new cases covering the organization id, the stored file name, and that an entry without a stored name still resolves to the active area (which is what the composer's restore prompt depends on). **Verified that the two regression cases fail against the pre-fix code**, with exactly the predicted failures: `expected: <org1> but was: <0_0_0_0_0_0_0_1~>`, and a name rebuilt as `1^VIEWSHEET^_NULL_~;~host-org^dashboard1^null~`.
- Auto save + repository tree suites: 24 run, 0 failures.
- All `inetsoft.web` tests: 655 run, 0 failures.
- `./mvnw install -pl community/core -am`: BUILD SUCCESS.

Manual (security + multi-tenancy enabled) — verified by the reporter's scenario:

1. Open a **saved** viewsheet in the composer, edit it, wait >25s for the auto save.
2. Kill the browser tab, reopen the viewsheet, answer **No** to *"Autosaved file exists. Restore?"*
3. EM > Content > Recycle Bin > Auto Saved Files lists the file under the user's **Dashboard** folder; restore and delete both work on it.

Regression checks:

- Untitled/temporary sheet behavior is unchanged.
- The composer's *"Autosaved file exists. Restore?"* prompt still works — it checks the active area, which this change does not move files out of prematurely.
- An ordinary edit > **Save** > close leaves nothing in the recycle bin.

Note that checking EM while a design session is still live correctly shows nothing: the draft has not been discarded yet. That is the recycle bin's meaning, and live drafts are recovered through the composer's own prompt.

Fixes Redmine #75777.