### PR TITLE
Bug #75845, pass an explicit injector when opening the query expression editor dialog

### DIFF
--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-query/query-main/query-field-pane/query-fields-pane.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-query/query-main/query-field-pane/query-fields-pane.component.ts
@@ -18,6 +18,7 @@
 import { HttpClient, HttpParams } from "@angular/common/http";
 import {
    Component,
+   Injector,
    Input,
    OnChanges,
    OnInit,
@@ -110,7 +111,8 @@ export class QueryFieldsPaneComponent implements OnInit, OnChanges {
    constructor(private http: HttpClient,
                private modalService: NgbModal,
                private queryModelService: DataQueryModelService,
-               private dragService: DragService)
+               private dragService: DragService,
+               private injector: Injector)
    {
    }
 
@@ -474,7 +476,8 @@ export class QueryFieldsPaneComponent implements OnInit, OnChanges {
    showFieldDialog(add: boolean = false): void {
       let modalOptions: NgbModalOptions = {
          backdrop: "static",
-         windowClass: "query-field-dialog"
+         windowClass: "query-field-dialog",
+         injector: this.injector
       };
       const dialog = ComponentTool.showDialog(this.modalService, EditFieldDialogComponent,
          (expression) => {


### PR DESCRIPTION
## Summary

In the worksheet Composer, opening a SQL-bound table's "Edit Query" dialog, switching to the Field pane, and clicking the add/edit expression icon threw a console error and did nothing:

```
ERROR NG0201: No provider found for `DataQueryModelService`. Source: Standalone[_EditFieldDialogComponent].
```

## Root Cause

`EditFieldDialogComponent` constructor-injects `DataQueryModelService`, which is only provided at a specific component/route scope (e.g. `SQLQueryDialog`'s `providers: [DataQueryModelService]`, or the portal/composer route-level `providers` arrays) — it is not `providedIn: 'root'`.

`QueryFieldsPaneComponent.showFieldDialog()` opens `EditFieldDialogComponent` via raw `NgbModal.open()` (through `ComponentTool.showDialog`) without passing an `injector` option. Since `NgbModal` creates the dialog as a new, detached component root rather than as a child within `QueryFieldsPaneComponent`'s own component tree, its DI resolution isn't guaranteed to include the scoped `DataQueryModelService` provider — causing the `NG0201` failure. This codebase already has an established pattern for this exact situation: `DialogService`/`SlideOutService` always thread an explicit `Injector` through when opening dialogs dynamically.

## Fix

In `query-fields-pane.component.ts`:
- Inject Angular's `Injector` into `QueryFieldsPaneComponent`'s constructor.
- Pass it via `injector: this.injector` in the `NgbModalOptions` used to open `EditFieldDialogComponent`.

This mirrors the existing `DialogService`/`SlideOutService` pattern and guarantees the dialog resolves `DataQueryModelService` from the same injector chain that `QueryFieldsPaneComponent` itself already successfully uses.

## Test Plan

- [x] Reproduced the bug using the attached asset from Redmine #75845 (import into Composer, open worksheet, right-click a SQL-bound table → Edit Query → Field pane → add/edit expression icon)
- [x] Confirmed the fix resolves the error and the Add/Edit Expression dialog opens correctly
- [x] `npm run build` (portal/elements/viewer-element/em) succeeds
- [x] Relevant TL test suites pass (177/177) in `database-query/**`, including `query-fields-pane.component.risk.tl.spec.ts` and `query-fields-pane.component.interaction.tl.spec.ts`
- [x] Code review via automated reviewer found no issues

Fixes Redmine #75845.