### PR TITLE
fix(wiz): read the PrimaryKey column attribute as a boolean, not a string

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -172,7 +172,7 @@ public class MetadataApiService {
 
          String columnName = columnNode.getName();
          String columnType = columnNode instanceof XTypeNode typeNode ? typeNode.getType() : null;
-         boolean isPK = "true".equals(columnNode.getAttribute("PrimaryKey"));
+         boolean isPK = isPrimaryKeyColumn(columnNode);
          Integer length = (Integer) columnNode.getAttribute("length");
          String comment = (String) columnNode.getAttribute("comment");
          List<String[]> foreignKeys = extractForeignKeys(columnNode);
@@ -295,6 +295,32 @@ public class MetadataApiService {
       catch(Exception e) {
          throw new RuntimeException("Failed to serialize field custom extension", e);
       }
+   }
+
+   /**
+    * True when a column node is flagged as part of the table's primary key.
+    *
+    * <p>The attribute is written by {@code JDBCHandler} as a <b>boolean</b>
+    * ({@code node.setAttribute("PrimaryKey", isPrimary)}), and
+    * {@link XNode#setAttribute(String, Object)} stores the value as an {@code Object} without
+    * coercing it. The previous test here was {@code "true".equals(getAttribute("PrimaryKey"))},
+    * which compares a {@code String} to a {@code Boolean} and is therefore <b>always false</b> —
+    * so every column was reported as a non-key and {@code dataset.primary_key} came back null for
+    * every table on every datasource. The sibling {@code ForeignKey} attribute was unaffected
+    * because {@link #extractForeignKeys} reads it as an object rather than string-comparing it,
+    * which is why relationships worked while primary keys silently did not.</p>
+    *
+    * <p>A {@code String} is still accepted: an {@link XNode} that has round-tripped through XML
+    * carries its attributes as text rather than as their original types.</p>
+    */
+   private static boolean isPrimaryKeyColumn(XNode columnNode) {
+      Object attr = columnNode.getAttribute("PrimaryKey");
+
+      if(attr instanceof Boolean flag) {
+         return flag;
+      }
+
+      return attr != null && "true".equalsIgnoreCase(attr.toString());
    }
 
    private List<String[]> extractForeignKeys(XNode columnNode) {
@@ -1823,7 +1849,7 @@ public class MetadataApiService {
          DatabaseTableMeta.ColumnMeta col = new DatabaseTableMeta.ColumnMeta();
          col.setName(columnNode.getName());
          col.setType(columnNode instanceof XTypeNode typeNode ? typeNode.getType() : null);
-         col.setPrimaryKey("true".equals(columnNode.getAttribute("PrimaryKey")));
+         col.setPrimaryKey(isPrimaryKeyColumn(columnNode));
 
          Integer length = (Integer) columnNode.getAttribute("length");
          col.setLength(length != null ? length : 0);

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePrimaryKeyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePrimaryKeyTest.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.XNode;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for the PrimaryKey attribute type mismatch.
+ *
+ * JDBCHandler writes the attribute as a BOOLEAN (JDBCHandler:3179,
+ * {@code node.setAttribute("PrimaryKey", isPrimary)}), and XNode.setAttribute stores the value as an
+ * Object without coercing it. MetadataApiService used to read it with
+ * {@code "true".equals(getAttribute("PrimaryKey"))} — a String compared to a Boolean, which is
+ * ALWAYS false. Every column was therefore reported as a non-key and {@code dataset.primary_key}
+ * was null for every table on every datasource, which silently disabled every downstream feature
+ * gated on a known primary key.
+ *
+ * The boolean case below is the one that reproduces the bug; it fails against the old
+ * string-comparison form.
+ */
+@Tag("core")
+class MetadataApiServicePrimaryKeyTest {
+   private static boolean isPK(Object attrValue) throws Exception {
+      XNode node = new XNode("some_column");
+
+      if(attrValue != null) {
+         node.setAttribute("PrimaryKey", attrValue);
+      }
+
+      Method m = MetadataApiService.class
+         .getDeclaredMethod("isPrimaryKeyColumn", XNode.class);
+      m.setAccessible(true);
+      return (Boolean) m.invoke(null, node);
+   }
+
+   @Test
+   void booleanTrueIsAPrimaryKey() throws Exception {
+      // THE BUG: this is exactly what JDBCHandler writes, and it used to evaluate to false.
+      assertTrue(isPK(Boolean.TRUE));
+   }
+
+   @Test
+   void booleanFalseIsNotAPrimaryKey() throws Exception {
+      assertFalse(isPK(Boolean.FALSE));
+   }
+
+   @Test
+   void stringTrueIsStillAccepted() throws Exception {
+      // An XNode round-tripped through XML carries its attributes as text.
+      assertTrue(isPK("true"));
+      assertTrue(isPK("TRUE"));
+   }
+
+   @Test
+   void stringFalseAndOtherValuesAreNotPrimaryKeys() throws Exception {
+      assertFalse(isPK("false"));
+      assertFalse(isPK("yes"));
+      assertFalse(isPK(1));
+   }
+
+   @Test
+   void aMissingAttributeIsNotAPrimaryKey() throws Exception {
+      assertFalse(isPK(null));
+   }
+}


### PR DESCRIPTION
## The bug

`JDBCHandler` writes the primary-key flag as a **boolean**:

```java
// JDBCHandler.java:3179
node.setAttribute("PrimaryKey", isPrimary);   // isPrimary is a boolean
```

`XNode.setAttribute(String key, Object val)` stores the value as an `Object` without coercing it, so the attribute stays a `Boolean`. `MetadataApiService` then read it as a string:

```java
boolean isPK = "true".equals(columnNode.getAttribute("PrimaryKey"));
```

`String.equals(Boolean)` is **always false**. Every column was therefore reported as a non-key, and `dataset.primary_key` came back `null` for every table on every datasource.

## Why this went unnoticed

The sibling `ForeignKey` attribute is written two lines later in the same block (`JDBCHandler:3182`) and works correctly — because `extractForeignKeys` reads it as an *object* rather than string-comparing it. So the relationship graph looked healthy while primary keys were silently empty, which made the failure look like missing data rather than a read bug.

## Impact

Anything gated on a known primary key was silently dark. Confirmed live against two datasources, where the generated annotation prose describes a column as a primary key while the structured field disagrees:

| table | column | annotation says | `isPrimaryKey` |
|---|---|---|---|
| `odoo.res_country` | `id` | "Surrogate primary key for the country row" | `false` |
| `odoo.res_partner` | `id` | "Surrogate primary key for the partner" | `false` |
| `suitecrm.opportunities` | `id` | "Unique UUID primary key for the opportunity record" | `false` |

## The fix

Both read sites (`MetadataApiService:175` and `:1852`) now share one helper that accepts a `Boolean` and still accepts a `String` — an `XNode` that has round-tripped through XML carries its attributes as text rather than their original types.

## Tests

Five regression tests in `MetadataApiServicePrimaryKeyTest`. The boolean case is the one that reproduces the bug.

Verified red/green rather than assumed: reverting the helper body to the old `"true".equals(attr)` form fails 2 of the 5 (`booleanTrueIsAPrimaryKey`, `stringTrueIsStillAccepted`), and the suite passes once restored.

```
./mvnw -o test -pl core -Dtest='MetadataApiServicePrimaryKeyTest'
Tests run: 5, Failures: 0
```

Also built and deployed as a local image (core-only rebuild; no new beans, so AOT-safe) and confirmed a clean boot.

## Note for reviewers

This corrects the *read* path only. Datasources annotated before this fix still carry the empty `primary_key` in their stored documents; they need a fresh annotation run to repopulate it, since `buildAnnotationInputs` deliberately reuses the cached document without writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)