### PR TITLE
Bug #75756, write back rewritten createdBy/lastModifiedBy on data cycle migration

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/DataCycleManager.java
+++ b/core/src/main/java/inetsoft/sree/internal/DataCycleManager.java
@@ -946,6 +946,7 @@ public class DataCycleManager
       if(!Tool.isEmptyString(createdBy) && idChanged) {
          IdentityID identityID = IdentityID.getIdentityIDFromKey(createdBy);
          identityID.setOrgID(norg.getId());
+         cycleInfo.setCreatedBy(identityID.convertToKey());
       }
 
       String lastModifiedBy = cycleInfo.getLastModifiedBy();
@@ -953,6 +954,7 @@ public class DataCycleManager
       if(!Tool.isEmptyString(lastModifiedBy) && idChanged) {
          IdentityID identityID = IdentityID.getIdentityIDFromKey(lastModifiedBy);
          identityID.setOrgID(norg.getId());
+         cycleInfo.setLastModifiedBy(identityID.convertToKey());
       }
    }
 

--- a/core/src/test/java/inetsoft/sree/internal/DataCycleManagerOrgLifecycleTest.java
+++ b/core/src/test/java/inetsoft/sree/internal/DataCycleManagerOrgLifecycleTest.java
@@ -225,11 +225,12 @@ class DataCycleManagerOrgLifecycleTest {
                 + "future IndexedStorage re-bucketing change silently orphaning Data Cycle assets");
    }
 
-   // ── scenario 5e: confirmed defect -- migrateCycleInfo() never persists the rewritten
-   //    identity fields back onto the CycleInfo it mutates (DataCycleManager.java:937-957) ──
+   // ── scenario 5e: migrateCycleInfo() (DataCycleManager.java:937-959) must rewrite the
+   //    createdBy/lastModifiedBy identity keys to the target org, not just compute them.
+   //    Regression guard for Bug #75756. ──
 
    @Test
-   void migrateCycleInfo_createdByAndModifiedBy_remainStaleAfterMigration() throws Exception {
+   void migrateCycleInfo_createdByAndModifiedBy_rewrittenToTargetOrg() throws Exception {
       String fromOrgId = "cycle_identity_from";
       String toOrgId = "cycle_identity_to";
 
@@ -255,22 +256,26 @@ class DataCycleManagerOrgLifecycleTest {
       assertNotNull(migrated);
       DataCycleManager.CycleInfo migratedInfo = migrated.getInfo();
 
-      // migrateCycleInfo() (:937-957) does `IdentityID identityID =
+      // Bug #75756: migrateCycleInfo() used to do `IdentityID identityID =
       // IdentityID.getIdentityIDFromKey(createdBy); identityID.setOrgID(norg.getId());` and then
-      // throws the result away -- it never calls cycleInfo.setCreatedBy(identityID.convertToKey())
-      // (or the lastModifiedBy equivalent). The asset's own orgId field IS rewritten (a different
-      // field, set directly two lines above in migrateDataCycles() itself), but the identity
-      // strings inside CycleInfo are untouched -- this is the current, confirmed (not
-      // hypothetical) behavior, recorded here as the regression baseline for a known bug, not as
-      // asserting it is correct.
-      assertEquals(createdByBefore, migratedInfo.getCreatedBy(),
-                  "confirmed defect: createdBy is left pointing at the OLD org after migration -- "
-                  + "migrateCycleInfo() computes the rewritten IdentityID but never writes it back");
-      assertEquals(modifiedByBefore, migratedInfo.getLastModifiedBy(),
-                  "confirmed defect: lastModifiedBy has the same never-written-back bug");
+      // throw the result away, never calling cycleInfo.setCreatedBy(identityID.convertToKey())
+      // (or the lastModifiedBy equivalent) -- leaving both identity strings keyed to the OLD org
+      // while the asset's own orgId field (set directly in migrateDataCycles()) was rewritten
+      // correctly. Both identity keys must now name the same user under the TARGET org, matching
+      // MigrateScheduleTask.syncIdentityAttribute()'s rewrite idiom for schedule task owners.
+      String expectedIdentity = new IdentityID("erin", toOrgId).convertToKey();
+
+      assertEquals(expectedIdentity, migratedInfo.getCreatedBy(),
+                  "createdBy must be re-keyed to the target org -- the rewritten IdentityID has to "
+                  + "be written back onto the CycleInfo, not just computed (Bug #75756)");
+      assertEquals(expectedIdentity, migratedInfo.getLastModifiedBy(),
+                  "lastModifiedBy must be re-keyed the same way");
+      assertNotEquals(createdByBefore, migratedInfo.getCreatedBy(),
+                     "sanity check: the pre-migration source-org key must not survive");
+      assertNotEquals(modifiedByBefore, migratedInfo.getLastModifiedBy(),
+                     "sanity check: same for lastModifiedBy");
       assertEquals(toOrgId, migrated.getOrgId(),
-                  "meanwhile the asset's own orgId field (a separate field, set directly in "
-                  + "migrateDataCycles()) is correctly rewritten -- the inconsistency IS the bug");
+                  "the asset's own orgId field stays consistent with the re-keyed identities");
    }
 
    // ── scenario 5f (new, not in the original 5a-5e list): the current-org-context coupling

--- a/core/src/test/resources/docs/org-lifecycle-resource-matrix.md
+++ b/core/src/test/resources/docs/org-lifecycle-resource-matrix.md
@@ -331,7 +331,7 @@
 
 | # | 场景 | 预期 | 测试状态 |
 |---|---|---|---|
-| 5a | `migrateDataCycles(oorg, norg, replace=false)`，从源组织自身上下文发起（见下方 5f 的前提说明） | 复制 `DataCycleAsset`（`orgId` 字段正确改写），不删源；`CycleInfo` 身份字段**理论上**应同步改写，实测确认并未（见 5e） | `[已落地]` `DataCycleManagerOrgLifecycleTest#copy_migrateDataCycles_copiesAssetAndLeavesSourceUntouched` |
+| 5a | `migrateDataCycles(oorg, norg, replace=false)`，从源组织自身上下文发起（见下方 5f 的前提说明） | 复制 `DataCycleAsset`（`orgId` 字段正确改写），不删源；`CycleInfo` 身份字段同步改写（Bug #75756 修复后，见 5e） | `[已落地]` `DataCycleManagerOrgLifecycleTest#copy_migrateDataCycles_copiesAssetAndLeavesSourceUntouched` |
 
 **Rename 场景**
 
@@ -346,11 +346,11 @@
 | 5c | `clearDataCycles(orgId)`（共享背景 delete 清单 `:612`），从被删组织自身上下文发起 | 该组织所有 `DataCycleId` 精确清除，无残留 | `[已落地]` `DataCycleManagerOrgLifecycleTest#delete_clearDataCycles_removesAllCyclesForOrg` |
 | 5d | 普通 Schedule Task（非 Data Cycle）Delete：靠 `indexedStorage.removeStorage(orgId)` 整桶清理 | 断言删除后确实不可读，防止未来 `IndexedStorage` 改分桶策略后失去覆盖 | `[已落地]` `DataCycleManagerOrgLifecycleTest#delete_indexedStorageRemoveStorage_wholeOrgBucketGone`——低优先级回归防护 |
 
-**已确认缺陷 1（Bug #75756）：** `migrateCycleInfo()`（`DataCycleManager.java:937-957`）——`identityID.setOrgID(norg.getId())` 只修改局部变量，从未调用 `cycleInfo.setCreatedBy()`/`setLastModifiedBy()` 写回。Copy/Rename 后 `CycleInfo.createdBy`/`lastModifiedBy` 仍指向源组织用户身份，跟 `DataCycleAsset.orgId`（同一次迁移里另一个字段，在 `migrateDataCycles()` 里直接 `asset.setOrgId(norg.getId())` 正确改写）行为不一致。
+**已确认缺陷 1（Bug #75756，~~已修复~~）：** `migrateCycleInfo()`（`DataCycleManager.java:937-959`）——`identityID.setOrgID(norg.getId())` 原先只修改局部变量，从未调用 `cycleInfo.setCreatedBy()`/`setLastModifiedBy()` 写回。Copy/Rename 后 `CycleInfo.createdBy`/`lastModifiedBy` 仍指向源组织用户身份，跟 `DataCycleAsset.orgId`（同一次迁移里另一个字段，在 `migrateDataCycles()` 里直接 `asset.setOrgId(norg.getId())` 正确改写）行为不一致。**修复方式**：两处都补上 `cycleInfo.setCreatedBy(identityID.convertToKey())`/`setLastModifiedBy(...)` 写回，与 `MigrateScheduleTask.syncIdentityAttribute()`（`util/migrate/MigrateScheduleTask.java:320-341`，改写 Schedule Task owner 身份）的既有惯例一致。
 
 | # | 场景 | 预期 | 测试状态 |
 |---|---|---|---|
-| 5e | 上述缺陷的回归基线 | 断言当前（错误）行为存在，作为后续修复基线：`createdBy`/`lastModifiedBy` 保持迁移前的值，`orgId` 字段则正确改写 | `[已落地]` `DataCycleManagerOrgLifecycleTest#migrateCycleInfo_createdByAndModifiedBy_remainStaleAfterMigration` |
+| 5e | 上述缺陷的回归防护 | 断言修复后行为：`createdBy`/`lastModifiedBy` 都被重写成目标组织下的同名用户身份，`orgId` 字段同样正确改写 | `[已落地]` `DataCycleManagerOrgLifecycleTest#migrateCycleInfo_createdByAndModifiedBy_rewrittenToTargetOrg` |
 
 **已确认缺陷 2（新发现，落地 5a-5e 时实测确认，不在原场景清单里）：** `getDataCycleIds(String orgId)`（私有，`DataCycleManager.java:741-756`）调用的是 `IndexedStorage.getKeys(Filter)` 的**单参**重载，内部（`BlobIndexedStorage.getMetadataStorage(null)`）落回 `OrganizationManager.getCurrentOrgID()`（当前线程组织上下文），完全不使用传入的 `orgId` 参数去限定查询范围——这个参数只在拿到 key 集合之后，用来给结果 `DataCycleId` 贴标签。`migrateDataCycles()`/`clearDataCycles()` 的两个真实调用方——`AbstractEditableAuthenticationProvider.copyOrganizationInternal()`（`:273`）、`IdentityService.syncIdentity()`（`:622`）——都**没有**像同一方法里其它步骤那样把这次调用包在 `OrganizationManager.runInOrgScope(oldOrgId, ...)` 里。
 


### PR DESCRIPTION
## Summary

When an organization is renamed or cloned, the migrated Data Cycle's `CycleInfo.createdBy` / `CycleInfo.lastModifiedBy` identity keys were left pointing at the *source* organization, while `DataCycleAsset.orgId` and `CycleInfo.orgId` were rewritten to the target org correctly. Visible only in the stored asset XML — no UI or functional impact, since these fields are audit/display only.

Reproduced by the reporter as: after cloning `host-org` into `org0`, the stored asset reads

```xml
<DataCycle name="cycle1" orgId="org0" enabled="true">
  <CycleInfo name="cycle1" orgId="org0" ... createdBy="admin1~;~host-org" ... modifiedBy="admin1~;~host-org"/>
```

## Root Cause

`DataCycleManager.migrateCycleInfo()` parsed each identity key into a fresh `IdentityID` and rewrote its `orgID`, then discarded the result — it never wrote the rewritten key back onto the `CycleInfo`:

```java
if(!Tool.isEmptyString(createdBy) && idChanged) {
   IdentityID identityID = IdentityID.getIdentityIDFromKey(createdBy);
   identityID.setOrgID(norg.getId());   // mutates a local temporary
}                                       // result discarded
```

## Fix

Write the rewritten key back via `cycleInfo.setCreatedBy(identityID.convertToKey())` and the `setLastModifiedBy` equivalent. This matches the established identity-rewrite idiom for org migration in `MigrateScheduleTask.syncIdentityAttribute()` (`util/migrate/MigrateScheduleTask.java:320-341`), which does `getIdentityIDFromKey` → `setOrgID(newOrgID)` → `convertToKey()` → write back, with no guard on the identity's pre-existing orgID once the org has changed. No such guard is added here, for consistency.

Also updated: `DataCycleManagerOrgLifecycleTest` scenario 5e explicitly pinned the buggy behavior as a documented "confirmed defect / regression baseline", so it is flipped to assert the corrected behavior and renamed; the corresponding rows in `org-lifecycle-resource-matrix.md` are updated to match.

### Side effects considered

- `migrateCycleInfo()` is private with a single caller (`migrateDataCycles()`), reached only during org rename/clone when the org ID actually changes. No behavior change when `oorg.getId().equals(norg.getId())` — the existing `idChanged` guard is untouched.
- `generateTasks()`, called immediately after in `migrateDataCycles()`, only *reads* cycle info; nothing in that call graph writes to `IndexedStorage`, so the corrected values are not overwritten.
- No aliasing hazard: `BlobIndexedStorage.getXMLSerializable()` builds a fresh instance per call, so mutating the asset read from the old entry cannot corrupt the source org's stored copy when `replace=false` (clone).
- Legacy identity keys with no `~;~` delimiter get normalized to keyed form, the same behavior `syncIdentityAttribute()` already has on schedule tasks.

## Test Plan

- `DataCycleManagerOrgLifecycleTest` — 7/7 pass. Verified the updated scenario 5e genuinely catches the regression: with the fix reverted it fails with `expected: <erin~;~cycle_identity_to> but was: <erin~;~cycle_identity_from>`; with the fix applied it passes.
- Full org-lifecycle suite (`*OrgLifecycleTest`) — 35 tests, 0 failures.
- Data-cycle / schedule adjacent suites (`ScheduleCycleServiceTest`, `ScheduleCycleControllerTest`, `ScheduleManagerTest`, `MVControllerTest`, `OrgLifecycleDataSpaceIntegrationTest`) — 32 tests, 0 failures.
- `./mvnw clean install -pl core -am -DskipTests` — BUILD SUCCESS.
- Manual verification by the reporter's steps: create a Data Cycle in `host-org`, clone the org, back up and unzip the storage, inspect the `cycle1` file — `createdBy`/`modifiedBy` now read `<user>~;~org0`.

Fixes Redmine #75756.

🤖 Generated with [Claude Code](https://claude.com/claude-code)