### PR TITLE
Bug #75770, keep the scheduled task select panel from re-opening on select

### DIFF
--- a/web/projects/em/src/app/settings/schedule/task-action-pane/schedule-task-select/schedule-task-select.component.tl.spec.ts
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/schedule-task-select/schedule-task-select.component.tl.spec.ts
@@ -1,0 +1,186 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * ScheduleTaskSelectComponent — Testing Library style
+ *
+ * Risk-first coverage:
+ *   Group 1 [Risk 1] — picking a task from the tree must not re-create the tree nodes
+ *   Group 2 [Risk 2] — programmatic selection still rebuilds the tree and reveals the node
+ *
+ * KEY contracts:
+ *   - onChange() (the mat-select valueChange handler) stores the value and emits
+ *     selectedChange without rebuilding the tree. Rebuilding detaches the DOM node
+ *     that is being clicked, which defeats MatSelect.onContainerClick()'s
+ *     "click came from the panel" check and re-opens the panel (Bug #75770).
+ *   - Setting selectedTaskName to a new value (writeValue / @Input) still rebuilds
+ *     the tree so the selected node's parents are expanded.
+ *   - Setting selectedTaskName to the value it already holds is a no-op.
+ */
+
+import { provideHttpClient } from "@angular/common/http";
+import { render } from "@testing-library/angular";
+import { http, HttpResponse } from "msw";
+
+import { server } from "@test-mocks/server";
+import { ScheduleTaskSelectComponent } from "./schedule-task-select.component";
+import { ScheduleTaskModel } from "../../../../../../../shared/schedule/model/schedule-task-model";
+
+const OWNER = { name: "admin", orgID: "host-org" };
+
+function makeTasks(): ScheduleTaskModel[] {
+   return [
+      { name: "dash1", label: "dash1", path: "org-schedule task", owner: OWNER },
+      { name: "dash2", label: "dash2", path: "org-schedule task", owner: OWNER },
+      { name: "batch1", label: "batch1", path: "org-schedule task/admin", owner: OWNER }
+   ] as ScheduleTaskModel[];
+}
+
+beforeEach(() => {
+   server.use(http.get("*/api/em/navbar/organization", () => HttpResponse.json("host-org")));
+});
+
+async function renderComp(tasks: ScheduleTaskModel[] = makeTasks()) {
+   const result = await render(ScheduleTaskSelectComponent, {
+      providers: [provideHttpClient()],
+      componentProperties: { tasks }
+   });
+
+   result.fixture.detectChanges();
+   await result.fixture.whenStable();
+
+   const comp = result.fixture.componentInstance as ScheduleTaskSelectComponent;
+   return { comp, fixture: result.fixture };
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Group 1 [Risk 1] — selecting from the tree must not re-create the tree nodes
+// ════════════════════════════════════════════════════════════════════════════
+
+describe("ScheduleTaskSelectComponent — onChange(): tree is left intact", () => {
+
+   // 🔁 Regression-sensitive (Bug #75770): rebuilding the tree while the option's
+   // click event is still propagating detaches the clicked DOM node, so
+   // MatSelect.onContainerClick() no longer recognizes the click as coming from
+   // the panel and immediately re-opens it.
+   it("should not rebuild the tree nodes when a task is picked from the tree", async () => {
+      const { comp } = await renderComp();
+
+      const nodesBefore = comp.treeControl.dataNodes;
+      const expandedBefore = comp.treeControl.expansionModel.selected.slice();
+
+      comp.onChange("admin~;~host-org:dash1");
+
+      expect(comp.treeControl.dataNodes).toBe(nodesBefore);
+      expect(comp.treeControl.dataNodes.every((n, i) => n === nodesBefore[i])).toBe(true);
+      expect(comp.treeControl.expansionModel.selected).toEqual(expandedBefore);
+   });
+
+   // Risk Point/Contract: the picked value is still stored and emitted so the
+   // parent editor and the mat-select trigger stay in sync.
+   it("should store and emit the picked task name", async () => {
+      const { comp } = await renderComp();
+      const emitted: string[] = [];
+      comp.selectedChange.subscribe(v => emitted.push(v));
+
+      comp.onChange("admin~;~host-org:dash1");
+
+      expect(comp.selectedTaskName).toBe("admin~;~host-org:dash1");
+      expect(emitted).toEqual(["admin~;~host-org:dash1"]);
+   });
+
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// Group 2 [Risk 2] — programmatic selection still rebuilds/reveals
+// ════════════════════════════════════════════════════════════════════════════
+
+describe("ScheduleTaskSelectComponent — selectedTaskName setter", () => {
+
+   // 🔁 Regression-sensitive: writeValue()/@Input still has to rebuild the tree so
+   // the parents of the selected node get expanded and the node becomes visible.
+   it("should rebuild the tree and expand the selected node's parents when set programmatically", async () => {
+      const { comp } = await renderComp();
+
+      const nodesBefore = comp.treeControl.dataNodes;
+      comp.writeValue("batch1");
+
+      expect(comp.treeControl.dataNodes).not.toBe(nodesBefore);
+
+      const expandedNames = comp.treeControl.expansionModel.selected.map(n => n.name);
+      expect(expandedNames).toContain("org-schedule task");
+      expect(expandedNames).toContain("admin");
+   });
+
+   // Risk Point/Contract: re-setting the value it already holds must not rebuild
+   // the tree (avoids needless DOM churn while the panel is open).
+   it("should be a no-op when set to the value it already holds", async () => {
+      const { comp } = await renderComp();
+
+      comp.writeValue("batch1");
+      const nodesBefore = comp.treeControl.dataNodes;
+
+      comp.writeValue("batch1");
+
+      expect(comp.treeControl.dataNodes).toBe(nodesBefore);
+   });
+
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// Group 3 [Risk 2] — ngOnChanges(): rebuild is driven by the tasks input only
+// ════════════════════════════════════════════════════════════════════════════
+
+describe("ScheduleTaskSelectComponent — ngOnChanges(): selective rebuild", () => {
+
+   // 🔁 Regression-sensitive: a new task list must still repopulate the tree.
+   it("should rebuild the tree when the tasks input changes", async () => {
+      const { comp } = await renderComp();
+
+      const nodesBefore = comp.treeControl.dataNodes;
+      comp.tasks = [
+         { name: "other", label: "other", path: "/", owner: OWNER }
+      ] as ScheduleTaskModel[];
+      comp.ngOnChanges({
+         tasks: { currentValue: comp.tasks, previousValue: null, firstChange: false,
+            isFirstChange: () => false }
+      });
+
+      expect(comp.treeControl.dataNodes).not.toBe(nodesBefore);
+      expect(comp.treeControl.dataNodes.map(n => n.name)).toEqual(["other"]);
+   });
+
+   // 🔁 Regression-sensitive (Bug #75770): the parent echoes the picked value back
+   // through [selectedTaskName] after the user clicks a node. That re-binding must
+   // not rebuild the tree a second time — the setter already decided it was a no-op.
+   it("should not rebuild the tree when only selectedTaskName is re-bound after a pick", async () => {
+      const { comp } = await renderComp();
+
+      comp.onChange("admin~;~host-org:dash1");
+      const nodesBefore = comp.treeControl.dataNodes;
+
+      comp.selectedTaskName = "admin~;~host-org:dash1";
+      comp.ngOnChanges({
+         selectedTaskName: { currentValue: "admin~;~host-org:dash1", previousValue: null,
+            firstChange: false, isFirstChange: () => false }
+      });
+
+      expect(comp.treeControl.dataNodes).toBe(nodesBefore);
+   });
+
+});

--- a/web/projects/em/src/app/settings/schedule/task-action-pane/schedule-task-select/schedule-task-select.component.ts
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/schedule-task-select/schedule-task-select.component.ts
@@ -86,6 +86,10 @@ export class ScheduleTaskSelectComponent implements OnInit, OnChanges, ControlVa
    }
 
    set selectedTaskName(val: string) {
+      if(this._selectedTaskName === val) {
+         return;
+      }
+
       this._selectedTaskName = val;
       this.updateScheduleTaskTree();
    }
@@ -106,7 +110,14 @@ export class ScheduleTaskSelectComponent implements OnInit, OnChanges, ControlVa
 
    ngOnChanges(changes: SimpleChanges): void {
       this.init();
-      this.updateScheduleTaskTree();
+
+      // a change to selectedTaskName is already handled by its setter, which
+      // rebuilds the tree only when the value actually changed. Rebuilding here
+      // as well would throw the tree away again right after the user picked a
+      // node from it.
+      if(changes.tasks) {
+         this.updateScheduleTaskTree();
+      }
    }
 
    init(): void {
@@ -132,8 +143,12 @@ export class ScheduleTaskSelectComponent implements OnInit, OnChanges, ControlVa
    }
 
    onChange: (value: any) => void = (value: any) => {
-      this.selectedTaskName = value;
-      this.selectedChange.emit(this.selectedTaskName);
+      // the node was picked from the tree, so it is already rendered and its
+      // parents are already expanded. Rebuilding the tree here would destroy
+      // the DOM node that is being clicked, which defeats the check that keeps
+      // mat-select from re-opening its panel when a click bubbles out of it.
+      this._selectedTaskName = value;
+      this.selectedChange.emit(this._selectedTaskName);
    };
 
    onTouched = () => {


### PR DESCRIPTION
## Summary

In Enterprise Manager, creating a task with a **Batch** action and picking a task in the **Select Scheduled Task** dropdown left the tree panel open: the value was applied (checkmark + trigger text) but the panel stayed up.

## Root Cause

1. The mat-select's `(valueChange)` called `ScheduleTaskSelectComponent.onChange()`, which assigned `this.selectedTaskName = value`; the setter calls `updateScheduleTaskTree()`, reassigning `dataSource.data` and calling `expandAll()` / `collapseAll()`.
2. `MatTree.renderNodeChanges()` runs `detectChanges()` **synchronously**, so every tree row — including the `<mat-option>` that was just clicked — was destroyed and re-created *while the click event was still propagating*.
3. In CDK/Material 21 the select panel is rendered inline via the popover overlay (`.cdk-overlay-popover`), so it is a DOM descendant of `<mat-form-field>`. The click therefore kept bubbling to MatFormField's wrapper, which calls `MatSelect.onContainerClick(event)`.
4. That method ignores clicks originating in the panel via `target.closest('.mat-mdc-select-panel')`. Because step 2 detached the clicked node from the document, `closest()` returned `null`, the guard failed, and it called `focus(); open();` — re-opening the panel immediately after `close()`.

Confirmed by running the component under real Chromium with real pointer events and capturing the call stacks:

```
CLOSE() CALLED  ->  openedChange: false
OPEN() CALLED   <-  MatSelect.onContainerClick <- _MatFormField_Template_div_click_2_listener
openedChange: true    PANELS IN DOM: 1
```

jsdom does not reproduce this (no popover-overlay or real pointer-event semantics), which is why it needed a real browser.

## Fix

- `onChange()` stores the picked value in the backing field directly instead of going through the setter. A node picked from the tree is already rendered with its parents expanded, so no rebuild is needed.
- The `selectedTaskName` setter short-circuits when the value is unchanged.
- `ngOnChanges()` only rebuilds when the `tasks` input changes; a `selectedTaskName` change is already handled by its setter. This stops the parent's echo of the picked value (via `[selectedTaskName]`) from throwing the tree away again on the next change-detection pass.

Programmatic selection (`writeValue()` / `@Input`) still rebuilds the tree and expands the selected node's ancestors, and a new task list still repopulates the tree.

## Test Plan

Added `schedule-task-select.component.tl.spec.ts` (6 tests). Each of the 3 regression-sensitive assertions was confirmed to fail against the unfixed code:

- selecting from the tree does not re-create the tree nodes or change the expansion state
- the picked value is still stored and emitted
- programmatic selection still rebuilds the tree and expands the selected node's parents
- re-setting the value it already holds is a no-op
- a change to the `tasks` input still rebuilds the tree
- re-binding `selectedTaskName` after a pick does not rebuild the tree

Manual verification: in EM, create task1 with a Dashboard action, then create task2 with a Batch action and pick task1 — the dropdown now closes on selection. Editing an existing batch action still opens with the saved task revealed and selected in the tree.

Also run: `npm run test:em:tl` (815 passed, 19 expected-fail), `npm run test:em` (356 passed), `ng lint em` (0 errors), `ng build em`.

Fixes Redmine #75770.