### PR TITLE
Bug #75785, fix spurious sheet-expired error after chart Full Editor Finish

### DIFF
--- a/web/projects/portal/src/app/vsview/edit/vs-binding-pane.component.ts
+++ b/web/projects/portal/src/app/vsview/edit/vs-binding-pane.component.ts
@@ -861,6 +861,15 @@ export class VSBindingPane extends CommandProcessor implements OnInit, OnDestroy
                                           .set("originalMode", this.originalMode);
 
       if(save) {
+         // The commit below destroys this runtime server-side (finishEdit -> closeViewsheet).
+         // Stop the heartbeat first, otherwise a tick landing in the window between the
+         // commit and ngOnDestroy() can ping the already-closed runtime and the server
+         // responds with a spurious "sheet has expired" error.
+         if(this.heartBeat) {
+            this.heartBeat.unsubscribe();
+            this.heartBeat = null;
+         }
+
          promise = promise.then(
             () => this.modelService.getModel("../api/vsbinding/commit", params).toPromise());
 


### PR DESCRIPTION
## Summary
- Clicking Finish in the chart Full Editor commits via `POST /api/vsbinding/commit`, and `VSBindingService.finishEdit()` ends that request by calling `engine.closeViewsheet(nid, principal)`, destroying the Full Editor's server-side runtime.
- The client only unsubscribed its 25s keepalive in `ngOnDestroy()`, which fires later during pane teardown. A heartbeat tick landing in the window between the commit and teardown pinged the already-closed runtime, and the server correctly responded with an expiry error — surfaced to the user as a false "timed-out"/"has expired" dialog on an edit that had already succeeded.
- Fix: unsubscribe the heartbeat as the first step of the `save` branch in `closeHandler0()`, before the commit request fires, closing the race entirely. `ngOnDestroy()` already null-guards `heartBeat`, so no further change is needed there.

## Test plan
- [x] Reviewed `VSBindingService.finishEdit()` and confirmed `closeViewsheet()` runs synchronously as part of the commit request
- [x] Confirmed heartbeat cadence (25000ms) and teardown ordering in `vs-binding-pane.component.ts` / `stomp-client.service.ts`
- [ ] Ran `portal:test-tl` — pre-existing, unrelated failure in 41/43 files (circular import in `sort-column-event.ts`, outside this change's scope) prevents the binding-pane TL specs from loading in this environment; no regression introduced by this change