### PR TITLE
Update ai assistant package version to most recent build

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/router": "^21.2.15",
         "@ckeditor/ckeditor5-angular": "^9.1.0",
         "@ctrl/tinycolor": "^3.4.1",
-        "@inetsoft-technology/ai-assistant": "^0.0.20260713195139",
+        "@inetsoft-technology/ai-assistant": "^0.0.20260729181003",
         "@ng-bootstrap/ng-bootstrap": "^20.0.0",
         "@popperjs/core": "^2.11.8",
         "@thebespokepixel/es-tinycolor": "^2.1.1",
@@ -5030,9 +5030,9 @@
       }
     },
     "node_modules/@inetsoft-technology/ai-assistant": {
-      "version": "0.0.20260713195139",
-      "resolved": "https://npm.pkg.github.com/download/@inetsoft-technology/ai-assistant/0.0.20260713195139/c1ae838e184363bbdcf11da78d0e5a13446ea699",
-      "integrity": "sha512-wxFkY2GiCOX3G4ub8e76T+LquJrSr0vPepdEA6VQWhPRm5tpZQjbcKQlkQ1DroGB/WHnbUPh/7OrohbrZG2kQA=="
+      "version": "0.0.20260729181003",
+      "resolved": "https://npm.pkg.github.com/download/@inetsoft-technology/ai-assistant/0.0.20260729181003/f75eca8f06225b3b6c2f2c830a9b8c2246b58b70",
+      "integrity": "sha512-wLvKi1Mt01HJstSl5c30KKaOBH+1n8XufgZKDVVJ+q/4yUXibca2m4dEqlBK2Lql/+EXNWkN/sntMNHOnwudJg=="
     },
     "node_modules/@inquirer/ansi": {
       "version": "2.0.5",
@@ -7650,9 +7650,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7670,9 +7667,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7690,9 +7684,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7710,9 +7701,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7730,9 +7718,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7750,9 +7735,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7770,9 +7752,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8642,9 +8621,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8666,9 +8642,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8690,9 +8663,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8714,9 +8684,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8738,9 +8705,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8762,9 +8726,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9132,9 +9093,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9152,9 +9110,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9172,9 +9127,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9192,9 +9144,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9415,9 +9364,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9432,9 +9378,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9449,9 +9392,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9466,9 +9406,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9483,9 +9420,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9500,9 +9434,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9517,9 +9448,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9534,9 +9462,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9551,9 +9476,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9568,9 +9490,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9585,9 +9504,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9602,9 +9518,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9619,9 +9532,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18870,6 +18780,21 @@
         }
       }
     },
+    "node_modules/html-encoding-sniffer/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -20410,6 +20335,21 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/jsdom/node_modules/css-tree": {
@@ -32382,6 +32322,21 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/whatwg-url/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/which": {

--- a/web/package.json
+++ b/web/package.json
@@ -35,7 +35,7 @@
     "@angular/router": "^21.2.15",
     "@ckeditor/ckeditor5-angular": "^9.1.0",
     "@ctrl/tinycolor": "^3.4.1",
-    "@inetsoft-technology/ai-assistant": "^0.0.20260713195139",
+    "@inetsoft-technology/ai-assistant": "^0.0.20260729181003",
     "@ng-bootstrap/ng-bootstrap": "^20.0.0",
     "@popperjs/core": "^2.11.8",
     "@thebespokepixel/es-tinycolor": "^2.1.1",


### PR DESCRIPTION
## Summary
- Bump `@inetsoft-technology/ai-assistant` from `0.0.20260713195139` to `0.0.20260729181003` in `web/package.json` and `web/package-lock.json`, matching the newly published build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)