### PR TITLE
Bug #75783, clean up dependency index when deleting data model objects in EM

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryObjectService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryObjectService.java
@@ -327,9 +327,13 @@ public class RepositoryObjectService {
                         }
 
                         dataModel.removePartition(node.label());
+                        removeDataModelDependencies(
+                           dataModelPath + "/" + node.label(), AssetEntry.Type.PARTITION, true);
                      }
                      else {
                         dataModel.removeVirtualPrivateModel(node.label());
+                        removeDataModelDependencies(
+                           dataModelPath + "/" + node.label(), AssetEntry.Type.VPM, false);
                      }
                   }
                }
@@ -575,7 +579,25 @@ public class RepositoryObjectService {
       }
 
       dataModel.removeLogicalModel(name);
+      removeDataModelDependencies(path, AssetEntry.Type.LOGIC_MODEL, true);
       return null;
+   }
+
+   /**
+    * Removes the dependency information of a deleted data model object so that it is no longer
+    * reported as a dependency of its data source, physical view or logical model.
+    *
+    * @param path       the path of the deleted object, in the form of "datasource/name".
+    * @param type       the asset type of the deleted object.
+    * @param removeKey  <tt>true</tt> to also remove the dependencies stored for the object itself.
+    */
+   private void removeDataModelDependencies(String path, AssetEntry.Type type, boolean removeKey) {
+      AssetEntry entry = new AssetEntry(AssetRepository.QUERY_SCOPE, type, path, null);
+      dependencyHandler.deleteDependencies(entry);
+
+      if(removeKey) {
+         dependencyHandler.deleteDependenciesKey(entry);
+      }
    }
 
    public void deleteAutoSaveNodes(List<TreeNodeInfo> nodes, Principal principal) throws MessageException {

--- a/core/src/test/java/inetsoft/web/admin/content/repository/RepositoryObjectServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/repository/RepositoryObjectServiceTest.java
@@ -1,0 +1,268 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.content.repository;
+
+/*
+ * General-purpose test file for RepositoryObjectService. Add further scenarios for this class here
+ * rather than creating new per-scenario test classes -- keep each scenario's own rationale in a
+ * comment block right above its test method(s), the way the dependency-cleanup scenario below does,
+ * so the file-level comment doesn't have to be rewritten every time a new scenario is added.
+ */
+
+import inetsoft.report.LibManagerProvider;
+import inetsoft.sree.RepletRegistryManager;
+import inetsoft.sree.RepositoryEntry;
+import inetsoft.sree.security.IdentityID;
+import inetsoft.sree.security.OrganizationContextHolder;
+import inetsoft.sree.security.Resource;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SRPrincipal;
+import inetsoft.sree.security.SecurityProvider;
+import inetsoft.sree.web.dashboard.DashboardRegistryManager;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetObject;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.DependencyHandler;
+import inetsoft.uql.asset.sync.DependenciesInfo;
+import inetsoft.uql.asset.sync.DependencyStorageService;
+import inetsoft.uql.asset.sync.RenameTransformHandler;
+import inetsoft.uql.erm.XDataModel;
+import inetsoft.uql.erm.XLogicalModel;
+import inetsoft.uql.erm.XPartition;
+import inetsoft.uql.service.DataSourceRegistry;
+import inetsoft.util.ThreadContext;
+import inetsoft.web.RecycleBin;
+import inetsoft.web.admin.content.database.model.DataModelFolderManagerService;
+import inetsoft.web.admin.content.repository.model.TreeNodeInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class,
+                                  RepositoryObjectServiceTest.TestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+@SreeHome
+@Tag("core")
+class RepositoryObjectServiceTest {
+   /*
+    * DependencyStorageService is a @Service picked up by component scan in production, so it is not
+    * in the test context. The logical model path reaches it through the static
+    * DependencyStorageService.getInstance() -> ConfigurationContext.getSpringBean(), which throws
+    * when the bean is missing -- and deleteNodes() swallows that, silently skipping the deletion.
+    */
+   @Configuration
+   static class TestConfiguration {
+      @Bean
+      public DependencyStorageService dependencyStorageService() {
+         return mock(DependencyStorageService.class);
+      }
+   }
+
+   @BeforeEach
+   void setUp() {
+      // the context is cached across test methods, so drop the previous method's stubbing
+      reset(dependencyStorageService);
+      dataSourceRegistry = mock(DataSourceRegistry.class);
+      resourcePermissionService = mock(ResourcePermissionService.class);
+      dependencyHandler = mock(DependencyHandler.class);
+      dataModel = mock(XDataModel.class);
+
+      when(dataModel.getDataSource()).thenReturn(DATA_SOURCE);
+      when(dataSourceRegistry.getDataModel(DATA_SOURCE)).thenReturn(dataModel);
+      // the base logical model/physical view branch of checkPermission() dereferences the resource
+      when(resourcePermissionService.getRepositoryResourceType(anyInt(), anyString()))
+         .thenReturn(new Resource(ResourceType.DATA_SOURCE, DATA_SOURCE));
+
+      service = new RepositoryObjectService(
+         mock(RepletRegistryService.class), mock(ContentRepositoryTreeService.class),
+         mock(SecurityProvider.class), resourcePermissionService, mock(XRepository.class),
+         mock(RepositoryDashboardService.class), mock(DataModelFolderManagerService.class),
+         dataSourceRegistry, mock(LibManagerProvider.class), mock(RecycleBin.class),
+         dependencyHandler, mock(RenameTransformHandler.class), mock(RepletRegistryManager.class),
+         mock(DashboardRegistryManager.class));
+
+      principal = new SRPrincipal(new IdentityID("admin", ORG_ID), new IdentityID[0],
+                                  new String[0], ORG_ID, 1L);
+   }
+
+   @AfterEach
+   void tearDown() {
+      ThreadContext.setContextPrincipal(null);
+      OrganizationContextHolder.setCurrentOrgId(null);
+   }
+
+   /*
+    * Bug #75783: deleting a data model object from the EM content tree removed it from the registry
+    * but left its reverse-dependency edge in DependencyStorageService behind, so the deleted object
+    * was still reported as a dependent when its data source was deleted afterwards.
+    *
+    * These tests pin the two things that make the cleanup work, both of which are easy to break
+    * silently:
+    *
+    * 1. The AssetEntry identifier -- QUERY_SCOPE, the object's own type and the "datasource/name"
+    *    path form (no data-model-folder segment) -- must match what registers the edge, e.g.
+    *    UpdateDependencyHandler.addVPMDependencies() and XDataModel.removeVirtualPrivateModel().
+    *    A mismatch makes the cleanup a silent no-op, which is exactly the failure being fixed.
+    * 2. deleteDependenciesKey() is called for physical views and logical models but NOT for VPMs,
+    *    mirroring the portal (PhysicalModelManagerService/LogicalModelService vs. VPMController).
+    */
+   @Test
+   void deleteVpmRemovesDependencyEdgeButNotKey() throws Exception {
+      TreeNodeInfo node = TreeNodeInfo.builder()
+         .label(VPM_NAME)
+         .path(DATA_SOURCE + "^" + VPM_NAME)
+         .type(RepositoryEntry.VPM)
+         .build();
+
+      service.deleteNodes(new TreeNodeInfo[]{ node }, principal, false, false);
+
+      verify(dataModel).removeVirtualPrivateModel(VPM_NAME);
+      assertEquals(identifier(AssetEntry.Type.VPM, VPM_NAME), capturedDeletedDependency());
+      // the portal does not remove the VPM's own dependency key -- neither should the EM path
+      verify(dependencyHandler, never()).deleteDependenciesKey(any());
+   }
+
+   @Test
+   void deletePhysicalViewRemovesDependencyEdgeAndKey() throws Exception {
+      XPartition physicalView = mock(XPartition.class);
+      when(physicalView.getPartitionNames()).thenReturn(new String[0]);
+      when(dataModel.getPartition(PHYSICAL_VIEW_NAME)).thenReturn(physicalView);
+      when(dataModel.getLogicalModelNames()).thenReturn(new String[0]);
+      when(dataModel.getVirtualPrivateModelNames()).thenReturn(new String[0]);
+
+      TreeNodeInfo node = TreeNodeInfo.builder()
+         .label(PHYSICAL_VIEW_NAME)
+         .path(DATA_SOURCE + "^" + PHYSICAL_VIEW_NAME)
+         .type(RepositoryEntry.PARTITION | RepositoryEntry.FOLDER)
+         .build();
+
+      service.deleteNodes(new TreeNodeInfo[]{ node }, principal, false, false);
+
+      verify(dataModel).removePartition(PHYSICAL_VIEW_NAME);
+      String expected = identifier(AssetEntry.Type.PARTITION, PHYSICAL_VIEW_NAME);
+      assertEquals(expected, capturedDeletedDependency());
+      assertEquals(expected, capturedDeletedDependencyKey());
+   }
+
+   @Test
+   void deleteLogicalModelRemovesDependencyEdgeAndKey() throws Exception {
+      XLogicalModel logicalModel = mock(XLogicalModel.class);
+      when(logicalModel.getLogicalModelNames()).thenReturn(new String[0]);
+      when(dataModel.getLogicalModel(LOGICAL_MODEL_NAME)).thenReturn(logicalModel);
+
+      TreeNodeInfo node = TreeNodeInfo.builder()
+         .label(LOGICAL_MODEL_NAME)
+         .path(DATA_SOURCE + "^" + LOGICAL_MODEL_NAME)
+         .type(RepositoryEntry.LOGIC_MODEL | RepositoryEntry.FOLDER)
+         .build();
+
+      service.deleteNodes(new TreeNodeInfo[]{ node }, principal, false, false);
+
+      verify(dataModel).removeLogicalModel(LOGICAL_MODEL_NAME);
+      String expected = identifier(AssetEntry.Type.LOGIC_MODEL, LOGICAL_MODEL_NAME);
+      assertEquals(expected, capturedDeletedDependency());
+      assertEquals(expected, capturedDeletedDependencyKey());
+   }
+
+   /*
+    * The other half of the fix: a delete that is *rejected* because something still depends on the
+    * object must not touch the dependency index. removeLogicalModel() returns the warning before it
+    * reaches the cleanup, so this guards against the cleanup being hoisted above that check.
+    */
+   @Test
+   void blockedLogicalModelDeleteLeavesDependencyIndexAlone() throws Exception {
+      XLogicalModel logicalModel = mock(XLogicalModel.class);
+      when(logicalModel.getLogicalModelNames()).thenReturn(new String[0]);
+      when(dataModel.getLogicalModel(LOGICAL_MODEL_NAME)).thenReturn(logicalModel);
+
+      DependenciesInfo dependencies = new DependenciesInfo();
+      dependencies.setDependencies(List.of(new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, "boundWorksheet", null)));
+      when(dependencyStorageService.getWithOrg(anyString(), any())).thenReturn(dependencies);
+
+      TreeNodeInfo node = TreeNodeInfo.builder()
+         .label(LOGICAL_MODEL_NAME)
+         .path(DATA_SOURCE + "^" + LOGICAL_MODEL_NAME)
+         .type(RepositoryEntry.LOGIC_MODEL | RepositoryEntry.FOLDER)
+         .build();
+
+      assertNotNull(service.deleteNodes(new TreeNodeInfo[]{ node }, principal, false, false),
+                    "the delete should be rejected while a worksheet still depends on the model");
+      verify(dataModel, never()).removeLogicalModel(anyString());
+      verify(dependencyHandler, never()).deleteDependencies(any());
+      verify(dependencyHandler, never()).deleteDependenciesKey(any());
+   }
+
+   private String identifier(AssetEntry.Type type, String name) {
+      return new AssetEntry(AssetRepository.QUERY_SCOPE, type, DATA_SOURCE + "/" + name, null)
+         .toIdentifier();
+   }
+
+   private String capturedDeletedDependency() {
+      ArgumentCaptor<AssetObject> captor = ArgumentCaptor.forClass(AssetObject.class);
+      verify(dependencyHandler).deleteDependencies(captor.capture());
+      return ((AssetEntry) captor.getValue()).toIdentifier();
+   }
+
+   private String capturedDeletedDependencyKey() {
+      ArgumentCaptor<AssetObject> captor = ArgumentCaptor.forClass(AssetObject.class);
+      verify(dependencyHandler).deleteDependenciesKey(captor.capture());
+      return ((AssetEntry) captor.getValue()).toIdentifier();
+   }
+
+   private RepositoryObjectService service;
+   private DataSourceRegistry dataSourceRegistry;
+   private ResourcePermissionService resourcePermissionService;
+   private DependencyHandler dependencyHandler;
+   @Autowired private DependencyStorageService dependencyStorageService;
+   private XDataModel dataModel;
+   private Principal principal;
+
+   private static final String ORG_ID = "bug75783_org";
+   private static final String DATA_SOURCE = "Derby Embedded";
+   private static final String VPM_NAME = "vpm";
+   private static final String PHYSICAL_VIEW_NAME = "physicalView";
+   private static final String LOGICAL_MODEL_NAME = "logicalModel";
+}


### PR DESCRIPTION
## Summary

Deleting a VPM from the EM content tree and then deleting its data source popped up a bogus warning: `Data Source/Derby Embedded/vpm depend(s) on Data Source/Derby Embedded! Proceed?` — the already-deleted VPM was still reported as a dependent of the data source.

## Root Cause

On import, `DeployManagerService` calls `UpdateDependencyHandler.addVPMDependencies()`, which registers the reverse-dependency edge `datasource -> [VPM entry]` in `DependencyStorageService`.

The EM content delete path, `RepositoryObjectService.deleteNodes()`, removed the object from the registry (`XDataModel.removeVirtualPrivateModel()`) but never removed the reverse-dependency index entry — `XDataModel` only calls `getRegistry().removeObject()`. The stale edge therefore survived the deletion, and `deleteDataSource()` → `checkAssetEntryDependencies()` → `DependencyTool.getDependencies()` still found the deleted VPM and raised a `DependencyException`.

The portal data page does not have this bug because it explicitly cleans up after removal: `VPMController.removeModel()` calls `deleteDependencies()`, and `LogicalModelService` / `PhysicalModelManagerService` call both `deleteDependencies()` and `deleteDependenciesKey()`. The EM path simply omitted those calls — for VPMs, physical views and logical models alike.

## Fix

Added a private `removeDataModelDependencies()` helper to `RepositoryObjectService` and call it right after the EM deletion of a base VPM, physical view or logical model, mirroring the portal semantics exactly (same `AssetEntry` scope/type/path; `deleteDependencies` only for VPM, plus `deleteDependenciesKey` for physical views and logical models).

The cleanup was deliberately kept at the delete call sites rather than moved into `XDataModel.removeVirtualPrivateModel()`: that method is also called during an overwriting import by `VirtualPrivateModelAsset.parseContent()`, and `DeployManagerService` registers the dependency *before* calling `parseContent()`, so a cleanup inside it would erase the just-registered edge. `VPMController.updateModel()` and `DataDependencyTransformer` also call it in non-delete contexts.

Extended (child) logical models and physical views are handled by a separate branch and are unchanged — the portal has no equivalent cleanup for them either, as their dependency entries use a different path form.

## Test Plan

1. Import a deployment archive containing a data source with a VPM (e.g. `Derby Embedded.zip` attached to the issue).
2. In EM → Content, expand the data source node, delete the VPM, then delete the data source — no dependency warning should appear.
3. Repeat for a physical view and for a logical model that nothing else references: deleting the object and then the data source should not warn.
4. Regression: with a worksheet or viewsheet genuinely bound to a logical model, deleting that logical model still warns as before.
5. Regression: deleting a VPM / physical view / logical model from the portal data page still behaves as before.
6. `./mvnw test -pl community/core` — 4213 tests, 0 failures.

Fixes Redmine #75783.