### PR TITLE
fix(wiz): condMirror aggregate refs must be base-qualified like prevMirror

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
@@ -207,6 +207,61 @@ public class WsMergeService {
                   // worksheet persist/reload path gates on isAggregate(), silently dropping a
                   // genuinely non-empty AggregateInfo by the time the worksheet reloads.
                   condMirror.setAggregate(condHasAggr);
+
+                  // Qualify condMirror's own AGGREGATE refs against the table it mirrors, exactly
+                  // as ensureBaseHasPrevMirror does for prevMirror -- condMirror missed this and it
+                  // is the same bug: AssetQuery.createAssetQuery (via AssetQuerySandbox#
+                  // refreshColumnSelection, every viewsheet open) re-derives this mirror's columns
+                  // from the mirrored table's raw outputs (outer-attribute qualified) and
+                  // AggregateInfo#validate() drops any aggregate whose ref doesn't resolve against
+                  // them. srcBound's aggregate refs point at bare/aliased names (e.g. "order_count"
+                  // aliasing "id", "avg_order_value" aliasing "amount_total") that the raw
+                  // re-derivation never produces, so they were silently dropped -- collapsing the
+                  // chart to just its group ("Aggregate not found: <alias>").
+                  //
+                  // Unlike prevMirror (whose aggregates were on already-base-named columns),
+                  // condMirror's aggregate outputs are ALIASED: qualifying the aliased column
+                  // itself would yield "base.order_count" (getOuterAttribute uses the alias as the
+                  // name), which still won't match the raw re-derivation. Qualify the aggregate's
+                  // UNDERLYING column instead ("base.id") and re-apply the output alias, so the ref
+                  // resolves against the re-derived raw column while keeping its output name.
+                  if(condHasAggr) {
+                     AggregateInfo condAggr = condMirror.getAggregateInfo();
+                     ColumnSelection condPub = condMirror.getColumnSelection(true);
+                     ColumnSelection condPriv = condMirror.getColumnSelection(false);
+                     String condBase = stackOn.getName();
+
+                     for(int ai = 0; ai < condAggr.getAggregateCount(); ai++) {
+                        AggregateRef aref = condAggr.getAggregate(ai);
+                        DataRef aggColRef = aref.getDataRef();
+
+                        if(aggColRef == null) {
+                           continue;
+                        }
+
+                        String outputName = aggColRef.getName();
+                        String alias = (aggColRef instanceof ColumnRef)
+                           ? ((ColumnRef) aggColRef).getAlias() : null;
+                        // Qualify the underlying column (raw name), not the aliased wrapper, so the
+                        // result is "base.<rawName>" matching what the re-derivation produces.
+                        DataRef underlying = (aggColRef instanceof ColumnRef)
+                           ? ((ColumnRef) aggColRef).getDataRef() : aggColRef;
+                        ColumnRef qualifiedRef =
+                           new ColumnRef(AssetUtil.getOuterAttribute(condBase, underlying));
+
+                        if(alias != null) {
+                           qualifiedRef.setAlias(alias);
+                        }
+
+                        aref.setDataRef(qualifiedRef);
+                        replaceColumnByName(condPub, outputName, qualifiedRef);
+                        replaceColumnByName(condPriv, outputName, qualifiedRef);
+                     }
+
+                     condMirror.setColumnSelection(condPub, true);
+                     condMirror.setColumnSelection(condPriv, false);
+                  }
+
                   condMirror.setProperty(PROP_WIZ_MERGED, "true");
                   dashWS.addAssembly(condMirror);
                   wsRenameMap.put(srcBound.getName(), condMirrorName);

--- a/core/src/test/java/inetsoft/web/wiz/service/WsMergeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WsMergeServiceTest.java
@@ -29,6 +29,7 @@ import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.asset.TableAssembly;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.test.BaseTestConfiguration;
@@ -601,5 +602,103 @@ class WsMergeServiceTest {
       TableAssembly base = (TableAssembly) dashWS.getAssembly("PT_actual_base");
       assertNotNull(base, "the raw physical table must be renamed to \"_base\"");
       assertTrue(base.getAggregateInfo().isEmpty());
+   }
+
+   /**
+    * Regression for the condMirror sibling of the prevMirror bug fixed earlier: a chart that
+    * carries its OWN aggregation on a shared physical table is stacked as a condMirror, and its
+    * aggregate refs must be qualified against the table it mirrors the SAME way prevMirror's are
+    * -- otherwise {@code AssetQuery.createAssetQuery} (via {@code AssetQuerySandbox#
+    * refreshColumnSelection}, every viewsheet open) re-derives the condMirror's columns from the
+    * mirrored table's raw outputs and {@code AggregateInfo#validate()} silently drops any
+    * aggregate whose ref doesn't resolve against them, collapsing the chart to just its group
+    * ("Aggregate not found: &lt;alias&gt;" in GraphGenerator on a fresh dashboard open --
+    * reproduced live).
+    *
+    * <p>Crucially exercises the ALIASED-output case (the real shape wiz charts produce, e.g.
+    * "amount_total AS avg_order_value"): the fix must qualify the aggregate's UNDERLYING column to
+    * the base ("PT_base.amount_total") while preserving the output alias, since qualifying the
+    * aliased wrapper itself ("PT_base.avg_order_value") would still not match the raw
+    * re-derivation.</p>
+    */
+   @Test
+   void condMirrorAggregateRefsAreBaseQualifiedPreservingOutputAlias() {
+      Worksheet dashWS = new Worksheet();
+      // First chart (its own aggregation) -> becomes prevMirror carrying aggregation, so the
+      // second chart's condMirror stacks on the raw "PT_base".
+      dashWS.addAssembly(physicalTableWithGroupedAggregate(
+         dashWS, "PT", "date_order", "Quarter(date_order)", "order_count", AggregateFormula.COUNT_ALL));
+
+      // Second chart: its own aggregate is an ALIAS of a raw base column ("amount_total AS
+      // avg_order_value") -- the shape that reproduced the live bug.
+      Worksheet vizWS = new Worksheet();
+      vizWS.addAssembly(physicalTableWithAliasedAggregate(
+         vizWS, "PT", "date_order", "Quarter(date_order)", "amount_total", "avg_order_value",
+         AggregateFormula.AVG));
+
+      Map<String, String> renameMap = service.mergeWorksheet(vizWS, dashWS, "suffix1", new HashMap<>());
+
+      String condMirrorName = renameMap.get("PT");
+      assertNotNull(condMirrorName, "the second (own-aggregation) chart must map to a condMirror");
+      TableAssembly condMirror = (TableAssembly) dashWS.getAssembly(condMirrorName);
+      assertNotNull(condMirror);
+      assertEquals(MirrorTableAssembly.class, condMirror.getClass());
+
+      // prevMirror carries the first chart's aggregation, so the condMirror stacks on the raw base.
+      String stackedOn = ((MirrorTableAssembly) condMirror).getAssemblyName();
+      assertEquals("PT_base", stackedOn);
+
+      AggregateInfo condAggr = condMirror.getAggregateInfo();
+      assertEquals(1, condAggr.getAggregateCount());
+      DataRef aggRef = condAggr.getAggregate(0).getDataRef();
+
+      // The aggregate's UNDERLYING column must now be qualified to the mirrored table ("PT_base"),
+      // matching the outer-attribute shape the query engine re-derives -- while the OUTPUT name
+      // stays the alias so the chart binding still resolves "avg_order_value".
+      assertEquals("PT_base", aggRef.getEntity(),
+         "condMirror's aggregate ref must be qualified against the table it mirrors, so the query " +
+         "engine's independent re-derivation finds a match instead of dropping it");
+      assertEquals("amount_total", aggRef.getAttribute(),
+         "the underlying raw column must be what's qualified (not the alias)");
+      assertEquals("avg_order_value", aggRef.getName(),
+         "the aggregate's output alias must be preserved as its name");
+
+      // The condMirror's own column selection must carry a matching entry under that output name.
+      assertNotNull(condMirror.getColumnSelection(true).getAttribute("avg_order_value"),
+         "condMirror's column selection must contain a column matching its aggregate output name");
+   }
+
+   private static PhysicalBoundTableAssembly physicalTableWithAliasedAggregate(
+      Worksheet ws, String assemblyName, String rawGroupField, String groupOutputName,
+      String rawAggColumn, String aggregateAlias, AggregateFormula formula)
+   {
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, assemblyName);
+      table.setSourceInfo(new SourceInfo(SourceInfo.PHYSICAL_TABLE, "postgres", "public.product_template"));
+
+      ColumnSelection priv = new ColumnSelection();
+      priv.addAttribute(rawColumn(groupOutputName));
+      priv.addAttribute(rawColumn(rawGroupField));
+      priv.addAttribute(aliasedColumn(rawAggColumn, aggregateAlias));
+      table.setColumnSelection(priv, false);
+
+      ColumnSelection pub = new ColumnSelection();
+      pub.addAttribute(rawColumn(groupOutputName));
+      pub.addAttribute(aliasedColumn(rawAggColumn, aggregateAlias));
+      table.setColumnSelection(pub, true);
+
+      AggregateInfo aggr = new AggregateInfo();
+      aggr.addGroup(groupRef(groupOutputName));
+      aggr.addAggregate(new AggregateRef(aliasedColumn(rawAggColumn, aggregateAlias), formula));
+      table.setAggregateInfo(aggr);
+      return table;
+   }
+
+   private static ColumnRef aliasedColumn(String rawAttr, String alias) {
+      AttributeRef ref = new AttributeRef(null, rawAttr);
+      ref.setDataType(XSchema.DOUBLE);
+      ColumnRef col = new ColumnRef(ref);
+      col.setDataType(XSchema.DOUBLE);
+      col.setAlias(alias);
+      return col;
    }
 }


### PR DESCRIPTION
## Summary

The 4th and final bug from the same production dashboard investigated in #4422/#4424/#4434 — and it turned out to be the **uncovered sibling of #4422**, not a regression from any of them (nothing reverted).

PR #4422 fixed a chart's aggregation vanishing on a fresh dashboard open for the **prevMirror** table (qualify its own `AggregateRef`s with outer-attribute naming so `AssetQuery.createAssetQuery`'s independent per-open re-derivation — via `AssetQuerySandbox#refreshColumnSelection` — finds a match instead of dropping them in `AggregateInfo#validate`). The **condMirror** path (the mirror stacked for a chart carrying its *own* conditions/aggregation) has the identical exposure but never got the same treatment, so a merged dashboard's single-group aggregate chart (e.g. "Order Count vs Avg Order Value by Quarter") still lost both aggregate outputs on every fresh open — surfacing as `Aggregate not found: avg_order_value` in `GraphGenerator`.

**Confirmed live via targeted tracing:** on a fresh viewsheet open the condMirror's column selection was re-derived down to the mirrored table's raw base columns, and its `AggregateInfo` aggregate refs (pointing at `order_count`/`avg_order_value`) no longer resolved, so they were silently dropped and the chart collapsed to just its `Quarter` group.

## Why this evaded earlier verification

`verify_visualization` (and the MCP tooling) opens the runtime with `active=true`, which *executes* the aggregate query and never hits the `active=false` re-derivation path the real browser viewer takes — so it returned `ok:true` (7 rows = 7 quarters) even while the browser failed. Only a real browser open reproduces it. This is documented so future work doesn't trust `verify_visualization` alone for this class of bug.

## Fix

Qualify condMirror's own aggregate refs against the table it mirrors, mirroring `ensureBaseHasPrevMirror`. One adaptation vs prevMirror: a wiz chart's aggregate outputs are **aliased** (`amount_total AS avg_order_value`), and `getOuterAttribute` names the outer attribute by the alias — yielding `base.avg_order_value`, which still wouldn't match the raw re-derivation. So qualify the aggregate's **underlying** column (`base.amount_total`) and re-apply the output alias, so the ref resolves against the re-derived raw column while keeping its output name. Handles the non-aliased case identically.

## Test plan

- [x] New regression test `condMirrorAggregateRefsAreBaseQualifiedPreservingOutputAlias` — exercises the aliased-output case; **confirmed it fails without the fix** (aggregate ref left bare/`null`-entity, reproducing the drop) and passes with it.
- [x] Full `inetsoft.web.wiz.**` + `inetsoft.uql.asset.**` + `inetsoft.report.composition.**` + `ChartVSAQueryTest`: 769/769 passing.
- [x] Verified live end-to-end: the reported production dashboard now renders all 7 tiles (including both single-group aggregate charts) on a fresh browser open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)