### PR TITLE
Bug #75754, align the worksheet column drop indicator with the columns

### DIFF
--- a/web/projects/portal/src/app/composer/gui/ws/editor/ws-details-table-data.component.scss
+++ b/web/projects/portal/src/app/composer/gui/ws/editor/ws-details-table-data.component.scss
@@ -80,10 +80,13 @@
   left: 0;
   top: 0;
   background-color: transparent;
+  // use flex, like the header and data rows, so that the whitespace between the column
+  // elements is not rendered and the drop columns line up with the table columns (75754).
+  display: flex;
 }
 
 .drop-table__column {
-  display: inline-block;
+  flex: 0 0 auto;
   height: 100%;
 }
 


### PR DESCRIPTION
## Summary

In the worksheet details pane, dragging a column from the data source tree onto an existing column drew the green drop-target highlight offset to the right of the column it was supposed to outline. The offset grew with the column index (~20px by the 7th column). Because the same elements provide the drop hit regions, a drop near a column boundary could also resolve to the wrong column, or to "replace" instead of "insert".

## Root Cause

The drop overlay (`ws-details-table-data.component.html`) is a `.drop-table` div holding one `.drop-table__column` div per visible column, each sized to `colInfos[i].width`, with the highlight applied as a CSS border (`.bl-/.br-/.bd-highlight`). The overlay was laid out in normal inline flow:

```scss
.drop-table { position: absolute; /* block container */ }
.drop-table__column { display: inline-block; }
```

while the real header row (`.ws-table-headers`) and data rows (`.table-data__row`) both use `display: flex`.

That difference matters because this app preserves template whitespace: `web/tsconfig.json` sets `"preserveWhitespaces": "off"`, and `"off"` is a truthy *string* — ngtsc reads the option as `this.options.preserveWhitespaces || false`, so whitespace preservation is on (it has been since the initial commit; the value looks like it was meant to be `false`).

A flex container does not render whitespace-only children, so the header and data rows line up. A block container with `inline-block` children does render them: the newline/indentation between each `@for`-generated div becomes a space (~3.4px at the 13px host font), and those gaps accumulate left to right, drifting overlay column *n* about `n × 3.4px` to the right of the real column. The accumulated width could also push the trailing overlay column onto a second line.

## Fix

Lay the overlay out with flex, matching the header and data rows, so the whitespace between the column elements is not rendered:

- `.drop-table` — added `display: flex`
- `.drop-table__column` — `display: inline-block` replaced with `flex: 0 0 auto` (never grow/shrink, so each column keeps exactly its bound pixel width; `height: 100%` still resolves against the parent's explicit `tableHeight`)

CSS only — no template, TypeScript, or event-payload changes. `tsconfig.json` was deliberately left alone: correcting `preserveWhitespaces` app-wide would change rendered whitespace in every portal and EM template, which is well outside the scope of this bug (worth its own ticket).

## Test Plan

1. Open a worksheet with a bound table wide enough to show several columns (e.g. the attached `insertcolumn` asset on the issue, table `Customer1`).
2. Drag a column from the data source tree (`Data Source/Examples/Orders/Order Model/Customer` → `State`) over the details pane.
3. Hover the middle of a column well to the right of the first one (e.g. `Reseller`, the 7th column): the green box now outlines that column exactly, on both edges.
4. Hover within 10px of a column's left/right edge: the highlight becomes a single insertion border on the correct boundary, and dropping inserts the column at that position.
5. Drop in the middle of a column: it replaces that column (the one actually under the cursor).
6. Scroll the details pane horizontally and repeat 3–5 — the highlight still tracks the columns.
7. Regression: drag an existing column header to reorder it, verify the indicator and the resulting order are correct; verify the drop target just past the last column (the scrollbar-width strip) still works and no longer wraps below the table.

Verified: `ng build portal` succeeds; 223 worksheet testing-library tests and the worksheet unit tests pass; `ng lint portal` reports 0 errors.

Fixes Redmine #75754.