### PR TITLE
Bug #75757, preserve created by/date when renaming a registry object

### DIFF
--- a/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
@@ -1352,6 +1352,10 @@ public class DataSourceRegistry implements MessageListener {
          .orElse(oentry);
 
       nentry.copyProperties(oentry);
+      // keep the original creation info, renaming or updating an object should only
+      // change the last modified info, not who created it or when it was created
+      nentry.setCreatedUsername(oentry.getCreatedUsername());
+      nentry.setCreatedDate(oentry.getCreatedDate());
       updateObject(oentry, nentry, obj);
    }
 


### PR DESCRIPTION
## Summary

Renaming a logical model in the portal replaced the model's "Created By" and "Creation Date" with the renaming user and the rename timestamp. This carries the original creation info forward so a rename only updates the last-modified info.

## Root Cause

The "Created By" / "Creation Date" shown for a logical model come from the `AssetEntry` stored in the `DataSourceRegistry` root folder (`DataSourceService.buildLogicalModel()` reads `entry.getCreatedUsername()` / `entry.getCreatedDate()`).

The rename path is `LogicalModelController.renameModel` → `LogicalModelService.renameModel` → `XDataModel.renameLogicalModel` → `DataSourceRegistry.updateObject(String oname, String nname, AssetEntry.Type, XMLSerializable)`.

That method builds a fresh `AssetEntry` for the new path and calls `nentry.copyProperties(oentry)`, which copies only the string property map — `createdUsername` and `createdDate` are separate fields, so they stayed `null` on the new entry. `AssetUtil.updateMetaData()` then fills in nulls with the current user and time, so the renaming user became the creator and the rename time became the creation date.

`DataSourceRegistry.renameObjects(..., keepCreatedInfo = true)` already performs this same copy for the renamed object's children, so only the renamed object's own entry lost its creation info.

Note that `LogicalModelService.renameModel` already attempts to restore the creation info after the rename, but that repair never took effect: it goes through `DataSourceService.updateDataSourceAssetEntry()` → `DataSourceRegistry.setObject()`, which does `entry = root.getEntry(entry)` and discards the caller-supplied entry (`AssetEntry` equality ignores metadata). The same dead repair pattern exists in `PhysicalModelManagerService` and `VPMController`; those are left alone here and are worth a separate cleanup.

## Fix

In `DataSourceRegistry.updateObject(String, String, AssetEntry.Type, XMLSerializable)`, copy `createdUsername` and `createdDate` from the existing entry onto the new entry alongside the existing `copyProperties()` call. `AssetUtil.updateMetaData()` then leaves the creation info alone (it only fills nulls) and still refreshes `modifiedDate` / `modifiedUsername`, so the rename is recorded as a modification.

This is the shared code path for renaming/updating registry objects, so the same defect is fixed for logical models, extended logical models, VPMs, physical views (partitions), extended partitions, data sources, data source folders, and additional connections.

When the old entry is not found in the registry (a genuinely new object), both values are `null` and `updateMetaData()` assigns the current user and time exactly as before — no change to that path. The import path is also unaffected: `updateMetaData()` only gates the modified-info branch on `IS_IMPORTING`.

## Test Plan

Manual verification of the reported repro:

1. On the default org, with the Examples datasource present, create `user0` in EM and grant R/W/D permission on the datasource.
2. Log into the portal as `user0` and rename a logical model (e.g. "Order Model") whose creation info is still intact.
3. Confirm "Created By" still shows the original creator and "Creation Date" still shows the original timestamp.
4. Confirm the rename itself succeeded and dependent assets still resolve.

Regression checks:

- Creating a new logical model still records the current user and time as the creator/creation date.
- Editing (saving) a logical model still leaves the creation info unchanged.
- Renaming a physical view, VPM, data source, and data source folder all preserve creation info and update last-modified info.

Automated:

- `./mvnw install -pl core -am -DskipTests` — BUILD SUCCESS
- `./mvnw test -pl core` — Tests run: 4203, Failures: 0, Errors: 0, Skipped: 66

Fixes Redmine #75757.