### PR TITLE
Bug #75810, fix O(N x D) latency when renaming a table style folder

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/RenameAssetController.java
+++ b/core/src/main/java/inetsoft/web/composer/RenameAssetController.java
@@ -37,8 +37,6 @@ import inetsoft.util.audit.Audit;
 import inetsoft.web.admin.content.repository.ResourcePermissionService;
 import inetsoft.web.composer.model.RenameAssetEvent;
 import inetsoft.web.viewsheet.command.MessageCommand;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -318,13 +316,6 @@ public class RenameAssetController {
          subName = idx < 0 ? subName : subName.substring(idx + 1);
          renameTableStyleFolder(folder, nname + LibManager.SEPARATOR + subName, manager);
       }
-
-      try {
-         manager.save();
-      }
-      catch(Exception e) {
-         LOG.error("Failed to save table style folder.", e);
-      }
    }
 
    /**
@@ -346,6 +337,4 @@ public class RenameAssetController {
    private final SecurityProvider securityProvider;
    private final LibManagerProvider libManagerProvider;
    private final DataSourceRegistry dataSourceRegistry;
-   private static final Logger LOG =
-      LoggerFactory.getLogger(RenameAssetController.class);
 }


### PR DESCRIPTION
## Summary
- `RenameAssetController.renameTableStyleFolder()` called `manager.save()` once per recursion level (once per subfolder being renamed). `LibManager.save()` rewrites the entire `style/folders.xml` for the whole library on any pending folder transaction, so a rename of a folder with D subfolders in a library with N total folders cost O(N x D) instead of O(N).
- The recursive rename/query calls (`renameTableStyle`, `renameTableStyleFolder`, `getTableStyles`, `getTableStyleFolders`) all operate on in-memory state and don't depend on intermediate saves — only the single `manager.save()` already performed by the caller after the full recursive rename completes is needed.
- Removed the redundant per-level `save()` (and the now-unused `LOG` field/imports it required).

## Test plan
- [ ] Rename a table style folder with a few (2-3) styles in a library with several hundred unrelated styles; confirm `POST api/composer/asset-tree/rename-asset` completes quickly and the rename (including nested subfolders/styles) persists correctly after a page reload.
- [ ] Rename a table style folder containing nested subfolders; confirm all nested folders/styles are renamed and persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)