### PR TITLE
Bug #75800, copy org-scoped presentation settings when cloning an organization

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
@@ -239,6 +239,46 @@ public abstract class AbstractEditableAuthenticationProvider
          manager.save();
       }
 
+      String logo = manager.getLogoEntries().get(fromOrgId);
+
+      if(logo != null) {
+         String logoName = logo.substring(logo.lastIndexOf('/') + 1);
+         String odir = "portal/" + fromOrgId;
+         String dir = "portal/" + newOrgID;
+
+         try(InputStream in = dataSpace.getInputStream(odir, logoName)) {
+            if(in != null) {
+               dataSpace.withOutputStream(dir, logoName, out -> Tool.copyTo(in, out));
+            }
+         }
+         catch(IOException e) {
+            throw new RuntimeException(e);
+         }
+
+         manager.addLogoEntry(newOrgID, dir + "/" + logoName);
+         manager.save();
+      }
+
+      String favicon = manager.getFaviconEntries().get(fromOrgId);
+
+      if(favicon != null) {
+         String faviconName = favicon.substring(favicon.lastIndexOf('/') + 1);
+         String odir = "portal/" + fromOrgId;
+         String dir = "portal/" + newOrgID;
+
+         try(InputStream in = dataSpace.getInputStream(odir, faviconName)) {
+            if(in != null) {
+               dataSpace.withOutputStream(dir, faviconName, out -> Tool.copyTo(in, out));
+            }
+         }
+         catch(IOException e) {
+            throw new RuntimeException(e);
+         }
+
+         manager.addFaviconEntry(newOrgID, dir + "/" + faviconName);
+         manager.save();
+      }
+
       PortalWelcomePage welcomePage = manager.getWelcomePage(fromOrgId);
 
       if(welcomePage != null) {
@@ -292,6 +332,8 @@ public abstract class AbstractEditableAuthenticationProvider
          FSService.clearServerNodeCache(fromOrgId);
          XJobPool.resetOrgCache(fromOrgId);
          manager.removeCSSEntry(fromOrgId);
+         manager.removeLogoEntry(fromOrgId);
+         manager.removeFaviconEntry(fromOrgId);
          manager.removeWelcomePage(fromOrgId);
          manager.save();
          RepletRegistryManager.getInstance().clearOrgCache(fromOrgId);

--- a/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
@@ -218,16 +218,19 @@ public abstract class AbstractEditableAuthenticationProvider
 
       PortalThemesManager manager = PortalThemesManager.getManager();
       DataSpace dataSpace = DataSpace.getDataSpace();
+      String odir = "portal/" + fromOrgId;
+      String dir = "portal/" + newOrgID;
       String viewsheet = manager.getCssEntries().get(fromOrgId);
 
       if(viewsheet != null) {
          String[] viewsheetFile = viewsheet.split("/");
          String cssName = viewsheetFile[1];
-         String odir = "portal/" + fromOrgId;
-         String dir = "portal/" + newOrgID;
+         boolean copied;
 
          try(InputStream in = dataSpace.getInputStream(odir, cssName)) {
-            if(in != null) {
+            copied = in != null;
+
+            if(copied) {
                dataSpace.withOutputStream(dir, cssName, out -> Tool.copyTo(in, out));
             }
          }
@@ -235,19 +238,22 @@ public abstract class AbstractEditableAuthenticationProvider
             throw new RuntimeException(e);
          }
 
-         manager.addCSSEntry(newOrgID, newOrgID + "/" + cssName);
-         manager.save();
+         if(copied) {
+            manager.addCSSEntry(newOrgID, newOrgID + "/" + cssName);
+            manager.save();
+         }
       }
 
       String logo = manager.getLogoEntries().get(fromOrgId);
 
       if(logo != null) {
          String logoName = logo.substring(logo.lastIndexOf('/') + 1);
-         String odir = "portal/" + fromOrgId;
-         String dir = "portal/" + newOrgID;
+         boolean copied;
 
          try(InputStream in = dataSpace.getInputStream(odir, logoName)) {
-            if(in != null) {
+            copied = in != null;
+
+            if(copied) {
                dataSpace.withOutputStream(dir, logoName, out -> Tool.copyTo(in, out));
             }
          }
@@ -255,19 +261,22 @@ public abstract class AbstractEditableAuthenticationProvider
             throw new RuntimeException(e);
          }
 
-         manager.addLogoEntry(newOrgID, dir + "/" + logoName);
-         manager.save();
+         if(copied) {
+            manager.addLogoEntry(newOrgID, dir + "/" + logoName);
+            manager.save();
+         }
       }
 
       String favicon = manager.getFaviconEntries().get(fromOrgId);
 
       if(favicon != null) {
          String faviconName = favicon.substring(favicon.lastIndexOf('/') + 1);
-         String odir = "portal/" + fromOrgId;
-         String dir = "portal/" + newOrgID;
+         boolean copied;
 
          try(InputStream in = dataSpace.getInputStream(odir, faviconName)) {
-            if(in != null) {
+            copied = in != null;
+
+            if(copied) {
                dataSpace.withOutputStream(dir, faviconName, out -> Tool.copyTo(in, out));
             }
          }
@@ -275,8 +284,10 @@ public abstract class AbstractEditableAuthenticationProvider
             throw new RuntimeException(e);
          }
 
-         manager.addFaviconEntry(newOrgID, dir + "/" + faviconName);
-         manager.save();
+         if(copied) {
+            manager.addFaviconEntry(newOrgID, dir + "/" + faviconName);
+            manager.save();
+         }
       }
 
       PortalWelcomePage welcomePage = manager.getWelcomePage(fromOrgId);

--- a/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
@@ -225,12 +225,9 @@ public abstract class AbstractEditableAuthenticationProvider
       if(viewsheet != null) {
          String[] viewsheetFile = viewsheet.split("/");
          String cssName = viewsheetFile[1];
-         boolean copied;
 
          try(InputStream in = dataSpace.getInputStream(odir, cssName)) {
-            copied = in != null;
-
-            if(copied) {
+            if(in != null) {
                dataSpace.withOutputStream(dir, cssName, out -> Tool.copyTo(in, out));
             }
          }
@@ -238,22 +235,17 @@ public abstract class AbstractEditableAuthenticationProvider
             throw new RuntimeException(e);
          }
 
-         if(copied) {
-            manager.addCSSEntry(newOrgID, newOrgID + "/" + cssName);
-            manager.save();
-         }
+         manager.addCSSEntry(newOrgID, newOrgID + "/" + cssName);
+         manager.save();
       }
 
       String logo = manager.getLogoEntries().get(fromOrgId);
 
       if(logo != null) {
          String logoName = logo.substring(logo.lastIndexOf('/') + 1);
-         boolean copied;
 
          try(InputStream in = dataSpace.getInputStream(odir, logoName)) {
-            copied = in != null;
-
-            if(copied) {
+            if(in != null) {
                dataSpace.withOutputStream(dir, logoName, out -> Tool.copyTo(in, out));
             }
          }
@@ -261,22 +253,17 @@ public abstract class AbstractEditableAuthenticationProvider
             throw new RuntimeException(e);
          }
 
-         if(copied) {
-            manager.addLogoEntry(newOrgID, dir + "/" + logoName);
-            manager.save();
-         }
+         manager.addLogoEntry(newOrgID, dir + "/" + logoName);
+         manager.save();
       }
 
       String favicon = manager.getFaviconEntries().get(fromOrgId);
 
       if(favicon != null) {
          String faviconName = favicon.substring(favicon.lastIndexOf('/') + 1);
-         boolean copied;
 
          try(InputStream in = dataSpace.getInputStream(odir, faviconName)) {
-            copied = in != null;
-
-            if(copied) {
+            if(in != null) {
                dataSpace.withOutputStream(dir, faviconName, out -> Tool.copyTo(in, out));
             }
          }
@@ -284,10 +271,8 @@ public abstract class AbstractEditableAuthenticationProvider
             throw new RuntimeException(e);
          }
 
-         if(copied) {
-            manager.addFaviconEntry(newOrgID, dir + "/" + faviconName);
-            manager.save();
-         }
+         manager.addFaviconEntry(newOrgID, dir + "/" + faviconName);
+         manager.save();
       }
 
       PortalWelcomePage welcomePage = manager.getWelcomePage(fromOrgId);

--- a/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/AbstractEditableAuthenticationProvider.java
@@ -220,7 +220,8 @@ public abstract class AbstractEditableAuthenticationProvider
       DataSpace dataSpace = DataSpace.getDataSpace();
       String odir = "portal/" + fromOrgId;
       String dir = "portal/" + newOrgID;
-      String viewsheet = manager.getCssEntries().get(fromOrgId);
+      Map<String, String> cssEntries = manager.getCssEntries();
+      String viewsheet = cssEntries != null ? cssEntries.get(fromOrgId) : null;
 
       if(viewsheet != null) {
          String[] viewsheetFile = viewsheet.split("/");
@@ -239,7 +240,8 @@ public abstract class AbstractEditableAuthenticationProvider
          manager.save();
       }
 
-      String logo = manager.getLogoEntries().get(fromOrgId);
+      Map<String, String> logoEntries = manager.getLogoEntries();
+      String logo = logoEntries != null ? logoEntries.get(fromOrgId) : null;
 
       if(logo != null) {
          String logoName = logo.substring(logo.lastIndexOf('/') + 1);
@@ -257,7 +259,8 @@ public abstract class AbstractEditableAuthenticationProvider
          manager.save();
       }
 
-      String favicon = manager.getFaviconEntries().get(fromOrgId);
+      Map<String, String> faviconEntries = manager.getFaviconEntries();
+      String favicon = faviconEntries != null ? faviconEntries.get(fromOrgId) : null;
 
       if(favicon != null) {
          String faviconName = favicon.substring(favicon.lastIndexOf('/') + 1);


### PR DESCRIPTION
## Summary
- Some org-scoped Presentation/Organization Settings were not copied when creating a new organization by cloning an existing one: the new org's Welcome Page and Login Banner reverted to defaults (repro: set Welcome Page/Login Banner on the host org, clone it, switch to the new org — settings are missing).
- `AbstractEditableAuthenticationProvider.copyOrganizationInternal()` already copied `PortalThemesManager.cssEntries` on clone/rename, but never copied the sibling `logoEntries`, `faviconEntries`, or `welcomePageEntries` maps (the latter backs both Welcome Page and Login Banner).
- Added copy logic for logo/favicon (file + map entry) and welcome page/login banner (object clone) alongside the existing CSS handling, plus matching cleanup of the source org's entries in the rename (`replace=true`) path.

## Test plan
- [x] `core` module compiles cleanly
- [ ] Manually verify: as host admin, set Welcome Page + Login Banner + Logo + Favicon under Presentation/Organization Settings, clone the host org, switch to the new org, confirm all four are present
- [ ] Manually verify: rename an organization and confirm the settings still resolve under the new org id, and the old org id no longer has stale entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)