### PR TITLE
Bug #75747, fix data missing when converting crosstab to freehand table

### DIFF
--- a/core/src/main/java/inetsoft/report/LayoutTool.java
+++ b/core/src/main/java/inetsoft/report/LayoutTool.java
@@ -629,7 +629,7 @@ public class LayoutTool {
       return aref;
    }
 
-   protected static void fillCalcTableLens(FormulaTable table,
+   protected static void fillCalcTableLens(FormulaTable table, TableLens base,
                                            VariableTable vars,
                                            boolean crossTabSupported)
    {
@@ -729,7 +729,7 @@ public class LayoutTool {
                      }
                   }
 
-                  String exp = createCalcBindingExpression(table, n2c, layout,
+                  String exp = createCalcBindingExpression(table, base, n2c, layout,
                      bind, c2p, new Point(r, j), crossTabSupported, sortOthersLast);
                   clens.setFormula(r, j, exp);
                }
@@ -2271,7 +2271,7 @@ public class LayoutTool {
    /**
     * Create the expression script for a calc cell column binding.
     */
-   private static String createCalcBindingExpression(FormulaTable table,
+   private static String createCalcBindingExpression(FormulaTable table, TableLens base,
       Map<String, CellHolder> n2c, TableLayout layout,
       TableCellBinding cell, Map<String, Point> c2p, Point point,
       boolean crossTabSupported, boolean sortOthersLast)
@@ -2328,7 +2328,7 @@ public class LayoutTool {
       String exp = null;
 
       if(crossTabSupported) {
-         exp = createCrosstabCalcExpression(list, groups, gnames, cell, var,
+         exp = createCrosstabCalcExpression(base, list, groups, gnames, cell, var,
             cell.getBType() == TableCellBinding.GROUP, sortOthersLast);
       }
       else if(cell.getBType() == TableCellBinding.DETAIL) {
@@ -2382,24 +2382,39 @@ public class LayoutTool {
    }
 
    /**
-    * Get the physical column name backing a crosstab-supported group cell. The
-    * cell's own binding value may hold the dimension's display full name (e.g.
-    * "None(Month(ndate))") rather than the physical column name ("Month(ndate)")
-    * for date-grouped dimensions, so prefer the resolved CalcGroup's attribute
-    * (unqualified, unlike getName() which may carry an "entity." table prefix).
+    * Get the physical column name backing a crosstab-supported group cell's data
+    * lookup key. In the common case the cell's own binding value is already the
+    * physical column name backing the regenerated crosstab's data, and must be
+    * used as-is (e.g. a date-grouped dimension whose worksheet column is itself
+    * literally named with its display form, such as "Year(Date)"). Only when the
+    * raw value does NOT correspond to an actual column of the regenerated
+    * crosstab's own result table (e.g. a date-grouped dimension nested under
+    * another group, whose binding value is the dimension's display full name
+    * "None(Month(ndate))" while the regenerated crosstab's actual column is the
+    * unwrapped "Month(ndate)") do we fall back to the unwrapped column name.
+    * `base`, when available, is that regenerated crosstab's own result table --
+    * checking directly against it (rather than re-deriving the worksheet's column
+    * selection) guarantees this always agrees with what the data actually
+    * contains.
     */
-   private static String getGroupColumnName(CalcGroup group, TableCellBinding cell) {
-      if(group != null) {
-         return BindingTool.getPureField(group).getAttribute();
+   private static String getGroupColumnName(TableLens base, TableCellBinding cell) {
+      String value = cell.getValue();
+
+      if(base == null || Util.findColumn(base, value) >= 0) {
+         return value;
       }
 
-      return cell.getValue();
+      String original = getOriginalColumn(value);
+
+      return !Tool.equals(original, value) && Util.findColumn(base, original) >= 0 ?
+         original : value;
    }
 
    /**
     * Create calc for crosstab supported expression.
     */
-   private static String createCrosstabCalcExpression(List<TableCellBinding> list,
+   private static String createCrosstabCalcExpression(TableLens base,
+                                                      List<TableCellBinding> list,
                                                       CalcGroup[] groups,
                                                       String[] gnames,
                                                       TableCellBinding bind,
@@ -2418,15 +2433,7 @@ public class LayoutTool {
 
       CalcGroup group = groups.length > 0 ? groups[groups.length - 1] : null;
 
-      // bind.getValue() may hold the dimension's display full name (e.g.
-      // "None(Month(ndate))") instead of the physical column name backing the
-      // crosstab data ("Month(ndate)") when the cell's binding was derived from
-      // a date-grouped dimension. When this cell is itself a group cell,
-      // groups[groups.length - 1] is its own resolved CalcGroup (createGroupField()
-      // resolved the real column), so prefer that for the actual data key. When
-      // this cell is an aggregate/summary cell, it is not part of groups[], so
-      // bind.getValue() (the aggregate's own column reference) must be used as-is.
-      exp += var + "['" + escapeColName(isGroup ? getGroupColumnName(group, bind) : bind.getValue());
+      exp += var + "['" + escapeColName(isGroup ? getGroupColumnName(base, bind) : bind.getValue());
 
       int len = isGroup ? list.size() - 1 : list.size();
 
@@ -2439,8 +2446,7 @@ public class LayoutTool {
             exp += ";";
          }
 
-         CalcGroup pgroup = i < groups.length ? groups[i] : null;
-         String value = escapeColName(getGroupColumnName(pgroup, list.get(i)));
+         String value = escapeColName(getGroupColumnName(base, list.get(i)));
          value = Tool.replaceAll(value, ":", LayoutTool.SCRIPT_ESCAPED_COLON);
          exp += value + ":$" + escapeColName(Tool.escapeJavascript(gnames[i]));
       }

--- a/core/src/main/java/inetsoft/report/composition/execution/CalcTableVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/CalcTableVSAQuery.java
@@ -174,7 +174,7 @@ public class CalcTableVSAQuery extends DataVSAQuery {
          if(datas.size() > 0) {
             for(int i = 0; i < datas.size(); i++) {
                CalcTableVSAssembly cassemblyChild = cassemblys.get(i);
-               VSLayoutTool.createCalcLens(cassemblys.get(i), null, box.getVariableTable(),
+               VSLayoutTool.createCalcLens(cassemblys.get(i), datas.get(i), box.getVariableTable(),
                                            (crosstabs != null && crosstabs.size() > 0));
                // copy back
                cassemblyChild.setTable(cassemblyChild.getBaseTable());

--- a/core/src/main/java/inetsoft/uql/viewsheet/VSLayoutTool.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/VSLayoutTool.java
@@ -55,7 +55,7 @@ public class VSLayoutTool extends LayoutTool {
                                      TableLens base, VariableTable vars,
                                      boolean crossTabSupported)
    {
-      createCalcLayout(assembly, vars, crossTabSupported);
+      createCalcLayout(assembly, base, vars, crossTabSupported);
       createDataPathMapping(assembly.getTableLayout(), assembly.getBaseTable());
    }
 
@@ -242,11 +242,11 @@ public class VSLayoutTool extends LayoutTool {
    /**
     * Create a calc table layout by TableLayout.
     */
-   private static void createCalcLayout(CalcTableVSAssembly assembly,
+   private static void createCalcLayout(CalcTableVSAssembly assembly, TableLens base,
                                         VariableTable vars,
                                         boolean crossTabSupported)
    {
-      fillCalcTableLens(assembly, vars, crossTabSupported);
+      fillCalcTableLens(assembly, base, vars, crossTabSupported);
    }
 
    /**

--- a/core/src/test/java/inetsoft/report/LayoutToolTest.java
+++ b/core/src/test/java/inetsoft/report/LayoutToolTest.java
@@ -1,0 +1,117 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report;
+
+import inetsoft.report.lens.DefaultTableLens;
+import inetsoft.test.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression guard for #75747 / #75801: converting a crosstab to a freehand table
+ * generates a {@code toList(data['Col'], ...)} expression per row/column GROUP cell,
+ * where "Col" is the physical column name backing the regenerated crosstab's data.
+ * {@code LayoutTool.getGroupColumnName()} decides that name from a cell binding's
+ * value, which can hold either the physical column name or the dimension's display
+ * full name (e.g. "None(Month(ndate))") depending on how the dimension was bound.
+ * Guessing wrong collapses the group cell's expansion to zero rows (#75747), and
+ * "fixing" it by always stripping the wrapper breaks dimensions whose physical
+ * column genuinely is named with its display form, such as "Year(Date)" (#75801).
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class LayoutToolTest {
+   @Test
+   void usesRawValueWhenItIsAlreadyTheOuterDateDimensionsPhysicalColumn() throws Exception {
+      // #75801 (CroTable7): "Year(Date)" is a sole/outer date GROUP dimension whose
+      // crosstab column is genuinely named with its display form -- must be used as-is.
+      DefaultTableLens base = new DefaultTableLens(new Object[][] {
+         { "Year(Date)", "Sum(Total)" },
+         { "2022", 100.0 }
+      });
+
+      TableCellBinding cell = new TableCellBinding(CellBinding.BIND_COLUMN, "Year(Date)");
+      assertEquals("Year(Date)", getGroupColumnName(base, cell));
+   }
+
+   @Test
+   void unwrapsDisplayNameForNestedDateDimension() throws Exception {
+      // #75747 (GroupAndTab): "None(Month(ndate))" is the display full name for a
+      // date dimension nested under another group; the crosstab's actual column is
+      // the unwrapped "Month(ndate))".
+      DefaultTableLens base = new DefaultTableLens(new Object[][] {
+         { "state", "Month(ndate)", "Sum(eid)" },
+         { "Others", "2022-01", 5.0 }
+      });
+
+      TableCellBinding cell = new TableCellBinding(CellBinding.BIND_COLUMN, "None(Month(ndate))");
+      assertEquals("Month(ndate)", getGroupColumnName(base, cell));
+   }
+
+   @Test
+   void unwrapsDisplayNameForMultipleNestedPassthroughDateDimensions() throws Exception {
+      // #75801 (Special2): several nested date/passthrough dimensions, each whose
+      // display full name must be unwrapped to its own physical column.
+      DefaultTableLens base = new DefaultTableLens(new Object[][] {
+         { "NDateTime", "NDate", "NTime", "Sum(x)" },
+         { "2022-01-01", "2022-01-01", "10:00", 3.0 }
+      });
+
+      assertEquals("NDateTime", getGroupColumnName(base,
+         new TableCellBinding(CellBinding.BIND_COLUMN, "None(NDateTime)")));
+      assertEquals("NDate", getGroupColumnName(base,
+         new TableCellBinding(CellBinding.BIND_COLUMN, "None(NDate)")));
+      assertEquals("NTime", getGroupColumnName(base,
+         new TableCellBinding(CellBinding.BIND_COLUMN, "None(NTime)")));
+   }
+
+   @Test
+   void returnsRawValueUncheckedWhenBaseIsNull() throws Exception {
+      TableCellBinding cell = new TableCellBinding(CellBinding.BIND_COLUMN, "None(Month(ndate))");
+      assertEquals("None(Month(ndate))", getGroupColumnName(null, cell));
+   }
+
+   @Test
+   void returnsRawValueWhenNeitherFormMatchesAnyColumn() throws Exception {
+      DefaultTableLens base = new DefaultTableLens(new Object[][] {
+         { "unrelated_column" },
+         { "x" }
+      });
+
+      TableCellBinding cell = new TableCellBinding(CellBinding.BIND_COLUMN, "None(Month(ndate))");
+      assertEquals("None(Month(ndate))", getGroupColumnName(base, cell));
+   }
+
+   private static String getGroupColumnName(TableLens base, TableCellBinding cell) throws Exception {
+      Method method = LayoutTool.class.getDeclaredMethod(
+         "getGroupColumnName", TableLens.class, TableCellBinding.class);
+      method.setAccessible(true);
+      return (String) method.invoke(null, base, cell);
+   }
+}


### PR DESCRIPTION
## Summary
- Converting a crosstab with a nested date-grouped row dimension (e.g. `Month(ndate)` nested under another dimension) to a freehand table produced a table with only the header row — all data rows were missing.
- Root cause: `LayoutTool.createCrosstabCalcExpression` built the generated `toList()`/`none()` script expressions from `TableCellBinding.getValue()`, which for such nested date-grouped dimensions holds the dimension's display full name (e.g. `"None(Month(ndate))"`) instead of the physical column name backing the crosstab's actual data (`"Month(ndate)"`). The generated formula referenced a nonexistent column, the lookup returned `null`, and the row group never expanded.
- **This is a corrected re-fix.** The first attempt (merged as #4387, then reverted as bug #75801/#4443) unconditionally resolved the column name via a `CalcGroup`, which broke other dimensions whose binding value was *already* the correct physical column name (e.g. `"Year(Date)"` as a sole/outer date dimension, or multiple nested passthrough date dimensions). This revision instead only substitutes the unwrapped column name when the cell's raw binding value does not match an actual column of the regenerated crosstab's own result table — checked directly against that table (threaded through via the previously-unused `base` parameter of `VSLayoutTool.createCalcLens`), rather than re-derived from the worksheet's column selection, so the decision can never disagree with what the generated formula is actually evaluated against.

## Test plan
- [x] Added `LayoutToolTest` covering all three previously-manually-verified scenarios: a date dimension nested under another group (#75747), a sole/outer date dimension (#75801/CroTable7), and multiple nested passthrough date dimensions (#75801/Special2).
- [x] Verified manually on a live running server: all three scenarios (GroupAndTab, CroTable7, Special2) now render correctly in a single test pass.
- [x] `./mvnw -pl core test-compile` and `-Dtest=LayoutToolTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)