### PR TITLE
fix(wiz): stop auto-titling detail tables with every column name joined

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1366,10 +1366,12 @@ public class WizVsService {
                }
             }
 
-            // Title crosstab/table assemblies with a binding-derived heading instead of StyleBI's
+            // Title crosstab assemblies with a binding-derived heading instead of StyleBI's
             // bland default "Table". The plugin recommender path (create_viewsheet) doesn't run the
             // interactive wizard's title logic (VSWizardBindingHandler), so derive it here on the
-            // finalized assembly — design headers if present, else the runtime headers.
+            // finalized assembly — design headers if present, else the runtime headers. Plain detail
+            // tables are left untitled: their columns already ARE the content shown in the header
+            // row, so joining every column name into one line is redundant, not helpful.
             if(assembly instanceof CrosstabVSAssembly ctAssembly
                && ctAssembly.getVSCrosstabInfo() != null)
             {
@@ -1383,18 +1385,6 @@ public class WizVsService {
                }
 
                applyGridTitle(ctAssembly, gridTitle);
-            }
-            else if(assembly instanceof TableVSAssembly tblAssembly
-               && tblAssembly.getColumnSelection() != null)
-            {
-               ColumnSelection sel = tblAssembly.getColumnSelection();
-               DataRef[] detailRefs = new DataRef[sel.getAttributeCount()];
-
-               for(int i = 0; i < sel.getAttributeCount(); i++) {
-                  detailRefs[i] = sel.getAttribute(i);
-               }
-
-               applyGridTitle(tblAssembly, buildGridTitle(null, null, detailRefs));
             }
             else if(assembly instanceof ChartVSAssembly titleChart
                && titleChart.getVSChartInfo() != null)
@@ -3393,15 +3383,6 @@ public class WizVsService {
          }
 
          table.setColumnSelection(columns);
-
-         // A detail table's columns ARE its content, so title it with them rather than "Table".
-         DataRef[] details = new DataRef[columns.getAttributeCount()];
-
-         for(int i = 0; i < columns.getAttributeCount(); i++) {
-            details[i] = columns.getAttribute(i);
-         }
-
-         applyGridTitle(table, buildGridTitle(null, null, details));
       }
 
       return table;
@@ -3409,10 +3390,10 @@ public class WizVsService {
 
    /**
     * Build a human-readable title like "Sum(amount) by sales_stage, name" from a grid binding's
-    * measures + dimensions, so a crosstab/table reads like a real visualization instead of showing
-    * StyleBI's bland default "Table". The plugin create path (unlike the interactive wizard's
-    * VSWizardBindingHandler) does not otherwise title these assemblies. Returns null when there's
-    * nothing to build from (caller then leaves the default).
+    * measures + dimensions, so a crosstab/chart reads like a real visualization instead of showing
+    * StyleBI's bland default "Table"/"Chart". The plugin create path (unlike the interactive
+    * wizard's VSWizardBindingHandler) does not otherwise title these assemblies. Returns null when
+    * there's nothing to build from (caller then leaves the default).
     */
    private static String buildGridTitle(DataRef[] measures, DataRef[] cols, DataRef[] rows) {
       StringBuilder meas = new StringBuilder();


### PR DESCRIPTION
## Summary
- Fixes bug 75805: newly created detail tables in the wiz chat UI showed a redundant title above the header row listing every bound column joined with commas (e.g. `SUPPLIER_ID, CONTACT, COMPANY, ...`).
- `WizVsService.buildGridTitle`/`applyGridTitle` derives a binding-based heading for assemblies the plugin create path doesn't otherwise title. For a plain detail table this joined *all* bound columns into one line, which is purely redundant since those same names already appear in the table's header row.
- Removed the two `TableVSAssembly` call sites (`createViewsheet`'s finalize step, and `createTableAssembly`) that produced this title. Crosstab and chart titling (which derive a meaningful "measure by dimension" heading) are unaffected.

## Test plan
- [x] `mvn -o -pl community/core -am compile` passes.
- [ ] Manually create a multi-column detail table via the wiz chat UI (create_viewsheet) and confirm no column-list title appears above the table.
- [ ] Confirm crosstab/chart titles are still generated as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)