### PR TITLE
Bug #75649 - Fix "Labels on Opposite Side" leaving the original axis line in place

### DIFF
--- a/core/src/main/java/inetsoft/graph/AxisSpec.java
+++ b/core/src/main/java/inetsoft/graph/AxisSpec.java
@@ -89,11 +89,20 @@ public class AxisSpec implements Cloneable, Serializable {
    }
 
    /**
-    * Get the axis style for this coord.
+    * Get the axis style for this coord. This is the effective style and may differ from the
+    * style passed to setAxisStyle() when the labels have been moved to the opposite side.
     */
    @TernMethod(url = "#ProductDocs/chartAPI/html/Common_Chart_AxisSpec_getAxisStyle.htm")
    public int getAxisStyle() {
-      return labelOnSecondaryAxis ? (style | AXIS_LABEL_OPPOSITE_SIDE) : style;
+      if(!labelOnSecondaryAxis) {
+         return style;
+      }
+
+      // a single axis has one line, so relocating its labels moves the axis itself rather than
+      // leaving the original behind; a double axis has both lines already, so only labels move.
+      return (style & AXIS_DOUBLE) == AXIS_SINGLE
+         ? (style & ~AXIS_SINGLE) | AXIS_SINGLE2
+         : style | AXIS_LABEL_OPPOSITE_SIDE;
    }
 
    /**

--- a/core/src/test/java/inetsoft/graph/coord/RectCoordOppositeSideLabelsTest.java
+++ b/core/src/test/java/inetsoft/graph/coord/RectCoordOppositeSideLabelsTest.java
@@ -1,0 +1,181 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.graph.coord;
+
+import inetsoft.graph.*;
+import inetsoft.graph.data.DefaultDataSet;
+import inetsoft.graph.element.LineElement;
+import inetsoft.graph.guide.axis.DefaultAxis;
+import inetsoft.graph.scale.*;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Guards "Labels on Opposite Side" on a single-axis chart. A single axis has one line, so
+ * moving its labels must move the whole axis to the opposite side rather than leaving the
+ * original line behind and drawing a second one. A double-style axis keeps both lines and
+ * only relocates the labels.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class RectCoordOppositeSideLabelsTest {
+   @Test
+   void singleStyleResolvesToSecondaryAxisStyle() {
+      AxisSpec spec = new AxisSpec();
+      spec.setAxisStyle(AxisSpec.AXIS_SINGLE);
+      spec.setLabelOnSecondaryAxis(true);
+
+      assertEquals(AxisSpec.AXIS_SINGLE2, spec.getAxisStyle(),
+                   "single axis with relocated labels is the secondary axis, not a second axis");
+   }
+
+   @Test
+   void doubleStyleKeepsBothAxes() {
+      AxisSpec spec = new AxisSpec();
+      spec.setAxisStyle(AxisSpec.AXIS_DOUBLE);
+      spec.setLabelOnSecondaryAxis(true);
+
+      assertEquals(AxisSpec.AXIS_DOUBLE2, spec.getAxisStyle(),
+                   "double axis with relocated labels must keep both axis lines");
+   }
+
+   @Test
+   void secondaryStyleIsIdempotent() {
+      AxisSpec spec = new AxisSpec();
+      spec.setAxisStyle(AxisSpec.AXIS_SINGLE2);
+      spec.setLabelOnSecondaryAxis(true);
+
+      assertEquals(AxisSpec.AXIS_SINGLE2, spec.getAxisStyle());
+   }
+
+   @Test
+   void crossStyleKeepsCrossBit() {
+      AxisSpec spec = new AxisSpec();
+      spec.setAxisStyle(AxisSpec.AXIS_CROSS);
+      spec.setLabelOnSecondaryAxis(true);
+
+      int crossBit = AxisSpec.AXIS_CROSS & ~AxisSpec.AXIS_SINGLE;
+
+      assertEquals(crossBit, spec.getAxisStyle() & crossBit,
+                   "relocating labels must not drop the cross-axis bit");
+   }
+
+   @Test
+   void yAxisMovesToTheRight() {
+      RectCoord coord = coord(true, false);
+      DefaultAxis y1 = coord.getAxisAt(Coordinate.LEFT_AXIS);
+      DefaultAxis y2 = coord.getAxisAt(Coordinate.RIGHT_AXIS);
+
+      assertTrue(y1 == null || y1.getZIndex() < 0,
+                 "left y axis must not be drawn once its labels moved right; regression: both "
+                    + "the left and right axis lines are visible");
+      assertNotNull(y2, "right y axis must exist");
+      assertTrue(y2.getZIndex() >= 0, "right y axis must be drawn");
+      assertTrue(y2.isLabelVisible(), "right y axis must carry the labels");
+   }
+
+   @Test
+   void xAxisMovesToTheTop() {
+      RectCoord coord = coord(false, true);
+      DefaultAxis x1 = coord.getAxisAt(Coordinate.BOTTOM_AXIS);
+      DefaultAxis x2 = coord.getAxisAt(Coordinate.TOP_AXIS);
+
+      assertTrue(x1 == null || x1.getZIndex() < 0,
+                 "bottom x axis must not be drawn once its labels moved to the top");
+      assertNotNull(x2, "top x axis must exist");
+      assertTrue(x2.getZIndex() >= 0, "top x axis must be drawn");
+      assertTrue(x2.isLabelVisible(), "top x axis must carry the labels");
+   }
+
+   @Test
+   void doubleStyleYKeepsBothLines() {
+      EGraph egraph = new EGraph();
+      egraph.addElement(new LineElement("Year", "Price"));
+
+      Scale yscale = new LinearScale("Price");
+      yscale.getAxisSpec().setAxisStyle(AxisSpec.AXIS_DOUBLE);
+      yscale.getAxisSpec().setLabelOnSecondaryAxis(true);
+
+      RectCoord coord = new RectCoord(new CategoricalScale("Year"), yscale);
+      egraph.setCoordinate(coord);
+      assertNotNull(Plotter.getPlotter(egraph).plotAndLayout(data(), 0, 0, 800, 600));
+
+      DefaultAxis y1 = coord.getAxisAt(Coordinate.LEFT_AXIS);
+      DefaultAxis y2 = coord.getAxisAt(Coordinate.RIGHT_AXIS);
+
+      assertNotNull(y1, "double style must keep the primary axis");
+      assertTrue(y1.getZIndex() >= 0, "double style must keep the left axis line");
+      assertNotNull(y2, "double style must keep the secondary axis");
+      assertTrue(y2.getZIndex() >= 0, "double style must keep the right axis line");
+      assertTrue(y2.isLabelVisible(), "labels move to the right on double style too");
+   }
+
+   @Test
+   void plainSingleStyleKeepsLabelsInPlace() {
+      RectCoord coord = coord(false, false);
+      DefaultAxis y1 = coord.getAxisAt(Coordinate.LEFT_AXIS);
+      DefaultAxis y2 = coord.getAxisAt(Coordinate.RIGHT_AXIS);
+
+      assertNotNull(y1, "left y axis must be drawn when labels are not relocated");
+      assertTrue(y1.getZIndex() >= 0, "left y axis must be drawn");
+      assertTrue(y1.isLabelVisible(), "left y axis must carry the labels");
+      assertTrue(y2 == null || y2.getZIndex() < 0, "single style must not draw a right axis");
+   }
+
+   private static RectCoord coord(boolean yOpposite, boolean xOpposite) {
+      EGraph egraph = new EGraph();
+      egraph.addElement(new LineElement("Year", "Price"));
+
+      Scale xscale = new CategoricalScale("Year");
+      xscale.getAxisSpec().setAxisStyle(AxisSpec.AXIS_SINGLE);
+      xscale.getAxisSpec().setLabelOnSecondaryAxis(xOpposite);
+
+      Scale yscale = new LinearScale("Price");
+      yscale.getAxisSpec().setAxisStyle(AxisSpec.AXIS_SINGLE);
+      yscale.getAxisSpec().setLabelOnSecondaryAxis(yOpposite);
+
+      RectCoord coord = new RectCoord(xscale, yscale);
+      egraph.setCoordinate(coord);
+
+      assertNotNull(Plotter.getPlotter(egraph).plotAndLayout(data(), 0, 0, 800, 600),
+                    "Plotter.plotAndLayout must produce a vgraph for the test fixture");
+      return coord;
+   }
+
+   private static DefaultDataSet data() {
+      return new DefaultDataSet(new Object[][] {
+         { "Year",  "Price" },
+         { "2022",  400000.0 },
+         { "2023",  450000.0 },
+         { "2024",  420000.0 },
+         { "2025",  480000.0 },
+      });
+   }
+}


### PR DESCRIPTION
AxisSpec.getAxisStyle() built the effective style by OR-ing the opposite-side bit
into the configured style, so a single axis produced AXIS_SINGLE | 0x10 = 0x11,
which is not one of the defined styles. RectCoord.createAxis() then read it two
ways that disagreed: (style & 0x1) != 0 kept the primary axis, while
(style & AXIS_SINGLE2) != 0 also drew the secondary one, leaving both the left
and right y-axis lines visible. The same arithmetic drove x1vis/x2vis, so moving
x labels to the top left the bottom line behind as well. Labels were placed
correctly throughout because the label checks test the 0x10 bit on its own.

AXIS_SINGLE2 already means "one axis, on the opposite side" and renders exactly
that, so getAxisStyle() now resolves single plus relocated labels to it. The
primary-axis bit is cleared by masking rather than by replacing the whole value,
which preserves the cross-axis bit for AXIS_CROSS. A double axis still maps to
AXIS_DOUBLE2 and keeps both lines, and AXIS_SINGLE2 stays idempotent. Fixing it
where the style vocabulary is defined covers both x and y, and keeps the
vocabulary closed to the six declared constants instead of adding another
special case to the coordinate.

Measured plot bounds confirm the result is byte-identical to AXIS_SINGLE2
(x=5.0 w=756.0 versus x=40.0 for a left-labelled single axis), so the plot also
reclaims the width the hidden labels were holding.

Add RectCoordOppositeSideLabelsTest covering the four style mappings including
cross-bit preservation and idempotency, the y axis moving right, the x axis
moving to the top, a double-style axis keeping both lines, and a plain single
axis keeping its labels in place.