### PR TITLE
Bug #75755, show partial REST/GraphQL preview data on query timeout

### DIFF
--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/AbstractRestRuntime.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/AbstractRestRuntime.java
@@ -44,6 +44,13 @@ public abstract class AbstractRestRuntime extends TabularRuntime {
          r -> new GroupedThread(r, ThreadContext.getContextPrincipal()));
       boolean cancelled = false;
       XTableNode result = null;
+      boolean liveMode = false;
+
+      try {
+         liveMode = params != null && "true".equals(params.get(XQuery.HINT_PREVIEW));
+      }
+      catch(Exception ignore) {
+      }
 
       try {
          final QueryRunner queryRunner = getQueryRunner(query);
@@ -107,10 +114,23 @@ public abstract class AbstractRestRuntime extends TabularRuntime {
                TimedQueue.remove(timeoutRunnable);
 
                if(timedOut[0]) {
-                  LOG.error("Query timed out. Failed to load data for " + query.getName());
-                  Tool.addUserMessage(Catalog.getCatalog().getString("common.timeout",
-                                                                     query.getName()),
-                                      ConfirmException.ERROR);
+                  // a cancelled live/preview query already returns whatever partial data
+                  // was fetched (see QueryRunner.run()), so notify with a non-blocking
+                  // toast instead of the modal error dialog that would otherwise make the
+                  // partial result look like a failure
+                  if(liveMode) {
+                     LOG.warn("Query timed out during preview, returning partial results " +
+                              "for " + query.getName());
+                     Tool.addUserMessage(Catalog.getCatalog().getString("common.timeout.partial",
+                                                                        query.getName()),
+                                         ConfirmException.INFO);
+                  }
+                  else {
+                     LOG.error("Query timed out. Failed to load data for " + query.getName());
+                     Tool.addUserMessage(Catalog.getCatalog().getString("common.timeout",
+                                                                        query.getName()),
+                                         ConfirmException.ERROR);
+                  }
                }
             }
 

--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/AbstractRestRuntime.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/AbstractRestRuntime.java
@@ -44,13 +44,16 @@ public abstract class AbstractRestRuntime extends TabularRuntime {
          r -> new GroupedThread(r, ThreadContext.getContextPrincipal()));
       boolean cancelled = false;
       XTableNode result = null;
-      boolean liveMode = false;
+      boolean preview = false;
 
       try {
-         liveMode = params != null && "true".equals(params.get(XQuery.HINT_PREVIEW));
+         preview = params != null && "true".equals(params.get(XQuery.HINT_PREVIEW));
       }
-      catch(Exception ignore) {
+      catch(Exception ex) {
+         LOG.debug("Failed to get the preview hint for " + query.getName(), ex);
       }
+
+      final boolean liveMode = preview;
 
       try {
          final QueryRunner queryRunner = getQueryRunner(query);
@@ -68,7 +71,7 @@ public abstract class AbstractRestRuntime extends TabularRuntime {
                if(queryRunner instanceof AbstractQueryRunner) {
                   AbstractQueryRunner<?> queryRunner2 = (AbstractQueryRunner<?>) queryRunner;
                   queryRunner2.setExecutionThread(Thread.currentThread());
-                  queryRunner2.setLiveMode("true".equals(params.get(XQuery.HINT_PREVIEW)));
+                  queryRunner2.setLiveMode(liveMode);
 
                   Object ts = params.get(XQuery.HINT_TOUCH_TIMESTAMP);
 
@@ -119,7 +122,7 @@ public abstract class AbstractRestRuntime extends TabularRuntime {
                   // toast instead of the modal error dialog that would otherwise make the
                   // partial result look like a failure
                   if(liveMode) {
-                     LOG.warn("Query timed out during preview, returning partial results " +
+                     LOG.info("Query timed out during preview, returning partial results " +
                               "for " + query.getName());
                      Tool.addUserMessage(Catalog.getCatalog().getString("common.timeout.partial",
                                                                         query.getName()),

--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/json/GraphQLCursorIteratorStrategy.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/json/GraphQLCursorIteratorStrategy.java
@@ -94,6 +94,7 @@ public class GraphQLCursorIteratorStrategy extends HttpRestDataIteratorStrategy<
    private boolean isEmpty(Object json, PaginationSpec spec) {
       try {
          Object result = transformer.transform(json, spec.getRecordCountPath());
+         String cursor = null;
 
          if(result != null) {
             if(result.getClass().isArray()) {
@@ -103,15 +104,21 @@ public class GraphQLCursorIteratorStrategy extends HttpRestDataIteratorStrategy<
                   Object value = Array.get(result, 0);
 
                   if(value instanceof String) {
-                     lastCursor = (String) value;
-                     return false;
+                     cursor = (String) value;
                   }
                }
             }
             else if(result instanceof String) {
-               lastCursor = (String) result;
-               return false;
+               cursor = (String) result;
             }
+         }
+
+         // some GraphQL APIs keep echoing the last page's cursor instead of returning
+         // null once there is no more data, so treat a blank or unchanged cursor as the
+         // end of pagination to avoid looping forever
+         if(cursor != null && !cursor.isEmpty() && !cursor.equals(lastCursor)) {
+            lastCursor = cursor;
+            return false;
          }
       }
       catch(Exception e) {

--- a/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/json/GraphQLCursorIteratorStrategyTest.java
+++ b/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/json/GraphQLCursorIteratorStrategyTest.java
@@ -1,0 +1,139 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.rest.json;
+
+import inetsoft.test.*;
+import inetsoft.uql.rest.HttpResponse;
+import inetsoft.uql.rest.IHttpHandler;
+import inetsoft.uql.rest.RestErrorHandler;
+import inetsoft.uql.rest.RestRequest;
+import inetsoft.uql.rest.datasource.graphql.GraphQLDataSource;
+import inetsoft.uql.rest.datasource.graphql.GraphQLQuery;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests the pagination termination conditions of the GraphQL cursor strategy.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, CredentialTestConfig.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+public class GraphQLCursorIteratorStrategyTest {
+   /**
+    * A new cursor on every page keeps the iteration going until the API stops returning
+    * one.
+    */
+   @Test
+   public void distinctCursorsPaginateUntilCursorIsNull() throws Exception {
+      assertEquals(2, countPages(page("c1"), page("c2"), page(null)));
+   }
+
+   /**
+    * Some GraphQL APIs echo the last page's cursor instead of returning null, which would
+    * otherwise paginate forever.
+    */
+   @Test
+   public void echoedCursorEndsPagination() throws Exception {
+      assertEquals(1, countPages(page("c1"), page("c1")));
+   }
+
+   @Test
+   public void blankCursorEndsPagination() throws Exception {
+      assertEquals(0, countPages(page("")));
+   }
+
+   @Test
+   public void missingCursorEndsPagination() throws Exception {
+      assertEquals(0, countPages("{\"data\":{\"items\":{\"pageInfo\":{}}}}"));
+   }
+
+   /**
+    * Iterates the strategy over the given response bodies and returns the number of pages
+    * that were consumed.
+    */
+   private int countPages(String... responseBodies) throws Exception {
+      final GraphQLQuery query = createQuery();
+      final SequencedHttpHandler httpHandler = new SequencedHttpHandler(responseBodies);
+      final GraphQLCursorIteratorStrategy strategy = new GraphQLCursorIteratorStrategy(
+         query, new JsonTransformer(), httpHandler, new RestErrorHandler());
+      int count = 0;
+
+      while(strategy.hasNext()) {
+         assertNotNull(strategy.next());
+         count++;
+      }
+
+      return count;
+   }
+
+   private GraphQLQuery createQuery() {
+      final GraphQLDataSource dataSource = new GraphQLDataSource();
+      dataSource.setURL("http://host/graphql");
+
+      final GraphQLQuery query = new GraphQLQuery();
+      query.setDataSource(dataSource);
+      query.setRequestType("POST");
+      query.setQueryString("query($cursor: String) { items(after: $cursor) { pageInfo { endCursor } } }");
+      query.setVariables("{}");
+      query.setUsePagination(true);
+      query.setCursorPagination(true);
+      query.setPaginationVariable("cursor");
+      query.setPaginationCountPath(CURSOR_PATH);
+
+      return query;
+   }
+
+   private String page(String cursor) {
+      final String value = cursor == null ? "null" : "\"" + cursor + "\"";
+      return "{\"data\":{\"items\":{\"pageInfo\":{\"endCursor\":" + value + "}}}}";
+   }
+
+   /**
+    * Returns the configured response bodies in order. The shared TestHttpHandler cannot be
+    * used here because every page of a GraphQL query is requested from the same URL, so all
+    * of the responses would collapse onto a single request key.
+    */
+   private static final class SequencedHttpHandler implements IHttpHandler {
+      SequencedHttpHandler(String... responseBodies) {
+         this.responseBodies = new ArrayDeque<>(Arrays.asList(responseBodies));
+      }
+
+      @Override
+      public HttpResponse executeRequest(RestRequest request) {
+         assertFalse(responseBodies.isEmpty(), "Unexpected request, all responses consumed");
+         return new TestHttpResponse(responseBodies.remove());
+      }
+
+      @Override
+      public void close() {
+         // no-op
+      }
+
+      private final Deque<String> responseBodies;
+   }
+
+   private static final String CURSOR_PATH = "$.data.items.pageInfo.endCursor";
+}

--- a/core/src/main/java/inetsoft/web/composer/ws/TableModeService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/TableModeService.java
@@ -107,6 +107,7 @@ public class TableModeService extends WorksheetControllerService {
 
       if(table != null) {
          setLiveTableMode(table);
+         loadTabularColumns(table, rws);
          applyChanges(commandDispatcher, rws, tableName, principal);
       }
 
@@ -351,6 +352,29 @@ public class TableModeService extends WorksheetControllerService {
       AggregateInfo group = table.getAggregateInfo();
       info.setAggregate(group != null && !group.isEmpty());
       info.setPixelSize(new Dimension(AssetUtil.defw, info.getPixelSize().height));
+   }
+
+   /**
+    * Discover the columns of a tabular query that has never been executed. Without this
+    * the live data would be loaded against an empty column selection and the table would
+    * render as blank, forcing the user to run the query a second time.
+    */
+   private void loadTabularColumns(TableAssembly table, RuntimeWorksheet rws) {
+      if(!(table instanceof TabularTableAssembly) ||
+         table.getColumnSelection(false).getAttributeCount() > 0)
+      {
+         return;
+      }
+
+      AssetQuerySandbox box = rws.getAssetQuerySandbox();
+
+      try {
+         ((TabularTableAssembly) table).loadColumnSelection(
+            box.getVariableTable(), true, box.getQueryManager());
+      }
+      catch(Exception ex) {
+         LOG.warn("Failed to load the columns for " + table.getName(), ex);
+      }
    }
 
    private void applyChanges(

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -3458,6 +3458,7 @@ common.tableView.maxRowCheck=Max Rows must be positive and less than 2147483647
 common.timeSeriesColMaxCount=Time series columns limited to\: {0}
 common.timeSeriesRowMaxCount=Time series rows limited to\: {0}
 common.timeout=Error loading data due to query timeout for\: {0}.\n\nPlease try increasing timeout value in the Enterprise Manager Performance Settings.
+common.timeout.partial=Only partial preview data loaded due to query timeout for\: {0}.
 common.topToolbarNewQuery=in the top toolbar to create a new query
 common.tree.changeFolderForbidden=Cannot move an opened asset or a folder containing an opened asset.
 common.tree.deleteCalField=Delete the Calculated Field?


### PR DESCRIPTION
## Summary

A worksheet bound to a paginated GraphQL data source (GitHub GraphQL API) showed a modal **"Error loading data due to query timeout"** dialog and an empty preview table, even though partial data had been fetched successfully before the timeout.

## Root Cause

Three separate defects combined to produce the reported symptom:

1. **Timeout reported as a hard error even for previews.** `AbstractRestRuntime.runQuery()` unconditionally logged `LOG.error` and queued a `ConfirmException.ERROR` user message whenever the timeout fired. The composer renders `ERROR`/`WARNING` as a blocking modal dialog. This happened despite `QueryRunner.run()` already returning a valid *partial* table when cancelled in live/preview mode — the data was never actually lost, it just looked like a failure.

2. **Live mode never discovered the query's columns.** `TableModeService.setLiveMode()` called only `loadTableData` / `refreshAssembly` / `layout`. A tabular query that has never been executed ships with an empty column selection, so the data was projected against zero columns and the grid rendered blank (`Rows: 159 / cols: 0 of 0`). `WSQueryService.runQuery()` already called `loadColumnSelection(...)`, which is why the table only appeared after separately clicking **Run Query** and sitting through a *second* full timeout.

3. **Cursor pagination could never terminate.** `GraphQLCursorIteratorStrategy.isEmpty()` treated any non-null String cursor as "keep paginating". Relay-style APIs commonly echo the last page's `endCursor` rather than returning `null`, so the loop could run until the timeout killed it.

Note the row cap itself was *not* broken — `query.preview.maxrow=5000` is correctly applied via `TabularBoundQuery.merge()`. The timeout simply fires first, because 5000 rows at 10 rows/page × ~200ms per request ≈ 100s, well beyond the 30s timeout. Partial results are the expected outcome here.

## Fix

- **`AbstractRestRuntime`** — branch the timeout handling on `HINT_PREVIEW`. A preview now reports the timeout via a non-blocking informational toast (`ConfirmException.INFO`) using a new, benign `common.timeout.partial` message. A real (non-preview) execution keeps the original `LOG.error` + `ConfirmException.ERROR` behavior byte-for-byte, because partial data would silently corrupt post-processing such as aggregation.
- **`TableModeService`** — discover columns before loading live data, matching what `runQuery` already does. Guarded on an empty column selection so no redundant probe query is issued once columns are known. Column discovery runs with `maxRows=100` (~2s), so the switch does not incur a second 30s round trip.
- **`GraphQLCursorIteratorStrategy`** — stop paginating when the extracted cursor is blank or unchanged from the previous page.

## Test Plan

1. Import the `TC-9` test case from the Redmine issue (GraphQL data source against `octocat/Hello-World` issues, cursor pagination, `Authorization: bearer <token>` header).
2. Open the worksheet in Composer and switch the table to **Live Data** mode.
3. Verify columns are discovered (~2s), the query then runs to the 30s timeout, and:
   - a **non-blocking toast** appears reading "Only partial preview data loaded due to query timeout..." — no modal error dialog;
   - the preview table **renders the partial rows** (no extra Run Query click needed).
4. Verify **Run Query** still behaves correctly and shows partial data.
5. Regression: confirm a non-preview execution (scheduled task / viewsheet runtime) still surfaces a hard error on timeout rather than silently returning partial data.
6. Regression: confirm a GraphQL cursor query that completes normally still paginates through every page and returns the full result set.

Verified locally: `inetsoft-rest` builds and all 103 module tests pass; behavior confirmed end-to-end against the TC-9 test case.

Fixes Redmine #75755.