### PR TITLE
fix(wiz): honor a fieldConfig's title on the rendered axis

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -289,6 +289,7 @@ public class WizAutoBindingService {
                   }
 
                   applyFieldConfigs(chartAsm.getVSChartInfo(), configMap);
+                  applyAxisTitlesFromFieldConfigs(chartAsm, configMap);
                }
                // The crosstab recommender decides row/col header placement itself and ignores
                // rows/cols pins (ChartPreference, the only pin channel into the recommender, models
@@ -492,6 +493,72 @@ public class WizAutoBindingService {
       applyAestheticFieldConfig(chartInfo.getShapeField(), configMap, chartType);
       applyAestheticFieldConfig(chartInfo.getSizeField(), configMap, chartType);
       applyAestheticFieldConfig(chartInfo.getTextField(), configMap, chartType);
+   }
+
+   /**
+    * Title the X/Y AXES from the {@code title} on whichever fieldConfig is bound to each axis.
+    *
+    * <p>THE DEFECT THIS FIXES. A caller-supplied {@code title} was accepted, forwarded, and applied
+    * to the chart ref as its caption ({@link #applyTitleAndFormat}) — and the axis still read the raw
+    * column name, because AN AXIS TITLE IS NOT A REF CAPTION. It comes from the chart descriptor's
+    * {@link TitlesDescriptor}, and when that carries no value StyleBI falls back to the field's full
+    * name. So {@code title: "Project"} rendered as {@code name} and {@code title: "Estimated Hours"}
+    * as {@code Sum(total_estimated_hours)} (reproduced live on the openproject dataset — the setting
+    * was taken without complaint and silently discarded, the failure mode CLAUDE.md calls out).
+    *
+    * <p>This writes the SAME descriptor that {@code setChartFormat}'s {@code xAxisTitle}/
+    * {@code yAxisTitle} writes, so the two paths agree on what an axis title is. A later explicit
+    * {@code set_chart_format} call still overrides this, which is the right precedence: it is the
+    * more specific instruction, and it runs after.
+    *
+    * <p>FIRST TITLED FIELD WINS per axis. An axis has exactly one title but may carry several fields
+    * (a multi-measure Y, a nested dimension); there is no defensible way to render two titles in one
+    * slot, and concatenating them produces a label no caller asked for. Fields with no {@code title}
+    * are skipped rather than contributing an empty string, so a partially-titled axis still gets the
+    * title that was actually supplied.
+    */
+   private void applyAxisTitlesFromFieldConfigs(ChartVSAssembly chartAsm,
+                                                Map<String, SimpleFieldInfo> configMap)
+   {
+      VSChartInfo vsChartInfo = chartAsm.getVSChartInfo();
+      ChartDescriptor desc = chartAsm.getChartInfo() == null
+         ? null : chartAsm.getChartInfo().getChartDescriptor();
+
+      if(vsChartInfo == null || desc == null || desc.getTitlesDescriptor() == null) {
+         return;
+      }
+
+      TitlesDescriptor titles = desc.getTitlesDescriptor();
+      applyAxisTitle(titles.getXTitleDescriptor(), vsChartInfo.getXFields(), configMap);
+      applyAxisTitle(titles.getYTitleDescriptor(), vsChartInfo.getYFields(), configMap);
+   }
+
+   /**
+    * Set one axis title from the first field on that axis whose fieldConfig carries a title.
+    *
+    * <p>Package-private and static so it can be unit-tested directly with mocked refs, mirroring
+    * {@link #applyDateGroup}.
+    */
+   static void applyAxisTitle(TitleDescriptor titleDesc, ChartRef[] refs,
+                              Map<String, SimpleFieldInfo> configMap)
+   {
+      if(titleDesc == null || refs == null) {
+         return;
+      }
+
+      for(ChartRef ref : refs) {
+         if(ref == null) {
+            continue;
+         }
+
+         SimpleFieldInfo fc = configMap.get(WizardRecommenderUtil.getChartRefFieldName(ref));
+         String title = fc == null ? null : fc.getTitle();
+
+         if(title != null && !title.isEmpty()) {
+            titleDesc.setTitleValue(title);
+            return;
+         }
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -516,13 +516,18 @@ public class WizAutoBindingService {
     * slot, and concatenating them produces a label no caller asked for. Fields with no {@code title}
     * are skipped rather than contributing an empty string, so a partially-titled axis still gets the
     * title that was actually supplied.
+    *
+    * <p>The SECONDARY Y axis ({@code getY2TitleDescriptor}) is deliberately not written. A measure
+    * with {@code secondaryY:true} and a title has it applied to the primary Y descriptor — the same
+    * gap {@code setChartFormat}'s {@code yAxisTitle} path has, so this inherits an existing
+    * inconsistency rather than introducing a new one. Worth a follow-up if secondary-Y titles are
+    * ever asked for.
     */
    private void applyAxisTitlesFromFieldConfigs(ChartVSAssembly chartAsm,
                                                 Map<String, SimpleFieldInfo> configMap)
    {
       VSChartInfo vsChartInfo = chartAsm.getVSChartInfo();
-      ChartDescriptor desc = chartAsm.getChartInfo() == null
-         ? null : chartAsm.getChartInfo().getChartDescriptor();
+      ChartDescriptor desc = chartAsm.getChartDescriptor();
 
       if(vsChartInfo == null || desc == null || desc.getTitlesDescriptor() == null) {
          return;

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceAxisTitleTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceAxisTitleTest.java
@@ -1,0 +1,187 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.graph.ChartRef;
+import inetsoft.uql.viewsheet.graph.TitleDescriptor;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
+import inetsoft.web.wiz.model.DimensionFieldInfo;
+import inetsoft.web.wiz.model.MeasureFieldInfo;
+import inetsoft.web.wiz.model.SimpleFieldInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Regression tests for {@link WizAutoBindingService#applyAxisTitle}.
+ *
+ * <p>The bug: a caller-supplied {@code fieldConfigs[].title} was accepted, forwarded to
+ * {@code /viewsheet/autoBinding}, and applied to the chart ref as its CAPTION — and the rendered
+ * axis still read the raw column name, because an axis title is not a ref caption. It comes from
+ * the chart descriptor's {@code TitlesDescriptor}, which nothing on this path was writing, so
+ * StyleBI fell back to the field's full name. Live on the openproject dataset, a bar created with
+ * {@code title: "Project"} / {@code title: "Estimated Hours"} rendered its axes as {@code name} and
+ * {@code Sum(total_estimated_hours)} — the setting taken without complaint and silently discarded.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizAutoBindingServiceAxisTitleTest {
+   private static VSChartDimensionRef dimRef(String field) {
+      VSChartDimensionRef ref = mock(VSChartDimensionRef.class);
+      when(ref.getGroupColumnValue()).thenReturn(field);
+      return ref;
+   }
+
+   private static VSChartAggregateRef aggRef(String field) {
+      VSChartAggregateRef ref = mock(VSChartAggregateRef.class);
+      when(ref.getColumnValue()).thenReturn(field);
+      return ref;
+   }
+
+   private static SimpleFieldInfo dimFc(String field, String title) {
+      DimensionFieldInfo fc = new DimensionFieldInfo();
+      fc.setField(field);
+      fc.setTitle(title);
+      return fc;
+   }
+
+   private static SimpleFieldInfo measureFc(String field, String title) {
+      MeasureFieldInfo fc = new MeasureFieldInfo();
+      fc.setField(field);
+      fc.setTitle(title);
+      return fc;
+   }
+
+   @Test
+   void titlesTheAxisFromTheBoundDimensionsFieldConfig() {
+      TitleDescriptor td = mock(TitleDescriptor.class);
+      ChartRef[] refs = { dimRef("name") };
+
+      WizAutoBindingService.applyAxisTitle(td, refs, Map.of("name", dimFc("name", "Project")));
+
+      verify(td).setTitleValue("Project");
+   }
+
+   @Test
+   void titlesTheAxisFromTheBoundMeasuresFieldConfig() {
+      TitleDescriptor td = mock(TitleDescriptor.class);
+      ChartRef[] refs = { aggRef("total_estimated_hours") };
+
+      WizAutoBindingService.applyAxisTitle(
+         td, refs, Map.of("total_estimated_hours", measureFc("total_estimated_hours", "Estimated Hours")));
+
+      verify(td).setTitleValue("Estimated Hours");
+   }
+
+   @Test
+   void firstTitledFieldWinsWhenAnAxisCarriesSeveral() {
+      // An axis has exactly one title but may carry several fields (a multi-measure Y). Rendering
+      // two titles in one slot is impossible and concatenating them invents a label nobody asked
+      // for, so the first titled field is taken and the rest ignored.
+      TitleDescriptor td = mock(TitleDescriptor.class);
+      ChartRef[] refs = { aggRef("revenue"), aggRef("cost") };
+
+      WizAutoBindingService.applyAxisTitle(td, refs, Map.of(
+         "revenue", measureFc("revenue", "Revenue"),
+         "cost", measureFc("cost", "Cost")));
+
+      verify(td).setTitleValue("Revenue");
+      verify(td, never()).setTitleValue("Cost");
+   }
+
+   @Test
+   void skipsUntitledFieldsRatherThanTitlingTheAxisEmpty() {
+      // A partially-titled axis must still get the title that WAS supplied — an untitled leading
+      // field may not blank the axis or short-circuit the search.
+      TitleDescriptor td = mock(TitleDescriptor.class);
+      ChartRef[] refs = { aggRef("revenue"), aggRef("cost") };
+
+      WizAutoBindingService.applyAxisTitle(td, refs, Map.of(
+         "revenue", measureFc("revenue", null),
+         "cost", measureFc("cost", "Cost")));
+
+      verify(td).setTitleValue("Cost");
+   }
+
+   @Test
+   void leavesTheAxisUntouchedWhenNoBoundFieldCarriesATitle() {
+      // No title supplied ⇒ StyleBI's own default (the field's full name) must stand. Writing an
+      // empty value here would blank an axis the caller never asked to change.
+      TitleDescriptor td = mock(TitleDescriptor.class);
+      ChartRef[] refs = { dimRef("name") };
+
+      WizAutoBindingService.applyAxisTitle(td, refs, Map.of("name", dimFc("name", null)));
+
+      verify(td, never()).setTitleValue(anyString());
+   }
+
+   @Test
+   void anEmptyTitleIsTreatedAsNoTitle() {
+      TitleDescriptor td = mock(TitleDescriptor.class);
+      ChartRef[] refs = { dimRef("name") };
+
+      WizAutoBindingService.applyAxisTitle(td, refs, Map.of("name", dimFc("name", "")));
+
+      verify(td, never()).setTitleValue(anyString());
+   }
+
+   @Test
+   void ignoresARefWithNoMatchingFieldConfig() {
+      TitleDescriptor td = mock(TitleDescriptor.class);
+      ChartRef[] refs = { dimRef("unbound") };
+
+      WizAutoBindingService.applyAxisTitle(td, refs, Map.of("name", dimFc("name", "Project")));
+
+      verify(td, never()).setTitleValue(anyString());
+   }
+
+   @Test
+   void isANoOpOnANullDescriptorOrNullRefs() {
+      TitleDescriptor td = mock(TitleDescriptor.class);
+
+      WizAutoBindingService.applyAxisTitle(null, new ChartRef[] { dimRef("name") },
+                                           Map.of("name", dimFc("name", "Project")));
+      WizAutoBindingService.applyAxisTitle(td, null, Map.of("name", dimFc("name", "Project")));
+
+      verify(td, never()).setTitleValue(anyString());
+   }
+
+   @Test
+   void skipsANullRefWithoutThrowing() {
+      TitleDescriptor td = mock(TitleDescriptor.class);
+      ChartRef[] refs = { null, dimRef("name") };
+
+      WizAutoBindingService.applyAxisTitle(td, refs, Map.of("name", dimFc("name", "Project")));
+
+      verify(td).setTitleValue("Project");
+   }
+}


### PR DESCRIPTION
## What

A caller-supplied `fieldConfigs[].title` was accepted, forwarded to `/viewsheet/autoBinding`, applied by `applyTitleAndFormat` as the chart ref's **caption** — and the rendered axis still read the raw column name.

Live on the openproject dataset, a bar created with `title: "Project"` and `title: "Estimated Hours"` rendered its axes as `name` and `Sum(total_estimated_hours)`. The setting was taken without complaint and silently discarded.

## Root cause

**An axis title is not a ref caption.** It comes from the chart descriptor's `TitlesDescriptor` — the same thing `setChartFormat`'s `xAxisTitle`/`yAxisTitle` writes — and nothing on the autoBinding path was writing it, so StyleBI fell back to the field's full name.

## Fix

`applyAxisTitlesFromFieldConfigs` writes that descriptor after `applyFieldConfigs`, so the autoBinding and `setChartFormat` paths agree on what an axis title is. A later explicit `set_chart_format` still overrides it — the more specific instruction, and it runs after.

**First titled field wins per axis.** An axis has exactly one title but may carry several fields (a multi-measure Y, a nested dimension); concatenating them would render a label no caller asked for. Untitled fields are skipped rather than contributing an empty string, so a partially-titled axis still gets the title that was supplied.

`applyAxisTitle` is package-private static so it can be unit-tested directly with mocked refs, mirroring `applyDateGroup`.

## A dead end worth recording

The first attempt re-applied caption/format to the **runtime** refs (`getRTXFields()`/`getRTYFields()`), following the pattern `applyStaticColor` documents for color:

> the renderer reads getRTYFields()/getRTXFields(), clones made at execution time, so painting only the design refs would leave the next render on the old color

That pattern is real for color but changed nothing observable for titles. It was removed rather than shipped unverified, and the fix was re-verified afterwards to confirm it stands on the axis-descriptor change alone.

## Verification

- 9 new unit tests in `WizAutoBindingServiceAxisTitleTest` (plus `WizAutoBindingServiceDateGroupTest` still green): 14 run, 0 failures.
- Built as `local-1134` and verified visually end to end against the openproject dataset — the axes now read **Project** and **Estimated Hours**.

## Not covered

`fieldConfigs[].format` sets the ref's *text* format (mark labels), not axis ticks, so this change neither fixes nor tests it. Whether `format` reaches the render is still unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)