### PR TITLE
Bug #75793, detach org-lifecycle registry fixtures from the data space file watch

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/cluster/MockCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/MockCluster.java
@@ -248,7 +248,7 @@ public class MockCluster implements Cluster {
 
    @Override
    public <K, V> void addMapListener(String name, MapChangeListener<K, V> l) {
-      mapListeners.computeIfAbsent(name, k -> new ArrayList<>()).add(l);
+      mapListeners.computeIfAbsent(name, k -> new CopyOnWriteArrayList<>()).add(l);
    }
 
    @Override
@@ -1051,7 +1051,7 @@ public class MockCluster implements Cluster {
          EntryEvent<?, ?> event = null;
 
          for(MapChangeListener<?, ?> listener :
-            mapListeners.computeIfAbsent(name, k -> new ArrayList<>()))
+            mapListeners.computeIfAbsent(name, k -> new CopyOnWriteArrayList<>()))
          {
             if(event == null) {
                event = supplier.get();

--- a/core/src/main/java/inetsoft/sree/web/dashboard/DashboardRegistry.java
+++ b/core/src/main/java/inetsoft/sree/web/dashboard/DashboardRegistry.java
@@ -247,9 +247,11 @@ public class DashboardRegistry {
    }
 
    /**
-    * Clear the listeners.
+    * Clear the listeners. Detaches this registry from the data space file watch, so that it is
+    * no longer re-loaded from its backing file when that file changes. Same role as
+    * {@link inetsoft.sree.RepletRegistry#shutdown()}.
     */
-   void clear() {
+   public void clear() {
       dmgr.clear();
    }
 

--- a/core/src/test/java/inetsoft/sree/internal/cluster/MockClusterMapListenerConcurrencyTest.java
+++ b/core/src/test/java/inetsoft/sree/internal/cluster/MockClusterMapListenerConcurrencyTest.java
@@ -1,0 +1,120 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.sree.internal.cluster;
+
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Production Ignite registers map listeners in a thread-safe registry, so callers are free to
+ * add and remove listeners from any thread. MockCluster stands in for Ignite in every core test
+ * (surefire sets inetsoft.sree.internal.cluster.implementation to it), so it has to offer the
+ * same guarantee -- otherwise unrelated tests that legitimately exercise concurrency fail with
+ * an artifact of the mock rather than a real defect.
+ */
+@Tag("core")
+class MockClusterMapListenerConcurrencyTest {
+   /**
+    * Two threads closing the same KeyValueStorage each call removeReplicatedMapListener() with
+    * the same listener instance. Against a plain ArrayList both threads can locate the element
+    * and then both run fastRemove(), driving size to -1 and throwing
+    * ArrayIndexOutOfBoundsException: Index -1 -- which surfaced as an intermittent failure of
+    * OrgLifecycleDependencyMigrationTest.concurrentDuplicateRename_noExceptionNoDuplicateNoLoss.
+    * Removing an already-removed listener must instead be a silent no-op.
+    */
+   @Test
+   @Timeout(60)
+   void concurrentRemoveOfSameMapListener_doesNotCorruptListenerList() throws Exception {
+      ExecutorService executor = Executors.newFixedThreadPool(2);
+
+      try {
+         // the race window only opens once the removal loop is JIT-compiled, so a handful of
+         // iterations would not detect a regression; 5000 caught the unfixed code in 4 of 5
+         // local runs (typically by iteration ~400) and still completes in well under a
+         // second once the list is thread-safe, at which point it can no longer fail at all
+         for(int i = 0; i < 5000; i++) {
+            MockCluster cluster = new MockCluster();
+            MapChangeListener<String, String> listener = new NoOpMapChangeListener();
+            cluster.addMapListener(MAP_NAME, listener);
+
+            CyclicBarrier barrier = new CyclicBarrier(2);
+            Callable<Void> remove = () -> {
+               barrier.await(10, TimeUnit.SECONDS);
+               cluster.removeMapListener(MAP_NAME, listener);
+               return null;
+            };
+
+            for(Future<Void> future : executor.invokeAll(List.of(remove, remove))) {
+               final int iteration = i;
+               assertDoesNotThrow(() -> future.get(10, TimeUnit.SECONDS),
+                                  "removing the same map listener from two threads must not " +
+                                  "throw (iteration " + iteration + ")");
+            }
+         }
+      }
+      finally {
+         executor.shutdownNow();
+      }
+   }
+
+   /**
+    * A listener that unregisters itself while an entry event is being dispatched must not break
+    * the dispatch loop -- a plain ArrayList would throw ConcurrentModificationException here.
+    */
+   @Test
+   @Timeout(60)
+   void removeMapListenerDuringDispatch_doesNotBreakIteration() {
+      MockCluster cluster = new MockCluster();
+      DistributedMap<String, String> map = cluster.getMap(MAP_NAME);
+      MapChangeListener<String, String> second = new NoOpMapChangeListener();
+      MapChangeListener<String, String> first = new NoOpMapChangeListener() {
+         @Override
+         public void entryAdded(EntryEvent<String, String> event) {
+            cluster.removeMapListener(MAP_NAME, this);
+            cluster.removeMapListener(MAP_NAME, second);
+         }
+      };
+
+      cluster.addMapListener(MAP_NAME, first);
+      cluster.addMapListener(MAP_NAME, second);
+
+      assertDoesNotThrow(() -> map.put("k", "v"),
+                         "a listener unregistering itself mid-dispatch must not break the " +
+                         "dispatch loop");
+   }
+
+   private static class NoOpMapChangeListener implements MapChangeListener<String, String> {
+      @Override
+      public void entryAdded(EntryEvent<String, String> event) {
+      }
+
+      @Override
+      public void entryUpdated(EntryEvent<String, String> event) {
+      }
+
+      @Override
+      public void entryRemoved(EntryEvent<String, String> event) {
+      }
+   }
+
+   private static final String MAP_NAME = "mockClusterListenerConcurrencyTestMap";
+}

--- a/core/src/test/java/inetsoft/sree/security/DashboardRegistryOrgLifecycleTest.java
+++ b/core/src/test/java/inetsoft/sree/security/DashboardRegistryOrgLifecycleTest.java
@@ -444,6 +444,7 @@ class DashboardRegistryOrgLifecycleTest {
       DashboardRegistry registry = dashboardRegistryManager.getRegistry(orgId);
       registry.addDashboard(dashboardName, newVsDashboard(vsOrgId, null));
       registry.save();
+      detachFileWatch(registry);
    }
 
    private void seedUserDashboard(IdentityID user, String dashboardName, String vsOrgId,
@@ -452,6 +453,34 @@ class DashboardRegistryOrgLifecycleTest {
       DashboardRegistry registry = dashboardRegistryManager.getRegistry(user);
       registry.addDashboard(dashboardName, newVsDashboard(vsOrgId, vsUserName));
       registry.save();
+      detachFileWatch(registry);
+   }
+
+   /**
+    * Remove the seeded registry's data space change listener (Bug #75793).
+    *
+    * <p>DashboardRegistry watches its backing dashboard-registry.xml and, on change, reset()s
+    * dashboardsMap and re-loads it from the file at its *current* path. Those change events are
+    * delivered asynchronously (LocalKeyValueStorage.ListenerDelegate hands off to
+    * ThreadPool.addOnDemand, which submits to BlobStorage's single-thread eventExecutor), so the
+    * event for the seeding save() above can land at an arbitrary later point -- including in the
+    * middle of DashboardRegistryManager.migrateRegistry(), which mutates the registry in memory
+    * (migrateVSDashboard rewrites the embedded viewsheet's org segment), re-points the listener at
+    * the new org's path (modifyOrgId) and only then save()s. A late callback landing before
+    * modifyOrgId reverts the in-memory rewrite from the old file, so the new file is written with
+    * the *old* org id; one landing between modifyOrgId and save() re-loads from the new path, which
+    * does not exist yet, leaving an empty map that is then saved as an empty registry. Both were
+    * observed intermittently, and only when the JVM is busy enough to delay delivery, i.e. when the
+    * whole security package runs in one surefire JVM.
+    *
+    * <p>clear() unregisters the listener, so any pending or later event is a no-op for this
+    * instance. The instance stays in the manager's cache, so the code under test still operates on
+    * this same object -- evicting it (DashboardRegistryManager.clear()) would instead have
+    * migrateRegistry() re-load a fresh instance that registers a new listener on the same path,
+    * which would leave the race open.
+    */
+   private static void detachFileWatch(DashboardRegistry registry) {
+      registry.clear();
    }
 
    private VSDashboard newVsDashboard(String orgId, String userName) {

--- a/core/src/test/java/inetsoft/sree/security/OrgLifecycleRepletRegistryIntegrationTest.java
+++ b/core/src/test/java/inetsoft/sree/security/OrgLifecycleRepletRegistryIntegrationTest.java
@@ -136,6 +136,8 @@ class OrgLifecycleRepletRegistryIntegrationTest {
       RepletRegistry fromRegistry = repletRegistryManager.getRegistry(fromOrgId);
       fromRegistry.addFolder("Sales", false);
       fromRegistry.save();
+      // detach from the data space file watch -- see detachFileWatch() below.
+      detachFileWatch(fromRegistry);
 
       IdentityService identityService = newIdentityService(mock(SecurityEngine.class));
 
@@ -175,6 +177,10 @@ class OrgLifecycleRepletRegistryIntegrationTest {
       registry.save();
       assertTrue(dataSpace.exists(orgId, "repository.xml"),
                  "precondition: folder must actually be persisted to the backing repository.xml file");
+      // detach from the data space file watch -- see detachFileWatch() below. The cache
+      // eviction + reload below is driven explicitly by clearOrgCache(), not by the file watch,
+      // so removing the listener does not weaken what this test documents.
+      detachFileWatch(registry);
 
       IdentityService identityService = newIdentityService(mock(SecurityEngine.class));
       identityService.updateRepletRegistry(orgId, null);
@@ -198,6 +204,27 @@ class OrgLifecycleRepletRegistryIntegrationTest {
    }
 
    // ── fixture helpers ──
+
+   /**
+    * Remove the registry's data space change listener (Bug #75793).
+    *
+    * <p>RepletRegistry watches its backing {orgId}/repository.xml and re-runs init() -- which
+    * clears and re-loads the in-memory folder map -- whenever that file changes. Those change
+    * events are delivered asynchronously (LocalKeyValueStorage.ListenerDelegate hands off to
+    * ThreadPool.addOnDemand, which submits to BlobStorage's single-thread eventExecutor), so the
+    * event for a fixture's own save() can land at an arbitrary later point. When it lands after
+    * updateRepletRegistry() has done its in-memory-only folder removal, the reload from the
+    * (deliberately unmodified) file brings the folder right back and the assertion below fails --
+    * intermittently, and only when the JVM is busy enough to delay delivery, i.e. when the whole
+    * security package runs in one surefire JVM.
+    *
+    * <p>shutdown() unregisters the listener, so any pending or later event is a no-op for this
+    * instance. Nothing in these scenarios saves the registry again afterward (save() would
+    * re-register it), and the file-watch reload path is not what these tests exercise.
+    */
+   private static void detachFileWatch(RepletRegistry registry) {
+      registry.shutdown();
+   }
 
    private static byte[] bytes(String s) {
       return s.getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
## Summary

`inetsoft.sree.security.DashboardRegistryOrgLifecycleTest` and `inetsoft.sree.security.OrgLifecycleRepletRegistryIntegrationTest` failed intermittently when the whole security package ran in one surefire JVM (measured ~1 in 3 runs on unmodified `main`), while both passed reliably in isolation. This removes the race so those tests are deterministic.

## Root Cause

Not stale cross-test cache state, but a race with **asynchronous** data space change-event delivery.

Every DataSpace write produces a blob change event that is delivered on background threads: `LocalKeyValueStorage.ListenerDelegate` hands off via `ThreadPool.addOnDemand`, which submits to `BlobStorage`'s single-thread `eventExecutor` (`BlobStorage.java:667-706`), which then walks `DataSpace`'s `ListenerTree`. Delivery can therefore land arbitrarily later than the write that caused it.

`RepletRegistry` (`RepletRegistry.java:850`) and `DashboardRegistry` (`DashboardRegistry.java:462`) each register a `DataChangeListener` on their backing file. On fire, `RepletRegistry.init()` clears and re-loads the folder map; `DashboardRegistry` `reset()`s `dashboardsMap` and re-loads it from the file at its *current* path.

Both tests seed fixtures by writing registry files and then assert on state that only exists in memory. When the JVM is busy enough to delay delivery — i.e. when the whole package runs — the event for the test's own seeding `save()` lands mid-test and re-initializes the registry from disk:

- **`updateRepletRegistry()`** (`IdentityService.java:1172`) removes folders in memory only. A late callback re-`init()`s from the unchanged file, so the folder reappears — `source org's in-memory registry must have the folder removed ... expected: <false> but was: <true>`.
- **`DashboardRegistryManager.migrateRegistry()`** (`:180`) rewrites the org id in memory, then `modifyOrgId()` re-points the listener at the new path, then `save()`s. A late callback landing *before* `modifyOrgId` reverts the rewrite from the old file, so the new file is written with the old org id (`expected: <dashreg_full_to> but was: <dashreg_full_from>`); one landing *between* `modifyOrgId` and `save()` re-loads from the new path, which does not exist yet, leaving an empty map that is then saved as an empty registry (`registry XML must contain a viewsheet entry ... expected: <true> but was: <false>`). `DashboardRegistry.reset()` has exactly one caller — that change listener — so the empty-registry failure can only come from this path.

## Fix

Detach the seeded registry instances from the file watch after seeding, so pending or late events are no-ops for them:

- `OrgLifecycleRepletRegistryIntegrationTest` (scenarios 9b/9c): call the already-public `RepletRegistry.shutdown()` after the seeding `save()`. Scenario 9a is untouched — it only asserts state that matches the file, so a reload there is harmless.
- `DashboardRegistryOrgLifecycleTest`: detach in the shared `seedAdminDashboard`/`seedUserDashboard` helpers. The instance stays in the manager's cache, so `migrateRegistry()` still operates on the same object — evicting it (`DashboardRegistryManager.clear()`) would instead have a fresh instance re-register a listener on the same path and leave the race open.

The only production change is widening `DashboardRegistry.clear()` from package-private to `public` (visibility only, no behavior change), mirroring `RepletRegistry.shutdown()`, which is already public. Its sole existing caller, `DashboardRegistryManager.clear(String, String)`, is unaffected, and no subclass overrides it.

## Test Plan

- Baseline on unmodified `main`: 1 failure in 3 runs of `./mvnw -pl core test "-Dtest=inetsoft.sree.security.**"` (the empty-registry variant), matching the reported rate.
- With this change: **13 consecutive clean runs** of the same command (657 tests, 0 failures, 0 errors each) across two independent verification passes.
- `./mvnw -pl core install -DskipTests` — BUILD SUCCESS.
- No frontend changes, so no lint/Vitest impact.

Fixes Redmine #75793.

---

## Second flake: `MockCluster`'s map listener registry is not thread-safe

The validation build for this branch failed on a *different*, pre-existing flake, untouched by the change above:

```
OrgLifecycleDependencyMigrationTest.concurrentDuplicateRename_noExceptionNoDuplicateNoLoss
  ==> java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 10
      at java.util.ArrayList.fastRemove(ArrayList.java:724)
      at inetsoft.sree.internal.cluster.MockCluster.removeMapListener(MockCluster.java:259)
      at inetsoft.storage.LocalKeyValueStorage.close(LocalKeyValueStorage.java:171)
      at inetsoft.uql.asset.sync.DependencyStorageService.removeDependencyStorage(:124)
      at inetsoft.uql.asset.sync.DependencyStorageService.migrateStorageData(:142)
```

### Root cause

`MockCluster` stores each map's listeners in a plain `ArrayList` (`MockCluster.java:251`). That test runs two concurrent `migrateStorageData(..., removeOld = true)` calls; both reach `LocalKeyValueStorage.close()` → `removeReplicatedMapListener` with the same listener instance. Both threads locate the element and both run `ArrayList.fastRemove()`, so `size` goes to `-1` and `es[size = newSize] = null` indexes at `-1` — exactly the `Index -1 out of bounds for length 10` above.

The same unsynchronized list is walked by `fireEntryEvent()` (`:1053`), so a listener that unregisters itself during dispatch throws `ConcurrentModificationException`.

Production Ignite registers listeners in a thread-safe registry, and `MockCluster` substitutes for it in **every** core test (surefire sets `inetsoft.sree.internal.cluster.implementation`), so it has to offer the same guarantee — otherwise tests that legitimately exercise concurrency fail on an artifact of the mock rather than a real defect.

### Fix

Switch the per-map listener lists to `CopyOnWriteArrayList`, matching the `messageListeners` field already in the same class. Double removal becomes a silent no-op; dispatch iterates a stable snapshot.

### Test plan

- New `MockClusterMapListenerConcurrencyTest` covers both failure modes. Against the unfixed `MockCluster` the concurrent-removal test reproduced the `Index -1` AIOOBE in **4 of 5** runs (typically by iteration ~400) and the mid-dispatch test threw `ConcurrentModificationException` in **3 of 3**. Both pass with the fix.
- `OrgLifecycleDependencyMigrationTest` + the new test: **5 consecutive clean runs**.
- Full `./mvnw -pl core test`: **4206 tests, 0 failures, 0 errors** — BUILD SUCCESS.
