### PR TITLE
Bug #75843, check WRITE permission on destination folder in updateRepositoryFolder

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepletRegistryService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepletRegistryService.java
@@ -139,6 +139,15 @@ public class RepletRegistryService {
             checkPermission(oldPath, ResourceType.REPORT, ResourceAction.DELETE, principal);
          }
 
+         int oldParentIdx = oldPath.lastIndexOf('/');
+         String oldParentPath = oldParentIdx < 0 ? "/" : oldPath.substring(0, oldParentIdx);
+         int newParentIdx = newPath.lastIndexOf('/');
+         String newParentPath = newParentIdx < 0 ? "/" : newPath.substring(0, newParentIdx);
+
+         if(!Tool.equals(oldParentPath, newParentPath)) {
+            checkPermission(newParentPath, ResourceType.REPORT, ResourceAction.WRITE, principal);
+         }
+
          if(SUtil.isDuplicatedRepositoryPath(newPath, newUser)) {
             throw new DuplicateNameException();
          }


### PR DESCRIPTION
## Summary

`RepletRegistryService.updateRepositoryFolder()` checked `ResourceAction.DELETE` permission on the source path but only checked for a name collision on the destination (`SUtil.isDuplicatedRepositoryPath`), never a `WRITE` permission check. This is the EM folder-settings counterpart to the same defect fixed for the public API in the enterprise repo (see linked PR).

## Root Cause

The destination path was only validated for a naming collision, never for permission. A caller with folder-level `ADMIN` on the source (required by the calling `RepositoryFolderService`) could move it into a destination folder they had no `WRITE` access to.

## Fix

Check `WRITE` permission on the destination's parent folder, but only when the folder is actually moving to a different parent (i.e. this is a move, not just an in-place rename). This mirrors `RepositoryTreeController`'s existing "move to folder" check (`community/core/.../RepositoryTreeController.java:788-810`), which already checks `WRITE` on both the entry being moved and the destination folder. Plain in-place renames (same parent) are unaffected, matching how `RepositoryTreeController.renameRepositoryEntry0()` treats plain renames.

Enterprise PR (same defect, public API path): https://github.com/inetsoft-technology/stylebi-enterprise/pull/584

## Test Plan

- [x] `./mvnw install -pl core -am -DskipTests` builds clean
- [x] Existing repository-related unit tests pass (`RepositoryObjectServiceTest`, `ContentRepositoryTreeServiceTest`, `RepositoryRecycleBinControllerTest`)
- [ ] Manual verification against a live instance (not yet performed for this specific EM path)

Fixes Redmine #75843.