### PR TITLE
fix(wiz): stop dashboard merge from polluting shared base with aggregate-output column names

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
@@ -130,13 +130,34 @@ public class WsMergeService {
                boolean hasAggregation = srcAggr != null && !srcAggr.isEmpty();
 
                if(hasConditions || hasAggregation) {
-                  // srcBound carries its own conditions or aggregation. Stack a mirror of
-                  // prevMirror (not _base) so that runtime filters applied to prevMirror
-                  // propagate through this mirror and on to any join that references it,
-                  // preserving cross-chart filter interaction while retaining srcBound's
-                  // conditions and aggregation.
+                  // srcBound carries its own conditions or aggregation. Normally stack a mirror of
+                  // prevMirror (not _base) so that runtime filters applied to prevMirror propagate
+                  // through this mirror and on to any join that references it, preserving
+                  // cross-chart filter interaction while retaining srcBound's conditions and
+                  // aggregation.
+                  //
+                  // EXCEPTION -- prevMirror carries its OWN non-empty AggregateInfo (from whichever
+                  // earlier chart first claimed this physical table): stacking srcBound's aggregation
+                  // on top of prevMirror would group/aggregate an ALREADY-aggregated, differently
+                  // grouped result, which is structurally unsound whenever the two charts group by
+                  // different levels (e.g. two independent Quarter(date_order) groupings from two
+                  // unrelated charts on the same source table). Confirmed live: this produces a
+                  // duplicate/incompatible output column name (e.g. both charts' own grouping emits
+                  // "Quarter(date_order)") that the SQL engine then silently disambiguates with a
+                  // "_1" suffix neither chart's own VSChartInfo binding is told about, crashing the
+                  // FIRST chart's own graph render with ColumnNotFoundException the next time its
+                  // dashboard tile is opened -- even though nothing about the first chart itself
+                  // changed. Stack on the raw, unaggregated _base table instead in this case:
+                  // correctness beats cross-chart-filter-sharing convenience for a case that was
+                  // already producing wrong (crashing) results. existingTable here IS the raw base
+                  // (ensureBaseHasPrevMirror already renamed it to "{name}_base" and stripped its
+                  // conditions/aggregation), so it's always a safe, clean stacking point regardless
+                  // of what prevMirror carries.
+                  AggregateInfo prevOwnAggr = prevMirror.getAggregateInfo();
+                  boolean prevHasIncompatibleAggr = prevOwnAggr != null && !prevOwnAggr.isEmpty();
+                  TableAssembly stackOn = prevHasIncompatibleAggr ? existingTable : prevMirror;
                   String condMirrorName = ensureUniqueName(prevMirrorName, dashWS);
-                  MirrorTableAssembly condMirror = new MirrorTableAssembly(dashWS, condMirrorName, prevMirror);
+                  MirrorTableAssembly condMirror = new MirrorTableAssembly(dashWS, condMirrorName, stackOn);
                   condMirror.setColumnSelection(srcBound.getColumnSelection(true).clone(), true);
                   condMirror.setPreConditionList(srcPre != null ? (ConditionListWrapper) srcPre.clone() : new ConditionList());
                   condMirror.setPostConditionList(srcPost != null ? (ConditionListWrapper) srcPost.clone() : new ConditionList());
@@ -344,7 +365,7 @@ public class WsMergeService {
     */
    private void mergeColumns(BoundTableAssembly base, BoundTableAssembly srcTable) {
       ColumnSelection baseColumns = base.getColumnSelection(true);
-      ColumnSelection srcColumns = srcTable.getColumnSelection(true);
+      ColumnSelection srcColumns = mergeableSourceColumns(srcTable);
 
       for(int i = 0; i < srcColumns.getAttributeCount(); i++) {
          DataRef col = srcColumns.getAttribute(i);
@@ -368,6 +389,65 @@ public class WsMergeService {
 
       base.setColumnSelection(basePrivate, false);
       base.setColumnSelection(baseColumns, true);
+   }
+
+   /**
+    * Returns the columns from {@code srcTable} that are safe to merge into a SHARED, raw physical
+    * base table (see {@link #mergeColumns}).
+    *
+    * <p>When {@code srcTable} carries no aggregation of its own, its public (output) selection IS
+    * its set of genuine raw/pass-through columns — return those directly (unchanged behavior).</p>
+    *
+    * <p>When {@code srcTable} carries its OWN non-empty {@link AggregateInfo} (the shape
+    * {@code create_worksheet_table}'s baked-in aggregateInfo produces), its public selection
+    * instead reflects AGGREGATE OUTPUT names (e.g. a date-grouped "Quarter(date_order)", or an
+    * aggregate alias like "order_count") — these are NOT genuine physical/raw columns. Merging
+    * them into the shared base corrupts it: the base then falsely claims to already HAVE a column
+    * with that name, so ANY OTHER chart merged onto the same physical table that independently
+    * produces an output with the identical name (its own date-grouping, its own aggregate alias,
+    * even a different chart's own chart-level dimension binding) collides with this bogus
+    * pre-existing "raw" column. StyleBI's SQL builder then silently disambiguates the alias with
+    * a "_1" suffix that no chart's own VSChartInfo binding is told about, crashing that OTHER
+    * chart's graph render with ColumnNotFoundException the next time its dashboard tile opens —
+    * confirmed live: two independent charts merged onto the same physical table, each producing
+    * their own "Quarter(date_order)"-named output, crashed the FIRST chart's render this way even
+    * though nothing about the first chart itself changed.
+    *
+    * <p>In that case, use {@code srcTable}'s PRIVATE selection instead — confirmed live to carry
+    * the genuinely-fetched underlying raw column(s) the aggregation reads from (e.g. "date_order"
+    * alongside its own "Quarter(date_order)" output) — filtered to exclude any column whose name
+    * IS one of the aggregateInfo's own group/aggregate output names, so only the real raw
+    * column(s) get merged onto the shared base.</p>
+    */
+   private ColumnSelection mergeableSourceColumns(BoundTableAssembly srcTable) {
+      AggregateInfo srcAggr = srcTable.getAggregateInfo();
+
+      if(srcAggr == null || srcAggr.isEmpty()) {
+         return srcTable.getColumnSelection(true);
+      }
+
+      Set<String> outputNames = new HashSet<>();
+
+      for(int i = 0; i < srcAggr.getGroupCount(); i++) {
+         outputNames.add(srcAggr.getGroup(i).getName());
+      }
+
+      for(int i = 0; i < srcAggr.getAggregateCount(); i++) {
+         outputNames.add(srcAggr.getAggregate(i).getName());
+      }
+
+      ColumnSelection rawCols = new ColumnSelection();
+      ColumnSelection srcPrivate = srcTable.getColumnSelection(false);
+
+      for(int i = 0; i < srcPrivate.getAttributeCount(); i++) {
+         DataRef col = srcPrivate.getAttribute(i);
+
+         if(!outputNames.contains(col.getName())) {
+            rawCols.addAttribute(col);
+         }
+      }
+
+      return rawCols;
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/service/WsMergeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WsMergeServiceTest.java
@@ -18,7 +18,12 @@
 package inetsoft.web.wiz.service;
 
 import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.asset.AggregateFormula;
+import inetsoft.uql.asset.AggregateInfo;
+import inetsoft.uql.asset.AggregateRef;
 import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.GroupRef;
+import inetsoft.uql.asset.MirrorTableAssembly;
 import inetsoft.uql.asset.PhysicalBoundTableAssembly;
 import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.asset.TableAssembly;
@@ -36,8 +41,11 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.HashMap;
+import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Regression coverage for a live bug: when two charts merged into the same dashboard both bind
@@ -123,5 +131,164 @@ class WsMergeServiceTest {
 
       ColumnSelection mirrorPublicCols = prevMirror.getColumnSelection(true);
       assertNotNull(mirrorPublicCols.getAttribute("product_name_json"));
+   }
+
+   private static GroupRef groupRef(String field) {
+      AttributeRef ref = new AttributeRef(null, field);
+      ref.setDataType(XSchema.STRING);
+      ColumnRef col = new ColumnRef(ref);
+      col.setDataType(XSchema.STRING);
+      return new GroupRef(col);
+   }
+
+   private static AggregateRef aggregateRef(String field, AggregateFormula formula) {
+      AttributeRef ref = new AttributeRef(null, field);
+      ref.setDataType(XSchema.DOUBLE);
+      ColumnRef col = new ColumnRef(ref);
+      col.setDataType(XSchema.DOUBLE);
+      return new AggregateRef(col, formula);
+   }
+
+   private static PhysicalBoundTableAssembly physicalTableWithAggregate(
+      Worksheet ws, String assemblyName, String groupField, String aggregateField,
+      AggregateFormula formula)
+   {
+      PhysicalBoundTableAssembly table = physicalTable(ws, assemblyName, groupField, aggregateField);
+      AggregateInfo aggr = new AggregateInfo();
+      aggr.addGroup(groupRef(groupField));
+      aggr.addAggregate(aggregateRef(aggregateField, formula));
+      table.setAggregateInfo(aggr);
+      return table;
+   }
+
+   /**
+    * Regression for a reproduced live crash: two charts on a dashboard both bind to the same
+    * physical table (e.g. two independent charts both grouping odoo's sale_order by
+    * Quarter(date_order), each with its own distinct aggregate) but with DIFFERENT groupings/
+    * aggregates baked directly onto their own BoundTableAssembly (the shape create_worksheet_table
+    * produces). The second chart to merge used to stack its own condMirror on top of "prevMirror"
+    * -- which, per ensureBaseHasPrevMirror, inherits the FIRST chart's own AggregateInfo -- so the
+    * second chart's aggregation ran on top of an ALREADY aggregated, differently-grouped result.
+    * That produced a duplicate output column name the SQL engine silently disambiguated with a
+    * "_1" suffix, which the FIRST chart's own (unrelated) VSChartInfo binding was never told
+    * about, crashing ITS graph render the next time its dashboard tile opened
+    * (ColumnNotFoundException) -- confirmed live against a real StyleBI deployment. The fix:
+    * stack on the raw "_base" table instead whenever prevMirror carries its own non-empty
+    * AggregateInfo.
+    */
+   @Test
+   void mergingTwoChartsWithDifferentOwnAggregatesOnTheSamePhysicalTableStacksOnTheRawBase() {
+      Worksheet dashWS = new Worksheet();
+      // First chart: e.g. a boxplot grouping by "quarter", aggregating "amount_total".
+      dashWS.addAssembly(physicalTableWithAggregate(dashWS, "PT", "quarter", "amount_total", AggregateFormula.NONE));
+
+      // Second chart: a DIFFERENT own aggregation (e.g. Count/Average) on the SAME physical table.
+      Worksheet vizWS = new Worksheet();
+      vizWS.addAssembly(physicalTableWithAggregate(vizWS, "PT", "quarter", "order_count", AggregateFormula.COUNT_ALL));
+
+      Map<String, String> wsRenameMap = service.mergeWorksheet(vizWS, dashWS, "suffix1", new HashMap<>());
+
+      String secondChartFinalName = wsRenameMap.get("PT");
+      assertNotNull(secondChartFinalName, "expected the second chart's table to be mapped to a merged name");
+
+      TableAssembly secondChartMirror = (TableAssembly) dashWS.getAssembly(secondChartFinalName);
+      assertNotNull(secondChartMirror, "expected the second chart's condMirror to exist in dashWS");
+      assertEquals(MirrorTableAssembly.class, secondChartMirror.getClass());
+
+      // Must stack on "PT_base" (the raw, unaggregated table) -- NOT "PT" (prevMirror, which
+      // carries the FIRST chart's own incompatible "quarter"/"amount_total" aggregation).
+      String stackedOn = ((MirrorTableAssembly) secondChartMirror).getAssemblyName();
+      assertEquals("PT_base", stackedOn,
+         "the second chart's own aggregation must stack on the raw base table, not on a " +
+         "prevMirror that already carries a different chart's own incompatible aggregation");
+   }
+
+   private static ColumnRef rawColumn(String name) {
+      AttributeRef ref = new AttributeRef(null, name);
+      ref.setDataType(XSchema.STRING);
+      ColumnRef col = new ColumnRef(ref);
+      col.setDataType(XSchema.STRING);
+      return col;
+   }
+
+   /**
+    * Builds a table whose public (output) selection is JUST its aggregate's own output names,
+    * and whose private (fetched) selection carries BOTH those output names AND the genuine
+    * underlying raw column the aggregation reads from -- the exact shape confirmed live for a
+    * create_worksheet_table-style baked-in AggregateInfo (private=[Quarter(date_order),
+    * date_order, order_count] for a table grouping date_order by quarter and counting rows).
+    */
+   private static PhysicalBoundTableAssembly physicalTableWithGroupedAggregate(
+      Worksheet ws, String assemblyName, String rawGroupField, String groupOutputName,
+      String aggregateOutputName, AggregateFormula formula)
+   {
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, assemblyName);
+      table.setSourceInfo(new SourceInfo(SourceInfo.PHYSICAL_TABLE, "postgres", "public.product_template"));
+
+      ColumnSelection priv = new ColumnSelection();
+      priv.addAttribute(rawColumn(groupOutputName));
+      priv.addAttribute(rawColumn(rawGroupField));
+      priv.addAttribute(rawColumn(aggregateOutputName));
+      table.setColumnSelection(priv, false);
+
+      ColumnSelection pub = new ColumnSelection();
+      pub.addAttribute(rawColumn(groupOutputName));
+      pub.addAttribute(rawColumn(aggregateOutputName));
+      table.setColumnSelection(pub, true);
+
+      AggregateInfo aggr = new AggregateInfo();
+      aggr.addGroup(groupRef(groupOutputName));
+      aggr.addAggregate(aggregateRef(aggregateOutputName, formula));
+      table.setAggregateInfo(aggr);
+      return table;
+   }
+
+   /**
+    * Regression for the actual root cause of a reproduced live crash (the sibling test above
+    * fixed a related-but-different hazard in the SAME merge). {@link WsMergeService#mergeColumns}
+    * used to merge a source table's PUBLIC selection into the shared physical base unconditionally
+    * -- but when the source table carries its OWN baked-in {@link AggregateInfo} (the shape
+    * create_worksheet_table produces), that public selection reflects AGGREGATE OUTPUT names
+    * (e.g. a date-grouped "Quarter(date_order)", an aggregate alias "order_count"), not genuine
+    * physical columns. Merging those names onto the shared base made it falsely claim to already
+    * HAVE a column with that name -- so a DIFFERENT, unrelated chart also merged onto the same
+    * physical table (e.g. one computing its OWN "Quarter(date_order)" via chart-level date
+    * grouping, with no aggregateInfo of its own at all) collided with that bogus pre-existing
+    * "raw" column. StyleBI's SQL builder then silently disambiguated the alias with a "_1" suffix
+    * neither chart's own VSChartInfo binding was told about, crashing the OTHER (unrelated)
+    * chart's graph render with ColumnNotFoundException the next time its dashboard tile opened --
+    * confirmed live against a real StyleBI deployment (error: "Column not found: Quarter(date_order)
+    * in amount_total,Quarter(date_order)_1"). Fix: merge only the genuine underlying raw column(s)
+    * an aggregated source table's own grouping/aggregates read from -- never its own output names.
+    */
+   @Test
+   void mergingAChartsOwnAggregateOutputColumnsDoesNotPolluteTheSharedRawBase() {
+      Worksheet dashWS = new Worksheet();
+      // First chart (e.g. a boxplot): plain, unaggregated view of the raw table -- its OWN
+      // date-grouping (if any) happens at the chart-binding level, not baked into the worksheet.
+      dashWS.addAssembly(physicalTable(dashWS, "PT", "date_order", "amount_total", "id"));
+
+      // Second chart (e.g. order-count): its OWN baked-in aggregation grouping "date_order" by
+      // quarter (output "Quarter(date_order)") and counting rows (output "order_count").
+      Worksheet vizWS = new Worksheet();
+      vizWS.addAssembly(physicalTableWithGroupedAggregate(
+         vizWS, "PT", "date_order", "Quarter(date_order)", "order_count", AggregateFormula.COUNT_ALL));
+
+      service.mergeWorksheet(vizWS, dashWS, "suffix1", new HashMap<>());
+
+      TableAssembly base = (TableAssembly) dashWS.getAssembly("PT_base");
+      assertNotNull(base, "expected the existing 'PT' to be promoted to 'PT_base'");
+
+      ColumnSelection publicCols = base.getColumnSelection(true);
+      assertNull(publicCols.getAttribute("Quarter(date_order)"),
+         "the second chart's own aggregate-OUTPUT column name must NOT be merged onto the shared " +
+         "raw base -- it isn't a genuine physical column, and a false pre-existing column with " +
+         "that name collides with ANY other chart that independently produces the same output name");
+      assertNull(publicCols.getAttribute("order_count"),
+         "same for the aggregate's own alias -- not a genuine raw column either");
+
+      assertNotNull(publicCols.getAttribute("date_order"),
+         "the genuine underlying raw column the aggregation reads from must still be merged, so " +
+         "the shared base can supply it to whatever mirror stacks on it");
    }
 }


### PR DESCRIPTION
## Summary
Reproduced live (via the wiz-services plugin): composing a dashboard from multiple charts that share a physical table (e.g. two independent charts both querying `sale_order`, one via chart-level date grouping, the other via a baked-in `AggregateInfo` grouping by `Quarter(date_order)` and counting rows) crashed with a 500 the next time the dashboard was opened:

```
inetsoft.uql.viewsheet.ColumnNotFoundException: Column not found: Quarter(date_order) in amount_total,Quarter(date_order)_1
	at inetsoft.graph.data.AbstractDataSet.getType(AbstractDataSet.java:562)
	at inetsoft.report.composition.graph.GraphGenerator.fixDScale(GraphGenerator.java:1843)
	at inetsoft.report.composition.graph.SeparateGraphGenerator.createEGraph0(SeparateGraphGenerator.java:343)
	at inetsoft.report.composition.graph.GraphGenerator.createEGraph(GraphGenerator.java:858)
	at inetsoft.report.composition.graph.VGraphPair$Creator.createGraph(VGraphPair.java:2710)
```

Root cause, confirmed via targeted diagnostic logging against a live reproduction: `WsMergeService.mergeColumns` unconditionally merged a merging chart's PUBLIC (output) column selection into the shared physical base table. When that chart carries its own baked-in `AggregateInfo` (the shape `create_worksheet_table` produces), its public selection reflects **aggregate output names** (e.g. `Quarter(date_order)`, `order_count`) — not genuine physical columns. Merging those names onto the shared base made it falsely claim to already have a column with that name. A *different*, unrelated chart also merged onto the same physical table — one computing its own `Quarter(date_order)` via chart-level date grouping, with no `AggregateInfo` of its own — then collided with that bogus pre-existing "raw" column. StyleBI's SQL builder silently disambiguated the alias with a `_1` suffix that neither chart's own `VSChartInfo` binding was told about, crashing the *other* chart's graph render.

## Fixes
1. **`mergeColumns`**: when the merging table carries its own non-empty `AggregateInfo`, merge only the genuine underlying raw column(s) its groups/aggregates actually read from (derived from its private selection minus its own group/aggregate output names) — never the aggregate output names themselves.
2. **condMirror stacking**: when stacking a second chart's own conditions/aggregation, stack on the raw `_base` table instead of `prevMirror` whenever `prevMirror` itself already carries a non-empty (and potentially incompatible) `AggregateInfo` from an earlier chart — avoids aggregating on top of an already-aggregated, differently-grouped result.

## Test plan
- [x] Added regression test: a chart's own aggregate output column names are NOT merged onto the shared raw base; the genuine underlying raw column IS.
- [x] Added regression test: stacking a second chart's own aggregation onto a `prevMirror` that already carries a different, incompatible `AggregateInfo` stacks on the raw `_base` instead.
- [x] Existing `mergingATableWithExtraColumnsAddsThemToBothPublicAndPrivateSelection` test (unrelated prior fix) still passes — confirms the plain-column merge path is unaffected.
- [x] `./mvnw -pl community/core test -Dtest=WsMergeServiceTest` — 3/3 passing.
- [x] Manually reproduced and fixed against a live local StyleBI build: before the fix, `verify_visualization` on the composed dashboard returned 500 with the exact `ColumnNotFoundException` above; after, it returns `ok:true` and all 7 chart tiles on the board render with `renderError: null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)