### PR TITLE
fix(wiz): render per-chart dashboard filters as compact dropdowns

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -286,6 +286,13 @@ public class WizDashboardFilterBuilder {
       // (date/numeric) has no show type and is already single-row, so it is deliberately untouched.
       if(control instanceof SelectionListVSAssembly list) {
          list.setShowTypeValue(SelectionVSAssemblyInfo.DROPDOWN_SHOW_TYPE);
+         // A dropdown draws ONLY its title row and ignores the rest of the assembly's pixel height
+         // (default AssetUtil.defh = 20). Anything reserved beyond what the row draws shows up as a
+         // GAP between the filter and its chart, breaking the single-enclosing-card look
+         // applyGroupedCardStyle builds. Pin the row to the caller's reserved height so the two agree
+         // by construction instead of relying on two constants happening to match. The DESIGN value
+         // (not the runtime one) is set because a composed dashboard is saved and reopened.
+         list.getSelectionListInfo().setTitleHeightValue(height);
       }
 
       if(request.label() != null && control instanceof TitledVSAssembly titled) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -24,6 +24,7 @@ import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.RectangleVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.SelectionVSAssemblyInfo;
 import org.springframework.stereotype.Component;
 
 import java.awt.Color;
@@ -275,6 +276,17 @@ public class WizDashboardFilterBuilder {
 
       ColumnRef colRef = AddFilterService.buildColumnRef(request.field(), request.dataType());
       AbstractSelectionVSAssembly control = createControlForType(vs, request.dataType(), colRef);
+
+      // A per-chart control lives INSIDE its chart's tile, so a multi-row checkbox list steals
+      // that height from the chart itself (four such filters cost ~480px on a five-chart board).
+      // Dropdown mode collapses it to a single title row -- SelectionListVSAssemblyInfo#getSizeScale
+      // pins the Y scale to 1 in that mode, so it cannot stretch back open. Applied HERE rather than
+      // in createControlForType because that factory delegates to AddFilterService, whose own
+      // interactive add-filter flow must keep StyleBI's default list rendering. A TimeSliderVSAssembly
+      // (date/numeric) has no show type and is already single-row, so it is deliberately untouched.
+      if(control instanceof SelectionListVSAssembly list) {
+         list.setShowTypeValue(SelectionVSAssemblyInfo.DROPDOWN_SHOW_TYPE);
+      }
 
       if(request.label() != null && control instanceof TitledVSAssembly titled) {
          titled.setTitleValue(request.label());

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -594,10 +594,15 @@ public class WizDashboardService {
     *  grows to make room. See {@link #closeBand}/{@link GridLayoutResult} for the exact scoping
     *  (deliberately NOT "every tile in the band," which would shift unrelated charts stacked
     *  anywhere below an unrelated filtered one in the common single-column dashboard shape).
-    *  {@link WizDashboardFilterBuilder#buildPerChart} sizes its control to this full height (its
-    *  own selection list can show several category checkboxes), independent of the deliberately
-    *  more compact shared filter bar ({@link WizDashboardFilterBuilder}'s FILTER_CONTROL_HEIGHT). */
-   private static final int PER_CHART_FILTER_ROW_HEIGHT = 120;
+    *  {@link WizDashboardFilterBuilder#buildPerChart} sizes its control to this height and renders
+    *  it as a DROPDOWN (one title row) rather than an open checkbox list, so this only has to cover
+    *  a single collapsed control -- not several visible category rows. It was 120 while those
+    *  controls rendered as open lists, which cost ~480px of pure filter chrome on a board with four
+    *  per-chart filters; the shared filter bar stays separately sized by
+    *  {@link WizDashboardFilterBuilder}'s FILTER_CONTROL_HEIGHT.
+    *  Package-private (matching {@link #FILTER_BAR_ROW_HEIGHT}) so the grid tests assert geometry
+    *  against the constant instead of a literal that silently rots when this is tuned. */
+   static final int PER_CHART_FILTER_ROW_HEIGHT = 40;
 
    /**
     * The rendered pixel size for a tile spanning {@code spanCols} columns and {@code spanRows}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -602,7 +602,7 @@ public class WizDashboardService {
     *  {@link WizDashboardFilterBuilder}'s FILTER_CONTROL_HEIGHT.
     *  Package-private (matching {@link #FILTER_BAR_ROW_HEIGHT}) so the grid tests assert geometry
     *  against the constant instead of a literal that silently rots when this is tuned. */
-   static final int PER_CHART_FILTER_ROW_HEIGHT = 40;
+   static final int PER_CHART_FILTER_ROW_HEIGHT = 28;
 
    /**
     * The rendered pixel size for a tile spanning {@code spanCols} columns and {@code spanRows}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -98,6 +98,30 @@ class WizDashboardFilterBuilderTest {
    }
 
    @Test
+   void perChartDropdownTitleRowFillsTheReservedHeightSoNoGapShowsAboveTheChart() {
+      // A dropdown draws ONLY its title row (default AssetUtil.defh = 20), ignoring the rest of the
+      // assembly's pixel height. Reserving more than the row draws leaves the difference as a visible
+      // gap between the filter and the chart it belongs to, breaking the single-enclosing-card look
+      // applyGroupedCardStyle creates. Pin the title row to the reserved height so the two agree by
+      // construction rather than by two magic numbers happening to match.
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name"));
+
+      Viewsheet vs = new Viewsheet();
+
+      builder.buildPerChart(vs, ws, 100, 200, 640, 28,
+         new WizDashboardFilterBuilder.FilterRequest("category_name", "string", "Category"), "CHART_FINAL", null);
+
+      SelectionListVSAssembly control = java.util.Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof SelectionListVSAssembly)
+         .map(a -> (SelectionListVSAssembly) a)
+         .findFirst().orElseThrow();
+      // The DESIGN value is the one that survives save/reopen, which is how a composed dashboard is used.
+      assertEquals(28, control.getSelectionListInfo().getTitleHeightValue(),
+         "the dropdown's title row must fill the reserved height exactly, or the leftover shows as a gap");
+   }
+
+   @Test
    void perChartRangeSliderIsLeftAloneByTheDropdownTreatment() {
       // TimeSlider has no show type -- it is already a single-row control. The dropdown
       // treatment must not touch it (or throw when it is the control that was created).

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -28,6 +28,7 @@ import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.SelectionVSAssemblyInfo;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,6 +62,56 @@ class WizDashboardFilterBuilderTest {
       Viewsheet vs = new Viewsheet();
       assertTrue(builder.createControlForType(vs, "date", column("OrderDate", "date")) instanceof TimeSliderVSAssembly);
       assertTrue(builder.createControlForType(vs, "integer", column("Qty", "integer")) instanceof TimeSliderVSAssembly);
+   }
+
+   @Test
+   void theSharedFilterFactoryStaysInListModeForOtherCallers() {
+      // createControlForType delegates to AddFilterService.createFilterAssembly, which the
+      // non-dashboard add-filter flow also uses. Dashboard compaction must NOT leak into it.
+      Viewsheet vs = new Viewsheet();
+      SelectionListVSAssembly a =
+         (SelectionListVSAssembly) builder.createControlForType(vs, "string", column("Region", "string"));
+      assertEquals(SelectionVSAssemblyInfo.LIST_SHOW_TYPE, a.getSelectionListInfo().getShowType(),
+         "the shared factory must keep StyleBI's default list rendering");
+   }
+
+   @Test
+   void perChartCategoricalFilterRendersAsADropdownNotATallList() {
+      // A per-chart filter sits INSIDE its chart's tile, so a multi-row checkbox list steals
+      // height from the chart itself. Dropdown mode collapses it to a single title row
+      // (SelectionListVSAssemblyInfo#getSizeScale pins the Y scale to 1 in that mode).
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name"));
+
+      Viewsheet vs = new Viewsheet();
+
+      WizDashboardFilterBuilder.FilterControlPlacement placement = builder.buildPerChart(vs, ws, 100, 200, 640, 40,
+         new WizDashboardFilterBuilder.FilterRequest("category_name", "string", "Category"), "CHART_FINAL", null);
+
+      assertNotNull(placement);
+      SelectionListVSAssembly control = java.util.Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof SelectionListVSAssembly)
+         .map(a -> (SelectionListVSAssembly) a)
+         .findFirst().orElseThrow();
+      assertEquals(SelectionVSAssemblyInfo.DROPDOWN_SHOW_TYPE, control.getSelectionListInfo().getShowType(),
+         "a per-chart categorical filter must render as a dropdown, not a multi-row list");
+   }
+
+   @Test
+   void perChartRangeSliderIsLeftAloneByTheDropdownTreatment() {
+      // TimeSlider has no show type -- it is already a single-row control. The dropdown
+      // treatment must not touch it (or throw when it is the control that was created).
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "CHART_FINAL", "order_qty"));
+
+      Viewsheet vs = new Viewsheet();
+
+      WizDashboardFilterBuilder.FilterControlPlacement placement = builder.buildPerChart(vs, ws, 0, 0, 640, 40,
+         new WizDashboardFilterBuilder.FilterRequest("order_qty", "integer", "Qty"), "CHART_FINAL", null);
+
+      assertNotNull(placement);
+      assertTrue(java.util.Arrays.stream(vs.getAssemblies()).anyMatch(a -> a instanceof TimeSliderVSAssembly),
+         "a numeric per-chart filter must still be a range slider");
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardServiceGridTest.java
@@ -123,14 +123,18 @@ class WizDashboardServiceGridTest {
          WizDashboardService.computeGridLayout(spans, rowSpans, hasFilter, 2);
       List<WizDashboardService.TilePlacement> placements = result.placements();
 
+      // Derived from the constant, not hardcoded: the reserved per-chart filter height is tuned
+      // (it shrank once its control became a dropdown), and literals here silently rot when it is.
+      final int filterH = WizDashboardService.PER_CHART_FILTER_ROW_HEIGHT;
+
       assertEquals(new WizDashboardService.TilePlacement(0, 0, 640, 420), placements.get(0));     // A -- untouched
-      assertEquals(new WizDashboardService.TilePlacement(664, 0, 640, 984), placements.get(1));   // B -- stretched to match column 0
-      assertEquals(new WizDashboardService.TilePlacement(0, 444, 640, 540), placements.get(2));   // C -- its own filter height
-      assertEquals(new WizDashboardService.TilePlacement(0, 1008, 900, 420), placements.get(3));  // D -- fresh band
+      assertEquals(new WizDashboardService.TilePlacement(664, 0, 640, 864 + filterH), placements.get(1));   // B -- stretched to match column 0
+      assertEquals(new WizDashboardService.TilePlacement(0, 444, 640, 420 + filterH), placements.get(2));   // C -- its own filter height
+      assertEquals(new WizDashboardService.TilePlacement(0, 888 + filterH, 900, 420), placements.get(3));   // D -- fresh band
 
       assertEquals(0, result.headerHeights()[0], "A owns no filter and has no misaligned sibling");
       assertEquals(0, result.headerHeights()[1], "B owns no filter and has no misaligned sibling");
-      assertEquals(120, result.headerHeights()[2], "C owns the filter directly");
+      assertEquals(filterH, result.headerHeights()[2], "C owns the filter directly");
       assertEquals(0, result.headerHeights()[3]);
    }
 
@@ -153,11 +157,12 @@ class WizDashboardServiceGridTest {
       assertEquals(new WizDashboardService.TilePlacement(0, 0, 640, 420), placements.get(0),
          "the first tile must be completely unaffected by a filter buried deeper in the same column");
       assertEquals(new WizDashboardService.TilePlacement(0, 444, 640, 420), placements.get(1));
-      assertEquals(new WizDashboardService.TilePlacement(0, 888, 640, 540), placements.get(2));
+      assertEquals(new WizDashboardService.TilePlacement(0, 888, 640,
+         420 + WizDashboardService.PER_CHART_FILTER_ROW_HEIGHT), placements.get(2));
 
       assertEquals(0, result.headerHeights()[0]);
       assertEquals(0, result.headerHeights()[1]);
-      assertEquals(120, result.headerHeights()[2]);
+      assertEquals(WizDashboardService.PER_CHART_FILTER_ROW_HEIGHT, result.headerHeights()[2]);
    }
 
    @Test
@@ -174,10 +179,12 @@ class WizDashboardServiceGridTest {
          WizDashboardService.computeGridLayout(spans, rowSpans, hasFilter, 2);
       List<WizDashboardService.TilePlacement> placements = result.placements();
 
-      assertEquals(new WizDashboardService.TilePlacement(0, 0, 640, 540), placements.get(0));     // A -- 420 + its own 120
-      assertEquals(new WizDashboardService.TilePlacement(664, 0, 640, 540), placements.get(1));   // B -- 420 + alignment top-up
-      assertEquals(120, result.headerHeights()[0], "A owns the filter");
-      assertEquals(120, result.headerHeights()[1], "B has no filter but aligns with its side-by-side sibling A");
+      final int filterH = WizDashboardService.PER_CHART_FILTER_ROW_HEIGHT;
+
+      assertEquals(new WizDashboardService.TilePlacement(0, 0, 640, 420 + filterH), placements.get(0));     // A -- 420 + its own filter row
+      assertEquals(new WizDashboardService.TilePlacement(664, 0, 640, 420 + filterH), placements.get(1));   // B -- 420 + alignment top-up
+      assertEquals(filterH, result.headerHeights()[0], "A owns the filter");
+      assertEquals(filterH, result.headerHeights()[1], "B has no filter but aligns with its side-by-side sibling A");
    }
 
    @Test


### PR DESCRIPTION
A generated dashboard's per-chart filters rendered as open checkbox lists **inside** their chart's tile, stealing that height from the chart itself. On a five-chart board with four per-chart `Category` filters that cost roughly **480px of pure filter chrome** — only two charts were visible without scrolling, and the tall radar tile left a dead column beside it.

## Nothing was missing from StyleBI

`SelectionListVSAssembly` already supports `DROPDOWN_SHOW_TYPE`, and `SelectionListVSAssemblyInfo#getSizeScale` pins the Y scale to `1` in that mode so the control cannot stretch back open. `WizDashboardFilterBuilder` simply never called it, so every control kept the default `LIST_SHOW_TYPE = 0`.

## Changes

**1. `buildPerChart` flips its `SelectionListVSAssembly` to `DROPDOWN_SHOW_TYPE`.**

Applied at the dashboard call site rather than inside `createControlForType`, because that factory delegates to `AddFilterService.createFilterAssembly`, which the interactive add-filter flow also uses — that path must keep StyleBI's default list rendering. A `TimeSliderVSAssembly` (date/numeric) has no show type and is already single-row, so it is deliberately untouched.

**2. The dropdown's title row is pinned to the reserved height.**

A dropdown draws *only* its title row (`AssetUtil.defh = 20` by default) and ignores the rest of the assembly's pixel height. Reserving more than the row draws leaves the difference as a visible **gap** between the filter and its chart, breaking the single-enclosing-card look `applyGroupedCardStyle` builds — which is exactly what happened on the first attempt at 40px. `setTitleHeightValue(height)` makes the two agree by construction instead of relying on two constants happening to match. The **design** value is set rather than the runtime one, because a composed dashboard is saved and reopened and the runtime value would not survive that round-trip.

**3. `PER_CHART_FILTER_ROW_HEIGHT` 120 → 28**, and made package-private following `FILTER_BAR_ROW_HEIGHT`'s existing precedent so the grid tests can assert against it. 28 gives a comfortable single row rather than the cramped 20px default.

**4. The grid tests no longer hardcode the geometry.** They derived expectations from literal `120` / `540` / `1008`, which silently rot whenever that constant is tuned; they now compute from the constant itself.

## Verification

Measured in a browser against a locally built image, not only by test assertions:

| | before | after |
|---|---|---|
| per-chart filter block | 120px, ~5 visible checkbox rows | **28px, one collapsed row** |
| four of them | ~480px of chrome | **~112px** |
| gap to its chart | — (first attempt left ~20px) | **-1px, i.e. flush** |
| charts visible without scrolling | 2 | **5** |

Tests: **44/44** wiz dashboard tests, including three new guards — the shared factory stays in `LIST` mode for its other caller, the dropdown's title row fills its reserved height, and a numeric per-chart filter is still a range slider.

## Notes for reviewers

- **The browser verification was done on a tree that also contained #4452** (pre-aggregation filters), since that is what was deployed locally. This branch is the same two commits cherry-picked cleanly onto `stylebi-wiz-main-rebase` with no conflicts, and the suite passes here — but the pixel measurements above came from the combined tree.
- **`static final int` is inlined into referencing classes at compile time**, so an incremental rebuild after changing `PER_CHART_FILTER_ROW_HEIGHT` leaves the old value baked into the tests' derived expectations. Run `clean test`, not `test`, or three grid assertions fail against a phantom mismatch. This bit me once while developing the change.
- The shared filter bar is untouched: it is already compact at `FILTER_CONTROL_HEIGHT = 60` and sits outside any chart tile, so it keeps list rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)