### PR TITLE
Bug #75841, copy the Welcome Page setting when cloning/renaming an organization

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
@@ -239,6 +239,13 @@ public abstract class AbstractEditableAuthenticationProvider
          manager.save();
       }
 
+      PortalWelcomePage welcomePage = manager.getWelcomePage(fromOrgId);
+
+      if(welcomePage != null) {
+         manager.setWelcomePage(newOrgID, (PortalWelcomePage) welcomePage.clone());
+         manager.save();
+      }
+
       // edit org update members has been process in the IdentityService#updateOrganizationMembers
       if(editedNewOrganization != null && replace) {
          newOrg.setMembers(editedNewOrganization.getMembers());
@@ -285,6 +292,7 @@ public abstract class AbstractEditableAuthenticationProvider
          FSService.clearServerNodeCache(fromOrgId);
          XJobPool.resetOrgCache(fromOrgId);
          manager.removeCSSEntry(fromOrgId);
+         manager.removeWelcomePage(fromOrgId);
          manager.save();
          RepletRegistryManager.getInstance().clearOrgCache(fromOrgId);
 


### PR DESCRIPTION
## Summary

When a new organization is created by cloning an existing one ("Clone From Existing Organization" in EM), the new org's Welcome Page setting (EM > Presentation > Welcome Page) always shows "None selected" instead of inheriting the source org's configured resource. The same underlying setting is shared with the "Login Banner" panel, so that is affected too.

## Root Cause

The Welcome Page/Login Banner setting is stored per-org in `PortalThemesManager.welcomePageEntries` (`Map<orgId, PortalWelcomePage>`), persisted in a single global `portalthemes.xml` file — org isolation is done purely by map key.

`AbstractEditableAuthenticationProvider.copyOrganizationInternal()` already copies CSS branding (`cssEntries`) correctly when cloning or renaming an organization, but never copied or cleaned up the corresponding `welcomePageEntries` entry. So a cloned org's map simply has no entry, and `WelcomePageService.getModel()` falls back to the global setting or the hardcoded default (`type=NONE, source=""`), which the UI renders as "None selected".

## Fix

Mirror the existing `cssEntries` handling in `copyOrganizationInternal()`:
- After the CSS copy block: if the source org has a `PortalWelcomePage` entry, clone it (it implements `Cloneable`) and store the clone under the new org's ID, then persist.
- In the rename cleanup block (alongside `removeCSSEntry`): remove the source org's now-stale `welcomePageEntries` entry.

The entry is cloned rather than copied by reference because `WelcomePageService.setModel()` mutates the `PortalWelcomePage` object in place — sharing a reference between two orgs would mean editing one org's Welcome Page later silently mutates the other's.

## Test Plan

- [x] `./mvnw clean install -pl core -am -DskipTests` — build succeeds
- [x] `./mvnw test -pl core -am -Dtest=AbstractEditableAuthenticationProviderTest,OrgLifecycleScopedPropertiesIntegrationTest` — 42 tests pass, 0 failures
- [x] Code review via code-reviewer subagent — no blocking issues
- [x] Manually reproduced steps 1-5 from the bug report and confirmed org1 now shows org0's Welcome Page setting after the fix

Fixes Redmine #75841.