### PR TITLE
Bug #75807, restore Rhino scope-chain and constructor coercion for crosstab scripts

### DIFF
--- a/core/src/main/java/inetsoft/report/script/viewsheet/ViewsheetScope.java
+++ b/core/src/main/java/inetsoft/report/script/viewsheet/ViewsheetScope.java
@@ -391,9 +391,15 @@ public class ViewsheetScope implements Cloneable, DynamicScope {
          return propmap.get(id);
       }
 
+      if(members.containsKey(id)) {
+         return members.get(id);
+      }
+
       // the dynamic-scope fallback (executing scope) is now provided centrally
       // by BindingRootProxy
-      return members.get(id);
+      ScriptScope owner = findInChain(id);
+
+      return owner == null ? null : owner.getMember(id);
    }
 
    @Override
@@ -440,7 +446,43 @@ public class ViewsheetScope implements Cloneable, DynamicScope {
          return true;
       }
 
-      return members.containsKey(name);
+      if(members.containsKey(name)) {
+         return true;
+      }
+
+      return findInChain(name) != null;
+   }
+
+   /**
+    * Find the scope in this scope's lookup chain that defines a name this scope
+    * does not define itself. The chain is populated by
+    * {@link JavaScriptEngine#addToPrototype(Object, Object)} -- in practice with
+    * the base worksheet's {@code AssetQueryScope}, which resolves worksheet
+    * table assembly names.
+    *
+    * <p>A qualified read such as {@code viewsheet['<worksheet table>']} is
+    * dispatched straight at this scope by {@code ScopeProxy}, so it never goes
+    * through {@code BindingRootProxy}'s chain walk (that only covers unqualified
+    * names). Rhino resolved such a read through this object's prototype chain,
+    * which is what {@code addToPrototype} populated, so the chain has to be
+    * walked here to keep the qualified form resolving. Both the read and the
+    * presence test need it, since GraalJS only calls {@code getMember} after
+    * {@code hasMember} reported the name present. (#75807)
+    *
+    * @param name the member name to look for.
+    *
+    * @return the owning scope, or <tt>null</tt> if the name is not in the chain.
+    */
+   private ScriptScope findInChain(String name) {
+      for(ScriptScope scope = getParentScope();
+          scope != null && scope != this; scope = scope.getParentScope())
+      {
+         if(scope.hasMember(name)) {
+            return scope;
+         }
+      }
+
+      return null;
    }
 
    /**

--- a/core/src/main/java/inetsoft/util/script/graal/JavaClassProxy.java
+++ b/core/src/main/java/inetsoft/util/script/graal/JavaClassProxy.java
@@ -67,11 +67,131 @@ public final class JavaClassProxy implements ProxyObject, ProxyExecutable, Proxy
    @Override
    public Object execute(Value... arguments) {
       // Rhino allowed construction without `new`: java.awt.Color(0xaed581).
-      return hostType.newInstance((Object[]) arguments);
+      return construct(arguments);
    }
 
    @Override
    public Object newInstance(Value... arguments) {
-      return hostType.newInstance((Object[]) arguments);
+      return construct(arguments);
+   }
+
+   /**
+    * Instantiate the host type, retrying once with numeric-string arguments
+    * coerced to numbers if GraalVM's overload resolution rejects the call.
+    *
+    * <p>Rhino's {@code NativeJavaClass.construct} ran every argument through
+    * {@code ScriptRuntime.toNumber} when scoring a numeric constructor
+    * parameter, so a script could pass a numeric string where an {@code int} was
+    * declared -- the common idiom being a hex colour built by concatenation,
+    * {@code java.awt.Color('0x' + row['Cell Color'])}, which selected
+    * {@code Color(int)}. GraalVM does no such conversion and fails the call with
+    * "Invalid argument when instantiating", so the coercion is reproduced here.
+    *
+    * <p>Applied only as a retry after GraalVM has already rejected the
+    * arguments, so a call that resolves natively keeps its existing overload --
+    * this can never re-target a working call. The original exception is rethrown
+    * if nothing could be coerced or the retry also fails, keeping the reported
+    * error about the argument the script actually passed. (#75807)
+    */
+   private Object construct(Value... arguments) {
+      try {
+         return hostType.newInstance((Object[]) arguments);
+      }
+      catch(IllegalArgumentException ex) {
+         Object[] coerced = coerceNumericStrings(arguments);
+
+         if(coerced == null) {
+            throw ex;
+         }
+
+         try {
+            return hostType.newInstance(coerced);
+         }
+         catch(IllegalArgumentException ignore) {
+            throw ex;
+         }
+      }
+   }
+
+   /**
+    * Copy the arguments with every numeric-string element replaced by its
+    * numeric value, or <tt>null</tt> if no element was a numeric string (in
+    * which case a retry would be pointless).
+    */
+   private static Object[] coerceNumericStrings(Value[] arguments) {
+      Object[] coerced = null;
+
+      for(int i = 0; i < arguments.length; i++) {
+         Value arg = arguments[i];
+         Number num = arg != null && arg.isString() ? toNumber(arg.asString()) : null;
+
+         if(num != null) {
+            if(coerced == null) {
+               // a genuine Object[] -- storing a Number into the Value[] that
+               // clone() would return throws ArrayStoreException.
+               coerced = new Object[arguments.length];
+               System.arraycopy(arguments, 0, coerced, 0, arguments.length);
+            }
+
+            coerced[i] = num;
+         }
+      }
+
+      return coerced;
+   }
+
+   /**
+    * Parse a string as a JavaScript numeric literal: a {@code 0x}/{@code 0X}
+    * prefixed hex integer, or a decimal number. An {@link Integer} is returned
+    * when the value is integral and fits, so GraalVM's overload resolution
+    * prefers an {@code int} parameter (e.g. {@code Color(int)}) over a
+    * {@code float}/{@code double} one.
+    *
+    * <p>Unlike JavaScript {@code ToNumber}, an empty/blank string is not mapped
+    * to {@code 0} and an unparseable string is not mapped to {@code NaN};
+    * both return <tt>null</tt> so the argument is left alone and the caller
+    * reports GraalVM's original argument-mismatch error rather than silently
+    * constructing from a nonsense value.
+    *
+    * @return the parsed number, or <tt>null</tt> if the string is not numeric.
+    */
+   private static Number toNumber(String str) {
+      String s = str.trim();
+
+      if(s.isEmpty()) {
+         return null;
+      }
+
+      try {
+         // JS treats a leading zero as decimal ("010" is 10), so only an
+         // explicit 0x/0X prefix is a radix change -- matching Rhino, which
+         // likewise recognized only the unsigned hex form.
+         if(s.length() > 2 && s.charAt(0) == '0' && (s.charAt(1) == 'x' || s.charAt(1) == 'X')) {
+            return narrow(Long.parseLong(s.substring(2), 16));
+         }
+
+         return narrow(Double.parseDouble(s));
+      }
+      catch(NumberFormatException ex) {
+         return null;
+      }
+   }
+
+   /**
+    * Return an integral value in {@code int} range as an {@link Integer}, so it
+    * scores against an {@code int} parameter; anything else keeps its width.
+    */
+   private static Number narrow(double value) {
+      if(value == Math.rint(value) && !Double.isInfinite(value) &&
+         value >= Integer.MIN_VALUE && value <= Integer.MAX_VALUE)
+      {
+         return (int) value;
+      }
+
+      return value;
+   }
+
+   private static Number narrow(long value) {
+      return value >= Integer.MIN_VALUE && value <= Integer.MAX_VALUE ? (int) value : value;
    }
 }

--- a/core/src/main/java/inetsoft/util/script/graal/JavaClassProxy.java
+++ b/core/src/main/java/inetsoft/util/script/graal/JavaClassProxy.java
@@ -30,7 +30,8 @@ import java.util.regex.Pattern;
  * class as a function ({@code java.awt.Color(0xaed581)}) instantiates it.
  */
 public final class JavaClassProxy implements ProxyObject, ProxyExecutable, ProxyInstantiable {
-   // the JavaScript numeric literal grammar accepted by toNumber().
+   // the numeric literal forms toNumber() accepts -- JS Number()'s grammar,
+   // less the NaN/Infinity words (see toNumber).
    private static final Pattern HEX_LITERAL = Pattern.compile("0[xX][0-9a-fA-F]+");
    private static final Pattern DECIMAL_LITERAL =
       Pattern.compile("[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)(?:[eE][+-]?\\d+)?");
@@ -158,7 +159,9 @@ public final class JavaClassProxy implements ProxyObject, ProxyExecutable, Proxy
     * to {@code 0} and an unparseable string is not mapped to {@code NaN};
     * both return <tt>null</tt> so the argument is left alone and the caller
     * reports GraalVM's original argument-mismatch error rather than silently
-    * constructing from a nonsense value.
+    * constructing from a nonsense value. The {@code NaN} and {@code Infinity}
+    * words are left alone for the same reason, even though {@code ToNumber}
+    * does accept signed {@code Infinity}.
     *
     * @return the parsed number, or <tt>null</tt> if the string is not numeric.
     */
@@ -168,9 +171,12 @@ public final class JavaClassProxy implements ProxyObject, ProxyExecutable, Proxy
       // the literal grammar is matched before parsing because the Java parsers
       // accept forms JS Number() rejects, and each would otherwise silently
       // coerce a non-number: a sign after the 0x prefix ("0x-5" is -5 to
-      // Long.parseLong, which permits a sign for any radix), the NaN/Infinity
-      // words, and the d/f width suffixes ("12F"). An empty string matches
-      // neither pattern, so it is left alone as documented.
+      // Long.parseLong, which permits a sign for any radix), and the d/f width
+      // suffixes ("12F"). The NaN and Infinity words are excluded as well --
+      // Number() does accept signed Infinity as a literal, but a data-derived
+      // "Infinity" is a nonsense constructor argument, so it follows the
+      // leave-it-alone rule rather than building from a non-finite value. An
+      // empty string matches neither pattern, so it is also left alone.
       try {
          // JS treats a leading zero as decimal ("010" is 10), so only an
          // explicit 0x/0X prefix is a radix change -- matching Rhino, which

--- a/core/src/main/java/inetsoft/util/script/graal/JavaClassProxy.java
+++ b/core/src/main/java/inetsoft/util/script/graal/JavaClassProxy.java
@@ -20,6 +20,8 @@ package inetsoft.util.script.graal;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.proxy.*;
 
+import java.util.regex.Pattern;
+
 /**
  * A resolved Java class leaf produced by the {@link LegacyJavaShim}. Wraps the
  * GraalVM host type (from {@code Java.type}) so that static members and {@code
@@ -28,6 +30,11 @@ import org.graalvm.polyglot.proxy.*;
  * class as a function ({@code java.awt.Color(0xaed581)}) instantiates it.
  */
 public final class JavaClassProxy implements ProxyObject, ProxyExecutable, ProxyInstantiable {
+   // the JavaScript numeric literal grammar accepted by toNumber().
+   private static final Pattern HEX_LITERAL = Pattern.compile("0[xX][0-9a-fA-F]+");
+   private static final Pattern DECIMAL_LITERAL =
+      Pattern.compile("[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)(?:[eE][+-]?\\d+)?");
+
    private final Value hostType;
    private final String className;
 
@@ -158,23 +165,29 @@ public final class JavaClassProxy implements ProxyObject, ProxyExecutable, Proxy
    private static Number toNumber(String str) {
       String s = str.trim();
 
-      if(s.isEmpty()) {
-         return null;
-      }
-
+      // the literal grammar is matched before parsing because the Java parsers
+      // accept forms JS Number() rejects, and each would otherwise silently
+      // coerce a non-number: a sign after the 0x prefix ("0x-5" is -5 to
+      // Long.parseLong, which permits a sign for any radix), the NaN/Infinity
+      // words, and the d/f width suffixes ("12F"). An empty string matches
+      // neither pattern, so it is left alone as documented.
       try {
          // JS treats a leading zero as decimal ("010" is 10), so only an
          // explicit 0x/0X prefix is a radix change -- matching Rhino, which
          // likewise recognized only the unsigned hex form.
-         if(s.length() > 2 && s.charAt(0) == '0' && (s.charAt(1) == 'x' || s.charAt(1) == 'X')) {
+         if(HEX_LITERAL.matcher(s).matches()) {
             return narrow(Long.parseLong(s.substring(2), 16));
          }
 
-         return narrow(Double.parseDouble(s));
+         if(DECIMAL_LITERAL.matcher(s).matches()) {
+            return narrow(Double.parseDouble(s));
+         }
       }
-      catch(NumberFormatException ex) {
-         return null;
+      catch(NumberFormatException ignore) {
+         // a hex literal too wide for long
       }
+
+      return null;
    }
 
    /**

--- a/core/src/test/java/inetsoft/report/script/viewsheet/ViewsheetScopeTest.java
+++ b/core/src/test/java/inetsoft/report/script/viewsheet/ViewsheetScopeTest.java
@@ -20,12 +20,16 @@ package inetsoft.report.script.viewsheet;
 
 import inetsoft.report.composition.FormTableRow;
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.AssetQuerySandbox;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.report.lens.DefaultTableLens;
+import inetsoft.report.script.TableArray;
+import inetsoft.report.script.formula.AssetQueryScope;
 import inetsoft.test.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.util.XEmbeddedTable;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.util.script.JavaScriptEngine;
 import inetsoft.web.viewsheet.event.OpenViewsheetEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,6 +46,7 @@ import java.net.URL;
 import java.security.Principal;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -314,6 +319,38 @@ public class ViewsheetScopeTest {
 
       ViewsheetScope viewsheetScope1 = (ViewsheetScope)viewsheetScope.clone();
       assertEquals("ViewsheetScope", viewsheetScope1.getClassName());
+   }
+
+   /**
+    * Bug #75807, a qualified read of a base-worksheet table name -- e.g.
+    * viewsheet['Query1'] -- is dispatched straight at the viewsheet scope, so it
+    * has to resolve through the chain that addToPrototype() links to the
+    * worksheet's AssetQueryScope.
+    */
+   @Test
+   void testWorksheetTableResolvedThroughChain() {
+      AssetQuerySandbox wbox = sandbox.getAssetQuerySandbox();
+      String tname = Arrays.stream(wbox.getWorksheet().getAssemblies())
+         .filter(a -> a instanceof TableAssembly)
+         .map(Assembly::getName)
+         .filter(name -> !viewsheetScope.hasMember(name))
+         .findFirst()
+         .orElseThrow();
+
+      // not resolvable until the worksheet scope is chained onto this scope
+      assertFalse(viewsheetScope.hasMember(tname));
+      assertNull(viewsheetScope.getMember(tname));
+
+      AssetQueryScope wscope = new AssetQueryScope(wbox);
+      wscope.setMode(viewsheetScope.getMode());
+      JavaScriptEngine.addToPrototype(viewsheetScope, wscope);
+
+      assertTrue(viewsheetScope.hasMember(tname));
+      assertInstanceOf(TableArray.class, viewsheetScope.getMember(tname));
+
+      // a name owned by neither scope stays absent
+      assertFalse(viewsheetScope.hasMember("NoSuchTable75807"));
+      assertNull(viewsheetScope.getMember("NoSuchTable75807"));
    }
 
    private static OpenViewsheetEvent createOpenViewsheetEvent() {

--- a/core/src/test/java/inetsoft/util/script/graal/LegacyJavaShimTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/LegacyJavaShimTest.java
@@ -112,9 +112,11 @@ class LegacyJavaShimTest {
    }
 
    /**
-    * The Java number parsers accept forms JavaScript's Number() grammar rejects,
-    * so the literal is matched before parsing -- otherwise these would coerce to
-    * real values instead of being left alone. (#75807)
+    * The Java number parsers accept forms that would silently coerce to a real
+    * value instead of being left alone, so the literal is matched before
+    * parsing. Number() rejects all of these except signed Infinity, which is
+    * excluded by choice -- a data-derived "Infinity" is a nonsense constructor
+    * argument. (#75807)
     */
    @Test
    void javaOnlyNumericFormsDoNotCoerce() throws Exception {
@@ -131,6 +133,7 @@ class LegacyJavaShimTest {
       assertThrows(Exception.class, () -> eval("java.awt.Color('66051f').getRed()"));
 
       // ...and the NaN/Infinity words, which reached a float parameter.
+      // Number() does accept signed Infinity; it is left alone here by choice.
       assertThrows(Exception.class, () -> eval("java.awt.BasicStroke('NaN').getLineWidth()"));
       assertThrows(Exception.class,
                    () -> eval("java.awt.BasicStroke('Infinity').getLineWidth()"));

--- a/core/src/test/java/inetsoft/util/script/graal/LegacyJavaShimTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/LegacyJavaShimTest.java
@@ -69,6 +69,58 @@ class LegacyJavaShimTest {
    }
 
    /**
+    * Bug #75807, Rhino coerced a numeric string to a number when scoring a
+    * numeric constructor parameter, so a hex colour built by concatenation --
+    * java.awt.Color('0x' + 'FF6B58') -- selected Color(int).
+    */
+   @Test
+   void numericStringCoercesToConstructorNumber() throws Exception {
+      // the failing idiom: the hex digits come from data, so the argument is a
+      // string, not the 0xFF6B58 numeric literal.
+      assertEquals((double) 0xFF, num(eval("java.awt.Color('0x' + 'FF6B58').getRed()")));
+      assertEquals((double) 0x6B, num(eval("java.awt.Color('0xFF6B58').getGreen()")));
+      assertEquals((double) 0x58, num(eval("new java.awt.Color('0xFF6B58').getBlue()")));
+
+      // a plain decimal string coerces too, and reaches the int overload
+      assertEquals(3.0, num(eval("java.awt.Color('66051').getBlue()")));
+   }
+
+   /**
+    * The coercion is a retry after GraalVM rejects the arguments, so a string
+    * argument that a real String constructor accepts is never re-targeted at a
+    * numeric overload.
+    */
+   @Test
+   void numericStringStillPrefersStringConstructor() throws Exception {
+      // StringBuilder(String) and StringBuilder(int) both exist; "12" must build
+      // the two-character sequence, not a builder with capacity 12.
+      assertEquals(2.0, num(eval("new java.lang.StringBuilder('12').length()")));
+   }
+
+   /**
+    * A non-numeric string is left alone so the reported error still names the
+    * argument the script actually passed.
+    */
+   @Test
+   void nonNumericStringDoesNotCoerce() {
+      assertThrows(Exception.class, () -> eval("java.awt.Color('nonsense').getRed()"));
+
+      // a bare "0x" and a hex value too wide for long are not numbers either
+      assertThrows(Exception.class, () -> eval("java.awt.Color('0x').getRed()"));
+      assertThrows(Exception.class,
+                   () -> eval("java.awt.Color('0xFFFFFFFFFFFFFFFFFF').getRed()"));
+   }
+
+   /**
+    * A leading zero is decimal in JavaScript ("010" is 10, not octal 8), so only
+    * an explicit 0x prefix may change the radix.
+    */
+   @Test
+   void leadingZeroStringStaysDecimal() throws Exception {
+      assertEquals(10.0, num(eval("java.awt.Color('010').getBlue()")));
+   }
+
+   /**
     * Rhino parity: a JS Date passed where a numeric coordinate is expected
     * (e.g. LabelForm.setTuple(double[]) on a time axis) must coerce to epoch
     * millis, not error. Mirrors the Projection example viewsheet. (#75423)

--- a/core/src/test/java/inetsoft/util/script/graal/LegacyJavaShimTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/LegacyJavaShimTest.java
@@ -112,6 +112,33 @@ class LegacyJavaShimTest {
    }
 
    /**
+    * The Java number parsers accept forms JavaScript's Number() grammar rejects,
+    * so the literal is matched before parsing -- otherwise these would coerce to
+    * real values instead of being left alone. (#75807)
+    */
+   @Test
+   void javaOnlyNumericFormsDoNotCoerce() throws Exception {
+      // control: BasicStroke(float) is reachable and does take a coerced string,
+      // so the rejections below are the grammar check, not an unrelated failure.
+      assertEquals(2.0, num(eval("java.awt.BasicStroke('2').getLineWidth()")));
+
+      // Long.parseLong permits a sign for any radix, so "0x-5" parsed as -5.
+      assertThrows(Exception.class, () -> eval("java.awt.Color('0x-5').getRed()"));
+      assertThrows(Exception.class, () -> eval("java.awt.Color('0x+5').getRed()"));
+
+      // Double.parseDouble accepts the d/f width suffixes, so "66051f" parsed
+      // as the 66051 that reached Color(int).
+      assertThrows(Exception.class, () -> eval("java.awt.Color('66051f').getRed()"));
+
+      // ...and the NaN/Infinity words, which reached a float parameter.
+      assertThrows(Exception.class, () -> eval("java.awt.BasicStroke('NaN').getLineWidth()"));
+      assertThrows(Exception.class,
+                   () -> eval("java.awt.BasicStroke('Infinity').getLineWidth()"));
+      assertThrows(Exception.class,
+                   () -> eval("java.awt.BasicStroke('-Infinity').getLineWidth()"));
+   }
+
+   /**
     * A leading zero is decimal in JavaScript ("010" is 10, not octal 8), so only
     * an explicit 0x prefix may change the radix.
     */


### PR DESCRIPTION
## Summary

Opening the reported viewsheet popped up `Script execution error in assembly: Crosstab2` / `Crosstab3`, so the script that paints the risk-matrix heat map never ran and the crosstab cells rendered uncolored. Two independent Rhino→GraalJS migration regressions were hit in sequence by the same script; both are fixed here.

The script colors a matrix from a base-worksheet lookup table:

```js
var tableScale = 'Scale Risk Appetite1';   // a base WORKSHEET table, not a VS assembly
var fieldColour = 'Cell Color';
...
iRow = table.length - viewsheet[tableScale]['Likelihood Value'][i];   // line 21  <- regression 1
iCol = '0x' + viewsheet[tableScale][fieldColour][i];                  // line 23  -> '0xFF6B58'
tablelens.setBackground(iRow, iColumn, java.awt.Color(iCol));         // line 37  <- regression 2
```

## Root Cause

**1. Qualified worksheet-table read resolved to `undefined`** — `TypeError: Cannot read property 'Likelihood Value' of undefined`

`Scale Risk Appetite1` is a `SnapshotEmbeddedTableAssembly` in the base worksheet, resolved by `AssetQueryScope`, which `JavaScriptEngine.addToPrototype()` chains onto `ViewsheetScope`. Under Rhino, `viewsheet['X']` walked the object's **prototype chain**. Under GraalJS the prototype chain is gone and chain walking lives in `BindingRootProxy.findInChain()`, which only handles **unqualified** identifiers. A **qualified** read goes through `ScopeProxy`, which delegates solely to the wrapped scope with no parent walk — and because `hasMember` **gates** `getMember` under GraalJS, `ViewsheetScope.hasMember("Scale Risk Appetite1")` returning `false` meant `getMember` was never called and the read silently became `undefined`.

This is the qualified sibling of #75526, which restored only the unqualified form (`Orders['City']`).

**2. Numeric-string constructor argument rejected** — `Invalid argument when instantiating 'java.awt.Color' with arguments ['0xFF6B58' … TruffleString]`

`iCol` is a **string** built by concatenation from the `Cell Color` column, not a numeric literal. Rhino's `NativeJavaClass.construct` ran arguments through `ScriptRuntime.toNumber` when scoring a numeric constructor parameter, so `'0xFF6B58'` became `16739160` and selected `Color(int)`. GraalVM does no such conversion and rejects the call.

Same family as #75611 / #75693, neither of which covered *constructor* invocation.

## Fix

**`ViewsheetScope`** — `getMember` and `hasMember` now fall back to walking `getParentScope()` through a shared private `findInChain(String)` helper, so a qualified read reaches the chained `AssetQueryScope`. Both methods are needed since `hasMember` gates `getMember`. `getMemberKeys()` is deliberately unchanged — Rhino's `getIds()` likewise did not enumerate prototype ids.

**`JavaClassProxy`** — `execute()` (Rhino no-`new` construction) and `newInstance()` now share a `construct()` helper that attempts `hostType.newInstance(args)` unchanged and, **only if GraalVM throws `IllegalArgumentException`** (its argument-mismatch signal), retries once with numeric-string arguments coerced to numbers. Deliberately conservative:

- **Retry-only**, so a call GraalVM already resolves keeps its existing overload — this can never re-target working code.
- Integral values narrow to `Integer` so an `int` parameter is preferred over `float`/`double`.
- An empty or unparseable string is **not** mapped to `0`/`NaN` as JS `ToNumber` would; it is left alone so the reported error still names the argument the script actually passed.
- A leading zero stays decimal (`'010'` is 10, not octal), matching JS and Rhino; only an explicit `0x`/`0X` prefix changes the radix.
- Verified against the GraalVM 24.1.2 `Value.newInstance` contract: an exception thrown *by the constructor itself* surfaces as `PolyglotException`, not `IllegalArgumentException`, so the retry cannot mask a genuine constructor error.

Host **method** calls are intentionally untouched — only constructor invocation fails in this bug.

## Test Plan

Automated:

- `LegacyJavaShimTest` — 4 new tests: hex/decimal numeric strings coerce to the `int` constructor; `new java.lang.StringBuilder('12').length() == 2` proves a working `String` overload is never re-targeted; non-numeric, bare `'0x'`, and long-overflowing hex strings do not coerce; `'010'` stays decimal.
- `ViewsheetScopeTest.testWorksheetTableResolvedThroughChain` — a real base-worksheet table name is unresolvable before `addToPrototype`, and resolves to a `TableArray` after; a name owned by neither scope stays absent.
- Both new tests were confirmed to **fail** with only their respective production file reverted, reproducing the exact production errors.
- `inetsoft.util.script.graal.*Test` — 141 pass (1 pre-existing `assumeTrue` skip). `ViewsheetScopeTest` — 14 pass. `./mvnw clean install -pl core -am -DskipTests` — BUILD SUCCESS.

Manual: import the attached `Risk Dashboard V2.vso` from the issue and open the viewsheet. No script-error popups appear, both risk matrices render with their red/amber/green cell backgrounds, and no `Script execution error` lines are logged. Verified by the reporter's original reproduction.

Fixes Redmine #75807.