### PR TITLE
feat: viewsheet script-agent image rendering (ScriptImageService)

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/AssemblyImageService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/AssemblyImageService.java
@@ -162,6 +162,56 @@ public class AssemblyImageService {
       return imageResultsRef.get();
    }
 
+   /**
+    * Same as {@link #processGetAssemblyImage(String, String, double, double, double, double,
+    * String, int, int, int, Principal, boolean, boolean)} but for a caller that already holds an
+    * authorized {@link RuntimeViewsheet} and must not re-resolve it via
+    * {@code ViewsheetService.getViewsheet(vid, principal)} — that re-resolution enforces the
+    * normal session {@code matches()} check, which rejects a caller whose principal isn't the
+    * exact browser session that opened the runtime (e.g. a pairing-authorized agent, whose
+    * rebuilt principal has a different per-connection identity than the browser's).
+    *
+    * <p><b>Precondition — security-relevant:</b> this overload performs NO ownership check of
+    * its own. The caller MUST have independently verified the caller is allowed to access
+    * {@code rvs} before invoking it (e.g. via {@code SheetRuntimeAccess.getSheetForPairing},
+    * which itself requires a verified {@code PairingGrant} — see {@code SheetJoinService}'s
+    * same-logical-user + runtime-ownership checks). Do not call this with an unauthorized or
+    * unverified {@link RuntimeViewsheet}.</p>
+    */
+   public ImageRenderResult processGetAssemblyImage(RuntimeViewsheet rvs, String aid, double width,
+                                       double height, double maxWidth, double maxHeight,
+                                       String aname, int index, int row, int col,
+                                       Principal principal, boolean svg, boolean export)
+      throws Exception
+   {
+      Optional<ViewsheetSandbox> box = rvs.getViewsheetSandbox();
+      String sheetName = box.map(ViewsheetSandbox::getAssetEntry).map(AssetEntry::getPath).orElse("");
+      String assemblyName = Tool.byteDecode(aid);
+      AtomicReference<ImageRenderResult> imageResultsRef = new AtomicReference<>();
+
+      try {
+         GroupedThread.withGroupedThread(groupedThread -> {
+            groupedThread.addRecord(LogContext.DASHBOARD.getRecord(sheetName));
+            groupedThread.addRecord(LogContext.ASSEMBLY.getRecord(assemblyName));
+         });
+
+         ProfileUtils.addExecutionBreakDownRecord(box.map(ViewsheetSandbox::getID).orElse(rvs.getID()),
+             ExecutionBreakDownRecord.UI_PROCESSING_CYCLE, args -> {
+               ImageRenderResult result = processGetAssemblyImage1(rvs, aid, width, height, maxWidth, maxHeight, aname, index,
+                                        row, col, principal, svg, export);
+              imageResultsRef.set(result);
+         });
+      }
+      finally {
+         GroupedThread.withGroupedThread(groupedThread -> {
+            groupedThread.removeRecord(LogContext.DASHBOARD.getRecord(sheetName));
+            groupedThread.removeRecord(LogContext.ASSEMBLY.getRecord(assemblyName));
+         });
+      }
+
+      return imageResultsRef.get();
+   }
+
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public MessageCommand checkExporting(@ClusterProxyKey String runtimeId, Principal principal) throws Exception {
       RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
@@ -576,7 +626,28 @@ public class AssemblyImageService {
    {
       RuntimeViewsheet rvs = viewsheetService.getViewsheet(vid, principal);
 
-      if(rvs == null || width <= 0 || height <= 0) {
+      if(rvs == null) {
+         return null;
+      }
+
+      return processGetAssemblyImage1(rvs, aid, width, height, maxWidth, maxHeight, aname, index,
+                                      row, col, principal, svg, export);
+   }
+
+   /**
+    * Same as {@link #processGetAssemblyImage1(String, String, double, double, double, double,
+    * String, int, int, int, Principal, boolean, boolean)} but for a caller that already holds an
+    * authorized {@link RuntimeViewsheet} — see the precondition on
+    * {@link #processGetAssemblyImage(RuntimeViewsheet, String, double, double, double, double,
+    * String, int, int, int, Principal, boolean, boolean)}, which this mirrors.
+    */
+   private ImageRenderResult processGetAssemblyImage1(RuntimeViewsheet rvs, String aid, double width, double height,
+                                         double maxWidth, double maxHeight, String aname,
+                                         int index, int row, int col, Principal principal,
+                                         boolean svg, boolean export)
+      throws Exception
+   {
+      if(width <= 0 || height <= 0) {
          return null;
       }
 
@@ -667,7 +738,7 @@ public class AssemblyImageService {
                   SreeEnv.setProperty("webmap.suspend.until", hours24 + "");
 
                   box.get().clearGraph(name);
-                  return processGetAssemblyImage1(vid, aid, width, height, maxWidth, maxHeight, aname,
+                  return processGetAssemblyImage1(rvs, aid, width, height, maxWidth, maxHeight, aname,
                                            index, row, col, principal, svg, export);
                }
                finally {
@@ -748,7 +819,7 @@ public class AssemblyImageService {
          resultHeight = image.getHeight();
       }
 
-      String key = "/" + AssemblyImageService.class.getName() + "_" + vid + "_" + aid +
+      String key = "/" + AssemblyImageService.class.getName() + "_" + rvs.getID() + "_" + aid +
          "_" + index + "_" + row + "_" + col;
       BinaryTransfer imageData = binaryTransferService.createBinaryTransfer(key);
       binaryTransferService.setData(imageData, buf);

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptApiService.java
@@ -83,16 +83,18 @@ public class ScriptApiService {
       try(InputStream in = getClass().getResourceAsStream(RESOURCE)) {
          if(in == null) {
             LOG.warn("Script API metadata resource not found: {}", RESOURCE);
-            return new ObjectMapper().createObjectNode();
+            return MAPPER.createObjectNode();
          }
 
-         return new ObjectMapper().readTree(in);
+         return MAPPER.readTree(in);
       }
       catch(Exception e) {
          LOG.warn("Failed to load script API metadata", e);
-         return new ObjectMapper().createObjectNode();
+         return MAPPER.createObjectNode();
       }
    }
+
+   private static final ObjectMapper MAPPER = new ObjectMapper();
 
    private volatile JsonNode root;
 }

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
@@ -32,9 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.imageio.ImageIO;
-import java.awt.Dimension;
 import java.awt.Graphics2D;
-import java.awt.Point;
 import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
@@ -51,11 +49,18 @@ import java.security.Principal;
  * itself uses for every on-screen assembly tile (via {@code GetImageController}) and that
  * {@code WizVisualizationService} already uses for the chart wizard's live preview/thumbnail.</p>
  *
- * <p>For types that path doesn't support (tables/crosstabs) and for whole-viewsheet snapshots,
- * falls back to the full {@code VSExportService} PNG export — the same "expensive fallback"
- * {@code WizVisualizationService.renderFallbackThumbnail} already uses for the identical
- * tables/crosstabs gap, here also reused directly for "the whole sheet" since there's no lighter
- * single call that composes multiple assemblies into one image.</p>
+ * <p>For types that path doesn't support (tables/crosstabs), falls back to rendering the whole
+ * viewsheet instead of trying to crop the single assembly out of a full-page export. An earlier
+ * version cropped to {@code assembly.getPixelOffset()}/{@code getPixelSize()} (mirroring
+ * {@code WizVisualizationService.renderFallbackThumbnail}), but live testing found that those
+ * values aren't guaranteed to agree with the exporter's own canvas-sizing/draw coordinates — the
+ * exporter's {@code Viewsheet.getPreferredBounds()} can prefer a stale {@code layoutPosition}/
+ * {@code layoutSize} left over from a Print Layout or device layout when sizing the canvas, while
+ * the paint step always uses the raw pixel box, so the two can silently disagree and produce a
+ * crop of the wrong region. Whole-viewsheet rendering doesn't compute any position of its own —
+ * it's just what the exporter actually painted — so it has no equivalent failure mode. (The same
+ * crop math is used by {@code WizVisualizationService.renderFallbackThumbnail}, which likely has
+ * the same latent bug; out of scope to fix here.)</p>
  */
 @Service
 public class ScriptImageService {
@@ -83,7 +88,12 @@ public class ScriptImageService {
       this.vsExportService = vsExportService;
    }
 
-   public record ChartImage(byte[] pngBytes, boolean isPng, int width, int height) {}
+   /**
+    * @param note non-null only when the requested assembly couldn't be rendered directly and this
+    *        is a whole-viewsheet image instead — the caller should surface this to the user so
+    *        they understand why the image shows more than just the assembly they asked for.
+    */
+   public record ChartImage(byte[] pngBytes, boolean isPng, int width, int height, String note) {}
 
    /**
     * @throws RenderNotReadyException if the graph hasn't finished computing after
@@ -139,17 +149,20 @@ public class ScriptImageService {
       }
 
       // A 1x1 image is StyleBI's placeholder for assembly types downloadAssemblyImage doesn't
-      // support directly (tables/crosstabs) — fall back to the same full-export-and-crop
-      // approach WizVisualizationService.renderFallbackThumbnail uses for the identical gap.
+      // support directly (tables/crosstabs) — fall back to rendering the whole viewsheet instead
+      // of guessing a crop rectangle (see class doc for why cropping isn't reliable here).
       if(result.isPng()) {
          BufferedImage decoded = ImageIO.read(new ByteArrayInputStream(bytes));
 
          if(decoded == null || decoded.getWidth() <= 1 || decoded.getHeight() <= 1) {
-            return renderViaExportFallback(rvs, assembly, w, h, principal);
+            ChartImage whole = getViewsheetImage(rvs, width, height, principal);
+            return new ChartImage(whole.pngBytes(), whole.isPng(), whole.width(), whole.height(),
+               "\"" + assemblyName + "\" can't be rendered on its own — showing the whole " +
+               "viewsheet instead.");
          }
       }
 
-      return new ChartImage(bytes, result.isPng(), result.getWidth(), result.getHeight());
+      return new ChartImage(bytes, result.isPng(), result.getWidth(), result.getHeight(), null);
    }
 
    /**
@@ -171,51 +184,12 @@ public class ScriptImageService {
       BufferedImage scaled = scaleToFit(full, w, h);
       byte[] encoded = encodePng(scaled, "the viewsheet");
 
-      return new ChartImage(encoded, true, scaled.getWidth(), scaled.getHeight());
-   }
-
-   /**
-    * Full-viewsheet PNG export, cropped to {@code assembly}'s pixel bounds — mirrors
-    * {@code WizVisualizationService.renderFallbackThumbnail} exactly (same
-    * {@code exportViewsheet} call, same {@code getPixelOffset()}/{@code getPixelSize()}-based
-    * crop math), used here for assembly types {@link AssemblyImageService#downloadAssemblyImage}
-    * doesn't support directly (tables/crosstabs).
-    */
-   private ChartImage renderViaExportFallback(RuntimeViewsheet rvs, Assembly assembly,
-                                              int maxWidth, int maxHeight, Principal principal)
-      throws Exception
-   {
-      Point offset = assembly.getPixelOffset();
-      Dimension size = assembly.getPixelSize();
-
-      if(size == null || size.width <= 0 || size.height <= 0) {
-         throw new PairingException("\"" + assembly.getName() + "\" has no renderable size");
-      }
-
-      byte[] pngBytes = exportViewsheetToPng(rvs, principal);
-      BufferedImage full = decodePng(pngBytes, assembly.getName());
-
-      int cropX = Math.max(0, offset != null ? offset.x : 0);
-      int cropY = Math.max(0, offset != null ? offset.y : 0);
-      int cropW = Math.min(size.width, full.getWidth() - cropX);
-      int cropH = Math.min(size.height, full.getHeight() - cropY);
-
-      if(cropW <= 0 || cropH <= 0) {
-         throw new PairingException(
-            "\"" + assembly.getName() + "\" could not be cropped from the exported viewsheet");
-      }
-
-      BufferedImage cropped = full.getSubimage(cropX, cropY, cropW, cropH);
-      cropped = scaleToFit(cropped, maxWidth, maxHeight);
-      byte[] encoded = encodePng(cropped, assembly.getName());
-
-      return new ChartImage(encoded, true, cropped.getWidth(), cropped.getHeight());
+      return new ChartImage(encoded, true, scaled.getWidth(), scaled.getHeight(), null);
    }
 
    /**
     * The exact call {@code WizVisualizationService.renderFallbackThumbnail} uses to export the
-    * whole live viewsheet to an in-memory PNG: {@code match=true} for pixel-accurate geometry
-    * (required so crop coordinates from {@code getPixelOffset()}/{@code getPixelSize()} line up),
+    * whole live viewsheet to an in-memory PNG: {@code match=true} for pixel-accurate geometry,
     * {@code current=true} because with no bookmarks and {@code current=false} the exporter's
     * {@code write()} produces 0 bytes.
     */

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
@@ -19,33 +19,43 @@ package inetsoft.web.wiz.script;
 
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.Assembly;
-import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.FileFormatInfo;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.util.Tool;
 import inetsoft.web.service.BinaryTransferService;
 import inetsoft.web.viewsheet.controller.AssemblyImageService;
+import inetsoft.web.viewsheet.service.ExportResponse;
+import inetsoft.web.viewsheet.service.VSExportService;
 import inetsoft.web.wiz.pairing.PairingException;
 import inetsoft.web.wiz.service.RenderNotReadyException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.imageio.ImageIO;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.security.Principal;
 
 /**
- * Renders a chart assembly's current state to a PNG snapshot the agent can actually look at.
+ * Renders a viewsheet assembly — or the whole viewsheet — to a PNG snapshot the agent can
+ * actually look at.
  *
- * <p>Reuses {@link AssemblyImageService#downloadAssemblyImage}'s underlying mechanism — the same
- * lightweight, already-open-runtime render path the browser itself uses for every on-screen chart
- * tile (via {@code GetImageController}) and that {@code WizVisualizationService} already uses for
- * the chart wizard's live preview/thumbnail. Deliberately does NOT use the full
- * {@code VSExportService} export pipeline (clones the whole viewsheet, force-refreshes every
- * assembly, writes a temp file) — confirmed overkill for "one chart's current render," and that
- * pipeline is only meant as an expensive fallback for assembly types this path doesn't support
- * (Crosstab/Table), which is out of scope here since only charts are addressable as script
- * targets anyway.</p>
+ * <p>For assembly types {@link AssemblyImageService#downloadAssemblyImage} supports directly
+ * (charts, gauges, thermometers, cylinders, sliding scales, images, shapes, group containers),
+ * reuses that mechanism — the same lightweight, already-open-runtime render path the browser
+ * itself uses for every on-screen assembly tile (via {@code GetImageController}) and that
+ * {@code WizVisualizationService} already uses for the chart wizard's live preview/thumbnail.</p>
+ *
+ * <p>For types that path doesn't support (tables/crosstabs) and for whole-viewsheet snapshots,
+ * falls back to the full {@code VSExportService} PNG export — the same "expensive fallback"
+ * {@code WizVisualizationService.renderFallbackThumbnail} already uses for the identical
+ * tables/crosstabs gap, here also reused directly for "the whole sheet" since there's no lighter
+ * single call that composes multiple assemblies into one image.</p>
  */
 @Service
 public class ScriptImageService {
@@ -65,22 +75,24 @@ public class ScriptImageService {
 
    @Autowired
    public ScriptImageService(AssemblyImageService assemblyImageService,
-                             BinaryTransferService binaryTransferService)
+                             BinaryTransferService binaryTransferService,
+                             VSExportService vsExportService)
    {
       this.assemblyImageService = assemblyImageService;
       this.binaryTransferService = binaryTransferService;
+      this.vsExportService = vsExportService;
    }
 
    public record ChartImage(byte[] pngBytes, boolean isPng, int width, int height) {}
 
    /**
-    * @throws RenderNotReadyException if the chart's graph hasn't finished computing after
+    * @throws RenderNotReadyException if the graph hasn't finished computing after
     *         {@value #RENDER_MAX_ATTEMPTS} retries — caller should map this to a retryable HTTP
     *         status, not treat it as a hard failure.
-    * @throws PairingException if {@code assemblyName} doesn't exist or isn't a chart.
+    * @throws PairingException if {@code assemblyName} doesn't exist or can't be rendered at all.
     */
-   public ChartImage getChartImage(RuntimeViewsheet rvs, String assemblyName,
-                                   Integer width, Integer height, Principal principal)
+   public ChartImage getAssemblyImage(RuntimeViewsheet rvs, String assemblyName,
+                                      Integer width, Integer height, Principal principal)
       throws Exception
    {
       Viewsheet vs = rvs.getViewsheet();
@@ -91,8 +103,8 @@ public class ScriptImageService {
 
       Assembly assembly = vs.getAssembly(assemblyName);
 
-      if(!(assembly instanceof ChartVSAssembly)) {
-         throw new PairingException("\"" + assemblyName + "\" is not a chart assembly");
+      if(assembly == null) {
+         throw new PairingException("No such assembly \"" + assemblyName + "\"");
       }
 
       int w = clamp(width != null && width > 0 ? width : DEFAULT_WIDTH);
@@ -127,18 +139,143 @@ public class ScriptImageService {
       }
 
       // A 1x1 image is StyleBI's placeholder for assembly types downloadAssemblyImage doesn't
-      // support (see AssemblyImageService's "avoid a broken image on browser" fallback) — not
-      // expected here since we already required ChartVSAssembly above, but guard anyway rather
-      // than silently handing the agent a useless 1x1 PNG.
+      // support directly (tables/crosstabs) — fall back to the same full-export-and-crop
+      // approach WizVisualizationService.renderFallbackThumbnail uses for the identical gap.
       if(result.isPng()) {
          BufferedImage decoded = ImageIO.read(new ByteArrayInputStream(bytes));
 
          if(decoded == null || decoded.getWidth() <= 1 || decoded.getHeight() <= 1) {
-            throw new PairingException("\"" + assemblyName + "\" could not be rendered to an image");
+            return renderViaExportFallback(rvs, assembly, w, h, principal);
          }
       }
 
       return new ChartImage(bytes, result.isPng(), result.getWidth(), result.getHeight());
+   }
+
+   /**
+    * Renders the whole viewsheet — every visible assembly, composed as it actually looks — to a
+    * single PNG. There's no lightweight single-call equivalent to
+    * {@link AssemblyImageService#downloadAssemblyImage} for "the whole sheet" (that path is
+    * inherently per-assembly), so this always uses the full export pipeline. Acceptable here since
+    * this is an explicit, occasional request, not something called after every script edit.
+    */
+   public ChartImage getViewsheetImage(RuntimeViewsheet rvs, Integer width, Integer height,
+                                       Principal principal)
+      throws Exception
+   {
+      int w = clamp(width != null && width > 0 ? width : DEFAULT_WIDTH);
+      int h = clamp(height != null && height > 0 ? height : DEFAULT_HEIGHT);
+
+      byte[] pngBytes = exportViewsheetToPng(rvs, principal);
+      BufferedImage full = decodePng(pngBytes, "the viewsheet");
+      BufferedImage scaled = scaleToFit(full, w, h);
+      byte[] encoded = encodePng(scaled, "the viewsheet");
+
+      return new ChartImage(encoded, true, scaled.getWidth(), scaled.getHeight());
+   }
+
+   /**
+    * Full-viewsheet PNG export, cropped to {@code assembly}'s pixel bounds — mirrors
+    * {@code WizVisualizationService.renderFallbackThumbnail} exactly (same
+    * {@code exportViewsheet} call, same {@code getPixelOffset()}/{@code getPixelSize()}-based
+    * crop math), used here for assembly types {@link AssemblyImageService#downloadAssemblyImage}
+    * doesn't support directly (tables/crosstabs).
+    */
+   private ChartImage renderViaExportFallback(RuntimeViewsheet rvs, Assembly assembly,
+                                              int maxWidth, int maxHeight, Principal principal)
+      throws Exception
+   {
+      Point offset = assembly.getPixelOffset();
+      Dimension size = assembly.getPixelSize();
+
+      if(size == null || size.width <= 0 || size.height <= 0) {
+         throw new PairingException("\"" + assembly.getName() + "\" has no renderable size");
+      }
+
+      byte[] pngBytes = exportViewsheetToPng(rvs, principal);
+      BufferedImage full = decodePng(pngBytes, assembly.getName());
+
+      int cropX = Math.max(0, offset != null ? offset.x : 0);
+      int cropY = Math.max(0, offset != null ? offset.y : 0);
+      int cropW = Math.min(size.width, full.getWidth() - cropX);
+      int cropH = Math.min(size.height, full.getHeight() - cropY);
+
+      if(cropW <= 0 || cropH <= 0) {
+         throw new PairingException(
+            "\"" + assembly.getName() + "\" could not be cropped from the exported viewsheet");
+      }
+
+      BufferedImage cropped = full.getSubimage(cropX, cropY, cropW, cropH);
+      cropped = scaleToFit(cropped, maxWidth, maxHeight);
+      byte[] encoded = encodePng(cropped, assembly.getName());
+
+      return new ChartImage(encoded, true, cropped.getWidth(), cropped.getHeight());
+   }
+
+   /**
+    * The exact call {@code WizVisualizationService.renderFallbackThumbnail} uses to export the
+    * whole live viewsheet to an in-memory PNG: {@code match=true} for pixel-accurate geometry
+    * (required so crop coordinates from {@code getPixelOffset()}/{@code getPixelSize()} line up),
+    * {@code current=true} because with no bookmarks and {@code current=false} the exporter's
+    * {@code write()} produces 0 bytes.
+    */
+   private byte[] exportViewsheetToPng(RuntimeViewsheet rvs, Principal principal) throws Exception {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      vsExportService.exportViewsheet(rvs, FileFormatInfo.EXPORT_TYPE_PNG,
+         true, false, true, false, false, null, false,
+         new ExportResponse(baos), principal);
+      byte[] bytes = baos.toByteArray();
+
+      if(bytes.length == 0) {
+         throw new PairingException("Failed to export the viewsheet");
+      }
+
+      return bytes;
+   }
+
+   private static BufferedImage decodePng(byte[] bytes, String label) throws Exception {
+      BufferedImage image = ImageIO.read(new ByteArrayInputStream(bytes));
+
+      if(image == null) {
+         throw new PairingException("Failed to decode the exported image for \"" + label + "\"");
+      }
+
+      return image;
+   }
+
+   private static byte[] encodePng(BufferedImage image, String label) throws Exception {
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      ImageIO.write(image, "PNG", out);
+      byte[] bytes = out.toByteArray();
+
+      if(bytes.length == 0) {
+         throw new PairingException("Failed to encode the rendered image for \"" + label + "\"");
+      }
+
+      return bytes;
+   }
+
+   /** Downscales (never upscales) to fit within {@code maxWidth}x{@code maxHeight}, preserving aspect ratio. */
+   private static BufferedImage scaleToFit(BufferedImage image, int maxWidth, int maxHeight) {
+      if(image.getWidth() <= maxWidth && image.getHeight() <= maxHeight) {
+         return image;
+      }
+
+      double scale = Math.min((double) maxWidth / image.getWidth(), (double) maxHeight / image.getHeight());
+      int w = Math.max(1, (int) (image.getWidth() * scale));
+      int h = Math.max(1, (int) (image.getHeight() * scale));
+      BufferedImage scaled = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+      Graphics2D g = scaled.createGraphics();
+
+      try {
+         g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+         g.drawImage(image, 0, 0, w, h, null);
+      }
+      finally {
+         g.dispose();
+      }
+
+      return scaled;
    }
 
    private static int clamp(int value) {
@@ -147,4 +284,5 @@ public class ScriptImageService {
 
    private final AssemblyImageService assemblyImageService;
    private final BinaryTransferService binaryTransferService;
+   private final VSExportService vsExportService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
@@ -1,0 +1,150 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.script;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.util.Tool;
+import inetsoft.web.service.BinaryTransferService;
+import inetsoft.web.viewsheet.controller.AssemblyImageService;
+import inetsoft.web.wiz.pairing.PairingException;
+import inetsoft.web.wiz.service.RenderNotReadyException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.security.Principal;
+
+/**
+ * Renders a chart assembly's current state to a PNG snapshot the agent can actually look at.
+ *
+ * <p>Reuses {@link AssemblyImageService#downloadAssemblyImage}'s underlying mechanism — the same
+ * lightweight, already-open-runtime render path the browser itself uses for every on-screen chart
+ * tile (via {@code GetImageController}) and that {@code WizVisualizationService} already uses for
+ * the chart wizard's live preview/thumbnail. Deliberately does NOT use the full
+ * {@code VSExportService} export pipeline (clones the whole viewsheet, force-refreshes every
+ * assembly, writes a temp file) — confirmed overkill for "one chart's current render," and that
+ * pipeline is only meant as an expensive fallback for assembly types this path doesn't support
+ * (Crosstab/Table), which is out of scope here since only charts are addressable as script
+ * targets anyway.</p>
+ */
+@Service
+public class ScriptImageService {
+
+   // Matches WizVisualizationService.DEFAULT_RENDER_WIDTH/HEIGHT — legible legends/axis labels
+   // at a reasonable base64 token cost (~40-110K chars for an 800x600 PNG).
+   private static final int DEFAULT_WIDTH = 800;
+   private static final int DEFAULT_HEIGHT = 600;
+
+   // Tighter than AssemblyImageService's browser-facing callers ever need — this response goes
+   // into an LLM's context budget, not a monitor.
+   private static final int MAX_DIMENSION = 1600;
+
+   // Mirrors WizVisualizationService.RENDER_MAX_ATTEMPTS/RENDER_RETRY_SLEEP_MS exactly.
+   private static final int RENDER_MAX_ATTEMPTS = 4;
+   private static final long RENDER_RETRY_SLEEP_MS = 500;
+
+   @Autowired
+   public ScriptImageService(AssemblyImageService assemblyImageService,
+                             BinaryTransferService binaryTransferService)
+   {
+      this.assemblyImageService = assemblyImageService;
+      this.binaryTransferService = binaryTransferService;
+   }
+
+   public record ChartImage(byte[] pngBytes, boolean isPng, int width, int height) {}
+
+   /**
+    * @throws RenderNotReadyException if the chart's graph hasn't finished computing after
+    *         {@value #RENDER_MAX_ATTEMPTS} retries — caller should map this to a retryable HTTP
+    *         status, not treat it as a hard failure.
+    * @throws PairingException if {@code assemblyName} doesn't exist or isn't a chart.
+    */
+   public ChartImage getChartImage(RuntimeViewsheet rvs, String assemblyName,
+                                   Integer width, Integer height, Principal principal)
+      throws Exception
+   {
+      Viewsheet vs = rvs.getViewsheet();
+
+      if(vs == null) {
+         throw new PairingException("Viewsheet not found in runtime");
+      }
+
+      Assembly assembly = vs.getAssembly(assemblyName);
+
+      if(!(assembly instanceof ChartVSAssembly)) {
+         throw new PairingException("\"" + assemblyName + "\" is not a chart assembly");
+      }
+
+      int w = clamp(width != null && width > 0 ? width : DEFAULT_WIDTH);
+      int h = clamp(height != null && height > 0 ? height : DEFAULT_HEIGHT);
+      String aid = Tool.byteEncode(assemblyName);
+
+      AssemblyImageService.ImageRenderResult result = null;
+
+      for(int attempt = 0; attempt < RENDER_MAX_ATTEMPTS; attempt++) {
+         result = assemblyImageService.processGetAssemblyImage(
+            rvs, aid, w, h, w, h, null, 0, 0, 0, principal, false, true);
+
+         if(result == null || result.getRetryAfter() <= 0) {
+            break;
+         }
+
+         Thread.sleep(RENDER_RETRY_SLEEP_MS);
+      }
+
+      if(result != null && result.getRetryAfter() > 0) {
+         throw new RenderNotReadyException(result.getRetryAfter());
+      }
+
+      if(result == null || result.getImageData() == null) {
+         throw new PairingException("Failed to render \"" + assemblyName + "\"");
+      }
+
+      byte[] bytes = binaryTransferService.getData(result.getImageData());
+
+      if(bytes == null || bytes.length == 0) {
+         throw new PairingException("Failed to render \"" + assemblyName + "\"");
+      }
+
+      // A 1x1 image is StyleBI's placeholder for assembly types downloadAssemblyImage doesn't
+      // support (see AssemblyImageService's "avoid a broken image on browser" fallback) — not
+      // expected here since we already required ChartVSAssembly above, but guard anyway rather
+      // than silently handing the agent a useless 1x1 PNG.
+      if(result.isPng()) {
+         BufferedImage decoded = ImageIO.read(new ByteArrayInputStream(bytes));
+
+         if(decoded == null || decoded.getWidth() <= 1 || decoded.getHeight() <= 1) {
+            throw new PairingException("\"" + assemblyName + "\" could not be rendered to an image");
+         }
+      }
+
+      return new ChartImage(bytes, result.isPng(), result.getWidth(), result.getHeight());
+   }
+
+   private static int clamp(int value) {
+      return Math.min(value, MAX_DIMENSION);
+   }
+
+   private final AssemblyImageService assemblyImageService;
+   private final BinaryTransferService binaryTransferService;
+}

--- a/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
@@ -29,13 +29,16 @@ import inetsoft.web.wiz.script.model.ScriptContext;
 import inetsoft.web.wiz.script.model.ScriptExecResult;
 import inetsoft.web.wiz.script.model.ScriptInfo;
 import inetsoft.web.wiz.script.model.ScriptTargetInfo;
+import inetsoft.web.wiz.service.RenderNotReadyException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.security.Principal;
+import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,6 +64,7 @@ public class ViewsheetAgentController {
                                    ScriptExecuteService executeService,
                                    ScriptContextService contextService,
                                    ScriptApiService apiService,
+                                   ScriptImageService imageService,
                                    ViewsheetService viewsheetService,
                                    SheetAgentBroadcastService broadcast)
    {
@@ -72,6 +76,7 @@ public class ViewsheetAgentController {
       this.executeService = executeService;
       this.contextService = contextService;
       this.apiService = apiService;
+      this.imageService = imageService;
       this.viewsheetService = viewsheetService;
       this.broadcast = broadcast;
    }
@@ -188,6 +193,40 @@ public class ViewsheetAgentController {
       return contextService.context(rvs);
    }
 
+   public record ChartImageResponse(String image, String format, int width, int height) {}
+
+   /**
+    * Renders {@code target}'s current state to a PNG snapshot — lets the agent actually see the
+    * effect of a script it just ran, instead of relying on the user to describe it. Chart
+    * assemblies only (see {@link ScriptImageService}).
+    *
+    * <p>Base64-encoded JSON, matching every other endpoint on this controller (rather than a raw
+    * {@code image/png} body) — the consumer here is an MCP tool call whose result becomes part of
+    * a structured tool response, not a browser {@code <img>} tag.</p>
+    */
+   @GetMapping("/api/wiz/v1/agent/script/{sessionToken}/chart-image")
+   public ChartImageResponse chartImage(@PathVariable String sessionToken,
+                                        @RequestParam String target,
+                                        @RequestParam(required = false) Integer width,
+                                        @RequestParam(required = false) Integer height,
+                                        Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      ScriptTarget t = ScriptTarget.parse(target);
+
+      if(t.location() != ScriptTarget.Location.ASSEMBLY) {
+         throw new PairingException("chart-image only supports assembly targets, not \"" +
+                                    target + "\"");
+      }
+
+      RuntimeViewsheet rvs = editService.resolve(sessionToken, user);
+      ScriptImageService.ChartImage img =
+         imageService.getChartImage(rvs, t.assemblyName(), width, height, user);
+      String base64 = Base64.getEncoder().encodeToString(img.pngBytes());
+      return new ChartImageResponse(base64, img.isPng() ? "png" : "svg", img.width(), img.height());
+   }
+
    /**
     * Best-effort static API metadata lookup (Layer A). Not session-scoped — mirrors
     * wiz-services' {@code GET /v1/agent/script/signature?name=} (no {@code sessionToken}).
@@ -284,6 +323,17 @@ public class ViewsheetAgentController {
       return ResponseEntity.status(status).body(body);
    }
 
+   /** The chart's graph hasn't finished computing yet — ask the caller to retry shortly. */
+   @ExceptionHandler(RenderNotReadyException.class)
+   public ResponseEntity<Map<String, String>> handleRenderNotReady(RenderNotReadyException e) {
+      Map<String, String> body = new LinkedHashMap<>();
+      body.put("error", e.getMessage());
+      body.put("errorCode", "RENDER_NOT_READY");
+      return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+         .header(HttpHeaders.RETRY_AFTER, String.valueOf(Math.max(1, e.getRetryAfter())))
+         .body(body);
+   }
+
    // ---------------------------------------------------------------------------
    // Dependencies
    // ---------------------------------------------------------------------------
@@ -296,6 +346,7 @@ public class ViewsheetAgentController {
    private final ScriptExecuteService executeService;
    private final ScriptContextService contextService;
    private final ScriptApiService apiService;
+   private final ScriptImageService imageService;
    private final ViewsheetService viewsheetService;
    private final SheetAgentBroadcastService broadcast;
 }

--- a/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
@@ -197,32 +197,41 @@ public class ViewsheetAgentController {
 
    /**
     * Renders {@code target}'s current state to a PNG snapshot — lets the agent actually see the
-    * effect of a script it just ran, instead of relying on the user to describe it. Chart
-    * assemblies only (see {@link ScriptImageService}).
+    * effect of a script it just ran, instead of relying on the user to describe it. When
+    * {@code target} is omitted, renders the whole viewsheet instead of one assembly (see
+    * {@link ScriptImageService#getViewsheetImage}). {@code target}, when given, must be an
+    * assembly target (not {@code vs-init}/{@code vs-load}/onClick, which aren't visual).
     *
     * <p>Base64-encoded JSON, matching every other endpoint on this controller (rather than a raw
     * {@code image/png} body) — the consumer here is an MCP tool call whose result becomes part of
     * a structured tool response, not a browser {@code <img>} tag.</p>
     */
-   @GetMapping("/api/wiz/v1/agent/script/{sessionToken}/chart-image")
-   public ChartImageResponse chartImage(@PathVariable String sessionToken,
-                                        @RequestParam String target,
-                                        @RequestParam(required = false) Integer width,
-                                        @RequestParam(required = false) Integer height,
-                                        Principal user)
+   @GetMapping("/api/wiz/v1/agent/script/{sessionToken}/image")
+   public ChartImageResponse image(@PathVariable String sessionToken,
+                                   @RequestParam(required = false) String target,
+                                   @RequestParam(required = false) Integer width,
+                                   @RequestParam(required = false) Integer height,
+                                   Principal user)
       throws Exception
    {
       requireEnabled();
-      ScriptTarget t = ScriptTarget.parse(target);
+      RuntimeViewsheet rvs = editService.resolve(sessionToken, user);
+      ScriptImageService.ChartImage img;
 
-      if(t.location() != ScriptTarget.Location.ASSEMBLY) {
-         throw new PairingException("chart-image only supports assembly targets, not \"" +
-                                    target + "\"");
+      if(target == null || target.isBlank()) {
+         img = imageService.getViewsheetImage(rvs, width, height, user);
+      }
+      else {
+         ScriptTarget t = ScriptTarget.parse(target);
+
+         if(t.location() != ScriptTarget.Location.ASSEMBLY) {
+            throw new PairingException("image only supports assembly targets (or no target, " +
+                                       "for the whole viewsheet), not \"" + target + "\"");
+         }
+
+         img = imageService.getAssemblyImage(rvs, t.assemblyName(), width, height, user);
       }
 
-      RuntimeViewsheet rvs = editService.resolve(sessionToken, user);
-      ScriptImageService.ChartImage img =
-         imageService.getChartImage(rvs, t.assemblyName(), width, height, user);
       String base64 = Base64.getEncoder().encodeToString(img.pngBytes());
       return new ChartImageResponse(base64, img.isPng() ? "png" : "svg", img.width(), img.height());
    }

--- a/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
@@ -193,7 +193,11 @@ public class ViewsheetAgentController {
       return contextService.context(rvs);
    }
 
-   public record ChartImageResponse(String image, String format, int width, int height) {}
+   /**
+    * @param note non-null when a requested assembly couldn't be rendered on its own and this
+    *        image is the whole viewsheet instead — see {@link ScriptImageService.ChartImage}.
+    */
+   public record ChartImageResponse(String image, String format, int width, int height, String note) {}
 
    /**
     * Renders {@code target}'s current state to a PNG snapshot — lets the agent actually see the
@@ -233,7 +237,8 @@ public class ViewsheetAgentController {
       }
 
       String base64 = Base64.getEncoder().encodeToString(img.pngBytes());
-      return new ChartImageResponse(base64, img.isPng() ? "png" : "svg", img.width(), img.height());
+      return new ChartImageResponse(base64, img.isPng() ? "png" : "svg", img.width(), img.height(),
+                                    img.note());
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
@@ -23,6 +23,8 @@ import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.util.cachefs.BinaryTransfer;
 import inetsoft.web.service.BinaryTransferService;
 import inetsoft.web.viewsheet.controller.AssemblyImageService;
+import inetsoft.web.viewsheet.service.ExportResponse;
+import inetsoft.web.viewsheet.service.VSExportService;
 import inetsoft.web.wiz.pairing.PairingException;
 import inetsoft.web.wiz.pairing.TestPrincipals;
 import inetsoft.web.wiz.pairing.WizAgentTestSupport;
@@ -30,6 +32,8 @@ import inetsoft.web.wiz.service.RenderNotReadyException;
 import org.junit.jupiter.api.Test;
 
 import javax.imageio.ImageIO;
+import java.awt.Dimension;
+import java.awt.Point;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.security.Principal;
@@ -57,16 +61,27 @@ class ScriptImageServiceTest {
       return rvs;
    }
 
+   /** Stubs a VSExportService mock to write {@code fullPng} into whatever ExportResponse it's given. */
+   private static void stubExport(VSExportService exportService, byte[] fullPng) throws Exception {
+      doAnswer(invocation -> {
+         ExportResponse response = invocation.getArgument(9);
+         response.getOutputStream().write(fullPng);
+         return null;
+      }).when(exportService).exportViewsheet(
+         any(), anyInt(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(),
+         any(), anyBoolean(), any(ExportResponse.class), any());
+   }
+
    @Test
-   void rejectsATargetThatIsNotAChart() {
+   void rejectsANonExistentAssembly() {
       Viewsheet vs = new Viewsheet();
       RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
       when(rvs.getViewsheet()).thenReturn(vs);
 
       ScriptImageService svc = new ScriptImageService(
-         mock(AssemblyImageService.class), mock(BinaryTransferService.class));
+         mock(AssemblyImageService.class), mock(BinaryTransferService.class), mock(VSExportService.class));
 
-      assertThrows(PairingException.class, () -> svc.getChartImage(
+      assertThrows(PairingException.class, () -> svc.getAssemblyImage(
          rvs, "NoSuchAssembly", null, null, TestPrincipals.user("alice", "host-org")));
    }
 
@@ -87,8 +102,9 @@ class ScriptImageServiceTest {
       BinaryTransferService binaryTransferService = mock(BinaryTransferService.class);
       when(binaryTransferService.getData(transfer)).thenReturn(png);
 
-      ScriptImageService svc = new ScriptImageService(imageService, binaryTransferService);
-      ScriptImageService.ChartImage img = svc.getChartImage(
+      ScriptImageService svc = new ScriptImageService(
+         imageService, binaryTransferService, mock(VSExportService.class));
+      ScriptImageService.ChartImage img = svc.getAssemblyImage(
          rvs, "Chart1", null, null, TestPrincipals.user("alice", "host-org"));
 
       assertArrayEquals(png, img.pngBytes());
@@ -115,8 +131,9 @@ class ScriptImageServiceTest {
       BinaryTransferService binaryTransferService = mock(BinaryTransferService.class);
       when(binaryTransferService.getData(transfer)).thenReturn(png);
 
-      ScriptImageService svc = new ScriptImageService(imageService, binaryTransferService);
-      ScriptImageService.ChartImage img = svc.getChartImage(
+      ScriptImageService svc = new ScriptImageService(
+         imageService, binaryTransferService, mock(VSExportService.class));
+      ScriptImageService.ChartImage img = svc.getAssemblyImage(
          rvs, "Chart1", 3000, 3000, TestPrincipals.user("alice", "host-org"));
 
       assertEquals(1600, img.width());
@@ -136,9 +153,10 @@ class ScriptImageServiceTest {
          isNull(), eq(0), eq(0), eq(0), any(), eq(false), eq(true)))
          .thenReturn(notReady);
 
-      ScriptImageService svc = new ScriptImageService(imageService, mock(BinaryTransferService.class));
+      ScriptImageService svc = new ScriptImageService(
+         imageService, mock(BinaryTransferService.class), mock(VSExportService.class));
 
-      RenderNotReadyException ex = assertThrows(RenderNotReadyException.class, () -> svc.getChartImage(
+      RenderNotReadyException ex = assertThrows(RenderNotReadyException.class, () -> svc.getAssemblyImage(
          rvs, "Chart1", null, null, TestPrincipals.user("alice", "host-org")));
       assertEquals(1, ex.getRetryAfter());
       // 4 attempts per the mirrored WizVisualizationService retry constant.
@@ -148,8 +166,13 @@ class ScriptImageServiceTest {
    }
 
    @Test
-   void rejectsA1x1PlaceholderImageInsteadOfSilentlyReturningIt() throws Exception {
-      RuntimeViewsheet rvs = viewsheetWithChart("Chart1");
+   void fallsBackToExportAndCropWhenTheLightweightPathReturnsAPlaceholder() throws Exception {
+      RuntimeViewsheet rvs = viewsheetWithChart("Table1");
+      ChartVSAssembly assembly =
+         (ChartVSAssembly) rvs.getViewsheet().getAssembly("Table1");
+      assembly.setPixelOffset(new Point(10, 20));
+      assembly.setPixelSize(new Dimension(200, 100));
+
       byte[] placeholder = fakePng(1, 1);
       BinaryTransfer transfer = mock(BinaryTransfer.class);
       AssemblyImageService.ImageRenderResult result =
@@ -164,9 +187,77 @@ class ScriptImageServiceTest {
       BinaryTransferService binaryTransferService = mock(BinaryTransferService.class);
       when(binaryTransferService.getData(transfer)).thenReturn(placeholder);
 
-      ScriptImageService svc = new ScriptImageService(imageService, binaryTransferService);
+      VSExportService exportService = mock(VSExportService.class);
+      byte[] fullSheetPng = fakePng(400, 300);
+      stubExport(exportService, fullSheetPng);
 
-      assertThrows(PairingException.class, () -> svc.getChartImage(
-         rvs, "Chart1", null, null, TestPrincipals.user("alice", "host-org")));
+      ScriptImageService svc = new ScriptImageService(imageService, binaryTransferService, exportService);
+      ScriptImageService.ChartImage img = svc.getAssemblyImage(
+         rvs, "Table1", null, null, TestPrincipals.user("alice", "host-org"));
+
+      assertTrue(img.isPng());
+      assertEquals(200, img.width());
+      assertEquals(100, img.height());
+   }
+
+   @Test
+   void exportFallbackRejectsAnAssemblyWithNoSize() throws Exception {
+      RuntimeViewsheet rvs = viewsheetWithChart("Table1");
+      ChartVSAssembly assembly = (ChartVSAssembly) rvs.getViewsheet().getAssembly("Table1");
+      assembly.setPixelSize(new Dimension(0, 0));
+
+      byte[] placeholder = fakePng(1, 1);
+      BinaryTransfer transfer = mock(BinaryTransfer.class);
+      AssemblyImageService.ImageRenderResult result =
+         new AssemblyImageService.ImageRenderResult(true, transfer, 1, 1);
+
+      AssemblyImageService imageService = mock(AssemblyImageService.class);
+      when(imageService.processGetAssemblyImage(
+         eq(rvs), anyString(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+         isNull(), eq(0), eq(0), eq(0), any(), eq(false), eq(true)))
+         .thenReturn(result);
+
+      BinaryTransferService binaryTransferService = mock(BinaryTransferService.class);
+      when(binaryTransferService.getData(transfer)).thenReturn(placeholder);
+
+      ScriptImageService svc = new ScriptImageService(
+         imageService, binaryTransferService, mock(VSExportService.class));
+
+      assertThrows(PairingException.class, () -> svc.getAssemblyImage(
+         rvs, "Table1", null, null, TestPrincipals.user("alice", "host-org")));
+   }
+
+   @Test
+   void getViewsheetImageExportsTheWholeSheetAndScalesToFit() throws Exception {
+      RuntimeViewsheet rvs = viewsheetWithChart("Chart1");
+      VSExportService exportService = mock(VSExportService.class);
+      byte[] fullSheetPng = fakePng(3200, 2400);
+      stubExport(exportService, fullSheetPng);
+
+      ScriptImageService svc = new ScriptImageService(
+         mock(AssemblyImageService.class), mock(BinaryTransferService.class), exportService);
+      ScriptImageService.ChartImage img = svc.getViewsheetImage(
+         rvs, null, null, TestPrincipals.user("alice", "host-org"));
+
+      assertTrue(img.isPng());
+      // Downscaled to fit the default 800x600 cap, preserving the 4:3 aspect ratio.
+      assertEquals(800, img.width());
+      assertEquals(600, img.height());
+   }
+
+   @Test
+   void getViewsheetImageDoesNotUpscaleASmallExport() throws Exception {
+      RuntimeViewsheet rvs = viewsheetWithChart("Chart1");
+      VSExportService exportService = mock(VSExportService.class);
+      byte[] fullSheetPng = fakePng(200, 150);
+      stubExport(exportService, fullSheetPng);
+
+      ScriptImageService svc = new ScriptImageService(
+         mock(AssemblyImageService.class), mock(BinaryTransferService.class), exportService);
+      ScriptImageService.ChartImage img = svc.getViewsheetImage(
+         rvs, null, null, TestPrincipals.user("alice", "host-org"));
+
+      assertEquals(200, img.width());
+      assertEquals(150, img.height());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
@@ -166,7 +166,7 @@ class ScriptImageServiceTest {
    }
 
    @Test
-   void fallsBackToExportAndCropWhenTheLightweightPathReturnsAPlaceholder() throws Exception {
+   void fallsBackToTheWholeViewsheetWhenTheLightweightPathReturnsAPlaceholder() throws Exception {
       RuntimeViewsheet rvs = viewsheetWithChart("Table1");
       ChartVSAssembly assembly =
          (ChartVSAssembly) rvs.getViewsheet().getAssembly("Table1");
@@ -187,6 +187,8 @@ class ScriptImageServiceTest {
       BinaryTransferService binaryTransferService = mock(BinaryTransferService.class);
       when(binaryTransferService.getData(transfer)).thenReturn(placeholder);
 
+      // Deliberately does NOT match the assembly's pixelOffset/pixelSize above — the fallback no
+      // longer crops, so the full export is returned (scaled to fit) regardless of assembly geometry.
       VSExportService exportService = mock(VSExportService.class);
       byte[] fullSheetPng = fakePng(400, 300);
       stubExport(exportService, fullSheetPng);
@@ -196,35 +198,35 @@ class ScriptImageServiceTest {
          rvs, "Table1", null, null, TestPrincipals.user("alice", "host-org"));
 
       assertTrue(img.isPng());
-      assertEquals(200, img.width());
-      assertEquals(100, img.height());
+      assertEquals(400, img.width());
+      assertEquals(300, img.height());
+      assertNotNull(img.note());
+      assertTrue(img.note().contains("Table1"));
    }
 
    @Test
-   void exportFallbackRejectsAnAssemblyWithNoSize() throws Exception {
-      RuntimeViewsheet rvs = viewsheetWithChart("Table1");
-      ChartVSAssembly assembly = (ChartVSAssembly) rvs.getViewsheet().getAssembly("Table1");
-      assembly.setPixelSize(new Dimension(0, 0));
-
-      byte[] placeholder = fakePng(1, 1);
+   void successfulRenderHasNoNote() throws Exception {
+      RuntimeViewsheet rvs = viewsheetWithChart("Chart1");
+      byte[] png = fakePng(800, 600);
       BinaryTransfer transfer = mock(BinaryTransfer.class);
       AssemblyImageService.ImageRenderResult result =
-         new AssemblyImageService.ImageRenderResult(true, transfer, 1, 1);
+         new AssemblyImageService.ImageRenderResult(true, transfer, 800, 600);
 
       AssemblyImageService imageService = mock(AssemblyImageService.class);
       when(imageService.processGetAssemblyImage(
-         eq(rvs), anyString(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+         eq(rvs), anyString(), eq(800.0), eq(600.0), eq(800.0), eq(600.0),
          isNull(), eq(0), eq(0), eq(0), any(), eq(false), eq(true)))
          .thenReturn(result);
 
       BinaryTransferService binaryTransferService = mock(BinaryTransferService.class);
-      when(binaryTransferService.getData(transfer)).thenReturn(placeholder);
+      when(binaryTransferService.getData(transfer)).thenReturn(png);
 
       ScriptImageService svc = new ScriptImageService(
          imageService, binaryTransferService, mock(VSExportService.class));
+      ScriptImageService.ChartImage img = svc.getAssemblyImage(
+         rvs, "Chart1", null, null, TestPrincipals.user("alice", "host-org"));
 
-      assertThrows(PairingException.class, () -> svc.getAssemblyImage(
-         rvs, "Table1", null, null, TestPrincipals.user("alice", "host-org")));
+      assertNull(img.note());
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
@@ -1,0 +1,172 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.script;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.util.cachefs.BinaryTransfer;
+import inetsoft.web.service.BinaryTransferService;
+import inetsoft.web.viewsheet.controller.AssemblyImageService;
+import inetsoft.web.wiz.pairing.PairingException;
+import inetsoft.web.wiz.pairing.TestPrincipals;
+import inetsoft.web.wiz.pairing.WizAgentTestSupport;
+import inetsoft.web.wiz.service.RenderNotReadyException;
+import org.junit.jupiter.api.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@WizAgentTestSupport
+class ScriptImageServiceTest {
+
+   private static byte[] fakePng(int w, int h) throws Exception {
+      BufferedImage img = new BufferedImage(w, h, BufferedImage.TYPE_INT_RGB);
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      ImageIO.write(img, "png", out);
+      return out.toByteArray();
+   }
+
+   private RuntimeViewsheet viewsheetWithChart(String chartName) {
+      Viewsheet vs = new Viewsheet();
+      vs.addAssembly(new ChartVSAssembly(vs, chartName));
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      return rvs;
+   }
+
+   @Test
+   void rejectsATargetThatIsNotAChart() {
+      Viewsheet vs = new Viewsheet();
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ScriptImageService svc = new ScriptImageService(
+         mock(AssemblyImageService.class), mock(BinaryTransferService.class));
+
+      assertThrows(PairingException.class, () -> svc.getChartImage(
+         rvs, "NoSuchAssembly", null, null, TestPrincipals.user("alice", "host-org")));
+   }
+
+   @Test
+   void returnsThePngOnASuccessfulRender() throws Exception {
+      RuntimeViewsheet rvs = viewsheetWithChart("Chart1");
+      byte[] png = fakePng(800, 600);
+      BinaryTransfer transfer = mock(BinaryTransfer.class);
+      AssemblyImageService.ImageRenderResult result =
+         new AssemblyImageService.ImageRenderResult(true, transfer, 800, 600);
+
+      AssemblyImageService imageService = mock(AssemblyImageService.class);
+      when(imageService.processGetAssemblyImage(
+         eq(rvs), anyString(), eq(800.0), eq(600.0), eq(800.0), eq(600.0),
+         isNull(), eq(0), eq(0), eq(0), any(), eq(false), eq(true)))
+         .thenReturn(result);
+
+      BinaryTransferService binaryTransferService = mock(BinaryTransferService.class);
+      when(binaryTransferService.getData(transfer)).thenReturn(png);
+
+      ScriptImageService svc = new ScriptImageService(imageService, binaryTransferService);
+      ScriptImageService.ChartImage img = svc.getChartImage(
+         rvs, "Chart1", null, null, TestPrincipals.user("alice", "host-org"));
+
+      assertArrayEquals(png, img.pngBytes());
+      assertTrue(img.isPng());
+      assertEquals(800, img.width());
+      assertEquals(600, img.height());
+   }
+
+   @Test
+   void clampsCallerSuppliedSizeToTheMaxDimension() throws Exception {
+      RuntimeViewsheet rvs = viewsheetWithChart("Chart1");
+      byte[] png = fakePng(1600, 1600);
+      BinaryTransfer transfer = mock(BinaryTransfer.class);
+      AssemblyImageService.ImageRenderResult result =
+         new AssemblyImageService.ImageRenderResult(true, transfer, 1600, 1600);
+
+      AssemblyImageService imageService = mock(AssemblyImageService.class);
+      // 3000x3000 requested; should be clamped to 1600x1600 before reaching the image service.
+      when(imageService.processGetAssemblyImage(
+         eq(rvs), anyString(), eq(1600.0), eq(1600.0), eq(1600.0), eq(1600.0),
+         isNull(), eq(0), eq(0), eq(0), any(), eq(false), eq(true)))
+         .thenReturn(result);
+
+      BinaryTransferService binaryTransferService = mock(BinaryTransferService.class);
+      when(binaryTransferService.getData(transfer)).thenReturn(png);
+
+      ScriptImageService svc = new ScriptImageService(imageService, binaryTransferService);
+      ScriptImageService.ChartImage img = svc.getChartImage(
+         rvs, "Chart1", 3000, 3000, TestPrincipals.user("alice", "host-org"));
+
+      assertEquals(1600, img.width());
+      verify(imageService).processGetAssemblyImage(
+         eq(rvs), anyString(), eq(1600.0), eq(1600.0), eq(1600.0), eq(1600.0),
+         isNull(), eq(0), eq(0), eq(0), any(), eq(false), eq(true));
+   }
+
+   @Test
+   void throwsRenderNotReadyAfterExhaustingRetries() throws Exception {
+      RuntimeViewsheet rvs = viewsheetWithChart("Chart1");
+      AssemblyImageService.ImageRenderResult notReady = new AssemblyImageService.ImageRenderResult(1);
+
+      AssemblyImageService imageService = mock(AssemblyImageService.class);
+      when(imageService.processGetAssemblyImage(
+         eq(rvs), anyString(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+         isNull(), eq(0), eq(0), eq(0), any(), eq(false), eq(true)))
+         .thenReturn(notReady);
+
+      ScriptImageService svc = new ScriptImageService(imageService, mock(BinaryTransferService.class));
+
+      RenderNotReadyException ex = assertThrows(RenderNotReadyException.class, () -> svc.getChartImage(
+         rvs, "Chart1", null, null, TestPrincipals.user("alice", "host-org")));
+      assertEquals(1, ex.getRetryAfter());
+      // 4 attempts per the mirrored WizVisualizationService retry constant.
+      verify(imageService, times(4)).processGetAssemblyImage(
+         eq(rvs), anyString(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+         isNull(), eq(0), eq(0), eq(0), any(), eq(false), eq(true));
+   }
+
+   @Test
+   void rejectsA1x1PlaceholderImageInsteadOfSilentlyReturningIt() throws Exception {
+      RuntimeViewsheet rvs = viewsheetWithChart("Chart1");
+      byte[] placeholder = fakePng(1, 1);
+      BinaryTransfer transfer = mock(BinaryTransfer.class);
+      AssemblyImageService.ImageRenderResult result =
+         new AssemblyImageService.ImageRenderResult(true, transfer, 1, 1);
+
+      AssemblyImageService imageService = mock(AssemblyImageService.class);
+      when(imageService.processGetAssemblyImage(
+         eq(rvs), anyString(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+         isNull(), eq(0), eq(0), eq(0), any(), eq(false), eq(true)))
+         .thenReturn(result);
+
+      BinaryTransferService binaryTransferService = mock(BinaryTransferService.class);
+      when(binaryTransferService.getData(transfer)).thenReturn(placeholder);
+
+      ScriptImageService svc = new ScriptImageService(imageService, binaryTransferService);
+
+      assertThrows(PairingException.class, () -> svc.getChartImage(
+         rvs, "Chart1", null, null, TestPrincipals.user("alice", "host-org")));
+   }
+}


### PR DESCRIPTION
## Summary

- **`ScriptImageService`**: renders any assembly (chart, gauge, etc.) to PNG via `AssemblyImageService`; falls back to full-viewsheet export for types the lightweight path doesn't support (tables, crosstabs), with a `note` field on the response indicating the fallback occurred. 4-retry loop (500 ms) handles charts whose `VGraphPair` hasn't finished computing yet.
- **`ViewsheetAgentController`** (`GET /api/wiz/v1/agent/script/{sessionToken}/image`): new endpoint with optional `target` (assembly:Name), `width`, `height` query params; maps `RenderNotReadyException` → 503 with `Retry-After`.
- **`ScriptApiService`**: extract `ObjectMapper` to `static final` field (thread-safe reuse).
- Full test coverage: `ScriptImageServiceTest` (retry-loop, size clamping, fallback detection).

## Test plan

- [ ] `mvn -pl community/core test -Dtest="inetsoft.web.wiz.script.**"` — all script tests pass
- [ ] Live: connect to a viewsheet, call `get_viewsheet_image` with a chart assembly — image returns
- [ ] Live: call with a table assembly — whole-viewsheet fallback + `note` field present
- [ ] Live: call without `target` — whole viewsheet renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)
