### PR TITLE
Bug #75752, fix physical model graph moving unrelated table on drag

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-network-graph/physical-model-network-graph.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-network-graph/physical-model-network-graph.component.interaction.tl.spec.ts
@@ -126,6 +126,24 @@ describe("PhysicalModelNetworkGraphComponent — selectNode()", () => {
          [g1.node.treeLink, g2.node.treeLink]
       );
    });
+
+   // 🔁 Regression-sensitive: this is the bug this file's changes fix -- plain-clicking one
+   // of two auto-alias tables that share a tree path (and therefore end up together in a
+   // stale multi-node dragNodes selection) must collapse the selection down to just the
+   // clicked node, so dragging it doesn't drag its sibling alias along too.
+   it("should collapse to just the clicked node on a plain click within a stale multi-selection", async () => {
+      const g1 = makeGraph("customer-region");
+      const g2 = makeGraph("salesperson-region");
+      const { comp } = await renderComp({ graphViewModel: makeViewModel([g1, g2]) });
+      vi.spyOn(comp as any, "refreshDragSelection").mockImplementation(() => {});
+      // simulate a stale multi-selection containing both aliases, e.g. left over from the
+      // tree resolving both graph nodes for a shared tree path
+      (comp as any).dragNodes = [g1, g2];
+
+      comp.selectNode({ ctrlKey: false, shiftKey: false } as MouseEvent, g2);
+
+      expect((comp as any).dragNodes).toEqual([g2]);
+   });
 });
 
 // ---------------------------------------------------------------------------
@@ -519,6 +537,55 @@ describe("PhysicalModelNetworkGraphComponent — ngOnChanges()", () => {
       } as any);
 
       expect((comp as any).dragNodes).toEqual([g1, g2]);
+   });
+
+   // 🔁 Regression-sensitive: covers the other half of the fix -- selectNode() emits its
+   // own selection, and the parent echoes it back via selectedGraphModels after resolving
+   // the clicked table's tree path. For auto-alias tables that share a tree path with their
+   // source table, that echo can resolve to *every* alias of that table, not just the one
+   // clicked. The echo must be narrowed back down to the ids actually selected here.
+   it("should narrow an echoed selectedGraphModels change down to the ids selected here", async () => {
+      const g1 = makeGraph("customer-region");
+      const g2 = makeGraph("salesperson-region");
+      const { comp } = await renderComp({ graphViewModel: makeViewModel([g1, g2]) });
+      vi.spyOn(comp as any, "refreshDragSelection").mockImplementation(() => {});
+
+      // user plain-clicks g2 in the graph -- selectNode() records g2 as the pending
+      // self-selection before emitting
+      comp.selectNode({ ctrlKey: false, shiftKey: false } as MouseEvent, g2);
+      expect((comp as any).dragNodes).toEqual([g2]);
+
+      // parent resolves g2's tree path to both g1 and g2 (shared alias source table)
+      // and echoes that widened set back down via the selectedGraphModels @Input
+      comp.selectedGraphModels = [g1, g2];
+      comp.ngOnChanges({
+         selectedGraphModels: { currentValue: [g1, g2], previousValue: [] },
+      } as any);
+
+      // the echo should be narrowed back down to just g2, not widened to include g1
+      expect((comp as any).dragNodes).toEqual([g2]);
+   });
+
+   it("should apply an unrelated selectedGraphModels change even while a self-selection echo is still pending", async () => {
+      const g1 = makeGraph("t1");
+      const g2 = makeGraph("t2");
+      const g3 = makeGraph("t3");
+      const { comp } = await renderComp({ graphViewModel: makeViewModel([g1, g2, g3]) });
+      vi.spyOn(comp as any, "refreshDragSelection").mockImplementation(() => {});
+
+      // user selects g1 in the graph, but its echo never arrives (e.g. the tree's
+      // containing folder was still loading and the lookup fell through)
+      comp.selectNode({ ctrlKey: false, shiftKey: false } as MouseEvent, g1);
+
+      // a genuinely unrelated, real tree-driven selection of g2/g3 arrives in the
+      // meantime -- it must be applied as-is, not dropped because a self-selection
+      // echo is still pending
+      comp.selectedGraphModels = [g2, g3];
+      comp.ngOnChanges({
+         selectedGraphModels: { currentValue: [g2, g3], previousValue: [] },
+      } as any);
+
+      expect((comp as any).dragNodes).toEqual([g2, g3]);
    });
 
    it("should NOT reset nodes when an unrelated input changes", async () => {

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-network-graph/physical-model-network-graph.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-network-graph/physical-model-network-graph.component.ts
@@ -103,12 +103,15 @@ export class PhysicalModelNetworkGraphComponent implements OnInit, OnChanges, Af
    private isDragging: boolean = false; // drag endpoint
    private nodeMoving = false; // drag node
    private dragNodes: GraphModel[] = [];
-   // when a selection originates here (click/rubber-band), the parent echoes it back
+   // When a selection originates here (click/rubber-band), the parent echoes it back
    // via selectedGraphModels after resolving the tree node -- since auto-alias tables
    // share the same tree path as their source table, that echo can resolve to *every*
-   // alias of that source table, not just the one the user selected. Suppress applying
-   // that one echoed change so an unrelated alias doesn't get pulled into the drag group.
-   private suppressNextSelectionSync = false;
+   // alias of that source table, not just the one the user selected. This tracks the ids
+   // of a self-originated selection so that echo can be recognized (by superset match,
+   // since the echo may be delayed by async tree/folder loading or never arrive) and
+   // narrowed back down to just the ids selected here, instead of blindly suppressing
+   // the next selectedGraphModels change regardless of what it actually contains.
+   private pendingSelfSelectionIds: Set<string> | null = null;
    _scale: number = 1.0;
 
    private nodes: {[sourceIds: string]: GraphModel} = {}; // element id --> node model
@@ -272,12 +275,24 @@ export class PhysicalModelNetworkGraphComponent implements OnInit, OnChanges, Af
       }
 
       if(changes["selectedGraphModels"] && this.selectedGraphModels) {
-         if(this.suppressNextSelectionSync) {
-            this.suppressNextSelectionSync = false;
+         const incoming = this.selectedGraphModels;
+         const pending = this.pendingSelfSelectionIds;
+         const isEchoOfOwnSelection = !!pending && pending.size > 0 &&
+            Array.from(pending).every(id => incoming.some(g => g.node.id === id));
+
+         if(isEchoOfOwnSelection) {
+            // narrow the echoed selection back down to just the ids selected here,
+            // instead of taking whatever else it resolved to (e.g. sibling auto-aliases
+            // that share the same tree path as the selected table)
+            this.dragNodes = incoming.filter(g => pending.has(g.node.id));
          }
          else {
-            this.dragNodes = [...this.selectedGraphModels];
+            this.dragNodes = [...incoming];
          }
+
+         // any pending self-selection is now either consumed by its echo above, or
+         // superseded by an unrelated selection change -- either way it's no longer pending
+         this.pendingSelfSelectionIds = null;
       }
    }
 
@@ -650,7 +665,7 @@ export class PhysicalModelNetworkGraphComponent implements OnInit, OnChanges, Af
          this.dragNodes = [graph];
       }
 
-      this.suppressNextSelectionSync = true;
+      this.pendingSelfSelectionIds = new Set(this.dragNodes.map(g => g.node.id));
       this.fireSelectedNodesChanged();
       this.refreshDragSelection();
    }
@@ -818,13 +833,14 @@ export class PhysicalModelNetworkGraphComponent implements OnInit, OnChanges, Af
          this.physicalModelService.emitModelChange(true);
          this.onRemoveTable.emit(this.dragNodes);
          this.dragNodes = [];
+         this.pendingSelfSelectionIds = null;
          this.fireSelectedNodesChanged();
       });
    }
 
    selectAll(): void {
       this.dragNodes = this.graphViewModel.graphs;
-      this.suppressNextSelectionSync = true;
+      this.pendingSelfSelectionIds = new Set(this.dragNodes.map(g => g.node.id));
       this.fireSelectedNodesChanged();
       this.refreshDragSelection();
    }
@@ -836,7 +852,7 @@ export class PhysicalModelNetworkGraphComponent implements OnInit, OnChanges, Af
             .intersects(event.box);
       });
 
-      this.suppressNextSelectionSync = true;
+      this.pendingSelfSelectionIds = new Set(this.dragNodes.map(g => g.node.id));
       this.fireSelectedNodesChanged();
       this.refreshDragSelection();
    }
@@ -844,6 +860,7 @@ export class PhysicalModelNetworkGraphComponent implements OnInit, OnChanges, Af
    clearSelection(event: MouseEvent): void {
       if(event.target === event.currentTarget && this.dragNodes.length > 0) {
          this.dragNodes = [];
+         this.pendingSelfSelectionIds = null;
          this.fireSelectedNodesChanged();
          this.jsp.setSuspendDrawing(false, true);
       }

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-network-graph/physical-model-network-graph.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-network-graph/physical-model-network-graph.component.ts
@@ -103,6 +103,12 @@ export class PhysicalModelNetworkGraphComponent implements OnInit, OnChanges, Af
    private isDragging: boolean = false; // drag endpoint
    private nodeMoving = false; // drag node
    private dragNodes: GraphModel[] = [];
+   // when a selection originates here (click/rubber-band), the parent echoes it back
+   // via selectedGraphModels after resolving the tree node -- since auto-alias tables
+   // share the same tree path as their source table, that echo can resolve to *every*
+   // alias of that source table, not just the one the user selected. Suppress applying
+   // that one echoed change so an unrelated alias doesn't get pulled into the drag group.
+   private suppressNextSelectionSync = false;
    _scale: number = 1.0;
 
    private nodes: {[sourceIds: string]: GraphModel} = {}; // element id --> node model
@@ -266,7 +272,12 @@ export class PhysicalModelNetworkGraphComponent implements OnInit, OnChanges, Af
       }
 
       if(changes["selectedGraphModels"] && this.selectedGraphModels) {
-         this.dragNodes = [...this.selectedGraphModels];
+         if(this.suppressNextSelectionSync) {
+            this.suppressNextSelectionSync = false;
+         }
+         else {
+            this.dragNodes = [...this.selectedGraphModels];
+         }
       }
    }
 
@@ -618,17 +629,28 @@ export class PhysicalModelNetworkGraphComponent implements OnInit, OnChanges, Af
    }
 
    selectNode(event: MouseEvent, graph: GraphModel) {
-      if(this.dragNodes.some(g => g.node.id === graph.node.id)) {
-         // missing id or already selected
-         return;
-      }
-      else if(event.ctrlKey || event.shiftKey) {
+      const alreadySelected = this.dragNodes.some(g => g.node.id === graph.node.id);
+
+      if(event.ctrlKey || event.shiftKey) {
+         if(alreadySelected) {
+            // already part of the selection, nothing to change
+            return;
+         }
+
          this.dragNodes.push(graph);
       }
+      else if(alreadySelected && this.dragNodes.length === 1) {
+         // already the sole selection, nothing to change
+         return;
+      }
       else {
+         // plain click always narrows the selection to just this node, even if it
+         // was already part of a stale multi-selection (e.g. synced in from the
+         // tree, or left over from a rubber-band/select-all selection)
          this.dragNodes = [graph];
       }
 
+      this.suppressNextSelectionSync = true;
       this.fireSelectedNodesChanged();
       this.refreshDragSelection();
    }
@@ -802,6 +824,7 @@ export class PhysicalModelNetworkGraphComponent implements OnInit, OnChanges, Af
 
    selectAll(): void {
       this.dragNodes = this.graphViewModel.graphs;
+      this.suppressNextSelectionSync = true;
       this.fireSelectedNodesChanged();
       this.refreshDragSelection();
    }
@@ -813,6 +836,7 @@ export class PhysicalModelNetworkGraphComponent implements OnInit, OnChanges, Af
             .intersects(event.box);
       });
 
+      this.suppressNextSelectionSync = true;
       this.fireSelectedNodesChanged();
       this.refreshDragSelection();
    }


### PR DESCRIPTION
## Summary
- Dragging one table node in the physical model designer's graph view could also move (and select) an unrelated table when both were auto-aliases of the same source table (e.g. "Customer Region" and "Salesperson Region", both aliases of `REGIONS`).
- `selectNode()` short-circuited on a plain click whenever the clicked node was already part of the current `dragNodes` selection, without checking modifier keys, so a stale multi-node selection was never narrowed down to just the clicked node before a drag.
- Selecting a node also fed its tree path back up to the parent component, which re-derived the graph selection by matching *every* graph node sharing that tree path — since auto-alias tables share their source table's tree path, this re-widened the selection to include unrelated aliases.

## Fix
- `selectNode()` now always collapses a plain (non-ctrl/shift) click down to just the clicked node, even if it was previously part of a stale multi-selection.
- Added a `suppressNextSelectionSync` flag so a selection change originating in the graph itself (click, ctrl/shift-click, rubber-band select) is not immediately overwritten by the parent's echoed-back `selectedGraphModels`, which could resolve to multiple aliases of the same source table.

## Test plan
- [x] Manually reproduced in browser: opened a physical view with two auto-alias tables of the same source table, dragged one — confirmed only the dragged table moves/highlights, the other is untouched.