### PR TITLE
Bug #75830, fix incorrect login check on task-owner permission checks

### DIFF
--- a/core/src/main/java/inetsoft/sree/RepletEngine.java
+++ b/core/src/main/java/inetsoft/sree/RepletEngine.java
@@ -440,10 +440,18 @@ public class RepletEngine extends AbstractAssetEngine
       }
 
       IdentityID pId = principal == null ? null : IdentityID.getIdentityIDFromKey(principal.getName());
+      // Go straight to the SecurityProvider instead of through SecurityEngine.checkPermission(),
+      // which additionally requires the principal to be present in SecurityEngine's live-login
+      // cache. That cache is keyed by the principal's current identity, so it is not updated when
+      // the principal's owning identity is renamed, causing these checks to incorrectly report
+      // the caller as not logged in even though it holds an active EM WebSocket subscription
+      // (Bug #75830). hasTaskResourcePermission() replicates SecurityEngine's ADMIN-inheritance
+      // fallback so behavior otherwise matches.
+      SecurityProvider securityProvider = getSecurity().getSecurityProvider();
       boolean principalHasPermission =
-         checkPermission(principal, ResourceType.SCHEDULE_TASK, task.getTaskId(), ResourceAction.READ) &&
-         checkPermission(principal, ResourceType.SCHEDULE_TASK, task.getTaskId(), ResourceAction.WRITE) &&
-         checkPermission(principal, ResourceType.SCHEDULE_TASK, task.getTaskId(), ResourceAction.DELETE) &&
+         hasTaskResourcePermission(securityProvider, principal, task.getTaskId(), ResourceAction.READ) &&
+         hasTaskResourcePermission(securityProvider, principal, task.getTaskId(), ResourceAction.WRITE) &&
+         hasTaskResourcePermission(securityProvider, principal, task.getTaskId(), ResourceAction.DELETE) &&
          pId != null && pId.orgID.equals(task.getOwner().orgID);
 
       if(principalHasPermission) {
@@ -451,15 +459,15 @@ public class RepletEngine extends AbstractAssetEngine
       }
 
       boolean internalTaskPermission = ScheduleManager.isInternalTask(task.getTaskId()) &&
-         checkPermission(principal, ResourceType.SCHEDULE_TASK, task.getTaskId(), ResourceAction.READ) &&
+         hasTaskResourcePermission(securityProvider, principal, task.getTaskId(), ResourceAction.READ) &&
          XPrincipal.SYSTEM.equals(task.getOwner().name);
 
       if(internalTaskPermission || ScheduleManager.isInternalTask(task.getTaskId())) {
          return internalTaskPermission;
       }
 
-      boolean isOwnerAdmin = task.getOwner() != null && checkPermission(
-         principal, ResourceType.SECURITY_USER, task.getOwner(), ResourceAction.ADMIN);
+      boolean isOwnerAdmin = task.getOwner() != null && securityProvider.checkPermission(
+         principal, ResourceType.SECURITY_USER, task.getOwner().convertToKey(), ResourceAction.ADMIN);
 
       if(isOwnerAdmin) {
          return true;
@@ -468,6 +476,19 @@ public class RepletEngine extends AbstractAssetEngine
       boolean isShareRole = ScheduleManager.getScheduleManager()
          .hasShareGroupPermission(task, principal);
       return isShareRole;
+   }
+
+   /**
+    * Check a SCHEDULE_TASK resource permission directly against the SecurityProvider, applying
+    * the same ADMIN-inheritance fallback as SecurityEngine.checkPermission(Principal,
+    * ResourceType, String, ResourceAction) (a grant of ADMIN also satisfies non-ADMIN actions).
+    */
+   private boolean hasTaskResourcePermission(SecurityProvider securityProvider, Principal principal,
+                                             String taskId, ResourceAction action)
+   {
+      return securityProvider.checkPermission(principal, ResourceType.SCHEDULE_TASK, taskId, action) ||
+         (action != ResourceAction.ADMIN &&
+             securityProvider.checkPermission(principal, ResourceType.SCHEDULE_TASK, taskId, ResourceAction.ADMIN));
    }
 
    public boolean taskHasShareGroupPermission(IdentityID owner, Principal principal) {

--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleService.java
@@ -671,8 +671,14 @@ public class ScheduleService {
       boolean adminPermission = true;
 
       try {
-         adminPermission = securityEngine.checkPermission(
-            principal, ResourceType.SECURITY_USER, task.getOwner(), ResourceAction.ADMIN);
+         // Go straight to the SecurityProvider instead of through
+         // SecurityEngine.checkPermission(..., IdentityID, ...), which additionally requires the
+         // principal to be present in SecurityEngine's live-login cache. That cache is keyed by
+         // the principal's current identity, so it is not updated when the principal's owning
+         // identity is renamed, causing this check to incorrectly report the caller as not
+         // logged in even though it holds an active EM WebSocket subscription (Bug #75830).
+         adminPermission = securityEngine.getSecurityProvider().checkPermission(
+            principal, ResourceType.SECURITY_USER, task.getOwner().convertToKey(), ResourceAction.ADMIN);
       }
       catch(Exception e) {
          LOG.error("Failed to check permission for delete action", e);


### PR DESCRIPTION
## Summary

When a schedule task's owner identity is renamed while another admin holds an active EM WebSocket subscription to the schedule-task-changed topic, the real-time permission re-check for that subscriber fails with a spurious `SecurityException: "<user> did not log in."`, even though the subscriber is genuinely connected.

## Root Cause

`ScheduleTaskChangeController.dispatchAdminScheduleTask()` calls `RepletEngine.hasTaskPermission()` / `ScheduleService.canDeleteTask()` to decide whether to push a task-change notification to a given subscriber. When the subscriber isn't the task owner (the common case where a rename just changed ownership away from the subscriber), these fall back to checks like:

```java
checkPermission(principal, ResourceType.SCHEDULE_TASK, task.getTaskId(), ResourceAction.READ/WRITE/DELETE)
checkPermission(principal, ResourceType.SECURITY_USER, task.getOwner(), ResourceAction.ADMIN)
```

These route through `SecurityEngine.checkPermission(...)` overloads that require the principal to be present in `SecurityEngine`'s in-memory `users` login cache — keyed by the principal's *current* identity. That cache is never updated when a user is renamed, so it can miss for a legitimately-connected subscriber, `isLogin()` returns false, and a `SecurityException` is thrown and logged as an ERROR. Because the fast-path `isOwner` check normally short-circuits before reaching these fallbacks, this only surfaces once ownership diverges from the subscriber — exactly what a rename causes.

The same "is caller admin of the task owner" check already exists elsewhere (`ScheduleManager.hasTaskPermission`, used by `ScheduleService`, `EMScheduleBatchActionController`, `ResourcePermissionController`, `ContentRepositoryTreeService`) *without* this login-cache gate — it calls the `SecurityProvider` directly.

## Fix

- `RepletEngine.hasTaskPermission()`: check the `SecurityProvider` directly for the SCHEDULE_TASK READ/WRITE/DELETE checks and the SECURITY_USER/ADMIN owner check, instead of going through `SecurityEngine.checkPermission()`. A new private helper (`hasTaskResourcePermission`) preserves the ADMIN-inheritance fallback that `SecurityEngine.checkPermission(String)` provides, so behavior is otherwise unchanged.
- `ScheduleService.canDeleteTask()`: same treatment for its SECURITY_USER/ADMIN check.

## Test Plan

- [x] Reproduced: renamed a user owning a scheduled task while another org admin had an active EM WebSocket session; confirmed the `SecurityException` / ERROR log no longer appears and the fix was manually verified against a running instance by the reporter.
- [x] `./mvnw install -pl core -am -DskipTests` succeeds.
- [x] `inetsoft.web.admin.schedule.*Test`, `inetsoft.web.admin.content.repository.*Test`, `inetsoft.sree.schedule.*Test`, `inetsoft.sree.security.*Test` all pass.
- [x] Code-reviewed (two passes, covering the original and widened fix) with no blocking issues.

Fixes Redmine #75830.