### PR TITLE
Bug #75791, document required INETSOFT_ADMIN_PASSWORD for Docker Compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ You will need Docker installed with a version 1.29.0 or later of Docker Compose.
 
 Download the latest community-examples.zip file from the [StyleBI Release page](https://github.com/inetsoft-technology/stylebi/releases) and extract all file contents into a folder of your choosing. 
 
+Before starting the containers, set the `INETSOFT_ADMIN_PASSWORD` environment variable to the password you want to use for the "admin" account. This is required — there is no default password. The password must be at least 8 characters and include an uppercase letter, a lowercase letter, a digit, and a special character. You can either uncomment and set `INETSOFT_ADMIN_PASSWORD` in the `.env` file in the extracted folder, or set it directly in your shell:
+
+```shell
+export INETSOFT_ADMIN_PASSWORD="Test@admin1"
+```
+
+```powershell
+$env:INETSOFT_ADMIN_PASSWORD="Test@admin1"
+```
+
 For Docker Desktop, start it first then open a Command Prompt window. In the folder containing the extracted .yaml file, run the following command:
 
 ```shell

--- a/Troubleshoot.md
+++ b/Troubleshoot.md
@@ -21,3 +21,34 @@ Use the `-U` command line option  when building the Java libraries to force the 
 
 ```./mvnw clean install -U```
 
+## Storage Container Exits with "exit 1" During `docker compose up`
+
+If the `storage` container fails during initialization with a bare `exit 1` and no other obvious error in the top-level `docker compose` output, check the logs for that specific container:
+
+```shell
+docker compose logs storage
+```
+
+This error most commonly occurs when the `INETSOFT_ADMIN_PASSWORD` environment variable is missing or does not meet the password requirements. This variable sets the password for the "admin" user and is required — there is no default password. The password must be at least 8 characters and include an uppercase letter, a lowercase letter, a digit, and a special character.
+
+To resolve this, set `INETSOFT_ADMIN_PASSWORD` to a valid password before starting the containers, either in the `docker-compose.yaml` file:
+
+```yaml
+storage:
+  environment:
+    # the password for the "admin" user
+    INETSOFT_ADMIN_PASSWORD: "Test@admin1"
+```
+
+or as an environment variable in your shell before running `docker compose up`:
+
+```shell
+export INETSOFT_ADMIN_PASSWORD="Test@admin1"
+```
+
+```powershell
+$env:INETSOFT_ADMIN_PASSWORD="Test@admin1"
+```
+
+or by uncommenting and setting `INETSOFT_ADMIN_PASSWORD` in the `.env` file included with the community examples.
+

--- a/community-examples/.env
+++ b/community-examples/.env
@@ -1,5 +1,11 @@
 # make sure only one line is uncommented(without the leading #)
 # Stable release build - remove the leading # in next line to download this build
 STYLEBI_DOCKER_IMAGE=ghcr.io/inetsoft-technology/stylebi-community:latest
-# Experimental nightly build -- remove the leading # in next line to download this build 
+# Experimental nightly build -- remove the leading # in next line to download this build
 # STYLEBI_DOCKER_IMAGE=docker.inetsoft.com/public/stylebi-community:1.0
+
+# Required: the password for the "admin" user. Uncomment and set this to a secure
+# password before running docker compose. The password must be at least 8
+# characters and include an uppercase letter, a lowercase letter, a digit, and
+# a special character.
+# INETSOFT_ADMIN_PASSWORD=Test@admin1


### PR DESCRIPTION
## Summary
- The storage container requires `INETSOFT_ADMIN_PASSWORD` to be set and meet complexity requirements, but this was undocumented and failures surfaced only as a vague `exit 1` in the storage container logs.
- Document the requirement in the Quickstart section of the README, add a commented-out `INETSOFT_ADMIN_PASSWORD` entry to the community-examples `.env` file, and add a Troubleshooting entry describing the error and how to fix it.

## Test plan
- [ ] Review rendered Markdown for README.md and Troubleshoot.md
- [ ] Confirm `.env` file still parses correctly with docker compose (single/no active password line doesn't break anything when commented out)