### PR TITLE
Bug #75773, guard null principal in processAuthenticationChange

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/FileAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/FileAuthenticationProvider.java
@@ -720,6 +720,9 @@ public class FileAuthenticationProvider extends AbstractEditableAuthenticationPr
    {
       try {
          XPrincipal principal = (XPrincipal) ThreadContext.getPrincipal();
+         // may be null when not running on a request thread, e.g. tests, scheduler, import
+         IdentityID principalIdentity =
+            principal == null ? null : IdentityID.getIdentityIDFromKey(principal.getName());
 
          if(oldID.equals(newID) && !removed && Tool.equals(oldOrgID, newOrgID)) {
             return;
@@ -860,7 +863,7 @@ public class FileAuthenticationProvider extends AbstractEditableAuthenticationPr
                   userGroupCache.invalidate(userIdentity);
                   userRoleCache.invalidateAll();
 
-                  if(Tool.equals(userIdentity, IdentityID.getIdentityIDFromKey(principal.getName()))) {
+                  if(principalIdentity != null && Tool.equals(userIdentity, principalIdentity)) {
                      principal.setRoles(Tool.remove(principal.getRoles(), oldID));
                   }
                }


### PR DESCRIPTION
## Summary

`FileAuthenticationProvider.processAuthenticationChange()` threw a `NullPointerException` whenever a role, group, or organization was removed on a thread with no bound principal. Reproduced with:

```
./mvnw -pl community/core test -Dtest=PermissionMatrixSpecialTest
```

which logged the NPE twice while still reporting `Tests run: 10, Failures: 0` — the exception is caught and only logged, so it never failed the build.

## Root Cause

`processAuthenticationChange()` reads `ThreadContext.getPrincipal()`, which is only populated on HTTP request threads by `RequestPrincipalFilter`. On any other thread — JUnit teardown, the scheduler, deployment/import, cluster message handlers, the shell DSL — it is null. Inside the `Identity.ROLE` branch the code dereferenced `principal.getName()` unconditionally for every stored user that referenced the role being removed. The EM path (`IdentityService.removeRole`) always has a principal, which is why this never surfaced in the UI.

This is not merely a noisy log. The method's `try` block spans the entire body and the `catch` only logs `"Failed to update security graph"`, so the NPE aborted the rest of the `ROLE` branch at the *first* matching user:

- remaining users in the loop kept a dangling reference to the deleted role in storage,
- the subsequent `FSGroup` / `FSOrganization` loops never ran.

`fireAuthenticationChanged(...)` sits outside the `try`, so listeners still fired against half-updated storage with no visible failure.

Original code (blame: initial commit), not a regression.

## Fix

Resolve the principal's `IdentityID` once before the loop and null-guard the comparison, so the in-session role trim is skipped when there is no principal and the rest of the cleanup runs to completion.

On a request thread behavior is unchanged: `XPrincipal.getName()` always returns a delimiter-qualified key, so `IdentityID.getIdentityIDFromKey` resolves identically inside or outside the loop.

## Test Plan

- Before the fix: `./mvnw -pl community/core test -Dtest=PermissionMatrixSpecialTest` logs `Failed to update security graph` + the NPE twice. After the fix: no such log.
- `./mvnw install -pl community/core -am -DskipTests` — BUILD SUCCESS.
- Full `inetsoft.sree.security.**` suite (657 tests): 0 failures on 6 of 6 runs with the fix.

### Note on pre-existing flaky tests

While validating, `DashboardRegistryOrgLifecycleTest` and `OrgLifecycleRepletRegistryIntegrationTest` intermittently failed. A controlled A/B of 6 alternating pairs on the same machine showed these are **pre-existing** and unrelated to this change:

| | Runs | Failed |
|---|---|---|
| without fix | 6 | 2 |
| with fix | 6 | 0 |

They fail on unmodified `main` with the identical assertions. Two pre-existing suite issues observed but deliberately **not** addressed here: `PermissionMatrixActionsS8Test`'s parameterized sweep count varies per run (it walks the live production action tree, which earlier tests mutate), and the org-lifecycle tests depend on in-memory registry cache state shared across test classes in the same JVM.

Fixes Redmine #75773.