### PR TITLE
fix(wiz): align the shared filter bar to the charts and set it off in a toolbar band

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -23,9 +23,11 @@ import inetsoft.uql.asset.ColumnRef;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.RectangleVSAssemblyInfo;
 import org.springframework.stereotype.Component;
 
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.Insets;
 import java.awt.Point;
 import java.util.ArrayList;
@@ -145,13 +147,19 @@ public class WizDashboardFilterBuilder {
     * method has no way to distinguish "genuinely no matching table" from "caller loaded the
     * wrong worksheet" — getting the load right in the caller matters.</p>
     *
+    * <p>{@code startX} is the x-pixel the first control is placed at (subsequent controls tile to
+    * its right). Callers pass the merged charts' actual left edge so the bar lines up with the
+    * columns below it, rather than the raw canvas margin — the chart merge offsets each chart by
+    * +CANVAS_MARGIN, so the two would otherwise be misaligned (same offset the per-chart filters
+    * correct for).
+    *
     * @return which fields bound to &gt;=1 table (applied) vs none (skipped).
     */
-   public FilterResult build(Viewsheet vs, Worksheet baseWorksheet, List<FilterRequest> requests) {
+   public FilterResult build(Viewsheet vs, Worksheet baseWorksheet, List<FilterRequest> requests, int startX) {
       List<String> applied = new ArrayList<>();
       List<String> skipped = new ArrayList<>();
       List<FilterControlPlacement> placements = new ArrayList<>();
-      int x = FILTER_BAR_X;
+      int x = startX;
       int y = FILTER_BAR_Y;
       List<String> chartTableNames = mergedChartTableNames(vs);
 
@@ -187,6 +195,51 @@ public class WizDashboardFilterBuilder {
       }
 
       return new FilterResult(applied, skipped, placements);
+   }
+
+   /**
+    * Adds a full-width "filter toolbar" band behind the shared filter bar so its controls read as
+    * a distinct toolbar region rather than looking attached to the first chart below: a subtly
+    * tinted background rectangle spanning the chart area's width ({@code x}..{@code x+width}), and
+    * a thin gray divider bar along its bottom edge. Both are plain {@link RectangleVSAssembly}s
+    * styled purely via a background fill — the same VSCompositeFormat render path already proven to
+    * render for the selection controls — and MUST be added before the controls (this method is
+    * called first) so the controls layer on top of the band.
+    *
+    * <p>Returns the two rectangles' placements so the caller can carry them into the adaptive
+    * layout tiers, exactly as it already carries the filter controls' placements (otherwise an
+    * assembly with no per-tier layout entry is hidden when that tier is selected).
+    */
+   public List<FilterControlPlacement> buildFilterBarBand(Viewsheet vs, int x, int y, int width, int height) {
+      List<FilterControlPlacement> placements = new ArrayList<>();
+      placements.add(addFillRectangle(vs, "wizFilterBarBand", x, y, width, height, BAND_BACKGROUND));
+      placements.add(addFillRectangle(vs, "wizFilterBarDivider",
+         x, y + height - DIVIDER_THICKNESS, width, DIVIDER_THICKNESS, DIVIDER_COLOR));
+      return placements;
+   }
+
+   /**
+    * Creates a borderless {@link RectangleVSAssembly} rendered as a solid fill of {@code fill} at
+    * the given pixel bounds and adds it to {@code vs}. Uses setBackgroundValue (the persist-safe
+    * "...Value" setter that survives save/reload, like the card styling) plus the plain setter for
+    * any pre-persist read, and NO_BORDER line style so only the fill shows.
+    */
+   private static FilterControlPlacement addFillRectangle(
+      Viewsheet vs, String name, int x, int y, int width, int height, Color fill)
+   {
+      RectangleVSAssembly rect = new RectangleVSAssembly(vs, name);
+      rect.initDefaultFormat();
+      RectangleVSAssemblyInfo info = (RectangleVSAssemblyInfo) rect.getVSAssemblyInfo();
+      Point pos = new Point(x, y);
+      Dimension size = new Dimension(width, height);
+      info.setPixelOffset(pos);
+      info.setPixelSize(size);
+      info.setLineStyleValue(StyleConstants.NO_BORDER);
+      VSFormat fmt = info.getFormat().getUserDefinedFormat();
+      fmt.setBackground(fill);
+      fmt.setBackgroundValue(String.format("#%02x%02x%02x", fill.getRed(), fill.getGreen(), fill.getBlue()));
+      vs.addAssembly(rect);
+      return new FilterControlPlacement(rect.getName(), pos, size);
    }
 
    /**
@@ -309,6 +362,17 @@ public class WizDashboardFilterBuilder {
    /** Shared card border color -- a clearly-visible-but-neutral gray that outlines the grouped
     *  filter+chart without drawing attention away from the chart content itself. */
    private static final Color CARD_BORDER_COLOR = new Color(158, 166, 178);
+
+   /** Filter-toolbar band fill -- a light blue-gray tint, subtly darker than the dashboard canvas,
+    *  so the shared filter bar reads as its own toolbar region. */
+   private static final Color BAND_BACKGROUND = new Color(235, 238, 243);
+
+   /** Filter-toolbar bottom divider color -- matches {@link #CARD_BORDER_COLOR} for consistency
+    *  with the per-chart cards. */
+   private static final Color DIVIDER_COLOR = new Color(158, 166, 178);
+
+   /** Divider bar thickness, in pixels. */
+   private static final int DIVIDER_THICKNESS = 2;
 
    /**
     * Collects each merged chart's own final bound table name (its {@code SourceInfo.source},

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -412,7 +412,9 @@ public class WizDashboardFilterBuilder {
    private static final int FILTER_BAR_Y = WizDashboardService.CANVAS_MARGIN;
    private static final int FILTER_CONTROL_WIDTH = 200;
 
-   /** Control height, in pixels — leaves a small margin under
-    *  {@link WizDashboardService#FILTER_BAR_ROW_HEIGHT} (120px), the reserved row above charts. */
-   private static final int FILTER_CONTROL_HEIGHT = 100;
+   /** Shared-bar control height, in pixels — compact: a range slider (the usual shared filter) or
+    *  a short selection list needs far less than a chart tile, and the toolbar band
+    *  ({@link WizDashboardService#FILTER_BAND_HEIGHT}) wraps it snugly, so this stays small to keep
+    *  the top bar from looking oversized. */
+   private static final int FILTER_CONTROL_HEIGHT = 60;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -310,6 +310,7 @@ public class WizDashboardService {
          // would reproduce the same every-filter-skipped symptom this fix targets) — so the
          // filter builder sees the actual merged root tables.
          WizDashboardFilterBuilder.FilterResult filterResult = null;
+         List<WizDashboardFilterBuilder.FilterControlPlacement> bandPlacements = new ArrayList<>();
          List<String> perChartFiltersApplied = new ArrayList<>();
          List<String> perChartFiltersSkipped = new ArrayList<>();
          boolean hasPerChartFilters = grid && event.getPerChartFilters() != null &&
@@ -321,7 +322,20 @@ public class WizDashboardService {
                vs.getBaseEntry(), principal, false, AssetContent.ALL);
 
             if(hasFilters) {
-               filterResult = applyFilters(vs, baseWs, event.getFilters());
+               // Align the shared filter bar to the merged charts' actual left edge and span a
+               // toolbar band across their full width -- both derived from the charts' real
+               // post-merge geometry (addVisualization offsets each chart by +CANVAS_MARGIN, so the
+               // raw canvas margin no longer matches where the columns landed). The band is added
+               // BEFORE the controls so they layer on top of it.
+               java.awt.Rectangle chartsBox = mergedChartsBoundingBox(vs, identifierToAssemblyName.values());
+               int barLeftX = chartsBox != null ? chartsBox.x : CANVAS_MARGIN;
+
+               if(chartsBox != null) {
+                  bandPlacements = filterBuilder.buildFilterBarBand(
+                     vs, chartsBox.x, FILTER_BAND_TOP, chartsBox.width, FILTER_BAND_HEIGHT);
+               }
+
+               filterResult = applyFilters(vs, baseWs, event.getFilters(), barLeftX);
             }
 
             if(hasPerChartFilters) {
@@ -390,6 +404,11 @@ public class WizDashboardService {
             if(filterResult != null) {
                filterPlacements.addAll(filterResult.placements());
             }
+
+            // Carry the toolbar band + divider rectangles into every adaptive tier too (same as the
+            // filter controls above) -- an assembly with no per-tier layout entry is hidden when
+            // that tier is selected, at their base position (the existing documented scope limit).
+            filterPlacements.addAll(bandPlacements);
 
             String[] assemblyNamesInOrder = identifiers.stream()
                .map(identifierToAssemblyName::get)
@@ -472,12 +491,42 @@ public class WizDashboardService {
     * {@link WizDashboardFilterBuilder}, independent of the live-engine-only compose+save path.
     */
    WizDashboardFilterBuilder.FilterResult applyFilters(Viewsheet vs, Worksheet baseWs,
-                                                        List<WizDashboardEvent.FilterSpec> specs)
+                                                        List<WizDashboardEvent.FilterSpec> specs, int startX)
    {
       List<WizDashboardFilterBuilder.FilterRequest> reqs = specs.stream()
          .map(f -> new WizDashboardFilterBuilder.FilterRequest(f.getField(), f.getDataType(), f.getLabel()))
          .collect(java.util.stream.Collectors.toList());
-      return filterBuilder.build(vs, baseWs, reqs);
+      return filterBuilder.build(vs, baseWs, reqs, startX);
+   }
+
+   /**
+    * The bounding box (in pixels) enclosing every merged chart's ACTUAL post-merge position/size,
+    * or {@code null} if none resolve. Used to align + span the shared filter toolbar to the real
+    * chart columns (addVisualization offsets each chart, so pre-merge tile bounds don't match).
+    */
+   private static java.awt.Rectangle mergedChartsBoundingBox(
+      Viewsheet vs, java.util.Collection<String> chartAssemblyNames)
+   {
+      int minX = Integer.MAX_VALUE, minY = Integer.MAX_VALUE, maxX = Integer.MIN_VALUE, maxY = Integer.MIN_VALUE;
+      boolean any = false;
+
+      for(String name : chartAssemblyNames) {
+         inetsoft.uql.viewsheet.VSAssembly a = name != null ? vs.getAssembly(name) : null;
+
+         if(a == null) {
+            continue;
+         }
+
+         java.awt.Point p = a.getPixelOffset();
+         java.awt.Dimension d = a.getPixelSize();
+         minX = Math.min(minX, p.x);
+         minY = Math.min(minY, p.y);
+         maxX = Math.max(maxX, p.x + d.width);
+         maxY = Math.max(maxY, p.y + d.height);
+         any = true;
+      }
+
+      return any ? new java.awt.Rectangle(minX, minY, maxX - minX, maxY - minY) : null;
    }
 
    /**
@@ -503,6 +552,15 @@ public class WizDashboardService {
     *  {@link WizDashboardFilterBuilder} gives its selection/range controls, not a full chart
     *  tile's height. */
    static final int FILTER_BAR_ROW_HEIGHT = 120;
+
+   /** Top y (px) of the filter toolbar band -- a small inset above the controls (which sit at
+    *  CANVAS_MARGIN=24). */
+   private static final int FILTER_BAND_TOP = 12;
+
+   /** Filter toolbar band height (px): wraps the 100px controls (at y=24) with a little padding,
+    *  so the band bottom (its divider) lands at 12+124=136 -- above the first chart row (which the
+    *  reserved FILTER_BAR_ROW_HEIGHT + margin + merge offset pushes to ~168), leaving a clean gap. */
+   private static final int FILTER_BAND_HEIGHT = 124;
 
    /** Horizontal stride between grid columns, in pixels (paired with DASHBOARD_ROW_HEIGHT). */
    private static final int DASHBOARD_COL_WIDTH = 640;   // confirm vs composer default viz width

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -548,19 +548,21 @@ public class WizDashboardService {
     *  the single-column stack path and the grid path's row advance. */
    private static final int DASHBOARD_ROW_HEIGHT = 420;
 
-   /** Reserved row height for the top filter bar, in pixels — matches the compact pixel size
-    *  {@link WizDashboardFilterBuilder} gives its selection/range controls, not a full chart
-    *  tile's height. */
-   static final int FILTER_BAR_ROW_HEIGHT = 120;
+   /** Reserved row height for the top filter bar, in pixels — sized so the compact filter toolbar
+    *  band clears the first chart with a small gap (the chart is pushed to
+    *  FILTER_BAR_ROW_HEIGHT + CANVAS_MARGIN + merge offset ≈ 76+24+24 = 124, just below the band's
+    *  bottom at 92). Not a full chart tile's height. */
+   static final int FILTER_BAR_ROW_HEIGHT = 76;
 
    /** Top y (px) of the filter toolbar band -- a small inset above the controls (which sit at
     *  CANVAS_MARGIN=24). */
    private static final int FILTER_BAND_TOP = 12;
 
-   /** Filter toolbar band height (px): wraps the 100px controls (at y=24) with a little padding,
-    *  so the band bottom (its divider) lands at 12+124=136 -- above the first chart row (which the
-    *  reserved FILTER_BAR_ROW_HEIGHT + margin + merge offset pushes to ~168), leaving a clean gap. */
-   private static final int FILTER_BAND_HEIGHT = 124;
+   /** Filter toolbar band height (px): wraps the compact 60px controls (at y=24) with a little
+    *  padding, so the band bottom (its divider) lands at 12+80=92 -- above the first chart row
+    *  (which the reserved FILTER_BAR_ROW_HEIGHT + margin + merge offset pushes to ~124), leaving a
+    *  clean gap without the band looking oversized. */
+   private static final int FILTER_BAND_HEIGHT = 80;
 
    /** Horizontal stride between grid columns, in pixels (paired with DASHBOARD_ROW_HEIGHT). */
    private static final int DASHBOARD_COL_WIDTH = 640;   // confirm vs composer default viz width
@@ -592,10 +594,9 @@ public class WizDashboardService {
     *  grows to make room. See {@link #closeBand}/{@link GridLayoutResult} for the exact scoping
     *  (deliberately NOT "every tile in the band," which would shift unrelated charts stacked
     *  anywhere below an unrelated filtered one in the common single-column dashboard shape).
-    *  Matches {@link #FILTER_BAR_ROW_HEIGHT}
-    *  exactly: {@link WizDashboardFilterBuilder#buildPerChart} sizes its control with the SAME
-    *  {@code FILTER_CONTROL_HEIGHT} (100px) the shared filter bar uses -- there is no smaller
-    *  "compact" control variant -- so the same 20px margin applies here too. */
+    *  {@link WizDashboardFilterBuilder#buildPerChart} sizes its control to this full height (its
+    *  own selection list can show several category checkboxes), independent of the deliberately
+    *  more compact shared filter bar ({@link WizDashboardFilterBuilder}'s FILTER_CONTROL_HEIGHT). */
    private static final int PER_CHART_FILTER_ROW_HEIGHT = 120;
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -98,7 +98,8 @@ class WizDashboardFilterBuilderTest {
       vs.addAssembly(chart);
 
       WizDashboardFilterBuilder.FilterResult result = builder.build(
-         vs, ws, List.of(new WizDashboardFilterBuilder.FilterRequest("category_name", "string", "Category")));
+         vs, ws, List.of(new WizDashboardFilterBuilder.FilterRequest("category_name", "string", "Category")),
+         WizDashboardService.CANVAS_MARGIN);
 
       assertEquals(List.of("category_name"), result.applied());
       assertTrue(result.skipped().isEmpty());
@@ -122,7 +123,8 @@ class WizDashboardFilterBuilderTest {
       vs.addAssembly(chart);
 
       WizDashboardFilterBuilder.FilterResult result = builder.build(
-         vs, ws, List.of(new WizDashboardFilterBuilder.FilterRequest("category_name", "string", "Category")));
+         vs, ws, List.of(new WizDashboardFilterBuilder.FilterRequest("category_name", "string", "Category")),
+         WizDashboardService.CANVAS_MARGIN);
 
       assertEquals(1, result.placements().size());
       assertNotNull(result.placements().get(0).assemblyName());
@@ -140,16 +142,45 @@ class WizDashboardFilterBuilderTest {
       boundToTable(chart, "CHART_FINAL");
       vs.addAssembly(chart);
 
-      builder.build(vs, ws, List.of(new WizDashboardFilterBuilder.FilterRequest("category_name", "string", "Category")));
+      builder.build(vs, ws, List.of(new WizDashboardFilterBuilder.FilterRequest("category_name", "string", "Category")),
+         WizDashboardService.CANVAS_MARGIN);
 
       AbstractSelectionVSAssembly control = java.util.Arrays.stream(vs.getAssemblies())
          .filter(a -> a instanceof AbstractSelectionVSAssembly)
          .map(a -> (AbstractSelectionVSAssembly) a)
          .findFirst().orElseThrow();
       assertEquals(WizDashboardService.CANVAS_MARGIN, control.getPixelOffset().x,
-         "must not sit flush against the canvas's left edge");
+         "must sit at the passed startX (the merged charts' left edge)");
       assertEquals(WizDashboardService.CANVAS_MARGIN, control.getPixelOffset().y,
          "must not sit flush against the canvas's top edge");
+   }
+
+   @Test
+   void buildFilterBarBandAddsATintedBandAndAThinDividerSpanningTheGivenWidth() {
+      Viewsheet vs = new Viewsheet();
+
+      List<WizDashboardFilterBuilder.FilterControlPlacement> placements =
+         builder.buildFilterBarBand(vs, 48, 12, 1800, 124);
+
+      // Two rectangles: the band (full height) and a thin divider along its bottom edge.
+      assertEquals(2, placements.size());
+      assertEquals(new java.awt.Point(48, 12), placements.get(0).position());
+      assertEquals(new java.awt.Dimension(1800, 124), placements.get(0).size(), "band spans the given width x height");
+      assertEquals(new java.awt.Point(48, 12 + 124 - 2), placements.get(1).position(),
+         "divider sits along the band's bottom edge");
+      assertEquals(new java.awt.Dimension(1800, 2), placements.get(1).size(), "divider is a 2px-tall full-width bar");
+
+      // Both are borderless rectangles rendered as a solid background fill.
+      long rectangles = java.util.Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof RectangleVSAssembly).count();
+      assertEquals(2, rectangles);
+
+      for(inetsoft.uql.asset.Assembly a : vs.getAssemblies()) {
+         if(a instanceof RectangleVSAssembly rect) {
+            inetsoft.uql.viewsheet.VSFormat fmt = rect.getVSAssemblyInfo().getFormat().getUserDefinedFormat();
+            assertNotNull(fmt.getBackground(), "rectangle must carry a fill background so it renders");
+         }
+      }
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -232,21 +232,21 @@ class WizDashboardServiceGridTest {
       WizDashboardFilterBuilder filterBuilder = mock(WizDashboardFilterBuilder.class);
       WizDashboardFilterBuilder.FilterResult expected =
          new WizDashboardFilterBuilder.FilterResult(List.of("Region"), List.of("MissingField"));
-      when(filterBuilder.build(any(), any(), any())).thenReturn(expected);
+      when(filterBuilder.build(any(), any(), any(), eq(48))).thenReturn(expected);
 
       WizDashboardService svc = serviceWith(filterBuilder);
       Viewsheet vs = mock(Viewsheet.class);
       Worksheet baseWs = mock(Worksheet.class);
       WizDashboardEvent.FilterSpec spec = filterSpec("Region", "string", "Region");
 
-      WizDashboardFilterBuilder.FilterResult actual = svc.applyFilters(vs, baseWs, List.of(spec));
+      WizDashboardFilterBuilder.FilterResult actual = svc.applyFilters(vs, baseWs, List.of(spec), 48);
 
       assertSame(expected, actual);
 
       @SuppressWarnings("unchecked")
       ArgumentCaptor<List<WizDashboardFilterBuilder.FilterRequest>> captor =
          ArgumentCaptor.forClass(List.class);
-      verify(filterBuilder).build(eq(vs), eq(baseWs), captor.capture());
+      verify(filterBuilder).build(eq(vs), eq(baseWs), captor.capture(), eq(48));
       assertEquals(List.of(new WizDashboardFilterBuilder.FilterRequest("Region", "string", "Region")),
          captor.getValue());
    }


### PR DESCRIPTION
## Summary
Two issues with the **top shared filter bar** on a composed board dashboard (reported from the live viewer):

### 1. Left misalignment
The bar's controls were placed at the raw `CANVAS_MARGIN`, but `AddVisualizationService#addVisualization` offsets each merged chart by `+CANVAS_MARGIN` — so the bar sat a step to the left of the chart columns below it. (Same merge offset the per-chart filters were just fixed to correct for in #4448.) `WizDashboardFilterBuilder.build(...)` now takes a `startX`, and the caller passes the merged charts' **actual post-merge left edge**, so the bar lines up with the first column.

### 2. No separation from the first chart
The bar looked attached to the chart directly below it. Added a full-width **filter toolbar band** behind the controls: a subtly-tinted `RectangleVSAssembly` spanning the charts' width, plus a thin gray divider bar along its bottom edge — so the controls read as their own toolbar region set apart from the charts. Both rectangles render purely via a background fill (the persist-safe `setBackgroundValue` path proven for the selection controls / cards) and are carried into the adaptive-layout tiers alongside the filter controls (so they don't vanish when a tier is selected).

Both the alignment and the band are derived from the charts' real geometry, so they hold regardless of the merge offset.

## Test plan
- [x] `WizDashboardServiceGridTest` + `WizDashboardFilterBuilderTest` — 28 pass, incl. a new test asserting `buildFilterBarBand` adds a tinted band + a 2px full-width divider with a fill background, and the `build`/`applyFilters` seam threads the aligned `startX`.
- [x] `inetsoft.web.wiz.**` — 564 pass.
- [x] Verified live: the shared date filter now sits in a full-width tinted band aligned to the charts' left edge, with a divider clearly separating it from the first chart row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)