### PR TITLE
feat(wiz): pre-aggregation dashboard filters bind to the raw source table

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/WizDashboardEvent.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDashboardEvent.java
@@ -154,9 +154,25 @@ public class WizDashboardEvent {
          this.label = label;
       }
 
+      /** When true, bind this filter PRE-aggregation: to the raw source table(s) carrying the
+       *  column (a WHERE evaluated before any group-by), so it filters an aggregated chart's
+       *  underlying rows and the aggregate re-computes over the subset. Enables filtering by an
+       *  orthogonal column that never survives to the chart's final table (e.g. order `state` on a
+       *  revenue-by-quarter chart). Default false = bind to the chart's final table (post-agg),
+       *  the original behavior. The caller (wiz) is responsible for only setting this for
+       *  structurally-safe charts (a simple per-group aggregate) — see WizDashboardFilterBuilder. */
+      public boolean isPreAggregation() {
+         return preAggregation;
+      }
+
+      public void setPreAggregation(boolean preAggregation) {
+         this.preAggregation = preAggregation;
+      }
+
       private String field;
       private String dataType;
       private String label;
+      private boolean preAggregation;
    }
 
    /** A single chart-scoped filter, identified by which saved chart it targets. This list is

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -112,7 +112,13 @@ import java.util.List;
  */
 @Component
 public class WizDashboardFilterBuilder {
-   public record FilterRequest(String field, String dataType, String label) {}
+   public record FilterRequest(String field, String dataType, String label, boolean preAggregation) {
+      /** Compatibility constructor defaulting to post-aggregation (the original binding) -- used by
+       *  the per-chart path and by tests that predate the pre-aggregation flag. */
+      public FilterRequest(String field, String dataType, String label) {
+         this(field, dataType, label, false);
+      }
+   }
 
    public record FilterResult(List<String> applied, List<String> skipped,
                                List<FilterControlPlacement> placements) {
@@ -164,8 +170,19 @@ public class WizDashboardFilterBuilder {
       List<String> chartTableNames = mergedChartTableNames(vs);
 
       for(FilterRequest req : requests) {
-         List<String> tables =
-            AddFilterService.findColumnMatchingChartTables(baseWorksheet, chartTableNames, req.field());
+         // Post-aggregation (default): bind to each chart's FINAL bound table -- the control
+         // filters the already-aggregated display rows (see the class Javadoc). Pre-aggregation:
+         // bind to the RAW source table(s) carrying the column (findColumnMatchingRootTables) so
+         // the selection applies as a WHERE before any group-by, filtering the underlying rows and
+         // letting the aggregate re-compute over the subset -- the only way to filter by an
+         // orthogonal column that never survives to a chart's final table (e.g. order `state` on a
+         // revenue-by-quarter chart). The caller only sets preAggregation for structurally-safe
+         // charts (a simple per-group aggregate); a global-aggregate/normalization/window chart
+         // would have its cross-row aggregate collapsed by a subset WHERE, which is exactly why the
+         // default stays post-aggregation.
+         List<String> tables = req.preAggregation()
+            ? AddFilterService.findColumnMatchingRootTables(baseWorksheet, req.field())
+            : AddFilterService.findColumnMatchingChartTables(baseWorksheet, chartTableNames, req.field());
 
          if(tables.isEmpty()) {
             skipped.add(req.field());

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -494,7 +494,8 @@ public class WizDashboardService {
                                                         List<WizDashboardEvent.FilterSpec> specs, int startX)
    {
       List<WizDashboardFilterBuilder.FilterRequest> reqs = specs.stream()
-         .map(f -> new WizDashboardFilterBuilder.FilterRequest(f.getField(), f.getDataType(), f.getLabel()))
+         .map(f -> new WizDashboardFilterBuilder.FilterRequest(
+            f.getField(), f.getDataType(), f.getLabel(), f.isPreAggregation()))
          .collect(java.util.stream.Collectors.toList());
       return filterBuilder.build(vs, baseWs, reqs, startX);
    }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -113,6 +113,43 @@ class WizDashboardFilterBuilderTest {
    }
 
    @Test
+   void preAggregationFilterBindsToTheRawSourceTableNotTheChartsFinalTable() {
+      // A column (order `state`) present on the RAW source but NOT on the chart's aggregated final
+      // table. Post-aggregation (default) can't reach it -> skipped. Pre-aggregation binds to the
+      // raw source (a WHERE before the group-by) so the aggregate re-computes over the subset.
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "SO_RAW", "date_order", "amount_total", "state"));
+      // The chart's own final (aggregated) table: carries only the grouped dim + measure, no state.
+      ws.addAssembly(physicalTable(ws, "SO_REVENUE_BY_QTR", "Quarter(date_order)", "total_revenue"));
+
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(vs, "RevenueChart");
+      boundToTable(chart, "SO_REVENUE_BY_QTR");
+      vs.addAssembly(chart);
+
+      // Post-aggregation (default): state isn't on the chart's final table -> skipped, nothing added.
+      WizDashboardFilterBuilder.FilterResult post = builder.build(
+         vs, ws, List.of(new WizDashboardFilterBuilder.FilterRequest("state", "string", "Status")),
+         WizDashboardService.CANVAS_MARGIN);
+      assertEquals(List.of("state"), post.skipped(), "post-agg can't reach a column not on the final table");
+      assertTrue(post.applied().isEmpty());
+
+      // Pre-aggregation: binds to the raw source table that carries state.
+      WizDashboardFilterBuilder.FilterResult pre = builder.build(
+         vs, ws, List.of(new WizDashboardFilterBuilder.FilterRequest("state", "string", "Status", true)),
+         WizDashboardService.CANVAS_MARGIN);
+      assertEquals(List.of("state"), pre.applied());
+      assertTrue(pre.skipped().isEmpty());
+
+      AbstractSelectionVSAssembly control = java.util.Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof AbstractSelectionVSAssembly)
+         .map(a -> (AbstractSelectionVSAssembly) a)
+         .findFirst().orElseThrow();
+      assertEquals(List.of("SO_RAW"), control.getTableNames(),
+         "pre-aggregation must bind to the raw source table carrying the column");
+   }
+
+   @Test
    void buildReturnsThePlacementOfEachAppliedControl() {
       Worksheet ws = new Worksheet();
       ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name"));


### PR DESCRIPTION
## Summary
Lets a shared dashboard filter target an **orthogonal** column that never survives to a chart's final aggregated table (e.g. order `state` on a revenue-by-quarter chart), by binding **pre-aggregation**.

A `preAggregation` flag on `WizDashboardEvent.FilterSpec`: when set, `WizDashboardFilterBuilder.build()` binds the selection control via `findColumnMatchingRootTables` (the chart's **raw source** table) instead of `findColumnMatchingChartTables` (its final aggregated table). Binding to the raw source applies the selection as a WHERE **before** the group-by (confirmed via `AssetQuery.getPostBaseTableLens`), so the chart's own aggregate re-computes over the filtered rows — the chart looks unchanged but becomes sliceable by that dimension.

Default (`false`) is unchanged: bind post-aggregation to the final table (the existing behavior, which avoids collapsing a normalization/global-aggregate chart — see `WizDashboardFilterBuilder`'s class Javadoc).

## Safety
`preAggregation` is only safe for a **simple per-group-aggregate** chart. A chart with a global aggregate, a normalization/ratio expression, a window function, or stacked aggregate mirrors would have its cross-row math collapsed by a subset WHERE. That determination is made caller-side (`wiz-services`, guided by the skill, using `get_worksheet_structure`); this PR only honors the flag.

## Pairs with
- `stylebi-wiz` PR #1363 (wire-through: `curate_board` `additionalFilters.preAggregation` → compose payload → this endpoint).

## History
Supersedes #4450 (that PR was auto-closed when its stacked base branch — the now-merged #4449 — was deleted, and GitHub won't reopen a force-pushed branch). This branch has been rebased onto `stylebi-wiz-main-rebase`; the diff is exactly the pre-aggregation change (4 files, +75).

## Test plan
- [x] `WizDashboardFilterBuilderTest` — a new test asserts a `preAggregation` request binds to the raw source table and a post-agg request for the same column (absent from the final table) is skipped.
- [x] `inetsoft.web.wiz.**` — 564 pass.
- [x] Empirically confirmed (live, local-1117): a worksheet that selects `state` into the `sale_order` base but not the group-by retains `state` on the base root (`get_worksheet_structure`), while the final table has only `Quarter`/`total_revenue` — so the root matcher has a column to bind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)