### PR TITLE
feat(wiz): sync source chart configs onto rebuilt assembly

### DIFF
--- a/core/src/main/java/inetsoft/web/vswizard/handler/SyncChartHandler.java
+++ b/core/src/main/java/inetsoft/web/vswizard/handler/SyncChartHandler.java
@@ -110,7 +110,7 @@ public class SyncChartHandler extends SyncAssemblyHandler {
       targetAssemblyInfo.setEnabledValue(fromAssemblyInfo.getEnabledValue());
 
       // Title
-      if(tempInfo.getDescription() == null) {
+      if(tempInfo == null || tempInfo.getDescription() == null) {
          targetAssemblyInfo.setTitleValue(fromChart.getTitleValue());
          targetAssemblyInfo.setTitleVisibleValue(fromChart.getChartInfo().isTitleVisible());
       }

--- a/core/src/main/java/inetsoft/web/vswizard/handler/SyncChartHandler.java
+++ b/core/src/main/java/inetsoft/web/vswizard/handler/SyncChartHandler.java
@@ -170,9 +170,15 @@ public class SyncChartHandler extends SyncAssemblyHandler {
       String script = fromAssemblyInfo.getScript();
 
       if(!StringUtils.isEmpty(script)) {
-         VSWizardOriginalModel originalModel = tempInfo.getOriginalModel();
+         // tempInfo is null on the rebuild config-sync path (WizVsService.syncConfigs(null, ..)); guard the
+         // deref so a scripted source chart doesn't NPE here and abort the whole per-chart sync via the
+         // caller's catch. updateScript only rewrites viewsheet['<originalName>'] references, so with no
+         // original name there is nothing to rename -- copy the script verbatim (updateScript would NPE on
+         // a null oname via String.replaceAll(null, ..)).
+         VSWizardOriginalModel originalModel = tempInfo != null ? tempInfo.getOriginalModel() : null;
          String originalName = originalModel != null ? originalModel.getOriginalName() : null;
-         targetAssemblyInfo.setScript(updateScript(script, originalName, targetChart.getName()));
+         targetAssemblyInfo.setScript(
+            originalName != null ? updateScript(script, originalName, targetChart.getName()) : script);
       }
 
       targetAssemblyInfo.setScriptEnabled(fromAssemblyInfo.isScriptEnabled());

--- a/core/src/main/java/inetsoft/web/vswizard/handler/SyncInfoHandler.java
+++ b/core/src/main/java/inetsoft/web/vswizard/handler/SyncInfoHandler.java
@@ -60,22 +60,39 @@ public class SyncInfoHandler {
          return;
       }
 
+      syncConfigs(tempInfo, source, target);
+   }
+
+   /**
+    * Sync the source assembly's configs onto target, dispatching by type — WITHOUT the table-name
+    * gate that shouldSyncInfo (used by syncInfo) applies. Used when re-binding a chart against a
+    * REBUILT worksheet: the table name changes, but the configs must still carry over. Same-type
+    * only (configs are type-specific); cross-type is a no-op.
+    */
+   public void syncConfigs(VSTemporaryInfo tempInfo, VSAssembly source, VSAssembly target) {
+      if(source == null || target == null) {
+         return;
+      }
+
       syncScript(source, target);
 
-      if(source instanceof ChartVSAssembly) {
+      if(source instanceof ChartVSAssembly && target instanceof ChartVSAssembly) {
          chartHandler.syncChart(tempInfo, (ChartVSAssembly) source, (ChartVSAssembly) target,
                                 true, true);
       }
-      else if(source instanceof TableVSAssembly) {
+      else if(source instanceof TableVSAssembly && target instanceof TableVSAssembly) {
          tableHandler.syncTable((TableVSAssembly) source, (TableVSAssembly) target);
       }
-      else if(source instanceof CrosstabVSAssembly) {
+      else if(source instanceof CrosstabVSAssembly && target instanceof CrosstabVSAssembly) {
          crostabHandler.syncCrosstab((CrosstabVSAssembly) source, (CrosstabVSAssembly) target);
       }
-      else if(source instanceof OutputVSAssembly) {
+      else if(source instanceof OutputVSAssembly && target instanceof OutputVSAssembly) {
          VSAssemblyInfo info = source.getVSAssemblyInfo();
          FormatInfo formatInfo = info.getFormatInfo();
-         target.setFormatInfo(formatInfo.clone());
+
+         if(formatInfo != null) {
+            target.setFormatInfo(formatInfo.clone());
+         }
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/model/AutoBindingRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/AutoBindingRequest.java
@@ -156,6 +156,19 @@ public class AutoBindingRequest {
    }
 
    /**
+    * When true, the create call this autoBinding drives should sync the previous (source) chart's
+    * configs — highlight/format/condition/etc. — onto the freshly-bound assembly. Set by the AI
+    * layer only on a continuation (rebuild) turn; false on a fresh creation.
+    */
+   public boolean isSyncConfigs() {
+      return syncConfigs;
+   }
+
+   public void setSyncConfigs(boolean syncConfigs) {
+      this.syncConfigs = syncConfigs;
+   }
+
+   /**
     * When set, replace THIS SPECIFIC assembly in place instead of whichever assembly is currently
     * primary — a session shares one output viewsheet/runtime across every turn, so "whichever is
     * primary" is always the latest turn's chart, not necessarily the one the user targeted. Used
@@ -203,4 +216,5 @@ public class AutoBindingRequest {
 
    private boolean copy;
    private String assemblyName;
+   private boolean syncConfigs;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/CreateVisualizationModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/CreateVisualizationModel.java
@@ -113,6 +113,19 @@ public class CreateVisualizationModel {
    }
 
    /**
+    * When true, createViewsheetInternal syncs the source chart's configs (resolved via
+    * getAssemblyName()) onto the newly-built assembly — reusing the wizard's SyncInfoHandler.
+    * Gated so a fresh creation never inherits an unrelated chart's configs.
+    */
+   public boolean isSyncConfigs() {
+      return syncConfigs;
+   }
+
+   public void setSyncConfigs(boolean syncConfigs) {
+      this.syncConfigs = syncConfigs;
+   }
+
+   /**
     * Which existing chart this call addresses, by name (see
     * {@code WizVsService.createViewsheetInternal}). Null — the default and every pre-existing
     * caller — means the viewsheet's current PRIMARY assembly, i.e. the chart created or copied most
@@ -168,4 +181,5 @@ public class CreateVisualizationModel {
    private transient VSAssembly primaryAssembly;
    private transient boolean keepCondition;
    private boolean copy;
+   private boolean syncConfigs;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -320,6 +320,7 @@ public class WizAutoBindingService {
             vsModel.setSampleMaxRows(request.getSampleMaxRows());
             vsModel.setCopy(request.isCopy());
             vsModel.setAssemblyName(request.getAssemblyName());
+            vsModel.setSyncConfigs(request.isSyncConfigs());
 
             WizVsService.PostAssemblyHook hook = (wizRvs, asm) -> {
                if(asm instanceof ChartVSAssembly) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -62,13 +62,13 @@ import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.VSUtil;
 import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
+import inetsoft.web.vswizard.handler.SyncInfoHandler;
 import inetsoft.web.vswizard.recommender.WizardRecommenderUtil;
 import inetsoft.web.wiz.WizUtil;
 import inetsoft.web.wiz.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import inetsoft.web.vswizard.handler.SyncInfoHandler;
 
 import java.awt.Color;
 import java.awt.Font;
@@ -1288,6 +1288,13 @@ public class WizVsService {
             // etc.) onto the freshly-bound assembly. syncSource is the chart being refined (named via
             // model.getAssemblyName()), falling back to the displaced assembly. Reuses the wizard's
             // per-type sync, bypassing its table-name gate (the rebuild renamed the source table).
+            //
+            // NOTE: syncMode reaches here only on the createViewsheet (skipExecution=false) path — it is
+            // set from the /viewsheet/autoBinding request (autoBinding() -> autoBindingInternal(.., false)),
+            // never from the changeType skipExecution=true path. So the skipExecution-only displaced-primary
+            // removal below (see "remove the displaced primary before persisting") never runs together with a
+            // sync, and cannot orphan existingTarget or delete the wrong primary. If a future caller ever sets
+            // syncConfigs on a skipExecution path, revisit that interaction.
             VSAssembly syncSource = resolveSyncSource(syncMode, existingTarget, replacedAssembly, previousPrimaryAssembly);
 
             if(syncSource != null && syncInfoHandler != null) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -68,6 +68,7 @@ import inetsoft.web.wiz.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import inetsoft.web.vswizard.handler.SyncInfoHandler;
 
 import java.awt.Color;
 import java.awt.Font;
@@ -79,11 +80,32 @@ import java.util.stream.Collectors;
 @Service
 public class WizVsService {
    public WizVsService(ViewsheetService viewsheetService, AssetRepository engine,
-                       SecurityEngine securityEngine)
+                       SecurityEngine securityEngine, SyncInfoHandler syncInfoHandler)
    {
       this.viewsheetService = viewsheetService;
       this.engine = engine;
       this.securityEngine = securityEngine;
+      this.syncInfoHandler = syncInfoHandler;
+   }
+
+   /**
+    * The assembly to sync configs FROM on a rebuild. In sync mode the AI layer names the chart being
+    * refined via model.getAssemblyName() (resolved here as existingTarget); otherwise fall back to the
+    * displaced assembly (replaced, or the demoted previous primary — same precedence as
+    * displacedForCondition). Null when not in sync mode.
+    */
+   static VSAssembly resolveSyncSource(boolean syncMode, VSAssembly existingTarget,
+                                       VSAssembly replacedAssembly, VSAssembly previousPrimaryAssembly)
+   {
+      if(!syncMode) {
+         return null;
+      }
+
+      if(existingTarget != null) {
+         return existingTarget;
+      }
+
+      return replacedAssembly != null ? replacedAssembly : previousPrimaryAssembly;
    }
 
    @FunctionalInterface
@@ -1158,6 +1180,7 @@ public class WizVsService {
             // In this (standard) path the named assembly is the one to REPLACE in place; the
             // modificationOnly branch above reads the same field as the chart to modify.
             String targetAssemblyName = model.getAssemblyName();
+            boolean syncMode = model.isSyncConfigs();
             VSAssembly existingTarget = null;
 
             if(!Tool.isEmptyString(targetAssemblyName)) {
@@ -1175,7 +1198,7 @@ public class WizVsService {
                existingTarget = foundVs;
             }
 
-            String assemblyName = !Tool.isEmptyString(targetAssemblyName)
+            String assemblyName = !(Tool.isEmptyString(targetAssemblyName) || syncMode)
                ? targetAssemblyName : uniqueAssemblyName(targetVs, ctx.title());
 
             if(model.getPrimaryAssembly() != null) {
@@ -1195,7 +1218,7 @@ public class WizVsService {
                }
             }
 
-            if(existingTarget != null) {
+            if(existingTarget != null && !syncMode) {
                // Targeted replace: swap in the new assembly under the SAME name, carrying over the
                // old one's exact primary state — no other assembly is touched either way.
                // model.isCopy() is NOT consulted here (only in the else branch below, via
@@ -1259,6 +1282,19 @@ public class WizVsService {
                if(cond != null) {
                   newDataAsm.setPreConditionList(cond.clone());
                }
+            }
+
+            // On a rebuild (syncConfigs), carry the source chart's configs (highlight/format/condition/
+            // etc.) onto the freshly-bound assembly. syncSource is the chart being refined (named via
+            // model.getAssemblyName()), falling back to the displaced assembly. Reuses the wizard's
+            // per-type sync, bypassing its table-name gate (the rebuild renamed the source table).
+            VSAssembly syncSource = resolveSyncSource(syncMode, existingTarget, replacedAssembly, previousPrimaryAssembly);
+
+            if(syncSource != null && syncInfoHandler != null) {
+               // syncChart copies primary from the (demoted) source, so re-assert the new assembly as
+               // primary afterward to keep this branch's addAssembly+setPrimary(true) invariant.
+               syncInfoHandler.syncConfigs(null, syncSource, assembly);
+               assembly.setPrimary(true);
             }
          }
 
@@ -4598,6 +4634,7 @@ public class WizVsService {
    private final ViewsheetService viewsheetService;
    private final AssetRepository engine;
    private final SecurityEngine securityEngine;
+   private final SyncInfoHandler syncInfoHandler;
 
    private static final Logger LOG = LoggerFactory.getLogger(WizVsService.class);
    private static final Map<Class<?>, BiFunction<Viewsheet, String, VSAssembly>> ASSEMBLY_FACTORIES = Map.of(

--- a/core/src/test/java/inetsoft/web/vswizard/handler/SyncChartHandlerNullTempInfoTest.java
+++ b/core/src/test/java/inetsoft/web/vswizard/handler/SyncChartHandlerNullTempInfoTest.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.vswizard.handler;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.VSCube;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.graph.ChartDescriptor;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.web.graph.handler.ChartRegionHandler;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Guards the null-tempInfo config-sync path (WizVsService rebuild calls syncConfigs(null, ..) -> the real
+ * SyncChartHandler.syncChart with tempInfo == null). SyncInfoHandlerSyncConfigsTest mocks SyncChartHandler,
+ * so it never exercises this real path; without the null-guard in syncChartProperties a scripted source chart
+ * NPEs on tempInfo.getOriginalModel() and syncChart's catch silently swallows it, aborting the ENTIRE
+ * per-chart sync (script/condition/format/hyperlink/highlight). This test drives the real handler.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class SyncChartHandlerNullTempInfoTest {
+   private ChartVSAssembly newChart(Viewsheet vs, String name) {
+      ChartVSAssembly chart = new ChartVSAssembly(vs, name);
+      chart.setVSChartInfo(new VSChartInfo());
+      chart.setXCube(new VSCube());
+      chart.setChartDescriptor(new ChartDescriptor());
+      return chart;
+   }
+
+   @Test
+   void syncChartWithNullTempInfoCopiesScriptFromScriptedSource() {
+      SyncChartHandler handler = new SyncChartHandler(mock(ChartRegionHandler.class));
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly from = newChart(vs, "Source");
+      ChartVSAssembly target = newChart(vs, "Target");
+
+      // A non-empty script drives the previously-unguarded tempInfo.getOriginalModel() deref.
+      from.getChartInfo().setScript("data['x'] = 1;");
+
+      // tempInfo == null mirrors the rebuild config-sync path — must NOT NPE.
+      handler.syncChart(null, from, target, true, true);
+
+      // Script is set at the very line that used to NPE. If the deref had thrown, syncChart's catch would
+      // have swallowed it and left the target script null (and everything after it un-synced).
+      assertEquals("data['x'] = 1;", target.getChartInfo().getScript());
+   }
+}

--- a/core/src/test/java/inetsoft/web/vswizard/handler/SyncInfoHandlerSyncConfigsTest.java
+++ b/core/src/test/java/inetsoft/web/vswizard/handler/SyncInfoHandlerSyncConfigsTest.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.vswizard.handler;
+
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.TableVSAssembly;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Tag("core")
+class SyncInfoHandlerSyncConfigsTest {
+   private SyncChartHandler chartHandler;
+   private SyncTableHandler tableHandler;
+   private SyncCrosstabHandler crosstabHandler;
+   private SyncInfoHandler handler;
+
+   @BeforeEach
+   void setUp() {
+      chartHandler = mock(SyncChartHandler.class);
+      tableHandler = mock(SyncTableHandler.class);
+      crosstabHandler = mock(SyncCrosstabHandler.class);
+      handler = new SyncInfoHandler(chartHandler, tableHandler, crosstabHandler);
+   }
+
+   @Test
+   void syncConfigsDispatchesChartAcrossDifferentTableNames() {
+      ChartVSAssembly src = mock(ChartVSAssembly.class);
+      ChartVSAssembly tgt = mock(ChartVSAssembly.class);
+      when(src.getTableName()).thenReturn("T");
+      when(tgt.getTableName()).thenReturn("T_FILTERED");
+
+      handler.syncConfigs(null, src, tgt);
+
+      // Table-name gate is NOT applied on this path — chart sync runs even across a rename.
+      verify(chartHandler).syncChart(null, src, tgt, true, true);
+   }
+
+   // NOTE: syncInfo's own table-name gate (shouldSyncInfo) is structurally preserved — syncInfo still
+   // runs `if(!shouldSyncInfo(...)) return;` BEFORE delegating to syncConfigs. It is not unit-asserted
+   // here because syncInfo also runs syncDrillFilter unconditionally, and a bare ChartVSAssembly mock
+   // (which IS-A DrillFilterVSAssembly) NPEs there; the existing wizard Sync* tests cover non-regression.
+
+   @Test
+   void syncConfigsSkipsCrossType() {
+      ChartVSAssembly src = mock(ChartVSAssembly.class);
+      TableVSAssembly tgt = mock(TableVSAssembly.class);
+
+      handler.syncConfigs(null, src, tgt);
+
+      verify(chartHandler, never()).syncChart(any(), any(), any(), anyBoolean(), anyBoolean());
+      verify(tableHandler, never()).syncTable(any(), any());
+   }
+
+   @Test
+   void syncConfigsDispatchesTable() {
+      TableVSAssembly src = mock(TableVSAssembly.class);
+      TableVSAssembly tgt = mock(TableVSAssembly.class);
+      when(src.getTableName()).thenReturn("T");
+      when(tgt.getTableName()).thenReturn("T_FILTERED");
+
+      handler.syncConfigs(null, src, tgt);
+
+      verify(tableHandler).syncTable(src, tgt);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/model/SyncConfigsFieldTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/SyncConfigsFieldTest.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("core")
+class SyncConfigsFieldTest {
+   @Test
+   void autoBindingRequestSyncConfigsRoundTrips() {
+      AutoBindingRequest req = new AutoBindingRequest();
+      assertFalse(req.isSyncConfigs());
+      req.setSyncConfigs(true);
+      assertTrue(req.isSyncConfigs());
+   }
+
+   @Test
+   void createVisualizationModelSyncConfigsRoundTrips() {
+      CreateVisualizationModel model = new CreateVisualizationModel();
+      assertFalse(model.isSyncConfigs());
+      model.setSyncConfigs(true);
+      assertTrue(model.isSyncConfigs());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/BindingSlotsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/BindingSlotsTest.java
@@ -144,7 +144,7 @@ class BindingSlotsTest {
       CrosstabVSAssembly assembly = new CrosstabVSAssembly();
       assembly.setVSCrosstabInfo(cinfo);
 
-      WizVsService service = new WizVsService(null, null, null);
+      WizVsService service = new WizVsService(null, null, null, null);
       CreateViewsheetResult.FlatBinding binding = service.collectFlatBinding(assembly);
 
       assertEquals(1, binding.getDimensions().size());

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceApplyHighlightCopyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceApplyHighlightCopyTest.java
@@ -87,7 +87,7 @@ class WizVsServiceApplyHighlightCopyTest {
       AssetRepository engine = mock(AssetRepository.class);
       SecurityEngine securityEngine = mock(SecurityEngine.class);
 
-      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine);
+      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine, null);
       service = spy(real);
 
       // A simple TEXT output assembly — the highlight branch with the fewest collaborators to satisfy,

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceClassifyChartRefSecondaryYTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceClassifyChartRefSecondaryYTest.java
@@ -66,7 +66,7 @@ class WizVsServiceClassifyChartRefSecondaryYTest {
    @Test
    void collectFlatBindingEchoesSecondaryYTrueForAChartMeasureOnTheSecondaryAxis() {
       WizVsService service = new WizVsService(
-         mock(ViewsheetService.class), mock(AssetRepository.class), mock(SecurityEngine.class));
+         mock(ViewsheetService.class), mock(AssetRepository.class), mock(SecurityEngine.class), null);
 
       VSChartAggregateRef agg = new VSChartAggregateRef();
       agg.setColumnValue("Sales");

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceCreateViewsheetSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceCreateViewsheetSecurityTest.java
@@ -60,7 +60,7 @@ class WizVsServiceCreateViewsheetSecurityTest {
          eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
          .thenReturn(false);
 
-      WizVsService service = new WizVsService(vsService, engine, securityEngine);
+      WizVsService service = new WizVsService(vsService, engine, securityEngine, null);
       CreateVisualizationModel model = new CreateVisualizationModel();
 
       SecurityException ex = assertThrows(SecurityException.class,
@@ -92,7 +92,7 @@ class WizVsServiceCreateViewsheetSecurityTest {
       when(vsService.openTemporaryViewsheet(any(), any(), eq(principal), any()))
          .thenThrow(marker);
 
-      WizVsService service = new WizVsService(vsService, engine, securityEngine);
+      WizVsService service = new WizVsService(vsService, engine, securityEngine, null);
       CreateVisualizationModel model = new CreateVisualizationModel();
 
       RuntimeException thrown = assertThrows(RuntimeException.class,
@@ -123,7 +123,7 @@ class WizVsServiceCreateViewsheetSecurityTest {
          eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
          .thenReturn(false);
 
-      WizVsService service = new WizVsService(vsService, engine, securityEngine);
+      WizVsService service = new WizVsService(vsService, engine, securityEngine, null);
 
       assertThrows(SecurityException.class,
          () -> service.persistViewsheet(vs, "1^128^__NULL__^visualizations/abc^host-org", principal));
@@ -144,7 +144,7 @@ class WizVsServiceCreateViewsheetSecurityTest {
          eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
          .thenReturn(false);
 
-      WizVsService service = new WizVsService(vsService, engine, securityEngine);
+      WizVsService service = new WizVsService(vsService, engine, securityEngine, null);
 
       assertThrows(SecurityException.class,
          () -> service.validateBinding(new CreateVisualizationModel(), principal));
@@ -163,7 +163,7 @@ class WizVsServiceCreateViewsheetSecurityTest {
          eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
          .thenReturn(false);
 
-      WizVsService service = new WizVsService(vsService, engine, securityEngine);
+      WizVsService service = new WizVsService(vsService, engine, securityEngine, null);
 
       assertThrows(SecurityException.class,
          () -> service.deleteViewsheet("1^128^__NULL__^visualizations/abc^host-org", principal));

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceDuplicateAssemblyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceDuplicateAssemblyTest.java
@@ -64,7 +64,7 @@ class WizVsServiceDuplicateAssemblyTest {
       AssetRepository engine = mock(AssetRepository.class);
       SecurityEngine sec = mock(SecurityEngine.class);
       when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
-      return new WizVsService(vsService, engine, sec);
+      return new WizVsService(vsService, engine, sec, null);
    }
 
    private static RuntimeViewsheet rvsOf(Viewsheet vs) {

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceDuplicatePrimaryAssemblyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceDuplicatePrimaryAssemblyTest.java
@@ -64,7 +64,7 @@ class WizVsServiceDuplicatePrimaryAssemblyTest {
       AssetRepository engine = mock(AssetRepository.class);
       SecurityEngine sec = mock(SecurityEngine.class);
       when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
-      return new WizVsService(vsService, engine, sec);
+      return new WizVsService(vsService, engine, sec, null);
    }
 
    private static RuntimeViewsheet rvsOf(Viewsheet vs) {

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFilterCopyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFilterCopyTest.java
@@ -94,7 +94,7 @@ class WizVsServiceFilterCopyTest {
       when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
       user = mock(Principal.class);
 
-      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine);
+      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine, null);
       service = spy(real);
 
       // The current primary assembly (isPrimary()=true) that findPrimaryAssembly resolves in the

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRebindClearsStaleRuntimeChartRefsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRebindClearsStaleRuntimeChartRefsTest.java
@@ -104,7 +104,7 @@ class WizVsServiceRebindClearsStaleRuntimeChartRefsTest {
       when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
       Principal user = mock(Principal.class);
 
-      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine);
+      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine, null);
       WizVsService service = spy(real);
 
       // Source worksheet resolveSourceContext must find, with a primary table assembly.

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRemoveVisualizationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRemoveVisualizationTest.java
@@ -45,7 +45,7 @@ class WizVsServiceRemoveVisualizationTest {
       when(entry.getPath()).thenReturn(
          WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/abc");
 
-      WizVsService service = new WizVsService(vsService, engine, grantedSecurity());
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null);
       service.removeVisualization("rt-1", "Chart1", null);
 
       verify(vs).removeAssembly("Chart1");
@@ -71,7 +71,7 @@ class WizVsServiceRemoveVisualizationTest {
       when(rvs.getEntry()).thenReturn(entry);
       when(entry.getPath()).thenReturn("some/other/folder/abc");
 
-      WizVsService service = new WizVsService(vsService, engine, grantedSecurity());
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null);
       service.removeVisualization("rt-1", "Chart1", null);
 
       verify(vs).removeAssembly("Chart1");
@@ -89,7 +89,7 @@ class WizVsServiceRemoveVisualizationTest {
       when(rvs.getViewsheet()).thenReturn(vs);
       when(vs.getAssembly("Chart1")).thenReturn(null);
 
-      WizVsService service = new WizVsService(vsService, engine, grantedSecurity());
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null);
       service.removeVisualization("rt-1", "Chart1", null);
 
       verify(vs, never()).removeAssembly(anyString());
@@ -102,7 +102,7 @@ class WizVsServiceRemoveVisualizationTest {
 
       when(vsService.getViewsheet("rt-1", null)).thenThrow(new RuntimeException("expired"));
 
-      WizVsService service = new WizVsService(vsService, engine, grantedSecurity());
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null);
       assertDoesNotThrow(() -> service.removeVisualization("rt-1", "Chart1", null));
    }
 
@@ -110,7 +110,7 @@ class WizVsServiceRemoveVisualizationTest {
    void throwsWhenArgsBlank() throws Exception {
       ViewsheetService vsService = mock(ViewsheetService.class);
       AssetRepository engine = mock(AssetRepository.class);
-      WizVsService service = new WizVsService(vsService, engine, grantedSecurity());
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null);
 
       assertThrows(IllegalArgumentException.class,
                    () -> service.removeVisualization("", "Chart1", null));
@@ -129,7 +129,7 @@ class WizVsServiceRemoveVisualizationTest {
       SecurityEngine sec = mock(SecurityEngine.class);
       when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(false);
 
-      WizVsService service = new WizVsService(vsService, engine, sec);
+      WizVsService service = new WizVsService(vsService, engine, sec, null);
 
       assertThrows(SecurityException.class,
                    () -> service.removeVisualization("rt-1", "Chart1", null));

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceResolveSyncSourceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceResolveSyncSourceTest.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.viewsheet.VSAssembly;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+@Tag("core")
+class WizVsServiceResolveSyncSourceTest {
+   @Test
+   void syncModeWithExistingTargetPrefersIt() {
+      VSAssembly existingTarget = mock(VSAssembly.class);
+      VSAssembly prevPrimary = mock(VSAssembly.class);
+
+      assertSame(existingTarget,
+         WizVsService.resolveSyncSource(true, existingTarget, null, prevPrimary));
+   }
+
+   @Test
+   void syncModeWithoutExistingTargetFallsBackToDisplaced() {
+      VSAssembly replaced = mock(VSAssembly.class);
+      VSAssembly prevPrimary = mock(VSAssembly.class);
+
+      // replacedAssembly wins over previousPrimaryAssembly (mirrors displacedForCondition).
+      assertSame(replaced,
+         WizVsService.resolveSyncSource(true, null, replaced, prevPrimary));
+      assertSame(prevPrimary,
+         WizVsService.resolveSyncSource(true, null, null, prevPrimary));
+   }
+
+   @Test
+   void nonSyncModeReturnsNull() {
+      VSAssembly existingTarget = mock(VSAssembly.class);
+
+      assertNull(WizVsService.resolveSyncSource(false, existingTarget, null, existingTarget));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceSecondaryYAxisRenderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceSecondaryYAxisRenderTest.java
@@ -112,7 +112,7 @@ class WizVsServiceSecondaryYAxisRenderTest {
       when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
       Principal user = mock(Principal.class);
 
-      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine);
+      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine, null);
       WizVsService service = spy(real);
 
       // Source worksheet resolveSourceContext must find, with a primary table assembly.


### PR DESCRIPTION
Reuse the wizard's per-type sync so a worksheet rebuild carries the previous chart's configs (highlight/format/condition/hyperlink + chart props) onto the freshly-bound assembly, instead of losing them to the recommender's fresh bind.

- SyncInfoHandler: extract a table-name-gate-free syncConfigs(...) shared by syncInfo; dispatch chart/table/crosstab/output by double-instanceof (cross-type is a no-op); syncInfo keeps its shouldSyncInfo table-name gate.
- SyncChartHandler.syncChartProperties: tolerate a null VSTemporaryInfo.
- WizVsService: single 4-arg constructor injecting SyncInfoHandler; add resolveSyncSource(...); createViewsheetInternal syncMode wiring (unique name, skip targeted-replace, sync from the source chart, re-assert primary).
- AutoBindingRequest / CreateVisualizationModel: add syncConfigs flag; WizAutoBindingService threads request.isSyncConfigs() onto the model.
- update WizVsService test call sites to the 4-arg constructor; add SyncConfigsFieldTest, SyncInfoHandlerSyncConfigsTest, WizVsServiceResolveSyncSourceTest.