### PR TITLE
Bug #75851, fix stale node selected in Data Space pane after deleting a folder

### DIFF
--- a/web/projects/em/src/app/settings/content/content-data-space-view/content-data-space-view.component.ts
+++ b/web/projects/em/src/app/settings/content/content-data-space-view/content-data-space-view.component.ts
@@ -110,9 +110,22 @@ export class ContentDataSpaceViewComponent implements OnInit {
       let nextNode: FlatTreeNode<DataSpaceTreeNode> = null;
 
       if(this.currentNode) {
-         for(let i = 0; i < this.dataSource.data.length - 1; i++) {
-            if(Tool.isEquals(this.currentNode, this.dataSource.data[i])) {
-               nextNode = this.dataSource.data[i + 1];
+         const index = this.dataSource.data.findIndex(n => Tool.isEquals(this.currentNode, n));
+
+         if(index >= 0) {
+            // skip past the deleted node's own descendants so we don't select a
+            // child of the node being deleted as the next current node
+            const level = this.dataSource.data[index].level;
+            let nextIndex = index + 1;
+
+            while(nextIndex < this.dataSource.data.length &&
+               this.dataSource.data[nextIndex].level > level)
+            {
+               nextIndex++;
+            }
+
+            if(nextIndex < this.dataSource.data.length) {
+               nextNode = this.dataSource.data[nextIndex];
             }
          }
       }


### PR DESCRIPTION
## Summary

In Enterprise Manager's Data Space (Storage) page, deleting a folder that contains an item left the right-hand detail pane showing the deleted folder's child item as if it were still selected (e.g. `folder1/organization0.zip` remained "selected" after `folder1` was deleted).

## Root Cause

`ContentDataSpaceViewComponent.handleNodeDeleted()` picked the next node to select after a delete by simply taking the entry immediately following the current node in the flattened tree array (`dataSource.data[i + 1]`). Since expanded folders list their children immediately after themselves in that flat array, if the deleted folder had children, the "next" node picked was actually one of the deleted folder's own children — which was about to be removed along with its parent.

## Fix

`handleNodeDeleted()` now skips past all of the deleted node's descendants (comparing `FlatTreeNode.level`, the same technique already used in `DataSpaceTreeDataSource.deleteNode()`) before picking the next node to select, so it only ever lands on a true sibling/ancestor-level node instead of a child of the node being removed.

## Test Plan

- [x] Repro steps from the issue verified fixed: create a folder, upload a file into it, select the folder, delete it — the detail pane no longer shows the deleted folder's child as selected.
- [x] `ng build em --configuration development` succeeds.
- [x] `npm run test:em` — all 356 tests pass (101 files).
- [x] `ng lint --project=em` — 0 errors.

Fixes Redmine #75851.