### PR TITLE
Bug #75799, fix data missing when converting crosstab to freehand table

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/VSLayoutTool.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/VSLayoutTool.java
@@ -756,6 +756,15 @@ public class VSLayoutTool extends LayoutTool {
          return original;
       }
 
+      // aggrColName is itself a formula wrapping col unchanged (e.g. aggregating an
+      // upstream pre-aggregated worksheet column such as "Min(ftime)" produces the
+      // doubly-wrapped name "Min(Min(ftime))"). col is already the correct physical
+      // column name in that case, so stripping it down to the bare inner field
+      // ("ftime") would produce a lookup key that doesn't exist in the result table.
+      if(Tool.equals(col, getOriginalColumn(aggrColName))) {
+         return col;
+      }
+
       original = Tool.replaceAll(original, "[", "");
       original = Tool.replaceAll(original, "]", "");
 


### PR DESCRIPTION
## Summary
- Converting a crosstab whose aggregate is applied on top of an already pre-aggregated worksheet column (e.g. an embedded column literally named `Min(ftime)`) to a freehand table produced a table with only the header row.
- `VSLayoutTool.getAggregateColumn()` always stripped one layer of `formula(...)` wrapping off the cell value, assuming the physical result column is the bare base field name. That assumption breaks when the aggregate ref's own name is already formula-wrapped (e.g. `Min(Min(ftime))`), since the cell's unmodified value (`Min(ftime)`) is already the correct physical column name — stripping it further (`ftime`) produced a lookup key that doesn't exist in the result table, so the row never got data.
- Fixed by detecting when the aggregate ref's name is exactly a formula-wrap of the unmodified cell value, and returning the value unstripped in that case.

## Test plan
- [x] Reproduced with a crosstab built on a worksheet with pre-aggregated columns (`Min(ftime)`, `Concat(fecid)`), converted to freehand table — confirmed rows were missing before the fix.
- [x] Applied fix, rebuilt, reconverted — confirmed freehand table now shows all rows and grand total correctly.
- [x] Existing behavior for normal (non-nested) aggregates unaffected (equality check only triggers for the double-wrapped case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)