### PR TITLE
fix(wiz): give shared-bar filters a gap and a caption saying what they filter

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -26,6 +26,7 @@ import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.RectangleVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.SelectionVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.TitledVSAssemblyInfo;
+import inetsoft.uql.asset.internal.AssetUtil;
 import org.springframework.stereotype.Component;
 
 import java.awt.Color;
@@ -196,20 +197,22 @@ public class WizDashboardFilterBuilder {
 
          if(req.label() != null && control instanceof TitledVSAssembly titled) {
             titled.setTitleValue(req.label());
-
-            // Setting the title VALUE is not enough to make it appear: a TimeSliderVSAssembly
-            // (date/numeric range) renders with its title hidden by default, so a shared-bar range
-            // slider showed only its own value range -- "6..216" with nothing saying that is
-            // partner_id, and no way for a user to tell what the slider filters. Force the title
-            // visible so every control is self-describing.
-            //
-            // The DESIGN value (setTitleVisibleValue, not setTitleVisible) is what matters here: a
-            // composed dashboard is SAVED and reopened, and only the design value survives that
-            // round trip -- the same reason the per-chart dropdown sets setTitleHeightValue.
-            if(control.getVSAssemblyInfo() instanceof TitledVSAssemblyInfo titleInfo) {
-               titleInfo.setTitleVisibleValue(true);
-            }
          }
+
+         // KNOWN UNFIXED: a shared-bar range slider renders with NO visible title -- a numeric slider
+         // shows a bare "6..216" with nothing telling the user it filters partner_id. The label IS
+         // applied above (setTitleValue). These explanations have each been RULED OUT by test, so do
+         // NOT retry them:
+         //   - the DESIGN title-visible value (getTitleVisibleValue) is already true by default;
+         //   - the RUNTIME flag (isTitleVisible) is already true by default;
+         //   - the title height is already AssetUtil.defh (20), not zero.
+         // Explicit setTitleVisibleValue(true) and setTitleVisible(true) calls were both tried against
+         // a live dashboard and changed nothing, and a test asserting either passes with AND without
+         // them -- so any such "fix" here is vacuous. TitleInfo's no-arg constructor does leave
+         // titleVisible as a valueless DynamicValue2 (vs TitleInfo(String) seeding "true"), which
+         // looked like the cause but is not: both getters still report true.
+         // Remaining hypothesis: the client-side TimeSlider component renders no title area at all,
+         // which has to be investigated in the Angular viewer, not here.
 
          Point pos = new Point(x, y);
          java.awt.Dimension size = new java.awt.Dimension(FILTER_CONTROL_WIDTH, FILTER_CONTROL_HEIGHT);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -25,6 +25,7 @@ import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.RectangleVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.SelectionVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.TextVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.TitledVSAssemblyInfo;
 import inetsoft.uql.asset.internal.AssetUtil;
 import org.springframework.stereotype.Component;
@@ -214,8 +215,17 @@ public class WizDashboardFilterBuilder {
          // Remaining hypothesis: the client-side TimeSlider component renders no title area at all,
          // which has to be investigated in the Angular viewer, not here.
 
-         Point pos = new Point(x, y);
-         java.awt.Dimension size = new java.awt.Dimension(FILTER_CONTROL_WIDTH, FILTER_CONTROL_HEIGHT);
+         // Caption above the control, so a user can tell what the control filters -- a bare "6..216"
+         // range slider is otherwise unreadable. Its placement is returned alongside the control's:
+         // an assembly with no per-tier layout entry is hidden when that tier is selected.
+         if(req.label() != null) {
+            placements.add(addCaption(vs, "wizFilterLabel_" + control.getName(),
+                                      x, y, FILTER_CONTROL_WIDTH, FILTER_LABEL_HEIGHT, req.label()));
+         }
+
+         Point pos = new Point(x, y + FILTER_LABEL_HEIGHT);
+         java.awt.Dimension size =
+            new java.awt.Dimension(FILTER_CONTROL_WIDTH, FILTER_CONTROL_HEIGHT - FILTER_LABEL_HEIGHT);
          control.setTableNames(tables);
          control.setPixelOffset(pos);
          // Explicit compact size: SelectionList/TimeSlider's own default pixel size is not
@@ -259,6 +269,30 @@ public class WizDashboardFilterBuilder {
     * "...Value" setter that survives save/reload, like the card styling) plus the plain setter for
     * any pre-persist read, and NO_BORDER line style so only the fill shows.
     */
+   /**
+    * Adds a small static text caption at (x, y) reading {@code label} -- the stand-in for the title a
+    * standalone range slider refuses to render (see FILTER_LABEL_HEIGHT). Deliberately a plain
+    * TextVSAssembly rather than a styled one: it must read as a field caption, not compete with the
+    * control below it.
+    */
+   private static FilterControlPlacement addCaption(
+      Viewsheet vs, String name, int x, int y, int width, int height, String label)
+   {
+      TextVSAssembly text = new TextVSAssembly(vs, name);
+      text.initDefaultFormat();
+      TextVSAssemblyInfo info = (TextVSAssemblyInfo) text.getVSAssemblyInfo();
+      Point pos = new Point(x, y);
+      Dimension size = new Dimension(width, height);
+      info.setPixelOffset(pos);
+      info.setPixelSize(size);
+      info.setValue(label);
+      // setValue alone is the RUNTIME value; the design value is what survives the composed
+      // dashboard being saved and reopened (the same distinction that bit the title work).
+      info.setTextValue(label);
+      vs.addAssembly(text);
+      return new FilterControlPlacement(text.getName(), pos, size);
+   }
+
    private static FilterControlPlacement addFillRectangle(
       Viewsheet vs, String name, int x, int y, int width, int height, Color fill)
    {
@@ -491,6 +525,18 @@ public class WizDashboardFilterBuilder {
     * where one filter ended and the next began.
     */
    private static final int FILTER_CONTROL_GAP = 16;
+   /**
+    * Height of the caption drawn above each shared-bar control, in pixels.
+    *
+    * A range slider will NOT draw its own title: vs-range-slider.component.html gates the whole
+    * title header on {@code @if (isInSelectionContainer())}, which is true only inside a
+    * VSSelectionContainer or for an adhoc filter -- so a standalone bar control renders no title
+    * area no matter what the server sets (design AND runtime titleVisible are already true and the
+    * title height is already AssetUtil.defh; all three were ruled out by test). Rather than widen
+    * that shared component's behaviour for every standalone slider in the product, draw our own
+    * caption beside the control.
+    */
+   private static final int FILTER_LABEL_HEIGHT = 16;
 
    /** Shared-bar control height, in pixels — compact: a range slider (the usual shared filter) or
     *  a short selection list needs far less than a chart tile, and the toolbar band

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -25,6 +25,7 @@ import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.RectangleVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.SelectionVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.TitledVSAssemblyInfo;
 import org.springframework.stereotype.Component;
 
 import java.awt.Color;
@@ -195,6 +196,19 @@ public class WizDashboardFilterBuilder {
 
          if(req.label() != null && control instanceof TitledVSAssembly titled) {
             titled.setTitleValue(req.label());
+
+            // Setting the title VALUE is not enough to make it appear: a TimeSliderVSAssembly
+            // (date/numeric range) renders with its title hidden by default, so a shared-bar range
+            // slider showed only its own value range -- "6..216" with nothing saying that is
+            // partner_id, and no way for a user to tell what the slider filters. Force the title
+            // visible so every control is self-describing.
+            //
+            // The DESIGN value (setTitleVisibleValue, not setTitleVisible) is what matters here: a
+            // composed dashboard is SAVED and reopened, and only the design value survives that
+            // round trip -- the same reason the per-chart dropdown sets setTitleHeightValue.
+            if(control.getVSAssemblyInfo() instanceof TitledVSAssemblyInfo titleInfo) {
+               titleInfo.setTitleVisibleValue(true);
+            }
          }
 
          Point pos = new Point(x, y);
@@ -209,7 +223,7 @@ public class WizDashboardFilterBuilder {
          vs.addAssembly(control);
          applied.add(req.field());
          placements.add(new FilterControlPlacement(control.getName(), pos, size));
-         x += FILTER_CONTROL_WIDTH;
+         x += FILTER_CONTROL_WIDTH + FILTER_CONTROL_GAP;
       }
 
       return new FilterResult(applied, skipped, placements);
@@ -467,6 +481,13 @@ public class WizDashboardFilterBuilder {
    private static final int FILTER_BAR_X = WizDashboardService.CANVAS_MARGIN;
    private static final int FILTER_BAR_Y = WizDashboardService.CANVAS_MARGIN;
    private static final int FILTER_CONTROL_WIDTH = 200;
+   /**
+    * Horizontal gap between adjacent shared-bar controls, in pixels. Without it the stride equalled
+    * the control width exactly, so controls butted edge-to-edge and read as one continuous widget --
+    * two range sliders side by side looked like a single double-ended slider, and it was not obvious
+    * where one filter ended and the next began.
+    */
+   private static final int FILTER_CONTROL_GAP = 16;
 
    /** Shared-bar control height, in pixels — compact: a range slider (the usual shared filter) or
     *  a short selection list needs far less than a chart tile, and the toolbar band

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -217,14 +217,12 @@ class WizDashboardFilterBuilderTest {
    }
 
    @Test
-   void everySharedBarControlHasAVisibleTitleSoItSaysWhatItFilters() {
-      // Pins an invariant we depend on, NOT a regression test for a fix: this assertion passes both
-      // with and without the explicit setTitleVisibleValue(true) call, because the design default is
-      // already true. So the live symptom -- a numeric range slider rendering as bare "6..216" with
-      // nothing saying it filters partner_id -- is NOT explained by the design value and remains
-      // UNDIAGNOSED. Candidates still to check against a running instance: the RUNTIME titleVisible
-      // (as opposed to the design value), a zero title height, or TimeSliderVSAssembly's own renderer
-      // ignoring the title entirely. Do not read this test as proof the title now shows.
+   void aSharedBarControlCarriesItsLabelAsTheTitleValue() {
+      // Asserts ONLY what is actually true and load-bearing: the label reaches the control's title
+      // value. Deliberately does NOT assert visibility or height -- both are already true/non-zero by
+      // default, so such assertions pass with and without any change and prove nothing. The observed
+      // missing title is NOT explained by anything assertable here; see the note in
+      // WizDashboardFilterBuilder.build for what has been ruled out.
       Worksheet ws = new Worksheet();
       ws.addAssembly(physicalTable(ws, "SO", "partner_id"));
 
@@ -236,13 +234,9 @@ class WizDashboardFilterBuilderTest {
       WizDashboardFilterBuilder.FilterResult result = builder.build(vs, ws, List.of(
          new WizDashboardFilterBuilder.FilterRequest("partner_id", "integer", "Customer")), 0);
 
-      assertEquals(1, result.placements().size());
       VSAssembly placed = (VSAssembly) vs.getAssembly(result.placements().get(0).assemblyName());
-      assertTrue(placed instanceof TimeSliderVSAssembly,
-         "a numeric column should yield a range slider, got " + placed.getClass().getSimpleName());
       TitledVSAssemblyInfo info = (TitledVSAssemblyInfo) placed.getVSAssemblyInfo();
       assertEquals("Customer", info.getTitleValue());
-      assertTrue(info.getTitleVisibleValue(), "the title must be VISIBLE, not merely set");
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -30,6 +30,7 @@ import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.TitledVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.SelectionVSAssemblyInfo;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -187,6 +188,61 @@ class WizDashboardFilterBuilderTest {
          .findFirst().orElseThrow();
       assertEquals(List.of("CHART_FINAL"), control.getTableNames(),
          "must bind only to the chart's own table, never GLOBAL_STATS");
+   }
+
+   @Test
+   void adjacentSharedBarControlsAreSeparatedByAGap() {
+      // Observed live: two range sliders butted edge-to-edge read as ONE double-ended slider, with no
+      // visual cue where one filter stopped and the next began -- the stride equalled the control
+      // width exactly.
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "SO", "state", "region"));
+
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(vs, "C");
+      boundToTable(chart, "SO");
+      vs.addAssembly(chart);
+
+      WizDashboardFilterBuilder.FilterResult result = builder.build(vs, ws, List.of(
+         new WizDashboardFilterBuilder.FilterRequest("state", "string", "State"),
+         new WizDashboardFilterBuilder.FilterRequest("region", "string", "Region")), 0);
+
+      assertEquals(2, result.placements().size(), "both controls should be placed");
+      int firstX = result.placements().get(0).position().x;
+      int secondX = result.placements().get(1).position().x;
+      int width = result.placements().get(0).size().width;
+      assertTrue(secondX > firstX + width,
+         "adjacent controls must not touch: second x=" + secondX + " should exceed first x=" + firstX
+            + " plus width=" + width);
+   }
+
+   @Test
+   void everySharedBarControlHasAVisibleTitleSoItSaysWhatItFilters() {
+      // Pins an invariant we depend on, NOT a regression test for a fix: this assertion passes both
+      // with and without the explicit setTitleVisibleValue(true) call, because the design default is
+      // already true. So the live symptom -- a numeric range slider rendering as bare "6..216" with
+      // nothing saying it filters partner_id -- is NOT explained by the design value and remains
+      // UNDIAGNOSED. Candidates still to check against a running instance: the RUNTIME titleVisible
+      // (as opposed to the design value), a zero title height, or TimeSliderVSAssembly's own renderer
+      // ignoring the title entirely. Do not read this test as proof the title now shows.
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "SO", "partner_id"));
+
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(vs, "C");
+      boundToTable(chart, "SO");
+      vs.addAssembly(chart);
+
+      WizDashboardFilterBuilder.FilterResult result = builder.build(vs, ws, List.of(
+         new WizDashboardFilterBuilder.FilterRequest("partner_id", "integer", "Customer")), 0);
+
+      assertEquals(1, result.placements().size());
+      VSAssembly placed = (VSAssembly) vs.getAssembly(result.placements().get(0).assemblyName());
+      assertTrue(placed instanceof TimeSliderVSAssembly,
+         "a numeric column should yield a range slider, got " + placed.getClass().getSimpleName());
+      TitledVSAssemblyInfo info = (TitledVSAssemblyInfo) placed.getVSAssemblyInfo();
+      assertEquals("Customer", info.getTitleValue());
+      assertTrue(info.getTitleVisibleValue(), "the title must be VISIBLE, not merely set");
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -30,6 +30,7 @@ import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.TextVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.TitledVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.SelectionVSAssemblyInfo;
 import org.junit.jupiter.api.Tag;
@@ -207,10 +208,13 @@ class WizDashboardFilterBuilderTest {
          new WizDashboardFilterBuilder.FilterRequest("state", "string", "State"),
          new WizDashboardFilterBuilder.FilterRequest("region", "string", "Region")), 0);
 
-      assertEquals(2, result.placements().size(), "both controls should be placed");
-      int firstX = result.placements().get(0).position().x;
-      int secondX = result.placements().get(1).position().x;
-      int width = result.placements().get(0).size().width;
+      // Placements now carry a caption per control as well, so compare CONTROL placements only.
+      var ctls = result.placements().stream()
+         .filter(pl -> !pl.assemblyName().startsWith("wizFilterLabel_")).toList();
+      assertEquals(2, ctls.size(), "both controls should be placed");
+      int firstX = ctls.get(0).position().x;
+      int secondX = ctls.get(1).position().x;
+      int width = ctls.get(0).size().width;
       assertTrue(secondX > firstX + width,
          "adjacent controls must not touch: second x=" + secondX + " should exceed first x=" + firstX
             + " plus width=" + width);
@@ -234,9 +238,34 @@ class WizDashboardFilterBuilderTest {
       WizDashboardFilterBuilder.FilterResult result = builder.build(vs, ws, List.of(
          new WizDashboardFilterBuilder.FilterRequest("partner_id", "integer", "Customer")), 0);
 
-      VSAssembly placed = (VSAssembly) vs.getAssembly(result.placements().get(0).assemblyName());
-      TitledVSAssemblyInfo info = (TitledVSAssemblyInfo) placed.getVSAssemblyInfo();
-      assertEquals("Customer", info.getTitleValue());
+      // A CAPTION assembly carries the label, because a standalone range slider renders no title of
+      // its own (vs-range-slider.component.html gates the whole title header on
+      // isInSelectionContainer()). Server-side titleVisible/titleHeight were all ruled out by test.
+      VSAssembly caption = (VSAssembly) vs.getAssembly("wizFilterLabel_" + control(vs).getName());
+      assertNotNull(caption, "every labelled control needs a caption assembly");
+      assertEquals("Customer", ((TextVSAssemblyInfo) caption.getVSAssemblyInfo()).getTextValue());
+
+      // ...and the caption is carried into the layout placements, or it is hidden whenever a layout
+      // tier is selected (the same trap the filter-bar band rectangles documented).
+      assertTrue(result.placements().stream().anyMatch(pl -> pl.assemblyName().equals(caption.getName())),
+                 "the caption must appear in the returned placements");
+
+      // The caption sits ABOVE the control, and the pair still fits the band the service reserves.
+      java.awt.Point captionPos = result.placements().stream()
+         .filter(pl -> pl.assemblyName().equals(caption.getName())).findFirst().orElseThrow().position();
+      WizDashboardFilterBuilder.FilterControlPlacement ctl = result.placements().stream()
+         .filter(pl -> !pl.assemblyName().startsWith("wizFilterLabel_")).findFirst().orElseThrow();
+      assertTrue(ctl.position().y > captionPos.y, "control must sit below its caption");
+      assertTrue(ctl.position().y + ctl.size().height
+                    <= captionPos.y + WizDashboardService.FILTER_BAR_ROW_HEIGHT,
+                 "caption + control must fit the reserved filter-bar row");
+   }
+
+   private static VSAssembly control(Viewsheet vs) {
+      return java.util.Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof AbstractSelectionVSAssembly)
+         .map(a -> (VSAssembly) a)
+         .findFirst().orElseThrow();
    }
 
    @Test
@@ -290,10 +319,16 @@ class WizDashboardFilterBuilderTest {
          vs, ws, List.of(new WizDashboardFilterBuilder.FilterRequest("category_name", "string", "Category")),
          WizDashboardService.CANVAS_MARGIN);
 
-      assertEquals(1, result.placements().size());
-      assertNotNull(result.placements().get(0).assemblyName());
+      // Two placements per LABELLED control now: the control plus its caption (a standalone range
+      // slider renders no title of its own, so the caption stands in -- see FILTER_LABEL_HEIGHT).
+      // Both must be returned or an assembly with no per-tier layout entry is hidden.
+      assertEquals(2, result.placements().size());
+      assertTrue(result.placements().stream().allMatch(pl -> pl.assemblyName() != null));
+      // The CAPTION is the topmost thing in the bar, at the passed origin; the control sits under it.
+      var caption = result.placements().stream()
+         .filter(pl -> pl.assemblyName().startsWith("wizFilterLabel_")).findFirst().orElseThrow();
       assertEquals(new java.awt.Point(WizDashboardService.CANVAS_MARGIN, WizDashboardService.CANVAS_MARGIN),
-         result.placements().get(0).position());
+         caption.position());
    }
 
    @Test
@@ -315,8 +350,14 @@ class WizDashboardFilterBuilderTest {
          .findFirst().orElseThrow();
       assertEquals(WizDashboardService.CANVAS_MARGIN, control.getPixelOffset().x,
          "must sit at the passed startX (the merged charts' left edge)");
-      assertEquals(WizDashboardService.CANVAS_MARGIN, control.getPixelOffset().y,
-         "must not sit flush against the canvas's top edge");
+      // The control now sits BELOW its caption, so the caption is what must clear the top edge --
+      // same intent, one row up (see FILTER_LABEL_HEIGHT for why a caption exists at all).
+      assertTrue(control.getPixelOffset().y > WizDashboardService.CANVAS_MARGIN,
+         "the control sits below its caption");
+      var captionAssembly = vs.getAssembly("wizFilterLabel_" + control.getName());
+      assertNotNull(captionAssembly, "the control must have a caption above it");
+      assertEquals(WizDashboardService.CANVAS_MARGIN, ((VSAssembly) captionAssembly).getPixelOffset().y,
+         "the bar must not sit flush against the canvas's top edge");
    }
 
    @Test


### PR DESCRIPTION
Two defects seen on a live generated dashboard whose shared bar held two range sliders: the controls
butted edge-to-edge, and neither said what it filtered. Both fixed.

## 1. No gap between controls

`build()` advanced `x` by exactly `FILTER_CONTROL_WIDTH`, so adjacent controls touched — two range
sliders read as a single double-ended slider, with no cue where one filter ended and the next began.
Adds a 16px gap to the stride.

## 2. No title on a range slider

**Root cause is client-side.** `vs-range-slider.component.html:45` gates the entire title header —
the `vs-range-slider-header` div and everything reading `model.titleFormat` — on
`@if (isInSelectionContainer())`, true only inside a `VSSelectionContainer` or for an adhoc filter. A
standalone bar control therefore renders **no title area at all**, whatever the server sets.
`vs-range-slider.component.ts:952` corroborates it: the slider only subtracts `titleFormat.height`
from its own height when in a container.

**Three server-side explanations were tried and ruled out by test** — each assertion passes *with and
without* the corresponding call, so any such "fix" is vacuous:

| Hypothesis | Reality |
|---|---|
| design `getTitleVisibleValue()` was false | already `true` by default |
| runtime `isTitleVisible()` was false | already `true` by default |
| title height was zero | already `AssetUtil.defh` (20) |

`TitleInfo()`'s no-arg constructor *does* leave `titleVisible` as a valueless `DynamicValue2` while
`TitleInfo(String)` seeds `"true"` — which looked like a clean cause and is not; both getters still
report true. An explicit `setTitleVisibleValue`/`setTitleVisible` pair was deployed to a live
dashboard and changed nothing.

**The fix draws our own caption** rather than widening a component shared by every standalone slider
in the product, or moving our controls into a selection container: a plain `TextVSAssembly` above each
control carrying the request's label, with the control shifted down and shortened by the caption
height so the pair still fits the reserved filter-bar row. The caption's placement is returned with
the control's — an assembly with no per-tier layout entry is hidden whenever a layout tier is
selected, the trap the filter-bar band rectangles already document.

## Tests

`./mvnw -o -pl core test -Dtest='WizDashboardFilterBuilderTest,WizDashboardServiceGridTest,AddFilterServiceTest'`
→ **45/45**. Every new and updated assertion was confirmed to fail with the implementation reverted
(3 failures) — worth stating because the two earlier title attempts both passed *vacuously*, which is
how the false root causes above were caught.

Two existing tests legitimately changed shape rather than being weakened: a labelled control now
yields two placements (control + caption), and the CAPTION is now the topmost thing in the bar, so the
"must not sit flush against the top edge" assertion moved onto it — same intent, one row up.

## Verification

Built as `local-1122` and verified in a browser on a real generated dashboard: the gap appears and both
captions ("Quarter", "Customer") render. The gap was separately confirmed on `local-1121` before the
caption work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
