### PR TITLE
Bug #75808, copy EM favorites when cloning or renaming an organization

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
@@ -194,7 +194,7 @@ public abstract class AbstractEditableAuthenticationProvider
 
       for(IdentityID userID : getUsers()) {
          if(getUser(userID).getOrganizationID().equals(fromOrgId)) {
-            IdentityID newID = copyUserToOrganization(userID, newOrgID, fromOrgId, identityService, principal, defaultPassword);
+            IdentityID newID = copyUserToOrganization(userID, newOrgID, fromOrgId, identityService, principal, defaultPassword, replace);
 
             if(newID != null && !newID.name.isEmpty()) {
                addedMembers.add(newID);
@@ -669,11 +669,12 @@ public abstract class AbstractEditableAuthenticationProvider
       }
    }
 
-   private IdentityID copyUserToOrganization(IdentityID memberID, String orgID, String fromOrgID, IdentityService identityService, Principal principal, String defaultPassword) {
+   private IdentityID copyUserToOrganization(IdentityID memberID, String orgID, String fromOrgID, IdentityService identityService, Principal principal, String defaultPassword, boolean replace) {
       User fromUser = getUser(memberID);
 
       if(fromUser != null) {
          IdentityID newID = new IdentityID(memberID.name, orgID);
+         identityService.copyUserFavorites(memberID, newID, replace);
 
          FSUser newUser = new FSUser(newID);
          newUser.setGroups(fromUser.getGroups());

--- a/core/src/main/java/inetsoft/web/admin/favorites/FavoritesService.java
+++ b/core/src/main/java/inetsoft/web/admin/favorites/FavoritesService.java
@@ -116,6 +116,27 @@ public class FavoritesService {
    }
 
    /**
+    * Copies the EM favorites entry from one identity key to another, leaving the source
+    * entry intact, e.g. when an organization is cloned and its members are copied into the
+    * new organization. Does nothing if there is no entry for {@code fromKey}.
+    *
+    * @param fromKey the source identity key.
+    * @param toKey   the target identity key.
+    */
+   public void copyFavorites(String fromKey, String toKey) {
+      FavoriteList list = favorites.get(fromKey);
+
+      if(list != null) {
+         try {
+            favorites.put(toKey, list).get(10L, TimeUnit.SECONDS);
+         }
+         catch(InterruptedException | ExecutionException | TimeoutException e) {
+            LOG.error("Failed to copy favorites from {} to {}", fromKey, toKey, e);
+         }
+      }
+   }
+
+   /**
     * Removes the EM favorites entries for the given identities, so they are not left
     * orphaned after the identities are deleted.
     *

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -1228,6 +1228,24 @@ public class IdentityService {
       }
    }
 
+   /**
+    * Carries a user's EM favorites over to their copy in another organization, so an
+    * organization clone or rename does not leave the copied user with no favorites.
+    *
+    * @param fromID  the identity of the user in the source organization.
+    * @param toID    the identity of the user's copy in the target organization.
+    * @param replace {@code true} when the source organization is being replaced/renamed, so
+    *                the favorites are moved rather than copied.
+    */
+   public void copyUserFavorites(IdentityID fromID, IdentityID toID, boolean replace) {
+      if(replace) {
+         favoritesService.moveFavorites(fromID.convertToKey(), toID.convertToKey());
+      }
+      else {
+         favoritesService.copyFavorites(fromID.convertToKey(), toID.convertToKey());
+      }
+   }
+
    public void clearDataSourceMetadata() throws Exception {
       String[] dsNames = xRepository.getDataSourceNames();
 

--- a/core/src/test/java/inetsoft/sree/security/AbstractEditableAuthenticationProviderTest.java
+++ b/core/src/test/java/inetsoft/sree/security/AbstractEditableAuthenticationProviderTest.java
@@ -640,7 +640,7 @@ class AbstractEditableAuthenticationProviderTest {
       fromUser.setOrganization("fromOrg");
       provider.stubUser(memberID, fromUser);
 
-      IdentityID result = provider.callCopyUserToOrganization(memberID, "newOrg", "fromOrg", svc, mock(Principal.class), null);
+      IdentityID result = provider.callCopyUserToOrganization(memberID, "newOrg", "fromOrg", svc, mock(Principal.class), null, false);
 
       assertEquals("alice", result.name);
       assertEquals("newOrg", result.orgID);
@@ -650,6 +650,26 @@ class AbstractEditableAuthenticationProviderTest {
       assertEquals("existingHash", added.getPassword());
       assertEquals("bcrypt", added.getPasswordAlgorithm());
       assertEquals("newOrg", added.getOrganizationID());
+
+      verify(svc).copyUserFavorites(memberID, new IdentityID("alice", "newOrg"), false);
+   }
+
+   // [Path D] fromUser found, replace=true (org rename) → favorites moved, not copied
+   @Test
+   void copyUserToOrganization_replaceTrue_movesFavoritesInsteadOfCopying() {
+      IdentityService svc = mock(IdentityService.class);
+      when(svc.getPermission(any(), any(), any(), any())).thenReturn(List.of());
+
+      IdentityID memberID = new IdentityID("alice", "fromOrg");
+      FSUser fromUser = new FSUser(memberID);
+      fromUser.setPassword("existingHash");
+      fromUser.setPasswordAlgorithm("bcrypt");
+      fromUser.setOrganization("fromOrg");
+      provider.stubUser(memberID, fromUser);
+
+      provider.callCopyUserToOrganization(memberID, "newOrg", "fromOrg", svc, mock(Principal.class), null, true);
+
+      verify(svc).copyUserFavorites(memberID, new IdentityID("alice", "newOrg"), true);
    }
 
    // [Path B] fromUser found, defaultPassword given → new hash applied
@@ -667,7 +687,7 @@ class AbstractEditableAuthenticationProviderTest {
       fromUser.setOrganization("fromOrg");
       provider.stubUser(memberID, fromUser);
 
-      provider.callCopyUserToOrganization(memberID, "newOrg", "fromOrg", svc, mock(Principal.class), "newP@ssw0rd");
+      provider.callCopyUserToOrganization(memberID, "newOrg", "fromOrg", svc, mock(Principal.class), "newP@ssw0rd", false);
 
       User added = provider.getAddedUsers().get(0);
       assertNotEquals("oldHash", added.getPassword(), "Password must be re-hashed, not copied");
@@ -686,7 +706,7 @@ class AbstractEditableAuthenticationProviderTest {
       IdentityID memberID = new IdentityID("ghost", "fromOrg");
       // no user stubbed → getUser returns null
 
-      IdentityID result = provider.callCopyUserToOrganization(memberID, "newOrg", "fromOrg", svc, mock(Principal.class), null);
+      IdentityID result = provider.callCopyUserToOrganization(memberID, "newOrg", "fromOrg", svc, mock(Principal.class), null, false);
 
       assertEquals(1, provider.getAddedUsers().size());
       assertEquals("newOrg", provider.getAddedUsers().get(0).getIdentityID().orgID,
@@ -849,13 +869,13 @@ class AbstractEditableAuthenticationProviderTest {
 
       IdentityID callCopyUserToOrganization(IdentityID memberID, String orgID, String fromOrgID,
                                              IdentityService identityService, Principal principal,
-                                             String defaultPassword) {
+                                             String defaultPassword, boolean replace) {
          try {
             var m = AbstractEditableAuthenticationProvider.class.getDeclaredMethod(
                "copyUserToOrganization", IdentityID.class, String.class, String.class,
-               IdentityService.class, Principal.class, String.class);
+               IdentityService.class, Principal.class, String.class, boolean.class);
             m.setAccessible(true);
-            return (IdentityID) m.invoke(this, memberID, orgID, fromOrgID, identityService, principal, defaultPassword);
+            return (IdentityID) m.invoke(this, memberID, orgID, fromOrgID, identityService, principal, defaultPassword, replace);
          }
          catch(ReflectiveOperationException e) {
             throw new AssertionError("reflection failed: copyUserToOrganization", e);

--- a/core/src/test/java/inetsoft/web/admin/favorites/FavoritesServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/favorites/FavoritesServiceTest.java
@@ -128,6 +128,35 @@ class FavoritesServiceTest {
    }
 
    @Test
+   void copyFavorites_presentEntry_copiesToNewKeyWithoutRemovingSource() {
+      FavoriteList list = listOf(favorite("Users", "/settings/security/users"));
+      when(storage.get("alice~;~org1")).thenReturn(list);
+
+      service.copyFavorites("alice~;~org1", "alice~;~org2");
+
+      verify(storage).put("alice~;~org2", list);
+      verify(storage, never()).remove(anyString());
+   }
+
+   @Test
+   void copyFavorites_noEntry_doesNothing() {
+      when(storage.get("alice~;~org1")).thenReturn(null);
+
+      service.copyFavorites("alice~;~org1", "alice~;~org2");
+
+      verify(storage, never()).put(anyString(), any());
+   }
+
+   @Test
+   void copyFavorites_storageFailure_doesNotThrow() throws Exception {
+      when(storage.get("alice~;~org1"))
+         .thenReturn(listOf(favorite("Users", "/settings/security/users")));
+      when(storage.put(anyString(), any())).thenReturn(failing());
+
+      assertDoesNotThrow(() -> service.copyFavorites("alice~;~org1", "alice~;~org2"));
+   }
+
+   @Test
    void removeFavorites_identities_removesEachKey() {
       IdentityID alice = new IdentityID("alice", "org1");
       IdentityID bob = new IdentityID("bob", "org2");

--- a/core/src/test/java/inetsoft/web/admin/security/IdentityServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/security/IdentityServiceTest.java
@@ -168,6 +168,28 @@ class IdentityServiceTest {
    }
 
    @Test
+   void copyUserFavorites_replaceFalse_copiesFavoritesLeavingSourceIntact() {
+      IdentityID from = new IdentityID("alice", "org1");
+      IdentityID to = new IdentityID("alice", "org2");
+
+      service.copyUserFavorites(from, to, false);
+
+      verify(favoritesService).copyFavorites(from.convertToKey(), to.convertToKey());
+      verify(favoritesService, never()).moveFavorites(anyString(), anyString());
+   }
+
+   @Test
+   void copyUserFavorites_replaceTrue_movesFavorites() {
+      IdentityID from = new IdentityID("alice", "org1");
+      IdentityID to = new IdentityID("alice", "org2");
+
+      service.copyUserFavorites(from, to, true);
+
+      verify(favoritesService).moveFavorites(from.convertToKey(), to.convertToKey());
+      verify(favoritesService, never()).copyFavorites(anyString(), anyString());
+   }
+
+   @Test
    void getIdentityInfo_nullIdentity_returnsEmptyInfo() {
       IdentityID missing = new IdentityID("ghost", "org1");
       AuthenticationProvider provider = mock(AuthenticationProvider.class);


### PR DESCRIPTION
## Summary
- Organization clone/rename already copies each member's dashboards, permissions, and assets into the new org, but never copied their EM favorites (`FavoritesService`'s `emFavorites` KV store), so a newly cloned org's users always started with an empty favorites list.
- `copyUserToOrganization` now calls `IdentityService.copyUserFavorites(fromID, toID, replace)`, which moves the favorites entry on org rename and copies it (leaving the source intact) on clone.
- Added `FavoritesService.copyFavorites()` alongside the existing `moveFavorites()`/`removeFavorites()`.

## Test plan
- [x] `FavoritesServiceTest` — new `copyFavorites` unit tests (present entry, missing entry, storage failure)
- [x] `IdentityServiceTest` — new `copyUserFavorites` unit tests (replace=true moves, replace=false copies)
- [x] `AbstractEditableAuthenticationProviderTest` — new/updated `copyUserToOrganization` tests verifying favorites are moved/copied with the correct identity keys
- [x] Ran the full org-lifecycle regression suite (`PermissionMatrixOrgLifecycleTest`, `AbstractEditableAuthenticationProviderStaticDepTest`, `DashboardRegistryOrgLifecycleTest`, `OrgLifecycleRepletRegistryIntegrationTest`, `OrgLifecycleScopedPropertiesIntegrationTest`, `OrgLifecycleThemeOrchestrationTest`, `OrgLifecycleDataSpaceIntegrationTest`) — all pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)