### PR TITLE
Bug #75827, preserve recycle status when migrating autosave files across orgs

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
@@ -262,7 +262,7 @@ public abstract class AbstractEditableAuthenticationProvider
             // (still keyed by the source org's user ids), so migrate the files in place there --
             // not in fromOrganization's bucket. Pass newOrgID explicitly rather than relying on
             // the ambient principal/org context to resolve the right bucket.
-            identityService.updateAutoSaveFiles(fromOrganization, newOrg, newOrgID);
+            identityService.updateAutoSaveFilesInBucket(fromOrganization, newOrg, newOrgID);
          }
          catch(Exception e) {
             LOG.warn("Unable to migrate Auto Save Files: "+ e);

--- a/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
@@ -260,12 +260,9 @@ public abstract class AbstractEditableAuthenticationProvider
          try {
             // copyStorages() already raw-copied the __autoSave bucket into newOrg's own bucket
             // (still keyed by the source org's user ids), so migrate the files in place there --
-            // not in fromOrganization's bucket. Do not resolve the bucket via the ambient org
-            // context (e.g. runInOrgScope()): principal is still authenticated under fromOrgId at
-            // this point, and OrganizationManager.getCurrentOrgID(Principal) prefers the
-            // principal's own org id over any OrganizationContextHolder override, so that would
-            // silently operate on the wrong bucket.
-            identityService.updateAutoSaveFiles(fromOrganization, newOrg, principal, newOrgID);
+            // not in fromOrganization's bucket. Pass newOrgID explicitly rather than relying on
+            // the ambient principal/org context to resolve the right bucket.
+            identityService.updateAutoSaveFiles(fromOrganization, newOrg, newOrgID);
          }
          catch(Exception e) {
             LOG.warn("Unable to migrate Auto Save Files: "+ e);

--- a/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
@@ -258,11 +258,14 @@ public abstract class AbstractEditableAuthenticationProvider
 
       if(!replace) {
          try {
-            OrganizationManager.runInOrgScope(newOrgID, () -> {
-               identityService.updateAutoSaveFiles(fromOrganization, newOrg, principal);
-
-               return null;
-            });
+            // copyStorages() already raw-copied the __autoSave bucket into newOrg's own bucket
+            // (still keyed by the source org's user ids), so migrate the files in place there --
+            // not in fromOrganization's bucket. Do not resolve the bucket via the ambient org
+            // context (e.g. runInOrgScope()): principal is still authenticated under fromOrgId at
+            // this point, and OrganizationManager.getCurrentOrgID(Principal) prefers the
+            // principal's own org id over any OrganizationContextHolder override, so that would
+            // silently operate on the wrong bucket.
+            identityService.updateAutoSaveFiles(fromOrganization, newOrg, principal, newOrgID);
          }
          catch(Exception e) {
             LOG.warn("Unable to migrate Auto Save Files: "+ e);

--- a/core/src/main/java/inetsoft/web/AutoSaveUtils.java
+++ b/core/src/main/java/inetsoft/web/AutoSaveUtils.java
@@ -455,12 +455,34 @@ public final class AutoSaveUtils {
       }
    }
 
-   public static void migrateAutoSaveFiles(Organization oorg, Organization norg, Principal principal) {
+   /**
+    * Migrate the auto save files that already reside in the given organization's own blob
+    * storage bucket, rewriting each file's embedded user-org key (and, for viewsheets/worksheets,
+    * its content) from {@code oorg} to {@code norg}.
+    * <p>
+    * The bucket operated on is selected explicitly via {@code storageOrgId} rather than derived
+    * from the calling thread's ambient organization context. This matters because
+    * {@link #getStorage(Principal)} resolves its bucket via
+    * {@code OrganizationManager.getCurrentOrgID(Principal)}, which -- for a non-null principal --
+    * always prefers the principal's own current org id over any org id set on the
+    * {@code OrganizationContextHolder} (e.g. via {@code OrganizationManager.runInOrgScope()}).
+    * A caller migrating auto save files as part of an org copy/rename is typically still
+    * authenticated under the *source* org, so relying on ambient context silently operates on the
+    * wrong bucket depending on call order relative to the underlying blob-bucket copy.
+    *
+    * @param storageOrgId the id of the organization whose bucket currently holds the files to be
+    *                      migrated in place (the source org's bucket when called before the raw
+    *                      bucket copy, or the target org's bucket when called after it).
+    */
+   public static void migrateAutoSaveFiles(Organization oorg, Organization norg, Principal principal,
+                                           String storageOrgId)
+   {
       if(oorg.getId().equals(norg.getId())) {
          return;
       }
 
-      List<String> list = AutoSaveUtils.getAutoSavedFiles(principal);
+      BlobStorage<Metadata> blobStorage = getStorageForOrg(storageOrgId);
+      List<String> list = blobStorage.paths().collect(Collectors.toList());
 
       if(list.isEmpty()) {
          return;
@@ -489,11 +511,24 @@ public final class AutoSaveUtils {
 
          userID.setOrgID(norg.getId());
          attrs[2] = userID.convertToKey();
-         String newFilePath = String.join("^", attrs);
-         AutoSaveUtils.renameAutoSaveFile(file, newFilePath, principal);
+         // getName() above stripped the recycle prefix to split out the name fields; re-apply it
+         // here so a recycled (discarded) draft doesn't turn into an active autosave file after
+         // migration -- otherwise it silently drops off the EM "Auto Saved Files" recycle view,
+         // which only lists paths still carrying the RECYCLE_PREFIX.
+         String newFilePath = file.startsWith(AutoSaveUtils.RECYCLE_PREFIX) ?
+            AutoSaveUtils.RECYCLE_PREFIX + String.join("^", attrs) : String.join("^", attrs);
+
+         try {
+            blobStorage.rename(file, newFilePath);
+         }
+         catch(Exception e) {
+            LOG.debug("Failed to write auto save file to recycle bin {}", file, e);
+            continue;
+         }
+
          Document document = null;
 
-         try(InputStream in = AutoSaveUtils.getInputStream(newFilePath, principal)) {
+         try(InputStream in = getBlobInputStream(blobStorage, newFilePath)) {
             AssetEntry assetEntry = AutoSaveUtils.createAssetEntry(
                file.startsWith(AutoSaveUtils.RECYCLE_PREFIX) ?
                   file.substring(AutoSaveUtils.RECYCLE_PREFIX.length()) : file);
@@ -513,13 +548,25 @@ public final class AutoSaveUtils {
          }
 
          if(document != null) {
-            migrateProcessingInstructionAndWrite(document, norg, newFilePath, principal);
+            migrateProcessingInstructionAndWrite(blobStorage, document, norg, newFilePath);
          }
       }
    }
 
-   private static void migrateProcessingInstructionAndWrite(Document document, Organization norg,
-                                                            String newFilePath, Principal principal)
+   private static InputStream getBlobInputStream(BlobStorage<Metadata> blobStorage, String file)
+      throws IOException
+   {
+      try {
+         return blobStorage.getInputStream(file);
+      }
+      catch(FileNotFoundException | NoSuchFileException ignore) {
+         return null;
+      }
+   }
+
+   private static void migrateProcessingInstructionAndWrite(BlobStorage<Metadata> blobStorage,
+                                                            Document document, Organization norg,
+                                                            String newFilePath)
    {
       if(document == null) {
          return;
@@ -576,7 +623,20 @@ public final class AutoSaveUtils {
       }
 
       XMLTool.writeAssets(document, bout, className, identifier);
-      AutoSaveUtils.writeAutoSaveFile(bout.toByteArray(), newFilePath, principal);
+      writeBlobFile(blobStorage, bout.toByteArray(), newFilePath);
+   }
+
+   private static void writeBlobFile(BlobStorage<Metadata> blobStorage, byte[] data, String file) {
+      try(BlobTransaction<Metadata> tx = blobStorage.beginTransaction();
+          OutputStream out = tx.newStream(file, null))
+      {
+         out.write(data);
+         out.flush();
+         tx.commit();
+      }
+      catch(IOException ex) {
+         LOG.error("Failed to write to the blob storage: {}", file, ex);
+      }
    }
 
    public static void writeAutoSaveFile(byte[] data, String file, Principal principal) {

--- a/core/src/main/java/inetsoft/web/AutoSaveUtils.java
+++ b/core/src/main/java/inetsoft/web/AutoSaveUtils.java
@@ -429,8 +429,12 @@ public final class AutoSaveUtils {
    }
 
    public static InputStream getInputStream(String file, Principal principal) throws IOException {
-      BlobStorage<Metadata> blobStorage = getStorage(principal);
+      return getInputStream(file, getStorage(principal));
+   }
 
+   private static InputStream getInputStream(String file, BlobStorage<Metadata> blobStorage)
+      throws IOException
+   {
       try {
          return blobStorage.getInputStream(file);
       }
@@ -461,22 +465,16 @@ public final class AutoSaveUtils {
     * its content) from {@code oorg} to {@code norg}.
     * <p>
     * The bucket operated on is selected explicitly via {@code storageOrgId} rather than derived
-    * from the calling thread's ambient organization context. This matters because
-    * {@link #getStorage(Principal)} resolves its bucket via
-    * {@code OrganizationManager.getCurrentOrgID(Principal)}, which -- for a non-null principal --
-    * always prefers the principal's own current org id over any org id set on the
-    * {@code OrganizationContextHolder} (e.g. via {@code OrganizationManager.runInOrgScope()}).
-    * A caller migrating auto save files as part of an org copy/rename is typically still
-    * authenticated under the *source* org, so relying on ambient context silently operates on the
-    * wrong bucket depending on call order relative to the underlying blob-bucket copy.
+    * from the calling thread's ambient principal/org context (as the {@link Principal}-based
+    * helpers on this class do via {@link #getStorage(Principal)}), so the caller doesn't have to
+    * reason about which org the acting principal is currently scoped to relative to the org
+    * copy/rename's own bucket-migration order.
     *
     * @param storageOrgId the id of the organization whose bucket currently holds the files to be
     *                      migrated in place (the source org's bucket when called before the raw
     *                      bucket copy, or the target org's bucket when called after it).
     */
-   public static void migrateAutoSaveFiles(Organization oorg, Organization norg, Principal principal,
-                                           String storageOrgId)
-   {
+   public static void migrateAutoSaveFiles(Organization oorg, Organization norg, String storageOrgId) {
       if(oorg.getId().equals(norg.getId())) {
          return;
       }
@@ -528,7 +526,7 @@ public final class AutoSaveUtils {
 
          Document document = null;
 
-         try(InputStream in = getBlobInputStream(blobStorage, newFilePath)) {
+         try(InputStream in = getInputStream(newFilePath, blobStorage)) {
             AssetEntry assetEntry = AutoSaveUtils.createAssetEntry(
                file.startsWith(AutoSaveUtils.RECYCLE_PREFIX) ?
                   file.substring(AutoSaveUtils.RECYCLE_PREFIX.length()) : file);
@@ -550,17 +548,6 @@ public final class AutoSaveUtils {
          if(document != null) {
             migrateProcessingInstructionAndWrite(blobStorage, document, norg, newFilePath);
          }
-      }
-   }
-
-   private static InputStream getBlobInputStream(BlobStorage<Metadata> blobStorage, String file)
-      throws IOException
-   {
-      try {
-         return blobStorage.getInputStream(file);
-      }
-      catch(FileNotFoundException | NoSuchFileException ignore) {
-         return null;
       }
    }
 
@@ -623,25 +610,14 @@ public final class AutoSaveUtils {
       }
 
       XMLTool.writeAssets(document, bout, className, identifier);
-      writeBlobFile(blobStorage, bout.toByteArray(), newFilePath);
-   }
-
-   private static void writeBlobFile(BlobStorage<Metadata> blobStorage, byte[] data, String file) {
-      try(BlobTransaction<Metadata> tx = blobStorage.beginTransaction();
-          OutputStream out = tx.newStream(file, null))
-      {
-         out.write(data);
-         out.flush();
-         tx.commit();
-      }
-      catch(IOException ex) {
-         LOG.error("Failed to write to the blob storage: {}", file, ex);
-      }
+      writeAutoSaveFile(bout.toByteArray(), newFilePath, blobStorage);
    }
 
    public static void writeAutoSaveFile(byte[] data, String file, Principal principal) {
-      BlobStorage<Metadata> blobStorage = getStorage(principal);
+      writeAutoSaveFile(data, file, getStorage(principal));
+   }
 
+   private static void writeAutoSaveFile(byte[] data, String file, BlobStorage<Metadata> blobStorage) {
       try(BlobTransaction<Metadata> tx = blobStorage.beginTransaction();
           OutputStream out = tx.newStream(file, null))
       {

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -2694,7 +2694,18 @@ public class IdentityService {
    }
 
    public void updateAutoSaveFiles(Organization oorg, Organization norg, Principal principal) {
-      AutoSaveUtils.migrateAutoSaveFiles(oorg, norg, principal);
+      updateAutoSaveFiles(oorg, norg, principal, oorg.getId());
+   }
+
+   /**
+    * @param storageOrgId the id of the organization whose blob bucket currently holds the auto
+    *                      save files to migrate in place -- see
+    *                      {@link AutoSaveUtils#migrateAutoSaveFiles(Organization, Organization, Principal, String)}.
+    */
+   public void updateAutoSaveFiles(Organization oorg, Organization norg, Principal principal,
+                                   String storageOrgId)
+   {
+      AutoSaveUtils.migrateAutoSaveFiles(oorg, norg, principal, storageOrgId);
    }
 
    public void updateTaskSaveFiles(Organization oorganization, Organization norganization) {

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -2693,19 +2693,21 @@ public class IdentityService {
       }
    }
 
+   // `principal` is unused now that the target bucket is resolved via an explicit storageOrgId
+   // rather than the ambient principal/org context -- kept for call-site/API stability (the
+   // rename call site in AbstractEditableAuthenticationProvider and existing test mocks all
+   // still call this 3-arg form).
    public void updateAutoSaveFiles(Organization oorg, Organization norg, Principal principal) {
-      updateAutoSaveFiles(oorg, norg, principal, oorg.getId());
+      updateAutoSaveFiles(oorg, norg, oorg.getId());
    }
 
    /**
     * @param storageOrgId the id of the organization whose blob bucket currently holds the auto
     *                      save files to migrate in place -- see
-    *                      {@link AutoSaveUtils#migrateAutoSaveFiles(Organization, Organization, Principal, String)}.
+    *                      {@link AutoSaveUtils#migrateAutoSaveFiles(Organization, Organization, String)}.
     */
-   public void updateAutoSaveFiles(Organization oorg, Organization norg, Principal principal,
-                                   String storageOrgId)
-   {
-      AutoSaveUtils.migrateAutoSaveFiles(oorg, norg, principal, storageOrgId);
+   public void updateAutoSaveFiles(Organization oorg, Organization norg, String storageOrgId) {
+      AutoSaveUtils.migrateAutoSaveFiles(oorg, norg, storageOrgId);
    }
 
    public void updateTaskSaveFiles(Organization oorganization, Organization norganization) {

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -2698,15 +2698,20 @@ public class IdentityService {
    // rename call site in AbstractEditableAuthenticationProvider and existing test mocks all
    // still call this 3-arg form).
    public void updateAutoSaveFiles(Organization oorg, Organization norg, Principal principal) {
-      updateAutoSaveFiles(oorg, norg, oorg.getId());
+      updateAutoSaveFilesInBucket(oorg, norg, oorg.getId());
    }
 
    /**
+    * Named distinctly from {@link #updateAutoSaveFiles(Organization, Organization, Principal)}
+    * rather than overloaded on it -- a same-name {@code (Organization, Organization, String)}
+    * overload makes {@code any(), any(), any()} Mockito stubs against this class ambiguous at
+    * compile time (neither {@code Principal} nor {@code String} is more specific than the other).
+    *
     * @param storageOrgId the id of the organization whose blob bucket currently holds the auto
     *                      save files to migrate in place -- see
     *                      {@link AutoSaveUtils#migrateAutoSaveFiles(Organization, Organization, String)}.
     */
-   public void updateAutoSaveFiles(Organization oorg, Organization norg, String storageOrgId) {
+   public void updateAutoSaveFilesInBucket(Organization oorg, Organization norg, String storageOrgId) {
       AutoSaveUtils.migrateAutoSaveFiles(oorg, norg, storageOrgId);
    }
 

--- a/core/src/test/java/inetsoft/web/AutoSaveServiceOrgLifecycleTest.java
+++ b/core/src/test/java/inetsoft/web/AutoSaveServiceOrgLifecycleTest.java
@@ -140,22 +140,13 @@ class AutoSaveServiceOrgLifecycleTest {
                   + "(suspected incorrect) behavior for confirmation, not the desired one");
    }
 
-   // ── scenario 6g: migrateAutoSaveFiles() scopes to the explicit storageOrgId bucket regardless
-   //    of the acting principal's own org or ambient OrganizationContextHolder state (Bug #75827
-   //    fix: the method no longer resolves its bucket via getStorage(principal)/runInOrgScope,
-   //    which was fragile -- OrganizationManager.getCurrentOrgID(Principal) prefers the
-   //    principal's own org id/curr_org_id property over any OrganizationContextHolder override) ──
+   // ── scenario 6g: migrateAutoSaveFiles() scopes strictly to the explicit storageOrgId bucket --
+   //    it takes no Principal at all, so there's no ambient principal/org context to fall back to ──
 
    @Test
    void migrateAutoSaveFiles_explicitStorageOrgId_scopesToTargetBucket() throws Exception {
       String sourceOrgId = "sixg_source_org";
       String targetOrgId = "sixg_target_org";
-      String actorOrgId = "sixg_unrelated_actor_org";
-
-      // acting principal's OWN org is unrelated to both source/target -- proves resolution comes
-      // from the explicit storageOrgId argument, not from the principal's own identity
-      Principal principal = new SRPrincipal(new IdentityID("sixg_actor", actorOrgId),
-                                            new IdentityID[0], new String[0], actorOrgId, 1L);
 
       // simulates the state right after 6a/6b's bucket-level copyStorages("__autoSave", copy=true):
       // the raw file already lives in the TARGET org's bucket, still filename-tagged with the
@@ -167,7 +158,7 @@ class AutoSaveServiceOrgLifecycleTest {
       Organization oorg = new Organization(sourceOrgId);
       Organization norg = new Organization(targetOrgId);
 
-      AutoSaveUtils.migrateAutoSaveFiles(oorg, norg, principal, targetOrgId);
+      AutoSaveUtils.migrateAutoSaveFiles(oorg, norg, targetOrgId);
 
       String newUserKey = new IdentityID("sixg_user", targetOrgId).convertToKey();
       String expectedNewFileName = "8^VIEWSHEET^" + newUserKey + "^Untitled-1^0_0_0_0_0_0_0_1~";
@@ -180,7 +171,7 @@ class AutoSaveServiceOrgLifecycleTest {
       assertTrue(targetBucket.exists(expectedNewFileName),
                 "migrateAutoSaveFiles() must rename the file (within the target org's own bucket) "
                 + "to carry the target org's identity string, using the explicit storageOrgId "
-                + "argument despite the acting principal's own org being unrelated to source/target");
+                + "argument");
    }
 
    // ── Issue #75827 (confirmed root cause of the reported "autosave file missing after org
@@ -195,9 +186,6 @@ class AutoSaveServiceOrgLifecycleTest {
       String sourceOrgId = "recyclepfx_source_org";
       String targetOrgId = "recyclepfx_target_org";
 
-      Principal principal = new SRPrincipal(new IdentityID("recyclepfx_actor", targetOrgId),
-                                            new IdentityID[0], new String[0], targetOrgId, 1L);
-
       String oldUserKey = new IdentityID("recyclepfx_user", sourceOrgId).convertToKey();
       String recycledFileName =
          AutoSaveUtils.RECYCLE_PREFIX + "8^WORKSHEET^" + oldUserKey + "^Untitled-1^0_0_0_0_0_0_0_1~";
@@ -206,7 +194,7 @@ class AutoSaveServiceOrgLifecycleTest {
       Organization oorg = new Organization(sourceOrgId);
       Organization norg = new Organization(targetOrgId);
 
-      AutoSaveUtils.migrateAutoSaveFiles(oorg, norg, principal, targetOrgId);
+      AutoSaveUtils.migrateAutoSaveFiles(oorg, norg, targetOrgId);
 
       String newUserKey = new IdentityID("recyclepfx_user", targetOrgId).convertToKey();
       String expectedNewFileName = AutoSaveUtils.RECYCLE_PREFIX +

--- a/core/src/test/java/inetsoft/web/AutoSaveServiceOrgLifecycleTest.java
+++ b/core/src/test/java/inetsoft/web/AutoSaveServiceOrgLifecycleTest.java
@@ -140,17 +140,20 @@ class AutoSaveServiceOrgLifecycleTest {
                   + "(suspected incorrect) behavior for confirmation, not the desired one");
    }
 
-   // ── scenario 6g: migrateAutoSaveFiles() under runInOrgScope(newOrgID,...) correctly scopes to the
-   //    new org's bucket -- confirmed correct, not a bug (see matrix doc for the 6g correction) ──
+   // ── scenario 6g: migrateAutoSaveFiles() scopes to the explicit storageOrgId bucket regardless
+   //    of the acting principal's own org or ambient OrganizationContextHolder state (Bug #75827
+   //    fix: the method no longer resolves its bucket via getStorage(principal)/runInOrgScope,
+   //    which was fragile -- OrganizationManager.getCurrentOrgID(Principal) prefers the
+   //    principal's own org id/curr_org_id property over any OrganizationContextHolder override) ──
 
    @Test
-   void migrateAutoSaveFiles_runInOrgScope_correctlyScopesToNewOrgBucket() throws Exception {
+   void migrateAutoSaveFiles_explicitStorageOrgId_scopesToTargetBucket() throws Exception {
       String sourceOrgId = "sixg_source_org";
       String targetOrgId = "sixg_target_org";
       String actorOrgId = "sixg_unrelated_actor_org";
 
       // acting principal's OWN org is unrelated to both source/target -- proves resolution comes
-      // from OrganizationContextHolder (set by runInOrgScope), not from the principal's own identity
+      // from the explicit storageOrgId argument, not from the principal's own identity
       Principal principal = new SRPrincipal(new IdentityID("sixg_actor", actorOrgId),
                                             new IdentityID[0], new String[0], actorOrgId, 1L);
 
@@ -164,10 +167,7 @@ class AutoSaveServiceOrgLifecycleTest {
       Organization oorg = new Organization(sourceOrgId);
       Organization norg = new Organization(targetOrgId);
 
-      OrganizationManager.runInOrgScope(targetOrgId, () -> {
-         AutoSaveUtils.migrateAutoSaveFiles(oorg, norg, principal);
-         return null;
-      });
+      AutoSaveUtils.migrateAutoSaveFiles(oorg, norg, principal, targetOrgId);
 
       String newUserKey = new IdentityID("sixg_user", targetOrgId).convertToKey();
       String expectedNewFileName = "8^VIEWSHEET^" + newUserKey + "^Untitled-1^0_0_0_0_0_0_0_1~";
@@ -179,9 +179,48 @@ class AutoSaveServiceOrgLifecycleTest {
                  "the old, source-org-tagged filename must be renamed away within the target bucket");
       assertTrue(targetBucket.exists(expectedNewFileName),
                 "migrateAutoSaveFiles() must rename the file (within the target org's own bucket) "
-                + "to carry the target org's identity string, proving runInOrgScope(newOrgID, ...) "
-                + "correctly scoped getStorage(principal) to the target org despite the acting "
-                + "principal's own org being unrelated to source/target");
+                + "to carry the target org's identity string, using the explicit storageOrgId "
+                + "argument despite the acting principal's own org being unrelated to source/target");
+   }
+
+   // ── Issue #75827 (confirmed root cause of the reported "autosave file missing after org
+   //    clone" bug): migrateAutoSaveFiles() strips the "recycle/" prefix via getName() to split
+   //    out the name fields, then rebuilds the migrated filename from those fields WITHOUT
+   //    re-applying the prefix -- so a recycled (discarded) draft silently turns into an ACTIVE
+   //    autosave file after migration. addRecycleAutoSaved() only lists paths that still start
+   //    with RECYCLE_PREFIX, so the migrated file drops off the EM "Auto Saved Files" tree ──
+
+   @Test
+   void migrateAutoSaveFiles_recycledDraft_keepsRecyclePrefixAfterMigration() throws Exception {
+      String sourceOrgId = "recyclepfx_source_org";
+      String targetOrgId = "recyclepfx_target_org";
+
+      Principal principal = new SRPrincipal(new IdentityID("recyclepfx_actor", targetOrgId),
+                                            new IdentityID[0], new String[0], targetOrgId, 1L);
+
+      String oldUserKey = new IdentityID("recyclepfx_user", sourceOrgId).convertToKey();
+      String recycledFileName =
+         AutoSaveUtils.RECYCLE_PREFIX + "8^WORKSHEET^" + oldUserKey + "^Untitled-1^0_0_0_0_0_0_0_1~";
+      seedAutoSaveBlob(targetOrgId, recycledFileName, "not-real-xml-content".getBytes());
+
+      Organization oorg = new Organization(sourceOrgId);
+      Organization norg = new Organization(targetOrgId);
+
+      AutoSaveUtils.migrateAutoSaveFiles(oorg, norg, principal, targetOrgId);
+
+      String newUserKey = new IdentityID("recyclepfx_user", targetOrgId).convertToKey();
+      String expectedNewFileName = AutoSaveUtils.RECYCLE_PREFIX +
+         "8^WORKSHEET^" + newUserKey + "^Untitled-1^0_0_0_0_0_0_0_1~";
+
+      BlobStorage<AutoSaveUtils.Metadata> targetBucket =
+         blobStorageManager.getStorage(targetOrgId.toLowerCase() + "__autoSave", false);
+
+      assertFalse(targetBucket.exists(recycledFileName),
+                 "the old, source-org-tagged filename must be renamed away");
+      assertTrue(targetBucket.exists(expectedNewFileName),
+                "migrateAutoSaveFiles() must preserve the RECYCLE_PREFIX on the migrated filename "
+                + "-- otherwise the recycled draft becomes an active autosave file and silently "
+                + "drops off the EM \"Auto Saved Files\" recycle-bin tree (Issue #75827)");
    }
 
    // ── scenario 6h: removeExpiredAutoSaveFiles() only ever inspects the default org's bucket -- a


### PR DESCRIPTION
## Summary
- `AutoSaveUtils.migrateAutoSaveFiles()` stripped the `recycle/` prefix to split out the autosave filename's fields, but never re-applied it when building the migrated filename — a discarded/recycled draft silently turned into an active autosave file after an org copy or rename, so it dropped off the EM "Auto Saved Files" recycle-bin tree (`ContentRepositoryTreeService.addRecycleAutoSaved()` only lists paths still carrying the recycle prefix).
- `migrateAutoSaveFiles()` now resolves the blob bucket via an explicit `storageOrgId` parameter instead of the ambient principal/`OrganizationContextHolder` context — removes a fragile dependency and makes the target bucket obvious at each call site.

## Test plan
- [x] `AutoSaveServiceOrgLifecycleTest` — added `migrateAutoSaveFiles_recycledDraft_keepsRecyclePrefixAfterMigration`, pins the fix; updated the existing `6g` test for the new signature. All pass.
- [x] `IdentityServiceAutoSaveOrgLifecycleTest` — unaffected, still passes.
- [x] Manual repro: create a viewsheet as host org admin, discard the draft (goes to Auto Saved Files recycle bin), clone the org — file now correctly still shows up in the new org's Auto Saved Files tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)