### PR TITLE
Bug #75880, dismiss identities-copied toast on next click so it doesn't block Apply

### DIFF
--- a/web/projects/em/src/app/settings/security/security-table-view/security-table-view.component.ts
+++ b/web/projects/em/src/app/settings/security/security-table-view/security-table-view.component.ts
@@ -29,7 +29,8 @@ import { SecurityTreeDialogComponent } from "../security-tree-dialog/security-tr
 import { SecurityTreeDialogData } from "../security-tree-dialog/security-tree-dialog-data";
 import { MatPaginator } from "@angular/material/paginator";
 import { MatSnackBar } from "@angular/material/snack-bar";
-import { take } from "rxjs/operators";
+import { fromEvent } from "rxjs";
+import { take, takeUntil } from "rxjs/operators";
 import { IdentityClipboardService, IdentityCopyPasteContext } from "./identity-clipboard.service";
 import { MessageDialog, MessageDialogType } from "../../../common/util/message-dialog";
 import { equalsIdentity } from "../users/identity-id";
@@ -228,7 +229,16 @@ export class SecurityTableViewComponent implements OnChanges, AfterViewInit {
       }
 
       this.clipboardService.copy(toCopy, this.copyPasteContext);
-      this.snackBar.open("_#(js:em.security.identitiesCopied)", null, { duration: Tool.SNACKBAR_DURATION });
+      const snackBarRef = this.snackBar.open("_#(js:em.security.identitiesCopied)", null, { duration: Tool.SNACKBAR_DURATION_SHORT });
+
+      // dismiss as soon as the user interacts elsewhere so the toast doesn't linger over the Apply button.
+      // Deferred so the listener isn't registered until after the triggering click finishes bubbling to
+      // document, otherwise the toast would be dismissed by its own opening click.
+      setTimeout(() => {
+         fromEvent(document, "click")
+            .pipe(take(1), takeUntil(snackBarRef.afterDismissed()))
+            .subscribe(() => snackBarRef.dismiss());
+      });
    }
 
    private pasteDialogOpen = false;


### PR DESCRIPTION
## Summary

In Enterprise Manager, copying identity permissions (Copy action on the Users node) and navigating to paste them onto another identity showed a persistent "Identities copied." toast that visually overlapped and intercepted clicks on the Apply button of the identity editor panel.

## Root Cause

`SecurityTableViewComponent.copyIdentities()` opened the "Identities copied." toast with the full 5s snackbar duration (`Tool.SNACKBAR_DURATION`) and no dismiss action, unlike the sibling "Identities pasted." toast which already used the shorter 2s duration (`Tool.SNACKBAR_DURATION_SHORT`). Since MatSnackBar renders at the bottom of the viewport by default (no custom positioning is configured anywhere in the app) and the identity editor panel's fixed Apply button sits at the bottom of that same page, the toast covered the Apply button for the full duration of its display.

## Fix

- Shortened the "Identities copied." toast duration to match the "Identities pasted." convention.
- The toast now also dismisses immediately on the user's next click anywhere on the page (deferred registration via `setTimeout` so it isn't dismissed by the very click that opened it), instead of requiring the full timer to elapse.

## Test Plan

- [x] Reproduced the original issue: create a user, grant Administrator Permissions, Copy, navigate to Groups, Paste — toast blocked Apply for ~5s.
- [x] Verified the toast now dismisses on the next click instead of lingering over Apply.
- [x] `security-table-view.component.spec.ts` (21 tests) and `.tl.spec.ts` (9 tests) pass.
- [x] `npx eslint` clean on the changed file.
- [x] `tsc --noEmit` clean for the `em` project.

Fixes Redmine #75880.