### PR TITLE
feat(wiz): per-chart pre-aggregation filters bind to that chart's own raw source

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/WizDashboardEvent.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDashboardEvent.java
@@ -212,9 +212,27 @@ public class WizDashboardEvent {
          this.label = label;
       }
 
+      /** When true, bind this filter PRE-aggregation: to the raw source table(s) carrying the
+       *  column that are reachable from THIS chart's own final table (a WHERE evaluated before any
+       *  group-by), so it filters the chart's underlying rows and its aggregate re-computes over
+       *  the subset. Enables filtering by an orthogonal column that never survives to the chart's
+       *  final table (e.g. order `state` on a revenue-by-quarter chart). Default false = bind to
+       *  the chart's final table (post-agg), the original behavior. Unlike the shared filter bar's
+       *  {@link FilterSpec#isPreAggregation()}, the binding is scoped to this one chart's own raw
+       *  source, so its structural safety is independent of every other chart on the board — see
+       *  WizDashboardFilterBuilder. */
+      public boolean isPreAggregation() {
+         return preAggregation;
+      }
+
+      public void setPreAggregation(boolean preAggregation) {
+         this.preAggregation = preAggregation;
+      }
+
       private String identifier;
       private String field;
       private String dataType;
       private String label;
+      private boolean preAggregation;
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/AddFilterService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/AddFilterService.java
@@ -199,20 +199,91 @@ public class AddFilterService {
             continue;
          }
 
-         ColumnSelection cols = table.getColumnSelection(true);
+         if(tableHasColumn(table, attribute)) {
+            result.add(a.getName());
+         }
+      }
 
-         for(int i = 0; i < cols.getAttributeCount(); i++) {
-            if(!(cols.getAttribute(i) instanceof ColumnRef cref)) {
-               continue;
+      return result;
+   }
+
+   /**
+    * Returns the names of the visible root tables <b>reachable from {@code chartTableName}</b> that
+    * contain a column matching the given {@code attribute} name (alias-first lookup, the identical
+    * matching rule {@link #findColumnMatchingRootTables} and
+    * {@link #findColumnMatchingChartTables} use — see {@link #tableHasColumn}).
+    *
+    * <p>This is {@link #findColumnMatchingRootTables} narrowed to ONE chart. That method scans
+    * <i>every</i> visible root table in the merged dashboard worksheet, which is defensible for the
+    * shared filter bar (one control, every chart) but forces its caller into a conservative veto:
+    * a pre-aggregation filter can only be offered when EVERY chart whose raw source exposes that
+    * column name is structurally safe, because a WHERE bound to a shared root also reaches a chart
+    * whose cross-row math (a window function, a global-aggregate ratio) a subset WHERE would
+    * collapse — silently producing wrong numbers. A PER-CHART filter's control belongs to exactly
+    * one chart's tile, so binding it to only THAT chart's own raw source makes one chart's safety
+    * independent of every other chart's, and the veto becomes unnecessary.</p>
+    *
+    * <p>Reachability is resolved by walking {@code chartTableName}'s transitive
+    * {@code getDependeds} — the set of assemblies a table itself depends on — down to tables whose
+    * own {@code getDependeds} set is empty. Those are the roots, exactly as
+    * {@link #findColumnMatchingRootTables} documents (a wiz merge stacks
+    * {@link MirrorTableAssembly} instances over a shared {@link BoundTableAssembly} base, and each
+    * mirror reports the table it mirrors here; a join reports every table it joins, so a joined
+    * chart correctly resolves to whichever of its roots carries the column). Note the same warning
+    * that method carries: {@code getDependings()} is the REVERSE relation (who depends on this
+    * table) and must NOT be used — it is non-empty for root tables, the opposite of what is wanted.
+    * A {@code visited} set guards termination: a malformed/cyclic or self-referential dependency
+    * graph must not hang the dashboard compose.</p>
+    *
+    * <p>Visibility is checked when a root is REPORTED, matching what the two sibling methods gate
+    * on. It is deliberately not a traversal gate: neither sibling reports intermediate tables at
+    * all, and an invisible intermediate mirror must not sever reachability to a visible root.</p>
+    *
+    * <p>Package-visible (reuse seam, mirrors {@link #findColumnMatchingRootTables}): used by
+    * {@link WizDashboardFilterBuilder#buildPerChart} for a pre-aggregation per-chart filter.
+    */
+   static List<String> findColumnMatchingRootTablesForChart(Worksheet ws, String chartTableName,
+                                                            String attribute)
+   {
+      if(ws == null || chartTableName == null) {
+         return Collections.emptyList();
+      }
+
+      List<String> result = new ArrayList<>();
+      Set<String> visited = new HashSet<>();
+      Deque<String> pending = new ArrayDeque<>();
+      pending.push(chartTableName);
+
+      while(!pending.isEmpty()) {
+         String name = pending.pop();
+
+         // Termination guard: a cyclic or self-referential dependency graph (only reachable from a
+         // malformed worksheet, but it must not hang the compose) revisits a name forever otherwise.
+         if(!visited.add(name)) {
+            continue;
+         }
+
+         if(!(ws.getAssembly(name) instanceof TableAssembly table)) {
+            // Not a table (e.g. a VARIABLE_ASSET a condition depends on) or an unresolvable
+            // dangling reference -- nothing to walk into and nothing to match.
+            continue;
+         }
+
+         Set<AssemblyRef> dependeds = new HashSet<>();
+         table.getDependeds(dependeds);
+
+         if(dependeds.isEmpty()) {
+            // A root: this is a raw source table, so a selection bound here becomes a WHERE
+            // evaluated before any downstream group-by.
+            if(table.isVisible() && table.isVisibleTable() && tableHasColumn(table, attribute)) {
+               result.add(name);
             }
 
-            String colName = cref.getAlias() != null && !cref.getAlias().isEmpty()
-               ? cref.getAlias() : cref.getAttribute();
+            continue;
+         }
 
-            if(colName.equals(attribute)) {
-               result.add(a.getName());
-               break;
-            }
+         for(AssemblyRef ref : dependeds) {
+            pending.push(ref.getEntry().getName());
          }
       }
 
@@ -255,24 +326,43 @@ public class AddFilterService {
             continue;
          }
 
-         ColumnSelection cols = table.getColumnSelection(true);
-
-         for(int i = 0; i < cols.getAttributeCount(); i++) {
-            if(!(cols.getAttribute(i) instanceof ColumnRef cref)) {
-               continue;
-            }
-
-            String colName = cref.getAlias() != null && !cref.getAlias().isEmpty()
-               ? cref.getAlias() : cref.getAttribute();
-
-            if(colName.equals(attribute)) {
-               result.add(name);
-               break;
-            }
+         if(tableHasColumn(table, attribute)) {
+            result.add(name);
          }
       }
 
       return result;
+   }
+
+   /**
+    * Returns whether {@code table}'s column selection exposes a column whose name matches
+    * {@code attribute}, alias-first: a {@link ColumnRef}'s {@code getAlias()} when it is non-null
+    * and non-empty, otherwise its {@code getAttribute()}.
+    *
+    * <p>Package-private (reuse seam, decision (a)): this is the single column-matching loop shared
+    * by all three table-lookup methods — {@link #findColumnMatchingRootTables},
+    * {@link #findColumnMatchingRootTablesForChart} and {@link #findColumnMatchingChartTables}.
+    * It is deliberately one implementation rather than three copies: if the matching rule diverged
+    * between them by even the alias precedence, a filter would bind through one lookup path and
+    * silently not bind through another.</p>
+    */
+   private static boolean tableHasColumn(TableAssembly table, String attribute) {
+      ColumnSelection cols = table.getColumnSelection(true);
+
+      for(int i = 0; i < cols.getAttributeCount(); i++) {
+         if(!(cols.getAttribute(i) instanceof ColumnRef cref)) {
+            continue;
+         }
+
+         String colName = cref.getAlias() != null && !cref.getAlias().isEmpty()
+            ? cref.getAlias() : cref.getAttribute();
+
+         if(colName.equals(attribute)) {
+            return true;
+         }
+      }
+
+      return false;
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/AddFilterService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/AddFilterService.java
@@ -283,7 +283,17 @@ public class AddFilterService {
          }
 
          for(AssemblyRef ref : dependeds) {
-            pending.push(ref.getEntry().getName());
+            // Null-guarded deliberately: ArrayDeque REJECTS null elements with a
+            // NullPointerException (it is not a null-permitting Collection), so an AssemblyRef with
+            // no entry -- or an entry with no name -- would abort the entire dashboard compose here
+            // rather than merely failing to resolve one filter. A ref we cannot name is a ref we
+            // cannot walk into, which is exactly the "resolves nothing -> request is skipped"
+            // outcome this lookup already produces for a dangling reference below.
+            String dep = ref.getEntry() != null ? ref.getEntry().getName() : null;
+
+            if(dep != null) {
+               pending.push(dep);
+            }
          }
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -265,9 +265,10 @@ public class WizDashboardFilterBuilder {
     * the given fixed point (the top of that chart's own tile) and sized to {@code width} ×
     * {@code height} — the caller passes the CHART's own width and the reserved header height so
     * the control spans the full width of, and sits flush against the top of, the chart it
-    * filters. Unlike {@link #build}, there is no multi-table candidate search — the single
-    * {@code chartTableName} IS the candidate, so binding is unambiguous by construction (no
-    * residual name-collision risk across charts).
+    * filters. Unlike {@link #build}, there is no board-wide candidate search — post-aggregation
+    * (the default) the single {@code chartTableName} IS the candidate, and pre-aggregation the
+    * candidates are only the root tables reachable from it, so either way the binding is scoped to
+    * this one chart by construction (no residual name-collision risk across charts).
     *
     * <p>When {@code chartAssemblyName} resolves to a real assembly on {@code vs}, the control and
     * that chart are styled as one visually-grouped "card" (matching background, a shared border
@@ -284,8 +285,27 @@ public class WizDashboardFilterBuilder {
                                                 int width, int height, FilterRequest request,
                                                 String chartTableName, String chartAssemblyName)
    {
-      List<String> tables = AddFilterService.findColumnMatchingChartTables(
-         baseWorksheet, List.of(chartTableName), request.field());
+      // Post-aggregation (default): bind to this chart's FINAL bound table -- the control filters
+      // the already-aggregated display rows (see the class Javadoc). Pre-aggregation: bind to the
+      // raw source table(s) carrying the column that are REACHABLE FROM THIS CHART's own table
+      // (findColumnMatchingRootTablesForChart) so the selection applies as a WHERE before any
+      // group-by, filtering the underlying rows and letting the aggregate re-compute over the
+      // subset -- the only way to filter by an orthogonal column that never survives to the
+      // chart's final table (e.g. order `state` on a revenue-by-quarter chart).
+      //
+      // Key distinction from the shared-bar path in build(): that one resolves via
+      // findColumnMatchingRootTables, which scans EVERY visible root table in the merged dashboard
+      // worksheet, so one WHERE can also reach a chart whose cross-row math (a window function, a
+      // global-aggregate ratio) a subset WHERE would collapse -- forcing its caller to veto the
+      // filter unless every chart sharing the column name is structurally safe. Here the control
+      // belongs to exactly ONE chart's tile and binds only to THAT chart's own raw source, so this
+      // chart's safety is decided independently of the rest of the board and no such veto is
+      // needed. Default (false) stays post-aggregation, unchanged.
+      List<String> tables = request.preAggregation()
+         ? AddFilterService.findColumnMatchingRootTablesForChart(
+              baseWorksheet, chartTableName, request.field())
+         : AddFilterService.findColumnMatchingChartTables(
+              baseWorksheet, List.of(chartTableName), request.field());
 
       if(tables.isEmpty()) {
          return null;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -540,8 +540,8 @@ public class WizDashboardService {
       Viewsheet vs, Worksheet baseWs, WizDashboardEvent.PerChartFilterSpec spec,
       int x, int y, int width, int height, String chartTableName, String chartAssemblyName)
    {
-      WizDashboardFilterBuilder.FilterRequest req =
-         new WizDashboardFilterBuilder.FilterRequest(spec.getField(), spec.getDataType(), spec.getLabel());
+      WizDashboardFilterBuilder.FilterRequest req = new WizDashboardFilterBuilder.FilterRequest(
+         spec.getField(), spec.getDataType(), spec.getLabel(), spec.isPreAggregation());
       return filterBuilder.buildPerChart(vs, baseWs, x, y, width, height, req, chartTableName, chartAssemblyName);
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -22,8 +22,10 @@ import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
 import inetsoft.uql.ColumnSelection;
 import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.MirrorTableAssembly;
 import inetsoft.uql.asset.PhysicalBoundTableAssembly;
 import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.asset.TableAssembly;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.schema.XSchema;
@@ -326,6 +328,139 @@ class WizDashboardFilterBuilderTest {
    }
 
    @Test
+   void perChartPreAggregationFilterBindsToTheChartsRawSourceNotItsFinalTable() {
+      // The chart is a revenue-by-quarter aggregate: its final table (a mirror over the raw source,
+      // exactly what the wiz merge stacks) carries only the grouped dim + measure. `state` lives
+      // only on the RAW source, so post-aggregation cannot reach it at all -- pre-aggregation binds
+      // there instead (a WHERE before the group-by) so the aggregate re-computes over the subset.
+      Worksheet ws = new Worksheet();
+      TableAssembly raw = physicalTable(ws, "SO_RAW", "date_order", "amount_total", "state");
+      ws.addAssembly(raw);
+      ws.addAssembly(mirrorTable(ws, "SO_REVENUE_BY_QTR", raw, "Quarter(date_order)", "total_revenue"));
+
+      Viewsheet vs = new Viewsheet();
+
+      WizDashboardFilterBuilder.FilterControlPlacement placement = builder.buildPerChart(vs, ws, 100, 200, 640, 28,
+         new WizDashboardFilterBuilder.FilterRequest("state", "string", "State", true),
+         "SO_REVENUE_BY_QTR", null);
+
+      assertNotNull(placement, "pre-aggregation must reach a column that never survives to the final table");
+
+      AbstractSelectionVSAssembly control = java.util.Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof AbstractSelectionVSAssembly)
+         .map(a -> (AbstractSelectionVSAssembly) a)
+         .findFirst().orElseThrow();
+      assertEquals(List.of("SO_RAW"), control.getTableNames(),
+         "pre-aggregation must bind to the chart's raw source table, not its aggregated final table");
+   }
+
+   @Test
+   void perChartPostAggregationStillBindsToTheFinalTableWithTheFlagFalseOrAbsent() {
+      // Regression guard for the default: with preAggregation false -- and with the flag simply
+      // absent (the 3-arg compatibility constructor) -- binding is byte-for-byte the old behavior:
+      // the chart's own FINAL table, and a column that only exists on the raw source is skipped.
+      Worksheet ws = new Worksheet();
+      TableAssembly raw = physicalTable(ws, "SO_RAW", "date_order", "amount_total", "state");
+      ws.addAssembly(raw);
+      ws.addAssembly(mirrorTable(ws, "SO_REVENUE_BY_QTR", raw, "Quarter(date_order)", "total_revenue"));
+
+      for(WizDashboardFilterBuilder.FilterRequest req : List.of(
+         new WizDashboardFilterBuilder.FilterRequest("total_revenue", "string", "Revenue", false),
+         new WizDashboardFilterBuilder.FilterRequest("total_revenue", "string", "Revenue")))
+      {
+         Viewsheet vs = new Viewsheet();
+         assertNotNull(builder.buildPerChart(vs, ws, 0, 0, 640, 28, req, "SO_REVENUE_BY_QTR", null));
+
+         AbstractSelectionVSAssembly control = java.util.Arrays.stream(vs.getAssemblies())
+            .filter(a -> a instanceof AbstractSelectionVSAssembly)
+            .map(a -> (AbstractSelectionVSAssembly) a)
+            .findFirst().orElseThrow();
+         assertEquals(List.of("SO_REVENUE_BY_QTR"), control.getTableNames(),
+            "post-aggregation must stay bound to the chart's final table");
+      }
+
+      // And post-aggregation still cannot reach a raw-source-only column -- unchanged.
+      Viewsheet vs = new Viewsheet();
+      assertNull(builder.buildPerChart(vs, ws, 0, 0, 640, 28,
+         new WizDashboardFilterBuilder.FilterRequest("state", "string", "State"), "SO_REVENUE_BY_QTR", null),
+         "post-aggregation must not reach a column absent from the final table");
+      assertEquals(0, vs.getAssemblies().length);
+   }
+
+   @Test
+   void perChartPreAggregationForOneChartNeverBindsToAnotherChartsRawSourceSharingTheColumnName() {
+      // THE isolation property this whole feature rests on. Two charts, each an aggregate over its
+      // OWN raw source, and BOTH raw sources expose a column called `state`. A per-chart
+      // pre-aggregation filter for chart A must bind to A_RAW only -- never B_RAW -- so chart B's
+      // structural safety (it could be a window/global-ratio chart a subset WHERE would collapse)
+      // is irrelevant to whether A's filter can be offered. That is what removes the conservative
+      // "every chart sharing the column name must be safe" veto the shared-bar path needs.
+      Worksheet ws = new Worksheet();
+      TableAssembly aRaw = physicalTable(ws, "A_RAW", "date_order", "amount_total", "state");
+      TableAssembly bRaw = physicalTable(ws, "B_RAW", "date_order", "amount_total", "state");
+      ws.addAssembly(aRaw);
+      ws.addAssembly(bRaw);
+      ws.addAssembly(mirrorTable(ws, "A_FINAL", aRaw, "Quarter(date_order)", "total_revenue"));
+      ws.addAssembly(mirrorTable(ws, "B_FINAL", bRaw, "Quarter(date_order)", "revenue_share"));
+
+      // The shared-bar resolver has no chart scope: it reaches BOTH raw sources from this same
+      // worksheet, which is precisely why its caller must veto on the least-safe chart.
+      assertEquals(List.of("A_RAW", "B_RAW"),
+         AddFilterService.findColumnMatchingRootTables(ws, "state"),
+         "the shared-bar resolver is board-wide -- the premise of the veto this test removes");
+
+      Viewsheet vs = new Viewsheet();
+
+      assertNotNull(builder.buildPerChart(vs, ws, 0, 0, 640, 28,
+         new WizDashboardFilterBuilder.FilterRequest("state", "string", "State", true), "A_FINAL", null));
+
+      AbstractSelectionVSAssembly control = java.util.Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof AbstractSelectionVSAssembly)
+         .map(a -> (AbstractSelectionVSAssembly) a)
+         .findFirst().orElseThrow();
+      assertEquals(List.of("A_RAW"), control.getTableNames(),
+         "chart A's pre-aggregation filter must bind ONLY to A's own root table, never B_RAW");
+   }
+
+   @Test
+   void perChartPreAggregationIsSkippedWhenTheColumnLivesOnlyOnAnUnrelatedChartsSource() {
+      // The chart-scoped lookup finds nothing (the column is on another chart's raw source, not
+      // reachable from this chart's table) -> the request is SKIPPED, never bound to the wrong
+      // table. Binding a pre-aggregation control to a table this chart doesn't read would filter
+      // nothing here while silently changing whatever else reads that table.
+      Worksheet ws = new Worksheet();
+      TableAssembly aRaw = physicalTable(ws, "A_RAW", "date_order", "amount_total");
+      ws.addAssembly(aRaw);
+      ws.addAssembly(mirrorTable(ws, "A_FINAL", aRaw, "Quarter(date_order)", "total_revenue"));
+      // `state` exists only here, on an unrelated chart's source.
+      ws.addAssembly(physicalTable(ws, "B_RAW", "state"));
+
+      Viewsheet vs = new Viewsheet();
+
+      assertNull(builder.buildPerChart(vs, ws, 0, 0, 640, 28,
+         new WizDashboardFilterBuilder.FilterRequest("state", "string", "State", true), "A_FINAL", null),
+         "a column only on an unrelated chart's source must be skipped, not mis-bound");
+      assertEquals(0, vs.getAssemblies().length, "no control may be added when nothing matched");
+   }
+
+   @Test
+   @org.junit.jupiter.api.Timeout(30)
+   void perChartPreAggregationTerminatesOnASelfReferentialDependencyGraph() {
+      // A malformed worksheet (a mirror whose base is itself) must not hang the dashboard compose:
+      // the walk's visited set terminates it. Nothing is reachable, so nothing binds.
+      Worksheet ws = new Worksheet();
+      MirrorTableAssembly cyclic = mirrorTable(ws, "CYCLE", physicalTable(ws, "SO_RAW", "state"), "state");
+      cyclic.setTableAssemblies(new TableAssembly[]{ cyclic });
+      ws.addAssembly(cyclic);
+
+      Viewsheet vs = new Viewsheet();
+
+      assertNull(builder.buildPerChart(vs, ws, 0, 0, 640, 28,
+         new WizDashboardFilterBuilder.FilterRequest("state", "string", "State", true), "CYCLE", null));
+      assertEquals(0, vs.getAssemblies().length);
+   }
+
+   @Test
    void buildPerChartReturnsNullWhenSkipped() {
       Worksheet ws = new Worksheet();
       ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name"));
@@ -405,7 +540,23 @@ class WizDashboardFilterBuilderTest {
       PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, assemblyName);
       SourceInfo si = new SourceInfo(SourceInfo.PHYSICAL_TABLE, "postgres", "public." + assemblyName);
       table.setSourceInfo(si);
+      table.setColumnSelection(columnSelection(columns), false);
+      return table;
+   }
 
+   // A wiz-merged chart's own final table is a MirrorTableAssembly stacked over the shared physical
+   // base (see WsMergeService) -- the shape the pre-aggregation walk has to traverse. Its own column
+   // selection is set explicitly to the AGGREGATE OUTPUT columns, so the raw columns are reachable
+   // only through getDependeds (which a mirror answers with the table it mirrors), never directly.
+   private static MirrorTableAssembly mirrorTable(Worksheet ws, String assemblyName,
+                                                  TableAssembly base, String... columns)
+   {
+      MirrorTableAssembly mirror = new MirrorTableAssembly(ws, assemblyName, base);
+      mirror.setColumnSelection(columnSelection(columns), false);
+      return mirror;
+   }
+
+   private static ColumnSelection columnSelection(String... columns) {
       ColumnSelection cs = new ColumnSelection();
 
       for(String name : columns) {
@@ -416,8 +567,7 @@ class WizDashboardFilterBuilderTest {
          cs.addAttribute(col);
       }
 
-      table.setColumnSelection(cs, false);
-      return table;
+      return cs;
    }
 
    // Helper mirrors AddFilterService.buildColumnRef (AttributeRef + ColumnRef with dataType).


### PR DESCRIPTION
## What

A pre-aggregation dashboard filter binds to a chart's RAW source table, so the selection becomes a
WHERE before the group-by and the chart's aggregate re-computes over the subset. #4452 added that for
the SHARED filter bar. This adds it for PER-CHART filters, and the difference matters more than parity.

`AddFilterService.findColumnMatchingRootTables(ws, attribute)` has **no chart scope** — it returns
every visible root table in the merged dashboard worksheet carrying a column of that name. For the
shared bar that is arguably right, but it forces the wiz-services caller into a conservative veto: it
may only offer a discovered pre-aggregation filter when EVERY chart whose raw source exposes that
column name is structurally safe, because otherwise the WHERE also reaches a chart whose cross-row
maths a subset WHERE would collapse (a window function, a global-aggregate ratio) — silently wrong
numbers. On a board mixing a plain per-group chart with a window or ratio chart over the same table,
common column names get vetoed and no filter appears.

A per-chart control belongs to exactly one tile. Binding it to only THAT chart's own raw source makes
each chart's safety independent of every other chart's, which **retires the veto** on this path.

## How

- **`AddFilterService.findColumnMatchingRootTablesForChart`** (new, package-visible beside its two
  siblings): walks the chart table's transitive `getDependeds` down to `getDependeds`-empty roots and
  matches the column among only those. Visited-set guarded, so a cyclic or self-referential graph in a
  malformed worksheet cannot hang a compose.
- The alias-first matching rule is now **one** implementation (`tableHasColumn`) shared by all three
  lookups. If that rule diverged between them by even the alias precedence, a filter would bind
  through one path and silently not bind through another.
- `WizDashboardEvent.PerChartFilterSpec` gains `preAggregation`; `buildPerChart` honours it;
  `WizDashboardService.applyPerChartFilter` stops using the 3-arg compatibility `FilterRequest`
  constructor, which hardcoded post-aggregation.
- Default (`false`) behaviour is unchanged, and #4466's dropdown/title-height handling below it is
  untouched.

## Verification

`./mvnw -o -pl core clean test -Dtest='WizDashboardFilterBuilderTest,AddFilterServiceTest,WizDashboardServiceGridTest,WizDashboardServiceTest'` → **47 tests, 0 failures**.

The load-bearing test is the isolation property this whole change exists for: two charts whose raw
sources BOTH expose a column of the same name, and chart A's per-chart pre-aggregation filter binds
ONLY to A's root, not B's. Also covered: pre-aggregation binds to the raw source rather than the final
aggregated table; `false` and absent both bind to the final table as before; and a chart-scoped lookup
finding nothing skips the request rather than binding the wrong table.

Two things confirmed rather than assumed:
- **The transitive-`getDependeds` walk really does reach raw sources.** `WsMergeService` stacks
  `MirrorTableAssembly` over a shared `BoundTableAssembly`; the mirror's `getDependeds` names the
  mirrored table and a plain bound table reports an empty set. Nothing is interposed that breaks it.
- **The new tests are non-vacuous** — with the new branch stubbed to `false`, 3 of the 5 fail with the
  expected assertion messages.

## Known limitation (pre-existing, fails safe)

A root `BoundTableAssembly` carrying a design-time condition that references a variable or subquery
table has a non-empty `getDependeds`, so neither the shared-bar resolver nor this one treats it as a
root. The walk then resolves nothing and the request is **skipped** — never mis-bound. Same blindness
as `findColumnMatchingRootTables`, so behaviour is consistent, and it errs toward "no filter" rather
than "wrong numbers".

Unit-tested only; no image build or browser verification. The wiz-services caller must set
`preAggregation` on `PerChartFilterSpec` before any of this is reachable end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
