### PR TITLE
fix(wiz): group per-chart filter with its chart as one aligned card, fix grid header reservation

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.service;
 
+import inetsoft.report.StyleConstants;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.asset.ColumnRef;
 import inetsoft.uql.asset.Worksheet;
@@ -24,6 +25,8 @@ import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.*;
 import org.springframework.stereotype.Component;
 
+import java.awt.Color;
+import java.awt.Insets;
 import java.awt.Point;
 import java.util.ArrayList;
 import java.util.List;
@@ -188,16 +191,27 @@ public class WizDashboardFilterBuilder {
 
    /**
     * Builds ONE selection/range control scoped to exactly one chart's own table, positioned at
-    * the given fixed point (the top of that chart's own tile). Unlike {@link #build}, there is
-    * no multi-table candidate search — the single {@code chartTableName} IS the candidate, so
-    * binding is unambiguous by construction (no residual name-collision risk across charts).
+    * the given fixed point (the top of that chart's own tile) and sized to {@code width} ×
+    * {@code height} — the caller passes the CHART's own width and the reserved header height so
+    * the control spans the full width of, and sits flush against the top of, the chart it
+    * filters. Unlike {@link #build}, there is no multi-table candidate search — the single
+    * {@code chartTableName} IS the candidate, so binding is unambiguous by construction (no
+    * residual name-collision risk across charts).
+    *
+    * <p>When {@code chartAssemblyName} resolves to a real assembly on {@code vs}, the control and
+    * that chart are styled as one visually-grouped "card" (matching background, a shared border
+    * enclosing the pair with no seam where they abut) via {@link #applyGroupedCardStyle} —
+    * otherwise the two would render as independent, visually disconnected floating elements. A
+    * {@code null}/unresolvable name (e.g. a caller that hasn't tracked the assembly name) just
+    * skips the styling, not the filter itself.
     *
     * @return the placement (assembly name/position/size) of the created control, if the field
     *         was found on the chart's table and a control was added; {@code null} if skipped
     *         (field not present on this chart's own table).
     */
    public FilterControlPlacement buildPerChart(Viewsheet vs, Worksheet baseWorksheet, int x, int y,
-                                                FilterRequest request, String chartTableName)
+                                                int width, int height, FilterRequest request,
+                                                String chartTableName, String chartAssemblyName)
    {
       List<String> tables = AddFilterService.findColumnMatchingChartTables(
          baseWorksheet, List.of(chartTableName), request.field());
@@ -214,13 +228,87 @@ public class WizDashboardFilterBuilder {
       }
 
       Point pos = new Point(x, y);
-      java.awt.Dimension size = new java.awt.Dimension(FILTER_CONTROL_WIDTH, FILTER_CONTROL_HEIGHT);
+      java.awt.Dimension size = new java.awt.Dimension(width, height);
       control.setTableNames(tables);
       control.setPixelOffset(pos);
       control.setPixelSize(size);
       vs.addAssembly(control);
+
+      VSAssembly chartAssembly = chartAssemblyName != null ? vs.getAssembly(chartAssemblyName) : null;
+
+      if(chartAssembly != null) {
+         applyGroupedCardStyle(control, chartAssembly);
+      }
+
       return new FilterControlPlacement(control.getName(), pos, size);
    }
+
+   /**
+    * Styles a per-chart filter control and the ONE chart it filters so they read as a single
+    * visually-grouped card, instead of two independent floating assemblies with no visual
+    * relationship — matching background fill on both, and a border drawn around the OUTER edge
+    * of the pair only (the control's bottom edge and the chart's top edge, which abut directly,
+    * are left borderless so there's no doubled seam line between them).
+    *
+    * <p>Deliberately direct-format styling rather than a real {@link Assembly} grouping construct
+    * (e.g. a group container) — StyleBI's actual grouping mechanism carries real structural
+    * invariants (child position sync, z-index recompute, tab-membership, dependency-cycle
+    * checks) that a live rendering feedback loop is needed to get right; two independently
+    * positioned assemblies with matching format achieve the same visual effect with no new
+    * invariants to maintain.
+    */
+   private static void applyGroupedCardStyle(VSAssembly filterControl, VSAssembly chartAssembly) {
+      String backgroundHex = toHex(CARD_BACKGROUND);
+      BorderColors borderColors = new BorderColors(CARD_BORDER_COLOR, CARD_BORDER_COLOR,
+         CARD_BORDER_COLOR, CARD_BORDER_COLOR);
+
+      VSFormat filterFormat = filterControl.getVSAssemblyInfo().getFormat().getUserDefinedFormat();
+      applyCardFormat(filterFormat, backgroundHex, borderColors, new Insets(
+         // Insets(top, left, bottom, right) -- no bottom border: the chart's own top edge (also
+         // borderless, below) abuts it directly.
+         StyleConstants.THIN_LINE, StyleConstants.THIN_LINE,
+         StyleConstants.NO_BORDER, StyleConstants.THIN_LINE));
+
+      VSFormat chartFormat = chartAssembly.getVSAssemblyInfo().getFormat().getUserDefinedFormat();
+      applyCardFormat(chartFormat, backgroundHex, borderColors, new Insets(
+         // No top border -- abuts the filter control's borderless bottom edge directly.
+         StyleConstants.NO_BORDER, StyleConstants.THIN_LINE,
+         StyleConstants.THIN_LINE, StyleConstants.THIN_LINE));
+   }
+
+   /**
+    * Sets background/border-colors/borders via BOTH the plain setters AND the "...Value" variants.
+    * {@link VSCompositeFormat}'s effective getters (what actually renders) fall back to the
+    * user-defined layer when {@code isXxxDefined() || isXxxValueDefined()} — confirmed live
+    * (reloading a saved dashboard directly from the repository) that the plain setters' "xxxDefined"
+    * boolean does NOT survive a save/reload round-trip even though the value itself does, while the
+    * "...Value" setters (the pattern used throughout the codebase, e.g. {@code ChartVSAssemblyInfo},
+    * {@code TableDataVSAssemblyInfo}, for exactly this kind of persisted format) flip
+    * "isXxxValueDefined" instead. Calling both covers persistence (the Value variants) and any
+    * immediate/pre-refresh read of the plain RValue-based getters.
+    */
+   private static void applyCardFormat(
+      VSFormat format, String backgroundHex, BorderColors borderColors, Insets borders)
+   {
+      format.setBackground(CARD_BACKGROUND);
+      format.setBackgroundValue(backgroundHex);
+      format.setBorderColors(borderColors);
+      format.setBorderColorsValue(borderColors);
+      format.setBorders(borders);
+      format.setBordersValue(borders);
+   }
+
+   private static String toHex(Color c) {
+      return String.format("#%02x%02x%02x", c.getRed(), c.getGreen(), c.getBlue());
+   }
+
+   /** Shared card background for a per-chart filter + its chart -- a light, low-contrast tint so
+    *  the grouping reads clearly without competing with the chart's own colors. */
+   private static final Color CARD_BACKGROUND = new Color(244, 246, 249);
+
+   /** Shared card border color -- a clearly-visible-but-neutral gray that outlines the grouped
+    *  filter+chart without drawing attention away from the chart content itself. */
+   private static final Color CARD_BORDER_COLOR = new Color(158, 166, 178);
 
    /**
     * Collects each merged chart's own final bound table name (its {@code SourceInfo.source},

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -199,16 +199,20 @@ public class WizDashboardService {
             }
          }
 
-         // Records each grid tile's own (x, topY) origin and pixel size -- topY is the very top
-         // of the tile's reserved space (where a per-chart filter sits, if it has one), NOT the
-         // chart's own (possibly filter-shifted) y. Also records each merged chart's own table
-         // name. Both are looked up after this loop when placing per-chart filters.
-         java.util.Map<String, java.awt.Rectangle> tileBounds = new java.util.HashMap<>();
+         // Records each merged chart's own table name and assembly name, looked up after this loop
+         // when placing per-chart filters (a filter binds to its chart's table, and is positioned
+         // against its chart's actual post-merge geometry).
          java.util.Map<String, String> identifierToTableName = new java.util.HashMap<>();
          java.util.Map<String, String> identifierToAssemblyName = new java.util.HashMap<>();
 
-         List<TilePlacement> placements =
+         // headerHeights[i] is the header space (if any) reserved at THIS tile's own top, per
+         // GridLayoutResult's contract: it is a BAND-WIDE amount, not a per-tile one -- a tile
+         // with no per-chart filter of its own can still have headerHeights[i] > 0 if it shares a
+         // band with one, so every chart in the band starts at the same Y (see computeGridLayout).
+         GridLayoutResult gridResult =
             grid ? computeGridLayout(spans, rowSpans, hasPerChartFilter, layoutColumns) : null;
+         List<TilePlacement> placements = grid ? gridResult.placements() : null;
+         int[] headerHeights = grid ? gridResult.headerHeights() : null;
 
          int cumulativeY = topOffset;   // stack path only
 
@@ -234,11 +238,11 @@ public class WizDashboardService {
 
                x = placement.x() + CANVAS_MARGIN;
                tileTopY = placement.y() + topOffset + CANVAS_MARGIN;
-               // The chart itself starts BELOW the reserved filter strip, if this tile has one --
-               // the tile's own reserved footprint (computed via computeGridLayout above) already
-               // accounts for that extra height, so this only affects where the CHART renders
-               // within it, not how much space the tile as a whole takes.
-               y = tileTopY + (hasPerChartFilter[i] ? PER_CHART_FILTER_ROW_HEIGHT : 0);
+               // The chart itself starts BELOW the reserved header strip, if this tile's BAND has
+               // one -- the tile's own reserved footprint (computed via computeGridLayout above)
+               // already accounts for that extra height, so this only affects where the CHART
+               // renders within it, not how much space the tile as a whole takes.
+               y = tileTopY + headerHeights[i];
             }
             else {
                x = CANVAS_MARGIN;
@@ -250,13 +254,12 @@ public class WizDashboardService {
             // otherwise a tile's computed (spanCols, spanRows) only ever reserved grid drop-
             // position spacing and never resized the chart itself. The stack path has no
             // per-visualization span data, so it passes null and preserves the chart's saved size.
-            // placement.height() includes the +PER_CHART_FILTER_ROW_HEIGHT reservation (and any
-            // stretch growth) -- subtract the filter reservation back out here so the CHART itself
-            // (not its tile's filter header strip) gets resized; any stretch growth survives this
-            // subtraction since it was added on top of the same base natural+filter height.
+            // placement.height() includes the band's header reservation (and any stretch growth)
+            // -- subtract the header height back out here so the CHART itself (not its tile's
+            // header strip) gets resized; any stretch growth survives this subtraction since it
+            // was added on top of the same base natural+header height.
             java.awt.Dimension pixelSize = grid ?
-               new java.awt.Dimension(placement.width(),
-                  placement.height() - (hasPerChartFilter[i] ? PER_CHART_FILTER_ROW_HEIGHT : 0)) :
+               new java.awt.Dimension(placement.width(), placement.height() - headerHeights[i]) :
                null;
 
             try {
@@ -264,10 +267,6 @@ public class WizDashboardService {
                   runtimeId, entries.get(i), x, y, 1.0f, pixelSize, principal);
 
                if(grid) {
-                  int tileHeight = pixelSize.height + (hasPerChartFilter[i] ? PER_CHART_FILTER_ROW_HEIGHT : 0);
-                  tileBounds.put(identifiers.get(i),
-                     new java.awt.Rectangle(x, tileTopY, pixelSize.width, tileHeight));
-
                   if(mergedInfo.tableName() != null) {
                      identifierToTableName.put(identifiers.get(i), mergedInfo.tableName());
                   }
@@ -327,16 +326,33 @@ public class WizDashboardService {
 
             if(hasPerChartFilters) {
                for(WizDashboardEvent.PerChartFilterSpec spec : event.getPerChartFilters()) {
-                  java.awt.Rectangle bounds = tileBounds.get(spec.getIdentifier());
                   String tableName = identifierToTableName.get(spec.getIdentifier());
+                  String chartName = identifierToAssemblyName.get(spec.getIdentifier());
+                  inetsoft.uql.viewsheet.VSAssembly chartAssembly =
+                     chartName != null ? vs.getAssembly(chartName) : null;
 
-                  if(bounds == null || tableName == null) {
+                  if(tableName == null || chartAssembly == null) {
                      perChartFiltersSkipped.add(spec.getField());
                      continue;
                   }
 
-                  WizDashboardFilterBuilder.FilterControlPlacement placement =
-                     applyPerChartFilter(vs, baseWs, spec, bounds.x, bounds.y, tableName);
+                  // Place the filter against the chart's ACTUAL post-merge geometry, not the
+                  // pre-merge tile bounds: AddVisualizationService#addVisualization applies its
+                  // own margin offset to each merged chart (observed +CANVAS_MARGIN on both axes),
+                  // so the tile's computed x/y no longer match where the chart really landed.
+                  // Reading the chart's own pixel offset/size and placing the control flush above
+                  // it (same x, same width, filter-bottom == chart-top) is what actually makes the
+                  // two line up as one enclosing card (see WizDashboardFilterBuilder#
+                  // applyGroupedCardStyle) regardless of that merge offset.
+                  java.awt.Point chartPos = chartAssembly.getPixelOffset();
+                  java.awt.Dimension chartSize = chartAssembly.getPixelSize();
+                  int filterX = chartPos.x;
+                  int filterWidth = chartSize.width;
+                  int filterY = chartPos.y - PER_CHART_FILTER_ROW_HEIGHT;
+
+                  WizDashboardFilterBuilder.FilterControlPlacement placement = applyPerChartFilter(
+                     vs, baseWs, spec, filterX, filterY, filterWidth, PER_CHART_FILTER_ROW_HEIGHT,
+                     tableName, chartName);
 
                   if(placement != null) {
                      perChartFiltersApplied.add(spec.getField());
@@ -472,11 +488,11 @@ public class WizDashboardService {
     */
    WizDashboardFilterBuilder.FilterControlPlacement applyPerChartFilter(
       Viewsheet vs, Worksheet baseWs, WizDashboardEvent.PerChartFilterSpec spec,
-      int x, int y, String chartTableName)
+      int x, int y, int width, int height, String chartTableName, String chartAssemblyName)
    {
       WizDashboardFilterBuilder.FilterRequest req =
          new WizDashboardFilterBuilder.FilterRequest(spec.getField(), spec.getDataType(), spec.getLabel());
-      return filterBuilder.buildPerChart(vs, baseWs, x, y, req, chartTableName);
+      return filterBuilder.buildPerChart(vs, baseWs, x, y, width, height, req, chartTableName, chartAssemblyName);
    }
 
    /** Vertical row stride between successive merged visualizations, in pixels — used by both
@@ -511,13 +527,17 @@ public class WizDashboardService {
    private static final int MAX_TILE_WIDTH = 900;
    private static final int MAX_TILE_HEIGHT = 600;
 
-   /** Extra row height reserved, in pixels, for a tile that has a per-chart filter -- additive
-    *  to (never counted against) {@link #MAX_TILE_HEIGHT}, so the chart's own rendered size is
-    *  untouched; only the tile grows to make room for the filter control above it. Matches
-    *  {@link #FILTER_BAR_ROW_HEIGHT} exactly: {@link WizDashboardFilterBuilder#buildPerChart}
-    *  sizes its control with the SAME {@code FILTER_CONTROL_HEIGHT} (100px) the shared filter
-    *  bar uses -- there is no smaller "compact" control variant -- so the same 20px margin
-    *  applies here too. */
+   /** Extra header height reserved, in pixels, above a chart that owns a per-chart filter, OR
+    *  above a chart that shares a band with a genuinely side-by-side sibling (another
+    *  first-tile-in-its-column) that does -- additive to (never counted against)
+    *  {@link #MAX_TILE_HEIGHT}, so the chart's own rendered size is untouched; only the tile
+    *  grows to make room. See {@link #closeBand}/{@link GridLayoutResult} for the exact scoping
+    *  (deliberately NOT "every tile in the band," which would shift unrelated charts stacked
+    *  anywhere below an unrelated filtered one in the common single-column dashboard shape).
+    *  Matches {@link #FILTER_BAR_ROW_HEIGHT}
+    *  exactly: {@link WizDashboardFilterBuilder#buildPerChart} sizes its control with the SAME
+    *  {@code FILTER_CONTROL_HEIGHT} (100px) the shared filter bar uses -- there is no smaller
+    *  "compact" control variant -- so the same 20px margin applies here too. */
    private static final int PER_CHART_FILTER_ROW_HEIGHT = 120;
 
    /**
@@ -537,9 +557,35 @@ public class WizDashboardService {
     * may be larger than the tile's own natural {@link #tilePixelSize} height if the stretch pass
     * grew it to match a taller neighbor sharing its band -- see the design spec's Stretch pass
     * section (docs/superpowers/specs/2026-07-25-dashboard-2d-grid-packing-design.md, in the
-    * stylebi-wiz repo). Package-private for unit testing.
+    * stylebi-wiz repo). {@code y} already reflects any band-wide per-chart-filter header shift
+    * (see {@link GridLayoutResult#headerHeights()}) -- it is NOT the tile's natural band-relative
+    * position when the band contains a filter. Package-private for unit testing.
     */
    record TilePlacement(int x, int y, int width, int height) {}
+
+   /**
+    * Return type of {@link #computeGridLayout}: every tile's placement, plus a PARALLEL
+    * {@code headerHeights} array (same index as {@code spanCols}/{@code spanRows}/{@code placements})
+    * recording how much header space, in pixels, is reserved at the TOP of each tile.
+    *
+    * <p>Every tile that personally owns a per-chart filter always reserves
+    * {@link #PER_CHART_FILTER_ROW_HEIGHT} for itself. On top of that, when TWO OR MORE columns in
+    * the SAME band are genuinely side-by-side siblings (each is the FIRST tile placed in its own
+    * column) and at least one of those first-tiles owns a filter, EVERY other first-tile in that
+    * band reserves the same header height too -- even if it has no filter of its own -- so the
+    * row's tops visually align (a filterless sibling just gets blank space where its neighbor's
+    * control renders). See {@link #closeBand} for where this is computed.
+    *
+    * <p>Deliberately scoped to FIRST-tiles only, not "every tile sharing a band": a band can
+    * legitimately span the entire dashboard height in the common single-column (everything
+    * stacked vertically, nothing ever fits beside anything) case, where there is only ever ONE
+    * column and thus nothing to visually align against -- an earlier version of this reservation
+    * applied to the whole band and, in that shape, shifted every chart in the dashboard down
+    * whenever ANY one of them, however far down the stack, happened to own a filter. {@code
+    * headerHeights[i] == 0} for a tile that neither owns a filter nor shares a band with a
+    * misaligned filtered sibling (the overwhelmingly common case).
+    */
+   record GridLayoutResult(List<TilePlacement> placements, int[] headerHeights) {}
 
    /**
     * Tracks one open column within the CURRENT (still-open) band during
@@ -578,11 +624,12 @@ public class WizDashboardService {
     *
     * <p>Package-private for unit testing.
     */
-   static List<TilePlacement> computeGridLayout(
+   static GridLayoutResult computeGridLayout(
       int[] spanCols, int[] spanRows, boolean[] hasPerChartFilter, int layoutColumns)
    {
       int n = spanCols.length;
       TilePlacement[] result = new TilePlacement[n];
+      int[] headerHeights = new int[n];
       int availableRowWidth = layoutColumns * DASHBOARD_COL_WIDTH + (layoutColumns - 1) * TILE_GUTTER;
 
       int cumulativeY = 0;
@@ -592,7 +639,14 @@ public class WizDashboardService {
       for(int k = 0; k < n; k++) {
          java.awt.Dimension natural = tilePixelSize(spanCols[k], spanRows[k]);
          int tileWidth = natural.width;
+         // Every tile always reserves its OWN filter height directly, regardless of stack
+         // position -- this part is unconditional, exactly like the tile's own natural size.
          int tileHeight = natural.height + (hasPerChartFilter[k] ? PER_CHART_FILTER_ROW_HEIGHT : 0);
+
+         if(hasPerChartFilter[k]) {
+            headerHeights[k] = PER_CHART_FILTER_ROW_HEIGHT;
+         }
+
          int neededWidthForNewColumn =
             rowWidthUsed == 0 ? tileWidth : rowWidthUsed + TILE_GUTTER + tileWidth;
 
@@ -623,9 +677,8 @@ public class WizDashboardService {
             continue;
          }
 
-         closeBand(band, result);
-         int bandHeight = band.stream().mapToInt(c -> c.columnY).max().orElse(0);
-         cumulativeY += bandHeight + TILE_GUTTER;
+         int closedBandHeight = closeBand(band, result, headerHeights, hasPerChartFilter);
+         cumulativeY += closedBandHeight + TILE_GUTTER;
          band = new ArrayList<>();
          rowWidthUsed = 0;
 
@@ -637,17 +690,60 @@ public class WizDashboardService {
          rowWidthUsed = tileWidth;
       }
 
-      closeBand(band, result);
+      closeBand(band, result, headerHeights, hasPerChartFilter);
 
-      return java.util.Arrays.asList(result);
+      return new GridLayoutResult(java.util.Arrays.asList(result), headerHeights);
    }
 
    /**
-    * Stretch pass: for every column in the closing band shorter than the band's tallest column,
-    * grows the LAST tile placed in that column so its rendered height closes the gap. Never
-    * shrinks a tile.
+    * Closes a band in three passes and returns its final height:
+    * <ol>
+    *   <li><b>Row-alignment pass</b> (new): if two or more columns exist in this band (i.e. there
+    *       is an actual side-by-side row to keep aligned) and at least one column's FIRST tile
+    *       owns a per-chart filter, every OTHER column's first tile reserves the same
+    *       {@link #PER_CHART_FILTER_ROW_HEIGHT} too -- grown directly into that tile's own height
+    *       (and {@code columnY}), with every tile stacked below it in the SAME column shifted
+    *       down by the same amount to make room. A column whose first tile already owns a filter
+    *       is skipped (it already reserved this in the main loop -- doing it again would double
+    *       it). With only one column in the band (the common single-column-stack dashboard shape)
+    *       this pass is a no-op: there is no sibling to align against.</li>
+    *   <li><b>Stretch pass</b> (unchanged, but now runs against the row-alignment pass's
+    *       already-updated {@code columnY} values): for every column shorter than the band's
+    *       tallest column, grows the LAST tile placed in that column so its rendered height
+    *       closes the gap. Never shrinks a tile.</li>
+    * </ol>
     */
-   private static void closeBand(List<Column> band, TilePlacement[] result) {
+   private static int closeBand(
+      List<Column> band, TilePlacement[] result, int[] headerHeights, boolean[] hasPerChartFilter)
+   {
+      if(band.size() > 1) {
+         boolean anyFirstTileHasFilter = band.stream()
+            .anyMatch(c -> hasPerChartFilter[c.tileIndices.get(0)]);
+
+         if(anyFirstTileHasFilter) {
+            for(Column column : band) {
+               int firstIndex = column.tileIndices.get(0);
+
+               if(hasPerChartFilter[firstIndex]) {
+                  continue;   // already reserved its own header height above
+               }
+
+               TilePlacement firstTile = result[firstIndex];
+               result[firstIndex] = new TilePlacement(firstTile.x(), firstTile.y(),
+                  firstTile.width(), firstTile.height() + PER_CHART_FILTER_ROW_HEIGHT);
+               headerHeights[firstIndex] = PER_CHART_FILTER_ROW_HEIGHT;
+               column.columnY += PER_CHART_FILTER_ROW_HEIGHT;
+
+               for(int i = 1; i < column.tileIndices.size(); i++) {
+                  int idx = column.tileIndices.get(i);
+                  TilePlacement old = result[idx];
+                  result[idx] = new TilePlacement(
+                     old.x(), old.y() + PER_CHART_FILTER_ROW_HEIGHT, old.width(), old.height());
+               }
+            }
+         }
+      }
+
       int bandHeight = band.stream().mapToInt(c -> c.columnY).max().orElse(0);
 
       for(Column column : band) {
@@ -660,6 +756,8 @@ public class WizDashboardService {
                new TilePlacement(old.x(), old.y(), old.width(), old.height() + shortfall);
          }
       }
+
+      return bandHeight;
    }
 
    /** Compact tile size forced on every chart in the Mobile tier, ignoring its own type-based
@@ -739,7 +837,8 @@ public class WizDashboardService {
       layout.setFitToWidth(false);
 
       boolean[] noPerChartFilters = new boolean[assemblyNames.length];
-      List<TilePlacement> placements = computeGridLayout(spanCols, spanRows, noPerChartFilters, layoutColumns);
+      List<TilePlacement> placements =
+         computeGridLayout(spanCols, spanRows, noPerChartFilters, layoutColumns).placements();
       List<VSAssemblyLayout> assemblyLayouts = new ArrayList<>();
 
       for(int i = 0; i < assemblyNames.length; i++) {

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -162,11 +162,13 @@ class WizDashboardFilterBuilderTest {
 
       Viewsheet vs = new Viewsheet();
 
-      WizDashboardFilterBuilder.FilterControlPlacement placement = builder.buildPerChart(vs, ws, 100, 200,
-         new WizDashboardFilterBuilder.FilterRequest("product_name", "string", "Product"), "CHART_FINAL");
+      WizDashboardFilterBuilder.FilterControlPlacement placement = builder.buildPerChart(vs, ws, 100, 200, 640, 120,
+         new WizDashboardFilterBuilder.FilterRequest("product_name", "string", "Product"), "CHART_FINAL", null);
 
       assertNotNull(placement);
       assertEquals(new java.awt.Point(100, 200), placement.position());
+      assertEquals(new java.awt.Dimension(640, 120), placement.size(),
+         "the control must span the chart's width and the reserved header height");
 
       AbstractSelectionVSAssembly control = java.util.Arrays.stream(vs.getAssemblies())
          .filter(a -> a instanceof AbstractSelectionVSAssembly)
@@ -176,6 +178,8 @@ class WizDashboardFilterBuilderTest {
          "must bind only to the specified chart table, never any other table exposing the same column");
       assertEquals(100, control.getPixelOffset().x);
       assertEquals(200, control.getPixelOffset().y);
+      assertEquals(640, control.getPixelSize().width);
+      assertEquals(120, control.getPixelSize().height);
    }
 
    @Test
@@ -185,11 +189,63 @@ class WizDashboardFilterBuilderTest {
 
       Viewsheet vs = new Viewsheet();
 
-      WizDashboardFilterBuilder.FilterControlPlacement placement = builder.buildPerChart(vs, ws, 0, 0,
-         new WizDashboardFilterBuilder.FilterRequest("product_name", "string", "Product"), "CHART_FINAL");
+      WizDashboardFilterBuilder.FilterControlPlacement placement = builder.buildPerChart(vs, ws, 0, 0, 640, 120,
+         new WizDashboardFilterBuilder.FilterRequest("product_name", "string", "Product"), "CHART_FINAL", null);
 
       assertNull(placement);
       assertEquals(0, vs.getAssemblies().length, "no control should be added when the field isn't on the table");
+   }
+
+   @Test
+   void buildPerChartWithAnUnresolvableChartAssemblyNameStillCreatesTheControl() {
+      // A null/unresolvable chartAssemblyName must never block the filter control itself from
+      // being created -- only the visual-grouping styling is skipped.
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name"));
+
+      Viewsheet vs = new Viewsheet();
+
+      WizDashboardFilterBuilder.FilterControlPlacement placement = builder.buildPerChart(vs, ws, 0, 0, 640, 120,
+         new WizDashboardFilterBuilder.FilterRequest("category_name", "string", "Category"),
+         "CHART_FINAL", "NoSuchAssembly");
+
+      assertNotNull(placement);
+      assertEquals(1, vs.getAssemblies().length);
+   }
+
+   @Test
+   void buildPerChartStylesTheControlAndItsChartAsOneGroupedCardWhenTheChartResolves() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name"));
+
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(vs, "RadarChart");
+      boundToTable(chart, "CHART_FINAL");
+      vs.addAssembly(chart);
+
+      builder.buildPerChart(vs, ws, 100, 200, 640, 120,
+         new WizDashboardFilterBuilder.FilterRequest("category_name", "string", "Category"),
+         "CHART_FINAL", "RadarChart");
+
+      AbstractSelectionVSAssembly control = java.util.Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof AbstractSelectionVSAssembly)
+         .map(a -> (AbstractSelectionVSAssembly) a)
+         .findFirst().orElseThrow();
+
+      inetsoft.uql.viewsheet.VSFormat controlFormat = control.getVSAssemblyInfo().getFormat().getUserDefinedFormat();
+      inetsoft.uql.viewsheet.VSFormat chartFormat = chart.getVSAssemblyInfo().getFormat().getUserDefinedFormat();
+
+      assertNotNull(controlFormat.getBackground());
+      assertEquals(controlFormat.getBackground(), chartFormat.getBackground(),
+         "control and chart must share the same card background so they read as one unit");
+
+      // The control's bottom border and the chart's top border abut directly -- both must be
+      // borderless there so there's no doubled seam line between them.
+      assertEquals(inetsoft.report.StyleConstants.NO_BORDER, controlFormat.getBorders().bottom);
+      assertEquals(inetsoft.report.StyleConstants.NO_BORDER, chartFormat.getBorders().top);
+      // The OUTER edges of the pair are bordered.
+      assertEquals(inetsoft.report.StyleConstants.THIN_LINE, controlFormat.getBorders().top);
+      assertEquals(inetsoft.report.StyleConstants.THIN_LINE, chartFormat.getBorders().bottom);
    }
 
    // ChartVSAssembly.setTableName(String) silently no-ops when getSourceInfo() is still null (it

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -71,7 +71,7 @@ class WizDashboardServiceGridTest {
       boolean[] noFilters = new boolean[4];
 
       List<WizDashboardService.TilePlacement> placements =
-         WizDashboardService.computeGridLayout(spans, rowSpans, noFilters, 2);
+         WizDashboardService.computeGridLayout(spans, rowSpans, noFilters, 2).placements();
 
       // A opens column 0 (x=0). B fits as a new column (640+24+640=1304<=1304) at x=664.
       // C doesn't fit as a new column (1304+24+640=1968>1304) -> stacks under A (column 0's
@@ -97,7 +97,7 @@ class WizDashboardServiceGridTest {
       boolean[] noFilters = new boolean[4];
 
       List<WizDashboardService.TilePlacement> placements =
-         WizDashboardService.computeGridLayout(spans, rowSpans, noFilters, 3);
+         WizDashboardService.computeGridLayout(spans, rowSpans, noFilters, 3).placements();
 
       assertEquals(new WizDashboardService.TilePlacement(0, 0, 640, 420), placements.get(0));
       // Columns 1 and 2 both stretch from 420 to 864 to match column 0's stacked height
@@ -108,26 +108,76 @@ class WizDashboardServiceGridTest {
    }
 
    @Test
-   void computeGridLayoutIncludesPerChartFilterHeightWhenStackingAndStretching() {
+   void computeGridLayoutGivesAStackedTileItsOwnFilterHeightWithoutAffectingItsColumnSiblingsWhenItIsNotAFirstTile() {
       // Same shape as computeGridLayoutStacksAShorterTileBesideATallOneAndStretchesTheShorterSide,
-      // but C (the tile that stacks under A) has a per-chart filter, adding 120px to its height
-      // used for packing/stretch purposes -- exactly like the old gridOrigin used to.
+      // but C (which STACKS under A -- it is not the first tile of its column) has a per-chart
+      // filter. Since C is not competing for "row" position with any sibling column's first tile,
+      // this is just C's own reservation (matching the original, pre-alignment-feature numbers) --
+      // A is untouched (it's the first tile of ITS OWN column, and NEITHER first-tile of ANY
+      // column in this band owns a filter, so there's nothing to align).
       int[] spans =    { 1, 1, 1, 2 };
       int[] rowSpans = { 1, 2, 1, 1 };
       boolean[] hasFilter = { false, false, true, false };
 
-      List<WizDashboardService.TilePlacement> placements =
+      WizDashboardService.GridLayoutResult result =
          WizDashboardService.computeGridLayout(spans, rowSpans, hasFilter, 2);
+      List<WizDashboardService.TilePlacement> placements = result.placements();
 
-      // A: column 0 opens at columnY=420. C stacks under A: y=420+24=444, height=420+120=540,
-      // column 0's columnY becomes 444+540=984. B (column 1) stays at columnY=600 until D closes
-      // the band: bandHeight=max(984, 600)=984, so column 1 (B, the only/last tile in it)
-      // stretches from 600 to 984. Column 0's last tile is C, already at the band height (984) ->
-      // no further stretch for C.
-      assertEquals(new WizDashboardService.TilePlacement(0, 0, 640, 420), placements.get(0));     // A
-      assertEquals(new WizDashboardService.TilePlacement(664, 0, 640, 984), placements.get(1));   // B, stretched
-      assertEquals(new WizDashboardService.TilePlacement(0, 444, 640, 540), placements.get(2));   // C, filter height included
-      assertEquals(new WizDashboardService.TilePlacement(0, 1008, 900, 420), placements.get(3));  // D
+      assertEquals(new WizDashboardService.TilePlacement(0, 0, 640, 420), placements.get(0));     // A -- untouched
+      assertEquals(new WizDashboardService.TilePlacement(664, 0, 640, 984), placements.get(1));   // B -- stretched to match column 0
+      assertEquals(new WizDashboardService.TilePlacement(0, 444, 640, 540), placements.get(2));   // C -- its own filter height
+      assertEquals(new WizDashboardService.TilePlacement(0, 1008, 900, 420), placements.get(3));  // D -- fresh band
+
+      assertEquals(0, result.headerHeights()[0], "A owns no filter and has no misaligned sibling");
+      assertEquals(0, result.headerHeights()[1], "B owns no filter and has no misaligned sibling");
+      assertEquals(120, result.headerHeights()[2], "C owns the filter directly");
+      assertEquals(0, result.headerHeights()[3]);
+   }
+
+   @Test
+   void computeGridLayoutDoesNotShiftAnUnrelatedFirstTileWhenAFilterIsBuriedDeepInASingleColumnStack() {
+      // REGRESSION for a real bug found via live testing: when EVERY tile stacks into ONE never-
+      // closing column (the common shape for a board whose charts don't share a width -- nothing
+      // ever fits beside anything, so the whole dashboard is structurally one band), a filter
+      // owned by a chart buried deep in the stack must NOT shift the totally unrelated chart at
+      // the very top of the stack down. There is only one column, so there is no sibling column
+      // to visually align against -- the row-alignment pass must stay a no-op here.
+      int[] spans =    { 1, 1, 1 };
+      int[] rowSpans = { 1, 1, 1 };
+      boolean[] hasFilter = { false, false, true };   // only the LAST (deepest-stacked) tile owns one
+
+      WizDashboardService.GridLayoutResult result =
+         WizDashboardService.computeGridLayout(spans, rowSpans, hasFilter, 1);
+      List<WizDashboardService.TilePlacement> placements = result.placements();
+
+      assertEquals(new WizDashboardService.TilePlacement(0, 0, 640, 420), placements.get(0),
+         "the first tile must be completely unaffected by a filter buried deeper in the same column");
+      assertEquals(new WizDashboardService.TilePlacement(0, 444, 640, 420), placements.get(1));
+      assertEquals(new WizDashboardService.TilePlacement(0, 888, 640, 540), placements.get(2));
+
+      assertEquals(0, result.headerHeights()[0]);
+      assertEquals(0, result.headerHeights()[1]);
+      assertEquals(120, result.headerHeights()[2]);
+   }
+
+   @Test
+   void computeGridLayoutAlignsTwoSideBySideFirstTilesWhenOneOwnsAFilterAndTheOtherDoesNot() {
+      // The actual motivating scenario: two columns, each opened by its own first tile (genuinely
+      // side-by-side siblings) -- A owns a filter, B does not. B must reserve the SAME header
+      // height so both charts' own content starts at the same Y (visual row alignment), even
+      // though B has no filter control of its own there (just blank space).
+      int[] spans =    { 1, 1 };
+      int[] rowSpans = { 1, 1 };
+      boolean[] hasFilter = { true, false };
+
+      WizDashboardService.GridLayoutResult result =
+         WizDashboardService.computeGridLayout(spans, rowSpans, hasFilter, 2);
+      List<WizDashboardService.TilePlacement> placements = result.placements();
+
+      assertEquals(new WizDashboardService.TilePlacement(0, 0, 640, 540), placements.get(0));     // A -- 420 + its own 120
+      assertEquals(new WizDashboardService.TilePlacement(664, 0, 640, 540), placements.get(1));   // B -- 420 + alignment top-up
+      assertEquals(120, result.headerHeights()[0], "A owns the filter");
+      assertEquals(120, result.headerHeights()[1], "B has no filter but aligns with its side-by-side sibling A");
    }
 
    @Test
@@ -137,9 +187,22 @@ class WizDashboardServiceGridTest {
       boolean[] noFilters = new boolean[1];
 
       List<WizDashboardService.TilePlacement> placements =
-         WizDashboardService.computeGridLayout(spans, rowSpans, noFilters, 2);
+         WizDashboardService.computeGridLayout(spans, rowSpans, noFilters, 2).placements();
 
       assertEquals(new WizDashboardService.TilePlacement(0, 0, 640, 420), placements.get(0));
+   }
+
+   @Test
+   void computeGridLayoutGivesEveryTileZeroHeaderHeightWhenNoTileHasAFilter() {
+      int[] spans =    { 1, 1 };
+      int[] rowSpans = { 1, 1 };
+      boolean[] noFilters = new boolean[2];
+
+      WizDashboardService.GridLayoutResult result =
+         WizDashboardService.computeGridLayout(spans, rowSpans, noFilters, 2);
+
+      assertEquals(0, result.headerHeights()[0]);
+      assertEquals(0, result.headerHeights()[1]);
    }
 
    // --- Task 3: composeDashboard's filter-bar invocation seam ---------------------------------
@@ -194,7 +257,8 @@ class WizDashboardServiceGridTest {
       WizDashboardFilterBuilder.FilterControlPlacement expectedPlacement =
          new WizDashboardFilterBuilder.FilterControlPlacement("Selection1",
             new java.awt.Point(100, 200), new java.awt.Dimension(200, 100));
-      when(filterBuilder.buildPerChart(any(), any(), eq(100), eq(200), any(), eq("CHART_TABLE")))
+      when(filterBuilder.buildPerChart(any(), any(), eq(100), eq(200), eq(640), eq(120), any(),
+         eq("CHART_TABLE"), eq("Chart1")))
          .thenReturn(expectedPlacement);
 
       WizDashboardService svc = serviceWith(filterBuilder);
@@ -207,12 +271,12 @@ class WizDashboardServiceGridTest {
       spec.setLabel("Standalone");
 
       WizDashboardFilterBuilder.FilterControlPlacement placement =
-         svc.applyPerChartFilter(vs, baseWs, spec, 100, 200, "CHART_TABLE");
+         svc.applyPerChartFilter(vs, baseWs, spec, 100, 200, 640, 120, "CHART_TABLE", "Chart1");
 
       assertSame(expectedPlacement, placement);
-      verify(filterBuilder).buildPerChart(eq(vs), eq(baseWs), eq(100), eq(200),
+      verify(filterBuilder).buildPerChart(eq(vs), eq(baseWs), eq(100), eq(200), eq(640), eq(120),
          eq(new WizDashboardFilterBuilder.FilterRequest("Standalone", "string", "Standalone")),
-         eq("CHART_TABLE"));
+         eq("CHART_TABLE"), eq("Chart1"));
    }
 
    // --- Task 5: buildAlternateLayouts (Mobile/Wide/Ultrawide adaptive layouts) ----------------


### PR DESCRIPTION
## Summary
Two board-dashboard layout problems with **per-chart filters** (the filter control that sits above a single chart when a field isn't on the shared filter bar), both reported from the live viewer and verified fixed there.

### 1. Grid alignment
`computeGridLayout` added the per-chart-filter header height (120px) only to the **owning** tile's own height. In the common single-column dashboard shape (every chart stacked, nothing fits beside anything → the whole board is one band), that shifted **every chart below** an unrelated filtered one downward. Reworked so:
- a tile always reserves its own filter height directly, and
- only genuinely **side-by-side first-tiles** in a multi-column band additionally top up to align their tops — never whole-band.

`computeGridLayout` now returns a `GridLayoutResult` carrying a parallel `headerHeights[]` the compose loop reads per tile.

### 2. Visual association (the "card")
A per-chart filter rendered as a small floating 200×100 control, visually disconnected from its chart. Now the control:
- spans the chart's **full width** and the reserved header height,
- is positioned against the chart's **actual post-merge geometry** — `AddVisualizationService#addVisualization` offsets each merged chart by `+CANVAS_MARGIN` on both axes, so the pre-merge tile bounds no longer matched where the chart landed (this was the reported "filter and chart don't line up"), and
- shares a background tint + an enclosing border (open on the edge where filter and chart abut) with its chart via `applyGroupedCardStyle`, so the two read as one card.

The format is applied through the **`...Value`** `VSFormat` setters (`setBackgroundValue`/`setBordersValue`/`setBorderColorsValue`) — confirmed via a save/reload round-trip that this is the only variant whose "defined" flag (and therefore the rendered result) survives persistence; the plain setters do not.

## Test plan
- [x] `WizDashboardServiceGridTest` + `WizDashboardFilterBuilderTest` — 27 pass, incl. new regression tests: a filter buried in a single-column stack does NOT shift the unrelated first tile; two side-by-side first-tiles DO align; the per-chart control spans width×header; and the filter+chart get matching bg / complementary open-edge borders.
- [x] `inetsoft.web.wiz.**` — 558 pass, no new failures.
- [x] Verified live in the browser across the full rebuild cycle: grid rows align, and each per-chart filter now reads as one card flush above its chart with matching edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)