### PR TITLE
Bug #75825, guard against undefined tree entry in isAssemblyTreeNode

### DIFF
--- a/web/projects/portal/src/app/binding/widget/binding-tree/vs-binding-tree-actions.ts
+++ b/web/projects/portal/src/app/binding/widget/binding-tree/vs-binding-tree-actions.ts
@@ -188,7 +188,7 @@ export class VSBindingTreeActions extends ContextMenuActions {
    }
 
    protected isAssemblyTreeNode(entry): boolean {
-      return entry.path.indexOf("/components/__vs_assembly") > -1;
+      return !!entry && !!entry.path && entry.path.indexOf("/components/__vs_assembly") > -1;
    }
 
    /**


### PR DESCRIPTION
## Summary

Opening the binding/edit pane for a crosstab throws a browser-console `TypeError: can't access property "path", entry is undefined` originating from `isAssemblyTreeNode`. The crosstab edit pane binding tree renders correctly, but the visibility check for context-menu items crashes silently in the background.

## Root Cause

`DataEditorBindingTree.hasMenu(node)` runs for every node rendered in the binding tree (not just a clicked node), building `ContextMenuActions` with that node as `selectedNode`. `VSBindingTreeActions.currentEntry` returns `selectedNode.data`, which is `undefined` for tree nodes without a backing `AssetEntry` (`TreeNodeModel.data` is optional — e.g. folder/category nodes).

`VSCrosstabBindingTreeActions.isConvertToMeasureVisible()` / `isConvertToDimensionVisible()` call `isAssemblyTreeNode(entry)` without guarding against `entry` being undefined, unlike the two other call sites in the base class (`isNewCalculatedVisible()` / `isEditCalculatedVisible()`), which both check `!this.currentEntry` first. `isAssemblyTreeNode` then dereferences `entry.path` unconditionally, throwing.

## Fix

Added a null/undefined guard directly in `isAssemblyTreeNode` (the single shared definition, covering all 4 call sites):

```diff
    protected isAssemblyTreeNode(entry): boolean {
-      return entry.path.indexOf("/components/__vs_assembly") > -1;
+      return !!entry && !!entry.path && entry.path.indexOf("/components/__vs_assembly") > -1;
    }
```

Downstream fallbacks (`isMeasureColumn`/`isDimensionColumn` → `BindingTreeService.getCubeColumnType`) already null-guard `entry`, so this brings `isAssemblyTreeNode` in line with the rest of the class's contract.

## Test Plan

- [x] Reproduced: imported the attached crosstab viewsheet, opened the crosstab edit/binding pane — console threw the TypeError.
- [x] Applied fix, rebuilt frontend (`npm run build`), reproduced the same steps — no error.
- [x] `npm run test:portal` (portal + em Vitest suites, 1302 tests) — all passing.
- [x] Code review via automated reviewer — confirmed correct, complete, no regressions.

Fixes Redmine #75825.