### PR TITLE
Bug #75823, fix range slider not showing minimum value when bound to a cube aggregate measure

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
@@ -139,6 +139,15 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
                sortinfo.addSort(sort);
                tassembly.setSortInfo(sortinfo);
             }
+
+            // ignore null otherwise a member with a null aggregate/measure value
+            // sorts to the front and shows as a blank min label
+            ConditionList conds = new ConditionList();
+            Condition cond = new Condition(column.getDataType());
+            cond.setNegated(true);
+            cond.setOperation(Condition.NULL);
+            conds.append(new ConditionItem(column, cond, 0));
+            tassembly.setPreRuntimeConditionList(conds);
          }
          else {
             if(column instanceof CalculateRef) {


### PR DESCRIPTION
## Summary
- When a RangeSlider (TimeSlider) is bound to an OLAP cube aggregate measure, `TimeSliderVSAQuery.getTableAssembly()` routes through the member-list branch (used for cube/MEMBER-type bindings) instead of the standard numeric MIN/MAX aggregation branch.
- That branch did not exclude members whose measure value is `null`. A null-valued member sorts to the front (ascending sort) and becomes the slider's "minimum" selection value, which renders as a blank label instead of a number — while the maximum still displays correctly.
- Fix: add the same null-exclusion pre-runtime condition that the non-cube aggregation branch already applies (see comment "ignore null otherwise a null could cause a numeric column not usable as in a range slider"), so a null-measure member can no longer become the slider's min/max anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)