### PR TITLE
75640, point chart (and line) not animating properly while in facet graph

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -140,9 +140,11 @@ public class SVGAnimationDOMInjector {
          double lastBarDelay = injectBarAnimationFromAnnotations(annotBars, svgRoot, doc, fadeOnly);
          animated = true;
 
-         // Pareto charts have both bars and a cumulative-% line.  Animate the line after the
-         // last bar finishes (no ghost fill, no stagger — typically exactly one line).
          List<Element> annotLines = collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_LINE);
+
+         // Pareto charts have both bars and a cumulative-% line.  Animate the line after the
+         // last bar finishes (no ghost fill, no stagger — typically exactly one line): it reads
+         // as a summary of the bars, so it should not appear until they are all there.
          List<Element> paretoLines = annotLines.stream()
             .filter(g -> "true".equals(g.getAttribute("data-" + SVGSupport.ATTR_PARETO)))
             .toList();
@@ -152,8 +154,24 @@ public class SVGAnimationDOMInjector {
             injectParetoLineAnimation(paretoLines, svgRoot, doc, lineDelay);
          }
 
-         // Gantt charts have interval bars plus a milestone point marker (a separate PointElement).
-         // Fade the milestones in after the last bar finishes, matching the bar-label timing.
+         // Multi-style charts bind one chart type per measure, so a single VGraph can hold BarVO
+         // together with LineVO / PointVO (in the same panel or, for a facet, in a panel of their
+         // own).  hasBarVO wins over hasLineVO/hasPointVO when the hint is chosen, so the line and
+         // point branches are never taken and those measures would otherwise render with no
+         // animation at all.  They are independent measures, not a summary of the bars, so they
+         // animate on their own timeline starting with the bars — exactly as they would in a
+         // standalone line or point chart.
+         List<Element> comboLines = annotLines.stream()
+            .filter(g -> !"true".equals(g.getAttribute("data-" + SVGSupport.ATTR_PARETO)))
+            .toList();
+
+         if(!comboLines.isEmpty()) {
+            injectComboLineAnimation(comboLines, svgRoot, doc);
+         }
+
+         // Gantt charts have interval bars plus a milestone point marker (a separate
+         // PointElement).  A milestone marks the end of its bar, so unlike a multi-style point
+         // measure it does fade in after the last bar finishes, matching the bar-label timing.
          // The base hint is the first token and ":" is the separator, so a ":gantt" substring
          // match is unambiguous (no base hint or other flag contains "gantt").
          if(animHint.contains(":" + SVGSupport.ANIMATION_FLAG_GANTT)) {
@@ -175,6 +193,12 @@ public class SVGAnimationDOMInjector {
             for(Element label : milestoneLabels) {
                applyAnimStyleToChildren(label, milestoneAnimStyle);
             }
+         }
+         // Point measures of a multi-style chart: same staggered largest-first fade a standalone
+         // point chart gets, so the markers appear alongside the bars.  Guarded so a plain bar
+         // chart does not get the unused point keyframe appended to its <defs>.
+         else if(!collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_POINT).isEmpty()) {
+            injectPointAnimation(svgRoot, doc);
          }
       }
 
@@ -1119,7 +1143,8 @@ public class SVGAnimationDOMInjector {
     * (they are visual artifacts regardless of dash state).
     *
     * <p>This helper is shared by {@link #injectLineAnimationFromAnnotations} (line/area charts)
-    * and {@link #injectParetoLineAnimation} (Pareto overlay line) so timing constants and
+    * {@link #injectComboLineAnimation} (multi-style line measures) and
+    * {@link #injectParetoLineAnimation} (Pareto overlay line) so timing constants and
     * keyframe names stay in one place.
     */
    private static void applyLineDrawAnimation(Element g, Element path, double delay) {
@@ -1175,6 +1200,48 @@ public class SVGAnimationDOMInjector {
          }
 
          applyLineDrawAnimation(g, path, lineDelay);
+      }
+   }
+
+   /**
+    * Animate the line measures of a multi-style chart (bar + line bound to different measures)
+    * with the same draw-on effect and per-series stagger a standalone line chart uses, starting
+    * with the bars rather than after them — a line measure is its own series, not a summary of
+    * the bars.
+    *
+    * <p>Series rank uses the composite {@code data-series|data-color} key for the same reason as
+    * {@link #injectLineAnimationFromAnnotations}: {@code data-series} alone collapses when one
+    * measure is split by a color dimension.  Ghost fill is intentionally omitted — a fill under
+    * the line would obscure the bars it overlays.
+    */
+   private static void injectComboLineAnimation(List<Element> comboLines,
+                                                Element svgRoot, Document doc)
+   {
+      appendStyle(svgRoot, doc,
+         "@keyframes inetsoft-line-draw{from{stroke-dashoffset:var(--len,2000)}to{stroke-dashoffset:0}}" +
+         "@keyframes inetsoft-line-wipe{from{clip-path:inset(0 100% 0 0)}to{clip-path:inset(0 0% 0 0)}}");
+
+      Map<String, Integer> seriesRank = new LinkedHashMap<>();
+
+      for(Element g : comboLines) {
+         String key = g.getAttribute("data-" + SVGSupport.ATTR_SERIES) + "|" +
+                      g.getAttribute("data-" + SVGSupport.ATTR_COLOR);
+         seriesRank.putIfAbsent(key, seriesRank.size());
+      }
+
+      int numSeries = seriesRank.size();
+
+      for(Element g : comboLines) {
+         Element path = firstDescendantPath(g);
+
+         if(path == null) {
+            continue;
+         }
+
+         String key = g.getAttribute("data-" + SVGSupport.ATTR_SERIES) + "|" +
+                      g.getAttribute("data-" + SVGSupport.ATTR_COLOR);
+         double delay = AnimationConstants.staggerDelay(seriesRank.getOrDefault(key, 0), numSeries);
+         applyLineDrawAnimation(g, path, delay);
       }
    }
 

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -142,6 +142,14 @@ public class SVGAnimationDOMInjector {
 
          List<Element> annotLines = collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_LINE);
 
+         // Both line helpers below use the same draw-on/wipe keyframes and can run in the same
+         // invocation (a chart with a Pareto line and an unrelated multi-style line measure), so
+         // the keyframes are emitted here exactly once.  Guarded on annotLines so a plain bar
+         // chart is not given line CSS it never references.
+         if(!annotLines.isEmpty()) {
+            appendLineDrawKeyframes(svgRoot, doc);
+         }
+
          // Pareto charts have both bars and a cumulative-% line.  Animate the line after the
          // last bar finishes (no ghost fill, no stagger — typically exactly one line): it reads
          // as a summary of the bars, so it should not appear until they are all there.
@@ -1179,19 +1187,28 @@ public class SVGAnimationDOMInjector {
    }
 
    /**
+    * Append the draw-on / wipe keyframes shared by every line animation.  Callers that can run
+    * more than once per {@link #injectAnimation} invocation (the Pareto and multi-style line
+    * helpers) rely on their caller emitting this once, so the SVG carries a single copy.
+    */
+   private static void appendLineDrawKeyframes(Element svgRoot, Document doc) {
+      appendStyle(svgRoot, doc,
+         "@keyframes inetsoft-line-draw{from{stroke-dashoffset:var(--len,2000)}to{stroke-dashoffset:0}}" +
+         "@keyframes inetsoft-line-wipe{from{clip-path:inset(0 100% 0 0)}to{clip-path:inset(0 0% 0 0)}}");
+   }
+
+   /**
     * Animate the Pareto cumulative-% line using a stroke-dashoffset draw-on effect.
     * Called from the bar-animation branch so bars animate first; the line begins drawing
     * only after the last bar has finished.  Ghost fill is intentionally omitted — the Pareto
     * line reads as a reference curve, not a data series.
+    *
+    * <p>The caller must have emitted the keyframes via {@link #appendLineDrawKeyframes}.
     */
    private static void injectParetoLineAnimation(List<Element> paretoLines,
                                                   Element svgRoot, Document doc,
                                                   double lineDelay)
    {
-      appendStyle(svgRoot, doc,
-         "@keyframes inetsoft-line-draw{from{stroke-dashoffset:var(--len,2000)}to{stroke-dashoffset:0}}" +
-         "@keyframes inetsoft-line-wipe{from{clip-path:inset(0 100% 0 0)}to{clip-path:inset(0 0% 0 0)}}");
-
       for(Element g : paretoLines) {
          Element path = firstDescendantPath(g);
 
@@ -1209,26 +1226,17 @@ public class SVGAnimationDOMInjector {
     * with the bars rather than after them — a line measure is its own series, not a summary of
     * the bars.
     *
-    * <p>Series rank uses the composite {@code data-series|data-color} key for the same reason as
+    * <p>Series rank comes from {@link #buildSeriesRank} for the same reason as
     * {@link #injectLineAnimationFromAnnotations}: {@code data-series} alone collapses when one
     * measure is split by a color dimension.  Ghost fill is intentionally omitted — a fill under
     * the line would obscure the bars it overlays.
+    *
+    * <p>The caller must have emitted the keyframes via {@link #appendLineDrawKeyframes}.
     */
    private static void injectComboLineAnimation(List<Element> comboLines,
                                                 Element svgRoot, Document doc)
    {
-      appendStyle(svgRoot, doc,
-         "@keyframes inetsoft-line-draw{from{stroke-dashoffset:var(--len,2000)}to{stroke-dashoffset:0}}" +
-         "@keyframes inetsoft-line-wipe{from{clip-path:inset(0 100% 0 0)}to{clip-path:inset(0 0% 0 0)}}");
-
-      Map<String, Integer> seriesRank = new LinkedHashMap<>();
-
-      for(Element g : comboLines) {
-         String key = g.getAttribute("data-" + SVGSupport.ATTR_SERIES) + "|" +
-                      g.getAttribute("data-" + SVGSupport.ATTR_COLOR);
-         seriesRank.putIfAbsent(key, seriesRank.size());
-      }
-
+      Map<String, Integer> seriesRank = buildSeriesRank(comboLines);
       int numSeries = seriesRank.size();
 
       for(Element g : comboLines) {
@@ -1238,11 +1246,35 @@ public class SVGAnimationDOMInjector {
             continue;
          }
 
-         String key = g.getAttribute("data-" + SVGSupport.ATTR_SERIES) + "|" +
-                      g.getAttribute("data-" + SVGSupport.ATTR_COLOR);
-         double delay = AnimationConstants.staggerDelay(seriesRank.getOrDefault(key, 0), numSeries);
+         double delay = AnimationConstants.staggerDelay(
+            seriesRank.getOrDefault(seriesKey(g), 0), numSeries);
          applyLineDrawAnimation(g, path, delay);
       }
+   }
+
+   /**
+    * Rank line annotation groups into stagger order: composite {@code data-series|data-color} key
+    * → 0-based rank in DOM first-seen order.
+    *
+    * <p>{@code data-series} alone ({@code getColIndex()}) collapses when one measure is split by a
+    * color/group dimension — all those LineVO share the same measure column index, so every line
+    * would rank 0 and animate at once.  Adding {@code data-color} distinguishes color-dimension
+    * series, while {@code data-series} still separates distinct measures that share a color.
+    */
+   private static Map<String, Integer> buildSeriesRank(List<Element> lineGroups) {
+      Map<String, Integer> rank = new LinkedHashMap<>();
+
+      for(Element g : lineGroups) {
+         rank.putIfAbsent(seriesKey(g), rank.size());
+      }
+
+      return rank;
+   }
+
+   /** The composite {@code data-series|data-color} stagger key of a line annotation group. */
+   private static String seriesKey(Element g) {
+      return g.getAttribute("data-" + SVGSupport.ATTR_SERIES) + "|" +
+             g.getAttribute("data-" + SVGSupport.ATTR_COLOR);
    }
 
    private static void injectLineAnimation(Element svgRoot, Document doc) {
@@ -1266,19 +1298,10 @@ public class SVGAnimationDOMInjector {
                                                             List<Element> annotAreas,
                                                             Element svgRoot, Document doc)
    {
-      // Line rank: composite data-series + data-color key, first-seen DOM order → 0-based rank.
-      // data-series alone (getColIndex()) collapses when one measure is split by a color/group
-      // dimension — all those LineVO share the same measure column index, so every line would
-      // rank 0 and animate at once (the same problem documented for area below).  Adding
-      // data-color distinguishes color-dimension series, while data-series still separates
-      // distinct measures that happen to share a color.
-      Map<String, Integer> lineSeriesRank = new LinkedHashMap<>();
-
-      for(Element g : annotLines) {
-         String key = g.getAttribute("data-" + SVGSupport.ATTR_SERIES) + "|" +
-                      g.getAttribute("data-" + SVGSupport.ATTR_COLOR);
-         lineSeriesRank.putIfAbsent(key, lineSeriesRank.size());
-      }
+      // Line rank: composite data-series + data-color key, first-seen DOM order → 0-based rank
+      // (see buildSeriesRank for why data-series alone is not enough — the same problem is
+      // documented for area below).
+      Map<String, Integer> lineSeriesRank = buildSeriesRank(annotLines);
 
       // Area rank: data-color in DOM first-seen order.
       // AreaVO.getColIndex() is unreliable for ordering — in stacked area charts all AreaVO
@@ -1326,9 +1349,7 @@ public class SVGAnimationDOMInjector {
             seriesIdx = areaColorRank.getOrDefault(color, 0);
          }
          else {
-            String key = g.getAttribute("data-" + SVGSupport.ATTR_SERIES) + "|" +
-                         g.getAttribute("data-" + SVGSupport.ATTR_COLOR);
-            seriesIdx = lineSeriesRank.getOrDefault(key, 0);
+            seriesIdx = lineSeriesRank.getOrDefault(seriesKey(g), 0);
          }
 
          double delay = AnimationConstants.staggerDelay(seriesIdx, numSeries);

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -1660,6 +1660,76 @@ class SVGAnimationDOMInjectorTest {
                  "the Pareto line must draw only after the last bar finishes");
    }
 
+   /**
+    * Both bar-branch line helpers use the same draw-on/wipe keyframes and can run in one
+    * injection (a Pareto line plus an unrelated multi-style line measure), so the keyframes must
+    * be emitted exactly once.  A bar chart with no lines at all must not carry them.
+    */
+   @Test
+   void combo_lineKeyframesEmittedOnce() throws Exception {
+      Document doc = newDocument();
+      addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR,
+                    Map.of("row", "0", "col", "0", "orient", "v"),
+                    0, 0, 50, 200);
+      addLineAnnot(doc, "1", "60,105,138", "M 0 100 L 100 50 L 200 20", true);   // Pareto
+      addLineAnnot(doc, "2", "200,100,50", "M 0 90 L 100 60 L 200 70", false);   // multi-style
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_GROW);
+
+      assertEquals(1, countOccurrences(allStyleContent(doc.getDocumentElement()),
+                                       "@keyframes inetsoft-line-draw"),
+                   "the shared line keyframes must be emitted exactly once");
+
+      // A plain bar chart references no line keyframes, so it must not be given any.
+      Document barOnly = newDocument();
+      addAnnotGroup(barOnly, SVGSupport.ANNOTATION_BAR,
+                    Map.of("row", "0", "col", "0", "orient", "v"),
+                    0, 0, 50, 200);
+      SVGAnimationDOMInjector.injectAnimation(barOnly.getDocumentElement(), SVGSupport.ANIMATION_GROW);
+
+      assertEquals(0, countOccurrences(allStyleContent(barOnly.getDocumentElement()),
+                                       "@keyframes inetsoft-line-draw"),
+                   "a bar chart with no line series must not carry line keyframes");
+   }
+
+   /**
+    * Adds a LineVO-shaped annotation group (outer g → inner g → path) to the SVG root.
+    *
+    * @return the line's {@code <path>} element
+    */
+   private static Element addLineAnnot(Document doc, String series, String color, String d,
+                                       boolean pareto)
+   {
+      Element lineAnnot = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
+      lineAnnot.setAttribute("class", SVGSupport.ANNOTATION_LINE);
+      lineAnnot.setAttribute("data-series", series);
+      lineAnnot.setAttribute("data-color", color);
+
+      if(pareto) {
+         lineAnnot.setAttribute("data-" + SVGSupport.ATTR_PARETO, "true");
+      }
+
+      Element lineInner = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
+      Element linePath = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "path");
+      linePath.setAttribute("d", d);
+      linePath.setAttribute("fill", "none");
+      lineInner.appendChild(linePath);
+      lineAnnot.appendChild(lineInner);
+      doc.getDocumentElement().appendChild(lineAnnot);
+      return linePath;
+   }
+
+   /** Number of non-overlapping occurrences of {@code needle} in {@code haystack}. */
+   private static int countOccurrences(String haystack, String needle) {
+      int count = 0;
+
+      for(int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) {
+         count++;
+      }
+
+      return count;
+   }
+
    // -------------------------------------------------------------------------
    // Faceted pie animation tests
    // -------------------------------------------------------------------------

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -1541,24 +1541,123 @@ class SVGAnimationDOMInjectorTest {
    }
 
    /**
-    * A combo bar+point chart (plain {@code grow} hint, no gantt flag) must NOT animate its
-    * point overlay — the milestone fade is strictly gated on the gantt flag.
+    * A multi-style bar+point chart carries the plain {@code grow} hint (hasBarVO wins over
+    * hasPointVO when the hint is chosen), so the point branch is never taken.  The point measure
+    * must still get the standalone point animation — staggered largest-first, starting with the
+    * bars rather than queued behind them (Redmine #75640).
     */
    @Test
-   void combo_barPoint_noGanttFlag_pointsNotAnimated() throws Exception {
+   void combo_barPoint_pointsAnimateWithBars() throws Exception {
       Document doc = newDocument();
-      addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR,
-                    Map.of("row", "0", "col", "0", "orient", "v"),
-                    0, 0, 50, 200);
-      Element point = addAnnotGroup(doc, SVGSupport.ANNOTATION_POINT,
-                                    Map.of("row", "0", "col", "0", "size", "9"),
-                                    20, 20, 10, 10);
+      Element bar0 = addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR,
+                                   Map.of("row", "0", "col", "0", "orient", "v"),
+                                   0, 0, 50, 200);
+      Element bar1 = addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR,
+                                   Map.of("row", "1", "col", "0", "orient", "v"),
+                                   100, 0, 50, 200);
+      Element small = addAnnotGroup(doc, SVGSupport.ANNOTATION_POINT,
+                                    Map.of("row", "0", "col", "2", "size", "4"),
+                                    20, 20, 8, 8);
+      Element large = addAnnotGroup(doc, SVGSupport.ANNOTATION_POINT,
+                                    Map.of("row", "1", "col", "2", "size", "14"),
+                                    120, 20, 28, 28);
 
       SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_GROW);
 
-      String pointStyle = firstChildStyle(point);
-      assertTrue(pointStyle == null || pointStyle.isEmpty(),
-                 "combo chart point overlay must not receive a fade without the gantt flag");
+      String largeStyle = firstChildStyle(large);
+      assertNotNull(largeStyle, "combo chart point measure must receive an animation style");
+      assertTrue(largeStyle.contains("inetsoft-point-fade"),
+                 "combo chart points must use the standalone point fade keyframe");
+
+      // Largest-first stagger, same as a standalone point chart.
+      double largeDelay = parseDelay(largeStyle);
+      double smallDelay = parseDelay(firstChildStyle(small));
+      assertEquals(0.0, largeDelay, 0.01, "largest point must start immediately");
+      assertTrue(smallDelay > largeDelay, "smaller point must follow the larger one");
+
+      // The points must animate alongside the bars, not after them.
+      double lastBarDelay = Math.max(parseDelay(firstChildStyle(bar0)),
+                                     parseDelay(firstChildStyle(bar1)));
+      assertTrue(largeDelay < lastBarDelay,
+                 "combo chart points must start before the last bar, not after all bars finish");
+   }
+
+   /**
+    * A multi-style bar+line chart also carries the plain {@code grow} hint, so its line series
+    * never reach injectLineAnimation.  The line must draw on starting with the bars (unlike the
+    * Pareto line, which is a summary of the bars and waits for them).
+    */
+   @Test
+   void combo_barLine_lineDrawsWithBars() throws Exception {
+      Document doc = newDocument();
+      Element bar0 = addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR,
+                                   Map.of("row", "0", "col", "0", "orient", "v"),
+                                   0, 0, 50, 200);
+      Element bar1 = addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR,
+                                   Map.of("row", "1", "col", "0", "orient", "v"),
+                                   100, 0, 50, 200);
+
+      // Line annotation group: outer g → inner g → path (LineVO's rendering structure).
+      Element lineAnnot = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
+      lineAnnot.setAttribute("class", SVGSupport.ANNOTATION_LINE);
+      lineAnnot.setAttribute("data-series", "1");
+      lineAnnot.setAttribute("data-color", "60,105,138");
+      Element lineInner = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
+      Element linePath = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "path");
+      linePath.setAttribute("d", "M 0 100 L 100 50 L 200 80");
+      linePath.setAttribute("fill", "none");
+      lineInner.appendChild(linePath);
+      lineAnnot.appendChild(lineInner);
+      doc.getDocumentElement().appendChild(lineAnnot);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_GROW);
+
+      String lineStyle = linePath.getAttribute("style");
+      assertTrue(lineStyle.contains("inetsoft-line-draw"),
+                 "combo chart line must receive the draw-on animation");
+      assertEquals(0.0, parseDelay(lineStyle), 0.01,
+                   "the only line series must start drawing immediately, with the first bar");
+
+      double lastBarDelay = Math.max(parseDelay(firstChildStyle(bar0)),
+                                     parseDelay(firstChildStyle(bar1)));
+      assertTrue(parseDelay(lineStyle) < lastBarDelay,
+                 "combo chart line must not wait for all bars to finish");
+   }
+
+   /**
+    * The Pareto cumulative-% line is flagged with {@code data-pareto} and keeps its
+    * after-the-bars timing — it summarizes the bars, so it must not draw alongside them.
+    */
+   @Test
+   void pareto_lineDrawsAfterBars() throws Exception {
+      Document doc = newDocument();
+      Element bar0 = addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR,
+                                   Map.of("row", "0", "col", "0", "orient", "v"),
+                                   0, 0, 50, 200);
+      Element bar1 = addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR,
+                                   Map.of("row", "1", "col", "0", "orient", "v"),
+                                   100, 0, 50, 200);
+
+      Element lineAnnot = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
+      lineAnnot.setAttribute("class", SVGSupport.ANNOTATION_LINE);
+      lineAnnot.setAttribute("data-series", "1");
+      lineAnnot.setAttribute("data-color", "60,105,138");
+      lineAnnot.setAttribute("data-" + SVGSupport.ATTR_PARETO, "true");
+      Element lineInner = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
+      Element linePath = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "path");
+      linePath.setAttribute("d", "M 0 100 L 100 50 L 200 20");
+      linePath.setAttribute("fill", "none");
+      lineInner.appendChild(linePath);
+      lineAnnot.appendChild(lineInner);
+      doc.getDocumentElement().appendChild(lineAnnot);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_GROW);
+
+      double lastBarDelay = Math.max(parseDelay(firstChildStyle(bar0)),
+                                     parseDelay(firstChildStyle(bar1)));
+      assertTrue(parseDelay(linePath.getAttribute("style"))
+                    >= lastBarDelay + AnimationConstants.DURATION - 0.01,
+                 "the Pareto line must draw only after the last bar finishes");
    }
 
    // -------------------------------------------------------------------------


### PR DESCRIPTION
Root Cause:
A multi-style chart binds a chart type per measure, so one VGraph can hold BarVO together with PointVO / LineVO (in the same panel, or in its own panel when faceted).

VGraphPair.applyAnimationHint picks a single, mutually-exclusive animation hint for the tile, and hasBarVO is tested before hasLineVO / hasPointVO. A chart with any bar measure therefore always gets the "grow" hint, so only the bar branch of SVGAnimationDOMInjector.injectAnimation runs. That branch animated the bars, the bar value labels, the Pareto cumulative-% line, and - only when the ":gantt" flag was present - point markers. The .inetsoft-point and non-Pareto .inetsoft-line groups of a multi-style chart received no animation style at all, so those measures were painted at full opacity on the first frame while the bars faded in.

Fix:
The bar branch now animates the other measures of a multi-style chart on their own timeline, starting together with the bars, so each measure animates exactly as it would in a standalone chart:

- Point measures get injectPointAnimation - the same largest-first staggered fade a standalone point chart uses, beginning at t=0 (guarded so a plain bar chart is unaffected).
- Line measures get a new injectComboLineAnimation - the standard stroke-dashoffset draw-on with a per-series stagger (ranked by data-series|data-color) beginning at t=0. Ghost fill is omitted so the fill cannot obscure the bars underneath.

Two existing behaviors are deliberately unchanged, since those elements summarize the bars rather than being independent measures: the Pareto cumulative-% line still draws after the last bar finishes, and gantt milestone markers/labels still fade in after their bars.

Covered by 3 new/updated cases in SVGAnimationDOMInjectorTest (combo bar+point concurrency, combo bar+line concurrency, Pareto after-bars timing); 68/68 tests pass in utils/inetsoft-xml-formats.