### PR TITLE
fix(wiz): copy pairing code via ngx-clipboard instead of navigator.clipboard

### DIFF
--- a/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.html
+++ b/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.html
@@ -8,7 +8,8 @@
   <div *ngIf="code" class="wiz-connect-code mt-2">
     <span class="wiz-connect-label">Pairing Code:</span>
     <code class="wiz-connect-value ms-2">{{ code }}</code>
-    <button (click)="copyCode()" class="btn btn-sm btn-outline-secondary ms-2">
+    <button ngxClipboard [cbContent]="code" (cbOnSuccess)="onCopySuccess()" (cbOnError)="onCopyError()"
+      class="btn btn-sm btn-outline-secondary ms-2">
       {{ copied ? 'Copied!' : 'Copy' }}
     </button>
   </div>

--- a/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.spec.ts
@@ -124,6 +124,41 @@ describe("ConnectToClaudeComponent", () => {
       expect(component.loading).toBe(false);
    });
 
+   it("copy button uses the ngxClipboard directive instead of navigator.clipboard", () => {
+      // navigator.clipboard is undefined in insecure contexts (plain http on a
+      // non-localhost host); the copy button must not depend on it directly.
+      let capturedHandler: ((msg: any) => void) | null = null;
+      mockStompConnection.subscribe.mockImplementation((_dest: string, handler: (msg: any) => void) => {
+         capturedHandler = handler;
+         return { unsubscribe: vi.fn() };
+      });
+
+      component.requestCode();
+      capturedHandler!({ frame: { body: JSON.stringify({ code: "ABC123" }) } });
+      fixture.detectChanges();
+
+      const copyButton: HTMLButtonElement = fixture.nativeElement.querySelector(".wiz-connect-code button");
+      expect(copyButton.hasAttribute("ngxclipboard")).toBe(true);
+      expect((component as any).copyCode).toBeUndefined();
+   });
+
+   it("onCopySuccess shows the copied indicator then clears it after a delay", () => {
+      vi.useFakeTimers();
+
+      component.onCopySuccess();
+      expect(component.copied).toBe(true);
+
+      vi.advanceTimersByTime(2000);
+      expect(component.copied).toBe(false);
+
+      vi.useRealTimers();
+   });
+
+   it("onCopyError sets an error message", () => {
+      component.onCopyError();
+      expect(component.error).toBe("Could not copy to clipboard — please copy the code manually.");
+   });
+
    it("ngOnDestroy unsubscribes pending mint", () => {
       const subSpy = { unsubscribe: vi.fn() };
       mockStompConnection.subscribe.mockReturnValue(subSpy);

--- a/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.ts
+++ b/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.ts
@@ -17,6 +17,7 @@
  */
 import { Component, Input, NgZone, OnChanges, OnDestroy, SimpleChanges } from "@angular/core";
 import { NgIf } from "@angular/common";
+import { ClipboardModule } from "ngx-clipboard";
 import { Subscription } from "rxjs";
 import { take } from "rxjs/operators";
 import { StompClientConnection } from "../../../../../../shared/stomp/stomp-client-connection";
@@ -26,7 +27,7 @@ import { ViewsheetClientService } from "../../../common/viewsheet-client";
    selector: "wiz-connect-to-claude",
    templateUrl: "./connect-to-claude.component.html",
    standalone: true,
-   imports: [NgIf]
+   imports: [NgIf, ClipboardModule]
 })
 export class ConnectToClaudeComponent implements OnChanges, OnDestroy {
    @Input() runtimeId!: string;
@@ -92,21 +93,17 @@ export class ConnectToClaudeComponent implements OnChanges, OnDestroy {
       });
    }
 
-   copyCode(): void {
-      navigator.clipboard.writeText(this.code!).then(() => {
+   onCopySuccess(): void {
+      this.copied = true;
+      setTimeout(() => {
          this.zone.run(() => {
-            this.copied = true;
-            setTimeout(() => {
-               this.zone.run(() => {
-                  this.copied = false;
-               });
-            }, 2000);
+            this.copied = false;
          });
-      }).catch(() => {
-         this.zone.run(() => {
-            this.error = "Could not copy to clipboard — please copy the code manually.";
-         });
-      });
+      }, 2000);
+   }
+
+   onCopyError(): void {
+      this.error = "Could not copy to clipboard — please copy the code manually.";
    }
 
    ngOnDestroy(): void {


### PR DESCRIPTION
## Summary
- `navigator.clipboard` only exists in secure contexts (HTTPS, or `http://localhost`/`127.0.0.1`), so the "Connect to Claude" pairing code Copy button silently failed when the server was accessed over plain HTTP on a non-localhost host (e.g. `http://192.168.5.148:14222/`).
- Switch the Copy button to the `ngx-clipboard` directive, which is already used elsewhere in the app (`share-link-dialog.component.ts`) for the same reason — it copies via `document.execCommand('copy')` and works regardless of secure-context restrictions.

## Test plan
- [x] Added unit tests covering `onCopySuccess`/`onCopyError` and the `ngxClipboard` directive wiring
- [x] `ng test --project portal` passes for `connect-to-claude.component.spec.ts` (8/8)
- [x] `eslint` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)