### PR TITLE
Bug #75816, key extended data model objects consistently in the dependency index

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/LocalDependencyHandler.java
+++ b/core/src/main/java/inetsoft/uql/asset/LocalDependencyHandler.java
@@ -694,8 +694,13 @@ public class LocalDependencyHandler implements DependencyHandler {
          return;
       }
 
+      // an extended model is identified by "datasource/base model/extended model" so that it is
+      // not confused with a base model of the same name
+      XLogicalModel baseModel = lmodel.getBaseModel();
+      String modelPath = baseModel == null ? lmodel.getDataSource() + "/" + lmodel.getName() :
+         lmodel.getDataSource() + "/" + baseModel.getName() + "/" + lmodel.getName();
       AssetEntry entry = new AssetEntry(AssetRepository.QUERY_SCOPE, AssetEntry.Type.LOGIC_MODEL,
-         lmodel.getDataSource() + "/" + lmodel.getName(),null);
+         modelPath, null);
       String view = getAssetId(lmodel.getDataSource() + "/" + lmodel.getPartition(),
          AssetEntry.Type.PARTITION);
       updateModelDependencies(lmodel, entry, add);

--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryObjectService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryObjectService.java
@@ -368,13 +368,19 @@ public class RepositoryObjectService {
 
                            if(logicalModel != null) {
                               logicalModel.removeLogicalModel(extendModel);
+                              removeDataModelDependencies(
+                                 datasource + "/" + baseModel + "/" + extendModel,
+                                 AssetEntry.Type.LOGIC_MODEL, true);
                            }
                         }
                         else if(node.type() == RepositoryEntry.PARTITION) {
-                           XPartition physicalView = dataModel.getPartition(extendedModelPath[1]);
+                           XPartition physicalView = dataModel.getPartition(baseModel);
 
                            if(physicalView != null) {
-                              physicalView.removePartition(extendedModelPath[2]);
+                              physicalView.removePartition(extendModel);
+                              removeDataModelDependencies(
+                                 datasource + "/" + baseModel + "/" + extendModel,
+                                 AssetEntry.Type.PARTITION, true);
                            }
                         }
                      }

--- a/core/src/main/java/inetsoft/web/portal/controller/database/LogicalModelService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/LogicalModelService.java
@@ -589,7 +589,7 @@ public class LogicalModelService {
          dataModel.removeLogicalModel(name);
       }
 
-      String path = dataSource + "/" + name;
+      String path = isExtended ? dataSource + "/" + parent + "/" + name : dataSource + "/" + name;
       AssetEntry entry = new AssetEntry(AssetRepository.QUERY_SCOPE, AssetEntry.Type.LOGIC_MODEL,
          path, null);
       dependencyHandler.deleteDependencies(entry);

--- a/core/src/test/java/inetsoft/uql/asset/LocalDependencyHandlerTest.java
+++ b/core/src/test/java/inetsoft/uql/asset/LocalDependencyHandlerTest.java
@@ -1,0 +1,187 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.asset;
+
+/*
+ * General-purpose test file for LocalDependencyHandler. Add further scenarios for this class here
+ * rather than creating new per-scenario test classes -- keep each scenario's own rationale in a
+ * comment block right above its test method(s), the way the logical model scenario below does, so
+ * the file-level comment doesn't have to be rewritten every time a new scenario is added.
+ */
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.asset.sync.DependenciesInfo;
+import inetsoft.uql.asset.sync.DependencyStorageService;
+import inetsoft.uql.asset.sync.RenameTransformObject;
+import inetsoft.uql.erm.XEntity;
+import inetsoft.uql.erm.XLogicalModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class,
+                                  LocalDependencyHandlerTest.TestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+@SreeHome
+@Tag("core")
+class LocalDependencyHandlerTest {
+   /*
+    * DependencyStorageService is a @Service picked up by component scan in production, so it is not
+    * in the test context. The handler reaches it through the static
+    * DependencyStorageService.getInstance() -> ConfigurationContext.getSpringBean(), which throws
+    * when the bean is missing -- and the handler swallows that, silently writing nothing.
+    */
+   @Configuration
+   static class TestConfiguration {
+      @Bean
+      public DependencyStorageService dependencyStorageService() {
+         return mock(DependencyStorageService.class);
+      }
+   }
+
+   @BeforeEach
+   void setUp() {
+      // the context is cached across test methods, so drop the previous method's stubbing
+      reset(dependencyStorageService);
+      handler = new LocalDependencyHandler(mock(XRepository.class));
+   }
+
+   /*
+    * Bug #75816: an extended (child) logical model was registered under the flat
+    * "datasource/extended name" path, the same form a base model uses. Extended names come from
+    * additional connections and can collide with a base model's name, so the edge could be
+    * attributed to -- and later deleted from -- the wrong model. Extended models are identified by
+    * the three-segment "datasource/base name/extended name" path instead, matching what the delete
+    * paths clean up (RepositoryObjectService.deleteNodes(), LogicalModelService.removeModel()).
+    *
+    * The key side is unchanged: XLogicalModel.getPartition() returns the base model's partition for
+    * an extended model, so both register under the base physical view.
+    */
+   @Test
+   void baseLogicalModelIsRegisteredUnderItsOwnName() throws Exception {
+      handler.updateModelDependencies(logicalModel(null), true);
+
+      assertEquals(List.of(identifier(AssetEntry.Type.LOGIC_MODEL, LOGICAL_MODEL_NAME)),
+                   capturedDependencies(identifier(AssetEntry.Type.PARTITION,
+                                                   PHYSICAL_VIEW_NAME)));
+   }
+
+   @Test
+   void extendedLogicalModelIsQualifiedByItsBaseModel() throws Exception {
+      handler.updateModelDependencies(logicalModel(LOGICAL_MODEL_NAME), true);
+
+      assertEquals(List.of(identifier(AssetEntry.Type.LOGIC_MODEL,
+                                      LOGICAL_MODEL_NAME + "/" + EXTENDED_NAME)),
+                   capturedDependencies(identifier(AssetEntry.Type.PARTITION,
+                                                   PHYSICAL_VIEW_NAME)));
+   }
+
+   /*
+    * Removal has to name the extended model exactly the way registration did, otherwise the rename
+    * path leaves a stale edge behind.
+    */
+   @Test
+   void removingAnExtendedLogicalModelUsesTheSameQualifiedName() throws Exception {
+      DependenciesInfo stored = new DependenciesInfo();
+      AssetEntry extended = new AssetEntry(
+         AssetRepository.QUERY_SCOPE, AssetEntry.Type.LOGIC_MODEL,
+         DATA_SOURCE + "/" + LOGICAL_MODEL_NAME + "/" + EXTENDED_NAME, null);
+      stored.setDependencies(new ArrayList<>(List.of(extended)));
+      when(dependencyStorageService.get(identifier(AssetEntry.Type.PARTITION, PHYSICAL_VIEW_NAME)))
+         .thenReturn(stored);
+
+      handler.updateModelDependencies(logicalModel(LOGICAL_MODEL_NAME), false);
+
+      assertTrue(capturedDependencies(identifier(AssetEntry.Type.PARTITION, PHYSICAL_VIEW_NAME))
+                    .isEmpty(),
+                 "the extended model should no longer depend on the physical view");
+   }
+
+   /**
+    * Creates a logical model bound to {@link #PHYSICAL_VIEW_NAME}.
+    *
+    * @param baseName the name of the base model, or {@code null} for a base model.
+    */
+   private XLogicalModel logicalModel(String baseName) {
+      XLogicalModel model = mock(XLogicalModel.class);
+      when(model.getDataSource()).thenReturn(DATA_SOURCE);
+      when(model.getPartition()).thenReturn(PHYSICAL_VIEW_NAME);
+      when(model.getEntities()).thenReturn(Collections.enumeration(List.<XEntity>of()));
+
+      if(baseName == null) {
+         when(model.getName()).thenReturn(LOGICAL_MODEL_NAME);
+      }
+      else {
+         XLogicalModel base = mock(XLogicalModel.class);
+         when(base.getName()).thenReturn(baseName);
+         when(model.getName()).thenReturn(EXTENDED_NAME);
+         when(model.getBaseModel()).thenReturn(base);
+      }
+
+      return model;
+   }
+
+   private String identifier(AssetEntry.Type type, String name) {
+      return new AssetEntry(AssetRepository.QUERY_SCOPE, type, DATA_SOURCE + "/" + name, null)
+         .toIdentifier();
+   }
+
+   /**
+    * @return the identifiers of the assets stored as dependents of the given key.
+    */
+   private List<String> capturedDependencies(String key) throws Exception {
+      ArgumentCaptor<RenameTransformObject> captor =
+         ArgumentCaptor.forClass(RenameTransformObject.class);
+      verify(dependencyStorageService).put(eq(key), captor.capture());
+
+      return ((DependenciesInfo) captor.getValue()).getDependencies().stream()
+         .map(asset -> ((AssetEntry) asset).toIdentifier())
+         .toList();
+   }
+
+   private LocalDependencyHandler handler;
+   @Autowired private DependencyStorageService dependencyStorageService;
+
+   private static final String DATA_SOURCE = "Derby Embedded";
+   private static final String PHYSICAL_VIEW_NAME = "physicalView";
+   private static final String LOGICAL_MODEL_NAME = "logicalModel";
+   private static final String EXTENDED_NAME = "additionalConnection";
+}

--- a/core/src/test/java/inetsoft/web/admin/content/repository/RepositoryObjectServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/repository/RepositoryObjectServiceTest.java
@@ -49,6 +49,7 @@ import inetsoft.uql.erm.XDataModel;
 import inetsoft.uql.erm.XLogicalModel;
 import inetsoft.uql.erm.XPartition;
 import inetsoft.uql.service.DataSourceRegistry;
+import inetsoft.uql.util.XUtil;
 import inetsoft.util.ThreadContext;
 import inetsoft.web.RecycleBin;
 import inetsoft.web.admin.content.database.model.DataModelFolderManagerService;
@@ -235,6 +236,82 @@ class RepositoryObjectServiceTest {
       verify(dependencyHandler, never()).deleteDependenciesKey(any());
    }
 
+   /*
+    * Bug #75816: the extended (child) logical model / physical view branch of deleteNodes() did no
+    * dependency cleanup at all, so the #75783 fix stopped one level short.
+    *
+    * An extended object is identified by the three-segment "datasource/base name/extended name"
+    * path -- the form used everywhere else the dependency index names one, e.g.
+    * LocalDependencyHandler.getModelPath() when a backup schedule task references it, and
+    * PhysicalModelManagerService.removeModel() in the portal. The flat "datasource/name" form used
+    * for base objects cannot be used here: an extended name may collide with a base object's name,
+    * in which case the cleanup would strip the *base* object's dependency information instead.
+    */
+   @Test
+   void deleteExtendedLogicalModelRemovesDependencyEdgeAndKey() throws Exception {
+      XLogicalModel logicalModel = mock(XLogicalModel.class);
+      when(dataModel.getLogicalModel(LOGICAL_MODEL_NAME)).thenReturn(logicalModel);
+
+      TreeNodeInfo node = TreeNodeInfo.builder()
+         .label(EXTENDED_NAME)
+         .path(DATA_SOURCE + "^" + LOGICAL_MODEL_NAME + "^" + EXTENDED_NAME)
+         .type(RepositoryEntry.LOGIC_MODEL)
+         .build();
+
+      service.deleteNodes(new TreeNodeInfo[]{ node }, principal, false, false);
+
+      verify(logicalModel).removeLogicalModel(EXTENDED_NAME);
+      String expected = identifier(
+         AssetEntry.Type.LOGIC_MODEL, LOGICAL_MODEL_NAME + "/" + EXTENDED_NAME);
+      assertEquals(expected, capturedDeletedDependency());
+      assertEquals(expected, capturedDeletedDependencyKey());
+   }
+
+   @Test
+   void deleteExtendedPhysicalViewRemovesDependencyEdgeAndKey() throws Exception {
+      XPartition physicalView = mock(XPartition.class);
+      when(dataModel.getPartition(PHYSICAL_VIEW_NAME)).thenReturn(physicalView);
+
+      TreeNodeInfo node = TreeNodeInfo.builder()
+         .label(EXTENDED_NAME)
+         .path(DATA_SOURCE + "^" + PHYSICAL_VIEW_NAME + "^" + EXTENDED_NAME)
+         .type(RepositoryEntry.PARTITION)
+         .build();
+
+      service.deleteNodes(new TreeNodeInfo[]{ node }, principal, false, false);
+
+      verify(physicalView).removePartition(EXTENDED_NAME);
+      String expected = identifier(
+         AssetEntry.Type.PARTITION, PHYSICAL_VIEW_NAME + "/" + EXTENDED_NAME);
+      assertEquals(expected, capturedDeletedDependency());
+      assertEquals(expected, capturedDeletedDependencyKey());
+   }
+
+   /*
+    * The data model folder is not part of the dependency path: node.path() carries it as a
+    * "datasource^__^folder" prefix, but the identifier stays "datasource/base name/extended name".
+    */
+   @Test
+   void deleteExtendedLogicalModelInFolderIgnoresTheFolderSegment() throws Exception {
+      XLogicalModel logicalModel = mock(XLogicalModel.class);
+      when(dataModel.getLogicalModel(LOGICAL_MODEL_NAME)).thenReturn(logicalModel);
+
+      TreeNodeInfo node = TreeNodeInfo.builder()
+         .label(EXTENDED_NAME)
+         .path(DATA_SOURCE + XUtil.DATAMODEL_FOLDER_SPLITER + MODEL_FOLDER + "^" +
+                  LOGICAL_MODEL_NAME + "^" + EXTENDED_NAME)
+         .type(RepositoryEntry.LOGIC_MODEL)
+         .build();
+
+      service.deleteNodes(new TreeNodeInfo[]{ node }, principal, false, false);
+
+      verify(logicalModel).removeLogicalModel(EXTENDED_NAME);
+      String expected = identifier(
+         AssetEntry.Type.LOGIC_MODEL, LOGICAL_MODEL_NAME + "/" + EXTENDED_NAME);
+      assertEquals(expected, capturedDeletedDependency());
+      assertEquals(expected, capturedDeletedDependencyKey());
+   }
+
    private String identifier(AssetEntry.Type type, String name) {
       return new AssetEntry(AssetRepository.QUERY_SCOPE, type, DATA_SOURCE + "/" + name, null)
          .toIdentifier();
@@ -265,4 +342,6 @@ class RepositoryObjectServiceTest {
    private static final String VPM_NAME = "vpm";
    private static final String PHYSICAL_VIEW_NAME = "physicalView";
    private static final String LOGICAL_MODEL_NAME = "logicalModel";
+   private static final String EXTENDED_NAME = "additionalConnection";
+   private static final String MODEL_FOLDER = "modelFolder";
 }


### PR DESCRIPTION
## Summary

Follow-up to #75783 (PR #4415), which cleaned up the reverse dependency index in `DependencyStorageService` when a base VPM, physical view or logical model is deleted. Extended (child) logical models and physical views were deliberately left out of that fix because they were named two different ways in the index, and picking one had to be settled across registration, lookup and cleanup at once.

## Root Cause

The dependency index is keyed on `AssetEntry.toIdentifier()`. Extended objects appeared in it in two inconsistent path forms:

- **`datasource/base name/extended name`**, with the plain `LOGIC_MODEL` / `PARTITION` type. This is what the rename transform already *looks up* — `DependencyTransformer.createExtendModelDependencyInfo()` and `createExtendPartitionsDependencyInfo()` — what `LocalDependencyHandler.getModelPath()` *registers* when a backup schedule task references an extended object, and what `PhysicalModelManagerService.removeModel()` already *removes*.
- **`datasource/name`** (flat), written by the one outlier, `LocalDependencyHandler.updateModelDependencies(XLogicalModel, boolean)`.

The flat form cannot identify an extended object. Extended names come from additional connections and may collide with a base object's name, in which case the edge is attributed to — and later deleted from — the wrong object.

On top of that, `RepositoryObjectService.deleteNodes()` did no dependency cleanup at all for extended objects: they are handled in a separate branch that #75783 never touched, so a deleted extended object's index entry survived forever.

## Fix

Settle on `datasource/base name/extended name` with the plain `LOGIC_MODEL` / `PARTITION` types, and make all three sides agree:

- `LocalDependencyHandler.updateModelDependencies()` qualifies an extended model with its base model name. The key side is unchanged, because `XLogicalModel.getPartition()` already returns the base model's physical view for an extended model.
- `LogicalModelService.removeModel()` removes the extended path instead of the base-name path, mirroring `PhysicalModelManagerService.removeModel()`.
- `RepositoryObjectService.deleteNodes()` calls the `removeDataModelDependencies()` helper added by #75783 for extended logical models and physical views.

`PhysicalModelManagerService.removeModel()` is unchanged — its path form was already the canonical one.

Note on existing data: edges already stored in the flat form are not also deleted. Doing so would reintroduce exactly the base-model collision this change removes. They are superseded the next time the model is saved.

## Test Plan

Added regression tests that pin the identifier form, which is what silently drifts:

- `LocalDependencyHandlerTest` (new): a base model registers under its own name; an extended model is qualified by its base model; removal names the extended model the same way registration did.
- `RepositoryObjectServiceTest`: EM deletion of an extended logical model and an extended physical view removes both the dependency edge and the key, with the three-segment identifier; a data model folder in the tree path does not leak into that identifier.

Manual verification: create a data source with an additional connection, delete the resulting extended physical view and extended logical model from both EM > Content and the portal data page, and confirm no stale dependency warnings — and that deleting base VPMs, physical views and logical models still behaves as it did after #75783.

`./mvnw test -pl core`: 4243 tests, 0 failures, 0 errors, 66 skipped.

Fixes Redmine #75816.