### PR TITLE
feat(wiz): per-field display formats on /viewsheet/format

### DIFF
--- a/core/src/main/java/inetsoft/web/vswizard/handler/VSWizardBindingHandler.java
+++ b/core/src/main/java/inetsoft/web/vswizard/handler/VSWizardBindingHandler.java
@@ -1809,8 +1809,13 @@ public class VSWizardBindingHandler {
    /**
     * Every ref of a chart that can carry a field-level display format, in no particular order and
     * without de-duplication (callers match by name, so a ref appearing twice is harmless). Mirrors the
-    * traversal updateChartFormat performs, and exists so a caller can resolve a field name to a ref
-    * without duplicating that traversal.
+    * traversal updateChartFormat performs in its updateAssembly=true direction, and exists so a caller
+    * can resolve a field name to a ref without duplicating that traversal.
+    *
+    * <p>Must stay in step with updateChartFormat: a ref that renders there but is missing here is
+    * reported to the caller as "not in the binding" even though its format would have applied.
+    * RelationChartInfo's refs are deliberately absent — updateChartFormat only walks those in the
+    * !updateAssembly (reload) direction.
     */
    public static List<ChartRef> collectFormattableRefs(VSChartInfo chartInfo) {
       if(chartInfo == null) {
@@ -1826,17 +1831,39 @@ public class VSWizardBindingHandler {
          refs.add(chartInfo.getPeriodField());
       }
 
-      for(AestheticRef aref : new AestheticRef[]{ chartInfo.getColorField(), chartInfo.getShapeField(),
-                                                  chartInfo.getSizeField(), chartInfo.getTextField() })
-      {
-         if(aref != null && aref.getDataRef() instanceof ChartRef) {
-            refs.add((ChartRef) aref.getDataRef());
+      addAestheticRefs(refs, chartInfo.getColorField(), chartInfo.getShapeField(),
+                       chartInfo.getSizeField(), chartInfo.getTextField());
+
+      // Under multi-aesthetic each aggregate carries its OWN color/shape/size/text refs instead of the
+      // chart-level ones, and updateChartFormat formats those per aggregate.
+      if(chartInfo.isMultiAesthetic()) {
+         for(ChartRef ref : chartInfo.getYFields()) {
+            if(ref instanceof VSChartAggregateRef aggr) {
+               addAestheticRefs(refs, aggr.getColorField(), aggr.getShapeField(),
+                                aggr.getSizeField(), aggr.getTextField());
+            }
+         }
+      }
+
+      if(chartInfo instanceof GanttVSChartInfo) {
+         for(ChartAggregateRef aRef : chartInfo.getAestheticAggregateRefs(false)) {
+            addAestheticRefs(refs, aRef.getColorField(), aRef.getShapeField(),
+                             aRef.getSizeField(), aRef.getTextField());
          }
       }
 
       refs.removeIf(Objects::isNull);
 
       return refs;
+   }
+
+   /** Adds each aesthetic ref's underlying ChartRef to the list, skipping nulls and non-ChartRefs. */
+   private static void addAestheticRefs(List<ChartRef> refs, AestheticRef... aestheticRefs) {
+      for(AestheticRef aref : aestheticRefs) {
+         if(aref != null && aref.getDataRef() instanceof ChartRef) {
+            refs.add((ChartRef) aref.getDataRef());
+         }
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/vswizard/handler/VSWizardBindingHandler.java
+++ b/core/src/main/java/inetsoft/web/vswizard/handler/VSWizardBindingHandler.java
@@ -1754,6 +1754,92 @@ public class VSWizardBindingHandler {
    }
 
    /**
+    * Apply user-defined display formats to a chart's refs, outside the wizard.
+    *
+    * <p>Same destination as an in-wizard format edit: updateChartFormat(updateAssembly=true) walks
+    * every place a field renders — axis label and column label, the period field, group fields' plot
+    * descriptor, the color/shape/size legends, the text field, each aggregate's aesthetic fields under
+    * multi-aesthetic, and the Gantt refs — and writes the field's VSFormat into the ref's
+    * CompositeTextFormat user-defined format. Callers outside vs-wizard must reuse it rather than walk
+    * the refs themselves; a hand-rolled loop silently misses most of those places.
+    *
+    * <p>The VSTemporaryInfo here is a throwaway holding nothing but these formats — it is never
+    * attached to the runtime. That works because in the updateAssembly=true direction changeFormat only
+    * READS it (getUserFormat/getDefaultFormat); it writes back only when updateAssembly is false. Refs
+    * with no entry therefore resolve to a null user format and are left untouched, which is what makes
+    * "reformat only the named fields" fall out with no matching logic here.
+    *
+    * <p>Keys are ref FULL names, the names a caller sees in the binding. They are translated to the
+    * internal format-map key by getNameForFormat — dimensions and most aggregates key by full name,
+    * while same-type formulas (sum/max/min/first/last) key by the bare column so they deliberately
+    * share one format. That rule stays inside this class rather than leaking into callers.
+    *
+    * @param formatsByFullName full name -> format; a null value clears that field's user format.
+    * @return the keys that matched no ref, for the caller to report; empty when everything matched.
+    */
+   public Set<String> applyFieldFormats(RuntimeViewsheet rvs, ChartVSAssembly chart,
+                                        Map<String, VSFormat> formatsByFullName)
+   {
+      if(chart == null || formatsByFullName == null || formatsByFullName.isEmpty()) {
+         return Collections.emptySet();
+      }
+
+      VSTemporaryInfo tempInfo = new VSTemporaryInfo();
+      Set<String> unmatched = new LinkedHashSet<>(formatsByFullName.keySet());
+
+      for(ChartRef ref : collectFormattableRefs(chart.getVSChartInfo())) {
+         String fullName = ref.getFullName();
+
+         if(formatsByFullName.containsKey(fullName)) {
+            unmatched.remove(fullName);
+            tempInfo.setFormat(getNameForFormat(ref), formatsByFullName.get(fullName));
+         }
+      }
+
+      if(unmatched.size() < formatsByFullName.size()) {
+         updateChartFormat(tempInfo, chart, rvs, true);
+         // The cached runtime chart info is rebuilt from the (now reformatted) design-time refs on the
+         // next execute; mirrors what updateFormats does after its own updateChartFormat call.
+         chart.getVSChartInfo().clearRuntime();
+      }
+
+      return unmatched;
+   }
+
+   /**
+    * Every ref of a chart that can carry a field-level display format, in no particular order and
+    * without de-duplication (callers match by name, so a ref appearing twice is harmless). Mirrors the
+    * traversal updateChartFormat performs, and exists so a caller can resolve a field name to a ref
+    * without duplicating that traversal.
+    */
+   public static List<ChartRef> collectFormattableRefs(VSChartInfo chartInfo) {
+      if(chartInfo == null) {
+         return Collections.emptyList();
+      }
+
+      List<ChartRef> refs = new ArrayList<>();
+      Collections.addAll(refs, chartInfo.getXFields());
+      Collections.addAll(refs, chartInfo.getYFields());
+      Collections.addAll(refs, chartInfo.getGroupFields());
+
+      if(chartInfo.getPeriodField() != null) {
+         refs.add(chartInfo.getPeriodField());
+      }
+
+      for(AestheticRef aref : new AestheticRef[]{ chartInfo.getColorField(), chartInfo.getShapeField(),
+                                                  chartInfo.getSizeField(), chartInfo.getTextField() })
+      {
+         if(aref != null && aref.getDataRef() instanceof ChartRef) {
+            refs.add((ChartRef) aref.getDataRef());
+         }
+      }
+
+      refs.removeIf(Objects::isNull);
+
+      return refs;
+   }
+
+   /**
     * Copy format from temp assembly to formatMap.
     */
    private void updateFormats(VSTemporaryInfo tempInfo, VSAssembly assembly,

--- a/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
@@ -19,6 +19,8 @@ package inetsoft.web.wiz.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
+
 /**
  * Request body for {@code POST /api/wiz/viewsheet/format} — applies chart-level FORMAT properties
  * (axis titles, y-axis scale, legend placement) to an existing runtime chart and re-renders it.
@@ -109,6 +111,18 @@ public class ChartFormatRequest {
    public Boolean getFillGapWithDash() { return fillGapWithDash; }
    public void setFillGapWithDash(Boolean fillGapWithDash) { this.fillGapWithDash = fillGapWithDash; }
 
+   /**
+    * Per-field display formats, keyed by the ref's full name as it appears in the chart's binding
+    * (e.g. {@code STATE}, {@code DistinctCount(CUSTOMER_ID)}). Null/empty = no change.
+    *
+    * <p>Scope is the FIELD, not one slot: a field bound in more than one place (x and color, say)
+    * is reformatted everywhere it renders. That is the wizard's own behavior — VSWizardFormatService
+    * keys formats by field name alone, and formulas that share a type (sum/max/min/first/last) even
+    * share one entry. See VSWizardBindingHandler.applyFieldFormats.
+    */
+   public Map<String, FieldFormatModel> getFieldFormats() { return fieldFormats; }
+   public void setFieldFormats(Map<String, FieldFormatModel> fieldFormats) { this.fieldFormats = fieldFormats; }
+
    /** The runtime viewsheet that holds the live chart (the plugin's active-chart runtimeId). */
    private String wizRuntimeId;
    /** The chart assembly name within that runtime. */
@@ -131,4 +145,5 @@ public class ChartFormatRequest {
    private Boolean fillTimeGap;
    private Boolean fillZero;
    private Boolean fillGapWithDash;
+   private Map<String, FieldFormatModel> fieldFormats;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/FieldFormatModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/FieldFormatModel.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * A field's display format, as the composer's Format pane models it — the number/date half of
+ * {@code inetsoft.web.adhoc.model.FormatInfoModel} ({@code format} / {@code formatSpec} /
+ * {@code dateSpec} / {@code durationPadZeros}), which is exactly what
+ * {@code VSWizardFormatService.updateFormat} consumes.
+ *
+ * <p>Deliberately NOT {@code FormatInfoModel} itself: that class carries the pane's whole style
+ * payload (colors, borders, font, alignment) and is annotated
+ * {@code @JsonTypeInfo(use = Id.CLASS, property = "type")}, which would require the caller to write
+ * a Java class name into the JSON. Nothing on this path sets styling, so this is the format subset
+ * on its own.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FieldFormatModel {
+   /**
+    * The format type, as an {@code XConstants} name: {@code DateFormat}, {@code CurrencyFormat},
+    * {@code PercentFormat}, {@code DecimalFormat}, {@code CommaFormat}, {@code MessageFormat}, or
+    * {@code DurationFormat}. Null or empty clears the field's user-defined format.
+    */
+   public String getFormat() { return format; }
+   public void setFormat(String format) { this.format = format; }
+
+   /**
+    * The format pattern (e.g. {@code #,##0.0%}). Null falls back to the Format pane's default for
+    * the chosen type, so a caller that only knows "percent" does not have to invent a pattern.
+    */
+   public String getFormatSpec() { return formatSpec; }
+   public void setFormatSpec(String formatSpec) { this.formatSpec = formatSpec; }
+
+   /**
+    * DateFormat only: {@code FULL}, {@code LONG}, {@code MEDIUM}, {@code SHORT}, or {@code Custom}.
+    * Anything other than {@code Custom} supplies the pattern itself, so formatSpec is ignored then —
+    * the same rule VSWizardFormatService applies.
+    */
+   public String getDateSpec() { return dateSpec; }
+   public void setDateSpec(String dateSpec) { this.dateSpec = dateSpec; }
+
+   /** DurationFormat only: pad with leading zeros. Null is treated as true (FormatInfoModel's default). */
+   public Boolean getDurationPadZeros() { return durationPadZeros; }
+   public void setDurationPadZeros(Boolean durationPadZeros) { this.durationPadZeros = durationPadZeros; }
+
+   private String format;
+   private String formatSpec;
+   private String dateSpec;
+   private Boolean durationPadZeros;
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -2330,7 +2330,14 @@ public class WizAutoBindingService {
       return result;
    }
 
-   /** Format pane defaults, applied when the caller names a type but no pattern. */
+   /**
+    * Patterns used when the caller names a numeric type but no pattern. These are the composer's own
+    * spec strings for each type (formatting-pane.component.ts, its decimal-adjust branch), but note
+    * this is a DELIBERATE divergence from the wizard: picking "Percent" fresh in the Format pane
+    * leaves formatSpec null. A pattern is supplied here because this API's callers describe intent
+    * ("show it as a percentage") rather than authoring a DecimalFormat string, and a null spec would
+    * make the type a no-op for them.
+    */
    private static final Map<String, String> DEFAULT_FORMAT_SPECS = Map.of(
       XConstants.PERCENT_FORMAT, "#,##0.0%",
       XConstants.CURRENCY_FORMAT, "¤#.000",
@@ -2346,8 +2353,9 @@ public class WizAutoBindingService {
     * Converts the wire model into the VSFormat the wizard's format machinery consumes, applying the
     * same normalizations VSWizardFormatService.updateFormat does so both entry points behave alike:
     * duration pad-zeros folded into the type, CommaFormat rewritten to DecimalFormat + "#,##0", and a
-    * non-Custom dateSpec used as the pattern. A named type with no pattern takes the Format pane's
-    * default rather than rendering unformatted.
+    * non-Custom dateSpec used as the pattern. It then goes one step further than that method and
+    * supplies a default pattern for a numeric type given without one — see DEFAULT_FORMAT_SPECS for
+    * why this API diverges there.
     *
     * <p>A null/blank type clears the field's user-defined format. An unrecognized one throws rather
     * than being dropped — silently ignoring it would render the chart unchanged with no indication
@@ -2403,25 +2411,93 @@ public class WizAutoBindingService {
          return;
       }
 
+      List<ChartRef> refs = VSWizardBindingHandler.collectFormattableRefs(chart.getVSChartInfo());
       Map<String, VSFormat> formats = new LinkedHashMap<>();
 
+      // Validate EVERY entry before applying any of them. applyFieldFormats mutates the live chart for
+      // the fields it matches and only then reports the ones it could not, so validating afterwards
+      // would leave a mixed valid/invalid request partially applied — and the non-copy path (the
+      // default) has no rollback for property writes, only for the assembly duplication. The caller
+      // would get a 400 for the whole request while some of it had already taken effect.
+      Set<String> unknown = new LinkedHashSet<>();
+
       for(Map.Entry<String, FieldFormatModel> entry : fieldFormats.entrySet()) {
-         formats.put(entry.getKey(), toVSFormat(entry.getKey(), entry.getValue()));
+         String field = entry.getKey();
+
+         if(refs.stream().noneMatch(ref -> field.equals(ref.getFullName()))) {
+            unknown.add(field);
+            continue;
+         }
+
+         VSFormat format = toVSFormat(field, entry.getValue());
+         checkFormatFitsFieldType(field, format, refs);
+         formats.put(field, format);
       }
 
-      Set<String> unmatched = bindingHandler.applyFieldFormats(rvs, chart, formats);
-
-      if(!unmatched.isEmpty()) {
-         String bindable = VSWizardBindingHandler.collectFormattableRefs(chart.getVSChartInfo())
-            .stream()
+      if(!unknown.isEmpty()) {
+         String bindable = refs.stream()
             .map(ChartRef::getFullName)
             .distinct()
             .sorted()
             .collect(Collectors.joining(", "));
 
          throw new IllegalArgumentException(
-            "No such field(s) in this chart's binding: " + String.join(", ", unmatched) +
+            "No such field(s) in this chart's binding: " + String.join(", ", unknown) +
             ". Bindable fields: " + (bindable.isEmpty() ? "(none)" : bindable));
+      }
+
+      // Everything resolved above, so nothing should come back unmatched; treated as a defect rather
+      // than ignored if the handler's own traversal ever diverges from collectFormattableRefs.
+      Set<String> unmatched = bindingHandler.applyFieldFormats(rvs, chart, formats);
+
+      if(!unmatched.isEmpty()) {
+         throw new IllegalStateException(
+            "Field format(s) resolved against the binding but matched no ref on apply: " +
+            String.join(", ", unmatched));
+      }
+   }
+
+   /** Formats that only mean something on a numeric field. */
+   private static final Set<String> NUMERIC_ONLY_FORMATS = Set.of(
+      XConstants.PERCENT_FORMAT, XConstants.CURRENCY_FORMAT, XConstants.DECIMAL_FORMAT);
+
+   /**
+    * Rejects a format that cannot mean anything for the field it names — a numeric format on a
+    * string dimension, or a date format on something that is not a date. StyleBI accepts such a
+    * format without complaint and renders the value exactly as before, so nothing downstream would
+    * ever reveal that the request had no effect.
+    *
+    * <p>Only a KNOWN mismatch is rejected. A name that matches no ref is reported separately by the
+    * caller, and a ref with no declared data type is left alone: refusing a valid edit on a guess is
+    * worse than letting an odd one through. DurationFormat and MessageFormat are not constrained —
+    * the composer's Format pane offers every type for every field, so this must not be stricter than
+    * the pane except where the outcome is provably nothing.
+    */
+   private static void checkFormatFitsFieldType(String fullName, VSFormat format, List<ChartRef> refs) {
+      String formatValue = format.getFormatValue();
+
+      if(formatValue == null) {
+         return;
+      }
+
+      String dataType = refs.stream()
+         .filter(ref -> fullName.equals(ref.getFullName()))
+         .map(ChartRef::getDataType)
+         .filter(type -> type != null && !type.isEmpty())
+         .findFirst()
+         .orElse(null);
+
+      if(dataType == null) {
+         return;
+      }
+
+      boolean mismatch = NUMERIC_ONLY_FORMATS.contains(formatValue) && !XSchema.isNumericType(dataType)
+         || XConstants.DATE_FORMAT.equals(formatValue) && !XSchema.isDateType(dataType);
+
+      if(mismatch) {
+         throw new IllegalArgumentException(
+            "Format '" + formatValue + "' does not apply to field '" + fullName +
+            "' (data type " + dataType + ")");
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -37,6 +37,7 @@ import inetsoft.sree.security.SecurityEngine;
 import inetsoft.sree.security.SecurityException;
 import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
+import inetsoft.web.adhoc.model.FormatInfoModel;
 import inetsoft.web.vswizard.handler.VSWizardBindingHandler;
 import inetsoft.web.vswizard.model.VSWizardData;
 import inetsoft.web.vswizard.model.recommender.*;
@@ -2261,6 +2262,11 @@ public class WizAutoBindingService {
             }
          }
 
+         // Per-field display formats (percent / currency / decimal / date / duration). Applied last so
+         // it runs against the chart the descriptor edits above have already settled, and inside this
+         // try block so a bad field name rolls the copy back like any other failure here.
+         applyFieldFormats(rvs, chart, request.getFieldFormats());
+
          // Invalidate the cached runtime descriptor so the change regenerates on re-execute.
          info.setRTChartDescriptor(null);
 
@@ -2322,6 +2328,101 @@ public class WizAutoBindingService {
       }
 
       return result;
+   }
+
+   /** Format pane defaults, applied when the caller names a type but no pattern. */
+   private static final Map<String, String> DEFAULT_FORMAT_SPECS = Map.of(
+      XConstants.PERCENT_FORMAT, "#,##0.0%",
+      XConstants.CURRENCY_FORMAT, "¤#.000",
+      XConstants.DECIMAL_FORMAT, "###0.0");
+
+   /** The format types the Format pane offers, plus CommaFormat, which is normalized away below. */
+   private static final Set<String> SUPPORTED_FORMATS = Set.of(
+      XConstants.DATE_FORMAT, XConstants.CURRENCY_FORMAT, XConstants.PERCENT_FORMAT,
+      XConstants.DECIMAL_FORMAT, XConstants.COMMA_FORMAT, XConstants.MESSAGE_FORMAT,
+      XConstants.DURATION_FORMAT);
+
+   /**
+    * Converts the wire model into the VSFormat the wizard's format machinery consumes, applying the
+    * same normalizations VSWizardFormatService.updateFormat does so both entry points behave alike:
+    * duration pad-zeros folded into the type, CommaFormat rewritten to DecimalFormat + "#,##0", and a
+    * non-Custom dateSpec used as the pattern. A named type with no pattern takes the Format pane's
+    * default rather than rendering unformatted.
+    *
+    * <p>A null/blank type clears the field's user-defined format. An unrecognized one throws rather
+    * than being dropped — silently ignoring it would render the chart unchanged with no indication
+    * anything was wrong.
+    */
+   static VSFormat toVSFormat(String field, FieldFormatModel model) {
+      VSFormat fmt = new VSFormat();
+      String type = model == null || model.getFormat() == null ? null : model.getFormat().trim();
+
+      if(type == null || type.isEmpty()) {
+         return fmt;
+      }
+
+      String canonical = SUPPORTED_FORMATS.stream()
+         .filter(supported -> supported.equalsIgnoreCase(type))
+         .findFirst()
+         .orElseThrow(() -> new IllegalArgumentException(
+            "Unsupported format '" + type + "' for field '" + field + "'; valid: " +
+            SUPPORTED_FORMATS.stream().sorted().collect(Collectors.joining(", "))));
+
+      boolean padZeros = model.getDurationPadZeros() == null || model.getDurationPadZeros();
+      String formatValue = FormatInfoModel.getDurationFormat(canonical, padZeros);
+      String formatSpec = model.getFormatSpec();
+      String dateSpec = model.getDateSpec();
+
+      if(XConstants.COMMA_FORMAT.equals(formatValue)) {
+         formatValue = XConstants.DECIMAL_FORMAT;
+         formatSpec = "#,##0";
+      }
+      else if(XConstants.DATE_FORMAT.equals(formatValue) && !"Custom".equals(dateSpec)) {
+         formatSpec = dateSpec;
+      }
+      else if(formatSpec == null || formatSpec.isEmpty()) {
+         formatSpec = DEFAULT_FORMAT_SPECS.get(formatValue);
+      }
+
+      fmt.setFormatValue(formatValue);
+      fmt.setFormatExtentValue(formatSpec);
+
+      return fmt;
+   }
+
+   /**
+    * Applies the request's per-field display formats to the chart, reusing the wizard's own apply step
+    * (see VSWizardBindingHandler.applyFieldFormats). A key that names no ref in the current binding is
+    * an error, not a no-op: StyleBI would render the chart unchanged and the caller would have no way
+    * to tell its format request was dropped.
+    */
+   private void applyFieldFormats(RuntimeViewsheet rvs, ChartVSAssembly chart,
+                                  Map<String, FieldFormatModel> fieldFormats)
+   {
+      if(fieldFormats == null || fieldFormats.isEmpty()) {
+         return;
+      }
+
+      Map<String, VSFormat> formats = new LinkedHashMap<>();
+
+      for(Map.Entry<String, FieldFormatModel> entry : fieldFormats.entrySet()) {
+         formats.put(entry.getKey(), toVSFormat(entry.getKey(), entry.getValue()));
+      }
+
+      Set<String> unmatched = bindingHandler.applyFieldFormats(rvs, chart, formats);
+
+      if(!unmatched.isEmpty()) {
+         String bindable = VSWizardBindingHandler.collectFormattableRefs(chart.getVSChartInfo())
+            .stream()
+            .map(ChartRef::getFullName)
+            .distinct()
+            .sorted()
+            .collect(Collectors.joining(", "));
+
+         throw new IllegalArgumentException(
+            "No such field(s) in this chart's binding: " + String.join(", ", unmatched) +
+            ". Bindable fields: " + (bindable.isEmpty() ? "(none)" : bindable));
+      }
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/model/ChartFormatRequestTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/ChartFormatRequestTest.java
@@ -67,4 +67,65 @@ class ChartFormatRequestTest {
       assertEquals("T", req.getXAxisTitle());
       assertTrue(mapper.writeValueAsString(req).contains("\"xAxisTitle\":\"T\""));
    }
+
+   @Test
+   void fieldFormatsDeserializeAsAMapKeyedByRefFullName() throws Exception {
+      // Keys are ref full names straight out of the binding, so they carry characters a property
+      // name never would — parentheses, spaces. They must survive as map keys verbatim.
+      ObjectMapper mapper = new ObjectMapper()
+         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+
+      ChartFormatRequest req = mapper.readValue(
+         """
+         { "wizRuntimeId": "rt-1", "assemblyName": "Chart1",
+           "fieldFormats": {
+              "DistinctCount(CUSTOMER_ID)": { "format": "PercentFormat", "formatSpec": "#,##0.0%" },
+              "Order Date": { "format": "DateFormat", "dateSpec": "SHORT" },
+              "Elapsed": { "format": "DurationFormat", "durationPadZeros": false }
+           } }
+         """,
+         ChartFormatRequest.class);
+
+      assertEquals(3, req.getFieldFormats().size());
+
+      FieldFormatModel percent = req.getFieldFormats().get("DistinctCount(CUSTOMER_ID)");
+      assertEquals("PercentFormat", percent.getFormat());
+      assertEquals("#,##0.0%", percent.getFormatSpec());
+      // Untouched fields stay null so the service can tell "not specified" from "set to empty".
+      assertNull(percent.getDateSpec());
+      assertNull(percent.getDurationPadZeros());
+
+      assertEquals("SHORT", req.getFieldFormats().get("Order Date").getDateSpec());
+      assertEquals(Boolean.FALSE, req.getFieldFormats().get("Elapsed").getDurationPadZeros());
+   }
+
+   @Test
+   void fieldFormatsIsOptional() throws Exception {
+      // Every existing caller omits it; absent must mean "no field formats", not an empty map.
+      ObjectMapper mapper = new ObjectMapper()
+         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+
+      ChartFormatRequest req = mapper.readValue(
+         "{ \"wizRuntimeId\": \"rt-1\", \"assemblyName\": \"Chart1\", \"chartTitle\": \"T\" }",
+         ChartFormatRequest.class);
+
+      assertNull(req.getFieldFormats());
+   }
+
+   @Test
+   void fieldFormatModelIgnoresUnknownProperties() throws Exception {
+      // The pane's full format model carries styling (color, font, borders) this subset does not
+      // model. A caller pasting one through must not 400 over the extra keys.
+      ObjectMapper mapper = new ObjectMapper()
+         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+
+      ChartFormatRequest req = mapper.readValue(
+         """
+         { "fieldFormats": { "SALES": {
+              "format": "CurrencyFormat", "color": "#000000", "font": { "fontSize": "11" } } } }
+         """,
+         ChartFormatRequest.class);
+
+      assertEquals("CurrencyFormat", req.getFieldFormats().get("SALES").getFormat());
+   }
 }


### PR DESCRIPTION
## What

`/viewsheet/format` carried chart-level properties only (titles, y-axis scale, legend, markers, time-gap fill). A request to format a bound field's *values* — percent, currency, decimal, date, duration — had nowhere to land.

Adds `ChartFormatRequest.fieldFormats`: a map of ref full name to `FieldFormatModel`, the number/date subset of the composer's Format pane (`format` / `formatSpec` / `dateSpec` / `durationPadZeros`).

## How

**Reuses the wizard's own apply step.** New `VSWizardBindingHandler.applyFieldFormats` builds a throwaway `VSTemporaryInfo` holding just the requested formats and hands it to the existing `updateChartFormat(updateAssembly=true)`. That works because `changeFormat` only *reads* the temporary info in that direction (`getUserFormat`/`getDefaultFormat`); every write to it lives in the `!updateAssembly` branch.

Two things follow from reusing it:

- The formats reach **every** place a field renders — axis and column labels, the period field, group fields' plot descriptor, the color/shape/size legends, the text field, each aggregate's aesthetic fields under multi-aesthetic, and the Gantt refs. A hand-rolled ref walk would silently cover a subset.
- Refs with no entry resolve to a null user format and are left untouched, so "reformat only the named fields" falls out with no matching logic of its own.

**Keys are ref full names.** The translation to `getNameForFormat`'s internal key — where same-type formulas (sum/max/min/first/last) deliberately share one entry under the bare column — stays inside the handler rather than leaking into the wire contract.

**Scope is the field, not one slot.** A field bound in more than one place is reformatted everywhere it renders. This is the wizard's own semantics: `VSWizardFormatService` keys formats by field name alone.

**Not `FormatInfoModel` itself.** That class carries the pane's whole style payload (colors, borders, font, alignment) and is annotated `@JsonTypeInfo(use = Id.CLASS, property = "type")`, which would require the caller to write a Java class name into the JSON. `FieldFormatModel` is the format subset on its own.

## Robustness

- Normalization follows `VSWizardFormatService.updateFormat`: duration pad-zeros folded into the type, `CommaFormat` rewritten to `DecimalFormat` + `#,##0`, and a non-`Custom` `dateSpec` used as the pattern.
- One deliberate divergence: a numeric type given without a pattern gets one (`PercentFormat` → `#,##0.0%`, `CurrencyFormat` → `¤#.000`, `DecimalFormat` → `###0.0`). Picking a type fresh in the Format pane leaves the spec null; this endpoint fills it in because its callers describe intent rather than authoring a DecimalFormat string, and a null spec would make the type a silent no-op for them.
- A format that cannot apply to the field it names — a numeric format on a non-numeric field, `DateFormat` on a non-date — is rejected with the field's data type. Only a known mismatch is refused: a ref with no declared data type is left alone, and `DurationFormat`/`MessageFormat` are unconstrained, so this is never stricter than the Format pane except where the outcome is provably nothing.
- Every entry is resolved and type-checked before any of them is applied, so a request mixing valid and invalid field names fails without having partly taken effect.
- A key naming no bound field is rejected with an `IllegalArgumentException` listing the bindable names (→ 400), never silently dropped — StyleBI would otherwise render the chart unchanged with no indication the request was ignored.
- An unrecognized format type is rejected the same way.
- The apply runs inside `setChartFormat`'s existing try block, so it reuses that block's copy-then-apply, rollback and persist machinery.

## Tests

`ChartFormatRequestTest` (existing file) gains wire-contract cases: `fieldFormats` deserializing as a map keyed by names that carry parentheses and spaces, the field staying optional for every existing caller, and `FieldFormatModel` tolerating the styling keys a pasted pane model would bring along. 5/5 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
