### PR TITLE
Bug #75801, fix freehand table showing no data for group cells

### DIFF
--- a/core/src/main/java/inetsoft/report/LayoutTool.java
+++ b/core/src/main/java/inetsoft/report/LayoutTool.java
@@ -2382,21 +2382,6 @@ public class LayoutTool {
    }
 
    /**
-    * Get the physical column name backing a crosstab-supported group cell. The
-    * cell's own binding value may hold the dimension's display full name (e.g.
-    * "None(Month(ndate))") rather than the physical column name ("Month(ndate)")
-    * for date-grouped dimensions, so prefer the resolved CalcGroup's attribute
-    * (unqualified, unlike getName() which may carry an "entity." table prefix).
-    */
-   private static String getGroupColumnName(CalcGroup group, TableCellBinding cell) {
-      if(group != null) {
-         return BindingTool.getPureField(group).getAttribute();
-      }
-
-      return cell.getValue();
-   }
-
-   /**
     * Create calc for crosstab supported expression.
     */
    private static String createCrosstabCalcExpression(List<TableCellBinding> list,
@@ -2416,17 +2401,7 @@ public class LayoutTool {
          exp += "none(";
       }
 
-      CalcGroup group = groups.length > 0 ? groups[groups.length - 1] : null;
-
-      // bind.getValue() may hold the dimension's display full name (e.g.
-      // "None(Month(ndate))") instead of the physical column name backing the
-      // crosstab data ("Month(ndate)") when the cell's binding was derived from
-      // a date-grouped dimension. When this cell is itself a group cell,
-      // groups[groups.length - 1] is its own resolved CalcGroup (createGroupField()
-      // resolved the real column), so prefer that for the actual data key. When
-      // this cell is an aggregate/summary cell, it is not part of groups[], so
-      // bind.getValue() (the aggregate's own column reference) must be used as-is.
-      exp += var + "['" + escapeColName(isGroup ? getGroupColumnName(group, bind) : bind.getValue());
+      exp += var + "['" + escapeColName(bind.getValue());
 
       int len = isGroup ? list.size() - 1 : list.size();
 
@@ -2434,13 +2409,14 @@ public class LayoutTool {
          exp += "@";
       }
 
+      CalcGroup group = groups.length > 0 ? groups[groups.length - 1] : null;
+
       for(int i = 0; i < len; i++) {
          if(i > 0) {
             exp += ";";
          }
 
-         CalcGroup pgroup = i < groups.length ? groups[i] : null;
-         String value = escapeColName(getGroupColumnName(pgroup, list.get(i)));
+         String value = escapeColName(list.get(i).getValue());
          value = Tool.replaceAll(value, ":", LayoutTool.SCRIPT_ESCAPED_COLON);
          exp += value + ":$" + escapeColName(Tool.escapeJavascript(gnames[i]));
       }


### PR DESCRIPTION
## Summary

Freehand tables using the crosstab-optimization path could render with no data rows (only the header row) for GROUP cells whose binding value is a date-level or formula-wrapped display name (e.g. `Year(Date)`, `None(NDateTime)`).

## Root Cause

`LayoutTool.createCrosstabCalcExpression()` built the generated `toList()`/`none()` script expression's data-lookup key from a resolved `CalcGroup`'s unqualified attribute name instead of the cell binding's own value. For these group cells, the binding's own value already matches the regenerated crosstab's actual column name, so substituting the unqualified attribute name (e.g. `Date` instead of `Year(Date)`, or `NDateTime` instead of `None(NDateTime)`) caused the lookup to miss, and the group cell never expanded.

## Fix

Restore using the cell binding's own value (`bind.getValue()` / `list.get(i).getValue()`) directly as the lookup key, as it was prior to the regression.

## Test Plan

- Reproduced with two viewsheets containing freehand tables using the crosstab optimization path (one with a plain date GROUP column, one with multiple nested date/passthrough GROUP columns) — both rendered with no data rows before the fix.
- Verified both now render with data after the fix, and confirmed via server-side logging that the generated lookup expression matches the regenerated crosstab's actual column headers.
- `community/core` compiles cleanly.