### PR TITLE
feat(wiz): FK integrity endpoint, two metadata-extraction fixes, and a shared-bar filter fix

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/JDBCHandler.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/JDBCHandler.java
@@ -2712,6 +2712,13 @@ public class JDBCHandler extends XHandler {
             String fkTableSchem = result.getString(6);
             String fkTableName = result.getString(7);
             String fkColumnName = result.getString(8);
+            // FK_NAME (column 12) is what separates two distinct constraints between the same pair
+            // of tables. Without it, callers can only group by table pair, which merges independent
+            // single-column FKs (e.g. sale_order.partner_id, .partner_invoice_id and
+            // .partner_shipping_id all referencing res_partner.id) into one bogus composite
+            // relationship. Drivers that do not supply it leave this null, and the table-pair
+            // grouping remains the fallback.
+            String fkName = result.getString(12);
 
             XNode keyNode = new XNode("ImportKey" + (cnt ++));
 
@@ -2723,6 +2730,7 @@ public class JDBCHandler extends XHandler {
             keyNode.setAttribute("fkTableSchem", fkTableSchem);
             keyNode.setAttribute("fkTableName", fkTableName);
             keyNode.setAttribute("fkColumnName", fkColumnName);
+            keyNode.setAttribute("fkName", fkName);
 
             root.addChild(keyNode, false, false);
          }

--- a/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
@@ -95,13 +95,15 @@ public class DatasourceMetaApiController {
    }
 
    /**
-    * Reports how many rows an INNER join from a fact table to its foreign-key target would drop.
+    * Reports both ways an INNER join from a fact table to its foreign-key target would change an
+    * aggregate: how many rows it would drop, and how many target key values would fan rows out.
     *
     * <p>Used before a dashboard filter is rewritten from a range slider over a surrogate key to a
-    * label list drawn from the FK target: that rewrite injects an INNER join, which would silently
-    * drop NULL and orphaned foreign keys and so change every unfiltered aggregate. The caller only
-    * proceeds on a {@code droppedRowCount} of 0, and treats any non-200 as a rejection — so every
-    * failure here must stay a failure rather than become a count.</p>
+    * label list drawn from the FK target. That rewrite injects an INNER join, which silently drops
+    * NULL and orphaned foreign keys (deflating every unfiltered aggregate) and duplicates rows
+    * when the target key is not unique (inflating them). The caller proceeds only when both counts
+    * are 0, and treats any non-200 as a rejection — so every failure here must stay a failure
+    * rather than become a count.</p>
     */
    @PostMapping("/datasource/fk-integrity")
    public FkIntegrityResponse getFkIntegrity(
@@ -109,7 +111,7 @@ public class DatasourceMetaApiController {
       Principal principal)
       throws Exception
    {
-      return new FkIntegrityResponse(fkIntegrityService.countDroppedRows(data, principal));
+      return fkIntegrityService.checkIntegrity(data, principal);
    }
 
    @GetMapping("/ws/meta/{id}")

--- a/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
@@ -27,8 +27,10 @@ import inetsoft.web.portal.controller.database.DataSourceService;
 import inetsoft.web.wiz.WizUtil;
 import inetsoft.web.wiz.model.*;
 import inetsoft.web.wiz.model.osi.OsiDataset;
+import inetsoft.web.wiz.request.FkIntegrityRequest;
 import inetsoft.web.wiz.request.GetDatabaseTableMetaRequest;
 import inetsoft.web.wiz.request.SchemaSearchRequest;
+import inetsoft.web.wiz.service.FkIntegrityService;
 import inetsoft.web.wiz.service.MetadataApiService;
 import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import org.slf4j.Logger;
@@ -45,11 +47,13 @@ import java.util.*;
 public class DatasourceMetaApiController {
    public DatasourceMetaApiController(MetadataApiService metadataService,
                                       XRepository xrepository,
-                                      DataSourceService dataSourceService)
+                                      DataSourceService dataSourceService,
+                                      FkIntegrityService fkIntegrityService)
    {
       this.metadataService = metadataService;
       this.xrepository = xrepository;
       this.dataSourceService = dataSourceService;
+      this.fkIntegrityService = fkIntegrityService;
    }
 
    /**
@@ -88,6 +92,24 @@ public class DatasourceMetaApiController {
       throws Exception
    {
       return metadataService.getMetaData(data, principal);
+   }
+
+   /**
+    * Reports how many rows an INNER join from a fact table to its foreign-key target would drop.
+    *
+    * <p>Used before a dashboard filter is rewritten from a range slider over a surrogate key to a
+    * label list drawn from the FK target: that rewrite injects an INNER join, which would silently
+    * drop NULL and orphaned foreign keys and so change every unfiltered aggregate. The caller only
+    * proceeds on a {@code droppedRowCount} of 0, and treats any non-200 as a rejection — so every
+    * failure here must stay a failure rather than become a count.</p>
+    */
+   @PostMapping("/datasource/fk-integrity")
+   public FkIntegrityResponse getFkIntegrity(
+      @RequestBody FkIntegrityRequest data,
+      Principal principal)
+      throws Exception
+   {
+      return new FkIntegrityResponse(fkIntegrityService.countDroppedRows(data, principal));
    }
 
    @GetMapping("/ws/meta/{id}")
@@ -327,4 +349,5 @@ public class DatasourceMetaApiController {
    private final MetadataApiService metadataService;
    private final XRepository xrepository;
    private final DataSourceService dataSourceService;
+   private final FkIntegrityService fkIntegrityService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/FkIntegrityResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/FkIntegrityResponse.java
@@ -19,13 +19,19 @@
 package inetsoft.web.wiz.model;
 
 /**
- * The number of rows an INNER join from the fact table to its foreign-key target would drop.
+ * The two ways an INNER join from the fact table to its foreign-key target could change an
+ * aggregate. The join is safe to inject only when <em>both</em> counts are zero — a zero drop
+ * count alone is not sufficient, because a non-unique target key inflates every aggregate while
+ * dropping nothing.
  *
- * <p>This body is only ever produced for a query that actually ran and returned a row. Every
- * failure mode is an error response instead, because a body carrying {@code 0} means "safe to
- * join" to the caller.</p>
+ * <p>This body is only ever produced when both queries actually ran and returned a row. Every
+ * failure mode is an error response instead, because a body carrying zeros means "safe to join"
+ * to the caller.</p>
  *
- * @param droppedRowCount rows whose FK is NULL plus rows whose FK has no matching target row.
+ * @param droppedRowCount         rows the join would drop: rows whose FK is NULL, plus rows whose
+ *                                FK has no matching target row. Non-zero deflates aggregates.
+ * @param duplicateTargetKeyCount target key values occurring more than once. Non-zero means the
+ *                                join fans rows out and inflates aggregates.
  */
-public record FkIntegrityResponse(long droppedRowCount) {
+public record FkIntegrityResponse(long droppedRowCount, long duplicateTargetKeyCount) {
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/FkIntegrityResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/FkIntegrityResponse.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+/**
+ * The number of rows an INNER join from the fact table to its foreign-key target would drop.
+ *
+ * <p>This body is only ever produced for a query that actually ran and returned a row. Every
+ * failure mode is an error response instead, because a body carrying {@code 0} means "safe to
+ * join" to the caller.</p>
+ *
+ * @param droppedRowCount rows whose FK is NULL plus rows whose FK has no matching target row.
+ */
+public record FkIntegrityResponse(long droppedRowCount) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/request/FkIntegrityRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/request/FkIntegrityRequest.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.request;
+
+/**
+ * Identifies the foreign key whose join integrity is being probed.
+ *
+ * <p>Deliberately carries identifiers, never SQL: the statement is composed server-side from
+ * these fields after each has been validated. See
+ * {@link inetsoft.web.wiz.service.FkIntegrityService}.</p>
+ */
+public class FkIntegrityRequest {
+   public String getDatasourcePath() {
+      return datasourcePath;
+   }
+
+   public void setDatasourcePath(String datasourcePath) {
+      this.datasourcePath = datasourcePath;
+   }
+
+   public String getSourceTable() {
+      return sourceTable;
+   }
+
+   public void setSourceTable(String sourceTable) {
+      this.sourceTable = sourceTable;
+   }
+
+   public String getFkColumn() {
+      return fkColumn;
+   }
+
+   public void setFkColumn(String fkColumn) {
+      this.fkColumn = fkColumn;
+   }
+
+   public String getTargetTable() {
+      return targetTable;
+   }
+
+   public void setTargetTable(String targetTable) {
+      this.targetTable = targetTable;
+   }
+
+   public String getTargetKeyColumn() {
+      return targetKeyColumn;
+   }
+
+   public void setTargetKeyColumn(String targetKeyColumn) {
+      this.targetKeyColumn = targetKeyColumn;
+   }
+
+   private String datasourcePath;
+   private String sourceTable;
+   private String fkColumn;
+   private String targetTable;
+   private String targetKeyColumn;
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/FkIntegrityService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/FkIntegrityService.java
@@ -22,6 +22,7 @@ import inetsoft.sree.security.ResourceAction;
 import inetsoft.uql.jdbc.JDBCDataSource;
 import inetsoft.uql.jdbc.JDBCHandler;
 import inetsoft.web.portal.controller.database.DataSourceService;
+import inetsoft.web.wiz.model.FkIntegrityResponse;
 import inetsoft.web.wiz.request.FkIntegrityRequest;
 import org.springframework.stereotype.Service;
 
@@ -33,23 +34,39 @@ import java.sql.SQLException;
 import java.util.regex.Pattern;
 
 /**
- * Counts the rows an INNER join from a fact table to a foreign-key target would silently drop.
+ * Measures whether injecting an INNER join from a fact table to a foreign-key target would change
+ * the dashboard's aggregates.
  *
  * <p>wiz-services wants to replace a range slider over a surrogate key (e.g. {@code partner_id})
  * with a filter listing the target's labels, which requires injecting an INNER join to the FK
- * target. That join drops every row whose FK is NULL or orphaned, which would change every
- * unfiltered aggregate on the dashboard. So the join is only injected when this count is zero.</p>
+ * target. An INNER join can change an aggregate in two independent ways, and both are measured
+ * here because either one alone is disqualifying:</p>
+ * <ul>
+ *   <li><b>Dropping rows</b> — every source row whose FK is NULL or orphaned disappears, so every
+ *       unfiltered SUM/COUNT deflates. That is {@code droppedRowCount}.</li>
+ *   <li><b>Duplicating rows</b> — if the target key is not unique, a source row matching n target
+ *       rows is emitted n times, so every unfiltered SUM/COUNT inflates. That is
+ *       {@code duplicateTargetKeyCount}. A zero drop count says nothing about this: a non-unique
+ *       target key inflates aggregates while dropping exactly zero rows.</li>
+ * </ul>
  *
- * <p>Two consequences shape this class:</p>
+ * <p>The join is therefore safe to inject only when <em>both</em> counts are zero.</p>
+ *
+ * <p>The caller does hold metadata claiming the target key is the target's single-column primary
+ * key, but that metadata comes from an annotation store and can be stale or wrong. This whole
+ * endpoint exists because the feature does not trust metadata for safety-critical facts — it
+ * measures them — and uniqueness is no different.</p>
+ *
+ * <p>Two further consequences shape this class:</p>
  * <ul>
  *   <li><b>A wrong zero is the worst failure.</b> Nothing here degrades into a count: no
- *       exception is swallowed, no missing result defaults to zero. Failures propagate to the
- *       controller's {@code @ExceptionHandler}, and wiz-services treats any non-200 as a
- *       rejection — the fail-closed outcome.</li>
+ *       exception is swallowed, no missing result defaults to zero, for either field. Failures
+ *       propagate to the controller's {@code @ExceptionHandler}, and wiz-services treats any
+ *       non-200 as a rejection — the fail-closed outcome.</li>
  *   <li><b>Identifier validation is the security boundary.</b> This is deliberately not a
  *       {@code {sql}}-accepting endpoint; accepting SQL would create an authenticated
  *       arbitrary-SQL surface over every registered datasource to serve one caller with one
- *       fixed query shape. Identifiers come in, the statement is composed here, and anything
+ *       fixed query shape. Identifiers come in, the statements are composed here, and anything
  *       outside the allowed character set is rejected rather than quoted or escaped.</li>
  * </ul>
  */
@@ -63,18 +80,22 @@ public class FkIntegrityService {
    }
 
    /**
-    * Counts the rows an INNER join from {@code sourceTable} to {@code targetTable} would drop.
+    * Measures both ways an INNER join from {@code sourceTable} to {@code targetTable} could change
+    * an aggregate: rows it would drop, and target key values that would fan rows out.
     *
     * @param request   the source/target tables and key columns, as identifiers.
     * @param principal the requesting user; must hold READ on the datasource.
-    * @return rows whose FK is NULL plus rows whose FK has no matching target row.
+    * @return both counts. The join is safe to inject only when both are zero.
     *
     * @throws IllegalArgumentException if any identifier fails validation — nothing is executed.
     * @throws SecurityException        if the user lacks READ on the datasource.
-    * @throws SQLException             if the query fails or returns no usable count. Never
-    *                                  translated into a count.
+    * @throws SQLException             if either query fails or returns no usable count. Never
+    *                                  translated into a count; a failure of either query fails
+    *                                  the whole request rather than reporting the other alone.
     */
-   public long countDroppedRows(FkIntegrityRequest request, Principal principal) throws Exception {
+   public FkIntegrityResponse checkIntegrity(FkIntegrityRequest request, Principal principal)
+      throws Exception
+   {
       if(request == null) {
          throw new IllegalArgumentException("A request body is required.");
       }
@@ -86,6 +107,9 @@ public class FkIntegrityService {
       }
 
       // Validate before anything else: a rejected identifier must never reach a connection.
+      // Every identifier later interpolated into SQL must pass through here. The parameterized
+      // wiring test pins each of these four call sites individually — mutating the shared helper
+      // only pins the rule, never the wiring of a particular field to it.
       String sourceTable = validateTableIdentifier(request.getSourceTable(), "sourceTable");
       String fkColumn = validateColumnIdentifier(request.getFkColumn(), "fkColumn");
       String targetTable = validateTableIdentifier(request.getTargetTable(), "targetTable");
@@ -97,10 +121,16 @@ public class FkIntegrityService {
       }
 
       JDBCDataSource ds = metadataService.getJDBCDatasource(dsName);
-      String sql = buildDroppedRowCountSql(sourceTable, fkColumn, targetTable, targetKeyColumn);
+      String droppedSql =
+         buildDroppedRowCountSql(sourceTable, fkColumn, targetTable, targetKeyColumn);
+      String duplicateSql = buildDuplicateTargetKeyCountSql(targetTable, targetKeyColumn);
 
       try(Connection conn = openConnection(ds, principal)) {
-         return executeCount(conn, sql);
+         // Both measurements share one connection so they describe the same database state.
+         long droppedRowCount = executeCount(conn, droppedSql);
+         long duplicateTargetKeyCount = executeCount(conn, duplicateSql);
+
+         return new FkIntegrityResponse(droppedRowCount, duplicateTargetKeyCount);
       }
    }
 
@@ -113,7 +143,7 @@ public class FkIntegrityService {
    }
 
    /**
-    * Runs the count. An absent row or a NULL count is an error, not a zero: {@code getLong}
+    * Runs one count. An absent row or a NULL count is an error, not a zero: {@code getLong}
     * returns 0 for SQL NULL, and 0 is precisely the answer that opens the gate.
     */
    private static long executeCount(Connection conn, String sql) throws SQLException {
@@ -122,14 +152,14 @@ public class FkIntegrityService {
       {
          if(!rs.next()) {
             throw new SQLException(
-               "Foreign key integrity count returned no row; refusing to report zero dropped rows.");
+               "Foreign key integrity count returned no row; refusing to report zero. SQL: " + sql);
          }
 
          long count = rs.getLong(1);
 
          if(rs.wasNull()) {
             throw new SQLException(
-               "Foreign key integrity count was NULL; refusing to report zero dropped rows.");
+               "Foreign key integrity count was NULL; refusing to report zero. SQL: " + sql);
          }
 
          return count;
@@ -137,7 +167,7 @@ public class FkIntegrityService {
    }
 
    /**
-    * Builds the counting statement from already-validated identifiers.
+    * Builds the drop-count statement from already-validated identifiers.
     *
     * <p>Both halves of "rows an INNER join would drop" are counted: NULL foreign keys, and
     * foreign keys with no matching target row. The orphan half is a correlated subquery, so the
@@ -153,6 +183,21 @@ public class FkIntegrityService {
    }
 
    /**
+    * Builds the duplicate-key statement from already-validated identifiers: how many target key
+    * values occur more than once. Any non-zero result means the join would fan rows out and
+    * inflate aggregates, no matter how many rows it drops.
+    *
+    * <p>NULL target keys are not excluded from the grouping. A NULL key can never match a source
+    * FK, so it cannot in fact duplicate anything — counting repeated NULLs as duplicates is
+    * therefore conservative, which is the correct direction for a gate whose dangerous failure
+    * mode is wrongly allowing the join.</p>
+    */
+   static String buildDuplicateTargetKeyCountSql(String targetTable, String targetKeyColumn) {
+      return "SELECT COUNT(*) FROM (SELECT " + targetKeyColumn + " FROM " + targetTable +
+         " GROUP BY " + targetKeyColumn + " HAVING COUNT(*) > 1) d";
+   }
+
+   /**
     * Validates a table name: at most two dot-separated segments (schema.table).
     */
    static String validateTableIdentifier(String identifier, String field) {
@@ -161,7 +206,7 @@ public class FkIntegrityService {
 
    /**
     * Validates a column name: exactly one segment. A dot in a column name is a rejection, not a
-    * qualification — the statement qualifies columns itself via its {@code src}/{@code tgt}
+    * qualification — the statements qualify columns themselves via their {@code src}/{@code tgt}
     * aliases.
     */
    static String validateColumnIdentifier(String identifier, String field) {

--- a/core/src/main/java/inetsoft/web/wiz/service/FkIntegrityService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/FkIntegrityService.java
@@ -1,0 +1,205 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.service;
+
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.uql.jdbc.JDBCDataSource;
+import inetsoft.uql.jdbc.JDBCHandler;
+import inetsoft.web.portal.controller.database.DataSourceService;
+import inetsoft.web.wiz.request.FkIntegrityRequest;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.regex.Pattern;
+
+/**
+ * Counts the rows an INNER join from a fact table to a foreign-key target would silently drop.
+ *
+ * <p>wiz-services wants to replace a range slider over a surrogate key (e.g. {@code partner_id})
+ * with a filter listing the target's labels, which requires injecting an INNER join to the FK
+ * target. That join drops every row whose FK is NULL or orphaned, which would change every
+ * unfiltered aggregate on the dashboard. So the join is only injected when this count is zero.</p>
+ *
+ * <p>Two consequences shape this class:</p>
+ * <ul>
+ *   <li><b>A wrong zero is the worst failure.</b> Nothing here degrades into a count: no
+ *       exception is swallowed, no missing result defaults to zero. Failures propagate to the
+ *       controller's {@code @ExceptionHandler}, and wiz-services treats any non-200 as a
+ *       rejection — the fail-closed outcome.</li>
+ *   <li><b>Identifier validation is the security boundary.</b> This is deliberately not a
+ *       {@code {sql}}-accepting endpoint; accepting SQL would create an authenticated
+ *       arbitrary-SQL surface over every registered datasource to serve one caller with one
+ *       fixed query shape. Identifiers come in, the statement is composed here, and anything
+ *       outside the allowed character set is rejected rather than quoted or escaped.</li>
+ * </ul>
+ */
+@Service
+public class FkIntegrityService {
+   public FkIntegrityService(MetadataApiService metadataService,
+                             DataSourceService dataSourceService)
+   {
+      this.metadataService = metadataService;
+      this.dataSourceService = dataSourceService;
+   }
+
+   /**
+    * Counts the rows an INNER join from {@code sourceTable} to {@code targetTable} would drop.
+    *
+    * @param request   the source/target tables and key columns, as identifiers.
+    * @param principal the requesting user; must hold READ on the datasource.
+    * @return rows whose FK is NULL plus rows whose FK has no matching target row.
+    *
+    * @throws IllegalArgumentException if any identifier fails validation — nothing is executed.
+    * @throws SecurityException        if the user lacks READ on the datasource.
+    * @throws SQLException             if the query fails or returns no usable count. Never
+    *                                  translated into a count.
+    */
+   public long countDroppedRows(FkIntegrityRequest request, Principal principal) throws Exception {
+      if(request == null) {
+         throw new IllegalArgumentException("A request body is required.");
+      }
+
+      String dsName = request.getDatasourcePath();
+
+      if(dsName == null || dsName.isEmpty()) {
+         throw new IllegalArgumentException("datasourcePath is required.");
+      }
+
+      // Validate before anything else: a rejected identifier must never reach a connection.
+      String sourceTable = validateTableIdentifier(request.getSourceTable(), "sourceTable");
+      String fkColumn = validateColumnIdentifier(request.getFkColumn(), "fkColumn");
+      String targetTable = validateTableIdentifier(request.getTargetTable(), "targetTable");
+      String targetKeyColumn =
+         validateColumnIdentifier(request.getTargetKeyColumn(), "targetKeyColumn");
+
+      if(!dataSourceService.checkPermission(dsName, ResourceAction.READ, principal)) {
+         throw new SecurityException("Access denied to data source: " + dsName);
+      }
+
+      JDBCDataSource ds = metadataService.getJDBCDatasource(dsName);
+      String sql = buildDroppedRowCountSql(sourceTable, fkColumn, targetTable, targetKeyColumn);
+
+      try(Connection conn = openConnection(ds, principal)) {
+         return executeCount(conn, sql);
+      }
+   }
+
+   /**
+    * The single connection-acquisition seam, mirroring MetadataApiService. Package-private and
+    * overridable so the surrounding logic is testable without a live database.
+    */
+   Connection openConnection(JDBCDataSource ds, Principal principal) throws Exception {
+      return new JDBCHandler().getConnection(ds, principal);
+   }
+
+   /**
+    * Runs the count. An absent row or a NULL count is an error, not a zero: {@code getLong}
+    * returns 0 for SQL NULL, and 0 is precisely the answer that opens the gate.
+    */
+   private static long executeCount(Connection conn, String sql) throws SQLException {
+      try(PreparedStatement stmt = conn.prepareStatement(sql);
+          ResultSet rs = stmt.executeQuery())
+      {
+         if(!rs.next()) {
+            throw new SQLException(
+               "Foreign key integrity count returned no row; refusing to report zero dropped rows.");
+         }
+
+         long count = rs.getLong(1);
+
+         if(rs.wasNull()) {
+            throw new SQLException(
+               "Foreign key integrity count was NULL; refusing to report zero dropped rows.");
+         }
+
+         return count;
+      }
+   }
+
+   /**
+    * Builds the counting statement from already-validated identifiers.
+    *
+    * <p>Both halves of "rows an INNER join would drop" are counted: NULL foreign keys, and
+    * foreign keys with no matching target row. The orphan half is a correlated subquery, so the
+    * FK value is compared column-to-column and never rendered into the statement text.</p>
+    */
+   static String buildDroppedRowCountSql(String sourceTable, String fkColumn,
+                                         String targetTable, String targetKeyColumn)
+   {
+      return "SELECT COUNT(*) FROM " + sourceTable + " src" +
+         " WHERE src." + fkColumn + " IS NULL" +
+         " OR NOT EXISTS (SELECT 1 FROM " + targetTable + " tgt" +
+         " WHERE tgt." + targetKeyColumn + " = src." + fkColumn + ")";
+   }
+
+   /**
+    * Validates a table name: at most two dot-separated segments (schema.table).
+    */
+   static String validateTableIdentifier(String identifier, String field) {
+      return validateIdentifier(identifier, field, 2);
+   }
+
+   /**
+    * Validates a column name: exactly one segment. A dot in a column name is a rejection, not a
+    * qualification — the statement qualifies columns itself via its {@code src}/{@code tgt}
+    * aliases.
+    */
+   static String validateColumnIdentifier(String identifier, String field) {
+      return validateIdentifier(identifier, field, 1);
+   }
+
+   private static String validateIdentifier(String identifier, String field, int maxSegments) {
+      if(identifier == null || identifier.isEmpty()) {
+         throw new IllegalArgumentException(field + " is required.");
+      }
+
+      // A -1 limit keeps trailing empty segments, so "sale_order." splits to ["sale_order", ""]
+      // and is rejected instead of slipping through with a dangling dot.
+      String[] segments = identifier.split("\\.", -1);
+
+      if(segments.length > maxSegments) {
+         throw new IllegalArgumentException(
+            field + " must have at most " + maxSegments + " name segment" +
+            (maxSegments == 1 ? "" : "s") + ": '" + identifier + "'.");
+      }
+
+      for(String segment : segments) {
+         if(!IDENTIFIER.matcher(segment).matches()) {
+            throw new IllegalArgumentException(
+               field + " is not a valid identifier: '" + identifier + "'. Each name segment must " +
+               "match " + IDENTIFIER.pattern() + ".");
+         }
+      }
+
+      return identifier;
+   }
+
+   /**
+    * The whole security boundary of this feature. Anything outside this set is refused; no
+    * attempt is made to quote or escape a rejected name into safety.
+    */
+   private static final Pattern IDENTIFIER = Pattern.compile("^[A-Za-z_][A-Za-z0-9_]*$");
+
+   private final MetadataApiService metadataService;
+   private final DataSourceService dataSourceService;
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -172,7 +172,7 @@ public class MetadataApiService {
 
          String columnName = columnNode.getName();
          String columnType = columnNode instanceof XTypeNode typeNode ? typeNode.getType() : null;
-         boolean isPK = "true".equals(columnNode.getAttribute("PrimaryKey"));
+         boolean isPK = isPrimaryKeyColumn(columnNode);
          Integer length = (Integer) columnNode.getAttribute("length");
          String comment = (String) columnNode.getAttribute("comment");
          List<String[]> foreignKeys = extractForeignKeys(columnNode);
@@ -295,6 +295,32 @@ public class MetadataApiService {
       catch(Exception e) {
          throw new RuntimeException("Failed to serialize field custom extension", e);
       }
+   }
+
+   /**
+    * True when a column node is flagged as part of the table's primary key.
+    *
+    * <p>The attribute is written by {@code JDBCHandler} as a <b>boolean</b>
+    * ({@code node.setAttribute("PrimaryKey", isPrimary)}), and
+    * {@link XNode#setAttribute(String, Object)} stores the value as an {@code Object} without
+    * coercing it. The previous test here was {@code "true".equals(getAttribute("PrimaryKey"))},
+    * which compares a {@code String} to a {@code Boolean} and is therefore <b>always false</b> —
+    * so every column was reported as a non-key and {@code dataset.primary_key} came back null for
+    * every table on every datasource. The sibling {@code ForeignKey} attribute was unaffected
+    * because {@link #extractForeignKeys} reads it as an object rather than string-comparing it,
+    * which is why relationships worked while primary keys silently did not.</p>
+    *
+    * <p>A {@code String} is still accepted: an {@link XNode} that has round-tripped through XML
+    * carries its attributes as text rather than as their original types.</p>
+    */
+   private static boolean isPrimaryKeyColumn(XNode columnNode) {
+      Object attr = columnNode.getAttribute("PrimaryKey");
+
+      if(attr instanceof Boolean flag) {
+         return flag;
+      }
+
+      return attr != null && "true".equalsIgnoreCase(attr.toString());
    }
 
    private List<String[]> extractForeignKeys(XNode columnNode) {
@@ -1823,7 +1849,7 @@ public class MetadataApiService {
          DatabaseTableMeta.ColumnMeta col = new DatabaseTableMeta.ColumnMeta();
          col.setName(columnNode.getName());
          col.setType(columnNode instanceof XTypeNode typeNode ? typeNode.getType() : null);
-         col.setPrimaryKey("true".equals(columnNode.getAttribute("PrimaryKey")));
+         col.setPrimaryKey(isPrimaryKeyColumn(columnNode));
 
          Integer length = (Integer) columnNode.getAttribute("length");
          col.setLength(length != null ? length : 0);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -27,6 +27,7 @@ import inetsoft.uql.viewsheet.internal.RectangleVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.SelectionVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.TextVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.TitledVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
 import inetsoft.uql.asset.internal.AssetUtil;
 import org.springframework.stereotype.Component;
 
@@ -200,12 +201,27 @@ public class WizDashboardFilterBuilder {
             titled.setTitleValue(req.label());
          }
 
+         // Only a control that draws NO title of its own gets a separate caption assembly (see
+         // addCaption / FILTER_LABEL_HEIGHT): that is the TimeSlider, whose Angular component gates
+         // its whole title header on isInSelectionContainer(). A SelectionList in DROPDOWN mode DOES
+         // draw a title row, so a caption there printed the label TWICE -- once as the caption and
+         // again as the dropdown's own title (observed live: "Res Partner Name" stacked over itself).
+         //
+         // Both control types still span the SAME total band height (FILTER_CONTROL_HEIGHT), so the
+         // bar stays visually even: a captioned slider spends FILTER_LABEL_HEIGHT of it on the
+         // caption, a dropdown spends none and grows its own row to swallow the difference. Sizing
+         // the dropdown to the smaller (captioned) height instead would leave a ragged 16px step
+         // between adjacent controls of different types.
+         boolean rendersOwnTitle = control instanceof SelectionListVSAssembly;
+         int captionHeight = rendersOwnTitle ? 0 : FILTER_LABEL_HEIGHT;
+         int controlHeight = FILTER_CONTROL_HEIGHT - captionHeight;
+
          // A shared-bar SelectionList must be a DROPDOWN, for the same reason the per-chart path
          // makes one (see addPerChartFilter): in list mode it draws a multi-row checkbox list, and
-         // the bar reserves only FILTER_CONTROL_HEIGHT - FILTER_LABEL_HEIGHT (44px) for it. A title
-         // row plus ~20px item rows means ONE item is visible inside a scroll area -- useless for
-         // picking a value out of, say, 141 customer names, which is exactly the case the FK-label
-         // filter feature produces.
+         // the bar reserves only FILTER_CONTROL_HEIGHT (60px) for it. A title row plus ~20px item
+         // rows means one or two items are visible inside a scroll area -- useless for picking a
+         // value out of, say, 141 customer names, which is exactly the case the FK-label filter
+         // feature produces.
          //
          // Dropdown mode collapses it to a single title row that opens on click, so the full list is
          // reachable regardless of how little vertical space the bar can spare.
@@ -216,8 +232,9 @@ public class WizDashboardFilterBuilder {
          // deliberately untouched, and it keeps the separate caption for the reason documented below.
          if(control instanceof SelectionListVSAssembly list) {
             list.setShowTypeValue(SelectionVSAssemblyInfo.DROPDOWN_SHOW_TYPE);
-            list.getSelectionListInfo()
-               .setTitleHeightValue(FILTER_CONTROL_HEIGHT - FILTER_LABEL_HEIGHT);
+            list.getSelectionListInfo().setTitleHeightValue(controlHeight);
+            centerTitleVertically(list);
+            applyDropdownPopupStyle(list);
          }
 
          // KNOWN UNFIXED: a shared-bar range slider renders with NO visible title -- a numeric slider
@@ -233,19 +250,19 @@ public class WizDashboardFilterBuilder {
          // titleVisible as a valueless DynamicValue2 (vs TitleInfo(String) seeding "true"), which
          // looked like the cause but is not: both getters still report true.
          // Remaining hypothesis: the client-side TimeSlider component renders no title area at all,
-         // which has to be investigated in the Angular viewer, not here.
+         // which has to be investigated in the Angular viewer, not here. NOTE this is ALSO why the
+         // caption cannot simply be deleted for every control: it is the slider's only label.
 
          // Caption above the control, so a user can tell what the control filters -- a bare "6..216"
          // range slider is otherwise unreadable. Its placement is returned alongside the control's:
          // an assembly with no per-tier layout entry is hidden when that tier is selected.
-         if(req.label() != null) {
+         if(captionHeight > 0 && req.label() != null) {
             placements.add(addCaption(vs, "wizFilterLabel_" + control.getName(),
-                                      x, y, FILTER_CONTROL_WIDTH, FILTER_LABEL_HEIGHT, req.label()));
+                                      x, y, FILTER_CONTROL_WIDTH, captionHeight, req.label()));
          }
 
-         Point pos = new Point(x, y + FILTER_LABEL_HEIGHT);
-         java.awt.Dimension size =
-            new java.awt.Dimension(FILTER_CONTROL_WIDTH, FILTER_CONTROL_HEIGHT - FILTER_LABEL_HEIGHT);
+         Point pos = new Point(x, y + captionHeight);
+         java.awt.Dimension size = new java.awt.Dimension(FILTER_CONTROL_WIDTH, controlHeight);
          control.setTableNames(tables);
          control.setPixelOffset(pos);
          // Explicit compact size: SelectionList/TimeSlider's own default pixel size is not
@@ -260,6 +277,83 @@ public class WizDashboardFilterBuilder {
       }
 
       return new FilterResult(applied, skipped, placements);
+   }
+
+   /**
+    * Vertically centres a control's own title row.
+    *
+    * <p>Without this the shared-bar dropdown's title text rendered hard against the TOP of its
+    * 60px row with a visibly empty band beneath it. Cause: nothing in this builder's path ever
+    * calls {@code initDefaultFormat()} — {@code AddFilterService.createFilterAssembly} just
+    * {@code new}s the assembly, and neither {@code SelectionListVSAssembly}'s constructor nor
+    * {@code Viewsheet.addAssembly} calls it. That method is the ONLY thing that seeds a TITLEPATH
+    * entry in the {@code FormatInfo} map (with {@code H_LEFT | V_CENTER}), so with no entry
+    * {@code FormatInfo.getFormat(TITLEPATH, false)} synthesises one by copying the OBJECT format's
+    * default layer, whose alignment is {@code VSFormat.ALIGN} = {@code H_LEFT | V_TOP}. That
+    * reaches the client as {@code align-items: flex-start} on the title cell's flex container
+    * (VSFormatModel → VSCSSUtil.getvAlign/getFlexAlignment → title-cell.component.html), i.e.
+    * top-aligned. The per-chart path shows no visible symptom only because it reserves 28px, close
+    * enough to the natural row height that there is little slack to misalign within.
+    *
+    * <p>This is approach (a) from the task brief — set V_CENTER on the TITLEPATH format — chosen
+    * over "give the title its natural height and centre the control in the band" because that
+    * would reintroduce the reserved-vs-drawn gap the title-height pinning exists to prevent (a
+    * dropdown draws only its title row and ignores the rest of the assembly's pixel height).
+    * H_LEFT is carried along deliberately: {@code fixAlignment} keeps the horizontal and vertical
+    * bits independently, so writing only V_CENTER would zero the horizontal bit and centre the
+    * caption text horizontally too.
+    *
+    * <p>The DESIGN ({@code ...Value}) setter is the load-bearing one — a composed dashboard is
+    * saved and reopened — and the runtime setter is called alongside it, matching
+    * {@link #applyCardFormat}'s pattern. Be aware the runtime call is belt-and-braces only and is
+    * NOT observable: alignment is a {@code DynamicValue2}, whose {@code getRValue()} falls back to
+    * the design value, so {@code getAlignment()} already reports V_CENTER from the {@code ...Value}
+    * setter alone (mutation-checked — deleting {@code setAlignment} fails no test, deleting
+    * {@code setAlignmentValue} fails
+    * {@code sharedBarDropdownTitleIsVerticallyCentredNotPinnedToTheTopOfItsRow}). Written to the
+    * USER-defined layer, not the default one, so it also outranks any CSS-layer alignment
+    * ({@link VSCompositeFormat#getAlignment} consults the user layer first).
+    */
+   private static void centerTitleVertically(VSAssembly control) {
+      FormatInfo fmtInfo = control.getVSAssemblyInfo().getFormatInfo();
+      VSCompositeFormat titleFormat = fmtInfo.getFormat(VSAssemblyInfo.TITLEPATH);
+
+      if(titleFormat == null) {
+         titleFormat = new VSCompositeFormat();
+         fmtInfo.setFormat(VSAssemblyInfo.TITLEPATH, titleFormat);
+      }
+
+      VSFormat fmt = titleFormat.getUserDefinedFormat();
+      int align = StyleConstants.H_LEFT | StyleConstants.V_CENTER;
+      fmt.setAlignmentValue(align);
+      fmt.setAlignment(align);
+   }
+
+   /**
+    * Gives a shared-bar dropdown an opaque background and an enclosing border, so its OPEN list
+    * reads as a floating list instead of transparent text laid over the chart behind it.
+    *
+    * <p>The popup has no background of its own: {@code .selection-list-body} carries none in
+    * vs-selection.component.scss, and the whole assembly (title row + popup) is painted by the one
+    * {@code [style.background-color]="model.objectFormat.background"} binding on its
+    * {@code .vs-object} wrapper. That background is unset here for the same reason the title was
+    * top-aligned — nothing calls {@code initDefaultFormat()} — so the list rendered fully
+    * transparent and its items overlapped the chart content underneath, unreadable.
+    *
+    * <p>Set on the OBJECT format (not TITLEPATH): the popup is part of the assembly, not the title
+    * row. White rather than {@link #CARD_BACKGROUND} so the control reads as an input widget
+    * against the tinted {@link #BAND_BACKGROUND} toolbar band and the open list reads as floating
+    * ABOVE the chart rather than as another tinted panel of it. Goes through
+    * {@link #applyCardFormat} for the persist-safe both-setters treatment — a background set only
+    * via the plain setter looks right in a unit test and vanishes for the user on reload.
+    */
+   private static void applyDropdownPopupStyle(VSAssembly control) {
+      applyCardFormat(control.getVSAssemblyInfo().getFormat().getUserDefinedFormat(),
+                      DROPDOWN_BACKGROUND,
+                      new BorderColors(CARD_BORDER_COLOR, CARD_BORDER_COLOR,
+                                       CARD_BORDER_COLOR, CARD_BORDER_COLOR),
+                      new Insets(StyleConstants.THIN_LINE, StyleConstants.THIN_LINE,
+                                 StyleConstants.THIN_LINE, StyleConstants.THIN_LINE));
    }
 
    /**
@@ -438,19 +532,18 @@ public class WizDashboardFilterBuilder {
     * invariants to maintain.
     */
    private static void applyGroupedCardStyle(VSAssembly filterControl, VSAssembly chartAssembly) {
-      String backgroundHex = toHex(CARD_BACKGROUND);
       BorderColors borderColors = new BorderColors(CARD_BORDER_COLOR, CARD_BORDER_COLOR,
          CARD_BORDER_COLOR, CARD_BORDER_COLOR);
 
       VSFormat filterFormat = filterControl.getVSAssemblyInfo().getFormat().getUserDefinedFormat();
-      applyCardFormat(filterFormat, backgroundHex, borderColors, new Insets(
+      applyCardFormat(filterFormat, CARD_BACKGROUND, borderColors, new Insets(
          // Insets(top, left, bottom, right) -- no bottom border: the chart's own top edge (also
          // borderless, below) abuts it directly.
          StyleConstants.THIN_LINE, StyleConstants.THIN_LINE,
          StyleConstants.NO_BORDER, StyleConstants.THIN_LINE));
 
       VSFormat chartFormat = chartAssembly.getVSAssemblyInfo().getFormat().getUserDefinedFormat();
-      applyCardFormat(chartFormat, backgroundHex, borderColors, new Insets(
+      applyCardFormat(chartFormat, CARD_BACKGROUND, borderColors, new Insets(
          // No top border -- abuts the filter control's borderless bottom edge directly.
          StyleConstants.NO_BORDER, StyleConstants.THIN_LINE,
          StyleConstants.THIN_LINE, StyleConstants.THIN_LINE));
@@ -466,12 +559,18 @@ public class WizDashboardFilterBuilder {
     * {@code TableDataVSAssemblyInfo}, for exactly this kind of persisted format) flip
     * "isXxxValueDefined" instead. Calling both covers persistence (the Value variants) and any
     * immediate/pre-refresh read of the plain RValue-based getters.
+    *
+    * <p>Takes the {@link Color} and derives the hex itself, rather than taking both: an earlier
+    * signature took a {@code backgroundHex} String but passed a hard-coded {@link #CARD_BACKGROUND}
+    * to the plain setter, so a second caller with a different color would have silently written two
+    * DIFFERENT backgrounds into the two layers — which layer you read would decide which color you
+    * got.
     */
    private static void applyCardFormat(
-      VSFormat format, String backgroundHex, BorderColors borderColors, Insets borders)
+      VSFormat format, Color background, BorderColors borderColors, Insets borders)
    {
-      format.setBackground(CARD_BACKGROUND);
-      format.setBackgroundValue(backgroundHex);
+      format.setBackground(background);
+      format.setBackgroundValue(toHex(background));
       format.setBorderColors(borderColors);
       format.setBorderColorsValue(borderColors);
       format.setBorders(borders);
@@ -489,6 +588,13 @@ public class WizDashboardFilterBuilder {
    /** Shared card border color -- a clearly-visible-but-neutral gray that outlines the grouped
     *  filter+chart without drawing attention away from the chart content itself. */
    private static final Color CARD_BORDER_COLOR = new Color(158, 166, 178);
+
+   /** Shared-bar dropdown fill -- opaque WHITE, deliberately not {@link #CARD_BACKGROUND}: this
+    *  background paints the control's OPEN popup list, which floats over a chart, so it has to read
+    *  as a floating list rather than as another tinted panel belonging to the chart. White also
+    *  makes the collapsed control read as an input widget against the tinted
+    *  {@link #BAND_BACKGROUND} toolbar band. */
+   private static final Color DROPDOWN_BACKGROUND = Color.WHITE;
 
    /** Filter-toolbar band fill -- a light blue-gray tint, subtly darker than the dashboard canvas,
     *  so the shared filter bar reads as its own toolbar region. */
@@ -546,7 +652,10 @@ public class WizDashboardFilterBuilder {
     */
    private static final int FILTER_CONTROL_GAP = 16;
    /**
-    * Height of the caption drawn above each shared-bar control, in pixels.
+    * Height of the caption drawn above a shared-bar control that draws NO title of its own, in
+    * pixels. Only the range slider is such a control; a dropdown draws its own title row and gets
+    * no caption (a caption there printed the label twice), spending this height on its own row
+    * instead so both control types still fill {@link #FILTER_CONTROL_HEIGHT}.
     *
     * A range slider will NOT draw its own title: vs-range-slider.component.html gates the whole
     * title header on {@code @if (isInSelectionContainer())}, which is true only inside a

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -207,18 +207,20 @@ public class WizDashboardFilterBuilder {
          // draw a title row, so a caption there printed the label TWICE -- once as the caption and
          // again as the dropdown's own title (observed live: "Res Partner Name" stacked over itself).
          //
-         // Both control types still span the SAME total band height (FILTER_CONTROL_HEIGHT), so the
-         // bar stays visually even: a captioned slider spends FILTER_LABEL_HEIGHT of it on the
-         // caption, a dropdown spends none and grows its own row to swallow the difference. Sizing
-         // the dropdown to the smaller (captioned) height instead would leave a ragged 16px step
-         // between adjacent controls of different types.
+         // EVERY control gets the SAME geometry regardless: the top FILTER_LABEL_HEIGHT of the band
+         // is the caption strip, and the control itself is FILTER_CONTROL_ROW_HEIGHT below it. A
+         // dropdown simply leaves its caption strip EMPTY (its label lives inside its own title row)
+         // rather than growing to swallow it. An earlier version did the latter -- it had the
+         // dropdown span the whole 60px band -- and the result was the live complaint this replaces:
+         // a tall white box next to a visibly much shorter range slider. Reserving the strip for both
+         // is what keeps the two control types' interactive rows on exactly the same baseline, which
+         // is what "the bar stays even" means to someone looking at it.
          boolean rendersOwnTitle = control instanceof SelectionListVSAssembly;
-         int captionHeight = rendersOwnTitle ? 0 : FILTER_LABEL_HEIGHT;
-         int controlHeight = FILTER_CONTROL_HEIGHT - captionHeight;
+         int controlHeight = FILTER_CONTROL_ROW_HEIGHT;
 
          // A shared-bar SelectionList must be a DROPDOWN, for the same reason the per-chart path
          // makes one (see addPerChartFilter): in list mode it draws a multi-row checkbox list, and
-         // the bar reserves only FILTER_CONTROL_HEIGHT (60px) for it. A title row plus ~20px item
+         // the bar reserves only FILTER_CONTROL_ROW_HEIGHT for it. A title row plus ~20px item
          // rows means one or two items are visible inside a scroll area -- useless for picking a
          // value out of, say, 141 customer names, which is exactly the case the FK-label filter
          // feature produces.
@@ -256,19 +258,21 @@ public class WizDashboardFilterBuilder {
          // Caption above the control, so a user can tell what the control filters -- a bare "6..216"
          // range slider is otherwise unreadable. Its placement is returned alongside the control's:
          // an assembly with no per-tier layout entry is hidden when that tier is selected.
-         if(captionHeight > 0 && req.label() != null) {
+         if(!rendersOwnTitle && req.label() != null) {
             placements.add(addCaption(vs, "wizFilterLabel_" + control.getName(),
-                                      x, y, FILTER_CONTROL_WIDTH, captionHeight, req.label()));
+                                      x, y, FILTER_CONTROL_WIDTH, FILTER_LABEL_HEIGHT, req.label()));
          }
 
-         Point pos = new Point(x, y + captionHeight);
+         // + FILTER_LABEL_HEIGHT unconditionally -- the caption strip is RESERVED for both control
+         // types even though only the slider draws into it, so both controls' rows share a baseline.
+         Point pos = new Point(x, y + FILTER_LABEL_HEIGHT);
          java.awt.Dimension size = new java.awt.Dimension(FILTER_CONTROL_WIDTH, controlHeight);
          control.setTableNames(tables);
          control.setPixelOffset(pos);
          // Explicit compact size: SelectionList/TimeSlider's own default pixel size is not
-         // reliably short, and WizDashboardService reserves only FILTER_BAR_ROW_HEIGHT (120px)
-         // above the charts -- an oversized control here would visually collide with the first
-         // chart row instead of leaving the intended small gap.
+         // reliably short, and WizDashboardService reserves only FILTER_BAR_ROW_HEIGHT above the
+         // charts -- an oversized control here would visually collide with the first chart row
+         // instead of leaving the intended small gap.
          control.setPixelSize(size);
          vs.addAssembly(control);
          applied.add(req.field());
@@ -652,10 +656,10 @@ public class WizDashboardFilterBuilder {
     */
    private static final int FILTER_CONTROL_GAP = 16;
    /**
-    * Height of the caption drawn above a shared-bar control that draws NO title of its own, in
-    * pixels. Only the range slider is such a control; a dropdown draws its own title row and gets
-    * no caption (a caption there printed the label twice), spending this height on its own row
-    * instead so both control types still fill {@link #FILTER_CONTROL_HEIGHT}.
+    * Height of the caption strip above every shared-bar control, in pixels. Only the range slider
+    * DRAWS into it (a dropdown's caption there printed the label twice, since it renders its own
+    * title row) but both control types RESERVE it, so their interactive rows sit on a common
+    * baseline and the bar reads as one row of controls rather than a ragged step.
     *
     * A range slider will NOT draw its own title: vs-range-slider.component.html gates the whole
     * title header on {@code @if (isInSelectionContainer())}, which is true only inside a
@@ -665,11 +669,32 @@ public class WizDashboardFilterBuilder {
     * that shared component's behaviour for every standalone slider in the product, draw our own
     * caption beside the control.
     */
-   private static final int FILTER_LABEL_HEIGHT = 16;
+   /* Package-visible so the geometry tests can assert against the constant rather than a literal
+    * that silently rots when this is tuned -- matching FILTER_CONTROL_HEIGHT and
+    * WizDashboardService's own PER_CHART_FILTER_ROW_HEIGHT. */
+   static final int FILTER_LABEL_HEIGHT = 16;
 
-   /** Shared-bar control height, in pixels — compact: a range slider (the usual shared filter) or
-    *  a short selection list needs far less than a chart tile, and the toolbar band
-    *  ({@link WizDashboardService#FILTER_BAND_HEIGHT}) wraps it snugly, so this stays small to keep
-    *  the top bar from looking oversized. */
-   private static final int FILTER_CONTROL_HEIGHT = 60;
+   /**
+    * The DRAWN height of a shared-bar control itself (excluding the caption strip above it), in
+    * pixels — deliberately the SAME constant the per-chart path sizes its control to, which is the
+    * established natural height for both of these widgets.
+    *
+    * <p>It used to be {@code FILTER_CONTROL_HEIGHT - FILTER_LABEL_HEIGHT} for a slider and the full
+    * {@code FILTER_CONTROL_HEIGHT} (60px) for a dropdown, on the theory that a dropdown should grow
+    * to swallow the caption height it does not need. Live, that made the dropdown render as a tall
+    * white box beside a much shorter range slider — the opposite of even. Both control types now
+    * draw at this one height and differ only in whether the strip above them carries a caption.
+    */
+   private static final int FILTER_CONTROL_ROW_HEIGHT = WizDashboardService.PER_CHART_FILTER_ROW_HEIGHT;
+
+   /** Total band height one shared-bar control occupies, in pixels: its caption strip plus its own
+    *  row. Identical for both control types, which is what keeps the bar even; only whether the
+    *  strip is drawn into differs. Derived rather than a literal so it cannot drift out of step
+    *  with the two heights it is the sum of.
+    *
+    *  <p>Package-visible so {@link WizDashboardService#FILTER_BAND_HEIGHT} can size the toolbar
+    *  band from it instead of carrying an independent literal that has to be remembered and
+    *  re-tuned whenever this changes — exactly what left a visibly empty strip under the controls
+    *  the first time this shrank. */
+   static final int FILTER_CONTROL_HEIGHT = FILTER_LABEL_HEIGHT + FILTER_CONTROL_ROW_HEIGHT;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -200,6 +200,26 @@ public class WizDashboardFilterBuilder {
             titled.setTitleValue(req.label());
          }
 
+         // A shared-bar SelectionList must be a DROPDOWN, for the same reason the per-chart path
+         // makes one (see addPerChartFilter): in list mode it draws a multi-row checkbox list, and
+         // the bar reserves only FILTER_CONTROL_HEIGHT - FILTER_LABEL_HEIGHT (44px) for it. A title
+         // row plus ~20px item rows means ONE item is visible inside a scroll area -- useless for
+         // picking a value out of, say, 141 customer names, which is exactly the case the FK-label
+         // filter feature produces.
+         //
+         // Dropdown mode collapses it to a single title row that opens on click, so the full list is
+         // reachable regardless of how little vertical space the bar can spare.
+         // SelectionListVSAssemblyInfo#getSizeScale pins the Y scale to 1 in this mode, so it cannot
+         // stretch back open. Title height is pinned to the SAME height the loop below reserves, so
+         // drawn and reserved agree by construction rather than by two constants happening to match.
+         // A TimeSliderVSAssembly (date/numeric) has no show type and is already single-row --
+         // deliberately untouched, and it keeps the separate caption for the reason documented below.
+         if(control instanceof SelectionListVSAssembly list) {
+            list.setShowTypeValue(SelectionVSAssemblyInfo.DROPDOWN_SHOW_TYPE);
+            list.getSelectionListInfo()
+               .setTitleHeightValue(FILTER_CONTROL_HEIGHT - FILTER_LABEL_HEIGHT);
+         }
+
          // KNOWN UNFIXED: a shared-bar range slider renders with NO visible title -- a numeric slider
          // shows a bare "6..216" with nothing telling the user it filters partner_id. The label IS
          // applied above (setTitleValue). These explanations have each been RULED OUT by test, so do

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardService.java
@@ -551,19 +551,30 @@ public class WizDashboardService {
 
    /** Reserved row height for the top filter bar, in pixels — sized so the compact filter toolbar
     *  band clears the first chart with a small gap (the chart is pushed to
-    *  FILTER_BAR_ROW_HEIGHT + CANVAS_MARGIN + merge offset ≈ 76+24+24 = 124, just below the band's
-    *  bottom at 92). Not a full chart tile's height. */
-   static final int FILTER_BAR_ROW_HEIGHT = 76;
+    *  FILTER_BAR_ROW_HEIGHT + CANVAS_MARGIN + merge offset ≈ 60+24+24 = 108, just below the band's
+    *  bottom at 76). Not a full chart tile's height. Dropped from 76 alongside the controls
+    *  shrinking from a 60px to a 44px band: left at 76 the gap under the band would have grown to
+    *  48px, which reads as the bar having been abandoned rather than deliberately spaced. */
+   static final int FILTER_BAR_ROW_HEIGHT = 60;
 
    /** Top y (px) of the filter toolbar band -- a small inset above the controls (which sit at
     *  CANVAS_MARGIN=24). */
    private static final int FILTER_BAND_TOP = 12;
 
-   /** Filter toolbar band height (px): wraps the compact 60px controls (at y=24) with a little
-    *  padding, so the band bottom (its divider) lands at 12+80=92 -- above the first chart row
-    *  (which the reserved FILTER_BAR_ROW_HEIGHT + margin + merge offset pushes to ~124), leaving a
-    *  clean gap without the band looking oversized. */
-   private static final int FILTER_BAND_HEIGHT = 80;
+   /** Filter toolbar band height (px): the inset above the controls (they sit at CANVAS_MARGIN,
+    *  the band starts at FILTER_BAND_TOP), the control band itself, and a small bottom inset. So
+    *  the band bottom (its divider) lands at 12+64=76 -- above the first chart row (which the
+    *  reserved FILTER_BAR_ROW_HEIGHT + margin + merge offset pushes to ~108), leaving a clean gap
+    *  without the band looking oversized.
+    *
+    *  DERIVED from the builder's own control height rather than restated as a literal: the two were
+    *  independent numbers, and shrinking the controls left the band still 80px tall with a visibly
+    *  empty strip beneath them. */
+   private static final int FILTER_BAND_BOTTOM_INSET = 8;
+   // CANVAS_MARGIN is qualified, not bare: it is declared further down this file, and a SIMPLE-name
+   // reference to a field declared later in the same class is an illegal forward reference.
+   private static final int FILTER_BAND_HEIGHT = (WizDashboardService.CANVAS_MARGIN - FILTER_BAND_TOP)
+      + WizDashboardFilterBuilder.FILTER_CONTROL_HEIGHT + FILTER_BAND_BOTTOM_INSET;
 
    /** Horizontal stride between grid columns, in pixels (paired with DASHBOARD_ROW_HEIGHT). */
    private static final int DASHBOARD_COL_WIDTH = 640;   // confirm vs composer default viz width

--- a/core/src/test/java/inetsoft/uql/jdbc/JDBCHandlerKeyRelationshipTest.java
+++ b/core/src/test/java/inetsoft/uql/jdbc/JDBCHandlerKeyRelationshipTest.java
@@ -1,0 +1,177 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.jdbc;
+
+import inetsoft.uql.XNode;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression test for the FK_NAME column being dropped from KEYRELATION meta-data.
+ *
+ * {@code getKeyRelationship} read only columns 1-8 of {@link DatabaseMetaData#getImportedKeys},
+ * never column 12 (FK_NAME). Its sole consumer, {@code MetadataApiService.buildRelationships},
+ * groups rows by (fkTable, pkTable, pkCatalog, pkSchema, fkName) so that two distinct constraints
+ * between the same pair of tables stay distinct. With fkName always absent, that key degraded to
+ * the table pair alone and INDEPENDENT single-column foreign keys were merged into one bogus
+ * composite relationship — e.g. Odoo's sale_order.partner_id, .partner_invoice_id and
+ * .partner_shipping_id, three separate constraints all referencing res_partner.id, collapsed into
+ * a single three-column relationship pointing at a one-column key.
+ *
+ * The driver does supply FK_NAME (verified against PostgreSQL 42.7.x); the loss was entirely in
+ * this reader. These tests pin the WIRING — that column 12 is read and surfaced as the
+ * {@code fkName} attribute — so reverting the fix fails them.
+ */
+@Tag("core")
+class JDBCHandlerKeyRelationshipTest {
+   /** One row of a getImportedKeys result, in JDBC column order for the fields we read. */
+   private record ImportedKeyRow(String pkTableName, String pkColumnName, String fkTableName,
+                                 String fkColumnName, String fkName) {}
+
+   /**
+    * Invokes the real private getKeyRelationship against a mocked driver, returning the XNode tree
+    * it builds.
+    */
+   private static XNode keyRelationship(List<ImportedKeyRow> rows) throws Exception {
+      ResultSet importedKeys = mock(ResultSet.class);
+      // next() walks the row list; the column getters read whichever row it landed on.
+      final int[] cursor = { -1 };
+
+      when(importedKeys.next()).thenAnswer(inv -> ++cursor[0] < rows.size());
+      when(importedKeys.getString(anyInt())).thenAnswer(inv -> {
+         ImportedKeyRow row = rows.get(cursor[0]);
+
+         return switch((Integer) inv.getArgument(0)) {
+            case 1, 2, 5, 6 -> null;          // pk/fk catalog + schema, unused here
+            case 3 -> row.pkTableName();
+            case 4 -> row.pkColumnName();
+            case 7 -> row.fkTableName();
+            case 8 -> row.fkColumnName();
+            case 12 -> row.fkName();          // FK_NAME — the column that used to be dropped
+            default -> null;
+         };
+      });
+
+      ResultSet schemas = mock(ResultSet.class);
+      when(schemas.next()).thenReturn(false);
+
+      DatabaseMetaData meta = mock(DatabaseMetaData.class);
+      when(meta.getImportedKeys(any(), any(), any())).thenReturn(importedKeys);
+      when(meta.getSchemas()).thenReturn(schemas);
+
+      JDBCHandler handler = new JDBCHandler();
+      // Mocked rather than constructed: JDBCDataSource's constructor resolves a CredentialService
+      // Spring bean, which does not exist in a plain unit test.
+      JDBCDataSource xds = mock(JDBCDataSource.class);
+      when(xds.getDatabaseType()).thenReturn(JDBCDataSource.JDBC_POSTGRESQL);
+      // The handler's datasource is normally installed by connect(); getUser() reads its type.
+      Field xdsField = JDBCHandler.class.getDeclaredField("xds");
+      xdsField.setAccessible(true);
+      xdsField.set(handler, xds);
+
+      XNode query = new XNode("sale_order");
+      query.setAttribute("type", "KEYRELATION");
+      // Supplying the schema keeps getUser() off the DBPROPERTIES round-trip.
+      query.setAttribute("schema", "public");
+
+      Method m = JDBCHandler.class
+         .getDeclaredMethod("getKeyRelationship", DatabaseMetaData.class, XNode.class);
+      m.setAccessible(true);
+      return (XNode) m.invoke(handler, meta, query);
+   }
+
+   private static List<String> attributes(XNode root, String attribute) {
+      List<String> values = new ArrayList<>();
+
+      for(int i = 0; i < root.getChildCount(); i++) {
+         values.add((String) root.getChild(i).getAttribute(attribute));
+      }
+
+      return values;
+   }
+
+   @Test
+   void fkNameIsReadFromColumn12() throws Exception {
+      XNode root = keyRelationship(List.of(new ImportedKeyRow(
+         "res_partner", "id", "sale_order", "partner_id", "sale_order_partner_id_fkey")));
+
+      assertEquals(1, root.getChildCount());
+      // THE BUG: this attribute was never set, so it read back null for every row.
+      assertEquals("sale_order_partner_id_fkey", root.getChild(0).getAttribute("fkName"));
+   }
+
+   @Test
+   void distinctConstraintsToTheSameTableKeepDistinctNames() throws Exception {
+      // The Odoo case that motivated the fix: three separate FKs, one target table.
+      XNode root = keyRelationship(List.of(
+         new ImportedKeyRow("res_partner", "id", "sale_order", "partner_id",
+                            "sale_order_partner_id_fkey"),
+         new ImportedKeyRow("res_partner", "id", "sale_order", "partner_invoice_id",
+                            "sale_order_partner_invoice_id_fkey"),
+         new ImportedKeyRow("res_partner", "id", "sale_order", "partner_shipping_id",
+                            "sale_order_partner_shipping_id_fkey")));
+
+      assertEquals(3, root.getChildCount());
+      // Distinct names are what let buildRelationships keep these three relationships apart
+      // instead of merging them into one three-column composite.
+      assertEquals(List.of("sale_order_partner_id_fkey",
+                           "sale_order_partner_invoice_id_fkey",
+                           "sale_order_partner_shipping_id_fkey"),
+                   attributes(root, "fkName"));
+      assertEquals(List.of("partner_id", "partner_invoice_id", "partner_shipping_id"),
+                   attributes(root, "fkColumnName"));
+   }
+
+   @Test
+   void compositeConstraintSharesOneName() throws Exception {
+      // Both columns of a genuine composite FK carry the same FK_NAME, which is what tells
+      // buildRelationships to fold them into ONE multi-column relationship.
+      XNode root = keyRelationship(List.of(
+         new ImportedKeyRow("target", "key_a", "source", "col_a", "source_composite_fkey"),
+         new ImportedKeyRow("target", "key_b", "source", "col_b", "source_composite_fkey")));
+
+      assertEquals(List.of("source_composite_fkey", "source_composite_fkey"),
+                   attributes(root, "fkName"));
+   }
+
+   @Test
+   void aDriverThatOmitsFkNameStillProducesRows() throws Exception {
+      // Not every driver populates FK_NAME. A null must degrade to the table-pair grouping,
+      // never break the read.
+      XNode root = keyRelationship(List.of(
+         new ImportedKeyRow("res_partner", "id", "sale_order", "partner_id", null)));
+
+      assertEquals(1, root.getChildCount());
+      assertNotNull(root.getChild(0).getAttribute("fkColumnName"));
+      assertEquals(null, root.getChild(0).getAttribute("fkName"));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/DatasourceMetaApiControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/DatasourceMetaApiControllerTest.java
@@ -96,12 +96,12 @@ class DatasourceMetaApiControllerTest {
    }
 
    /**
-    * The FK-integrity endpoint answers "how many rows would an INNER join drop?". wiz-services
-    * only injects the join when the answer is 0, so the controller must hand back exactly what
-    * the service computed, under the {@code droppedRowCount} key the caller reads.
+    * The FK-integrity endpoint answers both halves of "would an INNER join change the aggregates?"
+    * — rows dropped and rows duplicated. wiz-services injects the join only when both are 0, so
+    * the controller must hand back exactly what the service measured, under both keys.
     */
    @Test
-   void getFkIntegrity_returnsTheServiceCountAndPassesThePrincipalThrough() throws Exception {
+   void getFkIntegrity_returnsBothServiceCountsAndPassesThePrincipalThrough() throws Exception {
       MetadataApiService metadataService = mock(MetadataApiService.class);
       XRepository xrepository = mock(XRepository.class);
       DataSourceService dataSourceService = mock(DataSourceService.class);
@@ -112,12 +112,14 @@ class DatasourceMetaApiControllerTest {
 
       FkIntegrityRequest request = new FkIntegrityRequest();
       Principal principal = mock(Principal.class);
-      when(fkIntegrityService.countDroppedRows(request, principal)).thenReturn(42L);
+      when(fkIntegrityService.checkIntegrity(request, principal))
+         .thenReturn(new FkIntegrityResponse(42L, 7L));
 
       FkIntegrityResponse response = controller.getFkIntegrity(request, principal);
 
       assertEquals(42L, response.droppedRowCount());
-      verify(fkIntegrityService).countDroppedRows(request, principal);
+      assertEquals(7L, response.duplicateTargetKeyCount());
+      verify(fkIntegrityService).checkIntegrity(request, principal);
    }
 
    /**
@@ -137,7 +139,7 @@ class DatasourceMetaApiControllerTest {
 
       FkIntegrityRequest request = new FkIntegrityRequest();
       Principal principal = mock(Principal.class);
-      when(fkIntegrityService.countDroppedRows(request, principal))
+      when(fkIntegrityService.checkIntegrity(request, principal))
          .thenThrow(new IllegalArgumentException("fkColumn is not a valid identifier"));
 
       assertThrows(IllegalArgumentException.class,

--- a/core/src/test/java/inetsoft/web/wiz/controller/DatasourceMetaApiControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/DatasourceMetaApiControllerTest.java
@@ -19,8 +19,11 @@ package inetsoft.web.wiz.controller;
 
 import inetsoft.uql.XRepository;
 import inetsoft.web.portal.controller.database.DataSourceService;
+import inetsoft.web.wiz.model.FkIntegrityResponse;
 import inetsoft.web.wiz.model.osi.OsiDataset;
+import inetsoft.web.wiz.request.FkIntegrityRequest;
 import inetsoft.web.wiz.request.GetDatabaseTableMetaRequest;
+import inetsoft.web.wiz.service.FkIntegrityService;
 import inetsoft.web.wiz.service.MetadataApiService;
 import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import org.junit.jupiter.api.Tag;
@@ -31,6 +34,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,9 +52,10 @@ class DatasourceMetaApiControllerTest {
       MetadataApiService metadataService = mock(MetadataApiService.class);
       XRepository xrepository = mock(XRepository.class);
       DataSourceService dataSourceService = mock(DataSourceService.class);
+      FkIntegrityService fkIntegrityService = mock(FkIntegrityService.class);
 
-      DatasourceMetaApiController controller =
-         new DatasourceMetaApiController(metadataService, xrepository, dataSourceService);
+      DatasourceMetaApiController controller = new DatasourceMetaApiController(
+         metadataService, xrepository, dataSourceService, fkIntegrityService);
 
       GetDatabaseTableMetaRequest request = new GetDatabaseTableMetaRequest();
       request.setDsName("Examples/Orders");
@@ -76,9 +81,10 @@ class DatasourceMetaApiControllerTest {
       MetadataApiService metadataService = mock(MetadataApiService.class);
       XRepository xrepository = mock(XRepository.class);
       DataSourceService dataSourceService = mock(DataSourceService.class);
+      FkIntegrityService fkIntegrityService = mock(FkIntegrityService.class);
 
-      DatasourceMetaApiController controller =
-         new DatasourceMetaApiController(metadataService, xrepository, dataSourceService);
+      DatasourceMetaApiController controller = new DatasourceMetaApiController(
+         metadataService, xrepository, dataSourceService, fkIntegrityService);
 
       UnsupportedDatasourceException ex =
          new UnsupportedDatasourceException("MongoDB REST", "Mongo");
@@ -87,5 +93,54 @@ class DatasourceMetaApiControllerTest {
 
       assertEquals("Mongo", body.get("datasourceType"));
       assertEquals(ex.getMessage(), body.get("error"));
+   }
+
+   /**
+    * The FK-integrity endpoint answers "how many rows would an INNER join drop?". wiz-services
+    * only injects the join when the answer is 0, so the controller must hand back exactly what
+    * the service computed, under the {@code droppedRowCount} key the caller reads.
+    */
+   @Test
+   void getFkIntegrity_returnsTheServiceCountAndPassesThePrincipalThrough() throws Exception {
+      MetadataApiService metadataService = mock(MetadataApiService.class);
+      XRepository xrepository = mock(XRepository.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      FkIntegrityService fkIntegrityService = mock(FkIntegrityService.class);
+
+      DatasourceMetaApiController controller = new DatasourceMetaApiController(
+         metadataService, xrepository, dataSourceService, fkIntegrityService);
+
+      FkIntegrityRequest request = new FkIntegrityRequest();
+      Principal principal = mock(Principal.class);
+      when(fkIntegrityService.countDroppedRows(request, principal)).thenReturn(42L);
+
+      FkIntegrityResponse response = controller.getFkIntegrity(request, principal);
+
+      assertEquals(42L, response.droppedRowCount());
+      verify(fkIntegrityService).countDroppedRows(request, principal);
+   }
+
+   /**
+    * A failure must reach the class's {@code @ExceptionHandler} (400/403), which wiz-services
+    * treats as a rejection. The controller must never convert a failure into a response body —
+    * a body carrying 0 would read as "safe to join".
+    */
+   @Test
+   void getFkIntegrity_letsServiceFailuresPropagateInsteadOfReturningACount() throws Exception {
+      MetadataApiService metadataService = mock(MetadataApiService.class);
+      XRepository xrepository = mock(XRepository.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      FkIntegrityService fkIntegrityService = mock(FkIntegrityService.class);
+
+      DatasourceMetaApiController controller = new DatasourceMetaApiController(
+         metadataService, xrepository, dataSourceService, fkIntegrityService);
+
+      FkIntegrityRequest request = new FkIntegrityRequest();
+      Principal principal = mock(Principal.class);
+      when(fkIntegrityService.countDroppedRows(request, principal))
+         .thenThrow(new IllegalArgumentException("fkColumn is not a valid identifier"));
+
+      assertThrows(IllegalArgumentException.class,
+         () -> controller.getFkIntegrity(request, principal));
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/FkIntegrityServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/FkIntegrityServiceTest.java
@@ -20,10 +20,13 @@ package inetsoft.web.wiz.service;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.uql.jdbc.JDBCDataSource;
 import inetsoft.web.portal.controller.database.DataSourceService;
+import inetsoft.web.wiz.model.FkIntegrityResponse;
 import inetsoft.web.wiz.request.FkIntegrityRequest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -32,6 +35,11 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -39,23 +47,51 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 /**
- * Covers {@link FkIntegrityService}, which answers one question for wiz-services: how many rows
- * would an INNER join from a fact table to its FK target silently drop?
+ * Covers {@link FkIntegrityService}, which measures whether injecting an INNER join from a fact
+ * table to its FK target would change the dashboard's aggregates.
  *
- * <p>Two properties are load-bearing and are what this test class exists to pin down:</p>
+ * <p>Three properties are load-bearing and are what this test class exists to pin down:</p>
  * <ul>
  *   <li><b>Identifier validation is the security boundary.</b> The endpoint deliberately does not
- *       accept SQL — it accepts identifiers and builds the statement server-side. Every identifier
- *       segment must match {@code ^[A-Za-z_][A-Za-z0-9_]*$}. Anything else is rejected outright,
- *       never quoted or escaped into "safety", and never executed.</li>
- *   <li><b>A wrong zero is the worst possible failure.</b> {@code 0} means "no rows would be
- *       dropped", which is what opens the gate for the join injection. So no failure path may
- *       degrade into a count: exceptions propagate, and an empty or NULL result row is an error,
- *       not a zero.</li>
+ *       accept SQL — it accepts identifiers and builds the statements server-side. Every
+ *       identifier segment must match {@code ^[A-Za-z_][A-Za-z0-9_]*$}. Anything else is rejected
+ *       outright, never quoted or escaped into "safety", and never executed.</li>
+ *   <li><b>Every interpolated field is wired to that boundary.</b> Pinning the validation rule is
+ *       not the same as pinning that a given field goes through it: all four fields funnel into
+ *       one shared helper, so mutating that helper proves only that the rule is enforced
+ *       somewhere — it cannot detect a field wired straight from the request into the SQL
+ *       builder. {@link #checkIntegrity_rejectsBadIdentifiersInEveryFieldWithoutOpeningAConnection}
+ *       exists specifically to pin the four call sites individually.</li>
+ *   <li><b>A wrong zero is the worst possible failure.</b> Zeros mean "safe to join", which is
+ *       what opens the gate. So no failure path may degrade into a count, for either field:
+ *       exceptions propagate, and an empty or NULL result row is an error, not a zero.</li>
  * </ul>
  */
 @Tag("core")
 class FkIntegrityServiceTest {
+   /** The exact statements the service must emit for the canonical request. */
+   private static final String DROP_SQL =
+      "SELECT COUNT(*) FROM public.sale_order src WHERE src.partner_id IS NULL " +
+      "OR NOT EXISTS (SELECT 1 FROM public.res_partner tgt WHERE tgt.id = src.partner_id)";
+   private static final String DUPLICATE_SQL =
+      "SELECT COUNT(*) FROM (SELECT id FROM public.res_partner GROUP BY id HAVING COUNT(*) > 1) d";
+
+   /**
+    * Injection attempts the endpoint exists to refuse. Every one of these is invalid as a table
+    * name AND as a column name, so the one list drives both validation paths and the per-field
+    * wiring test.
+    */
+   private static final List<String> HOSTILE_IDENTIFIERS = List.of(
+      "partner_id; DROP TABLE x",
+      "partner_id--",
+      "partner_id'",
+      "\"partner_id\"",
+      "partner id",
+      "sale_order) UNION SELECT 1 --",
+      "partner_id/*x*/",
+      "1partner",
+      "");
+
    // ------------------------------------------------------------------
    // Identifier validation — the security boundary
    // ------------------------------------------------------------------
@@ -72,31 +108,37 @@ class FkIntegrityServiceTest {
       assertEquals(identifier, FkIntegrityService.validateTableIdentifier(identifier, "sourceTable"));
    }
 
-   /**
-    * The injection attempts the endpoint exists to refuse. Each of these must be rejected as a
-    * 400-class {@link IllegalArgumentException} — not sanitized, not quoted, not executed.
-    */
    @ParameterizedTest
-   @ValueSource(strings = {
-      "partner_id; DROP TABLE x",
-      "partner_id--",
-      "partner_id'",
-      "\"partner_id\"",
-      "partner id",
-      "partner_id)",
-      "1partner",
-      "partner-id",
-      "partner_id/*x*/",
-      " partner_id",
-      "partner_id ",
-      "パートナー"
-   })
+   @MethodSource("hostileIdentifiers")
    void validateColumnIdentifier_rejectsAnythingOutsideTheAllowedCharacterSet(String identifier) {
       IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
          () -> FkIntegrityService.validateColumnIdentifier(identifier, "fkColumn"));
 
       assertTrue(ex.getMessage().contains("fkColumn"),
          "the error must name the offending field so the caller can fix its request");
+   }
+
+   /**
+    * The table path interpolates just as directly as the column path, so it gets the same hostile
+    * payloads. Its wider contract (two segments are legal) must not widen the character set.
+    */
+   @ParameterizedTest
+   @MethodSource("hostileIdentifiers")
+   void validateTableIdentifier_rejectsAnythingOutsideTheAllowedCharacterSet(String identifier) {
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> FkIntegrityService.validateTableIdentifier(identifier, "sourceTable"));
+
+      assertTrue(ex.getMessage().contains("sourceTable"));
+   }
+
+   /** Qualifying a hostile payload must not launder it through the other segment. */
+   @ParameterizedTest
+   @MethodSource("hostileIdentifiers")
+   void validateTableIdentifier_rejectsHostilePayloadsInEitherSegment(String identifier) {
+      assertThrows(IllegalArgumentException.class,
+         () -> FkIntegrityService.validateTableIdentifier("public." + identifier, "targetTable"));
+      assertThrows(IllegalArgumentException.class,
+         () -> FkIntegrityService.validateTableIdentifier(identifier + ".sale_order", "targetTable"));
    }
 
    @ParameterizedTest
@@ -153,111 +195,232 @@ class FkIntegrityServiceTest {
       String sql = FkIntegrityService.buildDroppedRowCountSql(
          "public.sale_order", "partner_id", "public.res_partner", "id");
 
-      assertTrue(sql.startsWith("SELECT COUNT(*) FROM public.sale_order"), sql);
+      assertEquals(DROP_SQL, sql);
       assertTrue(sql.contains("src.partner_id IS NULL"), sql);
       assertTrue(sql.contains("NOT EXISTS"), sql);
-      assertTrue(sql.contains("FROM public.res_partner"), sql);
       assertTrue(sql.contains("tgt.id = src.partner_id"), sql);
       // the orphan half is a correlated subquery, not a concatenated literal
       assertFalse(sql.contains("'"), "the statement must contain no string literals: " + sql);
    }
 
+   /**
+    * The uniqueness half of the question. A target key appearing more than once fans source rows
+    * out, inflating every aggregate — while dropping exactly zero rows, so the drop count cannot
+    * detect it.
+    */
+   @Test
+   void buildDuplicateTargetKeyCountSql_countsTargetKeyValuesOccurringMoreThanOnce() {
+      String sql = FkIntegrityService.buildDuplicateTargetKeyCountSql("public.res_partner", "id");
+
+      assertEquals(DUPLICATE_SQL, sql);
+      assertTrue(sql.contains("GROUP BY id"), sql);
+      assertTrue(sql.contains("HAVING COUNT(*) > 1"), sql);
+      assertFalse(sql.contains("'"), "the statement must contain no string literals: " + sql);
+   }
+
    // ------------------------------------------------------------------
-   // countDroppedRows — never degrade into a zero
+   // checkIntegrity — both measurements, never a wrong zero
    // ------------------------------------------------------------------
 
    @Test
-   void countDroppedRows_returnsTheCountFromTheFirstColumn() throws Exception {
+   void checkIntegrity_returnsBothCountsFromTheFirstColumnOfEachQuery() throws Exception {
       Harness harness = new Harness();
-      when(harness.resultSet.next()).thenReturn(true);
-      when(harness.resultSet.getLong(1)).thenReturn(17L);
+      harness.dropCount(17L);
+      harness.duplicateCount(3L);
 
-      assertEquals(17L, harness.service.countDroppedRows(request(), harness.principal));
+      FkIntegrityResponse response = harness.service.checkIntegrity(request(), harness.principal);
 
-      verify(harness.connection).prepareStatement(FkIntegrityService.buildDroppedRowCountSql(
-         "public.sale_order", "partner_id", "public.res_partner", "id"));
+      assertEquals(17L, response.droppedRowCount());
+      assertEquals(3L, response.duplicateTargetKeyCount());
+   }
+
+   /** Both statements must run, on the one connection, which must then be closed. */
+   @Test
+   void checkIntegrity_runsBothMeasurementsOnASingleConnection() throws Exception {
+      Harness harness = new Harness();
+
+      harness.service.checkIntegrity(request(), harness.principal);
+
+      assertEquals(1, harness.connectionsOpened);
+      verify(harness.connection).prepareStatement(DROP_SQL);
+      verify(harness.connection).prepareStatement(DUPLICATE_SQL);
       verify(harness.connection).close();
    }
 
    @Test
-   void countDroppedRows_returnsZeroOnlyWhenTheDatabaseActuallySaysZero() throws Exception {
+   void checkIntegrity_returnsZeroesOnlyWhenTheDatabaseActuallySaysZero() throws Exception {
       Harness harness = new Harness();
-      when(harness.resultSet.next()).thenReturn(true);
-      when(harness.resultSet.getLong(1)).thenReturn(0L);
+      harness.dropCount(0L);
+      harness.duplicateCount(0L);
 
-      assertEquals(0L, harness.service.countDroppedRows(request(), harness.principal));
+      FkIntegrityResponse response = harness.service.checkIntegrity(request(), harness.principal);
+
+      assertEquals(0L, response.droppedRowCount());
+      assertEquals(0L, response.duplicateTargetKeyCount());
+   }
+
+   /**
+    * The case a drop count alone cannot see: nothing would be dropped, but the target key is not
+    * unique, so the join would fan rows out and inflate every aggregate. The response must carry
+    * that, otherwise a caller gating on "droppedRowCount == 0" would wrongly proceed.
+    */
+   @Test
+   void checkIntegrity_reportsDuplicateKeysEvenWhenNothingWouldBeDropped() throws Exception {
+      Harness harness = new Harness();
+      harness.dropCount(0L);
+      harness.duplicateCount(5L);
+
+      FkIntegrityResponse response = harness.service.checkIntegrity(request(), harness.principal);
+
+      assertEquals(0L, response.droppedRowCount());
+      assertEquals(5L, response.duplicateTargetKeyCount(),
+         "a non-unique target key must be reported even though no row would be dropped");
    }
 
    /** A SQLException must surface as a failure, never be swallowed into a "safe to join" zero. */
    @Test
-   void countDroppedRows_propagatesSqlExceptionsInsteadOfReturningZero() throws Exception {
+   void checkIntegrity_propagatesSqlExceptionsFromTheDropQueryInsteadOfReturningZero()
+      throws Exception
+   {
       Harness harness = new Harness();
-      when(harness.statement.executeQuery()).thenThrow(new SQLException("relation does not exist"));
+      when(harness.dropStatement.executeQuery())
+         .thenThrow(new SQLException("relation does not exist"));
 
       SQLException ex = assertThrows(SQLException.class,
-         () -> harness.service.countDroppedRows(request(), harness.principal));
+         () -> harness.service.checkIntegrity(request(), harness.principal));
 
       assertTrue(ex.getMessage().contains("relation does not exist"));
       verify(harness.connection).close();
    }
 
+   /**
+    * A failure of the second measurement must fail the whole request. Reporting the drop count
+    * alongside a defaulted duplicate count of 0 would be exactly the wrong-zero failure.
+    */
+   @Test
+   void checkIntegrity_propagatesSqlExceptionsFromTheDuplicateQueryInsteadOfReturningZero()
+      throws Exception
+   {
+      Harness harness = new Harness();
+      harness.dropCount(0L);
+      when(harness.duplicateStatement.executeQuery())
+         .thenThrow(new SQLException("permission denied for table res_partner"));
+
+      SQLException ex = assertThrows(SQLException.class,
+         () -> harness.service.checkIntegrity(request(), harness.principal));
+
+      assertTrue(ex.getMessage().contains("permission denied"));
+      verify(harness.connection).close();
+   }
+
    /** An empty result set is a broken query, not "zero dropped rows". */
    @Test
-   void countDroppedRows_throwsWhenTheResultSetHasNoRow() throws Exception {
+   void checkIntegrity_throwsWhenTheDropResultSetHasNoRow() throws Exception {
       Harness harness = new Harness();
-      when(harness.resultSet.next()).thenReturn(false);
+      when(harness.dropResultSet.next()).thenReturn(false);
 
       assertThrows(SQLException.class,
-         () -> harness.service.countDroppedRows(request(), harness.principal));
+         () -> harness.service.checkIntegrity(request(), harness.principal));
+   }
+
+   @Test
+   void checkIntegrity_throwsWhenTheDuplicateResultSetHasNoRow() throws Exception {
+      Harness harness = new Harness();
+      when(harness.duplicateResultSet.next()).thenReturn(false);
+
+      assertThrows(SQLException.class,
+         () -> harness.service.checkIntegrity(request(), harness.principal));
    }
 
    /** getLong() returns 0 for a SQL NULL — which would read as "safe to join". Refuse it. */
    @Test
-   void countDroppedRows_throwsWhenTheCountIsSqlNull() throws Exception {
+   void checkIntegrity_throwsWhenTheDropCountIsSqlNull() throws Exception {
       Harness harness = new Harness();
-      when(harness.resultSet.next()).thenReturn(true);
-      when(harness.resultSet.getLong(1)).thenReturn(0L);
-      when(harness.resultSet.wasNull()).thenReturn(true);
+      when(harness.dropResultSet.wasNull()).thenReturn(true);
 
       assertThrows(SQLException.class,
-         () -> harness.service.countDroppedRows(request(), harness.principal));
+         () -> harness.service.checkIntegrity(request(), harness.principal));
    }
 
-   /** A rejected identifier must never reach the database — validation precedes connection. */
    @Test
-   void countDroppedRows_rejectsBadIdentifiersWithoutOpeningAConnection() throws Exception {
+   void checkIntegrity_throwsWhenTheDuplicateCountIsSqlNull() throws Exception {
+      Harness harness = new Harness();
+      when(harness.duplicateResultSet.wasNull()).thenReturn(true);
+
+      assertThrows(SQLException.class,
+         () -> harness.service.checkIntegrity(request(), harness.principal));
+   }
+
+   // ------------------------------------------------------------------
+   // Wiring — each interpolated field is individually pinned to the validator
+   // ------------------------------------------------------------------
+
+   /**
+    * Every identifier that reaches the generated SQL must be validated, and that must be pinned
+    * per field rather than per rule. All four fields funnel into one shared helper, so mutating
+    * the helper proves only that the rule is enforced somewhere — it cannot detect a field wired
+    * straight from the request into the SQL builder. This test covers each call site
+    * individually: deleting the validation call for any single field turns it red.
+    */
+   @ParameterizedTest(name = "{0} = \"{1}\"")
+   @MethodSource("hostileFieldAssignments")
+   void checkIntegrity_rejectsBadIdentifiersInEveryFieldWithoutOpeningAConnection(
+      String field, String hostileValue, BiConsumer<FkIntegrityRequest, String> setter)
+      throws Exception
+   {
       Harness harness = new Harness();
       FkIntegrityRequest request = request();
-      request.setFkColumn("partner_id; DROP TABLE x");
+      setter.accept(request, hostileValue);
 
-      assertThrows(IllegalArgumentException.class,
-         () -> harness.service.countDroppedRows(request, harness.principal));
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> harness.service.checkIntegrity(request, harness.principal),
+         field + " must be validated before the SQL is built");
 
-      assertEquals(0, harness.connectionsOpened);
+      assertTrue(ex.getMessage().contains(field),
+         "the rejection must name " + field + ", not some other field: " + ex.getMessage());
+      assertEquals(0, harness.connectionsOpened,
+         "a rejected " + field + " must never reach a connection");
       verify(harness.connection, never()).prepareStatement(anyString());
    }
 
+   /** The same wiring guarantee for a null in any of the four fields. */
+   @ParameterizedTest(name = "{0} = null")
+   @MethodSource("nullFieldAssignments")
+   void checkIntegrity_rejectsNullIdentifiersInEveryFieldWithoutOpeningAConnection(
+      String field, BiConsumer<FkIntegrityRequest, String> setter) throws Exception
+   {
+      Harness harness = new Harness();
+      FkIntegrityRequest request = request();
+      setter.accept(request, null);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> harness.service.checkIntegrity(request, harness.principal));
+
+      assertTrue(ex.getMessage().contains(field), ex.getMessage());
+      assertEquals(0, harness.connectionsOpened);
+   }
+
    @Test
-   void countDroppedRows_requiresADatasourcePath() throws Exception {
+   void checkIntegrity_requiresADatasourcePath() throws Exception {
       Harness harness = new Harness();
       FkIntegrityRequest request = request();
       request.setDatasourcePath(null);
 
       assertThrows(IllegalArgumentException.class,
-         () -> harness.service.countDroppedRows(request, harness.principal));
+         () -> harness.service.checkIntegrity(request, harness.principal));
 
       assertEquals(0, harness.connectionsOpened);
    }
 
    /** No READ permission on the datasource means no query at all. */
    @Test
-   void countDroppedRows_deniesAccessWithoutReadPermission() throws Exception {
+   void checkIntegrity_deniesAccessWithoutReadPermission() throws Exception {
       Harness harness = new Harness();
       when(harness.dataSourceService.checkPermission(
          eq("odoo"), eq(ResourceAction.READ), any())).thenReturn(false);
 
       assertThrows(SecurityException.class,
-         () -> harness.service.countDroppedRows(request(), harness.principal));
+         () -> harness.service.checkIntegrity(request(), harness.principal));
 
       assertEquals(0, harness.connectionsOpened);
    }
@@ -265,6 +428,35 @@ class FkIntegrityServiceTest {
    // ------------------------------------------------------------------
    // helpers
    // ------------------------------------------------------------------
+
+   private static Stream<String> hostileIdentifiers() {
+      return HOSTILE_IDENTIFIERS.stream();
+   }
+
+   /** The four SQL-interpolated fields, crossed with the hostile payloads. */
+   private static Stream<Arguments> hostileFieldAssignments() {
+      return identifierSetters().entrySet().stream()
+         .flatMap(setter -> HOSTILE_IDENTIFIERS.stream()
+            .map(payload -> Arguments.of(setter.getKey(), payload, setter.getValue())));
+   }
+
+   private static Stream<Arguments> nullFieldAssignments() {
+      return identifierSetters().entrySet().stream()
+         .map(setter -> Arguments.of(setter.getKey(), setter.getValue()));
+   }
+
+   /**
+    * Every request field that ends up interpolated into a generated statement. If a field is ever
+    * added to the SQL, it belongs here too.
+    */
+   private static Map<String, BiConsumer<FkIntegrityRequest, String>> identifierSetters() {
+      Map<String, BiConsumer<FkIntegrityRequest, String>> setters = new LinkedHashMap<>();
+      setters.put("sourceTable", FkIntegrityRequest::setSourceTable);
+      setters.put("fkColumn", FkIntegrityRequest::setFkColumn);
+      setters.put("targetTable", FkIntegrityRequest::setTargetTable);
+      setters.put("targetKeyColumn", FkIntegrityRequest::setTargetKeyColumn);
+      return setters;
+   }
 
    private static FkIntegrityRequest request() {
       FkIntegrityRequest request = new FkIntegrityRequest();
@@ -278,16 +470,32 @@ class FkIntegrityServiceTest {
 
    /**
     * Wires a {@link FkIntegrityService} over a mocked JDBC stack by overriding the single
-    * connection-acquisition seam, so the whole method — validation, permission, execution and
-    * result handling — is exercised without a live database.
+    * connection-acquisition seam, so the whole method — validation, permission, both queries and
+    * result handling — is exercised without a live database. Statements are routed by SQL text so
+    * the two measurements can be failed independently.
     */
    private static final class Harness {
       Harness() throws Exception {
          when(metadataService.getJDBCDatasource("odoo")).thenReturn(dataSource);
          when(dataSourceService.checkPermission(anyString(), any(ResourceAction.class), any()))
             .thenReturn(true);
-         when(connection.prepareStatement(anyString())).thenReturn(statement);
-         when(statement.executeQuery()).thenReturn(resultSet);
+         // Anything other than the two expected statements is a leak — most likely an identifier
+         // that reached the SQL without being validated. Fail loudly and quote the statement,
+         // rather than letting an unstubbed mock return null and surface as a bare NPE.
+         // do*/when form throughout: when(mock.call()) would invoke the catch-all answer while
+         // recording the two specific stubs below, and blow up during setup.
+         doAnswer(invocation -> {
+            throw new AssertionError(
+               "unexpected SQL reached the database: " + invocation.getArgument(0));
+         }).when(connection).prepareStatement(anyString());
+         doReturn(dropStatement).when(connection).prepareStatement(DROP_SQL);
+         doReturn(duplicateStatement).when(connection).prepareStatement(DUPLICATE_SQL);
+         when(dropStatement.executeQuery()).thenReturn(dropResultSet);
+         when(duplicateStatement.executeQuery()).thenReturn(duplicateResultSet);
+         // Both measurements succeed with 0 by default; each test overrides only what it means to
+         // exercise, so an unrelated failure can't masquerade as the behaviour under test.
+         dropCount(0L);
+         duplicateCount(0L);
 
          service = new FkIntegrityService(metadataService, dataSourceService) {
             @Override
@@ -298,12 +506,24 @@ class FkIntegrityServiceTest {
          };
       }
 
+      void dropCount(long count) throws SQLException {
+         when(dropResultSet.next()).thenReturn(true);
+         when(dropResultSet.getLong(1)).thenReturn(count);
+      }
+
+      void duplicateCount(long count) throws SQLException {
+         when(duplicateResultSet.next()).thenReturn(true);
+         when(duplicateResultSet.getLong(1)).thenReturn(count);
+      }
+
       final MetadataApiService metadataService = mock(MetadataApiService.class);
       final DataSourceService dataSourceService = mock(DataSourceService.class);
       final JDBCDataSource dataSource = mock(JDBCDataSource.class);
       final Connection connection = mock(Connection.class);
-      final PreparedStatement statement = mock(PreparedStatement.class);
-      final ResultSet resultSet = mock(ResultSet.class);
+      final PreparedStatement dropStatement = mock(PreparedStatement.class);
+      final PreparedStatement duplicateStatement = mock(PreparedStatement.class);
+      final ResultSet dropResultSet = mock(ResultSet.class);
+      final ResultSet duplicateResultSet = mock(ResultSet.class);
       final Principal principal = mock(Principal.class);
       final FkIntegrityService service;
       int connectionsOpened;

--- a/core/src/test/java/inetsoft/web/wiz/service/FkIntegrityServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/FkIntegrityServiceTest.java
@@ -1,0 +1,311 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.uql.jdbc.JDBCDataSource;
+import inetsoft.web.portal.controller.database.DataSourceService;
+import inetsoft.web.wiz.request.FkIntegrityRequest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.security.Principal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * Covers {@link FkIntegrityService}, which answers one question for wiz-services: how many rows
+ * would an INNER join from a fact table to its FK target silently drop?
+ *
+ * <p>Two properties are load-bearing and are what this test class exists to pin down:</p>
+ * <ul>
+ *   <li><b>Identifier validation is the security boundary.</b> The endpoint deliberately does not
+ *       accept SQL — it accepts identifiers and builds the statement server-side. Every identifier
+ *       segment must match {@code ^[A-Za-z_][A-Za-z0-9_]*$}. Anything else is rejected outright,
+ *       never quoted or escaped into "safety", and never executed.</li>
+ *   <li><b>A wrong zero is the worst possible failure.</b> {@code 0} means "no rows would be
+ *       dropped", which is what opens the gate for the join injection. So no failure path may
+ *       degrade into a count: exceptions propagate, and an empty or NULL result row is an error,
+ *       not a zero.</li>
+ * </ul>
+ */
+@Tag("core")
+class FkIntegrityServiceTest {
+   // ------------------------------------------------------------------
+   // Identifier validation — the security boundary
+   // ------------------------------------------------------------------
+
+   @ParameterizedTest
+   @ValueSource(strings = { "partner_id", "sale_order", "_private", "Order2", "A1_b2" })
+   void validateColumnIdentifier_acceptsPlainIdentifiers(String identifier) {
+      assertEquals(identifier, FkIntegrityService.validateColumnIdentifier(identifier, "fkColumn"));
+   }
+
+   @ParameterizedTest
+   @ValueSource(strings = { "sale_order", "public.sale_order", "_s._t" })
+   void validateTableIdentifier_acceptsPlainAndSchemaQualifiedTables(String identifier) {
+      assertEquals(identifier, FkIntegrityService.validateTableIdentifier(identifier, "sourceTable"));
+   }
+
+   /**
+    * The injection attempts the endpoint exists to refuse. Each of these must be rejected as a
+    * 400-class {@link IllegalArgumentException} — not sanitized, not quoted, not executed.
+    */
+   @ParameterizedTest
+   @ValueSource(strings = {
+      "partner_id; DROP TABLE x",
+      "partner_id--",
+      "partner_id'",
+      "\"partner_id\"",
+      "partner id",
+      "partner_id)",
+      "1partner",
+      "partner-id",
+      "partner_id/*x*/",
+      " partner_id",
+      "partner_id ",
+      "パートナー"
+   })
+   void validateColumnIdentifier_rejectsAnythingOutsideTheAllowedCharacterSet(String identifier) {
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> FkIntegrityService.validateColumnIdentifier(identifier, "fkColumn"));
+
+      assertTrue(ex.getMessage().contains("fkColumn"),
+         "the error must name the offending field so the caller can fix its request");
+   }
+
+   @ParameterizedTest
+   @NullAndEmptySource
+   void validateColumnIdentifier_rejectsNullAndEmpty(String identifier) {
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> FkIntegrityService.validateColumnIdentifier(identifier, "fkColumn"));
+
+      assertTrue(ex.getMessage().contains("fkColumn"));
+   }
+
+   @ParameterizedTest
+   @NullAndEmptySource
+   void validateTableIdentifier_rejectsNullAndEmpty(String identifier) {
+      assertThrows(IllegalArgumentException.class,
+         () -> FkIntegrityService.validateTableIdentifier(identifier, "sourceTable"));
+   }
+
+   /** A column is exactly one segment: a dot in a column name is a rejection, not a qualification. */
+   @Test
+   void validateColumnIdentifier_rejectsAQualifiedName() {
+      assertThrows(IllegalArgumentException.class,
+         () -> FkIntegrityService.validateColumnIdentifier("src.partner_id", "fkColumn"));
+   }
+
+   /** A table is at most two segments (schema.table); catalog.schema.table is out of contract. */
+   @Test
+   void validateTableIdentifier_rejectsMoreThanTwoSegments() {
+      assertThrows(IllegalArgumentException.class,
+         () -> FkIntegrityService.validateTableIdentifier("odoo.public.sale_order", "sourceTable"));
+   }
+
+   /**
+    * Splitting must retain empty segments. If it didn't, "sale_order." would split to a single
+    * valid segment and slip through with a dangling dot in the generated SQL.
+    */
+   @ParameterizedTest
+   @ValueSource(strings = { "sale_order.", ".sale_order", "public..sale_order", "." })
+   void validateTableIdentifier_rejectsEmptySegments(String identifier) {
+      assertThrows(IllegalArgumentException.class,
+         () -> FkIntegrityService.validateTableIdentifier(identifier, "sourceTable"));
+   }
+
+   // ------------------------------------------------------------------
+   // Generated SQL
+   // ------------------------------------------------------------------
+
+   /**
+    * Both halves of "rows an INNER join would drop" must be counted: NULL FKs, and FKs with no
+    * matching target row. Counting only one half would under-report and open the gate wrongly.
+    */
+   @Test
+   void buildDroppedRowCountSql_countsBothNullFksAndOrphanedFks() {
+      String sql = FkIntegrityService.buildDroppedRowCountSql(
+         "public.sale_order", "partner_id", "public.res_partner", "id");
+
+      assertTrue(sql.startsWith("SELECT COUNT(*) FROM public.sale_order"), sql);
+      assertTrue(sql.contains("src.partner_id IS NULL"), sql);
+      assertTrue(sql.contains("NOT EXISTS"), sql);
+      assertTrue(sql.contains("FROM public.res_partner"), sql);
+      assertTrue(sql.contains("tgt.id = src.partner_id"), sql);
+      // the orphan half is a correlated subquery, not a concatenated literal
+      assertFalse(sql.contains("'"), "the statement must contain no string literals: " + sql);
+   }
+
+   // ------------------------------------------------------------------
+   // countDroppedRows — never degrade into a zero
+   // ------------------------------------------------------------------
+
+   @Test
+   void countDroppedRows_returnsTheCountFromTheFirstColumn() throws Exception {
+      Harness harness = new Harness();
+      when(harness.resultSet.next()).thenReturn(true);
+      when(harness.resultSet.getLong(1)).thenReturn(17L);
+
+      assertEquals(17L, harness.service.countDroppedRows(request(), harness.principal));
+
+      verify(harness.connection).prepareStatement(FkIntegrityService.buildDroppedRowCountSql(
+         "public.sale_order", "partner_id", "public.res_partner", "id"));
+      verify(harness.connection).close();
+   }
+
+   @Test
+   void countDroppedRows_returnsZeroOnlyWhenTheDatabaseActuallySaysZero() throws Exception {
+      Harness harness = new Harness();
+      when(harness.resultSet.next()).thenReturn(true);
+      when(harness.resultSet.getLong(1)).thenReturn(0L);
+
+      assertEquals(0L, harness.service.countDroppedRows(request(), harness.principal));
+   }
+
+   /** A SQLException must surface as a failure, never be swallowed into a "safe to join" zero. */
+   @Test
+   void countDroppedRows_propagatesSqlExceptionsInsteadOfReturningZero() throws Exception {
+      Harness harness = new Harness();
+      when(harness.statement.executeQuery()).thenThrow(new SQLException("relation does not exist"));
+
+      SQLException ex = assertThrows(SQLException.class,
+         () -> harness.service.countDroppedRows(request(), harness.principal));
+
+      assertTrue(ex.getMessage().contains("relation does not exist"));
+      verify(harness.connection).close();
+   }
+
+   /** An empty result set is a broken query, not "zero dropped rows". */
+   @Test
+   void countDroppedRows_throwsWhenTheResultSetHasNoRow() throws Exception {
+      Harness harness = new Harness();
+      when(harness.resultSet.next()).thenReturn(false);
+
+      assertThrows(SQLException.class,
+         () -> harness.service.countDroppedRows(request(), harness.principal));
+   }
+
+   /** getLong() returns 0 for a SQL NULL — which would read as "safe to join". Refuse it. */
+   @Test
+   void countDroppedRows_throwsWhenTheCountIsSqlNull() throws Exception {
+      Harness harness = new Harness();
+      when(harness.resultSet.next()).thenReturn(true);
+      when(harness.resultSet.getLong(1)).thenReturn(0L);
+      when(harness.resultSet.wasNull()).thenReturn(true);
+
+      assertThrows(SQLException.class,
+         () -> harness.service.countDroppedRows(request(), harness.principal));
+   }
+
+   /** A rejected identifier must never reach the database — validation precedes connection. */
+   @Test
+   void countDroppedRows_rejectsBadIdentifiersWithoutOpeningAConnection() throws Exception {
+      Harness harness = new Harness();
+      FkIntegrityRequest request = request();
+      request.setFkColumn("partner_id; DROP TABLE x");
+
+      assertThrows(IllegalArgumentException.class,
+         () -> harness.service.countDroppedRows(request, harness.principal));
+
+      assertEquals(0, harness.connectionsOpened);
+      verify(harness.connection, never()).prepareStatement(anyString());
+   }
+
+   @Test
+   void countDroppedRows_requiresADatasourcePath() throws Exception {
+      Harness harness = new Harness();
+      FkIntegrityRequest request = request();
+      request.setDatasourcePath(null);
+
+      assertThrows(IllegalArgumentException.class,
+         () -> harness.service.countDroppedRows(request, harness.principal));
+
+      assertEquals(0, harness.connectionsOpened);
+   }
+
+   /** No READ permission on the datasource means no query at all. */
+   @Test
+   void countDroppedRows_deniesAccessWithoutReadPermission() throws Exception {
+      Harness harness = new Harness();
+      when(harness.dataSourceService.checkPermission(
+         eq("odoo"), eq(ResourceAction.READ), any())).thenReturn(false);
+
+      assertThrows(SecurityException.class,
+         () -> harness.service.countDroppedRows(request(), harness.principal));
+
+      assertEquals(0, harness.connectionsOpened);
+   }
+
+   // ------------------------------------------------------------------
+   // helpers
+   // ------------------------------------------------------------------
+
+   private static FkIntegrityRequest request() {
+      FkIntegrityRequest request = new FkIntegrityRequest();
+      request.setDatasourcePath("odoo");
+      request.setSourceTable("public.sale_order");
+      request.setFkColumn("partner_id");
+      request.setTargetTable("public.res_partner");
+      request.setTargetKeyColumn("id");
+      return request;
+   }
+
+   /**
+    * Wires a {@link FkIntegrityService} over a mocked JDBC stack by overriding the single
+    * connection-acquisition seam, so the whole method — validation, permission, execution and
+    * result handling — is exercised without a live database.
+    */
+   private static final class Harness {
+      Harness() throws Exception {
+         when(metadataService.getJDBCDatasource("odoo")).thenReturn(dataSource);
+         when(dataSourceService.checkPermission(anyString(), any(ResourceAction.class), any()))
+            .thenReturn(true);
+         when(connection.prepareStatement(anyString())).thenReturn(statement);
+         when(statement.executeQuery()).thenReturn(resultSet);
+
+         service = new FkIntegrityService(metadataService, dataSourceService) {
+            @Override
+            Connection openConnection(JDBCDataSource ds, Principal principal) {
+               connectionsOpened++;
+               return connection;
+            }
+         };
+      }
+
+      final MetadataApiService metadataService = mock(MetadataApiService.class);
+      final DataSourceService dataSourceService = mock(DataSourceService.class);
+      final JDBCDataSource dataSource = mock(JDBCDataSource.class);
+      final Connection connection = mock(Connection.class);
+      final PreparedStatement statement = mock(PreparedStatement.class);
+      final ResultSet resultSet = mock(ResultSet.class);
+      final Principal principal = mock(Principal.class);
+      final FkIntegrityService service;
+      int connectionsOpened;
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePrimaryKeyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePrimaryKeyTest.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.XNode;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for the PrimaryKey attribute type mismatch.
+ *
+ * JDBCHandler writes the attribute as a BOOLEAN (JDBCHandler:3179,
+ * {@code node.setAttribute("PrimaryKey", isPrimary)}), and XNode.setAttribute stores the value as an
+ * Object without coercing it. MetadataApiService used to read it with
+ * {@code "true".equals(getAttribute("PrimaryKey"))} — a String compared to a Boolean, which is
+ * ALWAYS false. Every column was therefore reported as a non-key and {@code dataset.primary_key}
+ * was null for every table on every datasource, which silently disabled every downstream feature
+ * gated on a known primary key.
+ *
+ * The boolean case below is the one that reproduces the bug; it fails against the old
+ * string-comparison form.
+ */
+@Tag("core")
+class MetadataApiServicePrimaryKeyTest {
+   private static boolean isPK(Object attrValue) throws Exception {
+      XNode node = new XNode("some_column");
+
+      if(attrValue != null) {
+         node.setAttribute("PrimaryKey", attrValue);
+      }
+
+      Method m = MetadataApiService.class
+         .getDeclaredMethod("isPrimaryKeyColumn", XNode.class);
+      m.setAccessible(true);
+      return (Boolean) m.invoke(null, node);
+   }
+
+   @Test
+   void booleanTrueIsAPrimaryKey() throws Exception {
+      // THE BUG: this is exactly what JDBCHandler writes, and it used to evaluate to false.
+      assertTrue(isPK(Boolean.TRUE));
+   }
+
+   @Test
+   void booleanFalseIsNotAPrimaryKey() throws Exception {
+      assertFalse(isPK(Boolean.FALSE));
+   }
+
+   @Test
+   void stringTrueIsStillAccepted() throws Exception {
+      // An XNode round-tripped through XML carries its attributes as text.
+      assertTrue(isPK("true"));
+      assertTrue(isPK("TRUE"));
+   }
+
+   @Test
+   void stringFalseAndOtherValuesAreNotPrimaryKeys() throws Exception {
+      assertFalse(isPK("false"));
+      assertFalse(isPK("yes"));
+      assertFalse(isPK(1));
+   }
+
+   @Test
+   void aMissingAttributeIsNotAPrimaryKey() throws Exception {
+      assertFalse(isPK(null));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -80,6 +80,61 @@ class WizDashboardFilterBuilderTest {
    }
 
    @Test
+   void sharedBarCategoricalFilterRendersAsADropdownNotATallList() {
+      // THE BUG: the shared bar reserves FILTER_CONTROL_HEIGHT - FILTER_LABEL_HEIGHT (44px) for a
+      // control. In list mode a SelectionList draws a title row plus ~20px item rows inside that,
+      // leaving exactly ONE item visible in a scroll area -- unusable for choosing among, say, 141
+      // customer names, which is precisely what the FK-label filter feature puts on this bar.
+      // Dropdown mode was applied to the per-chart path only; the shared bar was missed.
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "SO", "res_partner_name"));
+
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(vs, "C");
+      boundToTable(chart, "SO");
+      vs.addAssembly(chart);
+
+      builder.build(vs, ws, List.of(
+         new WizDashboardFilterBuilder.FilterRequest("res_partner_name", "string", "Customer")), 0);
+
+      SelectionListVSAssembly control = java.util.Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof SelectionListVSAssembly)
+         .map(a -> (SelectionListVSAssembly) a)
+         .findFirst().orElseThrow();
+
+      assertEquals(SelectionVSAssemblyInfo.DROPDOWN_SHOW_TYPE, control.getSelectionListInfo().getShowType(),
+         "a shared-bar categorical filter must render as a dropdown, not a multi-row list");
+   }
+
+   @Test
+   void sharedBarDropdownTitleRowFillsTheHeightTheBarReserves() {
+      // A dropdown draws ONLY its title row and ignores the rest of the assembly's pixel height, so
+      // reserving more than it draws leaves the difference as a gap in the filter bar. Pin the row
+      // to the height the bar actually reserves rather than relying on two constants matching.
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "SO", "res_partner_name"));
+
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(vs, "C");
+      boundToTable(chart, "SO");
+      vs.addAssembly(chart);
+
+      WizDashboardFilterBuilder.FilterResult result = builder.build(vs, ws, List.of(
+         new WizDashboardFilterBuilder.FilterRequest("res_partner_name", "string", "Customer")), 0);
+
+      SelectionListVSAssembly control = java.util.Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof SelectionListVSAssembly)
+         .map(a -> (SelectionListVSAssembly) a)
+         .findFirst().orElseThrow();
+      int reserved = result.placements().stream()
+         .filter(pl -> pl.assemblyName().equals(control.getName()))
+         .findFirst().orElseThrow().size().height;
+
+      assertEquals(reserved, control.getSelectionListInfo().getTitleHeightValue(),
+         "the dropdown's title row must fill exactly the height the bar reserved for it");
+   }
+
+   @Test
    void perChartCategoricalFilterRendersAsADropdownNotATallList() {
       // A per-chart filter sits INSIDE its chart's tile, so a multi-row checkbox list steals
       // height from the chart itself. Dropdown mode collapses it to a single title row

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -259,7 +259,14 @@ class WizDashboardFilterBuilderTest {
    void bothSharedBarControlTypesFillTheSameBandHeightSoTheBarStaysEven() {
       // A dropdown has no caption and a slider does, so without compensating the two would occupy
       // different total heights and the bar would step by 16px between adjacent controls of
-      // different types. The dropdown grows its own row by exactly the caption's height instead.
+      // different types.
+      //
+      // The compensation used to be "the dropdown grows its own row by exactly the caption's
+      // height", which made both span the band top-to-bottom -- and rendered live as a 60px white
+      // box beside a much shorter slider (the D3 complaint). Now BOTH reserve the caption strip and
+      // BOTH draw a control of FILTER_CONTROL_ROW_HEIGHT below it; the dropdown just leaves the
+      // strip empty. So the band is still identical for the two types, and their control rows now
+      // additionally share a baseline -- a strictly stronger evenness property than before.
       Worksheet ws = new Worksheet();
       ws.addAssembly(physicalTable(ws, "SO", "res_partner_name", "partner_id"));
 
@@ -280,17 +287,30 @@ class WizDashboardFilterBuilderTest {
 
       int dropdownTop = list.getPixelOffset().y;
       int dropdownBottom = dropdownTop + list.getPixelSize().height;
+      int sliderTop = slider.getPixelOffset().y;
       int sliderBandTop = caption.getPixelOffset().y;
-      int sliderBandBottom = slider.getPixelOffset().y + slider.getPixelSize().height;
+      int sliderBandBottom = sliderTop + slider.getPixelSize().height;
 
-      assertEquals(sliderBandTop, dropdownTop, "both control types start at the same band top");
+      assertEquals(sliderTop, dropdownTop,
+                   "both control types' own rows sit on the same baseline");
       assertEquals(sliderBandBottom, dropdownBottom, "and end at the same band bottom");
-      // The dropdown's title row still fills exactly what was reserved for it (no gap), now that
-      // "what was reserved" is the whole band rather than the band minus a caption.
+      assertEquals(slider.getPixelSize().height, list.getPixelSize().height,
+                   "and are drawn at the same height -- the dropdown must not be a taller box");
+      // The caption strip is RESERVED by the dropdown too (it just draws nothing into it), so the
+      // total band each control type occupies is still identical and the bar cannot step.
+      assertEquals(sliderBandBottom - sliderBandTop, dropdownBottom - sliderBandTop,
+                   "both control types occupy the same total band height");
+      assertTrue(dropdownTop > sliderBandTop,
+                 "the dropdown leaves the caption strip empty rather than growing to swallow it");
+      // The dropdown's title row still fills exactly what was reserved for it -- no gap.
       int reserved = result.placements().stream()
          .filter(pl -> pl.assemblyName().equals(list.getName()))
          .findFirst().orElseThrow().size().height;
       assertEquals(reserved, list.getSelectionListInfo().getTitleHeightValue());
+      // ...and that is the SAME natural row height the per-chart path uses, which is the whole
+      // point of D3: 60px was a box, 28px is a control.
+      assertEquals(WizDashboardService.PER_CHART_FILTER_ROW_HEIGHT, reserved,
+                   "the shared bar must use the per-chart path's established natural row height");
    }
 
    private static SelectionListVSAssembly dropdown(Viewsheet vs) {
@@ -541,20 +561,24 @@ class WizDashboardFilterBuilderTest {
          WizDashboardService.CANVAS_MARGIN);
 
       // A string field is a DROPDOWN, which draws its own title row -- so exactly ONE placement, the
-      // control itself, sitting at the passed origin. (It used to be two: the control plus a caption,
-      // which printed the label twice.) A LABELLED SLIDER still returns two -- see
-      // aSharedBarControlCarriesItsLabelAsTheTitleValue.
+      // control itself. (It used to be two: the control plus a caption, which printed the label
+      // twice.) A LABELLED SLIDER still returns two -- see aSharedBarControlCarriesItsLabelAsTheTitleValue.
       assertEquals(1, result.placements().size());
       assertTrue(result.placements().stream().allMatch(pl -> pl.assemblyName() != null));
-      assertEquals(new java.awt.Point(WizDashboardService.CANVAS_MARGIN, WizDashboardService.CANVAS_MARGIN),
+      // It sits at the passed origin plus the caption STRIP, which every control type reserves even
+      // when (as here) nothing is drawn into it -- that is what puts both types' rows on one
+      // baseline. Asserting the bare origin would re-pin the 60px full-band dropdown D3 removed.
+      assertEquals(new java.awt.Point(WizDashboardService.CANVAS_MARGIN,
+                                      WizDashboardService.CANVAS_MARGIN + WizDashboardFilterBuilder.FILTER_LABEL_HEIGHT),
          result.placements().get(0).position());
    }
 
    @Test
    void firstControlIsOffsetByTheCanvasMarginNotFlushAgainstTheEdge() {
       Worksheet ws = new Worksheet();
-      // Both control types, because what "the top of the bar" IS differs between them: a dropdown
-      // draws its own title so IT sits at the origin, while a slider's caption does.
+      // Both control types, because the two must line up: a slider's CAPTION is what sits at the
+      // origin, and a dropdown -- which draws no caption -- still starts one caption strip down, on
+      // the same baseline as the slider itself.
       ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name", "order_qty"));
 
       Viewsheet vs = new Viewsheet();
@@ -570,11 +594,11 @@ class WizDashboardFilterBuilderTest {
       SelectionListVSAssembly list = dropdown(vs);
       assertEquals(WizDashboardService.CANVAS_MARGIN, list.getPixelOffset().x,
          "must sit at the passed startX (the merged charts' left edge)");
-      assertEquals(WizDashboardService.CANVAS_MARGIN, list.getPixelOffset().y,
-         "a dropdown has no caption above it, so IT is what must clear the canvas's top edge");
 
       VSAssembly slider = (VSAssembly) java.util.Arrays.stream(vs.getAssemblies())
          .filter(a -> a instanceof TimeSliderVSAssembly).findFirst().orElseThrow();
+      assertEquals(slider.getPixelOffset().y, list.getPixelOffset().y,
+         "the dropdown starts one caption strip down, level with the slider itself");
       // The slider sits BELOW its caption, so the caption is what must clear the top edge --
       // same intent, one row up (see FILTER_LABEL_HEIGHT for why a caption exists at all).
       assertTrue(slider.getPixelOffset().y > WizDashboardService.CANVAS_MARGIN,

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.service;
 
+import inetsoft.report.StyleConstants;
 import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
@@ -33,6 +34,7 @@ import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.TextVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.TitledVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.SelectionVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -132,6 +134,170 @@ class WizDashboardFilterBuilderTest {
 
       assertEquals(reserved, control.getSelectionListInfo().getTitleHeightValue(),
          "the dropdown's title row must fill exactly the height the bar reserved for it");
+   }
+
+   @Test
+   void sharedBarDropdownTitleIsVerticallyCentredNotPinnedToTheTopOfItsRow() {
+      // THE BUG (live screenshot): the dropdown's title text sat hard against the TOP of its 60px
+      // row with an obvious empty band beneath it. Nothing in this path calls initDefaultFormat(),
+      // which is the only thing that seeds a TITLEPATH format (with H_LEFT|V_CENTER); with no entry
+      // the title inherits the OBJECT format's default alignment, VSFormat.ALIGN = H_LEFT|V_TOP,
+      // which reaches the client as align-items:flex-start on the title cell.
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "SO", "res_partner_name"));
+
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(vs, "C");
+      boundToTable(chart, "SO");
+      vs.addAssembly(chart);
+
+      builder.build(vs, ws, List.of(
+         new WizDashboardFilterBuilder.FilterRequest("res_partner_name", "string", "Customer")), 0);
+
+      VSCompositeFormat titleFormat = dropdown(vs).getVSAssemblyInfo().getFormatInfo()
+         .getFormat(VSAssemblyInfo.TITLEPATH);
+      assertNotNull(titleFormat, "the dropdown needs its own TITLEPATH format to align at all");
+      // The DESIGN value is the one that survives the composed dashboard being saved and reopened.
+      assertTrue((titleFormat.getAlignmentValue() & StyleConstants.V_CENTER) != 0,
+                 "the dropdown's title must be vertically centred in the row the bar reserves");
+      assertTrue((titleFormat.getAlignment() & StyleConstants.V_CENTER) != 0,
+                 "...and the effective (runtime) alignment must agree");
+      // V_TOP is what it inherited before the fix; asserting its ABSENCE is what distinguishes
+      // "centred" from "both bits set", which fixAlignment would happily store.
+      assertEquals(0, titleFormat.getAlignmentValue() & StyleConstants.V_TOP);
+      // Horizontal alignment must be carried along: fixAlignment keeps the horizontal and vertical
+      // bits independently, so writing V_CENTER alone would zero H_LEFT and centre the text
+      // horizontally too.
+      assertTrue((titleFormat.getAlignmentValue() & StyleConstants.H_LEFT) != 0,
+                 "the title must stay left-aligned horizontally");
+   }
+
+   @Test
+   void sharedBarDropdownPopupHasAnOpaqueBackgroundThatSurvivesAReload() {
+      // THE BUG (live screenshot): the OPEN dropdown list painted transparently on top of the chart
+      // behind it -- its items overlapped chart content and were unreadable. The popup has no
+      // background of its own (.selection-list-body carries none); the whole assembly is painted by
+      // the single [style.background-color]="model.objectFormat.background" binding on .vs-object,
+      // and that was unset because nothing here calls initDefaultFormat().
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "SO", "res_partner_name"));
+
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(vs, "C");
+      boundToTable(chart, "SO");
+      vs.addAssembly(chart);
+
+      builder.build(vs, ws, List.of(
+         new WizDashboardFilterBuilder.FilterRequest("res_partner_name", "string", "Customer")), 0);
+
+      VSCompositeFormat objectFormat = dropdown(vs).getVSAssemblyInfo().getFormat();
+      // Assert through the getter that SURVIVES a save/reload -- the design "...Value" layer. The
+      // plain setter's isBackgroundDefined flag does not survive the round-trip (see
+      // applyCardFormat), so a background set only that way looks right here and vanishes for the
+      // user; reading getBackgroundValue is what makes this test able to tell the difference.
+      assertEquals("#ffffff",
+                   objectFormat.getUserDefinedFormat().getBackgroundValue(),
+                   "the popup needs an opaque background that survives save/reload");
+      assertTrue(objectFormat.getUserDefinedFormat().isBackgroundValueDefined(),
+                 "...and the value must be flagged defined, or the composite getter ignores it");
+      // The effective (composite) getter is what actually renders.
+      assertEquals(java.awt.Color.WHITE, objectFormat.getBackground());
+      // A floating list needs an outline too, or it bleeds into the chart it covers.
+      assertEquals(inetsoft.report.StyleConstants.THIN_LINE, objectFormat.getBorders().top);
+      assertEquals(inetsoft.report.StyleConstants.THIN_LINE, objectFormat.getBorders().bottom);
+      assertNotNull(objectFormat.getBorderColors());
+   }
+
+   @Test
+   void sharedBarDropdownGetsNoCaptionBecauseItDrawsItsOwnTitleRow() {
+      // THE BUG (live screenshot): "Res Partner Name" appeared TWICE -- once as the caption assembly
+      // above the control and again as the dropdown's own title row. The caption exists for the
+      // TimeSlider, which renders no title at all; a dropdown does, so for it the caption is a
+      // duplicate.
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "SO", "res_partner_name"));
+
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(vs, "C");
+      boundToTable(chart, "SO");
+      vs.addAssembly(chart);
+
+      WizDashboardFilterBuilder.FilterResult result = builder.build(vs, ws, List.of(
+         new WizDashboardFilterBuilder.FilterRequest("res_partner_name", "string", "Customer")), 0);
+
+      SelectionListVSAssembly control = dropdown(vs);
+      assertNull(vs.getAssembly("wizFilterLabel_" + control.getName()),
+                 "a dropdown draws its own title -- a caption assembly would print the label twice");
+      assertTrue(result.placements().stream().noneMatch(pl -> pl.assemblyName().startsWith("wizFilterLabel_")),
+                 "and no caption placement may be returned either");
+      // The label still reaches the user -- through the control's OWN title row.
+      assertEquals("Customer", ((TitledVSAssemblyInfo) control.getVSAssemblyInfo()).getTitleValue());
+   }
+
+   @Test
+   void sharedBarRangeSliderStillGetsACaptionBecauseItRendersNoTitleOfItsOwn() {
+      // The other half of the caption rule: vs-range-slider.component.html gates its whole title
+      // header on isInSelectionContainer(), so a standalone slider on the bar shows a bare "6..216"
+      // with nothing naming the column. Removing the caption for EVERY control would strip its only
+      // label.
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "SO", "partner_id"));
+
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(vs, "C");
+      boundToTable(chart, "SO");
+      vs.addAssembly(chart);
+
+      builder.build(vs, ws, List.of(
+         new WizDashboardFilterBuilder.FilterRequest("partner_id", "integer", "Customer")), 0);
+
+      assertNotNull(vs.getAssembly("wizFilterLabel_" + control(vs).getName()),
+                    "a range slider renders no title, so it still needs its caption");
+   }
+
+   @Test
+   void bothSharedBarControlTypesFillTheSameBandHeightSoTheBarStaysEven() {
+      // A dropdown has no caption and a slider does, so without compensating the two would occupy
+      // different total heights and the bar would step by 16px between adjacent controls of
+      // different types. The dropdown grows its own row by exactly the caption's height instead.
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "SO", "res_partner_name", "partner_id"));
+
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(vs, "C");
+      boundToTable(chart, "SO");
+      vs.addAssembly(chart);
+
+      WizDashboardFilterBuilder.FilterResult result = builder.build(vs, ws, List.of(
+         new WizDashboardFilterBuilder.FilterRequest("res_partner_name", "string", "Customer"),
+         new WizDashboardFilterBuilder.FilterRequest("partner_id", "integer", "Customer Id")), 0);
+
+      SelectionListVSAssembly list = dropdown(vs);
+      VSAssembly slider = (VSAssembly) java.util.Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof TimeSliderVSAssembly).findFirst().orElseThrow();
+      VSAssembly caption = (VSAssembly) vs.getAssembly("wizFilterLabel_" + slider.getName());
+      assertNotNull(caption);
+
+      int dropdownTop = list.getPixelOffset().y;
+      int dropdownBottom = dropdownTop + list.getPixelSize().height;
+      int sliderBandTop = caption.getPixelOffset().y;
+      int sliderBandBottom = slider.getPixelOffset().y + slider.getPixelSize().height;
+
+      assertEquals(sliderBandTop, dropdownTop, "both control types start at the same band top");
+      assertEquals(sliderBandBottom, dropdownBottom, "and end at the same band bottom");
+      // The dropdown's title row still fills exactly what was reserved for it (no gap), now that
+      // "what was reserved" is the whole band rather than the band minus a caption.
+      int reserved = result.placements().stream()
+         .filter(pl -> pl.assemblyName().equals(list.getName()))
+         .findFirst().orElseThrow().size().height;
+      assertEquals(reserved, list.getSelectionListInfo().getTitleHeightValue());
+   }
+
+   private static SelectionListVSAssembly dropdown(Viewsheet vs) {
+      return java.util.Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof SelectionListVSAssembly)
+         .map(a -> (SelectionListVSAssembly) a)
+         .findFirst().orElseThrow();
    }
 
    @Test
@@ -374,43 +540,47 @@ class WizDashboardFilterBuilderTest {
          vs, ws, List.of(new WizDashboardFilterBuilder.FilterRequest("category_name", "string", "Category")),
          WizDashboardService.CANVAS_MARGIN);
 
-      // Two placements per LABELLED control now: the control plus its caption (a standalone range
-      // slider renders no title of its own, so the caption stands in -- see FILTER_LABEL_HEIGHT).
-      // Both must be returned or an assembly with no per-tier layout entry is hidden.
-      assertEquals(2, result.placements().size());
+      // A string field is a DROPDOWN, which draws its own title row -- so exactly ONE placement, the
+      // control itself, sitting at the passed origin. (It used to be two: the control plus a caption,
+      // which printed the label twice.) A LABELLED SLIDER still returns two -- see
+      // aSharedBarControlCarriesItsLabelAsTheTitleValue.
+      assertEquals(1, result.placements().size());
       assertTrue(result.placements().stream().allMatch(pl -> pl.assemblyName() != null));
-      // The CAPTION is the topmost thing in the bar, at the passed origin; the control sits under it.
-      var caption = result.placements().stream()
-         .filter(pl -> pl.assemblyName().startsWith("wizFilterLabel_")).findFirst().orElseThrow();
       assertEquals(new java.awt.Point(WizDashboardService.CANVAS_MARGIN, WizDashboardService.CANVAS_MARGIN),
-         caption.position());
+         result.placements().get(0).position());
    }
 
    @Test
    void firstControlIsOffsetByTheCanvasMarginNotFlushAgainstTheEdge() {
       Worksheet ws = new Worksheet();
-      ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name"));
+      // Both control types, because what "the top of the bar" IS differs between them: a dropdown
+      // draws its own title so IT sits at the origin, while a slider's caption does.
+      ws.addAssembly(physicalTable(ws, "CHART_FINAL", "category_name", "order_qty"));
 
       Viewsheet vs = new Viewsheet();
       ChartVSAssembly chart = new ChartVSAssembly(vs, "RadarChart");
       boundToTable(chart, "CHART_FINAL");
       vs.addAssembly(chart);
 
-      builder.build(vs, ws, List.of(new WizDashboardFilterBuilder.FilterRequest("category_name", "string", "Category")),
+      builder.build(vs, ws, List.of(
+            new WizDashboardFilterBuilder.FilterRequest("category_name", "string", "Category"),
+            new WizDashboardFilterBuilder.FilterRequest("order_qty", "integer", "Qty")),
          WizDashboardService.CANVAS_MARGIN);
 
-      AbstractSelectionVSAssembly control = java.util.Arrays.stream(vs.getAssemblies())
-         .filter(a -> a instanceof AbstractSelectionVSAssembly)
-         .map(a -> (AbstractSelectionVSAssembly) a)
-         .findFirst().orElseThrow();
-      assertEquals(WizDashboardService.CANVAS_MARGIN, control.getPixelOffset().x,
+      SelectionListVSAssembly list = dropdown(vs);
+      assertEquals(WizDashboardService.CANVAS_MARGIN, list.getPixelOffset().x,
          "must sit at the passed startX (the merged charts' left edge)");
-      // The control now sits BELOW its caption, so the caption is what must clear the top edge --
+      assertEquals(WizDashboardService.CANVAS_MARGIN, list.getPixelOffset().y,
+         "a dropdown has no caption above it, so IT is what must clear the canvas's top edge");
+
+      VSAssembly slider = (VSAssembly) java.util.Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof TimeSliderVSAssembly).findFirst().orElseThrow();
+      // The slider sits BELOW its caption, so the caption is what must clear the top edge --
       // same intent, one row up (see FILTER_LABEL_HEIGHT for why a caption exists at all).
-      assertTrue(control.getPixelOffset().y > WizDashboardService.CANVAS_MARGIN,
-         "the control sits below its caption");
-      var captionAssembly = vs.getAssembly("wizFilterLabel_" + control.getName());
-      assertNotNull(captionAssembly, "the control must have a caption above it");
+      assertTrue(slider.getPixelOffset().y > WizDashboardService.CANVAS_MARGIN,
+         "the slider sits below its caption");
+      var captionAssembly = vs.getAssembly("wizFilterLabel_" + slider.getName());
+      assertNotNull(captionAssembly, "the slider must have a caption above it");
       assertEquals(WizDashboardService.CANVAS_MARGIN, ((VSAssembly) captionAssembly).getPixelOffset().y,
          "the bar must not sit flush against the canvas's top edge");
    }

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.display.tl.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.display.tl.spec.ts
@@ -584,6 +584,59 @@ describe("VSSelection �?Pass 3: Display", () => {
       });
    });
 
+   // A standalone DROPDOWN collapses to its title row, so with the selected-values half hidden the
+   // user sees only "Customer" and nothing at all indicating that two customers are ticked -- the
+   // current selection is discoverable only by re-opening the popup. The platform already computes
+   // the summary (updateListSelectedString runs on every model refresh regardless of container);
+   // only the display was gated on model.container.
+   //
+   // These assert the two getters the template binds, not rendered DOM: this suite instantiates the
+   // component directly rather than through TestBed, so there is no template to query.
+   describe("Group 9b �?selected-values display outside a selection container", () => {
+      it("should show the selected values for a STANDALONE dropdown", async () => {
+         const { comp } = await renderComponent();
+         comp.model = makeMockListModel({ dropdown: true, container: null } as any);
+         comp.updateListSelectedString();
+
+         expect(comp.selectedTextVisible).toBe(true);
+      });
+
+      it("should still hide them for a standalone list in LIST mode", async () => {
+         // The values are already visible in the list itself there, so a summary would be redundant
+         // and would only steal width from the title.
+         const { comp } = await renderComponent();
+         comp.model = makeMockListModel({ dropdown: false, container: null } as any);
+         comp.updateListSelectedString();
+
+         expect(comp.selectedTextVisible).toBe(false);
+      });
+
+      it("should leave a CONTAINED list showing them exactly as before", async () => {
+         const { comp } = await renderComponent();
+         comp.model = makeMockListModel({ dropdown: false, container: "Container1" } as any);
+         comp.updateListSelectedString();
+
+         expect(comp.selectedTextVisible).toBe(true);
+      });
+
+      it("should split the title row 50/50 for a standalone dropdown, not by the model default", async () => {
+         // VSSelectionBaseModel defaults titleRatio to 1 and only the container path overwrites it.
+         // Rendering the selected-values div at ratio 1 gives it width 0 -- invisible, which looks
+         // exactly like the un-gating not having worked.
+         const { comp } = await renderComponent();
+         comp.model = makeMockListModel({ dropdown: true, container: null, titleRatio: 1 } as any);
+
+         expect(comp.effectiveTitleRatio).toBe(0.5);
+      });
+
+      it("should defer to the container's own ratio when contained", async () => {
+         const { comp } = await renderComponent();
+         comp.model = makeMockListModel({ container: "Container1", titleRatio: 0.7 } as any);
+
+         expect(comp.effectiveTitleRatio).toBe(0.7);
+      });
+   });
+
    describe("Group 10 �?getIdentifier", () => {
       it("should return value for leaf node", async () => {
          const { comp } = await renderComponent();

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.html
@@ -97,8 +97,8 @@
       }
       <div class="float-start align-middle"
         [class.separator-visible]="model.containerType === 'VSSelectionContainer'"
-        [style.width.px]="(model.container && listSelectedString ? model.objectFormat.width * model.titleRatio : model.objectFormat.width)"
-        [style.max-width.%]="(model.container && listSelectedString ? model.titleRatio * 100 : 100)"
+        [style.width.px]="(selectedTextVisible ? model.objectFormat.width * effectiveTitleRatio : model.objectFormat.width)"
+        [style.max-width.%]="(selectedTextVisible ? effectiveTitleRatio * 100 : 100)"
         [style.height.px]="model.titleFormat.height"
         [style.border-right-color]="headerSeparatorBorderColor"
         [draggable]="true"
@@ -120,16 +120,21 @@
           (onTitleResizeMove)="titleResizeMove($event)"
         (onTitleResizeEnd)="titleResizeEnd()"></title-cell>
       </div>
-      @if (model.container && listSelectedString) {
+      <!-- The selected-values half of the title row. Shown for a CONTAINED list (as always) and
+           now also for a standalone DROPDOWN, which is otherwise collapsed to a bare title with
+           nothing indicating what is currently selected. interactableResizable stays gated on
+           model.container: updateTitleRatio posts the dragged ratio against model.container, so
+           for a standalone control there is no assembly to post it to. -->
+      @if (selectedTextVisible) {
         <div
           class="float-start align-middle selection-list-selected-text"
-          [style.width.px]="model.objectFormat.width - (model.objectFormat.width * model.titleRatio)"
-          [style.max-width.%]="100 - (model.titleRatio * 100)"
+          [style.width.px]="model.objectFormat.width - (model.objectFormat.width * effectiveTitleRatio)"
+          [style.max-width.%]="100 - (effectiveTitleRatio * 100)"
           [style.height.px]="model.titleFormat.height"
           [style.justify-content]="model.titleFormat.justifyContent"
           [style.background]="model.titleFormat.background"
           wInteractable
-          [interactableResizable]="!viewer && selected"
+          [interactableResizable]="!viewer && selected && !!model.container"
           [resizableTopEdge]="false"
           [resizableBottomEdge]="false"
           [resizableRightEdge]="false"

--- a/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/selection/vs-selection.component.ts
@@ -214,6 +214,13 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
    public static LIST_INDENT: number = 4;
    public static TREE_INDENT: number = 16;
 
+   // Title/selected-values width split for a STANDALONE dropdown -- the same value
+   // VSSelectionListModel falls back to for a contained list whose container ratio is NaN, so a
+   // dropdown splits its title row identically whether or not it sits in a container. There is no
+   // server-side titleRatio for a standalone control (the model's own default is 1, which would
+   // collapse the selected-values half to zero width).
+   public static STANDALONE_TITLE_RATIO: number = 0.5;
+
    private _quickSwitchClickCallback: (() => void) | null = null;
    private _overlayMouseLeaveUnlisten: (() => void) | null = null;
    private _overlayWheelUnlisten: (() => void) | null = null;
@@ -1010,6 +1017,37 @@ export class VSSelection extends NavigationComponent<VSSelectionBaseModel>
       if(this.listSelectedString == null) {
          this.listSelectedString = "(none)";
       }
+   }
+
+   /**
+    * Whether the title row shows the CURRENT SELECTION beside the title.
+    *
+    * A list inside a VSSelectionContainer has always shown it. A standalone DROPDOWN now does too:
+    * dropdown mode collapses the whole control to its title row, so with this hidden the user sees
+    * "Customer" and nothing at all telling them two customers are ticked -- the selection is only
+    * discoverable by re-opening the popup. It is the same one-line summary the container already
+    * renders, produced by the same updateListSelectedString() (which already ran unconditionally on
+    * every model refresh, container or not, so nothing here can go stale as the selection changes).
+    *
+    * Deliberately NOT extended to a standalone list in LIST mode: there the values are visible in
+    * the list itself, so a summary would be redundant and would only steal width from the title.
+    */
+   get selectedTextVisible(): boolean {
+      return !!this.listSelectedString && (!!this.model.container || this.model.dropdown);
+   }
+
+   /**
+    * The share of the title row's width given to the title, the rest going to the selected values.
+    *
+    * VSSelectionBaseModel defaults titleRatio to 1 and only VSSelectionListModel overwrites it (with
+    * 0.5) when the list is inside a CurrentSelectionVSAssembly -- there is no server-side knob for a
+    * standalone control. Un-gating the selected-values div without this would therefore render it at
+    * width 0 / max-width 0%, i.e. invisible, which looks exactly like the feature not working.
+    * STANDALONE_TITLE_RATIO is the same 0.5 the container path falls back to, so both cases split
+    * the row the same way.
+    */
+   get effectiveTitleRatio(): number {
+      return this.model.container ? this.model.titleRatio : VSSelection.STANDALONE_TITLE_RATIO;
    }
 
    updateTitle(newTitle: string): void {


### PR DESCRIPTION
Backend support for FK-label filter controls in wiz, plus three bugs found while building it. Each commit stands alone.

## `POST /api/wiz/datasource/fk-integrity` (dabbf0335, c60ba1cfe)

wiz needs to know whether an FK is orphan-free *before* it may inject an INNER join, because an inner join over a nullable or orphaned FK silently drops rows and changes every unfiltered aggregate on a dashboard. Nothing exposed that, and the alternative — an arbitrary-SQL endpoint — is not one worth creating.

This is a **narrow, structured** endpoint: it takes identifiers only, never SQL. It returns `{droppedRowCount, duplicateTargetKeyCount}` — dropped rows for orphans/NULLs, duplicate target keys because a non-unique key *multiplies* rows and moves aggregates just as surely as dropping them does.

It never answers with a false zero. Identifier validation (`^[A-Za-z_][A-Za-z0-9_]*$`, ≤2 segments for tables, 1 for columns) runs before any connection is opened, and every failure path — invalid identifier, permission denial, SQLException, empty ResultSet, SQL NULL — throws rather than returning a count. "Unknown" and "zero" must not be confusable when a wrong answer changes reported numbers.

## `PrimaryKey` read as a boolean, not a string (1ce4015cd)

`JDBCHandler` writes the attribute as a `Boolean`; `MetadataApiService` compared it with `"true".equals(...)`, a String against a Boolean, which is **always false**. Every column on every datasource reported as a non-key and `dataset.primary_key` was null everywhere, silently disabling every feature gated on a known primary key.

## `FK_NAME` dropped from KEYRELATION (ebe66e02f)

`getKeyRelationship` read columns 1-8 of `getImportedKeys` and never column 12. Its only consumer groups rows by `(fkTable, pkTable, pkCatalog, pkSchema, fkName)` precisely so two distinct constraints between the same table pair stay distinct — with `fkName` always empty that degraded to the table pair alone, folding independent single-column FKs into one bogus composite.

Odoo's `sale_order` has three separate constraints referencing `res_partner.id` (`partner_id`, `partner_invoice_id`, `partner_shipping_id`); they collapsed into a single three-column relationship pointing at a one-column key. `account_move` and `stock_picking` have the same shape.

The existing comment attributes this to drivers that "do not populate FK_NAME". Verified against PostgreSQL 42.7.x that the driver **does** populate it — the loss was entirely in this reader. Drivers that genuinely omit it still fall back to table-pair grouping, unchanged.

## Shared-bar selection filter rendered as a clipped list (f996f2a5d)

`WizDashboardFilterBuilder` creates filter controls on two paths. The per-chart path sets `DROPDOWN_SHOW_TYPE`; the shared-bar path in `build()` never did, so a categorical filter there drew a multi-row checkbox list inside a band reserving 44px — a title row plus ~20px item rows leaves exactly **one item visible** in a scroll area.

Reported from a live dashboard whose shared bar carried a customer-name filter over **141 distinct values**. The two paths were already known to differ (`addPerChartFilter`'s comment opens *"Key distinction from the shared-bar path in build()"*); the dropdown fix simply landed on one of them, and low-cardinality columns like an order `state` hid it.

`TimeSliderVSAssembly` is deliberately untouched — no show type, already single-row.

## Testing

`FkIntegrityServiceTest`, `MetadataApiServicePrimaryKeyTest`, `JDBCHandlerKeyRelationshipTest`, `WizDashboardFilterBuilderTest`.

Every fix is mutation-checked. The KEYRELATION tests pin the *wiring* — that column 12 is read and surfaced — so removing the one `setAttribute` line fails 3 of its 4. The filter tests fail with `expected: <1> but was: <0>` and `expected: <44> but was: <20>` when the branch is disabled, and the existing assertion that the *shared factory* stays in list mode still passes, so dashboard compaction has not leaked into `AddFilterService`'s interactive add-filter flow.

Verified live on an Odoo datasource: relationship extraction went from **69 edges to 2153**, against 2112 FK constraints declared in the database.

**Cache caveat for reviewers:** StyleBI's metadata cache is disk-backed, and `getCachedMetaData` reads the stored build number and *discards* it — a new build does **not** invalidate it. Clear `~/.srMetaData` or recreate the container, or the KEYRELATION fix appears to do nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
