### PR TITLE
Bug #75791-1, don't advertise a working sample admin password, label shell examples by terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,19 @@ Download the latest community-examples.zip file from the [StyleBI Release page](
 
 Before starting the containers, set the `INETSOFT_ADMIN_PASSWORD` environment variable to the password you want to use for the "admin" account. This is required — there is no default password. The password must be at least 8 characters and include an uppercase letter, a lowercase letter, a digit, and a special character. You can either uncomment and set `INETSOFT_ADMIN_PASSWORD` in the `.env` file in the extracted folder, or set it directly in your shell:
 
+On Linux or macOS:
+
 ```shell
-export INETSOFT_ADMIN_PASSWORD="Test@admin1"
+export INETSOFT_ADMIN_PASSWORD="changeme"
 ```
 
-```powershell
-$env:INETSOFT_ADMIN_PASSWORD="Test@admin1"
+On Windows (Command Prompt):
+
+```cmd
+set INETSOFT_ADMIN_PASSWORD=changeme
 ```
+
+Note that setting the variable this way only applies to the current terminal session, so you must run `docker compose up` in that same session.
 
 For Docker Desktop, start it first then open a Command Prompt window. In the folder containing the extracted .yaml file, run the following command:
 

--- a/Troubleshoot.md
+++ b/Troubleshoot.md
@@ -37,18 +37,24 @@ To resolve this, set `INETSOFT_ADMIN_PASSWORD` to a valid password before starti
 storage:
   environment:
     # the password for the "admin" user
-    INETSOFT_ADMIN_PASSWORD: "Test@admin1"
+    INETSOFT_ADMIN_PASSWORD: "changeme"
 ```
 
 or as an environment variable in your shell before running `docker compose up`:
 
+On Linux or macOS:
+
 ```shell
-export INETSOFT_ADMIN_PASSWORD="Test@admin1"
+export INETSOFT_ADMIN_PASSWORD="changeme"
 ```
 
-```powershell
-$env:INETSOFT_ADMIN_PASSWORD="Test@admin1"
+On Windows (Command Prompt):
+
+```cmd
+set INETSOFT_ADMIN_PASSWORD=changeme
 ```
+
+Note that setting the variable this way only applies to the current terminal session, so you must run `docker compose up` in that same session.
 
 or by uncommenting and setting `INETSOFT_ADMIN_PASSWORD` in the `.env` file included with the community examples.
 

--- a/community-examples/.env
+++ b/community-examples/.env
@@ -8,4 +8,4 @@ STYLEBI_DOCKER_IMAGE=ghcr.io/inetsoft-technology/stylebi-community:latest
 # password before running docker compose. The password must be at least 8
 # characters and include an uppercase letter, a lowercase letter, a digit, and
 # a special character.
-# INETSOFT_ADMIN_PASSWORD=Test@admin1
+# INETSOFT_ADMIN_PASSWORD=changeme


### PR DESCRIPTION
## Summary
- Replace the sample `INETSOFT_ADMIN_PASSWORD` value `Test@admin1` with `changeme` in README.md, Troubleshoot.md, and community-examples/.env. `Test@admin1` satisfied the password complexity requirements, so a user copy-pasting it verbatim would end up with a real, working admin credential — defeating the point of requiring a password in the first place. `changeme` intentionally fails the requirements, so the storage container still refuses to start (same `exit 1`) until the user sets their own password.
- Label the example shell commands for setting `INETSOFT_ADMIN_PASSWORD` by terminal (Linux/macOS vs. Windows Command Prompt) and swap the PowerShell snippet for a Command Prompt (`set VAR=value`) one, matching the Command Prompt instructions used later in the README.
- Note that the shell-variable approach only applies to the current terminal session, so `docker compose up` must be run in that same session.

Follow-up to PR #4417.

## Test plan
- [ ] Confirm no remaining occurrences of `Test@admin1` in the repo
- [ ] Manually verify the CMD snippet syntax (`set VAR=value`) is correct
- [ ] Verify docs render correctly (code fences, headings)