### PR TITLE
Bug #75778, keep bottom-tabs tables clear of the tab strip in Excel export

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
@@ -223,19 +223,20 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
     * Snapping the table down to the grid line makes {@code ceilY} a no-op so the drawn
     * bottom stays above the strip.</p>
     */
-   private void alignBottomTabsTables() {
+   // package-private for testing
+   void alignBottomTabsTables() {
       if(viewsheet == null) {
          return;
       }
 
       for(Assembly assembly : viewsheet.getAssemblies(true)) {
-         if(!(assembly instanceof TableDataVSAssembly) || !needExport((VSAssembly) assembly) ||
-            !TabVSAssemblyInfo.isInBottomTabs((VSAssembly) assembly))
+         if(!(assembly instanceof TableDataVSAssembly table) || !needExport(table) ||
+            !TabVSAssemblyInfo.isInBottomTabs(table))
          {
             continue;
          }
 
-         VSAssemblyInfo info = ((VSAssembly) assembly).getVSAssemblyInfo();
+         VSAssemblyInfo info = table.getVSAssemblyInfo();
          Point offset = info.getPixelOffset();
 
          if(offset == null) {

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
@@ -163,6 +163,7 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
       PoiExcelVSUtil.processOverlap(vsheet);
 
       super.prepareSheet(vsheet, sheetName, box);
+      alignBottomTabsTables();
       setUpSheet(sheetName);
 
       if(sheet == null) {
@@ -207,6 +208,50 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
          Row row = sheet.createRow(i);
          row.setHeight((short) ((rows[i + 1] - rows[i])
                                * ExcelVSUtil.EXCEL_PIXEL_HEIGHT_FACTOR));
+      }
+   }
+
+   /**
+    * Align the top of tables in a bottom-tabs container to the sheet's row grid.
+    *
+    * <p>A table's cells are snapped to the next grid line ({@link PoiExcelVSUtil#ceilY})
+    * and each table row consumes a whole grid row, so a table whose top is not on a
+    * grid line is drawn up to one row lower than its pixel position. The tab strip,
+    * on the other hand, is written as a picture at its exact pixel position and, in
+    * bottom-tabs mode, is pinned to the child's pixel bottom. That leaves no slack to
+    * absorb the rounding and the last row ends up underneath the strip (Bug #75778).
+    * Snapping the table down to the grid line makes {@code ceilY} a no-op so the drawn
+    * bottom stays above the strip.</p>
+    */
+   private void alignBottomTabsTables() {
+      if(viewsheet == null) {
+         return;
+      }
+
+      for(Assembly assembly : viewsheet.getAssemblies(true)) {
+         if(!(assembly instanceof TableDataVSAssembly) || !needExport((VSAssembly) assembly) ||
+            !TabVSAssemblyInfo.isInBottomTabs((VSAssembly) assembly))
+         {
+            continue;
+         }
+
+         VSAssemblyInfo info = ((VSAssembly) assembly).getVSAssemblyInfo();
+         Point offset = info.getPixelOffset();
+
+         if(offset == null) {
+            continue;
+         }
+
+         int y = PoiExcelVSUtil.floorY(offset.y);
+
+         if(y != offset.y) {
+            info.setPixelOffset(new Point(offset.x, y));
+            Point layout = info.getLayoutPosition();
+
+            if(layout != null) {
+               info.setLayoutPosition(new Point(layout.x, layout.y - (offset.y - y)));
+            }
+         }
       }
    }
 

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporterTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporterTest.java
@@ -1,0 +1,211 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.io.viewsheet.excel;
+
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.internal.AssetUtil;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.*;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.awt.*;
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link PoiExcelVSExporter#alignBottomTabsTables()} (Bug #75778).
+ *
+ * <p>The assembly infos are mocked rather than constructed: {@code VSAssemblyInfo}'s
+ * constructor reads {@code SreeEnv} properties, which needs a bootstrapped server
+ * this module's tests do not have.</p>
+ */
+class PoiExcelVSExporterTest {
+   /**
+    * A table in a bottom-tabs container whose top is off the sheet's row grid is
+    * snapped down to the grid line, and its layout position is shifted by the
+    * same amount so annotation placement stays anchored to the table.
+    */
+   @Test
+   void alignsOffGridBottomTabsTable() {
+      TableVSAssemblyInfo info = tableInfo(new Point(10, 250), new Point(30, 505));
+      TestExporter exporter = exporterFor(mockTable(info, bottomTabs(true)));
+
+      exporter.alignBottomTabsTables();
+
+      verify(info).setPixelOffset(new Point(10, 240));
+      verify(info).setLayoutPosition(new Point(30, 495));
+   }
+
+   /**
+    * The offset is floored, never rounded: a top just below a grid line moves
+    * back to the previous line rather than up to the next one.
+    */
+   @Test
+   void floorsRatherThanRoundsOffGridOffset() {
+      TableVSAssemblyInfo info = tableInfo(new Point(10, 259), null);
+      TestExporter exporter = exporterFor(mockTable(info, bottomTabs(true)));
+
+      exporter.alignBottomTabsTables();
+
+      verify(info).setPixelOffset(new Point(10, 240));
+      verify(info, never()).setLayoutPosition(any());
+   }
+
+   /**
+    * A table already sitting on a grid line is left completely alone, so
+    * grid-aligned exports stay byte-identical.
+    */
+   @Test
+   void leavesGridAlignedBottomTabsTableUnchanged() {
+      TableVSAssemblyInfo info =
+         tableInfo(new Point(10, 4 * AssetUtil.defh), new Point(30, 505));
+      TestExporter exporter = exporterFor(mockTable(info, bottomTabs(true)));
+
+      exporter.alignBottomTabsTables();
+
+      assertNotAdjusted(info);
+   }
+
+   /**
+    * Top-tab tables keep their exact pixel position — the tab strip is above
+    * them, so the grid rounding has room to absorb.
+    */
+   @Test
+   void ignoresTopTabsTable() {
+      TableVSAssemblyInfo info = tableInfo(new Point(10, 250), new Point(30, 505));
+      TestExporter exporter = exporterFor(mockTable(info, bottomTabs(false)));
+
+      exporter.alignBottomTabsTables();
+
+      assertNotAdjusted(info);
+   }
+
+   @Test
+   void ignoresTableNotInTab() {
+      TableVSAssemblyInfo info = tableInfo(new Point(10, 250), new Point(30, 505));
+      TestExporter exporter = exporterFor(mockTable(info, null));
+
+      exporter.alignBottomTabsTables();
+
+      assertNotAdjusted(info);
+   }
+
+   /**
+    * Only tables are snapped: other assembly types are drawn as pictures at
+    * their exact pixel position and must not move.
+    */
+   @Test
+   void ignoresNonTableAssembly() {
+      ChartVSAssemblyInfo info = Mockito.mock(ChartVSAssemblyInfo.class);
+      when(info.getPixelOffset()).thenReturn(new Point(10, 250));
+      TabVSAssembly tab = bottomTabs(true);
+      ChartVSAssembly chart = Mockito.mock(ChartVSAssembly.class);
+      when(chart.getVSAssemblyInfo()).thenReturn(info);
+      when(chart.getContainer()).thenReturn(tab);
+
+      exporterFor(chart).alignBottomTabsTables();
+
+      verify(info, never()).setPixelOffset(any());
+      verify(info, never()).setLayoutPosition(any());
+   }
+
+   /**
+    * Assemblies that are not written to the sheet (tip views, pop components,
+    * hidden assemblies) are skipped.
+    */
+   @Test
+   void skipsAssemblyExcludedFromExport() {
+      TableVSAssemblyInfo info = tableInfo(new Point(10, 250), new Point(30, 505));
+      TestExporter exporter = exporterFor(mockTable(info, bottomTabs(true)));
+      exporter.exportAll = false;
+
+      exporter.alignBottomTabsTables();
+
+      assertNotAdjusted(info);
+   }
+
+   @Test
+   void handlesNullPixelOffset() {
+      TableVSAssemblyInfo info = tableInfo(null, new Point(30, 505));
+      TestExporter exporter = exporterFor(mockTable(info, bottomTabs(true)));
+
+      assertDoesNotThrow(exporter::alignBottomTabsTables);
+      assertNotAdjusted(info);
+   }
+
+   @Test
+   void handlesNullViewsheet() {
+      TestExporter exporter = new TestExporter(null);
+      assertDoesNotThrow(exporter::alignBottomTabsTables);
+   }
+
+   private static void assertNotAdjusted(VSAssemblyInfo info) {
+      verify(info, never()).setPixelOffset(any());
+      verify(info, never()).setLayoutPosition(any());
+   }
+
+   private static TableVSAssemblyInfo tableInfo(Point pixelOffset, Point layoutPosition) {
+      TableVSAssemblyInfo info = Mockito.mock(TableVSAssemblyInfo.class);
+      when(info.getPixelOffset()).thenReturn(pixelOffset);
+      when(info.getLayoutPosition()).thenReturn(layoutPosition);
+      return info;
+   }
+
+   private static TableVSAssembly mockTable(TableVSAssemblyInfo info, TabVSAssembly container) {
+      TableVSAssembly table = Mockito.mock(TableVSAssembly.class);
+      when(table.getVSAssemblyInfo()).thenReturn(info);
+      when(table.getContainer()).thenReturn(container);
+      return table;
+   }
+
+   private static TabVSAssembly bottomTabs(boolean bottom) {
+      TabVSAssemblyInfo tabInfo = Mockito.mock(TabVSAssemblyInfo.class);
+      when(tabInfo.isBottomTabs()).thenReturn(bottom);
+      TabVSAssembly tab = Mockito.mock(TabVSAssembly.class);
+      when(tab.getVSAssemblyInfo()).thenReturn(tabInfo);
+      return tab;
+   }
+
+   private static TestExporter exporterFor(Assembly... assemblies) {
+      Viewsheet vs = Mockito.mock(Viewsheet.class);
+      when(vs.getAssemblies(true)).thenReturn(assemblies);
+      return new TestExporter(vs);
+   }
+
+   /**
+    * Stubs out {@code needExport()} so the test does not depend on viewsheet
+    * visibility state, tip-view/pop-component lookups, or a real workbook.
+    */
+   private static final class TestExporter extends PoiExcelVSExporter {
+      TestExporter(Viewsheet vs) {
+         super(Mockito.mock(ExcelContext.class), new ByteArrayOutputStream());
+         this.viewsheet = vs;
+      }
+
+      @Override
+      protected boolean needExport(VSAssembly assembly) {
+         return exportAll;
+      }
+
+      private boolean exportAll = true;
+   }
+}


### PR DESCRIPTION
## Summary

When a table lives in a tab container with **Tabs on Bottom** enabled, exporting the viewsheet to Excel with *Expand Components* drew the tab strip on top of the table's last row(s).

## Root Cause

Two coordinate systems disagree in the Excel exporter (1 Excel row = `AssetUtil.defh` = 20 px):

- Table cells are snapped to the sheet's row grid — `ExcelTableHelper.writeTitleCell` / `ExcelCrosstabHelper` do `startY = PoiExcelVSUtil.ceilY(startY)` and each table row consumes a whole grid row. A table whose `pixelOffset.y` is not a multiple of 20 is therefore drawn up to 19 px lower than its pixel position, while its drawn height matches its assembly height.
- The tab strip is written as a picture at its exact pixel position (`PoiExcelVSExporter.writeVSTab` → `getAnchorPosition`), and in bottom-tabs mode `TabVSAssembly.updateChildPosition` pins the strip to the child's pixel bottom (`child.y + child.height`).

Because the strip sits exactly at the child's pixel bottom, there is no slack to absorb the grid rounding, so the table's last row always lands underneath the strip whenever the child's top is off-grid. Measured on the reported asset: table drawn 240–380 px, strip at 364 px.

This is not specific to shrink-to-fit — shrink only determines where the table lands. It reproduced with `shrink=false` and with a plain expanded 700-row table as well.

## Fix

`PoiExcelVSExporter.alignBottomTabsTables()` aligns the top of tables inside a bottom-tabs container down to the grid line (`floorY`) after `super.prepareSheet()` (which is where the shrink shift from #74933 is applied) and before the sheet's row/column grid is built. `ceilY` then becomes a no-op, so the drawn bottom stays above the strip.

Scoped to the Excel exporter only — PDF/PNG/HTML place both the table and the strip in exact pixels and are unaffected. Gated on `TabVSAssemblyInfo.isInBottomTabs`, so top-tab and non-tab tables produce byte-identical output. The offset is set on the child's `VSAssemblyInfo` (mutating the strip instead would re-anchor the child right back via `updateChildPosition`), and the mutation happens on the throwaway viewsheet clone created by `AbstractVSExporter.export()`.

## Test Plan

Verified against a running server by exporting the reporter's asset and measuring the raw XLSX geometry (cell rows vs. the picture's `xdr:from`/`xdr:to` anchors):

| asset variant | before | after |
| --- | --- | --- |
| shrink=true, 5 rows (as reported) | table 240–380, strip 364 → **overlap 16 px** | table 220–360, strip 364 → gap 4 px |
| shrink=false, 5 rows | table 80–380, strip 364 → **overlap 16 px** | table 60–360, strip 364 → gap 4 px |
| shrink=true, 700 rows (expanded) | table 80–14120, strip 14105 → **overlap 15 px** | table 60–14100, strip 14105 → gap 5 px |
| shrink=false, 700 rows (expanded) | table 80–14120, strip 14105 → **overlap 15 px** | table 60–14100, strip 14105 → gap 5 px |

Also verified: `TabVSAssemblyTest` passes (4/4); top-tab and non-tab Excel exports unchanged.

To reproduce manually: import the `tab.zip` asset from the issue, open it in the portal, export to Excel with *Expand Components*, and confirm the tab labels no longer sit on top of the table's last row.

Fixes Redmine #75778.