### PR TITLE
Bug #75795, honor the Roles root grant for org-scoped role permission checks

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/DefaultCheckPermissionStrategy.java
+++ b/core/src/main/java/inetsoft/sree/security/DefaultCheckPermissionStrategy.java
@@ -136,17 +136,29 @@ public class DefaultCheckPermissionStrategy implements CheckPermissionStrategy {
          String rootRole = Organization.getRootRoleName(principal);
          String rootOrgRole = Organization.getRootOrgRoleName(principal);
          Role role = provider.getRole(IdentityID.getIdentityIDFromKey(resource));
-         Permission rootRolePer = provider.getPermission(type, rootRole);
-         Permission rootOrgRolePer = provider.getPermission(type, rootOrgRole);
+         Permission orgRoleRootPer;
 
-         // "Roles" and "Organization Roles" are two independent grantable nodes in the EM
-         // security tree (see UserTreeService), so a grant on either root must be honored
-         // here — checking only one caused admins granted on the "Roles" root to be denied
-         // access to org-scoped roles, since only "Organization Roles" was consulted before.
-         if((role == null ||
+         if(role != null && role.getOrganizationID() != null) {
+            orgRoleRootPer = provider.getPermission(type, rootOrgRole);
+
+            // "Organization Roles" is only exposed as a grantable node in the EM tree when
+            // multi-tenant mode is on (see UserTreeService/SecurityTreeServer); when nobody
+            // has ever configured a grant on it (no Permission object at all -- not merely
+            // "doesn't grant this action"), fall back to the "Roles" root, the only node an
+            // admin has ever had the option to grant on. Once "Organization Roles" is
+            // actually in use, its grants take precedence and the roots stay independent
+            // (Bug #75574).
+            if(orgRoleRootPer == null) {
+               orgRoleRootPer = provider.getPermission(type, rootRole);
+            }
+         }
+         else {
+            orgRoleRootPer = provider.getPermission(type, rootRole);
+         }
+
+         if(orgRoleRootPer != null && (role == null ||
             Tool.equals(role.getOrganizationID(), OrganizationManager.getInstance().getCurrentOrgID())) &&
-            ((rootRolePer != null && checker.checkPermission(identity, rootRolePer, action, true)) ||
-             (rootOrgRolePer != null && checker.checkPermission(identity, rootOrgRolePer, action, true))))
+            checker.checkPermission(identity, orgRoleRootPer, action, true))
          {
             return true;
          }

--- a/core/src/main/java/inetsoft/sree/security/DefaultCheckPermissionStrategy.java
+++ b/core/src/main/java/inetsoft/sree/security/DefaultCheckPermissionStrategy.java
@@ -136,18 +136,17 @@ public class DefaultCheckPermissionStrategy implements CheckPermissionStrategy {
          String rootRole = Organization.getRootRoleName(principal);
          String rootOrgRole = Organization.getRootOrgRoleName(principal);
          Role role = provider.getRole(IdentityID.getIdentityIDFromKey(resource));
-         Permission orgRoleRootPer;
+         Permission rootRolePer = provider.getPermission(type, rootRole);
+         Permission rootOrgRolePer = provider.getPermission(type, rootOrgRole);
 
-         if(role != null && role.getOrganizationID() != null) {
-            orgRoleRootPer = provider.getPermission(type, rootOrgRole);
-         }
-         else {
-            orgRoleRootPer = provider.getPermission(type, rootRole);
-         }
-
-         if(orgRoleRootPer != null && (role == null ||
+         // "Roles" and "Organization Roles" are two independent grantable nodes in the EM
+         // security tree (see UserTreeService), so a grant on either root must be honored
+         // here — checking only one caused admins granted on the "Roles" root to be denied
+         // access to org-scoped roles, since only "Organization Roles" was consulted before.
+         if((role == null ||
             Tool.equals(role.getOrganizationID(), OrganizationManager.getInstance().getCurrentOrgID())) &&
-            checker.checkPermission(identity, orgRoleRootPer, action, true))
+            ((rootRolePer != null && checker.checkPermission(identity, rootRolePer, action, true)) ||
+             (rootOrgRolePer != null && checker.checkPermission(identity, rootOrgRolePer, action, true))))
          {
             return true;
          }


### PR DESCRIPTION
## Summary
- Fixes a `SecurityException` thrown when an EM user granted Administrator (ADMIN) permission only on the "Roles" root node tries to view/select an org-scoped role (e.g. a custom role in a non-default org while multi-tenancy is disabled).
- `DefaultCheckPermissionStrategy.checkPermission()` only consulted the `"Organization Roles"` permission root for org-scoped roles, never the `"Roles"` root, even though `"Roles"` is the node actually exposed for granting in non-multi-tenant mode (see `UserTreeService`). Now both roots are checked (OR), matching the pattern already used elsewhere for `SECURITY_ROLE` (e.g. `checkOrgAdminPermission`).

## Test plan
- [x] `./mvnw -pl core -am compile -DskipTests` passes
- [x] `./mvnw -pl core test -Dtest=DefaultCheckPermissionStrategyTest,RoleControllerTest` passes
- [ ] Manual repro per the reported steps: grant a non-admin EM user ADMIN on the "Roles" node only, confirm they can now open an org-scoped role without the SecurityException

🤖 Generated with [Claude Code](https://claude.com/claude-code)