### PR TITLE
Bug #75797, extend the Roles-root fallback from Bug #75795 to remaining SECURITY_ROLE checks

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/DefaultCheckPermissionStrategy.java
+++ b/core/src/main/java/inetsoft/sree/security/DefaultCheckPermissionStrategy.java
@@ -351,6 +351,15 @@ public class DefaultCheckPermissionStrategy implements CheckPermissionStrategy {
          if(targetInOrgRoleScope) {
             Permission rolePerm = provider.getPermission(type, new IdentityID("Organization Roles", organization), orgID);
 
+            // "Organization Roles" is only exposed as a grantable node in the EM tree when
+            // multi-tenant mode is on; when nobody has ever configured a grant on it (no
+            // Permission object at all), fall back to the "Roles" root -- the only node an
+            // admin has ever had the option to grant on in non-multi-tenant mode. Mirrors the
+            // fallback at the dedicated root-check block above (Bug #75795).
+            if(rolePerm == null) {
+               rolePerm = provider.getPermission(type, new IdentityID("Roles", organization), orgID);
+            }
+
             if(rolePerm != null && checker.checkPermission(identity, rolePerm, action, true)) {
                return true;
             }
@@ -789,6 +798,14 @@ public class DefaultCheckPermissionStrategy implements CheckPermissionStrategy {
                Tool.equals(currentRole.getOrganizationID(), OrganizationManager.getInstance().getCurrentOrgID()))
             {
                perm = provider.getPermission(currentType, new IdentityID("Organization Roles", OrganizationManager.getInstance().getCurrentOrgID()));
+
+               // "Organization Roles" is only exposed as a grantable node when multi-tenant
+               // mode is on; when nobody has ever configured a grant on it, fall back to the
+               // "Roles" root -- the only node an admin has ever had the option to grant on
+               // in non-multi-tenant mode (Bug #75795).
+               if(perm == null) {
+                  perm = provider.getPermission(currentType, new IdentityID("Roles", OrganizationManager.getInstance().getCurrentOrgID()));
+               }
             }
             else if(currentRole == null || currentRole.getOrganizationID() == null) {
                perm = provider.getPermission(currentType, new IdentityID("Roles", OrganizationManager.getInstance().getCurrentOrgID()));


### PR DESCRIPTION
## Summary
- Users granted Administrator Permissions only on the "Roles" root node (the only root exposed for granting in non-multi-tenant mode) could not manage/see org-scoped roles (e.g. Designer) in some flows, such as the EM Security > Actions tab role picker.
- Bug #75795 added a "Roles" root fallback (used only when "Organization Roles" has no Permission object configured at all) to the top-of-method `SECURITY_ROLE` check in `DefaultCheckPermissionStrategy`, but two other code paths in the same file implementing the same "Organization Roles vs Roles" root resolution were missed:
  - the secondary `SECURITY_ROLE` check further down `checkPermission()`
  - the private cumulative ADMIN-merge helper `getPermission(...)`, used to build assignable-identity lists shown in EM
- This PR applies the identical fallback to both remaining paths, preserving the root-independence guarantee from Bug #75574 (fallback only applies when "Organization Roles" is entirely unconfigured).

## Test plan
- [x] `./mvnw -pl core compile` succeeds
- [x] `./mvnw -pl core test -Dtest=PermissionMatrixResourcesS2Test,DefaultCheckPermissionStrategyTest` — 81 tests, 0 failures
- [x] Manually confirmed with reporter that EM Security > Actions role permissions now load correctly for a non-multi-tenant user granted Administrator Permissions on the "Roles" node