### PR TITLE
Bug #75842, clear org-scoped Logo/Favicon/Welcome Page entries on org delete

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -625,6 +625,9 @@ public class IdentityService {
                updateRepletRegistry(orgID, null);
                themeService.removeTheme(orgID);
                themesManager.removeCSSEntry(orgID);
+               themesManager.removeLogoEntry(orgID);
+               themesManager.removeFaviconEntry(orgID);
+               themesManager.removeWelcomePage(orgID);
                CSSDictionary.resetDictionaryCache();
                themesManager.save();
                removeStorages(orgID);

--- a/core/src/test/java/inetsoft/web/admin/security/IdentityServiceAutoSaveOrgLifecycleTest.java
+++ b/core/src/test/java/inetsoft/web/admin/security/IdentityServiceAutoSaveOrgLifecycleTest.java
@@ -48,9 +48,16 @@ package inetsoft.web.admin.security;
 import inetsoft.mv.MVManager;
 import inetsoft.report.LibManager;
 import inetsoft.report.LibManagerProvider;
+import inetsoft.sree.RepletRegistryManager;
+import inetsoft.sree.internal.DataCycleManager;
+import inetsoft.sree.portal.PortalThemesManager;
 import inetsoft.sree.schedule.ScheduleManager;
+import inetsoft.sree.security.AuthorizationChain;
+import inetsoft.sree.security.EditableAuthenticationProvider;
 import inetsoft.sree.security.Organization;
+import inetsoft.sree.security.SecurityProvider;
 import inetsoft.sree.web.dashboard.DashboardManager;
+import inetsoft.sree.web.dashboard.DashboardRegistryManager;
 import inetsoft.storage.BlobStorage;
 import inetsoft.storage.BlobStorageManager;
 import inetsoft.storage.BlobTransaction;
@@ -59,9 +66,13 @@ import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
 import inetsoft.uql.asset.sync.DependencyStorageService;
+import inetsoft.uql.service.DataSourceRegistry;
 import inetsoft.util.IndexedStorage;
+import inetsoft.util.log.LogManager;
 import inetsoft.web.AutoSaveUtils;
 import inetsoft.web.RecycleBin;
+import inetsoft.web.admin.favorites.FavoritesService;
+import inetsoft.web.admin.security.user.IdentityThemeService;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.LoggerFactory;
@@ -72,6 +83,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -196,6 +208,69 @@ class IdentityServiceAutoSaveOrgLifecycleTest {
       service.updateTaskSaveFiles(same1, same2);
 
       verifyNoInteractions(externalStorageService);
+   }
+
+   // ── delete scenario (Redmine #75842): the org-delete branch of syncIdentity() must clear all
+   //    four PortalThemesManager org-keyed maps, not just cssEntries -- otherwise a subsequently
+   //    created org that reuses the same org ID string (e.g. accepting the same default clone
+   //    name after the original was deleted) inherits the deleted org's stale Logo/Favicon/
+   //    Welcome Page/Login Banner settings. ──
+
+   @Test
+   void delete_syncIdentity_organizationDelete_clearsAllPortalThemesManagerBrandingEntries()
+      throws Exception
+   {
+      String orgId = "branding_delete_org";
+
+      PortalThemesManager portalThemesManager = mock(PortalThemesManager.class);
+      ReflectionTestUtils.setField(service, "portalThemesManager", portalThemesManager);
+
+      AuthorizationChain authorizationChain = mock(AuthorizationChain.class);
+      SecurityProvider securityProvider = mock(SecurityProvider.class);
+      when(securityProvider.getAuthorizationProvider()).thenReturn(authorizationChain);
+      ReflectionTestUtils.setField(service, "securityProvider", securityProvider);
+
+      ReflectionTestUtils.setField(service, "dashboardRegistryManager",
+                                    mock(DashboardRegistryManager.class));
+      ReflectionTestUtils.setField(service, "dataCycleManager", mock(DataCycleManager.class));
+      ReflectionTestUtils.setField(service, "themeService", mock(IdentityThemeService.class));
+      ReflectionTestUtils.setField(service, "favoritesService", mock(FavoritesService.class));
+      ReflectionTestUtils.setField(service, "dataSourceRegistry", mock(DataSourceRegistry.class));
+      ReflectionTestUtils.setField(service, "repletRegistryManager",
+                                    mock(RepletRegistryManager.class));
+      ReflectionTestUtils.setField(service, "logManager", mock(LogManager.class));
+
+      // stub out real IdentityService methods unrelated to this scenario -- same rationale as
+      // OrgLifecycleScopedPropertiesIntegrationTest's stubbing of sibling collaborators: this
+      // test only cares about the PortalThemesManager cleanup added for this bug fix.
+      doNothing().when(service).removeOrgProperties(anyString());
+      doNothing().when(service).removeOrgScopedDataSpaceElements(any());
+      doNothing().when(service).updateRepletRegistry(any(), any());
+      doNothing().when(service).clearDataSourceMetadata();
+      doNothing().when(service).removeStorages(anyString());
+
+      EditableAuthenticationProvider eprovider = mock(EditableAuthenticationProvider.class);
+      Organization org = new Organization(orgId);
+      when(eprovider.getOrganization(orgId)).thenReturn(org);
+
+      invokeSyncIdentity(eprovider, org, null);
+
+      verify(portalThemesManager).removeCSSEntry(orgId);
+      verify(portalThemesManager).removeLogoEntry(orgId);
+      verify(portalThemesManager).removeFaviconEntry(orgId);
+      verify(portalThemesManager).removeWelcomePage(orgId);
+   }
+
+   private void invokeSyncIdentity(EditableAuthenticationProvider eprovider,
+                                    inetsoft.uql.util.Identity identity,
+                                    inetsoft.sree.security.IdentityID oID)
+      throws Exception
+   {
+      Method m = IdentityService.class.getDeclaredMethod(
+         "syncIdentity", EditableAuthenticationProvider.class,
+         inetsoft.uql.util.Identity.class, inetsoft.sree.security.IdentityID.class);
+      m.setAccessible(true);
+      m.invoke(service, eprovider, identity, oID);
    }
 
    // ── fixture helpers ──


### PR DESCRIPTION
## Summary

Org-scoped Presentation settings (Welcome Page, Login Banner, and also Logo/Favicon) could survive organization deletion and reappear on a newly created organization, if that new organization happened to reuse the same organization ID as the deleted one.

## Root Cause

`PortalThemesManager` keeps four maps keyed by organization ID: `cssEntries`, `logoEntries`, `faviconEntries`, and `welcomePageEntries` (the latter backs both the "Welcome Page" and "Login Banner" Presentation settings, which are two UI panels over the same object).

`IdentityService.syncIdentity()`'s organization-delete branch only called `themesManager.removeCSSEntry(orgID)` when cleaning up a deleted org's state — it never called the equivalent `removeLogoEntry`, `removeFaviconEntry`, or `removeWelcomePage` methods. Those three maps kept an orphaned entry for the deleted org's ID indefinitely (persisted in `portalthemes.xml`).

Separately, organization creation (including cloning with the default suggested name, e.g. "organization0") assigns the new org's ID directly from the entered/generated name string rather than a generated UUID. Once an org is deleted, its ID becomes available again, so accepting the same default name a second time produces the exact same org ID string. The new org's `getWelcomePage(orgId)`/etc. calls then found the previous org's orphaned entries and displayed stale settings instead of defaults.

## Fix

Added the three missing cleanup calls to the same delete branch, alongside the existing `removeCSSEntry` call:

```java
themesManager.removeCSSEntry(orgID);
themesManager.removeLogoEntry(orgID);
themesManager.removeFaviconEntry(orgID);
themesManager.removeWelcomePage(orgID);
```

This only affects the organization-deletion path; org rename/clone are unaffected (a separate, pre-existing gap in that path was intentionally left out of scope for this fix, per the code review).

## Test Plan

- [x] Built `core` module (`mvnw clean install -pl core -am -DskipTests`) — success
- [x] Ran `IdentityServiceTest`, `IdentityServiceAutoSaveOrgLifecycleTest`, `OrgLifecycle*` suite, `PermissionMatrixOrgLifecycleTest`, `DashboardRegistryOrgLifecycleTest`, `DataCycleManagerOrgLifecycleTest`, `RecycleBinOrgLifecycleTest`, `FavoritesServiceTest` — 69 run, 0 failures
- [x] Reviewed via code-reviewer subagent — confirmed correct, complete for this delete-path bug, no regression risk to rename/clone
- [ ] Manual repro: clone org accepting default name → set Welcome Page + Login Banner → delete org → clone again with same default name → verify Presentation settings show defaults, not stale values

Fixes Redmine #75842.