### PR TITLE
Bug #75824, fail fast on Ignite cache mode mismatch from a minReplicas change

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
@@ -103,6 +103,16 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
          r -> new GroupedThread(r, "IgniteMapEvents"));
 
       if(!config.isClientMode()) {
+         try {
+            checkCacheModeConsistency();
+         }
+         catch(RuntimeException e) {
+            // the node already joined discovery above; leave cleanly instead of lingering as a
+            // zombie member of the cluster it just failed to validate against.
+            ignite.close();
+            throw e;
+         }
+
          initLockTimer();
          ignite.getOrCreateCache(getCacheConfiguration(RW_MAP_NAME));
       }
@@ -494,6 +504,35 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
          CacheMode.PARTITIONED : CacheMode.REPLICATED;
    }
 
+   /**
+    * Fails fast if this node's minReplicas-derived cache mode disagrees with a node already
+    * running in the cluster, rather than letting a later cache creation throw a cache mode
+    * mismatch exception. This can happen if minReplicas is changed and applied as a rolling
+    * update instead of restarting the entire cluster, since the cache mode is decided locally
+    * by each node at startup and is never renegotiated once the cluster is running.
+    */
+   private void checkCacheModeConsistency() {
+      CacheMode localCacheMode = getDefaultCacheMode();
+      UUID localNodeId = ignite.cluster().localNode().id();
+
+      for(ClusterNode node : ignite.cluster().forServers().nodes()) {
+         if(node.id().equals(localNodeId)) {
+            continue;
+         }
+
+         String remoteCacheMode = node.attribute(CACHE_MODE_ATTR);
+
+         if(remoteCacheMode != null && !remoteCacheMode.equals(localCacheMode.name())) {
+            throw new IllegalStateException(
+               "This node computed Ignite cache mode " + localCacheMode + " from the " +
+               "configured minReplicas, but node " + getNodeName(node) + " in the cluster is " +
+               "already running with cache mode " + remoteCacheMode + ". minReplicas was " +
+               "changed across a threshold that alters the cluster cache mode; applying that " +
+               "change requires restarting every node in the cluster, not a rolling update.");
+         }
+      }
+   }
+
    private void initLockTimer() {
       timer.schedule(new TimerTask() {
          @Override
@@ -530,6 +569,7 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
       attrMap.put("inetsoft.host.ip", System.getProperty("inetsoft.host.ip"));
       attrMap.put("inetsoft.host.port", System.getProperty("inetsoft.host.port"));
       attrMap.put("inetsoft.host.outbound.port", System.getProperty("inetsoft.host.outbound.port"));
+      attrMap.put(CACHE_MODE_ATTR, getDefaultCacheMode().name());
       config.setUserAttributes(attrMap);
    }
 
@@ -1899,6 +1939,7 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
    private static final String MESSAGE_TOPIC = IgniteCluster.class.getName() + ".messageTopic";
    private static final String AFFINITY_TOPIC = IgniteCluster.class.getName() + ".affinityTopic";
    private static final String RW_MAP_NAME = IgniteCluster.class.getName() + ".rwMap";
+   private static final String CACHE_MODE_ATTR = "inetsoft.cluster.cacheMode";
    private static final IgnitePredicate<ClusterNode> SCHEDULE_SELECTOR = node -> {
       // select any node when config has cloud runner, because the separate scheduler server do not exist.
       if(InetsoftConfig.getInstance().getCloudRunner() != null) {

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
@@ -107,9 +107,11 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
             checkCacheModeConsistency();
          }
          catch(RuntimeException e) {
-            // the node already joined discovery above; leave cleanly instead of lingering as a
-            // zombie member of the cluster it just failed to validate against.
-            ignite.close();
+            // the node already joined discovery and opened the file transfer socket above;
+            // reuse the full close() so nothing (Ignite instance, socket, executors) is left
+            // running instead of lingering as a zombie member of the cluster it just failed to
+            // validate against.
+            close();
             throw e;
          }
 

--- a/core/src/test/java/inetsoft/sree/internal/cluster/ignite/IgniteClusterCacheModeConsistencyTest.java
+++ b/core/src/test/java/inetsoft/sree/internal/cluster/ignite/IgniteClusterCacheModeConsistencyTest.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.sree.internal.cluster.ignite;
+
+import inetsoft.test.*;
+import inetsoft.util.config.InetsoftConfig;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.TcpDiscoveryIpFinder;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies that a node whose minReplicas-derived Ignite cache mode disagrees with a node
+ * already running in the cluster fails fast on join (Bug #75824) instead of joining and later
+ * failing with an unexplained cache mode mismatch exception from Ignite itself.
+ */
+@Disabled
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+public class IgniteClusterCacheModeConsistencyTest {
+   @TempDir
+   Path clusterDir;
+
+   @BeforeEach
+   void saveMinNodes() {
+      originalMinNodes = InetsoftConfig.getInstance().getCluster().getMinNodes();
+   }
+
+   @AfterEach
+   void restoreMinNodes() {
+      InetsoftConfig.getInstance().getCluster().setMinNodes(originalMinNodes);
+   }
+
+   @Test
+   void joinFailsWhenCacheModeChangedAcrossThreshold() {
+      TcpDiscoveryIpFinder ipFinder = new TcpDiscoveryVmIpFinder(true);
+
+      // minNodes > 2 -> PARTITIONED
+      InetsoftConfig.getInstance().getCluster().setMinNodes(3);
+      IgniteCluster ignite1 = IgniteClusterTestUtils.getIgniteCluster("mismatch1", ipFinder, clusterDir);
+
+      try {
+         // minNodes <= 2 -> REPLICATED, simulating minReplicas dropped across the threshold
+         // and applied as a rolling update instead of a full cluster restart.
+         InetsoftConfig.getInstance().getCluster().setMinNodes(2);
+
+         IllegalStateException ex = assertThrows(IllegalStateException.class,
+            () -> IgniteClusterTestUtils.getIgniteCluster("mismatch2", ipFinder, clusterDir));
+         assertTrue(ex.getMessage().contains("restarting every node"), ex.getMessage());
+      }
+      finally {
+         ignite1.close();
+      }
+   }
+
+   @Test
+   void joinSucceedsWhenCacheModeUnchanged() {
+      TcpDiscoveryIpFinder ipFinder = new TcpDiscoveryVmIpFinder(true);
+      InetsoftConfig.getInstance().getCluster().setMinNodes(3);
+
+      IgniteCluster ignite1 = IgniteClusterTestUtils.getIgniteCluster("match1", ipFinder, clusterDir);
+      IgniteCluster ignite2 = null;
+
+      try {
+         ignite2 = IgniteClusterTestUtils.getIgniteCluster("match2", ipFinder, clusterDir);
+         assertEquals(2, ignite1.getIgniteInstance().cluster().forServers().nodes().size());
+      }
+      finally {
+         ignite1.close();
+
+         if(ignite2 != null) {
+            ignite2.close();
+         }
+      }
+   }
+
+   private int originalMinNodes;
+}


### PR DESCRIPTION
## Summary
- Cache mode (`PARTITIONED` vs `REPLICATED`) is derived independently by each Ignite node from the configured `minReplicas` at startup and is never renegotiated afterward. Changing `minReplicas` across the threshold that flips this and applying it as a rolling update (instead of restarting the whole cluster) leaves old and new pods disagreeing on cache mode for the same cache group.
- Previously this surfaced much later as an unexplained `IgniteException: Cache mode mismatch` whenever some code path first touched the affected (often lazily-created) cache, e.g. as a 500 error on the EM monitoring page.
- Each node now publishes its computed cache mode as a discovery attribute and checks it against already-joined server nodes before creating any cache, so the failure happens immediately on startup with an actionable message. A node that fails this check also leaves the discovery ring cleanly instead of lingering as a zombie member.

## Test plan
- [x] Added `IgniteClusterCacheModeConsistencyTest` (in-JVM two-node harness, matching sibling Ignite tests in this package) covering both the mismatch-fails and match-succeeds cases. Verified locally by temporarily removing `@Disabled` (matches convention of other multi-node Ignite tests in this package, which are excluded from routine CI runs).
- [x] `mvn test -pl core -Dtest=IgniteClusterCacheModeConsistencyTest` passes.

Redmine: https://www.inetsoft.com/redmine/issues/75824