### PR TITLE
Bug #75813, make UpgradableReadWriteLock.unlockAll() re-entrant

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -7810,8 +7810,8 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
     * Use when calling long-running operations (e.g. getData()) while a write lock is held,
     * to prevent blocking background threads that need a read lock.
     *
-    * <p>Not safe for re-entrant use: if a nested call to unlockAll() occurs on the
-    * same thread before restoreLocks() is called, the outer saved state will be lost.</p>
+    * <p>Safe for re-entrant use: a nested unlockAll()/restoreLocks() pair on the same
+    * thread does not discard the state saved by an enclosing unlockAll().</p>
     */
    public void unlockAll() {
       if(!AssetDataCache.isProcessorThread()) {

--- a/core/src/main/java/inetsoft/util/UpgradableReadWriteLock.java
+++ b/core/src/main/java/inetsoft/util/UpgradableReadWriteLock.java
@@ -79,14 +79,15 @@ public class UpgradableReadWriteLock {
     * Unlock all currently locked locks, and store the current lock states to be restored
     * in {@link #restoreLocks()}.
     *
-    * <p>Not safe for re-entrant use: if a nested call to unlockAll() occurs on the
-    * same thread before restoreLocks() is called, the outer saved state will be lost
-    * because thisOldLocks is a single-slot per-thread store.</p>
+    * <p>Safe for re-entrant use: the saved states are kept on a per-thread stack, so a
+    * nested unlockAll()/restoreLocks() pair does not discard the state saved by an
+    * enclosing unlockAll(). Each call must be paired with a restoreLocks() on the same
+    * thread.</p>
     */
    public void unlockAll() {
-      List<Integer> olocks = thisOldLocks.get();
+      List<Integer> olocks = new ArrayList<>();
       Stack<Integer> stack = (Stack<Integer>) getStack().clone();
-      olocks.clear();
+      thisOldLocks.get().push(olocks);
 
       while(!stack.empty()) {
          Integer op = stack.pop();
@@ -104,23 +105,35 @@ public class UpgradableReadWriteLock {
    }
 
    /**
-    * Restore the locks unlocked in unlockAll.
+    * Restore the locks unlocked in the matching unlockAll.
     */
    public void restoreLocks() {
-      List<Integer> olocks = thisOldLocks.get();
+      Deque<List<Integer>> saved = thisOldLocks.get();
 
-      for(int i = olocks.size() - 1; i >= 0; i--) {
-         switch(olocks.get(i)) {
-         case 0:
-            lockRead();
-            break;
-         case 1:
-            lockWrite();
-            break;
-         }
+      if(saved.isEmpty()) {
+         thisOldLocks.remove();
+         return;
       }
 
-      thisOldLocks.remove();
+      List<Integer> olocks = saved.pop();
+
+      try {
+         for(int i = olocks.size() - 1; i >= 0; i--) {
+            switch(olocks.get(i)) {
+            case 0:
+               lockRead();
+               break;
+            case 1:
+               lockWrite();
+               break;
+            }
+         }
+      }
+      finally {
+         if(saved.isEmpty()) {
+            thisOldLocks.remove();
+         }
+      }
    }
 
    private int pop() {
@@ -145,8 +158,8 @@ public class UpgradableReadWriteLock {
    }
 
    private final ReadWriteLock thisLock = new ReentrantReadWriteLock(false);
-   private final ThreadLocal<List<Integer>> thisOldLocks =
-      ThreadLocal.withInitial(ArrayList::new);
+   private final ThreadLocal<Deque<List<Integer>>> thisOldLocks =
+      ThreadLocal.withInitial(ArrayDeque::new);
    private static final ThreadLocal<Map<Object,Stack<Integer>>> thisLockState =
       ThreadLocal.withInitial(HashMap::new);
 }

--- a/core/src/test/java/inetsoft/util/UpgradableReadWriteLockTest.java
+++ b/core/src/test/java/inetsoft/util/UpgradableReadWriteLockTest.java
@@ -1,0 +1,175 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class UpgradableReadWriteLockTest {
+   @Test
+   void writeLockRestoredAfterUnlockAll() {
+      UpgradableReadWriteLock lock = new UpgradableReadWriteLock();
+      lock.lockWrite();
+
+      try {
+         lock.unlockAll();
+         lock.restoreLocks();
+      }
+      finally {
+         assertDoesNotThrow(lock::unlockWrite);
+      }
+
+      assertLockFree(lock);
+   }
+
+   @Test
+   void readLockRestoredAfterUnlockAll() {
+      UpgradableReadWriteLock lock = new UpgradableReadWriteLock();
+      lock.lockRead();
+
+      try {
+         lock.unlockAll();
+         lock.restoreLocks();
+      }
+      finally {
+         assertDoesNotThrow(lock::unlockRead);
+      }
+
+      assertLockFree(lock);
+   }
+
+   /**
+    * Bug #75813: a nested unlockAll()/restoreLocks() pair used to clear the single-slot
+    * saved state, so the enclosing restoreLocks() restored nothing and the outer
+    * unlockWrite() failed with EmptyStackException.
+    */
+   @Test
+   void nestedUnlockAllDoesNotDiscardOuterState() {
+      UpgradableReadWriteLock lock = new UpgradableReadWriteLock();
+      lock.lockWrite();
+
+      try {
+         // outer region: mirrors ViewsheetSandbox.doExecuteData() releasing the locks
+         // held by CoreLifecycleService.refreshViewsheet() for the duration of a fetch
+         lock.unlockAll();
+
+         try {
+            // a read lock taken while the outer region is unlocked, e.g. by
+            // TableVSAQuery.getTableLens()
+            lock.lockRead();
+
+            try {
+               // nested region: the source assembly of a vs-assembly binding is fetched
+               // in the middle of the outer fetch
+               lock.unlockAll();
+               lock.restoreLocks();
+            }
+            finally {
+               lock.unlockRead();
+            }
+         }
+         finally {
+            lock.restoreLocks();
+         }
+      }
+      finally {
+         assertDoesNotThrow(lock::unlockWrite);
+      }
+
+      assertLockFree(lock);
+   }
+
+   @Test
+   void deeplyNestedUnlockAllRestoresAllLevels() {
+      UpgradableReadWriteLock lock = new UpgradableReadWriteLock();
+      lock.lockWrite();
+      lock.lockRead();
+
+      try {
+         lock.unlockAll();
+         lock.unlockAll();
+         lock.unlockAll();
+         lock.restoreLocks();
+         lock.restoreLocks();
+         lock.restoreLocks();
+      }
+      finally {
+         assertDoesNotThrow(lock::unlockRead);
+         assertDoesNotThrow(lock::unlockWrite);
+      }
+
+      assertLockFree(lock);
+   }
+
+   @Test
+   void unmatchedRestoreLocksIsNoOp() {
+      UpgradableReadWriteLock lock = new UpgradableReadWriteLock();
+      lock.lockWrite();
+
+      try {
+         assertDoesNotThrow(lock::restoreLocks);
+      }
+      finally {
+         assertDoesNotThrow(lock::unlockWrite);
+      }
+
+      assertLockFree(lock);
+   }
+
+   @Test
+   void writeLockUpgradeReleasesAndReacquiresReadLock() {
+      UpgradableReadWriteLock lock = new UpgradableReadWriteLock();
+      lock.lockRead();
+
+      try {
+         lock.lockWrite();
+         lock.unlockWrite();
+      }
+      finally {
+         assertDoesNotThrow(lock::unlockRead);
+      }
+
+      assertLockFree(lock);
+   }
+
+   /**
+    * Verifies no lock is left held by the calling thread: another thread must be able to
+    * acquire the write lock immediately.
+    */
+   private void assertLockFree(UpgradableReadWriteLock lock) {
+      Thread thread = new Thread(() -> {
+         lock.lockWrite();
+         lock.unlockWrite();
+      });
+
+      thread.start();
+
+      try {
+         thread.join(5000);
+      }
+      catch(InterruptedException ex) {
+         Thread.currentThread().interrupt();
+         fail("Interrupted while waiting for the write lock");
+      }
+
+      assertFalse(thread.isAlive(), "lock is still held by the test thread");
+   }
+}


### PR DESCRIPTION
## Summary

Opening a viewsheet that contains an assembly bound to **another viewsheet assembly** (`SourceInfo.VS_ASSEMBLY`) failed with `java.util.EmptyStackException` and the client showed "An unexpected error has occurred." with no data.

```
java.util.EmptyStackException
	at java.base/java.util.Stack.pop(Stack.java:85)
	at inetsoft.util.UpgradableReadWriteLock.pop(UpgradableReadWriteLock.java:128)
	at inetsoft.util.UpgradableReadWriteLock.unlockWrite(UpgradableReadWriteLock.java:48)
	at inetsoft.report.composition.execution.ViewsheetSandbox.unlockWrite(ViewsheetSandbox.java:7784)
	at inetsoft.web.viewsheet.service.CoreLifecycleService.refreshViewsheet(CoreLifecycleService.java:871)
	...
```

## Root Cause

`UpgradableReadWriteLock` tracks the locks each thread holds in a per-thread `Stack<Integer>` (`0` = read, `1` = write). `unlockAll()` drops every lock the thread holds and saves what it dropped so `restoreLocks()` can put them back.

The saved state was a **single slot** per (lock instance, thread):

```java
private final ThreadLocal<List<Integer>> thisOldLocks = ThreadLocal.withInitial(ArrayList::new);
```

`unlockAll()` began with `olocks.clear()` and `restoreLocks()` ended with `thisOldLocks.remove()`. So a **nested** `unlockAll()` on the same lock and thread destroyed the outer saved state; the inner `restoreLocks()` removed the ThreadLocal; the outer `restoreLocks()` then got a fresh empty list and restored **nothing**, leaving the lock stack empty and the write lock not re-acquired. The next `pop()` threw `EmptyStackException`.

The nesting is reachable on viewsheet open, all on the same `ViewsheetSandbox.thisLock` and thread:

```
CoreLifecycleService.refreshViewsheet:543   box.lockWrite()                       stack [1]
  ViewsheetSandbox.getData:5530             lockRead()                            stack [1,0]
    doExecuteData:6126                      thisLock.unlockAll()   OUTER: saves [0,1], releases all
      query.getData() → TableVSAQuery.getTableLens:437   box.lockRead()           stack [0]
        getTableAssembly → VSAQuery.createAssemblyTable:1758  box.getTableData(src)
          → box.getData(src) → doExecuteData:6126
                                            thisLock.unlockAll()   NESTED: clobbers [0,1]
                                            thisLock.restoreLocks():6145
    doExecuteData:6145                      thisLock.restoreLocks()  restores NOTHING
  getData finally:5583                      unlockRead()  → EmptyStackException (swallowed by reset)
refreshViewsheet finally:871                unlockWrite() → EmptyStackException  ← reported trace
```

The `unlockAll()` calls in `doExecuteData` and `getData` were added for #74001/#74129 to avoid holding the sandbox write lock across a data fetch; they made same-lock nesting reachable for the first time.

## Fix

Keep the saved lock states on a **per-thread stack** instead of a single slot:

- `thisOldLocks` is now `ThreadLocal<Deque<List<Integer>>>`.
- `unlockAll()` builds a fresh list and pushes it (no longer clears shared state).
- `restoreLocks()` pops the most recent list, restores it in reverse order, and removes the ThreadLocal only once the deque empties — so pooled STOMP/worker threads leave no residual state.
- An unmatched `restoreLocks()` (empty deque) stays a no-op, as before.

Non-nested behavior is unchanged: one push then one pop yields the same list, the same restore order, and the same ThreadLocal cleanup. `lockRead`/`lockWrite`/`unlockRead`/`unlockWrite` and the read-lock rewind/re-acquire logic are untouched, so the write-upgrade semantics and the `AssetDataCache.isProcessorThread()` bypass are unaffected. All four `unlockAll()` call sites (`ViewsheetSandbox` 5493, 6126, 6692, 6812) are already `try`/`finally`-paired on the same thread, and there are no other callers anywhere in the community, enterprise, or server trees.

The now-obsolete "not safe for re-entrant use" javadoc warnings were updated in `UpgradableReadWriteLock.unlockAll()` and `ViewsheetSandbox.unlockAll()`.

## Test Plan

- New `UpgradableReadWriteLockTest` (6 tests) covering the nested `unlockAll`/`restoreLocks` scenario from the bug, a 3-deep nesting case, single-level read/write restore, an unmatched `restoreLocks()`, and the read→write upgrade. `nestedUnlockAllDoesNotDiscardOuterState` and `deeplyNestedUnlockAllRestoresAllLevels` fail with `EmptyStackException` on the old implementation and pass on the new one. Each test finishes by confirming from a second thread that no lock is left held.
- `./mvnw test -pl core -Dtest='inetsoft.util.*Test'` → 89 tests, 0 failures.
- `./mvnw clean install -pl core -am -DskipTests` → BUILD SUCCESS.
- Manual: import the `NT6.zip` asset from the issue and open the viewsheet in the portal. Previously it popped up "An unexpected error has occurred." with no data; it now opens and loads data. Verified by the reporter.
- Regression check: open viewsheets with embedded viewsheets and with charts (the other `unlockAll()` call sites at 5493/6692/6812) to confirm data loads and no lock errors appear in the log.

Fixes Redmine #75813.