### PR TITLE
fix(admin-chat): map admin AI endpoints under /api/wiz so the broker can reach them

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/AdminAiCallerGuard.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminAiCallerGuard.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * CSRF backstop for the admin-chat endpoints (`/api/wiz/v1/admin/*`).
+ *
+ * <p>These endpoints are called server-to-server by the wiz-services broker, which always presents
+ * the operator's SSO token as {@code Authorization: Bearer <jwt>}. They must be mapped under
+ * {@code /api/wiz/**} for that call to work at all: {@code WizServiceAuthenticationFilter}
+ * validates the JWT only on that prefix, and {@code CSRFFilter} exempts only that prefix (a broker
+ * has no session and therefore no CSRF token).
+ *
+ * <p>That exemption is a path match, so it assumes all wiz traffic is bearer-authenticated — an
+ * assumption the filters do not enforce. {@code WizServiceAuthenticationFilter} falls through when
+ * no bearer header is present ("let other filters handle authentication"), and
+ * {@code RequestPrincipalFilter} then resolves an ordinary browser-session principal into
+ * {@code getUserPrincipal()}, which is what {@code @Secured} and the Site-Administrator check read.
+ * Without this guard, a cross-site request could ride a logged-in administrator's session cookie
+ * into a server-property mutation, with CSRF protection skipped.
+ *
+ * <p>The check is on the request's {@code Authorization} header rather than the principal's
+ * {@code wiz} property: {@code WizServiceAuthenticationFilter} stores its principal in the HTTP
+ * session, so that property shows only that the *session* once presented a JWT, not that *this
+ * request* did. A cross-site form POST cannot set an {@code Authorization} header, and a scripted
+ * request that tries requires a CORS preflight an attacker cannot satisfy.
+ */
+public final class AdminAiCallerGuard {
+   private AdminAiCallerGuard() {
+   }
+
+   /**
+    * Requires that the in-flight request presented a bearer token, i.e. that it came from the
+    * broker rather than from a browser session riding the {@code /api/wiz/**} CSRF exemption.
+    *
+    * @throws ResponseStatusException with {@code 403} if there is no bearer token — including when
+    *                                 called outside a request context, so the guard fails closed
+    *                                 rather than silently passing.
+    */
+   public static void requireBearerAuthenticatedRequest() {
+      RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
+
+      if(!(attributes instanceof ServletRequestAttributes)) {
+         throw forbidden();
+      }
+
+      HttpServletRequest request = ((ServletRequestAttributes) attributes).getRequest();
+      String header = request.getHeader("Authorization");
+
+      if(header == null || !header.regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())
+         || header.substring(BEARER_PREFIX.length()).isBlank())
+      {
+         throw forbidden();
+      }
+   }
+
+   private static ResponseStatusException forbidden() {
+      // Deliberately terse: the caller is either the broker (which always sends the token) or an
+      // unintended browser-session caller, and neither benefits from detail here.
+      return new ResponseStatusException(
+         HttpStatus.FORBIDDEN, "Admin-chat endpoints require bearer-token authentication");
+   }
+
+   private static final String BEARER_PREFIX = "Bearer ";
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminAiCallerGuard.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminAiCallerGuard.java
@@ -18,6 +18,8 @@
 package inetsoft.web.admin.ai;
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -63,6 +65,7 @@ public final class AdminAiCallerGuard {
       RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
 
       if(!(attributes instanceof ServletRequestAttributes)) {
+         LOG.warn("Rejected admin-chat request with no servlet request context");
          throw forbidden();
       }
 
@@ -72,16 +75,20 @@ public final class AdminAiCallerGuard {
       if(header == null || !header.regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())
          || header.substring(BEARER_PREFIX.length()).isBlank())
       {
+         LOG.warn("Missing bearer token accessing {} from {}",
+                  request.getRequestURL(), request.getRemoteAddr());
          throw forbidden();
       }
    }
 
    private static ResponseStatusException forbidden() {
-      // Deliberately terse: the caller is either the broker (which always sends the token) or an
-      // unintended browser-session caller, and neither benefits from detail here.
+      // Deliberately terse response message: the caller is either the broker (which always sends
+      // the token) or an unintended browser-session caller, and neither benefits from detail here.
+      // The server-side log at the call site carries the diagnostic detail.
       return new ResponseStatusException(
          HttpStatus.FORBIDDEN, "Admin-chat endpoints require bearer-token authentication");
    }
 
    private static final String BEARER_PREFIX = "Bearer ";
+   private static final Logger LOG = LoggerFactory.getLogger(AdminAiCallerGuard.class);
 }

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminAiController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminAiController.java
@@ -39,7 +39,7 @@ public class AdminAiController {
       resourceType = ResourceType.EM_COMPONENT,
       resource = "settings/properties",
       actions = ResourceAction.ACCESS))
-   @PostMapping("/api/admin/ai/change")
+   @PostMapping("/api/wiz/v1/admin/change")
    public AdminChangeResult change(@RequestBody AdminChangeRequest req, Principal user) {
       requireSiteAdmin(user);
       return changeService.applyChange(req, user);
@@ -49,7 +49,7 @@ public class AdminAiController {
       resourceType = ResourceType.EM_COMPONENT,
       resource = "settings/properties",
       actions = ResourceAction.ACCESS))
-   @PostMapping("/api/admin/ai/backup")
+   @PostMapping("/api/wiz/v1/admin/backup")
    public Map<String, String> backup(@RequestBody Map<String, String> body, Principal user)
       throws Exception
    {
@@ -61,7 +61,7 @@ public class AdminAiController {
       resourceType = ResourceType.EM_COMPONENT,
       resource = "settings/properties",
       actions = ResourceAction.ACCESS))
-   @PostMapping("/api/admin/ai/restore")
+   @PostMapping("/api/wiz/v1/admin/restore")
    public Map<String, String> restore(@RequestBody Map<String, String> body, Principal user)
       throws Exception
    {
@@ -72,12 +72,16 @@ public class AdminAiController {
 
    /**
     * Per product decision, every admin-chat endpoint is restricted to callers holding the Site
-    * Administrator (system administrator) role, not merely EM_COMPONENT access.
+    * Administrator (system administrator) role, not merely EM_COMPONENT access. Also requires the
+    * request to carry a bearer token — see {@link AdminAiCallerGuard} for why the Site-Administrator
+    * check alone is not sufficient on the CSRF-exempt {@code /api/wiz/**} prefix.
     * {@link OrganizationManager#isSiteAdmin(Principal)} returns {@code true} for the default
     * admin principal in no-security deployments, so this guard does not lock out dev/single-user
     * setups and does not need an additional {@code isSecurityEnabled()} check.
     */
    private void requireSiteAdmin(Principal user) {
+      AdminAiCallerGuard.requireBearerAuthenticatedRequest();
+
       if(!OrganizationManager.getInstance().isSiteAdmin(user)) {
          throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Site Administrator role required");
       }

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminAiCallerGuardTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminAiCallerGuardTest.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai;
+
+import org.junit.jupiter.api.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the CSRF backstop for the admin-chat endpoints.
+ *
+ * <p>These endpoints live under {@code /api/wiz/**}, which {@code CSRFFilter} exempts from CSRF
+ * protection on the assumption that wiz traffic is bearer-JWT-authenticated. That assumption is
+ * not enforced by the filters: {@code WizServiceAuthenticationFilter} falls through when no bearer
+ * header is present, and {@code RequestPrincipalFilter} then resolves an ordinary browser session
+ * principal into {@code getUserPrincipal()}. Without this guard, a site administrator holding a
+ * live StyleBI session could be made to mutate server properties by a cross-site request.
+ *
+ * <p>Checking the request's {@code Authorization} header — rather than the principal's {@code wiz}
+ * property — is deliberate: {@code WizServiceAuthenticationFilter} persists its principal into the
+ * HTTP session, so that property proves only that the *session* once presented a JWT, not that
+ * *this request* did. A cross-site form POST cannot set an {@code Authorization} header.
+ */
+@Tag("core")
+class AdminAiCallerGuardTest {
+   @AfterEach
+   void tearDown() {
+      RequestContextHolder.resetRequestAttributes();
+   }
+
+   @Test
+   void bearerToken_isAccepted() {
+      bindRequestWith("Bearer some-jwt");
+      assertDoesNotThrow(AdminAiCallerGuard::requireBearerAuthenticatedRequest);
+   }
+
+   @Test
+   void bearerToken_isCaseInsensitiveOnTheScheme() {
+      // RFC 7235 makes the auth scheme case-insensitive; be forgiving where intent is unambiguous.
+      bindRequestWith("bearer some-jwt");
+      assertDoesNotThrow(AdminAiCallerGuard::requireBearerAuthenticatedRequest);
+   }
+
+   @Test
+   void missingAuthorizationHeader_isRejected() {
+      // The CSRF scenario: a browser session cookie carries the request, with no bearer header.
+      bindRequestWith(null);
+      assertForbidden();
+   }
+
+   @Test
+   void nonBearerScheme_isRejected() {
+      bindRequestWith("Basic dXNlcjpwYXNz");
+      assertForbidden();
+   }
+
+   @Test
+   void blankBearerToken_isRejected() {
+      bindRequestWith("Bearer   ");
+      assertForbidden();
+   }
+
+   @Test
+   void noRequestContext_isRejected() {
+      // Fail closed rather than silently passing when invoked outside a request (defence against
+      // this guard quietly becoming a no-op).
+      RequestContextHolder.resetRequestAttributes();
+      assertForbidden();
+   }
+
+   private static void assertForbidden() {
+      ResponseStatusException thrown = assertThrows(
+         ResponseStatusException.class, AdminAiCallerGuard::requireBearerAuthenticatedRequest);
+      assertEquals(HttpStatus.FORBIDDEN, thrown.getStatusCode());
+   }
+
+   private static void bindRequestWith(String authorization) {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+
+      if(authorization != null) {
+         request.addHeader("Authorization", authorization);
+      }
+
+      RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminAiControllerMappingTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminAiControllerMappingTest.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import java.lang.reflect.Method;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Guards the request-mapping prefix of the admin-chat endpoints.
+ *
+ * <p>The wiz-services broker calls these endpoints server-to-server, carrying the operator's SSO
+ * bearer token and no browser session. That makes the {@code /api/wiz/**} prefix load-bearing
+ * rather than cosmetic:
+ *
+ * <ul>
+ *   <li>{@code WizServiceAuthenticationFilter} validates the bearer JWT only when
+ *       {@code isWizRequest()} holds — the path matches {@code /api/wiz/**}, or a
+ *       {@code wiz_auth} cookie is present, which a server-to-server caller does not have.
+ *       Off that prefix the token is ignored and the request falls through to session auth.</li>
+ *   <li>{@code CSRFFilter} exempts {@code /api/wiz/**}; every other {@code /api/**} path requires
+ *       an {@code X-XSRF-TOKEN} that the broker has no way to obtain.</li>
+ * </ul>
+ *
+ * <p>Moving these mappings off the prefix breaks the broker asymmetrically — loudly for the POSTs
+ * (CSRF 403) and silently for the GETs (CSRF-safe methods), which is the harder failure to
+ * diagnose. {@code AdminAiEndpointPrefixTest} is the executable proof of both filter behaviours;
+ * this test pins the mappings that depend on them.
+ */
+@Tag("core")
+class AdminAiControllerMappingTest {
+   @Test
+   void everyEndpointLivesUnderTheWizPrefix() {
+      List<String> paths = postMappingPaths(AdminAiController.class);
+      assertFalse(paths.isEmpty(), "expected @PostMapping annotations on AdminAiController");
+
+      for(String path : paths) {
+         assertTrue(path.startsWith(WIZ_PREFIX), "endpoint '" + path + "' must live under '" +
+            WIZ_PREFIX + "' or the wiz-services broker cannot authenticate to it");
+      }
+   }
+
+   @Test
+   void mappingsMatchTheFrozenBrokerContract() {
+      assertEquals(
+         Set.of("/api/wiz/v1/admin/change",
+                "/api/wiz/v1/admin/backup",
+                "/api/wiz/v1/admin/restore"),
+         new HashSet<>(postMappingPaths(AdminAiController.class)));
+   }
+
+   private static List<String> postMappingPaths(Class<?> controller) {
+      List<String> paths = new ArrayList<>();
+
+      for(Method method : controller.getDeclaredMethods()) {
+         PostMapping mapping = method.getAnnotation(PostMapping.class);
+
+         if(mapping != null) {
+            paths.addAll(Arrays.asList(mapping.value()));
+         }
+      }
+
+      return paths;
+   }
+
+   private static final String WIZ_PREFIX = "/api/wiz/";
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminAiControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminAiControllerTest.java
@@ -23,6 +23,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -52,11 +55,60 @@ class AdminAiControllerTest {
       // default to a site-admin caller so the existing delegation tests exercise delegation;
       // individual tests override this to false to cover the FORBIDDEN gate
       lenient().when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+
+      // Every endpoint also requires a bearer-authenticated request (AdminAiCallerGuard); bind a
+      // request carrying one so these tests exercise the site-admin gate rather than that guard.
+      // AdminAiCallerGuardTest covers the guard itself.
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("Authorization", "Bearer test-jwt");
+      RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
    }
 
    @AfterEach
    void tearDown() {
       orgManagerStatic.close();
+      RequestContextHolder.resetRequestAttributes();
+   }
+
+   // -------------------------------------------------------------------------
+   // bearer-token gate (CSRF backstop on the /api/wiz/** prefix)
+   // -------------------------------------------------------------------------
+
+   @Test void changeThrowsForbiddenWithoutBearerToken() {
+      // A session-authenticated site admin (e.g. a cross-site request riding their session
+      // cookie) must still be rejected: /api/wiz/** is CSRF-exempt.
+      RequestContextHolder.setRequestAttributes(
+         new ServletRequestAttributes(new MockHttpServletRequest()));
+      AdminChangeRequest req = new AdminChangeRequest();
+      req.setProperty("max.rows");
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> controller.change(req, principal));
+
+      assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+      verifyNoInteractions(changeService);
+   }
+
+   @Test void backupThrowsForbiddenWithoutBearerToken() {
+      RequestContextHolder.setRequestAttributes(
+         new ServletRequestAttributes(new MockHttpServletRequest()));
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> controller.backup(Map.of("transactionId", "chg-1"), principal));
+
+      assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+      verifyNoInteractions(backupService);
+   }
+
+   @Test void restoreThrowsForbiddenWithoutBearerToken() {
+      RequestContextHolder.setRequestAttributes(
+         new ServletRequestAttributes(new MockHttpServletRequest()));
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> controller.restore(Map.of("backupRef", "admin-chg-1-123.zip"), principal));
+
+      assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+      verifyNoInteractions(backupService);
    }
 
    // -------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/security/AdminAiEndpointPrefixTest.java
+++ b/core/src/test/java/inetsoft/web/security/AdminAiEndpointPrefixTest.java
@@ -1,0 +1,137 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.security;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.sree.security.AuthenticationService;
+import inetsoft.sree.web.SessionLicenseServiceProvider;
+import inetsoft.web.security.support.FilterTestSupport;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Executable proof of why the admin-chat endpoints must be mapped under {@code /api/wiz/**}.
+ *
+ * <p>The wiz-services broker reaches StyleBI server-to-server with the operator's SSO bearer
+ * token and no browser session or cookies. These tests pin the two filter behaviours that make
+ * that call possible only on the wiz prefix, contrasting each against the plain
+ * {@code /api/admin/**} prefix the endpoints originally used.
+ *
+ * <p>Deduplication note: {@code CsrfFilterHttpTest} covers the CSRF filter's generic branches.
+ * This class asserts the specific admin-chat paths, so a future path change fails here with an
+ * explanation rather than surfacing as an unreachable endpoint at integration time.
+ */
+@ExtendWith(MockitoExtension.class)
+@Tag("core")
+class AdminAiEndpointPrefixTest {
+   @Mock private SessionLicenseServiceProvider licenseProvider;
+   @Mock private AuthenticationService authService;
+
+   private MockedStatic<SreeEnv> sreeEnvMock;
+   private MockMvc mvc;
+
+   @BeforeEach
+   void setUp() {
+      // LENIENT: same.site is not reached when the 403 fires before applyToken.
+      sreeEnvMock = mockStatic(SreeEnv.class, withSettings().strictness(Strictness.LENIENT));
+      sreeEnvMock.when(() -> SreeEnv.getProperty(eq("csrf.filter.enabled"), anyString()))
+         .thenReturn("true");
+      sreeEnvMock.when(() -> SreeEnv.getProperty(eq("same.site"), anyString()))
+         .thenReturn("Lax");
+      mvc = FilterTestSupport.builder()
+         .withFilter(new CSRFFilter(licenseProvider, authService))
+         .build();
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnvMock.close();
+   }
+
+   // ── CSRF: the broker holds no XSRF token, so the POSTs must be exempt ─────
+
+   @Test
+   void wizPrefixedAdminPost_isCsrfExempt() throws Exception {
+      mvc.perform(post("/api/wiz/v1/admin/change"))
+         .andExpect(status().isOk());
+   }
+
+   @Test
+   void wizPrefixedAdminBackupAndRestore_areCsrfExempt() throws Exception {
+      mvc.perform(post("/api/wiz/v1/admin/backup")).andExpect(status().isOk());
+      mvc.perform(post("/api/wiz/v1/admin/restore")).andExpect(status().isOk());
+   }
+
+   @Test
+   void unprefixedAdminPost_isCsrfProtected() throws Exception {
+      // Characterises the original mapping: a tokenless broker POST here is rejected outright.
+      mvc.perform(post("/api/admin/ai/change"))
+         .andExpect(status().isForbidden());
+   }
+
+   @Test
+   void unprefixedAdminGet_isNotCsrfProtected_theSilentHalfOfTheFailure() throws Exception {
+      // GET is a CSRF-safe method, so the changeset reads would have passed this filter and
+      // failed only on authentication — the asymmetry that made the original mapping deceptive.
+      mvc.perform(get("/api/admin/ai/changesets"))
+         .andExpect(status().isOk());
+   }
+
+   // ── Authentication: the bearer JWT is only honoured on the wiz prefix ─────
+
+   @Test
+   void wizPrefixedAdminPaths_areWizRequests() {
+      AbstractSecurityFilter filter = new CSRFFilter(licenseProvider, authService);
+
+      assertTrue(filter.isWizRequest(request("/api/wiz/v1/admin/change")));
+      assertTrue(filter.isWizRequest(request("/api/wiz/v1/admin/changesets")));
+      assertTrue(filter.isWizRequest(request("/api/wiz/v1/admin/changesets/tx-1")));
+   }
+
+   @Test
+   void unprefixedAdminPaths_areNotWizRequests_soTheBearerTokenIsIgnored() {
+      AbstractSecurityFilter filter = new CSRFFilter(licenseProvider, authService);
+
+      assertFalse(filter.isWizRequest(request("/api/admin/ai/change")),
+         "WizServiceAuthenticationFilter skips non-wiz paths, leaving the bearer token unvalidated");
+      assertFalse(filter.isWizRequest(request("/api/admin/ai/changesets")));
+   }
+
+   /**
+    * Builds a cookie-less request, matching how the broker calls StyleBI. {@code servletPath} is
+    * set because {@code getRequestedPage} resolves the path from it, not from the request URI.
+    */
+   private static HttpServletRequest request(String path) {
+      MockHttpServletRequest request = new MockHttpServletRequest("POST", path);
+      request.setServletPath(path);
+      return request;
+   }
+}


### PR DESCRIPTION
## Why

The admin-chat endpoints added in #4428 are called **server-to-server** by the wiz-services broker, carrying the operator's SSO bearer token and no browser session. As merged at `/api/admin/ai/*`, that call could never have worked:

1. **The bearer token was never validated.** `WizServiceAuthenticationFilter.doFilter` early-returns unless `isWizRequest()` holds — the path is under `/api/wiz/**`, *or* a `wiz_auth` cookie is present, which a server-to-server caller has not got. Off the prefix the JWT was skipped and the request fell through to session auth.
2. **CSRF blocked the POSTs.** `CSRFFilter.isCsrfProtectionRequired` exempts `/api/wiz/**`; every other `/api/**` path requires an `X-XSRF-TOKEN` that a broker with no session cannot obtain.

This surfaced during the Task-0 spike of the follow-on broker work, before any broker code was written against the endpoints.

Note the failure would have been **asymmetric and confusing**: `GET` is a CSRF-safe method, so the changeset reads (enterprise, see companion PR) would have failed on authentication alone while the three POSTs here failed on both filters.

## What changed

- Re-map the three endpoints to `/api/wiz/v1/admin/{change,backup,restore}`, mirroring the existing `WorksheetAgentController` pattern (`/api/wiz/v1/agent/worksheet/*`).
- Add `AdminAiCallerGuard` — see below.
- Add tests.

No behaviour, request/response shapes, or permission checks changed beyond the guard.

## The prefix costs CSRF protection, so add a bearer requirement

`/api/wiz/**` is CSRF-exempt, and that exemption is a **path** match — it assumes wiz traffic is bearer-JWT-authenticated, which the filters do **not** enforce. `WizServiceAuthenticationFilter` falls through when no bearer header is present ("let other filters handle authentication"), and `RequestPrincipalFilter` then resolves an ordinary browser-session principal into `getUserPrincipal()` — precisely what `@Secured` and the Site-Administrator check read. Without a backstop, a logged-in site administrator could be made to mutate server properties by a cross-site request, with CSRF skipped.

`AdminAiCallerGuard.requireBearerAuthenticatedRequest()` therefore requires the **current request** to carry `Authorization: Bearer <token>`, else `403`. A cross-site form POST cannot set that header, and a scripted request that tries needs a CORS preflight an attacker cannot satisfy. It fails closed when there is no request context, so it cannot quietly degrade into a no-op.

It checks the header rather than the principal's `wiz` property deliberately: `WizServiceAuthenticationFilter` persists its principal into the HTTP session, so that property proves only that the *session* once presented a JWT — not that *this request* did.

**Scope of the exposure, stated honestly:** `same.site` defaults to `Lax` (so a cross-site POST would not carry the session cookie in a default install), and through nginx `/api/wiz/v1/admin/*` routes to wiz-services rather than StyleBI. Exploiting it needed `SameSite=None` plus direct network reach to StyleBI. But the pre-re-map code *was* CSRF-protected, so this guard restores a guarantee rather than adding a new one.

## Tests

91 → **78 tests green in this module** for the admin/properties/security area (102 across both modules).

- `AdminAiEndpointPrefixTest` — exercises the **real** `CSRFFilter` through MockMvc and asserts `isWizRequest` directly, proving both filter behaviours and contrasting each against the old prefix (including the CSRF-safe-GET asymmetry). These assertions passed *before* the re-map, which is what confirmed the diagnosis rather than assuming it.
- `AdminAiControllerMappingTest` — reads the `@PostMapping` values off the controller by reflection and pins them to the frozen contract, so re-breaking the prefix fails here.
- `AdminAiCallerGuardTest` — the bearer gate: accepts a token, case-insensitive on the scheme, rejects missing/non-bearer/blank, and rejects when there is no request context.
- `AdminAiControllerTest` — adds bearer-less `403` cases for all three endpoints.

## Reviewer notes

- **Companion PR required:** the two enterprise changeset read endpoints move in lockstep (`stylebi-enterprise`). Merging one without the other leaves the contract split.
- Per repo policy this branch carries **no `community` submodule pointer bump**; the enterprise side references it at merge.
- These are the first `/api/wiz` controllers to use `@Secured`. Verified it works: `SecuredAspect` is AOP on the annotation (path-independent) and resolves the caller from `request.getUserPrincipal()`, which `WizServiceAuthenticationFilter` supplies via its `AuthenticatedRequest` wrapper; the JWT-rebuilt `SRPrincipal` carries roles/groups/`organizationId`, so `OrganizationManager.isSiteAdmin` holds.
- **Follow-on, not fixed here:** nginx sets `Authorization: Bearer $cookie_wiz_auth` from the browser's cookie for everything under `location /api/wiz/` — which is where the *broker's* own admin routes will live. So on the broker side a bearer header is **not** evidence the caller is not a browser, and this guard must not be ported there as an equivalent defence. Recorded as an explicit constraint in the broker plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
