### PR TITLE
fix(embed): track embed-assembly size per assembly, not one runtime-wide slot

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
@@ -55,6 +55,7 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -260,7 +261,11 @@ public class RuntimeViewsheet extends RuntimeSheet {
       wizardViewsheet = state.isWizardViewsheet();
 
       if(state.getEmbedAssemblyInfo() != null) {
-         embedAssemblyInfo = loadJson(EmbedAssemblyInfo.class, state.getEmbedAssemblyInfo(), mapper);
+         for(EmbedAssemblyInfo info : loadEmbedAssemblyInfoList(state.getEmbedAssemblyInfo(), mapper)) {
+            if(info.getAssemblyName() != null) {
+               embedAssemblyInfos.put(info.getAssemblyName(), info);
+            }
+         }
       }
 
       // Decode undo/redo checkpoints from VCDIFF deltas
@@ -2648,12 +2653,35 @@ public class RuntimeViewsheet extends RuntimeSheet {
       this.wizardViewsheet = wizardViewsheet;
    }
 
-   public EmbedAssemblyInfo getEmbedAssemblyInfo() {
-      return embedAssemblyInfo;
+   /**
+    * The tracked embed info for one specific assembly. A runtime can have more than one
+    * assembly embedded on it at once (e.g. wiz embeds several chart/table cards from the same
+    * conversation, each a different assembly on the SAME shared runtime) - each is tracked
+    * independently so concurrent refreshes for different assemblies never clobber each other.
+    */
+   public EmbedAssemblyInfo getEmbedAssemblyInfo(String assemblyName) {
+      return assemblyName == null ? null : embedAssemblyInfos.get(assemblyName);
    }
 
-   public void setEmbedAssemblyInfo(EmbedAssemblyInfo embedAssemblyInfo) {
-      this.embedAssemblyInfo = embedAssemblyInfo;
+   /**
+    * The single tracked embed assembly, for call sites that have no assembly name to key on
+    * (e.g. the whole-viewsheet {@code VSRefreshEvent} path, which predates multi-assembly
+    * embedding) and can only meaningfully apply to a runtime with exactly one. Returns null
+    * rather than guessing when more than one assembly is currently embedded.
+    */
+   public EmbedAssemblyInfo getSoleEmbedAssemblyInfo() {
+      return embedAssemblyInfos.size() == 1 ? embedAssemblyInfos.values().iterator().next() : null;
+   }
+
+   /**
+    * Whether any assembly is currently embedded on this runtime (regardless of which).
+    */
+   public boolean isEmbedded() {
+      return !embedAssemblyInfos.isEmpty();
+   }
+
+   public void putEmbedAssemblyInfo(String assemblyName, EmbedAssemblyInfo embedAssemblyInfo) {
+      embedAssemblyInfos.put(assemblyName, embedAssemblyInfo);
    }
 
    /**
@@ -2798,7 +2826,8 @@ public class RuntimeViewsheet extends RuntimeSheet {
       }
 
       state.setLayoutPoint(layoutPoint);
-      state.setEmbedAssemblyInfo(saveJson(embedAssemblyInfo, mapper));
+      state.setEmbedAssemblyInfo(embedAssemblyInfos.isEmpty() ? null :
+         saveJson(new ArrayList<>(embedAssemblyInfos.values()), mapper));
 
       if(temporaryInfo != null) {
          state.setTemporaryInfo(saveXml(temporaryInfo));
@@ -2853,9 +2882,20 @@ public class RuntimeViewsheet extends RuntimeSheet {
    private int layoutPoint = -1;
    private VSTemporaryInfo temporaryInfo;
    private boolean wizardViewsheet = false;
-   private EmbedAssemblyInfo embedAssemblyInfo;
+   private final Map<String, EmbedAssemblyInfo> embedAssemblyInfos = new ConcurrentHashMap<>();
    private ImageHashService imageHashService = new ImageHashService();
    private String wizSheetRuntimeId;
+
+   private static List<EmbedAssemblyInfo> loadEmbedAssemblyInfoList(String json, ObjectMapper mapper) {
+      try {
+         return mapper.readValue(json,
+            mapper.getTypeFactory().constructCollectionType(List.class, EmbedAssemblyInfo.class));
+      }
+      catch(Exception e) {
+         LOG.error("Failed to load value", e);
+         return Collections.emptyList();
+      }
+   }
 
    private static final Logger LOG =
       LoggerFactory.getLogger(RuntimeViewsheet.class);

--- a/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
@@ -2674,14 +2674,39 @@ public class RuntimeViewsheet extends RuntimeSheet {
    }
 
    /**
-    * Whether any assembly is currently embedded on this runtime (regardless of which).
+    * Whether any assembly is currently embedded on this runtime (regardless of which). Distinct
+    * from the pre-existing {@code Viewsheet#isEmbedded()}/{@code VSAssembly#isEmbedded()} (a sub-
+    * viewsheet embedded inside a container viewsheet) - named accordingly so the two concepts,
+    * which are used side by side in some of the same expressions, aren't confused for each other.
     */
-   public boolean isEmbedded() {
+   public boolean hasEmbeddedAssembly() {
       return !embedAssemblyInfos.isEmpty();
    }
 
    public void putEmbedAssemblyInfo(String assemblyName, EmbedAssemblyInfo embedAssemblyInfo) {
+      pruneStaleEmbedAssemblyInfos();
       embedAssemblyInfos.put(assemblyName, embedAssemblyInfo);
+   }
+
+   /**
+    * Drops tracked entries for assemblies that no longer exist on this runtime's viewsheet (e.g.
+    * the old assembly a type switch replaced). Without this, a runtime whose visualization type
+    * is switched repeatedly over a long-lived session (wiz keeps one runtime per conversation)
+    * would accumulate an ever-growing number of orphaned entries for assemblies nothing looks up
+    * anymore.
+    */
+   private void pruneStaleEmbedAssemblyInfos() {
+      if(embedAssemblyInfos.isEmpty()) {
+         return;
+      }
+
+      Viewsheet sheet = getViewsheet();
+
+      if(sheet == null) {
+         return;
+      }
+
+      embedAssemblyInfos.keySet().removeIf(name -> sheet.getAssembly(name) == null);
    }
 
    /**
@@ -2886,13 +2911,27 @@ public class RuntimeViewsheet extends RuntimeSheet {
    private ImageHashService imageHashService = new ImageHashService();
    private String wizSheetRuntimeId;
 
+   /**
+    * Parses the persisted embed-assembly-info blob. The current format is a JSON array (one
+    * runtime can now track more than one embedded assembly). A {@code RuntimeViewsheetState} can
+    * outlive a single process (e.g. cluster failover/rolling restarts via the Ignite-backed
+    * runtime sheet cache), so a blob written by a not-yet-upgraded node may still be in the old
+    * format (a single serialized object) - fall back to parsing that before giving up, so a
+    * rolling upgrade doesn't silently drop an in-flight embed session's tracked size.
+    */
    private static List<EmbedAssemblyInfo> loadEmbedAssemblyInfoList(String json, ObjectMapper mapper) {
       try {
          return mapper.readValue(json,
             mapper.getTypeFactory().constructCollectionType(List.class, EmbedAssemblyInfo.class));
       }
-      catch(Exception e) {
-         LOG.error("Failed to load value", e);
+      catch(Exception arrayEx) {
+         EmbedAssemblyInfo legacy = loadJson(EmbedAssemblyInfo.class, json, mapper);
+
+         if(legacy != null) {
+            return Collections.singletonList(legacy);
+         }
+
+         LOG.error("Failed to load value", arrayEx);
          return Collections.emptyList();
       }
    }

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/VSRefreshService.java
@@ -106,23 +106,23 @@ public class VSRefreshService {
             box.get().lockWrite();
 
             try {
-               EmbedAssemblyInfo embedAssemblyInfo = rvs.getEmbedAssemblyInfo();
+               // Tracked per assembly name, not as a single runtime-wide slot: a runtime can
+               // have more than one assembly embedded on it at once (e.g. wiz embeds several
+               // chart/table cards from the same conversation, each a different assembly on the
+               // SAME shared runtime), and each one's own WebSocket connection refreshes
+               // independently. A type switch (WizAutoBindingService#changeType replaces the
+               // old assembly with a differently-named one on the same runtime) simply gets its
+               // own new entry here - the old assembly's entry is orphaned (harmless: it no
+               // longer exists in the viewsheet, so applyEmbedChartSize() never looks it up
+               // again), with no need to "re-point" a shared name field.
+               EmbedAssemblyInfo embedAssemblyInfo = rvs.getEmbedAssemblyInfo(event.getAssemblyName());
 
                // Only create embed assembly metadata during the explicit embed refresh path.
                // Resize events may omit embed=true and should only update existing state.
                if(embedAssemblyInfo == null && event.getEmbed()) {
                   embedAssemblyInfo = new EmbedAssemblyInfo();
                   embedAssemblyInfo.setAssemblyName(event.getAssemblyName());
-                  rvs.setEmbedAssemblyInfo(embedAssemblyInfo);
-               }
-               // The embedded assembly can be swapped out for a differently-named one on the
-               // same runtime (e.g. WizAutoBindingService#changeType removes the old primary
-               // assembly and places a new one when the user switches viz type). Re-point the
-               // tracked name on every explicit embed refresh, or applyEmbedChartSize()'s name
-               // check keeps comparing against the original (now-gone) assembly forever and
-               // silently stops sizing the new one.
-               else if(embedAssemblyInfo != null && event.getEmbed()) {
-                  embedAssemblyInfo.setAssemblyName(event.getAssemblyName());
+                  rvs.putEmbedAssemblyInfo(event.getAssemblyName(), embedAssemblyInfo);
                }
 
                if(embedAssemblyInfo != null) {
@@ -186,7 +186,10 @@ public class VSRefreshService {
       pending.put(id, true);
 
       if(event.embedAssemblySize() != null) {
-         EmbedAssemblyInfo embedAssemblyInfo = rvs.getEmbedAssemblyInfo();
+         // This event carries no assembly name (it's a whole-viewsheet refresh, not a
+         // per-assembly one) - only meaningful when exactly one assembly is embedded on this
+         // runtime, which holds for the fresh single-asset embed-open path that sends it.
+         EmbedAssemblyInfo embedAssemblyInfo = rvs.getSoleEmbedAssemblyInfo();
 
          if(embedAssemblyInfo != null) {
             embedAssemblyInfo.setAssemblySize(event.embedAssemblySize());

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartAxesVisibilityService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartAxesVisibilityService.java
@@ -141,7 +141,7 @@ public class VSChartAxesVisibilityService extends VSChartControllerService<VSCha
 
       if(maxMode && chartState.getRuntimeViewsheet() != null &&
          (chartState.getRuntimeViewsheet().isBinding() ||
-            chartState.getRuntimeViewsheet().getEmbedAssemblyInfo() != null))
+            chartState.getRuntimeViewsheet().isEmbedded()))
       {
          setVisible(axisDescriptor, false, false);
       }
@@ -173,7 +173,7 @@ public class VSChartAxesVisibilityService extends VSChartControllerService<VSCha
 
       if(maxMode && chartState.getRuntimeViewsheet() != null &&
          (chartState.getRuntimeViewsheet().isBinding() ||
-            chartState.getRuntimeViewsheet().getEmbedAssemblyInfo() != null))
+            chartState.getRuntimeViewsheet().isEmbedded()))
       {
          showAllAxes(chartInfo, false);
       }

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartAxesVisibilityService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartAxesVisibilityService.java
@@ -141,7 +141,7 @@ public class VSChartAxesVisibilityService extends VSChartControllerService<VSCha
 
       if(maxMode && chartState.getRuntimeViewsheet() != null &&
          (chartState.getRuntimeViewsheet().isBinding() ||
-            chartState.getRuntimeViewsheet().isEmbedded()))
+            chartState.getRuntimeViewsheet().hasEmbeddedAssembly()))
       {
          setVisible(axisDescriptor, false, false);
       }
@@ -173,7 +173,7 @@ public class VSChartAxesVisibilityService extends VSChartControllerService<VSCha
 
       if(maxMode && chartState.getRuntimeViewsheet() != null &&
          (chartState.getRuntimeViewsheet().isBinding() ||
-            chartState.getRuntimeViewsheet().isEmbedded()))
+            chartState.getRuntimeViewsheet().hasEmbeddedAssembly()))
       {
          showAllAxes(chartInfo, false);
       }

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartLegendsVisibilityService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartLegendsVisibilityService.java
@@ -119,7 +119,7 @@ public class VSChartLegendsVisibilityService extends VSChartControllerService<VS
          Tool.clone(chartState.getChartAssemblyInfo());
       RuntimeViewsheet rvs = chartState.getRuntimeViewsheet();
       boolean changeNonMaxMode = rvs != null &&
-         (rvs.isBinding() || rvs.getEmbedAssemblyInfo() != null);
+         (rvs.isBinding() || rvs.isEmbedded());
 
       hideDescriptorLegends(info, info.getChartDescriptor(), event, changeNonMaxMode);
 
@@ -204,7 +204,7 @@ public class VSChartLegendsVisibilityService extends VSChartControllerService<VS
 
       if(maxMode && chartState.getRuntimeViewsheet() != null &&
          (chartState.getRuntimeViewsheet().isBinding() ||
-            chartState.getRuntimeViewsheet().getEmbedAssemblyInfo() != null))
+            chartState.getRuntimeViewsheet().isEmbedded()))
       {
          showAllLegends(info, visible, false);
       }

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartLegendsVisibilityService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartLegendsVisibilityService.java
@@ -119,7 +119,7 @@ public class VSChartLegendsVisibilityService extends VSChartControllerService<VS
          Tool.clone(chartState.getChartAssemblyInfo());
       RuntimeViewsheet rvs = chartState.getRuntimeViewsheet();
       boolean changeNonMaxMode = rvs != null &&
-         (rvs.isBinding() || rvs.isEmbedded());
+         (rvs.isBinding() || rvs.hasEmbeddedAssembly());
 
       hideDescriptorLegends(info, info.getChartDescriptor(), event, changeNonMaxMode);
 
@@ -204,7 +204,7 @@ public class VSChartLegendsVisibilityService extends VSChartControllerService<VS
 
       if(maxMode && chartState.getRuntimeViewsheet() != null &&
          (chartState.getRuntimeViewsheet().isBinding() ||
-            chartState.getRuntimeViewsheet().isEmbedded()))
+            chartState.getRuntimeViewsheet().hasEmbeddedAssembly()))
       {
          showAllLegends(info, visible, false);
       }

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartRefreshService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartRefreshService.java
@@ -83,7 +83,7 @@ public class VSChartRefreshService extends VSChartControllerService<VSChartRefre
       RuntimeViewsheet rvs = chartState.getRuntimeViewsheet();
       Optional<ViewsheetSandbox> box = rvs.getViewsheetSandbox();
 
-      if(rvs.isEmbedded()) {
+      if(rvs.hasEmbeddedAssembly()) {
          VSRefreshEvent refresh = VSRefreshEvent.builder()
             .confirmed(true)
             .initing(false)

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartRefreshService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartRefreshService.java
@@ -83,7 +83,7 @@ public class VSChartRefreshService extends VSChartControllerService<VSChartRefre
       RuntimeViewsheet rvs = chartState.getRuntimeViewsheet();
       Optional<ViewsheetSandbox> box = rvs.getViewsheetSandbox();
 
-      if(rvs.getEmbedAssemblyInfo() != null) {
+      if(rvs.isEmbedded()) {
          VSRefreshEvent refresh = VSRefreshEvent.builder()
             .confirmed(true)
             .initing(false)

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartTitlesVisibilityService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartTitlesVisibilityService.java
@@ -85,7 +85,7 @@ public class VSChartTitlesVisibilityService extends VSChartControllerService<VSC
 
       if(maxMode && chartState.getRuntimeViewsheet() != null &&
          (chartState.getRuntimeViewsheet().isBinding() ||
-            chartState.getRuntimeViewsheet().getEmbedAssemblyInfo() != null))
+            chartState.getRuntimeViewsheet().isEmbedded()))
       {
          hideTitle(axisType, info, false);
       }
@@ -175,7 +175,7 @@ public class VSChartTitlesVisibilityService extends VSChartControllerService<VSC
 
       if(maxMode && chartState.getRuntimeViewsheet() != null &&
          (chartState.getRuntimeViewsheet().isBinding() ||
-            chartState.getRuntimeViewsheet().getEmbedAssemblyInfo() != null))
+            chartState.getRuntimeViewsheet().isEmbedded()))
       {
          showTitles(info, false);
       }

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartTitlesVisibilityService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartTitlesVisibilityService.java
@@ -85,7 +85,7 @@ public class VSChartTitlesVisibilityService extends VSChartControllerService<VSC
 
       if(maxMode && chartState.getRuntimeViewsheet() != null &&
          (chartState.getRuntimeViewsheet().isBinding() ||
-            chartState.getRuntimeViewsheet().isEmbedded()))
+            chartState.getRuntimeViewsheet().hasEmbeddedAssembly()))
       {
          hideTitle(axisType, info, false);
       }
@@ -175,7 +175,7 @@ public class VSChartTitlesVisibilityService extends VSChartControllerService<VSC
 
       if(maxMode && chartState.getRuntimeViewsheet() != null &&
          (chartState.getRuntimeViewsheet().isBinding() ||
-            chartState.getRuntimeViewsheet().isEmbedded()))
+            chartState.getRuntimeViewsheet().hasEmbeddedAssembly()))
       {
          showTitles(info, false);
       }

--- a/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
@@ -555,7 +555,7 @@ public class CoreLifecycleService {
          // don't scale viewsheet in design mode or if height or width is set to 0
          if(vsinfo != null && vsinfo.isScaleToScreen() && rvs.isRuntime() &&
             (height != 0 || vsinfo.isFitToWidth()) && width != 0 &&
-            !rvs.isEmbedded())
+            !rvs.hasEmbeddedAssembly())
          {
             // if not initializing a viewsheet then always apply scale
             boolean applyScale = !initing || vsinfo.isDisableParameterSheet();
@@ -1378,7 +1378,7 @@ public class CoreLifecycleService {
 
       ViewsheetSandbox box = boxOpt.get();
 
-      if(rvs.isEmbedded() && name != null && rvs.getEmbedAssemblyInfo(name) == null) {
+      if(rvs.hasEmbeddedAssembly() && name != null && rvs.getEmbedAssemblyInfo(name) == null) {
          return;
       }
 

--- a/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
@@ -555,7 +555,7 @@ public class CoreLifecycleService {
          // don't scale viewsheet in design mode or if height or width is set to 0
          if(vsinfo != null && vsinfo.isScaleToScreen() && rvs.isRuntime() &&
             (height != 0 || vsinfo.isFitToWidth()) && width != 0 &&
-            rvs.getEmbedAssemblyInfo() == null)
+            !rvs.isEmbedded())
          {
             // if not initializing a viewsheet then always apply scale
             boolean applyScale = !initing || vsinfo.isDisableParameterSheet();
@@ -1378,9 +1378,7 @@ public class CoreLifecycleService {
 
       ViewsheetSandbox box = boxOpt.get();
 
-      if(rvs.getEmbedAssemblyInfo() != null && name != null &&
-         !Tool.equals(name, rvs.getEmbedAssemblyInfo().getAssemblyName()))
-      {
+      if(rvs.isEmbedded() && name != null && rvs.getEmbedAssemblyInfo(name) == null) {
          return;
       }
 
@@ -1589,14 +1587,17 @@ public class CoreLifecycleService {
    private void applyEmbedChartSize(RuntimeViewsheet rvs, VSAssembly assembly) {
       String name = assembly == null ? null : assembly.getAbsoluteName();
 
-      if(rvs.getEmbedAssemblyInfo() == null || name == null) {
+      if(name == null) {
          return;
       }
 
-      EmbedAssemblyInfo embedAssemblyInfo = rvs.getEmbedAssemblyInfo();
-      Dimension assemblySize = embedAssemblyInfo.getAssemblySize();
+      // Keyed by this assembly's own name, so concurrently-embedded sibling assemblies (e.g.
+      // wiz's multiple chart/table cards sharing one runtime) can never clobber each other's
+      // tracked size - see RuntimeViewsheet#getEmbedAssemblyInfo(String).
+      EmbedAssemblyInfo embedAssemblyInfo = rvs.getEmbedAssemblyInfo(name);
+      Dimension assemblySize = embedAssemblyInfo == null ? null : embedAssemblyInfo.getAssemblySize();
 
-      if(!Tool.equals(name, embedAssemblyInfo.getAssemblyName()) || assemblySize == null) {
+      if(assemblySize == null) {
          return;
       }
 
@@ -2893,7 +2894,7 @@ public class CoreLifecycleService {
          EmbedAssemblyInfo embedAssemblyInfo = new EmbedAssemblyInfo();
          embedAssemblyInfo.setAssemblyName(event.getEmbedAssemblyName());
          embedAssemblyInfo.setAssemblySize(event.getEmbedAssemblySize());
-         rvs.setEmbedAssemblyInfo(embedAssemblyInfo);
+         rvs.putEmbedAssemblyInfo(event.getEmbedAssemblyName(), embedAssemblyInfo);
       }
 
       if(event.isEmbed()) {

--- a/core/src/test/java/inetsoft/report/composition/RuntimeViewsheetEmbedAssemblyInfoTest.java
+++ b/core/src/test/java/inetsoft/report/composition/RuntimeViewsheetEmbedAssemblyInfoTest.java
@@ -1,0 +1,176 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.composition;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.embed.EmbedAssemblyInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.Dimension;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Coverage for two follow-up points raised in code review on the fix that replaced
+ * {@code RuntimeViewsheet}'s single runtime-wide {@code EmbedAssemblyInfo} field with a map keyed
+ * by assembly name (see {@code VSRefreshServiceEmbedAssemblyTest} /
+ * {@code CoreLifecycleServiceEmbedSizeTest} for the core race-condition regression coverage):
+ *
+ * <ol>
+ *   <li>The persisted JSON format changed from a single object to an array. A
+ *   {@code RuntimeViewsheetState} can outlive a single process (cluster failover/rolling
+ *   restarts), so a blob written by a not-yet-upgraded node may still be in the old format -
+ *   {@link RuntimeViewsheet}'s loader must fall back to parsing that instead of silently
+ *   dropping it.</li>
+ *   <li>Tracking embed info per assembly name means an assembly that stops being embedded (e.g.
+ *   a type switch replaces it with a differently-named one) leaves an orphaned entry behind.
+ *   {@code putEmbedAssemblyInfo} prunes entries for assemblies no longer present on the
+ *   viewsheet so a long-lived runtime (wiz keeps one per conversation) doesn't accumulate them
+ *   without bound.</li>
+ * </ol>
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class RuntimeViewsheetEmbedAssemblyInfoTest {
+   @SuppressWarnings("unchecked")
+   private static List<EmbedAssemblyInfo> loadEmbedAssemblyInfoList(String json) throws Exception {
+      Method method = RuntimeViewsheet.class
+         .getDeclaredMethod("loadEmbedAssemblyInfoList", String.class, ObjectMapper.class);
+      method.setAccessible(true);
+      return (List<EmbedAssemblyInfo>) method.invoke(null, json, new ObjectMapper());
+   }
+
+   /**
+    * The public {@code setViewsheet(Viewsheet)} setter no-ops unless the runtime already has a
+    * live {@code ViewsheetSandbox} (irrelevant plumbing for these tests) - set the backing field
+    * directly instead, exactly as {@code CoreLifecycleServiceEmbedSizeTest} reaches into private
+    * members via reflection for focused unit coverage.
+    */
+   private static void injectViewsheet(RuntimeViewsheet rvs, Viewsheet vs) throws Exception {
+      java.lang.reflect.Field field = RuntimeViewsheet.class.getDeclaredField("vs");
+      field.setAccessible(true);
+      field.set(rvs, vs);
+   }
+
+   @Test
+   void parsesTheCurrentArrayFormat() throws Exception {
+      String json = "[{\"assemblyName\":\"vs_chart_A\",\"assemblySize\":{\"width\":540,\"height\":300}}," +
+         "{\"assemblyName\":\"vs_table_B\",\"assemblySize\":{\"width\":540,\"height\":260}}]";
+
+      List<EmbedAssemblyInfo> infos = loadEmbedAssemblyInfoList(json);
+
+      assertEquals(2, infos.size());
+      assertEquals("vs_chart_A", infos.get(0).getAssemblyName());
+      assertEquals(new Dimension(540, 300), infos.get(0).getAssemblySize());
+      assertEquals("vs_table_B", infos.get(1).getAssemblyName());
+      assertEquals(new Dimension(540, 260), infos.get(1).getAssemblySize());
+   }
+
+   @Test
+   void fallsBackToTheLegacySingleObjectFormat() throws Exception {
+      // The format persisted before this fix - a bare object, not an array. A cluster node still
+      // running the old code could have written this to the shared runtime sheet cache.
+      String legacyJson = "{\"assemblyName\":\"vs_chart_A\",\"assemblySize\":{\"width\":540,\"height\":300}}";
+
+      List<EmbedAssemblyInfo> infos = loadEmbedAssemblyInfoList(legacyJson);
+
+      assertEquals(1, infos.size(),
+         "a pre-upgrade single-object blob must still be recovered, not silently dropped");
+      assertEquals("vs_chart_A", infos.get(0).getAssemblyName());
+      assertEquals(new Dimension(540, 300), infos.get(0).getAssemblySize());
+   }
+
+   @Test
+   void returnsEmptyListForUnparseableJson() throws Exception {
+      List<EmbedAssemblyInfo> infos = loadEmbedAssemblyInfoList("not json at all");
+      assertTrue(infos.isEmpty());
+   }
+
+   @Test
+   void putEmbedAssemblyInfoPrunesEntriesForAssembliesNoLongerOnTheViewsheet() throws Exception {
+      RuntimeViewsheet rvs = new RuntimeViewsheet();
+      Viewsheet vs = mock(Viewsheet.class);
+      injectViewsheet(rvs, vs);
+
+      EmbedAssemblyInfo tableInfo = new EmbedAssemblyInfo();
+      tableInfo.setAssemblyName("vs_table_1");
+      tableInfo.setAssemblySize(new Dimension(908, 600));
+
+      // The table assembly exists on the viewsheet at the time it's first tracked.
+      when(vs.getAssembly("vs_table_1")).thenReturn(mock(VSAssembly.class));
+      rvs.putEmbedAssemblyInfo("vs_table_1", tableInfo);
+      assertNotNull(rvs.getEmbedAssemblyInfo("vs_table_1"));
+
+      // User switches type: changeType() removes the table assembly and adds a differently-named
+      // crosstab assembly. The next embed refresh (for the new assembly) should prune the now-gone
+      // table entry rather than leaving it behind forever.
+      when(vs.getAssembly("vs_table_1")).thenReturn(null);
+      EmbedAssemblyInfo crosstabInfo = new EmbedAssemblyInfo();
+      crosstabInfo.setAssemblyName("vs_crosstab_2");
+      crosstabInfo.setAssemblySize(new Dimension(908, 600));
+      when(vs.getAssembly("vs_crosstab_2")).thenReturn(mock(VSAssembly.class));
+      rvs.putEmbedAssemblyInfo("vs_crosstab_2", crosstabInfo);
+
+      assertNull(rvs.getEmbedAssemblyInfo("vs_table_1"),
+         "the stale entry for the removed assembly must be pruned, or the map grows without " +
+         "bound across repeated type switches on a long-lived runtime");
+      assertNotNull(rvs.getEmbedAssemblyInfo("vs_crosstab_2"));
+   }
+
+   @Test
+   void putEmbedAssemblyInfoDoesNotPruneStillLiveSiblingAssemblies() throws Exception {
+      RuntimeViewsheet rvs = new RuntimeViewsheet();
+      Viewsheet vs = mock(Viewsheet.class);
+      injectViewsheet(rvs, vs);
+
+      // Two chart/table cards from the same wiz conversation, both still present on the SAME
+      // shared viewsheet at once - pruning must never remove a sibling that's still embedded.
+      when(vs.getAssembly("vs_chart_A")).thenReturn(mock(VSAssembly.class));
+      when(vs.getAssembly("vs_table_B")).thenReturn(mock(VSAssembly.class));
+
+      EmbedAssemblyInfo infoA = new EmbedAssemblyInfo();
+      infoA.setAssemblyName("vs_chart_A");
+      infoA.setAssemblySize(new Dimension(540, 300));
+      rvs.putEmbedAssemblyInfo("vs_chart_A", infoA);
+
+      EmbedAssemblyInfo infoB = new EmbedAssemblyInfo();
+      infoB.setAssemblyName("vs_table_B");
+      infoB.setAssemblySize(new Dimension(540, 260));
+      rvs.putEmbedAssemblyInfo("vs_table_B", infoB);
+
+      assertNotNull(rvs.getEmbedAssemblyInfo("vs_chart_A"));
+      assertNotNull(rvs.getEmbedAssemblyInfo("vs_table_B"));
+   }
+}

--- a/core/src/test/java/inetsoft/web/viewsheet/controller/VSRefreshServiceEmbedAssemblyTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/controller/VSRefreshServiceEmbedAssemblyTest.java
@@ -34,6 +34,8 @@ import org.junit.jupiter.api.Test;
 
 import java.awt.Dimension;
 import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,26 +44,68 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Regression coverage for the bug where switching a wiz-embedded visualization's type (e.g.
- * table -&gt; crosstab, or back) left the newly-swapped-in assembly without the embed
- * container's pixel size, reproducing the "blank space on the right" bug for the *second* and
- * later type switches even though the very first render of either type was fine.
+ * Regression coverage for two related bugs in how {@link VSRefreshService#refreshVsAssembly}
+ * tracks the embed container size of assemblies embedded via wiz's standalone
+ * {@code stylebi-embed-elements} package.
  *
- * <p>Root cause: {@code WizAutoBindingService#changeType} replaces the viewsheet's primary
- * assembly with a differently-named one on every type switch (same {@code wizRuntimeId}, new
- * assembly name) rather than mutating one assembly in place. The embed component always resends
- * an {@code embed=true} {@link RefreshVSAssemblyEvent} with its (new) assembly name after
- * remounting, but {@link VSRefreshService#refreshVsAssembly} only ever wrote
- * {@link EmbedAssemblyInfo#setAssemblyName} the *first* time an {@code EmbedAssemblyInfo} was
- * created for a runtime — every later switch kept comparing against the original, now-removed
- * assembly's name in {@code CoreLifecycleService#applyEmbedChartSize}, so the size was silently
- * never applied to the new assembly.
+ * <p>Bug 1 (type switch): switching a wiz-embedded visualization's type (e.g. table -&gt;
+ * crosstab, or back) left the newly-swapped-in assembly without the embed container's pixel
+ * size, reproducing the "blank space on the right" bug for the *second* and later type switches
+ * even though the very first render of either type was fine. Root cause:
+ * {@code WizAutoBindingService#changeType} replaces the viewsheet's primary assembly with a
+ * differently-named one on every type switch (same {@code wizRuntimeId}, new assembly name)
+ * rather than mutating one assembly in place.
+ *
+ * <p>Bug 2 (concurrent multi-chart embed): a single wiz conversation can have several chart/table
+ * cards that all embed different assemblies on the SAME shared runtime (each card its own
+ * {@code assemblyName}, same {@code wizRuntimeId}). Restoring the conversation after a service
+ * restart mounts every embed element in the same instant, so their independent WebSocket
+ * connections race to refresh the same runtime nearly simultaneously. Both bugs trace back to the
+ * same root cause: {@code RuntimeViewsheet} used to track embed info as a single runtime-wide
+ * slot ({@code EmbedAssemblyInfo}), so whichever assembly's refresh happened to run last
+ * overwrote the *only* record - either erasing a still-relevant sibling assembly's tracking
+ * (bug 2) or leaving the tracker permanently pointed at an assembly that no longer exists (bug
+ * 1), so {@code CoreLifecycleService#applyEmbedChartSize} silently stopped sizing the affected
+ * assembly. The fix tracks embed info per assembly name (see
+ * {@code RuntimeViewsheet#getEmbedAssemblyInfo(String)}), so sibling/successor assemblies can
+ * never clobber each other.
  */
 @Tag("core")
 class VSRefreshServiceEmbedAssemblyTest {
-   private VSRefreshService createService() {
+   /**
+    * Stubs {@code rvs.getEmbedAssemblyInfo(name)}/{@code putEmbedAssemblyInfo(name, info)} with a
+    * simple in-memory map keyed by assembly name, mirroring the real
+    * {@code ConcurrentHashMap}-backed implementation on {@link RuntimeViewsheet}.
+    */
+   private static Map<String, EmbedAssemblyInfo> stubEmbedAssemblyInfoStorage(RuntimeViewsheet rvs) {
+      Map<String, EmbedAssemblyInfo> stored = new HashMap<>();
+      when(rvs.getEmbedAssemblyInfo(any(String.class))).thenAnswer(inv -> stored.get(inv.getArgument(0)));
+      org.mockito.Mockito.doAnswer(inv -> {
+         stored.put(inv.getArgument(0), inv.getArgument(1));
+         return null;
+      }).when(rvs).putEmbedAssemblyInfo(any(), any());
+      return stored;
+   }
+
+   private RuntimeViewsheet mockRuntimeViewsheet(String runtimeId, ViewsheetService viewsheetService,
+                                                  Principal principal) throws Exception
+   {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      ViewsheetSandbox box = mock(ViewsheetSandbox.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+      // Neither assembly needs to actually exist for these tests: refreshVsAssembly only needs
+      // the embed-info bookkeeping to run, which happens before the (skipped, assembly == null)
+      // call to refreshAssemblyAndDependencies.
+      when(vs.getAssembly(any(String.class))).thenReturn(null);
+      when(viewsheetService.getViewsheet(runtimeId, principal)).thenReturn(rvs);
+      return rvs;
+   }
+
+   private VSRefreshService createService(ViewsheetService viewsheetService) {
       return new VSRefreshService(
-         mock(CoreLifecycleService.class), mock(ViewsheetService.class),
+         mock(CoreLifecycleService.class), viewsheetService,
          mock(VSObjectTreeService.class), mock(VSBookmarkService.class),
          mock(ParameterService.class), mock(XSessionService.class));
    }
@@ -72,24 +116,11 @@ class VSRefreshServiceEmbedAssemblyTest {
       Principal principal = mock(Principal.class);
       CommandDispatcher dispatcher = mock(CommandDispatcher.class);
 
-      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
-      Viewsheet vs = mock(Viewsheet.class);
-      ViewsheetSandbox box = mock(ViewsheetSandbox.class);
-      when(rvs.getViewsheet()).thenReturn(vs);
-      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
-      // Neither assembly needs to actually exist for this test: refreshVsAssembly only needs the
-      // embed-info bookkeeping to run, which happens before the (skipped, assembly == null) call
-      // to refreshAssemblyAndDependencies.
-      when(vs.getAssembly(any(String.class))).thenReturn(null);
-
       ViewsheetService viewsheetService = mock(ViewsheetService.class);
-      when(viewsheetService.getViewsheet(runtimeId, principal)).thenReturn(rvs);
+      RuntimeViewsheet rvs = mockRuntimeViewsheet(runtimeId, viewsheetService, principal);
+      stubEmbedAssemblyInfoStorage(rvs);
 
-      VSRefreshService service = new VSRefreshService(
-         mock(CoreLifecycleService.class), viewsheetService,
-         mock(VSObjectTreeService.class), mock(VSBookmarkService.class),
-         mock(ParameterService.class), mock(XSessionService.class));
-
+      VSRefreshService service = createService(viewsheetService);
       Dimension containerSize = new Dimension(908, 600);
 
       // First render: a table assembly is embedded and sized.
@@ -100,20 +131,10 @@ class VSRefreshServiceEmbedAssemblyTest {
          .assemblySize(containerSize)
          .build();
 
-      // The real rvs.getEmbedAssemblyInfo()/setEmbedAssemblyInfo() round-trip through a plain
-      // field on the (here mocked) RuntimeViewsheet - stub it with a simple in-memory holder so
-      // the second call sees what the first call stored, exactly as the real class behaves.
-      final EmbedAssemblyInfo[] stored = new EmbedAssemblyInfo[1];
-      when(rvs.getEmbedAssemblyInfo()).thenAnswer(inv -> stored[0]);
-      org.mockito.Mockito.doAnswer(inv -> {
-         stored[0] = inv.getArgument(0);
-         return null;
-      }).when(rvs).setEmbedAssemblyInfo(any());
-
       service.refreshVsAssembly(runtimeId, tableEvent, dispatcher, "", principal);
 
-      assertEquals("vs_table_1", rvs.getEmbedAssemblyInfo().getAssemblyName());
-      assertEquals(containerSize, rvs.getEmbedAssemblyInfo().getAssemblySize());
+      assertEquals("vs_table_1", rvs.getEmbedAssemblyInfo("vs_table_1").getAssemblyName());
+      assertEquals(containerSize, rvs.getEmbedAssemblyInfo("vs_table_1").getAssemblySize());
 
       // User switches type: changeType() replaced the table assembly with a differently-named
       // crosstab assembly on the SAME runtime. The embed component remounts and resends its
@@ -127,10 +148,46 @@ class VSRefreshServiceEmbedAssemblyTest {
 
       service.refreshVsAssembly(runtimeId, crosstabEvent, dispatcher, "", principal);
 
-      assertEquals("vs_crosstab_2", rvs.getEmbedAssemblyInfo().getAssemblyName(),
-         "the embed target must follow the currently-embedded assembly across a type switch, " +
-         "or applyEmbedChartSize() keeps comparing against the original (now-gone) assembly " +
-         "name forever and silently stops sizing the new one");
-      assertEquals(containerSize, rvs.getEmbedAssemblyInfo().getAssemblySize());
+      assertEquals("vs_crosstab_2", rvs.getEmbedAssemblyInfo("vs_crosstab_2").getAssemblyName(),
+         "the newly-swapped-in assembly must get its own tracked embed info, or " +
+         "applyEmbedChartSize() never finds a size to apply to it");
+      assertEquals(containerSize, rvs.getEmbedAssemblyInfo("vs_crosstab_2").getAssemblySize());
+   }
+
+   @Test
+   void concurrentlyEmbeddedSiblingAssembliesOnTheSameRuntimeDoNotClobberEachOther() throws Exception {
+      String runtimeId = "wiz-runtime-2";
+      Principal principal = mock(Principal.class);
+      CommandDispatcher dispatcher = mock(CommandDispatcher.class);
+
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      RuntimeViewsheet rvs = mockRuntimeViewsheet(runtimeId, viewsheetService, principal);
+      stubEmbedAssemblyInfoStorage(rvs);
+
+      VSRefreshService service = createService(viewsheetService);
+
+      Dimension sizeA = new Dimension(540, 300);
+      Dimension sizeB = new Dimension(540, 260);
+
+      // Two different chart/table cards from the same wiz conversation share this ONE runtime
+      // (same wizRuntimeId, different assemblyName). Restoring the conversation after a service
+      // restart mounts both embed elements in the same instant, so their independent WebSocket
+      // connections race to refresh the SAME shared runtime nearly simultaneously - B's refresh
+      // lands in between A's own bookkeeping steps.
+      RefreshVSAssemblyEvent eventA = RefreshVSAssemblyEvent.builder()
+         .vsRuntimeId(runtimeId).assemblyName("vs_chart_A").embed(true).assemblySize(sizeA).build();
+      RefreshVSAssemblyEvent eventB = RefreshVSAssemblyEvent.builder()
+         .vsRuntimeId(runtimeId).assemblyName("vs_table_B").embed(true).assemblySize(sizeB).build();
+
+      service.refreshVsAssembly(runtimeId, eventA, dispatcher, "", principal);
+      service.refreshVsAssembly(runtimeId, eventB, dispatcher, "", principal);
+
+      assertEquals("vs_chart_A", rvs.getEmbedAssemblyInfo("vs_chart_A").getAssemblyName(),
+         "assembly A's own tracked entry must survive assembly B's later, unrelated refresh - " +
+         "a single runtime-wide slot would have overwritten A's name/size with B's");
+      assertEquals(sizeA, rvs.getEmbedAssemblyInfo("vs_chart_A").getAssemblySize(),
+         "assembly A must keep its own container size, not fall back to B's or to null");
+      assertEquals("vs_table_B", rvs.getEmbedAssemblyInfo("vs_table_B").getAssemblyName());
+      assertEquals(sizeB, rvs.getEmbedAssemblyInfo("vs_table_B").getAssemblySize());
    }
 }

--- a/core/src/test/java/inetsoft/web/viewsheet/service/CoreLifecycleServiceEmbedSizeTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/service/CoreLifecycleServiceEmbedSizeTest.java
@@ -90,7 +90,7 @@ class CoreLifecycleServiceEmbedSizeTest {
       embedAssemblyInfo.setAssemblySize(containerSize);
 
       RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
-      when(rvs.getEmbedAssemblyInfo()).thenReturn(embedAssemblyInfo);
+      when(rvs.getEmbedAssemblyInfo("vs_crosstab_1")).thenReturn(embedAssemblyInfo);
 
       CrosstabVSAssemblyInfo info = new CrosstabVSAssemblyInfo();
       VSAssembly assembly = mock(VSAssembly.class);
@@ -115,7 +115,7 @@ class CoreLifecycleServiceEmbedSizeTest {
       embedAssemblyInfo.setAssemblySize(containerSize);
 
       RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
-      when(rvs.getEmbedAssemblyInfo()).thenReturn(embedAssemblyInfo);
+      when(rvs.getEmbedAssemblyInfo("vs_chart_1")).thenReturn(embedAssemblyInfo);
 
       ChartVSAssemblyInfo info = new ChartVSAssemblyInfo();
       VSAssembly assembly = mock(VSAssembly.class);
@@ -135,7 +135,10 @@ class CoreLifecycleServiceEmbedSizeTest {
       embedAssemblyInfo.setAssemblySize(new Dimension(908, 600));
 
       RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
-      when(rvs.getEmbedAssemblyInfo()).thenReturn(embedAssemblyInfo);
+      when(rvs.getEmbedAssemblyInfo("vs_crosstab_1")).thenReturn(embedAssemblyInfo);
+      // "some_other_assembly" is deliberately left unstubbed - rvs.getEmbedAssemblyInfo(name)
+      // returns null for it, exactly as the real keyed map would for an assembly that isn't
+      // embedded.
 
       CrosstabVSAssemblyInfo info = new CrosstabVSAssemblyInfo();
       Dimension originalSize = info.getPixelSize();
@@ -145,5 +148,42 @@ class CoreLifecycleServiceEmbedSizeTest {
       invokeApplyEmbedChartSize(createService(), rvs, assembly);
 
       assertEquals(originalSize, info.getPixelSize());
+   }
+
+   @Test
+   void sizesEachConcurrentlyEmbeddedSiblingAssemblyIndependently() throws Exception {
+      // Two chart/table cards from the same wiz conversation embedded on the SAME runtime at
+      // once (same wizRuntimeId, different assemblyName) - both entries are tracked
+      // simultaneously, unlike the single-slot model this replaced.
+      EmbedAssemblyInfo infoA = new EmbedAssemblyInfo();
+      infoA.setAssemblyName("vs_chart_A");
+      infoA.setAssemblySize(new Dimension(540, 300));
+
+      EmbedAssemblyInfo infoB = new EmbedAssemblyInfo();
+      infoB.setAssemblyName("vs_table_B");
+      infoB.setAssemblySize(new Dimension(540, 260));
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getEmbedAssemblyInfo("vs_chart_A")).thenReturn(infoA);
+      when(rvs.getEmbedAssemblyInfo("vs_table_B")).thenReturn(infoB);
+
+      ChartVSAssemblyInfo chartInfo = new ChartVSAssemblyInfo();
+      VSAssembly chartAssembly = mock(VSAssembly.class);
+      when(chartAssembly.getAbsoluteName()).thenReturn("vs_chart_A");
+      when(chartAssembly.getInfo()).thenReturn((AssemblyInfo) chartInfo);
+
+      CrosstabVSAssemblyInfo tableInfo = new CrosstabVSAssemblyInfo();
+      VSAssembly tableAssembly = mock(VSAssembly.class);
+      when(tableAssembly.getAbsoluteName()).thenReturn("vs_table_B");
+      when(tableAssembly.getInfo()).thenReturn((AssemblyInfo) tableInfo);
+
+      CoreLifecycleService service = createService();
+      invokeApplyEmbedChartSize(service, rvs, chartAssembly);
+      invokeApplyEmbedChartSize(service, rvs, tableAssembly);
+
+      assertEquals(infoA.getAssemblySize(), chartInfo.getPixelSize(),
+         "assembly A must get its own size even though assembly B is also embedded on the " +
+         "same runtime - a single runtime-wide slot would have let B's later refresh win");
+      assertEquals(infoB.getAssemblySize(), tableInfo.getPixelSize());
    }
 }


### PR DESCRIPTION
## Summary

- `RuntimeViewsheet` tracked embed-container sizing (`EmbedAssemblyInfo`) as a single field per runtime, keyed by whichever assembly's refresh happened to run last.
- wiz embeds several chart/table cards from one conversation on the **same shared `wizRuntimeId`** (different `assemblyName` each). Reopening a conversation with 2+ charts after a service restart mounts all their embed elements in the same instant, so their independent WebSocket connections race to refresh the same runtime nearly simultaneously.
- The last writer's assembly name/size silently overwrote the others', so `CoreLifecycleService#applyEmbedChartSize` stopped applying the real embed container size to the clobbered assembly — it rendered at its default/previous (smaller) size with blank space around it (see the second chart in the reporter's screenshot).
- Fix: replace the single field with a `Map<String, EmbedAssemblyInfo>` keyed by assembly name, so concurrently- or successively-embedded assemblies on the same runtime can never clobber each other. Updated all call sites accordingly (`VSRefreshService`, `CoreLifecycleService`, and four chart axes/legends/titles/refresh visibility services that only ever needed a boolean "is this runtime embedded at all" check).
- Extended the existing embed-assembly regression tests (`VSRefreshServiceEmbedAssemblyTest`, `CoreLifecycleServiceEmbedSizeTest`) with new cases covering the concurrent multi-assembly scenario, and adapted their stubbing to the new keyed API.

## Test plan

- [x] `mvn -pl core test -Dtest=VSRefreshServiceEmbedAssemblyTest,CoreLifecycleServiceEmbedSizeTest` — 6/6 pass
- [x] `mvn -pl core,server,schedule-server,connectors -am compile` — compiles clean
- [ ] Manual verification in wiz: rebuild/restart the StyleBI server, reopen a wiz conversation with 2+ charts after a restart, confirm both render at full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)